### PR TITLE
fix: require component for user APIs

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotAccessControlUserRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotAccessControlUserRestletResource.java
@@ -90,9 +90,18 @@ public class PinotAccessControlUserRestletResource {
    * {@inheritDoc}
    */
   public static final Logger LOGGER = LoggerFactory.getLogger(PinotAccessControlUserRestletResource.class);
+  private static final String COMPONENT_TYPE_REQUIRED_ERROR = "Component type is required as query parameter";
 
   @Inject
   PinotHelixResourceManager _pinotHelixResourceManager;
+
+  private static ComponentType validateRequiredComponentType(String componentTypeStr) {
+    ComponentType componentType = Constants.validateComponentType(componentTypeStr);
+    if (componentType == null) {
+      throw new ControllerApplicationException(LOGGER, COMPONENT_TYPE_REQUIRED_ERROR, Response.Status.BAD_REQUEST);
+    }
+    return componentType;
+  }
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
@@ -115,10 +124,11 @@ public class PinotAccessControlUserRestletResource {
   @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_USER)
   @ApiOperation(value = "Get an user in cluster", notes = "Get an user in cluster")
   public String getUser(@PathParam("username") String username,
-      @ApiParam(value = "CONTROLLER|SERVER|BROKER") @QueryParam("component") String componentTypeStr) {
+      @ApiParam(value = "CONTROLLER|SERVER|BROKER", required = true) @QueryParam("component")
+      String componentTypeStr) {
+    ComponentType componentType = validateRequiredComponentType(componentTypeStr);
     try {
       ZkHelixPropertyStore<ZNRecord> propertyStore = _pinotHelixResourceManager.getPropertyStore();
-      ComponentType componentType = Constants.validateComponentType(componentTypeStr);
       String usernameWithType = username + "_" + componentType.name();
 
       UserConfig userConfig = ZKMetadataProvider.getUserConfig(propertyStore, usernameWithType);
@@ -168,15 +178,18 @@ public class PinotAccessControlUserRestletResource {
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Delete a user", notes = "Delete a user")
   public SuccessResponse deleteUser(@PathParam("username") String username,
-      @ApiParam(value = "CONTROLLER|SERVER|BROKER") @QueryParam("component") String componentTypeStr) {
+      @ApiParam(value = "CONTROLLER|SERVER|BROKER", required = true) @QueryParam("component")
+      String componentTypeStr) {
 
     List<String> usersDeleted = new LinkedList<>();
-    String usernameWithComponentType = username + "_" + componentTypeStr;
+    ComponentType componentType = validateRequiredComponentType(componentTypeStr);
+    String componentTypeName = componentType.name();
+    String usernameWithComponentType = username + "_" + componentTypeName;
 
     try {
 
       boolean userExist = false;
-      userExist = _pinotHelixResourceManager.hasUser(username, componentTypeStr);
+      userExist = _pinotHelixResourceManager.hasUser(username, componentTypeName);
 
       _pinotHelixResourceManager.deleteUser(usernameWithComponentType);
       if (userExist) {
@@ -200,11 +213,14 @@ public class PinotAccessControlUserRestletResource {
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Update user config for a user", notes = "Update user config for user")
   public SuccessResponse updateUserConfig(@PathParam("username") String username,
-      @ApiParam(value = "CONTROLLER|SERVER|BROKER") @QueryParam("component") String componentTypeStr,
+      @ApiParam(value = "CONTROLLER|SERVER|BROKER", required = true) @QueryParam("component")
+      String componentTypeStr,
       @QueryParam("passwordChanged") boolean passwordChanged, String userConfigString) {
 
     UserConfig userConfig;
-    String usernameWithComponentType = username + "_" + componentTypeStr;
+    ComponentType componentType = validateRequiredComponentType(componentTypeStr);
+    String componentTypeName = componentType.name();
+    String usernameWithComponentType = username + "_" + componentTypeName;
     try {
       userConfig = JsonUtils.stringToObject(userConfigString, UserConfig.class);
       if (passwordChanged) {
@@ -216,7 +232,7 @@ public class PinotAccessControlUserRestletResource {
             "Request user " + usernameWithComponentType + " does not match " + usernameWithComponentTypeFromUserConfig
                 + " in the Request body", Response.Status.BAD_REQUEST);
       }
-      if (!_pinotHelixResourceManager.hasUser(username, componentTypeStr)) {
+      if (!_pinotHelixResourceManager.hasUser(username, componentTypeName)) {
         throw new ControllerApplicationException(LOGGER,
             "Request user " + usernameWithComponentType + " does not exist", Response.Status.NOT_FOUND);
       }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotAccessControlUserRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotAccessControlUserRestletResourceTest.java
@@ -19,7 +19,13 @@
 package org.apache.pinot.controller.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.swagger.annotations.ApiParam;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import javax.ws.rs.core.Response;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.utils.BcryptUtils;
+import org.apache.pinot.controller.api.resources.PinotAccessControlUserRestletResource;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.spi.config.user.ComponentType;
 import org.apache.pinot.spi.config.user.RoleType;
@@ -30,6 +36,8 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -53,6 +61,47 @@ public class PinotAccessControlUserRestletResourceTest {
     String usernameWithType = username + "_" + componentType;
     return JsonUtils.jsonNodeToObject(JsonUtils.stringToJsonNode(userConfigString).get(usernameWithType),
         UserConfig.class);
+  }
+
+  private static ApiParam getApiParam(Method method, int parameterIndex) {
+    for (Annotation annotation : method.getParameterAnnotations()[parameterIndex]) {
+      if (annotation instanceof ApiParam) {
+        return (ApiParam) annotation;
+      }
+    }
+    return null;
+  }
+
+  @Test
+  public void testGetUserWithoutComponentReturnsClearBadRequest()
+      throws Exception {
+    Pair<Integer, String> response = ControllerTest.sendGetRequestWithStatusCode(
+        TEST_INSTANCE.getControllerBaseApiUrl() + "/users/testUser", null);
+    assertEquals(response.getLeft().intValue(), Response.Status.BAD_REQUEST.getStatusCode());
+    assertTrue(response.getRight().contains("Component type is required"));
+    assertFalse(response.getRight().contains("Cannot invoke"));
+  }
+
+  @Test
+  public void testUserComponentQueryParamIsRequiredInSwagger()
+      throws Exception {
+    Method getUser = PinotAccessControlUserRestletResource.class.getDeclaredMethod("getUser", String.class,
+        String.class);
+    Method deleteUser = PinotAccessControlUserRestletResource.class.getDeclaredMethod("deleteUser", String.class,
+        String.class);
+    Method updateUserConfig = PinotAccessControlUserRestletResource.class.getDeclaredMethod("updateUserConfig",
+        String.class, String.class, boolean.class, String.class);
+
+    ApiParam getUserComponent = getApiParam(getUser, 1);
+    ApiParam deleteUserComponent = getApiParam(deleteUser, 1);
+    ApiParam updateUserComponent = getApiParam(updateUserConfig, 1);
+
+    assertNotNull(getUserComponent);
+    assertNotNull(deleteUserComponent);
+    assertNotNull(updateUserComponent);
+    assertTrue(getUserComponent.required());
+    assertTrue(deleteUserComponent.required());
+    assertTrue(updateUserComponent.required());
   }
 
   @Test


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Adds required component validation and uses normalized component for user lookup/delete/update\.

```mermaid
flowchart TD
  N0["validateRequiredComponentType #40;F1#41;"]:::stAdded
  N1["getUser #40;F1#41;"]:::stModified
  N2["deleteUser #40;F1#41;"]:::stModified
  N3["updateUserConfig #40;F1#41;"]:::stModified
  N4["hasUser #40;HelixResourceManager#41; #40;F1#41;"]:::stUnchanged
  N5["deleteUser #40;HelixResourceManager#41; #40;F1#41;"]:::stUnchanged
  N1 -->|"calls"| N0
  N1 -->|"calls"| N4
  N2 -->|"calls"| N0
  N2 -->|"calls"| N4
  N2 -->|"calls"| N5
  N3 -->|"calls"| N0
  N3 -->|"calls"| N4
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotAccessControlUserRestletResource\.java — [before](https://github.com/apache/pinot/blob/9f8eb1a4c90eb198b99b40478feea0436e73356d/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotAccessControlUserRestletResource.java) · [after](https://github.com/apache/pinot/blob/6517e601e68e698bfbc46a2a6a558cbfce70bbd5/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotAccessControlUserRestletResource.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjlmOGViMWE0YzkwZWIxOThiOTliNDA0NzhmZWVhMDQzNmU3MzM1NmQiLCJjb250ZXh0X2hhc2giOiJjNDQ1ZDJkZDAyYzY2NmE0NjAxZWRiZWFlYTU2ZmI2NDRiY2I0ZDg0ZmQ0NzM3Yzg1ZGM2NmUxYmEyZDdjM2M0IiwiZ2VuZXJhdGVkX2F0IjoxNzg5NDM2MjkyLCJoZWFkX3NoYSI6IjY1MTdlNjAxZTY4ZTY5OGJmYmM0NmEyYTZhNTU4Y2JmY2U3MGJiZDUiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI5ZjhlYjFhNGM5MGViMTk4Yjk5YjQwNDc4ZmVlYTA0MzZlNzMzNTZkIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 772ed5069b206d5be6e6ad80f2699417ba507aa1afd5282a9fb63f3da0163a2b -->
<!-- pinot-pr-flow:end -->

Fixes #14594.

## Summary
- mark the user API `component` query parameter as required for get/delete/update endpoints
- reject missing component values with a clear bad request instead of constructing `null` user names or surfacing an NPE
- normalize validated component values before update/delete user lookups

## Tests
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./mvnw -pl pinot-controller -am -Dtest=PinotAccessControlUserRestletResourceTest#testGetUserWithoutComponentReturnsClearBadRequest+testUserComponentQueryParamIsRequiredInSwagger -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./mvnw -pl pinot-controller -am -Dtest=PinotAccessControlUserRestletResourceTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`