### PR TITLE
[MaterializedView] Add isMaterializedView flag on TableConfig as the single MV identity

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TableConfigSerDeUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TableConfigSerDeUtils.java
@@ -66,6 +66,8 @@ public class TableConfigSerDeUtils {
 
     String tableType = simpleFields.get(TableConfig.TABLE_TYPE_KEY);
     boolean isDimTable = Boolean.parseBoolean(simpleFields.get(TableConfig.IS_DIM_TABLE_KEY));
+    boolean isMaterializedView =
+        Boolean.parseBoolean(simpleFields.get(TableConfig.IS_MATERIALIZED_VIEW_KEY));
     Preconditions.checkState(tableType != null, FIELD_MISSING_MESSAGE_TEMPLATE, TableConfig.TABLE_TYPE_KEY);
 
     String validationConfigString = simpleFields.get(TableConfig.VALIDATION_CONFIG_KEY);
@@ -198,7 +200,8 @@ public class TableConfigSerDeUtils {
         new TableConfig(tableName, tableType, validationConfig, tenantConfig, indexingConfig, customConfig,
             quotaConfig, taskConfig, routingConfig, queryConfig, instanceAssignmentConfigMap, fieldConfigList,
             upsertConfig, dedupConfig, dimensionTableConfig, ingestionConfig, tierConfigList, isDimTable,
-            tunerConfigList, instancePartitionsMap, segmentAssignmentConfigMap, tableSamplerConfigs);
+            tunerConfigList, instancePartitionsMap, segmentAssignmentConfigMap,
+            tableSamplerConfigs, isMaterializedView);
     tableConfig.setDescription(description);
     tableConfig.setTags(tags);
     return tableConfig;
@@ -216,6 +219,7 @@ public class TableConfigSerDeUtils {
     simpleFields.put(TableConfig.INDEXING_CONFIG_KEY, tableConfig.getIndexingConfig().toJsonString());
     simpleFields.put(TableConfig.CUSTOM_CONFIG_KEY, tableConfig.getCustomConfig().toJsonString());
     simpleFields.put(TableConfig.IS_DIM_TABLE_KEY, Boolean.toString(tableConfig.isDimTable()));
+    simpleFields.put(TableConfig.IS_MATERIALIZED_VIEW_KEY, Boolean.toString(tableConfig.isMaterializedView()));
 
     // Optional fields
     QuotaConfig quotaConfig = tableConfig.getQuotaConfig();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -163,6 +163,7 @@ import org.apache.pinot.controller.helix.core.util.MessagingServiceUtils;
 import org.apache.pinot.controller.workload.QueryWorkloadManager;
 import org.apache.pinot.core.util.NumberUtils;
 import org.apache.pinot.core.util.NumericException;
+import org.apache.pinot.materializedview.analysis.MaterializedViewAnalyzer;
 import org.apache.pinot.materializedview.consistency.MaterializedViewConsistencyManager;
 import org.apache.pinot.materializedview.metadata.MaterializedViewDefinitionMetadata;
 import org.apache.pinot.materializedview.metadata.MaterializedViewDefinitionMetadataUtils;
@@ -174,7 +175,6 @@ import org.apache.pinot.spi.config.instance.Instance;
 import org.apache.pinot.spi.config.instance.InstanceConfigValidatorRegistry;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableStatsHumanReadable;
-import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.TagOverrideConfig;
 import org.apache.pinot.spi.config.table.TenantConfig;
@@ -205,7 +205,6 @@ import org.apache.pinot.spi.utils.TimeUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.spi.utils.retry.RetryPolicies;
 import org.apache.pinot.spi.utils.retry.RetryPolicy;
-import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -5377,24 +5376,27 @@ public class PinotHelixResourceManager {
 
   private void notifyMaterializedViewConsistencyManagerForTableCreate(TableConfig tableConfig) {
     MaterializedViewConsistencyManager mgr = _materializedViewConsistencyManager;
-    if (mgr == null) {
+    if (mgr == null || !tableConfig.isMaterializedView()) {
       return;
     }
     try {
-      TableTaskConfig taskConfig = tableConfig.getTaskConfig();
-      if (taskConfig == null) {
+      MaterializedViewDefinitionMetadata definition =
+          MaterializedViewDefinitionMetadataUtils.fetch(_propertyStore, tableConfig.getTableName());
+      if (definition != null && definition.getBaseTables() != null && !definition.getBaseTables().isEmpty()) {
+        mgr.onMaterializedViewTableCreated(tableConfig.getTableName(), definition.getBaseTables());
         return;
       }
-      Map<String, String> materializedViewTaskConfigs =
-          taskConfig.getConfigsForTaskType(CommonConstants.MaterializedViewTask.TASK_TYPE);
+      Map<String, String> materializedViewTaskConfigs = tableConfig.getMaterializedViewTaskConfigs();
       if (materializedViewTaskConfigs == null) {
+        LOGGER.warn("MV table {} has no MaterializedViewTask config for consistency registration",
+            tableConfig.getTableName());
         return;
       }
       String definedSQL = materializedViewTaskConfigs.get(CommonConstants.MaterializedViewTask.DEFINED_SQL_KEY);
       if (definedSQL == null || definedSQL.isEmpty()) {
         return;
       }
-      String sourceTable = CalciteSqlParser.compileToPinotQuery(definedSQL).getDataSource().getTableName();
+      String sourceTable = MaterializedViewAnalyzer.extractSourceTableName(definedSQL);
       mgr.onMaterializedViewTableCreated(tableConfig.getTableName(), Collections.singletonList(sourceTable));
     } catch (Exception e) {
       LOGGER.warn("Failed to register MV table {} with consistency manager", tableConfig.getTableName(), e);
@@ -5407,33 +5409,19 @@ public class PinotHelixResourceManager {
       return;
     }
     try {
+      TableConfig tableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, tableNameWithType);
+      if (tableConfig != null && !tableConfig.isMaterializedView()) {
+        return;
+      }
       MaterializedViewDefinitionMetadata materializedViewDefinition =
           MaterializedViewDefinitionMetadataUtils.fetch(_propertyStore, tableNameWithType);
       if (materializedViewDefinition != null && materializedViewDefinition.getBaseTables() != null
           && !materializedViewDefinition.getBaseTables().isEmpty()) {
         mgr.onMaterializedViewTableDropped(tableNameWithType, materializedViewDefinition.getBaseTables());
-        return;
+      } else if (tableConfig != null && tableConfig.isMaterializedView()) {
+        LOGGER.warn("MV table {} dropped without definition metadata; consistency reverse index may be stale",
+            tableNameWithType);
       }
-      // Fall back to reading source table from table task config
-      TableConfig tableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, tableNameWithType);
-      if (tableConfig == null) {
-        return;
-      }
-      TableTaskConfig taskConfig = tableConfig.getTaskConfig();
-      if (taskConfig == null) {
-        return;
-      }
-      Map<String, String> materializedViewTaskConfigs =
-          taskConfig.getConfigsForTaskType(CommonConstants.MaterializedViewTask.TASK_TYPE);
-      if (materializedViewTaskConfigs == null) {
-        return;
-      }
-      String definedSQL = materializedViewTaskConfigs.get(CommonConstants.MaterializedViewTask.DEFINED_SQL_KEY);
-      if (definedSQL == null || definedSQL.isEmpty()) {
-        return;
-      }
-      String sourceTable = CalciteSqlParser.compileToPinotQuery(definedSQL).getDataSource().getTableName();
-      mgr.onMaterializedViewTableDropped(tableNameWithType, Collections.singletonList(sourceTable));
     } catch (Exception e) {
       LOGGER.warn("Failed to unregister MV table {} from consistency manager", tableNameWithType, e);
     }

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/analysis/MaterializedViewAnalyzer.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/analysis/MaterializedViewAnalyzer.java
@@ -102,6 +102,10 @@ public final class MaterializedViewAnalyzer {
   public static AnalysisResult analyze(String definedSql, TableConfig viewTableConfig, Schema viewSchema,
       Map<String, String> taskConfigs, MaterializedViewTaskGeneratorContext context) {
 
+    Preconditions.checkState(viewTableConfig.isMaterializedView(),
+        "MaterializedViewAnalyzer requires isMaterializedView=true on table: %s",
+        viewTableConfig.getTableName());
+
     // Step 4 first: cheap config checks that don't require parsing
     long bucketMs = validateTaskConfigs(viewTableConfig, taskConfigs, context);
 

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/scheduler/MaterializedViewTaskScheduler.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/scheduler/MaterializedViewTaskScheduler.java
@@ -129,6 +129,12 @@ public class MaterializedViewTaskScheduler {
     for (TableConfig tableConfig : tableConfigs) {
       String offlineTableName = tableConfig.getTableName();
 
+      if (!tableConfig.isMaterializedView()) {
+        LOGGER.warn("Skip generating task: {} for table: {} because isMaterializedView is not set",
+            taskType, offlineTableName);
+        continue;
+      }
+
       if (tableConfig.getTableType() != TableType.OFFLINE) {
         LOGGER.warn("Skip generating task: {} for non-OFFLINE table: {}", taskType, offlineTableName);
         continue;

--- a/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/analysis/MaterializedViewAnalyzerTest.java
+++ b/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/analysis/MaterializedViewAnalyzerTest.java
@@ -165,6 +165,7 @@ public class MaterializedViewAnalyzerTest {
     // point to the SELECT alias 'dayBucket' — not the inherited base name.
     TableConfig viewTableConfig = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName("mv_orders")
+        .setIsMaterializedView(true)
         .setTimeColumnName("dayBucket")
         .build();
     Map<String, String> taskConfigs = buildTaskConfigs(sql);
@@ -654,6 +655,30 @@ public class MaterializedViewAnalyzerTest {
   // -----------------------------------------------------------------------
 
   @Test
+  public void testAnalyzeRequiresIsMaterializedViewFlag() {
+    String sql = "SELECT DaysSinceEpoch, city, count(*) AS cnt FROM orders GROUP BY DaysSinceEpoch, city";
+    Schema viewSchema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("city", FieldSpec.DataType.STRING)
+        .addMetric("cnt", FieldSpec.DataType.LONG)
+        .addDateTime(TIME_COLUMN, FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:MILLISECONDS")
+        .build();
+
+    TableConfig viewTableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("mv_orders")
+        .setTimeColumnName(TIME_COLUMN)
+        .build();
+    Map<String, String> taskConfigs = buildTaskConfigs(sql);
+
+    try {
+      MaterializedViewAnalyzer.analyze(withLimit(sql), viewTableConfig, viewSchema, taskConfigs, _mockAccessor);
+      fail("Expected IllegalStateException when isMaterializedView is false");
+    } catch (IllegalStateException e) {
+      assertTrue(e.getMessage().contains("isMaterializedView=true"),
+          "Unexpected message: " + e.getMessage());
+    }
+  }
+
+  @Test
   public void testNonOfflineTableType() {
     String sql = "SELECT DaysSinceEpoch, city, count(*) AS cnt FROM orders GROUP BY DaysSinceEpoch, city";
     Schema viewSchema = new Schema.SchemaBuilder()
@@ -664,6 +689,7 @@ public class MaterializedViewAnalyzerTest {
 
     TableConfig realtimeConfig = new TableConfigBuilder(TableType.REALTIME)
         .setTableName("mv_orders")
+        .setIsMaterializedView(true)
         .setTimeColumnName(TIME_COLUMN)
         .build();
     Map<String, String> taskConfigs = buildTaskConfigs(sql);
@@ -800,6 +826,7 @@ public class MaterializedViewAnalyzerTest {
 
     TableConfig viewTableConfig = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName("mv_orders")
+        .setIsMaterializedView(true)
         .build();
     Map<String, String> taskConfigs = buildTaskConfigs(sql);
 
@@ -824,6 +851,7 @@ public class MaterializedViewAnalyzerTest {
     // timeColumnName points to a column that doesn't exist in the MV schema at all.
     TableConfig viewTableConfig = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName("mv_orders")
+        .setIsMaterializedView(true)
         .setTimeColumnName("nonexistent_time_col")
         .build();
     Map<String, String> taskConfigs = buildTaskConfigs(sql);
@@ -849,6 +877,7 @@ public class MaterializedViewAnalyzerTest {
     // timeColumnName points to a plain dimension, not a registered dateTime column.
     TableConfig viewTableConfig = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName("mv_orders")
+        .setIsMaterializedView(true)
         .setTimeColumnName("city")
         .build();
     Map<String, String> taskConfigs = buildTaskConfigs(sql);
@@ -878,6 +907,7 @@ public class MaterializedViewAnalyzerTest {
 
     TableConfig viewTableConfig = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName("mv_orders")
+        .setIsMaterializedView(true)
         .setTimeColumnName(TIME_COLUMN)
         .build();
     Map<String, String> taskConfigs = buildTaskConfigs(sql);
@@ -907,6 +937,7 @@ public class MaterializedViewAnalyzerTest {
 
     TableConfig viewTableConfig = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName("mv_orders")
+        .setIsMaterializedView(true)
         .setTimeColumnName("day")
         .build();
     Map<String, String> taskConfigs = buildTaskConfigs(sql);
@@ -978,6 +1009,7 @@ public class MaterializedViewAnalyzerTest {
 
     TableConfig viewTableConfig = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName("mv_orders")
+        .setIsMaterializedView(true)
         .setTimeColumnName("day")
         .build();
     Map<String, String> taskConfigs = buildTaskConfigs(sql);
@@ -1000,6 +1032,7 @@ public class MaterializedViewAnalyzerTest {
 
     TableConfig viewTableConfig = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName("mv_orders")
+        .setIsMaterializedView(true)
         .setTimeColumnName("hr")
         .build();
     Map<String, String> taskConfigs = buildTaskConfigs(sql);
@@ -1020,6 +1053,7 @@ public class MaterializedViewAnalyzerTest {
 
     TableConfig viewTableConfig = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName("mv_orders")
+        .setIsMaterializedView(true)
         .setTimeColumnName("ts_ms")
         .build();
     Map<String, String> taskConfigs = buildTaskConfigs(sql);
@@ -1041,6 +1075,7 @@ public class MaterializedViewAnalyzerTest {
 
     TableConfig viewTableConfig = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName("mv_orders")
+        .setIsMaterializedView(true)
         .setTimeColumnName("day")
         .build();
     Map<String, String> taskConfigs = buildTaskConfigs(sql);
@@ -1057,6 +1092,7 @@ public class MaterializedViewAnalyzerTest {
   private TableConfig buildMaterializedViewTableConfig() {
     return new TableConfigBuilder(TableType.OFFLINE)
         .setTableName("mv_orders")
+        .setIsMaterializedView(true)
         .setTimeColumnName(TIME_COLUMN)
         .build();
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -196,6 +196,7 @@ public final class TableConfigUtils {
     }
 
     validateTaskConfig(tableConfig);
+    validateMaterializedViewInvariants(tableConfig);
 
     if (_enforcePoolBasedAssignment) {
       validateInstancePoolsAndReplicaGroups(tableConfig);
@@ -1300,6 +1301,7 @@ public final class TableConfigUtils {
     List<String> violations = new ArrayList<>();
     validateUpsertConfigUpdate(newConfig, existingConfig, violations);
     validateDedupConfigUpdate(newConfig, existingConfig, violations);
+    validateMaterializedViewConfigUpdate(newConfig, existingConfig, violations);
 
     return violations;
   }
@@ -1422,6 +1424,73 @@ public final class TableConfigUtils {
         }
       }
     }
+  }
+
+  /**
+   * Validates materialized-view table identity and task-config consistency.
+   * Identity is declared only via {@link TableConfig#isMaterializedView()}; task configs alone do not
+   * make a table an MV.
+   */
+  @VisibleForTesting
+  static void validateMaterializedViewInvariants(TableConfig tableConfig) {
+    boolean isMaterializedView = tableConfig.isMaterializedView();
+    boolean hasMvTaskWithDefinedSql = tableConfig.hasMaterializedViewTaskWithDefinedSql();
+    boolean hasMvTask = tableConfig.getMaterializedViewTaskConfigs() != null;
+
+    if (isMaterializedView) {
+      Preconditions.checkState(tableConfig.getTableType() == TableType.OFFLINE,
+          "Materialized view tables must be OFFLINE, got: %s for table: %s", tableConfig.getTableType(),
+          tableConfig.getTableName());
+      Preconditions.checkState(hasMvTaskWithDefinedSql,
+          "isMaterializedView is true but MaterializedViewTask with non-empty definedSQL is required for table: %s",
+          tableConfig.getTableName());
+      Preconditions.checkState(!tableConfig.isDimTable(),
+          "A table cannot be both isDimTable and isMaterializedView: %s", tableConfig.getTableName());
+    }
+
+    if (hasMvTaskWithDefinedSql && !isMaterializedView) {
+      throw new IllegalStateException(String.format(
+          "MaterializedViewTask is configured but isMaterializedView is not true for table: %s. "
+              + "Set \"isMaterializedView\": true or remove MaterializedViewTask.",
+          tableConfig.getTableName()));
+    }
+
+    if (hasMvTask && !hasMvTaskWithDefinedSql) {
+      throw new IllegalStateException(String.format(
+          "MaterializedViewTask is configured but definedSQL is missing or empty for table: %s",
+          tableConfig.getTableName()));
+    }
+  }
+
+  private static void validateMaterializedViewConfigUpdate(TableConfig newConfig, TableConfig existingConfig,
+      List<String> violations) {
+    if (existingConfig.isMaterializedView() != newConfig.isMaterializedView()) {
+      violations.add(String.format("isMaterializedView (%s -> %s) cannot be changed; drop and recreate the table",
+          existingConfig.isMaterializedView(), newConfig.isMaterializedView()));
+    }
+
+    if (!existingConfig.isMaterializedView() && !newConfig.isMaterializedView()) {
+      return;
+    }
+
+    String existingDefinedSql = getDefinedSqlFromMaterializedViewTask(existingConfig);
+    String newDefinedSql = getDefinedSqlFromMaterializedViewTask(newConfig);
+    if (existingDefinedSql != null && newDefinedSql != null && !existingDefinedSql.equals(newDefinedSql)) {
+      violations.add("MaterializedViewTask.definedSQL is immutable after MV creation");
+    }
+
+    if (existingConfig.isMaterializedView() && !newConfig.hasMaterializedViewTaskWithDefinedSql()) {
+      violations.add("MaterializedViewTask with definedSQL cannot be removed from a materialized view table");
+    }
+  }
+
+  @Nullable
+  private static String getDefinedSqlFromMaterializedViewTask(TableConfig tableConfig) {
+    Map<String, String> configs = tableConfig.getMaterializedViewTaskConfigs();
+    if (configs == null) {
+      return null;
+    }
+    return configs.get(org.apache.pinot.spi.utils.CommonConstants.MaterializedViewTask.DEFINED_SQL_KEY);
   }
 
   /**

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -4261,4 +4261,78 @@ public class TableConfigUtilsTest {
     List<String> violations = TableConfigUtils.validateBackwardCompatibility(newConfig, existingConfig);
     assertTrue(violations.isEmpty(), "Expected no violations for non-upsert tables, but got: " + violations);
   }
+
+  @Test
+  public void testValidateMaterializedViewInvariantsFlagRequiresOfflineAndTask() {
+    TableConfig mvWithoutTask = new TableConfigBuilder(TableType.OFFLINE).setTableName("mv_test")
+        .setIsMaterializedView(true).build();
+    assertThrows(IllegalStateException.class, () -> TableConfigUtils.validateMaterializedViewInvariants(mvWithoutTask));
+
+    TableConfig mvRealtime = new TableConfigBuilder(TableType.REALTIME).setTableName("mv_test")
+        .setIsMaterializedView(true)
+        .setTaskConfig(new org.apache.pinot.spi.config.table.TableTaskConfig(buildMaterializedViewTaskMap("SELECT 1")))
+        .build();
+    assertThrows(IllegalStateException.class, () -> TableConfigUtils.validateMaterializedViewInvariants(mvRealtime));
+  }
+
+  @Test
+  public void testValidateMaterializedViewInvariantsTaskWithoutFlagRejected() {
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("mv_test")
+        .setTaskConfig(new org.apache.pinot.spi.config.table.TableTaskConfig(
+            buildMaterializedViewTaskMap("SELECT city FROM orders GROUP BY city")))
+        .build();
+    assertThrows(IllegalStateException.class,
+        () -> TableConfigUtils.validateMaterializedViewInvariants(tableConfig));
+  }
+
+  @Test
+  public void testValidateMaterializedViewInvariantsTaskWithoutDefinedSqlRejected() {
+    Map<String, Map<String, String>> taskTypeConfigsMap = new HashMap<>();
+    taskTypeConfigsMap.put(org.apache.pinot.spi.utils.CommonConstants.MaterializedViewTask.TASK_TYPE,
+        Map.of("bucketTimePeriod", "1d"));
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("mv_test")
+        .setTaskConfig(new org.apache.pinot.spi.config.table.TableTaskConfig(taskTypeConfigsMap))
+        .build();
+    assertThrows(IllegalStateException.class,
+        () -> TableConfigUtils.validateMaterializedViewInvariants(tableConfig));
+  }
+
+  @Test
+  public void testValidateBackwardCompatibilityMaterializedViewDefinedSqlImmutable() {
+    String sql = "SELECT city FROM orders GROUP BY city";
+    TableConfig existingConfig = buildMaterializedViewTableConfig(sql);
+    TableConfig newConfig = buildMaterializedViewTableConfig("SELECT city, count(*) FROM orders GROUP BY city");
+
+    List<String> violations = TableConfigUtils.validateBackwardCompatibility(newConfig, existingConfig);
+    assertEquals(violations.size(), 1);
+    assertTrue(violations.get(0).contains("definedSQL is immutable"));
+  }
+
+  @Test
+  public void testValidateBackwardCompatibilityMaterializedViewFlagCannotChange() {
+    String sql = "SELECT city FROM orders GROUP BY city";
+    TableConfig existingConfig = buildMaterializedViewTableConfig(sql);
+    TableConfig newConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("mv_test")
+        .setTaskConfig(new org.apache.pinot.spi.config.table.TableTaskConfig(buildMaterializedViewTaskMap(sql)))
+        .build();
+
+    List<String> violations = TableConfigUtils.validateBackwardCompatibility(newConfig, existingConfig);
+    assertEquals(violations.size(), 1);
+    assertTrue(violations.get(0).contains("isMaterializedView"));
+  }
+
+  private static Map<String, Map<String, String>> buildMaterializedViewTaskMap(String definedSql) {
+    Map<String, String> mvTaskConfig = new HashMap<>();
+    mvTaskConfig.put(org.apache.pinot.spi.utils.CommonConstants.MaterializedViewTask.DEFINED_SQL_KEY, definedSql);
+    Map<String, Map<String, String>> taskTypeConfigsMap = new HashMap<>();
+    taskTypeConfigsMap.put(org.apache.pinot.spi.utils.CommonConstants.MaterializedViewTask.TASK_TYPE, mvTaskConfig);
+    return taskTypeConfigsMap;
+  }
+
+  private static TableConfig buildMaterializedViewTableConfig(String definedSql) {
+    return new TableConfigBuilder(TableType.OFFLINE).setTableName("mv_test")
+        .setIsMaterializedView(true)
+        .setTaskConfig(new org.apache.pinot.spi.config.table.TableTaskConfig(buildMaterializedViewTaskMap(definedSql)))
+        .build();
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
@@ -37,6 +37,7 @@ import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.config.table.assignment.SegmentAssignmentConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.sampler.TableSamplerConfig;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 
 
@@ -45,6 +46,7 @@ public class TableConfig extends BaseJsonConfig {
   public static final String TABLE_NAME_KEY = "tableName";
   public static final String TABLE_TYPE_KEY = "tableType";
   public static final String IS_DIM_TABLE_KEY = "isDimTable";
+  public static final String IS_MATERIALIZED_VIEW_KEY = "isMaterializedView";
   public static final String VALIDATION_CONFIG_KEY = "segmentsConfig";
   public static final String TENANT_CONFIG_KEY = "tenants";
   public static final String INDEXING_CONFIG_KEY = "tableIndexConfig";
@@ -81,6 +83,9 @@ public class TableConfig extends BaseJsonConfig {
 
   @JsonPropertyDescription("Indicates whether the table is a dimension table or not")
   private final boolean _dimTable;
+
+  @JsonPropertyDescription("Indicates whether the table is a materialized view or not")
+  private final boolean _materializedView;
 
   private SegmentsValidationAndRetentionConfig _validationConfig;
   private TenantConfig _tenantConfig;
@@ -134,6 +139,30 @@ public class TableConfig extends BaseJsonConfig {
   @JsonPropertyDescription(value = "Configs for table samplers")
   private List<TableSamplerConfig> _tableSamplers;
 
+  /// Legacy constructor preserved for binary backward-compatibility on the public SPI surface.
+  /// Callers compiled against the pre-`isMaterializedView` signature still link against this entry
+  /// point; it forwards to the canonical constructor with `materializedView=false`. Prefer the
+  /// {@link TableConfigBuilder} or the canonical constructor below for new code.
+  @Deprecated
+  public TableConfig(String tableName, String tableType,
+      SegmentsValidationAndRetentionConfig validationConfig, TenantConfig tenantConfig,
+      IndexingConfig indexingConfig, TableCustomConfig customConfig, @Nullable QuotaConfig quotaConfig,
+      @Nullable TableTaskConfig taskConfig, @Nullable RoutingConfig routingConfig,
+      @Nullable QueryConfig queryConfig,
+      @Nullable Map<String, InstanceAssignmentConfig> instanceAssignmentConfigMap,
+      @Nullable List<FieldConfig> fieldConfigList, @Nullable UpsertConfig upsertConfig,
+      @Nullable DedupConfig dedupConfig, @Nullable DimensionTableConfig dimensionTableConfig,
+      @Nullable IngestionConfig ingestionConfig, @Nullable List<TierConfig> tierConfigsList, boolean dimTable,
+      @Nullable List<TunerConfig> tunerConfigList,
+      @Nullable Map<InstancePartitionsType, String> instancePartitionsMap,
+      @Nullable Map<String, SegmentAssignmentConfig> segmentAssignmentConfigMap,
+      @Nullable List<TableSamplerConfig> tableSamplers) {
+    this(tableName, tableType, validationConfig, tenantConfig, indexingConfig, customConfig, quotaConfig, taskConfig,
+        routingConfig, queryConfig, instanceAssignmentConfigMap, fieldConfigList, upsertConfig, dedupConfig,
+        dimensionTableConfig, ingestionConfig, tierConfigsList, dimTable, tunerConfigList, instancePartitionsMap,
+        segmentAssignmentConfigMap, tableSamplers, /*materializedView=*/ false);
+  }
+
   @JsonCreator
   public TableConfig(@JsonProperty(value = TABLE_NAME_KEY, required = true) String tableName,
       @JsonProperty(value = TABLE_TYPE_KEY, required = true) String tableType,
@@ -160,7 +189,8 @@ public class TableConfig extends BaseJsonConfig {
       Map<InstancePartitionsType, String> instancePartitionsMap,
       @JsonProperty(SEGMENT_ASSIGNMENT_CONFIG_MAP_KEY) @Nullable
       Map<String, SegmentAssignmentConfig> segmentAssignmentConfigMap,
-      @JsonProperty(TABLE_SAMPLERS_KEY) @Nullable List<TableSamplerConfig> tableSamplers) {
+      @JsonProperty(TABLE_SAMPLERS_KEY) @Nullable List<TableSamplerConfig> tableSamplers,
+      @JsonProperty(IS_MATERIALIZED_VIEW_KEY) boolean materializedView) {
     Preconditions.checkArgument(tableName != null, "'tableName' must be configured");
     Preconditions.checkArgument(!tableName.contains(TABLE_NAME_FORBIDDEN_SUBSTRING),
         "'tableName' cannot contain double underscore ('__')");
@@ -188,6 +218,7 @@ public class TableConfig extends BaseJsonConfig {
     _ingestionConfig = ingestionConfig;
     _tierConfigsList = tierConfigsList;
     _dimTable = dimTable;
+    _materializedView = materializedView;
     _tunerConfigList = tunerConfigList;
     _instancePartitionsMap = instancePartitionsMap;
     _segmentAssignmentConfigMap = segmentAssignmentConfigMap;
@@ -213,6 +244,7 @@ public class TableConfig extends BaseJsonConfig {
     _ingestionConfig = tableConfig.getIngestionConfig();
     _tierConfigsList = tableConfig.getTierConfigsList();
     _dimTable = tableConfig.isDimTable();
+    _materializedView = tableConfig.isMaterializedView();
     _tunerConfigList = tableConfig.getTunerConfigsList();
     _instancePartitionsMap = tableConfig.getInstancePartitionsMap();
     _segmentAssignmentConfigMap = tableConfig.getSegmentAssignmentConfigMap();
@@ -259,6 +291,32 @@ public class TableConfig extends BaseJsonConfig {
   @JsonProperty(IS_DIM_TABLE_KEY)
   public boolean isDimTable() {
     return _dimTable;
+  }
+
+  @JsonProperty(IS_MATERIALIZED_VIEW_KEY)
+  public boolean isMaterializedView() {
+    return _materializedView;
+  }
+
+  /// Returns task configs for [CommonConstants.MaterializedViewTask#TASK_TYPE], or null if absent.
+  @JsonIgnore
+  @Nullable
+  public Map<String, String> getMaterializedViewTaskConfigs() {
+    if (_taskConfig == null) {
+      return null;
+    }
+    return _taskConfig.getConfigsForTaskType(CommonConstants.MaterializedViewTask.TASK_TYPE);
+  }
+
+  /// Whether the table has a non-empty `definedSQL` under [CommonConstants.MaterializedViewTask#TASK_TYPE].
+  @JsonIgnore
+  public boolean hasMaterializedViewTaskWithDefinedSql() {
+    Map<String, String> configs = getMaterializedViewTaskConfigs();
+    if (configs == null) {
+      return false;
+    }
+    String definedSql = configs.get(CommonConstants.MaterializedViewTask.DEFINED_SQL_KEY);
+    return definedSql != null && !definedSql.trim().isEmpty();
   }
 
   @JsonProperty(VALIDATION_CONFIG_KEY)

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -66,6 +66,7 @@ public class TableConfigBuilder {
   private final TableType _tableType;
   private String _tableName;
   private boolean _isDimTable;
+  private boolean _isMaterializedView;
 
   // Segments config related
   private String _numReplicas = DEFAULT_NUM_REPLICAS;
@@ -158,6 +159,11 @@ public class TableConfigBuilder {
 
   public TableConfigBuilder setIsDimTable(boolean isDimTable) {
     _isDimTable = isDimTable;
+    return this;
+  }
+
+  public TableConfigBuilder setIsMaterializedView(boolean isMaterializedView) {
+    _isMaterializedView = isMaterializedView;
     return this;
   }
 
@@ -568,7 +574,8 @@ public class TableConfigBuilder {
         new TableConfig(_tableName, _tableType.toString(), validationConfig, tenantConfig, indexingConfig,
             _customConfig, _quotaConfig, _taskConfig, _routingConfig, _queryConfig, _instanceAssignmentConfigMap,
             _fieldConfigList, _upsertConfig, _dedupConfig, _dimensionTableConfig, _ingestionConfig, _tierConfigList,
-            _isDimTable, _tunerConfigList, _instancePartitionsMap, _segmentAssignmentConfigMap, _tableSamplers);
+            _isDimTable, _tunerConfigList, _instancePartitionsMap, _segmentAssignmentConfigMap,
+            _tableSamplers, _isMaterializedView);
     tableConfig.setDescription(_description);
     tableConfig.setTags(_tags);
     return tableConfig;

--- a/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/compile/PropertyMapping.java
+++ b/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/compile/PropertyMapping.java
@@ -300,6 +300,9 @@ public final class PropertyMapping {
       case "isdimtable":
         builder.setIsDimTable(parseBool(lowerKey, value));
         return true;
+      case "ismaterializedview":
+        builder.setIsMaterializedView(parseBool(lowerKey, value));
+        return true;
       case "invertedindexcolumns":
         builder.setInvertedIndexColumns(splitCsv(value));
         return true;

--- a/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/reverse/PropertyExtractor.java
+++ b/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/reverse/PropertyExtractor.java
@@ -332,6 +332,9 @@ public final class PropertyExtractor {
     if (config.isDimTable()) {
       props.put("isDimTable", "true");
     }
+    if (config.isMaterializedView()) {
+      props.put("isMaterializedView", "true");
+    }
     putIfPresent(props, "description", config.getDescription());
     List<String> tags = config.getTags();
     if (tags != null && !tags.isEmpty()) {

--- a/pinot-tools/src/main/resources/examples/batch/airlineStatsMv/airlineStatsMv_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/airlineStatsMv/airlineStatsMv_offline_table_config.json
@@ -1,6 +1,7 @@
 {
   "tableName": "airlineStatsMv",
   "tableType": "OFFLINE",
+  "isMaterializedView": true,
   "segmentsConfig": {
     "timeColumnName": "tsMs",
     "timeType": "MILLISECONDS",


### PR DESCRIPTION
## Motivation

Today, "is this a materialized view (MV) table?" requires scattered heuristics:

- scanning `tableConfig.task` for a `MaterializedViewTask` entry,
- fetching the MV definition znode from ZK,
- or parsing `definedSQL` with `CalciteSqlParser`.

This has three concrete problems:

1. **No single source of truth.** Different call sites use different checks; they can disagree and tend to drift apart over time.
2. **Identity is observable only after the scheduler has run.** The MV definition znode is created lazily by the scheduler on the first task run, not synchronously at table create — so any caller that asks "is MV?" between create and the first scheduler tick gets the wrong answer.
3. **Task config doubles as identity.** `MaterializedViewTask` (and `definedSQL`) describe *execution*, not *identity*. Using them for identity means the create/update path cannot reject malformed combinations early, and there is no place to anchor backward-compatibility invariants like "`definedSQL` is immutable".

## What this PR does

Introduce `isMaterializedView` on `TableConfig` as the **single source of truth** for MV identity, modeled on `isDimTable`. Every code path that needs to know "is this an MV table?" now reads exactly one boolean.

## Example

A minimal MV offline table config now declares identity with `"isMaterializedView": true` at the top level, while `MaterializedViewTask` continues to carry execution parameters (`definedSQL`, `bucketTimePeriod`, …). The two must agree — the validator rejects either side appearing alone.

```json
{
  "tableName": "airlineStatsMv",
  "tableType": "OFFLINE",
  "isMaterializedView": true,
  "segmentsConfig": {
    "timeColumnName": "tsMs",
    "timeType": "MILLISECONDS",
    "segmentPushType": "APPEND",
    "replication": "1"
  },
  "tenants": {},
  "tableIndexConfig": { "loadMode": "MMAP" },
  "metadata": { "customConfigs": {} },
  "task": {
    "taskTypeConfigsMap": {
      "MaterializedViewTask": {
        "definedSQL": "SELECT DaysSinceEpoch * 86400000 AS tsMs, Carrier, SUM(ArrDelay) AS sum_ArrDelay, COUNT(*) AS flight_count FROM airlineStats GROUP BY DaysSinceEpoch * 86400000, Carrier",
        "bucketTimePeriod": "1d",
        "maxTasksPerBatch": "31"
      }
    }
  }
}
```

Programmatic equivalent via `TableConfigBuilder`:

```java
TableConfig mv = new TableConfigBuilder(TableType.OFFLINE)
    .setTableName("airlineStatsMv")
    .setIsMaterializedView(true)
    .setTimeColumnName("tsMs")
    .setTaskConfig(new TableTaskConfig(Map.of(
        CommonConstants.MaterializedViewTask.TASK_TYPE,
        Map.of(
            CommonConstants.MaterializedViewTask.DEFINED_SQL_KEY,
                "SELECT ... FROM airlineStats GROUP BY ...",
            CommonConstants.MaterializedViewTask.BUCKET_TIME_PERIOD_KEY, "1d"
        )
    )))
    .build();
```

What the validator now enforces (all checked at `POST /tables` and `PUT /tables/{name}`):

| Config shape | Result |
|--------------|--------|
| `isMaterializedView: true` + `MaterializedViewTask` with `definedSQL` + `OFFLINE` | ✅ accepted |
| `isMaterializedView: true` but no `MaterializedViewTask` / empty `definedSQL` | ❌ rejected |
| `isMaterializedView: true` on `REALTIME` table | ❌ rejected |
| `isMaterializedView: true` together with `isDimTable: true` | ❌ rejected |
| `MaterializedViewTask` with `definedSQL` but `isMaterializedView` missing / `false` | ❌ rejected (must set the flag explicitly) |
| Update that toggles `isMaterializedView` | ❌ rejected (drop + recreate) |
| Update that changes `definedSQL` on an existing MV | ❌ rejected (immutable after creation) |

Querying identity from code is now a single call:

```java
if (tableConfig.isMaterializedView()) {
  // MV-aware path
}
```

A working end-to-end example lives at
`pinot-tools/src/main/resources/examples/batch/airlineStatsMv/airlineStatsMv_offline_table_config.json`,
runnable via the existing `PinotMaterializedViewQuickstart`.


## Resulting layering

| Layer | Responsibility | Owns |
|-------|----------------|------|
| **`pinot-spi` — `TableConfig.isMaterializedView`** | MV identity (declarative). | `IS_MATERIALIZED_VIEW_KEY` field, getter, `TableConfigBuilder.setIsMaterializedView`, ZN serde, DDL property mapping. |
| **`pinot-segment-local` — `TableConfigUtils`** | Structural invariants. | `validateMaterializedViewInvariants` (flag ⇒ `OFFLINE` + `MaterializedViewTask` + non-empty `definedSQL`; task without flag rejected; task without `definedSQL` rejected; cannot also be `isDimTable`). `validateBackwardCompatibility` — flag is immutable; `definedSQL` is immutable after creation; `MaterializedViewTask` cannot be removed from an MV table. |
| **`pinot-materialized-view` — `MaterializedViewAnalyzer` / `Scheduler`** | Semantic validation + task generation. | `analyze()` requires the flag; `MaterializedViewTaskScheduler.generateTasks` skips non-MV tables. |
| **`pinot-controller` — `PinotHelixResourceManager`** | Wire MV into cluster lifecycle. | Both `notifyMaterializedViewConsistencyManagerForTableCreate` and `…ForTableDrop` gated on the flag; the drop path no longer falls back to task-config scan or `CalciteSqlParser` to infer identity. |
| **ZK `Definition` / `Runtime` znodes** | Runtime view of the MV instance. | Unchanged — still drive `watermarkMs`, partition VALID/STALE, etc. Identity and runtime are now cleanly separated. |

Each layer depends only on the one above, with no circular reads. `MaterializedViewTask` keeps its original role: carrier of execution parameters (`definedSQL`, `bucketTimePeriod`, …), not identity.

## Benefits

- **One bit answers identity** — no more scanning task configs, fetching znodes, or parsing SQL just to ask "is this an MV?". Identity is now correct from the moment the table config is written, not from the first scheduler tick.
- **Fail-fast on create/update** — malformed combinations (e.g. `MaterializedViewTask` without the flag, flag without `OFFLINE`, flag together with `isDimTable`) are rejected at the validation gate, instead of producing a half-configured MV that the scheduler / consistency manager later trips over.
- **Immutability has a place to live** — `definedSQL` immutability and "can't drop `MaterializedViewTask` from an MV table" are now enforced by `validateBackwardCompatibility`, aligned with `pinot-materialized-view/DESIGN.md`.
- **Clean module boundaries** — `pinot-spi` owns the flag, `pinot-segment-local` owns the structural rules, `pinot-materialized-view` owns the semantics, `pinot-controller` only consumes the flag. `pinot-segment-local` does **not** depend on `pinot-materialized-view`.
- **Easier to extend** — future MV-aware code (broker rewrite, REST listings, UI filters, etc.) can rely on a single declarative bit instead of replicating heuristics.

## Tests

- `MaterializedViewAnalyzerTest`: every MV `TableConfigBuilder` now calls `.setIsMaterializedView(true)`; new test asserts `analyze()` fails when the flag is missing. 50/50 pass.
- `TableConfigUtilsTest`: new tests cover the four `validateMaterializedViewInvariants` branches and the backward-compat rules (`definedSQL` immutable, flag cannot change). Existing positional `TableConfig(...)` call sites updated for the new parameter.