### PR TITLE
Register lookup transform for query planning

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -175,7 +175,7 @@ public enum TransformFunctionType {
       ReturnTypes.cascade(opBinding -> positionalComponentType(opBinding, 2), SqlTypeTransforms.FORCE_NULLABLE),
       OperandTypes.family(List.of(SqlTypeFamily.ARRAY, SqlTypeFamily.ANY, SqlTypeFamily.ARRAY))),
   IN_ID_SET("inIdSet", ReturnTypes.BOOLEAN, OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.CHARACTER)),
-  LOOKUP("lookUp"),
+  LOOKUP("lookUp", ReturnTypes.explicit(SqlTypeName.ANY), OperandTypes.variadic(SqlOperandCountRanges.from(4))),
   GROOVY("groovy"),
   SCALAR("scalar"),
 

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
@@ -73,6 +73,13 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
     assertNotNull(dispatchableSubPlan);
   }
 
+  @Test
+  public void testLookupFunctionSupportsQualifiedJoinColumn() {
+    DispatchableSubPlan dispatchableSubPlan = _queryEnvironment.planQuery(
+        "SELECT lookup('b', 'col1', 'col2', e.col1) FROM a AS e JOIN b AS d ON e.col1 = d.col2");
+    assertNotNull(dispatchableSubPlan);
+  }
+
   @Test(dataProvider = "testUnaryOperatorQueries")
   public void testUnaryPrefixOperatorsPlanQuery(String query) {
     DispatchableSubPlan dispatchableSubPlan = _queryEnvironment.planQuery(query);


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

LOOKUP transform now has return type and operand counts; test verifies it works in qualified join queries\.

```mermaid
flowchart TD
  N0["LOOKUP transform with return type ANY and variadic operands #40;#62;#61;4#41; #40;F1#41;"]:::stModified
  N1["Test#58; lookup function with qualified join column compiles successfully #40;F2#41;"]:::stModified
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType\.java — [before](https://github.com/apache/pinot/blob/a7622546633ca8868bb8125ebac1145ade1beae6/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java) · [after](https://github.com/apache/pinot/blob/f47717692eb3bf022f4712bd1f53a6c0d4435d9e/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java)
- F2: pinot\-query\-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest\.java — [before](https://github.com/apache/pinot/blob/a7622546633ca8868bb8125ebac1145ade1beae6/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java) · [after](https://github.com/apache/pinot/blob/f47717692eb3bf022f4712bd1f53a6c0d4435d9e/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImE3NjIyNTQ2NjMzY2E4ODY4YmI4MTI1ZWJhYzExNDVhZGUxYmVhZTYiLCJjb250ZXh0X2hhc2giOiI4MGFkZmI3YWI2ZTBhMTk4YTU5MDA5YTExNDc0NjQ2Yjk3ZDM1YTI1Mjg4YzVhMTU2M2QxZGI5ZDVkZjY5M2ExIiwiZ2VuZXJhdGVkX2F0IjoxNzg5OTY5MDQxLCJoZWFkX3NoYSI6ImY0NzcxNzY5MmViM2JmMDIyZjQ3MTJiZDFmNTNhNmMwZDQ0MzVkOWUiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJhNzYyMjU0NjYzM2NhODg2OGJiODEyNWViYWMxMTQ1YWRlMWJlYWU2IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature aba89a7686968f69539dce924f4184d78e835eb1fd9a469889f825b45d5d2af1 -->
<!-- pinot-pr-flow:end -->

### Summary
- register the `lookup` transform with Calcite so multi-stage query planning can validate it
- add a query-planner regression test for `lookup` using a qualified join column

### Root cause
`LOOKUP` was listed as a transform function but had no return type inference, so it was skipped when building the Pinot operator table. Calcite then rejected queries with `No match found for function signature lookup(...)` before planning.

### Tests
- `./mvnw -pl pinot-query-planner -am -Dtest=QueryCompilationTest#testLookupFunctionSupportsQualifiedJoinColumn -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl pinot-query-planner -am -Dtest=QueryCompilationTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`

Addresses #12865.