### PR TITLE
Include MSE pipeline breaker stats by default

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -2339,31 +2339,42 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
           .set(scope, CommonConstants.MultiStageQueryRunner.KEY_OF_SKIP_PIPELINE_BREAKER_STATS, "false");
       String query = "select * from mytable "
           + "WHERE DayOfWeek in (select dayid from daysOfWeek)";
-      JsonNode response = postQuery(query);
-      assertNotNull(response.get("stageStats"), "Should have stage stats");
+      // Retry to give helix time to propagate the config change to the server.
+      String errorMsg = "Failed to verify presence of pipeline breaker stats after multiple attempts";
+      TestUtils.waitForCondition(() -> {
+        JsonNode response = postQuery(query);
+        assertNotNull(response.get("stageStats"), "Should have stage stats");
 
-      JsonNode receiveNode = response.get("stageStats");
-      Assertions.assertThat(receiveNode.get("type").asText()).isEqualTo("MAILBOX_RECEIVE");
+        JsonNode receiveNode = response.get("stageStats");
+        Assertions.assertThat(receiveNode.get("type").asText()).isEqualTo("MAILBOX_RECEIVE");
 
-      JsonNode sendNode = receiveNode.get("children").get(0);
-      Assertions.assertThat(sendNode.get("type").asText()).isEqualTo("MAILBOX_SEND");
+        JsonNode sendNode = receiveNode.get("children").get(0);
+        Assertions.assertThat(sendNode.get("type").asText()).isEqualTo("MAILBOX_SEND");
 
-      JsonNode mytableLeaf = sendNode.get("children").get(0);
-      Assertions.assertThat(mytableLeaf.get("type").asText()).isEqualTo("LEAF");
-      Assertions.assertThat(mytableLeaf.get("table").asText()).isEqualTo("mytable");
+        JsonNode mytableLeaf = sendNode.get("children").get(0);
+        Assertions.assertThat(mytableLeaf.get("type").asText()).isEqualTo("LEAF");
+        Assertions.assertThat(mytableLeaf.get("table").asText()).isEqualTo("mytable");
 
-      JsonNode pipelineReceive = mytableLeaf.get("children").get(0);
-      Assertions.assertThat(pipelineReceive.get("type").asText()).isEqualTo("MAILBOX_RECEIVE");
+        // Children are the kept pipeline breaker stats. They are absent until the config change has propagated.
+        if (mytableLeaf.get("children") == null) {
+          return false;
+        }
 
-      JsonNode pipelineSend = pipelineReceive.get("children").get(0);
-      Assertions.assertThat(pipelineSend.get("type").asText()).isEqualTo("MAILBOX_SEND");
+        JsonNode pipelineReceive = mytableLeaf.get("children").get(0);
+        Assertions.assertThat(pipelineReceive.get("type").asText()).isEqualTo("MAILBOX_RECEIVE");
 
-      JsonNode dayOfWeekLeaf = pipelineSend.get("children").get(0);
-      Assertions.assertThat(dayOfWeekLeaf.get("type").asText()).isEqualTo("LEAF");
-      Assertions.assertThat(dayOfWeekLeaf.get("table").asText()).isEqualTo("daysOfWeek");
+        JsonNode pipelineSend = pipelineReceive.get("children").get(0);
+        Assertions.assertThat(pipelineSend.get("type").asText()).isEqualTo("MAILBOX_SEND");
+
+        JsonNode dayOfWeekLeaf = pipelineSend.get("children").get(0);
+        Assertions.assertThat(dayOfWeekLeaf.get("type").asText()).isEqualTo("LEAF");
+        Assertions.assertThat(dayOfWeekLeaf.get("table").asText()).isEqualTo("daysOfWeek");
+        return true;
+      }, 100, 10_000L, errorMsg, Duration.ofSeconds(1));
     } finally {
+      // Restore the default (pipeline breaker stats are kept by default)
       _helixManager.getConfigAccessor()
-          .set(scope, CommonConstants.MultiStageQueryRunner.KEY_OF_SKIP_PIPELINE_BREAKER_STATS, "true");
+          .set(scope, CommonConstants.MultiStageQueryRunner.KEY_OF_SKIP_PIPELINE_BREAKER_STATS, "false");
     }
   }
 
