### PR TITLE
Add backward-incompatibility check for upsert deleteRecordColumn

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -1327,43 +1327,46 @@ public final class TableConfigUtils {
       UpsertConfig existingUpsertConfig = existingConfig.getUpsertConfig();
       UpsertConfig newUpsertConfig = newConfig.getUpsertConfig();
 
-      if (existingUpsertConfig.getMode() != newUpsertConfig.getMode()) {
+    if (existingUpsertConfig.getMode() != newUpsertConfig.getMode()) {
+      violations.add(
+          String.format("upsertConfig.mode (%s -> %s)", existingUpsertConfig.getMode(), newUpsertConfig.getMode()));
+    }
+    if (existingUpsertConfig.getHashFunction() != newUpsertConfig.getHashFunction()) {
+      violations.add(String.format("upsertConfig.hashFunction (%s -> %s)", existingUpsertConfig.getHashFunction(),
+          newUpsertConfig.getHashFunction()));
+    }
+    if (!Objects.equals(existingUpsertConfig.getComparisonColumns(), newUpsertConfig.getComparisonColumns())) {
+      violations.add(
+          String.format("upsertConfig.comparisonColumns (%s -> %s)", existingUpsertConfig.getComparisonColumns(),
+              newUpsertConfig.getComparisonColumns()));
+    }
+    List<String> existingComparisonColumns = existingUpsertConfig.getComparisonColumns();
+    if (existingComparisonColumns == null || existingComparisonColumns.isEmpty()) {
+      String existingTimeColumn =
+          existingConfig.getValidationConfig() != null ? existingConfig.getValidationConfig().getTimeColumnName()
+              : null;
+      String newTimeColumn =
+          newConfig.getValidationConfig() != null ? newConfig.getValidationConfig().getTimeColumnName() : null;
+      if (!Objects.equals(existingTimeColumn, newTimeColumn)) {
         violations.add(
-            String.format("upsertConfig.mode (%s -> %s)", existingUpsertConfig.getMode(), newUpsertConfig.getMode()));
+            String.format("timeColumnName (%s -> %s) - used as default comparison column", existingTimeColumn,
+                newTimeColumn));
       }
-      if (existingUpsertConfig.getHashFunction() != newUpsertConfig.getHashFunction()) {
-        violations.add(String.format("upsertConfig.hashFunction (%s -> %s)", existingUpsertConfig.getHashFunction(),
-            newUpsertConfig.getHashFunction()));
-      }
-      if (!Objects.equals(existingUpsertConfig.getComparisonColumns(),
-          newUpsertConfig.getComparisonColumns())) {
-        violations.add(
-            String.format("upsertConfig.comparisonColumns (%s -> %s)", existingUpsertConfig.getComparisonColumns(),
-                newUpsertConfig.getComparisonColumns()));
-      }
-      List<String> existingComparisonColumns = existingUpsertConfig.getComparisonColumns();
-      if (existingComparisonColumns == null || existingComparisonColumns.isEmpty()) {
-        String existingTimeColumn =
-            existingConfig.getValidationConfig() != null ? existingConfig.getValidationConfig().getTimeColumnName()
-                : null;
-        String newTimeColumn =
-            newConfig.getValidationConfig() != null ? newConfig.getValidationConfig().getTimeColumnName() : null;
-        if (!Objects.equals(existingTimeColumn, newTimeColumn)) {
-          violations.add(
-              String.format("timeColumnName (%s -> %s) - used as default comparison column", existingTimeColumn,
-                  newTimeColumn));
-        }
-      }
-      if (existingUpsertConfig.isDropOutOfOrderRecord() != newUpsertConfig.isDropOutOfOrderRecord()) {
-        violations.add(
-            String.format("upsertConfig.dropOutOfOrderRecord (%s -> %s)", existingUpsertConfig.isDropOutOfOrderRecord(),
-                newUpsertConfig.isDropOutOfOrderRecord()));
-      }
-      if (!Objects.equals(existingUpsertConfig.getOutOfOrderRecordColumn(),
-          newUpsertConfig.getOutOfOrderRecordColumn())) {
-        violations.add(String.format("upsertConfig.outOfOrderRecordColumn (%s -> %s)",
-            existingUpsertConfig.getOutOfOrderRecordColumn(), newUpsertConfig.getOutOfOrderRecordColumn()));
-      }
+    }
+    if (existingUpsertConfig.isDropOutOfOrderRecord() != newUpsertConfig.isDropOutOfOrderRecord()) {
+      violations.add(
+          String.format("upsertConfig.dropOutOfOrderRecord (%s -> %s)", existingUpsertConfig.isDropOutOfOrderRecord(),
+              newUpsertConfig.isDropOutOfOrderRecord()));
+    }
+    if (!Objects.equals(existingUpsertConfig.getOutOfOrderRecordColumn(),
+        newUpsertConfig.getOutOfOrderRecordColumn())) {
+      violations.add(String.format("upsertConfig.outOfOrderRecordColumn (%s -> %s)",
+          existingUpsertConfig.getOutOfOrderRecordColumn(), newUpsertConfig.getOutOfOrderRecordColumn()));
+    }
+    if (!Objects.equals(existingUpsertConfig.getDeleteRecordColumn(), newUpsertConfig.getDeleteRecordColumn())) {
+      violations.add(String.format("upsertConfig.deleteRecordColumn (%s -> %s)",
+          existingUpsertConfig.getDeleteRecordColumn(), newUpsertConfig.getDeleteRecordColumn()));
+    }
     }
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -4206,4 +4206,59 @@ public class TableConfigUtilsTest {
     assertTrue(violations.isEmpty(),
         "Expected no violations for partial-upsert strategy and default-strategy changes, but got: " + violations);
   }
