### PR TITLE
Surface per-server stats on BrokerResponse for SSE queries

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -1022,6 +1022,9 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
 
     brokerResponse.setRLSFiltersApplied(rlsFiltersApplied.get());
 
+    // Record per-server stats on the SSE BrokerResponse so downstream consumers can read it.
+    brokerResponse.setServerStats(serverStats.getServerStats());
+
     // Log query and stats
     _queryLogger.logQueryCompleted(
         new QueryLogger.QueryLogParams(requestContext, tableName, brokerResponse,
@@ -2397,6 +2400,8 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
     viewSplitResponse.setTimeUsedMs(totalTimeMs);
     augmentStatistics(requestContext, viewSplitResponse);
     viewSplitResponse.setRLSFiltersApplied(rlsFiltersApplied);
+    // Record per-server stats on the SSE BrokerResponse so downstream consumers can read it.
+    viewSplitResponse.setServerStats(serverStats.getServerStats());
     _queryLogger.logQueryCompleted(
         new QueryLogger.QueryLogParams(requestContext, tableName, viewSplitResponse,
             QueryLogger.QueryLogParams.QueryEngine.SINGLE_STAGE, requesterIdentity, serverStats),

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
@@ -58,7 +58,7 @@ import org.apache.pinot.spi.utils.JsonUtils;
     "explainPlanNumEmptyFilterSegments", "explainPlanNumMatchAllFilterSegments", "traceInfo", "tablesQueried",
     "offlineThreadMemAllocatedBytes", "realtimeThreadMemAllocatedBytes", "offlineResponseSerMemAllocatedBytes",
     "realtimeResponseSerMemAllocatedBytes", "offlineTotalMemAllocatedBytes", "realtimeTotalMemAllocatedBytes",
-    "pools", "rlsFiltersApplied", "groupsTrimmed", "materializedViewQueried"
+    "pools", "rlsFiltersApplied", "groupsTrimmed", "materializedViewQueried", "serverStats"
 })
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class BrokerResponseNative implements BrokerResponse {
@@ -125,6 +125,9 @@ public class BrokerResponseNative implements BrokerResponse {
 
   @Nullable
   private String _materializedViewQueried;
+
+  @Nullable
+  private String _serverStats;
 
   public BrokerResponseNative() {
   }
@@ -648,5 +651,17 @@ public class BrokerResponseNative implements BrokerResponse {
   @Override
   public String getMaterializedViewQueried() {
     return _materializedViewQueried;
+  }
+
+  @JsonProperty("serverStats")
+  public void setServerStats(@Nullable String serverStats) {
+    _serverStats = serverStats;
+  }
+
+  @Nullable
+  @JsonProperty("serverStats")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public String getServerStats() {
+    return _serverStats;
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/response/broker/BrokerResponseNativeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/response/broker/BrokerResponseNativeTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.common.response.broker;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.testng.Assert;
@@ -84,5 +86,31 @@ public class BrokerResponseNativeTest {
     String json = response.toJsonString();
     Assert.assertFalse(json.contains("materializedViewQueried"),
         "Null materializedViewQueried should be suppressed by @JsonInclude(NON_NULL)");
+  }
+
+  @Test
+  public void testServerStatsRoundTrip()
+      throws IOException {
+    BrokerResponseNative expected = new BrokerResponseNative();
+    String stats =
+        "Server=SubmitDelayMs,ResponseDelayMs,ResponseSize,DeserializationTimeMs,RequestSentDelayMs;"
+            + "pinot-server-0_O=0,1,7571,0,0;pinot-server-1_O=0,1,7574,0,0";
+    expected.setServerStats(stats);
+
+    BrokerResponseNative actual = BrokerResponseNative.fromJsonString(expected.toJsonString());
+    Assert.assertEquals(actual.getServerStats(), stats);
+  }
+
+  @Test
+  public void testServerStatsAbsentWhenNull()
+      throws IOException {
+    BrokerResponseNative response = new BrokerResponseNative();
+    JsonNode tree = new ObjectMapper().readTree(response.toJsonString());
+    Assert.assertFalse(tree.has("serverStats"));
+  }
+
+  @Test
+  public void testServerStatsDefaultsToNull() {
+    Assert.assertNull(new BrokerResponseNative().getServerStats());
   }
 }


### PR DESCRIPTION
Expose serverStats in SSE broker response.