@@ -2384,58 +2395,81 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
           + " GROUP BY DayOfWeek"
           + ")";
 
-      JsonNode response = postQuery(query);
-      assertNotNull(response.get("stageStats"), "Should have stage stats");
+      // Retry to give helix time to propagate the config change to the server.
+      String errorMsg = "Failed to verify numGroupsLimitReached on a pipeline breaker after multiple attempts";
+      TestUtils.waitForCondition(() -> {
+        JsonNode response = postQuery(query);
+        assertNotNull(response.get("stageStats"), "Should have stage stats");
 
-      JsonNode receiveNode = response.get("stageStats");
-      Assertions.assertThat(receiveNode.get("type").asText()).isEqualTo("MAILBOX_RECEIVE");
+        JsonNode receiveNode = response.get("stageStats");
+        Assertions.assertThat(receiveNode.get("type").asText()).isEqualTo("MAILBOX_RECEIVE");
 
-      JsonNode sendNode = receiveNode.get("children").get(0);
-      Assertions.assertThat(sendNode.get("type").asText()).isEqualTo("MAILBOX_SEND");
+        JsonNode sendNode = receiveNode.get("children").get(0);
+        Assertions.assertThat(sendNode.get("type").asText()).isEqualTo("MAILBOX_SEND");
 
-      JsonNode mytableLeaf = sendNode.get("children").get(0);
-      Assertions.assertThat(mytableLeaf.get("type").asText()).isEqualTo("LEAF");
-      Assertions.assertThat(mytableLeaf.get("table").asText()).isEqualToIgnoringCase("daysOfWeek");
+        JsonNode mytableLeaf = sendNode.get("children").get(0);
+        Assertions.assertThat(mytableLeaf.get("type").asText()).isEqualTo("LEAF");
+        Assertions.assertThat(mytableLeaf.get("table").asText()).isEqualToIgnoringCase("daysOfWeek");
 
-      JsonNode pipelineReceive = mytableLeaf.get("children").get(0);
-      Assertions.assertThat(pipelineReceive.get("type").asText()).isEqualTo("MAILBOX_RECEIVE");
+        // Children are the kept pipeline breaker stats. They are absent until the config change has propagated.
+        if (mytableLeaf.get("children") == null) {
+          return false;
+        }
 
-      JsonNode pipelineSend = pipelineReceive.get("children").get(0);
-      Assertions.assertThat(pipelineSend.get("type").asText()).isEqualTo("MAILBOX_SEND");
+        JsonNode pipelineReceive = mytableLeaf.get("children").get(0);
+        Assertions.assertThat(pipelineReceive.get("type").asText()).isEqualTo("MAILBOX_RECEIVE");
 
-      Assertions.assertThat(response.get("numGroupsLimitReached").asBoolean(false))
-          .describedAs("numGroupsLimitReached should be true even when the limit is reached on a pipeline breaker")
-          .isEqualTo(true);
+        JsonNode pipelineSend = pipelineReceive.get("children").get(0);
+        Assertions.assertThat(pipelineSend.get("type").asText()).isEqualTo("MAILBOX_SEND");
+
+        Assertions.assertThat(response.get("numGroupsLimitReached").asBoolean(false))
+            .describedAs("numGroupsLimitReached should be true even when the limit is reached on a pipeline breaker")
+            .isEqualTo(true);
+        return true;
+      }, 100, 10_000L, errorMsg, Duration.ofSeconds(1));
     } finally {
+      // Restore the default (pipeline breaker stats are kept by default)
       _helixManager.getConfigAccessor()
-          .set(scope, CommonConstants.MultiStageQueryRunner.KEY_OF_SKIP_PIPELINE_BREAKER_STATS, "true");
+          .set(scope, CommonConstants.MultiStageQueryRunner.KEY_OF_SKIP_PIPELINE_BREAKER_STATS, "false");
     }
   }
 
   @Test
   public void testPipelineBreakerWithoutKeepingStats() {
-    // let's try several times to give helix time to propagate the config change
-    String errorMsg = "Failed to verify absence of pipeline breaker stats after multiple attempts after 10 attempts";
-    TestUtils.waitForCondition(() -> {
-      String query = "select * from mytable "
-          + "WHERE DayOfWeek in (select dayid from daysOfWeek)";
-      JsonNode response = postQuery(query);
-      assertNotNull(response.get("stageStats"), "Should have stage stats");
+    HelixConfigScope scope =
+        new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER).forCluster(getHelixClusterName())
+            .build();
+    try {
+      // Pipeline breaker stats are kept by default, so explicitly skip them for this test.
+      _helixManager.getConfigAccessor()
+          .set(scope, CommonConstants.MultiStageQueryRunner.KEY_OF_SKIP_PIPELINE_BREAKER_STATS, "true");
+      // let's try several times to give helix time to propagate the config change
+      String errorMsg = "Failed to verify absence of pipeline breaker stats after multiple attempts after 10 attempts";
+      TestUtils.waitForCondition(() -> {
+        String query = "select * from mytable "
+            + "WHERE DayOfWeek in (select dayid from daysOfWeek)";
+        JsonNode response = postQuery(query);
+        assertNotNull(response.get("stageStats"), "Should have stage stats");
 
-      JsonNode receiveNode = response.get("stageStats");
-      Assertions.assertThat(receiveNode.get("type").asText()).isEqualTo("MAILBOX_RECEIVE");
+        JsonNode receiveNode = response.get("stageStats");
+        Assertions.assertThat(receiveNode.get("type").asText()).isEqualTo("MAILBOX_RECEIVE");
 
-      JsonNode sendNode = receiveNode.get("children").get(0);
-      Assertions.assertThat(sendNode.get("type").asText()).isEqualTo("MAILBOX_SEND");
+        JsonNode sendNode = receiveNode.get("children").get(0);
+        Assertions.assertThat(sendNode.get("type").asText()).isEqualTo("MAILBOX_SEND");
 
-      JsonNode mytableLeaf = sendNode.get("children").get(0);
-      Assertions.assertThat(mytableLeaf.get("type").asText()).isEqualTo("LEAF");
-      Assertions.assertThat(mytableLeaf.get("table").asText()).isEqualTo("mytable");
+        JsonNode mytableLeaf = sendNode.get("children").get(0);
+        Assertions.assertThat(mytableLeaf.get("type").asText()).isEqualTo("LEAF");
+        Assertions.assertThat(mytableLeaf.get("table").asText()).isEqualTo("mytable");
 
-      Assert.assertNull(mytableLeaf.get("children"), "When pipeline breaker stats are not kept, "
-          + "there should be no children under the leaf node");
-      return true;
-    }, 100, 10_000L, errorMsg, Duration.ofSeconds(1));
+        // Once the config change has propagated, there should be no children (pipeline breaker stats) under the leaf
+        // node. Return the result instead of asserting so that waitForCondition keeps retrying while the change is
+        // still propagating (AssertionError would not be caught and retried).
+        return mytableLeaf.get("children") == null;
+      }, 100, 10_000L, errorMsg, Duration.ofSeconds(1));
+    } finally {
+      _helixManager.getConfigAccessor()
+          .set(scope, CommonConstants.MultiStageQueryRunner.KEY_OF_SKIP_PIPELINE_BREAKER_STATS, "false");
+    }
   }
 
   @AfterClass

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -2329,109 +2329,87 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
   }
 
   @Test
