### PR TITLE
[bugfix] scope cluster-aware tableConfigs validations to validate/tune endpoints only

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -198,8 +198,7 @@ public class TableConfigsRestletResource {
   @ManualAuthorization // performed after parsing table configs
   public ConfigSuccessResponse addConfig(
       String tableConfigsStr,
-      @ApiParam(value = "comma separated list of validation type(s) to skip. supported types: "
-          + "(ALL|TASK|UPSERT|TENANT|MINION_INSTANCES|ACTIVE_TASKS)")
+      @ApiParam(value = "comma separated list of validation type(s) to skip. supported types: (ALL|TASK|UPSERT)")
       @QueryParam("validationTypesToSkip") @Nullable String typesToSkip,
       @DefaultValue("false") @QueryParam("ignoreActiveTasks") boolean ignoreActiveTasks,
       @Context HttpHeaders httpHeaders, @Context Request request)
@@ -366,8 +365,7 @@ public class TableConfigsRestletResource {
   public ConfigSuccessResponse updateConfig(
       @ApiParam(value = "TableConfigs name i.e. raw table name", required = true) @PathParam("tableName")
       String tableName,
-      @ApiParam(value = "comma separated list of validation type(s) to skip. supported types: "
-          + "(ALL|TASK|UPSERT|TENANT|MINION_INSTANCES|ACTIVE_TASKS)")
+      @ApiParam(value = "comma separated list of validation type(s) to skip. supported types: (ALL|TASK|UPSERT)")
       @QueryParam("validationTypesToSkip") @Nullable String typesToSkip,
       @ApiParam(value = "Reload the table if the new schema is backward compatible") @DefaultValue("false")
       @QueryParam("reload") boolean reload,
@@ -516,6 +514,25 @@ public class TableConfigsRestletResource {
     String rawTableName = DatabaseUtils.translateTableName(tableConfigs.getTableName(), databaseName);
     tableConfigs.setTableName(rawTableName);
 
+    // Cluster-aware validations are exclusive to the validate/tune pre-flight endpoints so that users get fail-fast
+    // feedback on tenant/minion/active-task issues without re-running them in the create/update paths (which already
+    // perform the equivalent checks inline or via PinotHelixResourceManager).
+    Set<TableConfigUtils.ValidationType> skipTypes = TableConfigUtils.parseTypesToSkipString(typesToSkip);
+    try {
+      if (tableConfigs.getOffline() != null) {
+        validateClusterAwareConfig(tableConfigs.getOffline(), skipTypes);
+      }
+      if (tableConfigs.getRealtime() != null) {
+        validateClusterAwareConfig(tableConfigs.getRealtime(), skipTypes);
+      }
+    } catch (ControllerApplicationException e) {
+      // Already logged by the inner constructor; let it propagate as-is.
+      throw e;
+    } catch (Exception e) {
+      throw new ControllerApplicationException(LOGGER,
+          String.format("Invalid TableConfigs: %s. %s", rawTableName, e.getMessage()), Response.Status.BAD_REQUEST, e);
+    }
+
     // validate permission
     String endpointUrl = request.getRequestURL().toString();
     AccessControl accessControl = _accessControlFactory.create();
@@ -524,6 +541,21 @@ public class TableConfigsRestletResource {
       throw new ControllerApplicationException(LOGGER, "Permission denied", Response.Status.FORBIDDEN);
     }
     return tableConfigsAndUnrecognizedProps;
+  }
+
+  private void validateClusterAwareConfig(TableConfig tableConfig, Set<TableConfigUtils.ValidationType> skipTypes) {
+    if (skipTypes.contains(TableConfigUtils.ValidationType.ALL)) {
+      return;
+    }
+    if (!skipTypes.contains(TableConfigUtils.ValidationType.TENANT)) {
+      _pinotHelixResourceManager.validateTableTenantConfig(tableConfig);
+    }
+    if (!skipTypes.contains(TableConfigUtils.ValidationType.MINION_INSTANCES)) {
+      _pinotHelixResourceManager.validateTableTaskMinionInstanceTagConfig(tableConfig);
+    }
+    if (!skipTypes.contains(TableConfigUtils.ValidationType.ACTIVE_TASKS)) {
+      PinotTableRestletResource.tableTasksValidation(tableConfig, _pinotHelixTaskResourceManager);
+    }
   }
 
   private void applyTuning(TableConfig tableConfig, Schema schema) {
@@ -553,8 +585,6 @@ public class TableConfigsRestletResource {
       Preconditions.checkState(rawTableName.equals(schemaName),
           "'tableName': %s must be equal to 'schemaName' from 'schema': %s", rawTableName, schema.getSchemaName());
       SchemaUtils.validate(schema);
-      // Parse validation types to skip using TableConfigUtils method
-      Set<TableConfigUtils.ValidationType> skipTypes = TableConfigUtils.parseTypesToSkipString(typesToSkip);
       if (offlineTableConfig != null) {
         String offlineRawTableName = DatabaseUtils.translateTableName(
             TableNameBuilder.extractRawTableName(offlineTableConfig.getTableName()), database);
@@ -562,17 +592,6 @@ public class TableConfigsRestletResource {
             "Name in 'offline' table config: %s must be equal to 'tableName': %s", offlineRawTableName, rawTableName);
         TableConfigUtils.validateTableName(offlineTableConfig);
         TableConfigUtils.validate(offlineTableConfig, schema, typesToSkip);
-        if (!skipTypes.contains(TableConfigUtils.ValidationType.ALL)) {
-          if (!skipTypes.contains(TableConfigUtils.ValidationType.TENANT)) {
-            _pinotHelixResourceManager.validateTableTenantConfig(offlineTableConfig);
-          }
-          if (!skipTypes.contains(TableConfigUtils.ValidationType.MINION_INSTANCES)) {
-            _pinotHelixResourceManager.validateTableTaskMinionInstanceTagConfig(offlineTableConfig);
-          }
-          if (!skipTypes.contains(TableConfigUtils.ValidationType.ACTIVE_TASKS)) {
-            PinotTableRestletResource.tableTasksValidation(offlineTableConfig, _pinotHelixTaskResourceManager);
-          }
-        }
         TaskConfigUtils.validateTaskConfigs(tableConfigs.getOffline(), schema, _pinotTaskManager, typesToSkip);
         TableConfigValidatorRegistry.validate(offlineTableConfig, schema);
       }
@@ -583,17 +602,6 @@ public class TableConfigsRestletResource {
             "Name in 'realtime' table config: %s must be equal to 'tableName': %s", realtimeRawTableName, rawTableName);
         TableConfigUtils.validateTableName(realtimeTableConfig);
         TableConfigUtils.validate(realtimeTableConfig, schema, typesToSkip);
-        if (!skipTypes.contains(TableConfigUtils.ValidationType.ALL)) {
-          if (!skipTypes.contains(TableConfigUtils.ValidationType.TENANT)) {
-            _pinotHelixResourceManager.validateTableTenantConfig(realtimeTableConfig);
-          }
-          if (!skipTypes.contains(TableConfigUtils.ValidationType.MINION_INSTANCES)) {
-            _pinotHelixResourceManager.validateTableTaskMinionInstanceTagConfig(realtimeTableConfig);
-          }
-          if (!skipTypes.contains(TableConfigUtils.ValidationType.ACTIVE_TASKS)) {
-            PinotTableRestletResource.tableTasksValidation(realtimeTableConfig, _pinotHelixTaskResourceManager);
-          }
-        }
         TaskConfigUtils.validateTaskConfigs(tableConfigs.getRealtime(), schema, _pinotTaskManager, typesToSkip);
         TableConfigValidatorRegistry.validate(realtimeTableConfig, schema);
       }


### PR DESCRIPTION
## Summary

Fixes regressions introduced by #16675 in `TableConfigsRestletResource`.

That PR added three new cluster-aware validation types — `TENANT`, `MINION_INSTANCES`, `ACTIVE_TASKS` — to enhance the `/tableConfigs/validate` endpoint (its stated intent). However, it wired them into the **shared** private `validateConfig(TableConfigs, String, String)` helper, which is also called from the create (`POST /tableConfigs`) and update (`PUT /tableConfigs/{tableName}`) endpoints. This leaked the new checks onto paths where they don't belong.

## Regressions observed

| # | Where | Description |
|---|---|---|
| **R1 (critical)** | `updateConfig` (PUT `/tableConfigs/{tableName}`) | `tableTasksValidation` now runs on every update; it throws if **any** task exists for the table, so any config update is blocked while tasks are in the queue. The active-task check is only intended for create (catches stale state) and delete (blocks deleting with running tasks). The sibling `PinotTableRestletResource.updateTableConfig` at `PUT /tables/{tableName}` correctly does not gate updates this way. |
| **R2** | `addConfig` (POST `/tableConfigs`) | `tableTasksValidation` is called **twice** for offline / realtime configs — once via the new block in the shared helper and again at the inline call sites in `addConfig`. |
| **R3** | `addConfig` | The pre-existing `@QueryParam("ignoreActiveTasks")` flag is bypassed by the new call site; the helper gates only on the `ACTIVE_TASKS` skip type, so `ignoreActiveTasks=true` no longer suppresses the active-task check by itself — clients that relied on it broke. |
| **R4** | `addConfig` | `validateTableTenantConfig` + `validateTableTaskMinionInstanceTagConfig` now run twice — once via the new helper, and again inside `PinotHelixResourceManager.addTable(...)`. |
| **R5** | `updateConfig` | Same double-call as R4 — once via the new helper, and again inside `PinotHelixResourceManager.updateTableConfig(...)`. |

R1–R3 are behavioral regressions affecting users; R4/R5 are duplicated Helix/ZK calls per request.

## Fix

Keep the PR's intent (`/tableConfigs/validate` and `/tableConfigs/tune` surface cluster-aware issues for fail-fast feedback), but stop leaking the new checks onto create/update:

1. Remove the cluster-aware blocks from the shared `validateConfig(TableConfigs, ...)` helper.
2. Extract a new private helper `validateClusterAwareConfig(TableConfig, Set<ValidationType>)` that runs only the three cluster-aware checks, gated by skip types.
3. Invoke the new helper only from `parseAndValidateTableConfigs` (the path shared by `validateConfig` and `tuneConfig` endpoints). The `addConfig` and `updateConfig` paths are not touched — they continue to rely on:
   - The existing inline `tableTasksValidation` call in `addConfig` (properly gated by `ignoreActiveTasks`).
   - `PinotHelixResourceManager.addTable(...)` and `updateTableConfig(...)` running tenant / minion checks internally (unchanged behavior, no double-call).
4. Revert the `@ApiParam` doc on `addConfig` and `updateConfig` back to `(ALL|TASK|UPSERT)` since those endpoints don't consume the new skip types. The validate/tune endpoints keep the expanded doc.

Net effect: `/tableConfigs/validate` and `/tableConfigs/tune` behave identically to #16675. `addConfig` and `updateConfig` are restored to their pre-#16675 behavior.

## Test plan

- [x] `./mvnw -pl pinot-controller -am compile` — succeeds
- [x] `./mvnw spotless:apply checkstyle:check license:check -pl pinot-controller` — all clean
- [x] PR #16675's tests still pass: `TableConfigsRestletResourceTest#testValidateConfigWithClusterValidationSkipTypes` and `testValidateConfigClusterValidationsEnabled` (2 run, 0 failures)
- [x] Manual: create a table with `taskConfig` + running task → `PUT /tableConfigs/{tableName}` succeeds (pre-fix: blocked with "dangling task data")
- [x] Manual: `POST /tableConfigs?ignoreActiveTasks=true` succeeds without also needing `validationTypesToSkip=ACTIVE_TASKS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)