### PR TITLE
Return false from HadoopPinotFS.isDirectory for missing paths

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-hdfs/src/main/java/org/apache/pinot/plugin/filesystem/HadoopPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-hdfs/src/main/java/org/apache/pinot/plugin/filesystem/HadoopPinotFS.java
@@ -239,7 +239,11 @@ public class HadoopPinotFS extends BasePinotFS {
   @Override
   public boolean isDirectory(URI uri)
       throws IOException {
-    return _hadoopFS.getFileStatus(new Path(uri)).isDirectory();
+    try {
+      return _hadoopFS.getFileStatus(new Path(uri)).isDirectory();
+    } catch (FileNotFoundException e) {
+      return false;
+    }
   }
 
   @Override

--- a/pinot-plugins/pinot-file-system/pinot-hdfs/src/test/java/org/apache/pinot/plugin/filesystem/HadoopPinotFSTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-hdfs/src/test/java/org/apache/pinot/plugin/filesystem/HadoopPinotFSTest.java
@@ -152,6 +152,17 @@ public class HadoopPinotFSTest {
   }
 
   @Test
+  public void testIsDirectoryReturnsFalseForNonExistentPath()
+      throws IOException {
+    URI missingPath = URI.create(TMP_DIR + "/testIsDirectoryReturnsFalseForNonExistentPath/missing");
+    try (HadoopPinotFS hadoopFS = new HadoopPinotFS()) {
+      hadoopFS.init(new PinotConfiguration());
+
+      Assert.assertFalse(hadoopFS.isDirectory(missingPath));
+    }
+  }
+
+  @Test
   public void testDeleteBatchWithEmptyList()
       throws IOException {
     try (HadoopPinotFS hadoopFS = new HadoopPinotFS()) {


### PR DESCRIPTION
## Summary

- Return `false` from `HadoopPinotFS.isDirectory()` when the target path does not exist
- Add a regression test covering the missing-path behavior

## Rationale

`HadoopPinotFS.isDirectory()` used `FileSystem#getFileStatus()` directly, so missing paths raised `FileNotFoundException`. Other filesystem implementations such as `LocalPinotFS` treat missing paths as not directories. This makes the Hadoop implementation consistent for callers that use `isDirectory()` as a predicate.

Addresses #7083.

## Test Plan

- `./mvnw -pl pinot-plugins/pinot-file-system/pinot-hdfs -am -Dtest=HadoopPinotFSTest#testIsDirectoryReturnsFalseForNonExistentPath -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl pinot-plugins/pinot-file-system/pinot-hdfs -am -Dtest=HadoopPinotFSTest -Dsurefire.failIfNoSpecifiedTests=false test`