### PR TITLE
Fix multi-topic ingestion halt when one Kafka topic is deleted

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaStreamMetadataProvider.java
@@ -48,6 +48,7 @@ import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.PartitionGroupConsumptionStatus;
 import org.apache.pinot.spi.stream.PartitionGroupMetadata;
 import org.apache.pinot.spi.stream.PartitionLagState;
+import org.apache.pinot.spi.stream.PermanentConsumerException;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConsumerFactory;
 import org.apache.pinot.spi.stream.StreamConsumerFactoryProvider;
@@ -384,7 +385,7 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
 
     if (lastError != null) {
       if (topicMissing) {
-        throw new RuntimeException("Topic does not exist: " + _topic);
+        throw new PermanentConsumerException(new RuntimeException("Topic does not exist: " + _topic));
       }
       if (lastError instanceof TransientConsumerException) {
         throw (TransientConsumerException) lastError;

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/main/java/org/apache/pinot/plugin/stream/kafka40/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/main/java/org/apache/pinot/plugin/stream/kafka40/KafkaStreamMetadataProvider.java
@@ -48,6 +48,7 @@ import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.PartitionGroupConsumptionStatus;
 import org.apache.pinot.spi.stream.PartitionGroupMetadata;
 import org.apache.pinot.spi.stream.PartitionLagState;
+import org.apache.pinot.spi.stream.PermanentConsumerException;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConsumerFactory;
 import org.apache.pinot.spi.stream.StreamConsumerFactoryProvider;
@@ -382,7 +383,7 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
 
     if (lastError != null) {
       if (topicMissing) {
-        throw new RuntimeException("Topic does not exist: " + _topic);
+        throw new PermanentConsumerException(new RuntimeException("Topic does not exist: " + _topic));
       }
       if (lastError instanceof TransientConsumerException) {
         throw (TransientConsumerException) lastError;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupMetadataFetcher.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupMetadataFetcher.java
@@ -43,6 +43,11 @@ public class PartitionGroupMetadataFetcher implements Callable<Boolean> {
   private final List<Integer> _pausedTopicIndices;
 
   private Exception _exception;
+  private final List<String> _failedTopics = new ArrayList<>();
+
+  public List<String> getFailedTopics() {
+    return Collections.unmodifiableList(_failedTopics);
+  }
 
   public PartitionGroupMetadataFetcher(List<StreamConfig> streamConfigs,
       List<PartitionGroupConsumptionStatus> partitionGroupConsumptionStatusList, List<Integer> pausedTopicIndices,
@@ -80,6 +85,7 @@ public class PartitionGroupMetadataFetcher implements Callable<Boolean> {
   public Boolean call()
       throws Exception {
     _streamMetadataList.clear();
+    _failedTopics.clear();
     _exception = null;
     return _streamConfigs.size() == 1 ? fetchSingleStream() : fetchMultipleStreams();
   }
@@ -151,6 +157,13 @@ public class PartitionGroupMetadataFetcher implements Callable<Boolean> {
         LOGGER.warn("Transient Exception: Could not get StreamMetadata for topic {}", topicName, e);
         _exception = e;
         return Boolean.FALSE;
+      } catch (PermanentConsumerException e) {
+        // A confirmed-permanent failure (e.g. topic deleted from Kafka) must not block metadata
+        // fetching for the remaining healthy topics in a multi-topic table. Log, record, and
+        // continue — the caller emits a metric and healthy topics proceed normally.
+        LOGGER.warn("Permanent failure fetching StreamMetadata for topic {}, skipping in multi-topic fetch",
+            topicName, e);
+        _failedTopics.add(topicName);
       } catch (Exception e) {
         LOGGER.warn("Could not get StreamMetadata for topic {}", topicName, e);
         _exception = e;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupMetadataFetcher.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupMetadataFetcher.java
@@ -80,7 +80,6 @@ public class PartitionGroupMetadataFetcher implements Callable<Boolean> {
   public Boolean call()
       throws Exception {
     _streamMetadataList.clear();
-    _failedTopics.clear();
     _exception = null;
     return _streamConfigs.size() == 1 ? fetchSingleStream() : fetchMultipleStreams();
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupMetadataFetcher.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupMetadataFetcher.java
@@ -43,11 +43,6 @@ public class PartitionGroupMetadataFetcher implements Callable<Boolean> {
   private final List<Integer> _pausedTopicIndices;
 
   private Exception _exception;
-  private final List<String> _failedTopics = new ArrayList<>();
-
-  public List<String> getFailedTopics() {
-    return Collections.unmodifiableList(_failedTopics);
-  }
 
   public PartitionGroupMetadataFetcher(List<StreamConfig> streamConfigs,
       List<PartitionGroupConsumptionStatus> partitionGroupConsumptionStatusList, List<Integer> pausedTopicIndices,
@@ -163,7 +158,6 @@ public class PartitionGroupMetadataFetcher implements Callable<Boolean> {
         // continue — the caller emits a metric and healthy topics proceed normally.
         LOGGER.warn("Permanent failure fetching StreamMetadata for topic {}, skipping in multi-topic fetch",
             topicName, e);
-        _failedTopics.add(topicName);
       } catch (Exception e) {
         LOGGER.warn("Could not get StreamMetadata for topic {}", topicName, e);
         _exception = e;

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/stream/PartitionGroupMetadataFetcherTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/stream/PartitionGroupMetadataFetcherTest.java
@@ -410,7 +410,6 @@ public class PartitionGroupMetadataFetcherTest {
       Assert.assertEquals(fetcher.getStreamMetadataList().size(), 1);
       Assert.assertEquals(fetcher.getStreamMetadataList().get(0).getNumPartitions(), 1);
       Assert.assertNull(fetcher.getException());
-      Assert.assertEquals(fetcher.getFailedTopics(), Collections.singletonList("topic2-deleted"));
     }
   }
 
@@ -448,13 +447,11 @@ public class PartitionGroupMetadataFetcherTest {
       Assert.assertTrue(result1);
       Assert.assertEquals(fetcher.getStreamMetadataList().size(), 1);
       Assert.assertNull(fetcher.getException());
-      Assert.assertEquals(fetcher.getFailedTopics(), Collections.singletonList("topic2"));
 
-      // Second call: both succeed — failedTopics cleared
+      // Second call: both succeed
       Boolean result2 = fetcher.call();
       Assert.assertTrue(result2);
       Assert.assertEquals(fetcher.getStreamMetadataList().size(), 2);
-      Assert.assertTrue(fetcher.getFailedTopics().isEmpty());
     }
   }
 
@@ -494,7 +491,6 @@ public class PartitionGroupMetadataFetcherTest {
       } catch (RuntimeException e) {
         Assert.assertEquals(e.getMessage(), "Auth failure");
       }
-      Assert.assertTrue(fetcher.getFailedTopics().isEmpty());
     }
   }
 

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/stream/PartitionGroupMetadataFetcherTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/stream/PartitionGroupMetadataFetcherTest.java
@@ -366,6 +366,138 @@ public class PartitionGroupMetadataFetcherTest {
     }
   }
 
+  /**
+   * When one topic in a multi-topic table is inaccessible (e.g. deleted from Kafka), the fetcher must
+   * continue fetching metadata for the remaining topics and return partial results rather than re-throwing
+   * and killing ingestion for all healthy topics.
+   */
+  @Test
+  public void testFetchMultipleStreamsOneTopicPermanentFailure()
+      throws Exception {
+    StreamConfig streamConfig1 = createMockStreamConfig("topic1", "test-table_REALTIME", false);
+    StreamConfig streamConfig2 = createMockStreamConfig("topic2-deleted", "test-table_REALTIME", false);
+    List<StreamConfig> streamConfigs = Arrays.asList(streamConfig1, streamConfig2);
+
+    StreamPartitionMsgOffset offset = mock(StreamPartitionMsgOffset.class);
+    PartitionGroupMetadata metadata = new PartitionGroupMetadata(0, offset);
+
+    // topic1 succeeds, topic2 throws a permanent (non-transient) exception
+    StreamMetadataProvider goodProvider = mock(StreamMetadataProvider.class);
+    when(goodProvider.computePartitionGroupMetadata(anyString(), any(StreamConfig.class),
+        any(List.class), anyInt(), anyBoolean())).thenReturn(Collections.singletonList(metadata));
+
+    StreamMetadataProvider badProvider = mock(StreamMetadataProvider.class);
+    when(badProvider.computePartitionGroupMetadata(anyString(), any(StreamConfig.class),
+        any(List.class), anyInt(), anyBoolean()))
+        .thenThrow(new PermanentConsumerException(new RuntimeException("Topic does not exist")));
+
+    StreamConsumerFactory factory = mock(StreamConsumerFactory.class);
+    when(factory.createStreamMetadataProvider(anyString()))
+        .thenReturn(goodProvider)   // called for topic1
+        .thenReturn(badProvider);   // called for topic2
+
+    try (MockedStatic<StreamConsumerFactoryProvider> mockedProvider = Mockito.mockStatic(
+        StreamConsumerFactoryProvider.class)) {
+      mockedProvider.when(() -> StreamConsumerFactoryProvider.create(any(StreamConfig.class))).thenReturn(factory);
+
+      PartitionGroupMetadataFetcher fetcher = new PartitionGroupMetadataFetcher(
+          streamConfigs, Collections.emptyList(), Collections.emptyList(), false);
+
+      Boolean result = fetcher.call();
+
+      // Fetch succeeds overall — only topic1's metadata is returned, topic2 is silently skipped
+      Assert.assertTrue(result);
+      Assert.assertEquals(fetcher.getStreamMetadataList().size(), 1);
+      Assert.assertEquals(fetcher.getStreamMetadataList().get(0).getNumPartitions(), 1);
+      Assert.assertNull(fetcher.getException());
+      Assert.assertEquals(fetcher.getFailedTopics(), Collections.singletonList("topic2-deleted"));
+    }
+  }
+
+  @Test
+  public void testFetchMultipleStreamsFailedTopicDoesNotBlockOthersOnRetry()
+      throws Exception {
+    StreamConfig streamConfig1 = createMockStreamConfig("topic1", "test-table_REALTIME", false);
+    StreamConfig streamConfig2 = createMockStreamConfig("topic2", "test-table_REALTIME", false);
+    List<StreamConfig> streamConfigs = Arrays.asList(streamConfig1, streamConfig2);
+
+    StreamPartitionMsgOffset offset = mock(StreamPartitionMsgOffset.class);
+    PartitionGroupMetadata metadata = new PartitionGroupMetadata(0, offset);
+
+    // First call: topic2 throws. Second call: both succeed.
+    StreamMetadataProvider provider = mock(StreamMetadataProvider.class);
+    when(provider.computePartitionGroupMetadata(anyString(), any(StreamConfig.class),
+        any(List.class), anyInt(), anyBoolean()))
+        .thenReturn(Collections.singletonList(metadata))           // topic1 first call
+        .thenThrow(new PermanentConsumerException(new RuntimeException("Topic does not exist")))   // topic2 first call
+        .thenReturn(Collections.singletonList(metadata))           // topic1 second call
+        .thenReturn(Collections.singletonList(metadata));          // topic2 second call
+
+    StreamConsumerFactory factory = mock(StreamConsumerFactory.class);
+    when(factory.createStreamMetadataProvider(anyString())).thenReturn(provider);
+
+    try (MockedStatic<StreamConsumerFactoryProvider> mockedProvider = Mockito.mockStatic(
+        StreamConsumerFactoryProvider.class)) {
+      mockedProvider.when(() -> StreamConsumerFactoryProvider.create(any(StreamConfig.class))).thenReturn(factory);
+
+      PartitionGroupMetadataFetcher fetcher = new PartitionGroupMetadataFetcher(
+          streamConfigs, Collections.emptyList(), Collections.emptyList(), false);
+
+      // First call: topic2 fails — only topic1's metadata returned, no exception
+      Boolean result1 = fetcher.call();
+      Assert.assertTrue(result1);
+      Assert.assertEquals(fetcher.getStreamMetadataList().size(), 1);
+      Assert.assertNull(fetcher.getException());
+      Assert.assertEquals(fetcher.getFailedTopics(), Collections.singletonList("topic2"));
+
+      // Second call: both succeed — failedTopics cleared
+      Boolean result2 = fetcher.call();
+      Assert.assertTrue(result2);
+      Assert.assertEquals(fetcher.getStreamMetadataList().size(), 2);
+      Assert.assertTrue(fetcher.getFailedTopics().isEmpty());
+    }
+  }
+
+  @Test
+  public void testFetchMultipleStreamsNonPermanentExceptionStillPropagates()
+      throws Exception {
+    StreamConfig streamConfig1 = createMockStreamConfig("topic1", "test-table_REALTIME", false);
+    StreamConfig streamConfig2 = createMockStreamConfig("topic2", "test-table_REALTIME", false);
+    List<StreamConfig> streamConfigs = Arrays.asList(streamConfig1, streamConfig2);
+
+    StreamMetadataProvider goodProvider = mock(StreamMetadataProvider.class);
+    when(goodProvider.computePartitionGroupMetadata(anyString(), any(StreamConfig.class),
+        any(List.class), anyInt(), anyBoolean()))
+        .thenReturn(Collections.singletonList(new PartitionGroupMetadata(0, mock(StreamPartitionMsgOffset.class))));
+
+    // Generic RuntimeException (not PermanentConsumerException) — auth error, NPE, etc.
+    StreamMetadataProvider badProvider = mock(StreamMetadataProvider.class);
+    when(badProvider.computePartitionGroupMetadata(anyString(), any(StreamConfig.class),
+        any(List.class), anyInt(), anyBoolean()))
+        .thenThrow(new RuntimeException("Auth failure"));
+
+    StreamConsumerFactory factory = mock(StreamConsumerFactory.class);
+    when(factory.createStreamMetadataProvider(anyString()))
+        .thenReturn(goodProvider)
+        .thenReturn(badProvider);
+
+    try (MockedStatic<StreamConsumerFactoryProvider> mockedProvider = Mockito.mockStatic(
+        StreamConsumerFactoryProvider.class)) {
+      mockedProvider.when(() -> StreamConsumerFactoryProvider.create(any(StreamConfig.class))).thenReturn(factory);
+
+      PartitionGroupMetadataFetcher fetcher = new PartitionGroupMetadataFetcher(
+          streamConfigs, Collections.emptyList(), Collections.emptyList(), false);
+
+      try {
+        fetcher.call();
+        Assert.fail("Expected RuntimeException to propagate");
+      } catch (RuntimeException e) {
+        Assert.assertEquals(e.getMessage(), "Auth failure");
+      }
+      Assert.assertTrue(fetcher.getFailedTopics().isEmpty());
+    }
+  }
+
   private StreamConfig createMockStreamConfig(String topicName, String tableName, boolean isEphemeral) {
     StreamConfig streamConfig = mock(StreamConfig.class);
     when(streamConfig.getTopicName()).thenReturn(topicName);


### PR DESCRIPTION
In a multi-topic table, if one Kafka topic becomes inaccessible (e.g. deleted externally), all other topics ingestion also stops. 

Fix: catch permanent (non-transient) exceptions per-topic in fetchMultipleStreams(), log and record the failed topic name in _failedTopics, and continue fetching the remaining topics. The caller (PinotTableIdealStateBuilder) reads getFailedTopics() after the fetch and emits a PARTITION_GROUP_METADATA_FETCH_ERROR metric tagged with the topic name for each failure, so operators can detect the inaccessible topic. Healthy topics proceed normally through ensureAllPartitionsConsuming().

TransientConsumerException handling is unchanged — transient failures still return false to trigger a retry via the retry policy.

`bugfix`