### PR TITLE
Initialize ServerMetrics in PredownloadScheduler

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/predownload/PredownloadScheduler.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/predownload/PredownloadScheduler.java
@@ -173,10 +173,15 @@ public class PredownloadScheduler {
           new ServerMetrics(serverConf.getMetricsPrefix(), metricsRegistry, serverConf.emitTableLevelMetrics(),
               serverConf.getAllowedTablesForEmittingMetrics());
       serverMetrics.initializeGlobalMeters();
-      ServerMetrics.register(serverMetrics);
-    } catch (Throwable t) {
+      boolean registered = ServerMetrics.register(serverMetrics);
+      if (registered) {
+        LOGGER.info("ServerMetrics successfully registered for predownload container");
+      } else {
+        LOGGER.error("Failed to register ServerMetrics; an instance was already registered");
+      }
+    } catch (Exception e) {
       LOGGER.error("Failed to initialize ServerMetrics in predownload container; "
-          + "continuing with the currently registered ServerMetrics instance", t);
+          + "continuing with the currently registered ServerMetrics instance", e);
     }
 
     _predownloadMetrics = new PredownloadMetrics();

--- a/pinot-server/src/main/java/org/apache/pinot/server/predownload/PredownloadScheduler.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/predownload/PredownloadScheduler.java
@@ -38,17 +38,15 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.utils.TarCompressionUtils;
 import org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory;
 import org.apache.pinot.server.conf.ServerConf;
+import org.apache.pinot.server.starter.ServerMetricsInitUtils;
 import org.apache.pinot.server.starter.helix.HelixInstanceDataManagerConfig;
 import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.crypt.PinotCrypterFactory;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
-import org.apache.pinot.spi.metrics.PinotMetricUtils;
-import org.apache.pinot.spi.metrics.PinotMetricsRegistry;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.retry.AttemptsExceededException;
 import org.slf4j.Logger;