-  public void testStageStatsPipelineBreaker()
-      throws Exception {
-    HelixConfigScope scope =
-        new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER).forCluster(getHelixClusterName())
-            .build();
-    try {
-      _helixManager.getConfigAccessor()
-          .set(scope, CommonConstants.MultiStageQueryRunner.KEY_OF_SKIP_PIPELINE_BREAKER_STATS, "false");
-      String query = "select * from mytable "
-          + "WHERE DayOfWeek in (select dayid from daysOfWeek)";
-      // Retry to give helix time to propagate the config change to the server.
-      String errorMsg = "Failed to verify presence of pipeline breaker stats after multiple attempts";
-      TestUtils.waitForCondition(() -> {
-        JsonNode response = postQuery(query);
-        assertNotNull(response.get("stageStats"), "Should have stage stats");
+  public void testStageStatsPipelineBreaker() {
+    String query = "select * from mytable "
+        + "WHERE DayOfWeek in (select dayid from daysOfWeek)";
+    // Pipeline breaker stats are kept by default. Retry in case a sibling test that overrode the default has just
+    // finished and the reset has not yet propagated to the server.
+    String errorMsg = "Failed to verify presence of pipeline breaker stats after multiple attempts";
+    TestUtils.waitForCondition(() -> {
+      JsonNode response = postQuery(query);
+      assertNotNull(response.get("stageStats"), "Should have stage stats");
 
-        JsonNode receiveNode = response.get("stageStats");
-        Assertions.assertThat(receiveNode.get("type").asText()).isEqualTo("MAILBOX_RECEIVE");
+      JsonNode receiveNode = response.get("stageStats");
+      Assertions.assertThat(receiveNode.get("type").asText()).isEqualTo("MAILBOX_RECEIVE");
 
-        JsonNode sendNode = receiveNode.get("children").get(0);
-        Assertions.assertThat(sendNode.get("type").asText()).isEqualTo("MAILBOX_SEND");
+      JsonNode sendNode = receiveNode.get("children").get(0);
+      Assertions.assertThat(sendNode.get("type").asText()).isEqualTo("MAILBOX_SEND");
 
-        JsonNode mytableLeaf = sendNode.get("children").get(0);
-        Assertions.assertThat(mytableLeaf.get("type").asText()).isEqualTo("LEAF");
-        Assertions.assertThat(mytableLeaf.get("table").asText()).isEqualTo("mytable");
+      JsonNode mytableLeaf = sendNode.get("children").get(0);
+      Assertions.assertThat(mytableLeaf.get("type").asText()).isEqualTo("LEAF");
+      Assertions.assertThat(mytableLeaf.get("table").asText()).isEqualTo("mytable");
 
-        // Children are the kept pipeline breaker stats. They are absent until the config change has propagated.
-        if (mytableLeaf.get("children") == null) {
-          return false;
-        }
+      if (mytableLeaf.get("children") == null) {
+        // Sibling test's reset has not yet propagated. Retry.
+        return false;
+      }
 
-        JsonNode pipelineReceive = mytableLeaf.get("children").get(0);
-        Assertions.assertThat(pipelineReceive.get("type").asText()).isEqualTo("MAILBOX_RECEIVE");
+      JsonNode pipelineReceive = mytableLeaf.get("children").get(0);
+      Assertions.assertThat(pipelineReceive.get("type").asText()).isEqualTo("MAILBOX_RECEIVE");
 
-        JsonNode pipelineSend = pipelineReceive.get("children").get(0);
-        Assertions.assertThat(pipelineSend.get("type").asText()).isEqualTo("MAILBOX_SEND");
+      JsonNode pipelineSend = pipelineReceive.get("children").get(0);
+      Assertions.assertThat(pipelineSend.get("type").asText()).isEqualTo("MAILBOX_SEND");
 
-        JsonNode dayOfWeekLeaf = pipelineSend.get("children").get(0);
-        Assertions.assertThat(dayOfWeekLeaf.get("type").asText()).isEqualTo("LEAF");
-        Assertions.assertThat(dayOfWeekLeaf.get("table").asText()).isEqualTo("daysOfWeek");
-        return true;
-      }, 100, 10_000L, errorMsg, Duration.ofSeconds(1));
-    } finally {
-      // Restore the default (pipeline breaker stats are kept by default)
-      _helixManager.getConfigAccessor()
-          .set(scope, CommonConstants.MultiStageQueryRunner.KEY_OF_SKIP_PIPELINE_BREAKER_STATS, "false");
-    }
+      JsonNode dayOfWeekLeaf = pipelineSend.get("children").get(0);
+      Assertions.assertThat(dayOfWeekLeaf.get("type").asText()).isEqualTo("LEAF");
+      Assertions.assertThat(dayOfWeekLeaf.get("table").asText()).isEqualTo("daysOfWeek");
+      return true;
+    }, 100, 10_000L, errorMsg, Duration.ofSeconds(1));
   }
 
   @Test
