### PR TITLE
Fix Pinot client scheme property merge

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransportFactory.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransportFactory.java
@@ -85,9 +85,9 @@ public class JsonAsyncHttpPinotClientTransportFactory implements PinotClientTran
       _headers = ConnectionUtils.getHeadersFromProperties(properties);
     }
 
-    String scheme = properties.getProperty("scheme", CommonConstants.HTTP_PROTOCOL);
-    if (_scheme == null || !_scheme.contentEquals(scheme)) {
-      _scheme = scheme;
+    _scheme = properties.getProperty("scheme", _scheme);
+    if (_scheme == null) {
+      _scheme = CommonConstants.HTTP_PROTOCOL;
     }
 
     if (_sslContext == null && _scheme.contentEquals(CommonConstants.HTTPS_PROTOCOL)) {

--- a/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransportTest.java
+++ b/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransportTest.java
@@ -30,6 +30,7 @@ import java.net.InetSocketAddress;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -138,6 +139,16 @@ public class JsonAsyncHttpPinotClientTransportTest implements HttpHandler {
       Throwable cause = ExceptionUtils.getRootCause(exception);
       assertEquals(cause.getClass().getName(), "java.util.concurrent.TimeoutException");
     }
+  }
+
+  @Test
+  public void withConnectionPropertiesRetainsConfiguredSchemeWhenSchemePropertyIsAbsent() {
+    JsonAsyncHttpPinotClientTransportFactory factory = new JsonAsyncHttpPinotClientTransportFactory();
+    factory.setScheme(CommonConstants.HTTPS_PROTOCOL);
+
+    factory.withConnectionProperties(new Properties());
+
+    assertEquals(factory.getScheme(), CommonConstants.HTTPS_PROTOCOL);
   }
 
   // Cursor-related tests


### PR DESCRIPTION
## Summary
- Preserve a previously configured JsonAsyncHttpPinotClientTransportFactory scheme when connection properties omit `scheme`
- Keep the default `http` fallback if the configured scheme is null
- Add a regression test for the setScheme + withConnectionProperties path

Fixes #14500.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./mvnw -pl pinot-clients/pinot-java-client -am -Dtest=JsonAsyncHttpPinotClientTransportTest -Dsurefire.failIfNoSpecifiedTests=false test`