### PR TITLE
Mark user component query parameter as required

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotAccessControlUserRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotAccessControlUserRestletResource.java
@@ -115,7 +115,8 @@ public class PinotAccessControlUserRestletResource {
   @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_USER)
   @ApiOperation(value = "Get an user in cluster", notes = "Get an user in cluster")
   public String getUser(@PathParam("username") String username,
-      @ApiParam(value = "CONTROLLER|SERVER|BROKER") @QueryParam("component") String componentTypeStr) {
+      @ApiParam(value = "CONTROLLER|SERVER|BROKER", required = true) @QueryParam("component")
+      String componentTypeStr) {
     try {
       ZkHelixPropertyStore<ZNRecord> propertyStore = _pinotHelixResourceManager.getPropertyStore();
       ComponentType componentType = Constants.validateComponentType(componentTypeStr);
@@ -168,7 +169,8 @@ public class PinotAccessControlUserRestletResource {
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Delete a user", notes = "Delete a user")
   public SuccessResponse deleteUser(@PathParam("username") String username,
-      @ApiParam(value = "CONTROLLER|SERVER|BROKER") @QueryParam("component") String componentTypeStr) {
+      @ApiParam(value = "CONTROLLER|SERVER|BROKER", required = true) @QueryParam("component")
+      String componentTypeStr) {
 
     List<String> usersDeleted = new LinkedList<>();
     String usernameWithComponentType = username + "_" + componentTypeStr;
@@ -200,7 +202,8 @@ public class PinotAccessControlUserRestletResource {
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Update user config for a user", notes = "Update user config for user")
   public SuccessResponse updateUserConfig(@PathParam("username") String username,
-      @ApiParam(value = "CONTROLLER|SERVER|BROKER") @QueryParam("component") String componentTypeStr,
+      @ApiParam(value = "CONTROLLER|SERVER|BROKER", required = true) @QueryParam("component")
+      String componentTypeStr,
       @QueryParam("passwordChanged") boolean passwordChanged, String userConfigString) {
 
     UserConfig userConfig;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotAccessControlUserRestletResourceSwaggerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotAccessControlUserRestletResourceSwaggerTest.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import io.swagger.annotations.ApiParam;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import javax.ws.rs.QueryParam;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+public class PinotAccessControlUserRestletResourceSwaggerTest {
+
+  @Test
+  public void testUserComponentQueryParamIsRequired()
+      throws Exception {
+    assertComponentQueryParamRequired(
+        PinotAccessControlUserRestletResource.class.getMethod("getUser", String.class, String.class));
+    assertComponentQueryParamRequired(
+        PinotAccessControlUserRestletResource.class.getMethod("deleteUser", String.class, String.class));
+    assertComponentQueryParamRequired(
+        PinotAccessControlUserRestletResource.class.getMethod("updateUserConfig", String.class, String.class,
+            boolean.class, String.class));
+  }
+
+  private static void assertComponentQueryParamRequired(Method method) {
+    ApiParam componentApiParam = null;
+    for (Annotation[] parameterAnnotations : method.getParameterAnnotations()) {
+      QueryParam queryParam = findAnnotation(parameterAnnotations, QueryParam.class);
+      if (queryParam != null && "component".equals(queryParam.value())) {
+        componentApiParam = findAnnotation(parameterAnnotations, ApiParam.class);
+        break;
+      }
+    }
+
+    assertNotNull(componentApiParam, "Missing @ApiParam for component on " + method.getName());
+    assertTrue(componentApiParam.required(), "component must be marked required on " + method.getName());
+  }
+
+  private static <T extends Annotation> T findAnnotation(Annotation[] annotations, Class<T> annotationClass) {
+    for (Annotation annotation : annotations) {
+      if (annotationClass.isInstance(annotation)) {
+        return annotationClass.cast(annotation);
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Mark component query param as required in User API and add test to verify

```mermaid
flowchart TD
  N0["getUser#40;String#44; String#41; #40;F1#41;"]:::stAdded
  N1["deleteUser#40;String#44; String#41; #40;F1#41;"]:::stAdded
  N2["updateUserConfig#40;String#44; String#44; boolean#44; String#41; #40;F1#41;"]:::stAdded
  N3["testUserComponentQueryParamIsRequired#40;#41; #40;F2#41;"]:::stAdded
  N4["assertComponentQueryParamRequired#40;Method#41; #40;F2#41;"]:::stAdded
  N3 -->|"calls"| N4
  N4 -->|"inspects"| N0
  N4 -->|"inspects"| N1
  N4 -->|"inspects"| N2
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotAccessControlUserRestletResource\.java — [before](https://github.com/apache/pinot/blob/a7622546633ca8868bb8125ebac1145ade1beae6/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotAccessControlUserRestletResource.java) · [after](https://github.com/apache/pinot/blob/21b605f276193ef4e6f7debb04c595e24e7417cd/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotAccessControlUserRestletResource.java)
- F2: pinot\-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotAccessControlUserRestletResourceSwaggerTest\.java — [after](https://github.com/apache/pinot/blob/21b605f276193ef4e6f7debb04c595e24e7417cd/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotAccessControlUserRestletResourceSwaggerTest.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImE3NjIyNTQ2NjMzY2E4ODY4YmI4MTI1ZWJhYzExNDVhZGUxYmVhZTYiLCJjb250ZXh0X2hhc2giOiJlNzMzYzBjMDM0MDA3N2U4ZmQ1ZGY3NTNmMDM1ZjEwMDhkYTk1OGNlNzczNjQ4NzFjNWEwMGQ4OGNjMzM3ZmY4IiwiZ2VuZXJhdGVkX2F0IjoxNzg5MTg3MzMwLCJoZWFkX3NoYSI6IjIxYjYwNWYyNzYxOTNlZjRlNmY3ZGViYjA0YzU5NWUyNGU3NDE3Y2QiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJhNzYyMjU0NjYzM2NhODg2OGJiODEyNWViYWMxMTQ1YWRlMWJlYWU2IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 154eab63a04e95fbefc272964a48c8b11945766848de108a2139c1f52f27c812 -->
<!-- pinot-pr-flow:end -->

## Summary
- mark the `component` query parameter as required for get, delete, and update User API operations
- add a reflection-based test to keep the Swagger contract aligned with the required User API parameter

## Why
The User API needs `component` to identify the component-specific user entry. Without this Swagger metadata, the UI can present the field as optional even though the request path requires it.

Fixes #14594

## Tests
- RED: `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./mvnw -pl pinot-controller -am -Dtest=PinotAccessControlUserRestletResourceSwaggerTest -Dsurefire.failIfNoSpecifiedTests=false test` failed before the annotation change with `component must be marked required on getUser expected [true] but found [false]`
- GREEN: `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./mvnw -pl pinot-controller -am -Dtest=PinotAccessControlUserRestletResourceSwaggerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`