### PR TITLE
Fix Zookeeper browser handling for missing nodes

### DIFF
--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -846,9 +846,9 @@ const getZookeeperData = (path, count) => {
     pathNames.forEach((pathName) => {
       const nodeStat = currentNodeListStat[pathName];
 
-      // Skip if nodeStat is null or undefined
-      if (!nodeStat) {
-        console.warn(`Skipping null node for path: ${pathName}`);
+      // Skip missing or error-response entries, such as { code, error } from a 404 response.
+      if (!nodeStat || typeof nodeStat !== 'object' || !Number.isInteger(nodeStat.numChildren)) {
+        console.warn(`Skipping invalid ZK child stat for path: ${pathName}`);
         return;
       }
       newTreeData[0].child.push({


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Skip invalid ZK child stats \(e\.g\., error responses\) to avoid fake children in ZooKeeper browser tree\.

```mermaid
flowchart TD
  N0["Get nodeStat for path #40;F1#41;"]:::stModified
  N1["Check if nodeStat invalid #40;F1#41;"]:::stModified
  N2["Log warning and skip #40;F1#41;"]:::stModified
  N3["Add child to tree #40;F1#41;"]:::stModified
  N0 --> N1
  N1 --> N2
  N1 --> N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-controller/src/main/resources/app/utils/PinotMethodUtils\.ts — [before](https://github.com/apache/pinot/blob/9f8eb1a4c90eb198b99b40478feea0436e73356d/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts) · [after](https://github.com/apache/pinot/blob/f71f35469c316a32472be77f080f893a3dfc9ace/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjlmOGViMWE0YzkwZWIxOThiOTliNDA0NzhmZWVhMDQzNmU3MzM1NmQiLCJjb250ZXh0X2hhc2giOiJiZTdiOTYyNjEyMmQyMTI0NWExNGJjZGFhNjM1M2MyNDk4Y2M1MWI5ZDA3MzM0ODVlMjZmMTkyMGE1NDY5MDBlIiwiZ2VuZXJhdGVkX2F0IjoxNzg5OTY4NzYzLCJoZWFkX3NoYSI6ImY3MWYzNTQ2OWMzMTZhMzI0NzJiZTc3ZjA4MGY4OTNhM2RmYzlhY2UiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI5ZjhlYjFhNGM5MGViMTk4Yjk5YjQwNDc4ZmVlYTA0MzZlNzMzNTZkIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 561a39e2dd85334787635423a5d76c8f4d1103ae83e7b5f9e124f06e63212502 -->
<!-- pinot-pr-flow:end -->

Fixes #9987.

When a selected znode disappears before the browser expands it, the controller can return a 404 payload such as `{ code, error }` from `/zk/lsl`. The browser currently iterates every key in that payload and renders `code` and `error` as child znodes.

This change only turns entries with a valid ZooKeeper stat shape into tree children, so missing-node responses leave the expanded node with no fake children while real children named `code` or `error` are still preserved when their values are stat objects.

Validation:
- `npm run build-dev`
- `npm run build`
- `git diff --check`
- local reproducer for missing-node and real `code`/`error` child payloads

I also ran `npx eslint app/utils/PinotMethodUtils.ts --quiet`; it still fails on existing repository lint configuration and pre-existing errors unrelated to this change.