+
+  @Test
+  public void testValidateBackwardCompatibilityRejectsDeleteRecordColumnChange() {
+    UpsertConfig existingUpsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
+    existingUpsertConfig.setDeleteRecordColumn("deleted");
+    UpsertConfig newUpsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
+    newUpsertConfig.setDeleteRecordColumn("is_deleted");
+
+    TableConfig existingConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName(TIME_COLUMN).setUpsertConfig(existingUpsertConfig).build();
+    TableConfig newConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName(TIME_COLUMN).setUpsertConfig(newUpsertConfig).build();
+
+    List<String> violations = TableConfigUtils.validateBackwardCompatibility(newConfig, existingConfig);
+    assertEquals(violations.size(), 1);
+    assertTrue(violations.get(0).contains("deleteRecordColumn"));
+
+    // Adding deleteRecordColumn where none existed
+    existingUpsertConfig.setDeleteRecordColumn(null);
+    existingConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName(TIME_COLUMN).setUpsertConfig(existingUpsertConfig).build();
+    violations = TableConfigUtils.validateBackwardCompatibility(newConfig, existingConfig);
+    assertEquals(violations.size(), 1);
+    assertTrue(violations.get(0).contains("deleteRecordColumn"));
+
+    // Removing deleteRecordColumn
+    violations = TableConfigUtils.validateBackwardCompatibility(existingConfig, newConfig);
+    assertEquals(violations.size(), 1);
+    assertTrue(violations.get(0).contains("deleteRecordColumn"));
+  }
+
+  @Test
+  public void testValidateBackwardCompatibilityAllowsIdenticalUpsertConfig() {
+    UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
+    upsertConfig.setDeleteRecordColumn("deleted");
+
+    TableConfig existingConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName(TIME_COLUMN).setUpsertConfig(upsertConfig).build();
+    TableConfig newConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName(TIME_COLUMN).setUpsertConfig(upsertConfig).build();
+
+    List<String> violations = TableConfigUtils.validateBackwardCompatibility(newConfig, existingConfig);
+    assertTrue(violations.isEmpty(), "Expected no violations for identical config, but got: " + violations);
+  }
+
+  @Test
+  public void testValidateBackwardCompatibilityNoViolationsForNonUpsertTables() {
+    TableConfig existingConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName(TIME_COLUMN).build();
+    TableConfig newConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName(TIME_COLUMN).build();
+
+    List<String> violations = TableConfigUtils.validateBackwardCompatibility(newConfig, existingConfig);
+    assertTrue(violations.isEmpty(), "Expected no violations for non-upsert tables, but got: " + violations);
+  }
 }


### PR DESCRIPTION
## Summary
The `deleteRecordColumn` field in `UpsertConfig` was documented in the javadoc of `validateUpsertConfigUpdate` as being checked during table config updates, but the check was never implemented. Changing it mid-flight causes deletes to silently use the wrong column, since the value is cached at partition manager initialization.

This PR adds the missing backward-compatibility check, following the same pattern as the existing checks for `mode`, `hashFunction`, `comparisonColumns`, etc. — rejected by default, bypassable with `force=true` on the update API.

### Why only deleteRecordColumn?
- **Enabling/disabling upsert** is a supported workflow (e.g., enabling upsert on an existing table after schema changes) — kept as INFO-level logging per existing design.
- **Changing `consistencyMode`** is an operational tuning decision that takes effect on server restart without data corruption — not a backward-incompatible change.

## Tests added
- Rejects changing, adding, or removing `deleteRecordColumn`
- Verifies identical upsert config produces no violations
- Verifies non-upsert tables produce no violations

## Test plan
- [x] All new backward-compat tests pass (`TableConfigUtilsTest#testValidateBackwardCompatibility*`)
- [x] Existing `testValidateBackwardCompatibilityAllowsPartialUpsertStrategyChanges` still passes
- [x] Spotless, checkstyle, license checks pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)