### PR TITLE
Auto-enable TimeSegmentPruner for materialized view tables

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerFactory.java
@@ -58,6 +58,7 @@ public class SegmentPrunerFactory {
       segmentPruners.add(new EmptySegmentPruner(tableConfig));
     }
 
+    boolean requestedTimePruner = false;
     RoutingConfig routingConfig = tableConfig.getRoutingConfig();
     if (routingConfig != null) {
       List<String> segmentPrunerTypes = routingConfig.getSegmentPrunerTypes();
@@ -71,6 +72,7 @@ public class SegmentPrunerFactory {
             }
           }
           if (RoutingConfig.TIME_SEGMENT_PRUNER_TYPE.equalsIgnoreCase(segmentPrunerType)) {
+            requestedTimePruner = true;
             TimeSegmentPruner timeSegmentPruner = getTimeSegmentPruner(tableConfig, propertyStore);
             if (timeSegmentPruner != null) {
               configuredSegmentPruners.add(timeSegmentPruner);
@@ -93,6 +95,20 @@ public class SegmentPrunerFactory {
             segmentPruners.add(partitionSegmentPruner);
           }
         }
+      }
+    }
+
+    /// Materialized view tables write segments per `[windowStartMs, windowEndMs)` bucket. Auto-enable
+    /// {@link TimeSegmentPruner} so time-range queries skip out-of-window segments without requiring
+    /// routing-config boilerplate. Skipped if the user already listed the time pruner type in
+    /// `routingConfig.segmentPrunerTypes` (regardless of whether it built successfully — the explicit
+    /// request is honored as-is and any misconfig is surfaced by the original warning, not duplicated
+    /// here). Silently skipped if the table has no time column / schema.
+    if (!requestedTimePruner && tableConfig.isMaterializedView()) {
+      TimeSegmentPruner timeSegmentPruner = getTimeSegmentPruner(tableConfig, propertyStore);
+      if (timeSegmentPruner != null) {
+        // Preserve the empty -> time -> partition order by inserting after any EmptySegmentPruner.
+        segmentPruners.add(needsEmptySegment ? 1 : 0, timeSegmentPruner);
       }
     }
     return segmentPruners;

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerTest.java
@@ -280,6 +280,81 @@ public class SegmentPrunerTest extends ControllerTest {
   }
 
   @Test
