### PR TITLE
feat(array): add arraySliceLong scalar function

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArrayFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArrayFunctions.java
@@ -140,6 +140,11 @@ public class ArrayFunctions {
   }
 
   @ScalarFunction
+  public static long[] arraySliceLong(long[] values, int start, int end) {
+    return Arrays.copyOfRange(values, start, end);
+  }
+
+  @ScalarFunction
   public static String[] arraySliceString(String[] values, int start, int end) {
     return Arrays.copyOfRange(values, start, end);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/ArrayFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/ArrayFunctionsTest.java
@@ -54,6 +54,7 @@ public class ArrayFunctionsTest {
     GenericRow row = new GenericRow();
     row.putValue("intArray", new int[]{3, 2, 10, 6, 1, 12});
     row.putValue("integerArray", new Integer[]{3, 2, 10, 6, 1, 12});
+    row.putValue("longArray", new long[]{3L, 2L, 10L, 6L, 1L, 12L});
     row.putValue("stringArray", new String[]{"3", "2", "10", "6", "1", "12"});
     row.putValue("stringArrayWithNulls", new String[]{"3", "2", "10", "6", "1", "12", "", null});
 
@@ -128,6 +129,9 @@ public class ArrayFunctionsTest {
         .add(new Object[]{"array_slice_int(intArray, 1, 2)", Collections.singletonList("intArray"), row, new int[]{2}});
     inputs.add(new Object[]{
         "array_slice_int(integerArray, 1, 2)", Collections.singletonList("integerArray"), row, new int[]{2}
+    });
+    inputs.add(new Object[]{
+        "array_slice_long(longArray, 1, 3)", Collections.singletonList("longArray"), row, new long[]{2L, 10L}
     });
     inputs.add(new Object[]{
         "array_slice_string(stringArray, 1, 2)", Collections.singletonList("stringArray"), row, new String[]{"2"}

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
@@ -692,6 +692,22 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   }
 
   @Test
+  public void testArraySliceLongTransformFunction() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpression(String.format("array_slice_long(%s, 1, 3)", LONG_MV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "arraySliceLong");
+    assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.LONG);
+    assertFalse(transformFunction.getResultMetadata().isSingleValue());
+    long[][] expectedValues = new long[NUM_ROWS][];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Arrays.copyOfRange(_longMVValues[i], 1, 3);
+    }
+    testTransformFunctionMV(transformFunction, expectedValues);
+  }
+
+  @Test
   public void testArrayDistinctIntTransformFunction() {
     ExpressionContext expression =
         RequestContextUtils.getExpression(String.format("array_distinct_int(%s)", INT_MV_COLUMN));

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/ArrayTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/ArrayTest.java
@@ -1015,6 +1015,23 @@ public class ArrayTest extends CustomDataQueryClusterIntegrationTest {
     }
   }
 
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testArraySliceLong(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    // LONG_ARRAY_COLUMN contains [0, 1, 2, 3]; slicing [1, 3) yields [1, 2]
+    String query = String.format("SELECT array_slice_long(%s, 1, 3) FROM %s WHERE %s = 0 LIMIT 1",
+        LONG_ARRAY_COLUMN, getTableName(), INT_COLUMN);
+    JsonNode result = postQuery(query).get("resultTable");
+    assertEquals(result.get("dataSchema").get("columnDataTypes").get(0).textValue(), "LONG_ARRAY");
+    JsonNode rows = result.get("rows");
+    assertEquals(rows.size(), 1);
+    JsonNode values = rows.get(0).get(0);
+    assertEquals(values.size(), 2);
+    assertEquals(values.get(0).longValue(), 1L);
+    assertEquals(values.get(1).longValue(), 2L);
+  }
+
   @Test(dataProvider = "useV1QueryEngine")
   public void testGenerateIntArray(boolean useMultiStageQueryEngine)
       throws Exception {

--- a/pinot-integration-tests/src/test/resources/udf-test-results/all-functions.yaml
+++ b/pinot-integration-tests/src/test/resources/udf-test-results/all-functions.yaml
@@ -218,6 +218,10 @@ arraysliceint:
   scalar: "ArgumentCountBasedScalarFunction{org.apache.pinot.common.function.scalar.ArrayFunctions.arraySliceInt}"
   transform: null
   udf: null
+arrayslicelong:
+  scalar: "ArgumentCountBasedScalarFunction{org.apache.pinot.common.function.scalar.ArrayFunctions.arraySliceLong}"
+  transform: null
+  udf: null
 arrayslicestring:
   scalar: "ArgumentCountBasedScalarFunction{org.apache.pinot.common.function.scalar.ArrayFunctions.arraySliceString}"
   transform: null


### PR DESCRIPTION
## Summary

- Adds `arraySliceLong(long[], int, int)` scalar function to complement the existing `arraySliceInt` and `arraySliceString`, filling a gap in the LONG-typed array function family.
- Delegates to `Arrays.copyOfRange` — same implementation pattern as `arraySliceInt`.
- Updates the UDF function snapshot (`all-functions.yaml`) to register the new function.

## Changes

| File | Change |
|---|---|
| `ArrayFunctions.java` | New `@ScalarFunction arraySliceLong` |
| `ArrayFunctionsTest.java` | Unit test via `InbuiltFunctionEvaluator` |
| `ScalarTransformFunctionWrapperTest.java` | Transform-layer test against `LONG_MV_COLUMN` |
| `ArrayTest.java` | Integration test through broker→server pipeline, both SSE and MSE |
| `all-functions.yaml` | Snapshot entry for `arrayslicelong` |

## Test plan

- [x] `ArrayFunctionsTest` — 46/46 pass
- [x] `ScalarTransformFunctionWrapperTest` — 91/91 pass (90 existing + 1 new)
- [x] `ArrayTest#testArraySliceLong` — integration test covering SSE and MSE query engines
- [x] `UdfTest` snapshot updated (`all-functions.yaml`)
- [x] Spotless, checkstyle, license checks all pass

### Manual end-to-end streaming quickstart test

To validate the function works in a live cluster against a real LONG MV column, a streaming quickstart was run locally with a temporary `group_ids` LONG MV column added to the `meetupRsvp` schema and data generator (changes reverted before commit — for testing only).

**Setup:**
- Extended `meetupRsvp_schema.json` with a `group_ids` LONG MV dimension column
- Extended `RsvpSourceGenerator.java` to emit `group_ids` as a 3-element JSON long array derived from the existing `group_id` field
- Rebuilt `pinot-tools` from source with the new function: `./mvnw -pl pinot-tools -am package -DskipTests`
- Started `quick-start-streaming.sh` (embedded Kafka + Zookeeper + Pinot cluster)

**Query issued to broker (`localhost:8000`):**
```sql
SELECT group_ids, array_slice_long(group_ids, 0, 2)
FROM meetupRsvp
LIMIT 5
```

**Result (excerpt):**
```
group_ids                                                           array_slice_long(group_ids, 0, 2)
[8102896326518987128, 8102896326518988128, 8102896326518989128]    [8102896326518987128, 8102896326518988128]
[4472432652246517336, 4472432652246518336, 4472432652246519336]    [4472432652246517336, 4472432652246518336]
[8233149444274759746, 8233149444274760746, 8233149444274761746]    [8233149444274759746, 8233149444274760746]
```

- Return type: `LONG_ARRAY` ✅
- Correct 2-element slice from 3-element input ✅
- No exceptions; `timeUsedMs: 15` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)