### PR TITLE
[Arrow] Column-major segment build for Arrow IPC sources

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-arrow/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/pom.xml
@@ -56,6 +56,11 @@
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-vector</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-segment-local</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowAccumulators.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowAccumulators.java
@@ -67,12 +67,9 @@ final class ArrowAccumulators {
     // ArrowRecordExtractor (setReader + prepareBatch); empty when no column is dictionary-encoded.
     Map<Long, Dictionary> dictionaries = reader.getDictionaryVectors();
 
-    // A half-built collection of Closeables must be unwound by whoever is mid-construction, because
-    // nobody else has a reference yet — populate() only hands ownership to the factory via the
-    // returned Result. So if anything throws after the first allocateNew() (a missing dictionary, a
-    // loadNextBatch IO error, or a VectorAppender failure), release the already-allocated off-heap
-    // accumulators here before propagating; otherwise the factory's _accumulatorVectors stays null and
-    // its close() can't free them, and the allocator close trips.
+    // Nothing else holds these accumulators until we return the Result, so on any failure after the
+    // first allocateNew() we must release them here (see the catch below); otherwise the off-heap
+    // vectors leak and the allocator's own close() trips on the outstanding allocation.
     Map<String, FieldVector> accumulators = new LinkedHashMap<>();
     try {
       Map<String, VectorAppender> appenders = new LinkedHashMap<>();
@@ -151,7 +148,12 @@ final class ArrowAccumulators {
     }
   }
 
-  private static Set<String> computeWantedColumns(Schema targetSchema, @Nullable Set<String> colsToRead) {
+  /**
+   * Resolve the set of columns to read: an explicit non-empty {@code colsToRead}, otherwise every
+   * non-virtual column in {@code targetSchema}. Shared by both columnar factories (materialized and
+   * file-backed) so the selection rule lives in one place.
+   */
+  static Set<String> computeWantedColumns(Schema targetSchema, @Nullable Set<String> colsToRead) {
     if (colsToRead != null && !colsToRead.isEmpty()) {
       return new HashSet<>(colsToRead);
     }

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowAccumulators.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowAccumulators.java
@@ -29,7 +29,11 @@ import javax.annotation.Nullable;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.dictionary.Dictionary;
+import org.apache.arrow.vector.dictionary.DictionaryEncoder;
 import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
+import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.util.VectorAppender;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
@@ -38,7 +42,7 @@ import org.apache.pinot.spi.data.readers.ColumnReader;
 
 /**
  * Package-private helper shared by {@link ArrowColumnReaderFactory} and
- * {@link InMemoryArrowColumnReaderFactory}: walks every record batch in an {@link ArrowReader},
+ * {@link ArrowFileColumnReaderFactory}: walks every record batch in an {@link ArrowReader},
  * concatenates each wanted column's values into a per-column accumulator {@link FieldVector} via
  * Arrow's {@link VectorAppender}, and produces one {@link ArrowColumnReader} per accumulator.
  *
@@ -52,63 +56,99 @@ final class ArrowAccumulators {
   }
 
   static Result populate(ArrowReader reader, BufferAllocator allocator, Schema targetSchema,
-      @Nullable Set<String> colsToRead)
+      @Nullable Set<String> colsToRead, boolean extractRawTimeValues)
       throws IOException {
     Set<String> wantedColumns = computeWantedColumns(targetSchema, colsToRead);
 
     VectorSchemaRoot perBatchRoot = reader.getVectorSchemaRoot();
     Set<String> availableColumns = Collections.unmodifiableSet(collectAvailableNames(perBatchRoot));
+    // Bound dictionaries, resolved up front (available once the reader's schema/footer is read, before
+    // any record batch). Used to decode dictionary-encoded columns per batch, mirroring the row-major
+    // ArrowRecordExtractor (setReader + prepareBatch); empty when no column is dictionary-encoded.
+    Map<Long, Dictionary> dictionaries = reader.getDictionaryVectors();
 
+    // A half-built collection of Closeables must be unwound by whoever is mid-construction, because
+    // nobody else has a reference yet — populate() only hands ownership to the factory via the
+    // returned Result. So if anything throws after the first allocateNew() (a missing dictionary, a
+    // loadNextBatch IO error, or a VectorAppender failure), release the already-allocated off-heap
+    // accumulators here before propagating; otherwise the factory's _accumulatorVectors stays null and
+    // its close() can't free them, and the allocator close trips.
     Map<String, FieldVector> accumulators = new LinkedHashMap<>();
-    Map<String, VectorAppender> appenders = new LinkedHashMap<>();
-    for (FieldVector source : perBatchRoot.getFieldVectors()) {
-      String name = source.getField().getName();
-      if (!wantedColumns.isEmpty() && !wantedColumns.contains(name)) {
-        continue;
-      }
-      // Dictionary-encoded columns surface as their index type (e.g. Int32) rather than the
-      // decoded logical type. Reject loudly so we don't silently produce a wrong segment. The
-      // row-major ArrowRecordExtractor decodes via DictionaryEncoder.decode; adding the same
-      // here is left as a follow-up once a real use case appears.
-      Preconditions.checkArgument(source.getField().getDictionary() == null,
-          "Dictionary-encoded Arrow column '%s' is not supported by Arrow column-major build. "
-              + "Use ArrowRecordReader (row-major) for files containing dictionary-encoded columns.",
-          name);
-      FieldVector accumulator = source.getField().createVector(allocator);
-      // Pre-allocate buffers so VectorAppender can read offsets / validity from them on the
-      // first append (otherwise BaseVariableWidthVector visits IOOBE on an empty offset buffer).
-      accumulator.allocateNew();
-      accumulators.put(name, accumulator);
-      appenders.put(name, new VectorAppender(accumulator));
-    }
-
-    // Walk every record batch and bulk-append each wanted column into its accumulator via
-    // Arrow's VectorAppender (Visitor-based; grows offset / data buffers once per batch and
-    // bulk-copies, rather than per-row copyValueSafe). Single-batch and multi-batch inputs go
-    // through the same code path — VectorAppender handles either correctly.
-    boolean anyBatchSeen = false;
-    while (reader.loadNextBatch()) {
-      if (perBatchRoot.getRowCount() == 0) {
-        continue;
-      }
-      anyBatchSeen = true;
+    try {
+      Map<String, VectorAppender> appenders = new LinkedHashMap<>();
       for (FieldVector source : perBatchRoot.getFieldVectors()) {
-        VectorAppender appender = appenders.get(source.getField().getName());
-        if (appender != null) {
-          source.accept(appender, null);
+        String name = source.getField().getName();
+        if (!wantedColumns.isEmpty() && !wantedColumns.contains(name)) {
+          continue;
+        }
+        // Dictionary-encoded columns (the standard Arrow representation for low-cardinality strings)
+        // surface as their index type (e.g. Int32) rather than the decoded logical type. The
+        // accumulator therefore holds the DECODED logical values, typed from the bound dictionary's
+        // value vector; each batch is decoded via DictionaryEncoder.decode before append, mirroring the
+        // row-major ArrowRecordExtractor. Non-dictionary columns accumulate the source type directly.
+        DictionaryEncoding encoding = source.getField().getDictionary();
+        FieldVector accumulator;
+        if (encoding == null) {
+          accumulator = source.getField().createVector(allocator);
+        } else {
+          Dictionary dictionary = dictionaries.get(encoding.getId());
+          Preconditions.checkArgument(dictionary != null,
+              "Arrow column '%s' is dictionary-encoded (dictionary id %s) but no matching dictionary is "
+                  + "present in the source", name, encoding.getId());
+          Field valueField = dictionary.getVector().getField();
+          accumulator = new Field(name, valueField.getFieldType(), valueField.getChildren())
+              .createVector(allocator);
+        }
+        // Pre-allocate buffers so VectorAppender can read offsets / validity from them on the
+        // first append (otherwise BaseVariableWidthVector visits IOOBE on an empty offset buffer).
+        accumulator.allocateNew();
+        accumulators.put(name, accumulator);
+        appenders.put(name, new VectorAppender(accumulator));
+      }
+
+      // Walk every record batch and bulk-append each wanted column into its accumulator via
+      // Arrow's VectorAppender (Visitor-based; grows offset / data buffers once per batch and
+      // bulk-copies, rather than per-row copyValueSafe). Single-batch and multi-batch inputs go
+      // through the same code path — VectorAppender handles either correctly. An input with no
+      // non-empty batches yields zero-doc accumulators, mirroring the row-major path's handling of
+      // an empty source (a zero-doc segment) rather than throwing.
+      while (reader.loadNextBatch()) {
+        if (perBatchRoot.getRowCount() == 0) {
+          continue;
+        }
+        for (FieldVector source : perBatchRoot.getFieldVectors()) {
+          VectorAppender appender = appenders.get(source.getField().getName());
+          if (appender == null) {
+            continue;
+          }
+          DictionaryEncoding encoding = source.getField().getDictionary();
+          if (encoding == null) {
+            source.accept(appender, null);
+          } else {
+            // Decode this batch's indices into logical values, append, then release the transient
+            // decoded copy (the accumulator retains its own values via the appender's bulk-copy).
+            try (FieldVector decoded =
+                (FieldVector) DictionaryEncoder.decode(source, dictionaries.get(encoding.getId()))) {
+              decoded.accept(appender, null);
+            }
+          }
         }
       }
-    }
-    if (!anyBatchSeen) {
-      throw new IOException("Arrow source contains no non-empty record batches");
-    }
 
-    Map<String, ColumnReader> readers = new LinkedHashMap<>();
-    for (Map.Entry<String, FieldVector> entry : accumulators.entrySet()) {
-      readers.put(entry.getKey(), new ArrowColumnReader(entry.getKey(), entry.getValue()));
-    }
+      Map<String, ColumnReader> readers = new LinkedHashMap<>();
+      for (Map.Entry<String, FieldVector> entry : accumulators.entrySet()) {
+        readers.put(entry.getKey(),
+            new ArrowColumnReader(entry.getKey(), entry.getValue(), extractRawTimeValues));
+      }
 
-    return new Result(accumulators, readers, availableColumns);
+      return new Result(accumulators, readers, availableColumns);
+    } catch (RuntimeException | IOException e) {
+      IOException closeFailure = closeAll(accumulators);
+      if (closeFailure != null) {
+        e.addSuppressed(closeFailure);
+      }
+      throw e;
+    }
   }
 
   private static Set<String> computeWantedColumns(Schema targetSchema, @Nullable Set<String> colsToRead) {

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowAccumulators.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowAccumulators.java
@@ -1,0 +1,184 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.arrow;
+
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.arrow.vector.util.VectorAppender;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.ColumnReader;
+
+
+/**
+ * Package-private helper shared by {@link ArrowColumnReaderFactory} and
+ * {@link InMemoryArrowColumnReaderFactory}: walks every record batch in an {@link ArrowReader},
+ * concatenates each wanted column's values into a per-column accumulator {@link FieldVector} via
+ * Arrow's {@link VectorAppender}, and produces one {@link ArrowColumnReader} per accumulator.
+ *
+ * <p>Accumulator vectors are allocated against the caller-supplied {@link BufferAllocator}. The
+ * caller (factory) owns and closes them via {@link Result#getAccumulators()}; this helper does
+ * not retain references.
+ */
+final class ArrowAccumulators {
+
+  private ArrowAccumulators() {
+  }
+
+  static Result populate(ArrowReader reader, BufferAllocator allocator, Schema targetSchema,
+      @Nullable Set<String> colsToRead)
+      throws IOException {
+    Set<String> wantedColumns = computeWantedColumns(targetSchema, colsToRead);
+
+    VectorSchemaRoot perBatchRoot = reader.getVectorSchemaRoot();
+    Set<String> availableColumns = Collections.unmodifiableSet(collectAvailableNames(perBatchRoot));
+
+    Map<String, FieldVector> accumulators = new LinkedHashMap<>();
+    Map<String, VectorAppender> appenders = new LinkedHashMap<>();
+    for (FieldVector source : perBatchRoot.getFieldVectors()) {
+      String name = source.getField().getName();
+      if (!wantedColumns.isEmpty() && !wantedColumns.contains(name)) {
+        continue;
+      }
+      // Dictionary-encoded columns surface as their index type (e.g. Int32) rather than the
+      // decoded logical type. Reject loudly so we don't silently produce a wrong segment. The
+      // row-major ArrowRecordExtractor decodes via DictionaryEncoder.decode; adding the same
+      // here is left as a follow-up once a real use case appears.
+      Preconditions.checkArgument(source.getField().getDictionary() == null,
+          "Dictionary-encoded Arrow column '%s' is not supported by Arrow column-major build. "
+              + "Use ArrowRecordReader (row-major) for files containing dictionary-encoded columns.",
+          name);
+      FieldVector accumulator = source.getField().createVector(allocator);
+      // Pre-allocate buffers so VectorAppender can read offsets / validity from them on the
+      // first append (otherwise BaseVariableWidthVector visits IOOBE on an empty offset buffer).
+      accumulator.allocateNew();
+      accumulators.put(name, accumulator);
+      appenders.put(name, new VectorAppender(accumulator));
+    }
+
+    // Walk every record batch and bulk-append each wanted column into its accumulator via
+    // Arrow's VectorAppender (Visitor-based; grows offset / data buffers once per batch and
+    // bulk-copies, rather than per-row copyValueSafe). Single-batch and multi-batch inputs go
+    // through the same code path — VectorAppender handles either correctly.
+    boolean anyBatchSeen = false;
+    while (reader.loadNextBatch()) {
+      if (perBatchRoot.getRowCount() == 0) {
+        continue;
+      }
+      anyBatchSeen = true;
+      for (FieldVector source : perBatchRoot.getFieldVectors()) {
+        VectorAppender appender = appenders.get(source.getField().getName());
+        if (appender != null) {
+          source.accept(appender, null);
+        }
+      }
+    }
+    if (!anyBatchSeen) {
+      throw new IOException("Arrow source contains no non-empty record batches");
+    }
+
+    Map<String, ColumnReader> readers = new LinkedHashMap<>();
+    for (Map.Entry<String, FieldVector> entry : accumulators.entrySet()) {
+      readers.put(entry.getKey(), new ArrowColumnReader(entry.getKey(), entry.getValue()));
+    }
+
+    return new Result(accumulators, readers, availableColumns);
+  }
+
+  private static Set<String> computeWantedColumns(Schema targetSchema, @Nullable Set<String> colsToRead) {
+    if (colsToRead != null && !colsToRead.isEmpty()) {
+      return new HashSet<>(colsToRead);
+    }
+    Set<String> targetColumns = new HashSet<>();
+    for (FieldSpec fieldSpec : targetSchema.getAllFieldSpecs()) {
+      if (!fieldSpec.isVirtualColumn()) {
+        targetColumns.add(fieldSpec.getName());
+      }
+    }
+    return targetColumns;
+  }
+
+  private static Set<String> collectAvailableNames(VectorSchemaRoot root) {
+    Set<String> names = new HashSet<>();
+    for (FieldVector vector : root.getFieldVectors()) {
+      names.add(vector.getField().getName());
+    }
+    return names;
+  }
+
+  /**
+   * Close each accumulator vector, accumulating the first failure as an {@link IOException}.
+   * Used by both factory {@code close()} paths so the per-vector close loop lives once.
+   *
+   * @param accumulators per-column accumulator vectors to close; may be {@code null}
+   * @return the first close failure encountered, or {@code null} if all closes succeeded
+   */
+  @Nullable
+  static IOException closeAll(@Nullable Map<String, FieldVector> accumulators) {
+    if (accumulators == null) {
+      return null;
+    }
+    IOException firstException = null;
+    for (FieldVector vector : accumulators.values()) {
+      try {
+        vector.close();
+      } catch (Exception e) {
+        if (firstException == null) {
+          firstException = new IOException("Failed to close Arrow accumulator vector", e);
+        }
+      }
+    }
+    return firstException;
+  }
+
+  static final class Result {
+    private final Map<String, FieldVector> _accumulators;
+    private final Map<String, ColumnReader> _readers;
+    private final Set<String> _availableColumns;
+
+    Result(Map<String, FieldVector> accumulators, Map<String, ColumnReader> readers,
+        Set<String> availableColumns) {
+      _accumulators = accumulators;
+      _readers = readers;
+      _availableColumns = availableColumns;
+    }
+
+    Map<String, FieldVector> getAccumulators() {
+      return _accumulators;
+    }
+
+    Map<String, ColumnReader> getReaders() {
+      return _readers;
+    }
+
+    Set<String> getAvailableColumns() {
+      return _availableColumns;
+    }
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReader.java
@@ -66,28 +66,58 @@ import org.apache.pinot.spi.data.readers.MultiValueResult;
  * {@code Object[]} for List variants, {@code LocalDate} / {@code LocalTime} /
  * {@code Timestamp} for temporal types.
  *
+ * <p><b>BitVector caveat:</b> Arrow's {@link FieldVector#getObject} returns a {@code Boolean}
+ * for a {@link BitVector}, but Pinot stores booleans as {@code INT} (0/1). The generic
+ * {@link #getValue(int)} therefore special-cases {@code BitVector} to return an {@code Integer}
+ * 0/1, keeping it consistent with {@link #getInt(int)} and the advertised INT mapping above
+ * rather than surfacing the shared converter's {@code Boolean}.
+ *
+ * <p>{@code @SuppressWarnings("serial")}: {@link ColumnReader} extends {@link java.io.Serializable}
+ * by SPI contract, but this reader holds a non-serializable Arrow {@link FieldVector} and is never
+ * actually serialized — it lives only for the duration of a columnar segment build. The suppression
+ * silences the missing-{@code serialVersionUID} warning; matches the Pinot convention used by other
+ * incidentally-{@code Serializable} build-time helpers.
+ *
  * <p>This class is not thread-safe.
  */
+@SuppressWarnings("serial")
 public class ArrowColumnReader implements ColumnReader {
 
   private final String _columnName;
   private final FieldVector _vector;
   private final int _totalDocs;
   private final boolean _isSingleValue;
+  private final boolean _extractRawTimeValues;
 
   private int _nextDocId;
+
+  /**
+   * Construct an ArrowColumnReader for the given vector, surfacing converted (non-raw) temporal
+   * values — equivalent to {@link #ArrowColumnReader(String, FieldVector, boolean)} with
+   * {@code extractRawTimeValues = false}.
+   *
+   * @param columnName Pinot column name
+   * @param vector Arrow field vector backing this column
+   */
+  public ArrowColumnReader(String columnName, FieldVector vector) {
+    this(columnName, vector, false);
+  }
 
   /**
    * Construct an ArrowColumnReader for the given vector.
    *
    * @param columnName Pinot column name
    * @param vector Arrow field vector backing this column
+   * @param extractRawTimeValues when {@code true}, temporal columns surface their raw epoch values
+   *        via the generic {@link #getValue(int)} path rather than canonical JDK temporal types,
+   *        mirroring {@code ArrowRecordExtractorConfig.EXTRACT_RAW_TIME_VALUES} on the row-major path
    */
-  public ArrowColumnReader(String columnName, FieldVector vector) {
+  public ArrowColumnReader(String columnName, FieldVector vector, boolean extractRawTimeValues) {
     _columnName = columnName;
     _vector = vector;
     _totalDocs = vector.getValueCount();
     _isSingleValue = !(vector instanceof ListVector);
+    _extractRawTimeValues = extractRawTimeValues;
     _nextDocId = 0;
   }
 
@@ -100,6 +130,7 @@ public class ArrowColumnReader implements ColumnReader {
   @Nullable
   public Object next()
       throws IOException {
+    requireHasNext();
     Object value = getValue(_nextDocId);
     _nextDocId++;
     return value;
@@ -108,12 +139,14 @@ public class ArrowColumnReader implements ColumnReader {
   @Override
   public boolean isNextNull()
       throws IOException {
+    requireHasNext();
     return _vector.isNull(_nextDocId);
   }
 
   @Override
   public void skipNext()
       throws IOException {
+    requireHasNext();
     _nextDocId++;
   }
 
@@ -124,42 +157,44 @@ public class ArrowColumnReader implements ColumnReader {
 
   @Override
   public boolean isInt() {
-    return _isSingleValue && (_vector instanceof IntVector || _vector instanceof BitVector);
+    FieldVector elementVector = elementVector();
+    return elementVector instanceof IntVector || elementVector instanceof BitVector;
   }
 
   @Override
   public boolean isLong() {
-    return _isSingleValue && _vector instanceof BigIntVector;
+    return elementVector() instanceof BigIntVector;
   }
 
   @Override
   public boolean isFloat() {
-    return _isSingleValue && _vector instanceof Float4Vector;
+    return elementVector() instanceof Float4Vector;
   }
 
   @Override
   public boolean isDouble() {
-    return _isSingleValue && _vector instanceof Float8Vector;
+    return elementVector() instanceof Float8Vector;
   }
 
   @Override
   public boolean isBigDecimal() {
-    return _isSingleValue && _vector instanceof DecimalVector;
+    return elementVector() instanceof DecimalVector;
   }
 
   @Override
   public boolean isString() {
-    return _isSingleValue && _vector instanceof VarCharVector;
+    return elementVector() instanceof VarCharVector;
   }
 
   @Override
   public boolean isBytes() {
-    return _isSingleValue && _vector instanceof VarBinaryVector;
+    return elementVector() instanceof VarBinaryVector;
   }
 
   @Override
   public int nextInt()
       throws IOException {
+    requireHasNext();
     int value = getInt(_nextDocId);
     _nextDocId++;
     return value;
@@ -168,6 +203,7 @@ public class ArrowColumnReader implements ColumnReader {
   @Override
   public long nextLong()
       throws IOException {
+    requireHasNext();
     long value = getLong(_nextDocId);
     _nextDocId++;
     return value;
@@ -176,6 +212,7 @@ public class ArrowColumnReader implements ColumnReader {
   @Override
   public float nextFloat()
       throws IOException {
+    requireHasNext();
     float value = getFloat(_nextDocId);
     _nextDocId++;
     return value;
@@ -184,6 +221,7 @@ public class ArrowColumnReader implements ColumnReader {
   @Override
   public double nextDouble()
       throws IOException {
+    requireHasNext();
     double value = getDouble(_nextDocId);
     _nextDocId++;
     return value;
@@ -192,6 +230,7 @@ public class ArrowColumnReader implements ColumnReader {
   @Override
   public BigDecimal nextBigDecimal()
       throws IOException {
+    requireHasNext();
     BigDecimal value = getBigDecimal(_nextDocId);
     _nextDocId++;
     return value;
@@ -200,6 +239,7 @@ public class ArrowColumnReader implements ColumnReader {
   @Override
   public String nextString()
       throws IOException {
+    requireHasNext();
     String value = getString(_nextDocId);
     _nextDocId++;
     return value;
@@ -208,6 +248,7 @@ public class ArrowColumnReader implements ColumnReader {
   @Override
   public byte[] nextBytes()
       throws IOException {
+    requireHasNext();
     byte[] value = getBytes(_nextDocId);
     _nextDocId++;
     return value;
@@ -216,6 +257,7 @@ public class ArrowColumnReader implements ColumnReader {
   @Override
   public MultiValueResult<int[]> nextIntMV()
       throws IOException {
+    requireHasNext();
     MultiValueResult<int[]> result = getIntMV(_nextDocId);
     _nextDocId++;
     return result;
@@ -224,6 +266,7 @@ public class ArrowColumnReader implements ColumnReader {
   @Override
   public MultiValueResult<long[]> nextLongMV()
       throws IOException {
+    requireHasNext();
     MultiValueResult<long[]> result = getLongMV(_nextDocId);
     _nextDocId++;
     return result;
@@ -232,6 +275,7 @@ public class ArrowColumnReader implements ColumnReader {
   @Override
   public MultiValueResult<float[]> nextFloatMV()
       throws IOException {
+    requireHasNext();
     MultiValueResult<float[]> result = getFloatMV(_nextDocId);
     _nextDocId++;
     return result;
@@ -240,6 +284,7 @@ public class ArrowColumnReader implements ColumnReader {
   @Override
   public MultiValueResult<double[]> nextDoubleMV()
       throws IOException {
+    requireHasNext();
     MultiValueResult<double[]> result = getDoubleMV(_nextDocId);
     _nextDocId++;
     return result;
@@ -248,6 +293,7 @@ public class ArrowColumnReader implements ColumnReader {
   @Override
   public BigDecimal[] nextBigDecimalMV()
       throws IOException {
+    requireHasNext();
     BigDecimal[] result = getBigDecimalMV(_nextDocId);
     _nextDocId++;
     return result;
@@ -256,6 +302,7 @@ public class ArrowColumnReader implements ColumnReader {
   @Override
   public String[] nextStringMV()
       throws IOException {
+    requireHasNext();
     String[] result = getStringMV(_nextDocId);
     _nextDocId++;
     return result;
@@ -264,6 +311,7 @@ public class ArrowColumnReader implements ColumnReader {
   @Override
   public byte[][] nextBytesMV()
       throws IOException {
+    requireHasNext();
     byte[][] result = getBytesMV(_nextDocId);
     _nextDocId++;
     return result;
@@ -369,6 +417,12 @@ public class ArrowColumnReader implements ColumnReader {
   public Object getValue(int docId)
       throws IOException {
     checkBounds(docId);
+    // BitVector maps to Pinot INT (0/1). The shared converter would surface a Boolean via
+    // FieldVector.getObject, so special-case it here to stay consistent with getInt() and the
+    // advertised INT mapping. See the "BitVector caveat" in the class Javadoc.
+    if (_vector instanceof BitVector) {
+      return _vector.isNull(docId) ? null : ((BitVector) _vector).get(docId);
+    }
     Object value = _vector.getObject(docId);
     if (value == null) {
       return null;
@@ -377,7 +431,7 @@ public class ArrowColumnReader implements ColumnReader {
     // ArrowRecordExtractor. Returns canonical JDK types: String for Utf8 / LargeUtf8 (unwrapped
     // from Arrow's Text), Object[] for List variants (with recursive element conversion),
     // LocalDate / LocalTime / Timestamp for temporal types, etc.
-    return ArrowToPinotTypeConverter.toPinotValue(_vector.getField(), value, false);
+    return ArrowToPinotTypeConverter.toPinotValue(_vector.getField(), value, _extractRawTimeValues);
   }
 
   @Override
@@ -410,11 +464,15 @@ public class ArrowColumnReader implements ColumnReader {
     checkBounds(docId);
     requireListVector();
     ListVector list = (ListVector) _vector;
+    FieldVector dataVector = list.getDataVector();
+    if (!(dataVector instanceof DecimalVector)) {
+      throw typeMismatch("BIG_DECIMAL_MV");
+    }
     int start = list.getElementStartIndex(docId);
     int end = list.getElementEndIndex(docId);
     int length = end - start;
     BigDecimal[] out = new BigDecimal[length];
-    DecimalVector elements = (DecimalVector) list.getDataVector();
+    DecimalVector elements = (DecimalVector) dataVector;
     for (int i = 0; i < length; i++) {
       out[i] = elements.isNull(start + i) ? null : elements.getObject(start + i);
     }
@@ -427,11 +485,15 @@ public class ArrowColumnReader implements ColumnReader {
     checkBounds(docId);
     requireListVector();
     ListVector list = (ListVector) _vector;
+    FieldVector dataVector = list.getDataVector();
+    if (!(dataVector instanceof VarCharVector)) {
+      throw typeMismatch("STRING_MV");
+    }
     int start = list.getElementStartIndex(docId);
     int end = list.getElementEndIndex(docId);
     int length = end - start;
     String[] out = new String[length];
-    VarCharVector elements = (VarCharVector) list.getDataVector();
+    VarCharVector elements = (VarCharVector) dataVector;
     for (int i = 0; i < length; i++) {
       if (elements.isNull(start + i)) {
         out[i] = null;
@@ -449,11 +511,15 @@ public class ArrowColumnReader implements ColumnReader {
     checkBounds(docId);
     requireListVector();
     ListVector list = (ListVector) _vector;
+    FieldVector dataVector = list.getDataVector();
+    if (!(dataVector instanceof VarBinaryVector)) {
+      throw typeMismatch("BYTES_MV");
+    }
     int start = list.getElementStartIndex(docId);
     int end = list.getElementEndIndex(docId);
     int length = end - start;
     byte[][] out = new byte[length][];
-    VarBinaryVector elements = (VarBinaryVector) list.getDataVector();
+    VarBinaryVector elements = (VarBinaryVector) dataVector;
     for (int i = 0; i < length; i++) {
       out[i] = elements.isNull(start + i) ? null : elements.get(start + i);
     }
@@ -562,6 +628,23 @@ public class ArrowColumnReader implements ColumnReader {
       throw new IOException("Unsupported primitive MV array type: " + arrayClass.getName());
     }
     return MultiValueResult.of((T) array, nulls);
+  }
+
+  /**
+   * The vector whose Arrow type determines the {@code isXxx()} predicates: the backing vector
+   * itself for single-value columns, or the {@link ListVector} element (data) vector for
+   * multi-value columns. Per the {@link ColumnReader} contract, {@code isInt()} / {@code isLong()} /
+   * ... report the element type regardless of single- vs multi-value, so a caller that also checks
+   * {@link #isSingleValue()} knows whether to use {@code nextInt()} or {@code nextIntMV()}.
+   */
+  private FieldVector elementVector() {
+    return _isSingleValue ? _vector : ((ListVector) _vector).getDataVector();
+  }
+
+  private void requireHasNext() {
+    if (!hasNext()) {
+      throw new IllegalStateException("No more values available");
+    }
   }
 
   private void requireListVector()

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReader.java
@@ -1,0 +1,595 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.arrow;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.BitSet;
+import javax.annotation.Nullable;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.DecimalVector;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.Float8Vector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VarBinaryVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.pinot.spi.data.readers.ColumnReader;
+import org.apache.pinot.spi.data.readers.MultiValueResult;
+
+
+/**
+ * Column reader for Apache Arrow {@link FieldVector}.
+ *
+ * <p>Wraps a single Arrow {@link FieldVector} and exposes sequential and random-access
+ * read patterns conforming to the {@link ColumnReader} contract. The vector is owned by
+ * the enclosing {@link ArrowColumnReaderFactory} which is responsible for its lifecycle;
+ * closing this reader is a no-op for the underlying vector.
+ *
+ * <p>Supported Arrow types map to Pinot's stored types as follows:
+ * <ul>
+ *   <li>{@code IntVector} / {@code BitVector} → {@code INT} (BitVector promoted to 0/1)</li>
+ *   <li>{@code BigIntVector} → {@code LONG}</li>
+ *   <li>{@code Float4Vector} → {@code FLOAT}</li>
+ *   <li>{@code Float8Vector} → {@code DOUBLE}</li>
+ *   <li>{@code DecimalVector} → {@code BIG_DECIMAL}</li>
+ *   <li>{@code VarCharVector} → {@code STRING}</li>
+ *   <li>{@code VarBinaryVector} → {@code BYTES}</li>
+ *   <li>{@code ListVector} of the above → multi-value variant</li>
+ * </ul>
+ *
+ * <p>The list above applies to the typed primitive accessors only ({@link #getInt},
+ * {@link #getString}, {@link #getIntMV}, ...). Complex types (Map, Struct, Union, ...)
+ * and temporal types are still readable via the generic {@link #getValue(int)} /
+ * {@link #next()} accessors, which delegate to {@link ArrowToPinotTypeConverter} and
+ * return the same canonical JDK types as the row-major path ({@link
+ * ArrowRecordExtractor}) — e.g. {@code Map<String, Object>} for Struct / Map,
+ * {@code Object[]} for List variants, {@code LocalDate} / {@code LocalTime} /
+ * {@code Timestamp} for temporal types.
+ *
+ * <p>This class is not thread-safe.
+ */
+public class ArrowColumnReader implements ColumnReader {
+
+  private final String _columnName;
+  private final FieldVector _vector;
+  private final int _totalDocs;
+  private final boolean _isSingleValue;
+
+  private int _nextDocId;
+
+  /**
+   * Construct an ArrowColumnReader for the given vector.
+   *
+   * @param columnName Pinot column name
+   * @param vector Arrow field vector backing this column
+   */
+  public ArrowColumnReader(String columnName, FieldVector vector) {
+    _columnName = columnName;
+    _vector = vector;
+    _totalDocs = vector.getValueCount();
+    _isSingleValue = !(vector instanceof ListVector);
+    _nextDocId = 0;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return _nextDocId < _totalDocs;
+  }
+
+  @Override
+  @Nullable
+  public Object next()
+      throws IOException {
+    Object value = getValue(_nextDocId);
+    _nextDocId++;
+    return value;
+  }
+
+  @Override
+  public boolean isNextNull()
+      throws IOException {
+    return _vector.isNull(_nextDocId);
+  }
+
+  @Override
+  public void skipNext()
+      throws IOException {
+    _nextDocId++;
+  }
+
+  @Override
+  public boolean isSingleValue() {
+    return _isSingleValue;
+  }
+
+  @Override
+  public boolean isInt() {
+    return _isSingleValue && (_vector instanceof IntVector || _vector instanceof BitVector);
+  }
+
+  @Override
+  public boolean isLong() {
+    return _isSingleValue && _vector instanceof BigIntVector;
+  }
+
+  @Override
+  public boolean isFloat() {
+    return _isSingleValue && _vector instanceof Float4Vector;
+  }
+
+  @Override
+  public boolean isDouble() {
+    return _isSingleValue && _vector instanceof Float8Vector;
+  }
+
+  @Override
+  public boolean isBigDecimal() {
+    return _isSingleValue && _vector instanceof DecimalVector;
+  }
+
+  @Override
+  public boolean isString() {
+    return _isSingleValue && _vector instanceof VarCharVector;
+  }
+
+  @Override
+  public boolean isBytes() {
+    return _isSingleValue && _vector instanceof VarBinaryVector;
+  }
+
+  @Override
+  public int nextInt()
+      throws IOException {
+    int value = getInt(_nextDocId);
+    _nextDocId++;
+    return value;
+  }
+
+  @Override
+  public long nextLong()
+      throws IOException {
+    long value = getLong(_nextDocId);
+    _nextDocId++;
+    return value;
+  }
+
+  @Override
+  public float nextFloat()
+      throws IOException {
+    float value = getFloat(_nextDocId);
+    _nextDocId++;
+    return value;
+  }
+
+  @Override
+  public double nextDouble()
+      throws IOException {
+    double value = getDouble(_nextDocId);
+    _nextDocId++;
+    return value;
+  }
+
+  @Override
+  public BigDecimal nextBigDecimal()
+      throws IOException {
+    BigDecimal value = getBigDecimal(_nextDocId);
+    _nextDocId++;
+    return value;
+  }
+
+  @Override
+  public String nextString()
+      throws IOException {
+    String value = getString(_nextDocId);
+    _nextDocId++;
+    return value;
+  }
+
+  @Override
+  public byte[] nextBytes()
+      throws IOException {
+    byte[] value = getBytes(_nextDocId);
+    _nextDocId++;
+    return value;
+  }
+
+  @Override
+  public MultiValueResult<int[]> nextIntMV()
+      throws IOException {
+    MultiValueResult<int[]> result = getIntMV(_nextDocId);
+    _nextDocId++;
+    return result;
+  }
+
+  @Override
+  public MultiValueResult<long[]> nextLongMV()
+      throws IOException {
+    MultiValueResult<long[]> result = getLongMV(_nextDocId);
+    _nextDocId++;
+    return result;
+  }
+
+  @Override
+  public MultiValueResult<float[]> nextFloatMV()
+      throws IOException {
+    MultiValueResult<float[]> result = getFloatMV(_nextDocId);
+    _nextDocId++;
+    return result;
+  }
+
+  @Override
+  public MultiValueResult<double[]> nextDoubleMV()
+      throws IOException {
+    MultiValueResult<double[]> result = getDoubleMV(_nextDocId);
+    _nextDocId++;
+    return result;
+  }
+
+  @Override
+  public BigDecimal[] nextBigDecimalMV()
+      throws IOException {
+    BigDecimal[] result = getBigDecimalMV(_nextDocId);
+    _nextDocId++;
+    return result;
+  }
+
+  @Override
+  public String[] nextStringMV()
+      throws IOException {
+    String[] result = getStringMV(_nextDocId);
+    _nextDocId++;
+    return result;
+  }
+
+  @Override
+  public byte[][] nextBytesMV()
+      throws IOException {
+    byte[][] result = getBytesMV(_nextDocId);
+    _nextDocId++;
+    return result;
+  }
+
+  @Override
+  public void rewind()
+      throws IOException {
+    _nextDocId = 0;
+  }
+
+  @Override
+  public String getColumnName() {
+    return _columnName;
+  }
+
+  @Override
+  public int getTotalDocs() {
+    return _totalDocs;
+  }
+
+  @Override
+  public boolean isNull(int docId) {
+    checkBounds(docId);
+    return _vector.isNull(docId);
+  }
+
+  @Override
+  public int getInt(int docId)
+      throws IOException {
+    checkBounds(docId);
+    if (_vector instanceof IntVector) {
+      return ((IntVector) _vector).get(docId);
+    }
+    if (_vector instanceof BitVector) {
+      return ((BitVector) _vector).get(docId);
+    }
+    throw typeMismatch("INT");
+  }
+
+  @Override
+  public long getLong(int docId)
+      throws IOException {
+    checkBounds(docId);
+    if (_vector instanceof BigIntVector) {
+      return ((BigIntVector) _vector).get(docId);
+    }
+    throw typeMismatch("LONG");
+  }
+
+  @Override
+  public float getFloat(int docId)
+      throws IOException {
+    checkBounds(docId);
+    if (_vector instanceof Float4Vector) {
+      return ((Float4Vector) _vector).get(docId);
+    }
+    throw typeMismatch("FLOAT");
+  }
+
+  @Override
+  public double getDouble(int docId)
+      throws IOException {
+    checkBounds(docId);
+    if (_vector instanceof Float8Vector) {
+      return ((Float8Vector) _vector).get(docId);
+    }
+    throw typeMismatch("DOUBLE");
+  }
+
+  @Override
+  public BigDecimal getBigDecimal(int docId)
+      throws IOException {
+    checkBounds(docId);
+    if (_vector instanceof DecimalVector) {
+      return ((DecimalVector) _vector).getObject(docId);
+    }
+    throw typeMismatch("BIG_DECIMAL");
+  }
+
+  @Override
+  public String getString(int docId)
+      throws IOException {
+    checkBounds(docId);
+    if (_vector instanceof VarCharVector) {
+      byte[] bytes = ((VarCharVector) _vector).get(docId);
+      return bytes == null ? null : new String(bytes, StandardCharsets.UTF_8);
+    }
+    throw typeMismatch("STRING");
+  }
+
+  @Override
+  public byte[] getBytes(int docId)
+      throws IOException {
+    checkBounds(docId);
+    if (_vector instanceof VarBinaryVector) {
+      return ((VarBinaryVector) _vector).get(docId);
+    }
+    throw typeMismatch("BYTES");
+  }
+
+  @Override
+  public Object getValue(int docId)
+      throws IOException {
+    checkBounds(docId);
+    Object value = _vector.getObject(docId);
+    if (value == null) {
+      return null;
+    }
+    // Delegate Arrow → Pinot type conversion to the shared utility extracted from
+    // ArrowRecordExtractor. Returns canonical JDK types: String for Utf8 / LargeUtf8 (unwrapped
+    // from Arrow's Text), Object[] for List variants (with recursive element conversion),
+    // LocalDate / LocalTime / Timestamp for temporal types, etc.
+    return ArrowToPinotTypeConverter.toPinotValue(_vector.getField(), value, false);
+  }
+
+  @Override
+  public MultiValueResult<int[]> getIntMV(int docId)
+      throws IOException {
+    return readPrimitiveMV(docId, int[].class);
+  }
+
+  @Override
+  public MultiValueResult<long[]> getLongMV(int docId)
+      throws IOException {
+    return readPrimitiveMV(docId, long[].class);
+  }
+
+  @Override
+  public MultiValueResult<float[]> getFloatMV(int docId)
+      throws IOException {
+    return readPrimitiveMV(docId, float[].class);
+  }
+
+  @Override
+  public MultiValueResult<double[]> getDoubleMV(int docId)
+      throws IOException {
+    return readPrimitiveMV(docId, double[].class);
+  }
+
+  @Override
+  public BigDecimal[] getBigDecimalMV(int docId)
+      throws IOException {
+    checkBounds(docId);
+    requireListVector();
+    ListVector list = (ListVector) _vector;
+    int start = list.getElementStartIndex(docId);
+    int end = list.getElementEndIndex(docId);
+    int length = end - start;
+    BigDecimal[] out = new BigDecimal[length];
+    DecimalVector elements = (DecimalVector) list.getDataVector();
+    for (int i = 0; i < length; i++) {
+      out[i] = elements.isNull(start + i) ? null : elements.getObject(start + i);
+    }
+    return out;
+  }
+
+  @Override
+  public String[] getStringMV(int docId)
+      throws IOException {
+    checkBounds(docId);
+    requireListVector();
+    ListVector list = (ListVector) _vector;
+    int start = list.getElementStartIndex(docId);
+    int end = list.getElementEndIndex(docId);
+    int length = end - start;
+    String[] out = new String[length];
+    VarCharVector elements = (VarCharVector) list.getDataVector();
+    for (int i = 0; i < length; i++) {
+      if (elements.isNull(start + i)) {
+        out[i] = null;
+      } else {
+        byte[] bytes = elements.get(start + i);
+        out[i] = new String(bytes, StandardCharsets.UTF_8);
+      }
+    }
+    return out;
+  }
+
+  @Override
+  public byte[][] getBytesMV(int docId)
+      throws IOException {
+    checkBounds(docId);
+    requireListVector();
+    ListVector list = (ListVector) _vector;
+    int start = list.getElementStartIndex(docId);
+    int end = list.getElementEndIndex(docId);
+    int length = end - start;
+    byte[][] out = new byte[length][];
+    VarBinaryVector elements = (VarBinaryVector) list.getDataVector();
+    for (int i = 0; i < length; i++) {
+      out[i] = elements.isNull(start + i) ? null : elements.get(start + i);
+    }
+    return out;
+  }
+
+  /**
+   * Read a primitive multi-value from a {@link ListVector}, populating a fresh array and a
+   * nulls BitSet for element-level validity.
+   */
+  @SuppressWarnings("unchecked")
+  private <T> MultiValueResult<T> readPrimitiveMV(int docId, Class<T> arrayClass)
+      throws IOException {
+    checkBounds(docId);
+    requireListVector();
+    ListVector list = (ListVector) _vector;
+    int start = list.getElementStartIndex(docId);
+    int end = list.getElementEndIndex(docId);
+    int length = end - start;
+    FieldVector elements = list.getDataVector();
+    BitSet nulls = null;
+
+    Object array;
+    if (arrayClass == int[].class) {
+      int[] values = new int[length];
+      if (elements instanceof IntVector) {
+        IntVector iv = (IntVector) elements;
+        for (int i = 0; i < length; i++) {
+          if (iv.isNull(start + i)) {
+            if (nulls == null) {
+              nulls = new BitSet(length);
+            }
+            nulls.set(i);
+          } else {
+            values[i] = iv.get(start + i);
+          }
+        }
+      } else if (elements instanceof BitVector) {
+        BitVector bv = (BitVector) elements;
+        for (int i = 0; i < length; i++) {
+          if (bv.isNull(start + i)) {
+            if (nulls == null) {
+              nulls = new BitSet(length);
+            }
+            nulls.set(i);
+          } else {
+            values[i] = bv.get(start + i);
+          }
+        }
+      } else {
+        throw typeMismatch("INT_MV");
+      }
+      array = values;
+    } else if (arrayClass == long[].class) {
+      long[] values = new long[length];
+      if (!(elements instanceof BigIntVector)) {
+        throw typeMismatch("LONG_MV");
+      }
+      BigIntVector lv = (BigIntVector) elements;
+      for (int i = 0; i < length; i++) {
+        if (lv.isNull(start + i)) {
+          if (nulls == null) {
+            nulls = new BitSet(length);
+          }
+          nulls.set(i);
+        } else {
+          values[i] = lv.get(start + i);
+        }
+      }
+      array = values;
+    } else if (arrayClass == float[].class) {
+      float[] values = new float[length];
+      if (!(elements instanceof Float4Vector)) {
+        throw typeMismatch("FLOAT_MV");
+      }
+      Float4Vector fv = (Float4Vector) elements;
+      for (int i = 0; i < length; i++) {
+        if (fv.isNull(start + i)) {
+          if (nulls == null) {
+            nulls = new BitSet(length);
+          }
+          nulls.set(i);
+        } else {
+          values[i] = fv.get(start + i);
+        }
+      }
+      array = values;
+    } else if (arrayClass == double[].class) {
+      double[] values = new double[length];
+      if (!(elements instanceof Float8Vector)) {
+        throw typeMismatch("DOUBLE_MV");
+      }
+      Float8Vector dv = (Float8Vector) elements;
+      for (int i = 0; i < length; i++) {
+        if (dv.isNull(start + i)) {
+          if (nulls == null) {
+            nulls = new BitSet(length);
+          }
+          nulls.set(i);
+        } else {
+          values[i] = dv.get(start + i);
+        }
+      }
+      array = values;
+    } else {
+      throw new IOException("Unsupported primitive MV array type: " + arrayClass.getName());
+    }
+    return MultiValueResult.of((T) array, nulls);
+  }
+
+  private void requireListVector()
+      throws IOException {
+    if (!(_vector instanceof ListVector)) {
+      throw new IOException(
+          "Column " + _columnName + " is not a ListVector; cannot read multi-value");
+    }
+  }
+
+  private void checkBounds(int docId) {
+    if (docId < 0 || docId >= _totalDocs) {
+      throw new IndexOutOfBoundsException(
+          "docId " + docId + " is out of range [0, " + _totalDocs + ") for column " + _columnName);
+    }
+  }
+
+  private IOException typeMismatch(String expectedType) {
+    return new IOException("Column " + _columnName + " (Arrow type " + _vector.getField().getType()
+        + ") cannot be read as " + expectedType);
+  }
+
+  /**
+   * The underlying vector is owned by {@link ArrowColumnReaderFactory}; closing this reader does
+   * not release the vector's memory.
+   */
+  @Override
+  public void close() {
+    // No-op: factory owns the vector lifecycle.
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReader.java
@@ -72,11 +72,9 @@ import org.apache.pinot.spi.data.readers.MultiValueResult;
  * 0/1, keeping it consistent with {@link #getInt(int)} and the advertised INT mapping above
  * rather than surfacing the shared converter's {@code Boolean}.
  *
- * <p>{@code @SuppressWarnings("serial")}: {@link ColumnReader} extends {@link java.io.Serializable}
- * by SPI contract, but this reader holds a non-serializable Arrow {@link FieldVector} and is never
- * actually serialized — it lives only for the duration of a columnar segment build. The suppression
- * silences the missing-{@code serialVersionUID} warning; matches the Pinot convention used by other
- * incidentally-{@code Serializable} build-time helpers.
+ * <p>{@code @SuppressWarnings("serial")}: {@link ColumnReader} is {@link java.io.Serializable} by SPI
+ * contract, but this reader holds non-serializable Arrow state and is never serialized — it lives
+ * only for the duration of a columnar segment build.
  *
  * <p>This class is not thread-safe.
  */
@@ -414,12 +412,11 @@ public class ArrowColumnReader implements ColumnReader {
   }
 
   @Override
+  @Nullable
   public Object getValue(int docId)
       throws IOException {
     checkBounds(docId);
-    // BitVector maps to Pinot INT (0/1). The shared converter would surface a Boolean via
-    // FieldVector.getObject, so special-case it here to stay consistent with getInt() and the
-    // advertised INT mapping. See the "BitVector caveat" in the class Javadoc.
+    // BitVector -> INT (0/1); see the BitVector caveat in the class Javadoc.
     if (_vector instanceof BitVector) {
       return _vector.isNull(docId) ? null : ((BitVector) _vector).get(docId);
     }
@@ -437,25 +434,101 @@ public class ArrowColumnReader implements ColumnReader {
   @Override
   public MultiValueResult<int[]> getIntMV(int docId)
       throws IOException {
-    return readPrimitiveMV(docId, int[].class);
+    checkBounds(docId);
+    requireListVector();
+    ListVector list = (ListVector) _vector;
+    FieldVector elements = list.getDataVector();
+    int start = list.getElementStartIndex(docId);
+    int length = list.getElementEndIndex(docId) - start;
+    BitSet nulls = elementNulls(elements, start, length);
+    int[] values = new int[length];
+    if (elements instanceof IntVector) {
+      IntVector iv = (IntVector) elements;
+      for (int i = 0; i < length; i++) {
+        if (notNull(nulls, i)) {
+          values[i] = iv.get(start + i);
+        }
+      }
+    } else if (elements instanceof BitVector) {
+      BitVector bv = (BitVector) elements;
+      for (int i = 0; i < length; i++) {
+        if (notNull(nulls, i)) {
+          values[i] = bv.get(start + i);
+        }
+      }
+    } else {
+      throw typeMismatch("INT_MV");
+    }
+    return MultiValueResult.of(values, nulls);
   }
 
   @Override
   public MultiValueResult<long[]> getLongMV(int docId)
       throws IOException {
-    return readPrimitiveMV(docId, long[].class);
+    checkBounds(docId);
+    requireListVector();
+    ListVector list = (ListVector) _vector;
+    FieldVector elements = list.getDataVector();
+    if (!(elements instanceof BigIntVector)) {
+      throw typeMismatch("LONG_MV");
+    }
+    BigIntVector lv = (BigIntVector) elements;
+    int start = list.getElementStartIndex(docId);
+    int length = list.getElementEndIndex(docId) - start;
+    BitSet nulls = elementNulls(elements, start, length);
+    long[] values = new long[length];
+    for (int i = 0; i < length; i++) {
+      if (notNull(nulls, i)) {
+        values[i] = lv.get(start + i);
+      }
+    }
+    return MultiValueResult.of(values, nulls);
   }
 
   @Override
   public MultiValueResult<float[]> getFloatMV(int docId)
       throws IOException {
-    return readPrimitiveMV(docId, float[].class);
+    checkBounds(docId);
+    requireListVector();
+    ListVector list = (ListVector) _vector;
+    FieldVector elements = list.getDataVector();
+    if (!(elements instanceof Float4Vector)) {
+      throw typeMismatch("FLOAT_MV");
+    }
+    Float4Vector fv = (Float4Vector) elements;
+    int start = list.getElementStartIndex(docId);
+    int length = list.getElementEndIndex(docId) - start;
+    BitSet nulls = elementNulls(elements, start, length);
+    float[] values = new float[length];
+    for (int i = 0; i < length; i++) {
+      if (notNull(nulls, i)) {
+        values[i] = fv.get(start + i);
+      }
+    }
+    return MultiValueResult.of(values, nulls);
   }
 
   @Override
   public MultiValueResult<double[]> getDoubleMV(int docId)
       throws IOException {
-    return readPrimitiveMV(docId, double[].class);
+    checkBounds(docId);
+    requireListVector();
+    ListVector list = (ListVector) _vector;
+    FieldVector elements = list.getDataVector();
+    if (!(elements instanceof Float8Vector)) {
+      throw typeMismatch("DOUBLE_MV");
+    }
+    Float8Vector dv = (Float8Vector) elements;
+    int start = list.getElementStartIndex(docId);
+    int length = list.getElementEndIndex(docId) - start;
+    BitSet nulls = elementNulls(elements, start, length);
+    double[] values = new double[length];
+    for (int i = 0; i < length; i++) {
+      if (notNull(nulls, i)) {
+        values[i] = dv.get(start + i);
+      }
+    }
+    return MultiValueResult.of(values, nulls);
   }
 
   @Override
@@ -527,107 +600,28 @@ public class ArrowColumnReader implements ColumnReader {
   }
 
   /**
-   * Read a primitive multi-value from a {@link ListVector}, populating a fresh array and a
-   * nulls BitSet for element-level validity.
+   * Scan element-level validity for the list slice {@code [start, start + length)} of
+   * {@code elements}, returning a BitSet whose set bits mark null elements, or {@code null} when no
+   * element is null (the common case, so callers skip the per-element check). The returned index
+   * space is element-local: bit {@code i} corresponds to element {@code start + i}.
    */
-  @SuppressWarnings("unchecked")
-  private <T> MultiValueResult<T> readPrimitiveMV(int docId, Class<T> arrayClass)
-      throws IOException {
-    checkBounds(docId);
-    requireListVector();
-    ListVector list = (ListVector) _vector;
-    int start = list.getElementStartIndex(docId);
-    int end = list.getElementEndIndex(docId);
-    int length = end - start;
-    FieldVector elements = list.getDataVector();
+  @Nullable
+  private static BitSet elementNulls(FieldVector elements, int start, int length) {
     BitSet nulls = null;
-
-    Object array;
-    if (arrayClass == int[].class) {
-      int[] values = new int[length];
-      if (elements instanceof IntVector) {
-        IntVector iv = (IntVector) elements;
-        for (int i = 0; i < length; i++) {
-          if (iv.isNull(start + i)) {
-            if (nulls == null) {
-              nulls = new BitSet(length);
-            }
-            nulls.set(i);
-          } else {
-            values[i] = iv.get(start + i);
-          }
+    for (int i = 0; i < length; i++) {
+      if (elements.isNull(start + i)) {
+        if (nulls == null) {
+          nulls = new BitSet(length);
         }
-      } else if (elements instanceof BitVector) {
-        BitVector bv = (BitVector) elements;
-        for (int i = 0; i < length; i++) {
-          if (bv.isNull(start + i)) {
-            if (nulls == null) {
-              nulls = new BitSet(length);
-            }
-            nulls.set(i);
-          } else {
-            values[i] = bv.get(start + i);
-          }
-        }
-      } else {
-        throw typeMismatch("INT_MV");
+        nulls.set(i);
       }
-      array = values;
-    } else if (arrayClass == long[].class) {
-      long[] values = new long[length];
-      if (!(elements instanceof BigIntVector)) {
-        throw typeMismatch("LONG_MV");
-      }
-      BigIntVector lv = (BigIntVector) elements;
-      for (int i = 0; i < length; i++) {
-        if (lv.isNull(start + i)) {
-          if (nulls == null) {
-            nulls = new BitSet(length);
-          }
-          nulls.set(i);
-        } else {
-          values[i] = lv.get(start + i);
-        }
-      }
-      array = values;
-    } else if (arrayClass == float[].class) {
-      float[] values = new float[length];
-      if (!(elements instanceof Float4Vector)) {
-        throw typeMismatch("FLOAT_MV");
-      }
-      Float4Vector fv = (Float4Vector) elements;
-      for (int i = 0; i < length; i++) {
-        if (fv.isNull(start + i)) {
-          if (nulls == null) {
-            nulls = new BitSet(length);
-          }
-          nulls.set(i);
-        } else {
-          values[i] = fv.get(start + i);
-        }
-      }
-      array = values;
-    } else if (arrayClass == double[].class) {
-      double[] values = new double[length];
-      if (!(elements instanceof Float8Vector)) {
-        throw typeMismatch("DOUBLE_MV");
-      }
-      Float8Vector dv = (Float8Vector) elements;
-      for (int i = 0; i < length; i++) {
-        if (dv.isNull(start + i)) {
-          if (nulls == null) {
-            nulls = new BitSet(length);
-          }
-          nulls.set(i);
-        } else {
-          values[i] = dv.get(start + i);
-        }
-      }
-      array = values;
-    } else {
-      throw new IOException("Unsupported primitive MV array type: " + arrayClass.getName());
     }
-    return MultiValueResult.of((T) array, nulls);
+    return nulls;
+  }
+
+  /** True when element {@code i} is not null, given the {@link #elementNulls} BitSet (possibly null). */
+  private static boolean notNull(@Nullable BitSet nulls, int i) {
+    return nulls == null || !nulls.get(i);
   }
 
   /**

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReaderFactory.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReaderFactory.java
@@ -49,9 +49,8 @@ import org.apache.pinot.spi.data.readers.ColumnReaderFactory;
  *
  * <p>This class is not thread-safe.
  *
- * <p>{@code @SuppressWarnings("serial")}: {@link ColumnReaderFactory} extends {@link
- * java.io.Serializable} by SPI contract, but this factory holds non-serializable Arrow handles and
- * is never actually serialized — it exists only for the duration of a columnar segment build.
+ * <p>{@code @SuppressWarnings("serial")}: {@link ColumnReaderFactory} is {@link java.io.Serializable}
+ * by SPI contract, but this factory holds non-serializable Arrow handles and is never serialized.
  */
 @SuppressWarnings("serial")
 public class ArrowColumnReaderFactory implements ColumnReaderFactory {

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReaderFactory.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReaderFactory.java
@@ -48,8 +48,17 @@ import org.apache.pinot.spi.data.readers.ColumnReaderFactory;
  * ArrowFileColumnReaderFactory}.
  *
  * <p>This class is not thread-safe.
+ *
+ * <p>{@code @SuppressWarnings("serial")}: {@link ColumnReaderFactory} extends {@link
+ * java.io.Serializable} by SPI contract, but this factory holds non-serializable Arrow handles and
+ * is never actually serialized — it exists only for the duration of a columnar segment build.
  */
+@SuppressWarnings("serial")
 public class ArrowColumnReaderFactory implements ColumnReaderFactory {
+
+  /// Config key (mirrors {@link ArrowRecordExtractorConfig#EXTRACT_RAW_TIME_VALUES} on the row-major
+  /// path): when `true`, temporal columns surface raw epoch values rather than canonical JDK types.
+  public static final String CONFIG_EXTRACT_RAW_TIME_VALUES = ArrowRecordExtractorConfig.EXTRACT_RAW_TIME_VALUES;
 
   private final ArrowReader _reader;
   private final BufferAllocator _allocator;
@@ -88,14 +97,16 @@ public class ArrowColumnReaderFactory implements ColumnReaderFactory {
   /**
    * Initialise the factory. {@code colsToRead == null} or an empty set both mean "read all
    * non-virtual columns from {@code targetSchema} that the Arrow source actually contains"; pass a
-   * non-empty set to restrict to a subset. The {@code configs} map is ignored — allocator sizing
-   * is the caller's responsibility for this factory.
+   * non-empty set to restrict to a subset. Allocator sizing is the caller's responsibility for this
+   * factory; the only honored {@code configs} key is {@link #CONFIG_EXTRACT_RAW_TIME_VALUES}.
    */
   @Override
   public void init(Schema targetSchema, @Nullable Set<String> colsToRead, Map<String, String> configs)
       throws IOException {
+    boolean extractRawTimeValues =
+        configs != null && Boolean.parseBoolean(configs.get(CONFIG_EXTRACT_RAW_TIME_VALUES));
     ArrowAccumulators.Result built =
-        ArrowAccumulators.populate(_reader, _allocator, targetSchema, colsToRead);
+        ArrowAccumulators.populate(_reader, _allocator, targetSchema, colsToRead, extractRawTimeValues);
     _accumulatorVectors = built.getAccumulators();
     _columnReaders = built.getReaders();
     _availableColumnNames = built.getAvailableColumns();

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReaderFactory.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReaderFactory.java
@@ -102,6 +102,12 @@ public class ArrowColumnReaderFactory implements ColumnReaderFactory {
   @Override
   public void init(Schema targetSchema, @Nullable Set<String> colsToRead, Map<String, String> configs)
       throws IOException {
+    if (_initialized) {
+      // Defensive: a second init() would otherwise overwrite _accumulatorVectors and leak the prior
+      // init's off-heap accumulator vectors (close() would only ever release the latest set). Release
+      // them first, mirroring ArrowFileColumnReaderFactory.init().
+      close();
+    }
     boolean extractRawTimeValues =
         configs != null && Boolean.parseBoolean(configs.get(CONFIG_EXTRACT_RAW_TIME_VALUES));
     ArrowAccumulators.Result built =

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReaderFactory.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReaderFactory.java
@@ -1,0 +1,143 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.arrow;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.ColumnReader;
+import org.apache.pinot.spi.data.readers.ColumnReaderFactory;
+
+
+/**
+ * {@link ColumnReaderFactory} backed by a caller-managed {@link ArrowReader}.
+ *
+ * <p>The caller supplies an already-open {@link ArrowReader} (any subclass — {@code
+ * ArrowFileReader}, {@code ArrowStreamReader}, or a custom subclass that yields in-process record
+ * batches) plus the {@link BufferAllocator} the reader was opened against. Per-column accumulator
+ * vectors are allocated against that allocator and concatenated from the reader's batches via the
+ * shared {@link ArrowAccumulators} helper, then exposed as one {@link ArrowColumnReader} per
+ * accumulator.
+ *
+ * <p><b>Ownership:</b> the supplied {@link ArrowReader} and {@link BufferAllocator} are owned by
+ * the caller and are NOT closed by this factory. Per-column accumulator vectors created during
+ * {@link #init} ARE owned by the factory and are released on {@link #close}. For the file-backed
+ * convenience that opens and owns its own reader and allocator, see {@link
+ * ArrowFileColumnReaderFactory}.
+ *
+ * <p>This class is not thread-safe.
+ */
+public class ArrowColumnReaderFactory implements ColumnReaderFactory {
+
+  private final ArrowReader _reader;
+  private final BufferAllocator _allocator;
+
+  private transient Map<String, FieldVector> _accumulatorVectors;
+  private transient Map<String, ColumnReader> _columnReaders;
+  private transient Set<String> _availableColumnNames;
+  private transient boolean _initialized;
+
+  /**
+   * Construct a factory reading from the given Arrow reader and allocator.
+   *
+   * @param reader Caller-managed Arrow reader (e.g. {@code ArrowStreamReader} over a byte buffer,
+   *               or a custom reader yielding pre-populated record batches). Not closed by this
+   *               factory.
+   * @param allocator Caller-managed Arrow allocator used for per-column accumulator allocations.
+   *                  Not closed by this factory.
+   */
+  public ArrowColumnReaderFactory(ArrowReader reader, BufferAllocator allocator) {
+    _reader = reader;
+    _allocator = allocator;
+  }
+
+  @Override
+  public void init(Schema targetSchema)
+      throws IOException {
+    init(targetSchema, null, Collections.emptyMap());
+  }
+
+  @Override
+  public void init(Schema targetSchema, Set<String> colsToRead)
+      throws IOException {
+    init(targetSchema, colsToRead, Collections.emptyMap());
+  }
+
+  /**
+   * Initialise the factory. {@code colsToRead == null} or an empty set both mean "read all
+   * non-virtual columns from {@code targetSchema} that the Arrow source actually contains"; pass a
+   * non-empty set to restrict to a subset. The {@code configs} map is ignored — allocator sizing
+   * is the caller's responsibility for this factory.
+   */
+  @Override
+  public void init(Schema targetSchema, @Nullable Set<String> colsToRead, Map<String, String> configs)
+      throws IOException {
+    ArrowAccumulators.Result built =
+        ArrowAccumulators.populate(_reader, _allocator, targetSchema, colsToRead);
+    _accumulatorVectors = built.getAccumulators();
+    _columnReaders = built.getReaders();
+    _availableColumnNames = built.getAvailableColumns();
+    _initialized = true;
+  }
+
+  @Override
+  public Set<String> getAvailableColumns() {
+    requireInitialized();
+    return _availableColumnNames;
+  }
+
+  @Override
+  @Nullable
+  public ColumnReader getColumnReader(String columnName) {
+    requireInitialized();
+    return _columnReaders.get(columnName);
+  }
+
+  @Override
+  public Map<String, ColumnReader> getAllColumnReaders() {
+    requireInitialized();
+    return Collections.unmodifiableMap(_columnReaders);
+  }
+
+  private void requireInitialized() {
+    if (!_initialized) {
+      throw new IllegalStateException("ArrowColumnReaderFactory must be initialized before use");
+    }
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    // _reader and _allocator are caller-owned; only release the accumulator vectors we created.
+    IOException accumulatorCloseFailure = ArrowAccumulators.closeAll(_accumulatorVectors);
+    _accumulatorVectors = null;
+    _columnReaders = null;
+    _availableColumnNames = null;
+    _initialized = false;
+    if (accumulatorCloseFailure != null) {
+      throw accumulatorCloseFailure;
+    }
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowFileColumnReaderFactory.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowFileColumnReaderFactory.java
@@ -19,15 +19,14 @@
 package org.apache.pinot.plugin.inputformat.arrow;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
-import org.apache.arrow.memory.RootAllocator;
-import org.apache.arrow.vector.FieldVector;
-import org.apache.arrow.vector.ipc.ArrowFileReader;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.ColumnReader;
 import org.apache.pinot.spi.data.readers.ColumnReaderFactory;
@@ -36,32 +35,36 @@ import org.apache.pinot.spi.data.readers.ColumnReaderFactory;
 /**
  * {@link ColumnReaderFactory} backed by an Apache Arrow IPC file on disk.
  *
- * <p>File-specialised convenience over {@link ArrowColumnReaderFactory}: this class opens a private
- * {@link RootAllocator} sized by {@link #CONFIG_ALLOCATOR_LIMIT}, opens the file via
- * {@link ArrowFileReader}, concatenates all record batches into per-column accumulators via the
- * shared {@link ArrowAccumulators} helper, and closes the file, reader, and allocator on
- * {@link #close}. Callers that already manage an {@link org.apache.arrow.vector.ipc.ArrowReader}
- * and {@link org.apache.arrow.memory.BufferAllocator} themselves should use
- * {@link ArrowColumnReaderFactory} directly.
+ * <p>File-specialised companion to {@link ArrowColumnReaderFactory} (which takes a caller-managed
+ * reader): this class opens and owns the file, the {@link org.apache.arrow.vector.ipc.ArrowFileReader},
+ * and a private allocator sized by {@link #CONFIG_ALLOCATOR_LIMIT}, all wrapped in a
+ * {@link BatchedArrowFileSource}, and closes them on {@link #close}.
+ *
+ * <p><b>Memory model — one record batch resident.</b> The file is read <b>one record batch at a
+ * time</b> through the seekable {@code ArrowFileReader}; the per-column {@link
+ * BatchedArrowColumnReader}s created here share a single batch cursor, so peak resident memory is the
+ * largest record batch rather than the whole materialised column set. That is the same model as the
+ * row-major {@link ArrowRecordReader}, and the batch size is a write-time, producer-chosen property.
+ * The trade-off is read amplification: consuming each column to completion re-loads every batch, so a
+ * column-major build over an {@code N}-column, multi-batch file performs {@code N x} batch loads —
+ * the accepted cost of Arrow's horizontal record-batch layout. A pathological single oversized batch
+ * is bounded by {@link #CONFIG_ALLOCATOR_LIMIT}: the build throws a catchable Arrow
+ * {@code OutOfMemoryException} at the ceiling rather than exhausting the heap.
  *
  * <p>{@link #getAvailableColumns()} reports the columns actually present in the Arrow source. A
  * target-schema column that is NOT present is absent from that set, and {@link
- * #getColumnReader(String)} returns {@code null} for it; supplying schema-evolution defaults for
- * such columns is the columnar build driver's responsibility.
+ * #getColumnReader(String)} returns {@code null} for it; supplying schema-evolution defaults for such
+ * columns is the columnar build driver's responsibility.
  *
- * <p><b>Dictionary-encoded columns are supported</b> (dictionary encoding is the standard Arrow
- * representation for low-cardinality strings): the shared {@link ArrowAccumulators} decodes each
- * batch against the bound dictionary via {@code DictionaryEncoder.decode} — mirroring the row-major
- * {@link ArrowRecordExtractor} — and accumulates the decoded logical values, so the produced segment
- * matches the row-major path for the same file.
+ * <p><b>Dictionary-encoded columns are supported</b> (the standard Arrow representation for
+ * low-cardinality strings): each batch is decoded against the bound dictionary via
+ * {@code DictionaryEncoder.decode}, mirroring the row-major {@link ArrowRecordExtractor}, so the
+ * produced segment matches the row-major path for the same file.
  *
- * <p>This class is not thread-safe. For very large inputs the per-column accumulators materialise
- * the full column set in the Arrow allocator; partition upstream so each factory instance handles
- * one shard.
- *
- * <p>{@code @SuppressWarnings("serial")}: {@link ColumnReaderFactory} extends {@link
- * java.io.Serializable} by SPI contract, but this factory holds non-serializable Arrow handles and
- * is never actually serialized — it exists only for the duration of a columnar segment build.
+ * <p>This class is not thread-safe. {@code @SuppressWarnings("serial")}: {@link ColumnReaderFactory}
+ * extends {@link java.io.Serializable} by SPI contract, but this factory holds non-serializable Arrow
+ * handles and is never actually serialized — it exists only for the duration of a columnar segment
+ * build.
  */
 @SuppressWarnings("serial")
 public class ArrowFileColumnReaderFactory implements ColumnReaderFactory {
@@ -78,13 +81,8 @@ public class ArrowFileColumnReaderFactory implements ColumnReaderFactory {
 
   private final File _dataFile;
 
-  private transient RootAllocator _allocator;
-  private transient FileInputStream _fileInputStream;
-  private transient ArrowFileReader _arrowFileReader;
-  // Per-column accumulator vectors holding values concatenated across all input batches.
-  // Owned by this factory; released in close() before the allocator.
-  private transient Map<String, FieldVector> _accumulatorVectors;
-  // Cached ColumnReader instances keyed by Pinot column name.
+  private transient BatchedArrowFileSource _source;
+  // ColumnReader instances (one per wanted, present column) over the shared batch-bounded source.
   private transient Map<String, ColumnReader> _columnReaders;
   private transient Set<String> _availableColumnNames;
   private transient boolean _initialized;
@@ -118,26 +116,30 @@ public class ArrowFileColumnReaderFactory implements ColumnReaderFactory {
   @Override
   public void init(Schema targetSchema, @Nullable Set<String> colsToRead, Map<String, String> configs)
       throws IOException {
+    if (_source != null) {
+      // Defensive: a second init() would otherwise overwrite _source and leak the prior source's
+      // file handle and allocator. Release it first.
+      close();
+    }
     long allocatorLimit = parseAllocatorLimit(configs);
     boolean extractRawTimeValues =
         configs != null && Boolean.parseBoolean(configs.get(CONFIG_EXTRACT_RAW_TIME_VALUES));
     try {
-      _allocator = new RootAllocator(allocatorLimit);
-      _fileInputStream = new FileInputStream(_dataFile);
-      _arrowFileReader = new ArrowFileReader(_fileInputStream.getChannel(), _allocator);
-
-      ArrowAccumulators.Result built = ArrowAccumulators.populate(_arrowFileReader, _allocator, targetSchema,
-          colsToRead, extractRawTimeValues);
-      _accumulatorVectors = built.getAccumulators();
-      _columnReaders = built.getReaders();
-      _availableColumnNames = built.getAvailableColumns();
-
+      _source = new BatchedArrowFileSource(_dataFile, allocatorLimit, extractRawTimeValues);
+      _availableColumnNames = _source.getAvailableColumns();
+      Set<String> wantedColumns = computeWantedColumns(targetSchema, colsToRead);
+      Map<String, ColumnReader> readers = new LinkedHashMap<>();
+      for (String name : _availableColumnNames) {
+        if (wantedColumns.isEmpty() || wantedColumns.contains(name)) {
+          readers.put(name, new BatchedArrowColumnReader(_source, name));
+        }
+      }
+      _columnReaders = readers;
       _initialized = true;
     } catch (RuntimeException | IOException e) {
-      // init() opens the allocator, file stream, and reader before populate() runs. If anything
-      // throws part-way, release whatever was opened — callers typically do not close a factory
-      // whose init() failed, so without this the file handle, ArrowFileReader, and RootAllocator
-      // would leak. close() is null-safe over the partially-assigned fields.
+      // The BatchedArrowFileSource opens the file, reader, and allocator in its constructor and
+      // releases them on its own failure; if a later step here throws, close() releases the source.
+      // Callers typically do not close a factory whose init() failed, so this prevents a leak.
       try {
         close();
       } catch (IOException closeFailure) {
@@ -145,6 +147,19 @@ public class ArrowFileColumnReaderFactory implements ColumnReaderFactory {
       }
       throw e;
     }
+  }
+
+  private Set<String> computeWantedColumns(Schema targetSchema, @Nullable Set<String> colsToRead) {
+    if (colsToRead != null && !colsToRead.isEmpty()) {
+      return new HashSet<>(colsToRead);
+    }
+    Set<String> wanted = new HashSet<>();
+    for (FieldSpec fieldSpec : targetSchema.getAllFieldSpecs()) {
+      if (!fieldSpec.isVirtualColumn()) {
+        wanted.add(fieldSpec.getName());
+      }
+    }
+    return wanted;
   }
 
   private long parseAllocatorLimit(Map<String, String> configs) {
@@ -192,54 +207,17 @@ public class ArrowFileColumnReaderFactory implements ColumnReaderFactory {
   @Override
   public void close()
       throws IOException {
-    // Close ordering: accumulator vectors first, then the file resources we opened (reader,
-    // stream, allocator). Each step's first failure is preserved and re-thrown at the end so
-    // later steps still run.
-    IOException firstException = ArrowAccumulators.closeAll(_accumulatorVectors);
-    _accumulatorVectors = null;
-
-    if (_arrowFileReader != null) {
-      try {
-        _arrowFileReader.close();
-      } catch (IOException e) {
-        if (firstException == null) {
-          firstException = e;
-        }
-      } finally {
-        _arrowFileReader = null;
-      }
-    }
-
-    if (_fileInputStream != null) {
-      try {
-        _fileInputStream.close();
-      } catch (IOException e) {
-        if (firstException == null) {
-          firstException = e;
-        }
-      } finally {
-        _fileInputStream = null;
-      }
-    }
-
-    if (_allocator != null) {
-      try {
-        _allocator.close();
-      } catch (Exception e) {
-        if (firstException == null) {
-          firstException = new IOException("Failed to close Arrow allocator", e);
-        }
-      } finally {
-        _allocator = null;
-      }
-    }
-
     _columnReaders = null;
     _availableColumnNames = null;
     _initialized = false;
-
-    if (firstException != null) {
-      throw firstException;
+    // The source owns the file, reader, and allocator; closing it releases them (and any current
+    // batch's decoded vectors). The per-column readers hold only a reference to it.
+    if (_source != null) {
+      try {
+        _source.close();
+      } finally {
+        _source = null;
+      }
     }
   }
 }

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowFileColumnReaderFactory.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowFileColumnReaderFactory.java
@@ -44,14 +44,26 @@ import org.apache.pinot.spi.data.readers.ColumnReaderFactory;
  * and {@link org.apache.arrow.memory.BufferAllocator} themselves should use
  * {@link ArrowColumnReaderFactory} directly.
  *
- * <p>Columns in the target schema that are absent from the Arrow file are reported via
- * {@link #getAvailableColumns()}, and {@link #getColumnReader(String)} returns {@code null} for
- * them; schema-evolution defaults are the columnar build driver's responsibility.
+ * <p>{@link #getAvailableColumns()} reports the columns actually present in the Arrow source. A
+ * target-schema column that is NOT present is absent from that set, and {@link
+ * #getColumnReader(String)} returns {@code null} for it; supplying schema-evolution defaults for
+ * such columns is the columnar build driver's responsibility.
+ *
+ * <p><b>Dictionary-encoded columns are supported</b> (dictionary encoding is the standard Arrow
+ * representation for low-cardinality strings): the shared {@link ArrowAccumulators} decodes each
+ * batch against the bound dictionary via {@code DictionaryEncoder.decode} — mirroring the row-major
+ * {@link ArrowRecordExtractor} — and accumulates the decoded logical values, so the produced segment
+ * matches the row-major path for the same file.
  *
  * <p>This class is not thread-safe. For very large inputs the per-column accumulators materialise
  * the full column set in the Arrow allocator; partition upstream so each factory instance handles
  * one shard.
+ *
+ * <p>{@code @SuppressWarnings("serial")}: {@link ColumnReaderFactory} extends {@link
+ * java.io.Serializable} by SPI contract, but this factory holds non-serializable Arrow handles and
+ * is never actually serialized — it exists only for the duration of a columnar segment build.
  */
+@SuppressWarnings("serial")
 public class ArrowFileColumnReaderFactory implements ColumnReaderFactory {
 
   /// Default allocator limit when no `configs` override is supplied. Matches
@@ -59,6 +71,10 @@ public class ArrowFileColumnReaderFactory implements ColumnReaderFactory {
   /// memory ceiling whether they pick the row-major or column-major reader path.
   public static final String CONFIG_ALLOCATOR_LIMIT = "arrowAllocatorLimit";
   public static final long DEFAULT_ALLOCATOR_LIMIT = ArrowRecordReaderConfig.DEFAULT_ALLOCATOR_LIMIT;
+
+  /// Config key (mirrors {@link ArrowRecordExtractorConfig#EXTRACT_RAW_TIME_VALUES} on the row-major
+  /// path): when `true`, temporal columns surface raw epoch values rather than canonical JDK types.
+  public static final String CONFIG_EXTRACT_RAW_TIME_VALUES = ArrowRecordExtractorConfig.EXTRACT_RAW_TIME_VALUES;
 
   private final File _dataFile;
 
@@ -103,17 +119,32 @@ public class ArrowFileColumnReaderFactory implements ColumnReaderFactory {
   public void init(Schema targetSchema, @Nullable Set<String> colsToRead, Map<String, String> configs)
       throws IOException {
     long allocatorLimit = parseAllocatorLimit(configs);
-    _allocator = new RootAllocator(allocatorLimit);
-    _fileInputStream = new FileInputStream(_dataFile);
-    _arrowFileReader = new ArrowFileReader(_fileInputStream.getChannel(), _allocator);
+    boolean extractRawTimeValues =
+        configs != null && Boolean.parseBoolean(configs.get(CONFIG_EXTRACT_RAW_TIME_VALUES));
+    try {
+      _allocator = new RootAllocator(allocatorLimit);
+      _fileInputStream = new FileInputStream(_dataFile);
+      _arrowFileReader = new ArrowFileReader(_fileInputStream.getChannel(), _allocator);
 
-    ArrowAccumulators.Result built =
-        ArrowAccumulators.populate(_arrowFileReader, _allocator, targetSchema, colsToRead);
-    _accumulatorVectors = built.getAccumulators();
-    _columnReaders = built.getReaders();
-    _availableColumnNames = built.getAvailableColumns();
+      ArrowAccumulators.Result built = ArrowAccumulators.populate(_arrowFileReader, _allocator, targetSchema,
+          colsToRead, extractRawTimeValues);
+      _accumulatorVectors = built.getAccumulators();
+      _columnReaders = built.getReaders();
+      _availableColumnNames = built.getAvailableColumns();
 
-    _initialized = true;
+      _initialized = true;
+    } catch (RuntimeException | IOException e) {
+      // init() opens the allocator, file stream, and reader before populate() runs. If anything
+      // throws part-way, release whatever was opened — callers typically do not close a factory
+      // whose init() failed, so without this the file handle, ArrowFileReader, and RootAllocator
+      // would leak. close() is null-safe over the partially-assigned fields.
+      try {
+        close();
+      } catch (IOException closeFailure) {
+        e.addSuppressed(closeFailure);
+      }
+      throw e;
+    }
   }
 
   private long parseAllocatorLimit(Map<String, String> configs) {

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowFileColumnReaderFactory.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowFileColumnReaderFactory.java
@@ -21,12 +21,10 @@ package org.apache.pinot.plugin.inputformat.arrow;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.ColumnReader;
 import org.apache.pinot.spi.data.readers.ColumnReaderFactory;
@@ -40,31 +38,23 @@ import org.apache.pinot.spi.data.readers.ColumnReaderFactory;
  * and a private allocator sized by {@link #CONFIG_ALLOCATOR_LIMIT}, all wrapped in a
  * {@link BatchedArrowFileSource}, and closes them on {@link #close}.
  *
- * <p><b>Memory model — one record batch resident.</b> The file is read <b>one record batch at a
- * time</b> through the seekable {@code ArrowFileReader}; the per-column {@link
- * BatchedArrowColumnReader}s created here share a single batch cursor, so peak resident memory is the
- * largest record batch rather than the whole materialised column set. That is the same model as the
- * row-major {@link ArrowRecordReader}, and the batch size is a write-time, producer-chosen property.
- * The trade-off is read amplification: consuming each column to completion re-loads every batch, so a
- * column-major build over an {@code N}-column, multi-batch file performs {@code N x} batch loads —
- * the accepted cost of Arrow's horizontal record-batch layout. A pathological single oversized batch
- * is bounded by {@link #CONFIG_ALLOCATOR_LIMIT}: the build throws a catchable Arrow
- * {@code OutOfMemoryException} at the ceiling rather than exhausting the heap.
+ * <p><b>Memory model — one record batch resident.</b> See {@link BatchedArrowFileSource} for the
+ * batch-bounded reading model and its read-amplification trade-off; the per-column {@link
+ * BatchedArrowColumnReader}s created here share that source's single batch cursor. A pathological
+ * single oversized batch is bounded by {@link #CONFIG_ALLOCATOR_LIMIT}, which throws a catchable
+ * Arrow {@code OutOfMemoryException} at the ceiling rather than exhausting the heap.
  *
  * <p>{@link #getAvailableColumns()} reports the columns actually present in the Arrow source. A
  * target-schema column that is NOT present is absent from that set, and {@link
  * #getColumnReader(String)} returns {@code null} for it; supplying schema-evolution defaults for such
  * columns is the columnar build driver's responsibility.
  *
- * <p><b>Dictionary-encoded columns are supported</b> (the standard Arrow representation for
- * low-cardinality strings): each batch is decoded against the bound dictionary via
- * {@code DictionaryEncoder.decode}, mirroring the row-major {@link ArrowRecordExtractor}, so the
- * produced segment matches the row-major path for the same file.
+ * <p>Dictionary-encoded columns are supported; see {@link BatchedArrowFileSource} for how each batch
+ * is decoded against its bound dictionary.
  *
  * <p>This class is not thread-safe. {@code @SuppressWarnings("serial")}: {@link ColumnReaderFactory}
- * extends {@link java.io.Serializable} by SPI contract, but this factory holds non-serializable Arrow
- * handles and is never actually serialized — it exists only for the duration of a columnar segment
- * build.
+ * is {@link java.io.Serializable} by SPI contract, but this factory holds non-serializable Arrow
+ * handles and is never serialized.
  */
 @SuppressWarnings("serial")
 public class ArrowFileColumnReaderFactory implements ColumnReaderFactory {
@@ -127,7 +117,7 @@ public class ArrowFileColumnReaderFactory implements ColumnReaderFactory {
     try {
       _source = new BatchedArrowFileSource(_dataFile, allocatorLimit, extractRawTimeValues);
       _availableColumnNames = _source.getAvailableColumns();
-      Set<String> wantedColumns = computeWantedColumns(targetSchema, colsToRead);
+      Set<String> wantedColumns = ArrowAccumulators.computeWantedColumns(targetSchema, colsToRead);
       Map<String, ColumnReader> readers = new LinkedHashMap<>();
       for (String name : _availableColumnNames) {
         if (wantedColumns.isEmpty() || wantedColumns.contains(name)) {
@@ -147,19 +137,6 @@ public class ArrowFileColumnReaderFactory implements ColumnReaderFactory {
       }
       throw e;
     }
-  }
-
-  private Set<String> computeWantedColumns(Schema targetSchema, @Nullable Set<String> colsToRead) {
-    if (colsToRead != null && !colsToRead.isEmpty()) {
-      return new HashSet<>(colsToRead);
-    }
-    Set<String> wanted = new HashSet<>();
-    for (FieldSpec fieldSpec : targetSchema.getAllFieldSpecs()) {
-      if (!fieldSpec.isVirtualColumn()) {
-        wanted.add(fieldSpec.getName());
-      }
-    }
-    return wanted;
   }
 
   private long parseAllocatorLimit(Map<String, String> configs) {

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowFileColumnReaderFactory.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowFileColumnReaderFactory.java
@@ -1,0 +1,214 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.arrow;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.ipc.ArrowFileReader;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.ColumnReader;
+import org.apache.pinot.spi.data.readers.ColumnReaderFactory;
+
+
+/**
+ * {@link ColumnReaderFactory} backed by an Apache Arrow IPC file on disk.
+ *
+ * <p>File-specialised convenience over {@link ArrowColumnReaderFactory}: this class opens a private
+ * {@link RootAllocator} sized by {@link #CONFIG_ALLOCATOR_LIMIT}, opens the file via
+ * {@link ArrowFileReader}, concatenates all record batches into per-column accumulators via the
+ * shared {@link ArrowAccumulators} helper, and closes the file, reader, and allocator on
+ * {@link #close}. Callers that already manage an {@link org.apache.arrow.vector.ipc.ArrowReader}
+ * and {@link org.apache.arrow.memory.BufferAllocator} themselves should use
+ * {@link ArrowColumnReaderFactory} directly.
+ *
+ * <p>Columns in the target schema that are absent from the Arrow file are reported via
+ * {@link #getAvailableColumns()}, and {@link #getColumnReader(String)} returns {@code null} for
+ * them; schema-evolution defaults are the columnar build driver's responsibility.
+ *
+ * <p>This class is not thread-safe. For very large inputs the per-column accumulators materialise
+ * the full column set in the Arrow allocator; partition upstream so each factory instance handles
+ * one shard.
+ */
+public class ArrowFileColumnReaderFactory implements ColumnReaderFactory {
+
+  /// Default allocator limit when no `configs` override is supplied. Matches
+  /// {@link ArrowRecordReaderConfig#DEFAULT_ALLOCATOR_LIMIT} so users get the same
+  /// memory ceiling whether they pick the row-major or column-major reader path.
+  public static final String CONFIG_ALLOCATOR_LIMIT = "arrowAllocatorLimit";
+  public static final long DEFAULT_ALLOCATOR_LIMIT = ArrowRecordReaderConfig.DEFAULT_ALLOCATOR_LIMIT;
+
+  private final File _dataFile;
+
+  private transient RootAllocator _allocator;
+  private transient FileInputStream _fileInputStream;
+  private transient ArrowFileReader _arrowFileReader;
+  // Per-column accumulator vectors holding values concatenated across all input batches.
+  // Owned by this factory; released in close() before the allocator.
+  private transient Map<String, FieldVector> _accumulatorVectors;
+  // Cached ColumnReader instances keyed by Pinot column name.
+  private transient Map<String, ColumnReader> _columnReaders;
+  private transient Set<String> _availableColumnNames;
+  private transient boolean _initialized;
+
+  /**
+   * Construct a factory reading from the given Arrow IPC file.
+   *
+   * @param dataFile Path to the Arrow IPC file to read
+   */
+  public ArrowFileColumnReaderFactory(File dataFile) {
+    _dataFile = dataFile;
+  }
+
+  @Override
+  public void init(Schema targetSchema)
+      throws IOException {
+    init(targetSchema, null, Collections.emptyMap());
+  }
+
+  @Override
+  public void init(Schema targetSchema, Set<String> colsToRead)
+      throws IOException {
+    init(targetSchema, colsToRead, Collections.emptyMap());
+  }
+
+  /**
+   * Initialise the factory. {@code colsToRead == null} or an empty set both mean "read all
+   * non-virtual columns from {@code targetSchema} that the Arrow file actually contains"; pass a
+   * non-empty set to restrict to a subset.
+   */
+  @Override
+  public void init(Schema targetSchema, @Nullable Set<String> colsToRead, Map<String, String> configs)
+      throws IOException {
+    long allocatorLimit = parseAllocatorLimit(configs);
+    _allocator = new RootAllocator(allocatorLimit);
+    _fileInputStream = new FileInputStream(_dataFile);
+    _arrowFileReader = new ArrowFileReader(_fileInputStream.getChannel(), _allocator);
+
+    ArrowAccumulators.Result built =
+        ArrowAccumulators.populate(_arrowFileReader, _allocator, targetSchema, colsToRead);
+    _accumulatorVectors = built.getAccumulators();
+    _columnReaders = built.getReaders();
+    _availableColumnNames = built.getAvailableColumns();
+
+    _initialized = true;
+  }
+
+  private long parseAllocatorLimit(Map<String, String> configs) {
+    if (configs == null) {
+      return DEFAULT_ALLOCATOR_LIMIT;
+    }
+    String raw = configs.get(CONFIG_ALLOCATOR_LIMIT);
+    if (raw == null) {
+      return DEFAULT_ALLOCATOR_LIMIT;
+    }
+    try {
+      return Long.parseLong(raw);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          "Invalid value '" + raw + "' for config '" + CONFIG_ALLOCATOR_LIMIT + "': expected a long",
+          e);
+    }
+  }
+
+  @Override
+  public Set<String> getAvailableColumns() {
+    requireInitialized();
+    return _availableColumnNames;
+  }
+
+  @Override
+  @Nullable
+  public ColumnReader getColumnReader(String columnName) {
+    requireInitialized();
+    return _columnReaders.get(columnName);
+  }
+
+  @Override
+  public Map<String, ColumnReader> getAllColumnReaders() {
+    requireInitialized();
+    return Collections.unmodifiableMap(_columnReaders);
+  }
+
+  private void requireInitialized() {
+    if (!_initialized) {
+      throw new IllegalStateException("ArrowFileColumnReaderFactory must be initialized before use");
+    }
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    // Close ordering: accumulator vectors first, then the file resources we opened (reader,
+    // stream, allocator). Each step's first failure is preserved and re-thrown at the end so
+    // later steps still run.
+    IOException firstException = ArrowAccumulators.closeAll(_accumulatorVectors);
+    _accumulatorVectors = null;
+
+    if (_arrowFileReader != null) {
+      try {
+        _arrowFileReader.close();
+      } catch (IOException e) {
+        if (firstException == null) {
+          firstException = e;
+        }
+      } finally {
+        _arrowFileReader = null;
+      }
+    }
+
+    if (_fileInputStream != null) {
+      try {
+        _fileInputStream.close();
+      } catch (IOException e) {
+        if (firstException == null) {
+          firstException = e;
+        }
+      } finally {
+        _fileInputStream = null;
+      }
+    }
+
+    if (_allocator != null) {
+      try {
+        _allocator.close();
+      } catch (Exception e) {
+        if (firstException == null) {
+          firstException = new IOException("Failed to close Arrow allocator", e);
+        }
+      } finally {
+        _allocator = null;
+      }
+    }
+
+    _columnReaders = null;
+    _availableColumnNames = null;
+    _initialized = false;
+
+    if (firstException != null) {
+      throw firstException;
+    }
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/BatchedArrowColumnReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/BatchedArrowColumnReader.java
@@ -40,14 +40,12 @@ import org.apache.pinot.spi.data.readers.MultiValueResult;
  * (decoded) Arrow {@link Field}, so they need no batch load. The column-major segment build consumes
  * each column to completion sequentially (rewind + next), one column at a time.
  *
- * <p>The per-batch delegate is rebuilt whenever this reader advances to a new batch <i>or the shared
- * source has been moved to a different batch by another reader</i> — the delegate wraps the source's
- * current-batch vector (raw vectors are refilled in place across loads, decoded dictionary vectors
- * are released on the next load), so a delegate from a no-longer-resident batch would read
- * overwritten or freed memory. With that guard, interleaving readers is correct (it just re-loads
- * batches); the build never interleaves.
+ * <p>The per-batch delegate is invalidated when the shared source moves to another batch (whether
+ * this reader advanced it or a different one did); {@link #delegate(int)} documents why and rebuilds
+ * it. Interleaving readers therefore stays correct (it just re-loads batches); the build never
+ * interleaves.
  *
- * <p>This class is not thread-safe. {@code @SuppressWarnings("serial")}: {@link ColumnReader} extends
+ * <p>This class is not thread-safe. {@code @SuppressWarnings("serial")}: {@link ColumnReader} is
  * {@link java.io.Serializable} by SPI contract, but this reader holds non-serializable Arrow state
  * and is never serialized.
  */

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/BatchedArrowColumnReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/BatchedArrowColumnReader.java
@@ -1,0 +1,484 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.arrow;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import javax.annotation.Nullable;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.pinot.spi.data.readers.ColumnReader;
+import org.apache.pinot.spi.data.readers.MultiValueResult;
+
+
+/**
+ * A {@link ColumnReader} over one column of a {@link BatchedArrowFileSource}. Reads are served by
+ * delegating to a per-batch {@link ArrowColumnReader} over the current record batch's column vector;
+ * the source loads at most one batch at a time, so peak resident memory is one batch (see
+ * {@link BatchedArrowFileSource}).
+ *
+ * <p>Random access ({@code getXxx(docId)}) seeks to the owning batch and reads it; sequential access
+ * ({@code next} / typed {@code nextXxx}) is built on it. Type predicates are derived from the column's
+ * (decoded) Arrow {@link Field}, so they need no batch load. The column-major segment build consumes
+ * each column to completion sequentially (rewind + next), one column at a time.
+ *
+ * <p>The per-batch delegate is rebuilt whenever this reader advances to a new batch <i>or the shared
+ * source has been moved to a different batch by another reader</i> — the delegate wraps the source's
+ * current-batch vector (raw vectors are refilled in place across loads, decoded dictionary vectors
+ * are released on the next load), so a delegate from a no-longer-resident batch would read
+ * overwritten or freed memory. With that guard, interleaving readers is correct (it just re-loads
+ * batches); the build never interleaves.
+ *
+ * <p>This class is not thread-safe. {@code @SuppressWarnings("serial")}: {@link ColumnReader} extends
+ * {@link java.io.Serializable} by SPI contract, but this reader holds non-serializable Arrow state
+ * and is never serialized.
+ */
+@SuppressWarnings("serial")
+public class BatchedArrowColumnReader implements ColumnReader {
+
+  private final BatchedArrowFileSource _source;
+  private final String _columnName;
+  private final boolean _extractRawTimeValues;
+  private final int _totalDocs;
+  private final Field _effectiveField;
+
+  private int _nextDocId;
+  private int _delegateBatchIdx = -1;
+  private ArrowColumnReader _delegate;
+
+  BatchedArrowColumnReader(BatchedArrowFileSource source, String columnName) {
+    _source = source;
+    _columnName = columnName;
+    _extractRawTimeValues = source.extractRawTimeValues();
+    _totalDocs = source.getTotalDocs();
+    _effectiveField = source.effectiveField(columnName);
+  }
+
+  // ---- sequential iteration (advance _nextDocId only after a successful read) ----
+
+  @Override
+  public boolean hasNext() {
+    return _nextDocId < _totalDocs;
+  }
+
+  @Override
+  @Nullable
+  public Object next()
+      throws IOException {
+    requireHasNext();
+    Object value = getValue(_nextDocId);
+    _nextDocId++;
+    return value;
+  }
+
+  @Override
+  public boolean isNextNull()
+      throws IOException {
+    requireHasNext();
+    // Peek; does not advance.
+    return isNull(_nextDocId);
+  }
+
+  @Override
+  public void skipNext()
+      throws IOException {
+    requireHasNext();
+    _nextDocId++;
+  }
+
+  @Override
+  public int nextInt()
+      throws IOException {
+    requireHasNext();
+    int value = getInt(_nextDocId);
+    _nextDocId++;
+    return value;
+  }
+
+  @Override
+  public long nextLong()
+      throws IOException {
+    requireHasNext();
+    long value = getLong(_nextDocId);
+    _nextDocId++;
+    return value;
+  }
+
+  @Override
+  public float nextFloat()
+      throws IOException {
+    requireHasNext();
+    float value = getFloat(_nextDocId);
+    _nextDocId++;
+    return value;
+  }
+
+  @Override
+  public double nextDouble()
+      throws IOException {
+    requireHasNext();
+    double value = getDouble(_nextDocId);
+    _nextDocId++;
+    return value;
+  }
+
+  @Override
+  public BigDecimal nextBigDecimal()
+      throws IOException {
+    requireHasNext();
+    BigDecimal value = getBigDecimal(_nextDocId);
+    _nextDocId++;
+    return value;
+  }
+
+  @Override
+  public String nextString()
+      throws IOException {
+    requireHasNext();
+    String value = getString(_nextDocId);
+    _nextDocId++;
+    return value;
+  }
+
+  @Override
+  public byte[] nextBytes()
+      throws IOException {
+    requireHasNext();
+    byte[] value = getBytes(_nextDocId);
+    _nextDocId++;
+    return value;
+  }
+
+  @Override
+  public MultiValueResult<int[]> nextIntMV()
+      throws IOException {
+    requireHasNext();
+    MultiValueResult<int[]> value = getIntMV(_nextDocId);
+    _nextDocId++;
+    return value;
+  }
+
+  @Override
+  public MultiValueResult<long[]> nextLongMV()
+      throws IOException {
+    requireHasNext();
+    MultiValueResult<long[]> value = getLongMV(_nextDocId);
+    _nextDocId++;
+    return value;
+  }
+
+  @Override
+  public MultiValueResult<float[]> nextFloatMV()
+      throws IOException {
+    requireHasNext();
+    MultiValueResult<float[]> value = getFloatMV(_nextDocId);
+    _nextDocId++;
+    return value;
+  }
+
+  @Override
+  public MultiValueResult<double[]> nextDoubleMV()
+      throws IOException {
+    requireHasNext();
+    MultiValueResult<double[]> value = getDoubleMV(_nextDocId);
+    _nextDocId++;
+    return value;
+  }
+
+  @Override
+  public BigDecimal[] nextBigDecimalMV()
+      throws IOException {
+    requireHasNext();
+    BigDecimal[] value = getBigDecimalMV(_nextDocId);
+    _nextDocId++;
+    return value;
+  }
+
+  @Override
+  public String[] nextStringMV()
+      throws IOException {
+    requireHasNext();
+    String[] value = getStringMV(_nextDocId);
+    _nextDocId++;
+    return value;
+  }
+
+  @Override
+  public byte[][] nextBytesMV()
+      throws IOException {
+    requireHasNext();
+    byte[][] value = getBytesMV(_nextDocId);
+    _nextDocId++;
+    return value;
+  }
+
+  @Override
+  public void rewind() {
+    _nextDocId = 0;
+    _delegateBatchIdx = -1;
+    _delegate = null;
+  }
+
+  // ---- random access (seeks to the owning batch) ----
+
+  @Override
+  public boolean isNull(int docId) {
+    checkBounds(docId);
+    int batchIdx = _source.batchIndexForDoc(docId);
+    try {
+      return delegate(batchIdx).isNull(localRow(docId, batchIdx));
+    } catch (IOException e) {
+      throw new RuntimeException("Failed reading column " + _columnName + " at doc " + docId, e);
+    }
+  }
+
+  @Override
+  public int getInt(int docId)
+      throws IOException {
+    checkBounds(docId);
+    int batchIdx = _source.batchIndexForDoc(docId);
+    return delegate(batchIdx).getInt(localRow(docId, batchIdx));
+  }
+
+  @Override
+  public long getLong(int docId)
+      throws IOException {
+    checkBounds(docId);
+    int batchIdx = _source.batchIndexForDoc(docId);
+    return delegate(batchIdx).getLong(localRow(docId, batchIdx));
+  }
+
+  @Override
+  public float getFloat(int docId)
+      throws IOException {
+    checkBounds(docId);
+    int batchIdx = _source.batchIndexForDoc(docId);
+    return delegate(batchIdx).getFloat(localRow(docId, batchIdx));
+  }
+
+  @Override
+  public double getDouble(int docId)
+      throws IOException {
+    checkBounds(docId);
+    int batchIdx = _source.batchIndexForDoc(docId);
+    return delegate(batchIdx).getDouble(localRow(docId, batchIdx));
+  }
+
+  @Override
+  public BigDecimal getBigDecimal(int docId)
+      throws IOException {
+    checkBounds(docId);
+    int batchIdx = _source.batchIndexForDoc(docId);
+    return delegate(batchIdx).getBigDecimal(localRow(docId, batchIdx));
+  }
+
+  @Override
+  public String getString(int docId)
+      throws IOException {
+    checkBounds(docId);
+    int batchIdx = _source.batchIndexForDoc(docId);
+    return delegate(batchIdx).getString(localRow(docId, batchIdx));
+  }
+
+  @Override
+  public byte[] getBytes(int docId)
+      throws IOException {
+    checkBounds(docId);
+    int batchIdx = _source.batchIndexForDoc(docId);
+    return delegate(batchIdx).getBytes(localRow(docId, batchIdx));
+  }
+
+  @Override
+  @Nullable
+  public Object getValue(int docId)
+      throws IOException {
+    checkBounds(docId);
+    int batchIdx = _source.batchIndexForDoc(docId);
+    return delegate(batchIdx).getValue(localRow(docId, batchIdx));
+  }
+
+  @Override
+  public MultiValueResult<int[]> getIntMV(int docId)
+      throws IOException {
+    checkBounds(docId);
+    int batchIdx = _source.batchIndexForDoc(docId);
+    return delegate(batchIdx).getIntMV(localRow(docId, batchIdx));
+  }
+
+  @Override
+  public MultiValueResult<long[]> getLongMV(int docId)
+      throws IOException {
+    checkBounds(docId);
+    int batchIdx = _source.batchIndexForDoc(docId);
+    return delegate(batchIdx).getLongMV(localRow(docId, batchIdx));
+  }
+
+  @Override
+  public MultiValueResult<float[]> getFloatMV(int docId)
+      throws IOException {
+    checkBounds(docId);
+    int batchIdx = _source.batchIndexForDoc(docId);
+    return delegate(batchIdx).getFloatMV(localRow(docId, batchIdx));
+  }
+
+  @Override
+  public MultiValueResult<double[]> getDoubleMV(int docId)
+      throws IOException {
+    checkBounds(docId);
+    int batchIdx = _source.batchIndexForDoc(docId);
+    return delegate(batchIdx).getDoubleMV(localRow(docId, batchIdx));
+  }
+
+  @Override
+  public BigDecimal[] getBigDecimalMV(int docId)
+      throws IOException {
+    checkBounds(docId);
+    int batchIdx = _source.batchIndexForDoc(docId);
+    return delegate(batchIdx).getBigDecimalMV(localRow(docId, batchIdx));
+  }
+
+  @Override
+  public String[] getStringMV(int docId)
+      throws IOException {
+    checkBounds(docId);
+    int batchIdx = _source.batchIndexForDoc(docId);
+    return delegate(batchIdx).getStringMV(localRow(docId, batchIdx));
+  }
+
+  @Override
+  public byte[][] getBytesMV(int docId)
+      throws IOException {
+    checkBounds(docId);
+    int batchIdx = _source.batchIndexForDoc(docId);
+    return delegate(batchIdx).getBytesMV(localRow(docId, batchIdx));
+  }
+
+  // ---- metadata / type predicates (derived from the schema field, no batch load) ----
+
+  @Override
+  public String getColumnName() {
+    return _columnName;
+  }
+
+  @Override
+  public int getTotalDocs() {
+    return _totalDocs;
+  }
+
+  @Override
+  public boolean isSingleValue() {
+    return !isList(_effectiveField.getType());
+  }
+
+  @Override
+  public boolean isInt() {
+    ArrowType type = elementType();
+    return (type instanceof ArrowType.Int && ((ArrowType.Int) type).getBitWidth() == 32)
+        || type instanceof ArrowType.Bool;
+  }
+
+  @Override
+  public boolean isLong() {
+    ArrowType type = elementType();
+    return type instanceof ArrowType.Int && ((ArrowType.Int) type).getBitWidth() == 64;
+  }
+
+  @Override
+  public boolean isFloat() {
+    ArrowType type = elementType();
+    return type instanceof ArrowType.FloatingPoint
+        && ((ArrowType.FloatingPoint) type).getPrecision() == FloatingPointPrecision.SINGLE;
+  }
+
+  @Override
+  public boolean isDouble() {
+    ArrowType type = elementType();
+    return type instanceof ArrowType.FloatingPoint
+        && ((ArrowType.FloatingPoint) type).getPrecision() == FloatingPointPrecision.DOUBLE;
+  }
+
+  @Override
+  public boolean isBigDecimal() {
+    return elementType() instanceof ArrowType.Decimal;
+  }
+
+  @Override
+  public boolean isString() {
+    return elementType() instanceof ArrowType.Utf8;
+  }
+
+  @Override
+  public boolean isBytes() {
+    return elementType() instanceof ArrowType.Binary;
+  }
+
+  @Override
+  public void close() {
+    // The shared BatchedArrowFileSource owns the file, reader, and allocator; the owning factory
+    // closes it. Closing one column reader must not tear down the source the others still use.
+  }
+
+  // ---- helpers ----
+
+  private ArrowColumnReader delegate(int batchIdx)
+      throws IOException {
+    // Rebuild the per-batch delegate when this reader advances to a new batch, OR when the shared
+    // source has since been moved to a different batch (another reader advanced the cursor) — the
+    // delegate wraps the source's current-batch vector, which is refilled (raw) or released
+    // (decoded) once the source loads a different batch.
+    if (_delegate == null || _delegateBatchIdx != batchIdx || _source.loadedBatchIdx() != batchIdx) {
+      FieldVector vector = _source.columnVector(_columnName, batchIdx);
+      _delegate = new ArrowColumnReader(_columnName, vector, _extractRawTimeValues);
+      _delegateBatchIdx = batchIdx;
+    }
+    return _delegate;
+  }
+
+  private int localRow(int docId, int batchIdx) {
+    return docId - _source.batchStartDoc(batchIdx);
+  }
+
+  private void checkBounds(int docId) {
+    if (docId < 0 || docId >= _totalDocs) {
+      throw new IndexOutOfBoundsException(
+          "docId " + docId + " is out of range [0, " + _totalDocs + ") for column " + _columnName);
+    }
+  }
+
+  private void requireHasNext() {
+    if (!hasNext()) {
+      throw new IllegalStateException("No more values available");
+    }
+  }
+
+  private ArrowType elementType() {
+    Field field = _effectiveField;
+    if (isList(field.getType())) {
+      field = field.getChildren().get(0);
+    }
+    return field.getType();
+  }
+
+  private static boolean isList(ArrowType type) {
+    return type instanceof ArrowType.List || type instanceof ArrowType.LargeList
+        || type instanceof ArrowType.FixedSizeList;
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/BatchedArrowFileSource.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/BatchedArrowFileSource.java
@@ -29,6 +29,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
@@ -105,6 +106,8 @@ final class BatchedArrowFileSource implements Closeable {
       }
       _batchStartDoc[_blocks.size()] = total;
       _totalDocs = total;
+      // The footer pass above left the last batch resident; record it so the first columnVector()
+      // call can skip a reload when it targets that batch.
       _loadedBatchIdx = _blocks.isEmpty() ? -1 : _blocks.size() - 1;
       initialized = true;
     } finally {
@@ -161,14 +164,10 @@ final class BatchedArrowFileSource implements Closeable {
    */
   Field effectiveField(String columnName) {
     FieldVector source = _root.getVector(columnName);
-    DictionaryEncoding encoding = source.getField().getDictionary();
-    if (encoding == null) {
+    Dictionary dictionary = resolveDictionary(source);
+    if (dictionary == null) {
       return source.getField();
     }
-    Dictionary dictionary = _dictionaries.get(encoding.getId());
-    Preconditions.checkArgument(dictionary != null,
-        "Arrow column '%s' is dictionary-encoded (dictionary id %s) but no matching dictionary is present",
-        columnName, encoding.getId());
     Field valueField = dictionary.getVector().getField();
     return new Field(columnName, valueField.getFieldType(), valueField.getChildren());
   }
@@ -185,18 +184,31 @@ final class BatchedArrowFileSource implements Closeable {
       return cached;
     }
     FieldVector source = _root.getVector(columnName);
-    DictionaryEncoding encoding = source.getField().getDictionary();
-    if (encoding == null) {
+    Dictionary dictionary = resolveDictionary(source);
+    if (dictionary == null) {
       // Raw vector owned by the VectorSchemaRoot; refilled in place on the next loadRecordBatch.
       return source;
+    }
+    FieldVector decoded = (FieldVector) DictionaryEncoder.decode(source, dictionary);
+    _decodedCache.put(columnName, decoded);
+    return decoded;
+  }
+
+  /**
+   * The bound dictionary for {@code source} if it is dictionary-encoded, or {@code null} otherwise.
+   * Throws if the column is dictionary-encoded but its dictionary is missing from the source.
+   */
+  @Nullable
+  private Dictionary resolveDictionary(FieldVector source) {
+    DictionaryEncoding encoding = source.getField().getDictionary();
+    if (encoding == null) {
+      return null;
     }
     Dictionary dictionary = _dictionaries.get(encoding.getId());
     Preconditions.checkArgument(dictionary != null,
         "Arrow column '%s' is dictionary-encoded (dictionary id %s) but no matching dictionary is present",
-        columnName, encoding.getId());
-    FieldVector decoded = (FieldVector) DictionaryEncoder.decode(source, dictionary);
-    _decodedCache.put(columnName, decoded);
-    return decoded;
+        source.getField().getName(), encoding.getId());
+    return dictionary;
   }
 
   private void ensureBatchLoaded(int batchIdx)

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/BatchedArrowFileSource.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/BatchedArrowFileSource.java
@@ -1,0 +1,265 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.arrow;
+
+import com.google.common.base.Preconditions;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.dictionary.Dictionary;
+import org.apache.arrow.vector.dictionary.DictionaryEncoder;
+import org.apache.arrow.vector.ipc.ArrowFileReader;
+import org.apache.arrow.vector.ipc.message.ArrowBlock;
+import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
+import org.apache.arrow.vector.types.pojo.Field;
+
+
+/**
+ * Reads an Apache Arrow IPC file <b>one record batch at a time</b> through the seekable
+ * {@link ArrowFileReader} ({@link ArrowFileReader#getRecordBlocks()} +
+ * {@link ArrowFileReader#loadRecordBatch}), so peak resident off-heap memory is a single record
+ * batch rather than the whole materialised column set. Shared by the per-column
+ * {@link BatchedArrowColumnReader}s created over it: at most one batch is loaded at any instant.
+ *
+ * <p>Peak memory therefore equals the largest record batch, which is a write-time, producer-chosen
+ * property — the same memory model as the row-major {@link ArrowRecordReader}. Reading a column to
+ * completion re-loads every batch (Arrow Java loads whole batches), so the column-major consumer
+ * pays {@code N x} batch loads across {@code N} columns; this read amplification is the accepted
+ * cost of Arrow's horizontal record-batch layout. Dictionary-encoded columns are decoded per batch
+ * (mirroring the row-major {@link ArrowRecordExtractor}); the transient decoded vectors are released
+ * when the next batch loads.
+ *
+ * <p>This class is not thread-safe.
+ */
+final class BatchedArrowFileSource implements Closeable {
+
+  private final RootAllocator _allocator;
+  private final FileInputStream _fileInputStream;
+  private final ArrowFileReader _reader;
+  private final VectorSchemaRoot _root;
+  private final List<ArrowBlock> _blocks;
+  private final Map<Long, Dictionary> _dictionaries;
+  private final Set<String> _availableColumns;
+  private final boolean _extractRawTimeValues;
+  // Cumulative first global docId of each batch; length numBatches + 1, last entry == total docs.
+  private final int[] _batchStartDoc;
+  private final int _totalDocs;
+
+  private int _loadedBatchIdx = -1;
+  // Decoded vectors for the currently-loaded batch, keyed by column; closed when the next batch loads.
+  private final Map<String, FieldVector> _decodedCache = new HashMap<>();
+
+  BatchedArrowFileSource(File dataFile, long allocatorLimit, boolean extractRawTimeValues)
+      throws IOException {
+    _allocator = new RootAllocator(allocatorLimit);
+    _extractRawTimeValues = extractRawTimeValues;
+    boolean initialized = false;
+    try {
+      _fileInputStream = new FileInputStream(dataFile);
+      _reader = new ArrowFileReader(_fileInputStream.getChannel(), _allocator);
+      _root = _reader.getVectorSchemaRoot();
+      _blocks = _reader.getRecordBlocks();
+      _dictionaries = _reader.getDictionaryVectors();
+
+      Set<String> names = new LinkedHashSet<>();
+      for (FieldVector vector : _root.getFieldVectors()) {
+        names.add(vector.getField().getName());
+      }
+      _availableColumns = Collections.unmodifiableSet(names);
+
+      // One up-front pass over the batch footers to learn each batch's row count, giving total docs
+      // and the per-batch global docId offsets. This loads one batch at a time (one-batch-resident);
+      // its cost is amortised into the column-major consumer's per-column re-reads.
+      _batchStartDoc = new int[_blocks.size() + 1];
+      int total = 0;
+      for (int i = 0; i < _blocks.size(); i++) {
+        _batchStartDoc[i] = total;
+        _reader.loadRecordBatch(_blocks.get(i));
+        total += _root.getRowCount();
+      }
+      _batchStartDoc[_blocks.size()] = total;
+      _totalDocs = total;
+      _loadedBatchIdx = _blocks.isEmpty() ? -1 : _blocks.size() - 1;
+      initialized = true;
+    } finally {
+      if (!initialized) {
+        closeQuietly();
+      }
+    }
+  }
+
+  int getTotalDocs() {
+    return _totalDocs;
+  }
+
+  Set<String> getAvailableColumns() {
+    return _availableColumns;
+  }
+
+  boolean hasColumn(String columnName) {
+    return _availableColumns.contains(columnName);
+  }
+
+  boolean extractRawTimeValues() {
+    return _extractRawTimeValues;
+  }
+
+  int batchStartDoc(int batchIdx) {
+    return _batchStartDoc[batchIdx];
+  }
+
+  /** The batch index currently resident, or -1 if none. A column reader's cached per-batch delegate
+   * is valid only while this equals the batch it was built for (the shared cursor may have moved). */
+  int loadedBatchIdx() {
+    return _loadedBatchIdx;
+  }
+
+  /** Index of the batch owning {@code docId} (binary search over the cumulative offsets). */
+  int batchIndexForDoc(int docId) {
+    int lo = 0;
+    int hi = _blocks.size() - 1;
+    while (lo < hi) {
+      int mid = (lo + hi + 1) >>> 1;
+      if (_batchStartDoc[mid] <= docId) {
+        lo = mid;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    return lo;
+  }
+
+  /**
+   * The effective Arrow {@link Field} of a column — the decoded value field for dictionary-encoded
+   * columns, the raw field otherwise. Used for type predicates without loading any batch data.
+   */
+  Field effectiveField(String columnName) {
+    FieldVector source = _root.getVector(columnName);
+    DictionaryEncoding encoding = source.getField().getDictionary();
+    if (encoding == null) {
+      return source.getField();
+    }
+    Dictionary dictionary = _dictionaries.get(encoding.getId());
+    Preconditions.checkArgument(dictionary != null,
+        "Arrow column '%s' is dictionary-encoded (dictionary id %s) but no matching dictionary is present",
+        columnName, encoding.getId());
+    Field valueField = dictionary.getVector().getField();
+    return new Field(columnName, valueField.getFieldType(), valueField.getChildren());
+  }
+
+  /**
+   * Ensure {@code batchIdx} is the loaded batch, then return the column's {@link FieldVector} for it
+   * (decoded if dictionary-encoded). The returned vector is valid only until the next batch loads.
+   */
+  FieldVector columnVector(String columnName, int batchIdx)
+      throws IOException {
+    ensureBatchLoaded(batchIdx);
+    FieldVector cached = _decodedCache.get(columnName);
+    if (cached != null) {
+      return cached;
+    }
+    FieldVector source = _root.getVector(columnName);
+    DictionaryEncoding encoding = source.getField().getDictionary();
+    if (encoding == null) {
+      // Raw vector owned by the VectorSchemaRoot; refilled in place on the next loadRecordBatch.
+      return source;
+    }
+    Dictionary dictionary = _dictionaries.get(encoding.getId());
+    Preconditions.checkArgument(dictionary != null,
+        "Arrow column '%s' is dictionary-encoded (dictionary id %s) but no matching dictionary is present",
+        columnName, encoding.getId());
+    FieldVector decoded = (FieldVector) DictionaryEncoder.decode(source, dictionary);
+    _decodedCache.put(columnName, decoded);
+    return decoded;
+  }
+
+  private void ensureBatchLoaded(int batchIdx)
+      throws IOException {
+    if (_loadedBatchIdx == batchIdx) {
+      return;
+    }
+    closeDecoded();
+    _reader.loadRecordBatch(_blocks.get(batchIdx));
+    _loadedBatchIdx = batchIdx;
+  }
+
+  private void closeDecoded() {
+    for (FieldVector vector : _decodedCache.values()) {
+      try {
+        vector.close();
+      } catch (Exception ignored) {
+        // best effort; the allocator close below is the backstop
+      }
+    }
+    _decodedCache.clear();
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    IOException firstException = null;
+    closeDecoded();
+    if (_reader != null) {
+      try {
+        _reader.close();
+      } catch (IOException e) {
+        firstException = e;
+      }
+    }
+    if (_fileInputStream != null) {
+      try {
+        _fileInputStream.close();
+      } catch (IOException e) {
+        if (firstException == null) {
+          firstException = e;
+        }
+      }
+    }
+    if (_allocator != null) {
+      try {
+        _allocator.close();
+      } catch (Exception e) {
+        if (firstException == null) {
+          firstException = new IOException("Failed to close Arrow allocator", e);
+        }
+      }
+    }
+    if (firstException != null) {
+      throw firstException;
+    }
+  }
+
+  private void closeQuietly() {
+    try {
+      close();
+    } catch (IOException ignored) {
+      // constructor cleanup path
+    }
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReaderFactoryTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReaderFactoryTest.java
@@ -1,0 +1,189 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.arrow;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.channels.Channels;
+import java.util.Arrays;
+import java.util.Collections;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowStreamReader;
+import org.apache.arrow.vector.ipc.ArrowStreamWriter;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.readers.ColumnReader;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Verifies {@link ArrowColumnReaderFactory} can consume a caller-managed {@link ArrowStreamReader}
+ * backed by a {@link ByteArrayInputStream}, without disk I/O, and that the caller-owned
+ * {@link RootAllocator} remains usable after the factory is closed.
+ */
+public class ArrowColumnReaderFactoryTest {
+
+  private static final int ROW_COUNT = 32;
+
+  @Test
+  public void testReadsValuesFromInMemoryReader()
+      throws Exception {
+    // Caller owns this allocator. Verify the factory does not close it.
+    try (RootAllocator callerAllocator = new RootAllocator(Long.MAX_VALUE)) {
+      byte[] ipcBytes = writeArrowStreamFixture(callerAllocator);
+
+      try (ArrowStreamReader streamReader = new ArrowStreamReader(
+          Channels.newChannel(new ByteArrayInputStream(ipcBytes)), callerAllocator);
+          ArrowColumnReaderFactory factory =
+              new ArrowColumnReaderFactory(streamReader, callerAllocator)) {
+
+        factory.init(newSchema());
+
+        try (ColumnReader intCol = factory.getColumnReader("intCol");
+            ColumnReader longCol = factory.getColumnReader("longCol");
+            ColumnReader stringCol = factory.getColumnReader("stringCol")) {
+
+          assertNotNull(intCol);
+          assertNotNull(longCol);
+          assertNotNull(stringCol);
+          assertEquals(intCol.getTotalDocs(), ROW_COUNT);
+          assertEquals(longCol.getTotalDocs(), ROW_COUNT);
+          assertEquals(stringCol.getTotalDocs(), ROW_COUNT);
+
+          for (int i = 0; i < ROW_COUNT; i++) {
+            assertEquals(intCol.getInt(i), i);
+            assertEquals(longCol.getLong(i), (long) i * 1000);
+            assertEquals(stringCol.getString(i), "row_" + i);
+          }
+        }
+      }
+
+      // Caller's allocator should still be usable after the factory closes — proves the factory
+      // did not close it. Allocate-and-release a small buffer to confirm.
+      try (IntVector probe = new IntVector("probe", callerAllocator)) {
+        probe.allocateNew(1);
+        probe.set(0, 42);
+        probe.setValueCount(1);
+        assertEquals(probe.get(0), 42);
+      }
+    }
+  }
+
+  @Test
+  public void testGetAllColumnReadersReflectsSourceSchema()
+      throws Exception {
+    try (RootAllocator callerAllocator = new RootAllocator(Long.MAX_VALUE)) {
+      byte[] ipcBytes = writeArrowStreamFixture(callerAllocator);
+
+      try (ArrowStreamReader streamReader = new ArrowStreamReader(
+          Channels.newChannel(new ByteArrayInputStream(ipcBytes)), callerAllocator);
+          ArrowColumnReaderFactory factory =
+              new ArrowColumnReaderFactory(streamReader, callerAllocator)) {
+
+        factory.init(newSchema());
+
+        assertEquals(factory.getAvailableColumns().size(), 3);
+        assertTrue(factory.getAvailableColumns().contains("intCol"));
+        assertTrue(factory.getAvailableColumns().contains("longCol"));
+        assertTrue(factory.getAvailableColumns().contains("stringCol"));
+        assertEquals(factory.getAllColumnReaders().size(), 3);
+      }
+    }
+  }
+
+  @Test
+  public void testColumnSubsetFiltering()
+      throws Exception {
+    try (RootAllocator callerAllocator = new RootAllocator(Long.MAX_VALUE)) {
+      byte[] ipcBytes = writeArrowStreamFixture(callerAllocator);
+
+      try (ArrowStreamReader streamReader = new ArrowStreamReader(
+          Channels.newChannel(new ByteArrayInputStream(ipcBytes)), callerAllocator);
+          ArrowColumnReaderFactory factory =
+              new ArrowColumnReaderFactory(streamReader, callerAllocator)) {
+
+        factory.init(newSchema(), Collections.singleton("intCol"));
+
+        // Only the requested column has a reader; the others fall back to null per the SPI.
+        assertNotNull(factory.getColumnReader("intCol"));
+        assertEquals(factory.getAllColumnReaders().size(), 1);
+        assertFalse(factory.getAllColumnReaders().containsKey("longCol"));
+        assertFalse(factory.getAllColumnReaders().containsKey("stringCol"));
+      }
+    }
+  }
+
+  private byte[] writeArrowStreamFixture(RootAllocator allocator)
+      throws IOException {
+    Field intField = new Field("intCol", FieldType.nullable(new ArrowType.Int(32, true)), null);
+    Field longField = new Field("longCol", FieldType.nullable(new ArrowType.Int(64, true)), null);
+    Field stringField = new Field("stringCol", FieldType.nullable(new ArrowType.Utf8()), null);
+    Schema arrowSchema = new Schema(Arrays.asList(intField, longField, stringField));
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator);
+        ArrowStreamWriter writer = new ArrowStreamWriter(root, null, Channels.newChannel(out))) {
+      IntVector intVec = (IntVector) root.getVector("intCol");
+      BigIntVector longVec = (BigIntVector) root.getVector("longCol");
+      VarCharVector stringVec = (VarCharVector) root.getVector("stringCol");
+
+      intVec.allocateNew(ROW_COUNT);
+      longVec.allocateNew(ROW_COUNT);
+      stringVec.allocateNew(ROW_COUNT * 8, ROW_COUNT);
+
+      for (int i = 0; i < ROW_COUNT; i++) {
+        intVec.set(i, i);
+        longVec.set(i, (long) i * 1000);
+        stringVec.set(i, ("row_" + i).getBytes());
+      }
+      intVec.setValueCount(ROW_COUNT);
+      longVec.setValueCount(ROW_COUNT);
+      stringVec.setValueCount(ROW_COUNT);
+      root.setRowCount(ROW_COUNT);
+
+      writer.start();
+      writer.writeBatch();
+      writer.end();
+    }
+    return out.toByteArray();
+  }
+
+  private org.apache.pinot.spi.data.Schema newSchema() {
+    org.apache.pinot.spi.data.Schema schema = new org.apache.pinot.spi.data.Schema();
+    schema.setSchemaName("inMemoryArrowTest");
+    schema.addField(new DimensionFieldSpec("intCol", DataType.INT, true));
+    schema.addField(new DimensionFieldSpec("longCol", DataType.LONG, true));
+    schema.addField(new DimensionFieldSpec("stringCol", DataType.STRING, true));
+    return schema;
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReaderFactoryTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReaderFactoryTest.java
@@ -22,16 +22,23 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.channels.Channels;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.dictionary.Dictionary;
+import org.apache.arrow.vector.dictionary.DictionaryEncoder;
+import org.apache.arrow.vector.dictionary.DictionaryProvider;
 import org.apache.arrow.vector.ipc.ArrowStreamReader;
 import org.apache.arrow.vector.ipc.ArrowStreamWriter;
 import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -43,6 +50,7 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 
@@ -143,6 +151,138 @@ public class ArrowColumnReaderFactoryTest {
     }
   }
 
+  /**
+   * After the reader is drained, the sequential accessors ({@code next}, the typed {@code nextXxx},
+   * {@code isNextNull}, {@code skipNext}) must throw {@link IllegalStateException} rather than read out
+   * of bounds — matching the {@code DefaultValueColumnReader} / {@code PinotSegmentColumnReaderImpl}
+   * SPI contract ("No more values available").
+   */
+  @Test
+  public void testSequentialAccessorsThrowPastEnd()
+      throws Exception {
+    try (RootAllocator callerAllocator = new RootAllocator(Long.MAX_VALUE)) {
+      byte[] ipcBytes = writeArrowStreamFixture(callerAllocator);
+
+      try (ArrowStreamReader streamReader = new ArrowStreamReader(
+          Channels.newChannel(new ByteArrayInputStream(ipcBytes)), callerAllocator);
+          ArrowColumnReaderFactory factory =
+              new ArrowColumnReaderFactory(streamReader, callerAllocator)) {
+
+        factory.init(newSchema());
+
+        try (ColumnReader intCol = factory.getColumnReader("intCol")) {
+          while (intCol.hasNext()) {
+            intCol.next();
+          }
+          assertFalse(intCol.hasNext());
+          assertThrows(IllegalStateException.class, intCol::next);
+          assertThrows(IllegalStateException.class, intCol::nextInt);
+          assertThrows(IllegalStateException.class, intCol::isNextNull);
+          assertThrows(IllegalStateException.class, intCol::skipNext);
+        }
+      }
+    }
+  }
+
+  /**
+   * Dictionary encoding is the standard Arrow representation for low-cardinality strings. The
+   * column-major path must DECODE it — surfacing the logical string values and the STRING type, not
+   * the underlying Int32 dictionary indices. Verifies the decode end-to-end through the factory and
+   * the resulting {@link ColumnReader} (both the typed {@code getString} and generic {@code getValue}
+   * accessors), and that the caller's allocator is left clean afterward.
+   */
+  @Test
+  public void testDecodesDictionaryEncodedStringColumn()
+      throws Exception {
+    String[] dictValues = {"red", "green", "blue"};
+    // Rows cycle through the dictionary so the encoded indices (0,1,2,...) differ from the decoded
+    // strings — a reader that forgot to decode would return the indices and fail getString().
+    String[] rows = {"red", "green", "blue", "red", "green", "blue", "blue", "red"};
+
+    try (RootAllocator callerAllocator = new RootAllocator(Long.MAX_VALUE)) {
+      byte[] ipcBytes = writeDictionaryEncodedStringStream(callerAllocator, dictValues, rows);
+
+      try (ArrowStreamReader streamReader = new ArrowStreamReader(
+          Channels.newChannel(new ByteArrayInputStream(ipcBytes)), callerAllocator);
+          ArrowColumnReaderFactory factory =
+              new ArrowColumnReaderFactory(streamReader, callerAllocator)) {
+
+        factory.init(dictColumnSchema());
+
+        try (ColumnReader colorCol = factory.getColumnReader("color")) {
+          assertNotNull(colorCol);
+          assertEquals(colorCol.getTotalDocs(), rows.length);
+          // Must report the DECODED logical type (STRING), not the Int32 index type.
+          assertTrue(colorCol.isString());
+          for (int i = 0; i < rows.length; i++) {
+            assertEquals(colorCol.getString(i), rows[i], "decoded getString mismatch at doc " + i);
+            assertEquals(colorCol.getValue(i), rows[i], "decoded getValue mismatch at doc " + i);
+          }
+        }
+      }
+
+      // Factory closed; the decoded-batch copies must have been released. Confirm the caller's
+      // allocator is still clean and usable.
+      try (IntVector probe = new IntVector("probe", callerAllocator)) {
+        probe.allocateNew(1);
+        probe.set(0, 7);
+        probe.setValueCount(1);
+        assertEquals(probe.get(0), 7);
+      }
+    }
+  }
+
+  /**
+   * Writes a single-column ("color") Arrow IPC stream where the column is dictionary-encoded against
+   * {@code dictValues}, following the standard Arrow {@code encode → write with DictionaryProvider}
+   * pattern. The dictionary vector is owned here and closed; the encoded vector is owned by the
+   * VectorSchemaRoot.
+   */
+  private byte[] writeDictionaryEncodedStringStream(RootAllocator allocator, String[] dictValues, String[] rows)
+      throws IOException {
+    DictionaryEncoding encoding = new DictionaryEncoding(1L, false, new ArrowType.Int(32, true));
+
+    VarCharVector dictVec = new VarCharVector("color-dict", allocator);
+    dictVec.allocateNew();
+    for (int i = 0; i < dictValues.length; i++) {
+      dictVec.setSafe(i, dictValues[i].getBytes(StandardCharsets.UTF_8));
+    }
+    dictVec.setValueCount(dictValues.length);
+    Dictionary dictionary = new Dictionary(dictVec, encoding);
+
+    VarCharVector unencoded = new VarCharVector("color", allocator);
+    unencoded.allocateNew();
+    for (int i = 0; i < rows.length; i++) {
+      unencoded.setSafe(i, rows[i].getBytes(StandardCharsets.UTF_8));
+    }
+    unencoded.setValueCount(rows.length);
+
+    DictionaryProvider.MapDictionaryProvider provider = new DictionaryProvider.MapDictionaryProvider();
+    provider.put(dictionary);
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (FieldVector encodedVec = (FieldVector) DictionaryEncoder.encode(unencoded, dictionary)) {
+      unencoded.close();
+      try (VectorSchemaRoot root =
+          new VectorSchemaRoot(List.of(encodedVec.getField()), List.of(encodedVec), rows.length);
+          ArrowStreamWriter writer = new ArrowStreamWriter(root, provider, Channels.newChannel(out))) {
+        writer.start();
+        writer.writeBatch();
+        writer.end();
+      }
+    } finally {
+      dictVec.close();
+    }
+    return out.toByteArray();
+  }
+
+  private org.apache.pinot.spi.data.Schema dictColumnSchema() {
+    org.apache.pinot.spi.data.Schema schema = new org.apache.pinot.spi.data.Schema();
+    schema.setSchemaName("dictEncodedArrowTest");
+    schema.addField(new DimensionFieldSpec("color", DataType.STRING, true));
+    return schema;
+  }
+
   private byte[] writeArrowStreamFixture(RootAllocator allocator)
       throws IOException {
     Field intField = new Field("intCol", FieldType.nullable(new ArrowType.Int(32, true)), null);
@@ -164,7 +304,7 @@ public class ArrowColumnReaderFactoryTest {
       for (int i = 0; i < ROW_COUNT; i++) {
         intVec.set(i, i);
         longVec.set(i, (long) i * 1000);
-        stringVec.set(i, ("row_" + i).getBytes());
+        stringVec.set(i, ("row_" + i).getBytes(StandardCharsets.UTF_8));
       }
       intVec.setValueCount(ROW_COUNT);
       longVec.setValueCount(ROW_COUNT);

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReaderFactoryTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReaderFactoryTest.java
@@ -152,6 +152,42 @@ public class ArrowColumnReaderFactoryTest {
   }
 
   /**
+   * A second {@code init()} on the same factory must release the first init's off-heap accumulator
+   * vectors rather than orphaning them. Without the re-init guard the first set leaks, and the
+   * caller-owned allocator throws {@code IllegalStateException} on its own {@code close()} because the
+   * outstanding buffers are still allocated — so reaching the end of the caller-allocator
+   * try-with-resources cleanly is the leak detector.
+   */
+  @Test
+  public void testReInitReleasesPriorAccumulators()
+      throws Exception {
+    try (RootAllocator callerAllocator = new RootAllocator(Long.MAX_VALUE)) {
+      byte[] ipcBytes = writeArrowStreamFixture(callerAllocator);
+
+      try (ArrowStreamReader streamReader = new ArrowStreamReader(
+          Channels.newChannel(new ByteArrayInputStream(ipcBytes)), callerAllocator);
+          ArrowColumnReaderFactory factory =
+              new ArrowColumnReaderFactory(streamReader, callerAllocator)) {
+
+        factory.init(newSchema());
+        // Second init() over the same (now-drained) reader: it allocates a fresh accumulator set and
+        // must release the first set instead of overwriting the only reference to it.
+        factory.init(newSchema());
+        assertTrue(factory.getAvailableColumns().contains("intCol"));
+      }
+
+      // factory.close() above released the latest accumulator set; if the first set had leaked, this
+      // allocator close (and the probe) would trip on the outstanding buffers.
+      try (IntVector probe = new IntVector("probe", callerAllocator)) {
+        probe.allocateNew(1);
+        probe.set(0, 1);
+        probe.setValueCount(1);
+        assertEquals(probe.get(0), 1);
+      }
+    }
+  }
+
+  /**
    * After the reader is drained, the sequential accessors ({@code next}, the typed {@code nextXxx},
    * {@code isNextNull}, {@code skipNext}) must throw {@link IllegalStateException} rather than read out
    * of bounds — matching the {@code DefaultValueColumnReader} / {@code PinotSegmentColumnReaderImpl}

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnarBuildIntegrationTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnarBuildIntegrationTest.java
@@ -1,0 +1,289 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.arrow;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowFileWriter;
+import org.apache.arrow.vector.ipc.ArrowStreamReader;
+import org.apache.arrow.vector.ipc.ArrowStreamWriter;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.spi.ColumnMetadata;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentMetadata;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+
+/**
+ * End-to-end tests that build a Pinot segment from the same Arrow data via row-major and
+ * column-major paths and assert the produced segments carry equivalent metadata.
+ *
+ * <p>Paths exercised:
+ * <ul>
+ *   <li>Row-major: {@link ArrowRecordReader} → {@code driver.init(config, recordReader)} →
+ *       {@code driver.build()}</li>
+ *   <li>Column-major (file): {@link ArrowFileColumnReaderFactory} →
+ *       {@code driver.init(config, columnReaderFactory)} → {@code driver.build()} →
+ *       {@code buildColumnar()}</li>
+ *   <li>Column-major (in-memory, disk-free): {@link ArrowColumnReaderFactory} over an
+ *       {@link ArrowStreamReader} backed by a {@link ByteArrayInputStream} → same driver path.
+ *       Proves the disk-free path produces the same segment metadata as the file path.</li>
+ * </ul>
+ *
+ * <p>The test asserts identical per-column cardinality, min, max, totalDocs, data type, and
+ * segment-level doc count across each compared pair.
+ */
+public class ArrowColumnarBuildIntegrationTest {
+
+  private static final String TABLE_NAME = "arrowColumnarBuildTest";
+  private static final int ROW_COUNT = 64;
+
+  private Path _tempDir;
+
+  @BeforeMethod
+  public void setUp()
+      throws IOException {
+    _tempDir = Files.createTempDirectory("arrow-columnar-integration");
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws IOException {
+    if (_tempDir != null) {
+      try (var stream = Files.walk(_tempDir)) {
+        stream.sorted((a, b) -> b.compareTo(a)).forEach(p -> {
+          try {
+            Files.deleteIfExists(p);
+          } catch (IOException ignored) {
+            // best effort
+          }
+        });
+      }
+    }
+  }
+
+  @Test
+  public void testSegmentMetadataEquivalenceRowMajorVsFileColumnar()
+      throws Exception {
+    File arrowFile = writeArrowFileFixture("equivalence-file.arrow");
+
+    File rowMajorSegmentDir = buildSegmentRowMajor(arrowFile, "rowMajor");
+    File columnarSegmentDir = buildSegmentFileColumnar(arrowFile, "fileColumnar");
+
+    assertSegmentMetadataEquivalence(rowMajorSegmentDir, columnarSegmentDir);
+  }
+
+  @Test
+  public void testSegmentMetadataEquivalenceRowMajorVsInMemoryColumnar()
+      throws Exception {
+    // Same data is materialised two ways. The row-major path needs a file because
+    // ArrowRecordReader.init only accepts File; the in-memory column-major path consumes the
+    // same data as Arrow IPC stream bytes via ArrowStreamReader — no file touched on that path.
+    File arrowFile = writeArrowFileFixture("equivalence-inmem-source.arrow");
+    byte[] streamBytes = writeArrowStreamBytes();
+
+    File rowMajorSegmentDir = buildSegmentRowMajor(arrowFile, "rowMajor");
+    File columnarSegmentDir = buildSegmentInMemoryColumnar(streamBytes, "inMemColumnar");
+
+    assertSegmentMetadataEquivalence(rowMajorSegmentDir, columnarSegmentDir);
+  }
+
+  private void assertSegmentMetadataEquivalence(File rowMajorSegmentDir, File columnarSegmentDir)
+      throws Exception {
+    IndexSegment rowMajorSegment = ImmutableSegmentLoader.load(rowMajorSegmentDir, ReadMode.heap);
+    IndexSegment columnarSegment = ImmutableSegmentLoader.load(columnarSegmentDir, ReadMode.heap);
+    try {
+      SegmentMetadata rowMajorMeta = rowMajorSegment.getSegmentMetadata();
+      SegmentMetadata columnarMeta = columnarSegment.getSegmentMetadata();
+
+      assertEquals(columnarMeta.getTotalDocs(), rowMajorMeta.getTotalDocs(),
+          "Segment-level doc count must match between row-major and columnar builds");
+
+      // Compare only the user-defined columns — virtual columns ($segmentName, $docId, ...)
+      // are populated post-build and their min/max naturally differ across segments.
+      for (String column : rowMajorMeta.getAllColumns()) {
+        if (column.startsWith("$")) {
+          continue;
+        }
+        ColumnMetadata rmCol = rowMajorMeta.getColumnMetadataFor(column);
+        ColumnMetadata colCol = columnarMeta.getColumnMetadataFor(column);
+        assertNotNull(rmCol, "Row-major missing column metadata for " + column);
+        assertNotNull(colCol, "Columnar missing column metadata for " + column);
+        assertEquals(colCol.getCardinality(), rmCol.getCardinality(),
+            "Cardinality mismatch on column " + column);
+        assertEquals(colCol.getMinValue(), rmCol.getMinValue(),
+            "Min value mismatch on column " + column);
+        assertEquals(colCol.getMaxValue(), rmCol.getMaxValue(),
+            "Max value mismatch on column " + column);
+        assertEquals(colCol.getTotalDocs(), rmCol.getTotalDocs(),
+            "Per-column doc count mismatch on column " + column);
+        assertEquals(colCol.getDataType(), rmCol.getDataType(),
+            "Data type mismatch on column " + column);
+      }
+    } finally {
+      rowMajorSegment.destroy();
+      columnarSegment.destroy();
+    }
+  }
+
+  private File buildSegmentRowMajor(File arrowFile, String segmentName)
+      throws Exception {
+    File outputDir = _tempDir.resolve("rm-out-" + segmentName).toFile();
+    SegmentGeneratorConfig config = newSegmentConfig(outputDir, segmentName);
+    try (ArrowRecordReader recordReader = new ArrowRecordReader()) {
+      recordReader.init(arrowFile, null, null);
+      SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+      driver.init(config, recordReader);
+      driver.build();
+    }
+    return new File(outputDir, segmentName);
+  }
+
+  private File buildSegmentFileColumnar(File arrowFile, String segmentName)
+      throws Exception {
+    File outputDir = _tempDir.resolve("col-file-out-" + segmentName).toFile();
+    SegmentGeneratorConfig config = newSegmentConfig(outputDir, segmentName);
+    try (ArrowFileColumnReaderFactory factory = new ArrowFileColumnReaderFactory(arrowFile)) {
+      SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+      driver.init(config, factory);
+      driver.build();
+    }
+    return new File(outputDir, segmentName);
+  }
+
+  private File buildSegmentInMemoryColumnar(byte[] streamBytes, String segmentName)
+      throws Exception {
+    File outputDir = _tempDir.resolve("col-inmem-out-" + segmentName).toFile();
+    SegmentGeneratorConfig config = newSegmentConfig(outputDir, segmentName);
+    // Caller manages the allocator and the ArrowStreamReader; the factory borrows them.
+    try (RootAllocator callerAllocator = new RootAllocator(Long.MAX_VALUE);
+        ArrowStreamReader streamReader = new ArrowStreamReader(
+            Channels.newChannel(new ByteArrayInputStream(streamBytes)), callerAllocator);
+        ArrowColumnReaderFactory factory =
+            new ArrowColumnReaderFactory(streamReader, callerAllocator)) {
+      SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+      driver.init(config, factory);
+      driver.build();
+    }
+    return new File(outputDir, segmentName);
+  }
+
+  private SegmentGeneratorConfig newSegmentConfig(File outputDir, String segmentName) {
+    org.apache.pinot.spi.data.Schema schema = new org.apache.pinot.spi.data.Schema();
+    schema.setSchemaName(TABLE_NAME);
+    schema.addField(new DimensionFieldSpec("intCol", DataType.INT, true));
+    schema.addField(new DimensionFieldSpec("longCol", DataType.LONG, true));
+    schema.addField(new DimensionFieldSpec("stringCol", DataType.STRING, true));
+
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
+
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+    config.setOutDir(outputDir.getAbsolutePath());
+    config.setSegmentName(segmentName);
+    return config;
+  }
+
+  private File writeArrowFileFixture(String fileName)
+      throws IOException {
+    File out = _tempDir.resolve(fileName).toFile();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        VectorSchemaRoot root = VectorSchemaRoot.create(fixtureArrowSchema(), allocator);
+        FileOutputStream fos = new FileOutputStream(out);
+        FileChannel channel = fos.getChannel();
+        ArrowFileWriter writer = new ArrowFileWriter(root, null, channel)) {
+      populateFixtureVectors(root);
+      writer.start();
+      writer.writeBatch();
+      writer.end();
+    }
+    return out;
+  }
+
+  private byte[] writeArrowStreamBytes()
+      throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        VectorSchemaRoot root = VectorSchemaRoot.create(fixtureArrowSchema(), allocator);
+        ArrowStreamWriter writer = new ArrowStreamWriter(root, null, Channels.newChannel(out))) {
+      populateFixtureVectors(root);
+      writer.start();
+      writer.writeBatch();
+      writer.end();
+    }
+    return out.toByteArray();
+  }
+
+  private Schema fixtureArrowSchema() {
+    Field intField = new Field("intCol", FieldType.nullable(new ArrowType.Int(32, true)), null);
+    Field longField = new Field("longCol", FieldType.nullable(new ArrowType.Int(64, true)), null);
+    Field stringField = new Field("stringCol", FieldType.nullable(new ArrowType.Utf8()), null);
+    return new Schema(Arrays.asList(intField, longField, stringField));
+  }
+
+  private void populateFixtureVectors(VectorSchemaRoot root) {
+    IntVector intVec = (IntVector) root.getVector("intCol");
+    BigIntVector longVec = (BigIntVector) root.getVector("longCol");
+    VarCharVector stringVec = (VarCharVector) root.getVector("stringCol");
+
+    intVec.allocateNew(ROW_COUNT);
+    longVec.allocateNew(ROW_COUNT);
+    stringVec.allocateNew(ROW_COUNT * 8, ROW_COUNT);
+
+    for (int i = 0; i < ROW_COUNT; i++) {
+      intVec.set(i, i);
+      longVec.set(i, (long) i * 1000);
+      stringVec.set(i, ("row_" + i).getBytes());
+    }
+    intVec.setValueCount(ROW_COUNT);
+    longVec.setValueCount(ROW_COUNT);
+    stringVec.setValueCount(ROW_COUNT);
+    root.setRowCount(ROW_COUNT);
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnarBuildIntegrationTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnarBuildIntegrationTest.java
@@ -25,17 +25,21 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.TimeStampMilliVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowFileWriter;
 import org.apache.arrow.vector.ipc.ArrowStreamReader;
 import org.apache.arrow.vector.ipc.ArrowStreamWriter;
+import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -50,6 +54,7 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.AfterMethod;
@@ -132,6 +137,128 @@ public class ArrowColumnarBuildIntegrationTest {
     File columnarSegmentDir = buildSegmentInMemoryColumnar(streamBytes, "inMemColumnar");
 
     assertSegmentMetadataEquivalence(rowMajorSegmentDir, columnarSegmentDir);
+  }
+
+  /**
+   * BOOLEAN and TIMESTAMP columns exercise the column-major type-normalization path: the Arrow source
+   * surfaces {@code Boolean} / {@code Timestamp} (or {@code LocalDateTime}) values that must be coerced
+   * to the stored {@code INT} / {@code LONG} to match what the row-major {@code DataTypeTransformer}
+   * produces. Before normalization the column-major build crashed on these types (the typed stats
+   * collectors / index creators cast-failed on the source Java type). Asserts both per-column metadata
+   * and per-docId record values match the row-major segment built from the same file.
+   */
+  @Test
+  public void testTypeNormalizationRowMajorVsColumnar()
+      throws Exception {
+    File arrowFile = writeTypedArrowFileFixture("typed-equivalence.arrow");
+    org.apache.pinot.spi.data.Schema schema = typedPinotSchema();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
+
+    File rowMajorDir = _tempDir.resolve("rm-typed").toFile();
+    try (ArrowRecordReader reader = new ArrowRecordReader()) {
+      reader.init(arrowFile, null, null);
+      SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+      config.setOutDir(rowMajorDir.getAbsolutePath());
+      config.setSegmentName("rmTyped");
+      SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+      driver.init(config, reader);
+      driver.build();
+    }
+
+    File columnarDir = _tempDir.resolve("col-typed").toFile();
+    try (ArrowFileColumnReaderFactory factory = new ArrowFileColumnReaderFactory(arrowFile)) {
+      SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+      config.setOutDir(columnarDir.getAbsolutePath());
+      config.setSegmentName("colTyped");
+      SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+      driver.init(config, factory);
+      driver.build();
+    }
+
+    File rowMajorSeg = new File(rowMajorDir, "rmTyped");
+    File columnarSeg = new File(columnarDir, "colTyped");
+    assertSegmentMetadataEquivalence(rowMajorSeg, columnarSeg);
+    assertPerDocRecordEquivalence(rowMajorSeg, columnarSeg,
+        new String[]{"intCol", "boolCol", "tsCol", "stringCol"});
+  }
+
+  private void assertPerDocRecordEquivalence(File segDirA, File segDirB, String[] columns)
+      throws Exception {
+    IndexSegment segA = ImmutableSegmentLoader.load(segDirA, ReadMode.heap);
+    IndexSegment segB = ImmutableSegmentLoader.load(segDirB, ReadMode.heap);
+    try {
+      int numDocs = segA.getSegmentMetadata().getTotalDocs();
+      assertEquals(segB.getSegmentMetadata().getTotalDocs(), numDocs, "doc count mismatch");
+      GenericRow rowA = new GenericRow();
+      GenericRow rowB = new GenericRow();
+      for (int docId = 0; docId < numDocs; docId++) {
+        rowA.clear();
+        rowB.clear();
+        segA.getRecord(docId, rowA);
+        segB.getRecord(docId, rowB);
+        for (String column : columns) {
+          assertEquals(rowB.getValue(column), rowA.getValue(column),
+              "value mismatch on column " + column + " at docId " + docId);
+        }
+      }
+    } finally {
+      segA.destroy();
+      segB.destroy();
+    }
+  }
+
+  private org.apache.pinot.spi.data.Schema typedPinotSchema() {
+    org.apache.pinot.spi.data.Schema schema = new org.apache.pinot.spi.data.Schema();
+    schema.setSchemaName(TABLE_NAME);
+    schema.addField(new DimensionFieldSpec("intCol", DataType.INT, true));
+    schema.addField(new DimensionFieldSpec("boolCol", DataType.BOOLEAN, true));
+    schema.addField(new DimensionFieldSpec("tsCol", DataType.TIMESTAMP, true));
+    schema.addField(new DimensionFieldSpec("stringCol", DataType.STRING, true));
+    return schema;
+  }
+
+  private File writeTypedArrowFileFixture(String fileName)
+      throws IOException {
+    Field intField = new Field("intCol", FieldType.nullable(new ArrowType.Int(32, true)), null);
+    Field boolField = new Field("boolCol", FieldType.nullable(new ArrowType.Bool()), null);
+    Field tsField =
+        new Field("tsCol", FieldType.nullable(new ArrowType.Timestamp(TimeUnit.MILLISECOND, null)), null);
+    Field stringField = new Field("stringCol", FieldType.nullable(new ArrowType.Utf8()), null);
+    Schema arrowSchema = new Schema(Arrays.asList(intField, boolField, tsField, stringField));
+
+    File out = _tempDir.resolve(fileName).toFile();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator);
+        FileOutputStream fos = new FileOutputStream(out);
+        FileChannel channel = fos.getChannel();
+        ArrowFileWriter writer = new ArrowFileWriter(root, null, channel)) {
+      IntVector intVec = (IntVector) root.getVector("intCol");
+      BitVector boolVec = (BitVector) root.getVector("boolCol");
+      TimeStampMilliVector tsVec = (TimeStampMilliVector) root.getVector("tsCol");
+      VarCharVector stringVec = (VarCharVector) root.getVector("stringCol");
+
+      intVec.allocateNew(ROW_COUNT);
+      boolVec.allocateNew(ROW_COUNT);
+      tsVec.allocateNew(ROW_COUNT);
+      stringVec.allocateNew(ROW_COUNT * 8, ROW_COUNT);
+
+      for (int i = 0; i < ROW_COUNT; i++) {
+        intVec.set(i, i);
+        boolVec.set(i, i % 2);                     // alternating false/true -> stored INT 0/1
+        tsVec.set(i, 1_700_000_000_000L + i);      // epoch millis
+        stringVec.set(i, ("row_" + i).getBytes(StandardCharsets.UTF_8));
+      }
+      intVec.setValueCount(ROW_COUNT);
+      boolVec.setValueCount(ROW_COUNT);
+      tsVec.setValueCount(ROW_COUNT);
+      stringVec.setValueCount(ROW_COUNT);
+      root.setRowCount(ROW_COUNT);
+
+      writer.start();
+      writer.writeBatch();
+      writer.end();
+    }
+    return out;
   }
 
   private void assertSegmentMetadataEquivalence(File rowMajorSegmentDir, File columnarSegmentDir)
@@ -279,7 +406,7 @@ public class ArrowColumnarBuildIntegrationTest {
     for (int i = 0; i < ROW_COUNT; i++) {
       intVec.set(i, i);
       longVec.set(i, (long) i * 1000);
-      stringVec.set(i, ("row_" + i).getBytes());
+      stringVec.set(i, ("row_" + i).getBytes(StandardCharsets.UTF_8));
     }
     intVec.setValueCount(ROW_COUNT);
     longVec.setValueCount(ROW_COUNT);

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnarBuildIntegrationTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnarBuildIntegrationTest.java
@@ -29,6 +29,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
@@ -36,16 +38,22 @@ import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.TimeStampMilliVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.impl.UnionListWriter;
+import org.apache.arrow.vector.dictionary.Dictionary;
+import org.apache.arrow.vector.dictionary.DictionaryProvider;
 import org.apache.arrow.vector.ipc.ArrowFileWriter;
 import org.apache.arrow.vector.ipc.ArrowStreamReader;
 import org.apache.arrow.vector.ipc.ArrowStreamWriter;
 import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.utils.CrcUtils;
 import org.apache.pinot.segment.spi.ColumnMetadata;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.SegmentMetadata;
@@ -63,6 +71,7 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 
 /**
@@ -197,8 +206,15 @@ public class ArrowColumnarBuildIntegrationTest {
         segA.getRecord(docId, rowA);
         segB.getRecord(docId, rowB);
         for (String column : columns) {
-          assertEquals(rowB.getValue(column), rowA.getValue(column),
-              "value mismatch on column " + column + " at docId " + docId);
+          Object expected = rowA.getValue(column);
+          Object actual = rowB.getValue(column);
+          String message = "value mismatch on column " + column + " at docId " + docId;
+          if (expected instanceof Object[] && actual instanceof Object[]) {
+            // Multi-value columns surface as Object[]; compare element-wise.
+            assertEquals((Object[]) actual, (Object[]) expected, message);
+          } else {
+            assertEquals(actual, expected, message);
+          }
         }
       }
     } finally {
@@ -257,6 +273,322 @@ public class ArrowColumnarBuildIntegrationTest {
       writer.start();
       writer.writeBatch();
       writer.end();
+    }
+    return out;
+  }
+
+  /**
+   * Guardrail for any change that processes the Arrow source one record batch at a time: a segment
+   * built from a multi-batch file must be byte-identical (same-path data CRC) and per-docId equal to
+   * one built from a single-batch file carrying the same logical rows, and the naturally-ascending
+   * column must stay sorted across the batch boundary. A batch-boundary ordering bug would change
+   * {@code isSorted}, the inverted index on {@code category}, or the per-doc values. Also cross-checks
+   * the multi-batch columnar segment against the row-major segment from the same file.
+   *
+   * <p>Passes on the current materialize-all build; its purpose is to fail loudly if a future
+   * batch-bounded reader misorders docs across a boundary.
+   */
+  @Test
+  public void testMultiBatchColumnarEquivalence()
+      throws Exception {
+    String[] columns = {"id", "category", "label"};
+    File singleBatchFile = writeGuardrailArrowFile("guardrail-single.arrow", 1, 60);
+    File multiBatchFile = writeGuardrailArrowFile("guardrail-multi.arrow", 3, 20);
+
+    File singleColSeg = buildGuardrailSegment(singleBatchFile, "guardSingleCol", true);
+    File multiColSeg = buildGuardrailSegment(multiBatchFile, "guardMultiCol", true);
+    File multiRowSeg = buildGuardrailSegment(multiBatchFile, "guardMultiRow", false);
+
+    // Same logical data, different batching -> byte-identical data files and per-doc values.
+    assertEquals(CrcUtils.computeDataCrc(multiColSeg), CrcUtils.computeDataCrc(singleColSeg),
+        "Multi-batch and single-batch columnar segments must have identical data CRC");
+    assertPerDocRecordEquivalence(singleColSeg, multiColSeg, columns);
+    // Cross-path: multi-batch columnar == row-major.
+    assertPerDocRecordEquivalence(multiRowSeg, multiColSeg, columns);
+
+    // The ascending column stays sorted across the batch boundary.
+    IndexSegment seg = ImmutableSegmentLoader.load(multiColSeg, ReadMode.heap);
+    try {
+      assertTrue(seg.getSegmentMetadata().getColumnMetadataFor("id").isSorted(),
+          "id must be detected as sorted across batches");
+    } finally {
+      seg.destroy();
+    }
+  }
+
+  private File buildGuardrailSegment(File arrowFile, String segmentName, boolean columnar)
+      throws Exception {
+    org.apache.pinot.spi.data.Schema schema = new org.apache.pinot.spi.data.Schema();
+    schema.setSchemaName(TABLE_NAME);
+    schema.addField(new DimensionFieldSpec("id", DataType.INT, true));
+    schema.addField(new DimensionFieldSpec("category", DataType.INT, true));
+    schema.addField(new DimensionFieldSpec("label", DataType.STRING, true));
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setInvertedIndexColumns(List.of("category"))
+        .setCreateInvertedIndexDuringSegmentGeneration(true)
+        .build();
+
+    File outDir = _tempDir.resolve("g-" + segmentName).toFile();
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+    config.setOutDir(outDir.getAbsolutePath());
+    config.setSegmentName(segmentName);
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    if (columnar) {
+      try (ArrowFileColumnReaderFactory factory = new ArrowFileColumnReaderFactory(arrowFile)) {
+        driver.init(config, factory);
+        driver.build();
+      }
+    } else {
+      try (ArrowRecordReader reader = new ArrowRecordReader()) {
+        reader.init(arrowFile, null, null);
+        driver.init(config, reader);
+        driver.build();
+      }
+    }
+    return new File(outDir, segmentName);
+  }
+
+  private File writeGuardrailArrowFile(String fileName, int batchCount, int rowsPerBatch)
+      throws IOException {
+    Field idField = new Field("id", FieldType.nullable(new ArrowType.Int(32, true)), null);
+    Field catField = new Field("category", FieldType.nullable(new ArrowType.Int(32, true)), null);
+    Field labelField = new Field("label", FieldType.nullable(new ArrowType.Utf8()), null);
+    Schema arrowSchema = new Schema(Arrays.asList(idField, catField, labelField));
+
+    File out = _tempDir.resolve(fileName).toFile();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator);
+        FileOutputStream fos = new FileOutputStream(out);
+        FileChannel channel = fos.getChannel();
+        ArrowFileWriter writer = new ArrowFileWriter(root, null, channel)) {
+      IntVector idVec = (IntVector) root.getVector("id");
+      IntVector catVec = (IntVector) root.getVector("category");
+      VarCharVector labelVec = (VarCharVector) root.getVector("label");
+
+      writer.start();
+      int globalRow = 0;
+      for (int batch = 0; batch < batchCount; batch++) {
+        root.allocateNew();
+        idVec.allocateNew(rowsPerBatch);
+        catVec.allocateNew(rowsPerBatch);
+        labelVec.allocateNew(rowsPerBatch * 10L, rowsPerBatch);
+        for (int row = 0; row < rowsPerBatch; row++) {
+          idVec.set(row, globalRow);             // globally ascending -> sorted across batches
+          catVec.set(row, globalRow % 4);        // low cardinality -> inverted index
+          labelVec.set(row, ("row_" + globalRow).getBytes(StandardCharsets.UTF_8));
+          globalRow++;
+        }
+        idVec.setValueCount(rowsPerBatch);
+        catVec.setValueCount(rowsPerBatch);
+        labelVec.setValueCount(rowsPerBatch);
+        root.setRowCount(rowsPerBatch);
+        writer.writeBatch();
+      }
+      writer.end();
+    }
+    return out;
+  }
+
+  /**
+   * The richest end-to-end equivalence: a multi-batch Arrow file combining a dictionary-encoded
+   * string, a nullable int with nulls crossing batch boundaries, a BOOLEAN, and a TIMESTAMP, built
+   * both row-major and column-major. Exercises together and across batch boundaries: the
+   * batch-bounded reader's per-batch dictionary decode, the null-value vector + default substitution,
+   * and Boolean/Timestamp stored-type coercion. Asserts per-docId record equality, metadata, and that
+   * the ascending id stays sorted across batches.
+   */
+  @Test
+  public void testRichMultiBatchEquivalence()
+      throws Exception {
+    File arrowFile = writeRichMultiBatchArrowFile("rich-multi.arrow", 3, 10); // 30 docs, nulls at 0,5,10,...
+    String[] columns = {"id", "color", "score", "flag", "ts"};
+
+    org.apache.pinot.spi.data.Schema schema = new org.apache.pinot.spi.data.Schema();
+    schema.setSchemaName(TABLE_NAME);
+    schema.addField(new DimensionFieldSpec("id", DataType.INT, true));
+    schema.addField(new DimensionFieldSpec("color", DataType.STRING, true));
+    schema.addField(new DimensionFieldSpec("score", DataType.INT, true));
+    schema.addField(new DimensionFieldSpec("flag", DataType.BOOLEAN, true));
+    schema.addField(new DimensionFieldSpec("ts", DataType.TIMESTAMP, true));
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setNullHandlingEnabled(true).build();
+
+    File rowMajorSeg = buildSegment(arrowFile, "richRow", schema, tableConfig, false);
+    File columnarSeg = buildSegment(arrowFile, "richCol", schema, tableConfig, true);
+
+    assertSegmentMetadataEquivalence(rowMajorSeg, columnarSeg);
+    assertPerDocRecordEquivalence(rowMajorSeg, columnarSeg, columns);
+
+    IndexSegment seg = ImmutableSegmentLoader.load(columnarSeg, ReadMode.heap);
+    try {
+      assertTrue(seg.getSegmentMetadata().getColumnMetadataFor("id").isSorted(),
+          "id must be sorted across batches");
+    } finally {
+      seg.destroy();
+    }
+  }
+
+  /**
+   * Multi-value column end-to-end across a batch boundary: a multi-batch Arrow file with an MV int
+   * column, built row-major and column-major. Exercises the column-major MV path through
+   * {@code ColumnarValueNormalizer} (Object[] standardisation) and the batch-bounded reader's MV reads
+   * across batches, asserting per-docId MV equality with the row-major segment.
+   */
+  @Test
+  public void testMultiValueMultiBatchEquivalence()
+      throws Exception {
+    File arrowFile = writeMultiValueMultiBatchArrowFile("mv-multi.arrow", 2, 4); // 8 docs
+    String[] columns = {"id", "intArr"};
+
+    org.apache.pinot.spi.data.Schema schema = new org.apache.pinot.spi.data.Schema.SchemaBuilder()
+        .setSchemaName(TABLE_NAME)
+        .addSingleValueDimension("id", DataType.INT)
+        .addMultiValueDimension("intArr", DataType.INT)
+        .build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
+
+    File rowMajorSeg = buildSegment(arrowFile, "mvRow", schema, tableConfig, false);
+    File columnarSeg = buildSegment(arrowFile, "mvCol", schema, tableConfig, true);
+
+    assertSegmentMetadataEquivalence(rowMajorSeg, columnarSeg);
+    assertPerDocRecordEquivalence(rowMajorSeg, columnarSeg, columns);
+  }
+
+  private File writeMultiValueMultiBatchArrowFile(String fileName, int batchCount, int rowsPerBatch)
+      throws IOException {
+    File out = _tempDir.resolve(fileName).toFile();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      Field idField = new Field("id", FieldType.nullable(new ArrowType.Int(32, true)), null);
+      Field elementField = new Field("element", FieldType.nullable(new ArrowType.Int(32, true)), null);
+      Field listField = new Field("intArr", FieldType.nullable(ArrowType.List.INSTANCE),
+          Collections.singletonList(elementField));
+      Schema arrowSchema = new Schema(Arrays.asList(idField, listField));
+
+      try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator);
+          FileOutputStream fos = new FileOutputStream(out);
+          FileChannel channel = fos.getChannel();
+          ArrowFileWriter writer = new ArrowFileWriter(root, null, channel)) {
+        IntVector idVec = (IntVector) root.getVector("id");
+        ListVector listVec = (ListVector) root.getVector("intArr");
+
+        writer.start();
+        int g = 0;
+        for (int b = 0; b < batchCount; b++) {
+          idVec.allocateNew(rowsPerBatch);
+          listVec.allocateNew();
+          UnionListWriter listWriter = listVec.getWriter();
+          for (int i = 0; i < rowsPerBatch; i++) {
+            idVec.set(i, g);
+            listWriter.setPosition(i);
+            listWriter.startList();
+            for (int k = 0; k <= g % 2; k++) {   // length 1 or 2; no null / empty elements
+              listWriter.integer().writeInt(g * 10 + k);
+            }
+            listWriter.endList();
+            g++;
+          }
+          idVec.setValueCount(rowsPerBatch);
+          listVec.setValueCount(rowsPerBatch);
+          root.setRowCount(rowsPerBatch);
+          writer.writeBatch();
+        }
+        writer.end();
+      }
+    }
+    return out;
+  }
+
+  private File buildSegment(File arrowFile, String segmentName, org.apache.pinot.spi.data.Schema schema,
+      TableConfig tableConfig, boolean columnar)
+      throws Exception {
+    File outDir = _tempDir.resolve("build-" + segmentName).toFile();
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+    config.setOutDir(outDir.getAbsolutePath());
+    config.setSegmentName(segmentName);
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    if (columnar) {
+      try (ArrowFileColumnReaderFactory factory = new ArrowFileColumnReaderFactory(arrowFile)) {
+        driver.init(config, factory);
+        driver.build();
+      }
+    } else {
+      try (ArrowRecordReader reader = new ArrowRecordReader()) {
+        reader.init(arrowFile, null, null);
+        driver.init(config, reader);
+        driver.build();
+      }
+    }
+    return new File(outDir, segmentName);
+  }
+
+  private File writeRichMultiBatchArrowFile(String fileName, int batchCount, int rowsPerBatch)
+      throws IOException {
+    String[] palette = {"red", "green", "blue"};
+    DictionaryEncoding encoding = new DictionaryEncoding(1L, false, new ArrowType.Int(32, true));
+    File out = _tempDir.resolve(fileName).toFile();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      VarCharVector dictVec = new VarCharVector("color-dict", allocator);
+      dictVec.allocateNew();
+      for (int i = 0; i < palette.length; i++) {
+        dictVec.setSafe(i, palette[i].getBytes(StandardCharsets.UTF_8));
+      }
+      dictVec.setValueCount(palette.length);
+      Dictionary dictionary = new Dictionary(dictVec, encoding);
+      DictionaryProvider.MapDictionaryProvider provider = new DictionaryProvider.MapDictionaryProvider();
+      provider.put(dictionary);
+      try {
+        Field idField = new Field("id", FieldType.nullable(new ArrowType.Int(32, true)), null);
+        // "color" is an Int32 index vector carrying the dictionary encoding.
+        Field colorField = new Field("color", new FieldType(true, new ArrowType.Int(32, true), encoding), null);
+        Field scoreField = new Field("score", FieldType.nullable(new ArrowType.Int(32, true)), null);
+        Field flagField = new Field("flag", FieldType.nullable(new ArrowType.Bool()), null);
+        Field tsField =
+            new Field("ts", FieldType.nullable(new ArrowType.Timestamp(TimeUnit.MILLISECOND, null)), null);
+        Schema arrowSchema = new Schema(Arrays.asList(idField, colorField, scoreField, flagField, tsField));
+
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator);
+            FileOutputStream fos = new FileOutputStream(out);
+            FileChannel channel = fos.getChannel();
+            ArrowFileWriter writer = new ArrowFileWriter(root, provider, channel)) {
+          IntVector idVec = (IntVector) root.getVector("id");
+          IntVector colorVec = (IntVector) root.getVector("color");
+          IntVector scoreVec = (IntVector) root.getVector("score");
+          BitVector flagVec = (BitVector) root.getVector("flag");
+          TimeStampMilliVector tsVec = (TimeStampMilliVector) root.getVector("ts");
+
+          writer.start();
+          int g = 0;
+          for (int b = 0; b < batchCount; b++) {
+            idVec.allocateNew(rowsPerBatch);
+            colorVec.allocateNew(rowsPerBatch);
+            scoreVec.allocateNew(rowsPerBatch);
+            flagVec.allocateNew(rowsPerBatch);
+            tsVec.allocateNew(rowsPerBatch);
+            for (int i = 0; i < rowsPerBatch; i++) {
+              idVec.set(i, g);                        // ascending -> sorted across batches
+              colorVec.set(i, g % palette.length);    // dictionary index
+              if (g % 5 == 0) {
+                scoreVec.setNull(i);                  // nulls at 0,5,10,15,20,25 -> cross batch boundaries
+              } else {
+                scoreVec.set(i, g * 7);
+              }
+              flagVec.set(i, g % 2);
+              tsVec.set(i, 1_700_000_000_000L + g);
+              g++;
+            }
+            idVec.setValueCount(rowsPerBatch);
+            colorVec.setValueCount(rowsPerBatch);
+            scoreVec.setValueCount(rowsPerBatch);
+            flagVec.setValueCount(rowsPerBatch);
+            tsVec.setValueCount(rowsPerBatch);
+            root.setRowCount(rowsPerBatch);
+            writer.writeBatch();
+          }
+          writer.end();
+        }
+      } finally {
+        dictVec.close();
+      }
     }
     return out;
   }

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowFileColumnReaderFactoryTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowFileColumnReaderFactoryTest.java
@@ -1,0 +1,456 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.arrow;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.Float8Vector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VarBinaryVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.impl.UnionListWriter;
+import org.apache.arrow.vector.ipc.ArrowFileWriter;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.readers.ColumnReader;
+import org.apache.pinot.spi.data.readers.MultiValueResult;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Unit tests for {@link ArrowColumnReaderFactory} and {@link ArrowColumnReader}.
+ *
+ * <p>Each test materialises a small Arrow IPC file on disk with a known fixture and verifies
+ * that the factory can read it back column-by-column using all three documented patterns:
+ * generic sequential {@code next()}, typed sequential {@code nextInt() / nextLong() / ...},
+ * and random-access {@code getInt(docId) / getLong(docId) / ...}.
+ */
+public class ArrowFileColumnReaderFactoryTest {
+
+  private static final int ROWS = 8;
+  private Path _tempDir;
+
+  @BeforeMethod
+  public void setUp()
+      throws IOException {
+    _tempDir = Files.createTempDirectory("arrow-column-reader-test");
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws IOException {
+    if (_tempDir != null) {
+      try (var stream = Files.walk(_tempDir)) {
+        stream.sorted((a, b) -> b.compareTo(a)).forEach(p -> {
+          try {
+            Files.deleteIfExists(p);
+          } catch (IOException ignored) {
+            // best effort
+          }
+        });
+      }
+    }
+  }
+
+  @Test
+  public void testSequentialReadAllPrimitiveTypes()
+      throws IOException {
+    File arrowFile = writePrimitiveFixture("primitive.arrow");
+    org.apache.pinot.spi.data.Schema schema = primitiveSchema();
+
+    try (ArrowFileColumnReaderFactory factory = new ArrowFileColumnReaderFactory(arrowFile)) {
+      factory.init(schema);
+
+      Map<String, ColumnReader> readers = factory.getAllColumnReaders();
+      assertEquals(readers.size(), 6);
+      for (ColumnReader r : readers.values()) {
+        assertEquals(r.getTotalDocs(), ROWS);
+        assertTrue(r.isSingleValue());
+      }
+
+      ColumnReader intReader = readers.get("intCol");
+      ColumnReader longReader = readers.get("longCol");
+      ColumnReader floatReader = readers.get("floatCol");
+      ColumnReader doubleReader = readers.get("doubleCol");
+      ColumnReader stringReader = readers.get("stringCol");
+      ColumnReader bytesReader = readers.get("bytesCol");
+
+      assertTrue(intReader.isInt());
+      assertTrue(longReader.isLong());
+      assertTrue(floatReader.isFloat());
+      assertTrue(doubleReader.isDouble());
+      assertTrue(stringReader.isString());
+      assertTrue(bytesReader.isBytes());
+
+      // Pattern 2: typed sequential read with null handling
+      for (int i = 0; i < ROWS; i++) {
+        if (i == 3) {
+          assertTrue(intReader.isNextNull(), "Row 3 INT should be null");
+          intReader.skipNext();
+          assertTrue(longReader.isNextNull(), "Row 3 LONG should be null");
+          longReader.skipNext();
+          assertTrue(stringReader.isNextNull(), "Row 3 STRING should be null");
+          stringReader.skipNext();
+          floatReader.nextFloat();
+          doubleReader.nextDouble();
+          bytesReader.nextBytes();
+        } else {
+          assertFalse(intReader.isNextNull());
+          assertEquals(intReader.nextInt(), i * 10);
+          assertEquals(longReader.nextLong(), (long) i * 100);
+          assertEquals(floatReader.nextFloat(), i + 0.5f, 0.0001f);
+          assertEquals(doubleReader.nextDouble(), i + 0.25, 0.0001);
+          assertEquals(stringReader.nextString(), "s_" + i);
+          assertEquals(new String(bytesReader.nextBytes()), "b_" + i);
+        }
+      }
+
+      // Verify rewind enables a second pass.
+      intReader.rewind();
+      stringReader.rewind();
+      assertTrue(intReader.hasNext());
+      assertEquals(intReader.nextInt(), 0);
+      assertEquals(stringReader.nextString(), "s_0");
+    }
+  }
+
+  @Test
+  public void testRandomAccessByDocId()
+      throws IOException {
+    File arrowFile = writePrimitiveFixture("random.arrow");
+    org.apache.pinot.spi.data.Schema schema = primitiveSchema();
+
+    try (ArrowFileColumnReaderFactory factory = new ArrowFileColumnReaderFactory(arrowFile)) {
+      factory.init(schema);
+      ColumnReader intReader = factory.getColumnReader("intCol");
+      ColumnReader longReader = factory.getColumnReader("longCol");
+
+      // Pattern 3: read out of order.
+      assertEquals(intReader.getInt(5), 50);
+      assertEquals(intReader.getInt(0), 0);
+      assertEquals(intReader.getInt(7), 70);
+      assertTrue(intReader.isNull(3));
+      assertEquals(longReader.getLong(2), 200L);
+      assertEquals(longReader.getValue(3), null);
+
+      // Sequential read is unaffected by prior random-access reads on the same reader.
+      assertTrue(intReader.hasNext());
+      assertEquals(intReader.nextInt(), 0);
+    }
+  }
+
+  @Test
+  public void testGenericNextHandlesNulls()
+      throws IOException {
+    File arrowFile = writePrimitiveFixture("generic.arrow");
+    org.apache.pinot.spi.data.Schema schema = primitiveSchema();
+
+    try (ArrowFileColumnReaderFactory factory = new ArrowFileColumnReaderFactory(arrowFile)) {
+      factory.init(schema);
+      ColumnReader stringReader = factory.getColumnReader("stringCol");
+
+      int nullCount = 0;
+      int nonNullCount = 0;
+      while (stringReader.hasNext()) {
+        Object value = stringReader.next();
+        if (value == null) {
+          nullCount++;
+        } else {
+          nonNullCount++;
+        }
+      }
+      assertEquals(nullCount, 1);
+      assertEquals(nonNullCount, ROWS - 1);
+    }
+  }
+
+  @Test
+  public void testMultiValueIntColumn()
+      throws IOException {
+    File arrowFile = writeMultiValueIntFixture("mv-int.arrow");
+    org.apache.pinot.spi.data.Schema schema = new org.apache.pinot.spi.data.Schema.SchemaBuilder()
+        .setSchemaName("mv")
+        .addMultiValueDimension("intArr", FieldSpec.DataType.INT)
+        .build();
+
+    try (ArrowFileColumnReaderFactory factory = new ArrowFileColumnReaderFactory(arrowFile)) {
+      factory.init(schema);
+      ColumnReader reader = factory.getColumnReader("intArr");
+      assertNotNull(reader);
+      assertFalse(reader.isSingleValue());
+      assertEquals(reader.getTotalDocs(), 3);
+
+      MultiValueResult<int[]> doc0 = reader.getIntMV(0);
+      assertEquals(doc0.getValues(), new int[]{1, 2, 3});
+      assertFalse(doc0.hasNulls());
+
+      MultiValueResult<int[]> doc1 = reader.getIntMV(1);
+      assertEquals(doc1.getValues().length, 2);
+      assertTrue(doc1.hasNulls());
+      assertTrue(doc1.isNull(1));
+      assertFalse(doc1.isNull(0));
+      assertEquals(doc1.getValues()[0], 4);
+
+      MultiValueResult<int[]> doc2 = reader.getIntMV(2);
+      assertEquals(doc2.getValues().length, 0);
+    }
+  }
+
+  @Test
+  public void testInitSubsetOfColumns()
+      throws IOException {
+    File arrowFile = writePrimitiveFixture("subset.arrow");
+    org.apache.pinot.spi.data.Schema schema = primitiveSchema();
+
+    try (ArrowFileColumnReaderFactory factory = new ArrowFileColumnReaderFactory(arrowFile)) {
+      factory.init(schema, java.util.Set.of("intCol", "stringCol"), Collections.emptyMap());
+      Map<String, ColumnReader> readers = factory.getAllColumnReaders();
+      assertEquals(readers.size(), 2);
+      assertTrue(readers.containsKey("intCol"));
+      assertTrue(readers.containsKey("stringCol"));
+      assertNull(factory.getColumnReader("longCol"));
+    }
+  }
+
+  @Test
+  public void testMultiBatchConcatenation()
+      throws IOException {
+    File arrowFile = writeMultiBatchFixture("multi-batch.arrow", 3, 4);
+    org.apache.pinot.spi.data.Schema schema = new org.apache.pinot.spi.data.Schema.SchemaBuilder()
+        .setSchemaName("multiBatch")
+        .addSingleValueDimension("seqCol", FieldSpec.DataType.INT)
+        .build();
+
+    try (ArrowFileColumnReaderFactory factory = new ArrowFileColumnReaderFactory(arrowFile)) {
+      factory.init(schema);
+      ColumnReader reader = factory.getColumnReader("seqCol");
+      assertNotNull(reader);
+      assertEquals(reader.getTotalDocs(), 12, "Expected 3 batches of 4 rows = 12 docs total");
+
+      // Sequential traversal yields the global doc order.
+      for (int i = 0; i < 12; i++) {
+        assertEquals(reader.nextInt(), i);
+      }
+      assertFalse(reader.hasNext());
+
+      // Random access across batch boundaries.
+      reader.rewind();
+      assertEquals(reader.getInt(0), 0);
+      assertEquals(reader.getInt(3), 3);   // last row of batch 0
+      assertEquals(reader.getInt(4), 4);   // first row of batch 1
+      assertEquals(reader.getInt(7), 7);   // last row of batch 1
+      assertEquals(reader.getInt(8), 8);   // first row of batch 2
+      assertEquals(reader.getInt(11), 11); // last row overall
+    }
+  }
+
+  @Test
+  public void testGetAvailableColumnsIncludesAllSourceColumns()
+      throws IOException {
+    File arrowFile = writePrimitiveFixture("available.arrow");
+    org.apache.pinot.spi.data.Schema schema = primitiveSchema();
+
+    try (ArrowFileColumnReaderFactory factory = new ArrowFileColumnReaderFactory(arrowFile)) {
+      factory.init(schema, java.util.Set.of("intCol"), Collections.emptyMap());
+      // getAvailableColumns reflects the source schema, not the requested subset.
+      assertTrue(factory.getAvailableColumns().containsAll(
+          Arrays.asList("intCol", "longCol", "floatCol", "doubleCol", "stringCol", "bytesCol")));
+    }
+  }
+
+  // ===== Fixture builders =====
+
+  private org.apache.pinot.spi.data.Schema primitiveSchema() {
+    org.apache.pinot.spi.data.Schema schema = new org.apache.pinot.spi.data.Schema();
+    schema.setSchemaName("primitive");
+    schema.addField(new DimensionFieldSpec("intCol", FieldSpec.DataType.INT, true));
+    schema.addField(new DimensionFieldSpec("longCol", FieldSpec.DataType.LONG, true));
+    schema.addField(new DimensionFieldSpec("floatCol", FieldSpec.DataType.FLOAT, true));
+    schema.addField(new DimensionFieldSpec("doubleCol", FieldSpec.DataType.DOUBLE, true));
+    schema.addField(new DimensionFieldSpec("stringCol", FieldSpec.DataType.STRING, true));
+    schema.addField(new DimensionFieldSpec("bytesCol", FieldSpec.DataType.BYTES, true));
+    return schema;
+  }
+
+  private File writePrimitiveFixture(String fileName)
+      throws IOException {
+    File out = _tempDir.resolve(fileName).toFile();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      Field intField = new Field("intCol", FieldType.nullable(new ArrowType.Int(32, true)), null);
+      Field longField = new Field("longCol", FieldType.nullable(new ArrowType.Int(64, true)), null);
+      Field floatField =
+          new Field("floatCol", FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)), null);
+      Field doubleField =
+          new Field("doubleCol", FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)), null);
+      Field stringField = new Field("stringCol", FieldType.nullable(new ArrowType.Utf8()), null);
+      Field bytesField = new Field("bytesCol", FieldType.nullable(new ArrowType.Binary()), null);
+      Schema schema =
+          new Schema(Arrays.asList(intField, longField, floatField, doubleField, stringField, bytesField));
+
+      try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+        IntVector intVec = (IntVector) root.getVector("intCol");
+        BigIntVector longVec = (BigIntVector) root.getVector("longCol");
+        Float4Vector floatVec = (Float4Vector) root.getVector("floatCol");
+        Float8Vector doubleVec = (Float8Vector) root.getVector("doubleCol");
+        VarCharVector stringVec = (VarCharVector) root.getVector("stringCol");
+        VarBinaryVector bytesVec = (VarBinaryVector) root.getVector("bytesCol");
+
+        intVec.allocateNew(ROWS);
+        longVec.allocateNew(ROWS);
+        floatVec.allocateNew(ROWS);
+        doubleVec.allocateNew(ROWS);
+        stringVec.allocateNew(ROWS * 8, ROWS);
+        bytesVec.allocateNew(ROWS * 8, ROWS);
+
+        for (int i = 0; i < ROWS; i++) {
+          if (i == 3) {
+            intVec.setNull(i);
+            longVec.setNull(i);
+            stringVec.setNull(i);
+          } else {
+            intVec.set(i, i * 10);
+            longVec.set(i, (long) i * 100);
+            stringVec.set(i, ("s_" + i).getBytes());
+          }
+          floatVec.set(i, i + 0.5f);
+          doubleVec.set(i, i + 0.25);
+          bytesVec.set(i, ("b_" + i).getBytes());
+        }
+        intVec.setValueCount(ROWS);
+        longVec.setValueCount(ROWS);
+        floatVec.setValueCount(ROWS);
+        doubleVec.setValueCount(ROWS);
+        stringVec.setValueCount(ROWS);
+        bytesVec.setValueCount(ROWS);
+        root.setRowCount(ROWS);
+
+        writeIpc(out, root);
+      }
+    }
+    return out;
+  }
+
+  private File writeMultiBatchFixture(String fileName, int batchCount, int rowsPerBatch)
+      throws IOException {
+    File out = _tempDir.resolve(fileName).toFile();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      Field seqField = new Field("seqCol", FieldType.nullable(new ArrowType.Int(32, true)), null);
+      Schema schema = new Schema(Collections.singletonList(seqField));
+
+      try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator);
+          FileOutputStream fos = new FileOutputStream(out);
+          FileChannel channel = fos.getChannel();
+          ArrowFileWriter writer = new ArrowFileWriter(root, null, channel)) {
+        writer.start();
+        IntVector seqVec = (IntVector) root.getVector("seqCol");
+
+        int globalSeq = 0;
+        for (int b = 0; b < batchCount; b++) {
+          seqVec.allocateNew(rowsPerBatch);
+          for (int i = 0; i < rowsPerBatch; i++) {
+            seqVec.set(i, globalSeq++);
+          }
+          seqVec.setValueCount(rowsPerBatch);
+          root.setRowCount(rowsPerBatch);
+          writer.writeBatch();
+        }
+        writer.end();
+      }
+    }
+    return out;
+  }
+
+  private File writeMultiValueIntFixture(String fileName)
+      throws IOException {
+    File out = _tempDir.resolve(fileName).toFile();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      Field elementField =
+          new Field("element", FieldType.nullable(new ArrowType.Int(32, true)), null);
+      Field listField = new Field("intArr", FieldType.nullable(ArrowType.List.INSTANCE),
+          Collections.singletonList(elementField));
+      Schema schema = new Schema(Collections.singletonList(listField));
+
+      try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+        ListVector listVec = (ListVector) root.getVector("intArr");
+        listVec.allocateNew();
+        UnionListWriter writer = listVec.getWriter();
+
+        writer.startList();
+        writer.setPosition(0);
+        writer.startList();
+        writer.integer().writeInt(1);
+        writer.integer().writeInt(2);
+        writer.integer().writeInt(3);
+        writer.endList();
+
+        writer.setPosition(1);
+        writer.startList();
+        writer.integer().writeInt(4);
+        writer.writeNull();
+        writer.endList();
+
+        writer.setPosition(2);
+        writer.startList();
+        writer.endList();
+
+        listVec.setValueCount(3);
+        root.setRowCount(3);
+
+        writeIpc(out, root);
+      }
+    }
+    return out;
+  }
+
+  private void writeIpc(File out, VectorSchemaRoot root)
+      throws IOException {
+    try (FileOutputStream fos = new FileOutputStream(out);
+        FileChannel channel = fos.getChannel();
+        ArrowFileWriter writer = new ArrowFileWriter(root, null, channel)) {
+      writer.start();
+      writer.writeBatch();
+      writer.end();
+    }
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowFileColumnReaderFactoryTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowFileColumnReaderFactoryTest.java
@@ -25,6 +25,7 @@ import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -33,6 +34,7 @@ import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.TimeStampMilliVector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
@@ -40,6 +42,7 @@ import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.impl.UnionListWriter;
 import org.apache.arrow.vector.ipc.ArrowFileWriter;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -236,6 +239,99 @@ public class ArrowFileColumnReaderFactoryTest {
 
       MultiValueResult<int[]> doc2 = reader.getIntMV(2);
       assertEquals(doc2.getValues().length, 0);
+    }
+  }
+
+  /**
+   * Type predicates on a multi-value reader reflect the list's <i>element</i> type, not the
+   * {@code ListVector} itself — so an INT multi-value column reports {@code isInt()} (and is not
+   * single-value), letting the build pick the right typed {@code getXxxMV} accessor.
+   */
+  @Test
+  public void testMultiValueColumnTypePredicates()
+      throws IOException {
+    File arrowFile = writeMultiValueIntFixture("mv-predicates.arrow");
+    org.apache.pinot.spi.data.Schema schema = new org.apache.pinot.spi.data.Schema.SchemaBuilder()
+        .setSchemaName("mv")
+        .addMultiValueDimension("intArr", FieldSpec.DataType.INT)
+        .build();
+
+    try (ArrowFileColumnReaderFactory factory = new ArrowFileColumnReaderFactory(arrowFile)) {
+      factory.init(schema);
+      ColumnReader reader = factory.getColumnReader("intArr");
+      assertNotNull(reader);
+      assertFalse(reader.isSingleValue());
+      assertTrue(reader.isInt(), "INT element type should report isInt()");
+      assertFalse(reader.isLong());
+      assertFalse(reader.isString());
+      assertFalse(reader.isBytes());
+    }
+  }
+
+  /**
+   * A wrong-type accessor must fail with {@link IOException} (the reader's {@code typeMismatch}
+   * contract), not return garbage or throw an opaque cast error: calling a STRING accessor on an INT
+   * column, a scalar accessor mismatch, and a multi-value accessor on a single-value column.
+   */
+  @Test
+  public void testTypeMismatchAccessorsThrow()
+      throws IOException {
+    File arrowFile = writePrimitiveFixture("type-mismatch.arrow");
+    org.apache.pinot.spi.data.Schema schema = primitiveSchema();
+
+    try (ArrowFileColumnReaderFactory factory = new ArrowFileColumnReaderFactory(arrowFile)) {
+      factory.init(schema);
+      ColumnReader intReader = factory.getColumnReader("intCol");
+      ColumnReader stringReader = factory.getColumnReader("stringCol");
+
+      // Wrong scalar type on a non-null doc (doc 0 is populated for both columns).
+      assertThrows(IOException.class, () -> intReader.getString(0));
+      assertThrows(IOException.class, () -> intReader.getLong(0));
+      assertThrows(IOException.class, () -> stringReader.getInt(0));
+      // Multi-value accessor on a single-value column (no ListVector to read).
+      assertThrows(IOException.class, () -> intReader.getIntMV(0));
+    }
+  }
+
+  /**
+   * {@code CONFIG_EXTRACT_RAW_TIME_VALUES} must flow through the factory to each column reader,
+   * mirroring the row-major {@code ArrowRecordExtractorConfig.EXTRACT_RAW_TIME_VALUES}: with it set, a
+   * TIMESTAMP column surfaces the raw epoch {@code long}; without it (the default), it surfaces a
+   * canonical {@link Timestamp}. Same fixture, two factories — proves the flag flips the behavior.
+   */
+  @Test
+  public void testExtractRawTimeValuesSurfacesRawEpoch()
+      throws IOException {
+    long[] epochMillis = {0L, 1_000L, 1_718_265_600_000L};
+    File arrowFile = writeTimestampFixture("timestamps.arrow", epochMillis);
+    org.apache.pinot.spi.data.Schema schema = new org.apache.pinot.spi.data.Schema.SchemaBuilder()
+        .setSchemaName("ts")
+        .addSingleValueDimension("tsCol", FieldSpec.DataType.TIMESTAMP)
+        .build();
+
+    // Raw mode: surfaces the raw epoch long.
+    try (ArrowFileColumnReaderFactory factory = new ArrowFileColumnReaderFactory(arrowFile)) {
+      factory.init(schema, null,
+          Map.of(ArrowFileColumnReaderFactory.CONFIG_EXTRACT_RAW_TIME_VALUES, "true"));
+      ColumnReader reader = factory.getColumnReader("tsCol");
+      assertNotNull(reader);
+      for (int i = 0; i < epochMillis.length; i++) {
+        Object value = reader.getValue(i);
+        assertTrue(value instanceof Long, "raw mode should surface a Long epoch, got " + value);
+        assertEquals(((Long) value).longValue(), epochMillis[i]);
+      }
+    }
+
+    // Default mode: surfaces a java.sql.Timestamp carrying the same instant.
+    try (ArrowFileColumnReaderFactory factory = new ArrowFileColumnReaderFactory(arrowFile)) {
+      factory.init(schema);
+      ColumnReader reader = factory.getColumnReader("tsCol");
+      assertNotNull(reader);
+      for (int i = 0; i < epochMillis.length; i++) {
+        Object value = reader.getValue(i);
+        assertTrue(value instanceof Timestamp, "default mode should surface a Timestamp, got " + value);
+        assertEquals(((Timestamp) value).getTime(), epochMillis[i]);
+      }
     }
   }
 
@@ -577,6 +673,30 @@ public class ArrowFileColumnReaderFactoryTest {
 
         listVec.setValueCount(3);
         root.setRowCount(3);
+
+        writeIpc(out, root);
+      }
+    }
+    return out;
+  }
+
+  private File writeTimestampFixture(String fileName, long[] epochMillis)
+      throws IOException {
+    File out = _tempDir.resolve(fileName).toFile();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      // No-timezone Timestamp vector in millisecond units (matches Pinot's TIMESTAMP storage unit).
+      Field tsField =
+          new Field("tsCol", FieldType.nullable(new ArrowType.Timestamp(TimeUnit.MILLISECOND, null)), null);
+      Schema schema = new Schema(Collections.singletonList(tsField));
+
+      try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+        TimeStampMilliVector tsVec = (TimeStampMilliVector) root.getVector("tsCol");
+        tsVec.allocateNew(epochMillis.length);
+        for (int i = 0; i < epochMillis.length; i++) {
+          tsVec.set(i, epochMillis[i]);
+        }
+        tsVec.setValueCount(epochMillis.length);
+        root.setRowCount(epochMillis.length);
 
         writeIpc(out, root);
       }

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowFileColumnReaderFactoryTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowFileColumnReaderFactoryTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -59,7 +60,7 @@ import static org.testng.Assert.assertTrue;
 
 
 /**
- * Unit tests for {@link ArrowColumnReaderFactory} and {@link ArrowColumnReader}.
+ * Unit tests for {@link ArrowFileColumnReaderFactory} and {@link ArrowColumnReader}.
  *
  * <p>Each test materialises a small Arrow IPC file on disk with a known fixture and verifies
  * that the factory can read it back column-by-column using all three documented patterns:
@@ -351,11 +352,11 @@ public class ArrowFileColumnReaderFactoryTest {
           } else {
             intVec.set(i, i * 10);
             longVec.set(i, (long) i * 100);
-            stringVec.set(i, ("s_" + i).getBytes());
+            stringVec.set(i, ("s_" + i).getBytes(StandardCharsets.UTF_8));
           }
           floatVec.set(i, i + 0.5f);
           doubleVec.set(i, i + 0.25);
-          bytesVec.set(i, ("b_" + i).getBytes());
+          bytesVec.set(i, ("b_" + i).getBytes(StandardCharsets.UTF_8));
         }
         intVec.setValueCount(ROWS);
         longVec.setValueCount(ROWS);
@@ -416,7 +417,7 @@ public class ArrowFileColumnReaderFactoryTest {
         listVec.allocateNew();
         UnionListWriter writer = listVec.getWriter();
 
-        writer.startList();
+        // Canonical Arrow list-writer pattern: setPosition(row) -> startList -> writes -> endList.
         writer.setPosition(0);
         writer.startList();
         writer.integer().writeInt(1);

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowFileColumnReaderFactoryTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowFileColumnReaderFactoryTest.java
@@ -56,6 +56,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 
@@ -300,7 +301,146 @@ public class ArrowFileColumnReaderFactoryTest {
     }
   }
 
+  @Test
+  public void testInterleavedReadersAcrossBatchesStayConsistent()
+      throws Exception {
+    // Two readers over a multi-batch file, accessed interleaved so they fight over the single shared
+    // batch cursor. Each must still return its own correct value — the per-batch delegate is rebuilt
+    // when the shared source has been moved by the other reader, rather than reading whichever batch
+    // the other reader last loaded.
+    File arrowFile = writeTwoColumnMultiBatchFixture("interleave.arrow", 3, 4); // 12 docs
+    try (ArrowFileColumnReaderFactory factory = new ArrowFileColumnReaderFactory(arrowFile)) {
+      factory.init(twoColumnSchema());
+      ColumnReader a = factory.getColumnReader("aCol");
+      ColumnReader b = factory.getColumnReader("bCol");
+      assertNotNull(a);
+      assertNotNull(b);
+      // aCol[i] == i, bCol[i] == 1000 + i.
+      assertEquals(a.getInt(9), 9);     // loads batch 2 for a
+      assertEquals(b.getInt(0), 1000);  // moves the shared cursor back to batch 0
+      assertEquals(a.getInt(9), 9);     // a must rebuild (source moved) -> batch 2, not batch 0
+      assertEquals(b.getInt(11), 1011); // batch 2
+      assertEquals(a.getInt(1), 1);     // batch 0
+    }
+  }
+
+  @Test
+  public void testEmptyFileRandomAccessThrowsBounds()
+      throws Exception {
+    File emptyFile = writeEmptyFixture("empty.arrow");
+    try (ArrowFileColumnReaderFactory factory = new ArrowFileColumnReaderFactory(emptyFile)) {
+      factory.init(oneIntColumnSchema("seqCol"));
+      ColumnReader reader = factory.getColumnReader("seqCol");
+      assertNotNull(reader);
+      assertEquals(reader.getTotalDocs(), 0);
+      assertFalse(reader.hasNext());
+      // SPI contract: an out-of-range docId yields IndexOutOfBoundsException, not an opaque internal
+      // error from seeking a non-existent batch.
+      assertThrows(IndexOutOfBoundsException.class, () -> reader.getValue(0));
+      assertThrows(IndexOutOfBoundsException.class, () -> reader.isNull(0));
+    }
+  }
+
+  @Test
+  public void testBatchBoundedConsumptionUnderTightAllocatorLimit()
+      throws Exception {
+    // The total data far exceeds the allocator limit, but each record batch fits. Because the reader
+    // holds one batch at a time, consuming every value twice (the stats + index passes of the build)
+    // succeeds under a limit a materialize-all reader would blow past — demonstrating the
+    // file-size-independent, one-batch-resident memory profile.
+    int batchCount = 8;
+    int rowsPerBatch = 50_000;                 // ~1.6 MB total int data; ~200 KB per batch
+    int total = batchCount * rowsPerBatch;
+    File arrowFile = writeMultiBatchFixture("mem-bound.arrow", batchCount, rowsPerBatch);
+    long oneMebibyte = 1L << 20;               // below the total footprint, well above one batch
+
+    org.apache.pinot.spi.data.Schema schema = oneIntColumnSchema("seqCol");
+    try (ArrowFileColumnReaderFactory factory = new ArrowFileColumnReaderFactory(arrowFile)) {
+      factory.init(schema, null,
+          Map.of(ArrowFileColumnReaderFactory.CONFIG_ALLOCATOR_LIMIT, Long.toString(oneMebibyte)));
+      ColumnReader reader = factory.getColumnReader("seqCol");
+      assertNotNull(reader);
+      assertEquals(reader.getTotalDocs(), total);
+      for (int pass = 0; pass < 2; pass++) {
+        reader.rewind();
+        int count = 0;
+        while (reader.hasNext()) {
+          assertEquals(reader.nextInt(), count);
+          count++;
+        }
+        assertEquals(count, total, "pass " + pass + " did not read every doc");
+      }
+    }
+  }
+
   // ===== Fixture builders =====
+
+  private org.apache.pinot.spi.data.Schema oneIntColumnSchema(String columnName) {
+    return new org.apache.pinot.spi.data.Schema.SchemaBuilder()
+        .setSchemaName("oneInt")
+        .addSingleValueDimension(columnName, FieldSpec.DataType.INT)
+        .build();
+  }
+
+  private org.apache.pinot.spi.data.Schema twoColumnSchema() {
+    return new org.apache.pinot.spi.data.Schema.SchemaBuilder()
+        .setSchemaName("twoCol")
+        .addSingleValueDimension("aCol", FieldSpec.DataType.INT)
+        .addSingleValueDimension("bCol", FieldSpec.DataType.INT)
+        .build();
+  }
+
+  private File writeEmptyFixture(String fileName)
+      throws IOException {
+    File out = _tempDir.resolve(fileName).toFile();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      Field seqField = new Field("seqCol", FieldType.nullable(new ArrowType.Int(32, true)), null);
+      Schema schema = new Schema(Collections.singletonList(seqField));
+      try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator);
+          FileOutputStream fos = new FileOutputStream(out);
+          FileChannel channel = fos.getChannel();
+          ArrowFileWriter writer = new ArrowFileWriter(root, null, channel)) {
+        // Schema header + footer, no record batches.
+        writer.start();
+        writer.end();
+      }
+    }
+    return out;
+  }
+
+  private File writeTwoColumnMultiBatchFixture(String fileName, int batchCount, int rowsPerBatch)
+      throws IOException {
+    File out = _tempDir.resolve(fileName).toFile();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      Field aField = new Field("aCol", FieldType.nullable(new ArrowType.Int(32, true)), null);
+      Field bField = new Field("bCol", FieldType.nullable(new ArrowType.Int(32, true)), null);
+      Schema schema = new Schema(Arrays.asList(aField, bField));
+      try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator);
+          FileOutputStream fos = new FileOutputStream(out);
+          FileChannel channel = fos.getChannel();
+          ArrowFileWriter writer = new ArrowFileWriter(root, null, channel)) {
+        writer.start();
+        IntVector aVec = (IntVector) root.getVector("aCol");
+        IntVector bVec = (IntVector) root.getVector("bCol");
+        int global = 0;
+        for (int b = 0; b < batchCount; b++) {
+          aVec.allocateNew(rowsPerBatch);
+          bVec.allocateNew(rowsPerBatch);
+          for (int i = 0; i < rowsPerBatch; i++) {
+            aVec.set(i, global);
+            bVec.set(i, 1000 + global);
+            global++;
+          }
+          aVec.setValueCount(rowsPerBatch);
+          bVec.setValueCount(rowsPerBatch);
+          root.setRowCount(rowsPerBatch);
+          writer.writeBatch();
+        }
+        writer.end();
+      }
+    }
+    return out;
+  }
 
   private org.apache.pinot.spi.data.Schema primitiveSchema() {
     org.apache.pinot.spi.data.Schema schema = new org.apache.pinot.spi.data.Schema();

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowTestDataUtils.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowTestDataUtils.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.IntVector;
@@ -61,7 +62,7 @@ public class ArrowTestDataUtils {
 
         for (int i = 0; i < numRows; i++) {
           idVector.set(i, i + 1);
-          nameVector.set(i, ("name_" + (i + 1)).getBytes());
+          nameVector.set(i, ("name_" + (i + 1)).getBytes(StandardCharsets.UTF_8));
         }
 
         idVector.setValueCount(numRows);
@@ -106,7 +107,7 @@ public class ArrowTestDataUtils {
           for (int row = 0; row < rowsPerBatch; row++) {
             idVector.set(row, totalRowId++);
             batchVector.set(row, batch);
-            valueVector.set(row, ("batch_" + batch + "_row_" + row).getBytes());
+            valueVector.set(row, ("batch_" + batch + "_row_" + row).getBytes(StandardCharsets.UTF_8));
           }
 
           idVector.setValueCount(rowsPerBatch);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/ColumnarValueNormalizer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/ColumnarValueNormalizer.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.creator.impl;
+
+import org.apache.pinot.segment.local.utils.DataTypeTransformerUtils;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.utils.PinotDataType;
+
+
+/**
+ * Normalizes a single column value read from a {@code ColumnReader} into the canonical form the
+ * per-column stats collectors and index creators expect, for the column-major
+ * ({@code buildColumnar}) path.
+ *
+ * <p>The row-major build runs each record through a {@code TransformPipeline} whose
+ * {@code NullValueTransformer} substitutes {@link FieldSpec#getDefaultNullValue()} for {@code null}
+ * and whose {@code DataTypeTransformer} coerces every value to the column's stored type (e.g.
+ * {@code Boolean} → {@code Integer} for a {@code BOOLEAN} column stored as {@code INT},
+ * {@code Timestamp} → {@code Long} for {@code TIMESTAMP}). The column-major driver deliberately runs
+ * with no transform pipeline, so a non-segment source (e.g. Arrow) delivers values in the source's
+ * logical type with raw {@code null}s — which the typed collectors / index creators do not accept.
+ *
+ * <p>This helper applies the equivalent of those two transformers to one value, in the same order:
+ * <ol>
+ *   <li>{@code NullValueTransformer}: a {@code null} value becomes the column default — the scalar
+ *       default for single-value columns, or a one-element {@code Object[]} of that scalar for
+ *       multi-value columns (matching {@code NullValueTransformerUtils.getDefaultNullValue}).</li>
+ *   <li>{@code DataTypeTransformer}: {@link DataTypeTransformerUtils#transformValue} standardizes the
+ *       value (collapsing single-element collections, dropping {@code null} elements from multi-value
+ *       arrays) and converts it to {@code destDataType} via {@link PinotDataType}.</li>
+ * </ol>
+ *
+ * <p>A whole-value {@code null} (or a value that standardizes to {@code null}, e.g. an empty array)
+ * therefore resolves to the column default rather than reaching the collector as {@code null}. The
+ * one intentional divergence from the row-major path is the configured time column: this helper uses
+ * the raw {@link FieldSpec#getDefaultNullValue()} rather than the row-major time-range-validated /
+ * current-time override; the stats and index paths stay mutually consistent (segment metadata agrees
+ * with the forward index).
+ */
+public final class ColumnarValueNormalizer {
+
+  private ColumnarValueNormalizer() {
+  }
+
+  /**
+   * @param column the column name (used only for error messages)
+   * @param fieldSpec the column's field spec (supplies the default null value and SV/MV-ness)
+   * @param destDataType the column's destination {@link PinotDataType}, i.e.
+   *        {@code PinotDataType.getPinotDataTypeForIngestion(fieldSpec)} — pass it in pre-computed so
+   *        it is resolved once per column rather than once per value
+   * @param value the raw value read from the {@code ColumnReader} (may be {@code null})
+   * @return the normalized, never-{@code null} value to feed to the stats collector / index creator
+   */
+  public static Object normalize(String column, FieldSpec fieldSpec, PinotDataType destDataType, Object value) {
+    if (value == null) {
+      value = defaultNullValue(fieldSpec);
+    }
+    value = DataTypeTransformerUtils.transformValue(column, value, destDataType);
+    if (value == null) {
+      // The value standardized to null (e.g. an empty multi-value array). Substitute the default so a
+      // null never reaches the typed collectors / index creators.
+      value = defaultNullValue(fieldSpec);
+    }
+    return value;
+  }
+
+  private static Object defaultNullValue(FieldSpec fieldSpec) {
+    Object defaultNullValue = fieldSpec.getDefaultNullValue();
+    return fieldSpec.isSingleValueField() ? defaultNullValue : new Object[]{defaultNullValue};
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -30,6 +30,7 @@ import org.apache.pinot.segment.spi.index.IndexCreator;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.readers.ColumnReader;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.PinotDataType;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -150,7 +151,7 @@ public class SegmentColumnarIndexCreator extends BaseSegmentCreator {
     FieldSpec fieldSpec = _schema.getFieldSpecFor(columnName);
     SegmentDictionaryCreator dictionaryCreator = _colIndexes.get(columnName).getDictionaryCreator();
 
-    Object defaultNullValue = fieldSpec.getDefaultNullValue();
+    PinotDataType destDataType = PinotDataType.getPinotDataTypeForIngestion(fieldSpec);
     Object reuseColumnValueToIndex;
 
     // Reset column reader to start from beginning
@@ -158,15 +159,17 @@ public class SegmentColumnarIndexCreator extends BaseSegmentCreator {
 
     int docId = 0;
     while (columnReader.hasNext()) {
-      reuseColumnValueToIndex = columnReader.next();
+      Object rawValue = columnReader.next();
 
-      // Handle null values
-      if (reuseColumnValueToIndex == null) {
-        if (nullVec != null) {
-          nullVec.setNull(docId);
-        }
-        reuseColumnValueToIndex = defaultNullValue;
+      // Record whole-value-null docs in the null-value vector BEFORE substituting the default (matching
+      // the row-major path, which marks null only for whole-value nulls). The column-major driver runs
+      // with no transform pipeline, so normalize the value the way the row-major NullValueTransformer +
+      // DataTypeTransformer would (null -> column default, coerce to the column's stored type), shared
+      // with the stats path via ColumnarValueNormalizer.
+      if (rawValue == null && nullVec != null) {
+        nullVec.setNull(docId);
       }
+      reuseColumnValueToIndex = ColumnarValueNormalizer.normalize(columnName, fieldSpec, destDataType, rawValue);
 
       try {
         if (fieldSpec.isSingleValueField()) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/ColumnarSegmentPreIndexStatsContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/ColumnarSegmentPreIndexStatsContainer.java
@@ -38,19 +38,15 @@ import org.apache.pinot.spi.utils.PinotDataType;
 
 
 /**
- * Stats container that efficiently collects statistics from columnar data using ColumnReader instances.
+ * {@link SegmentPreIndexStatsContainer} that collects column statistics directly from {@link
+ * ColumnReader} instances — one column at a time via the reader's sequential (rewind + next)
+ * contract — rather than row by row. For a columnar source this keeps peak working memory to a single
+ * column (or, for a batch-bounded reader, a single batch) instead of holding the whole row set, at
+ * the cost of re-reading the source once per column. The values feed the same underlying collectors
+ * as the row-based {@code SegmentPreIndexStatsCollectorImpl}.
  *
- * <p>This implementation collects statistics by iterating column-wise instead of row-wise,
- * which is more efficient for columnar data sources. It supports:
- * <ul>
- *   <li>Column-wise statistics collection</li>
- *   <li>Existing columns from source data</li>
- *   <li>New columns with default values</li>
- *   <li>Data type conversions during schema evolution</li>
- * </ul>
- *
- * <p>The statistics are collected using the same underlying collectors as the row-based approach
- * (SegmentPreIndexStatsCollectorImpl) but with more efficient column-wise iteration.
+ * <p>Handles columns present in the source, new columns materialized from their defaults, and the
+ * type coercion schema evolution requires (applied per value via {@link ColumnarValueNormalizer}).
  */
 public class ColumnarSegmentPreIndexStatsContainer implements SegmentPreIndexStatsContainer {
   private final Map<String, ColumnStatistics> _columnStatisticsMap;
@@ -58,6 +54,20 @@ public class ColumnarSegmentPreIndexStatsContainer implements SegmentPreIndexSta
 
   public ColumnarSegmentPreIndexStatsContainer(StatsCollectorConfig statsCollectorConfig,
       Map<String, ColumnReader> columnReaders) {
+    _totalDocCount = resolveTotalDocs(columnReaders);
+
+    Schema schema = statsCollectorConfig.getSchema();
+    Collection<FieldSpec> fieldSpecs = schema.getAllFieldSpecs();
+    _columnStatisticsMap = Maps.newHashMapWithExpectedSize(fieldSpecs.size());
+    if (_totalDocCount == 0) {
+      buildEmptyStatistics(statsCollectorConfig, fieldSpecs);
+    } else {
+      collectColumnStatistics(statsCollectorConfig, schema, fieldSpecs, columnReaders);
+    }
+  }
+
+  /** Validate that every reader agrees on the doc count and return it (throws if there are none). */
+  private static int resolveTotalDocs(Map<String, ColumnReader> columnReaders) {
     int totalDocs = -1;
     for (ColumnReader columnReader : columnReaders.values()) {
       if (totalDocs < 0) {
@@ -69,58 +79,65 @@ public class ColumnarSegmentPreIndexStatsContainer implements SegmentPreIndexSta
       }
     }
     Preconditions.checkState(totalDocs >= 0, "Total docs must not be negative, got: %s", totalDocs);
-    _totalDocCount = totalDocs;
+    return totalDocs;
+  }
 
-    Schema schema = statsCollectorConfig.getSchema();
-    Collection<FieldSpec> fieldSpecs = schema.getAllFieldSpecs();
-    _columnStatisticsMap = Maps.newHashMapWithExpectedSize(fieldSpecs.size());
-    if (_totalDocCount == 0) {
-      for (FieldSpec fieldSpec : fieldSpecs) {
-        if (!fieldSpec.isVirtualColumn()) {
-          String columnName = fieldSpec.getName();
-          PartitionFunction partitionFunction = statsCollectorConfig.getPartitionFunction(columnName);
-          Set<Integer> partitions = partitionFunction != null ? Set.of() : null;
-          _columnStatisticsMap.put(columnName, new EmptyColumnStatistics(fieldSpec, partitionFunction, partitions));
-        }
-      }
-    } else {
-      Map<String, FieldIndexConfigs> indexConfigsByCol =
-          FieldIndexConfigsUtil.createIndexConfigsByColName(statsCollectorConfig.getTableConfig(), schema);
-      for (FieldSpec fieldSpec : fieldSpecs) {
-        if (fieldSpec.isVirtualColumn()) {
-          continue;
-        }
+  /** Zero-doc segment: every non-virtual column gets empty statistics, mirroring the row-major path. */
+  private void buildEmptyStatistics(StatsCollectorConfig statsCollectorConfig, Collection<FieldSpec> fieldSpecs) {
+    for (FieldSpec fieldSpec : fieldSpecs) {
+      if (!fieldSpec.isVirtualColumn()) {
         String columnName = fieldSpec.getName();
-        AbstractColumnStatisticsCollector statsCollector =
-            StatsCollectorUtil.createStatsCollector(columnName, fieldSpec, indexConfigsByCol.get(columnName),
-                statsCollectorConfig);
-        ColumnReader columnReader = columnReaders.get(columnName);
-        Preconditions.checkState(columnReader != null, "Failed to find column reader for column: %s", columnName);
-        // The column-major driver runs with no transform pipeline, so each value must be normalized the
-        // way the row-major NullValueTransformer + DataTypeTransformer would: substitute the column
-        // default for nulls and coerce to the column's stored type (e.g. Boolean -> Integer for a
-        // BOOLEAN column stored as INT, Timestamp -> Long for TIMESTAMP). Without it a non-segment
-        // source (e.g. Arrow) feeds nulls / source-typed values into the typed collectors' established
-        // collect(Object) cast convention and NPEs / ClassCastExceptions. Shared with the index-write
-        // path via ColumnarValueNormalizer. Closes the "null/type handling in buildColumnar()"
-        // architectural gap (apache/pinot#18629).
-        PinotDataType destDataType = PinotDataType.getPinotDataTypeForIngestion(fieldSpec);
-        try {
-          // Consume the column sequentially (rewind + next) rather than by random getValue(docId).
-          // The sequential, rewindable contract is the one every columnar source can satisfy cheaply —
-          // including lazy / streaming readers that cannot serve random docId access without
-          // materializing the whole column. The index-write path already consumes this way.
-          columnReader.rewind();
-          while (columnReader.hasNext()) {
-            statsCollector.collect(
-                ColumnarValueNormalizer.normalize(columnName, fieldSpec, destDataType, columnReader.next()));
-          }
-        } catch (IOException e) {
-          throw new RuntimeException("Caught exception collecting stats for column: " + columnName, e);
-        }
-        statsCollector.seal();
-        _columnStatisticsMap.put(columnName, statsCollector);
+        PartitionFunction partitionFunction = statsCollectorConfig.getPartitionFunction(columnName);
+        Set<Integer> partitions = partitionFunction != null ? Set.of() : null;
+        _columnStatisticsMap.put(columnName, new EmptyColumnStatistics(fieldSpec, partitionFunction, partitions));
       }
+    }
+  }
+
+  private void collectColumnStatistics(StatsCollectorConfig statsCollectorConfig, Schema schema,
+      Collection<FieldSpec> fieldSpecs, Map<String, ColumnReader> columnReaders) {
+    Map<String, FieldIndexConfigs> indexConfigsByCol =
+        FieldIndexConfigsUtil.createIndexConfigsByColName(statsCollectorConfig.getTableConfig(), schema);
+    for (FieldSpec fieldSpec : fieldSpecs) {
+      if (fieldSpec.isVirtualColumn()) {
+        continue;
+      }
+      String columnName = fieldSpec.getName();
+      AbstractColumnStatisticsCollector statsCollector =
+          StatsCollectorUtil.createStatsCollector(columnName, fieldSpec, indexConfigsByCol.get(columnName),
+              statsCollectorConfig);
+      ColumnReader columnReader = columnReaders.get(columnName);
+      Preconditions.checkState(columnReader != null, "Failed to find column reader for column: %s", columnName);
+      collectColumn(columnName, fieldSpec, columnReader, statsCollector);
+      statsCollector.seal();
+      _columnStatisticsMap.put(columnName, statsCollector);
+    }
+  }
+
+  /**
+   * Consume one column sequentially (rewind + next) and feed each normalized value to its collector.
+   *
+   * <p>The column-major driver runs with no transform pipeline, so each value must be normalized here
+   * the way the row-major {@code NullValueTransformer} + {@code DataTypeTransformer} would: substitute
+   * the column default for nulls and coerce to the column's stored type (e.g. Boolean -> Integer for a
+   * BOOLEAN column stored as INT, Timestamp -> Long for TIMESTAMP). Without it a non-segment source
+   * (e.g. Arrow) feeds nulls / source-typed values into the typed collectors' {@code collect(Object)}
+   * cast convention and NPEs / ClassCastExceptions. Shared with the index-write path via {@link
+   * ColumnarValueNormalizer}; closes the null/type-handling gap in {@code buildColumnar()}
+   * (apache/pinot#18629). Sequential (rewindable) consumption is the contract every columnar source
+   * can satisfy cheaply, including lazy / streaming readers that cannot serve random docId access.
+   */
+  private static void collectColumn(String columnName, FieldSpec fieldSpec, ColumnReader columnReader,
+      AbstractColumnStatisticsCollector statsCollector) {
+    PinotDataType destDataType = PinotDataType.getPinotDataTypeForIngestion(fieldSpec);
+    try {
+      columnReader.rewind();
+      while (columnReader.hasNext()) {
+        statsCollector.collect(
+            ColumnarValueNormalizer.normalize(columnName, fieldSpec, destDataType, columnReader.next()));
+      }
+    } catch (IOException e) {
+      throw new RuntimeException("Caught exception collecting stats for column: " + columnName, e);
     }
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/ColumnarSegmentPreIndexStatsContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/ColumnarSegmentPreIndexStatsContainer.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import org.apache.pinot.segment.local.segment.creator.impl.ColumnarValueNormalizer;
 import org.apache.pinot.segment.spi.creator.ColumnStatistics;
 import org.apache.pinot.segment.spi.creator.SegmentPreIndexStatsContainer;
 import org.apache.pinot.segment.spi.creator.StatsCollectorConfig;
@@ -33,6 +34,7 @@ import org.apache.pinot.segment.spi.partition.PartitionFunction;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.ColumnReader;
+import org.apache.pinot.spi.utils.PinotDataType;
 
 
 /**
@@ -94,9 +96,19 @@ public class ColumnarSegmentPreIndexStatsContainer implements SegmentPreIndexSta
                 statsCollectorConfig);
         ColumnReader columnReader = columnReaders.get(columnName);
         Preconditions.checkState(columnReader != null, "Failed to find column reader for column: %s", columnName);
+        // The column-major driver runs with no transform pipeline, so each value must be normalized the
+        // way the row-major NullValueTransformer + DataTypeTransformer would: substitute the column
+        // default for nulls and coerce to the column's stored type (e.g. Boolean -> Integer for a
+        // BOOLEAN column stored as INT, Timestamp -> Long for TIMESTAMP). Without it a non-segment
+        // source (e.g. Arrow) feeds nulls / source-typed values into the typed collectors' established
+        // collect(Object) cast convention and NPEs / ClassCastExceptions. Shared with the index-write
+        // path via ColumnarValueNormalizer. Closes the "null/type handling in buildColumnar()"
+        // architectural gap (apache/pinot#18629).
+        PinotDataType destDataType = PinotDataType.getPinotDataTypeForIngestion(fieldSpec);
         try {
           for (int i = 0; i < _totalDocCount; i++) {
-            statsCollector.collect(columnReader.getValue(i));
+            statsCollector.collect(
+                ColumnarValueNormalizer.normalize(columnName, fieldSpec, destDataType, columnReader.getValue(i)));
           }
         } catch (IOException e) {
           throw new RuntimeException("Caught exception collecting stats for column: " + columnName, e);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/ColumnarSegmentPreIndexStatsContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/ColumnarSegmentPreIndexStatsContainer.java
@@ -106,9 +106,14 @@ public class ColumnarSegmentPreIndexStatsContainer implements SegmentPreIndexSta
         // architectural gap (apache/pinot#18629).
         PinotDataType destDataType = PinotDataType.getPinotDataTypeForIngestion(fieldSpec);
         try {
-          for (int i = 0; i < _totalDocCount; i++) {
+          // Consume the column sequentially (rewind + next) rather than by random getValue(docId).
+          // The sequential, rewindable contract is the one every columnar source can satisfy cheaply —
+          // including lazy / streaming readers that cannot serve random docId access without
+          // materializing the whole column. The index-write path already consumes this way.
+          columnReader.rewind();
+          while (columnReader.hasNext()) {
             statsCollector.collect(
-                ColumnarValueNormalizer.normalize(columnName, fieldSpec, destDataType, columnReader.getValue(i)));
+                ColumnarValueNormalizer.normalize(columnName, fieldSpec, destDataType, columnReader.next()));
           }
         } catch (IOException e) {
           throw new RuntimeException("Caught exception collecting stats for column: " + columnName, e);


### PR DESCRIPTION
**TL;DR:** Pinot normally builds a segment row-by-row (materializing each row as a `GenericRow`). When the input is already columnar (Apache Arrow), this PR adds an **optional column-by-column build path** that skips row materialization and — for on-disk Arrow files — caps peak build memory at a single record batch regardless of file size. It plugs Arrow IPC sources into the `buildColumnar()` path via two `ColumnReaderFactory` implementations. Purely additive and opt-in; the existing row-major `ArrowRecordReader` is untouched.

Tracks #18629. Builds on the `ColumnReader`/`ColumnReaderFactory` SPI (#16727) and the shared `ArrowToPinotTypeConverter` (#18632, merged).

### Key terms

- **Record batch** — Arrow's unit of columnar storage: a chunk of rows holding all columns. The file-backed path keeps at most one resident at a time.
- **`ColumnReader` / `ColumnReaderFactory`** (SPI from #16727) — a factory exposes **one `ColumnReader` per column**; a reader is a per-column cursor (`next()`, `rewind()`, random `getValue(docId)`).
- **`buildColumnar()`** — the column-major segment build on `SegmentIndexCreationDriverImpl` that consumes those readers, versus the row-major build that consumes a `RecordReader`.

### How the build consumes columns

`buildColumnar()` builds a segment **one column at a time** and reads each column **twice** — a stats pass (to size and *seal* the per-segment dictionary) then an index pass (to write values) — calling `rewind()` between passes and `next()` to advance. A file is seekable, so the file path re-reads batches on demand; a single-pass stream **can't be rewound**, so the in-memory path must buffer every column up front before the two passes run.

### Two paths

Both factories expose an Arrow source as `Map<String, ColumnReader>` and differ in source, ownership, reader, and memory:

```
  ArrowColumnReaderFactory                     ArrowFileColumnReaderFactory
  (in-process / single-pass stream)            (on-disk Arrow file)
  • any ArrowReader + caller's allocator       • opens & OWNS an ArrowFileReader +
    — factory does NOT close them                a private allocator — closes them
  • buffers ALL columns up front               • reads ONE record batch at a time
    (single-pass source can't be rewound)        (seekable file, one shared cursor)
             │                                              │
             ▼                                              ▼
  ArrowColumnReader (per column)               BatchedArrowColumnReader (per column)
  reads a fully-resident column                views current batch; re-seeks on rewind
             │                                              │
  peak memory = entire dataset resident        peak memory = ONE record batch
  (all columns, all rows; grows with data)     (independent of file size; an oversized
                                                batch trips a catchable Arrow OOM at the
                                                arrowAllocatorLimit config, not a JVM OOM)
             └──────────────────┬───────────────────────────┘
                                ▼
                   Map<String, ColumnReader>   (one reader per column)
                                ▼
            SegmentIndexCreationDriverImpl.buildColumnar()
```

Use **`ArrowFileColumnReaderFactory`** for Arrow files on disk — bounded, file-size-independent peak memory, the choice for large files. Use **`ArrowColumnReaderFactory`** when you already hold an `ArrowReader` in process (e.g. a Spark task emitting Arrow batches) and want to build without touching disk. `arrowAllocatorLimit` is a config (default matches the row-major reader) that caps the file path's allocator.

### Shared contract (both paths)

- **Values match the row-major path** — `getValue()` returns the same canonical JDK types the existing row-major path produces (`String`, `Object[]` for lists, `LocalDate`/`Timestamp`/…, `BigDecimal`), so no downstream change is needed; `ArrowColumnarBuildIntegrationTest` asserts per-doc equality against a row-major build.
- **Dictionary-encoded columns are decoded** per batch (`DictionaryEncoder.decode`), mirroring the row-major extractor.
- **Null & type normalization** — because the column path bypasses the row-major transform pipeline, it reapplies those transforms itself: `ColumnarValueNormalizer` substitutes the column default for nulls and coerces stored types (`BOOLEAN→INT`, `TIMESTAMP→LONG`) on both passes (the null/type-handling gap tracked in #18629); equivalence tests cover this.
- Single- and multi-value columns; an absent target-schema column surfaces as a `null` reader (defaults are the driver's job).

### How to use

Construct the factory for your source and hand it to the driver:

```java
// on-disk Arrow file:
ColumnReaderFactory factory = new ArrowFileColumnReaderFactory(arrowFile);
// or in-process Arrow: new ArrowColumnReaderFactory(arrowReader, allocator);

driver.init(config, factory);   // the ColumnReaderFactory overload selects the column-major path
driver.build();
```

Callers using the existing `init(config, recordReader)` overload are unaffected.

### Compatibility

Additive and opt-in; **no SPI changes** (consumes #16727's interfaces). The row-major path is unchanged.

### Testing

~25 new tests plus the 63-test row-major regression (88 total in `pinot-arrow`). Highlights: the caller-managed and file factories (interleaved readers, empty file, dictionary decode), a test that **proves only one record batch is resident** while reading a file far larger than a 1 MiB allocator limit, and `ArrowColumnarBuildIntegrationTest`, which builds a segment three ways from one fixture — row-major, file column-major, in-memory column-major — asserting per-doc value, `isSorted`, type-normalization, and multi-batch equivalence.

**Result:** segments identical to the row-major path, with the file-backed path holding only one record batch in memory regardless of file size.

### References

Tracking #18629 · SPI #16727 · Shared converter (merged) #18632