+  public void testSegmentPrunerFactoryForMaterializedView() {
+    // MV tables write per `[windowStartMs, windowEndMs)` bucketed segments, so the factory should
+    // auto-enable TimeSegmentPruner without requiring routingConfig boilerplate.
+    TableConfig tableConfig = mock(TableConfig.class);
+    when(tableConfig.getTableName()).thenReturn(OFFLINE_TABLE_NAME);
+    when(tableConfig.getTableType()).thenReturn(TableType.OFFLINE);
+    SegmentsValidationAndRetentionConfig validationConfig = mock(SegmentsValidationAndRetentionConfig.class);
+    when(validationConfig.getTimeColumnName()).thenReturn(TIME_COLUMN);
+    when(tableConfig.getValidationConfig()).thenReturn(validationConfig);
+    Schema schema = new Schema.SchemaBuilder().setSchemaName(RAW_TABLE_NAME)
+        .addDateTimeField(TIME_COLUMN, DataType.TIMESTAMP, "TIMESTAMP", "1:MILLISECONDS").build();
+    ZKMetadataProvider.setSchema(_propertyStore, schema);
+
+    // Sanity: non-MV table with no routing config -> no pruner auto-added.
+    when(tableConfig.isMaterializedView()).thenReturn(false);
+    List<SegmentPruner> segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
+    assertEquals(segmentPruners.size(), 0);
+
+    // MV table with no routing config -> TimeSegmentPruner auto-added.
+    when(tableConfig.isMaterializedView()).thenReturn(true);
+    segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
+    assertEquals(segmentPruners.size(), 1);
+    assertTrue(segmentPruners.get(0) instanceof TimeSegmentPruner);
+
+    // MV table with routing config but no segmentPrunerTypes -> still auto-added.
+    RoutingConfig routingConfig = mock(RoutingConfig.class);
+    when(tableConfig.getRoutingConfig()).thenReturn(routingConfig);
+    segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
+    assertEquals(segmentPruners.size(), 1);
+    assertTrue(segmentPruners.get(0) instanceof TimeSegmentPruner);
+
+    // MV table that already configures "time" explicitly -> no double-add.
+    when(routingConfig.getSegmentPrunerTypes()).thenReturn(List.of(RoutingConfig.TIME_SEGMENT_PRUNER_TYPE));
+    segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
+    assertEquals(segmentPruners.size(), 1);
+    assertTrue(segmentPruners.get(0) instanceof TimeSegmentPruner);
+
+    // MV table that configures only the partition pruner -> time pruner auto-added, sorted before partition.
+    IndexingConfig indexingConfig = mock(IndexingConfig.class);
+    when(tableConfig.getIndexingConfig()).thenReturn(indexingConfig);
+    Map<String, ColumnPartitionConfig> columnPartitionConfigMap = new HashMap<>();
+    columnPartitionConfigMap.put(PARTITION_COLUMN_1, new ColumnPartitionConfig("Modulo", 5));
+    when(indexingConfig.getSegmentPartitionConfig()).thenReturn(new SegmentPartitionConfig(columnPartitionConfigMap));
+    when(routingConfig.getSegmentPrunerTypes()).thenReturn(List.of(RoutingConfig.PARTITION_SEGMENT_PRUNER_TYPE));
+    segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
+    assertEquals(segmentPruners.size(), 2);
+    assertTrue(segmentPruners.get(0) instanceof TimeSegmentPruner);
+    assertTrue(segmentPruners.get(1) instanceof SinglePartitionColumnSegmentPruner);
+
+    // MV table that also needs an EmptySegmentPruner (Kinesis stream): order is empty -> time.
+    when(tableConfig.getTableName()).thenReturn(REALTIME_TABLE_NAME);
+    when(tableConfig.getTableType()).thenReturn(TableType.REALTIME);
+    when(indexingConfig.getSegmentPartitionConfig()).thenReturn(null);
+    when(indexingConfig.getStreamConfigs()).thenReturn(Map.of(StreamConfigProperties.STREAM_TYPE, KINESIS_STREAM_TYPE));
+    when(routingConfig.getSegmentPrunerTypes()).thenReturn(null);
+    segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
+    assertEquals(segmentPruners.size(), 2);
+    assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
+    assertTrue(segmentPruners.get(1) instanceof TimeSegmentPruner);
+
+    // MV table without a time column -> time pruner silently skipped (EmptySegmentPruner still added).
+    when(validationConfig.getTimeColumnName()).thenReturn(null);
+    segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
+    assertEquals(segmentPruners.size(), 1);
+    assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
+
+    // Explicit "time" request that fails to build (no time column) is honored as-is and NOT silently
+    // re-attempted by the MV branch: result has neither time pruner nor a duplicate warn-and-retry.
+    when(indexingConfig.getStreamConfigs()).thenReturn(null);
+    when(routingConfig.getSegmentPrunerTypes()).thenReturn(List.of(RoutingConfig.TIME_SEGMENT_PRUNER_TYPE));
+    segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
+    assertEquals(segmentPruners.size(), 0);
+  }
+
+  @Test
   public void testPartitionAwareSegmentPruner() {
     BrokerRequest brokerRequest1 = CalciteSqlCompiler.compileToBrokerRequest(QUERY_1);
     BrokerRequest brokerRequest2 = CalciteSqlCompiler.compileToBrokerRequest(QUERY_2);


### PR DESCRIPTION
## Summary

- Materialized view tables write segments per `[windowStartMs, windowEndMs)` bucket, but Pinot does not auto-enable `TimeSegmentPruner` on them today — none of the MV creation paths (controller endpoint, DDL, quickstart [airlineStatsMv_offline_table_config.json](https://github.com/apache/pinot/blob/master/pinot-tools/src/main/resources/examples/batch/airlineStatsMv/airlineStatsMv_offline_table_config.json)) set `routingConfig.segmentPrunerTypes = ["time"]`. As a result, time-range queries against an MV scan every window.
- This PR auto-adds `TimeSegmentPruner` in `SegmentPrunerFactory.getSegmentPruners` when `tableConfig.isMaterializedView()` is true and the user did not explicitly list the time pruner type — mirroring the existing auto-enable pattern for `EmptySegmentPruner`. No SQL or filter-AST mutation; pure broker-side routing pruning.
- Explicit user config is honored as-is: if the user listed `"time"` but the build fails (missing time column / schema), the MV branch does not silently re-attempt and mask the misconfig.

## Test plan

- [x] New unit test `SegmentPrunerTest#testSegmentPrunerFactoryForMaterializedView` covers:
  - non-MV sanity (no auto-add)
  - MV with no routing config (auto-add)
  - MV with routing config but no `segmentPrunerTypes` (auto-add)
  - MV with explicit `"time"` (no double-add)
  - MV with partition pruner alongside (auto-added, sort order preserved: empty → time → partition)
  - MV REALTIME requiring `EmptySegmentPruner` (empty → time ordering preserved)
  - MV without a time column (silently skipped)
  - MV with explicit `"time"` request that fails to build (not silently re-attempted)
- [x] `./mvnw spotless:check checkstyle:check license:check -pl pinot-broker` — all pass
- [x] `./mvnw test-compile -pl pinot-broker` — no new warnings on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)