### PR TITLE
Scope overwriteTableConfigForTier Table config Jackson to sub-configs that can hold tier overrides

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -2081,52 +2080,82 @@ public final class TableConfigUtils {
       return tableConfig;
     }
     try {
-      boolean updated = false;
-      JsonNode tblCfgJson = tableConfig.toJsonNode();
-      // Apply tier specific overwrites for `tableIndexConfig`
-      JsonNode tblIdxCfgJson = tblCfgJson.get(TableConfig.INDEXING_CONFIG_KEY);
-      if (tblIdxCfgJson != null && tblIdxCfgJson.has(TableConfig.TIER_OVERWRITES_KEY)) {
-        JsonNode tierCfgJson = tblIdxCfgJson.get(TableConfig.TIER_OVERWRITES_KEY).get(tier);
-        if (tierCfgJson != null) {
-          LOGGER.debug("Got table index config overwrites: {} for tier: {}", tierCfgJson, tier);
-          overwriteConfig(tblIdxCfgJson, tierCfgJson);
-          updated = true;
-        }
-      }
-      // Apply tier specific overwrites for `fieldConfigList`
-      JsonNode fieldCfgListJson = tblCfgJson.get(TableConfig.FIELD_CONFIG_LIST_KEY);
-      if (fieldCfgListJson != null && fieldCfgListJson.isArray()) {
-        Iterator<JsonNode> fieldCfgListItr = fieldCfgListJson.elements();
-        while (fieldCfgListItr.hasNext()) {
-          JsonNode fieldCfgJson = fieldCfgListItr.next();
-          if (!fieldCfgJson.has(TableConfig.TIER_OVERWRITES_KEY)) {
-            continue;
-          }
-          JsonNode tierCfgJson = fieldCfgJson.get(TableConfig.TIER_OVERWRITES_KEY).get(tier);
-          if (tierCfgJson != null) {
-            LOGGER.debug("Got field index config overwrites: {} for tier: {}", tierCfgJson, tier);
-            overwriteConfig(fieldCfgJson, tierCfgJson);
-            updated = true;
-          }
-        }
-      }
-      if (updated) {
-        LOGGER.debug("Got overwritten table config: {} for tier: {}", tblCfgJson, tier);
-        return JsonUtils.jsonNodeToObject(tblCfgJson, TableConfig.class);
-      } else {
-        LOGGER.debug("No table config overwrites for tier: {}", tier);
+      IndexingConfig effectiveIndexing = applyIndexingConfigTierOverride(tableConfig.getIndexingConfig(), tier);
+      List<FieldConfig> effectiveFields = applyFieldConfigListTierOverrides(tableConfig.getFieldConfigList(), tier);
+      if (effectiveIndexing == tableConfig.getIndexingConfig()
+          && effectiveFields == tableConfig.getFieldConfigList()) {
         return tableConfig;
       }
+      TableConfig overwritten = new TableConfig(tableConfig);
+      overwritten.setIndexingConfig(effectiveIndexing);
+      overwritten.setFieldConfigList(effectiveFields);
+      return overwritten;
     } catch (IOException e) {
       LOGGER.warn("Failed to overwrite table config for tier: {} for table: {}", tier, tableConfig.getTableName(), e);
       return tableConfig;
     }
   }
 