@@ -168,17 +166,7 @@ public class PredownloadScheduler {
 
     try {
       ServerConf serverConf = new ServerConf(_pinotConfig);
-      PinotMetricsRegistry metricsRegistry = PinotMetricUtils.getPinotMetricsRegistry(serverConf.getMetricsConfig());
-      ServerMetrics serverMetrics =
-          new ServerMetrics(serverConf.getMetricsPrefix(), metricsRegistry, serverConf.emitTableLevelMetrics(),
-              serverConf.getAllowedTablesForEmittingMetrics());
-      serverMetrics.initializeGlobalMeters();
-      boolean registered = ServerMetrics.register(serverMetrics);
-      if (registered) {
-        LOGGER.info("ServerMetrics successfully registered for predownload container");
-      } else {
-        LOGGER.error("Failed to register ServerMetrics; an instance was already registered");
-      }
+      ServerMetricsInitUtils.initServerMetrics(serverConf);
     } catch (Exception e) {
       LOGGER.error("Failed to initialize ServerMetrics in predownload container; "
           + "continuing with the currently registered ServerMetrics instance", e);

--- a/pinot-server/src/main/java/org/apache/pinot/server/predownload/PredownloadScheduler.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/predownload/PredownloadScheduler.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.utils.TarCompressionUtils;
 import org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory;
 import org.apache.pinot.server.conf.ServerConf;
@@ -46,6 +47,8 @@ import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.crypt.PinotCrypterFactory;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.metrics.PinotMetricUtils;
+import org.apache.pinot.spi.metrics.PinotMetricsRegistry;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.retry.AttemptsExceededException;
 import org.slf4j.Logger;
@@ -162,6 +165,19 @@ public class PredownloadScheduler {
 
   void initializeMetricsReporter() {
     LOGGER.info("Initializing metrics reporter");
+
+    try {
+      ServerConf serverConf = new ServerConf(_pinotConfig);
+      PinotMetricsRegistry metricsRegistry = PinotMetricUtils.getPinotMetricsRegistry(serverConf.getMetricsConfig());
+      ServerMetrics serverMetrics =
+          new ServerMetrics(serverConf.getMetricsPrefix(), metricsRegistry, serverConf.emitTableLevelMetrics(),
+              serverConf.getAllowedTablesForEmittingMetrics());
+      serverMetrics.initializeGlobalMeters();
+      ServerMetrics.register(serverMetrics);
+    } catch (Throwable t) {
+      LOGGER.error("Failed to initialize ServerMetrics in predownload container; "
+          + "continuing with the currently registered ServerMetrics instance", t);
+    }
 
     _predownloadMetrics = new PredownloadMetrics();
     PredownloadStatusRecorder.registerMetrics(_predownloadMetrics);

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerMetricsInitUtils.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerMetricsInitUtils.java
@@ -41,10 +41,10 @@ public final class ServerMetricsInitUtils {
     boolean registered = ServerMetrics.register(serverMetrics);
     if (registered) {
       LOGGER.info("ServerMetrics successfully registered");
+      return serverMetrics;
     } else {
-      LOGGER.error("Failed to register ServerMetrics; an instance was already registered");
-      throw new IllegalStateException("Failed to register ServerMetrics; an instance was already registered");
+      LOGGER.warn("ServerMetrics already registered; returning existing instance");
+      return ServerMetrics.get();
     }
-    return serverMetrics;
   }
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerMetricsInitUtils.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerMetricsInitUtils.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.server.starter;
+
+import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.server.conf.ServerConf;
+import org.apache.pinot.spi.metrics.PinotMetricUtils;
+import org.apache.pinot.spi.metrics.PinotMetricsRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public final class ServerMetricsInitUtils {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ServerMetricsInitUtils.class);
+
+  private ServerMetricsInitUtils() {
+  }
+
+  public static ServerMetrics initServerMetrics(ServerConf serverConf)
+      throws Exception {
+    PinotMetricsRegistry metricsRegistry = PinotMetricUtils.getPinotMetricsRegistry(serverConf.getMetricsConfig());
+    ServerMetrics serverMetrics = new ServerMetrics(serverConf.getMetricsPrefix(), metricsRegistry,
+        serverConf.emitTableLevelMetrics(), serverConf.getAllowedTablesForEmittingMetrics());
+    serverMetrics.initializeGlobalMeters();
+    boolean registered = ServerMetrics.register(serverMetrics);
+    if (registered) {
+      LOGGER.info("ServerMetrics successfully registered");
+    } else {
+      LOGGER.error("Failed to register ServerMetrics; an instance was already registered");
+      throw new IllegalStateException("Failed to register ServerMetrics; an instance was already registered");
+    }
+    return serverMetrics;
+  }
+}

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -114,6 +114,7 @@ import org.apache.pinot.server.conf.ServerConf;
 import org.apache.pinot.server.realtime.ControllerLeaderLocator;
 import org.apache.pinot.server.realtime.ServerSegmentCompletionProtocolHandler;
 import org.apache.pinot.server.starter.ServerInstance;
+import org.apache.pinot.server.starter.ServerMetricsInitUtils;
 import org.apache.pinot.server.starter.ServerQueriesDisabledTracker;
 import org.apache.pinot.server.worker.WorkerQueryServer;
 import org.apache.pinot.spi.accounting.ThreadAccountant;
@@ -126,8 +127,6 @@ import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.environmentprovider.PinotEnvironmentProvider;
 import org.apache.pinot.spi.environmentprovider.PinotEnvironmentProviderFactory;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
-import org.apache.pinot.spi.metrics.PinotMetricUtils;
-import org.apache.pinot.spi.metrics.PinotMetricsRegistry;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.services.ServiceRole;
 import org.apache.pinot.spi.services.ServiceStartable;
@@ -678,14 +677,9 @@ public abstract class BaseServerStarter implements ServiceStartable {
 
     LOGGER.info("Initializing server metrics");
     ServerConf serverConf = new ServerConf(_serverConf);
-    PinotMetricsRegistry metricsRegistry = PinotMetricUtils.getPinotMetricsRegistry(serverConf.getMetricsConfig());
-    _serverMetrics =
-        new ServerMetrics(serverConf.getMetricsPrefix(), metricsRegistry, serverConf.emitTableLevelMetrics(),
-            serverConf.getAllowedTablesForEmittingMetrics());
-    _serverMetrics.initializeGlobalMeters();
+    _serverMetrics = ServerMetricsInitUtils.initServerMetrics(serverConf);
     _serverMetrics.setValueOfGlobalGauge(ServerGauge.VERSION, PinotVersion.VERSION_METRIC_NAME, 1);
-    ServerMetrics.register(_serverMetrics);
-    MseMetrics.registerFromConfig(_serverConf, metricsRegistry);
+    MseMetrics.registerFromConfig(_serverConf, _serverMetrics.getMetricsRegistry());
 
     LOGGER.info("Initializing reload job status cache");
     _reloadJobStatusCache = new ServerReloadJobStatusCache(_instanceId);

--- a/pinot-server/src/test/java/org/apache/pinot/server/predownload/PredownloadSchedulerTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/predownload/PredownloadSchedulerTest.java
@@ -56,7 +56,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
 
 
 public class PredownloadSchedulerTest {

--- a/pinot-server/src/test/java/org/apache/pinot/server/predownload/PredownloadSchedulerTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/predownload/PredownloadSchedulerTest.java
@@ -33,15 +33,19 @@ import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.utils.TarCompressionUtils;
 import org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory;
 import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.metrics.PinotMetricUtils;
+import org.apache.pinot.spi.metrics.PinotMetricsRegistry;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 import static org.apache.pinot.server.predownload.PredownloadTestUtil.*;
@@ -51,6 +55,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 
 public class PredownloadSchedulerTest {
@@ -85,6 +91,11 @@ public class PredownloadSchedulerTest {
     // static mock is not working in separate threads, according to
     // https://github.com/mockito/mockito/issues/2142
     _predownloadScheduler._executor = Runnable::run;
+  }
+
+  @AfterMethod
+  public void cleanUpMetrics() {
+    ServerMetrics.deregister();
   }
 
   @AfterClass
@@ -354,5 +365,69 @@ public class PredownloadSchedulerTest {
     assertEquals(zeroExecutor.getCorePoolSize(), expectedDefaultThreads,
         "Zero parallelism should fall back to default");
     zeroScheduler.stop();
+  }
+
+  @Test
+  public void testInitializeMetricsReporterRegistersServerMetrics()
+      throws Exception {
+    String propertiesFilePath = this.getClass().getClassLoader().getResource(SAMPLE_PROPERTIES_FILE_NAME).getPath();
+    PropertiesConfiguration properties = CommonsConfigurationUtils.fromPath(propertiesFilePath);
+    PredownloadScheduler scheduler = new PredownloadScheduler(properties);
+
+    try (MockedStatic<PinotMetricUtils> pinotMetricUtilsMockedStatic = mockStatic(PinotMetricUtils.class)) {
+      PinotMetricsRegistry mockRegistry = mock(PinotMetricsRegistry.class);
+      pinotMetricUtilsMockedStatic.when(() -> PinotMetricUtils.getPinotMetricsRegistry(any()))
+          .thenReturn(mockRegistry);
+
+      scheduler.initializeMetricsReporter();
+
+      pinotMetricUtilsMockedStatic.verify(() -> PinotMetricUtils.getPinotMetricsRegistry(any()), times(1));
+      ServerMetrics registeredMetrics = ServerMetrics.get();
+      assertNotNull(registeredMetrics, "ServerMetrics should be registered after initializeMetricsReporter");
+    } finally {
+      scheduler.stop();
+    }
+  }
+
+  @Test
+  public void testInitializeMetricsReporterFallsBackOnFailure()
+      throws Exception {
+    String propertiesFilePath = this.getClass().getClassLoader().getResource(SAMPLE_PROPERTIES_FILE_NAME).getPath();
+    PropertiesConfiguration properties = CommonsConfigurationUtils.fromPath(propertiesFilePath);
+    PredownloadScheduler scheduler = new PredownloadScheduler(properties);
+
+    try (MockedStatic<PinotMetricUtils> pinotMetricUtilsMockedStatic = mockStatic(PinotMetricUtils.class)) {
+      pinotMetricUtilsMockedStatic.when(() -> PinotMetricUtils.getPinotMetricsRegistry(any()))
+          .thenThrow(new RuntimeException("Metrics factory not available"));
+
+      scheduler.initializeMetricsReporter();
+
+      ServerMetrics registeredMetrics = ServerMetrics.get();
+      assertNotNull(registeredMetrics, "ServerMetrics.get() should return NOOP instance, not null");
+    } finally {
+      scheduler.stop();
+    }
+  }
+
+  @Test
+  public void testInitializeMetricsReporterAlwaysCreatesPredownloadMetrics()
+      throws Exception {
+    String propertiesFilePath = this.getClass().getClassLoader().getResource(SAMPLE_PROPERTIES_FILE_NAME).getPath();
+    PropertiesConfiguration properties = CommonsConfigurationUtils.fromPath(propertiesFilePath);
+    PredownloadScheduler scheduler = spy(new PredownloadScheduler(properties));
+
+    try (MockedStatic<PinotMetricUtils> pinotMetricUtilsMockedStatic = mockStatic(PinotMetricUtils.class);
+         MockedStatic<PredownloadStatusRecorder> statusRecorderMockedStatic =
+             mockStatic(PredownloadStatusRecorder.class)) {
+      pinotMetricUtilsMockedStatic.when(() -> PinotMetricUtils.getPinotMetricsRegistry(any()))
+          .thenThrow(new RuntimeException("Metrics factory not available"));
+
+      scheduler.initializeMetricsReporter();
+
+      statusRecorderMockedStatic.verify(
+          () -> PredownloadStatusRecorder.registerMetrics(any(PredownloadMetrics.class)), times(1));
+    } finally {
+      scheduler.stop();
+    }
   }
 }

--- a/pinot-server/src/test/java/org/apache/pinot/server/starter/ServerMetricsInitUtilsTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/starter/ServerMetricsInitUtilsTest.java
@@ -28,7 +28,6 @@ import static org.apache.pinot.spi.utils.CommonConstants.CONFIG_OF_METRICS_FACTO
 import static org.apache.pinot.spi.utils.CommonConstants.Server.METRICS_CONFIG_PREFIX;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertSame;
-import static org.testng.Assert.assertThrows;
 
 
 public class ServerMetricsInitUtilsTest {
@@ -55,11 +54,12 @@ public class ServerMetricsInitUtilsTest {
   }
 
   @Test
-  public void testInitServerMetricsThrowsWhenAlreadyRegistered()
+  public void testInitServerMetricsReturnsExistingWhenAlreadyRegistered()
       throws Exception {
     ServerConf serverConf = buildServerConf();
-    ServerMetricsInitUtils.initServerMetrics(serverConf);
+    ServerMetrics first = ServerMetricsInitUtils.initServerMetrics(serverConf);
+    ServerMetrics second = ServerMetricsInitUtils.initServerMetrics(serverConf);
 
-    assertThrows(IllegalStateException.class, () -> ServerMetricsInitUtils.initServerMetrics(serverConf));
+    assertSame(second, first, "Should return the already-registered instance");
   }
 }

--- a/pinot-server/src/test/java/org/apache/pinot/server/starter/ServerMetricsInitUtilsTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/starter/ServerMetricsInitUtilsTest.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.server.starter;
+
+import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.server.conf.ServerConf;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.spi.utils.CommonConstants.CONFIG_OF_METRICS_FACTORY_CLASS_NAME;
+import static org.apache.pinot.spi.utils.CommonConstants.Server.METRICS_CONFIG_PREFIX;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertThrows;
+
+
+public class ServerMetricsInitUtilsTest {
+
+  @AfterMethod
+  public void tearDown() {
+    ServerMetrics.deregister();
+  }
+
+  private static ServerConf buildServerConf() {
+    PinotConfiguration pinotConfig = new PinotConfiguration();
+    pinotConfig.setProperty(METRICS_CONFIG_PREFIX + "." + CONFIG_OF_METRICS_FACTORY_CLASS_NAME,
+        "org.apache.pinot.plugin.metrics.yammer.YammerMetricsFactory");
+    return new ServerConf(pinotConfig);
+  }
+
+  @Test
+  public void testInitServerMetricsConstructsAndRegisters()
+      throws Exception {
+    ServerMetrics serverMetrics = ServerMetricsInitUtils.initServerMetrics(buildServerConf());
+
+    assertNotNull(serverMetrics);
+    assertSame(ServerMetrics.get(), serverMetrics, "Returned ServerMetrics should be the registered instance");
+  }
+
+  @Test
+  public void testInitServerMetricsThrowsWhenAlreadyRegistered()
+      throws Exception {
+    ServerConf serverConf = buildServerConf();
+    ServerMetricsInitUtils.initServerMetrics(serverConf);
+
+    assertThrows(IllegalStateException.class, () -> ServerMetricsInitUtils.initServerMetrics(serverConf));
+  }
+}


### PR DESCRIPTION
## Problem

The `PredownloadScheduler` runs in a separate **predownload container** that starts before the main Pinot server process. Its purpose is to pre-download segments from deep storage so the server can start faster.

Previously, the `initializeMetricsReporter()` method in `PredownloadScheduler` only created `PredownloadMetrics` but **never initialized the `ServerMetrics` registry**. As a result:

1. `PredownloadMetrics` internally depends on `ServerMetrics.get()` for reporting server-level meters and timers.
2. Since `ServerMetrics` was never initialized in the predownload container lifecycle, `ServerMetrics.get()` always returned the **NOOP instance**.
3. This meant **no server-level metrics (download latency, failure counts, etc.) were emitted** from the predownload container — metrics were silently dropped.

### Call chain showing the gap

```
PredownloadScheduler.start()
  → initializeMetricsReporter()
      → new PredownloadMetrics()       // created
      → ServerMetrics was never set up // missing — falls back to NOOP
```

In contrast, the normal server startup path initializes `ServerMetrics` via `PinotMetricUtils.getPinotMetricsRegistry()` before any metrics are used.

## Changes

This PR adds `ServerMetrics` initialization to `PredownloadScheduler.initializeMetricsReporter()`:

1. Creates a `ServerConf` from the existing `_pinotConfig`
2. Initializes `PinotMetricsRegistry` via `PinotMetricUtils.getPinotMetricsRegistry()`
3. Creates and registers a `ServerMetrics` instance with the proper prefix, table-level metrics config, and allowed tables

### Graceful fallback

The initialization is wrapped in a `try-catch(Throwable)` so that if the configured `PinotMetricsFactory` cannot be created (e.g., because a vendor-specific metrics client is not yet available during the predownload lifecycle), the predownload process **continues with the default NOOP `ServerMetrics`** rather than crashing. This ensures the predownload container remains resilient regardless of the metrics backend availability.

### Before (no ServerMetrics)
```java
void initializeMetricsReporter() {
    _predownloadMetrics = new PredownloadMetrics();
    PredownloadStatusRecorder.registerMetrics(_predownloadMetrics);
}
```

### After (ServerMetrics initialized with fallback)
```java
void initializeMetricsReporter() {
    try {
        ServerConf serverConf = new ServerConf(_pinotConfig);
        PinotMetricsRegistry metricsRegistry =
            PinotMetricUtils.getPinotMetricsRegistry(serverConf.getMetricsConfig());
        ServerMetrics serverMetrics = new ServerMetrics(...);
        serverMetrics.initializeGlobalMeters();
        ServerMetrics.register(serverMetrics);
    } catch (Throwable t) {
        LOGGER.error("Failed to initialize ServerMetrics; "
            + "continuing with NOOP instance", t);
    }

    _predownloadMetrics = new PredownloadMetrics();
    PredownloadStatusRecorder.registerMetrics(_predownloadMetrics);
}
```

## Test Plan
- Verified that the predownload container starts successfully with and without a metrics factory on the classpath
- When the metrics factory is available, `ServerMetrics` is properly initialized and metrics are emitted
- When the metrics factory is unavailable, the catch block logs the error and the container continues with NOOP metrics without crashing

<img width="1322" height="571" alt="image" src="https://github.com/user-attachments/assets/03acdc7b-e0a5-4b90-ad1e-7910c3514aaf" />





