### PR TITLE
Null Handling in JSON Extract (Scalar and Index Based)

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunction.java
@@ -64,7 +64,7 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
 
   // Cache for the per-ValueBlock SV scan result. Both the SV transforms and getNullBitmap need
   // the same `String[]` for the same ValueBlock; without caching, we'd hit the JSON index twice
-  // per block on the null-handling path. Identity comparison is safe — the broker constructs a
+  // per block on the null-handling path. Identity comparison is safe — the server constructs a
   // fresh ValueBlock per batch and never mutates a previously returned one.
   private ValueBlock _cachedValueBlock;
   private String[] _cachedValuesSV;
@@ -134,22 +134,27 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
       if (!(fourthArgument instanceof LiteralTransformFunction)) {
         throw new IllegalArgumentException("Default value must be a literal");
       }
-
-      if (_isSingleValue) {
-        _defaultValue = dataType.convert(((LiteralTransformFunction) fourthArgument).getStringLiteral());
-      } else {
-        try {
-          JsonNode mvArray = JsonUtils.stringToJsonNode(((LiteralTransformFunction) fourthArgument).getStringLiteral());
-          if (!mvArray.isArray()) {
+      LiteralTransformFunction literalFn = (LiteralTransformFunction) fourthArgument;
+      // SQL NULL literal as the default ⇒ behave like the 3-arg form: leave `_defaultValue` null
+      // so unresolved rows surface as SQL NULL (NH on) or throw (NH off). This mirrors the scalar
+      // function's `_defaultIsNull` handling without needing a separate flag.
+      if (!literalFn.isNull()) {
+        if (_isSingleValue) {
+          _defaultValue = dataType.convert(literalFn.getStringLiteral());
+        } else {
+          try {
+            JsonNode mvArray = JsonUtils.stringToJsonNode(literalFn.getStringLiteral());
+            if (!mvArray.isArray()) {
+              throw new IllegalArgumentException("Default value must be a valid JSON array");
+            }
+            Object[] defaultValues = new Object[mvArray.size()];
+            for (int i = 0; i < mvArray.size(); i++) {
+              defaultValues[i] = dataType.convert(mvArray.get(i).asText());
+            }
+            _defaultValue = defaultValues;
+          } catch (IOException e) {
             throw new IllegalArgumentException("Default value must be a valid JSON array");
           }
-          Object[] defaultValues = new Object[mvArray.size()];
-          for (int i = 0; i < mvArray.size(); i++) {
-            defaultValues[i] = dataType.convert(mvArray.get(i).asText());
-          }
-          _defaultValue = defaultValues;
-        } catch (IOException e) {
-          throw new IllegalArgumentException("Default value must be a valid JSON array");
         }
       }
     }
@@ -324,10 +329,10 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
   @Override
   public RoaringBitmap getNullBitmap(ValueBlock valueBlock) {
     // Short-circuit to argument-bitmap propagation when this function isn't introducing nulls of
-    // its own: non-SV output, null handling disabled, or any default literal supplied (the SV
-    // transform writes it for unresolved rows). Unlike the scalar function, the parser converts a
-    // SQL-NULL literal to the typed zero ("" for STRING, throws at init for numerics), so there's
-    // no SQL-NULL-default path to fall through.
+    // its own: non-SV output, null handling disabled, or a non-null default literal supplied (the
+    // SV transform writes it for unresolved rows). The SQL NULL literal case is handled in `init`
+    // by leaving `_defaultValue` null so it falls through to the scan below — same as the 3-arg
+    // form.
     if (!_isSingleValue || !_nullHandlingEnabled || _defaultValue != null) {
       return super.getNullBitmap(valueBlock);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunction.java
@@ -24,6 +24,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.function.JsonPathCache;
 import org.apache.pinot.core.operator.ColumnContext;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
@@ -32,6 +33,7 @@ import org.apache.pinot.segment.spi.index.IndexService;
 import org.apache.pinot.segment.spi.index.IndexType;
 import org.apache.pinot.segment.spi.index.reader.JsonIndexReader;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.CommonConstants.NullValuePlaceHolder;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.roaringbitmap.RoaringBitmap;
 
@@ -53,6 +55,11 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
   private Map<String, RoaringBitmap> _valueToMatchingDocsMap;
   private boolean _isSingleValue;
   private String _filterJsonPath;
+  // True when null-handling is enabled AND no default literal was supplied for the SV path. In that
+  // mode, single-value transforms emit the type's null placeholder for unresolved JSON paths (instead
+  // of throwing) and surface the unresolved row through {@link #getNullBitmap}, matching the broker's
+  // null-handling contract for upstream operators such as {@code JsonIndexDistinctOperator}.
+  private boolean _emitNullOnUnresolved;
 
   @Override
   public String getName() {
@@ -60,8 +67,9 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
   }
 
   @Override
-  public void init(List<TransformFunction> arguments, Map<String, ColumnContext> columnContextMap) {
-    super.init(arguments, columnContextMap);
+  public void init(List<TransformFunction> arguments, Map<String, ColumnContext> columnContextMap,
+      boolean nullHandlingEnabled) {
+    super.init(arguments, columnContextMap, nullHandlingEnabled);
     // Check that there are exactly 3 or 4 or 5 arguments
     if (arguments.size() < 3 || arguments.size() > 5) {
       throw new IllegalArgumentException(
@@ -146,6 +154,7 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
       _filterJsonPath = ((LiteralTransformFunction) fifthArgument).getStringLiteral();
     }
 
+    _emitNullOnUnresolved = _isSingleValue && _nullHandlingEnabled && _defaultValue == null;
     _resultMetadata = new TransformResultMetadata(dataType, _isSingleValue, false);
   }
 
@@ -166,6 +175,10 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
       if (value == null) {
         if (_defaultValue != null) {
           _intValuesSV[i] = (int) _defaultValue;
+          continue;
+        }
+        if (_emitNullOnUnresolved) {
+          _intValuesSV[i] = NullValuePlaceHolder.INT;
           continue;
         }
         throw new RuntimeException(
@@ -190,6 +203,10 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
           _longValuesSV[i] = (long) _defaultValue;
           continue;
         }
+        if (_emitNullOnUnresolved) {
+          _longValuesSV[i] = NullValuePlaceHolder.LONG;
+          continue;
+        }
         throw new RuntimeException(
             String.format("Illegal Json Path: [%s], for docId [%s]", _jsonPathString, inputDocIds[i]));
       }
@@ -210,6 +227,10 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
       if (value == null) {
         if (_defaultValue != null) {
           _floatValuesSV[i] = (float) _defaultValue;
+          continue;
+        }
+        if (_emitNullOnUnresolved) {
+          _floatValuesSV[i] = NullValuePlaceHolder.FLOAT;
           continue;
         }
         throw new RuntimeException(
@@ -234,6 +255,10 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
           _doubleValuesSV[i] = (double) _defaultValue;
           continue;
         }
+        if (_emitNullOnUnresolved) {
+          _doubleValuesSV[i] = NullValuePlaceHolder.DOUBLE;
+          continue;
+        }
         throw new RuntimeException(
             String.format("Illegal Json Path: [%s], for docId [%s]", _jsonPathString, inputDocIds[i]));
       }
@@ -254,6 +279,10 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
       if (value == null) {
         if (_defaultValue != null) {
           _bigDecimalValuesSV[i] = (BigDecimal) _defaultValue;
+          continue;
+        }
+        if (_emitNullOnUnresolved) {
+          _bigDecimalValuesSV[i] = NullValuePlaceHolder.BIG_DECIMAL;
           continue;
         }
         throw new RuntimeException(
@@ -278,12 +307,33 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
           _stringValuesSV[i] = (String) _defaultValue;
           continue;
         }
+        if (_emitNullOnUnresolved) {
+          _stringValuesSV[i] = NullValuePlaceHolder.STRING;
+          continue;
+        }
         throw new RuntimeException(
             String.format("Illegal Json Path: [%s], for docId [%s]", _jsonPathString, inputDocIds[i]));
       }
       _stringValuesSV[i] = value;
     }
     return _stringValuesSV;
+  }
+
+  @Override
+  @Nullable
+  public RoaringBitmap getNullBitmap(ValueBlock valueBlock) {
+    if (!_emitNullOnUnresolved) {
+      return super.getNullBitmap(valueBlock);
+    }
+    String[] valuesFromIndex = _jsonIndexReader.getValuesSV(valueBlock.getDocIds(), valueBlock.getNumDocs(),
+        getValueToMatchingDocsMap(), false);
+    RoaringBitmap nullBitmap = new RoaringBitmap();
+    for (int i = 0; i < valuesFromIndex.length; i++) {
+      if (valuesFromIndex[i] == null) {
+        nullBitmap.add(i);
+      }
+    }
+    return nullBitmap.isEmpty() ? null : nullBitmap;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunction.java
@@ -43,6 +43,12 @@ import org.roaringbitmap.RoaringBitmap;
  * implementation changed to read values from the JSON index. For large JSON blobs this can be faster than parsing
  * GBs of JSON at query time. For small JSON blobs/highly filtered input this is generally slower than the *scalar
  * implementation. The inflection point is highly dependent on the number of docs remaining post filter.
+ *
+ * <p><b>Null handling:</b> when query-level null handling is enabled (e.g. {@code SET enableNullHandling = true})
+ * and no default literal is supplied, an unresolved JSON path on a row surfaces as SQL {@code NULL} via the
+ * {@link #getNullBitmap(ValueBlock)} bitmap rather than throwing. With null handling disabled, the legacy throw
+ * is preserved. A user-supplied non-null default literal takes precedence and is written for unresolved rows
+ * regardless of null-handling state.
  */
 public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
   public static final String FUNCTION_NAME = "jsonExtractIndex";
@@ -55,6 +61,13 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
   private Map<String, RoaringBitmap> _valueToMatchingDocsMap;
   private boolean _isSingleValue;
   private String _filterJsonPath;
+
+  // Cache for the per-ValueBlock SV scan result. Both the SV transforms and getNullBitmap need
+  // the same `String[]` for the same ValueBlock; without caching, we'd hit the JSON index twice
+  // per block on the null-handling path. Identity comparison is safe — the broker constructs a
+  // fresh ValueBlock per batch and never mutates a previously returned one.
+  private ValueBlock _cachedValueBlock;
+  private String[] _cachedValuesSV;
 
   @Override
   public String getName() {
@@ -162,8 +175,7 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
     int numDocs = valueBlock.getNumDocs();
     int[] inputDocIds = valueBlock.getDocIds();
     initIntValuesSV(numDocs);
-    String[] valuesFromIndex = _jsonIndexReader.getValuesSV(valueBlock.getDocIds(), valueBlock.getNumDocs(),
-        getValueToMatchingDocsMap(), false);
+    String[] valuesFromIndex = getCachedValuesFromIndex(valueBlock);
     for (int i = 0; i < numDocs; i++) {
       String value = valuesFromIndex[i];
       if (value == null) {
@@ -188,8 +200,7 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
     int numDocs = valueBlock.getNumDocs();
     int[] inputDocIds = valueBlock.getDocIds();
     initLongValuesSV(numDocs);
-    String[] valuesFromIndex = _jsonIndexReader.getValuesSV(valueBlock.getDocIds(), valueBlock.getNumDocs(),
-        getValueToMatchingDocsMap(), false);
+    String[] valuesFromIndex = getCachedValuesFromIndex(valueBlock);
     for (int i = 0; i < numDocs; i++) {
       String value = valuesFromIndex[i];
       if (value == null) {
@@ -214,8 +225,7 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
     int numDocs = valueBlock.getNumDocs();
     int[] inputDocIds = valueBlock.getDocIds();
     initFloatValuesSV(numDocs);
-    String[] valuesFromIndex = _jsonIndexReader.getValuesSV(valueBlock.getDocIds(), valueBlock.getNumDocs(),
-        getValueToMatchingDocsMap(), false);
+    String[] valuesFromIndex = getCachedValuesFromIndex(valueBlock);
     for (int i = 0; i < numDocs; i++) {
       String value = valuesFromIndex[i];
       if (value == null) {
@@ -240,8 +250,7 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
     int numDocs = valueBlock.getNumDocs();
     int[] inputDocIds = valueBlock.getDocIds();
     initDoubleValuesSV(numDocs);
-    String[] valuesFromIndex = _jsonIndexReader.getValuesSV(valueBlock.getDocIds(), valueBlock.getNumDocs(),
-        getValueToMatchingDocsMap(), false);
+    String[] valuesFromIndex = getCachedValuesFromIndex(valueBlock);
     for (int i = 0; i < numDocs; i++) {
       String value = valuesFromIndex[i];
       if (value == null) {
@@ -266,8 +275,7 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
     int numDocs = valueBlock.getNumDocs();
     int[] inputDocIds = valueBlock.getDocIds();
     initBigDecimalValuesSV(numDocs);
-    String[] valuesFromIndex = _jsonIndexReader.getValuesSV(valueBlock.getDocIds(), valueBlock.getNumDocs(),
-        getValueToMatchingDocsMap(), false);
+    String[] valuesFromIndex = getCachedValuesFromIndex(valueBlock);
     for (int i = 0; i < numDocs; i++) {
       String value = valuesFromIndex[i];
       if (value == null) {
@@ -292,8 +300,7 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
     int numDocs = valueBlock.getNumDocs();
     int[] inputDocIds = valueBlock.getDocIds();
     initStringValuesSV(numDocs);
-    String[] valuesFromIndex = _jsonIndexReader.getValuesSV(valueBlock.getDocIds(), valueBlock.getNumDocs(),
-        getValueToMatchingDocsMap(), false);
+    String[] valuesFromIndex = getCachedValuesFromIndex(valueBlock);
     for (int i = 0; i < numDocs; i++) {
       String value = valuesFromIndex[i];
       if (value == null) {
@@ -313,8 +320,8 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
     return _stringValuesSV;
   }
 
-  @Override
   @Nullable
+  @Override
   public RoaringBitmap getNullBitmap(ValueBlock valueBlock) {
     // Short-circuit to argument-bitmap propagation when this function isn't introducing nulls of
     // its own: non-SV output, null handling disabled, or any default literal supplied (the SV
@@ -324,10 +331,10 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
     if (!_isSingleValue || !_nullHandlingEnabled || _defaultValue != null) {
       return super.getNullBitmap(valueBlock);
     }
-    String[] valuesFromIndex = _jsonIndexReader.getValuesSV(valueBlock.getDocIds(), valueBlock.getNumDocs(),
-        getValueToMatchingDocsMap(), false);
+    String[] valuesFromIndex = getCachedValuesFromIndex(valueBlock);
+    int numDocs = valueBlock.getNumDocs();
     RoaringBitmap nullBitmap = new RoaringBitmap();
-    for (int i = 0; i < valuesFromIndex.length; i++) {
+    for (int i = 0; i < numDocs; i++) {
       if (valuesFromIndex[i] == null) {
         nullBitmap.add(i);
       }
@@ -481,5 +488,18 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
       }
     }
     return _valueToMatchingDocsMap;
+  }
+
+  /**
+   * Returns the JSON-index SV scan result for the given block, caching it so that the SV
+   * transform and {@link #getNullBitmap} don't each pay the cost on the null-handling path.
+   */
+  private String[] getCachedValuesFromIndex(ValueBlock valueBlock) {
+    if (valueBlock != _cachedValueBlock) {
+      _cachedValuesSV = _jsonIndexReader.getValuesSV(valueBlock.getDocIds(), valueBlock.getNumDocs(),
+          getValueToMatchingDocsMap(), false);
+      _cachedValueBlock = valueBlock;
+    }
+    return _cachedValuesSV;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunction.java
@@ -55,11 +55,6 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
   private Map<String, RoaringBitmap> _valueToMatchingDocsMap;
   private boolean _isSingleValue;
   private String _filterJsonPath;
-  // True when null-handling is enabled AND no default literal was supplied for the SV path. In that
-  // mode, single-value transforms emit the type's null placeholder for unresolved JSON paths (instead
-  // of throwing) and surface the unresolved row through {@link #getNullBitmap}, matching the broker's
-  // null-handling contract for upstream operators such as {@code JsonIndexDistinctOperator}.
-  private boolean _emitNullOnUnresolved;
 
   @Override
   public String getName() {
@@ -154,7 +149,6 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
       _filterJsonPath = ((LiteralTransformFunction) fifthArgument).getStringLiteral();
     }
 
-    _emitNullOnUnresolved = _isSingleValue && _nullHandlingEnabled && _defaultValue == null;
     _resultMetadata = new TransformResultMetadata(dataType, _isSingleValue, false);
   }
 
@@ -177,7 +171,7 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
           _intValuesSV[i] = (int) _defaultValue;
           continue;
         }
-        if (_emitNullOnUnresolved) {
+        if (_nullHandlingEnabled) {
           _intValuesSV[i] = NullValuePlaceHolder.INT;
           continue;
         }
@@ -203,7 +197,7 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
           _longValuesSV[i] = (long) _defaultValue;
           continue;
         }
-        if (_emitNullOnUnresolved) {
+        if (_nullHandlingEnabled) {
           _longValuesSV[i] = NullValuePlaceHolder.LONG;
           continue;
         }
@@ -229,7 +223,7 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
           _floatValuesSV[i] = (float) _defaultValue;
           continue;
         }
-        if (_emitNullOnUnresolved) {
+        if (_nullHandlingEnabled) {
           _floatValuesSV[i] = NullValuePlaceHolder.FLOAT;
           continue;
         }
@@ -255,7 +249,7 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
           _doubleValuesSV[i] = (double) _defaultValue;
           continue;
         }
-        if (_emitNullOnUnresolved) {
+        if (_nullHandlingEnabled) {
           _doubleValuesSV[i] = NullValuePlaceHolder.DOUBLE;
           continue;
         }
@@ -281,7 +275,7 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
           _bigDecimalValuesSV[i] = (BigDecimal) _defaultValue;
           continue;
         }
-        if (_emitNullOnUnresolved) {
+        if (_nullHandlingEnabled) {
           _bigDecimalValuesSV[i] = NullValuePlaceHolder.BIG_DECIMAL;
           continue;
         }
@@ -307,7 +301,7 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
           _stringValuesSV[i] = (String) _defaultValue;
           continue;
         }
-        if (_emitNullOnUnresolved) {
+        if (_nullHandlingEnabled) {
           _stringValuesSV[i] = NullValuePlaceHolder.STRING;
           continue;
         }
@@ -322,7 +316,12 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
   @Override
   @Nullable
   public RoaringBitmap getNullBitmap(ValueBlock valueBlock) {
-    if (!_emitNullOnUnresolved) {
+    // Short-circuit to argument-bitmap propagation when this function isn't introducing nulls of
+    // its own: non-SV output, null handling disabled, or any default literal supplied (the SV
+    // transform writes it for unresolved rows). Unlike the scalar function, the parser converts a
+    // SQL-NULL literal to the typed zero ("" for STRING, throws at init for numerics), so there's
+    // no SQL-NULL-default path to fall through.
+    if (!_isSingleValue || !_nullHandlingEnabled || _defaultValue != null) {
       return super.getNullBitmap(valueBlock);
     }
     String[] valuesFromIndex = _jsonIndexReader.getValuesSV(valueBlock.getDocIds(), valueBlock.getNumDocs(),

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunction.java
@@ -98,11 +98,6 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
   private DataType _storedType;
   private Object _defaultValue;
   private boolean _defaultIsNull;
-  // True when null-handling is enabled AND no default literal was supplied. In that mode, single-value
-  // transforms emit the type's zero/empty sentinel for unresolved JSON paths (instead of throwing) and
-  // surface the unresolved row through {@link #getNullBitmap}, matching the broker's null-handling
-  // contract for upstream operators (e.g. JsonIndexDistinctOperator).
-  private boolean _emitNullOnUnresolved;
   private TransformResultMetadata _resultMetadata;
 
   @Override
@@ -183,7 +178,6 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
           );
       }
     }
-    _emitNullOnUnresolved = _nullHandlingEnabled && _defaultValue == null;
     _resultMetadata = new TransformResultMetadata(_dataType, isSingleValue, false);
   }
 
@@ -195,7 +189,14 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
   @Override
   @Nullable
   public RoaringBitmap getNullBitmap(ValueBlock valueBlock) {
-    if (!_defaultIsNull && !_emitNullOnUnresolved) {
+    // Short-circuit to argument-bitmap propagation when this function isn't introducing nulls of
+    // its own. Two cases qualify:
+    //  - null handling is disabled (the SV transform either fills a default or throws), or
+    //  - a real (non-SQL-NULL) default was supplied (the SV transform writes the default for
+    //    unresolved rows).
+    // The 4-arg SQL-NULL case has _defaultIsNull=true and falls through to the per-row scan
+    // below, so unresolved rows surface as SQL NULL via the bitmap.
+    if (!_nullHandlingEnabled || (_defaultValue != null && !_defaultIsNull)) {
       return super.getNullBitmap(valueBlock);
     }
     RoaringBitmap bitmap = new RoaringBitmap();
@@ -248,7 +249,7 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
           _intValuesSV[i] = defaultValue;
           continue;
         }
-        if (_emitNullOnUnresolved) {
+        if (_nullHandlingEnabled) {
           // Write the null placeholder so stale data from a reused buffer can't surface.
           // getNullBitmap marks the row null; consumers should read the bitmap, not this value.
           _intValuesSV[i] = NullValuePlaceHolder.INT;
@@ -283,7 +284,7 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
           _longValuesSV[i] = defaultValue;
           continue;
         }
-        if (_emitNullOnUnresolved) {
+        if (_nullHandlingEnabled) {
           _longValuesSV[i] = NullValuePlaceHolder.LONG;
           continue;
         }
@@ -315,7 +316,7 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
           _floatValuesSV[i] = defaultValue;
           continue;
         }
-        if (_emitNullOnUnresolved) {
+        if (_nullHandlingEnabled) {
           _floatValuesSV[i] = NullValuePlaceHolder.FLOAT;
           continue;
         }
@@ -347,7 +348,7 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
           _doubleValuesSV[i] = defaultValue;
           continue;
         }
-        if (_emitNullOnUnresolved) {
+        if (_nullHandlingEnabled) {
           _doubleValuesSV[i] = NullValuePlaceHolder.DOUBLE;
           continue;
         }
@@ -379,7 +380,7 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
           _bigDecimalValuesSV[i] = defaultValue;
           continue;
         }
-        if (_emitNullOnUnresolved) {
+        if (_nullHandlingEnabled) {
           _bigDecimalValuesSV[i] = NullValuePlaceHolder.BIG_DECIMAL;
           continue;
         }
@@ -411,7 +412,7 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
           _stringValuesSV[i] = defaultValue;
           continue;
         }
-        if (_emitNullOnUnresolved) {
+        if (_nullHandlingEnabled) {
           _stringValuesSV[i] = NullValuePlaceHolder.STRING;
           continue;
         }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunction.java
@@ -40,6 +40,7 @@ import org.apache.pinot.core.util.NumberUtils;
 import org.apache.pinot.core.util.NumericException;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.BooleanUtils;
+import org.apache.pinot.spi.utils.CommonConstants.NullValuePlaceHolder;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.TimestampUtils;
 import org.roaringbitmap.RoaringBitmap;
@@ -54,9 +55,11 @@ import org.roaringbitmap.RoaringBitmap;
 /// - `jsonField` — single-value `STRING` or `BYTES` column / transform expression containing JSON.
 /// - `jsonPath` — JsonPath expression used to read the value.
 /// - `resultsType` — Pinot data type for the output. Append `_ARRAY` for multi-value results.
-/// - `defaultValue` (optional) — used when the path resolves to `null` or fails. Without it, unresolved
-///   SV rows throw `IllegalArgumentException`; MV rows surface as empty arrays, but null elements within
-///   a resolved array still throw.
+/// - `defaultValue` (optional) — used when the path resolves to `null` or fails. Without it, the
+///   behavior depends on query-level null handling: when enabled, unresolved SV rows surface as SQL
+///   `NULL` (typed zero/empty sentinel + a bit in [#getNullBitmap]); when disabled, unresolved SV
+///   rows throw `IllegalArgumentException`. MV rows always surface as empty arrays when the path
+///   doesn't resolve; null elements within a resolved array still throw if no default is set.
 ///
 /// **Supported `resultsType`:** `INT`, `LONG`, `FLOAT`, `DOUBLE`, `BIG_DECIMAL`, `BOOLEAN`, `TIMESTAMP`,
 /// `STRING`, `JSON`, `BYTES`, plus `_ARRAY` variants of `INT` / `LONG` / `FLOAT` / `DOUBLE` /
@@ -95,6 +98,11 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
   private DataType _storedType;
   private Object _defaultValue;
   private boolean _defaultIsNull;
+  // True when null-handling is enabled AND no default literal was supplied. In that mode, single-value
+  // transforms emit the type's zero/empty sentinel for unresolved JSON paths (instead of throwing) and
+  // surface the unresolved row through {@link #getNullBitmap}, matching the broker's null-handling
+  // contract for upstream operators (e.g. JsonIndexDistinctOperator).
+  private boolean _emitNullOnUnresolved;
   private TransformResultMetadata _resultMetadata;
 
   @Override
@@ -175,6 +183,7 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
           );
       }
     }
+    _emitNullOnUnresolved = _nullHandlingEnabled && _defaultValue == null;
     _resultMetadata = new TransformResultMetadata(_dataType, isSingleValue, false);
   }
 
@@ -186,7 +195,7 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
   @Override
   @Nullable
   public RoaringBitmap getNullBitmap(ValueBlock valueBlock) {
-    if (!_defaultIsNull) {
+    if (!_defaultIsNull && !_emitNullOnUnresolved) {
       return super.getNullBitmap(valueBlock);
     }
     RoaringBitmap bitmap = new RoaringBitmap();
@@ -239,6 +248,12 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
           _intValuesSV[i] = defaultValue;
           continue;
         }
+        if (_emitNullOnUnresolved) {
+          // Write the null placeholder so stale data from a reused buffer can't surface.
+          // getNullBitmap marks the row null; consumers should read the bitmap, not this value.
+          _intValuesSV[i] = NullValuePlaceHolder.INT;
+          continue;
+        }
         throw new IllegalArgumentException(
             "Cannot resolve JSON path on some records. Consider setting a default value.");
       }
@@ -266,6 +281,10 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
       if (result == null) {
         if (_defaultValue != null) {
           _longValuesSV[i] = defaultValue;
+          continue;
+        }
+        if (_emitNullOnUnresolved) {
+          _longValuesSV[i] = NullValuePlaceHolder.LONG;
           continue;
         }
         throw new IllegalArgumentException(
@@ -296,6 +315,10 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
           _floatValuesSV[i] = defaultValue;
           continue;
         }
+        if (_emitNullOnUnresolved) {
+          _floatValuesSV[i] = NullValuePlaceHolder.FLOAT;
+          continue;
+        }
         throw new IllegalArgumentException(
             "Cannot resolve JSON path on some records. Consider setting a default value.");
       }
@@ -322,6 +345,10 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
       if (result == null) {
         if (_defaultValue != null) {
           _doubleValuesSV[i] = defaultValue;
+          continue;
+        }
+        if (_emitNullOnUnresolved) {
+          _doubleValuesSV[i] = NullValuePlaceHolder.DOUBLE;
           continue;
         }
         throw new IllegalArgumentException(
@@ -352,6 +379,10 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
           _bigDecimalValuesSV[i] = defaultValue;
           continue;
         }
+        if (_emitNullOnUnresolved) {
+          _bigDecimalValuesSV[i] = NullValuePlaceHolder.BIG_DECIMAL;
+          continue;
+        }
         throw new IllegalArgumentException(
             "Cannot resolve JSON path on some records. Consider setting a default value.");
       }
@@ -378,6 +409,10 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
       if (result == null) {
         if (_defaultValue != null) {
           _stringValuesSV[i] = defaultValue;
+          continue;
+        }
+        if (_emitNullOnUnresolved) {
+          _stringValuesSV[i] = NullValuePlaceHolder.STRING;
           continue;
         }
         throw new IllegalArgumentException(

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunctionTest.java
@@ -33,6 +33,8 @@ import org.apache.pinot.common.function.JsonPathCache;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.assertj.core.api.Assertions;
+import org.roaringbitmap.RoaringBitmap;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -422,5 +424,119 @@ public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunction
 
   private <T> T getValueForKey(String blob, JsonPath path, TypeRef<T> typeRef) {
     return JSON_PARSER_CONTEXT.parse(blob).read(path, typeRef);
+  }
+
+  // === Null-handling contract for unresolved JSON paths ===
+  //
+  // The base fixture's JSON_STRING_SV_COLUMN has no '$.noField' key in any row, so the JSON-index
+  // lookup returns null for every doc. With query-level null handling ENABLED, the SV transforms
+  // must surface those rows as SQL NULL (type-default + a bit in getNullBitmap()), matching
+  // JsonIndexDistinctOperator's null-group semantics. With null handling DISABLED and no default
+  // literal, the legacy RuntimeException must be preserved.
+
+  @DataProvider(name = "unresolvedPathSvTypes")
+  public Object[][] unresolvedPathSvTypes() {
+    return new Object[][]{
+        {"INT", DataType.INT},
+        {"LONG", DataType.LONG},
+        {"FLOAT", DataType.FLOAT},
+        {"DOUBLE", DataType.DOUBLE},
+        {"BIG_DECIMAL", DataType.BIG_DECIMAL},
+        {"STRING", DataType.STRING}
+    };
+  }
+
+  @Test(dataProvider = "unresolvedPathSvTypes")
+  public void testNullHandlingEnabledEmitsNullForUnresolvedPath(String resultsType, DataType resultsDataType) {
+    String expressionStr = String.format("jsonExtractIndex(%s,'$.noField','%s')", JSON_STRING_SV_COLUMN, resultsType);
+    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    TransformFunction transformFunction =
+        TransformFunctionFactory.getNullHandlingEnabled(expression, _dataSourceMap);
+
+    Assert.assertTrue(transformFunction instanceof JsonExtractIndexTransformFunction);
+    Assert.assertEquals(transformFunction.getResultMetadata().getDataType(), resultsDataType);
+
+    switch (resultsDataType) {
+      case INT:
+        int[] intValues = transformFunction.transformToIntValuesSV(_projectionBlock);
+        for (int i = 0; i < NUM_ROWS; i++) {
+          Assert.assertEquals(intValues[i], 0);
+        }
+        break;
+      case LONG:
+        long[] longValues = transformFunction.transformToLongValuesSV(_projectionBlock);
+        for (int i = 0; i < NUM_ROWS; i++) {
+          Assert.assertEquals(longValues[i], 0L);
+        }
+        break;
+      case FLOAT:
+        float[] floatValues = transformFunction.transformToFloatValuesSV(_projectionBlock);
+        for (int i = 0; i < NUM_ROWS; i++) {
+          Assert.assertEquals(floatValues[i], 0f);
+        }
+        break;
+      case DOUBLE:
+        double[] doubleValues = transformFunction.transformToDoubleValuesSV(_projectionBlock);
+        for (int i = 0; i < NUM_ROWS; i++) {
+          Assert.assertEquals(doubleValues[i], 0d);
+        }
+        break;
+      case BIG_DECIMAL:
+        BigDecimal[] bigDecimalValues = transformFunction.transformToBigDecimalValuesSV(_projectionBlock);
+        for (int i = 0; i < NUM_ROWS; i++) {
+          Assert.assertEquals(bigDecimalValues[i].compareTo(BigDecimal.ZERO), 0);
+        }
+        break;
+      case STRING:
+        String[] stringValues = transformFunction.transformToStringValuesSV(_projectionBlock);
+        for (int i = 0; i < NUM_ROWS; i++) {
+          Assert.assertEquals(stringValues[i], "");
+        }
+        break;
+      default:
+        throw new UnsupportedOperationException("Unsupported test type: " + resultsDataType);
+    }
+
+    RoaringBitmap nullBitmap = transformFunction.getNullBitmap(_projectionBlock);
+    Assert.assertNotNull(nullBitmap, "Null bitmap must be populated when all rows are unresolved");
+    Assert.assertEquals(nullBitmap.getCardinality(), NUM_ROWS,
+        "Every row should be marked null when the JSON path doesn't resolve");
+  }
+
+  @Test(dataProvider = "unresolvedPathSvTypes")
+  public void testNullHandlingDisabledStillThrowsForUnresolvedPath(String resultsType, DataType resultsDataType) {
+    String expressionStr = String.format("jsonExtractIndex(%s,'$.noField','%s')", JSON_STRING_SV_COLUMN, resultsType);
+    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+
+    Assert.assertTrue(transformFunction instanceof JsonExtractIndexTransformFunction);
+
+    try {
+      switch (resultsDataType) {
+        case INT:
+          transformFunction.transformToIntValuesSV(_projectionBlock);
+          break;
+        case LONG:
+          transformFunction.transformToLongValuesSV(_projectionBlock);
+          break;
+        case FLOAT:
+          transformFunction.transformToFloatValuesSV(_projectionBlock);
+          break;
+        case DOUBLE:
+          transformFunction.transformToDoubleValuesSV(_projectionBlock);
+          break;
+        case BIG_DECIMAL:
+          transformFunction.transformToBigDecimalValuesSV(_projectionBlock);
+          break;
+        case STRING:
+          transformFunction.transformToStringValuesSV(_projectionBlock);
+          break;
+        default:
+          throw new UnsupportedOperationException("Unsupported test type: " + resultsDataType);
+      }
+      Assert.fail("Expected RuntimeException when null handling is disabled");
+    } catch (RuntimeException e) {
+      Assertions.assertThat(e.getMessage()).contains("Illegal Json Path");
+    }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunctionTest.java
@@ -456,11 +456,18 @@ public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunction
   //   `nestedJson` — multi-level shapes (nested object, array, array of objects) with mixed
   //                  resolved / null / missing data at depth.
   //
-  // Tests are grouped by query shape in this order: projection → DISTINCT → GROUP BY. Each group
-  // has a null-handling-on case (verifies SQL NULL surfaces) and a null-handling-off case
-  // (verifies the legacy throw is preserved). Result rows are ordered by the projected expression
-  // ASC NULLS LAST so the comparison is deterministic across the framework's segment-duplication
-  // behavior (one segment becomes two, so per-row counts in GROUP BY results are ×2).
+  // Tests are grouped by query shape in this order: projection → DISTINCT → GROUP BY. Each section
+  // covers three sub-cases, in order:
+  //
+  //   .1  NH on, 3-arg                          — unresolved rows surface as SQL NULL (E4 fix)
+  //   .2  NH on, 4-arg with a non-null default   — default wins over NH placeholder
+  //   .3  NH off                                  — legacy throw preserved
+  //
+  // Unlike the scalar function, the index function has no `_defaultIsNull` path: a `NULL` literal
+  // as the 4-arg default fails at init (numeric) or silently becomes empty string (STRING) — both
+  // pre-existing quirks outside the scope of this PR. Result rows in every assertion are ordered
+  // by the projected expression ASC NULLS LAST so the comparison is deterministic across the
+  // framework's segment-duplication behavior (one segment becomes two, so per-row counts ×2).
   // ============================================================================================
 
   protected File _baseDir;
@@ -562,18 +569,15 @@ public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunction
   // ============================================================================================
 
   /**
-   * Projection with null handling ON. Each row's resolution depends on the column + path; the SV
-   * transform must surface SQL NULL for unresolved rows and pass resolved values through.
+   * 1.1 — NH on, 3-arg. The SV transform must surface SQL NULL for unresolved rows and pass
+   * resolved values through.
    * <pre>
    *   Example — `flatJson.country` (STRING):
    *     per-row: row 0 -> "US", row 1 -> "CA", row 2 -> NULL (explicit), row 3 -> NULL (missing)
-   *
    *     Query:  SET enableNullHandling = true;
    *             SELECT jsonExtractIndex(flatJson, '$.country', 'STRING') AS c
    *             FROM clicks ORDER BY c ASC NULLS LAST
-   *
-   *     Result rows (×2 for segment duplication):
-   *             "CA", "CA", "US", "US", NULL, NULL, NULL, NULL
+   *     Result (×2 dup): "CA", "CA", "US", "US", NULL, NULL, NULL, NULL
    * </pre>
    */
   @Test(dataProvider = "projectionCases")
@@ -586,10 +590,24 @@ public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunction
   }
 
   /**
-   * Null handling OFF: any unresolved row throws (legacy behavior, preserved by the fix's
-   * `_nullHandlingEnabled` gate). One representative path is enough — the throw is independent of
-   * path shape and result type. The error message for `jsonExtractIndex` differs from the scalar
-   * function's: `"Illegal Json Path: [...], for docId [...]"`.
+   * 1.2 — NH on, 4-arg with non-null default. The SV transform's priority is: real default >
+   * null-handling placeholder > throw. The user-supplied default surfaces for unresolved rows;
+   * no null bit is set in the bitmap.
+   */
+  @Test(dataProvider = "defaultPrecedenceProjectionCases")
+  public void testProjectionDefaultBeatsNullHandlingPlaceholder(String column, String jsonPath,
+      String defaultLiteral, Object[][] expectedRows, String label) {
+    String expr = String.format(
+        "jsonExtractIndex(%s, '%s', 'STRING', %s)", column, jsonPath, defaultLiteral);
+    givenCountryClickTable(true)
+        .whenQuery(String.format("SELECT %s AS c FROM clicks ORDER BY c ASC", expr))
+        .thenResultIs(expectedRows);
+  }
+
+  /**
+   * 1.3 — NH off: any unresolved row throws. One representative path; throw is path-independent.
+   * The index function's error message differs from the scalar's ("Illegal Json Path" vs "Cannot
+   * resolve JSON path").
    */
   @Test
   public void testProjectionNullHandlingOffThrows() {
@@ -603,11 +621,7 @@ public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunction
     }
   }
 
-  /**
-   * Each row is `(column, jsonPath, resultsType, expected 8-row result, label)`. Result rows are
-   * ordered by value ASC NULLS LAST. With segment duplication, the per-row count in the fixture
-   * is ×2 in the result.
-   */
+  /** 1.1 cases — `(column, jsonPath, resultsType, expected 8-row result, label)`, ordered ASC NULLS LAST. */
   @DataProvider(name = "projectionCases")
   public static Object[][] projectionCases() {
     return new Object[][]{
@@ -629,51 +643,52 @@ public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunction
         {"flatJson", "$.clicks", "DOUBLE", new Object[][]{
             {3d}, {3d}, {5d}, {5d}, {null}, {null}, {null}, {null}
         }, "flatJson.clicks DOUBLE"},
-        // BIG_DECIMAL is formatted as String by the broker (BigDecimal.toPlainString).
+        // BIG_DECIMAL is formatted as String by the broker.
         {"flatJson", "$.clicks", "BIG_DECIMAL", new Object[][]{
             {"3"}, {"3"}, {"5"}, {"5"}, {null}, {null}, {null}, {null}
         }, "flatJson.clicks BIG_DECIMAL"},
 
         // ----- nestedJson: multi-level shapes -----
-        // $.location.country: row0="US", row1=missing (no country key), row2=parent null, row3=missing.
         {"nestedJson", "$.location.country", "STRING", new Object[][]{
             {"US"}, {"US"}, {null}, {null}, {null}, {null}, {null}, {null}
         }, "nestedJson.location.country STRING"},
-        // $.tags[0]: row0="red", row1="green", row2=null parent, row3=missing.
         {"nestedJson", "$.tags[0]", "STRING", new Object[][]{
             {"green"}, {"green"}, {"red"}, {"red"}, {null}, {null}, {null}, {null}
         }, "nestedJson.tags[0] STRING"},
-        // $.tags[1]: row0="blue", row1=out-of-bounds (only one element), row2=null parent, row3=missing.
         {"nestedJson", "$.tags[1]", "STRING", new Object[][]{
             {"blue"}, {"blue"}, {null}, {null}, {null}, {null}, {null}, {null}
         }, "nestedJson.tags[1] STRING (OOB on row 1)"},
-        // $.events[0].country: row0="US", row1=explicit inner null, row2=null array, row3=missing.
         {"nestedJson", "$.events[0].country", "STRING", new Object[][]{
             {"US"}, {"US"}, {null}, {null}, {null}, {null}, {null}, {null}
         }, "nestedJson.events[0].country STRING"}
     };
   }
 
+  /** 1.2 cases — `(column, jsonPath, default SQL literal, expected 8-row result ASC, label)`. */
+  @DataProvider(name = "defaultPrecedenceProjectionCases")
+  public static Object[][] defaultPrecedenceProjectionCases() {
+    return new Object[][]{
+        {"flatJson", "$.country", "'foobar'", new Object[][]{
+            {"CA"}, {"CA"}, {"US"}, {"US"},
+            {"foobar"}, {"foobar"}, {"foobar"}, {"foobar"}
+        }, "flatJson.country default 'foobar'"},
+        {"nestedJson", "$.location.country", "'foobar'", new Object[][]{
+            {"US"}, {"US"},
+            {"foobar"}, {"foobar"}, {"foobar"}, {"foobar"}, {"foobar"}, {"foobar"}
+        }, "nestedJson.location.country default 'foobar'"}
+    };
+  }
+
   // ============================================================================================
   // 2. DISTINCT
+  //
+  // Pinot rejects positional `ORDER BY 1` for DISTINCT, so each DISTINCT test repeats the
+  // projected expression in ORDER BY.
   // ============================================================================================
 
   /**
-   * DISTINCT with null handling ON. The distinct set must include exactly one null entry
-   * alongside the resolved values (deduped across segments).
-   * <pre>
-   *   Example — `flatJson.country` (STRING):
-   *     Query:  SET enableNullHandling = true;
-   *             SELECT DISTINCT jsonExtractIndex(flatJson, '$.country', 'STRING') FROM clicks
-   *             ORDER BY jsonExtractIndex(flatJson, '$.country', 'STRING') ASC NULLS LAST
-   *
-   *     Result: "CA", "US", NULL
-   * </pre>
-   * For STRING DISTINCT against a JSON-indexed column, the broker actually routes the query
-   * through {@code JsonIndexDistinctOperator} (not the transform-fn path) — so this case
-   * indirectly exercises that operator. The other types fall back to the transform-fn path
-   * because the operator's parser converts the default literal in a way that fails for
-   * non-string types; that fallback is what this fix corrects.
+   * 2.1 — NH on, 3-arg. The distinct set must include exactly one null entry alongside the
+   * resolved values (deduped across segments).
    */
   @Test(dataProvider = "distinctCases")
   public void testDistinctNullHandlingOn(String column, String jsonPath, String resultsType,
@@ -683,6 +698,18 @@ public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunction
     givenCountryClickTable(true).whenQuery(query).thenResultIs(expectedRows);
   }
 
+  /** 2.2 — NH on, 4-arg with non-null default. Default appears as a regular distinct entry (no null). */
+  @Test(dataProvider = "defaultPrecedenceDistinctCases")
+  public void testDistinctDefaultBeatsNullHandlingPlaceholder(String column, String jsonPath,
+      String defaultLiteral, Object[][] expectedRows, String label) {
+    String expr = String.format(
+        "jsonExtractIndex(%s, '%s', 'STRING', %s)", column, jsonPath, defaultLiteral);
+    givenCountryClickTable(true)
+        .whenQuery(String.format("SELECT DISTINCT %s FROM clicks ORDER BY %s ASC", expr, expr))
+        .thenResultIs(expectedRows);
+  }
+
+  /** 2.3 — NH off: DISTINCT throws on unresolved rows. */
   @Test
   public void testDistinctNullHandlingOffThrows() {
     try {
@@ -695,7 +722,7 @@ public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunction
     }
   }
 
-  /** Each row is `(column, jsonPath, resultsType, expected distinct rows ASC NULLS LAST, label)`. */
+  /** 2.1 cases — `(column, jsonPath, resultsType, expected distinct rows ASC NULLS LAST, label)`. */
   @DataProvider(name = "distinctCases")
   public static Object[][] distinctCases() {
     return new Object[][]{
@@ -710,33 +737,51 @@ public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunction
     };
   }
 
+  /** 2.2 cases — `(column, jsonPath, default literal, expected distinct rows ASC, label)`. */
+  @DataProvider(name = "defaultPrecedenceDistinctCases")
+  public static Object[][] defaultPrecedenceDistinctCases() {
+    return new Object[][]{
+        {"flatJson", "$.country", "'foobar'",
+            new Object[][]{{"CA"}, {"US"}, {"foobar"}}, "flatJson.country default 'foobar'"},
+        {"nestedJson", "$.location.country", "'foobar'",
+            new Object[][]{{"US"}, {"foobar"}}, "nestedJson.location.country default 'foobar'"}
+    };
+  }
+
   // ============================================================================================
   // 3. GROUP BY
   // ============================================================================================
 
   /**
-   * GROUP BY with null handling ON. Unresolved rows must collapse into a single null group with
-   * the correct count, alongside the resolved value groups.
-   * <pre>
-   *   Example — `flatJson.country` (STRING):
-   *     per-row: row 0 -> "US", row 1 -> "CA", row 2 -> NULL (explicit), row 3 -> NULL (missing)
-   *
-   *     Query:  SET enableNullHandling = true;
-   *             SELECT jsonExtractIndex(flatJson, '$.country', 'STRING') AS v, COUNT(*)
-   *             FROM clicks GROUP BY v ORDER BY v ASC NULLS LAST
-   *
-   *     Result (counts ×2 for segment duplication): ("CA", 2), ("US", 2), (NULL, 4)
-   * </pre>
+   * 3.1 — NH on, 3-arg. Unresolved rows collapse into a single null group with the correct count,
+   * alongside the resolved value groups.
    */
   @Test(dataProvider = "groupByCases")
   public void testGroupByNullHandlingOn(String column, String jsonPath, String resultsType,
       Object[][] expectedRows, String label) {
     String expr = String.format("jsonExtractIndex(%s, '%s', '%s')", column, jsonPath, resultsType);
-    String query = String.format(
-        "SELECT %s AS v, COUNT(*) FROM clicks GROUP BY v ORDER BY v ASC NULLS LAST", expr);
-    givenCountryClickTable(true).whenQuery(query).thenResultIs(expectedRows);
+    givenCountryClickTable(true)
+        .whenQuery(String.format(
+            "SELECT %s AS v, COUNT(*) FROM clicks GROUP BY v ORDER BY v ASC NULLS LAST", expr))
+        .thenResultIs(expectedRows);
   }
 
+  /**
+   * 3.2 — NH on, 4-arg with non-null default. Unresolved rows count toward the default's group;
+   * no NULL group surfaces.
+   */
+  @Test(dataProvider = "defaultPrecedenceGroupByCases")
+  public void testGroupByDefaultBeatsNullHandlingPlaceholder(String column, String jsonPath,
+      String defaultLiteral, Object[][] expectedRows, String label) {
+    String expr = String.format(
+        "jsonExtractIndex(%s, '%s', 'STRING', %s)", column, jsonPath, defaultLiteral);
+    givenCountryClickTable(true)
+        .whenQuery(String.format(
+            "SELECT %s AS v, COUNT(*) FROM clicks GROUP BY v ORDER BY v ASC", expr))
+        .thenResultIs(expectedRows);
+  }
+
+  /** 3.3 — NH off: GROUP BY throws on unresolved rows. */
   @Test
   public void testGroupByNullHandlingOffThrows() {
     try {
@@ -749,10 +794,7 @@ public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunction
     }
   }
 
-  /**
-   * Each row is `(column, jsonPath, resultsType, expected (value, count) rows ASC NULLS LAST,
-   * label)`. Counts are ×2 the per-row count due to segment duplication.
-   */
+  /** 3.1 cases — `(column, jsonPath, resultsType, expected (value, count) rows ASC NULLS LAST, label)`. */
   @DataProvider(name = "groupByCases")
   public static Object[][] groupByCases() {
     return new Object[][]{
@@ -774,111 +816,13 @@ public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunction
     };
   }
 
-  // ============================================================================================
-  // 4. Default-value precedence under null handling ON
-  //
-  // When a non-null default literal is supplied AND null handling is on, the SV transform's
-  // priority order is: real default > null-handling placeholder > throw. The user-supplied
-  // default surfaces for unresolved rows; the null-handling placeholder is NOT emitted, and
-  // no null bit is set in the bitmap. These tests pin that ordering across projection,
-  // DISTINCT, and GROUP BY so a future refactor can't silently swap the priority.
-  // ============================================================================================
-
-  /**
-   * Projection with NH on AND a non-null default literal. Unresolved rows must surface as the
-   * default, not SQL NULL — across both flat scalar and nested-object shapes.
-   * <pre>
-   *   Example — flatJson.country with default 'foobar':
-   *     per-row: row 0 -> "US", row 1 -> "CA", row 2 -> "foobar" (was null),
-   *              row 3 -> "foobar" (was missing)
-   *
-   *     Query: SET enableNullHandling = true;
-   *            SELECT jsonExtractIndex(flatJson, '$.country', 'STRING', 'foobar') AS c
-   *            FROM clicks ORDER BY c ASC
-   *
-   *     Result rows (×2 segment dup; ASCII order, uppercase before lowercase):
-   *             "CA", "CA", "US", "US", "foobar", "foobar", "foobar", "foobar"
-   * </pre>
-   */
-  @Test(dataProvider = "defaultPrecedenceProjectionCases")
-  public void testProjectionDefaultBeatsNullHandlingPlaceholder(String column, String jsonPath,
-      String defaultLiteral, Object[][] expectedRows, String label) {
-    String expr = String.format(
-        "jsonExtractIndex(%s, '%s', 'STRING', %s)", column, jsonPath, defaultLiteral);
-    givenCountryClickTable(true)
-        .whenQuery(String.format("SELECT %s AS c FROM clicks ORDER BY c ASC", expr))
-        .thenResultIs(expectedRows);
-  }
-
-  /**
-   * Each row: `(column, jsonPath, default SQL literal, expected 8-row result, label)`. Result
-   * rows are ordered ASC. Each per-row value in the fixture appears ×2 due to segment duplication.
-   */
-  @DataProvider(name = "defaultPrecedenceProjectionCases")
-  public static Object[][] defaultPrecedenceProjectionCases() {
-    return new Object[][]{
-        // flatJson.country: row0="US", row1="CA", row2=null, row3=missing -> 2 each, 4 'foobar'.
-        {"flatJson", "$.country", "'foobar'", new Object[][]{
-            {"CA"}, {"CA"}, {"US"}, {"US"},
-            {"foobar"}, {"foobar"}, {"foobar"}, {"foobar"}
-        }, "flatJson.country default 'foobar'"},
-        // nestedJson.location.country: row0="US", rows 1/2/3 unresolved -> 2 "US" + 6 'foobar'.
-        {"nestedJson", "$.location.country", "'foobar'", new Object[][]{
-            {"US"}, {"US"},
-            {"foobar"}, {"foobar"}, {"foobar"}, {"foobar"}, {"foobar"}, {"foobar"}
-        }, "nestedJson.location.country default 'foobar'"}
-    };
-  }
-
-  /**
-   * DISTINCT with NH on AND a non-null default literal. The distinct set includes the default
-   * value as a regular entry — no separate null entry.
-   */
-  @Test(dataProvider = "defaultPrecedenceDistinctCases")
-  public void testDistinctDefaultBeatsNullHandlingPlaceholder(String column, String jsonPath,
-      String defaultLiteral, Object[][] expectedRows, String label) {
-    String expr = String.format(
-        "jsonExtractIndex(%s, '%s', 'STRING', %s)", column, jsonPath, defaultLiteral);
-    givenCountryClickTable(true)
-        .whenQuery(String.format("SELECT DISTINCT %s FROM clicks ORDER BY %s ASC", expr, expr))
-        .thenResultIs(expectedRows);
-  }
-
-  /** Each row: `(column, jsonPath, default literal, expected distinct rows ASC, label)`. */
-  @DataProvider(name = "defaultPrecedenceDistinctCases")
-  public static Object[][] defaultPrecedenceDistinctCases() {
-    return new Object[][]{
-        {"flatJson", "$.country", "'foobar'",
-            new Object[][]{{"CA"}, {"US"}, {"foobar"}}, "flatJson.country default 'foobar'"},
-        {"nestedJson", "$.location.country", "'foobar'",
-            new Object[][]{{"US"}, {"foobar"}}, "nestedJson.location.country default 'foobar'"}
-    };
-  }
-
-  /**
-   * GROUP BY with NH on AND a non-null default literal. Unresolved rows count toward the
-   * default's group — no NULL group surfaces.
-   */
-  @Test(dataProvider = "defaultPrecedenceGroupByCases")
-  public void testGroupByDefaultBeatsNullHandlingPlaceholder(String column, String jsonPath,
-      String defaultLiteral, Object[][] expectedRows, String label) {
-    String expr = String.format(
-        "jsonExtractIndex(%s, '%s', 'STRING', %s)", column, jsonPath, defaultLiteral);
-    givenCountryClickTable(true)
-        .whenQuery(String.format(
-            "SELECT %s AS v, COUNT(*) FROM clicks GROUP BY v ORDER BY v ASC", expr))
-        .thenResultIs(expectedRows);
-  }
-
-  /** Each row: `(column, jsonPath, default literal, expected (value, count) rows ASC, label)`. */
+  /** 3.2 cases — `(column, jsonPath, default literal, expected (value, count) rows ASC, label)`. */
   @DataProvider(name = "defaultPrecedenceGroupByCases")
   public static Object[][] defaultPrecedenceGroupByCases() {
     return new Object[][]{
-        // flatJson.country: 2 "CA" + 2 "US" + 4 'foobar'.
         {"flatJson", "$.country", "'foobar'", new Object[][]{
             {"CA", 2L}, {"US", 2L}, {"foobar", 4L}
         }, "flatJson.country default 'foobar'"},
-        // nestedJson.location.country: 2 "US" + 6 'foobar'.
         {"nestedJson", "$.location.country", "'foobar'", new Object[][]{
             {"US", 2L}, {"foobar", 6L}
         }, "nestedJson.location.country default 'foobar'"}

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunctionTest.java
@@ -773,4 +773,84 @@ public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunction
         }, "nestedJson.events[0].country"}
     };
   }
+
+  // ============================================================================================
+  // 4. Default-value precedence under null handling ON
+  //
+  // When a non-null default literal is supplied AND null handling is on, the SV transform's
+  // priority order is: real default > null-handling placeholder > throw. The user-supplied
+  // default surfaces for unresolved rows; the null-handling placeholder is NOT emitted, and
+  // no null bit is set in the bitmap. These tests pin that ordering across projection,
+  // DISTINCT, and GROUP BY so a future refactor can't silently swap the priority.
+  // ============================================================================================
+
+  /**
+   * Projection with NH on AND default `'foobar'`. Unresolved rows must surface as `"foobar"`,
+   * not SQL NULL.
+   * <pre>
+   *   Per-row resolution: row 0 -> "US", row 1 -> "CA", row 2 -> "foobar", row 3 -> "foobar"
+   *
+   *   Query: SET enableNullHandling = true;
+   *          SELECT jsonExtractIndex(flatJson, '$.country', 'STRING', 'foobar') AS c
+   *          FROM clicks ORDER BY c ASC
+   *
+   *   Result rows (×2 for segment duplication; ASCII order: uppercase < lowercase):
+   *           "CA", "CA", "US", "US", "foobar", "foobar", "foobar", "foobar"
+   * </pre>
+   */
+  @Test
+  public void testProjectionDefaultBeatsNullHandlingPlaceholder() {
+    givenCountryClickTable(true)
+        .whenQuery("SELECT jsonExtractIndex(flatJson, '$.country', 'STRING', 'foobar') AS c "
+            + "FROM clicks ORDER BY c ASC")
+        .thenResultIs(
+            new Object[]{"CA"}, new Object[]{"CA"},
+            new Object[]{"US"}, new Object[]{"US"},
+            new Object[]{"foobar"}, new Object[]{"foobar"},
+            new Object[]{"foobar"}, new Object[]{"foobar"});
+  }
+
+  /**
+   * DISTINCT with NH on AND default `'foobar'`. The distinct set must include the default value
+   * as a regular distinct entry — no separate null entry.
+   * <pre>
+   *   Query: SET enableNullHandling = true;
+   *          SELECT DISTINCT jsonExtractIndex(flatJson, '$.country', 'STRING', 'foobar') FROM clicks
+   *          ORDER BY jsonExtractIndex(flatJson, '$.country', 'STRING', 'foobar') ASC
+   *
+   *   Result (ASCII order: uppercase < lowercase): "CA", "US", "foobar"
+   * </pre>
+   */
+  @Test
+  public void testDistinctDefaultBeatsNullHandlingPlaceholder() {
+    String expr = "jsonExtractIndex(flatJson, '$.country', 'STRING', 'foobar')";
+    givenCountryClickTable(true)
+        .whenQuery(String.format("SELECT DISTINCT %s FROM clicks ORDER BY %s ASC", expr, expr))
+        .thenResultIs(new Object[]{"CA"}, new Object[]{"US"}, new Object[]{"foobar"});
+  }
+
+  /**
+   * GROUP BY with NH on AND default `'foobar'`. Unresolved rows count toward the default's
+   * group, not a null group — so the result has no NULL group at all.
+   * <pre>
+   *   Per-row resolution: row 0 -> "US", row 1 -> "CA", row 2 -> "foobar", row 3 -> "foobar"
+   *
+   *   Query: SET enableNullHandling = true;
+   *          SELECT jsonExtractIndex(flatJson, '$.country', 'STRING', 'foobar') AS v, COUNT(*)
+   *          FROM clicks GROUP BY v ORDER BY v ASC
+   *
+   *   Result (counts ×2 for segment duplication; ASCII order: uppercase < lowercase):
+   *           ("CA", 2), ("US", 2), ("foobar", 4)
+   * </pre>
+   */
+  @Test
+  public void testGroupByDefaultBeatsNullHandlingPlaceholder() {
+    givenCountryClickTable(true)
+        .whenQuery("SELECT jsonExtractIndex(flatJson, '$.country', 'STRING', 'foobar') AS v, COUNT(*) "
+            + "FROM clicks GROUP BY v ORDER BY v ASC")
+        .thenResultIs(
+            new Object[]{"CA", 2L},
+            new Object[]{"US", 2L},
+            new Object[]{"foobar", 4L});
+  }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunctionTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
@@ -25,17 +27,29 @@ import com.jayway.jsonpath.ParseContext;
 import com.jayway.jsonpath.TypeRef;
 import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.math.BigDecimal;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.function.JsonPathCache;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.apache.pinot.queries.FluentQueryTest;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.assertj.core.api.Assertions;
-import org.roaringbitmap.RoaringBitmap;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -426,117 +440,337 @@ public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunction
     return JSON_PARSER_CONTEXT.parse(blob).read(path, typeRef);
   }
 
-  // === Null-handling contract for unresolved JSON paths ===
+  // ============================================================================================
+  // Country/click null-handling tests for jsonExtractIndex (issue #18568).
   //
-  // The base fixture's JSON_STRING_SV_COLUMN has no '$.noField' key in any row, so the JSON-index
-  // lookup returns null for every doc. With query-level null handling ENABLED, the SV transforms
-  // must surface those rows as SQL NULL (type-default + a bit in getNullBitmap()), matching
-  // JsonIndexDistinctOperator's null-group semantics. With null handling DISABLED and no default
-  // literal, the legacy RuntimeException must be preserved.
+  // The SV null-handling fix: with `enableNullHandling = true` and no default literal, an
+  // unresolved JSON path must surface as SQL NULL instead of throwing.
+  //
+  // All tests below share a single `clicks` table fixture with two JSON-indexed columns and four
+  // rows. The fixture mirrors the one in JsonExtractScalarTransformFunctionTest so that, modulo
+  // the function name, expected results are identical — `jsonExtractIndex` and
+  // `jsonExtractScalar` must agree on null semantics after the fix.
+  //
+  //   `flatJson`   — 1-level scalar shapes. Each row exercises one case: resolved value, explicit
+  //                  JSON null, missing key, empty document.
+  //   `nestedJson` — multi-level shapes (nested object, array, array of objects) with mixed
+  //                  resolved / null / missing data at depth.
+  //
+  // Tests are grouped by query shape in this order: projection → DISTINCT → GROUP BY. Each group
+  // has a null-handling-on case (verifies SQL NULL surfaces) and a null-handling-off case
+  // (verifies the legacy throw is preserved). Result rows are ordered by the projected expression
+  // ASC NULLS LAST so the comparison is deterministic across the framework's segment-duplication
+  // behavior (one segment becomes two, so per-row counts in GROUP BY results are ×2).
+  // ============================================================================================
 
-  @DataProvider(name = "unresolvedPathSvTypes")
-  public Object[][] unresolvedPathSvTypes() {
+  protected File _baseDir;
+
+  @BeforeClass
+  void createBaseDir() {
+    try {
+      _baseDir = Files.createTempDirectory(getClass().getSimpleName()).toFile();
+    } catch (IOException ex) {
+      throw new UncheckedIOException(ex);
+    }
+  }
+
+  @AfterClass
+  void destroyBaseDir()
+      throws IOException {
+    if (_baseDir != null) {
+      FileUtils.deleteDirectory(_baseDir);
+    }
+  }
+
+  // ---------------- Fixture ----------------
+  //
+  // Pretty-printed contents of the 4-row × 2-column fixture:
+  //
+  //   row 0 — fully populated:
+  //     flatJson:   { "country": "US", "clicks": 5 }
+  //     nestedJson: { "location": {"city": "SF", "country": "US"},
+  //                   "tags":     ["red", "blue", "green"],
+  //                   "events":   [{"country": "US"}, {"country": "CA"}] }
+  //
+  //   row 1 — partial / explicit-null at depth:
+  //     flatJson:   { "country": "CA", "clicks": 3 }
+  //     nestedJson: { "location": {"city": "Tor"},          // <-- no country key
+  //                   "tags":     ["green"],                 // <-- only one element
+  //                   "events":   [{"country": null}] }     // <-- inner explicit null
+  //
+  //   row 2 — every field explicit JSON null:
+  //     flatJson:   { "country": null, "clicks": null }
+  //     nestedJson: { "location": null, "tags": null, "events": null }
+  //
+  //   row 3 — empty documents:
+  //     flatJson:   {}
+  //     nestedJson: {}
+
+  private static final Object[][] COUNTRY_CLICK_FIXTURE = {
+      // {flatJson, nestedJson}
+      {
+          "{\"country\":\"US\",\"clicks\":5}",
+          "{\"location\":{\"city\":\"SF\",\"country\":\"US\"},"
+              + "\"tags\":[\"red\",\"blue\",\"green\"],"
+              + "\"events\":[{\"country\":\"US\"},{\"country\":\"CA\"}]}"
+      },
+      {
+          "{\"country\":\"CA\",\"clicks\":3}",
+          "{\"location\":{\"city\":\"Tor\"},"
+              + "\"tags\":[\"green\"],"
+              + "\"events\":[{\"country\":null}]}"
+      },
+      {
+          "{\"country\":null,\"clicks\":null}",
+          "{\"location\":null,\"tags\":null,\"events\":null}"
+      },
+      {"{}", "{}"}
+  };
+
+  // ---------------- Helper ----------------
+  //
+  // `jsonExtractIndex` requires the column to have a JSON index. The helper wires a JSON index
+  // onto both columns via FieldConfig — same shape as the JSON index in
+  // BaseTransformFunctionTest.getTableConfig().
+
+  private FluentQueryTest.OnFirstInstance givenCountryClickTable(boolean nullHandling) {
+    Schema schema = new Schema.SchemaBuilder()
+        .setSchemaName("clicks")
+        .setEnableColumnBasedNullHandling(true)
+        .addDimensionField("flatJson", DataType.JSON)
+        .addDimensionField("nestedJson", DataType.JSON)
+        .build();
+    ObjectNode jsonIndexNode = JsonNodeFactory.instance.objectNode();
+    jsonIndexNode.set("json", JsonNodeFactory.instance.objectNode());
+    List<FieldConfig> fieldConfigs = List.of(
+        new FieldConfig("flatJson", FieldConfig.EncodingType.DICTIONARY, null, null, null, null, jsonIndexNode, null,
+            null),
+        new FieldConfig("nestedJson", FieldConfig.EncodingType.DICTIONARY, null, null, null, null, jsonIndexNode, null,
+            null));
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("clicks")
+        .setFieldConfigList(fieldConfigs)
+        .build();
+    return FluentQueryTest.withBaseDir(_baseDir)
+        .withNullHandling(nullHandling)
+        .givenTable(schema, tableConfig)
+        .onFirstInstance(COUNTRY_CLICK_FIXTURE);
+  }
+
+  // ============================================================================================
+  // 1. Projection
+  // ============================================================================================
+
+  /**
+   * Projection with null handling ON. Each row's resolution depends on the column + path; the SV
+   * transform must surface SQL NULL for unresolved rows and pass resolved values through.
+   * <pre>
+   *   Example — `flatJson.country` (STRING):
+   *     per-row: row 0 -> "US", row 1 -> "CA", row 2 -> NULL (explicit), row 3 -> NULL (missing)
+   *
+   *     Query:  SET enableNullHandling = true;
+   *             SELECT jsonExtractIndex(flatJson, '$.country', 'STRING') AS c
+   *             FROM clicks ORDER BY c ASC NULLS LAST
+   *
+   *     Result rows (×2 for segment duplication):
+   *             "CA", "CA", "US", "US", NULL, NULL, NULL, NULL
+   * </pre>
+   */
+  @Test(dataProvider = "projectionCases")
+  public void testProjectionNullHandlingOn(String column, String jsonPath, String resultsType,
+      Object[][] expectedRows, String label) {
+    String expr = String.format("jsonExtractIndex(%s, '%s', '%s')", column, jsonPath, resultsType);
+    givenCountryClickTable(true)
+        .whenQuery(String.format("SELECT %s FROM clicks ORDER BY %s ASC NULLS LAST", expr, expr))
+        .thenResultIs(expectedRows);
+  }
+
+  /**
+   * Null handling OFF: any unresolved row throws (legacy behavior, preserved by the fix's
+   * `_nullHandlingEnabled` gate). One representative path is enough — the throw is independent of
+   * path shape and result type. The error message for `jsonExtractIndex` differs from the scalar
+   * function's: `"Illegal Json Path: [...], for docId [...]"`.
+   */
+  @Test
+  public void testProjectionNullHandlingOffThrows() {
+    try {
+      givenCountryClickTable(false)
+          .whenQuery("SELECT jsonExtractIndex(flatJson, '$.country', 'STRING') FROM clicks")
+          .thenResultIs(new Object[]{"unused"});
+      Assert.fail("Expected projection to fail when null handling is off and rows are unresolved");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).contains("Illegal Json Path");
+    }
+  }
+
+  /**
+   * Each row is `(column, jsonPath, resultsType, expected 8-row result, label)`. Result rows are
+   * ordered by value ASC NULLS LAST. With segment duplication, the per-row count in the fixture
+   * is ×2 in the result.
+   */
+  @DataProvider(name = "projectionCases")
+  public static Object[][] projectionCases() {
     return new Object[][]{
-        {"INT", DataType.INT},
-        {"LONG", DataType.LONG},
-        {"FLOAT", DataType.FLOAT},
-        {"DOUBLE", DataType.DOUBLE},
-        {"BIG_DECIMAL", DataType.BIG_DECIMAL},
-        {"STRING", DataType.STRING}
+        // ----- flatJson: 1-level scalar shape -----
+        // $.country: row0="US", row1="CA", row2=null (explicit), row3=null (missing).
+        {"flatJson", "$.country", "STRING", new Object[][]{
+            {"CA"}, {"CA"}, {"US"}, {"US"}, {null}, {null}, {null}, {null}
+        }, "flatJson.country STRING"},
+        // $.clicks across all 6 numeric SV types: row0=5, row1=3, row2=null, row3=null.
+        {"flatJson", "$.clicks", "INT", new Object[][]{
+            {3}, {3}, {5}, {5}, {null}, {null}, {null}, {null}
+        }, "flatJson.clicks INT"},
+        {"flatJson", "$.clicks", "LONG", new Object[][]{
+            {3L}, {3L}, {5L}, {5L}, {null}, {null}, {null}, {null}
+        }, "flatJson.clicks LONG"},
+        {"flatJson", "$.clicks", "FLOAT", new Object[][]{
+            {3f}, {3f}, {5f}, {5f}, {null}, {null}, {null}, {null}
+        }, "flatJson.clicks FLOAT"},
+        {"flatJson", "$.clicks", "DOUBLE", new Object[][]{
+            {3d}, {3d}, {5d}, {5d}, {null}, {null}, {null}, {null}
+        }, "flatJson.clicks DOUBLE"},
+        // BIG_DECIMAL is formatted as String by the broker (BigDecimal.toPlainString).
+        {"flatJson", "$.clicks", "BIG_DECIMAL", new Object[][]{
+            {"3"}, {"3"}, {"5"}, {"5"}, {null}, {null}, {null}, {null}
+        }, "flatJson.clicks BIG_DECIMAL"},
+
+        // ----- nestedJson: multi-level shapes -----
+        // $.location.country: row0="US", row1=missing (no country key), row2=parent null, row3=missing.
+        {"nestedJson", "$.location.country", "STRING", new Object[][]{
+            {"US"}, {"US"}, {null}, {null}, {null}, {null}, {null}, {null}
+        }, "nestedJson.location.country STRING"},
+        // $.tags[0]: row0="red", row1="green", row2=null parent, row3=missing.
+        {"nestedJson", "$.tags[0]", "STRING", new Object[][]{
+            {"green"}, {"green"}, {"red"}, {"red"}, {null}, {null}, {null}, {null}
+        }, "nestedJson.tags[0] STRING"},
+        // $.tags[1]: row0="blue", row1=out-of-bounds (only one element), row2=null parent, row3=missing.
+        {"nestedJson", "$.tags[1]", "STRING", new Object[][]{
+            {"blue"}, {"blue"}, {null}, {null}, {null}, {null}, {null}, {null}
+        }, "nestedJson.tags[1] STRING (OOB on row 1)"},
+        // $.events[0].country: row0="US", row1=explicit inner null, row2=null array, row3=missing.
+        {"nestedJson", "$.events[0].country", "STRING", new Object[][]{
+            {"US"}, {"US"}, {null}, {null}, {null}, {null}, {null}, {null}
+        }, "nestedJson.events[0].country STRING"}
     };
   }
 
-  @Test(dataProvider = "unresolvedPathSvTypes")
-  public void testNullHandlingEnabledEmitsNullForUnresolvedPath(String resultsType, DataType resultsDataType) {
-    String expressionStr = String.format("jsonExtractIndex(%s,'$.noField','%s')", JSON_STRING_SV_COLUMN, resultsType);
-    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
-    TransformFunction transformFunction =
-        TransformFunctionFactory.getNullHandlingEnabled(expression, _dataSourceMap);
+  // ============================================================================================
+  // 2. DISTINCT
+  // ============================================================================================
 
-    Assert.assertTrue(transformFunction instanceof JsonExtractIndexTransformFunction);
-    Assert.assertEquals(transformFunction.getResultMetadata().getDataType(), resultsDataType);
-
-    switch (resultsDataType) {
-      case INT:
-        int[] intValues = transformFunction.transformToIntValuesSV(_projectionBlock);
-        for (int i = 0; i < NUM_ROWS; i++) {
-          Assert.assertEquals(intValues[i], 0);
-        }
-        break;
-      case LONG:
-        long[] longValues = transformFunction.transformToLongValuesSV(_projectionBlock);
-        for (int i = 0; i < NUM_ROWS; i++) {
-          Assert.assertEquals(longValues[i], 0L);
-        }
-        break;
-      case FLOAT:
-        float[] floatValues = transformFunction.transformToFloatValuesSV(_projectionBlock);
-        for (int i = 0; i < NUM_ROWS; i++) {
-          Assert.assertEquals(floatValues[i], 0f);
-        }
-        break;
-      case DOUBLE:
-        double[] doubleValues = transformFunction.transformToDoubleValuesSV(_projectionBlock);
-        for (int i = 0; i < NUM_ROWS; i++) {
-          Assert.assertEquals(doubleValues[i], 0d);
-        }
-        break;
-      case BIG_DECIMAL:
-        BigDecimal[] bigDecimalValues = transformFunction.transformToBigDecimalValuesSV(_projectionBlock);
-        for (int i = 0; i < NUM_ROWS; i++) {
-          Assert.assertEquals(bigDecimalValues[i].compareTo(BigDecimal.ZERO), 0);
-        }
-        break;
-      case STRING:
-        String[] stringValues = transformFunction.transformToStringValuesSV(_projectionBlock);
-        for (int i = 0; i < NUM_ROWS; i++) {
-          Assert.assertEquals(stringValues[i], "");
-        }
-        break;
-      default:
-        throw new UnsupportedOperationException("Unsupported test type: " + resultsDataType);
-    }
-
-    RoaringBitmap nullBitmap = transformFunction.getNullBitmap(_projectionBlock);
-    Assert.assertNotNull(nullBitmap, "Null bitmap must be populated when all rows are unresolved");
-    Assert.assertEquals(nullBitmap.getCardinality(), NUM_ROWS,
-        "Every row should be marked null when the JSON path doesn't resolve");
+  /**
+   * DISTINCT with null handling ON. The distinct set must include exactly one null entry
+   * alongside the resolved values (deduped across segments).
+   * <pre>
+   *   Example — `flatJson.country` (STRING):
+   *     Query:  SET enableNullHandling = true;
+   *             SELECT DISTINCT jsonExtractIndex(flatJson, '$.country', 'STRING') FROM clicks
+   *             ORDER BY jsonExtractIndex(flatJson, '$.country', 'STRING') ASC NULLS LAST
+   *
+   *     Result: "CA", "US", NULL
+   * </pre>
+   * For STRING DISTINCT against a JSON-indexed column, the broker actually routes the query
+   * through {@code JsonIndexDistinctOperator} (not the transform-fn path) — so this case
+   * indirectly exercises that operator. The other types fall back to the transform-fn path
+   * because the operator's parser converts the default literal in a way that fails for
+   * non-string types; that fallback is what this fix corrects.
+   */
+  @Test(dataProvider = "distinctCases")
+  public void testDistinctNullHandlingOn(String column, String jsonPath, String resultsType,
+      Object[][] expectedRows, String label) {
+    String expr = String.format("jsonExtractIndex(%s, '%s', '%s')", column, jsonPath, resultsType);
+    String query = String.format("SELECT DISTINCT %s FROM clicks ORDER BY %s ASC NULLS LAST", expr, expr);
+    givenCountryClickTable(true).whenQuery(query).thenResultIs(expectedRows);
   }
 
-  @Test(dataProvider = "unresolvedPathSvTypes")
-  public void testNullHandlingDisabledStillThrowsForUnresolvedPath(String resultsType, DataType resultsDataType) {
-    String expressionStr = String.format("jsonExtractIndex(%s,'$.noField','%s')", JSON_STRING_SV_COLUMN, resultsType);
-    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
-    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-
-    Assert.assertTrue(transformFunction instanceof JsonExtractIndexTransformFunction);
-
+  @Test
+  public void testDistinctNullHandlingOffThrows() {
     try {
-      switch (resultsDataType) {
-        case INT:
-          transformFunction.transformToIntValuesSV(_projectionBlock);
-          break;
-        case LONG:
-          transformFunction.transformToLongValuesSV(_projectionBlock);
-          break;
-        case FLOAT:
-          transformFunction.transformToFloatValuesSV(_projectionBlock);
-          break;
-        case DOUBLE:
-          transformFunction.transformToDoubleValuesSV(_projectionBlock);
-          break;
-        case BIG_DECIMAL:
-          transformFunction.transformToBigDecimalValuesSV(_projectionBlock);
-          break;
-        case STRING:
-          transformFunction.transformToStringValuesSV(_projectionBlock);
-          break;
-        default:
-          throw new UnsupportedOperationException("Unsupported test type: " + resultsDataType);
-      }
-      Assert.fail("Expected RuntimeException when null handling is disabled");
-    } catch (RuntimeException e) {
+      givenCountryClickTable(false)
+          .whenQuery("SELECT DISTINCT jsonExtractIndex(flatJson, '$.country', 'STRING') FROM clicks")
+          .thenResultIs(new Object[]{"unused"});
+      Assert.fail("Expected DISTINCT to fail when null handling is off and rows are unresolved");
+    } catch (AssertionError e) {
       Assertions.assertThat(e.getMessage()).contains("Illegal Json Path");
     }
+  }
+
+  /** Each row is `(column, jsonPath, resultsType, expected distinct rows ASC NULLS LAST, label)`. */
+  @DataProvider(name = "distinctCases")
+  public static Object[][] distinctCases() {
+    return new Object[][]{
+        {"flatJson", "$.country", "STRING", new Object[][]{{"CA"}, {"US"}, {null}}, "flatJson.country"},
+        {"flatJson", "$.clicks", "INT", new Object[][]{{3}, {5}, {null}}, "flatJson.clicks INT"},
+        {"nestedJson", "$.location.country", "STRING", new Object[][]{{"US"}, {null}},
+            "nestedJson.location.country"},
+        {"nestedJson", "$.tags[0]", "STRING", new Object[][]{{"green"}, {"red"}, {null}},
+            "nestedJson.tags[0]"},
+        {"nestedJson", "$.events[0].country", "STRING", new Object[][]{{"US"}, {null}},
+            "nestedJson.events[0].country"}
+    };
+  }
+
+  // ============================================================================================
+  // 3. GROUP BY
+  // ============================================================================================
+
+  /**
+   * GROUP BY with null handling ON. Unresolved rows must collapse into a single null group with
+   * the correct count, alongside the resolved value groups.
+   * <pre>
+   *   Example — `flatJson.country` (STRING):
+   *     per-row: row 0 -> "US", row 1 -> "CA", row 2 -> NULL (explicit), row 3 -> NULL (missing)
+   *
+   *     Query:  SET enableNullHandling = true;
+   *             SELECT jsonExtractIndex(flatJson, '$.country', 'STRING') AS v, COUNT(*)
+   *             FROM clicks GROUP BY v ORDER BY v ASC NULLS LAST
+   *
+   *     Result (counts ×2 for segment duplication): ("CA", 2), ("US", 2), (NULL, 4)
+   * </pre>
+   */
+  @Test(dataProvider = "groupByCases")
+  public void testGroupByNullHandlingOn(String column, String jsonPath, String resultsType,
+      Object[][] expectedRows, String label) {
+    String expr = String.format("jsonExtractIndex(%s, '%s', '%s')", column, jsonPath, resultsType);
+    String query = String.format(
+        "SELECT %s AS v, COUNT(*) FROM clicks GROUP BY v ORDER BY v ASC NULLS LAST", expr);
+    givenCountryClickTable(true).whenQuery(query).thenResultIs(expectedRows);
+  }
+
+  @Test
+  public void testGroupByNullHandlingOffThrows() {
+    try {
+      givenCountryClickTable(false)
+          .whenQuery("SELECT jsonExtractIndex(flatJson, '$.country', 'STRING'), COUNT(*) FROM clicks GROUP BY 1")
+          .thenResultIs(new Object[]{"unused"});
+      Assert.fail("Expected GROUP BY to fail when null handling is off and rows are unresolved");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).contains("Illegal Json Path");
+    }
+  }
+
+  /**
+   * Each row is `(column, jsonPath, resultsType, expected (value, count) rows ASC NULLS LAST,
+   * label)`. Counts are ×2 the per-row count due to segment duplication.
+   */
+  @DataProvider(name = "groupByCases")
+  public static Object[][] groupByCases() {
+    return new Object[][]{
+        {"flatJson", "$.country", "STRING", new Object[][]{
+            {"CA", 2L}, {"US", 2L}, {null, 4L}
+        }, "flatJson.country"},
+        {"flatJson", "$.clicks", "INT", new Object[][]{
+            {3, 2L}, {5, 2L}, {null, 4L}
+        }, "flatJson.clicks INT"},
+        {"nestedJson", "$.location.country", "STRING", new Object[][]{
+            {"US", 2L}, {null, 6L}
+        }, "nestedJson.location.country"},
+        {"nestedJson", "$.tags[0]", "STRING", new Object[][]{
+            {"green", 2L}, {"red", 2L}, {null, 4L}
+        }, "nestedJson.tags[0]"},
+        {"nestedJson", "$.events[0].country", "STRING", new Object[][]{
+            {"US", 2L}, {null, 6L}
+        }, "nestedJson.events[0].country"}
+    };
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunctionTest.java
@@ -457,17 +457,18 @@ public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunction
   //                  resolved / null / missing data at depth.
   //
   // Tests are grouped by query shape in this order: projection → DISTINCT → GROUP BY. Each section
-  // covers three sub-cases, in order:
+  // covers the same four sub-cases, in order:
   //
   //   .1  NH on, 3-arg                          — unresolved rows surface as SQL NULL (E4 fix)
-  //   .2  NH on, 4-arg with a non-null default   — default wins over NH placeholder
-  //   .3  NH off                                  — legacy throw preserved
+  //   .2  NH on, 4-arg with SQL NULL literal     — same result as .1; `init` detects the null
+  //                                                literal and leaves `_defaultValue` null so the
+  //                                                3-arg semantics apply
+  //   .3  NH on, 4-arg with a non-null default   — default wins over NH placeholder
+  //   .4  NH off                                  — legacy throw preserved
   //
-  // Unlike the scalar function, the index function has no `_defaultIsNull` path: a `NULL` literal
-  // as the 4-arg default fails at init (numeric) or silently becomes empty string (STRING) — both
-  // pre-existing quirks outside the scope of this PR. Result rows in every assertion are ordered
-  // by the projected expression ASC NULLS LAST so the comparison is deterministic across the
-  // framework's segment-duplication behavior (one segment becomes two, so per-row counts ×2).
+  // Result rows in every assertion are ordered by the projected expression ASC NULLS LAST so the
+  // comparison is deterministic across the framework's segment-duplication behavior (one segment
+  // becomes two, so per-row counts ×2).
   // ============================================================================================
 
   protected File _baseDir;
@@ -590,7 +591,20 @@ public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunction
   }
 
   /**
-   * 1.2 — NH on, 4-arg with non-null default. The SV transform's priority is: real default >
+   * 1.2 — NH on, 4-arg with `NULL` literal. Same result as 1.1: `init` detects the null literal
+   * and leaves `_defaultValue` null, so the 3-arg code path applies.
+   */
+  @Test(dataProvider = "sqlNullDefaultProjectionCases")
+  public void testProjectionWithSqlNullDefaultEmitsNull(String column, String jsonPath,
+      Object[][] expectedRows, String label) {
+    String expr = String.format("jsonExtractIndex(%s, '%s', 'STRING', NULL)", column, jsonPath);
+    givenCountryClickTable(true)
+        .whenQuery(String.format("SELECT %s AS c FROM clicks ORDER BY c ASC NULLS LAST", expr))
+        .thenResultIs(expectedRows);
+  }
+
+  /**
+   * 1.3 — NH on, 4-arg with non-null default. The SV transform's priority is: real default >
    * null-handling placeholder > throw. The user-supplied default surfaces for unresolved rows;
    * no null bit is set in the bitmap.
    */
@@ -605,7 +619,7 @@ public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunction
   }
 
   /**
-   * 1.3 — NH off: any unresolved row throws. One representative path; throw is path-independent.
+   * 1.4 — NH off: any unresolved row throws. One representative path; throw is path-independent.
    * The index function's error message differs from the scalar's ("Illegal Json Path" vs "Cannot
    * resolve JSON path").
    */
@@ -664,7 +678,20 @@ public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunction
     };
   }
 
-  /** 1.2 cases — `(column, jsonPath, default SQL literal, expected 8-row result ASC, label)`. */
+  /** 1.2 cases — `(column, jsonPath, expected 8-row result ordered ASC NULLS LAST, label)`. */
+  @DataProvider(name = "sqlNullDefaultProjectionCases")
+  public static Object[][] sqlNullDefaultProjectionCases() {
+    return new Object[][]{
+        {"flatJson", "$.country", new Object[][]{
+            {"CA"}, {"CA"}, {"US"}, {"US"}, {null}, {null}, {null}, {null}
+        }, "flatJson.country NULL default"},
+        {"nestedJson", "$.location.country", new Object[][]{
+            {"US"}, {"US"}, {null}, {null}, {null}, {null}, {null}, {null}
+        }, "nestedJson.location.country NULL default"}
+    };
+  }
+
+  /** 1.3 cases — `(column, jsonPath, default SQL literal, expected 8-row result ASC, label)`. */
   @DataProvider(name = "defaultPrecedenceProjectionCases")
   public static Object[][] defaultPrecedenceProjectionCases() {
     return new Object[][]{
@@ -698,7 +725,17 @@ public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunction
     givenCountryClickTable(true).whenQuery(query).thenResultIs(expectedRows);
   }
 
-  /** 2.2 — NH on, 4-arg with non-null default. Default appears as a regular distinct entry (no null). */
+  /** 2.2 — NH on, 4-arg with `NULL` literal. Same distinct set as 2.1 (includes a null entry). */
+  @Test(dataProvider = "sqlNullDefaultDistinctCases")
+  public void testDistinctWithSqlNullDefaultIncludesNull(String column, String jsonPath,
+      Object[][] expectedRows, String label) {
+    String expr = String.format("jsonExtractIndex(%s, '%s', 'STRING', NULL)", column, jsonPath);
+    givenCountryClickTable(true)
+        .whenQuery(String.format("SELECT DISTINCT %s FROM clicks ORDER BY %s ASC NULLS LAST", expr, expr))
+        .thenResultIs(expectedRows);
+  }
+
+  /** 2.3 — NH on, 4-arg with non-null default. Default appears as a regular distinct entry (no null). */
   @Test(dataProvider = "defaultPrecedenceDistinctCases")
   public void testDistinctDefaultBeatsNullHandlingPlaceholder(String column, String jsonPath,
       String defaultLiteral, Object[][] expectedRows, String label) {
@@ -709,7 +746,7 @@ public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunction
         .thenResultIs(expectedRows);
   }
 
-  /** 2.3 — NH off: DISTINCT throws on unresolved rows. */
+  /** 2.4 — NH off: DISTINCT throws on unresolved rows. */
   @Test
   public void testDistinctNullHandlingOffThrows() {
     try {
@@ -737,7 +774,17 @@ public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunction
     };
   }
 
-  /** 2.2 cases — `(column, jsonPath, default literal, expected distinct rows ASC, label)`. */
+  /** 2.2 cases — `(column, jsonPath, expected distinct rows ASC NULLS LAST, label)`. */
+  @DataProvider(name = "sqlNullDefaultDistinctCases")
+  public static Object[][] sqlNullDefaultDistinctCases() {
+    return new Object[][]{
+        {"flatJson", "$.country", new Object[][]{{"CA"}, {"US"}, {null}}, "flatJson.country NULL default"},
+        {"nestedJson", "$.location.country", new Object[][]{{"US"}, {null}},
+            "nestedJson.location.country NULL default"}
+    };
+  }
+
+  /** 2.3 cases — `(column, jsonPath, default literal, expected distinct rows ASC, label)`. */
   @DataProvider(name = "defaultPrecedenceDistinctCases")
   public static Object[][] defaultPrecedenceDistinctCases() {
     return new Object[][]{
@@ -766,8 +813,19 @@ public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunction
         .thenResultIs(expectedRows);
   }
 
+  /** 3.2 — NH on, 4-arg with `NULL` literal. Same groups as 3.1 (null group with correct count). */
+  @Test(dataProvider = "sqlNullDefaultGroupByCases")
+  public void testGroupByWithSqlNullDefaultProducesNullGroup(String column, String jsonPath,
+      Object[][] expectedRows, String label) {
+    String expr = String.format("jsonExtractIndex(%s, '%s', 'STRING', NULL)", column, jsonPath);
+    givenCountryClickTable(true)
+        .whenQuery(String.format(
+            "SELECT %s AS v, COUNT(*) FROM clicks GROUP BY v ORDER BY v ASC NULLS LAST", expr))
+        .thenResultIs(expectedRows);
+  }
+
   /**
-   * 3.2 — NH on, 4-arg with non-null default. Unresolved rows count toward the default's group;
+   * 3.3 — NH on, 4-arg with non-null default. Unresolved rows count toward the default's group;
    * no NULL group surfaces.
    */
   @Test(dataProvider = "defaultPrecedenceGroupByCases")
@@ -781,7 +839,7 @@ public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunction
         .thenResultIs(expectedRows);
   }
 
-  /** 3.3 — NH off: GROUP BY throws on unresolved rows. */
+  /** 3.4 — NH off: GROUP BY throws on unresolved rows. */
   @Test
   public void testGroupByNullHandlingOffThrows() {
     try {
@@ -816,7 +874,18 @@ public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunction
     };
   }
 
-  /** 3.2 cases — `(column, jsonPath, default literal, expected (value, count) rows ASC, label)`. */
+  /** 3.2 cases — `(column, jsonPath, expected (value, count) rows ASC NULLS LAST, label)`. */
+  @DataProvider(name = "sqlNullDefaultGroupByCases")
+  public static Object[][] sqlNullDefaultGroupByCases() {
+    return new Object[][]{
+        {"flatJson", "$.country", new Object[][]{{"CA", 2L}, {"US", 2L}, {null, 4L}},
+            "flatJson.country NULL default"},
+        {"nestedJson", "$.location.country", new Object[][]{{"US", 2L}, {null, 6L}},
+            "nestedJson.location.country NULL default"}
+    };
+  }
+
+  /** 3.3 cases — `(column, jsonPath, default literal, expected (value, count) rows ASC, label)`. */
   @DataProvider(name = "defaultPrecedenceGroupByCases")
   public static Object[][] defaultPrecedenceGroupByCases() {
     return new Object[][]{

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunctionTest.java
@@ -785,72 +785,103 @@ public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunction
   // ============================================================================================
 
   /**
-   * Projection with NH on AND default `'foobar'`. Unresolved rows must surface as `"foobar"`,
-   * not SQL NULL.
+   * Projection with NH on AND a non-null default literal. Unresolved rows must surface as the
+   * default, not SQL NULL — across both flat scalar and nested-object shapes.
    * <pre>
-   *   Per-row resolution: row 0 -> "US", row 1 -> "CA", row 2 -> "foobar", row 3 -> "foobar"
+   *   Example — flatJson.country with default 'foobar':
+   *     per-row: row 0 -> "US", row 1 -> "CA", row 2 -> "foobar" (was null),
+   *              row 3 -> "foobar" (was missing)
    *
-   *   Query: SET enableNullHandling = true;
-   *          SELECT jsonExtractIndex(flatJson, '$.country', 'STRING', 'foobar') AS c
-   *          FROM clicks ORDER BY c ASC
+   *     Query: SET enableNullHandling = true;
+   *            SELECT jsonExtractIndex(flatJson, '$.country', 'STRING', 'foobar') AS c
+   *            FROM clicks ORDER BY c ASC
    *
-   *   Result rows (×2 for segment duplication; ASCII order: uppercase < lowercase):
-   *           "CA", "CA", "US", "US", "foobar", "foobar", "foobar", "foobar"
+   *     Result rows (×2 segment dup; ASCII order, uppercase before lowercase):
+   *             "CA", "CA", "US", "US", "foobar", "foobar", "foobar", "foobar"
    * </pre>
    */
-  @Test
-  public void testProjectionDefaultBeatsNullHandlingPlaceholder() {
+  @Test(dataProvider = "defaultPrecedenceProjectionCases")
+  public void testProjectionDefaultBeatsNullHandlingPlaceholder(String column, String jsonPath,
+      String defaultLiteral, Object[][] expectedRows, String label) {
+    String expr = String.format(
+        "jsonExtractIndex(%s, '%s', 'STRING', %s)", column, jsonPath, defaultLiteral);
     givenCountryClickTable(true)
-        .whenQuery("SELECT jsonExtractIndex(flatJson, '$.country', 'STRING', 'foobar') AS c "
-            + "FROM clicks ORDER BY c ASC")
-        .thenResultIs(
-            new Object[]{"CA"}, new Object[]{"CA"},
-            new Object[]{"US"}, new Object[]{"US"},
-            new Object[]{"foobar"}, new Object[]{"foobar"},
-            new Object[]{"foobar"}, new Object[]{"foobar"});
+        .whenQuery(String.format("SELECT %s AS c FROM clicks ORDER BY c ASC", expr))
+        .thenResultIs(expectedRows);
   }
 
   /**
-   * DISTINCT with NH on AND default `'foobar'`. The distinct set must include the default value
-   * as a regular distinct entry — no separate null entry.
-   * <pre>
-   *   Query: SET enableNullHandling = true;
-   *          SELECT DISTINCT jsonExtractIndex(flatJson, '$.country', 'STRING', 'foobar') FROM clicks
-   *          ORDER BY jsonExtractIndex(flatJson, '$.country', 'STRING', 'foobar') ASC
-   *
-   *   Result (ASCII order: uppercase < lowercase): "CA", "US", "foobar"
-   * </pre>
+   * Each row: `(column, jsonPath, default SQL literal, expected 8-row result, label)`. Result
+   * rows are ordered ASC. Each per-row value in the fixture appears ×2 due to segment duplication.
    */
-  @Test
-  public void testDistinctDefaultBeatsNullHandlingPlaceholder() {
-    String expr = "jsonExtractIndex(flatJson, '$.country', 'STRING', 'foobar')";
+  @DataProvider(name = "defaultPrecedenceProjectionCases")
+  public static Object[][] defaultPrecedenceProjectionCases() {
+    return new Object[][]{
+        // flatJson.country: row0="US", row1="CA", row2=null, row3=missing -> 2 each, 4 'foobar'.
+        {"flatJson", "$.country", "'foobar'", new Object[][]{
+            {"CA"}, {"CA"}, {"US"}, {"US"},
+            {"foobar"}, {"foobar"}, {"foobar"}, {"foobar"}
+        }, "flatJson.country default 'foobar'"},
+        // nestedJson.location.country: row0="US", rows 1/2/3 unresolved -> 2 "US" + 6 'foobar'.
+        {"nestedJson", "$.location.country", "'foobar'", new Object[][]{
+            {"US"}, {"US"},
+            {"foobar"}, {"foobar"}, {"foobar"}, {"foobar"}, {"foobar"}, {"foobar"}
+        }, "nestedJson.location.country default 'foobar'"}
+    };
+  }
+
+  /**
+   * DISTINCT with NH on AND a non-null default literal. The distinct set includes the default
+   * value as a regular entry — no separate null entry.
+   */
+  @Test(dataProvider = "defaultPrecedenceDistinctCases")
+  public void testDistinctDefaultBeatsNullHandlingPlaceholder(String column, String jsonPath,
+      String defaultLiteral, Object[][] expectedRows, String label) {
+    String expr = String.format(
+        "jsonExtractIndex(%s, '%s', 'STRING', %s)", column, jsonPath, defaultLiteral);
     givenCountryClickTable(true)
         .whenQuery(String.format("SELECT DISTINCT %s FROM clicks ORDER BY %s ASC", expr, expr))
-        .thenResultIs(new Object[]{"CA"}, new Object[]{"US"}, new Object[]{"foobar"});
+        .thenResultIs(expectedRows);
+  }
+
+  /** Each row: `(column, jsonPath, default literal, expected distinct rows ASC, label)`. */
+  @DataProvider(name = "defaultPrecedenceDistinctCases")
+  public static Object[][] defaultPrecedenceDistinctCases() {
+    return new Object[][]{
+        {"flatJson", "$.country", "'foobar'",
+            new Object[][]{{"CA"}, {"US"}, {"foobar"}}, "flatJson.country default 'foobar'"},
+        {"nestedJson", "$.location.country", "'foobar'",
+            new Object[][]{{"US"}, {"foobar"}}, "nestedJson.location.country default 'foobar'"}
+    };
   }
 
   /**
-   * GROUP BY with NH on AND default `'foobar'`. Unresolved rows count toward the default's
-   * group, not a null group — so the result has no NULL group at all.
-   * <pre>
-   *   Per-row resolution: row 0 -> "US", row 1 -> "CA", row 2 -> "foobar", row 3 -> "foobar"
-   *
-   *   Query: SET enableNullHandling = true;
-   *          SELECT jsonExtractIndex(flatJson, '$.country', 'STRING', 'foobar') AS v, COUNT(*)
-   *          FROM clicks GROUP BY v ORDER BY v ASC
-   *
-   *   Result (counts ×2 for segment duplication; ASCII order: uppercase < lowercase):
-   *           ("CA", 2), ("US", 2), ("foobar", 4)
-   * </pre>
+   * GROUP BY with NH on AND a non-null default literal. Unresolved rows count toward the
+   * default's group — no NULL group surfaces.
    */
-  @Test
-  public void testGroupByDefaultBeatsNullHandlingPlaceholder() {
+  @Test(dataProvider = "defaultPrecedenceGroupByCases")
+  public void testGroupByDefaultBeatsNullHandlingPlaceholder(String column, String jsonPath,
+      String defaultLiteral, Object[][] expectedRows, String label) {
+    String expr = String.format(
+        "jsonExtractIndex(%s, '%s', 'STRING', %s)", column, jsonPath, defaultLiteral);
     givenCountryClickTable(true)
-        .whenQuery("SELECT jsonExtractIndex(flatJson, '$.country', 'STRING', 'foobar') AS v, COUNT(*) "
-            + "FROM clicks GROUP BY v ORDER BY v ASC")
-        .thenResultIs(
-            new Object[]{"CA", 2L},
-            new Object[]{"US", 2L},
-            new Object[]{"foobar", 4L});
+        .whenQuery(String.format(
+            "SELECT %s AS v, COUNT(*) FROM clicks GROUP BY v ORDER BY v ASC", expr))
+        .thenResultIs(expectedRows);
+  }
+
+  /** Each row: `(column, jsonPath, default literal, expected (value, count) rows ASC, label)`. */
+  @DataProvider(name = "defaultPrecedenceGroupByCases")
+  public static Object[][] defaultPrecedenceGroupByCases() {
+    return new Object[][]{
+        // flatJson.country: 2 "CA" + 2 "US" + 4 'foobar'.
+        {"flatJson", "$.country", "'foobar'", new Object[][]{
+            {"CA", 2L}, {"US", 2L}, {"foobar", 4L}
+        }, "flatJson.country default 'foobar'"},
+        // nestedJson.location.country: 2 "US" + 6 'foobar'.
+        {"nestedJson", "$.location.country", "'foobar'", new Object[][]{
+            {"US", 2L}, {"foobar", 6L}
+        }, "nestedJson.location.country default 'foobar'"}
+    };
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunctionTest.java
@@ -447,432 +447,6 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 
-  // ====================================================================================
-  // === Country/click null-handling tests for jsonExtractScalar.                       ===
-  // ===                                                                                ===
-  // === The SV null-handling fix: with `enableNullHandling = true` and no default      ===
-  // === literal, an unresolved JSON path must surface as SQL NULL instead of throwing. ===
-  // === These tests use a country/click data model — JSON documents shaped like        ===
-  // === `{country, clicks, location, tags, events}` — to exercise the fix across four  ===
-  // === JSON structural shapes (flat scalar, nested object, array element, array of    ===
-  // === objects) and three query shapes (projection, GROUP BY, DISTINCT).              ===
-  // ====================================================================================
-
-  // ---------------- Named single-row JSON documents (used by single-row tests) ----------------
-  //
-  // Pretty-printed JSON for each constant is shown above its declaration. The string literal
-  // itself is kept compact — Jackson tolerates either form, but the comment above is what a
-  // human reads when scanning a test failure.
-
-  // { "country": "US", "clicks": 5 }
-  private static final String CC_FLAT_RESOLVED = "{\"country\": \"US\", \"clicks\": 5}";
-  // { "clicks": 5 }                                       <- country key missing
-  private static final String CC_FLAT_COUNTRY_MISSING = "{\"clicks\": 5}";
-  // { "country": null, "clicks": 5 }                      <- country explicit JSON null
-  private static final String CC_FLAT_COUNTRY_EXPLICIT_NULL = "{\"country\": null, \"clicks\": 5}";
-  // { }                                                   <- empty document
-  private static final String CC_FLAT_EMPTY = "{}";
-  // { "country": "US" }                                   <- clicks key missing
-  private static final String CC_FLAT_CLICKS_MISSING = "{\"country\": \"US\"}";
-  // { "country": "US", "clicks": null }                   <- clicks explicit JSON null
-  private static final String CC_FLAT_CLICKS_EXPLICIT_NULL = "{\"country\": \"US\", \"clicks\": null}";
-
-  // { "location": { "city": "SF", "country": "US" } }
-  private static final String CC_NESTED_RESOLVED = "{\"location\": {\"city\": \"SF\", \"country\": \"US\"}}";
-  // { "location": { "city": "SF" } }                      <- nested inner key missing
-  private static final String CC_NESTED_INNER_MISSING = "{\"location\": {\"city\": \"SF\"}}";
-  // { "location": null }                                  <- nested parent explicit JSON null
-  private static final String CC_NESTED_PARENT_EXPLICIT_NULL = "{\"location\": null}";
-  // { "country": "US" }                                   <- nested parent itself missing
-  private static final String CC_NESTED_PARENT_MISSING = "{\"country\": \"US\"}";
-
-  // { "tags": ["red", "blue", "green"] }
-  private static final String CC_ARRAY_RESOLVED = "{\"tags\": [\"red\", \"blue\", \"green\"]}";
-  // { "tags": null }                                      <- array parent explicit JSON null
-  private static final String CC_ARRAY_NULL_PARENT = "{\"tags\": null}";
-  // { "tags": [] }                                        <- empty array
-  private static final String CC_ARRAY_EMPTY = "{\"tags\": []}";
-  // { "tags": ["red"] }                                   <- array index 1 out-of-bounds
-  private static final String CC_ARRAY_SINGLE_ELEM = "{\"tags\": [\"red\"]}";
-  // { "country": "US" }                                   <- array parent itself missing
-  private static final String CC_ARRAY_PARENT_MISSING = "{\"country\": \"US\"}";
-
-  // { "events": [{"country": "US"}, {"country": "CA"}] }
-  private static final String CC_AOO_RESOLVED = "{\"events\": [{\"country\": \"US\"}, {\"country\": \"CA\"}]}";
-  // { "events": [{"country": null}] }                     <- inner explicit JSON null
-  private static final String CC_AOO_INNER_EXPLICIT_NULL = "{\"events\": [{\"country\": null}]}";
-  // { "events": [{}] }                                    <- inner key missing
-  private static final String CC_AOO_INNER_KEY_MISSING = "{\"events\": [{}]}";
-  // { "events": [] }                                      <- empty array of objects
-  private static final String CC_AOO_EMPTY_ARRAY = "{\"events\": []}";
-  // { "events": null }                                    <- null array of objects
-  private static final String CC_AOO_NULL_ARRAY = "{\"events\": null}";
-  // { "events": [{"country": "US"}] }                     <- inner numeric (clicks) missing
-  private static final String CC_AOO_INNER_NUMERIC_MISSING = "{\"events\": [{\"country\": \"US\"}]}";
-  // { "events": [{"clicks": 1}, {"clicks": 7}] }
-  private static final String CC_AOO_NUMERIC_RESOLVED = "{\"events\": [{\"clicks\": 1}, {\"clicks\": 7}]}";
-
-  // ---------------- Multi-row fixture (used by GROUP BY / DISTINCT tests) ----------------
-  //
-  // Pretty-printed JSON for each row:
-  //
-  //   Row 0 — fully populated:
-  //     { "country": "US", "clicks": 5,
-  //       "location": { "city": "SF", "country": "US" },
-  //       "tags":     ["red", "blue", "green"],
-  //       "events":   [{"country": "US"}, {"country": "CA"}] }
-  //
-  //   Row 1 — partial: location has no country; events[0].country is explicit null:
-  //     { "country": "CA", "clicks": 3,
-  //       "location": { "city": "Tor" },
-  //       "tags":     ["green"],
-  //       "events":   [{"country": null}] }
-  //
-  //   Row 2 — every field explicit JSON null:
-  //     { "country": null, "clicks": null, "location": null, "tags": null, "events": null }
-  //
-  //   Row 3 — empty document:
-  //     {}
-  //
-  // Across the four rows, every path covered by the GROUP BY / DISTINCT tests has at least one
-  // resolved value AND at least one unresolved occurrence (missing key or explicit null), so
-  // both the value groups and the null group must surface in the result.
-
-  private static final String CC_ROW_0_FULL = "{\"country\": \"US\", \"clicks\": 5,"
-      + " \"location\": {\"city\": \"SF\", \"country\": \"US\"},"
-      + " \"tags\": [\"red\", \"blue\", \"green\"],"
-      + " \"events\": [{\"country\": \"US\"}, {\"country\": \"CA\"}]}";
-
-  private static final String CC_ROW_1_PARTIAL = "{\"country\": \"CA\", \"clicks\": 3,"
-      + " \"location\": {\"city\": \"Tor\"},"
-      + " \"tags\": [\"green\"],"
-      + " \"events\": [{\"country\": null}]}";
-
-  private static final String CC_ROW_2_ALL_NULL =
-      "{\"country\": null, \"clicks\": null, \"location\": null, \"tags\": null, \"events\": null}";
-
-  private static final String CC_ROW_3_EMPTY = "{}";
-
-  private static final Object[][] COUNTRY_CLICK_FIXTURE = {
-      {CC_ROW_0_FULL},
-      {CC_ROW_1_PARTIAL},
-      {CC_ROW_2_ALL_NULL},
-      {CC_ROW_3_EMPTY}
-  };
-
-  // ---------------- Helpers ----------------
-
-  private FluentQueryTest.OnFirstInstance givenSingleRowJsonTable(boolean nullHandling, String json) {
-    Schema schema = new Schema.SchemaBuilder()
-        .setSchemaName("testTable")
-        .setEnableColumnBasedNullHandling(true)
-        .addDimensionField("json", DataType.JSON)
-        .build();
-    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    return FluentQueryTest.withBaseDir(_baseDir)
-        .withNullHandling(nullHandling)
-        .givenTable(schema, tableConfig)
-        .onFirstInstance(new Object[]{json});
-  }
-
-  private FluentQueryTest.OnFirstInstance givenCountryClickFixture(boolean nullHandling) {
-    Schema schema = new Schema.SchemaBuilder()
-        .setSchemaName("testTable")
-        .setEnableColumnBasedNullHandling(true)
-        .addDimensionField("json", DataType.JSON)
-        .build();
-    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    return FluentQueryTest.withBaseDir(_baseDir)
-        .withNullHandling(nullHandling)
-        .givenTable(schema, tableConfig)
-        .onFirstInstance(COUNTRY_CLICK_FIXTURE);
-  }
-
-  /** Asserts that the 3-arg `jsonExtractScalar(...)` query returns SQL NULL for a single-row fixture. */
-  private void assertSingleRowReturnsNull(boolean nullHandling, String json, String jsonPath, String resultsType) {
-    Object[] expectedNullRow = new Object[]{null};
-    givenSingleRowJsonTable(nullHandling, json)
-        .whenQuery(String.format("SELECT jsonExtractScalar(json, '%s', '%s') FROM testTable", jsonPath, resultsType))
-        // Segment duplication: the same row is returned twice (one per duplicated segment).
-        .thenResultIs(expectedNullRow, expectedNullRow);
-  }
-
-  /** Asserts that the 3-arg `jsonExtractScalar(...)` query throws when null handling is off. */
-  private void assertSingleRowThrowsForUnresolved(String json, String jsonPath, String resultsType, String label) {
-    try {
-      givenSingleRowJsonTable(false, json)
-          .whenQuery(String.format("SELECT jsonExtractScalar(json, '%s', '%s') FROM testTable", jsonPath, resultsType))
-          .thenResultIs(new Object[]{"unused"});
-      Assert.fail("Expected query to fail for " + label);
-    } catch (AssertionError e) {
-      Assertions.assertThat(e.getMessage())
-          .describedAs("Case: " + label)
-          .contains("Cannot resolve JSON path on some records");
-    }
-  }
-
-  // ---------------- Unresolved paths: null-handling ON must surface SQL NULL ----------------
-
-  /**
-   * The SV null-handling fix. With null handling on and no default literal, an unresolved JSON
-   * path must surface as SQL NULL in the projection — matching the contract that
-   * {@code JsonIndexDistinctOperator} already provides for the DISTINCT route.
-   * <p>
-   * Example (flat, missing key):
-   * <pre>
-   *   JSON:   { "clicks": 5 }
-   *   Query:  SET enableNullHandling = true;
-   *           SELECT jsonExtractScalar(json, '$.country', 'STRING') FROM testTable
-   *   Result: NULL
-   * </pre>
-   * See {@link #unresolvedSinglePathCases()} for the full per-case matrix.
-   */
-  @Test(dataProvider = "unresolvedSinglePathCases")
-  public void testNullHandlingOnReturnsNullForUnresolvedPath(String resultsType, String jsonPath, String json,
-      String label) {
-    assertSingleRowReturnsNull(true, json, jsonPath, resultsType);
-  }
-
-  /**
-   * Legacy behavior preservation. With null handling off and no default, the same unresolved-path
-   * cases must throw — the E4 fix is gated on {@code _nullHandlingEnabled}, so callers that
-   * haven't opted in see no behavior change.
-   * <p>
-   * Example (flat, missing key):
-   * <pre>
-   *   JSON:   { "clicks": 5 }
-   *   Query:  SELECT jsonExtractScalar(json, '$.country', 'STRING') FROM testTable
-   *   Result: throws IllegalArgumentException("Cannot resolve JSON path on some records.…")
-   * </pre>
-   */
-  @Test(dataProvider = "unresolvedSinglePathCases")
-  public void testNullHandlingOffThrowsForUnresolvedPath(String resultsType, String jsonPath, String json,
-      String label) {
-    assertSingleRowThrowsForUnresolved(json, jsonPath, resultsType, label);
-  }
-
-  /**
-   * Each row is `(resultsType, jsonPath, JSON document, structural-shape label)`. Every case is
-   * one where `jsonPath` does NOT resolve in the given JSON document — that's what makes it
-   * exercise the null-handling code path.
-   */
-  @DataProvider(name = "unresolvedSinglePathCases")
-  public static Object[][] unresolvedSinglePathCases() {
-    return new Object[][]{
-        // FLAT — string path
-        {"STRING", "$.country", CC_FLAT_COUNTRY_MISSING, "flat: country key missing"},
-        {"STRING", "$.country", CC_FLAT_COUNTRY_EXPLICIT_NULL, "flat: country explicit JSON null"},
-        {"STRING", "$.country", CC_FLAT_EMPTY, "flat: empty document"},
-        // FLAT — numeric path, all 5 numeric SV types
-        {"INT", "$.clicks", CC_FLAT_CLICKS_MISSING, "flat: clicks missing (INT)"},
-        {"LONG", "$.clicks", CC_FLAT_CLICKS_MISSING, "flat: clicks missing (LONG)"},
-        {"FLOAT", "$.clicks", CC_FLAT_CLICKS_MISSING, "flat: clicks missing (FLOAT)"},
-        {"DOUBLE", "$.clicks", CC_FLAT_CLICKS_MISSING, "flat: clicks missing (DOUBLE)"},
-        {"BIG_DECIMAL", "$.clicks", CC_FLAT_CLICKS_MISSING, "flat: clicks missing (BIG_DECIMAL)"},
-        {"INT", "$.clicks", CC_FLAT_CLICKS_EXPLICIT_NULL, "flat: clicks explicit JSON null (INT)"},
-        // NESTED OBJECT
-        {"STRING", "$.location.country", CC_NESTED_INNER_MISSING, "nested: inner key missing"},
-        {"STRING", "$.location.country", CC_NESTED_PARENT_EXPLICIT_NULL, "nested: parent explicit JSON null"},
-        {"STRING", "$.location.country", CC_NESTED_PARENT_MISSING, "nested: parent key missing"},
-        // ARRAY ELEMENT
-        {"STRING", "$.tags[0]", CC_ARRAY_NULL_PARENT, "array: parent explicit JSON null"},
-        {"STRING", "$.tags[0]", CC_ARRAY_EMPTY, "array: empty array"},
-        {"STRING", "$.tags[1]", CC_ARRAY_SINGLE_ELEM, "array: index out-of-bounds"},
-        {"STRING", "$.tags[0]", CC_ARRAY_PARENT_MISSING, "array: parent key missing"},
-        // ARRAY OF OBJECTS
-        {"STRING", "$.events[0].country", CC_AOO_INNER_EXPLICIT_NULL, "array-of-obj: inner explicit JSON null"},
-        {"STRING", "$.events[0].country", CC_AOO_INNER_KEY_MISSING, "array-of-obj: inner key missing"},
-        {"STRING", "$.events[0].country", CC_AOO_EMPTY_ARRAY, "array-of-obj: empty array"},
-        {"STRING", "$.events[0].country", CC_AOO_NULL_ARRAY, "array-of-obj: null array"},
-        // ARRAY OF OBJECTS — numeric (INT) confirms typed coverage at depth
-        {"INT", "$.events[0].clicks", CC_AOO_INNER_NUMERIC_MISSING, "array-of-obj: inner numeric missing (INT)"}
-    };
-  }
-
-  // ---------------- Resolved paths: null-handling ON must pass values through ----------------
-
-  /**
-   * Resolved-path regression guard. The fix only changes the unresolved-row behavior; resolved
-   * paths must still produce their values verbatim at every JSON nesting depth.
-   * <p>
-   * Example (array of objects, numeric):
-   * <pre>
-   *   JSON:   { "events": [{"clicks": 1}, {"clicks": 7}] }
-   *   Query:  SET enableNullHandling = true;
-   *           SELECT jsonExtractScalar(json, '$.events[1].clicks', 'INT') FROM testTable
-   *   Result: 7
-   * </pre>
-   */
-  @Test(dataProvider = "resolvedSinglePathCases")
-  public void testNullHandlingOnPassesResolvedValueThrough(String resultsType, String jsonPath, String json,
-      Object expectedValue, String label) {
-    Object[] expectedRow = new Object[]{expectedValue};
-    givenSingleRowJsonTable(true, json)
-        .whenQuery(String.format("SELECT jsonExtractScalar(json, '%s', '%s') FROM testTable", jsonPath, resultsType))
-        .thenResultIs(expectedRow, expectedRow);
-  }
-
-  /** Each row is `(resultsType, jsonPath, JSON document, expected resolved value, label)`. */
-  @DataProvider(name = "resolvedSinglePathCases")
-  public static Object[][] resolvedSinglePathCases() {
-    return new Object[][]{
-        {"STRING", "$.country", CC_FLAT_RESOLVED, "US", "flat string"},
-        {"INT", "$.clicks", CC_FLAT_RESOLVED, 5, "flat int"},
-        {"STRING", "$.location.country", CC_NESTED_RESOLVED, "US", "nested string"},
-        {"STRING", "$.tags[1]", CC_ARRAY_RESOLVED, "blue", "array element"},
-        {"STRING", "$.events[0].country", CC_AOO_RESOLVED, "US", "array-of-obj inner string"},
-        {"INT", "$.events[1].clicks", CC_AOO_NUMERIC_RESOLVED, 7, "array-of-obj inner numeric"}
-    };
-  }
-
-  // ---------------- 4-arg with SQL NULL default + null-handling ON (regression guard) ----------------
-
-  /**
-   * 4-arg `jsonExtractScalar(json, path, type, NULL)` + null handling ON. This is the pre-existing
-   * {@code _defaultIsNull} code path — must continue producing SQL NULL at every nesting depth so
-   * the E4 fix doesn't disturb it.
-   * <p>
-   * Example (nested, inner missing):
-   * <pre>
-   *   JSON:   { "location": { "city": "SF" } }
-   *   Query:  SET enableNullHandling = true;
-   *           SELECT jsonExtractScalar(json, '$.location.country', 'STRING', NULL) FROM testTable
-   *   Result: NULL
-   * </pre>
-   */
-  @Test(dataProvider = "fourArgSqlNullDefaultCases")
-  public void testFourArgSqlNullDefaultReturnsNullWithNullHandlingOn(String jsonPath, String json, String label) {
-    Object[] expectedRow = new Object[]{null};
-    givenSingleRowJsonTable(true, json)
-        .whenQuery(String.format("SELECT jsonExtractScalar(json, '%s', 'STRING', NULL) FROM testTable", jsonPath))
-        .thenResultIs(expectedRow, expectedRow);
-  }
-
-  /** Each row is `(jsonPath, JSON document, label)` — all rows pick a path that does NOT resolve. */
-  @DataProvider(name = "fourArgSqlNullDefaultCases")
-  public static Object[][] fourArgSqlNullDefaultCases() {
-    return new Object[][]{
-        {"$.country", CC_FLAT_COUNTRY_MISSING, "flat: key missing"},
-        {"$.location.country", CC_NESTED_INNER_MISSING, "nested: inner missing"},
-        {"$.location.country", CC_NESTED_PARENT_EXPLICIT_NULL, "nested: parent explicit JSON null"},
-        {"$.tags[0]", CC_ARRAY_EMPTY, "array: empty"},
-        {"$.tags[0]", CC_ARRAY_NULL_PARENT, "array: null parent"},
-        {"$.events[0].country", CC_AOO_INNER_EXPLICIT_NULL, "array-of-obj: inner explicit JSON null"},
-        {"$.events[0].country", CC_FLAT_EMPTY, "deep path against empty root"}
-    };
-  }
-
-  // ---------------- GROUP BY: null-handling ON must produce a single null group ----------------
-
-  /**
-   * GROUP BY over the multi-row country/click fixture, with null handling ON. The unresolved rows
-   * (per the row breakdown in the fixture Javadoc above) must collapse into a single null group
-   * with the correct count, alongside the resolved value groups.
-   * <p>
-   * Example (flat country):
-   * <pre>
-   *   Rows (×2 for segment duplication):
-   *     Row 0: country = "US"        Row 1: country = "CA"
-   *     Row 2: country = JSON null   Row 3: country missing
-   *
-   *   Query: SELECT jsonExtractScalar(json, '$.country', 'STRING') AS v, COUNT(*)
-   *          FROM testTable GROUP BY v ORDER BY v ASC NULLS LAST
-   *
-   *   Result rows: ("CA", 2), ("US", 2), (NULL, 4)
-   * </pre>
-   * The data provider lists the expected (value, count) rows for each path covered.
-   */
-  @Test(dataProvider = "groupByCases")
-  public void testGroupByOnUnresolvedPathProducesNullGroup(String jsonPath, Object[][] expectedRows, String label) {
-    String query = String.format(
-        "SELECT jsonExtractScalar(json, '%s', 'STRING') AS v, COUNT(*) FROM testTable "
-            + "GROUP BY v ORDER BY v ASC NULLS LAST",
-        jsonPath);
-    givenCountryClickFixture(true).whenQuery(query).thenResultIs(expectedRows);
-  }
-
-  /**
-   * Each row is `(jsonPath, expected (value, count) rows after ORDER BY v ASC NULLS LAST, label)`.
-   * Counts are ×2 the per-row count due to segment duplication (one segment becomes two).
-   */
-  @DataProvider(name = "groupByCases")
-  public static Object[][] groupByCases() {
-    return new Object[][]{
-        // $.country — row0="US", row1="CA", row2=null, row3=missing → 2 of each + 4 null
-        {"$.country", new Object[][]{{"CA", 2L}, {"US", 2L}, {null, 4L}}, "flat country"},
-        // $.location.country — row0="US", row1=missing, row2=null parent, row3=missing → 2 "US" + 6 null
-        {"$.location.country", new Object[][]{{"US", 2L}, {null, 6L}}, "nested country"},
-        // $.tags[0] — row0="red", row1="green", row2=null array, row3=missing → 2 each + 4 null
-        {"$.tags[0]", new Object[][]{{"green", 2L}, {"red", 2L}, {null, 4L}}, "array first element"},
-        // $.events[0].country — row0="US", row1=null inner, row2=null array, row3=missing → 2 "US" + 6 null
-        {"$.events[0].country", new Object[][]{{"US", 2L}, {null, 6L}}, "array-of-obj inner country"}
-    };
-  }
-
-  /**
-   * GROUP BY with null handling OFF over the same mixed-resolution fixture must throw — the
-   * broker surfaces the failure as a query error which the FluentQueryTest framework escalates
-   * to an {@link AssertionError}.
-   */
-  @Test
-  public void testGroupByOnUnresolvedPathThrowsWhenNullHandlingOff() {
-    try {
-      givenCountryClickFixture(false)
-          .whenQuery("SELECT jsonExtractScalar(json, '$.country', 'STRING'), COUNT(*) FROM testTable GROUP BY 1")
-          .thenResultIs(new Object[]{"unused"});
-      Assert.fail("Expected GROUP BY query to fail when null handling is off and rows are unresolved");
-    } catch (AssertionError e) {
-      Assertions.assertThat(e.getMessage()).contains("Cannot resolve JSON path on some records");
-    }
-  }
-
-  // ---------------- DISTINCT: null-handling ON must include null in the distinct set ----------------
-
-  /**
-   * SELECT DISTINCT over the multi-row country/click fixture with null handling ON. The distinct
-   * set must include exactly one null entry alongside the resolved values — null must not blow up
-   * across segments, and must not throw.
-   * <p>
-   * Example (flat country):
-   * <pre>
-   *   Query: SELECT DISTINCT jsonExtractScalar(json, '$.country', 'STRING') FROM testTable
-   *          ORDER BY jsonExtractScalar(json, '$.country', 'STRING') ASC NULLS LAST
-   *
-   *   Result rows: ("CA"), ("US"), (NULL)
-   * </pre>
-   * Pinot requires the ORDER BY expression to match a DISTINCT column literally — positional
-   * ORDER BY (e.g. `ORDER BY 1`) is rejected with
-   * "ORDER-BY columns should be included in the DISTINCT columns" — hence the explicit expression.
-   */
-  @Test(dataProvider = "distinctCases")
-  public void testDistinctOnUnresolvedPathIncludesNull(String jsonPath, Object[][] expectedRows, String label) {
-    String expr = String.format("jsonExtractScalar(json, '%s', 'STRING')", jsonPath);
-    String query = String.format("SELECT DISTINCT %s FROM testTable ORDER BY %s ASC NULLS LAST", expr, expr);
-    givenCountryClickFixture(true).whenQuery(query).thenResultIs(expectedRows);
-  }
-
-  /** Each row is `(jsonPath, expected distinct values after ORDER BY v ASC NULLS LAST, label)`. */
-  @DataProvider(name = "distinctCases")
-  public static Object[][] distinctCases() {
-    return new Object[][]{
-        {"$.country", new Object[][]{{"CA"}, {"US"}, {null}}, "flat country"},
-        {"$.location.country", new Object[][]{{"US"}, {null}}, "nested country"},
-        {"$.tags[0]", new Object[][]{{"green"}, {"red"}, {null}}, "array first element"},
-        {"$.events[0].country", new Object[][]{{"US"}, {null}}, "array-of-obj inner country"}
-    };
-  }
-
-  @Test
-  public void testDistinctOnUnresolvedPathThrowsWhenNullHandlingOff() {
-    try {
-      givenCountryClickFixture(false)
-          .whenQuery("SELECT DISTINCT jsonExtractScalar(json, '$.country', 'STRING') FROM testTable")
-          .thenResultIs(new Object[]{"unused"});
-      Assert.fail("Expected DISTINCT query to fail when null handling is off and rows are unresolved");
-    } catch (AssertionError e) {
-      Assertions.assertThat(e.getMessage()).contains("Cannot resolve JSON path on some records");
-    }
-  }
 
   @Test(dataProvider = "testParsingIllegalQueries", expectedExceptions = {SqlCompilationException.class})
   public void testParsingIllegalQueries(String expressionStr) {
@@ -1393,5 +967,309 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
         // Cast STRING-result to LONG triggers the base-class cross-type path: STRING → parseLong.
         .whenQuery("SELECT CAST(jsonExtractScalar(json, '$.v', 'STRING') AS LONG) FROM testTable")
         .thenResultIs(new Object[]{42L}, new Object[]{42L});
+  }
+
+  // ============================================================================================
+  // Country/click null-handling tests for jsonExtractScalar (issue #18568).
+  //
+  // The SV null-handling fix: with `enableNullHandling = true` and no default literal, an
+  // unresolved JSON path must surface as SQL NULL instead of throwing.
+  //
+  // All tests below share a single `clicks` table fixture with two JSON columns and four rows:
+  //
+  //   `flatJson`   — 1-level scalar shapes. Each row exercises one case: resolved value, explicit
+  //                  JSON null, missing key, empty document.
+  //   `nestedJson` — multi-level shapes (nested object, array, array of objects) with mixed
+  //                  resolved / null / missing data at depth.
+  //
+  // Tests are grouped by query shape in this order: projection → DISTINCT → GROUP BY. Each group
+  // has a null-handling-on case (verifies SQL NULL surfaces) and a null-handling-off case
+  // (verifies the legacy throw is preserved). Result rows in every assertion are ordered by the
+  // projected expression ASC NULLS LAST so the comparison is deterministic across the framework's
+  // segment-duplication behavior (a single segment shows up twice, so per-row counts are ×2).
+  // ============================================================================================
+
+  // ---------------- Fixture ----------------
+  //
+  // Pretty-printed contents of the 4-row × 2-column fixture:
+  //
+  //   row 0 — fully populated:
+  //     flatJson:   { "country": "US", "clicks": 5 }
+  //     nestedJson: { "location": {"city": "SF", "country": "US"},
+  //                   "tags":     ["red", "blue", "green"],
+  //                   "events":   [{"country": "US"}, {"country": "CA"}] }
+  //
+  //   row 1 — partial / explicit-null at depth:
+  //     flatJson:   { "country": "CA", "clicks": 3 }
+  //     nestedJson: { "location": {"city": "Tor"},          // <-- no country key
+  //                   "tags":     ["green"],                 // <-- only one element
+  //                   "events":   [{"country": null}] }     // <-- inner explicit null
+  //
+  //   row 2 — every field explicit JSON null:
+  //     flatJson:   { "country": null, "clicks": null }
+  //     nestedJson: { "location": null, "tags": null, "events": null }
+  //
+  //   row 3 — empty documents:
+  //     flatJson:   {}
+  //     nestedJson: {}
+  //
+  // Across the four rows, every path covered by the tests has at least one resolved value AND
+  // at least one unresolved occurrence (missing key, explicit JSON null, null parent, or
+  // out-of-bounds array index), so both the value groups and the null group must show up.
+
+  private static final Object[][] COUNTRY_CLICK_FIXTURE = {
+      // {flatJson, nestedJson}
+      {
+          "{\"country\":\"US\",\"clicks\":5}",
+          "{\"location\":{\"city\":\"SF\",\"country\":\"US\"},"
+              + "\"tags\":[\"red\",\"blue\",\"green\"],"
+              + "\"events\":[{\"country\":\"US\"},{\"country\":\"CA\"}]}"
+      },
+      {
+          "{\"country\":\"CA\",\"clicks\":3}",
+          "{\"location\":{\"city\":\"Tor\"},"
+              + "\"tags\":[\"green\"],"
+              + "\"events\":[{\"country\":null}]}"
+      },
+      {
+          "{\"country\":null,\"clicks\":null}",
+          "{\"location\":null,\"tags\":null,\"events\":null}"
+      },
+      {"{}", "{}"}
+  };
+
+  // ---------------- Helper ----------------
+
+  private FluentQueryTest.OnFirstInstance givenCountryClickTable(boolean nullHandling) {
+    Schema schema = new Schema.SchemaBuilder()
+        .setSchemaName("clicks")
+        .setEnableColumnBasedNullHandling(true)
+        .addDimensionField("flatJson", DataType.JSON)
+        .addDimensionField("nestedJson", DataType.JSON)
+        .build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("clicks").build();
+    return FluentQueryTest.withBaseDir(_baseDir)
+        .withNullHandling(nullHandling)
+        .givenTable(schema, tableConfig)
+        .onFirstInstance(COUNTRY_CLICK_FIXTURE);
+  }
+
+  // ============================================================================================
+  // 1. Projection
+  // ============================================================================================
+
+  /**
+   * Projection with null handling ON. Each row's resolution depends on the column + path; the SV
+   * transform must surface SQL NULL for unresolved rows and pass resolved values through.
+   * <pre>
+   *   Example — `flatJson.country` (STRING):
+   *     per-row: row 0 -> "US", row 1 -> "CA", row 2 -> NULL (explicit), row 3 -> NULL (missing)
+   *
+   *     Query:  SET enableNullHandling = true;
+   *             SELECT jsonExtractScalar(flatJson, '$.country', 'STRING') AS c
+   *             FROM clicks ORDER BY c ASC NULLS LAST
+   *
+   *     Result rows (×2 for segment duplication):
+   *             "CA", "CA", "US", "US", NULL, NULL, NULL, NULL
+   * </pre>
+   */
+  @Test(dataProvider = "projectionCases")
+  public void testProjectionNullHandlingOn(String column, String jsonPath, String resultsType,
+      Object[][] expectedRows, String label) {
+    String expr = String.format("jsonExtractScalar(%s, '%s', '%s')", column, jsonPath, resultsType);
+    givenCountryClickTable(true)
+        .whenQuery(String.format("SELECT %s FROM clicks ORDER BY %s ASC NULLS LAST", expr, expr))
+        .thenResultIs(expectedRows);
+  }
+
+  /**
+   * Null handling OFF: any unresolved row throws. One representative path is enough — the throw
+   * is independent of path shape and result type.
+   */
+  @Test
+  public void testProjectionNullHandlingOffThrows() {
+    try {
+      givenCountryClickTable(false)
+          .whenQuery("SELECT jsonExtractScalar(flatJson, '$.country', 'STRING') FROM clicks")
+          .thenResultIs(new Object[]{"unused"});
+      Assert.fail("Expected projection to fail when null handling is off and rows are unresolved");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).contains("Cannot resolve JSON path on some records");
+    }
+  }
+
+  /**
+   * Each row is `(column, jsonPath, resultsType, expected 8-row result, label)`. Result rows are
+   * ordered by value ASC NULLS LAST. With segment duplication, the per-row count in the fixture
+   * is ×2 in the result.
+   */
+  @DataProvider(name = "projectionCases")
+  public static Object[][] projectionCases() {
+    return new Object[][]{
+        // ----- flatJson: 1-level scalar shape -----
+        // $.country: row0="US", row1="CA", row2=null (explicit), row3=null (missing).
+        {"flatJson", "$.country", "STRING", new Object[][]{
+            {"CA"}, {"CA"}, {"US"}, {"US"}, {null}, {null}, {null}, {null}
+        }, "flatJson.country STRING"},
+        // $.clicks across all 6 numeric SV types: row0=5, row1=3, row2=null, row3=null.
+        {"flatJson", "$.clicks", "INT", new Object[][]{
+            {3}, {3}, {5}, {5}, {null}, {null}, {null}, {null}
+        }, "flatJson.clicks INT"},
+        {"flatJson", "$.clicks", "LONG", new Object[][]{
+            {3L}, {3L}, {5L}, {5L}, {null}, {null}, {null}, {null}
+        }, "flatJson.clicks LONG"},
+        {"flatJson", "$.clicks", "FLOAT", new Object[][]{
+            {3f}, {3f}, {5f}, {5f}, {null}, {null}, {null}, {null}
+        }, "flatJson.clicks FLOAT"},
+        {"flatJson", "$.clicks", "DOUBLE", new Object[][]{
+            {3d}, {3d}, {5d}, {5d}, {null}, {null}, {null}, {null}
+        }, "flatJson.clicks DOUBLE"},
+        // BIG_DECIMAL is formatted as String by the broker (BigDecimal.toPlainString).
+        {"flatJson", "$.clicks", "BIG_DECIMAL", new Object[][]{
+            {"3"}, {"3"}, {"5"}, {"5"}, {null}, {null}, {null}, {null}
+        }, "flatJson.clicks BIG_DECIMAL"},
+
+        // ----- nestedJson: multi-level shapes -----
+        // $.location.country: row0="US", row1=missing (no country key), row2=parent null, row3=missing.
+        {"nestedJson", "$.location.country", "STRING", new Object[][]{
+            {"US"}, {"US"}, {null}, {null}, {null}, {null}, {null}, {null}
+        }, "nestedJson.location.country STRING"},
+        // $.tags[0]: row0="red", row1="green", row2=null parent, row3=missing.
+        {"nestedJson", "$.tags[0]", "STRING", new Object[][]{
+            {"green"}, {"green"}, {"red"}, {"red"}, {null}, {null}, {null}, {null}
+        }, "nestedJson.tags[0] STRING"},
+        // $.tags[1]: row0="blue", row1=out-of-bounds (only one element), row2=null parent, row3=missing.
+        {"nestedJson", "$.tags[1]", "STRING", new Object[][]{
+            {"blue"}, {"blue"}, {null}, {null}, {null}, {null}, {null}, {null}
+        }, "nestedJson.tags[1] STRING (OOB on row 1)"},
+        // $.events[0].country: row0="US", row1=explicit inner null, row2=null array, row3=missing.
+        {"nestedJson", "$.events[0].country", "STRING", new Object[][]{
+            {"US"}, {"US"}, {null}, {null}, {null}, {null}, {null}, {null}
+        }, "nestedJson.events[0].country STRING"}
+    };
+  }
+
+  // ============================================================================================
+  // 2. DISTINCT
+  // ============================================================================================
+
+  /**
+   * DISTINCT with null handling ON. The distinct set must include exactly one null entry
+   * alongside the resolved values (deduped across segments).
+   * <pre>
+   *   Example — `flatJson.country` (STRING):
+   *     Query:  SET enableNullHandling = true;
+   *             SELECT DISTINCT jsonExtractScalar(flatJson, '$.country', 'STRING') FROM clicks
+   *             ORDER BY jsonExtractScalar(flatJson, '$.country', 'STRING') ASC NULLS LAST
+   *
+   *     Result: "CA", "US", NULL
+   * </pre>
+   * Pinot rejects positional `ORDER BY 1` for DISTINCT ("ORDER-BY columns should be included in
+   * the DISTINCT columns"), so the expression is repeated in the ORDER BY clause.
+   */
+  @Test(dataProvider = "distinctCases")
+  public void testDistinctNullHandlingOn(String column, String jsonPath, String resultsType,
+      Object[][] expectedRows, String label) {
+    String expr = String.format("jsonExtractScalar(%s, '%s', '%s')", column, jsonPath, resultsType);
+    String query = String.format("SELECT DISTINCT %s FROM clicks ORDER BY %s ASC NULLS LAST", expr, expr);
+    givenCountryClickTable(true).whenQuery(query).thenResultIs(expectedRows);
+  }
+
+  @Test
+  public void testDistinctNullHandlingOffThrows() {
+    try {
+      givenCountryClickTable(false)
+          .whenQuery("SELECT DISTINCT jsonExtractScalar(flatJson, '$.country', 'STRING') FROM clicks")
+          .thenResultIs(new Object[]{"unused"});
+      Assert.fail("Expected DISTINCT to fail when null handling is off and rows are unresolved");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).contains("Cannot resolve JSON path on some records");
+    }
+  }
+
+  /** Each row is `(column, jsonPath, resultsType, expected distinct rows ASC NULLS LAST, label)`. */
+  @DataProvider(name = "distinctCases")
+  public static Object[][] distinctCases() {
+    return new Object[][]{
+        // flatJson: 1-level scalar.
+        {"flatJson", "$.country", "STRING", new Object[][]{{"CA"}, {"US"}, {null}}, "flatJson.country"},
+        {"flatJson", "$.clicks", "INT", new Object[][]{{3}, {5}, {null}}, "flatJson.clicks INT"},
+        // nestedJson: multi-level paths.
+        {"nestedJson", "$.location.country", "STRING", new Object[][]{{"US"}, {null}},
+            "nestedJson.location.country"},
+        {"nestedJson", "$.tags[0]", "STRING", new Object[][]{{"green"}, {"red"}, {null}},
+            "nestedJson.tags[0]"},
+        {"nestedJson", "$.events[0].country", "STRING", new Object[][]{{"US"}, {null}},
+            "nestedJson.events[0].country"}
+    };
+  }
+
+  // ============================================================================================
+  // 3. GROUP BY
+  // ============================================================================================
+
+  /**
+   * GROUP BY with null handling ON. Unresolved rows must collapse into a single null group with
+   * the correct count, alongside the resolved value groups.
+   * <pre>
+   *   Example — `flatJson.country` (STRING):
+   *     per-row: row 0 -> "US", row 1 -> "CA", row 2 -> NULL (explicit), row 3 -> NULL (missing)
+   *
+   *     Query:  SET enableNullHandling = true;
+   *             SELECT jsonExtractScalar(flatJson, '$.country', 'STRING') AS v, COUNT(*)
+   *             FROM clicks GROUP BY v ORDER BY v ASC NULLS LAST
+   *
+   *     Result (counts ×2 for segment duplication): ("CA", 2), ("US", 2), (NULL, 4)
+   * </pre>
+   */
+  @Test(dataProvider = "groupByCases")
+  public void testGroupByNullHandlingOn(String column, String jsonPath, String resultsType,
+      Object[][] expectedRows, String label) {
+    String expr = String.format("jsonExtractScalar(%s, '%s', '%s')", column, jsonPath, resultsType);
+    String query = String.format(
+        "SELECT %s AS v, COUNT(*) FROM clicks GROUP BY v ORDER BY v ASC NULLS LAST", expr);
+    givenCountryClickTable(true).whenQuery(query).thenResultIs(expectedRows);
+  }
+
+  @Test
+  public void testGroupByNullHandlingOffThrows() {
+    try {
+      givenCountryClickTable(false)
+          .whenQuery("SELECT jsonExtractScalar(flatJson, '$.country', 'STRING'), COUNT(*) FROM clicks GROUP BY 1")
+          .thenResultIs(new Object[]{"unused"});
+      Assert.fail("Expected GROUP BY to fail when null handling is off and rows are unresolved");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).contains("Cannot resolve JSON path on some records");
+    }
+  }
+
+  /**
+   * Each row is `(column, jsonPath, resultsType, expected (value, count) rows ASC NULLS LAST,
+   * label)`. Counts are ×2 the per-row count due to segment duplication.
+   */
+  @DataProvider(name = "groupByCases")
+  public static Object[][] groupByCases() {
+    return new Object[][]{
+        // flatJson.country: row0="US", row1="CA", row2=null, row3=null -> 2 each + 4 null.
+        {"flatJson", "$.country", "STRING", new Object[][]{
+            {"CA", 2L}, {"US", 2L}, {null, 4L}
+        }, "flatJson.country"},
+        // flatJson.clicks INT: row0=5, row1=3, row2=null, row3=null -> 2 each + 4 null.
+        {"flatJson", "$.clicks", "INT", new Object[][]{
+            {3, 2L}, {5, 2L}, {null, 4L}
+        }, "flatJson.clicks INT"},
+        // nestedJson.location.country: row0="US", rows 1/2/3 unresolved -> 2 "US" + 6 null.
+        {"nestedJson", "$.location.country", "STRING", new Object[][]{
+            {"US", 2L}, {null, 6L}
+        }, "nestedJson.location.country"},
+        // nestedJson.tags[0]: row0="red", row1="green", rows 2/3 unresolved -> 2 each + 4 null.
+        {"nestedJson", "$.tags[0]", "STRING", new Object[][]{
+            {"green", 2L}, {"red", 2L}, {null, 4L}
+        }, "nestedJson.tags[0]"},
+        // nestedJson.events[0].country: row0="US", rows 1/2/3 unresolved -> 2 "US" + 6 null.
+        {"nestedJson", "$.events[0].country", "STRING", new Object[][]{
+            {"US", 2L}, {null, 6L}
+        }, "nestedJson.events[0].country"}
+    };
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunctionTest.java
@@ -1284,72 +1284,191 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
   // ============================================================================================
 
   /**
-   * Projection with NH on AND default `'foobar'`. Unresolved rows must surface as `"foobar"`,
-   * not SQL NULL.
+   * Projection with NH on AND a non-null default literal. Unresolved rows must surface as the
+   * default, not SQL NULL — across both flat scalar and nested-object shapes.
    * <pre>
-   *   Per-row resolution: row 0 -> "US", row 1 -> "CA", row 2 -> "foobar", row 3 -> "foobar"
+   *   Example — flatJson.country with default 'foobar':
+   *     per-row: row 0 -> "US", row 1 -> "CA", row 2 -> "foobar" (was null),
+   *              row 3 -> "foobar" (was missing)
    *
-   *   Query: SET enableNullHandling = true;
-   *          SELECT jsonExtractScalar(flatJson, '$.country', 'STRING', 'foobar') AS c
-   *          FROM clicks ORDER BY c ASC
+   *     Query: SET enableNullHandling = true;
+   *            SELECT jsonExtractScalar(flatJson, '$.country', 'STRING', 'foobar') AS c
+   *            FROM clicks ORDER BY c ASC
    *
-   *   Result rows (×2 for segment duplication; ASCII order: uppercase < lowercase):
-   *           "CA", "CA", "US", "US", "foobar", "foobar", "foobar", "foobar"
+   *     Result rows (×2 segment dup; ASCII order, uppercase before lowercase):
+   *             "CA", "CA", "US", "US", "foobar", "foobar", "foobar", "foobar"
    * </pre>
    */
-  @Test
-  public void testProjectionDefaultBeatsNullHandlingPlaceholder() {
+  @Test(dataProvider = "defaultPrecedenceProjectionCases")
+  public void testProjectionDefaultBeatsNullHandlingPlaceholder(String column, String jsonPath,
+      String defaultLiteral, Object[][] expectedRows, String label) {
+    String expr = String.format(
+        "jsonExtractScalar(%s, '%s', 'STRING', %s)", column, jsonPath, defaultLiteral);
     givenCountryClickTable(true)
-        .whenQuery("SELECT jsonExtractScalar(flatJson, '$.country', 'STRING', 'foobar') AS c "
-            + "FROM clicks ORDER BY c ASC")
-        .thenResultIs(
-            new Object[]{"CA"}, new Object[]{"CA"},
-            new Object[]{"US"}, new Object[]{"US"},
-            new Object[]{"foobar"}, new Object[]{"foobar"},
-            new Object[]{"foobar"}, new Object[]{"foobar"});
+        .whenQuery(String.format("SELECT %s AS c FROM clicks ORDER BY c ASC", expr))
+        .thenResultIs(expectedRows);
   }
 
   /**
-   * DISTINCT with NH on AND default `'foobar'`. The distinct set must include the default value
-   * as a regular distinct entry — no separate null entry.
-   * <pre>
-   *   Query: SET enableNullHandling = true;
-   *          SELECT DISTINCT jsonExtractScalar(flatJson, '$.country', 'STRING', 'foobar') FROM clicks
-   *          ORDER BY jsonExtractScalar(flatJson, '$.country', 'STRING', 'foobar') ASC
-   *
-   *   Result (ASCII order: uppercase < lowercase): "CA", "US", "foobar"
-   * </pre>
+   * Each row: `(column, jsonPath, default SQL literal, expected 8-row result, label)`. Result
+   * rows are ordered ASC. Each per-row value in the fixture appears ×2 due to segment duplication.
    */
-  @Test
-  public void testDistinctDefaultBeatsNullHandlingPlaceholder() {
-    String expr = "jsonExtractScalar(flatJson, '$.country', 'STRING', 'foobar')";
+  @DataProvider(name = "defaultPrecedenceProjectionCases")
+  public static Object[][] defaultPrecedenceProjectionCases() {
+    return new Object[][]{
+        // flatJson.country: row0="US", row1="CA", row2=null, row3=missing -> 2 each, 4 'foobar'.
+        {"flatJson", "$.country", "'foobar'", new Object[][]{
+            {"CA"}, {"CA"}, {"US"}, {"US"},
+            {"foobar"}, {"foobar"}, {"foobar"}, {"foobar"}
+        }, "flatJson.country default 'foobar'"},
+        // nestedJson.location.country: row0="US", rows 1/2/3 unresolved -> 2 "US" + 6 'foobar'.
+        {"nestedJson", "$.location.country", "'foobar'", new Object[][]{
+            {"US"}, {"US"},
+            {"foobar"}, {"foobar"}, {"foobar"}, {"foobar"}, {"foobar"}, {"foobar"}
+        }, "nestedJson.location.country default 'foobar'"}
+    };
+  }
+
+  /**
+   * DISTINCT with NH on AND a non-null default literal. The distinct set includes the default
+   * value as a regular entry — no separate null entry.
+   */
+  @Test(dataProvider = "defaultPrecedenceDistinctCases")
+  public void testDistinctDefaultBeatsNullHandlingPlaceholder(String column, String jsonPath,
+      String defaultLiteral, Object[][] expectedRows, String label) {
+    String expr = String.format(
+        "jsonExtractScalar(%s, '%s', 'STRING', %s)", column, jsonPath, defaultLiteral);
     givenCountryClickTable(true)
         .whenQuery(String.format("SELECT DISTINCT %s FROM clicks ORDER BY %s ASC", expr, expr))
-        .thenResultIs(new Object[]{"CA"}, new Object[]{"US"}, new Object[]{"foobar"});
+        .thenResultIs(expectedRows);
+  }
+
+  /** Each row: `(column, jsonPath, default literal, expected distinct rows ASC, label)`. */
+  @DataProvider(name = "defaultPrecedenceDistinctCases")
+  public static Object[][] defaultPrecedenceDistinctCases() {
+    return new Object[][]{
+        {"flatJson", "$.country", "'foobar'",
+            new Object[][]{{"CA"}, {"US"}, {"foobar"}}, "flatJson.country default 'foobar'"},
+        {"nestedJson", "$.location.country", "'foobar'",
+            new Object[][]{{"US"}, {"foobar"}}, "nestedJson.location.country default 'foobar'"}
+    };
   }
 
   /**
-   * GROUP BY with NH on AND default `'foobar'`. Unresolved rows count toward the default's
-   * group, not a null group — so the result has no NULL group at all.
+   * GROUP BY with NH on AND a non-null default literal. Unresolved rows count toward the
+   * default's group — no NULL group surfaces.
+   */
+  @Test(dataProvider = "defaultPrecedenceGroupByCases")
+  public void testGroupByDefaultBeatsNullHandlingPlaceholder(String column, String jsonPath,
+      String defaultLiteral, Object[][] expectedRows, String label) {
+    String expr = String.format(
+        "jsonExtractScalar(%s, '%s', 'STRING', %s)", column, jsonPath, defaultLiteral);
+    givenCountryClickTable(true)
+        .whenQuery(String.format(
+            "SELECT %s AS v, COUNT(*) FROM clicks GROUP BY v ORDER BY v ASC", expr))
+        .thenResultIs(expectedRows);
+  }
+
+  /** Each row: `(column, jsonPath, default literal, expected (value, count) rows ASC, label)`. */
+  @DataProvider(name = "defaultPrecedenceGroupByCases")
+  public static Object[][] defaultPrecedenceGroupByCases() {
+    return new Object[][]{
+        // flatJson.country: 2 "CA" + 2 "US" + 4 'foobar'.
+        {"flatJson", "$.country", "'foobar'", new Object[][]{
+            {"CA", 2L}, {"US", 2L}, {"foobar", 4L}
+        }, "flatJson.country default 'foobar'"},
+        // nestedJson.location.country: 2 "US" + 6 'foobar'.
+        {"nestedJson", "$.location.country", "'foobar'", new Object[][]{
+            {"US", 2L}, {"foobar", 6L}
+        }, "nestedJson.location.country default 'foobar'"}
+    };
+  }
+
+  // ============================================================================================
+  // 5. 4-arg with SQL NULL literal as default, under null handling ON
+  //
+  // Result is identical to the 3-arg + NH-on case (unresolved rows surface as SQL NULL), but
+  // the code path is different: `init` sets `_defaultValue` to the typed zero (0, "", etc.) and
+  // marks `_defaultIsNull=true`. The SV transform writes the typed zero via the
+  // `_defaultValue != null` branch; `getNullBitmap` scans and marks unresolved rows null thanks
+  // to the `!_defaultIsNull` carve-out in its short-circuit condition. These tests pin that
+  // code path so a future refactor that removes `_defaultIsNull` won't silently break this case.
+  // ============================================================================================
+
+  /**
+   * Projection with NH on AND `NULL` literal as the default. Unresolved rows surface as SQL NULL,
+   * same as the 3-arg form.
    * <pre>
-   *   Per-row resolution: row 0 -> "US", row 1 -> "CA", row 2 -> "foobar", row 3 -> "foobar"
+   *   Example — flatJson.country:
+   *     Query: SET enableNullHandling = true;
+   *            SELECT jsonExtractScalar(flatJson, '$.country', 'STRING', NULL) AS c
+   *            FROM clicks ORDER BY c ASC NULLS LAST
    *
-   *   Query: SET enableNullHandling = true;
-   *          SELECT jsonExtractScalar(flatJson, '$.country', 'STRING', 'foobar') AS v, COUNT(*)
-   *          FROM clicks GROUP BY v ORDER BY v ASC
-   *
-   *   Result (counts ×2 for segment duplication; ASCII order: uppercase < lowercase):
-   *           ("CA", 2), ("US", 2), ("foobar", 4)
+   *     Result rows (×2 segment dup):
+   *             "CA", "CA", "US", "US", NULL, NULL, NULL, NULL
    * </pre>
    */
-  @Test
-  public void testGroupByDefaultBeatsNullHandlingPlaceholder() {
+  @Test(dataProvider = "sqlNullDefaultProjectionCases")
+  public void testProjectionWithSqlNullDefaultEmitsNull(String column, String jsonPath,
+      Object[][] expectedRows, String label) {
+    String expr = String.format("jsonExtractScalar(%s, '%s', 'STRING', NULL)", column, jsonPath);
     givenCountryClickTable(true)
-        .whenQuery("SELECT jsonExtractScalar(flatJson, '$.country', 'STRING', 'foobar') AS v, COUNT(*) "
-            + "FROM clicks GROUP BY v ORDER BY v ASC")
-        .thenResultIs(
-            new Object[]{"CA", 2L},
-            new Object[]{"US", 2L},
-            new Object[]{"foobar", 4L});
+        .whenQuery(String.format("SELECT %s AS c FROM clicks ORDER BY c ASC NULLS LAST", expr))
+        .thenResultIs(expectedRows);
+  }
+
+  /** Each row: `(column, jsonPath, expected 8-row result ordered ASC NULLS LAST, label)`. */
+  @DataProvider(name = "sqlNullDefaultProjectionCases")
+  public static Object[][] sqlNullDefaultProjectionCases() {
+    return new Object[][]{
+        {"flatJson", "$.country", new Object[][]{
+            {"CA"}, {"CA"}, {"US"}, {"US"}, {null}, {null}, {null}, {null}
+        }, "flatJson.country NULL default"},
+        {"nestedJson", "$.location.country", new Object[][]{
+            {"US"}, {"US"}, {null}, {null}, {null}, {null}, {null}, {null}
+        }, "nestedJson.location.country NULL default"}
+    };
+  }
+
+  /** DISTINCT with NH on AND `NULL` literal as default — the distinct set includes a null entry. */
+  @Test(dataProvider = "sqlNullDefaultDistinctCases")
+  public void testDistinctWithSqlNullDefaultIncludesNull(String column, String jsonPath,
+      Object[][] expectedRows, String label) {
+    String expr = String.format("jsonExtractScalar(%s, '%s', 'STRING', NULL)", column, jsonPath);
+    givenCountryClickTable(true)
+        .whenQuery(String.format("SELECT DISTINCT %s FROM clicks ORDER BY %s ASC NULLS LAST", expr, expr))
+        .thenResultIs(expectedRows);
+  }
+
+  /** Each row: `(column, jsonPath, expected distinct rows ASC NULLS LAST, label)`. */
+  @DataProvider(name = "sqlNullDefaultDistinctCases")
+  public static Object[][] sqlNullDefaultDistinctCases() {
+    return new Object[][]{
+        {"flatJson", "$.country", new Object[][]{{"CA"}, {"US"}, {null}}, "flatJson.country NULL default"},
+        {"nestedJson", "$.location.country", new Object[][]{{"US"}, {null}},
+            "nestedJson.location.country NULL default"}
+    };
+  }
+
+  /** GROUP BY with NH on AND `NULL` literal as default — unresolved rows form a null group. */
+  @Test(dataProvider = "sqlNullDefaultGroupByCases")
+  public void testGroupByWithSqlNullDefaultProducesNullGroup(String column, String jsonPath,
+      Object[][] expectedRows, String label) {
+    String expr = String.format("jsonExtractScalar(%s, '%s', 'STRING', NULL)", column, jsonPath);
+    givenCountryClickTable(true)
+        .whenQuery(String.format(
+            "SELECT %s AS v, COUNT(*) FROM clicks GROUP BY v ORDER BY v ASC NULLS LAST", expr))
+        .thenResultIs(expectedRows);
+  }
+
+  /** Each row: `(column, jsonPath, expected (value, count) rows ASC NULLS LAST, label)`. */
+  @DataProvider(name = "sqlNullDefaultGroupByCases")
+  public static Object[][] sqlNullDefaultGroupByCases() {
+    return new Object[][]{
+        {"flatJson", "$.country", new Object[][]{{"CA", 2L}, {"US", 2L}, {null, 4L}},
+            "flatJson.country NULL default"},
+        {"nestedJson", "$.location.country", new Object[][]{{"US", 2L}, {null, 6L}},
+            "nestedJson.location.country NULL default"}
+    };
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunctionTest.java
@@ -447,6 +447,314 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 
+  /**
+   * Country/click scenarios where the typed JSON path does NOT resolve to a value, spanning four
+   * JSON structural shapes:
+   * <ol>
+   *   <li><b>Flat:</b> top-level scalar key missing, explicitly null, or empty doc.</li>
+   *   <li><b>Nested object:</b> {@code $.location.country} — inner key missing, parent JSON null,
+   *       or root missing parent entirely.</li>
+   *   <li><b>Array element:</b> {@code $.tags[i]} — array null, empty, or index out-of-bounds.</li>
+   *   <li><b>Array of objects:</b> {@code $.events[0].country} — inner field null, array empty,
+   *       array null, or root missing.</li>
+   * </ol>
+   * JsonPath {@code SUPPRESS_EXCEPTIONS} folds every one of these into the same Java {@code null},
+   * so all must produce SQL NULL when query-level null handling is enabled, and all must throw
+   * {@code IllegalArgumentException} when null handling is disabled and no default is set.
+   */
+  @DataProvider(name = "countryClickUnresolvedCases")
+  public static Object[][] countryClickUnresolvedCases() {
+    return new Object[][]{
+        // --- Flat / top-level scalar ---
+        {"STRING", "$.country", "{\"clicks\": 5}", "flat country missing"},
+        {"STRING", "$.country", "{\"country\": null, \"clicks\": 5}", "flat country explicit-null"},
+        {"STRING", "$.country", "{}", "flat empty doc"},
+        // --- Flat / numeric across all typed SV paths ---
+        {"INT", "$.clicks", "{\"country\": \"US\"}", "flat clicks missing (INT)"},
+        {"LONG", "$.clicks", "{\"country\": \"US\"}", "flat clicks missing (LONG)"},
+        {"FLOAT", "$.clicks", "{\"country\": \"US\"}", "flat clicks missing (FLOAT)"},
+        {"DOUBLE", "$.clicks", "{\"country\": \"US\"}", "flat clicks missing (DOUBLE)"},
+        {"BIG_DECIMAL", "$.clicks", "{\"country\": \"US\"}", "flat clicks missing (BIG_DECIMAL)"},
+        {"INT", "$.clicks", "{\"country\": \"US\", \"clicks\": null}", "flat clicks explicit-null (INT)"},
+        // --- Nested object ---
+        {"STRING", "$.location.country", "{\"location\": {\"city\": \"SF\"}}", "nested inner key missing"},
+        {"STRING", "$.location.country", "{\"location\": null}", "nested parent explicit-null"},
+        {"STRING", "$.location.country", "{\"country\": \"US\"}", "nested parent missing"},
+        // --- Array element ---
+        {"STRING", "$.tags[0]", "{\"tags\": null}", "array null parent"},
+        {"STRING", "$.tags[0]", "{\"tags\": []}", "array empty"},
+        {"STRING", "$.tags[1]", "{\"tags\": [\"red\"]}", "array index out-of-bounds"},
+        {"STRING", "$.tags[0]", "{\"country\": \"US\"}", "array parent missing"},
+        // --- Array of objects ---
+        {"STRING", "$.events[0].country", "{\"events\": [{\"country\": null}]}", "array-of-obj inner explicit-null"},
+        {"STRING", "$.events[0].country", "{\"events\": [{}]}", "array-of-obj inner key missing"},
+        {"STRING", "$.events[0].country", "{\"events\": []}", "array-of-obj empty array"},
+        {"STRING", "$.events[0].country", "{\"events\": null}", "array-of-obj null array"},
+        // --- Array of objects, numeric (INT) — confirms typed coverage at depth ---
+        {"INT", "$.events[0].clicks", "{\"events\": [{\"country\": \"US\"}]}", "array-of-obj inner numeric missing"}
+    };
+  }
+
+  /**
+   * E4 behavior: 3-arg {@code jsonExtractScalar} + query-level null handling ENABLED + unresolved
+   * path. The transform must surface SQL NULL in the projection instead of throwing, so the scalar
+   * fallback agrees with index-aware operators ({@code JsonIndexDistinctOperator},
+   * {@code JsonIndexGroupByOperator}) on the null-group semantics.
+   */
+  @Test(dataProvider = "countryClickUnresolvedCases")
+  public void testCountryClickNullHandlingOnEmitsNull(String resultsType, String jsonPath, String json, String label) {
+    Schema schema = new Schema.SchemaBuilder()
+        .setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addDimensionField("json", DataType.JSON)
+        .build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("testTable")
+        .build();
+    Object[] expectedRow = new Object[]{null};
+    FluentQueryTest.withBaseDir(_baseDir)
+        .withNullHandling(true)
+        .givenTable(schema, tableConfig)
+        .onFirstInstance(new Object[]{json})
+        .whenQuery(String.format("SELECT jsonExtractScalar(json, '%s', '%s') FROM testTable", jsonPath, resultsType))
+        // TODO: Change the framework to do not duplicate segments when only one segment is used.
+        .thenResultIs(expectedRow, expectedRow);
+  }
+
+  /**
+   * E3 behavior preservation: 3-arg {@code jsonExtractScalar} + query-level null handling DISABLED
+   * + unresolved path must still throw. The E4 fix is gated on {@code _nullHandlingEnabled}, so
+   * callers that haven't opted in see the legacy behavior.
+   */
+  @Test(dataProvider = "countryClickUnresolvedCases")
+  public void testCountryClickNullHandlingOffThrows(String resultsType, String jsonPath, String json, String label) {
+    Schema schema = new Schema.SchemaBuilder()
+        .setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addDimensionField("json", DataType.JSON)
+        .build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("testTable")
+        .build();
+    try {
+      FluentQueryTest.withBaseDir(_baseDir)
+          .withNullHandling(false)
+          .givenTable(schema, tableConfig)
+          .onFirstInstance(new Object[]{json})
+          .whenQuery(String.format("SELECT jsonExtractScalar(json, '%s', '%s') FROM testTable", jsonPath, resultsType))
+          .thenResultIs(new Object[]{"unused"});
+      Assert.fail("Expected query to fail for " + label);
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage())
+          .describedAs("Case: " + label)
+          .contains("Cannot resolve JSON path on some records");
+    }
+  }
+
+  /**
+   * Positive cases: when the typed JSON path resolves — including at depth through nested objects,
+   * array elements, and array-of-objects — null-handling ON must surface the resolved value
+   * as-is. The fix only changes the unresolved-row behavior; resolved paths must be untouched at
+   * every nesting depth.
+   */
+  @DataProvider(name = "countryClickResolvedCases")
+  public static Object[][] countryClickResolvedCases() {
+    return new Object[][]{
+        // (resultsType, jsonPath, JSON doc, expected resolved value, label)
+        {"STRING", "$.country", "{\"country\": \"US\", \"clicks\": 5}", "US", "flat string"},
+        {"INT", "$.clicks", "{\"country\": \"US\", \"clicks\": 5}", 5, "flat int"},
+        {"STRING", "$.location.country", "{\"location\": {\"city\": \"SF\", \"country\": \"US\"}}", "US",
+            "nested string"},
+        {"STRING", "$.tags[1]", "{\"tags\": [\"red\", \"blue\", \"green\"]}", "blue", "array element"},
+        {"STRING", "$.events[0].country", "{\"events\": [{\"country\": \"US\"}, {\"country\": \"CA\"}]}", "US",
+            "array-of-obj inner"},
+        {"INT", "$.events[1].clicks", "{\"events\": [{\"clicks\": 1}, {\"clicks\": 7}]}", 7,
+            "array-of-obj inner numeric"}
+    };
+  }
+
+  @Test(dataProvider = "countryClickResolvedCases")
+  public void testCountryClickNullHandlingOnResolvedValuePassThrough(String resultsType, String jsonPath, String json,
+      Object expectedValue, String label) {
+    Schema schema = new Schema.SchemaBuilder()
+        .setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addDimensionField("json", DataType.JSON)
+        .build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("testTable")
+        .build();
+    Object[] expectedRow = new Object[]{expectedValue};
+    FluentQueryTest.withBaseDir(_baseDir)
+        .withNullHandling(true)
+        .givenTable(schema, tableConfig)
+        .onFirstInstance(new Object[]{json})
+        .whenQuery(String.format("SELECT jsonExtractScalar(json, '%s', '%s') FROM testTable", jsonPath, resultsType))
+        .thenResultIs(expectedRow, expectedRow);
+  }
+
+  /**
+   * 4-arg with SQL NULL default + null-handling ON: pre-existing {@code _defaultIsNull} path —
+   * must continue producing SQL NULL at every nesting depth (regression guard so the E4 fix
+   * doesn't disturb this case).
+   */
+  @DataProvider(name = "countryClickSqlNullDefaultCases")
+  public static Object[][] countryClickSqlNullDefaultCases() {
+    return new Object[][]{
+        // (jsonPath, JSON document, label)
+        {"$.country", "{\"clicks\": 5}", "flat missing key"},
+        {"$.location.country", "{\"location\": {\"city\": \"SF\"}}", "nested inner missing"},
+        {"$.location.country", "{\"location\": null}", "nested parent null"},
+        {"$.tags[0]", "{\"tags\": []}", "empty array"},
+        {"$.tags[0]", "{\"tags\": null}", "null array"},
+        {"$.events[0].country", "{\"events\": [{\"country\": null}]}", "array-of-obj inner explicit-null"},
+        {"$.events[0].country", "{}", "deep path with empty root"}
+    };
+  }
+
+  @Test(dataProvider = "countryClickSqlNullDefaultCases")
+  public void testCountryClickFourArgSqlNullDefaultNullHandlingOn(String jsonPath, String json, String label) {
+    Schema schema = new Schema.SchemaBuilder()
+        .setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addDimensionField("json", DataType.JSON)
+        .build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("testTable")
+        .build();
+    Object[] expectedRow = new Object[]{null};
+    FluentQueryTest.withBaseDir(_baseDir)
+        .withNullHandling(true)
+        .givenTable(schema, tableConfig)
+        .onFirstInstance(new Object[]{json})
+        // 4-arg form with SQL NULL literal as the default value; null-handling enabled.
+        .whenQuery(String.format("SELECT jsonExtractScalar(json, '%s', 'STRING', NULL) FROM testTable", jsonPath))
+        .thenResultIs(expectedRow, expectedRow);
+  }
+
+  // === Multi-row country-click fixture covering nested objects, arrays, and arrays of objects,
+  //     used to exercise GROUP BY and DISTINCT through jsonExtractScalar with mixed resolution. ===
+
+  /// Four-row mixed-resolution country-click fixture. Across the rows, each path covered by the
+  /// GROUP BY / DISTINCT tests has at least one resolved value and at least one unresolved
+  /// occurrence (missing or explicit null), so the null group / null distinct value must show up.
+  private static final Object[][] COUNTRY_CLICK_FIXTURE = new Object[][]{
+      // Row 0 — fully populated, two events.
+      {"{\"country\": \"US\", \"clicks\": 5, \"location\": {\"city\": \"SF\", \"country\": \"US\"},"
+          + " \"tags\": [\"red\", \"blue\", \"green\"], \"events\": [{\"country\": \"US\"}, {\"country\": \"CA\"}]}"},
+      // Row 1 — partial: location has no country; events[0].country is explicit null.
+      {"{\"country\": \"CA\", \"clicks\": 3, \"location\": {\"city\": \"Tor\"},"
+          + " \"tags\": [\"green\"], \"events\": [{\"country\": null}]}"},
+      // Row 2 — every field explicitly JSON null.
+      {"{\"country\": null, \"clicks\": null, \"location\": null, \"tags\": null, \"events\": null}"},
+      // Row 3 — empty doc.
+      {"{}"}
+  };
+
+  private FluentQueryTest.OnFirstInstance givenCountryClickFixture(boolean nullHandling) {
+    Schema schema = new Schema.SchemaBuilder()
+        .setSchemaName("testTable")
+        .setEnableColumnBasedNullHandling(true)
+        .addDimensionField("json", DataType.JSON)
+        .build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("testTable")
+        .build();
+    return FluentQueryTest.withBaseDir(_baseDir)
+        .withNullHandling(nullHandling)
+        .givenTable(schema, tableConfig)
+        .onFirstInstance(COUNTRY_CLICK_FIXTURE);
+  }
+
+  /**
+   * GROUP BY across paths with mixed resolution. With null handling ON, the unresolved rows must
+   * collapse into a single null group (not throw, not split per row), and resolved values must
+   * group as usual. Segment duplication means the broker sees two copies of the fixture, so all
+   * counts are doubled — this is the framework convention, not a semantic claim about Pinot.
+   */
+  @DataProvider(name = "countryClickGroupByCases")
+  public static Object[][] countryClickGroupByCases() {
+    // Path, list of expected (value, count) rows ordered by value ASC NULLS LAST.
+    //   $.country         : row0=US, row1=CA, row2=null, row3=null              → US=1, CA=1, null=2 → ×2 segments
+    //   $.location.country: row0=US, row1=missing, row2=null parent, row3=miss   → US=1, null=3
+    //   $.tags[0]         : row0=red, row1=green, row2=null array, row3=miss     → red=1, green=1, null=2
+    //   $.events[0].country: row0=US, row1=null inner, row2=null array, row3=miss → US=1, null=3
+    return new Object[][]{
+        {"$.country", new Object[][]{{"CA", 2L}, {"US", 2L}, {null, 4L}}, "flat country"},
+        {"$.location.country", new Object[][]{{"US", 2L}, {null, 6L}}, "nested country"},
+        {"$.tags[0]", new Object[][]{{"green", 2L}, {"red", 2L}, {null, 4L}}, "array element"},
+        {"$.events[0].country", new Object[][]{{"US", 2L}, {null, 6L}}, "array-of-obj inner country"}
+    };
+  }
+
+  @Test(dataProvider = "countryClickGroupByCases")
+  public void testCountryClickGroupByCountIncludesNullGroup(String jsonPath, Object[][] expectedRows, String label) {
+    String query = String.format(
+        "SELECT jsonExtractScalar(json, '%s', 'STRING') AS v, COUNT(*) FROM testTable "
+            + "GROUP BY v ORDER BY v ASC NULLS LAST",
+        jsonPath);
+    givenCountryClickFixture(true)
+        .whenQuery(query)
+        .thenResultIs(expectedRows);
+  }
+
+  /**
+   * Symmetric check: with null handling OFF, GROUP BY across mixed-resolution rows must throw
+   * (preserves legacy behavior). The broker surfaces the failure as a query error which the
+   * FluentQueryTest framework escalates to an {@link AssertionError}.
+   */
+  @Test
+  public void testCountryClickGroupByNullHandlingOffThrows() {
+    try {
+      givenCountryClickFixture(false)
+          .whenQuery("SELECT jsonExtractScalar(json, '$.country', 'STRING'), COUNT(*) FROM testTable GROUP BY 1")
+          .thenResultIs(new Object[]{"unused"});
+      Assert.fail("Expected GROUP BY query to fail when null handling is off and rows are unresolved");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).contains("Cannot resolve JSON path on some records");
+    }
+  }
+
+  /**
+   * DISTINCT across paths with mixed resolution. With null handling ON, the distinct set must
+   * include exactly one null entry alongside the resolved values — null group must not blow up
+   * across segments (segment dedup), and must not throw.
+   */
+  @DataProvider(name = "countryClickDistinctCases")
+  public static Object[][] countryClickDistinctCases() {
+    return new Object[][]{
+        {"$.country", new Object[][]{{"CA"}, {"US"}, {null}}, "flat country"},
+        {"$.location.country", new Object[][]{{"US"}, {null}}, "nested country"},
+        {"$.tags[0]", new Object[][]{{"green"}, {"red"}, {null}}, "array element"},
+        {"$.events[0].country", new Object[][]{{"US"}, {null}}, "array-of-obj inner country"}
+    };
+  }
+
+  @Test(dataProvider = "countryClickDistinctCases")
+  public void testCountryClickDistinctIncludesNull(String jsonPath, Object[][] expectedRows, String label) {
+    // Pinot requires the ORDER BY expression to match a DISTINCT column literally — positional
+    // ORDER BY (e.g. ORDER BY 1) is rejected with "ORDER-BY columns should be included in the
+    // DISTINCT columns".
+    String expr = String.format("jsonExtractScalar(json, '%s', 'STRING')", jsonPath);
+    String query = String.format(
+        "SELECT DISTINCT %s FROM testTable ORDER BY %s ASC NULLS LAST", expr, expr);
+    givenCountryClickFixture(true)
+        .whenQuery(query)
+        .thenResultIs(expectedRows);
+  }
+
+  @Test
+  public void testCountryClickDistinctNullHandlingOffThrows() {
+    try {
+      givenCountryClickFixture(false)
+          .whenQuery("SELECT DISTINCT jsonExtractScalar(json, '$.country', 'STRING') FROM testTable")
+          .thenResultIs(new Object[]{"unused"});
+      Assert.fail("Expected DISTINCT query to fail when null handling is off and rows are unresolved");
+    } catch (AssertionError e) {
+      Assertions.assertThat(e.getMessage()).contains("Cannot resolve JSON path on some records");
+    }
+  }
+
   @Test(dataProvider = "testParsingIllegalQueries", expectedExceptions = {SqlCompilationException.class})
   public void testParsingIllegalQueries(String expressionStr) {
     RequestContextUtils.getExpression(expressionStr);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunctionTest.java
@@ -1272,4 +1272,84 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
         }, "nestedJson.events[0].country"}
     };
   }
+
+  // ============================================================================================
+  // 4. Default-value precedence under null handling ON
+  //
+  // When a non-null default literal is supplied AND null handling is on, the SV transform's
+  // priority order is: real default > null-handling placeholder > throw. The user-supplied
+  // default surfaces for unresolved rows; the null-handling placeholder is NOT emitted, and
+  // no null bit is set in the bitmap. These tests pin that ordering across projection,
+  // DISTINCT, and GROUP BY so a future refactor can't silently swap the priority.
+  // ============================================================================================
+
+  /**
+   * Projection with NH on AND default `'foobar'`. Unresolved rows must surface as `"foobar"`,
+   * not SQL NULL.
+   * <pre>
+   *   Per-row resolution: row 0 -> "US", row 1 -> "CA", row 2 -> "foobar", row 3 -> "foobar"
+   *
+   *   Query: SET enableNullHandling = true;
+   *          SELECT jsonExtractScalar(flatJson, '$.country', 'STRING', 'foobar') AS c
+   *          FROM clicks ORDER BY c ASC
+   *
+   *   Result rows (×2 for segment duplication; ASCII order: uppercase < lowercase):
+   *           "CA", "CA", "US", "US", "foobar", "foobar", "foobar", "foobar"
+   * </pre>
+   */
+  @Test
+  public void testProjectionDefaultBeatsNullHandlingPlaceholder() {
+    givenCountryClickTable(true)
+        .whenQuery("SELECT jsonExtractScalar(flatJson, '$.country', 'STRING', 'foobar') AS c "
+            + "FROM clicks ORDER BY c ASC")
+        .thenResultIs(
+            new Object[]{"CA"}, new Object[]{"CA"},
+            new Object[]{"US"}, new Object[]{"US"},
+            new Object[]{"foobar"}, new Object[]{"foobar"},
+            new Object[]{"foobar"}, new Object[]{"foobar"});
+  }
+
+  /**
+   * DISTINCT with NH on AND default `'foobar'`. The distinct set must include the default value
+   * as a regular distinct entry — no separate null entry.
+   * <pre>
+   *   Query: SET enableNullHandling = true;
+   *          SELECT DISTINCT jsonExtractScalar(flatJson, '$.country', 'STRING', 'foobar') FROM clicks
+   *          ORDER BY jsonExtractScalar(flatJson, '$.country', 'STRING', 'foobar') ASC
+   *
+   *   Result (ASCII order: uppercase < lowercase): "CA", "US", "foobar"
+   * </pre>
+   */
+  @Test
+  public void testDistinctDefaultBeatsNullHandlingPlaceholder() {
+    String expr = "jsonExtractScalar(flatJson, '$.country', 'STRING', 'foobar')";
+    givenCountryClickTable(true)
+        .whenQuery(String.format("SELECT DISTINCT %s FROM clicks ORDER BY %s ASC", expr, expr))
+        .thenResultIs(new Object[]{"CA"}, new Object[]{"US"}, new Object[]{"foobar"});
+  }
+
+  /**
+   * GROUP BY with NH on AND default `'foobar'`. Unresolved rows count toward the default's
+   * group, not a null group — so the result has no NULL group at all.
+   * <pre>
+   *   Per-row resolution: row 0 -> "US", row 1 -> "CA", row 2 -> "foobar", row 3 -> "foobar"
+   *
+   *   Query: SET enableNullHandling = true;
+   *          SELECT jsonExtractScalar(flatJson, '$.country', 'STRING', 'foobar') AS v, COUNT(*)
+   *          FROM clicks GROUP BY v ORDER BY v ASC
+   *
+   *   Result (counts ×2 for segment duplication; ASCII order: uppercase < lowercase):
+   *           ("CA", 2), ("US", 2), ("foobar", 4)
+   * </pre>
+   */
+  @Test
+  public void testGroupByDefaultBeatsNullHandlingPlaceholder() {
+    givenCountryClickTable(true)
+        .whenQuery("SELECT jsonExtractScalar(flatJson, '$.country', 'STRING', 'foobar') AS v, COUNT(*) "
+            + "FROM clicks GROUP BY v ORDER BY v ASC")
+        .thenResultIs(
+            new Object[]{"CA", 2L},
+            new Object[]{"US", 2L},
+            new Object[]{"foobar", 4L});
+  }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunctionTest.java
@@ -447,100 +447,160 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
     TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 
-  /**
-   * Country/click scenarios where the typed JSON path does NOT resolve to a value, spanning four
-   * JSON structural shapes:
-   * <ol>
-   *   <li><b>Flat:</b> top-level scalar key missing, explicitly null, or empty doc.</li>
-   *   <li><b>Nested object:</b> {@code $.location.country} — inner key missing, parent JSON null,
-   *       or root missing parent entirely.</li>
-   *   <li><b>Array element:</b> {@code $.tags[i]} — array null, empty, or index out-of-bounds.</li>
-   *   <li><b>Array of objects:</b> {@code $.events[0].country} — inner field null, array empty,
-   *       array null, or root missing.</li>
-   * </ol>
-   * JsonPath {@code SUPPRESS_EXCEPTIONS} folds every one of these into the same Java {@code null},
-   * so all must produce SQL NULL when query-level null handling is enabled, and all must throw
-   * {@code IllegalArgumentException} when null handling is disabled and no default is set.
-   */
-  @DataProvider(name = "countryClickUnresolvedCases")
-  public static Object[][] countryClickUnresolvedCases() {
-    return new Object[][]{
-        // --- Flat / top-level scalar ---
-        {"STRING", "$.country", "{\"clicks\": 5}", "flat country missing"},
-        {"STRING", "$.country", "{\"country\": null, \"clicks\": 5}", "flat country explicit-null"},
-        {"STRING", "$.country", "{}", "flat empty doc"},
-        // --- Flat / numeric across all typed SV paths ---
-        {"INT", "$.clicks", "{\"country\": \"US\"}", "flat clicks missing (INT)"},
-        {"LONG", "$.clicks", "{\"country\": \"US\"}", "flat clicks missing (LONG)"},
-        {"FLOAT", "$.clicks", "{\"country\": \"US\"}", "flat clicks missing (FLOAT)"},
-        {"DOUBLE", "$.clicks", "{\"country\": \"US\"}", "flat clicks missing (DOUBLE)"},
-        {"BIG_DECIMAL", "$.clicks", "{\"country\": \"US\"}", "flat clicks missing (BIG_DECIMAL)"},
-        {"INT", "$.clicks", "{\"country\": \"US\", \"clicks\": null}", "flat clicks explicit-null (INT)"},
-        // --- Nested object ---
-        {"STRING", "$.location.country", "{\"location\": {\"city\": \"SF\"}}", "nested inner key missing"},
-        {"STRING", "$.location.country", "{\"location\": null}", "nested parent explicit-null"},
-        {"STRING", "$.location.country", "{\"country\": \"US\"}", "nested parent missing"},
-        // --- Array element ---
-        {"STRING", "$.tags[0]", "{\"tags\": null}", "array null parent"},
-        {"STRING", "$.tags[0]", "{\"tags\": []}", "array empty"},
-        {"STRING", "$.tags[1]", "{\"tags\": [\"red\"]}", "array index out-of-bounds"},
-        {"STRING", "$.tags[0]", "{\"country\": \"US\"}", "array parent missing"},
-        // --- Array of objects ---
-        {"STRING", "$.events[0].country", "{\"events\": [{\"country\": null}]}", "array-of-obj inner explicit-null"},
-        {"STRING", "$.events[0].country", "{\"events\": [{}]}", "array-of-obj inner key missing"},
-        {"STRING", "$.events[0].country", "{\"events\": []}", "array-of-obj empty array"},
-        {"STRING", "$.events[0].country", "{\"events\": null}", "array-of-obj null array"},
-        // --- Array of objects, numeric (INT) — confirms typed coverage at depth ---
-        {"INT", "$.events[0].clicks", "{\"events\": [{\"country\": \"US\"}]}", "array-of-obj inner numeric missing"}
-    };
-  }
+  // ====================================================================================
+  // === Country/click null-handling tests for jsonExtractScalar.                       ===
+  // ===                                                                                ===
+  // === The SV null-handling fix: with `enableNullHandling = true` and no default      ===
+  // === literal, an unresolved JSON path must surface as SQL NULL instead of throwing. ===
+  // === These tests use a country/click data model — JSON documents shaped like        ===
+  // === `{country, clicks, location, tags, events}` — to exercise the fix across four  ===
+  // === JSON structural shapes (flat scalar, nested object, array element, array of    ===
+  // === objects) and three query shapes (projection, GROUP BY, DISTINCT).              ===
+  // ====================================================================================
 
-  /**
-   * E4 behavior: 3-arg {@code jsonExtractScalar} + query-level null handling ENABLED + unresolved
-   * path. The transform must surface SQL NULL in the projection instead of throwing, so the scalar
-   * fallback agrees with index-aware operators ({@code JsonIndexDistinctOperator},
-   * {@code JsonIndexGroupByOperator}) on the null-group semantics.
-   */
-  @Test(dataProvider = "countryClickUnresolvedCases")
-  public void testCountryClickNullHandlingOnEmitsNull(String resultsType, String jsonPath, String json, String label) {
+  // ---------------- Named single-row JSON documents (used by single-row tests) ----------------
+  //
+  // Pretty-printed JSON for each constant is shown above its declaration. The string literal
+  // itself is kept compact — Jackson tolerates either form, but the comment above is what a
+  // human reads when scanning a test failure.
+
+  // { "country": "US", "clicks": 5 }
+  private static final String CC_FLAT_RESOLVED = "{\"country\": \"US\", \"clicks\": 5}";
+  // { "clicks": 5 }                                       <- country key missing
+  private static final String CC_FLAT_COUNTRY_MISSING = "{\"clicks\": 5}";
+  // { "country": null, "clicks": 5 }                      <- country explicit JSON null
+  private static final String CC_FLAT_COUNTRY_EXPLICIT_NULL = "{\"country\": null, \"clicks\": 5}";
+  // { }                                                   <- empty document
+  private static final String CC_FLAT_EMPTY = "{}";
+  // { "country": "US" }                                   <- clicks key missing
+  private static final String CC_FLAT_CLICKS_MISSING = "{\"country\": \"US\"}";
+  // { "country": "US", "clicks": null }                   <- clicks explicit JSON null
+  private static final String CC_FLAT_CLICKS_EXPLICIT_NULL = "{\"country\": \"US\", \"clicks\": null}";
+
+  // { "location": { "city": "SF", "country": "US" } }
+  private static final String CC_NESTED_RESOLVED = "{\"location\": {\"city\": \"SF\", \"country\": \"US\"}}";
+  // { "location": { "city": "SF" } }                      <- nested inner key missing
+  private static final String CC_NESTED_INNER_MISSING = "{\"location\": {\"city\": \"SF\"}}";
+  // { "location": null }                                  <- nested parent explicit JSON null
+  private static final String CC_NESTED_PARENT_EXPLICIT_NULL = "{\"location\": null}";
+  // { "country": "US" }                                   <- nested parent itself missing
+  private static final String CC_NESTED_PARENT_MISSING = "{\"country\": \"US\"}";
+
+  // { "tags": ["red", "blue", "green"] }
+  private static final String CC_ARRAY_RESOLVED = "{\"tags\": [\"red\", \"blue\", \"green\"]}";
+  // { "tags": null }                                      <- array parent explicit JSON null
+  private static final String CC_ARRAY_NULL_PARENT = "{\"tags\": null}";
+  // { "tags": [] }                                        <- empty array
+  private static final String CC_ARRAY_EMPTY = "{\"tags\": []}";
+  // { "tags": ["red"] }                                   <- array index 1 out-of-bounds
+  private static final String CC_ARRAY_SINGLE_ELEM = "{\"tags\": [\"red\"]}";
+  // { "country": "US" }                                   <- array parent itself missing
+  private static final String CC_ARRAY_PARENT_MISSING = "{\"country\": \"US\"}";
+
+  // { "events": [{"country": "US"}, {"country": "CA"}] }
+  private static final String CC_AOO_RESOLVED = "{\"events\": [{\"country\": \"US\"}, {\"country\": \"CA\"}]}";
+  // { "events": [{"country": null}] }                     <- inner explicit JSON null
+  private static final String CC_AOO_INNER_EXPLICIT_NULL = "{\"events\": [{\"country\": null}]}";
+  // { "events": [{}] }                                    <- inner key missing
+  private static final String CC_AOO_INNER_KEY_MISSING = "{\"events\": [{}]}";
+  // { "events": [] }                                      <- empty array of objects
+  private static final String CC_AOO_EMPTY_ARRAY = "{\"events\": []}";
+  // { "events": null }                                    <- null array of objects
+  private static final String CC_AOO_NULL_ARRAY = "{\"events\": null}";
+  // { "events": [{"country": "US"}] }                     <- inner numeric (clicks) missing
+  private static final String CC_AOO_INNER_NUMERIC_MISSING = "{\"events\": [{\"country\": \"US\"}]}";
+  // { "events": [{"clicks": 1}, {"clicks": 7}] }
+  private static final String CC_AOO_NUMERIC_RESOLVED = "{\"events\": [{\"clicks\": 1}, {\"clicks\": 7}]}";
+
+  // ---------------- Multi-row fixture (used by GROUP BY / DISTINCT tests) ----------------
+  //
+  // Pretty-printed JSON for each row:
+  //
+  //   Row 0 — fully populated:
+  //     { "country": "US", "clicks": 5,
+  //       "location": { "city": "SF", "country": "US" },
+  //       "tags":     ["red", "blue", "green"],
+  //       "events":   [{"country": "US"}, {"country": "CA"}] }
+  //
+  //   Row 1 — partial: location has no country; events[0].country is explicit null:
+  //     { "country": "CA", "clicks": 3,
+  //       "location": { "city": "Tor" },
+  //       "tags":     ["green"],
+  //       "events":   [{"country": null}] }
+  //
+  //   Row 2 — every field explicit JSON null:
+  //     { "country": null, "clicks": null, "location": null, "tags": null, "events": null }
+  //
+  //   Row 3 — empty document:
+  //     {}
+  //
+  // Across the four rows, every path covered by the GROUP BY / DISTINCT tests has at least one
+  // resolved value AND at least one unresolved occurrence (missing key or explicit null), so
+  // both the value groups and the null group must surface in the result.
+
+  private static final String CC_ROW_0_FULL = "{\"country\": \"US\", \"clicks\": 5,"
+      + " \"location\": {\"city\": \"SF\", \"country\": \"US\"},"
+      + " \"tags\": [\"red\", \"blue\", \"green\"],"
+      + " \"events\": [{\"country\": \"US\"}, {\"country\": \"CA\"}]}";
+
+  private static final String CC_ROW_1_PARTIAL = "{\"country\": \"CA\", \"clicks\": 3,"
+      + " \"location\": {\"city\": \"Tor\"},"
+      + " \"tags\": [\"green\"],"
+      + " \"events\": [{\"country\": null}]}";
+
+  private static final String CC_ROW_2_ALL_NULL =
+      "{\"country\": null, \"clicks\": null, \"location\": null, \"tags\": null, \"events\": null}";
+
+  private static final String CC_ROW_3_EMPTY = "{}";
+
+  private static final Object[][] COUNTRY_CLICK_FIXTURE = {
+      {CC_ROW_0_FULL},
+      {CC_ROW_1_PARTIAL},
+      {CC_ROW_2_ALL_NULL},
+      {CC_ROW_3_EMPTY}
+  };
+
+  // ---------------- Helpers ----------------
+
+  private FluentQueryTest.OnFirstInstance givenSingleRowJsonTable(boolean nullHandling, String json) {
     Schema schema = new Schema.SchemaBuilder()
         .setSchemaName("testTable")
         .setEnableColumnBasedNullHandling(true)
         .addDimensionField("json", DataType.JSON)
         .build();
-    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
-        .setTableName("testTable")
-        .build();
-    Object[] expectedRow = new Object[]{null};
-    FluentQueryTest.withBaseDir(_baseDir)
-        .withNullHandling(true)
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
+    return FluentQueryTest.withBaseDir(_baseDir)
+        .withNullHandling(nullHandling)
         .givenTable(schema, tableConfig)
-        .onFirstInstance(new Object[]{json})
-        .whenQuery(String.format("SELECT jsonExtractScalar(json, '%s', '%s') FROM testTable", jsonPath, resultsType))
-        // TODO: Change the framework to do not duplicate segments when only one segment is used.
-        .thenResultIs(expectedRow, expectedRow);
+        .onFirstInstance(new Object[]{json});
   }
 
-  /**
-   * E3 behavior preservation: 3-arg {@code jsonExtractScalar} + query-level null handling DISABLED
-   * + unresolved path must still throw. The E4 fix is gated on {@code _nullHandlingEnabled}, so
-   * callers that haven't opted in see the legacy behavior.
-   */
-  @Test(dataProvider = "countryClickUnresolvedCases")
-  public void testCountryClickNullHandlingOffThrows(String resultsType, String jsonPath, String json, String label) {
+  private FluentQueryTest.OnFirstInstance givenCountryClickFixture(boolean nullHandling) {
     Schema schema = new Schema.SchemaBuilder()
         .setSchemaName("testTable")
         .setEnableColumnBasedNullHandling(true)
         .addDimensionField("json", DataType.JSON)
         .build();
-    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
-        .setTableName("testTable")
-        .build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
+    return FluentQueryTest.withBaseDir(_baseDir)
+        .withNullHandling(nullHandling)
+        .givenTable(schema, tableConfig)
+        .onFirstInstance(COUNTRY_CLICK_FIXTURE);
+  }
+
+  /** Asserts that the 3-arg `jsonExtractScalar(...)` query returns SQL NULL for a single-row fixture. */
+  private void assertSingleRowReturnsNull(boolean nullHandling, String json, String jsonPath, String resultsType) {
+    Object[] expectedNullRow = new Object[]{null};
+    givenSingleRowJsonTable(nullHandling, json)
+        .whenQuery(String.format("SELECT jsonExtractScalar(json, '%s', '%s') FROM testTable", jsonPath, resultsType))
+        // Segment duplication: the same row is returned twice (one per duplicated segment).
+        .thenResultIs(expectedNullRow, expectedNullRow);
+  }
+
+  /** Asserts that the 3-arg `jsonExtractScalar(...)` query throws when null handling is off. */
+  private void assertSingleRowThrowsForUnresolved(String json, String jsonPath, String resultsType, String label) {
     try {
-      FluentQueryTest.withBaseDir(_baseDir)
-          .withNullHandling(false)
-          .givenTable(schema, tableConfig)
-          .onFirstInstance(new Object[]{json})
+      givenSingleRowJsonTable(false, json)
           .whenQuery(String.format("SELECT jsonExtractScalar(json, '%s', '%s') FROM testTable", jsonPath, resultsType))
           .thenResultIs(new Object[]{"unused"});
       Assert.fail("Expected query to fail for " + label);
@@ -551,160 +611,211 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
     }
   }
 
+  // ---------------- Unresolved paths: null-handling ON must surface SQL NULL ----------------
+
   /**
-   * Positive cases: when the typed JSON path resolves — including at depth through nested objects,
-   * array elements, and array-of-objects — null-handling ON must surface the resolved value
-   * as-is. The fix only changes the unresolved-row behavior; resolved paths must be untouched at
-   * every nesting depth.
+   * The SV null-handling fix. With null handling on and no default literal, an unresolved JSON
+   * path must surface as SQL NULL in the projection — matching the contract that
+   * {@code JsonIndexDistinctOperator} already provides for the DISTINCT route.
+   * <p>
+   * Example (flat, missing key):
+   * <pre>
+   *   JSON:   { "clicks": 5 }
+   *   Query:  SET enableNullHandling = true;
+   *           SELECT jsonExtractScalar(json, '$.country', 'STRING') FROM testTable
+   *   Result: NULL
+   * </pre>
+   * See {@link #unresolvedSinglePathCases()} for the full per-case matrix.
    */
-  @DataProvider(name = "countryClickResolvedCases")
-  public static Object[][] countryClickResolvedCases() {
+  @Test(dataProvider = "unresolvedSinglePathCases")
+  public void testNullHandlingOnReturnsNullForUnresolvedPath(String resultsType, String jsonPath, String json,
+      String label) {
+    assertSingleRowReturnsNull(true, json, jsonPath, resultsType);
+  }
+
+  /**
+   * Legacy behavior preservation. With null handling off and no default, the same unresolved-path
+   * cases must throw — the E4 fix is gated on {@code _nullHandlingEnabled}, so callers that
+   * haven't opted in see no behavior change.
+   * <p>
+   * Example (flat, missing key):
+   * <pre>
+   *   JSON:   { "clicks": 5 }
+   *   Query:  SELECT jsonExtractScalar(json, '$.country', 'STRING') FROM testTable
+   *   Result: throws IllegalArgumentException("Cannot resolve JSON path on some records.…")
+   * </pre>
+   */
+  @Test(dataProvider = "unresolvedSinglePathCases")
+  public void testNullHandlingOffThrowsForUnresolvedPath(String resultsType, String jsonPath, String json,
+      String label) {
+    assertSingleRowThrowsForUnresolved(json, jsonPath, resultsType, label);
+  }
+
+  /**
+   * Each row is `(resultsType, jsonPath, JSON document, structural-shape label)`. Every case is
+   * one where `jsonPath` does NOT resolve in the given JSON document — that's what makes it
+   * exercise the null-handling code path.
+   */
+  @DataProvider(name = "unresolvedSinglePathCases")
+  public static Object[][] unresolvedSinglePathCases() {
     return new Object[][]{
-        // (resultsType, jsonPath, JSON doc, expected resolved value, label)
-        {"STRING", "$.country", "{\"country\": \"US\", \"clicks\": 5}", "US", "flat string"},
-        {"INT", "$.clicks", "{\"country\": \"US\", \"clicks\": 5}", 5, "flat int"},
-        {"STRING", "$.location.country", "{\"location\": {\"city\": \"SF\", \"country\": \"US\"}}", "US",
-            "nested string"},
-        {"STRING", "$.tags[1]", "{\"tags\": [\"red\", \"blue\", \"green\"]}", "blue", "array element"},
-        {"STRING", "$.events[0].country", "{\"events\": [{\"country\": \"US\"}, {\"country\": \"CA\"}]}", "US",
-            "array-of-obj inner"},
-        {"INT", "$.events[1].clicks", "{\"events\": [{\"clicks\": 1}, {\"clicks\": 7}]}", 7,
-            "array-of-obj inner numeric"}
+        // FLAT — string path
+        {"STRING", "$.country", CC_FLAT_COUNTRY_MISSING, "flat: country key missing"},
+        {"STRING", "$.country", CC_FLAT_COUNTRY_EXPLICIT_NULL, "flat: country explicit JSON null"},
+        {"STRING", "$.country", CC_FLAT_EMPTY, "flat: empty document"},
+        // FLAT — numeric path, all 5 numeric SV types
+        {"INT", "$.clicks", CC_FLAT_CLICKS_MISSING, "flat: clicks missing (INT)"},
+        {"LONG", "$.clicks", CC_FLAT_CLICKS_MISSING, "flat: clicks missing (LONG)"},
+        {"FLOAT", "$.clicks", CC_FLAT_CLICKS_MISSING, "flat: clicks missing (FLOAT)"},
+        {"DOUBLE", "$.clicks", CC_FLAT_CLICKS_MISSING, "flat: clicks missing (DOUBLE)"},
+        {"BIG_DECIMAL", "$.clicks", CC_FLAT_CLICKS_MISSING, "flat: clicks missing (BIG_DECIMAL)"},
+        {"INT", "$.clicks", CC_FLAT_CLICKS_EXPLICIT_NULL, "flat: clicks explicit JSON null (INT)"},
+        // NESTED OBJECT
+        {"STRING", "$.location.country", CC_NESTED_INNER_MISSING, "nested: inner key missing"},
+        {"STRING", "$.location.country", CC_NESTED_PARENT_EXPLICIT_NULL, "nested: parent explicit JSON null"},
+        {"STRING", "$.location.country", CC_NESTED_PARENT_MISSING, "nested: parent key missing"},
+        // ARRAY ELEMENT
+        {"STRING", "$.tags[0]", CC_ARRAY_NULL_PARENT, "array: parent explicit JSON null"},
+        {"STRING", "$.tags[0]", CC_ARRAY_EMPTY, "array: empty array"},
+        {"STRING", "$.tags[1]", CC_ARRAY_SINGLE_ELEM, "array: index out-of-bounds"},
+        {"STRING", "$.tags[0]", CC_ARRAY_PARENT_MISSING, "array: parent key missing"},
+        // ARRAY OF OBJECTS
+        {"STRING", "$.events[0].country", CC_AOO_INNER_EXPLICIT_NULL, "array-of-obj: inner explicit JSON null"},
+        {"STRING", "$.events[0].country", CC_AOO_INNER_KEY_MISSING, "array-of-obj: inner key missing"},
+        {"STRING", "$.events[0].country", CC_AOO_EMPTY_ARRAY, "array-of-obj: empty array"},
+        {"STRING", "$.events[0].country", CC_AOO_NULL_ARRAY, "array-of-obj: null array"},
+        // ARRAY OF OBJECTS — numeric (INT) confirms typed coverage at depth
+        {"INT", "$.events[0].clicks", CC_AOO_INNER_NUMERIC_MISSING, "array-of-obj: inner numeric missing (INT)"}
     };
   }
 
-  @Test(dataProvider = "countryClickResolvedCases")
-  public void testCountryClickNullHandlingOnResolvedValuePassThrough(String resultsType, String jsonPath, String json,
+  // ---------------- Resolved paths: null-handling ON must pass values through ----------------
+
+  /**
+   * Resolved-path regression guard. The fix only changes the unresolved-row behavior; resolved
+   * paths must still produce their values verbatim at every JSON nesting depth.
+   * <p>
+   * Example (array of objects, numeric):
+   * <pre>
+   *   JSON:   { "events": [{"clicks": 1}, {"clicks": 7}] }
+   *   Query:  SET enableNullHandling = true;
+   *           SELECT jsonExtractScalar(json, '$.events[1].clicks', 'INT') FROM testTable
+   *   Result: 7
+   * </pre>
+   */
+  @Test(dataProvider = "resolvedSinglePathCases")
+  public void testNullHandlingOnPassesResolvedValueThrough(String resultsType, String jsonPath, String json,
       Object expectedValue, String label) {
-    Schema schema = new Schema.SchemaBuilder()
-        .setSchemaName("testTable")
-        .setEnableColumnBasedNullHandling(true)
-        .addDimensionField("json", DataType.JSON)
-        .build();
-    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
-        .setTableName("testTable")
-        .build();
     Object[] expectedRow = new Object[]{expectedValue};
-    FluentQueryTest.withBaseDir(_baseDir)
-        .withNullHandling(true)
-        .givenTable(schema, tableConfig)
-        .onFirstInstance(new Object[]{json})
+    givenSingleRowJsonTable(true, json)
         .whenQuery(String.format("SELECT jsonExtractScalar(json, '%s', '%s') FROM testTable", jsonPath, resultsType))
         .thenResultIs(expectedRow, expectedRow);
   }
 
-  /**
-   * 4-arg with SQL NULL default + null-handling ON: pre-existing {@code _defaultIsNull} path —
-   * must continue producing SQL NULL at every nesting depth (regression guard so the E4 fix
-   * doesn't disturb this case).
-   */
-  @DataProvider(name = "countryClickSqlNullDefaultCases")
-  public static Object[][] countryClickSqlNullDefaultCases() {
+  /** Each row is `(resultsType, jsonPath, JSON document, expected resolved value, label)`. */
+  @DataProvider(name = "resolvedSinglePathCases")
+  public static Object[][] resolvedSinglePathCases() {
     return new Object[][]{
-        // (jsonPath, JSON document, label)
-        {"$.country", "{\"clicks\": 5}", "flat missing key"},
-        {"$.location.country", "{\"location\": {\"city\": \"SF\"}}", "nested inner missing"},
-        {"$.location.country", "{\"location\": null}", "nested parent null"},
-        {"$.tags[0]", "{\"tags\": []}", "empty array"},
-        {"$.tags[0]", "{\"tags\": null}", "null array"},
-        {"$.events[0].country", "{\"events\": [{\"country\": null}]}", "array-of-obj inner explicit-null"},
-        {"$.events[0].country", "{}", "deep path with empty root"}
+        {"STRING", "$.country", CC_FLAT_RESOLVED, "US", "flat string"},
+        {"INT", "$.clicks", CC_FLAT_RESOLVED, 5, "flat int"},
+        {"STRING", "$.location.country", CC_NESTED_RESOLVED, "US", "nested string"},
+        {"STRING", "$.tags[1]", CC_ARRAY_RESOLVED, "blue", "array element"},
+        {"STRING", "$.events[0].country", CC_AOO_RESOLVED, "US", "array-of-obj inner string"},
+        {"INT", "$.events[1].clicks", CC_AOO_NUMERIC_RESOLVED, 7, "array-of-obj inner numeric"}
     };
   }
 
-  @Test(dataProvider = "countryClickSqlNullDefaultCases")
-  public void testCountryClickFourArgSqlNullDefaultNullHandlingOn(String jsonPath, String json, String label) {
-    Schema schema = new Schema.SchemaBuilder()
-        .setSchemaName("testTable")
-        .setEnableColumnBasedNullHandling(true)
-        .addDimensionField("json", DataType.JSON)
-        .build();
-    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
-        .setTableName("testTable")
-        .build();
+  // ---------------- 4-arg with SQL NULL default + null-handling ON (regression guard) ----------------
+
+  /**
+   * 4-arg `jsonExtractScalar(json, path, type, NULL)` + null handling ON. This is the pre-existing
+   * {@code _defaultIsNull} code path — must continue producing SQL NULL at every nesting depth so
+   * the E4 fix doesn't disturb it.
+   * <p>
+   * Example (nested, inner missing):
+   * <pre>
+   *   JSON:   { "location": { "city": "SF" } }
+   *   Query:  SET enableNullHandling = true;
+   *           SELECT jsonExtractScalar(json, '$.location.country', 'STRING', NULL) FROM testTable
+   *   Result: NULL
+   * </pre>
+   */
+  @Test(dataProvider = "fourArgSqlNullDefaultCases")
+  public void testFourArgSqlNullDefaultReturnsNullWithNullHandlingOn(String jsonPath, String json, String label) {
     Object[] expectedRow = new Object[]{null};
-    FluentQueryTest.withBaseDir(_baseDir)
-        .withNullHandling(true)
-        .givenTable(schema, tableConfig)
-        .onFirstInstance(new Object[]{json})
-        // 4-arg form with SQL NULL literal as the default value; null-handling enabled.
+    givenSingleRowJsonTable(true, json)
         .whenQuery(String.format("SELECT jsonExtractScalar(json, '%s', 'STRING', NULL) FROM testTable", jsonPath))
         .thenResultIs(expectedRow, expectedRow);
   }
 
-  // === Multi-row country-click fixture covering nested objects, arrays, and arrays of objects,
-  //     used to exercise GROUP BY and DISTINCT through jsonExtractScalar with mixed resolution. ===
-
-  /// Four-row mixed-resolution country-click fixture. Across the rows, each path covered by the
-  /// GROUP BY / DISTINCT tests has at least one resolved value and at least one unresolved
-  /// occurrence (missing or explicit null), so the null group / null distinct value must show up.
-  private static final Object[][] COUNTRY_CLICK_FIXTURE = new Object[][]{
-      // Row 0 — fully populated, two events.
-      {"{\"country\": \"US\", \"clicks\": 5, \"location\": {\"city\": \"SF\", \"country\": \"US\"},"
-          + " \"tags\": [\"red\", \"blue\", \"green\"], \"events\": [{\"country\": \"US\"}, {\"country\": \"CA\"}]}"},
-      // Row 1 — partial: location has no country; events[0].country is explicit null.
-      {"{\"country\": \"CA\", \"clicks\": 3, \"location\": {\"city\": \"Tor\"},"
-          + " \"tags\": [\"green\"], \"events\": [{\"country\": null}]}"},
-      // Row 2 — every field explicitly JSON null.
-      {"{\"country\": null, \"clicks\": null, \"location\": null, \"tags\": null, \"events\": null}"},
-      // Row 3 — empty doc.
-      {"{}"}
-  };
-
-  private FluentQueryTest.OnFirstInstance givenCountryClickFixture(boolean nullHandling) {
-    Schema schema = new Schema.SchemaBuilder()
-        .setSchemaName("testTable")
-        .setEnableColumnBasedNullHandling(true)
-        .addDimensionField("json", DataType.JSON)
-        .build();
-    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
-        .setTableName("testTable")
-        .build();
-    return FluentQueryTest.withBaseDir(_baseDir)
-        .withNullHandling(nullHandling)
-        .givenTable(schema, tableConfig)
-        .onFirstInstance(COUNTRY_CLICK_FIXTURE);
-  }
-
-  /**
-   * GROUP BY across paths with mixed resolution. With null handling ON, the unresolved rows must
-   * collapse into a single null group (not throw, not split per row), and resolved values must
-   * group as usual. Segment duplication means the broker sees two copies of the fixture, so all
-   * counts are doubled — this is the framework convention, not a semantic claim about Pinot.
-   */
-  @DataProvider(name = "countryClickGroupByCases")
-  public static Object[][] countryClickGroupByCases() {
-    // Path, list of expected (value, count) rows ordered by value ASC NULLS LAST.
-    //   $.country         : row0=US, row1=CA, row2=null, row3=null              → US=1, CA=1, null=2 → ×2 segments
-    //   $.location.country: row0=US, row1=missing, row2=null parent, row3=miss   → US=1, null=3
-    //   $.tags[0]         : row0=red, row1=green, row2=null array, row3=miss     → red=1, green=1, null=2
-    //   $.events[0].country: row0=US, row1=null inner, row2=null array, row3=miss → US=1, null=3
+  /** Each row is `(jsonPath, JSON document, label)` — all rows pick a path that does NOT resolve. */
+  @DataProvider(name = "fourArgSqlNullDefaultCases")
+  public static Object[][] fourArgSqlNullDefaultCases() {
     return new Object[][]{
-        {"$.country", new Object[][]{{"CA", 2L}, {"US", 2L}, {null, 4L}}, "flat country"},
-        {"$.location.country", new Object[][]{{"US", 2L}, {null, 6L}}, "nested country"},
-        {"$.tags[0]", new Object[][]{{"green", 2L}, {"red", 2L}, {null, 4L}}, "array element"},
-        {"$.events[0].country", new Object[][]{{"US", 2L}, {null, 6L}}, "array-of-obj inner country"}
+        {"$.country", CC_FLAT_COUNTRY_MISSING, "flat: key missing"},
+        {"$.location.country", CC_NESTED_INNER_MISSING, "nested: inner missing"},
+        {"$.location.country", CC_NESTED_PARENT_EXPLICIT_NULL, "nested: parent explicit JSON null"},
+        {"$.tags[0]", CC_ARRAY_EMPTY, "array: empty"},
+        {"$.tags[0]", CC_ARRAY_NULL_PARENT, "array: null parent"},
+        {"$.events[0].country", CC_AOO_INNER_EXPLICIT_NULL, "array-of-obj: inner explicit JSON null"},
+        {"$.events[0].country", CC_FLAT_EMPTY, "deep path against empty root"}
     };
   }
 
-  @Test(dataProvider = "countryClickGroupByCases")
-  public void testCountryClickGroupByCountIncludesNullGroup(String jsonPath, Object[][] expectedRows, String label) {
+  // ---------------- GROUP BY: null-handling ON must produce a single null group ----------------
+
+  /**
+   * GROUP BY over the multi-row country/click fixture, with null handling ON. The unresolved rows
+   * (per the row breakdown in the fixture Javadoc above) must collapse into a single null group
+   * with the correct count, alongside the resolved value groups.
+   * <p>
+   * Example (flat country):
+   * <pre>
+   *   Rows (×2 for segment duplication):
+   *     Row 0: country = "US"        Row 1: country = "CA"
+   *     Row 2: country = JSON null   Row 3: country missing
+   *
+   *   Query: SELECT jsonExtractScalar(json, '$.country', 'STRING') AS v, COUNT(*)
+   *          FROM testTable GROUP BY v ORDER BY v ASC NULLS LAST
+   *
+   *   Result rows: ("CA", 2), ("US", 2), (NULL, 4)
+   * </pre>
+   * The data provider lists the expected (value, count) rows for each path covered.
+   */
+  @Test(dataProvider = "groupByCases")
+  public void testGroupByOnUnresolvedPathProducesNullGroup(String jsonPath, Object[][] expectedRows, String label) {
     String query = String.format(
         "SELECT jsonExtractScalar(json, '%s', 'STRING') AS v, COUNT(*) FROM testTable "
             + "GROUP BY v ORDER BY v ASC NULLS LAST",
         jsonPath);
-    givenCountryClickFixture(true)
-        .whenQuery(query)
-        .thenResultIs(expectedRows);
+    givenCountryClickFixture(true).whenQuery(query).thenResultIs(expectedRows);
   }
 
   /**
-   * Symmetric check: with null handling OFF, GROUP BY across mixed-resolution rows must throw
-   * (preserves legacy behavior). The broker surfaces the failure as a query error which the
-   * FluentQueryTest framework escalates to an {@link AssertionError}.
+   * Each row is `(jsonPath, expected (value, count) rows after ORDER BY v ASC NULLS LAST, label)`.
+   * Counts are ×2 the per-row count due to segment duplication (one segment becomes two).
+   */
+  @DataProvider(name = "groupByCases")
+  public static Object[][] groupByCases() {
+    return new Object[][]{
+        // $.country — row0="US", row1="CA", row2=null, row3=missing → 2 of each + 4 null
+        {"$.country", new Object[][]{{"CA", 2L}, {"US", 2L}, {null, 4L}}, "flat country"},
+        // $.location.country — row0="US", row1=missing, row2=null parent, row3=missing → 2 "US" + 6 null
+        {"$.location.country", new Object[][]{{"US", 2L}, {null, 6L}}, "nested country"},
+        // $.tags[0] — row0="red", row1="green", row2=null array, row3=missing → 2 each + 4 null
+        {"$.tags[0]", new Object[][]{{"green", 2L}, {"red", 2L}, {null, 4L}}, "array first element"},
+        // $.events[0].country — row0="US", row1=null inner, row2=null array, row3=missing → 2 "US" + 6 null
+        {"$.events[0].country", new Object[][]{{"US", 2L}, {null, 6L}}, "array-of-obj inner country"}
+    };
+  }
+
+  /**
+   * GROUP BY with null handling OFF over the same mixed-resolution fixture must throw — the
+   * broker surfaces the failure as a query error which the FluentQueryTest framework escalates
+   * to an {@link AssertionError}.
    */
   @Test
-  public void testCountryClickGroupByNullHandlingOffThrows() {
+  public void testGroupByOnUnresolvedPathThrowsWhenNullHandlingOff() {
     try {
       givenCountryClickFixture(false)
           .whenQuery("SELECT jsonExtractScalar(json, '$.country', 'STRING'), COUNT(*) FROM testTable GROUP BY 1")
@@ -715,36 +826,44 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
     }
   }
 
+  // ---------------- DISTINCT: null-handling ON must include null in the distinct set ----------------
+
   /**
-   * DISTINCT across paths with mixed resolution. With null handling ON, the distinct set must
-   * include exactly one null entry alongside the resolved values — null group must not blow up
-   * across segments (segment dedup), and must not throw.
+   * SELECT DISTINCT over the multi-row country/click fixture with null handling ON. The distinct
+   * set must include exactly one null entry alongside the resolved values — null must not blow up
+   * across segments, and must not throw.
+   * <p>
+   * Example (flat country):
+   * <pre>
+   *   Query: SELECT DISTINCT jsonExtractScalar(json, '$.country', 'STRING') FROM testTable
+   *          ORDER BY jsonExtractScalar(json, '$.country', 'STRING') ASC NULLS LAST
+   *
+   *   Result rows: ("CA"), ("US"), (NULL)
+   * </pre>
+   * Pinot requires the ORDER BY expression to match a DISTINCT column literally — positional
+   * ORDER BY (e.g. `ORDER BY 1`) is rejected with
+   * "ORDER-BY columns should be included in the DISTINCT columns" — hence the explicit expression.
    */
-  @DataProvider(name = "countryClickDistinctCases")
-  public static Object[][] countryClickDistinctCases() {
+  @Test(dataProvider = "distinctCases")
+  public void testDistinctOnUnresolvedPathIncludesNull(String jsonPath, Object[][] expectedRows, String label) {
+    String expr = String.format("jsonExtractScalar(json, '%s', 'STRING')", jsonPath);
+    String query = String.format("SELECT DISTINCT %s FROM testTable ORDER BY %s ASC NULLS LAST", expr, expr);
+    givenCountryClickFixture(true).whenQuery(query).thenResultIs(expectedRows);
+  }
+
+  /** Each row is `(jsonPath, expected distinct values after ORDER BY v ASC NULLS LAST, label)`. */
+  @DataProvider(name = "distinctCases")
+  public static Object[][] distinctCases() {
     return new Object[][]{
         {"$.country", new Object[][]{{"CA"}, {"US"}, {null}}, "flat country"},
         {"$.location.country", new Object[][]{{"US"}, {null}}, "nested country"},
-        {"$.tags[0]", new Object[][]{{"green"}, {"red"}, {null}}, "array element"},
+        {"$.tags[0]", new Object[][]{{"green"}, {"red"}, {null}}, "array first element"},
         {"$.events[0].country", new Object[][]{{"US"}, {null}}, "array-of-obj inner country"}
     };
   }
 
-  @Test(dataProvider = "countryClickDistinctCases")
-  public void testCountryClickDistinctIncludesNull(String jsonPath, Object[][] expectedRows, String label) {
-    // Pinot requires the ORDER BY expression to match a DISTINCT column literally — positional
-    // ORDER BY (e.g. ORDER BY 1) is rejected with "ORDER-BY columns should be included in the
-    // DISTINCT columns".
-    String expr = String.format("jsonExtractScalar(json, '%s', 'STRING')", jsonPath);
-    String query = String.format(
-        "SELECT DISTINCT %s FROM testTable ORDER BY %s ASC NULLS LAST", expr, expr);
-    givenCountryClickFixture(true)
-        .whenQuery(query)
-        .thenResultIs(expectedRows);
-  }
-
   @Test
-  public void testCountryClickDistinctNullHandlingOffThrows() {
+  public void testDistinctOnUnresolvedPathThrowsWhenNullHandlingOff() {
     try {
       givenCountryClickFixture(false)
           .whenQuery("SELECT DISTINCT jsonExtractScalar(json, '$.country', 'STRING') FROM testTable")

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunctionTest.java
@@ -982,11 +982,18 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
   //   `nestedJson` — multi-level shapes (nested object, array, array of objects) with mixed
   //                  resolved / null / missing data at depth.
   //
-  // Tests are grouped by query shape in this order: projection → DISTINCT → GROUP BY. Each group
-  // has a null-handling-on case (verifies SQL NULL surfaces) and a null-handling-off case
-  // (verifies the legacy throw is preserved). Result rows in every assertion are ordered by the
-  // projected expression ASC NULLS LAST so the comparison is deterministic across the framework's
-  // segment-duplication behavior (a single segment shows up twice, so per-row counts are ×2).
+  // Tests are grouped by query shape in this order: projection → DISTINCT → GROUP BY. Each section
+  // covers the same four sub-cases, in order:
+  //
+  //   .1  NH on, 3-arg                          — unresolved rows surface as SQL NULL (E4 fix)
+  //   .2  NH on, 4-arg with SQL NULL literal     — same result as .1 via the `_defaultIsNull`
+  //                                                code path in `getNullBitmap`
+  //   .3  NH on, 4-arg with a non-null default   — default wins over NH placeholder
+  //   .4  NH off                                  — legacy throw preserved
+  //
+  // Result rows in every assertion are ordered by the projected expression ASC NULLS LAST so the
+  // comparison is deterministic across the framework's segment-duplication behavior (a single
+  // segment shows up twice, so per-row counts are ×2).
   // ============================================================================================
 
   // ---------------- Fixture ----------------
@@ -1059,8 +1066,8 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
   // ============================================================================================
 
   /**
-   * Projection with null handling ON. Each row's resolution depends on the column + path; the SV
-   * transform must surface SQL NULL for unresolved rows and pass resolved values through.
+   * 1.1 — NH on, 3-arg. Each row's resolution depends on the column + path; the SV transform must
+   * surface SQL NULL for unresolved rows and pass resolved values through.
    * <pre>
    *   Example — `flatJson.country` (STRING):
    *     per-row: row 0 -> "US", row 1 -> "CA", row 2 -> NULL (explicit), row 3 -> NULL (missing)
@@ -1083,9 +1090,45 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
   }
 
   /**
-   * Null handling OFF: any unresolved row throws. One representative path is enough — the throw
-   * is independent of path shape and result type.
+   * 1.2 — NH on, 4-arg with `NULL` literal. Same result as 1.1, but exercises the `_defaultIsNull`
+   * code path in `getNullBitmap` (the SV transform writes the typed zero via `_defaultValue != null`,
+   * then `getNullBitmap` scans and marks unresolved rows null via the `!_defaultIsNull` carve-out).
    */
+  @Test(dataProvider = "sqlNullDefaultProjectionCases")
+  public void testProjectionWithSqlNullDefaultEmitsNull(String column, String jsonPath,
+      Object[][] expectedRows, String label) {
+    String expr = String.format("jsonExtractScalar(%s, '%s', 'STRING', NULL)", column, jsonPath);
+    givenCountryClickTable(true)
+        .whenQuery(String.format("SELECT %s AS c FROM clicks ORDER BY c ASC NULLS LAST", expr))
+        .thenResultIs(expectedRows);
+  }
+
+  /**
+   * 1.3 — NH on, 4-arg with non-null default. The SV transform's priority is: real default >
+   * null-handling placeholder > throw. The user-supplied default surfaces for unresolved rows;
+   * no null bit is set in the bitmap.
+   * <pre>
+   *   Example — flatJson.country with default 'foobar':
+   *     per-row: row 0 -> "US", row 1 -> "CA", row 2 -> "foobar", row 3 -> "foobar"
+   *
+   *     Query: SET enableNullHandling = true;
+   *            SELECT jsonExtractScalar(flatJson, '$.country', 'STRING', 'foobar') AS c
+   *            FROM clicks ORDER BY c ASC
+   *
+   *     Result (×2 dup; ASCII order): "CA", "CA", "US", "US", "foobar"×4
+   * </pre>
+   */
+  @Test(dataProvider = "defaultPrecedenceProjectionCases")
+  public void testProjectionDefaultBeatsNullHandlingPlaceholder(String column, String jsonPath,
+      String defaultLiteral, Object[][] expectedRows, String label) {
+    String expr = String.format(
+        "jsonExtractScalar(%s, '%s', 'STRING', %s)", column, jsonPath, defaultLiteral);
+    givenCountryClickTable(true)
+        .whenQuery(String.format("SELECT %s AS c FROM clicks ORDER BY c ASC", expr))
+        .thenResultIs(expectedRows);
+  }
+
+  /** 1.4 — NH off: any unresolved row throws. One representative path; throw is path-independent. */
   @Test
   public void testProjectionNullHandlingOffThrows() {
     try {
@@ -1098,11 +1141,7 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
     }
   }
 
-  /**
-   * Each row is `(column, jsonPath, resultsType, expected 8-row result, label)`. Result rows are
-   * ordered by value ASC NULLS LAST. With segment duplication, the per-row count in the fixture
-   * is ×2 in the result.
-   */
+  /** 1.1 cases — `(column, jsonPath, resultsType, expected 8-row result, label)`, ordered ASC NULLS LAST. */
   @DataProvider(name = "projectionCases")
   public static Object[][] projectionCases() {
     return new Object[][]{
@@ -1149,23 +1188,49 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
     };
   }
 
+  /** 1.2 cases — `(column, jsonPath, expected 8-row result ordered ASC NULLS LAST, label)`. */
+  @DataProvider(name = "sqlNullDefaultProjectionCases")
+  public static Object[][] sqlNullDefaultProjectionCases() {
+    return new Object[][]{
+        {"flatJson", "$.country", new Object[][]{
+            {"CA"}, {"CA"}, {"US"}, {"US"}, {null}, {null}, {null}, {null}
+        }, "flatJson.country NULL default"},
+        {"nestedJson", "$.location.country", new Object[][]{
+            {"US"}, {"US"}, {null}, {null}, {null}, {null}, {null}, {null}
+        }, "nestedJson.location.country NULL default"}
+    };
+  }
+
+  /** 1.3 cases — `(column, jsonPath, default SQL literal, expected 8-row result ASC, label)`. */
+  @DataProvider(name = "defaultPrecedenceProjectionCases")
+  public static Object[][] defaultPrecedenceProjectionCases() {
+    return new Object[][]{
+        // flatJson.country: row0="US", row1="CA", row2=null, row3=missing -> 2 each, 4 'foobar'.
+        {"flatJson", "$.country", "'foobar'", new Object[][]{
+            {"CA"}, {"CA"}, {"US"}, {"US"},
+            {"foobar"}, {"foobar"}, {"foobar"}, {"foobar"}
+        }, "flatJson.country default 'foobar'"},
+        // nestedJson.location.country: row0="US", rows 1/2/3 unresolved -> 2 "US" + 6 'foobar'.
+        {"nestedJson", "$.location.country", "'foobar'", new Object[][]{
+            {"US"}, {"US"},
+            {"foobar"}, {"foobar"}, {"foobar"}, {"foobar"}, {"foobar"}, {"foobar"}
+        }, "nestedJson.location.country default 'foobar'"}
+    };
+  }
+
   // ============================================================================================
   // 2. DISTINCT
+  //
+  // Pinot rejects positional `ORDER BY 1` for DISTINCT ("ORDER-BY columns should be included in
+  // the DISTINCT columns"), so each DISTINCT test repeats the projected expression in ORDER BY.
   // ============================================================================================
 
   /**
-   * DISTINCT with null handling ON. The distinct set must include exactly one null entry
-   * alongside the resolved values (deduped across segments).
+   * 2.1 — NH on, 3-arg. The distinct set must include exactly one null entry alongside the
+   * resolved values (deduped across segments).
    * <pre>
-   *   Example — `flatJson.country` (STRING):
-   *     Query:  SET enableNullHandling = true;
-   *             SELECT DISTINCT jsonExtractScalar(flatJson, '$.country', 'STRING') FROM clicks
-   *             ORDER BY jsonExtractScalar(flatJson, '$.country', 'STRING') ASC NULLS LAST
-   *
-   *     Result: "CA", "US", NULL
+   *   Example — `flatJson.country`: Result: "CA", "US", NULL
    * </pre>
-   * Pinot rejects positional `ORDER BY 1` for DISTINCT ("ORDER-BY columns should be included in
-   * the DISTINCT columns"), so the expression is repeated in the ORDER BY clause.
    */
   @Test(dataProvider = "distinctCases")
   public void testDistinctNullHandlingOn(String column, String jsonPath, String resultsType,
@@ -1175,6 +1240,28 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
     givenCountryClickTable(true).whenQuery(query).thenResultIs(expectedRows);
   }
 
+  /** 2.2 — NH on, 4-arg with `NULL` literal. Same distinct set as 2.1 (includes a null entry). */
+  @Test(dataProvider = "sqlNullDefaultDistinctCases")
+  public void testDistinctWithSqlNullDefaultIncludesNull(String column, String jsonPath,
+      Object[][] expectedRows, String label) {
+    String expr = String.format("jsonExtractScalar(%s, '%s', 'STRING', NULL)", column, jsonPath);
+    givenCountryClickTable(true)
+        .whenQuery(String.format("SELECT DISTINCT %s FROM clicks ORDER BY %s ASC NULLS LAST", expr, expr))
+        .thenResultIs(expectedRows);
+  }
+
+  /** 2.3 — NH on, 4-arg with non-null default. Default value appears as a regular distinct entry (no null). */
+  @Test(dataProvider = "defaultPrecedenceDistinctCases")
+  public void testDistinctDefaultBeatsNullHandlingPlaceholder(String column, String jsonPath,
+      String defaultLiteral, Object[][] expectedRows, String label) {
+    String expr = String.format(
+        "jsonExtractScalar(%s, '%s', 'STRING', %s)", column, jsonPath, defaultLiteral);
+    givenCountryClickTable(true)
+        .whenQuery(String.format("SELECT DISTINCT %s FROM clicks ORDER BY %s ASC", expr, expr))
+        .thenResultIs(expectedRows);
+  }
+
+  /** 2.4 — NH off: DISTINCT throws on unresolved rows. */
   @Test
   public void testDistinctNullHandlingOffThrows() {
     try {
@@ -1187,7 +1274,7 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
     }
   }
 
-  /** Each row is `(column, jsonPath, resultsType, expected distinct rows ASC NULLS LAST, label)`. */
+  /** 2.1 cases — `(column, jsonPath, resultsType, expected distinct rows ASC NULLS LAST, label)`. */
   @DataProvider(name = "distinctCases")
   public static Object[][] distinctCases() {
     return new Object[][]{
@@ -1204,33 +1291,75 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
     };
   }
 
+  /** 2.2 cases — `(column, jsonPath, expected distinct rows ASC NULLS LAST, label)`. */
+  @DataProvider(name = "sqlNullDefaultDistinctCases")
+  public static Object[][] sqlNullDefaultDistinctCases() {
+    return new Object[][]{
+        {"flatJson", "$.country", new Object[][]{{"CA"}, {"US"}, {null}}, "flatJson.country NULL default"},
+        {"nestedJson", "$.location.country", new Object[][]{{"US"}, {null}},
+            "nestedJson.location.country NULL default"}
+    };
+  }
+
+  /** 2.3 cases — `(column, jsonPath, default literal, expected distinct rows ASC, label)`. */
+  @DataProvider(name = "defaultPrecedenceDistinctCases")
+  public static Object[][] defaultPrecedenceDistinctCases() {
+    return new Object[][]{
+        {"flatJson", "$.country", "'foobar'",
+            new Object[][]{{"CA"}, {"US"}, {"foobar"}}, "flatJson.country default 'foobar'"},
+        {"nestedJson", "$.location.country", "'foobar'",
+            new Object[][]{{"US"}, {"foobar"}}, "nestedJson.location.country default 'foobar'"}
+    };
+  }
+
   // ============================================================================================
   // 3. GROUP BY
   // ============================================================================================
 
   /**
-   * GROUP BY with null handling ON. Unresolved rows must collapse into a single null group with
-   * the correct count, alongside the resolved value groups.
+   * 3.1 — NH on, 3-arg. Unresolved rows collapse into a single null group with the correct count,
+   * alongside the resolved value groups.
    * <pre>
-   *   Example — `flatJson.country` (STRING):
-   *     per-row: row 0 -> "US", row 1 -> "CA", row 2 -> NULL (explicit), row 3 -> NULL (missing)
-   *
-   *     Query:  SET enableNullHandling = true;
-   *             SELECT jsonExtractScalar(flatJson, '$.country', 'STRING') AS v, COUNT(*)
-   *             FROM clicks GROUP BY v ORDER BY v ASC NULLS LAST
-   *
-   *     Result (counts ×2 for segment duplication): ("CA", 2), ("US", 2), (NULL, 4)
+   *   Example — `flatJson.country`: Result (counts ×2 for segment dup): ("CA", 2), ("US", 2), (NULL, 4)
    * </pre>
    */
   @Test(dataProvider = "groupByCases")
   public void testGroupByNullHandlingOn(String column, String jsonPath, String resultsType,
       Object[][] expectedRows, String label) {
     String expr = String.format("jsonExtractScalar(%s, '%s', '%s')", column, jsonPath, resultsType);
-    String query = String.format(
-        "SELECT %s AS v, COUNT(*) FROM clicks GROUP BY v ORDER BY v ASC NULLS LAST", expr);
-    givenCountryClickTable(true).whenQuery(query).thenResultIs(expectedRows);
+    givenCountryClickTable(true)
+        .whenQuery(String.format(
+            "SELECT %s AS v, COUNT(*) FROM clicks GROUP BY v ORDER BY v ASC NULLS LAST", expr))
+        .thenResultIs(expectedRows);
   }
 
+  /** 3.2 — NH on, 4-arg with `NULL` literal. Same groups as 3.1 (null group with correct count). */
+  @Test(dataProvider = "sqlNullDefaultGroupByCases")
+  public void testGroupByWithSqlNullDefaultProducesNullGroup(String column, String jsonPath,
+      Object[][] expectedRows, String label) {
+    String expr = String.format("jsonExtractScalar(%s, '%s', 'STRING', NULL)", column, jsonPath);
+    givenCountryClickTable(true)
+        .whenQuery(String.format(
+            "SELECT %s AS v, COUNT(*) FROM clicks GROUP BY v ORDER BY v ASC NULLS LAST", expr))
+        .thenResultIs(expectedRows);
+  }
+
+  /**
+   * 3.3 — NH on, 4-arg with non-null default. Unresolved rows count toward the default's group,
+   * not a null group — so the result has no NULL group at all.
+   */
+  @Test(dataProvider = "defaultPrecedenceGroupByCases")
+  public void testGroupByDefaultBeatsNullHandlingPlaceholder(String column, String jsonPath,
+      String defaultLiteral, Object[][] expectedRows, String label) {
+    String expr = String.format(
+        "jsonExtractScalar(%s, '%s', 'STRING', %s)", column, jsonPath, defaultLiteral);
+    givenCountryClickTable(true)
+        .whenQuery(String.format(
+            "SELECT %s AS v, COUNT(*) FROM clicks GROUP BY v ORDER BY v ASC", expr))
+        .thenResultIs(expectedRows);
+  }
+
+  /** 3.4 — NH off: GROUP BY throws on unresolved rows. */
   @Test
   public void testGroupByNullHandlingOffThrows() {
     try {
@@ -1243,10 +1372,7 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
     }
   }
 
-  /**
-   * Each row is `(column, jsonPath, resultsType, expected (value, count) rows ASC NULLS LAST,
-   * label)`. Counts are ×2 the per-row count due to segment duplication.
-   */
+  /** 3.1 cases — `(column, jsonPath, resultsType, expected (value, count) rows ASC NULLS LAST, label)`. */
   @DataProvider(name = "groupByCases")
   public static Object[][] groupByCases() {
     return new Object[][]{
@@ -1273,103 +1399,18 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
     };
   }
 
-  // ============================================================================================
-  // 4. Default-value precedence under null handling ON
-  //
-  // When a non-null default literal is supplied AND null handling is on, the SV transform's
-  // priority order is: real default > null-handling placeholder > throw. The user-supplied
-  // default surfaces for unresolved rows; the null-handling placeholder is NOT emitted, and
-  // no null bit is set in the bitmap. These tests pin that ordering across projection,
-  // DISTINCT, and GROUP BY so a future refactor can't silently swap the priority.
-  // ============================================================================================
-
-  /**
-   * Projection with NH on AND a non-null default literal. Unresolved rows must surface as the
-   * default, not SQL NULL — across both flat scalar and nested-object shapes.
-   * <pre>
-   *   Example — flatJson.country with default 'foobar':
-   *     per-row: row 0 -> "US", row 1 -> "CA", row 2 -> "foobar" (was null),
-   *              row 3 -> "foobar" (was missing)
-   *
-   *     Query: SET enableNullHandling = true;
-   *            SELECT jsonExtractScalar(flatJson, '$.country', 'STRING', 'foobar') AS c
-   *            FROM clicks ORDER BY c ASC
-   *
-   *     Result rows (×2 segment dup; ASCII order, uppercase before lowercase):
-   *             "CA", "CA", "US", "US", "foobar", "foobar", "foobar", "foobar"
-   * </pre>
-   */
-  @Test(dataProvider = "defaultPrecedenceProjectionCases")
-  public void testProjectionDefaultBeatsNullHandlingPlaceholder(String column, String jsonPath,
-      String defaultLiteral, Object[][] expectedRows, String label) {
-    String expr = String.format(
-        "jsonExtractScalar(%s, '%s', 'STRING', %s)", column, jsonPath, defaultLiteral);
-    givenCountryClickTable(true)
-        .whenQuery(String.format("SELECT %s AS c FROM clicks ORDER BY c ASC", expr))
-        .thenResultIs(expectedRows);
-  }
-
-  /**
-   * Each row: `(column, jsonPath, default SQL literal, expected 8-row result, label)`. Result
-   * rows are ordered ASC. Each per-row value in the fixture appears ×2 due to segment duplication.
-   */
-  @DataProvider(name = "defaultPrecedenceProjectionCases")
-  public static Object[][] defaultPrecedenceProjectionCases() {
+  /** 3.2 cases — `(column, jsonPath, expected (value, count) rows ASC NULLS LAST, label)`. */
+  @DataProvider(name = "sqlNullDefaultGroupByCases")
+  public static Object[][] sqlNullDefaultGroupByCases() {
     return new Object[][]{
-        // flatJson.country: row0="US", row1="CA", row2=null, row3=missing -> 2 each, 4 'foobar'.
-        {"flatJson", "$.country", "'foobar'", new Object[][]{
-            {"CA"}, {"CA"}, {"US"}, {"US"},
-            {"foobar"}, {"foobar"}, {"foobar"}, {"foobar"}
-        }, "flatJson.country default 'foobar'"},
-        // nestedJson.location.country: row0="US", rows 1/2/3 unresolved -> 2 "US" + 6 'foobar'.
-        {"nestedJson", "$.location.country", "'foobar'", new Object[][]{
-            {"US"}, {"US"},
-            {"foobar"}, {"foobar"}, {"foobar"}, {"foobar"}, {"foobar"}, {"foobar"}
-        }, "nestedJson.location.country default 'foobar'"}
+        {"flatJson", "$.country", new Object[][]{{"CA", 2L}, {"US", 2L}, {null, 4L}},
+            "flatJson.country NULL default"},
+        {"nestedJson", "$.location.country", new Object[][]{{"US", 2L}, {null, 6L}},
+            "nestedJson.location.country NULL default"}
     };
   }
 
-  /**
-   * DISTINCT with NH on AND a non-null default literal. The distinct set includes the default
-   * value as a regular entry — no separate null entry.
-   */
-  @Test(dataProvider = "defaultPrecedenceDistinctCases")
-  public void testDistinctDefaultBeatsNullHandlingPlaceholder(String column, String jsonPath,
-      String defaultLiteral, Object[][] expectedRows, String label) {
-    String expr = String.format(
-        "jsonExtractScalar(%s, '%s', 'STRING', %s)", column, jsonPath, defaultLiteral);
-    givenCountryClickTable(true)
-        .whenQuery(String.format("SELECT DISTINCT %s FROM clicks ORDER BY %s ASC", expr, expr))
-        .thenResultIs(expectedRows);
-  }
-
-  /** Each row: `(column, jsonPath, default literal, expected distinct rows ASC, label)`. */
-  @DataProvider(name = "defaultPrecedenceDistinctCases")
-  public static Object[][] defaultPrecedenceDistinctCases() {
-    return new Object[][]{
-        {"flatJson", "$.country", "'foobar'",
-            new Object[][]{{"CA"}, {"US"}, {"foobar"}}, "flatJson.country default 'foobar'"},
-        {"nestedJson", "$.location.country", "'foobar'",
-            new Object[][]{{"US"}, {"foobar"}}, "nestedJson.location.country default 'foobar'"}
-    };
-  }
-
-  /**
-   * GROUP BY with NH on AND a non-null default literal. Unresolved rows count toward the
-   * default's group — no NULL group surfaces.
-   */
-  @Test(dataProvider = "defaultPrecedenceGroupByCases")
-  public void testGroupByDefaultBeatsNullHandlingPlaceholder(String column, String jsonPath,
-      String defaultLiteral, Object[][] expectedRows, String label) {
-    String expr = String.format(
-        "jsonExtractScalar(%s, '%s', 'STRING', %s)", column, jsonPath, defaultLiteral);
-    givenCountryClickTable(true)
-        .whenQuery(String.format(
-            "SELECT %s AS v, COUNT(*) FROM clicks GROUP BY v ORDER BY v ASC", expr))
-        .thenResultIs(expectedRows);
-  }
-
-  /** Each row: `(column, jsonPath, default literal, expected (value, count) rows ASC, label)`. */
+  /** 3.3 cases — `(column, jsonPath, default literal, expected (value, count) rows ASC, label)`. */
   @DataProvider(name = "defaultPrecedenceGroupByCases")
   public static Object[][] defaultPrecedenceGroupByCases() {
     return new Object[][]{
@@ -1381,94 +1422,6 @@ public class JsonExtractScalarTransformFunctionTest extends BaseTransformFunctio
         {"nestedJson", "$.location.country", "'foobar'", new Object[][]{
             {"US", 2L}, {"foobar", 6L}
         }, "nestedJson.location.country default 'foobar'"}
-    };
-  }
-
-  // ============================================================================================
-  // 5. 4-arg with SQL NULL literal as default, under null handling ON
-  //
-  // Result is identical to the 3-arg + NH-on case (unresolved rows surface as SQL NULL), but
-  // the code path is different: `init` sets `_defaultValue` to the typed zero (0, "", etc.) and
-  // marks `_defaultIsNull=true`. The SV transform writes the typed zero via the
-  // `_defaultValue != null` branch; `getNullBitmap` scans and marks unresolved rows null thanks
-  // to the `!_defaultIsNull` carve-out in its short-circuit condition. These tests pin that
-  // code path so a future refactor that removes `_defaultIsNull` won't silently break this case.
-  // ============================================================================================
-
-  /**
-   * Projection with NH on AND `NULL` literal as the default. Unresolved rows surface as SQL NULL,
-   * same as the 3-arg form.
-   * <pre>
-   *   Example — flatJson.country:
-   *     Query: SET enableNullHandling = true;
-   *            SELECT jsonExtractScalar(flatJson, '$.country', 'STRING', NULL) AS c
-   *            FROM clicks ORDER BY c ASC NULLS LAST
-   *
-   *     Result rows (×2 segment dup):
-   *             "CA", "CA", "US", "US", NULL, NULL, NULL, NULL
-   * </pre>
-   */
-  @Test(dataProvider = "sqlNullDefaultProjectionCases")
-  public void testProjectionWithSqlNullDefaultEmitsNull(String column, String jsonPath,
-      Object[][] expectedRows, String label) {
-    String expr = String.format("jsonExtractScalar(%s, '%s', 'STRING', NULL)", column, jsonPath);
-    givenCountryClickTable(true)
-        .whenQuery(String.format("SELECT %s AS c FROM clicks ORDER BY c ASC NULLS LAST", expr))
-        .thenResultIs(expectedRows);
-  }
-
-  /** Each row: `(column, jsonPath, expected 8-row result ordered ASC NULLS LAST, label)`. */
-  @DataProvider(name = "sqlNullDefaultProjectionCases")
-  public static Object[][] sqlNullDefaultProjectionCases() {
-    return new Object[][]{
-        {"flatJson", "$.country", new Object[][]{
-            {"CA"}, {"CA"}, {"US"}, {"US"}, {null}, {null}, {null}, {null}
-        }, "flatJson.country NULL default"},
-        {"nestedJson", "$.location.country", new Object[][]{
-            {"US"}, {"US"}, {null}, {null}, {null}, {null}, {null}, {null}
-        }, "nestedJson.location.country NULL default"}
-    };
-  }
-
-  /** DISTINCT with NH on AND `NULL` literal as default — the distinct set includes a null entry. */
-  @Test(dataProvider = "sqlNullDefaultDistinctCases")
-  public void testDistinctWithSqlNullDefaultIncludesNull(String column, String jsonPath,
-      Object[][] expectedRows, String label) {
-    String expr = String.format("jsonExtractScalar(%s, '%s', 'STRING', NULL)", column, jsonPath);
-    givenCountryClickTable(true)
-        .whenQuery(String.format("SELECT DISTINCT %s FROM clicks ORDER BY %s ASC NULLS LAST", expr, expr))
-        .thenResultIs(expectedRows);
-  }
-
-  /** Each row: `(column, jsonPath, expected distinct rows ASC NULLS LAST, label)`. */
-  @DataProvider(name = "sqlNullDefaultDistinctCases")
-  public static Object[][] sqlNullDefaultDistinctCases() {
-    return new Object[][]{
-        {"flatJson", "$.country", new Object[][]{{"CA"}, {"US"}, {null}}, "flatJson.country NULL default"},
-        {"nestedJson", "$.location.country", new Object[][]{{"US"}, {null}},
-            "nestedJson.location.country NULL default"}
-    };
-  }
-
-  /** GROUP BY with NH on AND `NULL` literal as default — unresolved rows form a null group. */
-  @Test(dataProvider = "sqlNullDefaultGroupByCases")
-  public void testGroupByWithSqlNullDefaultProducesNullGroup(String column, String jsonPath,
-      Object[][] expectedRows, String label) {
-    String expr = String.format("jsonExtractScalar(%s, '%s', 'STRING', NULL)", column, jsonPath);
-    givenCountryClickTable(true)
-        .whenQuery(String.format(
-            "SELECT %s AS v, COUNT(*) FROM clicks GROUP BY v ORDER BY v ASC NULLS LAST", expr))
-        .thenResultIs(expectedRows);
-  }
-
-  /** Each row: `(column, jsonPath, expected (value, count) rows ASC NULLS LAST, label)`. */
-  @DataProvider(name = "sqlNullDefaultGroupByCases")
-  public static Object[][] sqlNullDefaultGroupByCases() {
-    return new Object[][]{
-        {"flatJson", "$.country", new Object[][]{{"CA", 2L}, {"US", 2L}, {null, 4L}},
-            "flatJson.country NULL default"},
-        {"nestedJson", "$.location.country", new Object[][]{{"US", 2L}, {null, 6L}},
-            "nestedJson.location.country NULL default"}
     };
   }
 }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Unresolved JSON path: use default if set, else null placeholder if null handling enabled, else throw\.

```mermaid
flowchart TD
  N0["F1#58; Get values from index #40;cached#41; #40;F1#41;"]:::stModified
  N1["Check value #61;#61; null #40;F1#44; F2#41;"]:::stModified
  N2["Check default exists #40;F1#44; F2#41;"]:::stModified
  N3["Use default value #40;F1#44; F2#41;"]:::stModified
  N4["Check null handling enabled #40;F1#44; F2#41;"]:::stModified
  N5["Write null placeholder #40;F1#44; F2#41;"]:::stModified
  N6["Throw exception #40;F1#44; F2#41;"]:::stModified
  N0 -->|"after getting values"| N1
  N1 -->|"if value is null"| N2
  N2 -->|"if default exists"| N3
  N2 -->|"if no default"| N4
  N4 -->|"if null handling enabled"| N5
  N4 -->|"if null handling disabled"| N6
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

Partial evidence: 0 file patches omitted; 2 truncated.

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunction\.java — [before](https://github.com/apache/pinot/blob/ed41f5e23e998b998d9a86b8e8f5e763282f7c55/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunction.java) · [after](https://github.com/apache/pinot/blob/a76fc9ea88e7db0ba9b774c230cce5b80f9ec619/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunction.java)
- F2: pinot\-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunction\.java — [before](https://github.com/apache/pinot/blob/ed41f5e23e998b998d9a86b8e8f5e763282f7c55/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunction.java) · [after](https://github.com/apache/pinot/blob/a76fc9ea88e7db0ba9b774c230cce5b80f9ec619/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunction.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImVkNDFmNWUyM2U5OThiOTk4ZDlhODZiOGU4ZjVlNzYzMjgyZjdjNTUiLCJjb250ZXh0X2hhc2giOiJmNDVhMzZiMTc0NGVkNDY5MjQ1NGYzZGI0MjdmNDI2ODAyMzg4ZjQ1OTAzODA0ZmFkYWQ0OGE2NzIyMDYyODcwIiwiZ2VuZXJhdGVkX2F0IjoxNzg5ODg5Mzc2LCJoZWFkX3NoYSI6ImE3NmZjOWVhODhlN2RiMGJhOWI3NzRjMjMwY2NlNWI4MGY5ZWM2MTkiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJhNjQ2M2Q0Nzc0OThlOGY2NGI1Njc5Y2YyZDA2MjY4NTI4ZDZjOGU3IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature d2ad5b5b5210ec0faff5540a0164dda73798ed6df599e270ea09ebd06036a745 -->
<!-- pinot-pr-flow:end -->

Fixes #18568.

**Improvement Summary**

Both `JsonExtractScalarTransformFunction` and `JsonExtractIndexTransformFunction` had `_nullHandlingEnabled` plumbed through (or accessible from `BaseTransformFunction`) but their six typed SV methods (`transformTo{Int,Long,Float,Double,BigDecimal,String}ValuesSV`) ignored it and threw unconditionally when the JSON path didn't resolve and no default literal was supplied. This PR makes both transforms honor `_nullHandlingEnabled`: when query-level null handling is on, unresolved rows surface as SQL `NULL` (typed null placeholder + a bit in `getNullBitmap()`) instead of throwing.

 All examples use a clicks table with two JSON columns and 4 rows. Both columns have a JSON index (so jsonExtractIndex is applicable):

```
  row 0:  flatJson   = {"country":"US", "clicks":5}
          nestedJson = {"location":{"city":"SF","country":"US"},
                        "tags":["red","blue","green"],
                        "events":[{"country":"US"},{"country":"CA"}]}
```

```
  row 1:  flatJson   = {"country":"CA", "clicks":3}
          nestedJson = {"location":{"city":"Tor"},          -- no country key
                        "tags":["green"],
                        "events":[{"country":null}]}        -- inner explicit null
```

```
  row 2:  flatJson   = {"country":null, "clicks":null}
          nestedJson = {"location":null, "tags":null, "events":null}
```
  
```
  row 3:  flatJson   = {}
          nestedJson = {}
```

```
SET enableNullHandling = true;
```

**Scenario 1: Projection — flat path**

 ```
 SELECT jsonExtractScalar(flatJson, '$.country', 'STRING') AS c FROM clicks ORDER BY c ASC NULLS LAST;
 SELECT jsonExtractIndex(flatJson, '$.country', 'STRING') AS c FROM clicks ORDER BY c ASC NULLS LAST;
```

```
- `jsonExtractScalar`
    - Before: throws `IllegalArgumentException: Cannot resolve JSON path on some records…`
    - After: `"CA"`, `"US"`, `NULL`, `NULL`

  - `jsonExtractIndex`
    - Before: throws `RuntimeException: Illegal Json Path: [$.country], for docId [N]`
    - After: `"CA"`, `"US"`, `NULL`, `NULL`
```

**Scenario 2: Projection — nested path**

 ```
 SELECT jsonExtractScalar(nestedJson, '$.tags[0]', 'STRING') AS tag FROM clicks ORDER BY tag ASC NULLS LAST;
 SELECT jsonExtractIndex(nestedJson, '$.tags[0]', 'STRING') AS tag FROM clicks ORDER BY tag ASC NULLS LAST;
```

```
- `jsonExtractScalar`
    - Before: throws
    - After: `"green"`, `"red"`, `NULL`, `NULL`

  - `jsonExtractIndex`
    - Before: throws
    - After: `"green"`, `"red"`, `NULL`, `NULL`
```

 **Scenario 3: DISTINCT — flat path**
  
```
SELECT DISTINCT jsonExtractScalar(flatJson, '$.country', 'STRING') AS c 
              FROM clicks ORDER BY c ASC NULLS LAST;
SELECT DISTINCT jsonExtractIndex(flatJson, '$.country', 'STRING') AS c 
              FROM clicks ORDER BY c ASC NULLS LAST;
```

```
- `jsonExtractScalar`
    - Before: throws
    - After: `"CA"`, `"US"`, `NULL`

  - `jsonExtractIndex`
    - Before: **already returned `"CA"`, `"US"`, `NULL`** via `JsonIndexDistinctOperator` — operator path unchanged
    - After: `"CA"`, `"US"`, `NULL`
```

**Scenario 4: DISTINCT - nested path**

```
SELECT DISTINCT jsonExtractScalar(nestedJson, '$.location.country', 'STRING') AS c 
               FROM clicks ORDER BY c ASC NULLS LAST;
SELECT DISTINCT jsonExtractIndex(nestedJson, '$.location.country', 'STRING') AS c 
               FROM clicks ORDER BY c ASC NULLS LAST;
```

```
  - `jsonExtractScalar`
    - Before: throws
    - After: `"US"`, `NULL`

  - `jsonExtractIndex`
    - Before: **already returned `"US"`, `NULL`** (operator path)
    - After: `US`, `NULL`
```

**Scenario 5: GROUP BY + COUNT — flat path**
  
```
SELECT jsonExtractScalar(flatJson, '$.country', 'STRING') AS c, COUNT(*) 
              FROM clicks GROUP BY c ORDER BY c ASC NULLS LAST;
SELECT jsonExtractIndex(flatJson, '$.country', 'STRING') AS c, COUNT(*) 
              FROM clicks GROUP BY c ORDER BY c ASC NULLS LAST;
```

```
 - `jsonExtractScalar`
    - Before: throws
    - After: `("CA", 1)`, `("US", 1)`, `(NULL, 2)`

  - `jsonExtractIndex`
    - Before: throws
    - After: `("CA", 1)`, `("US", 1)`, `(NULL, 2)`
```

**Scenario 6: GROUP BY + COUNT — nested path**

```
SELECT jsonExtractScalar(nestedJson, '$.events[0].country', 'STRING') AS c, COUNT(*) 
              FROM clicks GROUP BY c ORDER BY c ASC NULLS LAST;
SELECT jsonExtractIndex(nestedJson, '$.events[0].country', 'STRING') AS c, COUNT(*) 
              FROM clicks GROUP BY c ORDER BY c ASC NULLS LAST;
```

```
  - `jsonExtractScalar`
    - Before: throws
    - After: `("US", 1)`, `(NULL, 3)`

  - `jsonExtractIndex`
    - Before: throws
    - After: `("US", 1)`, `(NULL, 3)`
```

**Scenario 7: 4-arg with SQL NULL literal as default, enableNullHandling = true**
  
- Semantically, passing NULL as the default is equivalent to passing no default at all under NH on — both should surface SQL NULL for unresolved rows. 
- Before this PR, jsonExtractScalar already behaved correctly here. No change there. 
- Before this PR, jsonExtractIndex did not — for STRING it silently emitted "", and for numeric types it failed at init with NumberFormatException. After the fix, init detects the SQL NULL literal and leaves _defaultValue null, so the 3-arg behavior applies.
 
``` 
SELECT jsonExtractScalar(nestedJson, '$.tags[0]', 'STRING', NULL) AS tag 
              FROM clicks ORDER BY tag ASC NULLS LAST;
SELECT jsonExtractIndex(nestedJson, '$.tags[0]', 'STRING', NULL) AS tag 
             FROM clicks ORDER BY tag ASC NULLS LAST;
```

``` ┌───────────────────┬───────────────────────────────────────────────────────┬────────────────────────────────────────┐
  │     Function      │                        Before                         │                 After                  │
  ├───────────────────┼───────────────────────────────────────────────────────┼────────────────────────────────────────┤
  │ jsonExtractScalar │ "green", "red", NULL, NULL (already correct)          │ "green", "red", NULL, NULL (unchanged) │
  ├───────────────────┼───────────────────────────────────────────────────────┼────────────────────────────────────────┤
  │ jsonExtractIndex  │ "green", "red", "", "" ← empty string instead of NULL │ "green", "red", NULL, NULL ✓           │
  └───────────────────┴───────────────────────────────────────────────────────┴────────────────────────────────────────┘
```

**Scenario 8: 4-arg with non-null default literal. Worked correctly before this PR as well** 

```
 -- NullHandling on or off — behavior is the same
 SELECT jsonExtractScalar(flatJson, '$.country', 'STRING', 'foobar') FROM clicks;
 SELECT jsonExtractIndex(flatJson, '$.country', 'STRING', 'foobar') FROM clicks;
```

 ```
┌─────────────────────────┬─────────────────────────────────────┐
  │       Query shape       │   Before & After (both functions)   │
  ├─────────────────────────┼─────────────────────────────────────┤
  │ Projection              │ "US", "CA", "foobar", "foobar"      │
  ├─────────────────────────┼─────────────────────────────────────┤
  │ DISTINCT (ORDER BY ASC) │ "CA", "US", "foobar"                │
  ├─────────────────────────┼─────────────────────────────────────┤
  │ GROUP BY + COUNT        │ ("CA", 1), ("US", 1), ("foobar", 2) │
  └─────────────────────────┴─────────────────────────────────────┘
```

 **Out of scope — pre-existing quirks intentionally not addressed**
  
  These have been documented as deferred follow-ups; no behavior change in this PR.

  NH off + SQL NULL literal as default

  -- enableNullHandling stays false
  SELECT jsonExtractScalar(flatJson, '$.country', 'STRING', NULL) FROM clicks;

  jsonExtractScalar silently emits the typed zero (0 for INT, "" for STRING, etc.) for unresolved rows. Arguably wrong — passing SQL NULL when NH is off has no consistent semantics — but pre-existing and out of scope.

  jsonExtractIndex previously had the same family of issues (STRING "", numeric init-throw); the Form B fix narrowed those to a consistent "behave like 3-arg form" under NH on but did not touch NH-off.

**Testing Done**

- Added new tests to JsonExtractScalarTransformFunctionTest and JsonExtractIndexTransformFunctionTest to get 100% coverage for null handling
- Added multiple query shapes -- PROJECT, DISTINCT and GROUP BY
- Added multiple Json column shapes -- flat, arbitrarily nested 