-  private static void overwriteConfig(JsonNode oldCfg, JsonNode newCfg) {
-    for (Map.Entry<String, JsonNode> cfgEntry : newCfg.properties()) {
-      ((ObjectNode) oldCfg).set(cfgEntry.getKey(), cfgEntry.getValue());
+  @Nullable
+  private static IndexingConfig applyIndexingConfigTierOverride(@Nullable IndexingConfig original, String tier)
+      throws IOException {
+    if (original == null) {
+      return null;
     }
+    JsonNode tierOverwrites = original.getTierOverwrites();
+    if (tierOverwrites == null || !tierOverwrites.has(tier)) {
+      return original;
+    }
+    JsonNode override = tierOverwrites.get(tier);
+    if (!override.isObject()) {
+      return original;
+    }
+    ObjectNode merged = (ObjectNode) JsonUtils.objectToJsonNode(original);
+    for (Map.Entry<String, JsonNode> entry : override.properties()) {
+      merged.set(entry.getKey(), entry.getValue());
+    }
+    return JsonUtils.jsonNodeToObject(merged, IndexingConfig.class);
+  }
+
+  @Nullable
+  private static List<FieldConfig> applyFieldConfigListTierOverrides(@Nullable List<FieldConfig> original, String tier)
+      throws IOException {
+    if (original == null || original.isEmpty()) {
+      return original;
+    }
+    List<FieldConfig> result = null;
+    for (int i = 0; i < original.size(); i++) {
+      FieldConfig fc = original.get(i);
+      FieldConfig effective = applyFieldConfigTierOverride(fc, tier);
+      if (effective != fc) {
+        if (result == null) {
+          result = new ArrayList<>(original);
+        }
+        result.set(i, effective);
+      }
+    }
+    return result != null ? result : original;
+  }
+
+  @Nullable
+  private static FieldConfig applyFieldConfigTierOverride(@Nullable FieldConfig original, String tier)
+      throws IOException {
+    if (original == null) {
+      return null;
+    }
+    JsonNode tierOverwrites = original.getTierOverwrites();
+    if (tierOverwrites == null || !tierOverwrites.has(tier)) {
+      return original;
+    }
+    JsonNode override = tierOverwrites.get(tier);
+    if (!override.isObject()) {
+      return original;
+    }
+    ObjectNode merged = (ObjectNode) JsonUtils.objectToJsonNode(original);
+    for (Map.Entry<String, JsonNode> entry : override.properties()) {
+      merged.set(entry.getKey(), entry.getValue());
+    }
+    return JsonUtils.jsonNodeToObject(merged, FieldConfig.class);
   }
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -2125,9 +2125,9 @@ public final class TableConfigUtils {
     }
     List<FieldConfig> result = null;
     for (int i = 0; i < original.size(); i++) {
-      FieldConfig fc = original.get(i);
-      FieldConfig effective = applyFieldConfigTierOverride(fc, tier);
-      if (effective != fc) {
+      FieldConfig config = original.get(i);
+      FieldConfig effective = applyFieldConfigTierOverride(config, tier);
+      if (effective != config) {
         if (result == null) {
           result = new ArrayList<>(original);
         }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -2096,12 +2096,8 @@ public final class TableConfigUtils {
     }
   }
 
-  @Nullable
-  private static IndexingConfig applyIndexingConfigTierOverride(@Nullable IndexingConfig original, String tier)
+  private static IndexingConfig applyIndexingConfigTierOverride(IndexingConfig original, String tier)
       throws IOException {
-    if (original == null) {
-      return null;
-    }
     JsonNode tierOverwrites = original.getTierOverwrites();
     if (tierOverwrites == null || !tierOverwrites.has(tier)) {
       return original;
@@ -2120,7 +2116,7 @@ public final class TableConfigUtils {
   @Nullable
   private static List<FieldConfig> applyFieldConfigListTierOverrides(@Nullable List<FieldConfig> original, String tier)
       throws IOException {
-    if (original == null || original.isEmpty()) {
+    if (CollectionUtils.isEmpty(original)) {
       return original;
     }
     List<FieldConfig> result = null;
@@ -2137,12 +2133,8 @@ public final class TableConfigUtils {
     return result != null ? result : original;
   }
 
-  @Nullable
-  private static FieldConfig applyFieldConfigTierOverride(@Nullable FieldConfig original, String tier)
+  private static FieldConfig applyFieldConfigTierOverride(FieldConfig original, String tier)
       throws IOException {
-    if (original == null) {
-      return null;
-    }
     JsonNode tierOverwrites = original.getTierOverwrites();
     if (tierOverwrites == null || !tierOverwrites.has(tier)) {
       return original;

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -3761,6 +3761,17 @@ public class TableConfigUtilsTest {
   }
 
   @Test
+  public void testOverwriteTableConfigForTierFastPathReturnsSameInstance() {
+    FieldConfig col1 = new FieldConfig.Builder("col1")
+        .withEncodingType(FieldConfig.EncodingType.DICTIONARY)
+        .build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setFieldConfigList(Collections.singletonList(col1))
+        .build();
+    assertSame(TableConfigUtils.overwriteTableConfigForTier(tableConfig, "coldTier"), tableConfig);
+  }
+
+  @Test
   public void testGetPartitionColumnWithoutAnyConfig() {
     // without instanceAssignmentConfigMap
     TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).build();


### PR DESCRIPTION
  **Problem**
`overwriteTableConfigForTier` runs on every segment during checkSegmentsReload polls. The current code does a full Jackson roundtrip on the entire TableConfig  — even though tier overrides can only live on `IndexingConfig._tierOverwrites` and `FieldConfig._tierOverwrites.`
Tables with no tierOverwrites defined anywhere would still pay the full serialize cost before, because the existing code serializes upfront and only then checks if there's anything to override. `overwriteTableConfigForTier` allocated ~**4.5** GB (319 calls × ~14 MB each). Largest single allocator on the reload-check path. This multiplies for huge number of segments and allocates unnecessary memory when not needed 

  **Fix:**
  Only roundtrip the pieces that can have overrides:
  - If `IndexingConfig.getTierOverwrites()` has an entry for this tier → roundtrip just IndexingConfig. Otherwise return the original reference.
  - For each FieldConfig with an override → roundtrip just that FieldConfig. Otherwise keep the original reference.
  - If nothing changed → return the original TableConfig reference (no allocation).
  - If something changed → shallow-copy TableConfig and swap the two affected fields.