### PR TITLE
Fall back to raw-value REGEXP_LIKE evaluator when no dict-consuming index is available

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -309,8 +309,13 @@ public class FilterPlanNode implements PlanNode {
               // Check if case-insensitive flag is present
               RegexpLikePredicate regexpLikePredicate = (RegexpLikePredicate) predicate;
               boolean caseInsensitive = regexpLikePredicate.isCaseInsensitive();
+              // IFST/FST evaluators are dict-id based and can only be consumed by sorted/inverted-index filter
+              // operators. If neither is available for this segment, the planner will fall through to
+              // ScanBasedFilterOperator, which reads raw values from the forward index and cannot service a
+              // dict-id evaluator (applySV(String) throws on BaseDictionaryBasedPredicateEvaluator). In that
+              // case, route through the raw-value evaluator instead.
               if (caseInsensitive) {
-                if (dataSource.getIFSTIndex() != null) {
+                if (dataSource.getIFSTIndex() != null && canConsumeDictIdEvaluator(dataSource, _queryContext)) {
                   predicateEvaluator =
                       IFSTBasedRegexpPredicateEvaluatorFactory.newIFSTBasedEvaluator(regexpLikePredicate,
                           dataSource.getIFSTIndex(), dataSource.getDictionary());
@@ -319,7 +324,7 @@ public class FilterPlanNode implements PlanNode {
                       PredicateEvaluatorProvider.getPredicateEvaluator(predicate, dataSource, _queryContext);
                 }
               } else {
-                if (dataSource.getFSTIndex() != null) {
+                if (dataSource.getFSTIndex() != null && canConsumeDictIdEvaluator(dataSource, _queryContext)) {
                   predicateEvaluator = FSTBasedRegexpPredicateEvaluatorFactory.newFSTBasedEvaluator(regexpLikePredicate,
                       dataSource.getFSTIndex(), dataSource.getDictionary());
                 } else {
@@ -431,6 +436,30 @@ public class FilterPlanNode implements PlanNode {
     DataSource dataSource = _indexSegment.getDataSource(column, _queryContext.getSchema());
     return constructVectorSimilarityOperator(dataSource, (VectorSimilarityPredicate) predicate, column,
         numDocs, true);
+  }
+
+  /// Returns true if a dictionary-id based REGEXP_LIKE evaluator (e.g. IFST/FST/DictId) can be consumed at run time
+  /// either by:
+  ///   1. A sorted-index filter operator (`SortedIndexBasedFilterOperator`).
+  ///   2. An inverted-index filter operator (`InvertedIndexFilterOperator`).
+  ///   3. The scan filter operator when the forward index is dictionary-encoded (`DictIdMatcher` in
+  ///      `SVScanDocIdIterator` reads dict ids from the forward index and calls `applySV(int dictId)`).
+  ///
+  /// When false, the scan path will pick a typed raw matcher (e.g. `StringMatcher`) and call
+  /// `applySV(<rawType>)`, which a dict-id evaluator cannot service. In that case the IFST/FST evaluator should be
+  /// skipped in favor of the raw-value evaluator
+  /// (`RegexpLikePredicateEvaluatorFactory#newRawValueBasedEvaluator`).
+  private static boolean canConsumeDictIdEvaluator(DataSource dataSource, QueryContext queryContext) {
+    if (dataSource.getDataSourceMetadata().isSorted()
+        && queryContext.isIndexUseAllowed(dataSource, FieldConfig.IndexType.SORTED)) {
+      return true;
+    }
+    if (dataSource.getInvertedIndex() != null
+        && queryContext.isIndexUseAllowed(dataSource, FieldConfig.IndexType.INVERTED)) {
+      return true;
+    }
+    ForwardIndexReader<?> forwardIndex = dataSource.getForwardIndex();
+    return forwardIndex != null && forwardIndex.isDictionaryEncoded();
   }
 
   /**


### PR DESCRIPTION
Follow-up to #18579 per @Jackie-Jiang's review feedback: <https://github.com/apache/pinot/pull/18579#issuecomment-4546819452>

> *"This is not the correct fix. It is way too expensive to lookup every single value within forward index. The correct fix should be within predicate evaluator to handle raw values even when dictionary exist"*

#18579 routed raw-value scans through a per-row `dictionary.indexOf(value)` translation in `SVScanDocIdIterator`. This PR replaces that approach with a planner-level guard that avoids constructing a dict-id-based evaluator in the first place when no dict-consuming operator is available.

## Bug

Even after #18579, `regexp_like(col, ...)` and `LIKE` against a RAW-encoded string column with a separate dictionary plus FST or IFST (and no inverted/sorted index) follow a suboptimal path: the IFST/FST evaluator is constructed (wasted FST automaton work) and then the scan does a per-row dict lookup to translate every value. This is what Jackie called out.

When the FST/IFST evaluator cannot be consumed by an index-based filter operator, it shouldn't be constructed at all — the existing `RawValueBasedRegexpLikePredicateEvaluator` is the right choice and already implements `applySV(String)` correctly.

## Root cause

`FilterPlanNode.case REGEXP_LIKE` unconditionally builds the IFST/FST dict-id evaluator when the corresponding index exists, bypassing the invariant that `PredicateEvaluatorProvider.getDictionaryUsableForFiltering` enforces for every other dict-based predicate type:

```java
case REGEXP_LIKE:
  return invertedAvailable ? dictionary : null;   // drops dict if no dict-consuming op
```

## Fix

Add the same invariant to the IFST/FST branches in `FilterPlanNode`:

```java
if (caseInsensitive) {
  if (dataSource.getIFSTIndex() != null
      && canConsumeDictIdEvaluator(dataSource, _queryContext)) {
    predicateEvaluator = IFSTBasedRegexpPredicateEvaluatorFactory.newIFSTBasedEvaluator(...);
  } else {
    predicateEvaluator = PredicateEvaluatorProvider.getPredicateEvaluator(predicate, dataSource, _queryContext);
  }
}
// mirror for case-sensitive FST branch

private static boolean canConsumeDictIdEvaluator(DataSource dataSource, QueryContext queryContext) {
  if (dataSource.getDataSourceMetadata().isSorted()
      && queryContext.isIndexUseAllowed(dataSource, FieldConfig.IndexType.SORTED)) {
    return true;
  }
  if (dataSource.getInvertedIndex() != null
      && queryContext.isIndexUseAllowed(dataSource, FieldConfig.IndexType.INVERTED)) {
    return true;
  }
  // Scan with DictIdMatcher can consume dict-id evaluators when the forward index is dict-encoded.
  ForwardIndexReader<?> forwardIndex = dataSource.getForwardIndex();
  return forwardIndex != null && forwardIndex.isDictionaryEncoded();
}
```

The helper covers all three runtime consumers of a dict-id evaluator:
1. `SortedIndexBasedFilterOperator`
2. `InvertedIndexFilterOperator`
3. `ScanBasedFilterOperator` when the forward index is dict-encoded (uses `DictIdMatcher`, which calls `applySV(int dictId)`)

When none of these will be picked, the IFST/FST evaluator is skipped and the raw-value evaluator is used instead — `RawValueBasedRegexpLikePredicateEvaluator` already implements `applySV(String)`.

## Behavior matrix

| Forward index | FST/IFST | Sorted | Inverted | Evaluator chosen | Filter operator | Status |
|---|---|---|---|---|---|---|
| DICT | yes | no | no | FST/IFST eval | scan + `DictIdMatcher` | ✅ |
| DICT | yes | no | yes | FST/IFST eval | InvertedIndex | ✅ |
| DICT | yes | yes | no | FST/IFST eval | SortedIndex | ✅ |
| RAW | yes | no | no | raw eval | scan + `StringMatcher` | ✅ was crashing |
| RAW | yes | no | yes | FST/IFST eval | InvertedIndex | ✅ |

## Reverts

This effectively reverts the matcher-level changes from #18579 (which Jackie identified as too expensive) by addressing the same crash at a higher layer with fewer lines and no public API change.

## What's NOT changed

- `SVScanDocIdIterator` — reverted to upstream/master state (removes the matchers added in #18579).
- `BaseDictionaryBasedPredicateEvaluator` — untouched.
- `FilterOperatorUtils.getLeafFilterOperator` — untouched.
- Concrete evaluator subclasses — untouched.

## Known limitation (separate follow-up)

The `ScanBasedRegexpLikePredicateEvaluator` (used when dict ≥10K entries) extends `BaseDictionaryBasedPredicateEvaluator` directly, not `BaseDictIdBasedRegexpLikePredicateEvaluator`. `FilterOperatorUtils.getLeafFilterOperator` checks for the latter only, so on **RAW forward + dict ≥10K + inverted index** (no FST/IFST), the planner builds a `ScanBased` evaluator but the operator selector falls through to scan, producing the same crash. Out of scope for this PR; will file a separate fix to broaden the `instanceof` check.

## Test plan

- [ ] Existing `PredicateEvaluatorProviderTest` should pass unchanged
- [ ] Manual: `regexp_like(col, 'pat')`, `regexp_like(col, 'pat', 'i')`, and `LIKE 'pat%'` all return correct results (no crash) on a table with RAW forward + dict + FST/IFST + no inverted (the iceberg/external-table scenario that triggered #18579)
- [ ] With inverted index added: queries still route to `InvertedIndexFilterOperator` (fast path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)