-  public void testPipelineBreakerKeepsNumGroupsLimitReached()
-      throws Exception {
-    HelixConfigScope scope =
-        new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER).forCluster(getHelixClusterName())
-            .build();
-    try {
-      _helixManager.getConfigAccessor()
-          .set(scope, CommonConstants.MultiStageQueryRunner.KEY_OF_SKIP_PIPELINE_BREAKER_STATS, "false");
-      String query = ""
-          + "SET numGroupsLimit = 1;"
-          + "SELECT * FROM daysOfWeek "
-          + "WHERE dayid in ("
-          + " SELECT DayOfWeek FROM mytable"
-          + " GROUP BY DayOfWeek"
-          + ")";
+  public void testPipelineBreakerKeepsNumGroupsLimitReached() {
+    String query = ""
+        + "SET numGroupsLimit = 1;"
+        + "SELECT * FROM daysOfWeek "
+        + "WHERE dayid in ("
+        + " SELECT DayOfWeek FROM mytable"
+        + " GROUP BY DayOfWeek"
+        + ")";
 
-      // Retry to give helix time to propagate the config change to the server.
-      String errorMsg = "Failed to verify numGroupsLimitReached on a pipeline breaker after multiple attempts";
-      TestUtils.waitForCondition(() -> {
-        JsonNode response = postQuery(query);
-        assertNotNull(response.get("stageStats"), "Should have stage stats");
+    // Pipeline breaker stats are kept by default. Retry in case a sibling test that overrode the default has just
+    // finished and the reset has not yet propagated to the server.
+    String errorMsg = "Failed to verify numGroupsLimitReached on a pipeline breaker after multiple attempts";
+    TestUtils.waitForCondition(() -> {
+      JsonNode response = postQuery(query);
+      assertNotNull(response.get("stageStats"), "Should have stage stats");
 
-        JsonNode receiveNode = response.get("stageStats");
-        Assertions.assertThat(receiveNode.get("type").asText()).isEqualTo("MAILBOX_RECEIVE");
+      JsonNode receiveNode = response.get("stageStats");
+      Assertions.assertThat(receiveNode.get("type").asText()).isEqualTo("MAILBOX_RECEIVE");
 
-        JsonNode sendNode = receiveNode.get("children").get(0);
-        Assertions.assertThat(sendNode.get("type").asText()).isEqualTo("MAILBOX_SEND");
+      JsonNode sendNode = receiveNode.get("children").get(0);
+      Assertions.assertThat(sendNode.get("type").asText()).isEqualTo("MAILBOX_SEND");
 
-        JsonNode mytableLeaf = sendNode.get("children").get(0);
-        Assertions.assertThat(mytableLeaf.get("type").asText()).isEqualTo("LEAF");
-        Assertions.assertThat(mytableLeaf.get("table").asText()).isEqualToIgnoringCase("daysOfWeek");
+      JsonNode mytableLeaf = sendNode.get("children").get(0);
+      Assertions.assertThat(mytableLeaf.get("type").asText()).isEqualTo("LEAF");
+      Assertions.assertThat(mytableLeaf.get("table").asText()).isEqualToIgnoringCase("daysOfWeek");
 
-        // Children are the kept pipeline breaker stats. They are absent until the config change has propagated.
-        if (mytableLeaf.get("children") == null) {
-          return false;
-        }
+      if (mytableLeaf.get("children") == null) {
+        // Sibling test's reset has not yet propagated. Retry.
+        return false;
+      }
 
-        JsonNode pipelineReceive = mytableLeaf.get("children").get(0);
-        Assertions.assertThat(pipelineReceive.get("type").asText()).isEqualTo("MAILBOX_RECEIVE");
+      JsonNode pipelineReceive = mytableLeaf.get("children").get(0);
+      Assertions.assertThat(pipelineReceive.get("type").asText()).isEqualTo("MAILBOX_RECEIVE");
 
-        JsonNode pipelineSend = pipelineReceive.get("children").get(0);
-        Assertions.assertThat(pipelineSend.get("type").asText()).isEqualTo("MAILBOX_SEND");
+      JsonNode pipelineSend = pipelineReceive.get("children").get(0);
+      Assertions.assertThat(pipelineSend.get("type").asText()).isEqualTo("MAILBOX_SEND");
 
-        Assertions.assertThat(response.get("numGroupsLimitReached").asBoolean(false))
-            .describedAs("numGroupsLimitReached should be true even when the limit is reached on a pipeline breaker")
-            .isEqualTo(true);
-        return true;
-      }, 100, 10_000L, errorMsg, Duration.ofSeconds(1));
-    } finally {
-      // Restore the default (pipeline breaker stats are kept by default)
-      _helixManager.getConfigAccessor()
-          .set(scope, CommonConstants.MultiStageQueryRunner.KEY_OF_SKIP_PIPELINE_BREAKER_STATS, "false");
-    }
+      Assertions.assertThat(response.get("numGroupsLimitReached").asBoolean(false))
+          .describedAs("numGroupsLimitReached should be true even when the limit is reached on a pipeline breaker")
+          .isEqualTo(true);
+      return true;
+    }, 100, 10_000L, errorMsg, Duration.ofSeconds(1));
   }
 
   @Test

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -2508,13 +2508,12 @@ public class CommonConstants {
     public static final String KEY_OF_SEND_STATS_MODE = "pinot.query.mse.stats.mode";
     public static final String DEFAULT_SEND_STATS_MODE = "ALWAYS";
 
-    /// Used to indicate whether MSE pipeline breaker stats should be included in the queryStats field.
-    /// This flag was introduced in 1.5.0. Before 1.5.0, MSE pipeline breaker stats were not kept. Starting from 1.5.0,
-    /// they are not included by default but can be included by setting this flag to false (upper or lower case).
-    ///
-    /// It is expected that in 1.6.0 and later, MSE pipeline breaker stats will be included by default.
+    /// Used to indicate whether MSE pipeline breaker stats should be included in the stageStats field.
+    /// This flag was introduced in 1.5.0. Before 1.5.0, MSE pipeline breaker stats were not kept. In 1.5.0 they were
+    /// not included by default but could be included by setting this flag to false (upper or lower case). Starting
+    /// from 1.6.0, they are included by default and can be excluded by setting this flag to true (upper or lower case).
     public static final String KEY_OF_SKIP_PIPELINE_BREAKER_STATS = "pinot.query.mse.skip.pipeline.breaker.stats";
-    public static final boolean DEFAULT_SKIP_PIPELINE_BREAKER_STATS = true;
+    public static final boolean DEFAULT_SKIP_PIPELINE_BREAKER_STATS = false;
 
     /// Used to indicate that MSE stats should be logged at INFO level for successful queries.
     ///


### PR DESCRIPTION
## Description

Flips the default of `pinot.query.mse.skip.pipeline.breaker.stats` from `true` to `false`, so multi-stage engine (MSE) pipeline breaker stats are included in the `stageStats` field by default.

## Motivation

This flag was introduced in 1.5.0 with the stats skipped by default, to stay conservative while the new stats format rolled out across mixed-version clusters. Now that 1.5.0 has been released and the format is understood by all instances, it is safe to include these stats by default — exactly the transition the flag's Javadoc already anticipated for 1.6.0. Pipeline breaker stats shouldn't be skipped by default: they are useful for diagnosing query performance, and the leaf-stage pipeline breaker sub-tree is otherwise invisible in the returned stage stats.

## Behavior change

For multi-stage queries that contain a leaf-stage pipeline breaker (e.g. a `WHERE col IN (SELECT ...)` semi-join pushed into the leaf stage), the `stageStats` JSON now includes the pipeline breaker's sub-tree (a `MAILBOX_RECEIVE` → `MAILBOX_SEND` → `LEAF` chain) under the leaf node. Consumers that parse `stageStats` will see these additional children. Queries without a leaf-stage pipeline breaker are unaffected.

## Opt-out

Set the cluster config `pinot.query.mse.skip.pipeline.breaker.stats=true` to restore the previous behavior. The flag is honored unchanged; only its default value moves.

## Tests

Updated the three pipeline-breaker tests in `MultiStageEngineIntegrationTest`:
- `testPipelineBreakerWithoutKeepingStats` now sets the flag to `true` explicitly (it previously relied on the old default) before verifying the leaf has no children.
- All three tests poll for config propagation via `waitForCondition` and reset to the new default (`false`) in a `finally` block, making them robust to propagation timing and test ordering.
