### PR TITLE
Expose indexOfInactiveTopics in pauseStatus API response

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/PauseStatusDetails.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/PauseStatusDetails.java
@@ -21,7 +21,9 @@ package org.apache.pinot.common.restlet.resources;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.table.PauseState;
 
 
@@ -32,18 +34,27 @@ public class PauseStatusDetails {
   private PauseState.ReasonCode _reasonCode;
   private String _comment;
   private String _timestamp;
+  private List<Integer> _indexOfInactiveTopics;
 
   @JsonCreator
   public PauseStatusDetails(@JsonProperty("pauseFlag") boolean pauseFlag,
       @JsonProperty("consumingSegments") Set<String> consumingSegments,
       @JsonProperty("reasonCode") PauseState.ReasonCode reasonCode,
       @JsonProperty("comment") String comment,
-      @JsonProperty("timestamp") String timestamp) {
+      @JsonProperty("timestamp") String timestamp,
+      @JsonProperty("indexOfInactiveTopics") List<Integer> indexOfInactiveTopics) {
     _pauseFlag = pauseFlag;
     _consumingSegments = consumingSegments;
     _reasonCode = reasonCode;
     _comment = comment != null ? comment : pauseFlag ? "Table is paused." : "Table is unpaused.";
     _timestamp = timestamp;
+    _indexOfInactiveTopics = (indexOfInactiveTopics != null && !indexOfInactiveTopics.isEmpty())
+        ? List.copyOf(indexOfInactiveTopics) : null;
+  }
+
+  public PauseStatusDetails(boolean pauseFlag, Set<String> consumingSegments, PauseState.ReasonCode reasonCode,
+      String comment, String timestamp) {
+    this(pauseFlag, consumingSegments, reasonCode, comment, timestamp, null);
   }
 
   public boolean getPauseFlag() {
@@ -64,5 +75,10 @@ public class PauseStatusDetails {
 
   public String getTimestamp() {
     return _timestamp;
+  }
+
+  @Nullable
+  public List<Integer> getIndexOfInactiveTopics() {
+    return _indexOfInactiveTopics;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -2921,9 +2921,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     Set<String> consumingSegments = findConsumingSegments(idealState);
     PauseState pauseState = extractTablePauseState(idealState);
     if (pauseState != null) {
-      // TODO: add paused topics information
       return new PauseStatusDetails(pauseState.isPaused(), consumingSegments, pauseState.getReasonCode(),
-          pauseState.getComment(), pauseState.getTimeInMillis());
+          pauseState.getComment(), pauseState.getTimeInMillis(), pauseState.getIndexOfInactiveTopics());
     }
     String isTablePausedStr = idealState.getRecord().getSimpleField(IS_TABLE_PAUSED);
     return new PauseStatusDetails(Boolean.parseBoolean(isTablePausedStr), consumingSegments,

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -529,6 +529,43 @@ public class PinotLLCRealtimeSegmentManagerTest {
   }
 
   @Test
+  public void testGetPauseStatusDetailsIncludesInactiveTopics()
+      throws Exception {
+    FakePinotLLCRealtimeSegmentManager segmentManager = new FakePinotLLCRealtimeSegmentManager();
+    String tableNameWithType = TableNameBuilder.REALTIME.tableNameWithType(RAW_TABLE_NAME);
+    setUpNewTable(segmentManager, 2, 4, 2);
+
+    List<Integer> inactiveTopicIndices = List.of(0, 1);
+    PauseState pauseState =
+        new PauseState(false, PauseState.ReasonCode.ADMINISTRATIVE, null, "12345", inactiveTopicIndices);
+    segmentManager._idealState.getRecord().setSimpleField(PinotLLCRealtimeSegmentManager.PAUSE_STATE,
+        pauseState.toJsonString());
+
+    PauseStatusDetails details = segmentManager.getPauseStatusDetails(tableNameWithType);
+
+    assertEquals(details.getIndexOfInactiveTopics(), inactiveTopicIndices,
+        "getPauseStatusDetails should propagate indexOfInactiveTopics from PauseState");
+    assertFalse(details.getPauseFlag());
+  }
+
+  @Test
+  public void testPauseStatusDetailsJsonRoundTrip()
+      throws Exception {
+    List<Integer> inactiveTopics = List.of(0, 2);
+    PauseStatusDetails original = new PauseStatusDetails(false, Collections.emptySet(),
+        PauseState.ReasonCode.ADMINISTRATIVE, "comment", "12345", inactiveTopics);
+
+    String json = org.apache.pinot.spi.utils.JsonUtils.objectToString(original);
+    PauseStatusDetails deserialized =
+        org.apache.pinot.spi.utils.JsonUtils.stringToObject(json, PauseStatusDetails.class);
+
+    assertEquals(deserialized.getIndexOfInactiveTopics(), inactiveTopics,
+        "indexOfInactiveTopics should survive JSON round-trip");
+    assertFalse(deserialized.getPauseFlag());
+    assertEquals(deserialized.getComment(), "comment");
+  }
+
+  @Test
   public void testCommitSegmentWithOffsetAutoResetOnOffset()
       throws Exception {
     // Set up a new table with 2 replicas, 5 instances, 4 partition


### PR DESCRIPTION
The /tables/{name}/pauseStatus endpoint returned only a boolean pauseFlag with no information about which topics were individually paused via the topic-level pause API. This change surfaces the list of inactive topic indices already stored in PauseState so callers can see per-topic pause state without inspecting ZooKeeper directly.

Changes:
- PauseStatusDetails: add indexOfInactiveTopics field with proper @JsonProperty binding in @JsonCreator for correct round-trip serialization; return List.copyOf to avoid aliasing PauseState internals; annotate getter @Nullable since the field is omitted when empty
- PinotLLCRealtimeSegmentManager.getPauseStatusDetails: pass pauseState.getIndexOfInactiveTopics() through to PauseStatusDetails, removing the TODO comment
- Tests: add round-trip JSON test and getPauseStatusDetails unit test covering the inactive-topics code path

`cleanup`