### PR TITLE
Check server data directories with a probe file

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -211,8 +211,7 @@ public class HelixInstanceDataManager implements InstanceDataManager {
         }
       }
     }
-    // Ensure we can write to the instance data dir
-    Preconditions.checkState(instanceDataDir.canWrite(), "Cannot write to the instance data dir: %s", instanceDataDir);
+    ensureDirectoryWritable(instanceDataDir, "instance data dir");
   }
 
   @VisibleForTesting
@@ -221,9 +220,24 @@ public class HelixInstanceDataManager implements InstanceDataManager {
       Preconditions.checkState(instanceSegmentTarDir.mkdirs(), "Failed to create instance segment tar dir: %s",
           instanceSegmentTarDir);
     }
-    // Ensure we can write to the instance segment tar dir
-    Preconditions.checkState(instanceSegmentTarDir.canWrite(), "Cannot write to the instance segment tar dir: %s",
-        instanceSegmentTarDir);
+    ensureDirectoryWritable(instanceSegmentTarDir, "instance segment tar dir");
+  }
+
+  @VisibleForTesting
+  static void ensureDirectoryWritable(File directory, String directoryDescription) {
+    Preconditions.checkState(directory.isDirectory(), "Expected %s to be a directory: %s", directoryDescription,
+        directory);
+
+    File probeFile = null;
+    try {
+      probeFile = File.createTempFile(".pinot-writability-check-", ".tmp", directory);
+    } catch (IOException e) {
+      throw new IllegalStateException("Cannot write to the " + directoryDescription + ": " + directory, e);
+    } finally {
+      if (probeFile != null) {
+        Preconditions.checkState(probeFile.delete(), "Failed to delete writability check file: %s", probeFile);
+      }
+    }
   }
 
   @Override

--- a/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerTest.java
@@ -19,13 +19,16 @@
 package org.apache.pinot.server.starter.helix;
 
 import java.io.File;
+import java.io.IOException;
 import org.apache.commons.io.FileUtils;
 import org.mockito.Mockito;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -87,6 +90,22 @@ public class HelixInstanceDataManagerTest {
     } finally {
       _testInstanceDataDir.setWritable(true);
     }
+  }
+
+  @Test
+  public void testDirectoryWritabilityCheckDoesNotLeaveProbeFile()
+      throws IOException {
+    if (!_testInstanceDataDir.exists()) {
+      assertTrue(_testInstanceDataDir.mkdirs(), "Failed to create test directory.");
+    } else {
+      FileUtils.cleanDirectory(_testInstanceDataDir);
+    }
+
+    HelixInstanceDataManager.ensureDirectoryWritable(_testInstanceDataDir, "instance data dir");
+
+    File[] files = _testInstanceDataDir.listFiles();
+    assertNotNull(files, "Expected test directory to remain listable after writability check.");
+    assertEquals(files.length, 0, "Writability check should not leave probe files behind.");
   }
 
   @Test


### PR DESCRIPTION
### Summary
- validate server data directories by creating and deleting a temporary probe file
- keep the existing directory creation and cleanup flow
- add coverage to ensure the writability check does not leave probe files behind

### Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./mvnw -pl pinot-server -am -Dtest=HelixInstanceDataManagerTest#testDirectoryWritabilityCheckDoesNotLeaveProbeFile -Dsurefire.failIfNoSpecifiedTests=false test -DskipShade -Dskip.license=true`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./mvnw -pl pinot-server -am -Dtest=HelixInstanceDataManagerTest -Dsurefire.failIfNoSpecifiedTests=false test -DskipShade -Dskip.license=true`
- `git diff --check`

Addresses #15860