### PR TITLE
Configurable segment upload timeout

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -650,7 +650,7 @@ public class FileUploadDownloadClient implements AutoCloseable {
   @Deprecated
   // Upload a set of segment metadata files (e.g., meta.properties and creation.meta) to controllers.
   public SimpleHttpResponse uploadSegmentMetadataFiles(URI uri, Map<String, File> metadataFiles,
-      int segmentUploadRequestTimeoutMs)
+      long segmentUploadRequestTimeoutMs)
       throws IOException, HttpErrorStatusException {
     return uploadSegmentMetadataFiles(uri, metadataFiles, Collections.emptyList(), Collections.emptyList(),
         segmentUploadRequestTimeoutMs);
@@ -658,7 +658,7 @@ public class FileUploadDownloadClient implements AutoCloseable {
 
   // Upload a set of segment metadata files (e.g., meta.properties and creation.meta) to controllers.
   public SimpleHttpResponse uploadSegmentMetadataFiles(URI uri, Map<String, File> metadataFiles,
-      @Nullable List<Header> headers, @Nullable List<NameValuePair> parameters, int segmentUploadRequestTimeoutMs)
+      @Nullable List<Header> headers, @Nullable List<NameValuePair> parameters, long segmentUploadRequestTimeoutMs)
       throws IOException, HttpErrorStatusException {
     return HttpClient.wrapAndThrowHttpException(
         _httpClient.sendRequest(getUploadSegmentMetadataFilesRequest(uri, metadataFiles, headers, parameters),

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/PushJobSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/PushJobSpec.java
@@ -79,6 +79,12 @@ public class PushJobSpec implements Serializable {
    */
   private boolean _preferMetadataTarGz = true;
 
+  /**
+   * Socket timeout in milliseconds for batch segment metadata upload (batchSegmentUpload=true)
+   * Defaults to 600000 ms (10 minutes), matching HttpClient.DEFAULT_SOCKET_TIMEOUT_MS
+   */
+  private long _segmentUploadTimeoutMs = 600 * 1000L;
+
   public boolean isPreferMetadataTarGz() {
     return _preferMetadataTarGz;
   }
@@ -176,5 +182,13 @@ public class PushJobSpec implements Serializable {
 
   public void setSegmentMetadataGenerationParallelism(int segmentMetadataGenerationParallelism) {
     _segmentMetadataGenerationParallelism = segmentMetadataGenerationParallelism;
+  }
+
+  public long getSegmentUploadTimeoutMs() {
+    return _segmentUploadTimeoutMs;
+  }
+
+  public void setSegmentUploadTimeoutMs(long segmentUploadTimeoutMs) {
+    _segmentUploadTimeoutMs = segmentUploadTimeoutMs;
   }
 }


### PR DESCRIPTION
## Summary

We run large batch segment uploads and occasionally hit timeout failures because the upload takes longer than the default allows. This PR makes the segment upload timeout configurable via `PushJobSpec` so callers can tune it without touching source code.

Two changes:

- **`PushJobSpec`**: adds `segmentUploadTimeoutMs` field (defaults to `600_000` ms / 10 min, matching `HttpClient.DEFAULT_SOCKET_TIMEOUT_MS`, so existing behavior is unchanged out of the box).
- **`FileUploadDownloadClient`**: changes the `segmentUploadRequestTimeoutMs` parameter on `uploadSegmentMetadataFiles` from `int` to `long` so it can accept the value from `PushJobSpec` without a cast. This is safe — Java widens `int` to `long` automatically, so any existing callers passing an `int` literal or variable continue to compile and work correctly without modification.
