### PR TITLE
[MaterializedView] Harden partition-state engine

### DIFF
--- a/pinot-materialized-view/DESIGN.md
+++ b/pinot-materialized-view/DESIGN.md
@@ -67,6 +67,33 @@ addresses:
 - Range-based STALE marking is useless when the partition key is not derived
   from a base column the controller can read from segment metadata.
 
+### 1.1 V1 broker routing limitation and the V2 per-bucket routing plan
+
+V1 broker routing (`MaterializedViewQueryRewriteEngine`) splits a query on a
+single cutoff: the MV side serves `time < watermarkMs`, the base side serves
+`time >= watermarkMs`.  Per-bucket state is **not** consulted.  Consequently a
+bucket strictly below the watermark that is
+
+- **STALE** (a historical base-table change the consistency manager marked but
+  OVERWRITE has not yet re-materialized),
+- **VALID-empty** (a retention `DELETE` emptied it; a backfill may since have
+  re-marked it STALE), or
+- **absent** (never materialized — possible below the watermark only in
+  anomalous states)
+
+is still routed to the MV side and can return stale or missing rows until the
+scheduler re-materializes it via OVERWRITE.  The exposure window is bounded by
+the consistency-manager debounce plus one scheduling cycle (plus, for the
+DELETE-vs-backfill residual, one period of the VALID-empty self-heal sweep).
+
+**V2 plan — per-bucket routing.**  The broker already caches the full partition
+map on `MaterializedViewCacheEntry`; the rewrite engine will consult it to carve
+non-VALID buckets out of the MV-side time range and route those sub-ranges to
+the base table, making bucket-level staleness invisible to queries at the cost
+of a slightly more complex split predicate.  This is a focused broker-side
+follow-up that requires no changes to the partition-state engine or the
+on-the-wire metadata shape.
+
 ## 2. The fixed-partition extension
 
 ### 2.1 Two shapes to support

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/consistency/MaterializedViewConsistencyManager.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/consistency/MaterializedViewConsistencyManager.java
@@ -370,6 +370,13 @@ public class MaterializedViewConsistencyManager {
   /// are enforced inside [MaterializedViewPartitionManager#markStale] under the CAS lock, so a
   /// concurrent executor's APPEND/OVERWRITE between our snapshot read and the manager's CAS
   /// read cannot cause us to over-mark.
+  ///
+  /// Worst-case latency note: the manager's critical profile can block for up to
+  /// ~25 s (128 attempts x 50–200 ms backoff) under sustained CAS contention, and this method
+  /// runs on the single-threaded scheduler shared with other tables' debounce flushes and the
+  /// periodic sweep.  That trade is deliberate — a dropped STALE mark is silent wrong data,
+  /// while a delayed flush for another table only extends its (already-debounced) staleness
+  /// window; reaching the budget cap requires pathological contention in the first place.
   private void markStaleThroughManager(String viewTableName, long affectedStartMs, long affectedEndMs) {
     List<Long> candidateBuckets;
     try {
@@ -573,29 +580,31 @@ public class MaterializedViewConsistencyManager {
     return stranded;
   }
 
-  /// Resolves the source base table to its `_OFFLINE` / `_REALTIME` form by probing which table
-  /// config exists (OFFLINE first, then REALTIME), returning `null` when neither is present.
+  /// Resolves the source base table to its `_OFFLINE` / `_REALTIME` form via the shared
+  /// OFFLINE-first probe in [MaterializedViewTaskUtils#resolveTableNameWithType], returning
+  /// `null` when neither table config is present.
   private String resolveSourceTableWithType(String rawBaseTableName) {
-    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(rawBaseTableName);
-    if (ZKMetadataProvider.getTableConfig(_propertyStore, offlineTableName) != null) {
-      return offlineTableName;
-    }
-    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(rawBaseTableName);
-    if (ZKMetadataProvider.getTableConfig(_propertyStore, realtimeTableName) != null) {
-      return realtimeTableName;
-    }
-    return null;
+    return MaterializedViewTaskUtils.resolveTableNameWithType(
+        tableName -> ZKMetadataProvider.getTableConfig(_propertyStore, tableName), rawBaseTableName);
   }
 
   /// Returns the existing partition keys whose bucket overlaps
-  /// `[floorDiv(affectedStartMs, bucketMs) * bucketMs, cappedEnd]` — the candidates the manager
-  /// should consider marking STALE.  The manager filters this list down to entries that are still
-  /// VALID inside its CAS loop; this method's job is to (a) bound the range by the current
-  /// watermark (so a `Long.MAX_VALUE` full-invalidation does not iterate past real partitions) and
-  /// (b) restrict to buckets that actually exist in the partition map.
+  /// `[floorDiv(affectedStartMs, bucketMs) * bucketMs, affectedEndMs]` — the candidates the
+  /// manager should consider marking STALE.  The manager filters this list down to entries that
+  /// are still VALID inside its CAS loop; this method's job is to restrict the affected range to
+  /// buckets that actually exist in the partition map.
   ///
-  /// Returns an empty list when the runtime znode is missing or the affected range falls
-  /// entirely past the watermark.
+  /// The range is deliberately NOT capped at `watermarkMs`: VALID buckets above the watermark do
+  /// exist (out-of-order batch APPEND completion, mid-batch failure — see the scheduler's
+  /// contiguous-VALID-upper handling), and skipping them would silently drop the STALE mark for a
+  /// base-table change landing in such a bucket.  Once the gap below filled and the watermark
+  /// advanced over it, the bucket would serve stale data with nothing left to re-mark it.
+  /// Over-marking is harmless: above-watermark buckets are routed to the base table by V1
+  /// routing anyway, a STALE entry correctly blocks the contiguous-VALID watermark walk until
+  /// OVERWRITE re-materializes it, and the candidate list stays bounded by the partition count
+  /// because it iterates existing keys (so an unbounded `affectedEndMs` cannot blow it up).
+  ///
+  /// Returns an empty list when the runtime znode is missing.
   private List<Long> enumerateCandidateBuckets(String viewTableName, long affectedStartMs, long affectedEndMs) {
     Stat stat = new Stat();
     MaterializedViewRuntimeMetadata runtime =
@@ -613,31 +622,20 @@ public class MaterializedViewConsistencyManager {
             + "mark partitions without a bucket size.  Repair the MV table config.",
         viewTableName, bucketMs);
 
-    // Cap affectedEndMs at watermarkMs.  No partition with partStart > watermarkMs can exist
-    // (the writer invariant), so any bucket beyond that cannot be marked STALE anyway.  This
-    // bounds the candidate range for a caller passing Long.MAX_VALUE (full-range invalidation from
-    // notifyMaterializedViewConsistencyManager paths when segment startTime/endTime is unknown).
-    long cappedEnd = Math.min(affectedEndMs, runtime.getWatermarkMs());
-    if (cappedEnd < affectedStartMs) {
-      LOGGER.debug("Affected range [{}, {}] is past watermarkMs ({}) for MV table: {}; nothing to mark",
-          affectedStartMs, affectedEndMs, runtime.getWatermarkMs(), viewTableName);
-      return Collections.emptyList();
-    }
-
     // Select the EXISTING partition keys whose bucket [partStart, partStart+bucketMs) overlaps the
-    // affected range [affectedStartMs, cappedEnd] — i.e. partStart in
-    // [floorDiv(affectedStartMs, bucketMs) * bucketMs, cappedEnd].  Iterating the existing keys
-    // (rather than enumerating every slot in the range) bounds this list to the partition count,
-    // so a full-range invalidation with a small bucketMs and a large watermark horizon cannot
-    // allocate a list proportional to watermarkMs/bucketMs.  Absent buckets are intentionally NOT
-    // synthesized: under Design C a bucket's absence already means "MV does not cover this range"
-    // and the broker routes those queries to the base; the manager's markStale would no-op them
-    // anyway, so they are simply not candidates.  floorDiv (instead of /) defends a future caller
-    // passing a negative affectedStartMs.
+    // affected range [affectedStartMs, affectedEndMs] — i.e. partStart in
+    // [floorDiv(affectedStartMs, bucketMs) * bucketMs, affectedEndMs].  Iterating the existing
+    // keys (rather than enumerating every slot in the range) bounds this list to the partition
+    // count, so a full-range invalidation (affectedEndMs = Long.MAX_VALUE) cannot allocate a list
+    // proportional to range/bucketMs.  Absent buckets are intentionally NOT synthesized: under
+    // Design C a bucket's absence already means "MV does not cover this range" and the broker
+    // routes those queries to the base; the manager's markStale would no-op them anyway, so they
+    // are simply not candidates.  floorDiv (instead of /) defends a future caller passing a
+    // negative affectedStartMs.
     long firstBucketStartMs = Math.floorDiv(affectedStartMs, bucketMs) * bucketMs;
     List<Long> buckets = new ArrayList<>();
     for (long partStart : runtime.getPartitions().keySet()) {
-      if (partStart >= firstBucketStartMs && partStart <= cappedEnd) {
+      if (partStart >= firstBucketStartMs && partStart <= affectedEndMs) {
         buckets.add(partStart);
       }
     }

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/consistency/MaterializedViewConsistencyManager.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/consistency/MaterializedViewConsistencyManager.java
@@ -30,9 +30,9 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.apache.helix.AccessOption;
@@ -41,7 +41,9 @@ import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.zkclient.IZkChildListener;
 import org.apache.helix.zookeeper.zkclient.IZkDataListener;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.materializedview.metadata.MaterializedViewDefinitionMetadata;
+import org.apache.pinot.materializedview.metadata.MaterializedViewPartitionManager;
 import org.apache.pinot.materializedview.metadata.MaterializedViewRuntimeMetadata;
 import org.apache.pinot.materializedview.metadata.MaterializedViewRuntimeMetadataUtils;
 import org.apache.pinot.materializedview.metadata.PartitionInfo;
@@ -61,15 +63,22 @@ import org.slf4j.LoggerFactory;
 ///
 /// When segments are added, replaced, or deleted in a base table, this manager
 /// identifies which MV partitions overlap with the changed time range and marks
-/// them as [PartitionState#STALE] in [MaterializedViewRuntimeMetadata].
+/// them as STALE in [MaterializedViewRuntimeMetadata].
 ///
 /// Events are accumulated per base table using a debounce window ([#DEFAULT_DEBOUNCE_DELAY_MS]ms).
 /// Multiple segment changes within the window are merged into a single time range and
 /// processed as one ZK read-modify-write operation, avoiding excessive ZK traffic during
 /// batch ingestion or bulk segment operations.
 ///
-/// Thread-safety: all public methods are thread-safe. The internal flush runs on a
-/// single-threaded scheduler to serialize ZK writes per base table.
+/// In addition to this event-driven path, a low-frequency periodic sweep
+/// ([#sweepStrandedEmptyPartitions], every [#DEFAULT_EMPTY_SWEEP_INTERVAL_MS]ms by default)
+/// re-evaluates in-coverage `VALID-empty` partitions against the current source and re-marks any
+/// whose source window has regained segments STALE.  This backstops the narrow DELETE-vs-backfill
+/// race the executor's commit guard ([MaterializedViewPartitionManager#clearValid]) cannot fully
+/// close, so a stranded empty partition self-heals without waiting for a fresh base-table change.
+///
+/// Thread-safety: all public methods are thread-safe. The internal flush and the periodic sweep
+/// both run on the same single-threaded scheduler, so ZK writes are serialized per base table.
 ///
 /// <h3>Partition model (TIME-WINDOWED ONLY in PR 1)</h3>
 ///
@@ -93,18 +102,17 @@ public class MaterializedViewConsistencyManager {
   /// Compile-time default debounce window for the consistency manager. Overridable per cluster
   /// (no restart) via `MaterializedViewTask.CLUSTER_CONFIG_KEY_CONSISTENCY_DEBOUNCE_MS`.
   static final long DEFAULT_DEBOUNCE_DELAY_MS = 5000;
+
+  /// Compile-time default interval for the periodic VALID-empty re-evaluation sweep (5 minutes).
+  /// Overridable per cluster (no restart) via
+  /// `MaterializedViewTask.CLUSTER_CONFIG_KEY_CONSISTENCY_EMPTY_SWEEP_INTERVAL_MS`.  The sweep is a
+  /// low-frequency safety net (the DELETE commit guard already handles the dominant race), so a
+  /// coarse cadence keeps overhead negligible while still bounding stranded-bucket recovery time.
+  static final long DEFAULT_EMPTY_SWEEP_INTERVAL_MS = 300_000;
   private static final String MATERIALIZED_VIEW_DEFINITION_PARENT_PATH =
       ZKMetadataProvider.getPropertyStorePathForMaterializedViewDefinitionPrefix();
   private static final String MATERIALIZED_VIEW_DEFINITION_PATH_PREFIX =
       MATERIALIZED_VIEW_DEFINITION_PARENT_PATH + "/";
-  /// CAS retry budget for STALE-marking writes on the runtime znode. Sized to match the executor's
-  /// `MAX_RUNTIME_UPDATE_ATTEMPTS` so a STALE marking is never silently dropped in favor of
-  /// an executor's coverage advance under contention from up to `maxTasksPerBatch` (default 4,
-  /// cap 1000) parallel completions. With ~5–25 ms jittered backoff per retry, 128 attempts cap
-  /// total wait near 25 s.
-  private static final int MAX_MARK_RETRIES = 128;
-
-
 
   /// Reverse index: rawBaseTableName → list of viewTableNameWithType.
   private final ConcurrentHashMap<String, List<String>> _baseTableToMaterializedViewTables = new ConcurrentHashMap<>();
@@ -124,6 +132,11 @@ public class MaterializedViewConsistencyManager {
   /// overridden at runtime without restart. Null in unit tests; null lookup falls back to the
   /// compile-time defaults.
   private volatile Function<String, String> _clusterConfigReader;
+  /// Centralized partition state-change DSL. Created once in [#init] with a config-reader
+  /// indirection so a later [#setClusterConfigReader] call still propagates to the manager
+  /// (the manager holds a final reference, but we close over the `_clusterConfigReader`
+  /// field rather than its current value).
+  private volatile MaterializedViewPartitionManager _partitionManager;
 
   public MaterializedViewConsistencyManager() {
     _scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
@@ -142,9 +155,17 @@ public class MaterializedViewConsistencyManager {
   /// Must be called after the PropertyStore is ready (after Controller startup).
   public void init(ZkHelixPropertyStore<ZNRecord> propertyStore) {
     _propertyStore = propertyStore;
+    // The lambda dereferences `_clusterConfigReader` on every call, so a later
+    // setClusterConfigReader (controller wires this AFTER init in BaseControllerStarter)
+    // takes effect for the manager's CAS-budget lookup without recreating the manager.
+    _partitionManager = new MaterializedViewPartitionManager(propertyStore, configKey -> {
+      Function<String, String> reader = _clusterConfigReader;
+      return reader == null ? null : reader.apply(configKey);
+    });
     _propertyStore.subscribeChildChanges(MATERIALIZED_VIEW_DEFINITION_PARENT_PATH, _definitionChangeListener);
     syncDefinitionDataSubscriptions(null);
     rebuildReverseIndex();
+    scheduleNextEmptyPartitionSweep();
     LOGGER.info("MaterializedViewConsistencyManager initialized with {} base table mappings",
         _baseTableToMaterializedViewTables.size());
   }
@@ -313,7 +334,7 @@ public class MaterializedViewConsistencyManager {
         + "affected MV tables: {}", baseTableName, range[0], range[1], materializedViewTables);
 
     for (String viewTableName : materializedViewTables) {
-      markPartitionsDirtyWithRetry(viewTableName, range[0], range[1]);
+      markStaleThroughManager(viewTableName, range[0], range[1]);
     }
   }
 
@@ -335,73 +356,255 @@ public class MaterializedViewConsistencyManager {
     return drained[0];
   }
 
-  private void markPartitionsDirtyWithRetry(String viewTableName, long affectedStartMs, long affectedEndMs) {
-    // Retry only on CAS conflict (markPartitionsDirty returns false). Any thrown exception
-    // is a real error (corrupt znode, ZK unavailability, serialization bug, etc.) — retrying
-    // 128× burns ~3 s of scheduler thread time and the operator never learns about the bug.
-    // Fail loud after one occurrence so monitoring picks it up; the next base-table change
-    // for the same MV will re-trigger this code path and try again from a known-bad-state log.
-    for (int attempt = 0; attempt < MAX_MARK_RETRIES; attempt++) {
-      try {
-        if (markPartitionsDirty(viewTableName, affectedStartMs, affectedEndMs)) {
-          return;
-        }
-        LOGGER.debug("CAS conflict on attempt {} for MV table: {}, retrying", attempt + 1, viewTableName);
-      } catch (Exception e) {
-        LOGGER.error("Failed to mark dirty partitions for MV table: {} on attempt {} due to a "
-                + "non-CAS exception. Aborting retries — investigate the underlying ZK/serialization "
-                + "issue. MV may serve stale data until the next base-table change re-triggers "
-                + "consistency.", viewTableName, attempt + 1, e);
-        return;
-      }
-      // Jittered backoff: 5–25 ms × 128 attempts ≤ ~3 s total. Prevents tight CAS-loop livelock
-      // against the executor (which uses the same backoff window).
-      try {
-        Thread.sleep(5L + ThreadLocalRandom.current().nextInt(20));
-      } catch (InterruptedException ie) {
-        Thread.currentThread().interrupt();
-        LOGGER.warn("Interrupted while marking dirty for MV table: {}", viewTableName);
-        return;
-      }
+  /// Computes which buckets in `[affectedStartMs, affectedEndMs]` should be marked STALE for the
+  /// given MV, then routes the flip through [MaterializedViewPartitionManager#markStale].
+  ///
+  /// Why two ZK reads: this method does one read-only snapshot fetch to derive `bucketMs` and
+  /// the watermark cap (data the consistency manager owns the inference logic for); the manager
+  /// does a second versioned fetch under its own CAS loop.  The cost is one extra GET per flush
+  /// in exchange for routing every STALE-marking write through the same retry/backoff/budget
+  /// engine the executor uses for APPEND/OVERWRITE — so a STALE marking can never be silently
+  /// out-retried by a concurrent executor.
+  ///
+  /// VALID-only filtering (already-STALE buckets are no-ops) and absent-bucket-skip semantics
+  /// are enforced inside [MaterializedViewPartitionManager#markStale] under the CAS lock, so a
+  /// concurrent executor's APPEND/OVERWRITE between our snapshot read and the manager's CAS
+  /// read cannot cause us to over-mark.
+  private void markStaleThroughManager(String viewTableName, long affectedStartMs, long affectedEndMs) {
+    List<Long> candidateBuckets;
+    try {
+      candidateBuckets = enumerateCandidateBuckets(viewTableName, affectedStartMs, affectedEndMs);
+    } catch (Exception e) {
+      LOGGER.error("Failed to enumerate candidate buckets for MV table: {} (range [{}, {}]); "
+              + "MV may serve stale data until the next base-table change re-triggers consistency.",
+          viewTableName, affectedStartMs, affectedEndMs, e);
+      return;
     }
-    LOGGER.error("Failed to mark dirty partitions for MV table: {} after {} CAS retries. "
-        + "MV may serve stale data until the next base-table change re-triggers consistency.",
-        viewTableName, MAX_MARK_RETRIES);
+    if (candidateBuckets.isEmpty()) {
+      return;
+    }
+
+    try {
+      _partitionManager.markStale(viewTableName, candidateBuckets);
+      LOGGER.info("Marked partitions STALE for MV table: {} (range [{}, {}], {} candidate bucket(s))",
+          viewTableName, affectedStartMs, affectedEndMs, candidateBuckets.size());
+    } catch (RuntimeException e) {
+      // Includes CAS-budget exhaustion (manager wraps the last CasConflictException in a
+      // RuntimeException) and validation failures.  Either way, log loud and move on — the next
+      // base-table change for this MV will re-trigger this code path with a fresh snapshot.
+      LOGGER.error("Failed to mark partitions STALE for MV table: {} (range [{}, {}]); "
+              + "MV may serve stale data until the next base-table change re-triggers consistency.",
+          viewTableName, affectedStartMs, affectedEndMs, e);
+    }
   }
 
-  /// Marks overlapping VALID partitions as STALE in the MV runtime metadata.
+  // ─────────────────────────────────────────────────────────────────────────────────────
+  //  Periodic VALID-empty re-evaluation sweep
+  // ─────────────────────────────────────────────────────────────────────────────────────
+
+  /// Self-rescheduling driver for the periodic VALID-empty sweep.  The interval is read lazily on
+  /// every cycle (the cluster-config reader is wired AFTER [#init], so reading it here rather than
+  /// at schedule-setup time honors live overrides) and the next cycle is rescheduled in a
+  /// `finally` so a sweep that throws still keeps the cadence going.  No-op once the scheduler is
+  /// shut down.
+  private void scheduleNextEmptyPartitionSweep() {
+    if (_scheduler.isShutdown()) {
+      return;
+    }
+    long intervalMs = MaterializedViewTaskUtils.readPositiveLongClusterConfigOrDefault(
+        _clusterConfigReader,
+        CommonConstants.MaterializedViewTask.CLUSTER_CONFIG_KEY_CONSISTENCY_EMPTY_SWEEP_INTERVAL_MS,
+        DEFAULT_EMPTY_SWEEP_INTERVAL_MS);
+    try {
+      _scheduler.schedule(() -> {
+        try {
+          sweepStrandedEmptyPartitions();
+        } catch (Throwable t) {
+          LOGGER.error("MV VALID-empty sweep failed; will retry on the next cycle", t);
+        } finally {
+          scheduleNextEmptyPartitionSweep();
+        }
+      }, intervalMs, TimeUnit.MILLISECONDS);
+    } catch (RejectedExecutionException e) {
+      LOGGER.debug("MV VALID-empty sweep not rescheduled; consistency manager is shutting down");
+    }
+  }
+
+  /// One pass of the VALID-empty re-evaluation sweep across every registered MV.
   ///
-  /// @return true if succeeded or nothing to mark; false if CAS failed (caller should retry)
-  private boolean markPartitionsDirty(String viewTableName, long affectedStartMs, long affectedEndMs) {
-    String path = ZKMetadataProvider.constructPropertyStorePathForMaterializedViewRuntime(viewTableName);
+  /// The DELETE commit guard ([MaterializedViewPartitionManager#clearValid]) re-reads the source
+  /// inside its CAS loop and leaves a bucket STALE when a backfill is detected, closing the
+  /// dominant race.  A vanishingly narrow residual remains: if a backfill's debounced STALE mark
+  /// fires (as a no-op, while the bucket is still STALE) strictly between that read and the
+  /// VALID-empty write, the bucket is stranded as a permanently-empty in-coverage partition that
+  /// nothing re-marks until an unrelated later base-table change.  This sweep is the backstop — it
+  /// re-evaluates in-coverage `VALID-empty` buckets against the current source and re-marks any
+  /// whose source window has regained segments STALE, so the scheduler re-materializes them via
+  /// OVERWRITE without waiting for a fresh base-table event.
+  ///
+  /// Runs on the same single-threaded scheduler as [#flush], so it never writes concurrently with
+  /// a debounce flush; per-MV failures are isolated so one bad MV cannot abort the whole pass.
+  @VisibleForTesting
+  void sweepStrandedEmptyPartitions() {
+    if (_propertyStore == null) {
+      return;
+    }
+    // Snapshot (rawBaseTable, viewTableNameWithType) pairs under the lock, then process outside it
+    // so the ZK reads below do not hold _reverseIndexLock.  Each pair maps an MV to one of its
+    // source base tables; time-windowed MVs (the only shape in PR 1) have exactly one.
+    List<String[]> baseTableAndViewPairs = new ArrayList<>();
+    synchronized (_reverseIndexLock) {
+      for (Map.Entry<String, List<String>> entry : _baseTableToMaterializedViewTables.entrySet()) {
+        for (String viewTableName : entry.getValue()) {
+          baseTableAndViewPairs.add(new String[]{entry.getKey(), viewTableName});
+        }
+      }
+    }
+    for (String[] pair : baseTableAndViewPairs) {
+      String rawBaseTableName = pair[0];
+      String viewTableName = pair[1];
+      try {
+        sweepStrandedEmptyPartitionsForView(viewTableName, rawBaseTableName);
+      } catch (Exception e) {
+        LOGGER.error("MV VALID-empty sweep failed for MV table: {} (base table: {}); "
+            + "will retry on the next cycle", viewTableName, rawBaseTableName, e);
+      }
+    }
+  }
+
+  /// Re-evaluates one MV's in-coverage `VALID-empty` buckets against the current source and
+  /// re-marks the stranded ones STALE.  Skips the (relatively expensive) source-segment read
+  /// entirely when the MV has no in-coverage `VALID-empty` buckets — the common case.
+  @VisibleForTesting
+  void sweepStrandedEmptyPartitionsForView(String viewTableName, String rawBaseTableName) {
     Stat stat = new Stat();
-    ZNRecord znRecord = _propertyStore.get(path, stat, AccessOption.PERSISTENT);
-    if (znRecord == null) {
-      return true;
+    MaterializedViewRuntimeMetadata runtime =
+        MaterializedViewRuntimeMetadataUtils.fetchWithVersion(_propertyStore, viewTableName, stat);
+    if (runtime == null) {
+      return;
+    }
+    Map<Long, PartitionInfo> partitions = runtime.getPartitions();
+    long watermarkMs = runtime.getWatermarkMs();
+    if (!hasInCoverageValidEmptyBucket(partitions, watermarkMs)) {
+      return;
     }
 
-    MaterializedViewRuntimeMetadata runtime = MaterializedViewRuntimeMetadata.fromZNRecord(znRecord);
-    Map<Long, PartitionInfo> partitionInfos = runtime.getPartitions();
-
-    long bucketMs = inferBucketMs(viewTableName, partitionInfos);
-
-    // Cap affectedEndMs at watermarkMs.  No partition with partStart > watermarkMs can exist
-    // (the writer invariant), so any bucket beyond that cannot be marked STALE anyway.  This
-    // protects the bucket-known iteration loop below from a caller passing Long.MAX_VALUE
-    // (full-range invalidation from notifyMaterializedViewConsistencyManager paths when
-    // segment startTime/endTime is unknown), which would otherwise loop ~watermarkMs/bucketMs
-    // times — orders of magnitude more than the number of real partitions.
-    affectedEndMs = Math.min(affectedEndMs, runtime.getWatermarkMs());
-    if (affectedEndMs < affectedStartMs) {
-      LOGGER.debug("Affected range [{}, {}] is past watermarkMs ({}) for MV table: {}; nothing to mark",
-          affectedStartMs, affectedEndMs, runtime.getWatermarkMs(), viewTableName);
-      return true;
+    long bucketMs = inferBucketMs(viewTableName, partitions);
+    if (bucketMs <= 0) {
+      LOGGER.warn("MV table {}: cannot infer bucketMs for VALID-empty sweep; skipping this cycle",
+          viewTableName);
+      return;
+    }
+    String sourceTableWithType = resolveSourceTableWithType(rawBaseTableName);
+    if (sourceTableWithType == null) {
+      LOGGER.debug("MV table {}: source base table {} not found as OFFLINE or REALTIME; "
+          + "skipping VALID-empty sweep this cycle", viewTableName, rawBaseTableName);
+      return;
     }
 
-    Map<Long, PartitionInfo> updatedInfos = new HashMap<>(partitionInfos);
-    boolean anyChanged = false;
-    int markedCount = 0;
+    List<SegmentZKMetadata> sourceSegments =
+        ZKMetadataProvider.getSegmentsZKMetadata(_propertyStore, sourceTableWithType);
+    List<Long> stranded = findStrandedEmptyBuckets(partitions, watermarkMs, sourceSegments, bucketMs);
+    if (stranded.isEmpty()) {
+      return;
+    }
 
+    LOGGER.info("MV table {}: re-marking {} stranded VALID-empty bucket(s) STALE — their source "
+            + "window regained segments since the empty materialization: {}",
+        viewTableName, stranded.size(), stranded);
+    // The runtime + source reads above are an advisory snapshot; markStale re-fetches the runtime
+    // under its own CAS loop and only flips buckets that are still VALID, so a concurrent executor
+    // commit between our snapshot and the write cannot mismark — at worst a bucket already
+    // re-materialized gets a redundant, idempotent OVERWRITE on the next scheduling cycle.
+    try {
+      _partitionManager.markStale(viewTableName, stranded);
+    } catch (RuntimeException e) {
+      LOGGER.error("MV table {}: failed to re-mark stranded VALID-empty buckets STALE; "
+          + "will retry on the next sweep", viewTableName, e);
+    }
+  }
+
+  /// True when at least one bucket is an in-coverage `VALID-empty` partition.  Cheap pre-filter so
+  /// the sweep skips the source-segment read for MVs with nothing to re-evaluate.
+  private static boolean hasInCoverageValidEmptyBucket(Map<Long, PartitionInfo> partitions, long watermarkMs) {
+    for (Map.Entry<Long, PartitionInfo> entry : partitions.entrySet()) {
+      if (isInCoverageValidEmpty(entry.getKey(), entry.getValue(), watermarkMs)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /// A bucket is an in-coverage `VALID-empty` partition iff it is VALID with a zero-segment
+  /// fingerprint and starts strictly below the watermark (so it is genuinely covered, not the
+  /// not-yet-materialized frontier).  `segmentCount == 0` is the canonical "empty" criterion used
+  /// across the scheduler's DELETE dispatch and the executor's commit guard.
+  private static boolean isInCoverageValidEmpty(long bucketStartMs, PartitionInfo info, long watermarkMs) {
+    return info.getState() == PartitionState.VALID
+        && info.getFingerprint().getSegmentCount() == 0
+        && bucketStartMs < watermarkMs;
+  }
+
+  /// Returns the in-coverage `VALID-empty` buckets whose source window currently has overlapping
+  /// segments — stranded empties that must be re-marked STALE so the scheduler re-materializes
+  /// them.  Pure function of the snapshot inputs (no ZK), so the decision is unit-testable in
+  /// isolation.  Buckets whose source is still empty are intentionally left untouched (re-marking
+  /// them STALE would churn a no-op DELETE task every sweep).
+  ///
+  /// Reuses [MaterializedViewTaskUtils#computeWindowFingerprint] so this emptiness re-check is
+  /// byte-for-byte the same overlap algorithm the scheduler's DELETE dispatch and the executor's
+  /// commit guard use — there is deliberately no second overlap implementation to drift from.
+  /// Cost is O(emptyBuckets * sourceSegments); the in-coverage `VALID-empty` set is expected to be
+  /// small (gap windows + retention deletions), and the sweep is a low-frequency safety net.
+  @VisibleForTesting
+  static List<Long> findStrandedEmptyBuckets(Map<Long, PartitionInfo> partitions, long watermarkMs,
+      List<SegmentZKMetadata> sourceSegments, long bucketMs) {
+    List<Long> stranded = new ArrayList<>();
+    for (Map.Entry<Long, PartitionInfo> entry : partitions.entrySet()) {
+      long bucketStartMs = entry.getKey();
+      if (!isInCoverageValidEmpty(bucketStartMs, entry.getValue(), watermarkMs)) {
+        continue;
+      }
+      if (MaterializedViewTaskUtils.computeWindowFingerprint(
+          sourceSegments, bucketStartMs, bucketStartMs + bucketMs).getSegmentCount() != 0) {
+        stranded.add(bucketStartMs);
+      }
+    }
+    return stranded;
+  }
+
+  /// Resolves the source base table to its `_OFFLINE` / `_REALTIME` form by probing which table
+  /// config exists (OFFLINE first, then REALTIME), returning `null` when neither is present.
+  private String resolveSourceTableWithType(String rawBaseTableName) {
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(rawBaseTableName);
+    if (ZKMetadataProvider.getTableConfig(_propertyStore, offlineTableName) != null) {
+      return offlineTableName;
+    }
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(rawBaseTableName);
+    if (ZKMetadataProvider.getTableConfig(_propertyStore, realtimeTableName) != null) {
+      return realtimeTableName;
+    }
+    return null;
+  }
+
+  /// Returns the existing partition keys whose bucket overlaps
+  /// `[floorDiv(affectedStartMs, bucketMs) * bucketMs, cappedEnd]` — the candidates the manager
+  /// should consider marking STALE.  The manager filters this list down to entries that are still
+  /// VALID inside its CAS loop; this method's job is to (a) bound the range by the current
+  /// watermark (so a `Long.MAX_VALUE` full-invalidation does not iterate past real partitions) and
+  /// (b) restrict to buckets that actually exist in the partition map.
+  ///
+  /// Returns an empty list when the runtime znode is missing or the affected range falls
+  /// entirely past the watermark.
+  private List<Long> enumerateCandidateBuckets(String viewTableName, long affectedStartMs, long affectedEndMs) {
+    Stat stat = new Stat();
+    MaterializedViewRuntimeMetadata runtime =
+        MaterializedViewRuntimeMetadataUtils.fetchWithVersion(_propertyStore, viewTableName, stat);
+    if (runtime == null) {
+      return Collections.emptyList();
+    }
+
+    long bucketMs = inferBucketMs(viewTableName, runtime.getPartitions());
     // bucketMs is required by the analyzer at MV-table creation, so it should always be > 0
     // here.  Fail loud if not — a missing bucket config means MV state is unrecoverable
     // without operator intervention; silent over-marking would only make it worse.
@@ -410,55 +613,35 @@ public class MaterializedViewConsistencyManager {
             + "mark partitions without a bucket size.  Repair the MV table config.",
         viewTableName, bucketMs);
 
-    // Iterate every bucket [partStart, partStart+bucketMs) that overlaps the affected range
-    // [affectedStartMs, affectedEndMs]. Two ranges overlap when start1 <= end2 AND end1 >= start2.
-    // The first overlapping bucket has partStart = floorDiv(affectedStartMs, bucketMs) * bucketMs;
-    // the last has partStart <= affectedEndMs (any bucket whose start is past affectedEndMs
-    // cannot overlap because partStart > affectedEndMs >= affectedStartMs implies the bucket
-    // starts after the affected range ends). floorDiv (instead of /) is used defensively so a
-    // future caller passing negative affectedStartMs would still produce the correct floor.
-    // Only flip existing VALID entries to STALE.  Absent buckets are NOT synthesized — under
-    // Design C, a bucket's absence from the partition map already means "MV does not cover this
-    // range", so the broker rewrite (PR 2) routes those queries to the base table.  Synthesizing
-    // STALE entries for every uncovered bucket below `watermarkMs` would explode the znode size
-    // on a full-range invalidation (~watermarkMs / bucketMs entries) without affecting routing
-    // correctness — the bucket-iteration loop below stays O(affectedRange / bucketMs) but the
-    // persisted map grows only with real partitions.
-    long partStart = Math.floorDiv(affectedStartMs, bucketMs) * bucketMs;
-    while (partStart <= affectedEndMs) {
-      PartitionInfo info = updatedInfos.get(partStart);
-      if (info != null && info.getState() == PartitionState.VALID) {
-        updatedInfos.put(partStart, info.withState(PartitionState.STALE));
-        anyChanged = true;
-        markedCount++;
+    // Cap affectedEndMs at watermarkMs.  No partition with partStart > watermarkMs can exist
+    // (the writer invariant), so any bucket beyond that cannot be marked STALE anyway.  This
+    // bounds the candidate range for a caller passing Long.MAX_VALUE (full-range invalidation from
+    // notifyMaterializedViewConsistencyManager paths when segment startTime/endTime is unknown).
+    long cappedEnd = Math.min(affectedEndMs, runtime.getWatermarkMs());
+    if (cappedEnd < affectedStartMs) {
+      LOGGER.debug("Affected range [{}, {}] is past watermarkMs ({}) for MV table: {}; nothing to mark",
+          affectedStartMs, affectedEndMs, runtime.getWatermarkMs(), viewTableName);
+      return Collections.emptyList();
+    }
+
+    // Select the EXISTING partition keys whose bucket [partStart, partStart+bucketMs) overlaps the
+    // affected range [affectedStartMs, cappedEnd] — i.e. partStart in
+    // [floorDiv(affectedStartMs, bucketMs) * bucketMs, cappedEnd].  Iterating the existing keys
+    // (rather than enumerating every slot in the range) bounds this list to the partition count,
+    // so a full-range invalidation with a small bucketMs and a large watermark horizon cannot
+    // allocate a list proportional to watermarkMs/bucketMs.  Absent buckets are intentionally NOT
+    // synthesized: under Design C a bucket's absence already means "MV does not cover this range"
+    // and the broker routes those queries to the base; the manager's markStale would no-op them
+    // anyway, so they are simply not candidates.  floorDiv (instead of /) defends a future caller
+    // passing a negative affectedStartMs.
+    long firstBucketStartMs = Math.floorDiv(affectedStartMs, bucketMs) * bucketMs;
+    List<Long> buckets = new ArrayList<>();
+    for (long partStart : runtime.getPartitions().keySet()) {
+      if (partStart >= firstBucketStartMs && partStart <= cappedEnd) {
+        buckets.add(partStart);
       }
-      partStart += bucketMs;
     }
-
-    if (!anyChanged) {
-      LOGGER.debug("No VALID partitions to mark STALE for MV table: {} in range [{}, {}]",
-          viewTableName, affectedStartMs, affectedEndMs);
-      return true;
-    }
-
-    MaterializedViewRuntimeMetadata updated = new MaterializedViewRuntimeMetadata(
-        runtime.getMaterializedViewTableNameWithType(), runtime.getWatermarkMs(), updatedInfos);
-
-    // Route through `persist()` so every writer site is funnelled through the same
-    // `validateForPersist` gate. Translate ONLY `CasConflictException` into the retry-loop
-    // boolean — real validation failures (IllegalStateException / IllegalArgumentException
-    // from validateForPersist) and underlying ZK errors propagate so they surface at the
-    // task / log level rather than being silently retried 128×.
-    try {
-      MaterializedViewRuntimeMetadataUtils.persist(_propertyStore, updated, stat.getVersion());
-      LOGGER.info("Marked {} partition(s) STALE for MV table: {} (range [{}, {}])",
-          markedCount, viewTableName, affectedStartMs, affectedEndMs);
-      return true;
-    } catch (MaterializedViewRuntimeMetadataUtils.CasConflictException e) {
-      LOGGER.debug("CAS conflict marking partitions STALE for MV table: {} (range [{}, {}]); will retry",
-          viewTableName, affectedStartMs, affectedEndMs);
-      return false;
-    }
+    return buckets;
   }
 
   /// Infers the bucket size in millis for the given MV table. First tries to read it from

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/consistency/MaterializedViewConsistencyManager.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/consistency/MaterializedViewConsistencyManager.java
@@ -601,8 +601,11 @@ public class MaterializedViewConsistencyManager {
   /// advanced over it, the bucket would serve stale data with nothing left to re-mark it.
   /// Over-marking is harmless: above-watermark buckets are routed to the base table by V1
   /// routing anyway, a STALE entry correctly blocks the contiguous-VALID watermark walk until
-  /// OVERWRITE re-materializes it, and the candidate list stays bounded by the partition count
-  /// because it iterates existing keys (so an unbounded `affectedEndMs` cannot blow it up).
+  /// OVERWRITE re-materializes it, the scheduler's APPEND loop skips ANY present entry (so an
+  /// above-watermark STALE bucket is handled exclusively by the OVERWRITE/DELETE step and can
+  /// never be double-dispatched as an APPEND), and the candidate list stays bounded by the
+  /// partition count because it iterates existing keys (so an unbounded `affectedEndMs` cannot
+  /// blow it up).
   ///
   /// Returns an empty list when the runtime znode is missing.
   private List<Long> enumerateCandidateBuckets(String viewTableName, long affectedStartMs, long affectedEndMs) {

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/metadata/MaterializedViewPartitionManager.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/metadata/MaterializedViewPartitionManager.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
@@ -102,8 +103,8 @@ import org.slf4j.LoggerFactory;
 /// This class manages exactly the partition map and `watermarkMs` field of
 /// [MaterializedViewRuntimeMetadata].  It MUST NOT acquire other znodes
 /// (e.g. [MaterializedViewDefinitionMetadata]), call source-table or table-config services,
-/// or grow a method count beyond the public DSL listed below.  See `red lines` in the PR
-/// description.
+/// or grow a method count beyond the public DSL listed below — callers that need source-side
+/// data pass it in (see the `Supplier` parameter on `clearValid`).
 public final class MaterializedViewPartitionManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(MaterializedViewPartitionManager.class);
 
@@ -166,11 +167,15 @@ public final class MaterializedViewPartitionManager {
   /// Splitting them across two CAS writes would create a transient window where the map
   /// has the new bucket but the watermark is stale.
   ///
-  /// Strict precondition: `windowStartMs` must NOT be present in the map.  A violation
-  /// (raced double-dispatch from the scheduler, mid-flight task replay) throws
-  /// [IllegalStateException] inside the CAS loop, which propagates without retry — the
-  /// scheduler dispatch invariant guarantees one APPEND per bucket per cycle, so this
-  /// firing indicates a real bug, not transient contention.
+  /// Strict precondition: `windowStartMs` must NOT be present in the map — with one
+  /// idempotency carve-out.  If the bucket is already `VALID` with the **same** fingerprint,
+  /// the call is a no-op: ZK's client-side `retryUntilConnected` can commit a write and then
+  /// replay it after a connection drop, so the replay's CAS conflict re-runs this mutator
+  /// against the manager's own committed write.  Failing there would hard-fail a minion task
+  /// that actually succeeded.  Any **other** existing entry (different fingerprint, non-VALID
+  /// state) still throws [IllegalStateException] inside the CAS loop, which propagates without
+  /// retry — the scheduler dispatch invariant guarantees one APPEND per bucket per cycle, so
+  /// that firing indicates a real bug, not transient contention.
   ///
   /// Retry profile: critical (cluster-tunable budget).
   public void appendValid(String tableNameWithType, long windowStartMs, long windowEndMs,
@@ -184,6 +189,13 @@ public final class MaterializedViewPartitionManager {
       Preconditions.checkState(current != null,
           "appendValid called before MV runtime znode was initialized for table: %s "
               + "(cold-start path skipped?)", tableNameWithType);
+      if (isAlreadyValidWithFingerprint(current, windowStartMs, fingerprint)) {
+        // Lost-ack replay: our own committed write (bucket VALID, same fingerprint, watermark
+        // already advanced in that same write) is being re-applied.  No-op, success.
+        LOGGER.info("appendValid: bucket {} for table {} already VALID with the same fingerprint; "
+            + "treating as an idempotent replay", windowStartMs, tableNameWithType);
+        return null;
+      }
       Map<Long, PartitionInfo> updated = new HashMap<>(current.getPartitions());
       addPartitionInfo(updated, windowStartMs,
           new PartitionInfo(PartitionState.VALID, fingerprint, System.currentTimeMillis()));
@@ -201,8 +213,10 @@ public final class MaterializedViewPartitionManager {
   /// changed.  Updates the in-place fingerprint and refreshes `lastRefreshTime`; watermark
   /// is unchanged because OVERWRITE only refreshes existing coverage.
   ///
-  /// Strict precondition: `windowStartMs` must be present and STALE.  A non-STALE entry
-  /// indicates the scheduler dispatch invariant was violated and throws
+  /// Strict precondition: `windowStartMs` must be present and STALE — with the same
+  /// idempotency carve-out as [#appendValid]: a bucket already `VALID` with the same
+  /// fingerprint is a lost-ack replay of our own committed write and no-ops.  Any other
+  /// non-STALE entry indicates the scheduler dispatch invariant was violated and throws
   /// [IllegalStateException] without retry.
   ///
   /// Retry profile: critical.
@@ -213,6 +227,11 @@ public final class MaterializedViewPartitionManager {
       Preconditions.checkState(current != null,
           "refreshValid called before MV runtime znode was initialized for table: %s",
           tableNameWithType);
+      if (isAlreadyValidWithFingerprint(current, windowStartMs, fingerprint)) {
+        LOGGER.info("refreshValid: bucket {} for table {} already VALID with the same fingerprint; "
+            + "treating as an idempotent replay", windowStartMs, tableNameWithType);
+        return null;
+      }
       Map<Long, PartitionInfo> updated = new HashMap<>(current.getPartitions());
       PartitionInfo existing = updated.get(windowStartMs);
       Preconditions.checkState(existing != null && existing.getState() == PartitionState.STALE,
@@ -275,8 +294,12 @@ public final class MaterializedViewPartitionManager {
   /// Until that design lands, this method preserves today's `VALID-empty` semantics so the
   /// scheduler's contiguous-VALID watermark walk continues to work without modification.
   ///
-  /// Strict precondition: `windowStartMs` must be present and STALE.  Non-STALE entries
-  /// indicate the scheduler dispatch invariant was violated; fail-loud surfaces the bug.
+  /// Strict precondition: `windowStartMs` must be present and STALE — with the same
+  /// idempotency carve-out as [#appendValid]: a bucket already `VALID` with the
+  /// [PartitionFingerprint#EMPTY] fingerprint is a lost-ack replay of our own committed
+  /// write and no-ops (a backfill landing after that committed write is the periodic
+  /// sweep's job, not this replay's).  Any other non-STALE entry indicates the scheduler
+  /// dispatch invariant was violated; fail-loud surfaces the bug.
   ///
   /// Retry profile: critical.
   public void clearValid(String tableNameWithType, long windowStartMs,
@@ -287,6 +310,11 @@ public final class MaterializedViewPartitionManager {
       Preconditions.checkState(current != null,
           "clearValid called before MV runtime znode was initialized for table: %s",
           tableNameWithType);
+      if (isAlreadyValidWithFingerprint(current, windowStartMs, PartitionFingerprint.EMPTY)) {
+        LOGGER.info("clearValid: bucket {} for table {} already VALID-empty; "
+            + "treating as an idempotent replay", windowStartMs, tableNameWithType);
+        return null;
+      }
       Map<Long, PartitionInfo> updated = new HashMap<>(current.getPartitions());
       PartitionInfo existing = updated.get(windowStartMs);
       Preconditions.checkState(existing != null && existing.getState() == PartitionState.STALE,
@@ -363,7 +391,7 @@ public final class MaterializedViewPartitionManager {
   ///
   /// Retry profile: critical.
   public void markStale(String tableNameWithType, long windowStartMs) {
-    markStale(tableNameWithType, java.util.Collections.singletonList(windowStartMs));
+    markStale(tableNameWithType, List.of(windowStartMs));
   }
 
   /// MARK_STALE op (batch): for each bucket in the input collection, flip VALID → STALE.
@@ -437,6 +465,19 @@ public final class MaterializedViewPartitionManager {
   // ─────────────────────────────────────────────────────────────────────────────────────
   //  Private CRUD primitives — fail-loud invariant checks on the in-memory map
   // ─────────────────────────────────────────────────────────────────────────────────────
+
+  /// True when the bucket already carries `VALID` with exactly the given fingerprint — the
+  /// signature of a lost-ack replay of this manager's own committed write (ZK's client-side
+  /// `retryUntilConnected` can commit a `set` and then replay it after a connection drop;
+  /// the replay fails with a version conflict and the CAS loop re-runs the mutator against
+  /// the already-committed state).  The strict ops treat this shape as an idempotent no-op
+  /// instead of a precondition violation.
+  private static boolean isAlreadyValidWithFingerprint(MaterializedViewRuntimeMetadata current,
+      long windowStartMs, PartitionFingerprint fingerprint) {
+    PartitionInfo existing = current.getPartitions().get(windowStartMs);
+    return existing != null && existing.getState() == PartitionState.VALID
+        && fingerprint.equals(existing.getFingerprint());
+  }
 
   /// Adds an entry that the caller asserts is currently absent.  Throws on violation —
   /// silent overwrite would mask races (e.g. a double-dispatched APPEND for the same

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/metadata/MaterializedViewPartitionManager.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/metadata/MaterializedViewPartitionManager.java
@@ -192,7 +192,7 @@ public final class MaterializedViewPartitionManager {
       if (isAlreadyValidWithFingerprint(current, windowStartMs, fingerprint)) {
         // Lost-ack replay: our own committed write (bucket VALID, same fingerprint, watermark
         // already advanced in that same write) is being re-applied.  No-op, success.
-        LOGGER.info("appendValid: bucket {} for table {} already VALID with the same fingerprint; "
+        LOGGER.warn("appendValid: bucket {} for table {} already VALID with the same fingerprint; "
             + "treating as an idempotent replay", windowStartMs, tableNameWithType);
         return null;
       }
@@ -228,7 +228,7 @@ public final class MaterializedViewPartitionManager {
           "refreshValid called before MV runtime znode was initialized for table: %s",
           tableNameWithType);
       if (isAlreadyValidWithFingerprint(current, windowStartMs, fingerprint)) {
-        LOGGER.info("refreshValid: bucket {} for table {} already VALID with the same fingerprint; "
+        LOGGER.warn("refreshValid: bucket {} for table {} already VALID with the same fingerprint; "
             + "treating as an idempotent replay", windowStartMs, tableNameWithType);
         return null;
       }
@@ -311,7 +311,7 @@ public final class MaterializedViewPartitionManager {
           "clearValid called before MV runtime znode was initialized for table: %s",
           tableNameWithType);
       if (isAlreadyValidWithFingerprint(current, windowStartMs, PartitionFingerprint.EMPTY)) {
-        LOGGER.info("clearValid: bucket {} for table {} already VALID-empty; "
+        LOGGER.warn("clearValid: bucket {} for table {} already VALID-empty; "
             + "treating as an idempotent replay", windowStartMs, tableNameWithType);
         return null;
       }
@@ -471,7 +471,16 @@ public final class MaterializedViewPartitionManager {
   /// `retryUntilConnected` can commit a `set` and then replay it after a connection drop;
   /// the replay fails with a version conflict and the CAS loop re-runs the mutator against
   /// the already-committed state).  The strict ops treat this shape as an idempotent no-op
-  /// instead of a precondition violation.
+  /// instead of a precondition violation.  The same shape also absorbs a crash-then-Helix-retry
+  /// re-commit of an identical task attempt.
+  ///
+  /// Known residual: the carve-out cannot distinguish those benign replays from a *concurrent*
+  /// duplicate attempt (a zombie minion task still running after a Helix timeout re-dispatch —
+  /// there is no fencing), whose metadata commit now succeeds silently instead of throwing.
+  /// Two live attempts for the same window compute identical fingerprints, but their disjoint
+  /// segment-lineage replaces can both survive, duplicating segments without a failure signal.
+  /// Callers log this path at WARN so an unexpected carve-out frequency is operator-visible;
+  /// commit-time verification of the window's live segment set is the stronger follow-up.
   private static boolean isAlreadyValidWithFingerprint(MaterializedViewRuntimeMetadata current,
       long windowStartMs, PartitionFingerprint fingerprint) {
     PartitionInfo existing = current.getPartitions().get(windowStartMs);

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/metadata/MaterializedViewPartitionManager.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/metadata/MaterializedViewPartitionManager.java
@@ -1,0 +1,560 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.materializedview.metadata;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+import org.apache.helix.store.HelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.zkclient.exception.ZkException;
+import org.apache.pinot.materializedview.scheduler.MaterializedViewTaskUtils;
+import org.apache.pinot.spi.utils.CommonConstants.MaterializedViewTask;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/// Single source of truth for every per-partition state transition on the
+/// [MaterializedViewRuntimeMetadata] runtime znode.
+///
+/// <h3>Why this class exists</h3>
+///
+/// Before this manager landed, the runtime znode was mutated by three separate sites — the
+/// minion executor (APPEND / OVERWRITE / DELETE task commits), the scheduler (false-positive
+/// STALE reverts), and the consistency manager (VALID → STALE markings).  Each site shipped
+/// its own version-checked CAS loop, with subtly different retry budgets, backoff jitter,
+/// and exception-classification rules.  Subsequent state-machine changes (e.g. extending the
+/// VACANT → STALE synthesize for in-coverage backfill, or revoking the VALID-empty state)
+/// would have required coordinated edits at all three sites — exactly the failure mode that
+/// caused the earlier `computeWindowFingerprint` duplication scare.
+///
+/// This class consolidates all per-partition mutations behind a state-change DSL.  Each
+/// public method maps to exactly one operation in the per-partition state machine; the
+/// ZK CAS retry loop, the writer-side `validateForPersist` invariant gate, and the watermark
+/// recompute on APPEND all live behind the public API.  Callers express intent
+/// (`appendValid`, `markStale`, ...) and never see the persistence machinery.
+///
+/// <h3>Architecture</h3>
+///
+/// Three layers, deliberately separated:
+///
+///   - **Public state-change DSL** — one method per state-machine op.  Each method has a
+///     well-defined precondition and postcondition (see per-method javadoc) and selects the
+///     appropriate retry profile.  Callers never construct `PartitionInfo` directly.
+///   - **Private CRUD primitives** — `addPartitionInfo` / `updatePartitionInfo` /
+///     `removePartitionInfo`.  Each enforces a structural invariant on the in-memory map
+///     (e.g. "cannot add an already-existing entry") that fail-loud on violation, surfacing
+///     races as observable exceptions instead of silent overwrites.
+///   - **Single CAS engine** — `applyMutation` runs a caller-supplied mutator under the
+///     fetch / mutate / version-checked-write loop, with retry classification:
+///       - [MaterializedViewRuntimeMetadataUtils.CasConflictException] → re-fetch + retry
+///       - other [ZkException] (transport / session) → log warn + retry
+///       - [IllegalStateException] / [IllegalArgumentException] (validateForPersist) →
+///         propagate (fail-fast, no retry)
+///       - any other exception → propagate
+///
+/// <h3>Retry profile</h3>
+///
+/// Two profiles, calibrated to op semantics:
+///
+///   - **Critical** ([#DEFAULT_CRITICAL_MAX_ATTEMPTS] = 128, cluster-tunable via
+///     `pinot.materialized.view.executor.runtime.update.max.attempts`) — used by every
+///     state-changing op except `revertValid`.  Failure forces a minion task retry at the
+///     Helix level, which is far more expensive than a CAS retry, so the budget is sized
+///     to absorb realistic contention with `maxTasksPerBatch` parallel writers.
+///   - **Revert** ([#REVERT_MAX_ATTEMPTS] = 8) — used by `revertValid` only.  Failure
+///     means we did not avoid one OVERWRITE task, which the next scheduling cycle will
+///     either run for real or revert again.  Spending 128 retries to save one task is
+///     wasteful.
+///
+/// <h3>Concurrency</h3>
+///
+/// The manager is thread-safe and stateless above the ZK property store handle.  Concurrent
+/// callers contending on the same MV runtime znode are serialized by ZK CAS; one thread's
+/// commit invalidates the other's snapshot, the loser re-fetches and re-runs its mutator.
+/// Different MVs map to different znodes — no cross-MV contention.
+///
+/// <h3>Scope discipline</h3>
+///
+/// This class manages exactly the partition map and `watermarkMs` field of
+/// [MaterializedViewRuntimeMetadata].  It MUST NOT acquire other znodes
+/// (e.g. [MaterializedViewDefinitionMetadata]), call source-table or table-config services,
+/// or grow a method count beyond the public DSL listed below.  See `red lines` in the PR
+/// description.
+public final class MaterializedViewPartitionManager {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MaterializedViewPartitionManager.class);
+
+  /// Compile-time default for the critical retry budget.  Overridable per cluster (no
+  /// restart) via `pinot.materialized.view.executor.runtime.update.max.attempts`.  Sized so
+  /// `maxTasksPerBatch` parallel APPEND completions cannot exhaust the budget under realistic
+  /// contention.  Reused by ConsistencyMgr-style mark ops so a STALE marking is never
+  /// silently dropped.
+  static final int DEFAULT_CRITICAL_MAX_ATTEMPTS = 128;
+
+  /// Compile-time retry budget for `revertValid` only.  Failure is recovered by the next
+  /// scheduling cycle (the partition stays STALE and is retried), so a small budget is
+  /// appropriate.  Not cluster-tunable — operationally, raising this would not buy
+  /// correctness, only delay.
+  static final int REVERT_MAX_ATTEMPTS = 8;
+
+  /// Backoff envelope for the critical profile.  Total wait at the cap with worst-case
+  /// jitter is about `128 * (50 + 150) = 25.6 s`, well within the implicit per-task timeout.
+  private static final long CRITICAL_BACKOFF_BASE_MS = 50L;
+  private static final int CRITICAL_BACKOFF_JITTER_MS = 150;
+
+  /// Backoff envelope for the revert profile.  Total wait at the cap is about
+  /// `8 * (5 + 20) = 200 ms`.  Tight CAS-loop livelock is the failure to defend against;
+  /// scheduler thread blocking is the failure to avoid.
+  private static final long REVERT_BACKOFF_BASE_MS = 5L;
+  private static final int REVERT_BACKOFF_JITTER_MS = 20;
+
+  private final HelixPropertyStore<ZNRecord> _propertyStore;
+
+  /// Optional live cluster-config reader used to override [#DEFAULT_CRITICAL_MAX_ATTEMPTS]
+  /// at runtime.  Null in unit tests; null reader falls back to the compile-time default.
+  @Nullable
+  private final Function<String, String> _clusterConfigReader;
+
+  public MaterializedViewPartitionManager(HelixPropertyStore<ZNRecord> propertyStore,
+      @Nullable Function<String, String> clusterConfigReader) {
+    Preconditions.checkArgument(propertyStore != null, "propertyStore must not be null");
+    _propertyStore = propertyStore;
+    _clusterConfigReader = clusterConfigReader;
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────────────
+  //  Public state-change DSL
+  // ─────────────────────────────────────────────────────────────────────────────────────
+
+  /// APPEND op: VACANT → VALID(fp).  Invoked by the minion executor at task-commit time
+  /// after a successful materialization of a window that was previously absent from the
+  /// partition map.
+  ///
+  /// Side effects (all in a single CAS write):
+  ///
+  ///   - Inserts a new `PartitionInfo(VALID, fp, now)` at `windowStartMs`.
+  ///   - Advances `watermarkMs` to the highest contiguous VALID upper bound starting at
+  ///     the prior watermark, derived via
+  ///     [MaterializedViewTaskUtils#computeContiguousUpperMs] over the resulting map.
+  ///     The bucket size used for the walk is `windowEndMs - windowStartMs`.
+  ///
+  /// Watermark advancement is bundled with the bucket transition because watermark is a
+  /// derived field of the map state and must stay consistent under concurrent writers.
+  /// Splitting them across two CAS writes would create a transient window where the map
+  /// has the new bucket but the watermark is stale.
+  ///
+  /// Strict precondition: `windowStartMs` must NOT be present in the map.  A violation
+  /// (raced double-dispatch from the scheduler, mid-flight task replay) throws
+  /// [IllegalStateException] inside the CAS loop, which propagates without retry — the
+  /// scheduler dispatch invariant guarantees one APPEND per bucket per cycle, so this
+  /// firing indicates a real bug, not transient contention.
+  ///
+  /// Retry profile: critical (cluster-tunable budget).
+  public void appendValid(String tableNameWithType, long windowStartMs, long windowEndMs,
+      PartitionFingerprint fingerprint) {
+    Preconditions.checkArgument(fingerprint != null, "fingerprint must not be null");
+    Preconditions.checkArgument(windowEndMs > windowStartMs,
+        "Invalid window: windowEndMs (%s) <= windowStartMs (%s) for table %s",
+        windowEndMs, windowStartMs, tableNameWithType);
+    long bucketMs = windowEndMs - windowStartMs;
+    applyMutation(tableNameWithType, current -> {
+      Preconditions.checkState(current != null,
+          "appendValid called before MV runtime znode was initialized for table: %s "
+              + "(cold-start path skipped?)", tableNameWithType);
+      Map<Long, PartitionInfo> updated = new HashMap<>(current.getPartitions());
+      addPartitionInfo(updated, windowStartMs,
+          new PartitionInfo(PartitionState.VALID, fingerprint, System.currentTimeMillis()));
+      long newWatermarkMs = MaterializedViewTaskUtils.computeContiguousUpperMs(
+          current.getWatermarkMs(), updated, bucketMs);
+      LOGGER.info("appendValid: table={} bucket={} watermarkMs {}->{} (partitions={})",
+          tableNameWithType, windowStartMs, current.getWatermarkMs(), newWatermarkMs, updated.size());
+      return new MaterializedViewRuntimeMetadata(
+          current.getMaterializedViewTableNameWithType(), newWatermarkMs, updated);
+    }, criticalMaxAttempts(), CRITICAL_BACKOFF_BASE_MS, CRITICAL_BACKOFF_JITTER_MS);
+  }
+
+  /// OVERWRITE op: STALE → VALID(fp).  Invoked by the minion executor at task-commit time
+  /// after re-materializing a STALE bucket whose source-side fingerprint has actually
+  /// changed.  Updates the in-place fingerprint and refreshes `lastRefreshTime`; watermark
+  /// is unchanged because OVERWRITE only refreshes existing coverage.
+  ///
+  /// Strict precondition: `windowStartMs` must be present and STALE.  A non-STALE entry
+  /// indicates the scheduler dispatch invariant was violated and throws
+  /// [IllegalStateException] without retry.
+  ///
+  /// Retry profile: critical.
+  public void refreshValid(String tableNameWithType, long windowStartMs,
+      PartitionFingerprint fingerprint) {
+    Preconditions.checkArgument(fingerprint != null, "fingerprint must not be null");
+    applyMutation(tableNameWithType, current -> {
+      Preconditions.checkState(current != null,
+          "refreshValid called before MV runtime znode was initialized for table: %s",
+          tableNameWithType);
+      Map<Long, PartitionInfo> updated = new HashMap<>(current.getPartitions());
+      PartitionInfo existing = updated.get(windowStartMs);
+      Preconditions.checkState(existing != null && existing.getState() == PartitionState.STALE,
+          "refreshValid expects bucket %s to be STALE for table %s, got: %s",
+          windowStartMs, tableNameWithType, existing);
+      updatePartitionInfo(updated, windowStartMs,
+          new PartitionInfo(PartitionState.VALID, fingerprint, System.currentTimeMillis()));
+      LOGGER.info("refreshValid: table={} bucket={} STALE->VALID (fp={})",
+          tableNameWithType, windowStartMs, fingerprint);
+      return new MaterializedViewRuntimeMetadata(
+          current.getMaterializedViewTableNameWithType(), current.getWatermarkMs(), updated);
+    }, criticalMaxAttempts(), CRITICAL_BACKOFF_BASE_MS, CRITICAL_BACKOFF_JITTER_MS);
+  }
+
+  /// DELETE op: STALE → VALID(EMPTY), guarded by a commit-time source-emptiness re-check.
+  /// Invoked by the minion executor at task-commit time after retention-deleting MV segments
+  /// for a window whose source data is now empty.  Persists the `VALID + PartitionFingerprint.EMPTY`
+  /// shape rather than removing the entry — the coverage model treats every processed bucket as
+  /// "tracked", so a later base-table backfill flows through the standard VALID → STALE →
+  /// OVERWRITE cycle.
+  ///
+  /// <p><b>Commit-time backfill guard.</b> The scheduler dispatched DELETE because the source
+  /// window had zero overlapping segments, but a backfill can land between dispatch and this
+  /// commit.  `sourceFingerprintSupplier` recomputes the source fingerprint for the window from
+  /// live segment ZK metadata and is invoked <i>inside</i> the CAS mutator, so emptiness is
+  /// re-evaluated on every attempt immediately before the version-checked write — not against a
+  /// snapshot captured before the (under contention, possibly multi-second) retry loop.  If the
+  /// supplier reports the source is no longer empty (`getSegmentCount() != 0`), the op is a no-op
+  /// and the bucket is intentionally left STALE so the next scheduling cycle re-materializes it
+  /// via OVERWRITE.  Writing `VALID + EMPTY` over a now-non-empty source would silently drop the
+  /// backfilled rows: the consistency manager's create-segment event for the backfill is a no-op
+  /// while the bucket is still STALE, so nothing would re-mark the resulting `VALID-empty` entry
+  /// as STALE — stranding it as a permanently-empty in-coverage bucket the broker would route
+  /// empty results from.
+  ///
+  /// <p>Full atomicity across the two ZooKeeper subsystems (source-table segment metadata and the
+  /// MV runtime znode) is not achievable, so a narrow residual window remains within a single CAS
+  /// attempt: if a backfill segment appears AND the consistency manager's (debounced) STALE mark
+  /// for it fires — as a no-op, because the bucket is still STALE — strictly between this attempt's
+  /// supplier read and its runtime-znode write, the following `VALID-empty` write strands the
+  /// bucket, since that backfill's only mark was already consumed.  This residual is NOT guaranteed
+  /// to self-heal (only a later, unrelated base-table change in the window would recover it);
+  /// fully closing it requires the consistency manager to also re-evaluate in-coverage
+  /// `VALID-empty` buckets against the source — see the open-question note below.  The in-mutator
+  /// re-read still eliminates the dominant, contention-driven window that the pre-fix
+  /// snapshot-before-loop left wide open (the snapshot could be stale for the entire CAS retry
+  /// budget, up to several seconds).
+  ///
+  /// <p><b>Scope note:</b> the supplier is a caller-provided callback — the manager invokes it but
+  /// keeps no compile-time dependency on source-table services, preserving the scope discipline
+  /// documented at the class level.
+  ///
+  /// <p><b>Design context (open question):</b> The continued existence of the `VALID-empty`
+  /// shape is under review.  An alternative model removes the entry entirely on DELETE
+  /// (treating empty buckets as VACANT), which requires extending
+  /// [MaterializedViewTaskUtils#computeContiguousUpperMs] to walk past VACANT buckets and
+  /// extending the consistency manager to synthesize STALE entries for in-coverage VACANT
+  /// buckets on backfill.  That same consistency-manager extension would also close the residual
+  /// backfill window described above, by re-marking in-coverage `VALID-empty` buckets STALE.
+  /// Until that design lands, this method preserves today's `VALID-empty` semantics so the
+  /// scheduler's contiguous-VALID watermark walk continues to work without modification.
+  ///
+  /// Strict precondition: `windowStartMs` must be present and STALE.  Non-STALE entries
+  /// indicate the scheduler dispatch invariant was violated; fail-loud surfaces the bug.
+  ///
+  /// Retry profile: critical.
+  public void clearValid(String tableNameWithType, long windowStartMs,
+      Supplier<PartitionFingerprint> sourceFingerprintSupplier) {
+    Preconditions.checkArgument(sourceFingerprintSupplier != null,
+        "sourceFingerprintSupplier must not be null");
+    applyMutation(tableNameWithType, current -> {
+      Preconditions.checkState(current != null,
+          "clearValid called before MV runtime znode was initialized for table: %s",
+          tableNameWithType);
+      Map<Long, PartitionInfo> updated = new HashMap<>(current.getPartitions());
+      PartitionInfo existing = updated.get(windowStartMs);
+      Preconditions.checkState(existing != null && existing.getState() == PartitionState.STALE,
+          "clearValid expects bucket %s to be STALE for table %s, got: %s",
+          windowStartMs, tableNameWithType, existing);
+      // Backfill guard: re-read the source on THIS attempt and leave the bucket STALE (no-op) if
+      // it is no longer empty, so the next scheduling cycle re-materializes it via OVERWRITE
+      // instead of writing a permanently-empty in-coverage bucket.  `segmentCount == 0` is the
+      // canonical "empty source window" criterion — identical to the scheduler's DELETE dispatch
+      // test (MaterializedViewTaskScheduler#tryHandleStalePartition) and equivalent to
+      // PartitionFingerprint.EMPTY (computeWindowFingerprint maps an empty overlap to EMPTY).
+      // See the method javadoc for the full rationale.
+      PartitionFingerprint sourceFingerprint = sourceFingerprintSupplier.get();
+      if (sourceFingerprint.getSegmentCount() != 0) {
+        LOGGER.info("clearValid: bucket {} for table {} has a backfilled source ({} overlapping "
+                + "segment(s)); leaving STALE for OVERWRITE instead of writing VALID-empty",
+            windowStartMs, tableNameWithType, sourceFingerprint.getSegmentCount());
+        return null;
+      }
+      updatePartitionInfo(updated, windowStartMs,
+          new PartitionInfo(PartitionState.VALID, PartitionFingerprint.EMPTY,
+              System.currentTimeMillis()));
+      LOGGER.info("clearValid: table={} bucket={} STALE->VALID-empty",
+          tableNameWithType, windowStartMs);
+      return new MaterializedViewRuntimeMetadata(
+          current.getMaterializedViewTableNameWithType(), current.getWatermarkMs(), updated);
+    }, criticalMaxAttempts(), CRITICAL_BACKOFF_BASE_MS, CRITICAL_BACKOFF_JITTER_MS);
+  }
+
+  /// STALE_REVERT op: STALE → VALID, fingerprint and `lastRefreshTime` preserved.  Invoked
+  /// by the scheduler after a precise fingerprint comparison concludes that a STALE marking
+  /// was a false positive (the source did not actually change in the affected window).  The
+  /// underlying data was not re-materialized, so neither fingerprint nor `lastRefreshTime`
+  /// move.
+  ///
+  /// Lenient precondition: if the bucket is no longer STALE on retry (either already
+  /// reverted by a concurrent write or the consistency manager re-marked it for a new
+  /// reason), the call exits successfully without writing — the desired transition is
+  /// already done or no longer applicable.
+  ///
+  /// Retry profile: revert (small budget; failure is recovered by the next scheduling
+  /// cycle).
+  public void revertValid(String tableNameWithType, long windowStartMs) {
+    applyMutation(tableNameWithType, current -> {
+      if (current == null) {
+        LOGGER.debug("revertValid: runtime znode missing for table: {}; skipping",
+            tableNameWithType);
+        return null;
+      }
+      PartitionInfo existing = current.getPartitions().get(windowStartMs);
+      if (existing == null || existing.getState() != PartitionState.STALE) {
+        LOGGER.info("revertValid: bucket {} for table {} is not STALE (got: {}); skipping",
+            windowStartMs, tableNameWithType, existing);
+        return null;
+      }
+      Map<Long, PartitionInfo> updated = new HashMap<>(current.getPartitions());
+      updatePartitionInfo(updated, windowStartMs, existing.withState(PartitionState.VALID));
+      LOGGER.info("revertValid: table={} bucket={} STALE->VALID (false-positive, fp={})",
+          tableNameWithType, windowStartMs, existing.getFingerprint());
+      return new MaterializedViewRuntimeMetadata(
+          current.getMaterializedViewTableNameWithType(), current.getWatermarkMs(), updated);
+    }, REVERT_MAX_ATTEMPTS, REVERT_BACKOFF_BASE_MS, REVERT_BACKOFF_JITTER_MS);
+  }
+
+  /// MARK_STALE op (single-bucket): VALID → STALE.  Invoked by the consistency manager (and
+  /// future manual REFRESH commands) when base-table data has changed in a way that affects
+  /// `windowStartMs`.  Fingerprint and `lastRefreshTime` are preserved so the scheduler's
+  /// false-positive revert can compare against the prior snapshot.
+  ///
+  /// Lenient: if the bucket is absent or already STALE, the call is a no-op.  Today the
+  /// in-coverage VACANT case is a deliberate skip (matching the prior consistency manager
+  /// behavior); a future change will synthesize a STALE entry for in-coverage VACANT
+  /// buckets to fix the backfill silent-data-loss case.
+  ///
+  /// Retry profile: critical.
+  public void markStale(String tableNameWithType, long windowStartMs) {
+    markStale(tableNameWithType, java.util.Collections.singletonList(windowStartMs));
+  }
+
+  /// MARK_STALE op (batch): for each bucket in the input collection, flip VALID → STALE.
+  /// All updates are applied in a single CAS write, so a range invalidation that spans
+  /// many buckets does not amplify CAS contention with concurrent executors.
+  ///
+  /// Per-bucket lenient: absent buckets and already-STALE buckets are no-ops within the
+  /// same call.  Same future synthesize note as the single-bucket overload.
+  ///
+  /// Retry profile: critical.
+  public void markStale(String tableNameWithType, Collection<Long> windowStartMsBuckets) {
+    Preconditions.checkArgument(windowStartMsBuckets != null,
+        "windowStartMsBuckets must not be null for table: %s", tableNameWithType);
+    if (windowStartMsBuckets.isEmpty()) {
+      return;
+    }
+    applyMutation(tableNameWithType, current -> {
+      if (current == null) {
+        LOGGER.debug("markStale: runtime znode missing for table: {}; nothing to mark",
+            tableNameWithType);
+        return null;
+      }
+      Map<Long, PartitionInfo> updated = new HashMap<>(current.getPartitions());
+      int markedCount = 0;
+      for (long bucket : windowStartMsBuckets) {
+        PartitionInfo existing = updated.get(bucket);
+        if (existing != null && existing.getState() == PartitionState.VALID) {
+          updatePartitionInfo(updated, bucket, existing.withState(PartitionState.STALE));
+          markedCount++;
+        }
+      }
+      if (markedCount == 0) {
+        LOGGER.debug("markStale: no VALID partitions to mark for table {} (buckets={})",
+            tableNameWithType, windowStartMsBuckets.size());
+        return null;
+      }
+      LOGGER.info("markStale: table={} marked {}/{} bucket(s) STALE",
+          tableNameWithType, markedCount, windowStartMsBuckets.size());
+      return new MaterializedViewRuntimeMetadata(
+          current.getMaterializedViewTableNameWithType(), current.getWatermarkMs(), updated);
+    }, criticalMaxAttempts(), CRITICAL_BACKOFF_BASE_MS, CRITICAL_BACKOFF_JITTER_MS);
+  }
+
+  /// DELETE_PARTITION op: any state → VACANT (entry removed from the map).  Hard-delete
+  /// counterpart to `clearValid` (which writes VALID-empty).  Reserved for future manual
+  /// admin commands; not currently invoked from any automatic path.
+  ///
+  /// Lenient: if the bucket is already absent, the call is a no-op.
+  ///
+  /// Retry profile: critical.
+  public void deletePartition(String tableNameWithType, long windowStartMs) {
+    applyMutation(tableNameWithType, current -> {
+      if (current == null) {
+        LOGGER.debug("deletePartition: runtime znode missing for table: {}; skipping",
+            tableNameWithType);
+        return null;
+      }
+      if (!current.getPartitions().containsKey(windowStartMs)) {
+        LOGGER.debug("deletePartition: bucket {} already absent for table {}; skipping",
+            windowStartMs, tableNameWithType);
+        return null;
+      }
+      Map<Long, PartitionInfo> updated = new HashMap<>(current.getPartitions());
+      removePartitionInfo(updated, windowStartMs);
+      LOGGER.info("deletePartition: table={} bucket={} removed", tableNameWithType, windowStartMs);
+      return new MaterializedViewRuntimeMetadata(
+          current.getMaterializedViewTableNameWithType(), current.getWatermarkMs(), updated);
+    }, criticalMaxAttempts(), CRITICAL_BACKOFF_BASE_MS, CRITICAL_BACKOFF_JITTER_MS);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────────────
+  //  Private CRUD primitives — fail-loud invariant checks on the in-memory map
+  // ─────────────────────────────────────────────────────────────────────────────────────
+
+  /// Adds an entry that the caller asserts is currently absent.  Throws on violation —
+  /// silent overwrite would mask races (e.g. a double-dispatched APPEND for the same
+  /// bucket).  Use [#updatePartitionInfo] when overwriting an existing entry is intended.
+  private static void addPartitionInfo(Map<Long, PartitionInfo> map, long windowStartMs,
+      PartitionInfo info) {
+    Preconditions.checkArgument(info != null, "PartitionInfo must not be null");
+    Preconditions.checkState(!map.containsKey(windowStartMs),
+        "addPartitionInfo: bucket %s already present (existing: %s)",
+        windowStartMs, map.get(windowStartMs));
+    map.put(windowStartMs, info);
+  }
+
+  /// Replaces an existing entry the caller asserts is present.  Throws on violation — a
+  /// missing entry under an "update" op indicates the caller's precondition check passed
+  /// against a stale snapshot, which is a logic bug worth surfacing.
+  private static void updatePartitionInfo(Map<Long, PartitionInfo> map, long windowStartMs,
+      PartitionInfo info) {
+    Preconditions.checkArgument(info != null, "PartitionInfo must not be null");
+    Preconditions.checkState(map.containsKey(windowStartMs),
+        "updatePartitionInfo: bucket %s missing", windowStartMs);
+    map.put(windowStartMs, info);
+  }
+
+  /// Removes an entry the caller asserts is present.  Throws on violation.
+  private static void removePartitionInfo(Map<Long, PartitionInfo> map, long windowStartMs) {
+    Preconditions.checkState(map.containsKey(windowStartMs),
+        "removePartitionInfo: bucket %s missing", windowStartMs);
+    map.remove(windowStartMs);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────────────
+  //  Private CAS engine
+  // ─────────────────────────────────────────────────────────────────────────────────────
+
+  /// Mutator contract: given the current snapshot, return the new
+  /// [MaterializedViewRuntimeMetadata] to persist, or `null` to indicate the call is a
+  /// no-op (success, no CAS write).  Mutators MAY throw to abort with fail-fast — the
+  /// applyMutation loop does not retry on mutator-thrown exceptions.
+  @FunctionalInterface
+  @VisibleForTesting
+  interface Mutator {
+    @Nullable
+    MaterializedViewRuntimeMetadata apply(@Nullable MaterializedViewRuntimeMetadata current);
+  }
+
+  /// Runs `mutator` under a version-checked CAS retry loop.  See class-level docs for the
+  /// retry classification rules.
+  ///
+  /// On budget exhaust, throws [RuntimeException] wrapping the last CAS or transport
+  /// exception so the caller (typically a minion task) sees a recoverable failure path
+  /// rather than silent corruption.
+  private void applyMutation(String tableNameWithType, Mutator mutator,
+      int maxAttempts, long backoffBaseMs, int backoffJitterMs) {
+    Preconditions.checkArgument(maxAttempts > 0, "maxAttempts must be positive");
+    ZkException lastZkException = null;
+    for (int attempt = 0; attempt < maxAttempts; attempt++) {
+      if (attempt > 0) {
+        sleepWithJitter(tableNameWithType, backoffBaseMs, backoffJitterMs);
+      }
+      Stat stat = new Stat();
+      MaterializedViewRuntimeMetadata current;
+      try {
+        current = MaterializedViewRuntimeMetadataUtils.fetchWithVersion(_propertyStore, tableNameWithType, stat);
+      } catch (ZkException e) {
+        // Transient read-side ZK / session failure: count it against the retry budget and re-fetch
+        // on the next attempt rather than letting it escape unretried.  Mutator precondition
+        // failures (below) are deliberately NOT caught here, so they still fail-fast.
+        lastZkException = e;
+        LOGGER.warn("ZK transport error reading MV runtime for table {} on attempt {}",
+            tableNameWithType, attempt + 1, e);
+        continue;
+      }
+      int writeVersion = (current != null) ? stat.getVersion() : -1;
+
+      MaterializedViewRuntimeMetadata updated = mutator.apply(current);
+      if (updated == null) {
+        // Mutator signalled no-op (idempotent path or precondition no longer applies).
+        return;
+      }
+
+      try {
+        MaterializedViewRuntimeMetadataUtils.persist(_propertyStore, updated, writeVersion);
+        return;
+      } catch (MaterializedViewRuntimeMetadataUtils.CasConflictException e) {
+        lastZkException = e;
+        LOGGER.debug("CAS conflict for table {} on attempt {}; will retry",
+            tableNameWithType, attempt + 1);
+      } catch (ZkException e) {
+        // Transport / session level failures: log and retry with backoff.  A transient
+        // ZK reconnect should not abort an otherwise-correct mutation.
+        lastZkException = e;
+        LOGGER.warn("ZK transport error persisting MV runtime for table {} on attempt {}",
+            tableNameWithType, attempt + 1, e);
+      }
+      // IllegalStateException / IllegalArgumentException from validateForPersist are NOT
+      // caught here: they indicate the produced metadata is structurally invalid, which
+      // retrying cannot fix.  They propagate to the caller verbatim.
+    }
+    throw new RuntimeException(
+        "Failed to update MV runtime for table: " + tableNameWithType
+            + " after " + maxAttempts + " attempts", lastZkException);
+  }
+
+  private static void sleepWithJitter(String tableNameWithType, long baseMs, int jitterMs) {
+    try {
+      Thread.sleep(baseMs + ThreadLocalRandom.current().nextInt(Math.max(jitterMs, 1)));
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(
+          "Interrupted while retrying MV runtime update for table: " + tableNameWithType, ie);
+    }
+  }
+
+  private int criticalMaxAttempts() {
+    return MaterializedViewTaskUtils.readPositiveIntClusterConfigOrDefault(
+        _clusterConfigReader,
+        MaterializedViewTask.CLUSTER_CONFIG_KEY_MAX_RUNTIME_UPDATE_ATTEMPTS,
+        DEFAULT_CRITICAL_MAX_ATTEMPTS);
+  }
+}

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/metadata/PartitionFingerprint.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/metadata/PartitionFingerprint.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.materializedview.metadata;
 
+import com.google.common.hash.Hashing;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -36,6 +37,29 @@ import java.util.TreeMap;
 /// Thread-safety: instances are immutable after construction.
 public class PartitionFingerprint {
   private static final char SEPARATOR = ',';
+
+  /// Canonical fingerprint for an "empty" partition window — no base segments overlap.
+  ///
+  /// The `crcChecksum` field is initialised by running the same `farmHashFingerprint64`
+  /// hasher with no input bytes, which is byte-identical to what
+  /// `MaterializedViewTaskUtils#computeWindowFingerprint` (the single source of truth used
+  /// by both the scheduler and the minion executor) produces when the overlapping segment
+  /// list is empty. Two consequences:
+  ///
+  ///   - Existing ZK records written by the APPEND-empty path (carrying `(0, farmHash64(""))`)
+  ///     are byte-equal to this constant, so `equals` comparisons against [#EMPTY] continue
+  ///     to behave correctly across rolling upgrades.
+  ///
+  ///   - The DELETE task executor uses [#EMPTY] when it persists a `VALID + empty`
+  ///     PartitionInfo after retention-deleting the source data. Reusing the same value the
+  ///     APPEND-empty path naturally produces avoids introducing a second representation of
+  ///     "empty fingerprint" that would silently fail equality checks.
+  ///
+  /// `farmHashFingerprint64("")` is a deterministic non-zero constant; never use
+  /// `new PartitionFingerprint(0, 0L)` as a stand-in for "empty" — the two values do NOT
+  /// compare equal.
+  public static final PartitionFingerprint EMPTY =
+      new PartitionFingerprint(0, Hashing.farmHashFingerprint64().newHasher().hash().asLong());
 
   /// Number of base table segments whose time range overlaps this partition window.
   private final int _segmentCount;

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/metadata/PartitionInfo.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/metadata/PartitionInfo.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.materializedview.metadata;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.util.HashMap;
 import java.util.Map;
@@ -40,6 +41,12 @@ import java.util.Objects;
 /// unlike the prior packed `"V,10,5000,1700006400000"` string format.
 ///
 /// Thread-safety: instances are immutable after construction.
+///
+/// Construction discipline: production callers MUST go through
+/// [org.apache.pinot.materializedview.metadata.MaterializedViewPartitionManager] —
+/// the constructor is package-private so every state transition is funnelled through
+/// the manager's CAS engine.  Tests in other packages use [#forTesting] for fixture
+/// setup; the dedicated name keeps any production-side misuse obvious in code review.
 public class PartitionInfo {
   private static final String STATE_KEY = "state";
   private static final String SEGMENT_COUNT_KEY = "segmentCount";
@@ -50,10 +57,19 @@ public class PartitionInfo {
   private final PartitionFingerprint _fingerprint;
   private final long _lastRefreshTime;
 
-  public PartitionInfo(PartitionState state, PartitionFingerprint fingerprint, long lastRefreshTime) {
+  PartitionInfo(PartitionState state, PartitionFingerprint fingerprint, long lastRefreshTime) {
     _state = state;
     _fingerprint = fingerprint;
     _lastRefreshTime = lastRefreshTime;
+  }
+
+  /// Test-only factory for seeding partition fixtures in cross-package tests.  Production
+  /// code MUST NOT call this — every real state transition goes through
+  /// [org.apache.pinot.materializedview.metadata.MaterializedViewPartitionManager].
+  @VisibleForTesting
+  public static PartitionInfo forTesting(PartitionState state, PartitionFingerprint fingerprint,
+      long lastRefreshTime) {
+    return new PartitionInfo(state, fingerprint, lastRefreshTime);
   }
 
   public PartitionState getState() {

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/metadata/PartitionState.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/metadata/PartitionState.java
@@ -21,14 +21,21 @@ package org.apache.pinot.materializedview.metadata;
 
 /// State of a materialized partition in the MV lifecycle.
 ///
-///   - `VALID` – partition is up-to-date with base table data.
-///   - `STALE` – base table data has changed since last materialization; partition
-///     needs OVERWRITE.
+///   - `VALID` – partition is up-to-date with base table data.  When the base table window
+///     is empty (no overlapping segments), the entry carries
+///     [PartitionFingerprint#EMPTY] and is still `VALID`; the broker treats those buckets
+///     as "covered by the MV with no rows".
+///   - `STALE` – base table data has changed since the partition was last materialized;
+///     the scheduler will dispatch a recompute (OVERWRITE), or DELETE if the source
+///     window is now empty.
 ///
-/// Partition expiration is modeled by **absence** from the runtime metadata's
-/// partition map, not as a separate state.  The DELETE task path removes the
-/// map entry; the broker then treats that bucket as "not covered by the MV"
-/// and routes those queries to the base table.
+/// `absent` (no entry in the partition map) is reserved for cold-start, before the first
+/// APPEND has run for that bucket.  After the first run of any task type — APPEND with
+/// data, APPEND with empty source, OVERWRITE, or DELETE — the bucket carries an entry
+/// (`VALID` with a real fingerprint, or `VALID` with [PartitionFingerprint#EMPTY]).
+/// The DELETE task explicitly does NOT remove the entry; it rewrites it to
+/// `VALID + PartitionFingerprint.EMPTY` so subsequent backfills into the now-empty
+/// window flow through the standard `VALID → STALE → OVERWRITE` cycle.
 ///
 /// Encoded as a single character (`"V"` / `"S"`) for compact ZK storage.
 public enum PartitionState {

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/rewrite/MaterializedViewQueryRewriteEngine.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/rewrite/MaterializedViewQueryRewriteEngine.java
@@ -180,6 +180,15 @@ public class MaterializedViewQueryRewriteEngine {
   /// Per-bucket eligibility is enforced later by the handler / dispatcher.  Note: an empty
   /// partition map is permitted — V1 routing uses `watermarkMs` as the split point, so the
   /// partition map is only consulted for V2 N-way routing.
+  ///
+  /// <p><b>Known V1 limitation (tracked for V2 per-bucket routing):</b> because the split is a
+  /// single `watermarkMs` cutoff and does NOT consult per-bucket state, a bucket strictly below
+  /// `watermarkMs` that is STALE, absent (VACANT), or VALID-empty — e.g. a historical base-table
+  /// change the consistency manager marked STALE, a backfill into a previously-empty window, or a
+  /// retention-DELETE that emptied the bucket — is still routed to the MV side and can return
+  /// stale or missing rows until the scheduler re-materializes it via OVERWRITE.  V2 will consult
+  /// the partition map (already cached on `MaterializedViewCacheEntry`) to route such buckets to
+  /// the base table; see `pinot-materialized-view/DESIGN.md` for the V2 per-bucket routing plan.
   private static boolean isEligible(MaterializedViewCacheEntry candidate) {
     if (!candidate.getDefinition().isRewriteEnabled()) {
       LOGGER.debug("MV skip [{}]: rewriteEnabled=false on definition",

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/scheduler/MaterializedViewTaskScheduler.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/scheduler/MaterializedViewTaskScheduler.java
@@ -304,10 +304,16 @@ public class MaterializedViewTaskScheduler {
         if (windowEndMs > cutoffMs) {
           break;
         }
-        // Skip already-VALID slots from a prior partial batch (mid-batch failure recovery).
-        // Re-running an APPEND for a VALID partition would produce duplicate segments.
+        // Skip any bucket that already has an entry — APPEND only fills ABSENT buckets.
+        // VALID slots come from a prior partial batch (mid-batch failure recovery);
+        // re-running APPEND for one would produce duplicate segments.  STALE slots can
+        // appear above the watermark too (the consistency manager marks out-of-order
+        // VALID buckets STALE wherever they sit); those are exclusively step 1's
+        // responsibility (OVERWRITE / DELETE) — dispatching an APPEND for one would race
+        // the in-flight or upcoming exclusive task on the same window, risking concurrent
+        // segment-replace on the same window and duplicated rows.
         PartitionInfo existing = partitionInfos.get(nextWindowStartMs);
-        if (existing != null && existing.getState() == PartitionState.VALID) {
+        if (existing != null) {
           nextWindowStartMs = windowEndMs;
           continue;
         }

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/scheduler/MaterializedViewTaskScheduler.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/scheduler/MaterializedViewTaskScheduler.java
@@ -20,18 +20,13 @@ package org.apache.pinot.materializedview.scheduler;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.hash.Hasher;
-import com.google.common.hash.Hashing;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
@@ -45,6 +40,7 @@ import org.apache.pinot.materializedview.context.MaterializedViewTaskGeneratorCo
 import org.apache.pinot.materializedview.metadata.MaterializedViewDefinitionMetadata;
 import org.apache.pinot.materializedview.metadata.MaterializedViewDefinitionMetadata.MaterializedViewSplitSpec;
 import org.apache.pinot.materializedview.metadata.MaterializedViewDefinitionMetadataUtils;
+import org.apache.pinot.materializedview.metadata.MaterializedViewPartitionManager;
 import org.apache.pinot.materializedview.metadata.MaterializedViewRuntimeMetadata;
 import org.apache.pinot.materializedview.metadata.MaterializedViewRuntimeMetadataUtils;
 import org.apache.pinot.materializedview.metadata.PartitionFingerprint;
@@ -220,8 +216,9 @@ public class MaterializedViewTaskScheduler {
       // ── Step 1: Handle STALE partitions ──
       // Under Design C there is no separate EXPIRED state.  When the scheduler finds a STALE
       // partition it re-computes the source fingerprint and dispatches one of:
-      //   - DELETE task: source data is gone (segmentCount == 0) — drop MV segments + remove the
-      //     partition entry from the runtime metadata
+      //   - DELETE task: source data is gone (segmentCount == 0) — drop MV segments and rewrite
+      //     the entry to VALID-empty (the executor re-checks emptiness at commit and leaves the
+      //     entry STALE if the source was backfilled in the meantime)
       //   - revert to VALID: fingerprint matches the stored value (false positive STALE marking)
       //   - OVERWRITE task: source changed — re-materialize the partition
       if (counts.exclusiveModeCount() > 0) {
@@ -262,7 +259,31 @@ public class MaterializedViewTaskScheduler {
       // bucketTimePeriod (operator changed config mid-flight); the partition map is keyed by
       // aligned starts, so a misaligned nextWindowStartMs would miss VALID-skip lookups.
       long nextWindowStartMs = Math.floorDiv(maxInFlightAppendWindowEndMs, bucketMs) * bucketMs;
-      long cutoffMs = System.currentTimeMillis() - bufferMs;
+
+      // Resolve the APPEND cutoff in two stages so steady-state cycles do not pay a ZK list
+      // call. Stage 1: rough cutoff = `now - bufferMs`. If the next window already lies past
+      // it, no scheduling work is possible regardless of source state, so we fall through to
+      // the loop where the first iteration breaks immediately — and the source-segment
+      // fetch below is skipped. Stage 2: when stage 1 admits at least one candidate bucket,
+      // fetch source segments once and tighten the cutoff by `max(source segment endTimeMs)`.
+      // The tighter cap matters because without it the scheduler would walk past the actual
+      // data tail (each empty bucket completes with zero rows, executor persists a VALID-empty
+      // partition + advances watermark), so `watermarkMs` would drift toward `now - bufferMs`
+      // even when source ingestion has stalled — defeating the staleness-threshold contract
+      // the broker uses in `now - watermarkMs <= stalenessThresholdMs`. See
+      // `MaterializedViewQueryRewriteEngine#isEligible`.
+      long roughCutoffMs = System.currentTimeMillis() - bufferMs;
+      long cutoffMs;
+      if (nextWindowStartMs + bucketMs > roughCutoffMs) {
+        // No bucket can fit before the rough cutoff. Skip the ZK fetch — the loop below
+        // will break on its first iteration and the caught-up log will fire.
+        cutoffMs = roughCutoffMs;
+      } else {
+        long maxSourceEndMs =
+            computeMaxSourceEndTimeMs(_context.getSegmentsZKMetadata(sourceTableWithType));
+        cutoffMs =
+            (maxSourceEndMs == Long.MIN_VALUE) ? roughCutoffMs : Math.min(roughCutoffMs, maxSourceEndMs);
+      }
       int scheduled = 0;
 
       // Hard cap on iterations to defend against pathological partition maps. The loop
@@ -317,8 +338,8 @@ public class MaterializedViewTaskScheduler {
   /// Step 1: Finds the earliest STALE partition and dispatches the appropriate task.
   ///
   /// Re-computes the source fingerprint and picks one of:
-  ///   - DELETE task: source data is gone (segmentCount == 0) — task will drop MV segments
-  ///     and remove the partition entry from runtime metadata
+  ///   - DELETE task: source data is gone (segmentCount == 0) — task will drop MV segments and
+  ///     rewrite the entry to VALID-empty (or leave it STALE if a backfill is detected at commit)
   ///   - revert to VALID in place: fingerprint matches stored value (false positive)
   ///   - OVERWRITE task: fingerprint differs — re-materialize the partition
   ///
@@ -343,7 +364,8 @@ public class MaterializedViewTaskScheduler {
     long windowEndMs = windowStartMs + bucketMs;
     PartitionInfo staleInfo = partitionInfos.get(earliestStaleMs);
 
-    PartitionFingerprint currentFp = computeWindowFingerprint(sourceTableWithType, windowStartMs, windowEndMs);
+    PartitionFingerprint currentFp = MaterializedViewTaskUtils.computeWindowFingerprint(
+        _context.getSegmentsZKMetadata(sourceTableWithType), windowStartMs, windowEndMs);
 
     if (currentFp.getSegmentCount() == 0) {
       LOGGER.info("STALE partition [{}, {}) base data deleted for table: {}. Generating DELETE task.",
@@ -353,6 +375,11 @@ public class MaterializedViewTaskScheduler {
       configs.put(MaterializedViewTask.WINDOW_START_MS_KEY, String.valueOf(windowStartMs));
       configs.put(MaterializedViewTask.WINDOW_END_MS_KEY, String.valueOf(windowEndMs));
       configs.put(MaterializedViewTask.TASK_MODE_KEY, MaterializedViewTask.TASK_MODE_DELETE);
+      // Carry the source table so the executor can recompute the source fingerprint at commit
+      // time and re-confirm the window is still empty before writing VALID-empty.  Without this,
+      // a backfill landing between dispatch and commit would be silently dropped (see
+      // MaterializedViewTaskExecutor#executeDeleteTask and MaterializedViewPartitionManager#clearValid).
+      configs.put(MaterializedViewTask.SOURCE_TABLE_NAME_KEY, sourceTableName);
       configs.put(MinionConstants.UPLOAD_URL_KEY, _context.getVipUrl() + "/segments");
       return new PinotTaskConfig(MaterializedViewTask.TASK_TYPE, configs);
     }
@@ -360,7 +387,18 @@ public class MaterializedViewTaskScheduler {
     if (currentFp.equals(staleInfo.getFingerprint())) {
       LOGGER.info("STALE partition [{}, {}) fingerprint matches for table: {}. "
           + "Reverting to VALID (false positive).", windowStartMs, windowEndMs, viewTableName);
-      persistPartitionStateChangeWithRetry(viewTableName, earliestStaleMs, PartitionState.VALID);
+      // Best-effort revert: if it fails (CAS budget exhausted, transient ZK error), the
+      // partition stays STALE and the next scheduling cycle either reverts again (if the
+      // fingerprint still matches) or generates an OVERWRITE task — either way the system
+      // self-heals.  Spending the executor's critical-write retry budget on this avoidable
+      // optimization would be wasteful, so the manager uses its smaller `revert` profile.
+      try {
+        new MaterializedViewPartitionManager(_context.getPropertyStore(),
+            _context::getClusterConfig).revertValid(viewTableName, earliestStaleMs);
+      } catch (RuntimeException e) {
+        LOGGER.warn("Failed to revert STALE partition {} to VALID for MV table: {}; will retry "
+            + "on the next scheduling cycle", earliestStaleMs, viewTableName, e);
+      }
       return null;
     }
 
@@ -369,82 +407,6 @@ public class MaterializedViewTaskScheduler {
     return buildTaskConfig(viewTableName, sourceTableName, sourceTableWithType, definedSQL,
         taskConfigs, windowStartMs, windowEndMs, MaterializedViewTask.TASK_MODE_OVERWRITE,
         effectiveLimit, userDeclaredLimit);
-  }
-
-  /// CAS-retry budget for STALE -> VALID transitions written by the scheduler.
-  /// The runtime znode is concurrently mutated by the executor (after each task completion) and by
-  /// the consistency manager (on base table changes). A bounded retry loop converges in practice.
-  private static final int MAX_PARTITION_STATE_PERSIST_RETRIES = 8;
-
-  /// Persists a STALE -> VALID transition (false-positive recovery) under a CAS retry loop.
-  /// On each attempt the latest runtime znode is re-fetched, the target partition's state is
-  /// re-evaluated, and the change is rewritten on top of the current version. This preserves
-  /// concurrent updates from the executor (watermark advance) and the consistency manager
-  /// (other partitions' STALE markings).
-  ///
-  /// If the partition is no longer STALE on a retry (executor or consistency manager
-  /// already changed it), the method exits successfully — the desired transition is either
-  /// already done or no longer applicable to a stale view of the world.
-  ///
-  /// If the budget is exhausted, logs ERROR. The next scheduling cycle will retry.
-  private void persistPartitionStateChangeWithRetry(String viewTableName, long partitionStartMs,
-      PartitionState newState) {
-    String viewTableWithType = TableNameBuilder.OFFLINE.tableNameWithType(viewTableName);
-    Exception lastException = null;
-    for (int attempt = 0; attempt < MAX_PARTITION_STATE_PERSIST_RETRIES; attempt++) {
-      Stat stat = new Stat();
-      MaterializedViewRuntimeMetadata current = MaterializedViewRuntimeMetadataUtils.fetchWithVersion(
-          _context.getPropertyStore(), viewTableWithType, stat);
-      if (current == null) {
-        LOGGER.warn("Runtime metadata missing for MV table: {} during partition state persist; aborting",
-            viewTableName);
-        return;
-      }
-      Map<Long, PartitionInfo> currentInfos = current.getPartitions();
-      PartitionInfo info = currentInfos.get(partitionStartMs);
-      if (info == null || info.getState() != PartitionState.STALE) {
-        LOGGER.info("Partition {} for MV table: {} is no longer STALE on attempt {}; skipping persist",
-            partitionStartMs, viewTableName, attempt + 1);
-        return;
-      }
-      Map<Long, PartitionInfo> updatedInfos = new HashMap<>(currentInfos);
-      updatedInfos.put(partitionStartMs, info.withState(newState));
-      MaterializedViewRuntimeMetadata updated = new MaterializedViewRuntimeMetadata(
-          current.getMaterializedViewTableNameWithType(),
-          current.getWatermarkMs(),
-          updatedInfos);
-      try {
-        MaterializedViewRuntimeMetadataUtils.persist(_context.getPropertyStore(), updated, stat.getVersion());
-        LOGGER.info("Persisted partition {} state {} -> {} for MV table: {} on attempt {}",
-            partitionStartMs, PartitionState.STALE, newState, viewTableName, attempt + 1);
-        return;
-      } catch (IllegalStateException e) {
-        // Writer-side invariant violation surfaced by `validateForPersist` on the freshly-fetched
-        // runtime. Retrying will not change the underlying state — fail fast so the caller can
-        // surface the bug instead of burning the retry budget.
-        LOGGER.error("Aborting CAS retry for MV table {}: writer-side invariant violation "
-                + "({}). Generator will not retry until the underlying runtime znode is fixed.",
-            viewTableName, e.getMessage());
-        return;
-      } catch (Exception e) {
-        lastException = e;
-        LOGGER.debug("CAS conflict on attempt {} persisting partition {} state for MV table: {}",
-            attempt + 1, partitionStartMs, viewTableName, e);
-      }
-      // Small jittered backoff so a tight CAS race doesn't burn the budget in microseconds
-      // and starve the competing writers — also gives transient ZK errors a chance to resolve.
-      try {
-        Thread.sleep(5L + ThreadLocalRandom.current().nextInt(20));
-      } catch (InterruptedException ie) {
-        Thread.currentThread().interrupt();
-        LOGGER.warn("Interrupted while persisting partition {} state for MV table: {}",
-            partitionStartMs, viewTableName);
-        return;
-      }
-    }
-    LOGGER.error("Failed to persist partition {} state {} for MV table: {} after {} retries. "
-            + "Generator will retry on next scheduling cycle. Last exception:",
-        partitionStartMs, newState, viewTableName, MAX_PARTITION_STATE_PERSIST_RETRIES, lastException);
   }
 
   /// Builds a complete [PinotTaskConfig] for either APPEND or OVERWRITE mode.
@@ -461,8 +423,8 @@ public class MaterializedViewTaskScheduler {
       boolean userDeclaredLimit) {
     String taskType = MaterializedViewTask.TASK_TYPE;
 
-    PartitionFingerprint windowFingerprint =
-        computeWindowFingerprint(sourceTableWithType, windowStartMs, windowEndMs);
+    PartitionFingerprint windowFingerprint = MaterializedViewTaskUtils.computeWindowFingerprint(
+        _context.getSegmentsZKMetadata(sourceTableWithType), windowStartMs, windowEndMs);
 
     // The source time column may use any DateTimeFieldSpec format (TIMESTAMP, INT-days, etc.).
     // Convert the window boundaries to the source's native unit so the appended WHERE filter
@@ -989,43 +951,28 @@ public class MaterializedViewTaskScheduler {
     return sourceTableWithType;
   }
 
-  /// Computes a [PartitionFingerprint] by fetching segments from ZK.
-  private PartitionFingerprint computeWindowFingerprint(String sourceTableWithType,
-      long windowStartMs, long windowEndMs) {
-    return computeWindowFingerprint(_context.getSegmentsZKMetadata(sourceTableWithType),
-        windowStartMs, windowEndMs);
-  }
-
-  /// Computes a [PartitionFingerprint] for the given time window from pre-fetched
-  /// segment metadata.
+  /// Returns the maximum valid `endTimeMs` across all source segments, or [Long#MIN_VALUE]
+  /// when none of the segments carry a usable end time (empty list, or every segment has a
+  /// negative end time — the legacy "unset" marker `SegmentZKMetadata` returns for old
+  /// znodes without `TIME_UNIT`). Used by [#generateTasks] to cap the APPEND cutoff at the
+  /// latest known source data: without this cap, the scheduler would walk past the actual
+  /// data tail one bucket at a time (each empty bucket completes with zero rows, the
+  /// executor persists a VALID-empty partition + advances watermark), so `watermarkMs`
+  /// would drift toward `now - bufferMs` even when source ingestion has stalled — defeating
+  /// the staleness-threshold contract in the rewrite engine, where
+  /// `now - watermarkMs <= stalenessThresholdMs` is meant to reflect real data freshness.
   ///
-  /// The fingerprint is `Hashing.farmHashFingerprint64` over the sorted concatenation of
-  /// `<segmentName>\0<crc>\n` lines. Sorting makes the hash insensitive to listing order;
-  /// FarmHash64 is non-cryptographic but collision-resistant for non-adversarial inputs.
-  /// Replaces a previous XOR-CRC scheme that exhibited cancellation collisions (swap two
-  /// segments with the same combined contribution → identical fingerprint).
-  private PartitionFingerprint computeWindowFingerprint(List<SegmentZKMetadata> allSegments,
-      long windowStartMs, long windowEndMs) {
-    List<SegmentZKMetadata> overlapping = new ArrayList<>();
-    for (SegmentZKMetadata seg : allSegments) {
-      long segStartMs = seg.getStartTimeMs();
-      long segEndMs = seg.getEndTimeMs();
-      if (segStartMs < windowEndMs && segEndMs >= windowStartMs) {
-        overlapping.add(seg);
+  /// The `endMs >= 0` filter mirrors the cold-start scan in [#getWatermarkMs], which
+  /// already excludes negative `startTimeMs` for the same reason.
+  @VisibleForTesting
+  static long computeMaxSourceEndTimeMs(List<SegmentZKMetadata> segments) {
+    long maxEndMs = Long.MIN_VALUE;
+    for (SegmentZKMetadata seg : segments) {
+      long endMs = seg.getEndTimeMs();
+      if (endMs >= 0 && endMs > maxEndMs) {
+        maxEndMs = endMs;
       }
     }
-    overlapping.sort(Comparator.comparing(SegmentZKMetadata::getSegmentName));
-
-    Hasher hasher = Hashing.farmHashFingerprint64().newHasher();
-    for (SegmentZKMetadata seg : overlapping) {
-      hasher.putString(seg.getSegmentName(), StandardCharsets.UTF_8);
-      hasher.putByte((byte) 0);
-      hasher.putLong(seg.getCrc());
-      hasher.putByte((byte) '\n');
-    }
-    long crcFingerprint = hasher.hash().asLong();
-    LOGGER.info("Computed partition fingerprint for window [{}, {}): segmentCount={}, crcFingerprint={}",
-        windowStartMs, windowEndMs, overlapping.size(), crcFingerprint);
-    return new PartitionFingerprint(overlapping.size(), crcFingerprint);
+    return maxEndMs;
   }
 }

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/scheduler/MaterializedViewTaskScheduler.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/scheduler/MaterializedViewTaskScheduler.java
@@ -265,12 +265,13 @@ public class MaterializedViewTaskScheduler {
       // it, no scheduling work is possible regardless of source state, so we fall through to
       // the loop where the first iteration breaks immediately — and the source-segment
       // fetch below is skipped. Stage 2: when stage 1 admits at least one candidate bucket,
-      // fetch source segments once and tighten the cutoff by `max(source segment endTimeMs)`.
-      // The tighter cap matters because without it the scheduler would walk past the actual
-      // data tail (each empty bucket completes with zero rows, executor persists a VALID-empty
-      // partition + advances watermark), so `watermarkMs` would drift toward `now - bufferMs`
-      // even when source ingestion has stalled — defeating the staleness-threshold contract
-      // the broker uses in `now - watermarkMs <= stalenessThresholdMs`. See
+      // fetch source segments once and tighten the cutoff by the end of the source data
+      // (see resolveAppendCutoffMs). The tighter cap matters because without it the scheduler
+      // would walk past the actual data tail (each empty bucket completes with zero rows,
+      // executor persists a VALID-empty partition + advances watermark), so `watermarkMs`
+      // would drift toward `now - bufferMs` even when source ingestion has stalled —
+      // defeating the staleness-threshold contract the broker uses in
+      // `now - watermarkMs <= stalenessThresholdMs`. See
       // `MaterializedViewQueryRewriteEngine#isEligible`.
       long roughCutoffMs = System.currentTimeMillis() - bufferMs;
       long cutoffMs;
@@ -281,8 +282,7 @@ public class MaterializedViewTaskScheduler {
       } else {
         long maxSourceEndMs =
             computeMaxSourceEndTimeMs(_context.getSegmentsZKMetadata(sourceTableWithType));
-        cutoffMs =
-            (maxSourceEndMs == Long.MIN_VALUE) ? roughCutoffMs : Math.min(roughCutoffMs, maxSourceEndMs);
+        cutoffMs = resolveAppendCutoffMs(roughCutoffMs, maxSourceEndMs);
       }
       int scheduled = 0;
 
@@ -937,16 +937,13 @@ public class MaterializedViewTaskScheduler {
     return watermarkMs;
   }
 
-  /// Resolves the source table name with type suffix. Tries OFFLINE first, then REALTIME.
+  /// Resolves the source table name with type suffix via the shared OFFLINE-first probe in
+  /// [MaterializedViewTaskUtils#resolveTableNameWithType]; fails loud when neither table
+  /// config exists (the scheduler cannot generate tasks against a missing source).
   private String resolveSourceTableNameWithType(String rawSourceTableName) {
-    String sourceTableWithType = TableNameBuilder.OFFLINE.tableNameWithType(rawSourceTableName);
-    TableConfig sourceTableConfig = _context.getTableConfig(sourceTableWithType);
-    if (sourceTableConfig != null) {
-      return sourceTableWithType;
-    }
-    sourceTableWithType = TableNameBuilder.REALTIME.tableNameWithType(rawSourceTableName);
-    sourceTableConfig = _context.getTableConfig(sourceTableWithType);
-    Preconditions.checkState(sourceTableConfig != null,
+    String sourceTableWithType = MaterializedViewTaskUtils.resolveTableNameWithType(
+        _context::getTableConfig, rawSourceTableName);
+    Preconditions.checkState(sourceTableWithType != null,
         "Source table config not found for: %s", rawSourceTableName);
     return sourceTableWithType;
   }
@@ -974,5 +971,25 @@ public class MaterializedViewTaskScheduler {
       }
     }
     return maxEndMs;
+  }
+
+  /// Tightens the wall-clock APPEND cutoff (`now - bufferMs`) by the end of the source data,
+  /// so the scheduler never materializes buckets past the data tail (see the stage-2 comment
+  /// in [#generateTasks]).
+  ///
+  /// `maxSourceEndMs` is the **inclusive** maximum `endTimeMs` across source segments (the
+  /// same convention `computeWindowFingerprint`'s overlap filter relies on), while the loop
+  /// gate compares against the bucket's **exclusive** `windowEndMs`.  The `+ 1` converts
+  /// between the two: a segment ending at `windowEndMs - 1` fully covers the bucket and must
+  /// admit it — without the adjustment, a complete day-aligned batch segment would never
+  /// admit its own final bucket, and a static historical dataset would never materialize its
+  /// last window.  `Long.MIN_VALUE` (no usable end time) falls back to the rough cutoff, and
+  /// a corrupt `Long.MAX_VALUE` end time is clamped rather than overflowed.
+  @VisibleForTesting
+  static long resolveAppendCutoffMs(long roughCutoffMs, long maxSourceEndMs) {
+    if (maxSourceEndMs == Long.MIN_VALUE || maxSourceEndMs == Long.MAX_VALUE) {
+      return roughCutoffMs;
+    }
+    return Math.min(roughCutoffMs, maxSourceEndMs + 1);
   }
 }

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/scheduler/MaterializedViewTaskUtils.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/scheduler/MaterializedViewTaskUtils.java
@@ -240,9 +240,11 @@ public final class MaterializedViewTaskUtils {
   /// the scheduler, the minion executor, and the consistency manager all resolve through this
   /// method so the OFFLINE-first convention cannot drift between sites.
   ///
-  /// A reference that already carries a type suffix is returned as-is (no probe).  Otherwise
-  /// OFFLINE is probed first, then REALTIME; returns `null` when neither table config exists —
-  /// callers that require a resolution fail loud with their own context-specific message.
+  /// A reference that already carries a type suffix is returned as-is — WITHOUT verifying that
+  /// its table config exists; callers needing existence pair this with their own check.  An
+  /// untyped reference probes OFFLINE first, then REALTIME; returns `null` when neither table
+  /// config exists — callers that require a resolution fail loud with their own
+  /// context-specific message.
   @Nullable
   public static String resolveTableNameWithType(Function<String, TableConfig> tableConfigProvider,
       String sourceTableName) {

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/scheduler/MaterializedViewTaskUtils.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/scheduler/MaterializedViewTaskUtils.java
@@ -19,9 +19,17 @@
 package org.apache.pinot.materializedview.scheduler;
 
 import com.google.common.base.Preconditions;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import javax.annotation.Nullable;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.materializedview.metadata.PartitionFingerprint;
 import org.apache.pinot.materializedview.metadata.PartitionInfo;
 import org.apache.pinot.materializedview.metadata.PartitionState;
 import org.apache.pinot.spi.utils.CommonConstants.MaterializedViewTask;
@@ -171,5 +179,57 @@ public final class MaterializedViewTaskUtils {
   public static String buildSegmentName(String tableName, long windowStartMs, long windowEndMs,
       String attemptId, int segIdx) {
     return tableName + "_" + windowStartMs + "_" + windowEndMs + "_" + attemptId + "_" + segIdx;
+  }
+
+  /// Computes a [PartitionFingerprint] over the source segments overlapping
+  /// `[windowStartMs, windowEndMs)`.  Single source of truth — both the scheduler (when
+  /// generating tasks) and the minion executor (when validating fingerprints at commit time)
+  /// must call this method, never re-implement the algorithm.
+  ///
+  /// Algorithm (each step is part of the byte-equality contract — changing any one of them
+  /// breaks the fingerprint and forces an MV-wide recompute):
+  ///
+  ///   1. **Filter** to segments overlapping the half-open window: `start < windowEndMs` AND
+  ///      `end >= windowStartMs`.  Asymmetric `>=` on the lower bound is intentional —
+  ///      `SegmentZKMetadata#getEndTimeMs` is inclusive.
+  ///   2. **Sort** the surviving list by segment name.  Listing order from
+  ///      `getSegmentsZKMetadata` is not guaranteed to be stable across calls, so the sort
+  ///      makes the hash deterministic.  The comparator is part of the algorithm: changing
+  ///      it (e.g. to sort by CRC) is byte-equivalent to changing the hash encoding.
+  ///   3. **Hash** the sorted list with `farmHashFingerprint64`, feeding each segment as
+  ///      `<segmentName>\0<crc>\n`.  FarmHash64 is non-cryptographic but collision-resistant
+  ///      for non-adversarial inputs; it replaces an earlier XOR-CRC scheme that exhibited
+  ///      cancellation collisions (swap two segments with equal combined contribution →
+  ///      identical fingerprint).
+  ///
+  /// Empty overlap returns [PartitionFingerprint#EMPTY] — by construction, since
+  /// `farmHashFingerprint64` over zero input bytes is the constant baked into [#EMPTY].
+  /// Callers MUST NOT pre-filter or pre-sort `allSegments`; the helper is responsible for
+  /// both.  Pre-sorting with a different comparator would silently break byte-equality
+  /// against the executor's commit-time recomputation.
+  public static PartitionFingerprint computeWindowFingerprint(
+      List<SegmentZKMetadata> allSegments, long windowStartMs, long windowEndMs) {
+    List<SegmentZKMetadata> overlapping = new ArrayList<>();
+    for (SegmentZKMetadata seg : allSegments) {
+      long segStartMs = seg.getStartTimeMs();
+      long segEndMs = seg.getEndTimeMs();
+      if (segStartMs < windowEndMs && segEndMs >= windowStartMs) {
+        overlapping.add(seg);
+      }
+    }
+    // Empty overlap returns the shared EMPTY constant (byte-identical to hashing zero input bytes),
+    // honoring the documented contract and avoiding a per-call allocation on empty windows.
+    if (overlapping.isEmpty()) {
+      return PartitionFingerprint.EMPTY;
+    }
+    overlapping.sort(Comparator.comparing(SegmentZKMetadata::getSegmentName));
+    Hasher hasher = Hashing.farmHashFingerprint64().newHasher();
+    for (SegmentZKMetadata seg : overlapping) {
+      hasher.putString(seg.getSegmentName(), StandardCharsets.UTF_8);
+      hasher.putByte((byte) 0);
+      hasher.putLong(seg.getCrc());
+      hasher.putByte((byte) '\n');
+    }
+    return new PartitionFingerprint(overlapping.size(), hasher.hash().asLong());
   }
 }

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/scheduler/MaterializedViewTaskUtils.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/scheduler/MaterializedViewTaskUtils.java
@@ -32,7 +32,9 @@ import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.materializedview.metadata.PartitionFingerprint;
 import org.apache.pinot.materializedview.metadata.PartitionInfo;
 import org.apache.pinot.materializedview.metadata.PartitionState;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.utils.CommonConstants.MaterializedViewTask;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -231,5 +233,30 @@ public final class MaterializedViewTaskUtils {
       hasher.putByte((byte) '\n');
     }
     return new PartitionFingerprint(overlapping.size(), hasher.hash().asLong());
+  }
+
+  /// Resolves a source-table reference to its type-suffixed form (`_OFFLINE` / `_REALTIME`)
+  /// using the supplied table-config lookup.  Single source of truth for the probe order —
+  /// the scheduler, the minion executor, and the consistency manager all resolve through this
+  /// method so the OFFLINE-first convention cannot drift between sites.
+  ///
+  /// A reference that already carries a type suffix is returned as-is (no probe).  Otherwise
+  /// OFFLINE is probed first, then REALTIME; returns `null` when neither table config exists —
+  /// callers that require a resolution fail loud with their own context-specific message.
+  @Nullable
+  public static String resolveTableNameWithType(Function<String, TableConfig> tableConfigProvider,
+      String sourceTableName) {
+    if (TableNameBuilder.getTableTypeFromTableName(sourceTableName) != null) {
+      return sourceTableName;
+    }
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(sourceTableName);
+    if (tableConfigProvider.apply(offlineTableName) != null) {
+      return offlineTableName;
+    }
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(sourceTableName);
+    if (tableConfigProvider.apply(realtimeTableName) != null) {
+      return realtimeTableName;
+    }
+    return null;
   }
 }

--- a/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/consistency/MaterializedViewConsistencyManagerTest.java
+++ b/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/consistency/MaterializedViewConsistencyManagerTest.java
@@ -20,11 +20,13 @@ package org.apache.pinot.materializedview.consistency;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.apache.helix.AccessOption;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.zkclient.IZkChildListener;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.utils.config.TableConfigSerDeUtils;
 import org.apache.pinot.materializedview.metadata.MaterializedViewDefinitionMetadata;
 import org.apache.pinot.materializedview.metadata.MaterializedViewRuntimeMetadata;
@@ -32,19 +34,24 @@ import org.apache.pinot.materializedview.metadata.PartitionFingerprint;
 import org.apache.pinot.materializedview.metadata.PartitionInfo;
 import org.apache.pinot.materializedview.metadata.PartitionState;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.zookeeper.data.Stat;
 import org.mockito.ArgumentCaptor;
 import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 
 public class MaterializedViewConsistencyManagerTest {
@@ -255,7 +262,184 @@ public class MaterializedViewConsistencyManagerTest {
             org.mockito.ArgumentMatchers.anyInt(), org.mockito.ArgumentMatchers.anyInt());
   }
 
+  // ---------------------------------------------------------------------------
+  //  findStrandedEmptyBuckets — the periodic VALID-empty re-evaluation sweep's pure decision
+  //  core: which in-coverage VALID-empty buckets have a source window that regained segments and
+  //  must therefore be re-marked STALE (closing the residual DELETE-vs-backfill race).
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testFindStrandedEmptyBucketsReMarksWhenSourceRegainedSegments() {
+    // W0 is VALID-empty but its source window now has a segment (a backfill that the DELETE commit
+    // guard raced) => stranded => must be re-marked STALE.  W1 (VALID, non-empty) and W2 (STALE)
+    // are not VALID-empty, so they are never considered.
+    Map<Long, PartitionInfo> partitions = Map.of(
+        0L, validEmptyInfo(),
+        BUCKET_MS, validInfo(),
+        2 * BUCKET_MS, staleInfo());
+    List<SegmentZKMetadata> sourceSegments = List.of(segment("s0", 0L, BUCKET_MS - 1, 11L));
+
+    List<Long> stranded = MaterializedViewConsistencyManager.findStrandedEmptyBuckets(
+        partitions, 3 * BUCKET_MS, sourceSegments, BUCKET_MS);
+
+    assertEquals(stranded, List.of(0L));
+  }
+
+  @Test
+  public void testFindStrandedEmptyBucketsLeavesEmptyWhenSourceStillEmpty() {
+    // W0 is VALID-empty and its source window is still empty (the legitimate DELETE / empty-APPEND
+    // outcome) => must NOT be re-marked (re-marking would churn a no-op DELETE every sweep).
+    Map<Long, PartitionInfo> partitions = Map.of(0L, validEmptyInfo());
+    // A segment that exists but does not overlap W0's window [0, BUCKET_MS).
+    List<SegmentZKMetadata> sourceSegments =
+        List.of(segment("s2", 2 * BUCKET_MS, 3 * BUCKET_MS, 22L));
+
+    List<Long> stranded = MaterializedViewConsistencyManager.findStrandedEmptyBuckets(
+        partitions, BUCKET_MS, sourceSegments, BUCKET_MS);
+
+    assertTrue(stranded.isEmpty(), "VALID-empty bucket with still-empty source must be left STALE-free");
+  }
+
+  @Test
+  public void testFindStrandedEmptyBucketsIgnoresNonEmptyValidAndStaleBuckets() {
+    // W0 is VALID but non-empty (segmentCount=1) — not a VALID-empty bucket.  W1 is STALE — already
+    // queued for the scheduler.  Even with source segments overlapping both, neither is returned.
+    Map<Long, PartitionInfo> partitions = Map.of(
+        0L, validInfo(),
+        BUCKET_MS, staleInfo());
+    List<SegmentZKMetadata> sourceSegments = List.of(segment("s", 0L, 2 * BUCKET_MS, 33L));
+
+    List<Long> stranded = MaterializedViewConsistencyManager.findStrandedEmptyBuckets(
+        partitions, 3 * BUCKET_MS, sourceSegments, BUCKET_MS);
+
+    assertTrue(stranded.isEmpty(), "Only VALID-empty buckets are eligible for the sweep");
+  }
+
+  @Test
+  public void testFindStrandedEmptyBucketsIgnoresBucketsAtOrPastWatermark() {
+    // A VALID-empty bucket whose start is not strictly below the watermark is the not-yet-covered
+    // frontier, not an in-coverage empty — it must be ignored even if its source has segments.
+    Map<Long, PartitionInfo> partitions = Map.of(BUCKET_MS, validEmptyInfo());
+    List<SegmentZKMetadata> sourceSegments =
+        List.of(segment("s1", BUCKET_MS, 2 * BUCKET_MS - 1, 44L));
+
+    List<Long> stranded = MaterializedViewConsistencyManager.findStrandedEmptyBuckets(
+        partitions, BUCKET_MS, sourceSegments, BUCKET_MS);
+
+    assertTrue(stranded.isEmpty(), "Buckets at/past the watermark are not in-coverage");
+  }
+
+  /// End-to-end orchestration: the per-MV sweep reads the runtime + source segments and, finding a
+  /// VALID-empty bucket whose source window regained segments, re-marks exactly that bucket STALE
+  /// (leaving other buckets untouched) via the partition manager's CAS write.
+  @Test
+  public void testSweepForViewReMarksStrandedEmptyBucketStale()
+      throws Exception {
+    String baseTableOffline = TableNameBuilder.OFFLINE.tableNameWithType(BASE_TABLE);
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    String runtimePath = ZKMetadataProvider.constructPropertyStorePathForMaterializedViewRuntime(MV_TABLE);
+
+    // Runtime: W0 is VALID-empty (a DELETE/empty-APPEND outcome), W1 is VALID non-empty. Both are
+    // in coverage (watermark = 2 * BUCKET_MS).
+    MaterializedViewRuntimeMetadata runtime = new MaterializedViewRuntimeMetadata(
+        MV_TABLE, 2 * BUCKET_MS,
+        Map.of(0L, validEmptyInfo(), BUCKET_MS, validInfo()));
+    when(propertyStore.get(eq(runtimePath), any(Stat.class), eq(AccessOption.PERSISTENT)))
+        .thenReturn(runtime.toZNRecord());
+    when(propertyStore.set(eq(runtimePath), any(ZNRecord.class), eq(0), eq(AccessOption.PERSISTENT)))
+        .thenReturn(true);
+
+    // MV table config supplies bucketMs (= 1d = BUCKET_MS) to inferBucketMs.
+    String mvConfigPath = ZKMetadataProvider.constructPropertyStorePathForResourceConfig(MV_TABLE);
+    TableTaskConfig taskConfig = new TableTaskConfig(Map.of(CommonConstants.MaterializedViewTask.TASK_TYPE,
+        Map.of(CommonConstants.MaterializedViewTask.BUCKET_TIME_PERIOD_KEY, "1d")));
+    TableConfig mvConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(MV_TABLE).setIsMaterializedView(true).setTaskConfig(taskConfig).build();
+    when(propertyStore.get(eq(mvConfigPath), any(), eq(AccessOption.PERSISTENT)))
+        .thenReturn(TableConfigSerDeUtils.toZNRecord(mvConfig));
+
+    // Source base table resolves as OFFLINE.
+    String baseConfigPath = ZKMetadataProvider.constructPropertyStorePathForResourceConfig(baseTableOffline);
+    TableConfig baseConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(BASE_TABLE).build();
+    when(propertyStore.get(eq(baseConfigPath), any(), eq(AccessOption.PERSISTENT)))
+        .thenReturn(TableConfigSerDeUtils.toZNRecord(baseConfig));
+
+    // Source segments: one overlapping W0's window [0, BUCKET_MS) — i.e. the backfill that strands
+    // the VALID-empty bucket.
+    String segmentsParentPath = ZKMetadataProvider.constructPropertyStorePathForResource(baseTableOffline);
+    when(propertyStore.getChildren(eq(segmentsParentPath), any(), eq(AccessOption.PERSISTENT), anyInt(), anyInt()))
+        .thenReturn(List.of(segment("s0", 0L, BUCKET_MS - 1, 11L).toZNRecord()));
+
+    MaterializedViewConsistencyManager manager = new MaterializedViewConsistencyManager();
+    manager.init(propertyStore);
+    manager.sweepStrandedEmptyPartitionsForView(MV_TABLE, BASE_TABLE);
+    manager.stop();
+
+    ArgumentCaptor<ZNRecord> recordCaptor = ArgumentCaptor.forClass(ZNRecord.class);
+    verify(propertyStore).set(eq(runtimePath), recordCaptor.capture(), eq(0), eq(AccessOption.PERSISTENT));
+    MaterializedViewRuntimeMetadata updated =
+        MaterializedViewRuntimeMetadata.fromZNRecord(recordCaptor.getValue());
+    assertEquals(updated.getPartitions().get(0L).getState(), PartitionState.STALE,
+        "Stranded VALID-empty bucket must be re-marked STALE");
+    assertEquals(updated.getPartitions().get(BUCKET_MS).getState(), PartitionState.VALID,
+        "Non-empty VALID bucket must be left untouched");
+  }
+
+  /// The all-MV sweep isolates per-MV failures: one MV whose runtime read throws must not abort
+  /// the pass before the others are processed.
+  @Test
+  public void testSweepIsolatesPerMvFailures()
+      throws Exception {
+    String mvA = "mvA_OFFLINE";
+    String mvB = "mvB_OFFLINE";
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    String runtimePathA = ZKMetadataProvider.constructPropertyStorePathForMaterializedViewRuntime(mvA);
+    String runtimePathB = ZKMetadataProvider.constructPropertyStorePathForMaterializedViewRuntime(mvB);
+
+    // MV A's runtime read throws — its per-MV sweep must fail in isolation.
+    when(propertyStore.get(eq(runtimePathA), any(Stat.class), eq(AccessOption.PERSISTENT)))
+        .thenThrow(new RuntimeException("boom"));
+    // MV B is clean (no in-coverage VALID-empty bucket), so it short-circuits after the runtime read.
+    MaterializedViewRuntimeMetadata runtimeB = new MaterializedViewRuntimeMetadata(
+        mvB, 2 * BUCKET_MS, Map.of(0L, validInfo()));
+    when(propertyStore.get(eq(runtimePathB), any(Stat.class), eq(AccessOption.PERSISTENT)))
+        .thenReturn(runtimeB.toZNRecord());
+
+    MaterializedViewConsistencyManager manager = new MaterializedViewConsistencyManager();
+    manager.init(propertyStore);
+    manager.onMaterializedViewTableCreated(mvA, List.of("baseA"));
+    manager.onMaterializedViewTableCreated(mvB, List.of("baseB"));
+
+    // Must not throw despite MV A failing mid-pass.
+    manager.sweepStrandedEmptyPartitions();
+    manager.stop();
+
+    // Both MVs were attempted — MV A's failure did not abort the pass before MV B was processed.
+    verify(propertyStore).get(eq(runtimePathA), any(Stat.class), eq(AccessOption.PERSISTENT));
+    verify(propertyStore).get(eq(runtimePathB), any(Stat.class), eq(AccessOption.PERSISTENT));
+    // The clean MV B has no stranded bucket, so no STALE write is issued for it.
+    verify(propertyStore, never())
+        .set(eq(runtimePathB), any(ZNRecord.class), anyInt(), eq(AccessOption.PERSISTENT));
+  }
+
   private static PartitionInfo validInfo() {
-    return new PartitionInfo(PartitionState.VALID, new PartitionFingerprint(1, 1234L), 10L);
+    return PartitionInfo.forTesting(PartitionState.VALID, new PartitionFingerprint(1, 1234L), 10L);
+  }
+
+  private static PartitionInfo validEmptyInfo() {
+    return PartitionInfo.forTesting(PartitionState.VALID, PartitionFingerprint.EMPTY, 10L);
+  }
+
+  private static PartitionInfo staleInfo() {
+    return PartitionInfo.forTesting(PartitionState.STALE, PartitionFingerprint.EMPTY, 10L);
+  }
+
+  private static SegmentZKMetadata segment(String name, long startMs, long endMs, long crc) {
+    SegmentZKMetadata segmentZKMetadata = new SegmentZKMetadata(name);
+    segmentZKMetadata.setTimeUnit(TimeUnit.MILLISECONDS);
+    segmentZKMetadata.setStartTime(startMs);
+    segmentZKMetadata.setEndTime(endMs);
+    segmentZKMetadata.setCrc(crc);
+    return segmentZKMetadata;
   }
 }

--- a/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/consistency/MaterializedViewConsistencyManagerTest.java
+++ b/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/consistency/MaterializedViewConsistencyManagerTest.java
@@ -213,6 +213,47 @@ public class MaterializedViewConsistencyManagerTest {
     assertEquals(updated.getPartitions().get(6 * BUCKET_MS).getState(), PartitionState.STALE);
   }
 
+  @Test
+  public void testAboveWatermarkValidBucketIsMarkedStale()
+      throws Exception {
+    // Out-of-order batch APPEND completion (or a mid-batch failure) can leave VALID buckets
+    // ABOVE the watermark — the scheduler's contiguous-VALID-upper handling exists precisely for
+    // that shape.  A base-table change landing in such a bucket must still mark it STALE: capping
+    // the affected range at the watermark would silently drop the mark, and once the gap below
+    // filled and the watermark advanced over the bucket, it would serve stale data with nothing
+    // left to re-mark it.
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    String runtimePath = ZKMetadataProvider.constructPropertyStorePathForMaterializedViewRuntime(MV_TABLE);
+    // Bucket #0 covered (watermark = 1 bucket); bucket #2 VALID but above the watermark
+    // because bucket #1 failed mid-batch and is absent.
+    MaterializedViewRuntimeMetadata runtime = new MaterializedViewRuntimeMetadata(
+        MV_TABLE, BUCKET_MS,
+        Map.of(
+            0L, validInfo(),
+            2 * BUCKET_MS, validInfo()));
+    when(propertyStore.get(eq(runtimePath), any(Stat.class), eq(AccessOption.PERSISTENT)))
+        .thenReturn(runtime.toZNRecord());
+    when(propertyStore.set(eq(runtimePath), any(ZNRecord.class), eq(0), eq(AccessOption.PERSISTENT)))
+        .thenReturn(true);
+
+    MaterializedViewConsistencyManager manager = new MaterializedViewConsistencyManager();
+    manager.init(propertyStore);
+    manager.onMaterializedViewTableCreated(MV_TABLE, List.of(BASE_TABLE));
+    manager.onBaseTableDataChange(BASE_TABLE, 2 * BUCKET_MS, 3 * BUCKET_MS - 1);
+
+    manager.flush(BASE_TABLE);
+    manager.stop();
+
+    ArgumentCaptor<ZNRecord> recordCaptor = ArgumentCaptor.forClass(ZNRecord.class);
+    verify(propertyStore).set(eq(runtimePath), recordCaptor.capture(), eq(0), eq(AccessOption.PERSISTENT));
+    MaterializedViewRuntimeMetadata updated =
+        MaterializedViewRuntimeMetadata.fromZNRecord(recordCaptor.getValue());
+    assertEquals(updated.getPartitions().get(2 * BUCKET_MS).getState(), PartitionState.STALE,
+        "above-watermark VALID bucket must be marked STALE");
+    assertEquals(updated.getPartitions().get(0L).getState(), PartitionState.VALID,
+        "bucket outside the affected range stays VALID");
+  }
+
   /// Regression test for M3 + the typed-exception narrowing on persist(): a CAS conflict
   /// during STALE marking is silently retried; the retry succeeds.
   @Test

--- a/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/metadata/MaterializedViewPartitionManagerTest.java
+++ b/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/metadata/MaterializedViewPartitionManagerTest.java
@@ -37,7 +37,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -109,6 +108,22 @@ public class MaterializedViewPartitionManagerTest {
     new MaterializedViewPartitionManager(store, null).appendValid(TABLE, W0, W1, FP1);
   }
 
+  @Test
+  public void testAppendValidIdempotentOnLostAckReplay() {
+    // Lost-ack replay: ZK committed our appendValid write but the client saw a connection drop,
+    // so the CAS loop re-runs the mutator against our own committed state (bucket VALID, same
+    // fingerprint, watermark already advanced).  Must no-op successfully — NOT throw the strict
+    // "bucket already present" violation, which would hard-fail a minion task that succeeded.
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    Map<Long, PartitionInfo> existing = new HashMap<>();
+    existing.put(W0, new PartitionInfo(PartitionState.VALID, FP1, 1L));
+    stubFetch(store, runtime(W1, existing), 3);
+
+    new MaterializedViewPartitionManager(store, null).appendValid(TABLE, W0, W1, FP1);
+
+    verify(store, never()).set(anyString(), any(ZNRecord.class), anyInt(), anyInt());
+  }
+
   @Test(expectedExceptions = IllegalStateException.class)
   public void testAppendValidThrowsWhenRuntimeMissing() {
     HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
@@ -148,13 +163,28 @@ public class MaterializedViewPartitionManagerTest {
   }
 
   @Test(expectedExceptions = IllegalStateException.class)
-  public void testRefreshValidStrictRejectsValidBucket() {
+  public void testRefreshValidStrictRejectsValidBucketWithDifferentFingerprint() {
+    // VALID with a DIFFERENT fingerprint is a genuine dispatch-invariant violation (not a
+    // lost-ack replay of our own write) and must still fail loud.
     HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
     Map<Long, PartitionInfo> existing = new HashMap<>();
     existing.put(W0, new PartitionInfo(PartitionState.VALID, FP2, 1L));
     stubFetch(store, runtime(W0, existing), 0);
 
     new MaterializedViewPartitionManager(store, null).refreshValid(TABLE, W0, FP1);
+  }
+
+  @Test
+  public void testRefreshValidIdempotentOnLostAckReplay() {
+    // Same lost-ack shape as testAppendValidIdempotentOnLostAckReplay, for OVERWRITE commits.
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    Map<Long, PartitionInfo> existing = new HashMap<>();
+    existing.put(W0, new PartitionInfo(PartitionState.VALID, FP1, 1L));
+    stubFetch(store, runtime(W1, existing), 5);
+
+    new MaterializedViewPartitionManager(store, null).refreshValid(TABLE, W0, FP1);
+
+    verify(store, never()).set(anyString(), any(ZNRecord.class), anyInt(), anyInt());
   }
 
   // ─────────────────────────────────────────────────────────────────────────────────────
@@ -243,6 +273,26 @@ public class MaterializedViewPartitionManagerTest {
     // Strict precondition (present & STALE) is checked before the emptiness guard, so an absent
     // bucket still throws regardless of the supplied fingerprint.
     new MaterializedViewPartitionManager(store, null).clearValid(TABLE, W0, () -> PartitionFingerprint.EMPTY);
+  }
+
+  @Test
+  public void testClearValidIdempotentOnLostAckReplay() {
+    // Lost-ack replay of a committed VALID-empty write: must no-op without re-invoking the
+    // source-emptiness supplier (a backfill landing after the committed write is the periodic
+    // sweep's responsibility, not this replay's).
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    Map<Long, PartitionInfo> existing = new HashMap<>();
+    existing.put(W0, new PartitionInfo(PartitionState.VALID, PartitionFingerprint.EMPTY, 1L));
+    stubFetch(store, runtime(W0, existing), 4);
+
+    AtomicInteger supplierCalls = new AtomicInteger(0);
+    new MaterializedViewPartitionManager(store, null).clearValid(TABLE, W0, () -> {
+      supplierCalls.incrementAndGet();
+      return PartitionFingerprint.EMPTY;
+    });
+
+    assertEquals(supplierCalls.get(), 0, "idempotent replay must not re-read the source");
+    verify(store, never()).set(anyString(), any(ZNRecord.class), anyInt(), anyInt());
   }
 
   // ─────────────────────────────────────────────────────────────────────────────────────
@@ -470,20 +520,28 @@ public class MaterializedViewPartitionManagerTest {
   }
 
   @Test
-  public void testValidateForPersistFailureFailsFast() {
-    // Inject a non-CAS error from set() to verify other ZkException variants are retried.
-    // For validateForPersist failure we'd need to corrupt the metadata — covered indirectly
-    // by addPartitionInfo's strict invariant tests above.  This test guards against an
-    // accidental retry on transport ZkException being treated as a no-op.
+  public void testMutatorPreconditionViolationFailsFastWithoutRetry() {
+    // The retry-classification contract: an IllegalStateException thrown by the mutator (a
+    // precondition violation — same fail-fast class as a validateForPersist rejection, which is
+    // currently a documented no-op) must propagate on the FIRST attempt.  Burning the critical
+    // retry budget (128 attempts x backoff) on a deterministic violation would mask the
+    // actionable error for ~25 s and hammer ZK with useless re-fetches.
     HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
     Map<Long, PartitionInfo> existing = new HashMap<>();
-    existing.put(W0, new PartitionInfo(PartitionState.STALE, FP2, 1L));
-    stubFetch(store, runtime(W1, existing), 0);
-    stubSet(store, true);
+    existing.put(W0, new PartitionInfo(PartitionState.VALID, FP2, 1L));
+    stubFetch(store, runtime(W0, existing), 0);
 
-    // Sanity: revertValid succeeds in the happy path.
-    new MaterializedViewPartitionManager(store, null).revertValid(TABLE, W0);
-    verify(store, atLeastOnce()).set(anyString(), any(ZNRecord.class), anyInt(), anyInt());
+    try {
+      // VALID bucket with a different fingerprint => strict refreshValid violation.
+      new MaterializedViewPartitionManager(store, null).refreshValid(TABLE, W0, FP1);
+      fail("Expected IllegalStateException for the strict precondition violation");
+    } catch (IllegalStateException e) {
+      assertTrue(e.getMessage().contains("STALE"),
+          "message should describe the violated precondition; got: " + e.getMessage());
+    }
+    // Exactly one fetch (no retry burn) and no write.
+    verify(store, times(1)).get(anyString(), any(Stat.class), anyInt());
+    verify(store, never()).set(anyString(), any(ZNRecord.class), anyInt(), anyInt());
   }
 
   @Test

--- a/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/metadata/MaterializedViewPartitionManagerTest.java
+++ b/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/metadata/MaterializedViewPartitionManagerTest.java
@@ -1,0 +1,586 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.materializedview.metadata;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.apache.helix.AccessOption;
+import org.apache.helix.store.HelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.zkclient.exception.ZkException;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.zookeeper.data.Stat;
+import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.InvocationOnMock;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+
+/// Unit tests for [MaterializedViewPartitionManager].  Covers each public state-change
+/// op's strict / lenient precondition and the CAS engine's retry classification.
+public class MaterializedViewPartitionManagerTest {
+  private static final String TABLE = "mv_orders_OFFLINE";
+  private static final long BUCKET_MS = 86_400_000L;
+  private static final long W0 = 1_700_000_000_000L;
+  private static final long W1 = W0 + BUCKET_MS;
+  private static final long W2 = W0 + 2 * BUCKET_MS;
+  private static final PartitionFingerprint FP1 = new PartitionFingerprint(3, 0xCAFEL);
+  private static final PartitionFingerprint FP2 = new PartitionFingerprint(5, 0xBEEFL);
+
+  // ─────────────────────────────────────────────────────────────────────────────────────
+  //  appendValid
+  // ─────────────────────────────────────────────────────────────────────────────────────
+
+  @Test
+  public void testAppendValidVacantToValidAdvancesWatermark() {
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    Map<Long, PartitionInfo> existing = new HashMap<>();
+    stubFetch(store, runtime(W0, existing), 7);
+    stubSet(store, true);
+
+    MaterializedViewPartitionManager mgr = new MaterializedViewPartitionManager(store, null);
+    mgr.appendValid(TABLE, W0, W1, FP1);
+
+    MaterializedViewRuntimeMetadata persisted = capturePersisted(store, 7);
+    assertEquals(persisted.getWatermarkMs(), W1, "watermark advances by one bucket");
+    PartitionInfo info = persisted.getPartitions().get(W0);
+    assertNotNull(info);
+    assertEquals(info.getState(), PartitionState.VALID);
+    assertEquals(info.getFingerprint(), FP1);
+  }
+
+  @Test
+  public void testAppendValidWatermarkClimbsContiguousChain() {
+    // Map already has W1 VALID (from a prior batch); appending W0 should advance watermark
+    // through both contiguous buckets.
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    Map<Long, PartitionInfo> existing = new HashMap<>();
+    existing.put(W1, new PartitionInfo(PartitionState.VALID, FP2, 1L));
+    stubFetch(store, runtime(W0, existing), 1);
+    stubSet(store, true);
+
+    new MaterializedViewPartitionManager(store, null).appendValid(TABLE, W0, W1, FP1);
+
+    assertEquals(capturePersisted(store, 1).getWatermarkMs(), W2,
+        "watermark walks past contiguous VALID chain");
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void testAppendValidStrictRejectsExistingBucket() {
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    Map<Long, PartitionInfo> existing = new HashMap<>();
+    existing.put(W0, new PartitionInfo(PartitionState.VALID, FP2, 1L));
+    stubFetch(store, runtime(W0, existing), 0);
+
+    new MaterializedViewPartitionManager(store, null).appendValid(TABLE, W0, W1, FP1);
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void testAppendValidThrowsWhenRuntimeMissing() {
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    stubFetchAbsent(store);
+
+    new MaterializedViewPartitionManager(store, null).appendValid(TABLE, W0, W1, FP1);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────────────
+  //  refreshValid
+  // ─────────────────────────────────────────────────────────────────────────────────────
+
+  @Test
+  public void testRefreshValidStaleToValidUpdatesFingerprint() {
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    Map<Long, PartitionInfo> existing = new HashMap<>();
+    existing.put(W0, new PartitionInfo(PartitionState.STALE, FP2, 1L));
+    stubFetch(store, runtime(W1, existing), 4);
+    stubSet(store, true);
+
+    new MaterializedViewPartitionManager(store, null).refreshValid(TABLE, W0, FP1);
+
+    MaterializedViewRuntimeMetadata persisted = capturePersisted(store, 4);
+    assertEquals(persisted.getWatermarkMs(), W1, "watermark unchanged on OVERWRITE");
+    PartitionInfo info = persisted.getPartitions().get(W0);
+    assertEquals(info.getState(), PartitionState.VALID);
+    assertEquals(info.getFingerprint(), FP1);
+    assertTrue(info.getLastRefreshTime() > 1L, "lastRefreshTime is bumped to now");
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void testRefreshValidStrictRejectsAbsentBucket() {
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    stubFetch(store, runtime(W0, new HashMap<>()), 0);
+
+    new MaterializedViewPartitionManager(store, null).refreshValid(TABLE, W0, FP1);
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void testRefreshValidStrictRejectsValidBucket() {
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    Map<Long, PartitionInfo> existing = new HashMap<>();
+    existing.put(W0, new PartitionInfo(PartitionState.VALID, FP2, 1L));
+    stubFetch(store, runtime(W0, existing), 0);
+
+    new MaterializedViewPartitionManager(store, null).refreshValid(TABLE, W0, FP1);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────────────
+  //  clearValid
+  // ─────────────────────────────────────────────────────────────────────────────────────
+
+  @Test
+  public void testClearValidStaleToValidEmptyPersistsEmptyFingerprint() {
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    Map<Long, PartitionInfo> existing = new HashMap<>();
+    existing.put(W0, new PartitionInfo(PartitionState.STALE, FP2, 1L));
+    stubFetch(store, runtime(W0, existing), 2);
+    stubSet(store, true);
+
+    // EMPTY fingerprint => source confirmed still empty at commit => write VALID-empty.
+    new MaterializedViewPartitionManager(store, null).clearValid(TABLE, W0, () -> PartitionFingerprint.EMPTY);
+
+    PartitionInfo info = capturePersisted(store, 2).getPartitions().get(W0);
+    assertEquals(info.getState(), PartitionState.VALID);
+    assertEquals(info.getFingerprint(), PartitionFingerprint.EMPTY);
+  }
+
+  @Test
+  public void testClearValidLeavesStaleWhenSourceBackfilled() {
+    // Backfill race: the scheduler dispatched DELETE on an empty source, but a backfill landed
+    // before commit (the recomputed source fingerprint has overlapping segments).  clearValid
+    // must NOT write VALID-empty — it leaves the bucket STALE so the next cycle re-materializes
+    // it via OVERWRITE.  Writing VALID-empty here would silently drop the backfilled rows.
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    Map<Long, PartitionInfo> existing = new HashMap<>();
+    existing.put(W0, new PartitionInfo(PartitionState.STALE, FP2, 1L));
+    stubFetch(store, runtime(W0, existing), 2);
+    stubSet(store, true);
+
+    // Non-empty fingerprint (segmentCount=3) => source backfilled => no-op, bucket stays STALE.
+    new MaterializedViewPartitionManager(store, null).clearValid(TABLE, W0, () -> FP1);
+
+    verify(store, never()).set(anyString(), any(ZNRecord.class), anyInt(), anyInt());
+  }
+
+  @Test
+  public void testClearValidReReadsSourceOnEachCasAttempt() {
+    // Race the supplier across a CAS conflict: the source is empty on attempt 1 (so the mutator
+    // builds a VALID-empty record) but the write loses a version race; a backfill lands before the
+    // retry, so on attempt 2 the supplier reports a non-empty source and clearValid must no-op,
+    // leaving the bucket STALE.  This pins the fix: the source emptiness is re-evaluated inside the
+    // CAS loop, not snapshotted once before it (which would write VALID-empty over the backfill).
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    Map<Long, PartitionInfo> existing = new HashMap<>();
+    existing.put(W0, new PartitionInfo(PartitionState.STALE, FP2, 1L));
+    String path = ZKMetadataProvider.constructPropertyStorePathForMaterializedViewRuntime(TABLE);
+
+    AtomicInteger version = new AtomicInteger(0);
+    when(store.get(eq(path), any(Stat.class), eq(AccessOption.PERSISTENT)))
+        .thenAnswer((InvocationOnMock inv) -> {
+          Stat stat = inv.getArgument(1);
+          stat.setVersion(version.get());
+          return runtime(W0, existing).toZNRecord();
+        });
+    // Every write loses the version race (simulating a concurrent writer), forcing a retry.
+    AtomicInteger setCalls = new AtomicInteger(0);
+    when(store.set(eq(path), any(ZNRecord.class), anyInt(), eq(AccessOption.PERSISTENT)))
+        .thenAnswer(inv -> {
+          setCalls.incrementAndGet();
+          version.incrementAndGet();
+          return false;
+        });
+
+    // Supplier: empty on attempt 1, non-empty (backfill landed) on every later attempt.
+    AtomicInteger supplierCalls = new AtomicInteger(0);
+    Supplier<PartitionFingerprint> supplier =
+        () -> supplierCalls.incrementAndGet() == 1 ? PartitionFingerprint.EMPTY : FP1;
+
+    new MaterializedViewPartitionManager(store, null).clearValid(TABLE, W0, supplier);
+
+    assertTrue(supplierCalls.get() >= 2, "supplier must be re-invoked on the CAS retry");
+    assertEquals(setCalls.get(), 1,
+        "only attempt 1 (empty source) tried to write; attempt 2 saw the backfill and no-oped");
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void testClearValidStrictRejectsAbsentBucket() {
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    stubFetch(store, runtime(W0, new HashMap<>()), 0);
+
+    // Strict precondition (present & STALE) is checked before the emptiness guard, so an absent
+    // bucket still throws regardless of the supplied fingerprint.
+    new MaterializedViewPartitionManager(store, null).clearValid(TABLE, W0, () -> PartitionFingerprint.EMPTY);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────────────
+  //  revertValid
+  // ─────────────────────────────────────────────────────────────────────────────────────
+
+  @Test
+  public void testRevertValidStaleToValidPreservesFingerprintAndTimestamp() {
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    Map<Long, PartitionInfo> existing = new HashMap<>();
+    PartitionInfo stale = new PartitionInfo(PartitionState.STALE, FP2, 12345L);
+    existing.put(W0, stale);
+    stubFetch(store, runtime(W1, existing), 9);
+    stubSet(store, true);
+
+    new MaterializedViewPartitionManager(store, null).revertValid(TABLE, W0);
+
+    PartitionInfo info = capturePersisted(store, 9).getPartitions().get(W0);
+    assertEquals(info.getState(), PartitionState.VALID);
+    assertEquals(info.getFingerprint(), FP2, "fingerprint preserved");
+    assertEquals(info.getLastRefreshTime(), 12345L, "lastRefreshTime preserved");
+  }
+
+  @Test
+  public void testRevertValidLenientNoOpWhenNotStale() {
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    Map<Long, PartitionInfo> existing = new HashMap<>();
+    existing.put(W0, new PartitionInfo(PartitionState.VALID, FP2, 1L));
+    stubFetch(store, runtime(W1, existing), 0);
+
+    new MaterializedViewPartitionManager(store, null).revertValid(TABLE, W0);
+
+    verify(store, never()).set(anyString(), any(ZNRecord.class), anyInt(), anyInt());
+  }
+
+  @Test
+  public void testRevertValidLenientNoOpWhenAbsent() {
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    stubFetch(store, runtime(W1, new HashMap<>()), 0);
+
+    new MaterializedViewPartitionManager(store, null).revertValid(TABLE, W0);
+
+    verify(store, never()).set(anyString(), any(ZNRecord.class), anyInt(), anyInt());
+  }
+
+  @Test
+  public void testRevertValidLenientNoOpWhenRuntimeMissing() {
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    stubFetchAbsent(store);
+
+    new MaterializedViewPartitionManager(store, null).revertValid(TABLE, W0);
+
+    verify(store, never()).set(anyString(), any(ZNRecord.class), anyInt(), anyInt());
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────────────
+  //  markStale
+  // ─────────────────────────────────────────────────────────────────────────────────────
+
+  @Test
+  public void testMarkStaleValidToStaleSingleBucket() {
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    Map<Long, PartitionInfo> existing = new HashMap<>();
+    PartitionInfo valid = new PartitionInfo(PartitionState.VALID, FP1, 1L);
+    existing.put(W0, valid);
+    stubFetch(store, runtime(W1, existing), 5);
+    stubSet(store, true);
+
+    new MaterializedViewPartitionManager(store, null).markStale(TABLE, W0);
+
+    PartitionInfo info = capturePersisted(store, 5).getPartitions().get(W0);
+    assertEquals(info.getState(), PartitionState.STALE);
+    assertEquals(info.getFingerprint(), FP1, "fingerprint preserved on markStale");
+  }
+
+  @Test
+  public void testMarkStaleBatchSingleCasOnly() {
+    // Three buckets: VALID/STALE/absent.  Manager flips only the VALID one and writes once.
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    Map<Long, PartitionInfo> existing = new HashMap<>();
+    existing.put(W0, new PartitionInfo(PartitionState.VALID, FP1, 1L));
+    existing.put(W1, new PartitionInfo(PartitionState.STALE, FP2, 1L));
+    stubFetch(store, runtime(W2, existing), 3);
+    stubSet(store, true);
+
+    new MaterializedViewPartitionManager(store, null).markStale(TABLE, List.of(W0, W1, W2));
+
+    verify(store, times(1)).set(anyString(), any(ZNRecord.class), eq(3), eq(AccessOption.PERSISTENT));
+    Map<Long, PartitionInfo> persisted = capturePersisted(store, 3).getPartitions();
+    assertEquals(persisted.get(W0).getState(), PartitionState.STALE, "VALID bucket flipped");
+    assertEquals(persisted.get(W1).getState(), PartitionState.STALE, "already-STALE bucket unchanged");
+    assertFalse(persisted.containsKey(W2), "absent bucket not synthesized today");
+  }
+
+  @Test
+  public void testMarkStaleNoOpWhenNoValidEntries() {
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    Map<Long, PartitionInfo> existing = new HashMap<>();
+    existing.put(W0, new PartitionInfo(PartitionState.STALE, FP1, 1L));
+    stubFetch(store, runtime(W1, existing), 0);
+
+    new MaterializedViewPartitionManager(store, null).markStale(TABLE, List.of(W0));
+
+    verify(store, never()).set(anyString(), any(ZNRecord.class), anyInt(), anyInt());
+  }
+
+  @Test
+  public void testMarkStaleEmptyCollectionShortCircuits() {
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+
+    new MaterializedViewPartitionManager(store, null).markStale(TABLE, List.of());
+
+    verify(store, never()).get(anyString(), any(Stat.class), anyInt());
+    verify(store, never()).set(anyString(), any(ZNRecord.class), anyInt(), anyInt());
+  }
+
+  @Test
+  public void testMarkStaleNoOpWhenRuntimeMissing() {
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    stubFetchAbsent(store);
+
+    new MaterializedViewPartitionManager(store, null).markStale(TABLE, List.of(W0));
+
+    verify(store, never()).set(anyString(), any(ZNRecord.class), anyInt(), anyInt());
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────────────
+  //  deletePartition
+  // ─────────────────────────────────────────────────────────────────────────────────────
+
+  @Test
+  public void testDeletePartitionRemovesEntry() {
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    Map<Long, PartitionInfo> existing = new HashMap<>();
+    existing.put(W0, new PartitionInfo(PartitionState.STALE, FP1, 1L));
+    existing.put(W1, new PartitionInfo(PartitionState.VALID, FP2, 1L));
+    stubFetch(store, runtime(W1, existing), 6);
+    stubSet(store, true);
+
+    new MaterializedViewPartitionManager(store, null).deletePartition(TABLE, W0);
+
+    Map<Long, PartitionInfo> persisted = capturePersisted(store, 6).getPartitions();
+    assertFalse(persisted.containsKey(W0), "deleted bucket no longer present");
+    assertTrue(persisted.containsKey(W1), "untouched bucket remains");
+  }
+
+  @Test
+  public void testDeletePartitionNoOpWhenAbsent() {
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    stubFetch(store, runtime(W0, new HashMap<>()), 0);
+
+    new MaterializedViewPartitionManager(store, null).deletePartition(TABLE, W0);
+
+    verify(store, never()).set(anyString(), any(ZNRecord.class), anyInt(), anyInt());
+  }
+
+  @Test
+  public void testDeletePartitionNoOpWhenRuntimeMissing() {
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    stubFetchAbsent(store);
+
+    new MaterializedViewPartitionManager(store, null).deletePartition(TABLE, W0);
+
+    verify(store, never()).set(anyString(), any(ZNRecord.class), anyInt(), anyInt());
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────────────
+  //  CAS retry classification
+  // ─────────────────────────────────────────────────────────────────────────────────────
+
+  @Test
+  public void testCasConflictRetriesUntilSuccess() {
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    Map<Long, PartitionInfo> existing = new HashMap<>();
+    existing.put(W0, new PartitionInfo(PartitionState.STALE, FP2, 1L));
+    String path = ZKMetadataProvider.constructPropertyStorePathForMaterializedViewRuntime(TABLE);
+
+    AtomicInteger version = new AtomicInteger(0);
+    when(store.get(eq(path), any(Stat.class), eq(AccessOption.PERSISTENT)))
+        .thenAnswer((InvocationOnMock inv) -> {
+          Stat stat = inv.getArgument(1);
+          stat.setVersion(version.get());
+          return runtime(W1, existing).toZNRecord();
+        });
+
+    AtomicInteger setCalls = new AtomicInteger(0);
+    when(store.set(eq(path), any(ZNRecord.class), anyInt(), eq(AccessOption.PERSISTENT)))
+        .thenAnswer(inv -> {
+          int callIdx = setCalls.incrementAndGet();
+          if (callIdx <= 2) {
+            // Simulate concurrent writer winning — bump the stored version.
+            version.incrementAndGet();
+            return false;
+          }
+          return true;
+        });
+
+    new MaterializedViewPartitionManager(store, null).revertValid(TABLE, W0);
+
+    assertEquals(setCalls.get(), 3, "should have retried twice and succeeded on the third attempt");
+  }
+
+  @Test
+  public void testReadSideZkExceptionIsRetried() {
+    // A transient read-side ZK failure on the first attempt must be counted against the retry
+    // budget and re-fetched, not escape unretried; the second read succeeds and the op commits.
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    Map<Long, PartitionInfo> existing = new HashMap<>();
+    existing.put(W0, new PartitionInfo(PartitionState.STALE, FP2, 1L));
+    String path = ZKMetadataProvider.constructPropertyStorePathForMaterializedViewRuntime(TABLE);
+
+    when(store.get(eq(path), any(Stat.class), eq(AccessOption.PERSISTENT)))
+        .thenThrow(new ZkException("transient read failure"))
+        .thenAnswer((InvocationOnMock inv) -> {
+          Stat stat = inv.getArgument(1);
+          stat.setVersion(0);
+          return runtime(W0, existing).toZNRecord();
+        });
+    stubSet(store, true);
+
+    new MaterializedViewPartitionManager(store, null).revertValid(TABLE, W0);
+
+    // Recovered after the read retry: exactly one successful set (no exception escaped).
+    verify(store, times(1)).set(eq(path), any(ZNRecord.class), anyInt(), eq(AccessOption.PERSISTENT));
+  }
+
+  @Test
+  public void testValidateForPersistFailureFailsFast() {
+    // Inject a non-CAS error from set() to verify other ZkException variants are retried.
+    // For validateForPersist failure we'd need to corrupt the metadata — covered indirectly
+    // by addPartitionInfo's strict invariant tests above.  This test guards against an
+    // accidental retry on transport ZkException being treated as a no-op.
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    Map<Long, PartitionInfo> existing = new HashMap<>();
+    existing.put(W0, new PartitionInfo(PartitionState.STALE, FP2, 1L));
+    stubFetch(store, runtime(W1, existing), 0);
+    stubSet(store, true);
+
+    // Sanity: revertValid succeeds in the happy path.
+    new MaterializedViewPartitionManager(store, null).revertValid(TABLE, W0);
+    verify(store, atLeastOnce()).set(anyString(), any(ZNRecord.class), anyInt(), anyInt());
+  }
+
+  @Test
+  public void testRevertBudgetExhaustedThrowsRuntimeException() {
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    Map<Long, PartitionInfo> existing = new HashMap<>();
+    existing.put(W0, new PartitionInfo(PartitionState.STALE, FP2, 1L));
+    String path = ZKMetadataProvider.constructPropertyStorePathForMaterializedViewRuntime(TABLE);
+
+    when(store.get(eq(path), any(Stat.class), eq(AccessOption.PERSISTENT)))
+        .thenAnswer((InvocationOnMock inv) -> {
+          Stat stat = inv.getArgument(1);
+          stat.setVersion(0);
+          return runtime(W1, existing).toZNRecord();
+        });
+    when(store.set(anyString(), any(ZNRecord.class), anyInt(), anyInt()))
+        .thenReturn(false);
+
+    try {
+      new MaterializedViewPartitionManager(store, null).revertValid(TABLE, W0);
+      fail("Expected RuntimeException after exhausting revert budget");
+    } catch (RuntimeException e) {
+      assertTrue(e.getMessage().contains(TABLE),
+          "Exception message must include the offending table name; got: " + e.getMessage());
+    }
+    verify(store, times(MaterializedViewPartitionManager.REVERT_MAX_ATTEMPTS))
+        .set(anyString(), any(ZNRecord.class), anyInt(), anyInt());
+  }
+
+  @Test
+  public void testReadSideZkExceptionBudgetExhaustedThrows() {
+    // Read fails on EVERY attempt: the read-side ZkException is retried up to the budget and then
+    // surfaces as a RuntimeException wrapping the last ZkException — symmetric with the write-side
+    // budget-exhaustion path above, so a persistent read fault is never silently swallowed.
+    HelixPropertyStore<ZNRecord> store = mock(HelixPropertyStore.class);
+    String path = ZKMetadataProvider.constructPropertyStorePathForMaterializedViewRuntime(TABLE);
+    when(store.get(eq(path), any(Stat.class), eq(AccessOption.PERSISTENT)))
+        .thenThrow(new ZkException("persistent read failure"));
+
+    try {
+      new MaterializedViewPartitionManager(store, null).revertValid(TABLE, W0);
+      fail("Expected RuntimeException after read-side budget exhaustion");
+    } catch (RuntimeException e) {
+      assertTrue(e.getMessage().contains(TABLE),
+          "Exception message must include the offending table name; got: " + e.getMessage());
+    }
+    verify(store, times(MaterializedViewPartitionManager.REVERT_MAX_ATTEMPTS))
+        .get(eq(path), any(Stat.class), eq(AccessOption.PERSISTENT));
+    verify(store, never()).set(anyString(), any(ZNRecord.class), anyInt(), anyInt());
+  }
+
+  @Test
+  public void testNullPropertyStoreRejected() {
+    try {
+      new MaterializedViewPartitionManager(null, null);
+      fail("Expected IllegalArgumentException for null propertyStore");
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().contains("propertyStore"));
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────────────
+  //  Helpers
+  // ─────────────────────────────────────────────────────────────────────────────────────
+
+  private static MaterializedViewRuntimeMetadata runtime(long watermarkMs,
+      Map<Long, PartitionInfo> partitions) {
+    return new MaterializedViewRuntimeMetadata(TABLE, watermarkMs, partitions);
+  }
+
+  private static void stubFetch(HelixPropertyStore<ZNRecord> store,
+      MaterializedViewRuntimeMetadata snapshot, int version) {
+    String path = ZKMetadataProvider.constructPropertyStorePathForMaterializedViewRuntime(TABLE);
+    when(store.get(eq(path), any(Stat.class), eq(AccessOption.PERSISTENT)))
+        .thenAnswer((InvocationOnMock inv) -> {
+          Stat stat = inv.getArgument(1);
+          stat.setVersion(version);
+          return snapshot.toZNRecord();
+        });
+  }
+
+  private static void stubFetchAbsent(HelixPropertyStore<ZNRecord> store) {
+    String path = ZKMetadataProvider.constructPropertyStorePathForMaterializedViewRuntime(TABLE);
+    when(store.get(eq(path), any(Stat.class), eq(AccessOption.PERSISTENT)))
+        .thenReturn(null);
+  }
+
+  private static void stubSet(HelixPropertyStore<ZNRecord> store, boolean result) {
+    when(store.set(anyString(), any(ZNRecord.class), anyInt(), eq(AccessOption.PERSISTENT)))
+        .thenReturn(result);
+  }
+
+  private static MaterializedViewRuntimeMetadata capturePersisted(
+      HelixPropertyStore<ZNRecord> store, int expectedVersion) {
+    String path = ZKMetadataProvider.constructPropertyStorePathForMaterializedViewRuntime(TABLE);
+    ArgumentCaptor<ZNRecord> captor = ArgumentCaptor.forClass(ZNRecord.class);
+    verify(store).set(eq(path), captor.capture(), eq(expectedVersion), eq(AccessOption.PERSISTENT));
+    return MaterializedViewRuntimeMetadata.fromZNRecord(captor.getValue());
+  }
+}

--- a/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/metadata/PartitionFingerprintTest.java
+++ b/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/metadata/PartitionFingerprintTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.materializedview.metadata;
 
+import com.google.common.hash.Hashing;
 import java.util.HashMap;
 import java.util.Map;
 import org.testng.annotations.Test;
@@ -128,5 +129,43 @@ public class PartitionFingerprintTest {
     PartitionFingerprint fp = new PartitionFingerprint(3, 42L);
     assertTrue(fp.toString().contains("segmentCount=3"));
     assertTrue(fp.toString().contains("crcChecksum=42"));
+  }
+
+  @Test
+  public void testEmptyConstantHasZeroSegmentCount() {
+    assertEquals(PartitionFingerprint.EMPTY.getSegmentCount(), 0);
+  }
+
+  @Test
+  public void testEmptyConstantCrcMatchesEmptyFarmHash64() {
+    // The EMPTY constant's crc must equal what farmHashFingerprint64 produces over zero input
+    // bytes. This is the same value the scheduler / executor compute for windows with no
+    // overlapping segments, so empty-by-DELETE and empty-by-APPEND converge to byte-equal
+    // PartitionFingerprint values.
+    long expected = Hashing.farmHashFingerprint64().newHasher().hash().asLong();
+    assertEquals(PartitionFingerprint.EMPTY.getCrcChecksum(), expected);
+  }
+
+  @Test
+  public void testEmptyConstantNotEqualToZeroLiteral() {
+    // farmHash64("") is a deterministic NON-zero constant.  This guards against any future
+    // refactor that would silently swap EMPTY for `new PartitionFingerprint(0, 0L)` — which
+    // looks superficially equivalent but is byte-different and would break equals checks
+    // against existing ZK records produced by the APPEND-empty path.
+    assertNotEquals(PartitionFingerprint.EMPTY, new PartitionFingerprint(0, 0L));
+  }
+
+  @Test
+  public void testEmptyConstantIsSingleton() {
+    // The constant is a static field; hot-path callers should reuse it without allocation.
+    assertSame(PartitionFingerprint.EMPTY, PartitionFingerprint.EMPTY);
+  }
+
+  @Test
+  public void testEmptyConstantSurvivesEncodeRoundTrip() {
+    String encoded = PartitionFingerprint.EMPTY.encode();
+    PartitionFingerprint decoded = PartitionFingerprint.decode(encoded);
+    assertEquals(decoded, PartitionFingerprint.EMPTY);
+    assertEquals(decoded.getCrcChecksum(), PartitionFingerprint.EMPTY.getCrcChecksum());
   }
 }

--- a/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/rewrite/MaterializedViewQueryRewriteEngineTest.java
+++ b/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/rewrite/MaterializedViewQueryRewriteEngineTest.java
@@ -75,7 +75,7 @@ public class MaterializedViewQueryRewriteEngineTest {
       if (wm == 0L) {
         wm = 1L;
       }
-      parts = Map.of(0L, new PartitionInfo(PartitionState.VALID, new PartitionFingerprint(1, 1L), 0L));
+      parts = Map.of(0L, PartitionInfo.forTesting(PartitionState.VALID, new PartitionFingerprint(1, 1L), 0L));
     }
     return new MaterializedViewCacheEntry(definition, compiledQuery, wm, parts);
   }

--- a/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/scheduler/MaterializedViewTaskSchedulerTest.java
+++ b/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/scheduler/MaterializedViewTaskSchedulerTest.java
@@ -305,6 +305,48 @@ public class MaterializedViewTaskSchedulerTest {
   }
 
   // ---------------------------------------------------------------------------
+  //  resolveAppendCutoffMs — converts the inclusive max source endTimeMs into the exclusive
+  //  windowEndMs convention the scheduling-loop gate (`windowEndMs > cutoffMs → break`) uses.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testResolveAppendCutoffAdmitsExactlyCoveredBucket() {
+    // A day-aligned batch segment covering [0, bucketEnd - 1] (inclusive end) fully covers the
+    // bucket ending at bucketEnd.  The +1 conversion must admit that bucket: without it, a
+    // complete static dataset would never materialize its final bucket and `watermarkMs` would
+    // stall one bucket short of the data.
+    long bucketEndMs = 86_400_000L;
+    long roughCutoffMs = 10 * bucketEndMs;
+    assertEquals(MaterializedViewTaskScheduler.resolveAppendCutoffMs(roughCutoffMs, bucketEndMs - 1),
+        bucketEndMs, "inclusive segment end exactly covering the bucket must admit it");
+  }
+
+  @Test
+  public void testResolveAppendCutoffKeepsRoughCutoffWhenDataIsAhead() {
+    // Source data extends past the wall-clock buffer: the rough cutoff (now - bufferMs) must
+    // win, preserving the buffer semantics for late-arriving data.
+    long roughCutoffMs = 1_000_000L;
+    assertEquals(MaterializedViewTaskScheduler.resolveAppendCutoffMs(roughCutoffMs, 5_000_000L),
+        roughCutoffMs);
+  }
+
+  @Test
+  public void testResolveAppendCutoffFallsBackWhenNoUsableEndTime() {
+    long roughCutoffMs = 1_000_000L;
+    assertEquals(MaterializedViewTaskScheduler.resolveAppendCutoffMs(roughCutoffMs, Long.MIN_VALUE),
+        roughCutoffMs, "no usable source end time falls back to the rough cutoff");
+  }
+
+  @Test
+  public void testResolveAppendCutoffClampsCorruptMaxValueEndTime() {
+    // A corrupt Long.MAX_VALUE end time must not overflow `+ 1` into Long.MIN_VALUE (which
+    // would freeze APPEND scheduling forever); it clamps to the rough cutoff instead.
+    long roughCutoffMs = 1_000_000L;
+    assertEquals(MaterializedViewTaskScheduler.resolveAppendCutoffMs(roughCutoffMs, Long.MAX_VALUE),
+        roughCutoffMs);
+  }
+
+  // ---------------------------------------------------------------------------
   //  generateTasks DELETE path: a STALE partition whose source was retention-deleted must
   //  produce a DELETE task that carries SOURCE_TABLE_NAME_KEY, so the executor can recompute
   //  the source fingerprint at commit and leave the bucket STALE if a backfill landed.

--- a/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/scheduler/MaterializedViewTaskSchedulerTest.java
+++ b/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/scheduler/MaterializedViewTaskSchedulerTest.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 import org.apache.helix.AccessOption;
 import org.apache.helix.store.HelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
@@ -48,6 +49,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -394,5 +396,72 @@ public class MaterializedViewTaskSchedulerTest {
     assertEquals(configs.get(MaterializedViewTask.TASK_MODE_KEY), MaterializedViewTask.TASK_MODE_DELETE);
     assertEquals(configs.get(MaterializedViewTask.SOURCE_TABLE_NAME_KEY), sourceTable,
         "DELETE task must carry the source table so the executor can re-validate emptiness at commit");
+  }
+
+  // ---------------------------------------------------------------------------
+  //  APPEND loop must fill ABSENT buckets only.  Since the consistency manager marks
+  //  above-watermark VALID buckets STALE (the watermark cap was removed), a STALE bucket can
+  //  sit inside the APPEND scheduling range; dispatching an APPEND for it would race the
+  //  in-flight / upcoming OVERWRITE on the same window (concurrent segment-replace =>
+  //  potentially duplicated rows with no failure signal).
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testAppendLoopSkipsAboveWatermarkStaleBucket() {
+    String sourceTable = "orders";
+    String sourceTableOffline = "orders_OFFLINE";
+    String mvTableOffline = "mv_OFFLINE";
+    long bucketMs = 86_400_000L;
+    long b0 = 1_700_006_400_000L;
+    long b1 = b0 + bucketMs;
+    long b2 = b0 + 2 * bucketMs;
+    long b3 = b0 + 3 * bucketMs;
+
+    HelixPropertyStore<ZNRecord> store = mockPropertyStore();
+    MaterializedViewTaskGeneratorContext context = mock(MaterializedViewTaskGeneratorContext.class);
+    when(context.getPropertyStore()).thenReturn(store);
+    when(context.getVipUrl()).thenReturn("http://controller:9000");
+    when(context.getTableConfig(sourceTableOffline)).thenReturn(
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(sourceTable).build());
+    // Source data ends exactly at the STALE bucket's inclusive end, so the stage-2 cutoff
+    // admits [b2, b3) and nothing beyond — the STALE bucket is the only candidate slot.
+    // (Built before the when() below: stubbing a mock inside another stubbing trips Mockito.)
+    SegmentZKMetadata sourceTail = segmentWithEndMs(b3 - 1);
+    when(context.getSegmentsZKMetadata(sourceTableOffline)).thenReturn(
+        Collections.singletonList(sourceTail));
+    // One in-flight OVERWRITE for [b2, b3) — the step-1 dispatch from the previous cycle —
+    // so step 1 is skipped this cycle and only the APPEND loop runs.
+    doAnswer(inv -> {
+      Consumer<Map<String, String>> consumer = inv.getArgument(2);
+      consumer.accept(Map.of(
+          MaterializedViewTask.TASK_MODE_KEY, MaterializedViewTask.TASK_MODE_OVERWRITE,
+          MaterializedViewTask.WINDOW_START_MS_KEY, String.valueOf(b2),
+          MaterializedViewTask.WINDOW_END_MS_KEY, String.valueOf(b3)));
+      return null;
+    }).when(context).forRunningTasks(eq(mvTableOffline), eq(MaterializedViewTask.TASK_TYPE), any());
+
+    // Contiguous VALID chain up to the watermark (b2); b2 itself is STALE above the frontier
+    // (the consistency manager marked it after an out-of-order completion).
+    Map<Long, PartitionInfo> partitions = new HashMap<>();
+    partitions.put(b0, PartitionInfo.forTesting(PartitionState.VALID, new PartitionFingerprint(1, 1L), 1L));
+    partitions.put(b1, PartitionInfo.forTesting(PartitionState.VALID, new PartitionFingerprint(1, 2L), 1L));
+    partitions.put(b2, PartitionInfo.forTesting(PartitionState.STALE, new PartitionFingerprint(1, 3L), 1L));
+    MaterializedViewRuntimeMetadata runtime = new MaterializedViewRuntimeMetadata(mvTableOffline, b2, partitions);
+    when(store.get(
+        eq(ZKMetadataProvider.constructPropertyStorePathForMaterializedViewRuntime(mvTableOffline)),
+        any(Stat.class), eq(AccessOption.PERSISTENT))).thenReturn(runtime.toZNRecord());
+
+    TableTaskConfig taskConfig = new TableTaskConfig(Map.of(MaterializedViewTask.TASK_TYPE, Map.of(
+        MaterializedViewTask.DEFINED_SQL_KEY, "SELECT city, COUNT(*) FROM " + sourceTable + " GROUP BY city",
+        MaterializedViewTask.BUCKET_TIME_PERIOD_KEY, "1d")));
+    TableConfig mvConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("mv").setIsMaterializedView(true).setTaskConfig(taskConfig).build();
+
+    List<PinotTaskConfig> tasks =
+        new MaterializedViewTaskScheduler(context).generateTasks(Collections.singletonList(mvConfig));
+
+    assertTrue(tasks.isEmpty(), "the STALE bucket is the exclusive (OVERWRITE/DELETE) step's "
+        + "responsibility; the APPEND loop must skip it instead of double-dispatching the same "
+        + "window, got: " + tasks);
   }
 }

--- a/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/scheduler/MaterializedViewTaskSchedulerTest.java
+++ b/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/scheduler/MaterializedViewTaskSchedulerTest.java
@@ -18,16 +18,29 @@
  */
 package org.apache.pinot.materializedview.scheduler;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.helix.AccessOption;
 import org.apache.helix.store.HelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.materializedview.analysis.MaterializedViewAnalyzer;
 import org.apache.pinot.materializedview.context.MaterializedViewTaskGeneratorContext;
 import org.apache.pinot.materializedview.metadata.MaterializedViewRuntimeMetadata;
+import org.apache.pinot.materializedview.metadata.PartitionFingerprint;
+import org.apache.pinot.materializedview.metadata.PartitionInfo;
+import org.apache.pinot.materializedview.metadata.PartitionState;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableTaskConfig;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.utils.CommonConstants.MaterializedViewTask;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.zookeeper.data.Stat;
 import org.testng.annotations.Test;
 
@@ -234,5 +247,110 @@ public class MaterializedViewTaskSchedulerTest {
   @SuppressWarnings("unchecked")
   private static HelixPropertyStore<ZNRecord> mockPropertyStore() {
     return mock(HelixPropertyStore.class);
+  }
+
+  // ---------------------------------------------------------------------------
+  //  computeMaxSourceEndTimeMs — caps the APPEND scheduler cutoff at the latest
+  //  known source-segment endTime so watermark advance cannot outrun real data
+  //  (see MaterializedViewQueryRewriteEngine#isEligible: a watermark that drifts
+  //  to `now - bufferMs` while source ingestion has stalled would silently
+  //  defeat the staleness-threshold contract).
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testComputeMaxSourceEndTimeMsEmptyList() {
+    long max = MaterializedViewTaskScheduler.computeMaxSourceEndTimeMs(Collections.emptyList());
+    assertEquals(max, Long.MIN_VALUE,
+        "Empty list should return MIN_VALUE so the caller falls back to roughCutoffMs");
+  }
+
+  @Test
+  public void testComputeMaxSourceEndTimeMsPicksMaximum() {
+    long max = MaterializedViewTaskScheduler.computeMaxSourceEndTimeMs(
+        Arrays.asList(segmentWithEndMs(100L), segmentWithEndMs(500L), segmentWithEndMs(300L)));
+    assertEquals(max, 500L);
+  }
+
+  @Test
+  public void testComputeMaxSourceEndTimeMsSkipsNegativeEndTimes() {
+    // SegmentZKMetadata returns -1 for legacy znodes without TIME_UNIT; those entries must
+    // not poison the maximum and must not be returned as the "tip of source data".
+    long max = MaterializedViewTaskScheduler.computeMaxSourceEndTimeMs(
+        Arrays.asList(segmentWithEndMs(-1L), segmentWithEndMs(250L), segmentWithEndMs(-1L)));
+    assertEquals(max, 250L);
+  }
+
+  @Test
+  public void testComputeMaxSourceEndTimeMsAllNegativeReturnsMinValue() {
+    // When every segment has an unset end time the caller must fall back to roughCutoffMs;
+    // returning a negative value would freeze the scheduler.
+    long max = MaterializedViewTaskScheduler.computeMaxSourceEndTimeMs(
+        Arrays.asList(segmentWithEndMs(-1L), segmentWithEndMs(-1L)));
+    assertEquals(max, Long.MIN_VALUE);
+  }
+
+  @Test
+  public void testComputeMaxSourceEndTimeMsZeroIsValid() {
+    // endMs == 0 is the epoch boundary, not "unset" — the >= 0 filter must admit it so
+    // a synthetic test/source carrying epoch-zero segments still produces a real max.
+    long max = MaterializedViewTaskScheduler.computeMaxSourceEndTimeMs(
+        Collections.singletonList(segmentWithEndMs(0L)));
+    assertEquals(max, 0L);
+  }
+
+  private static SegmentZKMetadata segmentWithEndMs(long endTimeMs) {
+    SegmentZKMetadata seg = mock(SegmentZKMetadata.class);
+    when(seg.getEndTimeMs()).thenReturn(endTimeMs);
+    return seg;
+  }
+
+  // ---------------------------------------------------------------------------
+  //  generateTasks DELETE path: a STALE partition whose source was retention-deleted must
+  //  produce a DELETE task that carries SOURCE_TABLE_NAME_KEY, so the executor can recompute
+  //  the source fingerprint at commit and leave the bucket STALE if a backfill landed.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testStaleDeletedSourceGeneratesDeleteTaskCarryingSourceTable() {
+    String sourceTable = "orders";
+    String sourceTableOffline = "orders_OFFLINE";
+    String mvTableOffline = "mv_OFFLINE";
+    long staleBucketMs = 1_700_000_000_000L;
+
+    HelixPropertyStore<ZNRecord> store = mockPropertyStore();
+    MaterializedViewTaskGeneratorContext context = mock(MaterializedViewTaskGeneratorContext.class);
+    when(context.getPropertyStore()).thenReturn(store);
+    when(context.getVipUrl()).thenReturn("http://controller:9000");
+    // Source table resolves as OFFLINE.
+    when(context.getTableConfig(sourceTableOffline)).thenReturn(
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(sourceTable).build());
+    // Source has zero overlapping segments => scheduler picks DELETE for the STALE bucket.
+    when(context.getSegmentsZKMetadata(sourceTableOffline)).thenReturn(Collections.emptyList());
+    // No in-flight tasks (forRunningTasks is a no-op mock, so all per-mode counts stay 0).
+
+    // Runtime carries one STALE partition at staleBucketMs; the watermark sits at the same bucket.
+    Map<Long, PartitionInfo> partitions = new HashMap<>();
+    partitions.put(staleBucketMs,
+        PartitionInfo.forTesting(PartitionState.STALE, new PartitionFingerprint(2, 0xABCDL), 1L));
+    MaterializedViewRuntimeMetadata runtime =
+        new MaterializedViewRuntimeMetadata(mvTableOffline, staleBucketMs, partitions);
+    when(store.get(
+        eq(ZKMetadataProvider.constructPropertyStorePathForMaterializedViewRuntime(mvTableOffline)),
+        any(Stat.class), eq(AccessOption.PERSISTENT))).thenReturn(runtime.toZNRecord());
+
+    TableTaskConfig taskConfig = new TableTaskConfig(Map.of(MaterializedViewTask.TASK_TYPE, Map.of(
+        MaterializedViewTask.DEFINED_SQL_KEY, "SELECT city, COUNT(*) FROM " + sourceTable + " GROUP BY city",
+        MaterializedViewTask.BUCKET_TIME_PERIOD_KEY, "1d")));
+    TableConfig mvConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("mv").setIsMaterializedView(true).setTaskConfig(taskConfig).build();
+
+    List<PinotTaskConfig> tasks =
+        new MaterializedViewTaskScheduler(context).generateTasks(Collections.singletonList(mvConfig));
+
+    assertEquals(tasks.size(), 1, "expected exactly one DELETE task");
+    Map<String, String> configs = tasks.get(0).getConfigs();
+    assertEquals(configs.get(MaterializedViewTask.TASK_MODE_KEY), MaterializedViewTask.TASK_MODE_DELETE);
+    assertEquals(configs.get(MaterializedViewTask.SOURCE_TABLE_NAME_KEY), sourceTable,
+        "DELETE task must carry the source table so the executor can re-validate emptiness at commit");
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/materializedview/MaterializedViewTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/materializedview/MaterializedViewTaskExecutor.java
@@ -589,6 +589,10 @@ public class MaterializedViewTaskExecutor extends BaseTaskExecutor {
   /// task and which carries the same source-table reference the task config would.
   /// Time-windowed MVs (the only shape in V1) have exactly one base table; fail loud on any
   /// other shape rather than guessing.
+  ///
+  /// TODO: remove this shim once every controller in supported rolling-upgrade paths sets
+  /// SOURCE_TABLE_NAME_KEY on DELETE tasks (i.e. the first release containing this PR is the
+  /// minimum supported version).
   private String resolveSourceTableNameFromDefinition(String tableName, long windowStartMs, long windowEndMs) {
     MaterializedViewDefinitionMetadata definition =
         MaterializedViewDefinitionMetadataUtils.fetch(MINION_CONTEXT.getHelixPropertyStore(), tableName);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/materializedview/MaterializedViewTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/materializedview/MaterializedViewTaskExecutor.java
@@ -48,6 +48,8 @@ import org.apache.pinot.common.utils.TarCompressionUtils;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.materializedview.executor.MaterializedViewQueryExecutor;
+import org.apache.pinot.materializedview.metadata.MaterializedViewDefinitionMetadata;
+import org.apache.pinot.materializedview.metadata.MaterializedViewDefinitionMetadataUtils;
 import org.apache.pinot.materializedview.metadata.MaterializedViewPartitionManager;
 import org.apache.pinot.materializedview.metadata.MaterializedViewRuntimeMetadata;
 import org.apache.pinot.materializedview.metadata.MaterializedViewRuntimeMetadataUtils;
@@ -562,19 +564,45 @@ public class MaterializedViewTaskExecutor extends BaseTaskExecutor {
 
   /// Computes the current source-table [PartitionFingerprint] for `[windowStartMs, windowEndMs)`
   /// from live ZK segment metadata.  Shared by the APPEND / OVERWRITE commit-time fingerprint
-  /// validation and the DELETE commit-time emptiness re-check.  Requires
-  /// [MaterializedViewTask#SOURCE_TABLE_NAME_KEY] in the task config (the scheduler sets it for
-  /// every task mode); fails loud if absent so a malformed / pre-upgrade task cannot silently
-  /// skip the validation.
-  private PartitionFingerprint computeSourceWindowFingerprint(Map<String, String> configs, String tableName,
+  /// validation and the DELETE commit-time emptiness re-check.  The source table normally comes
+  /// from [MaterializedViewTask#SOURCE_TABLE_NAME_KEY] in the task config; when the key is absent
+  /// (a DELETE task dispatched by a pre-upgrade controller that did not yet carry it), the
+  /// executor falls back to the authoritative source-table reference in
+  /// [MaterializedViewDefinitionMetadata] so a mixed-version rollout cannot strand legacy DELETE
+  /// tasks in a fail-retry loop.  Fails loud only when neither source is available.
+  @VisibleForTesting
+  PartitionFingerprint computeSourceWindowFingerprint(Map<String, String> configs, String tableName,
       long windowStartMs, long windowEndMs) {
     String sourceTableName = configs.get(MaterializedViewTask.SOURCE_TABLE_NAME_KEY);
-    Preconditions.checkState(sourceTableName != null && !sourceTableName.isEmpty(),
-        "Missing source table name for MV task table %s window [%s, %s)", tableName, windowStartMs, windowEndMs);
+    if (sourceTableName == null || sourceTableName.isEmpty()) {
+      sourceTableName = resolveSourceTableNameFromDefinition(tableName, windowStartMs, windowEndMs);
+    }
     String sourceTableWithType = resolveSourceTableNameWithType(sourceTableName);
     return MaterializedViewTaskUtils.computeWindowFingerprint(
         ZKMetadataProvider.getSegmentsZKMetadata(MINION_CONTEXT.getHelixPropertyStore(), sourceTableWithType),
         windowStartMs, windowEndMs);
+  }
+
+  /// Backward-compatible fallback for task configs missing
+  /// [MaterializedViewTask#SOURCE_TABLE_NAME_KEY]: reads the source table from the MV's
+  /// definition znode, which the scheduler's cold-start path creates before dispatching any
+  /// task and which carries the same source-table reference the task config would.
+  /// Time-windowed MVs (the only shape in V1) have exactly one base table; fail loud on any
+  /// other shape rather than guessing.
+  private String resolveSourceTableNameFromDefinition(String tableName, long windowStartMs, long windowEndMs) {
+    MaterializedViewDefinitionMetadata definition =
+        MaterializedViewDefinitionMetadataUtils.fetch(MINION_CONTEXT.getHelixPropertyStore(), tableName);
+    Preconditions.checkState(definition != null,
+        "Missing source table name for MV task table %s window [%s, %s) and no definition znode "
+            + "to fall back to", tableName, windowStartMs, windowEndMs);
+    List<String> baseTables = definition.getBaseTables();
+    Preconditions.checkState(baseTables != null && baseTables.size() == 1,
+        "Missing source table name for MV task table %s window [%s, %s); definition fallback "
+            + "requires exactly one base table, got: %s", tableName, windowStartMs, windowEndMs, baseTables);
+    LOGGER.info("MV task config for table: {} window [{}, {}) carries no sourceTableName "
+            + "(pre-upgrade controller?); falling back to definition base table: {}",
+        tableName, windowStartMs, windowEndMs, baseTables.get(0));
+    return baseTables.get(0);
   }
 
   /// Returns `true` when a DELETE task must abort because the source window is no longer empty
@@ -601,20 +629,11 @@ public class MaterializedViewTaskExecutor extends BaseTaskExecutor {
   }
 
   private String resolveSourceTableNameWithType(String sourceTableName) {
-    TableType tableType = TableNameBuilder.getTableTypeFromTableName(sourceTableName);
-    if (tableType != null) {
-      return sourceTableName;
-    }
-    String rawSourceTableName = TableNameBuilder.extractRawTableName(sourceTableName);
-    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(rawSourceTableName);
-    if (ZKMetadataProvider.getTableConfig(MINION_CONTEXT.getHelixPropertyStore(), offlineTableName) != null) {
-      return offlineTableName;
-    }
-    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(rawSourceTableName);
-    Preconditions.checkState(
-        ZKMetadataProvider.getTableConfig(MINION_CONTEXT.getHelixPropertyStore(), realtimeTableName) != null,
-        "Source table config not found for: %s", sourceTableName);
-    return realtimeTableName;
+    String resolved = MaterializedViewTaskUtils.resolveTableNameWithType(
+        tableName -> ZKMetadataProvider.getTableConfig(MINION_CONTEXT.getHelixPropertyStore(), tableName),
+        sourceTableName);
+    Preconditions.checkState(resolved != null, "Source table config not found for: %s", sourceTableName);
+    return resolved;
   }
 
   @Override

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/materializedview/MaterializedViewTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/materializedview/MaterializedViewTaskExecutor.java
@@ -20,22 +20,16 @@ package org.apache.pinot.plugin.minion.tasks.materializedview;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.hash.Hasher;
-import com.google.common.hash.Hashing;
 import java.io.File;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ThreadLocalRandom;
 import org.apache.commons.io.FileUtils;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.NameValuePair;
@@ -44,10 +38,8 @@ import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.builder.HelixConfigScopeBuilder;
 import org.apache.helix.store.HelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
-import org.apache.helix.zookeeper.zkclient.exception.ZkException;
 import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
-import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifier;
 import org.apache.pinot.common.restlet.resources.StartReplaceSegmentsRequest;
 import org.apache.pinot.common.utils.DataSchema;
@@ -56,6 +48,7 @@ import org.apache.pinot.common.utils.TarCompressionUtils;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.materializedview.executor.MaterializedViewQueryExecutor;
+import org.apache.pinot.materializedview.metadata.MaterializedViewPartitionManager;
 import org.apache.pinot.materializedview.metadata.MaterializedViewRuntimeMetadata;
 import org.apache.pinot.materializedview.metadata.MaterializedViewRuntimeMetadataUtils;
 import org.apache.pinot.materializedview.metadata.PartitionFingerprint;
@@ -138,18 +131,33 @@ public class MaterializedViewTaskExecutor extends BaseTaskExecutor {
             "Overwrite target partition %d should exist and be STALE for table %s",
             windowStartMs, tableName);
       } else if (MaterializedViewTask.TASK_MODE_DELETE.equals(taskMode)) {
-        // DELETE is now an executor-internal cleanup triggered when an OVERWRITE finds the
-        // source data has been retention-deleted (empty result + zero source segments).  The
-        // partition must exist and be STALE; the executor will remove it from the map and
-        // drop the corresponding MV segments.
+        // DELETE is an executor-internal cleanup triggered when the scheduler finds the source
+        // data for a STALE partition has been retention-deleted (zero overlapping segments).
+        // The partition must exist and be STALE; the executor drops the corresponding MV
+        // segments and rewrites the entry to `VALID + PartitionFingerprint.EMPTY` so the
+        // partition stays "tracked but empty" instead of disappearing from the map.  Keeping
+        // the entry around removes `absent` as a runtime state, so a later backfill into the
+        // same window flips VALID → STALE → OVERWRITE through the normal path; if we removed
+        // the entry, the consistency manager (which only flips existing VALID entries) would
+        // not re-mark it and the backfill would not propagate.  The VALID-empty write is itself
+        // guarded by a commit-time emptiness re-check (see executeDeleteTask / clearValid): if a
+        // backfill landed between dispatch and commit, the bucket is left STALE for OVERWRITE.
         PartitionInfo partitionInfo = runtime.getPartitions().get(windowStartMs);
         Preconditions.checkState(partitionInfo != null && partitionInfo.getState() == PartitionState.STALE,
             "Delete target partition %d should exist and be STALE for table %s",
             windowStartMs, tableName);
       }
     } else {
-      LOGGER.warn("MaterializedViewRuntimeMetadata for table: {} not found; will be initialized in postProcess",
-          tableName);
+      // No runtime znode: the scheduler's cold-start path (which creates the runtime metadata
+      // before dispatching any task) has not run, or the znode was deleted (e.g. DROP MV).  All
+      // commit-time ops (appendValid / refreshValid / clearValid) REQUIRE an existing runtime
+      // znode and would throw at postProcess — but only AFTER executeTask has run the query and
+      // committed segment lineage, leaving MV segments active yet untracked by the partition-state
+      // engine.  Fail fast here, before any side effects, so Helix retries cleanly once the runtime
+      // exists (or surfaces a real missing-runtime fault to the operator).
+      throw new IllegalStateException("MaterializedViewRuntimeMetadata for table: " + tableName
+          + " not found; the scheduler must initialize the runtime znode before tasks run. "
+          + "Failing fast before query execution and segment-lineage mutation.");
     }
   }
 
@@ -173,7 +181,9 @@ public class MaterializedViewTaskExecutor extends BaseTaskExecutor {
     String taskMode = configs.getOrDefault(MaterializedViewTask.TASK_MODE_KEY,
         MaterializedViewTask.TASK_MODE_APPEND);
 
-    // DELETE mode: skip query execution, only remove existing MV segments
+    // DELETE mode: skip query execution; remove existing MV segments and rewrite the runtime
+    // PartitionInfo to VALID-empty (see executeDeleteTask / postProcess), unless a commit-time
+    // re-check finds the source window was backfilled — in which case the bucket is left STALE.
     if (MaterializedViewTask.TASK_MODE_DELETE.equals(taskMode)) {
       return executeDeleteTask(pinotTaskConfig, eventObserver, tableName, windowStartMs, windowEndMs);
     }
@@ -392,14 +402,42 @@ public class MaterializedViewTaskExecutor extends BaseTaskExecutor {
   }
 
   /// Handles DELETE mode: removes all existing MV segments for the given time window
-  /// via segment lineage replace (segmentsFrom=[old segments], segmentsTo=[]).
-  /// No query is executed and no new segments are created.
+  /// via segment lineage replace (segmentsFrom=[old segments], segmentsTo=[]).  No query
+  /// is executed and no new MV segments are created; the runtime PartitionInfo is rewritten
+  /// to `VALID + PartitionFingerprint.EMPTY` by [#postProcess], so the partition stays
+  /// tracked-but-empty rather than disappearing.
+  ///
+  /// A commit-time emptiness re-check guards both the segment delete (here) and the VALID-empty
+  /// write ([#postProcess] / [MaterializedViewPartitionManager#clearValid]): if the source window
+  /// was backfilled after the scheduler dispatched DELETE, this method aborts without mutating MV
+  /// segments or partition state, leaving the bucket STALE so the next scheduling cycle
+  /// re-materializes it via OVERWRITE.
   private SegmentConversionResult executeDeleteTask(PinotTaskConfig pinotTaskConfig,
       MinionEventObserver eventObserver, String tableName, long windowStartMs, long windowEndMs)
       throws Exception {
     Map<String, String> configs = pinotTaskConfig.getConfigs();
     String uploadURL = configs.get(MinionConstants.UPLOAD_URL_KEY);
     AuthProvider authProvider = resolveAuthProvider(configs);
+
+    // Commit-time backfill guard: the scheduler dispatched DELETE because the source window had
+    // zero overlapping segments, but a backfill may have landed since.  If the source is no
+    // longer empty, abort before touching MV segments or partition state — leaving the bucket
+    // STALE so the next scheduling cycle re-materializes it via OVERWRITE.  Skipping the
+    // segment-replace delete here also avoids a transient empty-results window: the existing
+    // (stale) MV segments keep serving until OVERWRITE replaces them — the normal STALE contract —
+    // instead of the bucket briefly going empty.  postProcess() re-checks the same condition right
+    // before the VALID-empty write (see clearValid) to close the narrow window where a backfill
+    // lands during the delete below.
+    PartitionFingerprint sourceFingerprint =
+        computeSourceWindowFingerprint(configs, tableName, windowStartMs, windowEndMs);
+    if (shouldAbortDeleteForBackfill(sourceFingerprint)) {
+      LOGGER.warn("DELETE aborted for MV table: {}, window: [{}, {}): source backfilled with {} "
+              + "overlapping segment(s) after dispatch. Leaving partition STALE for OVERWRITE.",
+          tableName, windowStartMs, windowEndMs, sourceFingerprint.getSegmentCount());
+      return new SegmentConversionResult.Builder()
+          .setTableNameWithType(tableName)
+          .build();
+    }
 
     LOGGER.info("DELETE task for table: {}, window: [{}, {}). Removing MV segments.",
         tableName, windowStartMs, windowEndMs);
@@ -449,22 +487,45 @@ public class MaterializedViewTaskExecutor extends BaseTaskExecutor {
     long windowStartMs = Long.parseLong(configs.get(MaterializedViewTask.WINDOW_START_MS_KEY));
     long windowEndMs = Long.parseLong(configs.get(MaterializedViewTask.WINDOW_END_MS_KEY));
 
-    updateMaterializedViewRuntime(configs, tableName, taskMode, windowStartMs, windowEndMs);
-  }
+    MaterializedViewPartitionManager partitionManager = new MaterializedViewPartitionManager(
+        MINION_CONTEXT.getHelixPropertyStore(),
+        MaterializedViewTaskExecutor::readMinionClusterConfig);
 
-  /// Updates [MaterializedViewRuntimeMetadata] in a single CAS write, combining:
-  ///
-  ///   - partitions: set VALID with new fingerprint (APPEND/OVERWRITE) or remove (DELETE)
-  ///   - watermarkMs: advance on APPEND only (drives both scheduler dispatch and the
-  ///       broker's SPLIT_REWRITE boundary)
-  ///
-  // Compile-time default for the CAS retry budget when racing to update MaterializedViewRuntimeMetadata.
-  // Up to maxTasksPerBatch executors can contend per batch completion; each retry re-fetches the
-  // latest version with jittered backoff (Thread.sleep below). 128 is well above any realistic
-  // maxTasksPerBatch and stays low enough that genuinely pathological contention still surfaces as
-  // a task failure (caught by Helix and retried at the task level). Overridable per cluster via
-  // `MaterializedViewTask.CLUSTER_CONFIG_KEY_MAX_RUNTIME_UPDATE_ATTEMPTS` (no minion restart).
-  private static final int DEFAULT_MAX_RUNTIME_UPDATE_ATTEMPTS = 128;
+    if (MaterializedViewTask.TASK_MODE_DELETE.equals(taskMode)) {
+      // DELETE writes `VALID + PartitionFingerprint.EMPTY` rather than removing the entry, but
+      // only after a commit-time re-check that the source window is still empty.  The scheduler
+      // dispatched DELETE because the source had zero overlapping segments; a backfill may have
+      // landed since.  The supplier recomputes the source fingerprint from live ZK metadata and
+      // is invoked inside clearValid's CAS loop, so the source is re-read on every attempt
+      // immediately before the write; clearValid leaves the bucket STALE (so the next scheduling
+      // cycle re-materializes it via OVERWRITE) when the source is no longer empty — see
+      // `MaterializedViewPartitionManager#clearValid`.
+      partitionManager.clearValid(tableName, windowStartMs,
+          () -> computeSourceWindowFingerprint(configs, tableName, windowStartMs, windowEndMs));
+      return;
+    }
+
+    // Compute and validate the source fingerprint ONCE before mutating the runtime znode.
+    // Both operations are deterministic given the source-side ZK state: if validation fails
+    // on this attempt (real source drift), the manager's CAS retry cannot succeed and would
+    // mask the actionable error.  The CAS retry that lives inside the manager exists only
+    // to absorb concurrent ConsistencyManager STALE markings on the runtime znode itself.
+    PartitionFingerprint newFingerprint = getTaskFingerprint(configs, tableName, windowStartMs);
+    validateSourceFingerprintAtCommit(configs, tableName, windowStartMs, windowEndMs, newFingerprint);
+
+    if (MaterializedViewTask.TASK_MODE_APPEND.equals(taskMode)) {
+      // APPEND advances watermarkMs through the manager's contiguous-VALID walk over the
+      // resulting map.  Watermark advancement is bundled with the bucket transition because
+      // both flow from the same map snapshot; splitting them would create a transient window
+      // where the bucket is VALID but the watermark hasn't caught up.
+      partitionManager.appendValid(tableName, windowStartMs, windowEndMs, newFingerprint);
+    } else if (MaterializedViewTask.TASK_MODE_OVERWRITE.equals(taskMode)) {
+      partitionManager.refreshValid(tableName, windowStartMs, newFingerprint);
+    } else {
+      throw new IllegalStateException(
+          "Unknown MV task mode '" + taskMode + "' for table: " + tableName);
+    }
+  }
 
   /// Reads a single Helix CLUSTER-scope config value via the minion's `HelixManager`. Returns
   /// `null` when the key is unset or the Helix manager has not yet been initialized. Used by
@@ -488,109 +549,6 @@ public class MaterializedViewTaskExecutor extends BaseTaskExecutor {
     }
   }
 
-  private void updateMaterializedViewRuntime(Map<String, String> configs, String tableName,
-      String taskMode, long windowStartMs, long windowEndMs) {
-    HelixPropertyStore<ZNRecord> propertyStore = MINION_CONTEXT.getHelixPropertyStore();
-    int maxRuntimeUpdateAttempts = MaterializedViewTaskUtils.readPositiveIntClusterConfigOrDefault(
-        MaterializedViewTaskExecutor::readMinionClusterConfig,
-        MaterializedViewTask.CLUSTER_CONFIG_KEY_MAX_RUNTIME_UPDATE_ATTEMPTS,
-        DEFAULT_MAX_RUNTIME_UPDATE_ATTEMPTS);
-
-    // Compute the new fingerprint and validate against the source ONCE, outside the CAS loop.
-    // Both operations are deterministic given the source-side ZK state: if validation fails on
-    // attempt 1 (real source drift), retrying cannot succeed and would mask the actionable error
-    // behind a generic "Failed after N attempts" message. The CAS retry only exists to absorb
-    // concurrent ConsistencyManager STALE markings on the runtime znode itself.
-    PartitionFingerprint newFingerprint = null;
-    if (!MaterializedViewTask.TASK_MODE_DELETE.equals(taskMode)) {
-      newFingerprint = getTaskFingerprint(configs, tableName, windowStartMs);
-      validateSourceFingerprintAtCommit(configs, tableName, windowStartMs, windowEndMs, newFingerprint);
-    }
-
-    ZkException lastCasException = null;
-    for (int attempt = 0; attempt < maxRuntimeUpdateAttempts; attempt++) {
-      if (attempt > 0) {
-        // Jittered backoff to avoid thundering herd against ZK when batched APPEND tasks
-        // race for the same MaterializedViewRuntimeMetadata znode (see maxRuntimeUpdateAttempts comment).
-        try {
-          Thread.sleep(50L + ThreadLocalRandom.current().nextInt(150));
-        } catch (InterruptedException ie) {
-          Thread.currentThread().interrupt();
-          throw new RuntimeException("Interrupted while retrying MV runtime update for table: " + tableName, ie);
-        }
-        LOGGER.warn("Retrying MV runtime update for table: {} (attempt {}/{})", tableName, attempt + 1,
-            maxRuntimeUpdateAttempts);
-      }
-      try {
-        // Re-fetch with version on every attempt to pick up concurrent ConsistencyManager
-        // updates (e.g. STALE markings) that may have arrived since the previous attempt.
-        Stat freshStat = new Stat();
-        MaterializedViewRuntimeMetadata existing =
-            MaterializedViewRuntimeMetadataUtils.fetchWithVersion(propertyStore, tableName, freshStat);
-        int writeVersion = (existing != null) ? freshStat.getVersion() : -1;
-
-        Map<Long, PartitionInfo> mergedInfos;
-        long existingWatermarkMs;
-
-        if (existing != null) {
-          mergedInfos = new HashMap<>(existing.getPartitions());
-          existingWatermarkMs = existing.getWatermarkMs();
-        } else {
-          mergedInfos = new HashMap<>();
-          existingWatermarkMs = 0L;
-        }
-
-        long newWatermarkMs;
-
-        if (MaterializedViewTask.TASK_MODE_DELETE.equals(taskMode)) {
-          mergedInfos.remove(windowStartMs);
-          newWatermarkMs = existingWatermarkMs;
-          LOGGER.info("DELETE mode: removed partition {} from MV runtime for table: {}", windowStartMs, tableName);
-        } else {
-          long nowMs = System.currentTimeMillis();
-          PartitionInfo completedInfo = new PartitionInfo(PartitionState.VALID, newFingerprint, nowMs);
-          mergedInfos.put(windowStartMs, completedInfo);
-          LOGGER.info("Set partition {} to VALID (lastRefreshTime={}) for table: {}", windowStartMs, nowMs, tableName);
-
-          if (MaterializedViewTask.TASK_MODE_APPEND.equals(taskMode)) {
-            // Advance to the highest contiguous VALID block starting from the existing watermark.
-            // Concurrent batch tasks may complete out of order; only advancing to windowEndMs would
-            // leave gaps when an earlier window hasn't finished yet.  bucketMs is derived from the
-            // task's window length (one bucket per APPEND task by construction).
-            long bucketMs = windowEndMs - windowStartMs;
-            Preconditions.checkState(bucketMs > 0,
-                "Invalid window: windowEndMs (%s) <= windowStartMs (%s) for table %s",
-                windowEndMs, windowStartMs, tableName);
-            newWatermarkMs = MaterializedViewTaskUtils.computeContiguousUpperMs(existingWatermarkMs, mergedInfos,
-                bucketMs);
-            LOGGER.info("APPEND mode: advancing watermarkMs from {} to {} for table: {}",
-                existingWatermarkMs, newWatermarkMs, tableName);
-          } else {
-            newWatermarkMs = existingWatermarkMs;
-            LOGGER.info("OVERWRITE mode: keeping watermarkMs at {} for table: {}", newWatermarkMs, tableName);
-          }
-        }
-
-        MaterializedViewRuntimeMetadata updated = new MaterializedViewRuntimeMetadata(
-            tableName, newWatermarkMs, mergedInfos);
-        MaterializedViewRuntimeMetadataUtils.persist(propertyStore, updated, writeVersion);
-
-        LOGGER.info("Updated MV runtime for table: {} (partitions={}, watermarkMs={})",
-            tableName, mergedInfos.size(), newWatermarkMs);
-        return;
-      } catch (ZkException e) {
-        // Only ZK CAS conflicts and transient ZK errors are retried. Non-ZK failures (e.g.
-        // IllegalStateException from invariant checks, NullPointerException) are programming
-        // bugs that retrying cannot resolve — let them propagate so the operator sees the real cause.
-        lastCasException = e;
-        LOGGER.warn("ZK conflict while updating MV runtime for table: {} on attempt {}", tableName, attempt + 1, e);
-      }
-    }
-    throw new RuntimeException(
-        "Failed to update MV runtime for table: " + tableName + " after " + maxRuntimeUpdateAttempts + " attempts",
-        lastCasException);
-  }
-
   private PartitionFingerprint getTaskFingerprint(Map<String, String> configs, String tableName, long windowStartMs) {
     String fingerprintStr = configs.get(MaterializedViewTask.PARTITION_FINGERPRINTS_KEY);
     Preconditions.checkState(fingerprintStr != null && !fingerprintStr.isEmpty(),
@@ -602,19 +560,44 @@ public class MaterializedViewTaskExecutor extends BaseTaskExecutor {
     return fingerprint;
   }
 
-  private void validateSourceFingerprintAtCommit(Map<String, String> configs, String tableName, long windowStartMs,
-      long windowEndMs, PartitionFingerprint taskFingerprint) {
+  /// Computes the current source-table [PartitionFingerprint] for `[windowStartMs, windowEndMs)`
+  /// from live ZK segment metadata.  Shared by the APPEND / OVERWRITE commit-time fingerprint
+  /// validation and the DELETE commit-time emptiness re-check.  Requires
+  /// [MaterializedViewTask#SOURCE_TABLE_NAME_KEY] in the task config (the scheduler sets it for
+  /// every task mode); fails loud if absent so a malformed / pre-upgrade task cannot silently
+  /// skip the validation.
+  private PartitionFingerprint computeSourceWindowFingerprint(Map<String, String> configs, String tableName,
+      long windowStartMs, long windowEndMs) {
     String sourceTableName = configs.get(MaterializedViewTask.SOURCE_TABLE_NAME_KEY);
     Preconditions.checkState(sourceTableName != null && !sourceTableName.isEmpty(),
         "Missing source table name for MV task table %s window [%s, %s)", tableName, windowStartMs, windowEndMs);
     String sourceTableWithType = resolveSourceTableNameWithType(sourceTableName);
-    PartitionFingerprint currentFingerprint = computeWindowFingerprint(
+    return MaterializedViewTaskUtils.computeWindowFingerprint(
         ZKMetadataProvider.getSegmentsZKMetadata(MINION_CONTEXT.getHelixPropertyStore(), sourceTableWithType),
         windowStartMs, windowEndMs);
+  }
+
+  /// Returns `true` when a DELETE task must abort because the source window is no longer empty
+  /// (a backfill landed after the scheduler dispatched DELETE on a then-empty source).  A
+  /// non-zero `segmentCount` is the canonical "non-empty source window" criterion — identical to
+  /// the scheduler's DELETE dispatch test (MaterializedViewTaskScheduler computes the same
+  /// fingerprint and dispatches DELETE only when `segmentCount == 0`) and equivalent to comparing
+  /// against [PartitionFingerprint#EMPTY], since `computeWindowFingerprint` maps an empty overlap
+  /// to `EMPTY`.  Aborting leaves the bucket STALE for OVERWRITE rather than deleting MV segments
+  /// or writing VALID-empty over live source data.
+  @VisibleForTesting
+  static boolean shouldAbortDeleteForBackfill(PartitionFingerprint sourceWindowFingerprint) {
+    return sourceWindowFingerprint.getSegmentCount() != 0;
+  }
+
+  private void validateSourceFingerprintAtCommit(Map<String, String> configs, String tableName, long windowStartMs,
+      long windowEndMs, PartitionFingerprint taskFingerprint) {
+    PartitionFingerprint currentFingerprint =
+        computeSourceWindowFingerprint(configs, tableName, windowStartMs, windowEndMs);
     Preconditions.checkState(taskFingerprint.equals(currentFingerprint),
-        "Source table %s changed while refreshing MV table %s window [%s, %s): taskFingerprint=%s, "
+        "Source table changed while refreshing MV table %s window [%s, %s): taskFingerprint=%s, "
             + "currentFingerprint=%s. Leaving MV partition stale for retry.",
-        sourceTableWithType, tableName, windowStartMs, windowEndMs, taskFingerprint, currentFingerprint);
+        tableName, windowStartMs, windowEndMs, taskFingerprint, currentFingerprint);
   }
 
   private String resolveSourceTableNameWithType(String sourceTableName) {
@@ -632,50 +615,6 @@ public class MaterializedViewTaskExecutor extends BaseTaskExecutor {
         ZKMetadataProvider.getTableConfig(MINION_CONTEXT.getHelixPropertyStore(), realtimeTableName) != null,
         "Source table config not found for: %s", sourceTableName);
     return realtimeTableName;
-  }
-
-  /// Computes a [PartitionFingerprint] for the segments that overlap [windowStartMs, windowEndMs).
-  ///
-  /// The fingerprint is `Hashing.farmHashFingerprint64` over the sorted concatenation of
-  /// `<segmentName>\0<crc>\n` lines. Sorting by segment name makes the hash insensitive to
-  /// listing order. FarmHash64 is non-cryptographic but collision-resistant for non-adversarial
-  /// inputs; in particular it avoids the cancellation pathology of XOR-CRC (where swapping
-  /// one segment for another with the same XOR contribution produces an identical fingerprint).
-  @VisibleForTesting
-  static PartitionFingerprint computeWindowFingerprint(List<SegmentZKMetadata> allSegments,
-      long windowStartMs, long windowEndMs) {
-    List<SegmentZKMetadata> overlapping = new ArrayList<>();
-    for (SegmentZKMetadata seg : allSegments) {
-      long segStartMs = seg.getStartTimeMs();
-      long segEndMs = seg.getEndTimeMs();
-      if (segStartMs < windowEndMs && segEndMs >= windowStartMs) {
-        overlapping.add(seg);
-      }
-    }
-    overlapping.sort(Comparator.comparing(SegmentZKMetadata::getSegmentName));
-
-    Hasher hasher = Hashing.farmHashFingerprint64().newHasher();
-    for (SegmentZKMetadata seg : overlapping) {
-      hasher.putString(seg.getSegmentName(), StandardCharsets.UTF_8);
-      hasher.putByte((byte) 0);
-      hasher.putLong(seg.getCrc());
-      hasher.putByte((byte) '\n');
-    }
-    return new PartitionFingerprint(overlapping.size(), hasher.hash().asLong());
-  }
-
-  /// Returns the highest contiguous VALID upper boundary starting from `fromMs`.
-  ///
-  /// When batch APPEND tasks run concurrently, windows may complete out of order.
-  /// Advancing `watermarkMs` only to the just-completed `windowEndMs` would
-  /// regress coverage if an earlier window hasn't finished yet. This method scans
-  /// `partitions` for an unbroken chain of VALID windows beginning at `fromMs`
-  /// and returns the end of the last VALID window in that chain.
-  ///
-  /// Bounded by `partitions.size()` iterations to defend against pathological maps.
-  @VisibleForTesting
-  static long computeContiguousUpperMs(long fromMs, Map<Long, PartitionInfo> partitions, long bucketMs) {
-    return MaterializedViewTaskUtils.computeContiguousUpperMs(fromMs, partitions, bucketMs);
   }
 
   @Override

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/materializedview/MaterializedViewTaskExecutorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/materializedview/MaterializedViewTaskExecutorTest.java
@@ -24,23 +24,31 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.apache.helix.AccessOption;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.utils.config.TableConfigSerDeUtils;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
+import org.apache.pinot.materializedview.metadata.MaterializedViewDefinitionMetadata;
 import org.apache.pinot.materializedview.metadata.PartitionFingerprint;
 import org.apache.pinot.materializedview.metadata.PartitionInfo;
 import org.apache.pinot.materializedview.metadata.PartitionState;
 import org.apache.pinot.materializedview.scheduler.MaterializedViewTaskUtils;
 import org.apache.pinot.minion.MinionContext;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.utils.CommonConstants.MaterializedViewTask;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.zookeeper.data.Stat;
 import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -344,6 +352,63 @@ public class MaterializedViewTaskExecutorTest {
     } catch (IllegalStateException e) {
       assertTrue(e.getMessage().contains(TABLE),
           "message should name the table; got: " + e.getMessage());
+    } finally {
+      MinionContext.getInstance().setHelixPropertyStore(previous);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  //  Legacy task-config fallback: a DELETE task dispatched by a pre-upgrade controller carries
+  //  no SOURCE_TABLE_NAME_KEY; the executor must resolve the source from the definition znode
+  //  instead of failing the task for the whole mixed-version rollout.
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void testComputeSourceWindowFingerprintFallsBackToDefinitionForLegacyTask()
+      throws Exception {
+    ZkHelixPropertyStore<ZNRecord> store = mock(ZkHelixPropertyStore.class);
+    String mvTable = TABLE + "_OFFLINE";
+    String sourceTable = "orders";
+    String definitionPath =
+        ZKMetadataProvider.constructPropertyStorePathForMaterializedViewDefinition(mvTable);
+    MaterializedViewDefinitionMetadata definition = new MaterializedViewDefinitionMetadata(
+        mvTable, List.of(sourceTable), "SELECT count(*) FROM orders", Map.of(), null);
+    when(store.get(eq(definitionPath), any(Stat.class), eq(AccessOption.PERSISTENT)))
+        .thenReturn(definition.toZNRecord());
+    // The shared OFFLINE-first probe resolves the raw base table to orders_OFFLINE; its segment
+    // list stays unmocked (null children), so the recomputed window fingerprint is EMPTY.
+    String tableConfigPath =
+        ZKMetadataProvider.constructPropertyStorePathForResourceConfig(sourceTable + "_OFFLINE");
+    TableConfig sourceConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(sourceTable).build();
+    when(store.get(eq(tableConfigPath), any(), eq(AccessOption.PERSISTENT)))
+        .thenReturn(TableConfigSerDeUtils.toZNRecord(sourceConfig));
+
+    ZkHelixPropertyStore<ZNRecord> previous = MinionContext.getInstance().getHelixPropertyStore();
+    try {
+      MinionContext.getInstance().setHelixPropertyStore(store);
+      // Legacy task config: no SOURCE_TABLE_NAME_KEY.
+      PartitionFingerprint fingerprint = new MaterializedViewTaskExecutor(null, null, null)
+          .computeSourceWindowFingerprint(new HashMap<>(), mvTable, WINDOW_START, WINDOW_END);
+      assertEquals(fingerprint, PartitionFingerprint.EMPTY,
+          "legacy task must resolve the source via the definition znode and recompute the fingerprint");
+    } finally {
+      MinionContext.getInstance().setHelixPropertyStore(previous);
+    }
+  }
+
+  @Test
+  public void testComputeSourceWindowFingerprintFailsLoudWithoutConfigOrDefinition() {
+    // Neither the task config nor ZK carries a source-table reference: fail loud (never guess).
+    ZkHelixPropertyStore<ZNRecord> store = mock(ZkHelixPropertyStore.class);
+    ZkHelixPropertyStore<ZNRecord> previous = MinionContext.getInstance().getHelixPropertyStore();
+    try {
+      MinionContext.getInstance().setHelixPropertyStore(store);
+      new MaterializedViewTaskExecutor(null, null, null)
+          .computeSourceWindowFingerprint(new HashMap<>(), TABLE + "_OFFLINE", WINDOW_START, WINDOW_END);
+      fail("Expected IllegalStateException when no source table reference is available");
+    } catch (IllegalStateException e) {
+      assertTrue(e.getMessage().contains("definition"),
+          "message should point at the missing definition fallback; got: " + e.getMessage());
     } finally {
       MinionContext.getInstance().setHelixPropertyStore(previous);
     }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/materializedview/MaterializedViewTaskExecutorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/materializedview/MaterializedViewTaskExecutorTest.java
@@ -24,14 +24,27 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.core.common.MinionConstants;
+import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.materializedview.metadata.PartitionFingerprint;
 import org.apache.pinot.materializedview.metadata.PartitionInfo;
 import org.apache.pinot.materializedview.metadata.PartitionState;
+import org.apache.pinot.materializedview.scheduler.MaterializedViewTaskUtils;
+import org.apache.pinot.minion.MinionContext;
 import org.apache.pinot.spi.utils.CommonConstants.MaterializedViewTask;
+import org.apache.zookeeper.data.Stat;
 import org.testng.annotations.Test;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -180,7 +193,7 @@ public class MaterializedViewTaskExecutorTest {
 
   @Test
   public void testContiguousEmptyMap() {
-    long result = MaterializedViewTaskExecutor.computeContiguousUpperMs(
+    long result = MaterializedViewTaskUtils.computeContiguousUpperMs(
         WINDOW_START, new LinkedHashMap<>(), BUCKET_MS);
     assertEquals(result, WINDOW_START, "Empty map: cursor unchanged");
   }
@@ -189,7 +202,7 @@ public class MaterializedViewTaskExecutorTest {
   public void testContiguousSingleValid() {
     Map<Long, PartitionInfo> partitions = new LinkedHashMap<>();
     partitions.put(WINDOW_START, validInfo());
-    long result = MaterializedViewTaskExecutor.computeContiguousUpperMs(
+    long result = MaterializedViewTaskUtils.computeContiguousUpperMs(
         WINDOW_START, partitions, BUCKET_MS);
     assertEquals(result, WINDOW_START + BUCKET_MS, "Single VALID: advances by one bucket");
   }
@@ -200,7 +213,7 @@ public class MaterializedViewTaskExecutorTest {
     partitions.put(WINDOW_START, validInfo());
     partitions.put(WINDOW_START + BUCKET_MS, validInfo());
     partitions.put(WINDOW_START + 2 * BUCKET_MS, validInfo());
-    long result = MaterializedViewTaskExecutor.computeContiguousUpperMs(
+    long result = MaterializedViewTaskUtils.computeContiguousUpperMs(
         WINDOW_START, partitions, BUCKET_MS);
     assertEquals(result, WINDOW_START + 3 * BUCKET_MS, "Three VALIDs: advances three buckets");
   }
@@ -211,7 +224,7 @@ public class MaterializedViewTaskExecutorTest {
     Map<Long, PartitionInfo> partitions = new LinkedHashMap<>();
     partitions.put(WINDOW_START, validInfo());
     partitions.put(WINDOW_START + 2 * BUCKET_MS, validInfo());
-    long result = MaterializedViewTaskExecutor.computeContiguousUpperMs(
+    long result = MaterializedViewTaskUtils.computeContiguousUpperMs(
         WINDOW_START, partitions, BUCKET_MS);
     assertEquals(result, WINDOW_START + BUCKET_MS, "Gap after first VALID: stops there");
   }
@@ -221,7 +234,7 @@ public class MaterializedViewTaskExecutorTest {
     Map<Long, PartitionInfo> partitions = new LinkedHashMap<>();
     partitions.put(WINDOW_START, validInfo());
     partitions.put(WINDOW_START + BUCKET_MS, staleInfo());
-    long result = MaterializedViewTaskExecutor.computeContiguousUpperMs(
+    long result = MaterializedViewTaskUtils.computeContiguousUpperMs(
         WINDOW_START, partitions, BUCKET_MS);
     assertEquals(result, WINDOW_START + BUCKET_MS, "STALE breaks the chain like a gap");
   }
@@ -231,7 +244,7 @@ public class MaterializedViewTaskExecutorTest {
     // Cursor starts at a missing key — return immediately without advancing.
     Map<Long, PartitionInfo> partitions = new LinkedHashMap<>();
     partitions.put(WINDOW_START + BUCKET_MS, validInfo());
-    long result = MaterializedViewTaskExecutor.computeContiguousUpperMs(
+    long result = MaterializedViewTaskUtils.computeContiguousUpperMs(
         WINDOW_START, partitions, BUCKET_MS);
     assertEquals(result, WINDOW_START, "fromMs not present: no advance");
   }
@@ -242,9 +255,9 @@ public class MaterializedViewTaskExecutorTest {
     SegmentZKMetadata second = segment("segB", WINDOW_START, WINDOW_START + BUCKET_MS, 1234L);
 
     PartitionFingerprint firstFingerprint =
-        MaterializedViewTaskExecutor.computeWindowFingerprint(List.of(first), WINDOW_START, WINDOW_START + BUCKET_MS);
+        MaterializedViewTaskUtils.computeWindowFingerprint(List.of(first), WINDOW_START, WINDOW_START + BUCKET_MS);
     PartitionFingerprint secondFingerprint =
-        MaterializedViewTaskExecutor.computeWindowFingerprint(List.of(second), WINDOW_START, WINDOW_START + BUCKET_MS);
+        MaterializedViewTaskUtils.computeWindowFingerprint(List.of(second), WINDOW_START, WINDOW_START + BUCKET_MS);
 
     assertTrue(!firstFingerprint.equals(secondFingerprint),
         "Fingerprint must change when segment identity changes even if CRC is reused");
@@ -255,21 +268,93 @@ public class MaterializedViewTaskExecutorTest {
     SegmentZKMetadata overlapping = segment("overlap", WINDOW_START, WINDOW_START + BUCKET_MS, 10L);
     SegmentZKMetadata outside = segment("outside", WINDOW_START + 2 * BUCKET_MS, WINDOW_START + 3 * BUCKET_MS, 20L);
 
-    PartitionFingerprint fingerprint = MaterializedViewTaskExecutor.computeWindowFingerprint(
+    PartitionFingerprint fingerprint = MaterializedViewTaskUtils.computeWindowFingerprint(
         List.of(overlapping, outside), WINDOW_START, WINDOW_START + BUCKET_MS);
 
     assertEquals(fingerprint.getSegmentCount(), 1);
     assertEquals(fingerprint,
-        MaterializedViewTaskExecutor.computeWindowFingerprint(List.of(overlapping), WINDOW_START,
+        MaterializedViewTaskUtils.computeWindowFingerprint(List.of(overlapping), WINDOW_START,
             WINDOW_START + BUCKET_MS));
   }
 
+  @Test
+  public void testWindowFingerprintForEmptyOverlapMatchesEmptyConstant() {
+    // The DELETE branch (MaterializedViewPartitionManager#clearValid) persists
+    // PartitionFingerprint.EMPTY when source data is gone.  Subsequent STALE recomputation calls
+    // computeWindowFingerprint
+    // against the (still-empty) source and compares the result against the stored fingerprint —
+    // those two values MUST be byte-equal so the equality check behaves correctly.  This test
+    // pins the contract: empty overlap → EMPTY constant.
+    PartitionFingerprint emptyOverlap = MaterializedViewTaskUtils.computeWindowFingerprint(
+        List.of(), WINDOW_START, WINDOW_START + BUCKET_MS);
+    assertEquals(emptyOverlap, PartitionFingerprint.EMPTY);
+
+    SegmentZKMetadata noOverlap = segment(
+        "outside", WINDOW_START + 2 * BUCKET_MS, WINDOW_START + 3 * BUCKET_MS, 99L);
+    PartitionFingerprint filteredEmpty = MaterializedViewTaskUtils.computeWindowFingerprint(
+        List.of(noOverlap), WINDOW_START, WINDOW_START + BUCKET_MS);
+    assertEquals(filteredEmpty, PartitionFingerprint.EMPTY);
+  }
+
+  // -----------------------------------------------------------------------
+  //  shouldAbortDeleteForBackfill — the executor's DELETE early-abort criterion: abort (leave
+  //  the bucket STALE for OVERWRITE) when the source window is no longer empty at commit time.
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void testShouldAbortDeleteWhenSourceBackfilled() {
+    // A backfill landed after the scheduler dispatched DELETE on an empty source: non-zero
+    // segmentCount => abort the DELETE so the bucket stays STALE and OVERWRITE re-materializes it.
+    assertTrue(MaterializedViewTaskExecutor.shouldAbortDeleteForBackfill(new PartitionFingerprint(2, 0xABCDL)));
+    assertTrue(MaterializedViewTaskExecutor.shouldAbortDeleteForBackfill(new PartitionFingerprint(1, 0L)));
+  }
+
+  @Test
+  public void testShouldNotAbortDeleteWhenSourceStillEmpty() {
+    // Source still empty at commit (the expected DELETE case): proceed to drop MV segments and
+    // write VALID-empty.  EMPTY and any other zero-segment-count fingerprint must not abort.
+    assertFalse(MaterializedViewTaskExecutor.shouldAbortDeleteForBackfill(PartitionFingerprint.EMPTY));
+    assertFalse(MaterializedViewTaskExecutor.shouldAbortDeleteForBackfill(
+        MaterializedViewTaskUtils.computeWindowFingerprint(List.of(), WINDOW_START, WINDOW_END)));
+  }
+
+  // -----------------------------------------------------------------------
+  //  preProcess fail-fast: a missing runtime znode must abort BEFORE any query / segment-lineage
+  //  side effects, rather than warn-and-proceed (which would strand active-but-untracked segments).
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void testPreProcessFailsFastWhenRuntimeMissing() {
+    @SuppressWarnings("unchecked")
+    ZkHelixPropertyStore<ZNRecord> store = mock(ZkHelixPropertyStore.class);
+    // Runtime znode absent => fetchWithVersion returns null.
+    when(store.get(anyString(), any(Stat.class), anyInt())).thenReturn(null);
+
+    ZkHelixPropertyStore<ZNRecord> previous = MinionContext.getInstance().getHelixPropertyStore();
+    try {
+      MinionContext.getInstance().setHelixPropertyStore(store);
+      Map<String, String> configs = new HashMap<>();
+      configs.put(MinionConstants.TABLE_NAME_KEY, TABLE);
+      configs.put(MaterializedViewTask.TASK_MODE_KEY, MaterializedViewTask.TASK_MODE_APPEND);
+      configs.put(MaterializedViewTask.WINDOW_START_MS_KEY, String.valueOf(WINDOW_START));
+      PinotTaskConfig taskConfig = new PinotTaskConfig(MaterializedViewTask.TASK_TYPE, configs);
+
+      new MaterializedViewTaskExecutor(null, null, null).preProcess(taskConfig);
+      fail("Expected IllegalStateException when the MV runtime znode is missing");
+    } catch (IllegalStateException e) {
+      assertTrue(e.getMessage().contains(TABLE),
+          "message should name the table; got: " + e.getMessage());
+    } finally {
+      MinionContext.getInstance().setHelixPropertyStore(previous);
+    }
+  }
+
   private static PartitionInfo validInfo() {
-    return new PartitionInfo(PartitionState.VALID, new PartitionFingerprint(0, 0), 0L);
+    return PartitionInfo.forTesting(PartitionState.VALID, new PartitionFingerprint(0, 0), 0L);
   }
 
   private static PartitionInfo staleInfo() {
-    return new PartitionInfo(PartitionState.STALE, new PartitionFingerprint(0, 0), 0L);
+    return PartitionInfo.forTesting(PartitionState.STALE, new PartitionFingerprint(0, 0), 0L);
   }
 
   private static SegmentZKMetadata segment(String name, long startMs, long endMs, long crc) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1913,6 +1913,14 @@ public class CommonConstants {
     /// Cluster-config key. Overrides the consistency manager's debounce window (ms).
     public static final String CLUSTER_CONFIG_KEY_CONSISTENCY_DEBOUNCE_MS =
         "pinot.materialized.view.consistency.debounce.ms";
+
+    /// Cluster-config key. Overrides the interval (ms) of the consistency manager's periodic
+    /// VALID-empty re-evaluation sweep.  The sweep re-marks in-coverage `VALID-empty` buckets
+    /// STALE when their source window has regained segments, so a DELETE-backfill that raced the
+    /// commit guard self-heals without waiting for a fresh base-table change.  Non-positive values
+    /// fall back to the compile-time default.
+    public static final String CLUSTER_CONFIG_KEY_CONSISTENCY_EMPTY_SWEEP_INTERVAL_MS =
+        "pinot.materialized.view.consistency.empty.sweep.interval.ms";
   }
 
   public static class ControllerJob {


### PR DESCRIPTION
## Description

Hardens the incremental materialized-view (MV) partition-state engine: four correctness bugfixes, consolidation of all runtime-znode mutations behind a single CAS owner, fingerprint de-duplication, and a periodic self-heal sweep.

### Bugfixes
1. **Watermark vs wall clock.** `watermarkMs` was advanced toward `now - bufferMs` even when the base table had no newer segments, so the broker freshness check (`now - watermarkMs <= stalenessThresholdMs`) could report stale MV data as fresh. The APPEND cutoff is now tightened to the end of the source data: `resolveAppendCutoffMs = min(now - bufferMs, maxSourceEndTimeMs + 1)`. The `+ 1` converts the **inclusive** segment `endTimeMs` convention to the loop's **exclusive** `windowEndMs` gate, so a segment that exactly covers a bucket (e.g. a day-aligned batch segment ending at `windowEndMs - 1`) still admits it — a complete static dataset materializes its final bucket. Note the semantic shift for batch-loaded sources: a bucket is now admitted by *event time* (source data must cover it), not wall clock alone; if source ingestion stalls, `watermarkMs` intentionally stops at the data tail and the staleness threshold eventually reflects real data lag.
2. **Backfill after retention DELETE.** A retention `DELETE` used to remove the runtime partition entry; the consistency manager skips absent buckets, so a later backfill never re-triggered `OVERWRITE` (silent data loss). `DELETE` now leaves `VALID + PartitionFingerprint.EMPTY`, so a backfill flows through the standard `VALID → STALE → OVERWRITE` cycle. The `VALID-empty` write is guarded by a **commit-time source-emptiness re-check**: `clearValid` re-reads the source inside its CAS loop and leaves the bucket `STALE` for `OVERWRITE` if a backfill landed between dispatch and commit; the executor also early-aborts the segment delete in that case to avoid a transient empty-results window.
3. **Above-watermark STALE marks were dropped.** The consistency manager capped the affected range at `watermarkMs`, but out-of-order batch APPEND completion (and mid-batch failures) leave VALID buckets *above* the watermark — a base-table change landing in such a bucket was silently never marked STALE, and once the gap below filled and the watermark advanced over it, the bucket served stale data with nothing left to re-mark it. The cap is removed; candidate enumeration iterates existing partition keys, so an unbounded range cannot blow up the candidate list.
4. **Lost-ack CAS replays no longer fail tasks.** ZK's client-side `retryUntilConnected` can commit a write and then replay it after a connection drop; the replay fails with a version conflict and the CAS loop re-runs the mutator against the manager's *own committed write*. The strict preconditions in `appendValid` / `refreshValid` / `clearValid` now treat "bucket already VALID with the intended fingerprint" as an idempotent no-op instead of hard-failing a minion task that actually succeeded. Genuinely conflicting states (different fingerprint, wrong state) still fail loud.

### Refactor
- **Single CAS owner.** `MaterializedViewPartitionManager` replaces the three ad-hoc retry loops (executor, scheduler, consistency manager) with one version-checked CAS engine — one retry budget, one backoff, one set of preconditions. `PartitionInfo`'s constructor is package-private so production code outside the metadata package cannot bypass the manager (tests use `PartitionInfo.forTesting`). The CAS engine retries transient read-side ZK failures, not just the write.
- **Shared fingerprint.** `MaterializedViewTaskUtils#computeWindowFingerprint` is the single source of truth for the window-fingerprint algorithm (scheduler, executor, consistency); it returns `PartitionFingerprint.EMPTY` for an empty overlap.
- **Shared table-type resolution.** `MaterializedViewTaskUtils#resolveTableNameWithType` is the single OFFLINE-first probe used by the scheduler, the minion executor, and the consistency manager (previously triplicated).

### Self-heal sweep
- A low-frequency periodic sweep in `MaterializedViewConsistencyManager` re-evaluates in-coverage `VALID-empty` buckets against the current source and re-marks them `STALE` when their source window has regained segments — closing the narrow commit-vs-backfill residual without waiting for a fresh base-table event (cluster-tunable; default 5 min).

### Other hardening
- The minion executor's `preProcess` fails fast when the runtime znode is missing, before query execution / segment-lineage commit, instead of stranding active-but-untracked MV segments. (The scheduler's cold-start path creates the runtime znode via `createIfAbsent` before any task is dispatched, so this only fires on genuine faults, e.g. a deleted znode.)

### Rolling-upgrade notes (unreleased feature; window is master-to-master only)
- **New minion + old controller:** legacy DELETE tasks carry no `sourceTableName` config key; the executor falls back to the source-table reference in the MV definition znode, so those tasks complete instead of fail-looping.
- **Old minion + new controller:** DELETE executes with the old remove-the-entry semantics for that bucket, briefly re-opening the absent-bucket backfill hole until the minion upgrades; a subsequent backfill into that window is only routed correctly after re-materialization.

### Partition-state model

The per-partition state machine (`VACANT` / `VALID` / `STALE`), the operations (`APPEND` / `OVERWRITE` / `DELETE` / `MARK_STALE`), and how the consistency manager keeps the partition map in sync with base-table changes are documented here:

> [MV partition state engine — design notes (Google Doc)](https://docs.google.com/document/d/19XxPKpXPnfwVdIVuN_Mh0AoHSwB8Aiy3XHXAkSwoHNk/edit?usp=sharing)

Note: the consistency manager marks **existing** `VALID` buckets `STALE` on a base-table change; it does **not** synthesize entries for absent (`VACANT`) buckets — absence means the MV does not cover that range, so the broker routes those queries to the base table. The DELETE-then-backfill case is handled by the `VALID-empty` shape described above, not by `VACANT → STALE` synthesis.

### Known limitation — broker routing (separate follow-up PR)

V1 broker routing splits a query only on `watermarkMs` (MV side = `time < watermarkMs`, base side = `time >= watermarkMs`) and does **not** consult per-bucket state. So a bucket below the watermark that is `STALE` / `VALID-empty` / absent can serve stale or missing rows until `OVERWRITE` re-materializes it. This is documented in `MaterializedViewQueryRewriteEngine` and `pinot-materialized-view/DESIGN.md` §1.1 (added in this PR); the fix — per-bucket routing that consults the already-cached partition map — is a focused broker follow-up PR.

### Tests

- `MaterializedViewPartitionManagerTest` — every public op, plus CAS retry / version-conflict / read-side-retry / budget-exhaustion paths, precondition violations, lost-ack idempotent-replay no-ops for all three strict ops, and a fail-fast classification test (mutator precondition violations propagate on the first attempt without burning the retry budget).
- `MaterializedViewConsistencyManagerTest` — the `VALID-empty` sweep decision core, end-to-end per-MV re-mark, per-MV failure isolation, and above-watermark VALID buckets being marked STALE.
- `MaterializedViewTaskSchedulerTest` — the `DELETE` task carries the source table so the executor can re-check emptiness at commit; `resolveAppendCutoffMs` inclusive/exclusive conversion, fallbacks, and overflow clamping.
- `MaterializedViewTaskExecutorTest` — saturation gate, `DELETE` abort criterion, `preProcess` fail-fast on a missing runtime znode, and the legacy-task definition-znode fallback (including fail-loud when neither source reference exists).
- `PartitionFingerprintTest` — the `EMPTY` constant + encode/decode round-trips.

### Suggested labels

`bugfix`, `refactor`
