### PR TITLE
Limit table detail requests in controller UI

### DIFF
--- a/pinot-controller/src/main/resources/app/components/AsyncPinotTables.tsx
+++ b/pinot-controller/src/main/resources/app/components/AsyncPinotTables.tsx
@@ -24,6 +24,7 @@ import { PinotTableDetails, TableData } from 'Models';
 import { getQueryTables, getTenantTable } from '../requests';
 import Utils from '../utils/Utils';
 import PinotMethodUtils from '../utils/PinotMethodUtils';
+import { runWithConcurrencyLimit } from '../utils/requestLimiter';
 
 type BaseProps = {
   title: string;
@@ -50,6 +51,8 @@ const TableTooltipData = [
   null,
   'GOOD if all replicas of all segments are up',
 ];
+
+const TABLE_DETAILS_CONCURRENCY = 8;
 
 export const AsyncPinotTables = ({
   title,
@@ -155,8 +158,8 @@ export const AsyncPinotTables = ({
   };
 
   const fetchAllTableDetails = async (tables: string[]) => {
-    return tables.forEach((tableName) => {
-      PinotMethodUtils.getSegmentCountAndStatus(tableName).then(
+    const tasks = tables.map((tableName) => async () => {
+      const segmentDetails = PinotMethodUtils.getSegmentCountAndStatus(tableName).then(
         ({ segment_count, segment_status }) => {
           setTableData((prevState) => {
             const newRecords = [...prevState.records];
@@ -173,7 +176,7 @@ export const AsyncPinotTables = ({
         }
       );
 
-      PinotMethodUtils.getTableSizes(tableName).then(
+      const tableSizes = PinotMethodUtils.getTableSizes(tableName).then(
         ({ reported_size, estimated_size }) => {
           setTableData((prevState) => {
             const newRecords = [...prevState.records];
@@ -189,7 +192,10 @@ export const AsyncPinotTables = ({
           });
         }
       );
+
+      await Promise.all([segmentDetails, tableSizes]);
     });
+    return runWithConcurrencyLimit(tasks, TABLE_DETAILS_CONCURRENCY);
   };
 
   useEffect(() => {

--- a/pinot-controller/src/main/resources/app/utils/requestLimiter.test.ts
+++ b/pinot-controller/src/main/resources/app/utils/requestLimiter.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { runWithConcurrencyLimit } from './requestLimiter';
+
+const nextTick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+test('runWithConcurrencyLimit caps in-flight tasks', async () => {
+  let active = 0;
+  let maxActive = 0;
+  const releaseTasks: (() => void)[] = [];
+
+  const tasks = Array.from({ length: 10 }, (_, index) => async () => {
+    active++;
+    maxActive = Math.max(maxActive, active);
+    await new Promise<void>((resolve) => {
+      releaseTasks.push(resolve);
+    });
+    active--;
+    return index;
+  });
+
+  const resultPromise = runWithConcurrencyLimit(tasks, 3);
+
+  await nextTick();
+  assert.equal(maxActive, 3);
+
+  while (releaseTasks.length > 0) {
+    const release = releaseTasks.shift();
+    release?.();
+    await nextTick();
+  }
+
+  assert.deepEqual(await resultPromise, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+});

--- a/pinot-controller/src/main/resources/app/utils/requestLimiter.ts
+++ b/pinot-controller/src/main/resources/app/utils/requestLimiter.ts
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export const runWithConcurrencyLimit = async <T>(
+  tasks: (() => Promise<T>)[],
+  limit: number
+): Promise<T[]> => {
+  if (tasks.length === 0) {
+    return [];
+  }
+
+  const concurrency = Math.max(1, Math.floor(limit));
+  const results = new Array<T>(tasks.length);
+  let nextIndex = 0;
+
+  const worker = async () => {
+    while (nextIndex < tasks.length) {
+      const currentIndex = nextIndex++;
+      results[currentIndex] = await tasks[currentIndex]();
+    }
+  };
+
+  const workers = Array.from(
+    { length: Math.min(concurrency, tasks.length) },
+    () => worker()
+  );
+  await Promise.all(workers);
+  return results;
+};


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Limits concurrent table detail requests in controller UI using a concurrency‑limited task runner\.

```mermaid
flowchart TD
  N0["fetchAllTableDetails #40;F1#41;"]:::stModified
  N1["Create per#45;table task #40;F1#41;"]:::stModified
  N2["Execute segment #38; size requests #40;F1#41;"]:::stModified
  N3["runWithConcurrencyLimit #40;F3#41;"]:::stAdded
  N4["TABLE#95;DETAILS#95;CONCURRENCY constant #40;F1#41;"]:::stModified
  N0 -->|"creates"| N1
  N1 -->|"executes"| N2
  N2 -->|"awaited by"| N3
  N3 -->|"returns promise to"| N0
  N4 -->|"provides limit"| N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-controller/src/main/resources/app/components/AsyncPinotTables\.tsx — [before](https://github.com/apache/pinot/blob/6bff2295ebcb3530ea54fcf56e828e5bcdc5bf7e/pinot-controller/src/main/resources/app/components/AsyncPinotTables.tsx) · [after](https://github.com/apache/pinot/blob/e6da68aba17583b807d1fdb9a03886d415808101/pinot-controller/src/main/resources/app/components/AsyncPinotTables.tsx)
- F3: pinot\-controller/src/main/resources/app/utils/requestLimiter\.ts — [after](https://github.com/apache/pinot/blob/e6da68aba17583b807d1fdb9a03886d415808101/pinot-controller/src/main/resources/app/utils/requestLimiter.ts)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjZiZmYyMjk1ZWJjYjM1MzBlYTU0ZmNmNTZlODI4ZTViY2RjNWJmN2UiLCJjb250ZXh0X2hhc2giOiJlNTkzNzg1YjY2N2YyZTcyMTgzZWNmNmJlM2IxZjNjOGQ0MmU1OTExYjNiNzhhMjI5YTcyMjE4N2JlZjkxZjFjIiwiZ2VuZXJhdGVkX2F0IjoxNzg5OTY4OTQwLCJoZWFkX3NoYSI6ImU2ZGE2OGFiYTE3NTgzYjgwN2QxZmRiOWEwMzg4NmQ0MTU4MDgxMDEiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI2YmZmMjI5NWViY2IzNTMwZWE1NGZjZjU2ZTgyOGU1YmNkYzViZjdlIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 8ca643dce179932793eb04f0a8678c290879598854efe53861ee0aa5cf60a018 -->
<!-- pinot-pr-flow:end -->

## Summary
- Add a small concurrency-limited task runner for controller UI requests.
- Use it when loading table detail rows so large clusters do not fire all table size/status requests at once.
- Keep the existing incremental table row updates and loading placeholders unchanged.

## Root cause
The table listing loads all tables first, then starts detail requests for every table immediately. On clusters with hundreds of tables, that can overwhelm browsers with many concurrent `/tables/{table}/size` and segment status requests, matching the behavior reported in #11370.

Addresses #11370.

## Testing
- `rm -rf /tmp/pinot-ui-request-limiter-test && ./node_modules/.bin/tsc app/utils/requestLimiter.ts app/utils/requestLimiter.test.ts --outDir /tmp/pinot-ui-request-limiter-test --module commonjs --target es2020 --types node --skipLibCheck --esModuleInterop && node --test /tmp/pinot-ui-request-limiter-test/requestLimiter.test.js`
- `npm run build`
- `git diff --check`

## Notes
- `./node_modules/.bin/eslint app/utils/requestLimiter.ts app/utils/requestLimiter.test.ts --quiet` could not run cleanly because the current ESLint config references missing rules (`react/jsx-key`, `import/no-extraneous-dependencies`, `react/jsx-filename-extension`, `import/extensions`).
