### PR TITLE
Add join commutativity rule for reordering fact dimension join

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/routing/MockRoutingManagerFactory.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/routing/MockRoutingManagerFactory.java
@@ -53,6 +53,7 @@ public class MockRoutingManagerFactory {
   private final Map<String, String> _tableNameMap;
   private final Map<String, Schema> _schemaMap;
   private final Set<String> _hybridTables;
+  private final Set<String> _dimTables;
   private final Map<String, ServerInstance> _serverInstances;
   private final Map<String, Map<String, List<ServerInstance>>> _tableSegmentServersMap;
   private final Set<String> _disabledTables;
@@ -61,6 +62,7 @@ public class MockRoutingManagerFactory {
     _tableNameMap = new HashMap<>();
     _schemaMap = new HashMap<>();
     _hybridTables = new HashSet<>();
+    _dimTables = new HashSet<>();
     _serverInstances = new HashMap<>();
     _tableSegmentServersMap = new HashMap<>();
     _disabledTables = new HashSet<>();
@@ -77,6 +79,13 @@ public class MockRoutingManagerFactory {
       registerTableNameWithType(schema, TableNameBuilder.REALTIME.tableNameWithType(tableName));
       _hybridTables.add(tableName);
     }
+  }
+
+  /// Registers a table whose mocked TableConfig returns {@code isDimTable()=true}. Used by planner tests that
+  /// need to exercise dim-table-aware rules (e.g. {@code PinotJoinCommuteRule}).
+  public void registerDimTable(Schema schema, String tableName) {
+    registerTable(schema, tableName);
+    _dimTables.add(TableNameBuilder.extractRawTableName(tableName));
   }
 
   private void registerTableNameWithType(Schema schema, String tableNameWithType) {
@@ -164,7 +173,11 @@ public class MockRoutingManagerFactory {
     when(mock.getTableConfig(anyString())).thenAnswer(invocationOnMock -> {
       String tableName = invocationOnMock.getArgument(0);
       if (TableNameBuilder.getTableTypeFromTableName(tableName) != null && _tableNameMap.containsKey(tableName)) {
-        return mock(TableConfig.class);
+        TableConfig tableConfig = mock(TableConfig.class);
+        if (_dimTables.contains(TableNameBuilder.extractRawTableName(tableName))) {
+          when(tableConfig.isDimTable()).thenReturn(true);
+        }
+        return tableConfig;
       }
       return null;
     });

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotJoinCommuteRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotJoinCommuteRule.java
@@ -1,0 +1,196 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.calcite.rel.rules;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.core.JoinInfo;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.logical.LogicalAsofJoin;
+import org.apache.calcite.rel.rules.JoinCommuteRule;
+import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.pinot.calcite.rel.hint.PinotHintOptions.JoinHintOptions;
+import org.apache.pinot.query.catalog.PinotTable;
+
+
+/**
+ * Logical-phase rule that swaps the inputs of a join when the left input is a dimension table and the right is not.
+ *
+ * <p>Pinot's exchange-insertion ({@link PinotJoinExchangeNodeInsertRule}) and lookup-join planning are sensitive to
+ * which input appears on the right: the right side is broadcast for non-equi joins, becomes the build side at runtime
+ * (see {@code BaseJoinOperator}), and is required to be a dimension table for the lookup-join strategy. When a user
+ * writes {@code dim JOIN fact ON dim.k = fact.k}, the planner — without this rule — broadcasts and/or builds the fact
+ * side, which is exactly the wrong choice. Swapping the inputs so the dim ends up on the right fixes both problems
+ * with a single, locally reasoned transformation.
+ *
+ * <p>This is intentionally a narrow, no-statistics commute rule: it fires only when one side is configured as a
+ * dimension table (a property already known at catalog-construction time). It does <b>not</b> attempt size-based
+ * commutation between two non-dim tables; that requires a cardinality-aware cost model and is tracked as future
+ * work toward a full cost-based optimizer.
+ *
+ * <p>Predicate (all must hold for commutation to fire):
+ * <ol>
+ *   <li>Join type is INNER, LEFT, RIGHT, or FULL. SEMI / ANTI / ASOF are skipped because they are semantically
+ *       asymmetric (a separate rule, e.g. extension of {@link PinotJoinToDynamicBroadcastRule}, must handle the
+ *       small-side-on-left case for semi-joins).</li>
+ *   <li>The join has at least one equi-key. Non-equi joins use a different operator and runtime broadcast policy;
+ *       commuting them is in scope for a follow-up PR.</li>
+ *   <li>No user-supplied hint pins the distribution or join strategy. Specifically, the rule bails if the join
+ *       carries any of {@code left_distribution_type}, {@code right_distribution_type}, or
+ *       {@code is_colocated_by_join_keys} — these express explicit intent about side roles that the rule must not
+ *       silently invert. The rule also bails on {@code join_strategy='hash'} and
+ *       {@code join_strategy='dynamic_broadcast'}.
+ *
+ *       <p><b>Special case:</b> {@code join_strategy='lookup'} is the one strategy whose precondition is
+ *       <i>directional</i> — the right input must be a dimension table (enforced at runtime by
+ *       {@code LookupJoinOperator}). When the user writes {@code dim JOIN fact} with this hint, the hint is
+ *       <i>unsatisfiable as written</i>; the only valid interpretation is to commute. The rule therefore lets
+ *       commutation fire in this case; the preserved hint reaches downstream lookup-join planning, which then
+ *       applies cleanly on the commuted plan. We auto-correct only when the user's intent is otherwise
+ *       unrealizable.</li>
+ *   <li>The left input is "dim-shaped" — its rel subtree resolves through a chain of {@link Project}/{@link Filter}
+ *       nodes to a single {@link TableScan} of a dimension table. Subtrees containing {@code Aggregate},
+ *       {@code Join}, {@code Window}, {@code Union}, etc. are conservatively rejected: their output is no longer
+ *       guaranteed dim-sized.</li>
+ *   <li>The right input is <b>not</b> dim-shaped. If both sides are dim, the rule has no preference signal and
+ *       declines to fire — this also guarantees idempotency: once the dim is on the right, the predicate is false
+ *       and the rule will not flip the join back.</li>
+ * </ol>
+ *
+ * <p>The actual swap delegates to Calcite's
+ * {@link JoinCommuteRule#swap(Join, boolean, org.apache.calcite.tools.RelBuilder)} with {@code swapOuterJoins=true},
+ * which produces a Project-wrapped swapped Join with the join type and condition correctly inverted (LEFT ↔ RIGHT,
+ * condition operands swapped). Join hints are preserved by {@code Join.copy()}.
+ */
+public class PinotJoinCommuteRule extends RelOptRule {
+  public static final PinotJoinCommuteRule INSTANCE = new PinotJoinCommuteRule(PinotRuleUtils.PINOT_REL_FACTORY, null);
+
+  public static PinotJoinCommuteRule instanceWithDescription(String description) {
+    return new PinotJoinCommuteRule(PinotRuleUtils.PINOT_REL_FACTORY, description);
+  }
+
+  public PinotJoinCommuteRule(RelBuilderFactory factory, @Nullable String description) {
+    super(operand(Join.class, any()), factory, description);
+  }
+
+  @Override
+  public boolean matches(RelOptRuleCall call) {
+    Join join = call.rel(0);
+
+    // Asymmetric join types: semi/anti distinguish left from right by semantics, not just position; ASOF anchors
+    // the temporal scan on the left side. Calcite's swap() returns null for these as well, but we short-circuit
+    // here to avoid the dim-detection walk on joins we will never commute.
+    JoinRelType joinType = join.getJoinType();
+    if (joinType == JoinRelType.SEMI || joinType == JoinRelType.ANTI) {
+      return false;
+    }
+    if (join instanceof LogicalAsofJoin) {
+      return false;
+    }
+
+    // Require an equi-key. Without one, the runtime falls into NonEquiJoinOperator which has a separate broadcast
+    // policy; commuting it is in scope for a follow-up PR.
+    JoinInfo joinInfo = join.analyzeCondition();
+    if (joinInfo.leftKeys.isEmpty()) {
+      return false;
+    }
+
+    // Bail if the user has expressed any explicit intent about side roles. We do not want to silently invert a
+    // deliberate hint like right_distribution_type=broadcast or join_strategy=lookup.
+    if (hasUserPinnedSideHint(join)) {
+      return false;
+    }
+
+    // The decision signal: dim on the wrong side, and only on the wrong side.
+    return isDimShaped(join.getLeft()) && !isDimShaped(join.getRight());
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call) {
+    Join join = call.rel(0);
+    RelNode swapped = JoinCommuteRule.swap(join, /*swapOuterJoins=*/ true, call.builder());
+    // swap() should not return null given matches() guards, but defend in case Calcite adds new pre-conditions.
+    if (swapped != null) {
+      call.transformTo(swapped);
+    }
+  }
+
+  /**
+   * Returns {@code true} if any hint on the join expresses explicit intent about which side should play which role,
+   * <i>except</i> for {@code join_strategy='lookup'} with dim-on-left — that one combination is unsatisfiable as
+   * written and commuting is the unique way to honor the user's intent (see class Javadoc, "Special case").
+   */
+  private static boolean hasUserPinnedSideHint(Join join) {
+    String strategy = JoinHintOptions.getJoinStrategyHint(join);
+    if (strategy != null && !JoinHintOptions.LOOKUP_JOIN_STRATEGY.equalsIgnoreCase(strategy)) {
+      return true;
+    }
+    Map<String, String> hintOptions = JoinHintOptions.getJoinHintOptions(join);
+    if (hintOptions == null) {
+      return false;
+    }
+    return hintOptions.containsKey(JoinHintOptions.LEFT_DISTRIBUTION_TYPE)
+        || hintOptions.containsKey(JoinHintOptions.RIGHT_DISTRIBUTION_TYPE)
+        || hintOptions.containsKey(JoinHintOptions.IS_COLOCATED_BY_JOIN_KEYS);
+  }
+
+  /**
+   * Returns {@code true} if {@code input} resolves through a thin chain of {@link Project} / {@link Filter} nodes
+   * to a single {@link TableScan} whose underlying table is configured as a dimension table.
+   *
+   * <p>Single-input, single-output relational operators (Project, Filter) preserve the "this row corresponds to a
+   * dim table row" property and therefore do not invalidate the dim-shape detection. Multi-input or
+   * cardinality-changing operators (Join, Aggregate, Window, Union, etc.) do, and are conservatively rejected.
+   */
+  private static boolean isDimShaped(RelNode input) {
+    RelNode current = PinotRuleUtils.unboxRel(input);
+    while (true) {
+      if (current instanceof TableScan) {
+        return isDimTableScan((TableScan) current);
+      }
+      if (current instanceof Project || current instanceof Filter) {
+        current = PinotRuleUtils.unboxRel(current.getInput(0));
+        continue;
+      }
+      return false;
+    }
+  }
+
+  private static boolean isDimTableScan(TableScan scan) {
+    RelOptTable relOptTable = scan.getTable();
+    if (relOptTable == null) {
+      return false;
+    }
+    PinotTable pinotTable = unwrapPinotTable(relOptTable);
+    return pinotTable != null && pinotTable.isDimTable();
+  }
+
+  @Nullable
+  private static PinotTable unwrapPinotTable(RelOptTable relOptTable) {
+    return relOptTable.unwrap(PinotTable.class);
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotQueryRuleSets.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotQueryRuleSets.java
@@ -117,6 +117,11 @@ public class PinotQueryRuleSets {
       JoinPushExpressionsRule.Config.DEFAULT
           .withDescription(PlannerRuleNames.JOIN_PUSH_EXPRESSIONS).toRule(),
 
+      // swap join inputs so a dimension table is on the right (= build / broadcast / lookup side) regardless of
+      // how the user wrote the SQL. Cardinality-aware commute is future work; this rule fires on a dim-table
+      // signal that is already known at catalog construction time. See PinotJoinCommuteRule for the full predicate.
+      PinotJoinCommuteRule.instanceWithDescription(PlannerRuleNames.PINOT_JOIN_COMMUTE),
+
       // join and semi-join rules
       SemiJoinRule.ProjectToSemiJoinRule.ProjectToSemiJoinRuleConfig.DEFAULT
           .withDescription(PlannerRuleNames.PROJECT_TO_SEMI_JOIN).toRule(),

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotCatalog.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotCatalog.java
@@ -33,6 +33,7 @@ import org.apache.calcite.schema.Schemas;
 import org.apache.calcite.schema.Table;
 import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.common.utils.DatabaseUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 
 import static java.util.Objects.requireNonNull;
@@ -92,7 +93,29 @@ public class PinotCatalog implements Schema {
       return null;
     }
 
-    return new PinotTable(schema, _excludeVirtualColumns);
+    return new PinotTable(schema, _excludeVirtualColumns, isDimTable(tableName));
+  }
+
+  /**
+   * Returns whether the given physical table is configured as a dimension table on its OFFLINE side.
+   *
+   * <p>Pinot's dim-table machinery (segment-assignment replication, {@code DimensionTableDataManager},
+   * lookup-join eligibility) is wired up on OFFLINE tables only — see
+   * {@code DefaultTableDataManagerProvider}, which only consults {@code isDimTable()} under the OFFLINE
+   * branch, and {@code PinotTableRestletResource}, which documents "Dimension is a property (isDimTable)
+   * of an OFFLINE table." The {@code TableConfig} type itself does not enforce this (no {@code Preconditions}
+   * rejects {@code isDimTable=true} on a REALTIME config), so a misconfigured REALTIME table with the flag
+   * set would not be honored by the runtime; we intentionally do not honor it in the planner either.
+   *
+   * <p>Returns {@code false} for logical tables, missing tables, realtime-only tables, or any other lookup
+   * failure — callers should treat a {@code false} return as "not known to be an OFFLINE dim table" rather
+   * than "definitely not a dim table".
+   */
+  private boolean isDimTable(String tableName) {
+    String rawTableName = TableNameBuilder.extractRawTableName(tableName);
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(rawTableName);
+    TableConfig tableConfig = _tableCache.getTableConfig(offlineTableName);
+    return tableConfig != null && tableConfig.isDimTable();
   }
 
   /**

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotTable.java
@@ -36,11 +36,12 @@ import org.apache.pinot.spi.data.Schema;
  * {@link RelDataType} of the table to the planner.
  */
 public class PinotTable extends AbstractTable implements ScannableTable {
-  private Schema _schema;
-  private boolean _excludeVirtualColumns = false;
+  private final Schema _schema;
+  private final boolean _excludeVirtualColumns;
+  private final boolean _isDimTable;
 
   public PinotTable(Schema schema) {
-    this(schema, false);
+    this(schema, false, false);
   }
 
   /**
@@ -49,8 +50,19 @@ public class PinotTable extends AbstractTable implements ScannableTable {
    * should not participate in join condition matching.
    */
   public PinotTable(Schema schema, boolean excludeVirtualColumns) {
+    this(schema, excludeVirtualColumns, false);
+  }
+
+  /**
+   * Constructor with full options. {@code isDimTable} is consulted by planner rules that benefit from knowing
+   * a table is a small, fully-replicated dimension table (e.g. join-input commutation that wants the dim side as
+   * the build/broadcast side of a join). It must be derived from the table's {@code TableConfig.isDimTable()} at
+   * catalog construction time; the rules themselves do not have access to {@code TableCache}.
+   */
+  public PinotTable(Schema schema, boolean excludeVirtualColumns, boolean isDimTable) {
     _schema = schema;
     _excludeVirtualColumns = excludeVirtualColumns;
+    _isDimTable = isDimTable;
   }
 
   @Override
@@ -67,6 +79,10 @@ public class PinotTable extends AbstractTable implements ScannableTable {
     } else {
       return typeFactory.createRelDataTypeFromSchema(_schema);
     }
+  }
+
+  public boolean isDimTable() {
+    return _isDimTable;
   }
 
   @Override

--- a/pinot-query-planner/src/test/java/org/apache/pinot/calcite/rel/rules/PinotJoinCommuteRuleTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/calcite/rel/rules/PinotJoinCommuteRuleTest.java
@@ -1,0 +1,505 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.calcite.rel.rules;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.plan.hep.HepMatchOrder;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.RelDistributions;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.rel.logical.LogicalAsofJoin;
+import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.logical.LogicalJoin;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.logical.LogicalTableScan;
+import org.apache.calcite.rel.metadata.DefaultRelMetadataProvider;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.pinot.calcite.rel.hint.PinotHintOptions;
+import org.apache.pinot.calcite.rel.hint.PinotHintOptions.JoinHintOptions;
+import org.apache.pinot.calcite.rel.hint.PinotHintStrategyTable;
+import org.apache.pinot.query.catalog.PinotTable;
+import org.apache.pinot.query.type.TypeFactory;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Unit tests for {@link PinotJoinCommuteRule}.
+ *
+ * <p>Each test constructs a {@link LogicalJoin} backed by mock {@link RelOptTable} instances that wrap a real
+ * {@link PinotTable} with the desired {@code isDimTable} flag. The HepPlanner is configured with only the rule
+ * under test so that observed transformations are unambiguous.
+ *
+ * <p>The shared assertion shape after a successful commute is a {@link LogicalProject} whose input is the swapped
+ * {@link LogicalJoin}. The Project is inserted by {@link org.apache.calcite.rel.rules.JoinCommuteRule#swap} to
+ * preserve the original column order of the join output; we treat it as part of the contract and verify the
+ * swapped join via {@code project.getInput(0)}.
+ */
+public class PinotJoinCommuteRuleTest {
+  private static final TypeFactory TYPE_FACTORY = TypeFactory.INSTANCE;
+  private static final RexBuilder REX_BUILDER = new RexBuilder(TYPE_FACTORY);
+
+  private static final RelDataType ROW_TYPE = TYPE_FACTORY.builder()
+      .add("k", SqlTypeName.INTEGER)
+      .add("v", SqlTypeName.INTEGER)
+      .build();
+
+  private RelOptCluster _cluster;
+  private HepPlanner _planner;
+
+  @BeforeMethod
+  public void setUp() {
+    HepProgramBuilder programBuilder = new HepProgramBuilder();
+    programBuilder.addMatchOrder(HepMatchOrder.BOTTOM_UP);
+    programBuilder.addRuleInstance(PinotJoinCommuteRule.INSTANCE);
+    _planner = new HepPlanner(programBuilder.build());
+    _cluster = RelOptCluster.create(_planner, REX_BUILDER);
+    _cluster.setMetadataProvider(DefaultRelMetadataProvider.INSTANCE);
+    // Required so Calcite's hint validation accepts the {@code joinOptions} hint name when a rule that fires on
+    // a hinted join (e.g. {@link #lookupHintWithDimOnLeftSwaps}) walks through the swap path.
+    _cluster.setHintStrategies(PinotHintStrategyTable.PINOT_HINT_STRATEGY_TABLE);
+  }
+
+  // -------- Positive cases: rule fires --------
+
+  @Test
+  public void dimOnLeftInnerJoinSwaps() {
+    LogicalTableScan dim = scan("dim", /*isDim=*/ true);
+    LogicalTableScan fact = scan("fact", /*isDim=*/ false);
+    LogicalJoin join = innerJoin(dim, fact);
+
+    LogicalJoin commuted = runRuleAndExpectSwap(join);
+    assertSame(unwrapTable(commuted.getLeft()), unwrapTable(fact), "fact should be on left after commute");
+    assertSame(unwrapTable(commuted.getRight()), unwrapTable(dim), "dim should be on right after commute");
+    assertEquals(commuted.getJoinType(), JoinRelType.INNER);
+  }
+
+  @Test
+  public void dimOnLeftLeftJoinSwapsAndFlipsToRight() {
+    LogicalTableScan dim = scan("dim", true);
+    LogicalTableScan fact = scan("fact", false);
+    LogicalJoin join = joinOf(dim, fact, JoinRelType.LEFT);
+
+    LogicalJoin commuted = runRuleAndExpectSwap(join);
+    // LEFT swaps to RIGHT — fact (originally right) is now left, dim (originally left) is now right.
+    assertEquals(commuted.getJoinType(), JoinRelType.RIGHT);
+    assertSame(unwrapTable(commuted.getLeft()), unwrapTable(fact));
+    assertSame(unwrapTable(commuted.getRight()), unwrapTable(dim));
+  }
+
+  @Test
+  public void dimOnLeftRightJoinSwapsAndFlipsToLeft() {
+    LogicalTableScan dim = scan("dim", true);
+    LogicalTableScan fact = scan("fact", false);
+    LogicalJoin join = joinOf(dim, fact, JoinRelType.RIGHT);
+
+    LogicalJoin commuted = runRuleAndExpectSwap(join);
+    assertEquals(commuted.getJoinType(), JoinRelType.LEFT);
+  }
+
+  @Test
+  public void dimOnLeftFullJoinSwaps() {
+    LogicalTableScan dim = scan("dim", true);
+    LogicalTableScan fact = scan("fact", false);
+    LogicalJoin join = joinOf(dim, fact, JoinRelType.FULL);
+
+    LogicalJoin commuted = runRuleAndExpectSwap(join);
+    assertEquals(commuted.getJoinType(), JoinRelType.FULL);
+  }
+
+  @Test
+  public void filterOnDimSwaps() {
+    // Project/Filter chains on top of the dim scan still resolve to a dim-shaped input.
+    LogicalTableScan dim = scan("dim", true);
+    LogicalFilter filteredDim = LogicalFilter.create(dim, filterEqual(dim, 0, 42));
+    LogicalTableScan fact = scan("fact", false);
+    LogicalJoin join = innerJoin(filteredDim, fact);
+
+    runRuleAndExpectSwap(join);
+  }
+
+  @Test
+  public void projectOnDimSwaps() {
+    LogicalTableScan dim = scan("dim", true);
+    LogicalProject projectedDim = LogicalProject.create(dim, Collections.emptyList(),
+        List.of(REX_BUILDER.makeInputRef(ROW_TYPE.getFieldList().get(0).getType(), 0),
+            REX_BUILDER.makeInputRef(ROW_TYPE.getFieldList().get(1).getType(), 1)),
+        List.of("k", "v"));
+    LogicalTableScan fact = scan("fact", false);
+    LogicalJoin join = innerJoin(projectedDim, fact);
+
+    runRuleAndExpectSwap(join);
+  }
+
+  // -------- Negative cases: rule does not fire --------
+
+  @Test
+  public void dimOnRightInnerJoinDoesNotSwap() {
+    LogicalTableScan dim = scan("dim", true);
+    LogicalTableScan fact = scan("fact", false);
+    LogicalJoin join = innerJoin(fact, dim); // already canonical
+    runRuleAndExpectNoChange(join);
+  }
+
+  @Test
+  public void bothDimDoesNotSwap() {
+    LogicalTableScan dim1 = scan("dim1", true);
+    LogicalTableScan dim2 = scan("dim2", true);
+    runRuleAndExpectNoChange(innerJoin(dim1, dim2));
+  }
+
+  @Test
+  public void neitherDimDoesNotSwap() {
+    LogicalTableScan fact1 = scan("fact1", false);
+    LogicalTableScan fact2 = scan("fact2", false);
+    runRuleAndExpectNoChange(innerJoin(fact1, fact2));
+  }
+
+  @Test
+  public void semiJoinWithDimOnLeftDoesNotSwap() {
+    runRuleAndExpectNoChange(joinOf(scan("dim", true), scan("fact", false), JoinRelType.SEMI));
+  }
+
+  @Test
+  public void antiJoinWithDimOnLeftDoesNotSwap() {
+    runRuleAndExpectNoChange(joinOf(scan("dim", true), scan("fact", false), JoinRelType.ANTI));
+  }
+
+  /// ASOF anchors the temporal scan on the left side; commuting it would invert the ASOF semantics. The rule
+  /// short-circuits on {@code instanceof LogicalAsofJoin} before the dim-detection walk. Otherwise this join
+  /// — dim on left, fact on right, one equi-key — would meet every other predicate.
+  @Test
+  public void asofJoinWithDimOnLeftDoesNotSwap() {
+    LogicalTableScan dim = scan("dim", true);
+    LogicalTableScan fact = scan("fact", false);
+    int leftFieldCount = dim.getRowType().getFieldCount();
+    RexNode condition = REX_BUILDER.makeCall(SqlStdOperatorTable.EQUALS,
+        REX_BUILDER.makeInputRef(dim, 0),
+        REX_BUILDER.makeInputRef(fact, 0).accept(new InputRefShift(leftFieldCount)));
+    RexNode matchCondition = REX_BUILDER.makeLiteral(true);
+    LogicalAsofJoin asofJoin = LogicalAsofJoin.create(dim, fact, ImmutableList.of(), condition, matchCondition,
+        JoinRelType.LEFT_ASOF, ImmutableList.of());
+    runRuleAndExpectNoChange(asofJoin);
+  }
+
+  @Test
+  public void cartesianJoinWithDimOnLeftDoesNotSwap() {
+    // No equi-key — even though dim is on the left, the rule skips because the build/broadcast policy for
+    // NonEquiJoinOperator is out of scope for v1.
+    LogicalTableScan dim = scan("dim", true);
+    LogicalTableScan fact = scan("fact", false);
+    RexNode alwaysTrue = REX_BUILDER.makeLiteral(true);
+    LogicalJoin join = LogicalJoin.create(dim, fact, ImmutableList.of(), alwaysTrue, Collections.emptySet(),
+        JoinRelType.INNER);
+    runRuleAndExpectNoChange(join);
+  }
+
+  @DataProvider(name = "nonLookupJoinStrategies")
+  public Object[][] nonLookupJoinStrategies() {
+    return new Object[][] {
+        {JoinHintOptions.HASH_JOIN_STRATEGY},
+        {JoinHintOptions.DYNAMIC_BROADCAST_JOIN_STRATEGY},
+    };
+  }
+
+  /**
+   * {@code join_strategy='hash'} and {@code join_strategy='dynamic_broadcast'} are deliberate user intent that
+   * the rule must not silently invert. (LOOKUP is the special case — see {@link #lookupHintWithDimOnLeftSwaps}.)
+   * Note that a single HepPlanner instance must not be reused across iterations of this verification because it
+   * remembers equivalent sets across {@code setRoot} calls; using a {@code @DataProvider} gives each invocation
+   * a fresh planner from {@link #setUp()}.
+   */
+  @Test(dataProvider = "nonLookupJoinStrategies")
+  public void nonLookupJoinStrategyHintDoesNotSwap(String strategy) {
+    LogicalJoin join = innerJoinWithJoinOptionHint(JoinHintOptions.JOIN_STRATEGY, strategy);
+    runRuleAndExpectNoChange(join);
+  }
+
+  /**
+   * {@code join_strategy='lookup'} with dim-on-left is the one hint case where the user's intent is unsatisfiable
+   * as written — {@code LookupJoinOperator} requires dim on the right. The rule auto-corrects by committing to
+   * commute, so the downstream lookup-join planning pass sees a satisfiable plan. The lookup hint is preserved
+   * on the swapped join via Calcite's {@code Join.copy()}.
+   */
+  @Test
+  public void lookupHintWithDimOnLeftSwaps() {
+    LogicalJoin join = innerJoinWithJoinOptionHint(JoinHintOptions.JOIN_STRATEGY, JoinHintOptions.LOOKUP_JOIN_STRATEGY);
+    LogicalJoin commuted = runRuleAndExpectSwap(join);
+    // Confirm tables are swapped: the original left was dim, after commute right must be dim.
+    PinotTable rightAfter = unwrapTable(commuted.getRight());
+    assertTrue(rightAfter.isDimTable(), "Right side after commute must be the dim table");
+    // The lookup hint must travel with the swapped join so LookupJoinRule still recognizes it.
+    assertEquals(JoinHintOptions.getJoinStrategyHint(commuted), JoinHintOptions.LOOKUP_JOIN_STRATEGY,
+        "Lookup hint must be preserved on the commuted join so downstream rules still see it");
+  }
+
+  @DataProvider(name = "pinnedSideHints")
+  public Object[][] pinnedSideHints() {
+    return new Object[][] {
+        {JoinHintOptions.LEFT_DISTRIBUTION_TYPE, PinotHintOptions.DistributionType.BROADCAST_HINT},
+        {JoinHintOptions.RIGHT_DISTRIBUTION_TYPE, PinotHintOptions.DistributionType.HASH_HINT},
+        {JoinHintOptions.IS_COLOCATED_BY_JOIN_KEYS, "true"},
+    };
+  }
+
+  /// Any distribution/colocation hint signals explicit user intent about side roles. Each key path through
+  /// {@code hasUserPinnedSideHint} must short-circuit; if a future refactor accidentally drops a key from the
+  /// OR clause this parameterized run catches it.
+  @Test(dataProvider = "pinnedSideHints")
+  public void pinnedSideHintDoesNotSwap(String hintKey, String hintValue) {
+    runRuleAndExpectNoChange(innerJoinWithJoinOptionHint(hintKey, hintValue));
+  }
+
+  @Test
+  public void aggregateAboveDimScanDoesNotSwap() {
+    // Aggregate changes cardinality semantics: an aggregate over a dim table is not itself dim-sized in general
+    // (and our walker conservatively rejects multi-input / cardinality-changing nodes).
+    LogicalTableScan dim = scan("dim", true);
+    LogicalAggregate aggregate = LogicalAggregate.create(dim, ImmutableList.of(), ImmutableBitSet.of(0),
+        ImmutableList.of(), ImmutableList.<AggregateCall>of());
+    LogicalTableScan fact = scan("fact", false);
+    // The aggregate has one output column (the group-by key); join its col 0 against fact's col 0.
+    int aggFieldCount = aggregate.getRowType().getFieldCount();
+    RexNode cond = REX_BUILDER.makeCall(SqlStdOperatorTable.EQUALS,
+        REX_BUILDER.makeInputRef(aggregate, 0),
+        new RexInputRef(aggFieldCount, fact.getRowType().getFieldList().get(0).getType()));
+    LogicalJoin join = LogicalJoin.create(aggregate, fact, ImmutableList.of(), cond, Collections.emptySet(),
+        JoinRelType.INNER);
+    runRuleAndExpectNoChange(join);
+  }
+
+  @Test
+  public void joinAboveDimScanDoesNotSwap() {
+    // An inner join below the candidate join is multi-input; our walker bails at Join, so the outer join's left
+    // input is correctly classified as not-dim-shaped even though every leaf is a dim table.
+    LogicalTableScan dimA = scan("dim_a", true);
+    LogicalTableScan dimB = scan("dim_b", true);
+    LogicalJoin nestedDimJoin = innerJoin(dimA, dimB);
+    LogicalTableScan fact = scan("fact", false);
+    int nestedFieldCount = nestedDimJoin.getRowType().getFieldCount();
+    RexNode cond = REX_BUILDER.makeCall(SqlStdOperatorTable.EQUALS,
+        REX_BUILDER.makeInputRef(nestedDimJoin, 0),
+        new RexInputRef(nestedFieldCount, fact.getRowType().getFieldList().get(0).getType()));
+    LogicalJoin join = LogicalJoin.create(nestedDimJoin, fact, ImmutableList.of(), cond, Collections.emptySet(),
+        JoinRelType.INNER);
+    runRuleAndExpectNoChange(join);
+  }
+
+  // -------- Idempotency --------
+
+  @Test
+  public void idempotentAppliesOnlyOnce() {
+    LogicalTableScan dim = scan("dim", true);
+    LogicalTableScan fact = scan("fact", false);
+    LogicalJoin join = innerJoin(dim, fact);
+
+    _planner.setRoot(join);
+    RelNode firstRun = _planner.findBestExp();
+    LogicalJoin commuted = extractJoinFromResult(firstRun);
+    assertSame(unwrapTable(commuted.getRight()), unwrapTable(dim), "first run should put dim on right");
+
+    // Re-run the planner on the commuted result. Since the predicate now sees dim on the right, the rule
+    // must NOT fire again.
+    _planner.setRoot(firstRun);
+    RelNode secondRun = _planner.findBestExp();
+    LogicalJoin secondCommuted = extractJoinFromResult(secondRun);
+    assertSame(unwrapTable(secondCommuted.getRight()), unwrapTable(dim), "dim must remain on right after re-run");
+    assertSame(unwrapTable(secondCommuted.getLeft()), unwrapTable(fact), "fact must remain on left after re-run");
+  }
+
+  // -------- Helpers --------
+
+  private LogicalJoin runRuleAndExpectSwap(LogicalJoin original) {
+    _planner.setRoot(original);
+    RelNode result = _planner.findBestExp();
+    assertTrue(result instanceof LogicalProject,
+        "Expected a Project (inserted by JoinCommuteRule.swap) wrapping the swapped Join; got " + result.getClass());
+    return extractJoinFromResult(result);
+  }
+
+  /**
+   * Verifies that the rule did not commute the join. HepPlanner re-numbers nodes even when no rule fires, so
+   * we cannot rely on instance identity ({@code assertSame}). The smoking gun for a successful commute is
+   * (a) a Project wrapping the join and (b) the underlying tables swapped. Absence of (a) plus matching table
+   * identities under (b) = no commute happened.
+   *
+   * <p>Accepts the abstract {@link Join} (not just {@link LogicalJoin}) so the same assertion can verify the
+   * {@link LogicalAsofJoin} early-bail path — Calcite's commute returns a different concrete class, so we also
+   * check that the result class matches the input class.
+   */
+  private void runRuleAndExpectNoChange(Join original) {
+    PinotTable expectedLeftTable = tryUnwrapTable(original.getLeft());
+    PinotTable expectedRightTable = tryUnwrapTable(original.getRight());
+
+    _planner.setRoot(original);
+    RelNode result = _planner.findBestExp();
+
+    assertTrue(result instanceof Join,
+        "Expected the Join to be returned unchanged (no Project wrap from commute); got " + result.getClass());
+    Join returned = (Join) result;
+    assertEquals(returned.getClass(), original.getClass(),
+        "Concrete join class must be unchanged (e.g. LogicalAsofJoin must not become LogicalJoin)");
+    assertEquals(returned.getJoinType(), original.getJoinType(), "Join type must be unchanged");
+
+    PinotTable returnedLeft = tryUnwrapTable(returned.getLeft());
+    PinotTable returnedRight = tryUnwrapTable(returned.getRight());
+    if (expectedLeftTable != null) {
+      assertSame(returnedLeft, expectedLeftTable, "Left input table must be unchanged");
+    }
+    if (expectedRightTable != null) {
+      assertSame(returnedRight, expectedRightTable, "Right input table must be unchanged");
+    }
+  }
+
+  /**
+   * Walks through {@link LogicalProject}/{@link LogicalFilter} to find the underlying {@link PinotTable}.
+   * Returns {@code null} if the input is not a simple scan-chain (e.g. it sits below an Aggregate or Join);
+   * callers treat {@code null} as "no table identity to compare against".
+   */
+  private static PinotTable tryUnwrapTable(RelNode rel) {
+    RelNode current = rel;
+    while (current instanceof LogicalProject || current instanceof LogicalFilter) {
+      current = current.getInput(0);
+    }
+    if (current instanceof LogicalTableScan) {
+      return ((LogicalTableScan) current).getTable().unwrap(PinotTable.class);
+    }
+    return null;
+  }
+
+  private static LogicalJoin extractJoinFromResult(RelNode root) {
+    if (root instanceof LogicalJoin) {
+      return (LogicalJoin) root;
+    }
+    if (root instanceof LogicalProject) {
+      RelNode child = root.getInput(0);
+      assertTrue(child instanceof LogicalJoin, "Project's child should be a Join; got " + child.getClass());
+      return (LogicalJoin) child;
+    }
+    throw new AssertionError("Expected Join or Project(Join); got " + root.getClass());
+  }
+
+  private LogicalTableScan scan(String name, boolean isDim) {
+    PinotTable pinotTable = new PinotTable(stubPinotSchema(name), false, isDim);
+    RelOptTable mockTable = Mockito.mock(RelOptTable.class, Mockito.RETURNS_DEEP_STUBS);
+    Mockito.when(mockTable.unwrap(PinotTable.class)).thenReturn(pinotTable);
+    Mockito.when(mockTable.getRowType()).thenReturn(ROW_TYPE);
+    Mockito.when(mockTable.getQualifiedName()).thenReturn(List.of("default", name));
+    Mockito.when(mockTable.getRowCount()).thenReturn(100.0);
+    Mockito.when(mockTable.getCollationList()).thenReturn(ImmutableList.of());
+    Mockito.when(mockTable.getDistribution()).thenReturn(RelDistributions.ANY);
+    return LogicalTableScan.create(_cluster, mockTable, ImmutableList.of());
+  }
+
+  private static Schema stubPinotSchema(String name) {
+    return new Schema.SchemaBuilder()
+        .setSchemaName(name)
+        .addSingleValueDimension("k", FieldSpec.DataType.INT)
+        .addSingleValueDimension("v", FieldSpec.DataType.INT)
+        .build();
+  }
+
+  private LogicalJoin innerJoin(RelNode left, RelNode right) {
+    return joinOf(left, right, JoinRelType.INNER);
+  }
+
+  private LogicalJoin joinOf(RelNode left, RelNode right, JoinRelType joinType) {
+    int leftFieldCount = left.getRowType().getFieldCount();
+    RexNode condition = REX_BUILDER.makeCall(SqlStdOperatorTable.EQUALS,
+        REX_BUILDER.makeInputRef(left, 0),
+        REX_BUILDER.makeInputRef(right, 0).accept(new InputRefShift(leftFieldCount)));
+    return LogicalJoin.create(left, right, ImmutableList.of(), condition, Collections.emptySet(), joinType);
+  }
+
+  /**
+   * Builds an INNER join with a dim table on the left, a fact table on the right, and a single key/value entry in
+   * the {@code joinOptions} hint. Used by negative tests that verify the rule honors explicit user hints.
+   */
+  private LogicalJoin innerJoinWithJoinOptionHint(String hintKey, String hintValue) {
+    LogicalTableScan dim = scan("dim", true);
+    LogicalTableScan fact = scan("fact", false);
+    int leftFieldCount = dim.getRowType().getFieldCount();
+    RexNode condition = REX_BUILDER.makeCall(SqlStdOperatorTable.EQUALS,
+        REX_BUILDER.makeInputRef(dim, 0),
+        REX_BUILDER.makeInputRef(fact, 0).accept(new InputRefShift(leftFieldCount)));
+    RelHint hint = RelHint.builder(PinotHintOptions.JOIN_HINT_OPTIONS).hintOption(hintKey, hintValue).build();
+    return LogicalJoin.create(dim, fact, ImmutableList.of(hint), condition, Collections.emptySet(),
+        JoinRelType.INNER);
+  }
+
+  private RexNode filterEqual(RelNode child, int columnIndex, int literalValue) {
+    return REX_BUILDER.makeCall(SqlStdOperatorTable.EQUALS,
+        REX_BUILDER.makeInputRef(child, columnIndex),
+        REX_BUILDER.makeLiteral(literalValue, TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER)));
+  }
+
+  private static PinotTable unwrapTable(RelNode rel) {
+    RelNode current = rel;
+    while (current instanceof LogicalProject || current instanceof LogicalFilter) {
+      current = current.getInput(0);
+    }
+    assertTrue(current instanceof LogicalTableScan, "Expected to reach a TableScan, got " + current.getClass());
+    PinotTable pinotTable = ((LogicalTableScan) current).getTable().unwrap(PinotTable.class);
+    assertNotNull(pinotTable, "TableScan should be backed by a PinotTable");
+    return pinotTable;
+  }
+
+  /**
+   * RexShuttle helper to shift input-ref indexes by a fixed amount. Used to build cross-input join conditions
+   * where the right-side reference must be offset by the left-side field count.
+   */
+  private static final class InputRefShift extends RexShuttle {
+    private final int _shift;
+
+    InputRefShift(int shift) {
+      _shift = shift;
+    }
+
+    @Override
+    public RexNode visitInputRef(RexInputRef inputRef) {
+      return new RexInputRef(inputRef.getIndex() + _shift, inputRef.getType());
+    }
+  }
+}

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/PinotJoinCommutePlanTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/PinotJoinCommutePlanTest.java
@@ -1,0 +1,146 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.pinot.common.config.provider.TableCache;
+import org.apache.pinot.common.utils.config.QueryOptionsUtils;
+import org.apache.pinot.core.routing.MockRoutingManagerFactory;
+import org.apache.pinot.core.routing.RoutingManager;
+import org.apache.pinot.query.routing.WorkerManager;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Broker.PlannerRuleNames;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.apache.pinot.sql.parsers.PinotSqlType;
+import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
+
+
+/// End-to-end planner-pipeline tests for {@link org.apache.pinot.calcite.rel.rules.PinotJoinCommuteRule}.
+///
+/// <p>Unlike {@code PinotJoinCommuteRuleTest}, which exercises the rule in isolation via a private
+/// {@link org.apache.calcite.plan.hep.HepPlanner}, these tests run queries through the production
+/// {@link QueryEnvironment}. They prove the rule is wired into {@code BASIC_RULES} and that it survives composition
+/// with the rest of the logical-phase rules. They also verify the {@code skipPlannerRules} query option can disable
+/// the rule end-to-end — which is the off-switch users will reach for if a deployment ever wants to opt out.
+public class PinotJoinCommutePlanTest {
+
+  private static final Random RANDOM_REQUEST_ID_GEN = new Random();
+  private static final String DIM_TABLE = "dim_tbl_OFFLINE";
+  private static final String FACT_TABLE = "fact_tbl_OFFLINE";
+
+  private QueryEnvironment _queryEnvironment;
+
+  @BeforeClass
+  public void setUp() {
+    Schema dimSchema = new Schema.SchemaBuilder()
+        .setSchemaName("dim_tbl")
+        .addSingleValueDimension("dim_id", FieldSpec.DataType.INT)
+        .addSingleValueDimension("dim_name", FieldSpec.DataType.STRING)
+        .build();
+    Schema factSchema = new Schema.SchemaBuilder()
+        .setSchemaName("fact_tbl")
+        .addSingleValueDimension("fact_id", FieldSpec.DataType.INT)
+        .addSingleValueDimension("dim_id", FieldSpec.DataType.INT)
+        .addMetric("metric", FieldSpec.DataType.INT)
+        .build();
+
+    MockRoutingManagerFactory factory = new MockRoutingManagerFactory(1, 2);
+    factory.registerDimTable(dimSchema, DIM_TABLE);
+    factory.registerTable(factSchema, FACT_TABLE);
+    factory.registerSegment(1, DIM_TABLE, "dim_s1");
+    factory.registerSegment(2, DIM_TABLE, "dim_s2");
+    factory.registerSegment(1, FACT_TABLE, "fact_s1");
+    factory.registerSegment(2, FACT_TABLE, "fact_s2");
+
+    RoutingManager routingManager = factory.buildRoutingManager(null);
+    TableCache tableCache = factory.buildTableCache();
+    WorkerManager workerManager = new WorkerManager("Broker_localhost", "localhost", 3, routingManager);
+    _queryEnvironment = new QueryEnvironment(CommonConstants.DEFAULT_DATABASE, tableCache, workerManager);
+  }
+
+  /// Verifies the rule actually fires through the production planner. In EXPLAIN order, the LEFT input of a join
+  /// is printed before the RIGHT input. So a successful commute means {@code fact_tbl}'s table scan appears
+  /// BEFORE {@code dim_tbl}'s table scan in the output even though the user wrote {@code dim JOIN fact}.
+  @Test
+  public void testDimOnLeftCommutesEndToEnd() {
+    String query = "EXPLAIN PLAN FOR SELECT dim_tbl.dim_name, fact_tbl.metric "
+        + "FROM dim_tbl JOIN fact_tbl ON dim_tbl.dim_id = fact_tbl.dim_id";
+    String explain = _queryEnvironment.explainQuery(query, RANDOM_REQUEST_ID_GEN.nextLong());
+
+    int factScanIdx = explain.indexOf("LogicalTableScan(table=[[default, fact_tbl]])");
+    int dimScanIdx = explain.indexOf("LogicalTableScan(table=[[default, dim_tbl]])");
+    assertTrue(factScanIdx >= 0, "EXPLAIN missing fact_tbl scan. Got:\n" + explain);
+    assertTrue(dimScanIdx >= 0, "EXPLAIN missing dim_tbl scan. Got:\n" + explain);
+    assertTrue(factScanIdx < dimScanIdx,
+        "PinotJoinCommuteRule did not fire: fact_tbl scan should appear before dim_tbl scan in EXPLAIN "
+            + "(left input is printed first; commute should put dim on the right). Got:\n" + explain);
+  }
+
+  /// Sanity check: when the user already wrote the join in the optimal {@code fact JOIN dim} form, the rule must
+  /// NOT fire (right is already dim). {@code fact_tbl} should remain on the left in the EXPLAIN output.
+  @Test
+  public void testFactOnLeftDoesNotCommute() {
+    String query = "EXPLAIN PLAN FOR SELECT dim_tbl.dim_name, fact_tbl.metric "
+        + "FROM fact_tbl JOIN dim_tbl ON fact_tbl.dim_id = dim_tbl.dim_id";
+    String explain = _queryEnvironment.explainQuery(query, RANDOM_REQUEST_ID_GEN.nextLong());
+
+    int factScanIdx = explain.indexOf("LogicalTableScan(table=[[default, fact_tbl]])");
+    int dimScanIdx = explain.indexOf("LogicalTableScan(table=[[default, dim_tbl]])");
+    assertTrue(factScanIdx >= 0 && dimScanIdx >= 0);
+    assertTrue(factScanIdx < dimScanIdx,
+        "Rule should not commute fact-on-left form (dim is already on the right). Got:\n" + explain);
+  }
+
+  /// Verifies the {@code skipPlannerRules=PinotJoinCommuteRule} query option disables the rule end-to-end.
+  /// With the rule disabled, the dim-on-left join must remain in its user-written form.
+  @Test
+  public void testSkipPlannerRulesDisablesCommute() {
+    String query = "EXPLAIN PLAN FOR SELECT dim_tbl.dim_name, fact_tbl.metric "
+        + "FROM dim_tbl JOIN fact_tbl ON dim_tbl.dim_id = fact_tbl.dim_id";
+    String explain = explainWithRuleSkipped(query, PlannerRuleNames.PINOT_JOIN_COMMUTE);
+
+    int factScanIdx = explain.indexOf("LogicalTableScan(table=[[default, fact_tbl]])");
+    int dimScanIdx = explain.indexOf("LogicalTableScan(table=[[default, dim_tbl]])");
+    assertTrue(factScanIdx >= 0 && dimScanIdx >= 0);
+    assertTrue(dimScanIdx < factScanIdx,
+        "With PinotJoinCommuteRule skipped, dim_tbl should remain on the left (user-written form). Got:\n"
+            + explain);
+  }
+
+  private String explainWithRuleSkipped(String query, String ruleToSkip) {
+    SqlNode sqlNode = CalciteSqlParser.compileToSqlNodeAndOptions(query).getSqlNode();
+    Map<String, String> options = new HashMap<>();
+    options.put(CommonConstants.Broker.Request.QueryOptionKey.SKIP_PLANNER_RULES, ruleToSkip);
+    SqlNodeAndOptions sqlNodeAndOptions = new SqlNodeAndOptions(
+        sqlNode, PinotSqlType.DQL, QueryOptionsUtils.resolveCaseInsensitiveOptions(options));
+    return _queryEnvironment
+        .compile(query, sqlNodeAndOptions)
+        .explain(RANDOM_REQUEST_ID_GEN.nextLong(), null)
+        .getExplainPlan();
+  }
+}

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -295,9 +296,24 @@ public class QueryEnvironmentTestBase {
   public static QueryEnvironment getQueryEnvironment(int reducerPort, int port1, int port2,
       Map<String, Schema> schemaMap, Map<String, List<String>> segmentMap1, Map<String, List<String>> segmentMap2,
       @Nullable Map<String, Pair<String, List<List<String>>>> partitionedSegmentsMap) {
+    return getQueryEnvironment(reducerPort, port1, port2, schemaMap, segmentMap1, segmentMap2, partitionedSegmentsMap,
+        Collections.emptySet());
+  }
+
+  /// Overload that takes a set of <i>typed</i> table names (e.g. {@code dim_tbl_OFFLINE}) to be registered as
+  /// dimension tables. The mocked {@code TableConfig} returned by the {@code TableCache} for these tables will
+  /// report {@code isDimTable()=true}, so planner rules like {@code PinotJoinCommuteRule} that key off the dim
+  /// flag can be exercised end-to-end.
+  public static QueryEnvironment getQueryEnvironment(int reducerPort, int port1, int port2,
+      Map<String, Schema> schemaMap, Map<String, List<String>> segmentMap1, Map<String, List<String>> segmentMap2,
+      @Nullable Map<String, Pair<String, List<List<String>>>> partitionedSegmentsMap, Set<String> dimTables) {
     MockRoutingManagerFactory factory = new MockRoutingManagerFactory(port1, port2);
     for (Map.Entry<String, Schema> entry : schemaMap.entrySet()) {
-      factory.registerTable(entry.getValue(), entry.getKey());
+      if (dimTables.contains(entry.getKey())) {
+        factory.registerDimTable(entry.getValue(), entry.getKey());
+      } else {
+        factory.registerTable(entry.getValue(), entry.getKey());
+      }
     }
     for (Map.Entry<String, List<String>> entry : segmentMap1.entrySet()) {
       for (String segment : entry.getValue()) {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
@@ -106,6 +106,7 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
 
     // Scan through all the test cases.
     Map<String, Pair<String, List<List<String>>>> partitionedSegmentsMap = new HashMap<>();
+    Set<String> dimTables = new HashSet<>();
     for (Map.Entry<String, QueryTestCase> testCaseEntry : getTestCases().entrySet()) {
       String testCaseName = testCaseEntry.getKey();
       QueryTestCase testCase = testCaseEntry.getValue();
@@ -135,6 +136,9 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
           addSegmentReplicated(factory1, factory2, offlineTableName, genericRows);
           if (table._isDimTable) {
             registerMockDimensionTable(offlineTableName, schema, table, genericRows);
+            // Also signal isDimTable to the planner so rules keyed on the dim flag (e.g. PinotJoinCommuteRule)
+            // can be exercised end-to-end via this test harness.
+            dimTables.add(offlineTableName);
           }
           continue;
         }
@@ -241,7 +245,7 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
 
     _queryEnvironment = QueryEnvironmentTestBase.getQueryEnvironment(_reducerPort, server1.getPort(), server2.getPort(),
         factory1.getRegisteredSchemaMap(), factory1.buildTableSegmentNameMap(), factory2.buildTableSegmentNameMap(),
-        partitionedSegmentsMap);
+        partitionedSegmentsMap, dimTables);
   }
 
   private void addSegments(MockInstanceDataManagerFactory factory1, MockInstanceDataManagerFactory factory2,

--- a/pinot-query-runtime/src/test/resources/queries/JoinCommute.json
+++ b/pinot-query-runtime/src/test/resources/queries/JoinCommute.json
@@ -1,0 +1,207 @@
+{
+  "join_commute_dim_on_left": {
+    "comment": "Functional-correctness tests for PinotJoinCommuteRule. Every query is written with the dimension table on the LEFT of the join, the case the rule targets. Result correctness is validated against H2: each Pinot result must match H2's row set for the same SQL. Covers INNER/LEFT/RIGHT/FULL semantics; filters/projects/aggregates above the join; multi-column projection (exercises swap()'s introduced Project mapping); Project/Filter walkers in isDimShaped; Aggregate-above-dim negative (rule must NOT commute); and hint-guard negatives.",
+    "tables": {
+      "dim_tbl": {
+        "schema": [
+          {"name": "dim_id", "type": "INT"},
+          {"name": "dim_name", "type": "STRING"},
+          {"name": "dim_attr", "type": "INT"}
+        ],
+        "inputs": [
+          [1, "alpha", 10],
+          [2, "beta", 20],
+          [3, "gamma", 30],
+          [4, "delta", 40]
+        ],
+        "replicated": true,
+        "isDimTable": true,
+        "primaryKeyColumns": ["dim_id"]
+      },
+      "fact_tbl": {
+        "schema": [
+          {"name": "fact_id", "type": "INT"},
+          {"name": "dim_id", "type": "INT"},
+          {"name": "metric", "type": "INT"}
+        ],
+        "inputs": [
+          [101, 1, 100],
+          [102, 1, 200],
+          [103, 2, 150],
+          [104, 3, 300],
+          [105, 3, 250],
+          [106, 5, 500],
+          [107, 5, 600]
+        ]
+      }
+    },
+    "queries": [
+      {
+        "description": "INNER JOIN with dim on left. Rule commutes inputs; result must match H2.",
+        "sql": "SELECT {dim_tbl}.dim_id, {dim_tbl}.dim_name, {fact_tbl}.metric FROM {dim_tbl} JOIN {fact_tbl} ON {dim_tbl}.dim_id = {fact_tbl}.dim_id"
+      },
+      {
+        "description": "INNER JOIN with fact on left (already optimal). Rule must NOT commute. Result identical to dim-on-left form against H2.",
+        "sql": "SELECT {dim_tbl}.dim_id, {dim_tbl}.dim_name, {fact_tbl}.metric FROM {fact_tbl} JOIN {dim_tbl} ON {fact_tbl}.dim_id = {dim_tbl}.dim_id"
+      },
+      {
+        "description": "LEFT JOIN with dim on left. After commute becomes RIGHT JOIN; unmatched dim row (dim_id=4) must still appear with NULL fact columns.",
+        "sql": "SELECT {dim_tbl}.dim_id, {dim_tbl}.dim_name, {fact_tbl}.metric FROM {dim_tbl} LEFT JOIN {fact_tbl} ON {dim_tbl}.dim_id = {fact_tbl}.dim_id"
+      },
+      {
+        "description": "RIGHT JOIN with dim on left. After commute becomes LEFT JOIN; unmatched fact rows (dim_id=5) must still appear with NULL dim columns.",
+        "sql": "SELECT {dim_tbl}.dim_id, {dim_tbl}.dim_name, {fact_tbl}.fact_id, {fact_tbl}.metric FROM {dim_tbl} RIGHT JOIN {fact_tbl} ON {dim_tbl}.dim_id = {fact_tbl}.dim_id"
+      },
+      {
+        "description": "Filter on dim column above the join. Exercises Filter mapping through the Project introduced by swap().",
+        "sql": "SELECT {dim_tbl}.dim_id, {dim_tbl}.dim_name, {fact_tbl}.metric FROM {dim_tbl} JOIN {fact_tbl} ON {dim_tbl}.dim_id = {fact_tbl}.dim_id WHERE {dim_tbl}.dim_attr >= 20"
+      },
+      {
+        "description": "Filter on fact column above the join.",
+        "sql": "SELECT {dim_tbl}.dim_id, {dim_tbl}.dim_name, {fact_tbl}.metric FROM {dim_tbl} JOIN {fact_tbl} ON {dim_tbl}.dim_id = {fact_tbl}.dim_id WHERE {fact_tbl}.metric >= 200"
+      },
+      {
+        "description": "Compound filter spanning both sides.",
+        "sql": "SELECT {dim_tbl}.dim_id, {dim_tbl}.dim_name, {fact_tbl}.metric FROM {dim_tbl} JOIN {fact_tbl} ON {dim_tbl}.dim_id = {fact_tbl}.dim_id WHERE {dim_tbl}.dim_attr >= 20 AND {fact_tbl}.metric >= 200"
+      },
+      {
+        "description": "Aggregate above the join grouped by a dim column. Verifies the swap-introduced Project preserves dim columns correctly under GROUP BY/COUNT/SUM.",
+        "sql": "SELECT {dim_tbl}.dim_name, COUNT(*) AS cnt, SUM({fact_tbl}.metric) AS total FROM {dim_tbl} JOIN {fact_tbl} ON {dim_tbl}.dim_id = {fact_tbl}.dim_id GROUP BY {dim_tbl}.dim_name"
+      },
+      {
+        "description": "Aggregate above a LEFT JOIN grouped by a dim column. Unmatched dim row (id=4) must produce a group with COUNT=1 and SUM=NULL.",
+        "sql": "SELECT {dim_tbl}.dim_name, COUNT({fact_tbl}.metric) AS matched_cnt, SUM({fact_tbl}.metric) AS total FROM {dim_tbl} LEFT JOIN {fact_tbl} ON {dim_tbl}.dim_id = {fact_tbl}.dim_id GROUP BY {dim_tbl}.dim_name"
+      },
+      {
+        "description": "Multi-column projection drawing from both sides. Exercises row-layout reconstruction inside JoinCommuteRule.swap().",
+        "sql": "SELECT {dim_tbl}.dim_name, {dim_tbl}.dim_attr, {fact_tbl}.fact_id, {fact_tbl}.metric FROM {dim_tbl} JOIN {fact_tbl} ON {dim_tbl}.dim_id = {fact_tbl}.dim_id"
+      },
+      {
+        "description": "Projection subquery on dim, then JOIN fact. Exercises the Project walker in isDimShaped.",
+        "sql": "SELECT d.dim_name, {fact_tbl}.metric FROM (SELECT dim_id, dim_name FROM {dim_tbl}) d JOIN {fact_tbl} ON d.dim_id = {fact_tbl}.dim_id"
+      },
+      {
+        "description": "Filter subquery on dim, then JOIN fact. Exercises the Filter walker in isDimShaped.",
+        "sql": "SELECT d.dim_name, {fact_tbl}.metric FROM (SELECT * FROM {dim_tbl} WHERE dim_attr > 10) d JOIN {fact_tbl} ON d.dim_id = {fact_tbl}.dim_id"
+      },
+      {
+        "description": "Aggregate on dim (breaks dim-shape) then JOIN fact. Rule must NOT commute. Result still must match H2.",
+        "sql": "SELECT d.dim_id, d.cnt, {fact_tbl}.metric FROM (SELECT dim_id, COUNT(*) AS cnt FROM {dim_tbl} GROUP BY dim_id) d JOIN {fact_tbl} ON d.dim_id = {fact_tbl}.dim_id"
+      },
+      {
+        "description": "Hint guard: join_strategy='hash' pins strategy. Rule must NOT commute. Result still correct.",
+        "sql": "SELECT /*+ joinOptions(join_strategy='hash') */ {dim_tbl}.dim_id, {dim_tbl}.dim_name, {fact_tbl}.metric FROM {dim_tbl} JOIN {fact_tbl} ON {dim_tbl}.dim_id = {fact_tbl}.dim_id"
+      },
+      {
+        "description": "Hint guard: left_distribution_type pinned. Rule must NOT commute. Result still correct.",
+        "sql": "SELECT /*+ joinOptions(left_distribution_type='HASH') */ {dim_tbl}.dim_id, {dim_tbl}.dim_name, {fact_tbl}.metric FROM {dim_tbl} JOIN {fact_tbl} ON {dim_tbl}.dim_id = {fact_tbl}.dim_id"
+      },
+      {
+        "description": "Hint guard: right_distribution_type pinned. Rule must NOT commute. Result still correct.",
+        "sql": "SELECT /*+ joinOptions(right_distribution_type='BROADCAST') */ {dim_tbl}.dim_id, {dim_tbl}.dim_name, {fact_tbl}.metric FROM {dim_tbl} JOIN {fact_tbl} ON {dim_tbl}.dim_id = {fact_tbl}.dim_id"
+      },
+      {
+        "description": "Hint guard: join_strategy='dynamic_broadcast' pinned. Rule must NOT commute. Result still correct.",
+        "sql": "SELECT /*+ joinOptions(join_strategy='dynamic_broadcast') */ {dim_tbl}.dim_id, {dim_tbl}.dim_name, {fact_tbl}.metric FROM {dim_tbl} JOIN {fact_tbl} ON {dim_tbl}.dim_id = {fact_tbl}.dim_id"
+      }
+    ]
+  },
+  "join_commute_lookup_hint_auto_correct": {
+    "comment": "Verifies the auto-correct branch for join_strategy='lookup' with dim on the left. Without this rule, this query would error at runtime because LookupJoinOperator requires dim on the right. With the rule, the inputs are commuted and the lookup hint is preserved, so the downstream lookup-join pass produces a working plan. Lite mode is skipped because the broker lacks DimensionTableDataManager. Same data shape as the LookupJoin.json basic case.",
+    "tables": {
+      "fact_tbl": {
+        "schema": [
+          {"name": "dim_key", "type": "INT"},
+          {"name": "metric", "type": "INT"}
+        ],
+        "inputs": [
+          [1, 100],
+          [2, 200],
+          [3, 300],
+          [1, 400],
+          [4, 500]
+        ]
+      },
+      "dim_tbl": {
+        "schema": [
+          {"name": "id", "type": "INT"},
+          {"name": "name", "type": "STRING"}
+        ],
+        "inputs": [
+          [1, "alpha"],
+          [2, "beta"],
+          [3, "gamma"]
+        ],
+        "replicated": true,
+        "isDimTable": true,
+        "primaryKeyColumns": ["id"]
+      }
+    },
+    "queries": [
+      {
+        "description": "User wrote dim JOIN fact with lookup hint. Rule must commute so dim ends up on right, and LookupJoinRule then accepts the plan. Unmatched fact row (dim_key=4) is dropped by INNER join.",
+        "sql": "SELECT /*+ joinOptions(join_strategy='lookup') */ {fact_tbl}.dim_key, {dim_tbl}.name FROM {dim_tbl} JOIN {fact_tbl} ON {dim_tbl}.id = {fact_tbl}.dim_key ORDER BY {fact_tbl}.dim_key, {dim_tbl}.name",
+        "outputs": [
+          [1, "alpha"],
+          [1, "alpha"],
+          [2, "beta"],
+          [3, "gamma"]
+        ],
+        "ignoreLiteMode": true
+      }
+    ]
+  },
+  "join_commute_full_outer": {
+    "comment": "FULL OUTER JOIN coverage for PinotJoinCommuteRule. Separated from the H2-comparison case above because H2 in this build does not parse FULL OUTER JOIN. Uses explicit outputs. Same data as join_commute_dim_on_left.",
+    "tables": {
+      "dim_tbl": {
+        "schema": [
+          {"name": "dim_id", "type": "INT"},
+          {"name": "dim_name", "type": "STRING"},
+          {"name": "dim_attr", "type": "INT"}
+        ],
+        "inputs": [
+          [1, "alpha", 10],
+          [2, "beta", 20],
+          [3, "gamma", 30],
+          [4, "delta", 40]
+        ],
+        "replicated": true,
+        "isDimTable": true,
+        "primaryKeyColumns": ["dim_id"]
+      },
+      "fact_tbl": {
+        "schema": [
+          {"name": "fact_id", "type": "INT"},
+          {"name": "dim_id", "type": "INT"},
+          {"name": "metric", "type": "INT"}
+        ],
+        "inputs": [
+          [101, 1, 100],
+          [102, 1, 200],
+          [103, 2, 150],
+          [104, 3, 300],
+          [105, 3, 250],
+          [106, 5, 500],
+          [107, 5, 600]
+        ]
+      }
+    },
+    "queries": [
+      {
+        "description": "FULL OUTER JOIN with dim on left. Rule commutes inputs. Unmatched dim (id=4) and unmatched fact (dim_id=5) rows both preserved with NULL columns on the opposite side.",
+        "sql": "SELECT {dim_tbl}.dim_id, {dim_tbl}.dim_name, {fact_tbl}.fact_id, {fact_tbl}.metric FROM {dim_tbl} FULL OUTER JOIN {fact_tbl} ON {dim_tbl}.dim_id = {fact_tbl}.dim_id",
+        "outputs": [
+          [1, "alpha", 101, 100],
+          [1, "alpha", 102, 200],
+          [2, "beta", 103, 150],
+          [3, "gamma", 104, 300],
+          [3, "gamma", 105, 250],
+          [4, "delta", null, null],
+          [null, null, 106, 500],
+          [null, null, 107, 600]
+        ]
+      }
+    ]
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1008,6 +1008,7 @@ public class CommonConstants {
       public static final String PRUNE_EMPTY_JOIN_LEFT = "PruneEmptyJoinLeft";
       public static final String PRUNE_EMPTY_JOIN_RIGHT = "PruneEmptyJoinRight";
       public static final String JOIN_TO_ENRICHED_JOIN = "JoinToEnrichedJoin";
+      public static final String PINOT_JOIN_COMMUTE = "PinotJoinCommuteRule";
     }
 
     /**


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Adds planner rule to swap dimension and fact tables in joins when dimension is on left, optimizing build/broadcast side\.

```mermaid
flowchart TD
  N0["PinotCatalog creates PinotTable with isDimTable flag #40;F3#44; F4#41;"]:::stAdded
  N1["PinotTable#46;isDimTable#40;#41; returns dimension flag #40;F4#41;"]:::stAdded
  N2["PinotJoinCommuteRule#46;isDimShaped detects dim#45;shaped input #40;F1#41;"]:::stAdded
  N3["PinotJoinCommuteRule#46;matches evaluates join commute preconditions #40;F1#41;"]:::stAdded
  N4["PinotJoinCommuteRule#46;onMatch swaps join inputs #40;F1#41;"]:::stAdded
  N5["Rule outputs swapped join #40;Project#45;wrapped#41; to planner #40;F1#41;"]:::stAdded
  N0 -->|"stores flag"| N1
  N1 -->|"isDimShaped reads flag"| N2
  N2 -->|"matches uses isDimShaped"| N3
  N3 -->|"matches true #8594; onMatch"| N4
  N4 -->|"onMatch calls swap and transforms"| N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-query\-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotJoinCommuteRule\.java — [after](https://github.com/apache/pinot/blob/ba0e0a41280f21976927fe439c60fe7bf4e3b471/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotJoinCommuteRule.java)
- F3: pinot\-query\-planner/src/main/java/org/apache/pinot/query/catalog/PinotCatalog\.java — [before](https://github.com/apache/pinot/blob/29104455383b5b81581db6098cd9bf34020c64b9/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotCatalog.java) · [after](https://github.com/apache/pinot/blob/ba0e0a41280f21976927fe439c60fe7bf4e3b471/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotCatalog.java)
- F4: pinot\-query\-planner/src/main/java/org/apache/pinot/query/catalog/PinotTable\.java — [before](https://github.com/apache/pinot/blob/29104455383b5b81581db6098cd9bf34020c64b9/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotTable.java) · [after](https://github.com/apache/pinot/blob/ba0e0a41280f21976927fe439c60fe7bf4e3b471/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotTable.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjI5MTA0NDU1MzgzYjViODE1ODFkYjYwOThjZDliZjM0MDIwYzY0YjkiLCJjb250ZXh0X2hhc2giOiI2NGU5ODkzZmY1YjFjMDhjMzE0YWM4YTkxNzBlMjM3ZDgzYzZlNjZlNjI1OWVkNTM4YjFmMjg3ZDZlMjJkMWU4IiwiZ2VuZXJhdGVkX2F0IjoxNzg5MjA4OTQ1LCJoZWFkX3NoYSI6ImJhMGUwYTQxMjgwZjIxOTc2OTI3ZmU0MzljNjBmZTdiZjRlM2I0NzEiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI2ZjBlMDEzOTZiZTk4YTVlMTZiZjBhMzAxN2EwODI0MDU4ZWUwNGFjIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature c4742bce8521035cb6bdaf30a5aa2e0a542311324763108dd1d4941dacef0dbd -->
<!-- pinot-pr-flow:end -->

### Improvement Summary

- Adds `PinotJoinCommuteRule` to the MSE logical planner. 
- When a user writes `dim JOIN fact`, the rule swaps the inputs so the dim ends up on the right — fixing the build-side memory pressure that the syntactic-default planner gets wrong today 
  
### Problem
  
- In MSE, `PinotJoinExchangeNodeInsertRule` decides distribution **purely syntactically**, and the runtime always builds the hash table from the right input (`BaseJoinOperator` invariant). 
- So when a user writes `dim JOIN fact`:
    - The runtime builds a hash table from `fact_tbl` — the wrong side, memory-wise. For large fact tables this can exceed `max_rows_in_join` and fail queries that would otherwise succeed.
    - In specific cases** (non-equi joins, user-hinted broadcast, dynamic-broadcast semi-joins): the fact table is also broadcast to every worker, multiplying network cost.

Both problems share the same root: the right side is special (build side always, broadcast side sometimes), and the user's syntactic ordering puts the wrong table there.
  
   ```
BEFORE (user-written)                      AFTER (rule fires)

                JOIN                                       JOIN
               /    \                                     /    \
          dim_tbl  fact_tbl                          fact_tbl  dim_tbl
          (small)   (BIG)                              (BIG)   (small)

         Build side (runtime invariant):             Build side (runtime invariant):
           fact_tbl  (large hash table)  ❌            dim_tbl  (small hash table)  ✅

         Broadcast (when planner picks it,            Broadcast (when planner picks it,
         e.g. non-equi / hinted):                     e.g. non-equi / hinted):
           fact_tbl  (network blowup)    ❌            dim_tbl  (small)              ✅
```


### Solution

  - `dim INNER/LEFT/RIGHT/FULL JOIN fact` — auto-commuted so dim ends up on the right.
  - `dim JOIN fact` with `/*+ join_strategy='lookup' */` — previously a runtime error (`LookupJoinOperator` requires dim on the right); now auto-corrected. Lookup join no longer requires users to remember table order when writing the query.
  - `ResourceBasedQueriesTest` now propagates `isDimTable=true` to the planner, so dim-aware rules can be exercised end-to-end (was previously a silent gap).

### Testing
- Added PinotJoinCommuteRuleTest — isolated HepPlanner, every predicate branch including idempotency and the lookup auto-correct case.
- Added Plan-shape tests in PinotJoinCommutePlanTest) — real QueryEnvironment, asserts rule fires, doesn't over-fire, and respects the off-switch.
- Runtime query correctness via ResourceBasedQueriesTest — H2-compared INNER / LEFT / RIGHT / FULL OUTER, filters
- Ran Full pinot-query-planner and ResourceBasedQueriesTest - pass with zero failures.