### PR TITLE
Add schema deserialization compatibility test

### DIFF
--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/SchemaSerializationTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/SchemaSerializationTest.java
@@ -416,6 +416,32 @@ public class SchemaSerializationTest {
   }
 
   @Test
+  public void testDeserializeSimpleSchemaWithoutFieldType()
+      throws Exception {
+    final String simpleSchemaJson = "{"
+        + "\"schemaName\":\"mytable\","
+        + "\"metricFieldSpecs\":[{\"name\":\"ActualElapsedTime\",\"dataType\":\"INT\"}],"
+        + "\"timeFieldSpec\":{\"incomingGranularitySpec\":{"
+        + "\"name\":\"DaysSinceEpoch\",\"dataType\":\"INT\",\"timeType\":\"DAYS\"}},"
+        + "\"dimensionFieldSpecs\":["
+        + "{\"name\":\"AirlineID\",\"dataType\":\"LONG\"},"
+        + "{\"name\":\"DivAirportIDs\",\"dataType\":\"INT\",\"singleValueField\":false}"
+        + "]"
+        + "}";
+
+    final Schema deserializedSchema = Schema.fromString(simpleSchemaJson);
+
+    assertEquals(deserializedSchema.getSchemaName(), "mytable");
+    assertNotNull(deserializedSchema.getMetricSpec("ActualElapsedTime"));
+    assertEquals(deserializedSchema.getMetricSpec("ActualElapsedTime").getDataType(), DataType.INT);
+    assertNotNull(deserializedSchema.getDimensionSpec("AirlineID"));
+    assertEquals(deserializedSchema.getDimensionSpec("AirlineID").getDataType(), DataType.LONG);
+    assertFalse(deserializedSchema.getDimensionSpec("DivAirportIDs").isSingleValueField());
+    assertNotNull(deserializedSchema.getTimeFieldSpec());
+    assertEquals(deserializedSchema.getTimeFieldSpec().getIncomingGranularitySpec().getName(), "DaysSinceEpoch");
+  }
+
+  @Test
   public void testComplexFieldDefaultNullValue()
       throws Exception {
     // Test LIST


### PR DESCRIPTION
## Summary
- add a regression test for simple schema JSON that omits `fieldType` in metric, dimension, and time field specs
- cover the compatibility case reported in #14017 without changing production code

## Why
The reported schema now deserializes successfully on current `master`. This test keeps that compatibility covered so the older/simple schema format does not regress.

Fixes #14017

## Tests
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./mvnw -pl pinot-spi -Dtest=SchemaSerializationTest#testDeserializeSimpleSchemaWithoutFieldType test`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./mvnw -pl pinot-spi -Dtest=SchemaSerializationTest test`
- `git diff --check`