### PR TITLE
Fix intermittent clean install failure in pinot-common (missing SqlParserImpl)

### DIFF
--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -97,7 +97,53 @@
           </java>
         </configuration>
       </plugin>
-      <!-- Creates a Java class for the custom parser from Parser.jj -->
+      <!-- Stage 1 of SQL parser codegen: FMPP plugs Pinot's custom grammar (config.fmpp +
+           templates/Parser.jj) into Calcite's parser template and writes the JavaCC grammar to
+           target/generated-sources/javacc/Parser.jj. Declared before javacc-maven-plugin so it runs
+           first within the generate-sources phase (same-phase goals execute in POM declaration order). -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate-fmpp-sources</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target name="generate-parser">
+                <taskdef name="fmpp" classname="fmpp.tools.AntTask" classpathref="maven.compile.classpath" />
+                <!-- FMPP unconditionally rewrites its output, so generating straight into the JavaCC
+                     source dir would bump Parser.jj's timestamp every build and force JavaCC + the
+                     entire module to recompile. Instead generate into a staging dir, then copy into
+                     the JavaCC source dir only when the grammar content actually changed (compared
+                     byte-for-byte via the 'different' selector, ignoring timestamps). This keeps
+                     incremental builds fast while guaranteeing the grammar is regenerated after a
+                     clean. It replaces the old 'sqlparser' profile, whose file-based activation was
+                     evaluated before 'clean' deleted the file it keyed on, breaking 'clean install'. -->
+                <mkdir dir="${project.build.directory}/generated-sources/fmpp" />
+                <fmpp configuration="src/main/codegen/config.fmpp" sourceRoot="src/main/codegen/templates" outputRoot="${project.build.directory}/generated-sources/fmpp" />
+                <mkdir dir="${project.build.directory}/generated-sources/javacc" />
+                <copy todir="${project.build.directory}/generated-sources/javacc">
+                  <fileset dir="${project.build.directory}/generated-sources/fmpp/javacc">
+                    <include name="Parser.jj" />
+                    <different targetdir="${project.build.directory}/generated-sources/javacc" ignoreFileTimes="true" />
+                  </fileset>
+                </copy>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>net.sourceforge.fmpp</groupId>
+            <artifactId>fmpp</artifactId>
+            <version>${fmpp.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <!-- Stage 2 of SQL parser codegen: compile the generated Parser.jj into SqlParserImpl. -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>javacc-maven-plugin</artifactId>
@@ -383,61 +429,6 @@
       <properties>
         <shade.phase.prop>none</shade.phase.prop>
       </properties>
-    </profile>
-    <profile>
-      <!-- The Ant task doesn't care about unchanged (re)sources and will always generate.
-      This causes the maven-compiler-plugin to detect changes and always recompile the Java sources.
-
-      If there are changes in src/main/codegen, either enforcer activation of this profile by using -Psqlparser or by
-      removing the generated-sources/javacc directory
-
-      NOTICE: In Maven the profile activation is decided BEFORE plugin execution.
-      When running clean+verify, the profile will not be activated (because the file still exists),
-        clean will remove it and compiler-plugin will fail because of a missing class.
-        Either run 'mvn clean && mvn verify' or 'mvn verify -Psqlparser'
-       -->
-      <id>sqlparser</id>
-      <activation>
-        <file>
-          <missing>${basedir}/target/generated-sources/javacc/Parser.jj</missing>
-        </file>
-      </activation>
-      <build>
-        <plugins>
-          <!-- "Plugs in" the Calcite's Parser.jj with the variables present in config.fmpp. These contain the custom rules
-     as well as the class to which the custom implementation will get generated -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>generate-fmpp-sources</id>
-                <phase>generate-sources</phase>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-                <configuration>
-                  <target name="generate-code">
-                    <taskdef name="fmpp" classname="fmpp.tools.AntTask" classpathref="maven.compile.classpath" />
-                    <fmpp configuration="src/main/codegen/config.fmpp" sourceRoot="src/main/codegen/templates" outputRoot="${project.build.directory}/generated-sources/" />
-                  </target>
-                </configuration>
-              </execution>
-            </executions>
-            <dependencies>
-              <dependency>
-                <groupId>net.sourceforge.fmpp</groupId>
-                <artifactId>fmpp</artifactId>
-                <version>${fmpp.version}</version>
-              </dependency>
-            </dependencies>
-          </plugin>
-          <plugin> <!-- Enforce javacc-maven-plugin executions after maven-antrun-plugin -->
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>javacc-maven-plugin</artifactId>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
## Problem

`mvn clean install` intermittently fails to build `pinot-common` with:

```
[ERROR] .../sql/parsers/CalciteSqlParser.java:[69,42] cannot find symbol
[ERROR]   symbol:   class SqlParserImpl
[ERROR]   location: package org.apache.pinot.sql.parsers.parser
```

The same failure shows up "randomly" inside IDEs.

### Root cause

`pinot-common` generates its SQL parser in two `generate-sources` stages:

1. **FMPP** injects Pinot's custom grammar (`config.fmpp` + `templates/Parser.jj`) into Calcite's parser template and writes `target/generated-sources/javacc/Parser.jj`.
2. **javacc-maven-plugin** compiles that grammar into `SqlParserImpl.java`.

Stage 1 lived **only inside the `sqlparser` profile**, which auto-activated via `<file><missing>.../javacc/Parser.jj</missing></file>`. The catch: **Maven evaluates profile activation once, at reactor start — before `clean` runs.** So in a single `mvn clean install` after any prior build:

- Reactor start: the previous build's `Parser.jj` still exists → `sqlparser` is **inactive** → FMPP is excluded from the plan.
- `clean` deletes `target/` → `Parser.jj` is gone.
- `generate-sources`: FMPP never runs; javacc finds no grammar → generates nothing.
- `compile`: `SqlParserImpl` was never generated → **cannot find symbol**.

It "works sometimes" because a fresh checkout (no `target/`) activates the profile, and `mvn clean` followed by a **separate** `mvn install` also works. IDEs snapshot active profiles at import time (while `Parser.jj` exists) and then their rebuild wipes it — hence the random IDE failures. The old profile's own comment documented this footgun but only offered manual workarounds (`-Psqlparser` or two separate invocations).

## Fix

- Remove the `sqlparser` profile.
- Move the FMPP step into the main `<build><plugins>`, declared **before** `javacc-maven-plugin`, so it **always** runs in `generate-sources` (same-phase goals execute in POM declaration order).
- Preserve the incremental-build speed the profile gate was protecting: FMPP now writes to a staging dir (`target/generated-sources/fmpp`), then an Ant `<copy>` with a `<different ignoreFileTimes="true">` selector promotes `Parser.jj` into the javacc source dir **only when the generated grammar content actually changed**. Unchanged rebuilds don't bump the timestamp, so javacc and the compiler skip — no spurious full-module recompiles.

## Rationale (alternatives considered)

- **Always-run FMPP without the staging/`<different>` trick** — simplest, but reintroduces the always-recompile cost the profile was created to avoid (FMPP rewrites its output every run).
- **Keep the profile, change its activation trigger** — file-based activation that `clean` can touch risks the same ordering trap; property-based activation re-creates the `-Psqlparser` opt-in ergonomics problem.
- **Switch to a dedicated `fmpp-maven-plugin`** (Calcite/Drill upstream style) — clean, but adds a new plugin to the build's governance/supply-chain surface for what is fundamentally a build-ordering bug.
- **Chosen: staging dir + `<different>` selector** — reuses the already-present `maven-antrun-plugin` + `fmpp` dependency (no new plugin), guarantees the grammar is regenerated after a `clean` in every invocation mode, and keeps incremental builds fast. As a bonus, IDE codegen is now deterministic.

## Test plan

- [x] Reproduced the original failure: single-invocation `clean test-compile` with `Parser.jj` present → `cannot find symbol: SqlParserImpl`.
- [x] After the fix, the same single-invocation `clean install` succeeds and `SqlParserImpl` is generated.
- [x] Incremental no-op: rebuilding without grammar changes leaves `Parser.jj` untouched; javacc reports "all parsers are up to date" and the compiler skips.
- [x] Change detection: corrupting the on-disk `Parser.jj` triggers the copy and restores the correct grammar + regenerates `SqlParserImpl`.
- [x] Full module build (`clean install`, build cache disabled): `BUILD SUCCESS`, `Tests run: 1449, Failures: 0, Errors: 0`, shade/license/rat/spotless all clean, artifacts installed.