### PR TITLE
OPEN_STRUCT storage layer — columnar two-tier dense/sparse index (PR 2b/4)

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -261,6 +261,8 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   TRANSFORMATION_ERROR_COUNT("rows", false),
   DROPPED_RECORD_COUNT("rows", false),
   CORRUPTED_RECORD_COUNT("rows", false),
+  OPEN_STRUCT_TYPE_COERCION_FAILURES("values", false,
+      "Number of OPEN_STRUCT values dropped because the value could not be coerced to the key's inferred type"),
   // Workload related metrics
   WORKLOAD_BUDGET_EXCEEDED("workloadBudgetExceeded", true, "Number of times workload budget exceeded"),
   WORKLOAD_QUERIES("queries", false),

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/OpenStructIngestionCommitOfflineTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/OpenStructIngestionCommitOfflineTest.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests.custom;
+
+import org.testng.annotations.Test;
+
+
+/// OFFLINE end-to-end ingestion test for an OPEN_STRUCT column. Builds segments from Avro via the
+/// standard offline pipeline (row-major RecordReader path), uploads them, then reuses the inherited
+/// index_map + dense/sparse validation against the loaded OFFLINE segment.
+@Test(suiteName = "CustomClusterIntegrationTest")
+public class OpenStructIngestionCommitOfflineTest extends OpenStructIngestionCommitTestBase {
+
+  private static final String DEFAULT_TABLE_NAME = "OpenStructIngestionCommitOfflineTest";
+
+  @Override
+  public String getTableName() {
+    return DEFAULT_TABLE_NAME;
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/OpenStructIngestionCommitRealtimeTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/OpenStructIngestionCommitRealtimeTest.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests.custom;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.util.TestUtils;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/// REALTIME end-to-end ingestion + commit test for an OPEN_STRUCT column. Consumes the data from
+/// Kafka, triggers forceCommit so the consuming segment seals to a committed ONLINE segment, then
+/// reuses the inherited index_map + dense/sparse validation against the committed REALTIME segment.
+@Test(suiteName = "CustomClusterIntegrationTest")
+public class OpenStructIngestionCommitRealtimeTest extends OpenStructIngestionCommitTestBase {
+
+  private static final String DEFAULT_TABLE_NAME = "OpenStructIngestionCommitRealtimeTest";
+  private static final long FORCE_COMMIT_TIMEOUT_MS = 120_000L;
+
+  @Override
+  public String getTableName() {
+    return DEFAULT_TABLE_NAME;
+  }
+
+  @Override
+  public boolean isRealtimeTable() {
+    return true;
+  }
+
+  @Override
+  protected int getRealtimeSegmentFlushSize() {
+    // <= NUM_DOCS so a segment seals during consumption; forceCommit then seals any remainder.
+    return 500;
+  }
+
+  @Override
+  protected TableType getSegmentTableType() {
+    return TableType.REALTIME;
+  }
+
+  @BeforeClass
+  @Override
+  public void setUp()
+      throws Exception {
+    super.setUp();
+    forceCommitAndWait();
+  }
+
+  private void forceCommitAndWait()
+      throws Exception {
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(getTableName());
+    String response = getOrCreateAdminClient().getTableClient().forceCommit(realtimeTableName);
+    String jobId = JsonUtils.stringToJsonNode(response).get("forceCommitJobId").asText();
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        return isForceCommitJobCompleted(jobId);
+      } catch (Exception e) {
+        return false;
+      }
+    }, 1000L, FORCE_COMMIT_TIMEOUT_MS, "Force commit did not complete for " + realtimeTableName);
+  }
+
+  private boolean isForceCommitJobCompleted(String jobId)
+      throws Exception {
+    String status = getOrCreateAdminClient().getTableClient().getForceCommitJobStatus(jobId);
+    JsonNode node = JsonUtils.stringToJsonNode(status);
+    JsonNode pending = node.get(CommonConstants.ControllerJob.CONSUMING_SEGMENTS_YET_TO_BE_COMMITTED_LIST);
+    return pending != null && pending.size() == 0;
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/OpenStructIngestionCommitTestBase.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/OpenStructIngestionCommitTestBase.java
@@ -216,15 +216,18 @@ public abstract class OpenStructIngestionCommitTestBase extends CustomDataQueryC
     // index_map per key.
     try (SegmentDirectory dir = new SegmentLocalFSDirectory(segmentDir, ReadMode.mmap);
         SegmentDirectory.Reader reader = dir.createReader()) {
-      // views: dictionary + forward (inverted index propagation for per-key configs is a follow-up)
+      // views: dictionary + forward + inverted
       assertTrue(reader.hasIndexFor(views, StandardIndexes.dictionary()), "views must have dictionary");
       assertTrue(reader.hasIndexFor(views, StandardIndexes.forward()), "views must have forward");
-      // cpu: dictionary + forward
+      assertTrue(reader.hasIndexFor(views, StandardIndexes.inverted()), "views must have inverted");
+      // cpu: dictionary + forward, NO inverted
       assertTrue(reader.hasIndexFor(cpu, StandardIndexes.dictionary()), "cpu must have dictionary");
       assertTrue(reader.hasIndexFor(cpu, StandardIndexes.forward()), "cpu must have forward");
+      assertFalse(reader.hasIndexFor(cpu, StandardIndexes.inverted()), "cpu must NOT have inverted");
       // host: raw forward only
       assertFalse(reader.hasIndexFor(host, StandardIndexes.dictionary()), "host (raw) must NOT have dictionary");
       assertTrue(reader.hasIndexFor(host, StandardIndexes.forward()), "host must have forward");
+      assertFalse(reader.hasIndexFor(host, StandardIndexes.inverted()), "host must NOT have inverted");
       // sparse: raw forward, no dict, no inverted
       assertTrue(reader.hasIndexFor(sparse, StandardIndexes.forward()), "sparse column must have forward");
       assertFalse(reader.hasIndexFor(sparse, StandardIndexes.dictionary()), "sparse column must NOT have dictionary");

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/OpenStructIngestionCommitTestBase.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/OpenStructIngestionCommitTestBase.java
@@ -1,0 +1,284 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests.custom;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.File;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.pinot.segment.local.segment.store.SegmentLocalFSDirectory;
+import org.apache.pinot.segment.spi.ColumnMetadata;
+import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
+import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.segment.spi.store.SegmentDirectoryPaths;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.OpenStructIndexConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.OpenStructNaming;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.CommonsConfigurationUtils;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+/// Shared base for the OPEN_STRUCT end-to-end ingestion + commit tests.
+///
+/// Builds a table with one OPEN_STRUCT column `metrics` carrying a per-key index matrix
+/// (inverted; dictionary-only; raw) plus two sparse keys, ingests ~1000 rows, and validates the
+/// committed segment's materialized child columns, their `index_map`, and the dense/sparse split.
+///
+/// This class is abstract and is not run on its own; the concrete table-type variant (currently
+/// {@link OpenStructIngestionCommitRealtimeTest}) supplies the table name and commit trigger and
+/// reuses the inherited validation. An OFFLINE variant is added in a follow-up change once the
+/// offline OPEN_STRUCT build path is fixed.
+public abstract class OpenStructIngestionCommitTestBase extends CustomDataQueryClusterIntegrationTest {
+
+  protected static final String METRICS = "metrics";
+  // Matches OpenStructIndexType.INDEX_DISPLAY_NAME (kept as a literal to avoid a creator-side import).
+  private static final String OPEN_STRUCT_INDEX_NAME = "open_struct";
+  protected static final int NUM_DOCS = 1000;
+
+  @Override
+  protected long getCountStarResult() {
+    // createAvroFiles writes NUM_DOCS rows round-robin across the Avro files, so the total doc count
+    // is NUM_DOCS regardless of how many segments/partitions the data lands in.
+    return NUM_DOCS;
+  }
+
+  @Override
+  public Schema createSchema() {
+    // Declare child field specs so string Avro values coerce deterministically to typed columns.
+    Map<String, FieldSpec> children = new HashMap<>();
+    children.put("views", new DimensionFieldSpec("views", FieldSpec.DataType.LONG, true));
+    children.put("cpu", new DimensionFieldSpec("cpu", FieldSpec.DataType.DOUBLE, true));
+    children.put("host", new DimensionFieldSpec("host", FieldSpec.DataType.STRING, true));
+    children.put("region", new DimensionFieldSpec("region", FieldSpec.DataType.STRING, true));
+    children.put("latencyMs", new DimensionFieldSpec("latencyMs", FieldSpec.DataType.LONG, true));
+    ComplexFieldSpec metricsSpec = new ComplexFieldSpec(METRICS, FieldSpec.DataType.OPEN_STRUCT, true, children);
+    return new Schema.SchemaBuilder().setSchemaName(getTableName())
+        .addField(metricsSpec)
+        .addDateTimeField(TIMESTAMP_FIELD_NAME, FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS", "1:DAYS")
+        .build();
+  }
+
+  /// Per-key index matrix on the OPEN_STRUCT column:
+  ///   views  -> inverted (=> dictionary + forward + inverted)
+  ///   cpu    -> DICTIONARY encoding (=> dictionary + forward, no inverted)
+  ///   host   -> RAW encoding (=> raw forward only, no dict, no inverted)
+  /// region + latencyMs have no per-key config and are not in denseKeys, so the maxDenseKeys=3
+  /// budget (filled by views/cpu/host) forces them into the sparse column.
+  @Override
+  protected List<FieldConfig> getFieldConfigs() {
+    FieldConfig viewsCfg = new FieldConfig.Builder("views")
+        .withIndexes(JsonUtils.objectToJsonNode(Map.of("inverted", Map.of())))
+        .build();
+    FieldConfig cpuCfg = new FieldConfig.Builder("cpu")
+        .withEncodingType(FieldConfig.EncodingType.DICTIONARY)
+        .build();
+    FieldConfig hostCfg = new FieldConfig.Builder("host")
+        .withEncodingType(FieldConfig.EncodingType.RAW)
+        .build();
+    // First arg is `disabled` — false => enabled.
+    OpenStructIndexConfig osConfig = new OpenStructIndexConfig(false, null, 3,
+        Set.of("views", "cpu", "host"), 0.5, List.of(viewsCfg, cpuCfg, hostCfg));
+    ObjectNode indexes = JsonUtils.newObjectNode();
+    indexes.set(OPEN_STRUCT_INDEX_NAME, JsonUtils.objectToJsonNode(osConfig));
+    FieldConfig metricsCfg = new FieldConfig.Builder(METRICS).withIndexes(indexes).build();
+    return List.of(metricsCfg);
+  }
+
+  @Override
+  public TableConfig createOfflineTableConfig() {
+    return new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(getTableName())
+        .setTimeColumnName(getTimeColumnName())
+        .setFieldConfigList(getFieldConfigs())
+        .build();
+  }
+
+  @Override
+  public List<File> createAvroFiles()
+      throws Exception {
+    org.apache.avro.Schema avroSchema = org.apache.avro.Schema.createRecord("OpenStructRecord", null, null, false);
+    org.apache.avro.Schema mapSchema =
+        org.apache.avro.Schema.createMap(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING));
+    List<org.apache.avro.Schema.Field> fields = Arrays.asList(
+        new org.apache.avro.Schema.Field(METRICS, mapSchema, null, null),
+        new org.apache.avro.Schema.Field(TIMESTAMP_FIELD_NAME,
+            org.apache.avro.Schema.create(org.apache.avro.Schema.Type.LONG), null, null));
+    avroSchema.setFields(fields);
+
+    long tsBase = System.currentTimeMillis();
+    try (AvroFilesAndWriters avroFilesAndWriters = createAvroFilesAndWriters(avroSchema)) {
+      List<DataFileWriter<GenericData.Record>> writers = avroFilesAndWriters.getWriters();
+      for (int i = 0; i < NUM_DOCS; i++) {
+        Map<String, String> metrics = new HashMap<>();
+        metrics.put("views", String.valueOf(i));            // LONG, high cardinality (dict + inverted)
+        metrics.put("cpu", String.valueOf(i * 0.5));         // DOUBLE (dict)
+        metrics.put("host", "host-" + (i % 5));              // STRING, small set (raw forward)
+        metrics.put("region", "region-" + (i % 4));          // sparse
+        metrics.put("latencyMs", String.valueOf(i % 100));   // sparse
+        GenericData.Record record = new GenericData.Record(avroSchema);
+        record.put(METRICS, metrics);
+        record.put(TIMESTAMP_FIELD_NAME, tsBase + i);
+        writers.get(i % getNumAvroFiles()).append(record);
+      }
+      return avroFilesAndWriters.getAvroFiles();
+    }
+  }
+
+  /// OFFLINE by default; the realtime variant overrides to REALTIME so the locate helper scans the
+  /// correct table-name-with-type under the server data dirs.
+  protected TableType getSegmentTableType() {
+    return TableType.OFFLINE;
+  }
+
+  @Test
+  public void testCountStar()
+      throws Exception {
+    JsonNode response = postQuery("SELECT COUNT(*) FROM " + getTableName());
+    assertEquals(response.get("exceptions").size(), 0);
+    assertEquals(response.get("resultTable").get("rows").get(0).get(0).asLong(), NUM_DOCS);
+  }
+
+  /// White-box validation: open the committed on-disk segment and assert the materialized child
+  /// columns, their per-key index_map, and the dense/sparse split.
+  @Test
+  public void testCommittedSegmentIndexMap()
+      throws Exception {
+    SegmentDirAndMeta found = locateCommittedSegment();
+    assertNotNull(found,
+        "No committed segment containing OPEN_STRUCT child columns found under any server data dir");
+    File segmentDir = found._dir;
+    TreeMap<String, ColumnMetadata> cols = found._meta.getColumnMetadataMap();
+
+    String views = OpenStructNaming.materializedColumnName(METRICS, "views");
+    String cpu = OpenStructNaming.materializedColumnName(METRICS, "cpu");
+    String host = OpenStructNaming.materializedColumnName(METRICS, "host");
+    String region = OpenStructNaming.materializedColumnName(METRICS, "region");
+    String latencyMs = OpenStructNaming.materializedColumnName(METRICS, "latencyMs");
+    String sparse = OpenStructNaming.sparseColumnName(METRICS);
+
+    // Parent + dense child columns present with correct data types.
+    assertTrue(cols.containsKey(METRICS), "parent OPEN_STRUCT column missing");
+    assertEquals(cols.get(METRICS).getDataType(), FieldSpec.DataType.OPEN_STRUCT);
+    assertTrue(cols.containsKey(views), "dense child metrics$views missing");
+    assertTrue(cols.containsKey(cpu), "dense child metrics$cpu missing");
+    assertTrue(cols.containsKey(host), "dense child metrics$host missing");
+    assertEquals(cols.get(views).getDataType(), FieldSpec.DataType.LONG);
+    assertEquals(cols.get(cpu).getDataType(), FieldSpec.DataType.DOUBLE);
+    assertEquals(cols.get(host).getDataType(), FieldSpec.DataType.STRING);
+
+    // Dense/sparse split: region + latencyMs are NOT materialized; the single sparse column exists.
+    assertFalse(cols.containsKey(region), "metrics$region must NOT be materialized (forced sparse)");
+    assertFalse(cols.containsKey(latencyMs), "metrics$latencyMs must NOT be materialized (forced sparse)");
+    assertTrue(cols.containsKey(sparse), "sparse JSON column metrics$__sparse__ missing");
+    assertEquals(cols.get(sparse).getDataType(), FieldSpec.DataType.STRING);
+
+    // index_map per key.
+    try (SegmentDirectory dir = new SegmentLocalFSDirectory(segmentDir, ReadMode.mmap);
+        SegmentDirectory.Reader reader = dir.createReader()) {
+      // views: dictionary + forward (inverted index propagation for per-key configs is a follow-up)
+      assertTrue(reader.hasIndexFor(views, StandardIndexes.dictionary()), "views must have dictionary");
+      assertTrue(reader.hasIndexFor(views, StandardIndexes.forward()), "views must have forward");
+      // cpu: dictionary + forward
+      assertTrue(reader.hasIndexFor(cpu, StandardIndexes.dictionary()), "cpu must have dictionary");
+      assertTrue(reader.hasIndexFor(cpu, StandardIndexes.forward()), "cpu must have forward");
+      // host: raw forward only
+      assertFalse(reader.hasIndexFor(host, StandardIndexes.dictionary()), "host (raw) must NOT have dictionary");
+      assertTrue(reader.hasIndexFor(host, StandardIndexes.forward()), "host must have forward");
+      // sparse: raw forward, no dict, no inverted
+      assertTrue(reader.hasIndexFor(sparse, StandardIndexes.forward()), "sparse column must have forward");
+      assertFalse(reader.hasIndexFor(sparse, StandardIndexes.dictionary()), "sparse column must NOT have dictionary");
+    }
+
+    // Parent/child relationship + sparse flag from raw metadata.properties.
+    File metadataFile = SegmentDirectoryPaths.findMetadataFile(segmentDir);
+    PropertiesConfiguration props = CommonsConfigurationUtils.fromFile(metadataFile);
+    assertEquals(props.getString(V1Constants.MetadataKeys.Column.getKeyFor(
+        METRICS, V1Constants.MetadataKeys.Column.HAS_SPARSE_COLUMN)), "true");
+    assertEquals(props.getString(V1Constants.MetadataKeys.Column.getKeyFor(
+        views, V1Constants.MetadataKeys.Column.PARENT_COLUMN)), METRICS);
+    assertEquals(props.getString(V1Constants.MetadataKeys.Column.getKeyFor(
+        sparse, V1Constants.MetadataKeys.Column.PARENT_COLUMN)), METRICS);
+  }
+
+  /// Scans both server data dirs (the custom suite starts 2 servers) for a committed immutable
+  /// segment of this table that contains the OPEN_STRUCT dense child columns. Consuming/partial
+  /// segment dirs that fail to parse, or that lack the child columns, are skipped.
+  private SegmentDirAndMeta locateCommittedSegment() {
+    String tableNameWithType = getSegmentTableType() == TableType.REALTIME
+        ? TableNameBuilder.REALTIME.tableNameWithType(getTableName())
+        : TableNameBuilder.OFFLINE.tableNameWithType(getTableName());
+    String viewsChild = OpenStructNaming.materializedColumnName(METRICS, "views");
+    for (int serverId = 0; serverId < 2; serverId++) {
+      File tableDir = new File(TEMP_SERVER_DIR + File.separator + "dataDir-" + serverId, tableNameWithType);
+      if (!tableDir.isDirectory()) {
+        continue;
+      }
+      File[] segmentDirs = tableDir.listFiles(File::isDirectory);
+      if (segmentDirs == null) {
+        continue;
+      }
+      for (File segmentDir : segmentDirs) {
+        try {
+          SegmentMetadataImpl meta = new SegmentMetadataImpl(segmentDir);
+          if (meta.getColumnMetadataMap().containsKey(viewsChild)) {
+            return new SegmentDirAndMeta(segmentDir, meta);
+          }
+        } catch (Exception ignore) {
+          // Not a fully-built immutable segment directory; skip.
+        }
+      }
+    }
+    return null;
+  }
+
+  private static final class SegmentDirAndMeta {
+    private final File _dir;
+    private final SegmentMetadataImpl _meta;
+
+    private SegmentDirAndMeta(File dir, SegmentMetadataImpl meta) {
+      _dir = dir;
+      _meta = meta;
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -24,6 +24,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -34,6 +36,7 @@ import org.apache.pinot.segment.local.indexsegment.IndexSegmentUtils;
 import org.apache.pinot.segment.local.segment.index.datasource.ImmutableDataSource;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.segment.index.map.ImmutableMapDataSource;
+import org.apache.pinot.segment.local.segment.index.openstruct.ImmutableOpenStructDataSource;
 import org.apache.pinot.segment.local.segment.index.readers.text.MultiColumnLuceneTextIndexReader;
 import org.apache.pinot.segment.local.segment.readers.PinotSegmentColumnReader;
 import org.apache.pinot.segment.local.segment.readers.PinotSegmentRecordReader;
@@ -49,6 +52,7 @@ import org.apache.pinot.segment.spi.index.IndexReader;
 import org.apache.pinot.segment.spi.index.IndexType;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.segment.spi.index.column.ColumnIndexContainer;
+import org.apache.pinot.segment.spi.index.metadata.ColumnMetadataImpl;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
@@ -58,7 +62,9 @@ import org.apache.pinot.segment.spi.index.reader.TextIndexReader;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.segment.spi.store.SegmentDirectoryPaths;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.OpenStructNaming;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
@@ -98,13 +104,44 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
     _dataSources =
         new Object2ObjectOpenHashMap<>(segmentMetadata.getColumnMetadataMap().size());
 
+    Map<String, Map<String, DataSource>> openStructDenseChildren = new HashMap<>();
+    Map<String, DataSource> openStructSparseChildren = new HashMap<>();
+    Set<String> openStructParents = new HashSet<>();
+
     for (Map.Entry<String, ColumnMetadata> entry : segmentMetadata.getColumnMetadataMap().entrySet()) {
       String colName = entry.getKey();
       ColumnMetadata columnMetadata = entry.getValue();
+
+      if (columnMetadata instanceof ColumnMetadataImpl && ((ColumnMetadataImpl) columnMetadata).isMaterializedChild()) {
+        String parent = ((ColumnMetadataImpl) columnMetadata).getParentColumn();
+        openStructParents.add(parent);
+        DataSource childDs = new ImmutableDataSource(columnMetadata, _indexContainerMap.get(colName));
+        if (OpenStructNaming.isSparseColumn(colName)) {
+          openStructSparseChildren.put(parent, childDs);
+        } else {
+          openStructDenseChildren.computeIfAbsent(parent, k -> new HashMap<>())
+              .put(OpenStructNaming.parseKey(colName), childDs);
+        }
+        continue;
+      }
+
       if (columnMetadata.getFieldSpec().getDataType() == FieldSpec.DataType.MAP) {
-        _dataSources.put(colName, new ImmutableMapDataSource(entry.getValue(), _indexContainerMap.get(colName)));
+        _dataSources.put(colName, new ImmutableMapDataSource(columnMetadata, _indexContainerMap.get(colName)));
       } else {
-        _dataSources.put(colName, new ImmutableDataSource(entry.getValue(), _indexContainerMap.get(colName)));
+        _dataSources.put(colName, new ImmutableDataSource(columnMetadata, _indexContainerMap.get(colName)));
+      }
+    }
+
+    if (!openStructParents.isEmpty()) {
+      Schema schema = segmentMetadata.getSchema();
+      for (String parent : openStructParents) {
+        FieldSpec fieldSpec = schema != null ? schema.getFieldSpecFor(parent) : null;
+        if (!(fieldSpec instanceof ComplexFieldSpec)) {
+          continue;
+        }
+        _dataSources.put(parent, new ImmutableOpenStructDataSource((ComplexFieldSpec) fieldSpec,
+            openStructDenseChildren.getOrDefault(parent, Map.of()),
+            openStructSparseChildren.get(parent), segmentMetadata.getTotalDocs()));
       }
     }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
@@ -48,6 +48,7 @@ import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderRegistry;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.segment.spi.store.SegmentDirectoryPaths;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.OpenStructNaming;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.slf4j.Logger;
@@ -213,6 +214,17 @@ public class ImmutableSegmentLoader {
     if (schema != null) {
       Set<String> columnsInMetadata = new HashSet<>(columnMetadataMap.keySet());
       columnsInMetadata.removeIf(schema::hasColumn);
+      // Materialized OPEN_STRUCT child columns (col$key, col$__sparse__) live in segment metadata
+      // but not in the user-facing schema. Keep them when the parent OPEN_STRUCT column is in the
+      // schema; they will be grouped under their parent at segment-impl post-load (Task 16).
+      columnsInMetadata.removeIf(col -> {
+        if (!OpenStructNaming.isMaterializedOpenStructColumn(col)) {
+          return false;
+        }
+        String parent = OpenStructNaming.parseParentColumn(col);
+        return schema.hasColumn(parent)
+            && schema.getFieldSpecFor(parent).getDataType() == FieldSpec.DataType.OPEN_STRUCT;
+      });
       if (!columnsInMetadata.isEmpty()) {
         LOGGER.info("Skip loading columns only exist in metadata but not in schema: {}", columnsInMetadata);
         for (String column : columnsInMetadata) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -66,6 +66,8 @@ import org.apache.pinot.segment.local.realtime.impl.nullvalue.MutableNullValueVe
 import org.apache.pinot.segment.local.segment.index.datasource.MutableDataSource;
 import org.apache.pinot.segment.local.segment.index.dictionary.DictionaryIndexType;
 import org.apache.pinot.segment.local.segment.index.map.MutableMapDataSource;
+import org.apache.pinot.segment.local.segment.index.openstruct.MutableOpenStructDataSource;
+import org.apache.pinot.segment.local.segment.index.openstruct.MutableOpenStructIndex;
 import org.apache.pinot.segment.local.segment.readers.PinotSegmentColumnReader;
 import org.apache.pinot.segment.local.segment.readers.PinotSegmentRecordReader;
 import org.apache.pinot.segment.local.segment.virtualcolumn.VirtualColumnContext;
@@ -106,6 +108,7 @@ import org.apache.pinot.segment.spi.partition.PartitionFunction;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.IndexConfig;
 import org.apache.pinot.spi.config.table.MultiColumnTextIndexConfig;
+import org.apache.pinot.spi.config.table.OpenStructIndexConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.config.table.ingestion.AggregationConfig;
@@ -299,7 +302,8 @@ public class MutableSegmentImpl implements MutableSegment {
 
     Set<IndexType> specialIndexes =
         Sets.newHashSet(StandardIndexes.dictionary(), // dictionary implements other contract
-            StandardIndexes.nullValueVector()); // null value vector implements other contract
+            StandardIndexes.nullValueVector(), // null value vector implements other contract
+            StandardIndexes.openStruct()); // open-struct is constructed out-of-band below
 
     // Initialize for each column
     boolean hasColumnWithReuseMutableTextIndex = false;
@@ -422,6 +426,15 @@ public class MutableSegmentImpl implements MutableSegment {
           } else {
             dictionary = new SameValueMutableDictionary(rawValueForTextIndex, dictionary);
           }
+        }
+      }
+
+      if (dataType == DataType.OPEN_STRUCT && fieldSpec instanceof ComplexFieldSpec) {
+        IndexConfig openStructConfig = indexConfigs.getConfig(StandardIndexes.openStruct());
+        if (openStructConfig instanceof OpenStructIndexConfig && openStructConfig.isEnabled()) {
+          MutableOpenStructIndex openStructIndex = new MutableOpenStructIndex(column, (ComplexFieldSpec) fieldSpec,
+              (OpenStructIndexConfig) openStructConfig, _memoryManager, _capacity);
+          mutableIndexes.put(StandardIndexes.openStruct(), openStructIndex);
         }
       }
 
@@ -566,7 +579,7 @@ public class MutableSegmentImpl implements MutableSegment {
    */
   private boolean isNoDictionaryColumn(FieldIndexConfigs indexConfigs, FieldSpec fieldSpec, String column) {
     DataType dataType = fieldSpec.getDataType();
-    if (dataType == DataType.MAP) {
+    if (dataType == DataType.MAP || dataType == DataType.OPEN_STRUCT) {
       return true;
     }
     if (indexConfigs == null) {
@@ -910,6 +923,17 @@ public class MutableSegmentImpl implements MutableSegment {
       if (fieldSpec.isSingleValueField()) {
         // Update numValues info
         indexContainer._valuesInfo.updateSVNumValues();
+
+        // Route OPEN_STRUCT values to the dedicated mutable index. OPEN_STRUCT has no forward
+        // index / dictionary / min-max, so the standard per-IndexType loop and the comparable
+        // tracking below would be no-ops at best and crash at worst (Map is not Comparable).
+        if (dataType == DataType.OPEN_STRUCT) {
+          MutableIndex openStructIndex = indexContainer._mutableIndexes.get(StandardIndexes.openStruct());
+          if (openStructIndex != null) {
+            openStructIndex.add(value, -1, docId);
+          }
+          continue;
+        }
 
         // Update indexes
         int dictId = indexContainer._dictId;
@@ -1278,6 +1302,20 @@ public class MutableSegmentImpl implements MutableSegment {
     if (_multiColumnTextIndex != null) {
       _multiColumnTextIndex.commit();
     }
+  }
+
+  /**
+   * Returns the per-column mutable OPEN_STRUCT index, or {@code null} if the column is not OPEN_STRUCT
+   * or the index has not been initialized.
+   */
+  @Nullable
+  public MutableOpenStructIndex getOpenStructIndex(String column) {
+    IndexContainer container = _indexContainerMap.get(column);
+    if (container == null) {
+      return null;
+    }
+    MutableIndex index = container._mutableIndexes.get(StandardIndexes.openStruct());
+    return index instanceof MutableOpenStructIndex ? (MutableOpenStructIndex) index : null;
   }
 
   @Override
@@ -1650,7 +1688,10 @@ public class MutableSegmentImpl implements MutableSegment {
         @Nullable Set<Integer> partitions, ValuesInfo valuesInfo, Map<IndexType, MutableIndex> mutableIndexes,
         @Nullable MutableDictionary dictionary, @Nullable MutableNullValueVector nullValueVector,
         @Nullable String sourceColumn, @Nullable ValueAggregator valueAggregator) {
-      Preconditions.checkArgument(mutableIndexes.containsKey(StandardIndexes.forward()), "Forward index is required");
+      Preconditions.checkArgument(
+          mutableIndexes.containsKey(StandardIndexes.forward())
+              || mutableIndexes.containsKey(StandardIndexes.openStruct()),
+          "Forward index or OPEN_STRUCT index is required");
       _fieldSpec = fieldSpec;
       _mutableIndexes = mutableIndexes;
       _dictionary = dictionary;
@@ -1663,6 +1704,11 @@ public class MutableSegmentImpl implements MutableSegment {
     }
 
     DataSource toDataSource() {
+      if (_fieldSpec.getDataType() == DataType.OPEN_STRUCT) {
+        MutableIndex idx = _mutableIndexes.get(StandardIndexes.openStruct());
+        return new MutableOpenStructDataSource((ComplexFieldSpec) _fieldSpec, (MutableOpenStructIndex) idx,
+            _numDocsIndexed);
+      }
       if (_fieldSpec.getDataType() == MAP) {
         return new MutableMapDataSource(_fieldSpec, _numDocsIndexed, _valuesInfo._numValues,
             _valuesInfo._maxNumValuesPerMVEntry, _dictionary == null ? -1 : _dictionary.length(), _partitionFunction,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/RealtimeSegmentStatsContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/RealtimeSegmentStatsContainer.java
@@ -26,6 +26,7 @@ import javax.annotation.Nullable;
 import org.apache.pinot.segment.local.segment.creator.impl.stats.EmptyColumnStatistics;
 import org.apache.pinot.segment.local.segment.creator.impl.stats.MapColumnPreIndexStatsCollector;
 import org.apache.pinot.segment.local.segment.index.map.MutableMapDataSource;
+import org.apache.pinot.segment.local.segment.index.openstruct.MutableOpenStructDataSource;
 import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.segment.spi.creator.ColumnStatistics;
 import org.apache.pinot.segment.spi.creator.SegmentPreIndexStatsContainer;
@@ -77,6 +78,13 @@ public class RealtimeSegmentStatsContainer implements SegmentPreIndexStatsContai
     // TODO: Add compaction support to MAP
     if (dataSource instanceof MutableMapDataSource) {
       return createMapColumnStatistics(dataSource, validDocIds, statsCollectorConfig);
+    }
+    // OPEN_STRUCT parent columns have no forward index of their own — per-key stats are recomputed
+    // by the splitter at offline-segment build time. Return EmptyColumnStatistics so the standard
+    // dispatch (which would call getForwardIndex / getDictionary) doesn't NPE.
+    if (dataSource instanceof MutableOpenStructDataSource) {
+      return new EmptyColumnStatistics(dataSourceMetadata.getFieldSpec(), dataSourceMetadata.getPartitionFunction(),
+          dataSourceMetadata.getPartitions());
     }
     if (validDocIds != null) {
       if (dataSource.getDictionary() != null) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/BaseSegmentCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/BaseSegmentCreator.java
@@ -68,6 +68,7 @@ import org.apache.pinot.segment.spi.index.IndexService;
 import org.apache.pinot.segment.spi.index.IndexType;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.segment.spi.index.TextIndexConfig;
+import org.apache.pinot.segment.spi.index.creator.ColumnarOpenStructIndexCreator;
 import org.apache.pinot.segment.spi.index.creator.ForwardIndexCreator;
 import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderContext;
 import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderRegistry;
@@ -587,6 +588,22 @@ public abstract class BaseSegmentCreator implements SegmentCreator {
           }
         }
         compressionMetadata.applyTo(properties, column);
+      }
+    }
+
+    // OPEN_STRUCT splitters produce per-key materialized child columns (col$key, col$__sparse__) that
+    // are not in _columnStatisticsMap. Merge their pre-built metadata into the segment properties so
+    // each child appears as its own column at load time.
+    for (ColumnIndexCreators columnIndexCreators : _colIndexes.values()) {
+      for (IndexCreator indexCreator : columnIndexCreators.getIndexCreators()) {
+        if (indexCreator instanceof ColumnarOpenStructIndexCreator) {
+          ColumnarOpenStructIndexCreator splitter = (ColumnarOpenStructIndexCreator) indexCreator;
+          for (Map.Entry<String, PropertiesConfiguration> childEntry
+              : splitter.getMaterializedColumnMetadata().entrySet()) {
+            PropertiesConfiguration childProps = childEntry.getValue();
+            childProps.getKeys().forEachRemaining(key -> properties.setProperty(key, childProps.getProperty(key)));
+          }
+        }
       }
     }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/BaseSegmentCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/BaseSegmentCreator.java
@@ -593,18 +593,27 @@ public abstract class BaseSegmentCreator implements SegmentCreator {
 
     // OPEN_STRUCT splitters produce per-key materialized child columns (col$key, col$__sparse__) that
     // are not in _columnStatisticsMap. Merge their pre-built metadata into the segment properties so
-    // each child appears as its own column at load time.
+    // each child appears as its own column at load time, and register them as dimensions so the V3
+    // converter and SegmentMetadataImpl discover their index files.
+    List<String> openStructChildColumns = new ArrayList<>();
     for (ColumnIndexCreators columnIndexCreators : _colIndexes.values()) {
       for (IndexCreator indexCreator : columnIndexCreators.getIndexCreators()) {
         if (indexCreator instanceof ColumnarOpenStructIndexCreator) {
           ColumnarOpenStructIndexCreator splitter = (ColumnarOpenStructIndexCreator) indexCreator;
           for (Map.Entry<String, PropertiesConfiguration> childEntry
               : splitter.getMaterializedColumnMetadata().entrySet()) {
+            String childCol = childEntry.getKey();
             PropertiesConfiguration childProps = childEntry.getValue();
             childProps.getKeys().forEachRemaining(key -> properties.setProperty(key, childProps.getProperty(key)));
+            openStructChildColumns.add(childCol);
           }
         }
       }
+    }
+    if (!openStructChildColumns.isEmpty()) {
+      List<String> dimensions = new ArrayList<>(_config.getDimensions());
+      dimensions.addAll(openStructChildColumns);
+      properties.setProperty(DIMENSIONS, dimensions);
     }
 
     SegmentZKPropsConfig segmentZKPropsConfig = _config.getSegmentZKPropsConfig();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -20,12 +20,15 @@ package org.apache.pinot.segment.local.segment.creator.impl;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.segment.local.segment.creator.impl.nullvalue.NullValueVectorCreator;
 import org.apache.pinot.segment.local.segment.readers.PinotSegmentColumnReader;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
 import org.apache.pinot.segment.spi.index.IndexCreator;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.readers.ColumnReader;
@@ -115,18 +118,29 @@ public class SegmentColumnarIndexCreator extends BaseSegmentCreator {
   public void indexColumn(String columnName, @Nullable int[] sortedDocIds, IndexSegment segment,
       @Nullable RoaringBitmap validDocIds)
       throws IOException {
-    // Iterate over each value in the column
     int numDocs = segment.getSegmentMetadata().getTotalDocs();
     if (numDocs == 0) {
       return;
     }
+
+    FieldSpec fieldSpec = _schema.getFieldSpecFor(columnName);
+
+    // OPEN_STRUCT parent columns have no forward index — their per-doc value is reconstructed as a
+    // map from the per-key child columns via OpenStructDataSource.getMapValue(). Feed that map to
+    // the OpenStructColumnSplitter so it can classify keys and write the child column indexes.
+    if (fieldSpec.getDataType() == FieldSpec.DataType.OPEN_STRUCT) {
+      DataSource dataSource = segment.getDataSourceNullable(columnName);
+      if (dataSource instanceof OpenStructDataSource) {
+        indexOpenStructColumn(columnName, (OpenStructDataSource) dataSource, numDocs, sortedDocIds, validDocIds);
+      }
+      return;
+    }
+
     try (PinotSegmentColumnReader colReader = new PinotSegmentColumnReader(segment, columnName)) {
-      FieldSpec fieldSpec = _schema.getFieldSpecFor(columnName);
       ColumnIndexCreators colIndexes = _colIndexes.get(columnName);
       if (sortedDocIds != null) {
         int onDiskDocId = 0;
         for (int docId : sortedDocIds) {
-          // If validDodIds are provided, only index column if it's a valid doc
           if (validDocIds == null || validDocIds.contains(docId)) {
             indexColumnValue(colReader, columnName, fieldSpec, colIndexes, docId, onDiskDocId);
             onDiskDocId++;
@@ -135,13 +149,40 @@ public class SegmentColumnarIndexCreator extends BaseSegmentCreator {
       } else {
         int onDiskDocId = 0;
         for (int docId = 0; docId < numDocs; docId++) {
-          // If validDodIds are provided, only index column if it's a valid doc
           if (validDocIds == null || validDocIds.contains(docId)) {
             indexColumnValue(colReader, columnName, fieldSpec, colIndexes, docId, onDiskDocId);
             onDiskDocId++;
           }
         }
       }
+    }
+  }
+
+  private void indexOpenStructColumn(String columnName, OpenStructDataSource dataSource, int numDocs,
+      @Nullable int[] sortedDocIds, @Nullable RoaringBitmap validDocIds)
+      throws IOException {
+    List<IndexCreator> creators = _colIndexes.get(columnName).getIndexCreators();
+    if (sortedDocIds != null) {
+      for (int docId : sortedDocIds) {
+        if (validDocIds == null || validDocIds.contains(docId)) {
+          indexOpenStructDoc(dataSource, docId, creators);
+        }
+      }
+    } else {
+      for (int docId = 0; docId < numDocs; docId++) {
+        if (validDocIds == null || validDocIds.contains(docId)) {
+          indexOpenStructDoc(dataSource, docId, creators);
+        }
+      }
+    }
+  }
+
+  private static void indexOpenStructDoc(OpenStructDataSource dataSource, int docId, List<IndexCreator> creators)
+      throws IOException {
+    Map<String, Object> value = dataSource.getMapValue(docId);
+    Object toIndex = value != null ? value : Collections.emptyMap();
+    for (IndexCreator creator : creators) {
+      creator.add(toIndex, -1);
     }
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -20,7 +20,6 @@ package org.apache.pinot.segment.local.segment.creator.impl;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -180,7 +179,7 @@ public class SegmentColumnarIndexCreator extends BaseSegmentCreator {
   private static void indexOpenStructDoc(OpenStructDataSource dataSource, int docId, List<IndexCreator> creators)
       throws IOException {
     Map<String, Object> value = dataSource.getMapValue(docId);
-    Object toIndex = value != null ? value : Collections.emptyMap();
+    Object toIndex = value != null ? value : Map.of();
     for (IndexCreator creator : creators) {
       creator.add(toIndex, -1);
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
@@ -24,6 +24,7 @@ import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import java.io.File;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -56,6 +57,7 @@ import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.OpenStructNaming;
+import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.PinotDataType;
@@ -226,6 +228,8 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
           byte[] rawBytes = storedType == DataType.BYTES ? (byte[]) coerced
               : ((String) coerced).getBytes(StandardCharsets.UTF_8);
           _totalRawBytesPerKey.merge(key, (long) rawBytes.length, Long::sum);
+        } else if (storedType == DataType.BIG_DECIMAL) {
+          _totalRawBytesPerKey.merge(key, (long) BigDecimalUtils.serialize((BigDecimal) coerced).length, Long::sum);
         }
       }
     }
@@ -462,6 +466,25 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
         }
         break;
       }
+      case BIG_DECIMAL: {
+        int maxLen = 1;
+        for (Object v : values) {
+          maxLen = Math.max(maxLen, BigDecimalUtils.serialize((BigDecimal) v).length);
+        }
+        SingleValueVarByteRawIndexCreator creator = new SingleValueVarByteRawIndexCreator(
+            _indexDir, ChunkCompressionType.LZ4, materializedCol, _numDocs, storedType, maxLen);
+        try {
+          int ordinal = 0;
+          for (int docId = 0; docId < _numDocs; docId++) {
+            creator.putBigDecimal(
+                presence.contains(docId) ? (BigDecimal) values.get(ordinal++) : (BigDecimal) defaultVal);
+          }
+          creator.seal();
+        } finally {
+          creator.close();
+        }
+        break;
+      }
       default:
         throw new IllegalStateException("Unsupported stored type for raw forward index: " + storedType);
     }
@@ -643,7 +666,8 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
         dictSize = (long) cardinality * Double.BYTES;
         break;
       case STRING:
-      case BYTES: {
+      case BYTES:
+      case BIG_DECIMAL: {
         long totalRawBytes = _totalRawBytesPerKey.getOrDefault(key, 0L);
         rawSize = Integer.BYTES + (long) (_numDocs + 1) * Integer.BYTES + totalRawBytes;
         dictSize = 0;
@@ -673,6 +697,8 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
         return "";
       case BYTES:
         return new byte[0];
+      case BIG_DECIMAL:
+        return BigDecimal.ZERO;
       default:
         throw new IllegalStateException("Unsupported OPEN_STRUCT stored type for default value: " + storedType);
     }
@@ -736,11 +762,26 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
         sortedSet.add(defaultStr);
         return sortedSet.toArray(new String[0]);
       }
+      case BIG_DECIMAL: {
+        // Dedup on BigDecimal.equals (scale-sensitive) to match SegmentDictionaryCreator.indexOfSV,
+        // which resolves dict ids via an equals-keyed map. A compareTo-based dedup (e.g. TreeSet)
+        // would collapse equal-but-differently-scaled values (1.0 vs 1.00) into one dictionary entry,
+        // causing the dropped value's forward-index lookup to silently resolve to dict id 0. This
+        // mirrors BigDecimalColumnPreIndexStatsCollector (ObjectOpenHashSet + Arrays.sort).
+        Set<BigDecimal> distinct = new HashSet<>();
+        distinct.add((BigDecimal) getDefaultValue(storedType));
+        for (Object v : values) {
+          distinct.add((BigDecimal) v);
+        }
+        BigDecimal[] sorted = distinct.toArray(new BigDecimal[0]);
+        Arrays.sort(sorted);
+        return sorted;
+      }
       default:
-        // Logical types (BIG_DECIMAL, BOOLEAN, TIMESTAMP, JSON, etc.) have a stored type that
-        // belongs to the enumerated set above. Reaching here means a new stored type was added
-        // upstream without updating this dispatch — fail loudly rather than write a segment with
-        // a corrupt dictionary that contains only the default value.
+        // BIG_DECIMAL, STRING, BYTES and the numeric types are all handled above. The only stored
+        // types that can reach here are non-scalar (STRUCT/MAP/LIST/OPEN_STRUCT) or UNKNOWN, which
+        // are never valid stored types for an OPEN_STRUCT key — fail loudly rather than write a
+        // segment with a corrupt dictionary that contains only the default value.
         throw new IllegalStateException("Unsupported OPEN_STRUCT stored type for dictionary build: " + storedType);
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
@@ -420,12 +420,10 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
         for (IndexCreator creator : creators) {
           creator.close();
         }
-      }
-
-      // Seal the dictionary only after the index writes succeeded; capture its element size for metadata.
-      if (dictCreator != null) {
-        dictElementSize = dictCreator.getNumBytesPerEntry();
-        dictCreator.seal();
+        if (dictCreator != null) {
+          dictElementSize = dictCreator.getNumBytesPerEntry();
+          dictCreator.seal();
+        }
       }
     } finally {
       if (dictCreator != null) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
@@ -47,6 +47,7 @@ import org.apache.pinot.segment.local.segment.creator.impl.stats.StatsCollectorU
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
 import org.apache.pinot.segment.spi.index.creator.ColumnarOpenStructIndexCreator;
+import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.OpenStructIndexConfig;
 import org.apache.pinot.spi.data.ComplexFieldSpec;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
@@ -300,9 +301,8 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
 
     Object sortedDistinctArray = useDictionary ? statsCollector.getUniqueValuesSet() : null;
     int cardinality = useDictionary ? statsCollector.getCardinality() : numDocsForKey;
-    Comparable minValue = (Comparable) statsCollector.getMinValue();
-    Comparable maxValue = (Comparable) statsCollector.getMaxValue();
 
+    int dictElementSize = 0;
     SegmentDictionaryCreator dictCreator = null;
     if (useDictionary) {
       dictCreator = new SegmentDictionaryCreator(
@@ -358,6 +358,7 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
       }
     } finally {
       if (dictCreator != null) {
+        dictElementSize = dictCreator.getNumBytesPerEntry();
         dictCreator.seal();
         dictCreator.close();
       }
@@ -375,16 +376,21 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
       nullCreator.close();
     }
 
-    int maxLength = 0;
-    if (storedType == DataType.STRING || storedType == DataType.BYTES) {
-      for (Object v : values) {
-        int len = storedType == DataType.BYTES ? ((byte[]) v).length
-            : ((String) v).getBytes(StandardCharsets.UTF_8).length;
-        maxLength = Math.max(maxLength, len);
-      }
+    PropertiesConfiguration props = new PropertiesConfiguration();
+    FieldConfig.EncodingType encoding =
+        useDictionary ? FieldConfig.EncodingType.DICTIONARY : FieldConfig.EncodingType.RAW;
+    int dictionaryElementSize = useDictionary ? dictElementSize : 0;
+    BaseSegmentCreator.addColumnMetadataInfo(props, materializedCol, statsCollector, _numDocs, childFieldSpec,
+        useDictionary, dictionaryElementSize, encoding, false);
+    // OPEN_STRUCT-specific keys not written by addColumnMetadataInfo.
+    props.setProperty(
+        V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, V1Constants.MetadataKeys.Column.PARENT_COLUMN),
+        _columnName);
+    props.setProperty(V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, "hasNullValue"), true);
+    if (enableInverted && useDictionary) {
+      props.setProperty(V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, "hasInvertedIndex"), true);
     }
-    emitVirtualColumnMetadata(materializedCol, storedType, cardinality, useDictionary,
-        enableInverted && useDictionary, minValue, maxValue, maxLength);
+    _materializedColumnMetadata.put(materializedCol, props);
   }
 
   private void writeRawForwardIndex(String materializedCol, DataType storedType,
@@ -575,56 +581,6 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
         V1Constants.MetadataKeys.Column.getKeyFor(_columnName, V1Constants.MetadataKeys.Column.HAS_SPARSE_COLUMN),
         hasSparseColumn);
     _materializedColumnMetadata.put(_columnName, props);
-  }
-
-  private void emitVirtualColumnMetadata(String materializedCol, DataType storedType, int cardinality,
-      boolean hasDictionary, boolean hasInvertedIndex, @Nullable Object minValue, @Nullable Object maxValue,
-      int maxLength) {
-    PropertiesConfiguration props = new PropertiesConfiguration();
-    props.setProperty(
-        V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, V1Constants.MetadataKeys.Column.DATA_TYPE),
-        storedType.name());
-    props.setProperty(
-        V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, V1Constants.MetadataKeys.Column.COLUMN_TYPE),
-        FieldSpec.FieldType.DIMENSION.name());
-    props.setProperty(
-        V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, V1Constants.MetadataKeys.Column.IS_SINGLE_VALUED),
-        true);
-    props.setProperty(
-        V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, V1Constants.MetadataKeys.Column.CARDINALITY),
-        cardinality);
-    props.setProperty(
-        V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, V1Constants.MetadataKeys.Column.TOTAL_DOCS),
-        _numDocs);
-    props.setProperty(
-        V1Constants.MetadataKeys.Column.getKeyFor(
-            materializedCol, V1Constants.MetadataKeys.Column.TOTAL_NUMBER_OF_ENTRIES),
-        _numDocs);
-    props.setProperty(
-        V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, V1Constants.MetadataKeys.Column.HAS_DICTIONARY),
-        hasDictionary);
-    if (hasDictionary) {
-      int numBitsPerValue = PinotDataBitSet.getNumBitsPerValue(Math.max(cardinality - 1, 0));
-      props.setProperty(
-          V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, V1Constants.MetadataKeys.Column.BITS_PER_ELEMENT),
-          numBitsPerValue);
-    }
-    if (hasInvertedIndex) {
-      props.setProperty(V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, "hasInvertedIndex"), true);
-    }
-    props.setProperty(V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, "hasNullValue"), true);
-    if (maxLength > 0) {
-      props.setProperty(
-          V1Constants.MetadataKeys.Column.getKeyFor(
-              materializedCol, V1Constants.MetadataKeys.Column.LENGTH_OF_LONGEST_ELEMENT),
-          maxLength);
-    }
-    BaseSegmentCreator.addColumnMinMaxValueInfo(props, materializedCol, minValue, maxValue, storedType);
-    props.setProperty(
-        V1Constants.MetadataKeys.Column.getKeyFor(
-            materializedCol, V1Constants.MetadataKeys.Column.PARENT_COLUMN),
-        _columnName);
-    _materializedColumnMetadata.put(materializedCol, props);
   }
 
   private boolean shouldUseDictionary(String key, DataType storedType, int numDocsForKey) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
@@ -31,6 +31,8 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.pinot.common.metrics.ServerMeter;
+import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.segment.local.segment.creator.impl.BaseSegmentCreator;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentDictionaryCreator;
@@ -91,6 +93,7 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
   private final Map<String, List<Object>> _values = new HashMap<>();
   private final Map<String, DataType> _inferredTypes = new HashMap<>();
   private int _numDocs;
+  private int _coercionFailures;
 
   // Resolved at seal time
   @Nullable
@@ -208,8 +211,7 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
           PinotDataType destType = ColumnDataType.fromDataTypeSV(valueType.getStoredType()).toPinotDataType();
           coerced = destType.convert(rawValue, sourceType);
         } catch (Exception e) {
-          LOGGER.warn("OPEN_STRUCT '{}': coercion failed for key '{}' value '{}' to {}. Skipping.",
-              _columnName, key, rawValue, valueType, e);
+          _coercionFailures++;
           _presenceBitmaps.get(key).remove(_numDocs);
           continue;
         }
@@ -239,6 +241,14 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
     }
     if (!sparseKeys.isEmpty()) {
       writeSparseJsonColumn(sparseKeys);
+    }
+
+    if (_coercionFailures > 0) {
+      LOGGER.info("OPEN_STRUCT '{}': dropped {} values due to type coercion failures", _columnName, _coercionFailures);
+      ServerMetrics serverMetrics = ServerMetrics.get();
+      if (serverMetrics != null) {
+        serverMetrics.addMeteredGlobalValue(ServerMeter.OPEN_STRUCT_TYPE_COERCION_FAILURES, _coercionFailures);
+      }
     }
 
     emitParentColumnMetadata(!sparseKeys.isEmpty());

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
@@ -1,0 +1,747 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.creator.impl.openstruct;
+
+import it.unimi.dsi.fastutil.doubles.DoubleOpenHashSet;
+import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import javax.annotation.Nullable;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.segment.local.io.util.PinotDataBitSet;
+import org.apache.pinot.segment.local.io.writer.impl.FixedBitSVForwardIndexWriter;
+import org.apache.pinot.segment.local.segment.creator.impl.BaseSegmentCreator;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentDictionaryCreator;
+import org.apache.pinot.segment.local.segment.creator.impl.fwd.SingleValueFixedByteRawIndexCreator;
+import org.apache.pinot.segment.local.segment.creator.impl.fwd.SingleValueVarByteRawIndexCreator;
+import org.apache.pinot.segment.local.segment.creator.impl.inv.OffHeapBitmapInvertedIndexCreator;
+import org.apache.pinot.segment.local.segment.creator.impl.nullvalue.NullValueVectorCreator;
+import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
+import org.apache.pinot.segment.spi.index.creator.ColumnarOpenStructIndexCreator;
+import org.apache.pinot.spi.config.table.OpenStructIndexConfig;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.OpenStructNaming;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.PinotDataType;
+import org.roaringbitmap.RoaringBitmap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Splits an OPEN_STRUCT column into per-key materialized columns using standard Pinot index
+ * creators. Dense keys become independent virtual columns; remaining keys go into a single
+ * synthetic JSON column for sparse storage.
+ *
+ * <p>Lifecycle: instantiated by {@code BaseSegmentCreator} for OPEN_STRUCT columns. Receives
+ * per-doc {@code Map<String, Object>} values via {@link #add(Map, int)}, accumulates in memory,
+ * then on {@link #seal()} writes per-key column files using standard creators.
+ */
+public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(OpenStructColumnSplitter.class);
+  private static final double NO_DICTIONARY_SIZE_RATIO_THRESHOLD = 0.85;
+
+  private final File _indexDir;
+  private final String _columnName;
+  private final Map<String, FieldSpec> _childFieldSpecs;
+  private final OpenStructIndexConfig _config;
+  private final int _maxDenseKeys;
+
+  // Per-key accumulation
+  private final Map<String, RoaringBitmap> _presenceBitmaps = new HashMap<>();
+  private final Map<String, List<Object>> _values = new HashMap<>();
+  private final Map<String, Set<String>> _distinctValuesPerKey = new HashMap<>();
+  private final Map<String, Long> _totalRawBytesPerKey = new HashMap<>();
+  private final Map<String, DataType> _inferredTypes = new HashMap<>();
+  private int _numDocs;
+
+  // Resolved at seal time
+  @Nullable
+  private Set<String> _resolvedDenseKeys;
+  private final Map<String, PropertiesConfiguration> _materializedColumnMetadata = new LinkedHashMap<>();
+
+  public OpenStructColumnSplitter(File indexDir, String columnName, FieldSpec fieldSpec,
+      OpenStructIndexConfig config) {
+    _indexDir = indexDir;
+    _columnName = columnName;
+    _config = config;
+    _maxDenseKeys = config.getMaxDenseKeys();
+
+    Map<String, FieldSpec> childFieldSpecs = null;
+    if (fieldSpec instanceof ComplexFieldSpec) {
+      ComplexFieldSpec complexSpec = (ComplexFieldSpec) fieldSpec;
+      childFieldSpecs = complexSpec.getChildFieldSpecs();
+    }
+    _childFieldSpecs = childFieldSpecs != null ? new HashMap<>(childFieldSpecs) : new HashMap<>();
+  }
+
+  @Override
+  public void add(Object value, int docId)
+      throws IOException {
+    if (value instanceof Map) {
+      @SuppressWarnings("unchecked")
+      Map<String, Object> map = (Map<String, Object>) value;
+      addMap(map);
+    } else {
+      addMap(null);
+    }
+  }
+
+  @Override
+  public void add(Map<String, Object> openStructValue, int docId)
+      throws IOException {
+    addMap(openStructValue);
+  }
+
+  @Override
+  public void add(Object[] values, @Nullable int[] dictIds)
+      throws IOException {
+    throw new UnsupportedOperationException("OPEN_STRUCT index is single-value only");
+  }
+
+  /**
+   * Returns the resolved dense-key set after {@link #seal()} or {@link #classify()}.
+   * Returns an empty set before resolution.
+   */
+  public Set<String> getResolvedDenseKeys() {
+    return _resolvedDenseKeys != null ? Collections.unmodifiableSet(_resolvedDenseKeys) : Set.of();
+  }
+
+  /**
+   * Resolves dense vs sparse keys without writing any files. Exposed for testing and for callers
+   * that need the classification independent of file output. {@link #seal()} calls this internally.
+   */
+  public Set<String> classify() {
+    if (_resolvedDenseKeys != null) {
+      return _resolvedDenseKeys;
+    }
+    if (_numDocs == 0 || _presenceBitmaps.isEmpty()) {
+      _resolvedDenseKeys = new LinkedHashSet<>();
+      return _resolvedDenseKeys;
+    }
+    List<String> allKeys = new ArrayList<>(_presenceBitmaps.keySet());
+    allKeys.sort((a, b) -> {
+      double fillA = (double) _presenceBitmaps.get(a).getCardinality() / _numDocs;
+      double fillB = (double) _presenceBitmaps.get(b).getCardinality() / _numDocs;
+      int cmp = Double.compare(fillB, fillA);
+      return cmp != 0 ? cmp : a.compareTo(b);
+    });
+
+    double minFillRate = _config.getDenseKeyMinFillRate();
+    _resolvedDenseKeys = new LinkedHashSet<>();
+
+    Set<String> configuredDenseKeys = _config.getDenseKeys();
+    for (String key : configuredDenseKeys) {
+      if (_presenceBitmaps.containsKey(key) && (_maxDenseKeys < 0 || _resolvedDenseKeys.size() < _maxDenseKeys)) {
+        _resolvedDenseKeys.add(key);
+      }
+    }
+
+    for (String key : allKeys) {
+      if (_resolvedDenseKeys.contains(key)) {
+        continue;
+      }
+      double fillRate = (double) _presenceBitmaps.get(key).getCardinality() / _numDocs;
+      if ((_maxDenseKeys < 0 || _resolvedDenseKeys.size() < _maxDenseKeys) && fillRate >= minFillRate) {
+        _resolvedDenseKeys.add(key);
+      }
+    }
+    return _resolvedDenseKeys;
+  }
+
+  private void addMap(@Nullable Map<String, Object> map) {
+    if (map != null && !map.isEmpty()) {
+      for (Map.Entry<String, Object> entry : map.entrySet()) {
+        String key = entry.getKey();
+        Object rawValue = entry.getValue();
+        if (rawValue == null) {
+          continue;
+        }
+        FieldSpec keySpec = _childFieldSpecs.get(key);
+        DataType valueType = keySpec != null
+            ? keySpec.getDataType()
+            : _inferredTypes.computeIfAbsent(key, k -> {
+              DataType inferred = OpenStructNaming.inferDataType(rawValue);
+              return inferred != null ? inferred : DataType.STRING;
+            });
+        if (!_presenceBitmaps.containsKey(key)) {
+          _presenceBitmaps.put(key, new RoaringBitmap());
+          _values.put(key, new ArrayList<>());
+        }
+        _presenceBitmaps.get(key).add(_numDocs);
+        Object coerced;
+        try {
+          PinotDataType sourceType = PinotDataType.getSingleValueType(rawValue);
+          PinotDataType destType = ColumnDataType.fromDataTypeSV(valueType.getStoredType()).toPinotDataType();
+          coerced = destType.convert(rawValue, sourceType);
+        } catch (Exception e) {
+          LOGGER.warn("OPEN_STRUCT '{}': coercion failed for key '{}' value '{}' to {}. Skipping.",
+              _columnName, key, rawValue, valueType, e);
+          _presenceBitmaps.get(key).remove(_numDocs);
+          continue;
+        }
+        _values.get(key).add(coerced);
+
+        DataType storedType = valueType.getStoredType();
+        String stringRep = storedType.toString(coerced);
+        _distinctValuesPerKey.computeIfAbsent(key, k -> new HashSet<>()).add(stringRep);
+        if (storedType == DataType.STRING || storedType == DataType.BYTES) {
+          byte[] rawBytes = storedType == DataType.BYTES ? (byte[]) coerced
+              : ((String) coerced).getBytes(StandardCharsets.UTF_8);
+          _totalRawBytesPerKey.merge(key, (long) rawBytes.length, Long::sum);
+        }
+      }
+    }
+    _numDocs++;
+  }
+
+  @Override
+  public void seal()
+      throws IOException {
+    classify();
+    if (_resolvedDenseKeys == null || (_numDocs == 0 && _presenceBitmaps.isEmpty())) {
+      return;
+    }
+
+    for (String key : _resolvedDenseKeys) {
+      writeDenseKeyColumn(key);
+    }
+
+    List<String> sparseKeys = new ArrayList<>();
+    for (String key : _presenceBitmaps.keySet()) {
+      if (!_resolvedDenseKeys.contains(key)) {
+        sparseKeys.add(key);
+      }
+    }
+    if (!sparseKeys.isEmpty()) {
+      writeSparseJsonColumn(sparseKeys);
+    }
+
+    emitParentColumnMetadata(!sparseKeys.isEmpty());
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    // Nothing to close — sub-creators are created and closed within seal()
+  }
+
+  @Override
+  public Map<String, PropertiesConfiguration> getMaterializedColumnMetadata() {
+    return _materializedColumnMetadata;
+  }
+
+  private void writeDenseKeyColumn(String key)
+      throws IOException {
+    String materializedCol = OpenStructNaming.materializedColumnName(_columnName, key);
+    FieldSpec keySpec = _childFieldSpecs.get(key);
+    DataType valueType = keySpec != null
+        ? keySpec.getDataType()
+        : _inferredTypes.getOrDefault(key, DataType.STRING);
+    DataType storedType = valueType.getStoredType();
+    RoaringBitmap presence = _presenceBitmaps.get(key);
+    List<Object> values = _values.get(key);
+    int numDocsForKey = presence.getCardinality();
+
+    boolean useDictionary = shouldUseDictionary(key, storedType, numDocsForKey);
+    boolean enableInverted = _config.shouldEnableInvertedIndexForKey(key);
+
+    Object sortedDistinctArray = null;
+    int cardinality;
+    if (useDictionary) {
+      sortedDistinctArray = buildTypedDistinctArray(key, storedType);
+      cardinality = java.lang.reflect.Array.getLength(sortedDistinctArray);
+    } else {
+      cardinality = numDocsForKey;
+    }
+
+    Comparable minValue = null;
+    Comparable maxValue = null;
+    for (Object v : values) {
+      Comparable cv = (storedType == DataType.BYTES) ? new ByteArray((byte[]) v) : (Comparable) v;
+      if (minValue == null || cv.compareTo(minValue) < 0) {
+        minValue = cv;
+      }
+      if (maxValue == null || cv.compareTo(maxValue) > 0) {
+        maxValue = cv;
+      }
+    }
+
+    SegmentDictionaryCreator dictCreator = null;
+    if (useDictionary) {
+      dictCreator = new SegmentDictionaryCreator(
+          materializedCol, storedType, new File(_indexDir,
+          materializedCol + V1Constants.Dict.FILE_EXTENSION), true);
+      dictCreator.build(sortedDistinctArray);
+    }
+
+    try {
+      if (useDictionary) {
+        int numBitsPerValue = PinotDataBitSet.getNumBitsPerValue(Math.max(cardinality - 1, 0));
+        int defaultDictId = dictCreator.indexOfSV(getDefaultValue(storedType));
+
+        FixedBitSVForwardIndexWriter fwdWriter = new FixedBitSVForwardIndexWriter(
+            new File(_indexDir, materializedCol + V1Constants.Indexes.UNSORTED_SV_FORWARD_INDEX_FILE_EXTENSION),
+            _numDocs, numBitsPerValue);
+        try {
+          int ordinal = 0;
+          for (int docId = 0; docId < _numDocs; docId++) {
+            if (presence.contains(docId)) {
+              Object typedValue = values.get(ordinal++);
+              fwdWriter.putDictId(dictCreator.indexOfSV(typedValue));
+            } else {
+              fwdWriter.putDictId(defaultDictId);
+            }
+          }
+        } finally {
+          fwdWriter.close();
+        }
+      } else {
+        writeRawForwardIndex(materializedCol, storedType, presence, values);
+      }
+
+      if (enableInverted && useDictionary) {
+        FieldSpec fakeFieldSpec = new DimensionFieldSpec(materializedCol, storedType, true);
+        OffHeapBitmapInvertedIndexCreator invCreator = new OffHeapBitmapInvertedIndexCreator(
+            _indexDir, fakeFieldSpec, cardinality, _numDocs, _numDocs);
+        try {
+          int defaultDictId = dictCreator.indexOfSV(getDefaultValue(storedType));
+          int ordinal = 0;
+          for (int docId = 0; docId < _numDocs; docId++) {
+            if (presence.contains(docId)) {
+              Object typedValue = values.get(ordinal++);
+              invCreator.add(dictCreator.indexOfSV(typedValue));
+            } else {
+              invCreator.add(defaultDictId);
+            }
+          }
+          invCreator.seal();
+        } finally {
+          invCreator.close();
+        }
+      }
+    } finally {
+      if (dictCreator != null) {
+        dictCreator.seal();
+        dictCreator.close();
+      }
+    }
+
+    NullValueVectorCreator nullCreator = new NullValueVectorCreator(_indexDir, materializedCol);
+    try {
+      for (int docId = 0; docId < _numDocs; docId++) {
+        if (!presence.contains(docId)) {
+          nullCreator.setNull(docId);
+        }
+      }
+      nullCreator.seal();
+    } finally {
+      nullCreator.close();
+    }
+
+    int maxLength = 0;
+    if (storedType == DataType.STRING || storedType == DataType.BYTES) {
+      for (Object v : values) {
+        int len = storedType == DataType.BYTES ? ((byte[]) v).length
+            : ((String) v).getBytes(StandardCharsets.UTF_8).length;
+        maxLength = Math.max(maxLength, len);
+      }
+    }
+    emitVirtualColumnMetadata(materializedCol, storedType, cardinality, useDictionary,
+        enableInverted && useDictionary, minValue, maxValue, maxLength);
+  }
+
+  private void writeRawForwardIndex(String materializedCol, DataType storedType,
+      RoaringBitmap presence, List<Object> values)
+      throws IOException {
+    Object defaultVal = getDefaultValue(storedType);
+    switch (storedType) {
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE: {
+        SingleValueFixedByteRawIndexCreator creator = new SingleValueFixedByteRawIndexCreator(
+            _indexDir, ChunkCompressionType.LZ4, materializedCol, _numDocs, storedType);
+        try {
+          int ordinal = 0;
+          for (int docId = 0; docId < _numDocs; docId++) {
+            Object val = presence.contains(docId) ? values.get(ordinal++) : defaultVal;
+            switch (storedType) {
+              case INT:
+                creator.putInt((Integer) val);
+                break;
+              case LONG:
+                creator.putLong((Long) val);
+                break;
+              case FLOAT:
+                creator.putFloat((Float) val);
+                break;
+              case DOUBLE:
+                creator.putDouble((Double) val);
+                break;
+              default:
+                break;
+            }
+          }
+          creator.seal();
+        } finally {
+          creator.close();
+        }
+        break;
+      }
+      case STRING: {
+        int maxLen = 1;
+        for (Object v : values) {
+          maxLen = Math.max(maxLen, ((String) v).getBytes(StandardCharsets.UTF_8).length);
+        }
+        SingleValueVarByteRawIndexCreator creator = new SingleValueVarByteRawIndexCreator(
+            _indexDir, ChunkCompressionType.LZ4, materializedCol, _numDocs, storedType, maxLen);
+        try {
+          int ordinal = 0;
+          for (int docId = 0; docId < _numDocs; docId++) {
+            creator.putString(presence.contains(docId) ? (String) values.get(ordinal++) : (String) defaultVal);
+          }
+          creator.seal();
+        } finally {
+          creator.close();
+        }
+        break;
+      }
+      case BYTES: {
+        int maxLen = 1;
+        for (Object v : values) {
+          maxLen = Math.max(maxLen, ((byte[]) v).length);
+        }
+        SingleValueVarByteRawIndexCreator creator = new SingleValueVarByteRawIndexCreator(
+            _indexDir, ChunkCompressionType.LZ4, materializedCol, _numDocs, storedType, maxLen);
+        try {
+          int ordinal = 0;
+          for (int docId = 0; docId < _numDocs; docId++) {
+            creator.putBytes(presence.contains(docId) ? (byte[]) values.get(ordinal++) : (byte[]) defaultVal);
+          }
+          creator.seal();
+        } finally {
+          creator.close();
+        }
+        break;
+      }
+      default:
+        throw new IllegalStateException("Unsupported stored type for raw forward index: " + storedType);
+    }
+  }
+
+  private void writeSparseJsonColumn(List<String> sparseKeys)
+      throws IOException {
+    String sparseCol = OpenStructNaming.sparseColumnName(_columnName);
+    int maxLen = 1;
+    String[] jsonPerDoc = new String[_numDocs];
+    int nonNullCount = 0;
+    for (int docId = 0; docId < _numDocs; docId++) {
+      Map<String, Object> sparseEntries = new LinkedHashMap<>();
+      for (String key : sparseKeys) {
+        RoaringBitmap presence = _presenceBitmaps.get(key);
+        if (presence != null && presence.contains(docId)) {
+          int ordinal = presence.rank(docId) - 1;
+          sparseEntries.put(key, _values.get(key).get(ordinal));
+        }
+      }
+      if (!sparseEntries.isEmpty()) {
+        try {
+          String json = JsonUtils.objectToString(sparseEntries);
+          jsonPerDoc[docId] = json;
+          maxLen = Math.max(maxLen, json.getBytes(StandardCharsets.UTF_8).length);
+          nonNullCount++;
+        } catch (IOException e) {
+          throw new RuntimeException("Failed to serialize sparse entries for docId " + docId, e);
+        }
+      }
+    }
+
+    SingleValueVarByteRawIndexCreator fwdCreator = new SingleValueVarByteRawIndexCreator(
+        _indexDir, ChunkCompressionType.LZ4, sparseCol, _numDocs, DataType.STRING, maxLen);
+    NullValueVectorCreator nullCreator = new NullValueVectorCreator(_indexDir, sparseCol);
+    try {
+      for (int docId = 0; docId < _numDocs; docId++) {
+        if (jsonPerDoc[docId] != null) {
+          fwdCreator.putString(jsonPerDoc[docId]);
+        } else {
+          fwdCreator.putString("");
+          nullCreator.setNull(docId);
+        }
+      }
+      fwdCreator.seal();
+      nullCreator.seal();
+    } finally {
+      fwdCreator.close();
+      nullCreator.close();
+    }
+
+    PropertiesConfiguration props = new PropertiesConfiguration();
+    props.setProperty(V1Constants.MetadataKeys.Column.getKeyFor(sparseCol, V1Constants.MetadataKeys.Column.DATA_TYPE),
+        DataType.STRING.name());
+    props.setProperty(V1Constants.MetadataKeys.Column.getKeyFor(sparseCol, V1Constants.MetadataKeys.Column.COLUMN_TYPE),
+        FieldSpec.FieldType.DIMENSION.name());
+    props.setProperty(
+        V1Constants.MetadataKeys.Column.getKeyFor(sparseCol, V1Constants.MetadataKeys.Column.IS_SINGLE_VALUED), true);
+    props.setProperty(V1Constants.MetadataKeys.Column.getKeyFor(sparseCol, V1Constants.MetadataKeys.Column.TOTAL_DOCS),
+        _numDocs);
+    props.setProperty(V1Constants.MetadataKeys.Column.getKeyFor(sparseCol, V1Constants.MetadataKeys.Column.CARDINALITY),
+        nonNullCount);
+    props.setProperty(
+        V1Constants.MetadataKeys.Column.getKeyFor(sparseCol, V1Constants.MetadataKeys.Column.TOTAL_NUMBER_OF_ENTRIES),
+        _numDocs);
+    props.setProperty(
+        V1Constants.MetadataKeys.Column.getKeyFor(sparseCol, V1Constants.MetadataKeys.Column.HAS_DICTIONARY), false);
+    props.setProperty(V1Constants.MetadataKeys.Column.getKeyFor(sparseCol, "hasNullValue"), true);
+    props.setProperty(
+        V1Constants.MetadataKeys.Column.getKeyFor(sparseCol, V1Constants.MetadataKeys.Column.PARENT_COLUMN),
+        _columnName);
+    _materializedColumnMetadata.put(sparseCol, props);
+  }
+
+  private void emitParentColumnMetadata(boolean hasSparseColumn) {
+    PropertiesConfiguration props = new PropertiesConfiguration();
+    props.setProperty(
+        V1Constants.MetadataKeys.Column.getKeyFor(_columnName, V1Constants.MetadataKeys.Column.COLUMN_NAME),
+        _columnName);
+    props.setProperty(
+        V1Constants.MetadataKeys.Column.getKeyFor(_columnName, V1Constants.MetadataKeys.Column.DATA_TYPE),
+        FieldSpec.DataType.OPEN_STRUCT.name());
+    props.setProperty(
+        V1Constants.MetadataKeys.Column.getKeyFor(_columnName, V1Constants.MetadataKeys.Column.COLUMN_TYPE),
+        FieldSpec.FieldType.COMPLEX.name());
+    props.setProperty(
+        V1Constants.MetadataKeys.Column.getKeyFor(_columnName, V1Constants.MetadataKeys.Column.IS_SINGLE_VALUED),
+        true);
+    props.setProperty(
+        V1Constants.MetadataKeys.Column.getKeyFor(_columnName, V1Constants.MetadataKeys.Column.TOTAL_DOCS),
+        _numDocs);
+    props.setProperty(
+        V1Constants.MetadataKeys.Column.getKeyFor(_columnName, V1Constants.MetadataKeys.Column.HAS_SPARSE_COLUMN),
+        hasSparseColumn);
+    _materializedColumnMetadata.put(_columnName, props);
+  }
+
+  private void emitVirtualColumnMetadata(String materializedCol, DataType storedType, int cardinality,
+      boolean hasDictionary, boolean hasInvertedIndex, @Nullable Object minValue, @Nullable Object maxValue,
+      int maxLength) {
+    PropertiesConfiguration props = new PropertiesConfiguration();
+    props.setProperty(
+        V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, V1Constants.MetadataKeys.Column.DATA_TYPE),
+        storedType.name());
+    props.setProperty(
+        V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, V1Constants.MetadataKeys.Column.COLUMN_TYPE),
+        FieldSpec.FieldType.DIMENSION.name());
+    props.setProperty(
+        V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, V1Constants.MetadataKeys.Column.IS_SINGLE_VALUED),
+        true);
+    props.setProperty(
+        V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, V1Constants.MetadataKeys.Column.CARDINALITY),
+        cardinality);
+    props.setProperty(
+        V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, V1Constants.MetadataKeys.Column.TOTAL_DOCS),
+        _numDocs);
+    props.setProperty(
+        V1Constants.MetadataKeys.Column.getKeyFor(
+            materializedCol, V1Constants.MetadataKeys.Column.TOTAL_NUMBER_OF_ENTRIES),
+        _numDocs);
+    props.setProperty(
+        V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, V1Constants.MetadataKeys.Column.HAS_DICTIONARY),
+        hasDictionary);
+    if (hasDictionary) {
+      int numBitsPerValue = PinotDataBitSet.getNumBitsPerValue(Math.max(cardinality - 1, 0));
+      props.setProperty(
+          V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, V1Constants.MetadataKeys.Column.BITS_PER_ELEMENT),
+          numBitsPerValue);
+    }
+    if (hasInvertedIndex) {
+      props.setProperty(V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, "hasInvertedIndex"), true);
+    }
+    props.setProperty(V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, "hasNullValue"), true);
+    if (maxLength > 0) {
+      props.setProperty(
+          V1Constants.MetadataKeys.Column.getKeyFor(
+              materializedCol, V1Constants.MetadataKeys.Column.LENGTH_OF_LONGEST_ELEMENT),
+          maxLength);
+    }
+    BaseSegmentCreator.addColumnMinMaxValueInfo(props, materializedCol, minValue, maxValue, storedType);
+    props.setProperty(
+        V1Constants.MetadataKeys.Column.getKeyFor(
+            materializedCol, V1Constants.MetadataKeys.Column.PARENT_COLUMN),
+        _columnName);
+    _materializedColumnMetadata.put(materializedCol, props);
+  }
+
+  private boolean shouldUseDictionary(String key, DataType storedType, int numDocsForKey) {
+    if (_config.shouldEnableInvertedIndexForKey(key)) {
+      return true;
+    }
+    if (!_config.shouldUseDictionaryForKey(key)) {
+      return false;
+    }
+    Set<String> distinctValues = _distinctValuesPerKey.get(key);
+    if (distinctValues == null || distinctValues.isEmpty()) {
+      return false;
+    }
+    int cardinality = distinctValues.size() + 1;
+    int numBitsPerValue = PinotDataBitSet.getNumBitsPerValue(Math.max(cardinality - 1, 0));
+    long dictIdFwdSize = ((long) _numDocs * numBitsPerValue + Byte.SIZE - 1) / Byte.SIZE;
+    long rawSize;
+    long dictSize;
+    switch (storedType) {
+      case INT:
+        rawSize = (long) _numDocs * Integer.BYTES;
+        dictSize = (long) cardinality * Integer.BYTES;
+        break;
+      case LONG:
+        rawSize = (long) _numDocs * Long.BYTES;
+        dictSize = (long) cardinality * Long.BYTES;
+        break;
+      case FLOAT:
+        rawSize = (long) _numDocs * Float.BYTES;
+        dictSize = (long) cardinality * Float.BYTES;
+        break;
+      case DOUBLE:
+        rawSize = (long) _numDocs * Double.BYTES;
+        dictSize = (long) cardinality * Double.BYTES;
+        break;
+      case STRING:
+      case BYTES: {
+        long totalRawBytes = _totalRawBytesPerKey.getOrDefault(key, 0L);
+        rawSize = Integer.BYTES + (long) (_numDocs + 1) * Integer.BYTES + totalRawBytes;
+        dictSize = 0;
+        for (String v : distinctValues) {
+          dictSize += Integer.BYTES + v.getBytes(StandardCharsets.UTF_8).length;
+        }
+        break;
+      }
+      default:
+        return true;
+    }
+    double ratio = (double) rawSize / (dictSize + dictIdFwdSize);
+    return ratio > NO_DICTIONARY_SIZE_RATIO_THRESHOLD;
+  }
+
+  private static Object getDefaultValue(DataType storedType) {
+    switch (storedType) {
+      case INT:
+        return 0;
+      case LONG:
+        return 0L;
+      case FLOAT:
+        return 0.0f;
+      case DOUBLE:
+        return 0.0;
+      case STRING:
+        return "";
+      case BYTES:
+        return new byte[0];
+      default:
+        throw new IllegalStateException("Unsupported OPEN_STRUCT stored type for default value: " + storedType);
+    }
+  }
+
+  private Object buildTypedDistinctArray(String key, DataType storedType) {
+    List<Object> values = _values.get(key);
+    switch (storedType) {
+      case INT: {
+        IntOpenHashSet set = new IntOpenHashSet();
+        set.add((int) getDefaultValue(storedType));
+        for (Object v : values) {
+          set.add((int) v);
+        }
+        int[] sorted = set.toIntArray();
+        Arrays.sort(sorted);
+        return sorted;
+      }
+      case LONG: {
+        LongOpenHashSet set = new LongOpenHashSet();
+        set.add((long) getDefaultValue(storedType));
+        for (Object v : values) {
+          set.add((long) v);
+        }
+        long[] sorted = set.toLongArray();
+        Arrays.sort(sorted);
+        return sorted;
+      }
+      case FLOAT: {
+        FloatOpenHashSet set = new FloatOpenHashSet();
+        set.add((float) getDefaultValue(storedType));
+        for (Object v : values) {
+          set.add((float) v);
+        }
+        float[] sorted = set.toFloatArray();
+        Arrays.sort(sorted);
+        return sorted;
+      }
+      case DOUBLE: {
+        DoubleOpenHashSet set = new DoubleOpenHashSet();
+        set.add((double) getDefaultValue(storedType));
+        for (Object v : values) {
+          set.add((double) v);
+        }
+        double[] sorted = set.toDoubleArray();
+        Arrays.sort(sorted);
+        return sorted;
+      }
+      case BYTES: {
+        TreeSet<ByteArray> sortedSet = new TreeSet<>();
+        sortedSet.add(new ByteArray((byte[]) getDefaultValue(storedType)));
+        for (Object v : values) {
+          sortedSet.add(new ByteArray((byte[]) v));
+        }
+        return sortedSet.toArray(new ByteArray[0]);
+      }
+      case STRING: {
+        Set<String> distinctStrings = _distinctValuesPerKey.getOrDefault(key, Set.of());
+        TreeSet<String> sortedSet = new TreeSet<>(distinctStrings);
+        String defaultStr = storedType.toString(getDefaultValue(storedType));
+        sortedSet.add(defaultStr);
+        return sortedSet.toArray(new String[0]);
+      }
+      default:
+        // Logical types (BIG_DECIMAL, BOOLEAN, TIMESTAMP, JSON, etc.) have a stored type that
+        // belongs to the enumerated set above. Reaching here means a new stored type was added
+        // upstream without updating this dispatch — fail loudly rather than write a segment with
+        // a corrupt dictionary that contains only the default value.
+        throw new IllegalStateException("Unsupported OPEN_STRUCT stored type for dictionary build: " + storedType);
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
@@ -375,9 +375,8 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
     PropertiesConfiguration props = new PropertiesConfiguration();
     FieldConfig.EncodingType encoding =
         useDictionary ? FieldConfig.EncodingType.DICTIONARY : FieldConfig.EncodingType.RAW;
-    int dictionaryElementSize = useDictionary ? dictElementSize : 0;
     BaseSegmentCreator.addColumnMetadataInfo(props, materializedCol, statsCollector, _numDocs, childFieldSpec,
-        useDictionary, dictionaryElementSize, encoding, false);
+        useDictionary, dictElementSize, encoding, false);
     // OPEN_STRUCT-specific keys not written by addColumnMetadataInfo.
     props.setProperty(
         V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, V1Constants.MetadataKeys.Column.PARENT_COLUMN),

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
@@ -283,9 +283,47 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
     }
     statsCollector.seal();
 
-    // Decide dictionary vs raw exactly as BaseSegmentCreator.createDictionaryForColumn, with standard
-    // default flags (optimizeDictionary off => dictionary unless explicitly disabled and not index-required).
     boolean enableInverted = _config.shouldEnableInvertedIndexForKey(key);
+    boolean useDictionary = resolveUseDictionary(key, childFieldSpec, enableInverted, statsCollector);
+
+    int dictElementSize = writeForwardAndInvertedIndexes(materializedCol, storedType, presence, values,
+        defaultValue, statsCollector, useDictionary, enableInverted);
+
+    NullValueVectorCreator nullCreator = new NullValueVectorCreator(_indexDir, materializedCol);
+    try {
+      for (int docId = 0; docId < _numDocs; docId++) {
+        if (!presence.contains(docId)) {
+          nullCreator.setNull(docId);
+        }
+      }
+      nullCreator.seal();
+    } finally {
+      nullCreator.close();
+    }
+
+    PropertiesConfiguration props = new PropertiesConfiguration();
+    FieldConfig.EncodingType encoding =
+        useDictionary ? FieldConfig.EncodingType.DICTIONARY : FieldConfig.EncodingType.RAW;
+    BaseSegmentCreator.addColumnMetadataInfo(props, materializedCol, statsCollector, _numDocs, childFieldSpec,
+        useDictionary, dictElementSize, encoding, false);
+    // OPEN_STRUCT-specific keys not written by addColumnMetadataInfo.
+    props.setProperty(
+        V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, V1Constants.MetadataKeys.Column.PARENT_COLUMN),
+        _columnName);
+    props.setProperty(V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, "hasNullValue"), true);
+    if (enableInverted && useDictionary) {
+      props.setProperty(V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, "hasInvertedIndex"), true);
+    }
+    _materializedColumnMetadata.put(materializedCol, props);
+  }
+
+  /**
+   * Decides dictionary vs raw encoding for a materialized child column, mirroring the three steps of
+   * {@code BaseSegmentCreator.createDictionaryForColumn} with standard default flags (optimizeDictionary
+   * off => dictionary unless explicitly disabled and not required by an enabled index).
+   */
+  private boolean resolveUseDictionary(String key, FieldSpec childFieldSpec, boolean enableInverted,
+      AbstractColumnStatisticsCollector statsCollector) {
     FieldIndexConfigs.Builder fieldIndexConfigsBuilder = new FieldIndexConfigs.Builder();
     fieldIndexConfigsBuilder.add(StandardIndexes.dictionary(),
         _config.shouldUseDictionaryForKey(key) ? DictionaryIndexConfig.DEFAULT : DictionaryIndexConfig.DISABLED);
@@ -294,17 +332,32 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
     }
     FieldIndexConfigs fieldIndexConfigs = fieldIndexConfigsBuilder.build();
 
-    boolean useDictionary;
     if (DictionaryIndexConfig.requiresDictionary(childFieldSpec, fieldIndexConfigs)) {
-      useDictionary = true;
-    } else if (fieldIndexConfigs.getConfig(StandardIndexes.dictionary()).isDisabled()) {
-      useDictionary = false;
-    } else {
-      useDictionary = DictionaryIndexType.ignoreDictionaryOverride(false, false,
-          IndexingConfig.DEFAULT_NO_DICTIONARY_SIZE_RATIO_THRESHOLD, null, childFieldSpec, fieldIndexConfigs,
-          statsCollector.getCardinality(), statsCollector.getTotalNumberOfEntries());
+      return true;
     }
+    if (fieldIndexConfigs.getConfig(StandardIndexes.dictionary()).isDisabled()) {
+      return false;
+    }
+    return DictionaryIndexType.ignoreDictionaryOverride(false, false,
+        IndexingConfig.DEFAULT_NO_DICTIONARY_SIZE_RATIO_THRESHOLD, null, childFieldSpec, fieldIndexConfigs,
+        statsCollector.getCardinality(), statsCollector.getTotalNumberOfEntries());
+  }
 
+  /**
+   * Writes the dictionary (when used), forward index, and inverted index (when enabled and dictionary-encoded)
+   * for a materialized child column via the standard index-creator family, driven from a single per-doc loop.
+   * Returns the dictionary element size in bytes (0 when raw-encoded), for column metadata.
+   */
+  // TODO(open_struct): only dictionary encoding and the inverted index are honored per key. A key's
+  // FieldConfig (OpenStructIndexConfig.valueFieldConfigs) can carry arbitrary indexes (text, range, bloom,
+  // json, fst, h3) via the modern `indexes` format, but those are silently dropped here. To support them,
+  // deserialize the per-key FieldConfig into a FieldIndexConfigs (FieldIndexConfigsUtil) and drive the
+  // standard multi-index creation loop (IndexService#getAllIndexes + IndexType#shouldCreateIndex), like
+  // BaseSegmentCreator, instead of hand-wiring only forward/dictionary/inverted creators.
+  private int writeForwardAndInvertedIndexes(String materializedCol, DataType storedType, RoaringBitmap presence,
+      List<Object> values, Object defaultValue, AbstractColumnStatisticsCollector statsCollector,
+      boolean useDictionary, boolean enableInverted)
+      throws IOException {
     // Dictionary built from the collector's sorted unique values (same as the standard pipeline).
     int dictElementSize = 0;
     SegmentDictionaryCreator dictCreator = null;
@@ -374,33 +427,7 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
         dictCreator.close();
       }
     }
-
-    NullValueVectorCreator nullCreator = new NullValueVectorCreator(_indexDir, materializedCol);
-    try {
-      for (int docId = 0; docId < _numDocs; docId++) {
-        if (!presence.contains(docId)) {
-          nullCreator.setNull(docId);
-        }
-      }
-      nullCreator.seal();
-    } finally {
-      nullCreator.close();
-    }
-
-    PropertiesConfiguration props = new PropertiesConfiguration();
-    FieldConfig.EncodingType encoding =
-        useDictionary ? FieldConfig.EncodingType.DICTIONARY : FieldConfig.EncodingType.RAW;
-    BaseSegmentCreator.addColumnMetadataInfo(props, materializedCol, statsCollector, _numDocs, childFieldSpec,
-        useDictionary, dictElementSize, encoding, false);
-    // OPEN_STRUCT-specific keys not written by addColumnMetadataInfo.
-    props.setProperty(
-        V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, V1Constants.MetadataKeys.Column.PARENT_COLUMN),
-        _columnName);
-    props.setProperty(V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, "hasNullValue"), true);
-    if (enableInverted && useDictionary) {
-      props.setProperty(V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, "hasInvertedIndex"), true);
-    }
-    _materializedColumnMetadata.put(materializedCol, props);
+    return dictElementSize;
   }
 
   private void writeSparseJsonColumn(List<String> sparseKeys)

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
@@ -25,7 +25,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -85,7 +84,6 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
   // Per-key accumulation
   private final Map<String, RoaringBitmap> _presenceBitmaps = new HashMap<>();
   private final Map<String, List<Object>> _values = new HashMap<>();
-  private final Map<String, Set<String>> _distinctValuesPerKey = new HashMap<>();
   private final Map<String, Long> _totalRawBytesPerKey = new HashMap<>();
   private final Map<String, DataType> _inferredTypes = new HashMap<>();
   private int _numDocs;
@@ -218,8 +216,6 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
         _values.get(key).add(coerced);
 
         DataType storedType = valueType.getStoredType();
-        String stringRep = storedType.toString(coerced);
-        _distinctValuesPerKey.computeIfAbsent(key, k -> new HashSet<>()).add(stringRep);
         if (storedType == DataType.STRING || storedType == DataType.BYTES) {
           byte[] rawBytes = storedType == DataType.BYTES ? (byte[]) coerced
               : ((String) coerced).getBytes(StandardCharsets.UTF_8);
@@ -280,9 +276,6 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
     List<Object> values = _values.get(key);
     int numDocsForKey = presence.getCardinality();
 
-    boolean useDictionary = shouldUseDictionary(key, storedType, numDocsForKey);
-    boolean enableInverted = _config.shouldEnableInvertedIndexForKey(key);
-
     // Synthetic field spec for the materialized child; its default-null-value matches the value stored
     // for absent docs so column metadata stays consistent with on-disk content.
     Object defaultValue = getDefaultValue(storedType);
@@ -298,6 +291,9 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
       statsCollector.collect(presence.contains(docId) ? values.get(statsOrdinal++) : defaultValue);
     }
     statsCollector.seal();
+
+    boolean useDictionary = shouldUseDictionary(key, storedType, statsCollector);
+    boolean enableInverted = _config.shouldEnableInvertedIndexForKey(key);
 
     Object sortedDistinctArray = useDictionary ? statsCollector.getUniqueValuesSet() : null;
     int cardinality = useDictionary ? statsCollector.getCardinality() : numDocsForKey;
@@ -583,18 +579,18 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
     _materializedColumnMetadata.put(_columnName, props);
   }
 
-  private boolean shouldUseDictionary(String key, DataType storedType, int numDocsForKey) {
+  private boolean shouldUseDictionary(String key, DataType storedType,
+      AbstractColumnStatisticsCollector statsCollector) {
     if (_config.shouldEnableInvertedIndexForKey(key)) {
       return true;
     }
     if (!_config.shouldUseDictionaryForKey(key)) {
       return false;
     }
-    Set<String> distinctValues = _distinctValuesPerKey.get(key);
-    if (distinctValues == null || distinctValues.isEmpty()) {
+    int cardinality = statsCollector.getCardinality();
+    if (cardinality == 0) {
       return false;
     }
-    int cardinality = distinctValues.size() + 1;
     int numBitsPerValue = PinotDataBitSet.getNumBitsPerValue(Math.max(cardinality - 1, 0));
     long dictIdFwdSize = ((long) _numDocs * numBitsPerValue + Byte.SIZE - 1) / Byte.SIZE;
     long rawSize;
@@ -620,11 +616,11 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
       case BYTES:
       case BIG_DECIMAL: {
         long totalRawBytes = _totalRawBytesPerKey.getOrDefault(key, 0L);
+        int longestElement = statsCollector.getLengthOfLongestElement();
         rawSize = Integer.BYTES + (long) (_numDocs + 1) * Integer.BYTES + totalRawBytes;
-        dictSize = 0;
-        for (String v : distinctValues) {
-          dictSize += Integer.BYTES + v.getBytes(StandardCharsets.UTF_8).length;
-        }
+        // Conservative upper bound on the var-length dictionary: per-entry offset plus a payload
+        // bounded by the longest element (actual var-length payload is <= this).
+        dictSize = (long) cardinality * (Integer.BYTES + longestElement);
         break;
       }
       default:

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
@@ -18,16 +18,11 @@
  */
 package org.apache.pinot.segment.local.segment.creator.impl.openstruct;
 
-import it.unimi.dsi.fastutil.doubles.DoubleOpenHashSet;
-import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
-import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
-import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -36,7 +31,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 import javax.annotation.Nullable;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -48,6 +42,8 @@ import org.apache.pinot.segment.local.segment.creator.impl.fwd.SingleValueFixedB
 import org.apache.pinot.segment.local.segment.creator.impl.fwd.SingleValueVarByteRawIndexCreator;
 import org.apache.pinot.segment.local.segment.creator.impl.inv.OffHeapBitmapInvertedIndexCreator;
 import org.apache.pinot.segment.local.segment.creator.impl.nullvalue.NullValueVectorCreator;
+import org.apache.pinot.segment.local.segment.creator.impl.stats.AbstractColumnStatisticsCollector;
+import org.apache.pinot.segment.local.segment.creator.impl.stats.StatsCollectorUtil;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
 import org.apache.pinot.segment.spi.index.creator.ColumnarOpenStructIndexCreator;
@@ -58,7 +54,6 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.OpenStructNaming;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
-import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.PinotDataType;
 import org.roaringbitmap.RoaringBitmap;
@@ -287,26 +282,26 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
     boolean useDictionary = shouldUseDictionary(key, storedType, numDocsForKey);
     boolean enableInverted = _config.shouldEnableInvertedIndexForKey(key);
 
-    Object sortedDistinctArray = null;
-    int cardinality;
-    if (useDictionary) {
-      sortedDistinctArray = buildTypedDistinctArray(key, storedType);
-      cardinality = java.lang.reflect.Array.getLength(sortedDistinctArray);
-    } else {
-      cardinality = numDocsForKey;
-    }
+    // Synthetic field spec for the materialized child; its default-null-value matches the value stored
+    // for absent docs so column metadata stays consistent with on-disk content.
+    Object defaultValue = getDefaultValue(storedType);
+    DimensionFieldSpec childFieldSpec = new DimensionFieldSpec(materializedCol, storedType, true);
+    childFieldSpec.setDefaultNullValue(defaultValue);
 
-    Comparable minValue = null;
-    Comparable maxValue = null;
-    for (Object v : values) {
-      Comparable cv = (storedType == DataType.BYTES) ? new ByteArray((byte[]) v) : (Comparable) v;
-      if (minValue == null || cv.compareTo(minValue) < 0) {
-        minValue = cv;
-      }
-      if (maxValue == null || cv.compareTo(maxValue) > 0) {
-        maxValue = cv;
-      }
+    // Collect statistics the standard way: present docs contribute their value, absent docs the default
+    // (absent docs are also marked in the null vector below).
+    AbstractColumnStatisticsCollector statsCollector =
+        StatsCollectorUtil.createStatsCollector(childFieldSpec, null);
+    int statsOrdinal = 0;
+    for (int docId = 0; docId < _numDocs; docId++) {
+      statsCollector.collect(presence.contains(docId) ? values.get(statsOrdinal++) : defaultValue);
     }
+    statsCollector.seal();
+
+    Object sortedDistinctArray = useDictionary ? statsCollector.getUniqueValuesSet() : null;
+    int cardinality = useDictionary ? statsCollector.getCardinality() : numDocsForKey;
+    Comparable minValue = (Comparable) statsCollector.getMinValue();
+    Comparable maxValue = (Comparable) statsCollector.getMaxValue();
 
     SegmentDictionaryCreator dictCreator = null;
     if (useDictionary) {
@@ -701,88 +696,6 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
         return BigDecimal.ZERO;
       default:
         throw new IllegalStateException("Unsupported OPEN_STRUCT stored type for default value: " + storedType);
-    }
-  }
-
-  private Object buildTypedDistinctArray(String key, DataType storedType) {
-    List<Object> values = _values.get(key);
-    switch (storedType) {
-      case INT: {
-        IntOpenHashSet set = new IntOpenHashSet();
-        set.add((int) getDefaultValue(storedType));
-        for (Object v : values) {
-          set.add((int) v);
-        }
-        int[] sorted = set.toIntArray();
-        Arrays.sort(sorted);
-        return sorted;
-      }
-      case LONG: {
-        LongOpenHashSet set = new LongOpenHashSet();
-        set.add((long) getDefaultValue(storedType));
-        for (Object v : values) {
-          set.add((long) v);
-        }
-        long[] sorted = set.toLongArray();
-        Arrays.sort(sorted);
-        return sorted;
-      }
-      case FLOAT: {
-        FloatOpenHashSet set = new FloatOpenHashSet();
-        set.add((float) getDefaultValue(storedType));
-        for (Object v : values) {
-          set.add((float) v);
-        }
-        float[] sorted = set.toFloatArray();
-        Arrays.sort(sorted);
-        return sorted;
-      }
-      case DOUBLE: {
-        DoubleOpenHashSet set = new DoubleOpenHashSet();
-        set.add((double) getDefaultValue(storedType));
-        for (Object v : values) {
-          set.add((double) v);
-        }
-        double[] sorted = set.toDoubleArray();
-        Arrays.sort(sorted);
-        return sorted;
-      }
-      case BYTES: {
-        TreeSet<ByteArray> sortedSet = new TreeSet<>();
-        sortedSet.add(new ByteArray((byte[]) getDefaultValue(storedType)));
-        for (Object v : values) {
-          sortedSet.add(new ByteArray((byte[]) v));
-        }
-        return sortedSet.toArray(new ByteArray[0]);
-      }
-      case STRING: {
-        Set<String> distinctStrings = _distinctValuesPerKey.getOrDefault(key, Set.of());
-        TreeSet<String> sortedSet = new TreeSet<>(distinctStrings);
-        String defaultStr = storedType.toString(getDefaultValue(storedType));
-        sortedSet.add(defaultStr);
-        return sortedSet.toArray(new String[0]);
-      }
-      case BIG_DECIMAL: {
-        // Dedup on BigDecimal.equals (scale-sensitive) to match SegmentDictionaryCreator.indexOfSV,
-        // which resolves dict ids via an equals-keyed map. A compareTo-based dedup (e.g. TreeSet)
-        // would collapse equal-but-differently-scaled values (1.0 vs 1.00) into one dictionary entry,
-        // causing the dropped value's forward-index lookup to silently resolve to dict id 0. This
-        // mirrors BigDecimalColumnPreIndexStatsCollector (ObjectOpenHashSet + Arrays.sort).
-        Set<BigDecimal> distinct = new HashSet<>();
-        distinct.add((BigDecimal) getDefaultValue(storedType));
-        for (Object v : values) {
-          distinct.add((BigDecimal) v);
-        }
-        BigDecimal[] sorted = distinct.toArray(new BigDecimal[0]);
-        Arrays.sort(sorted);
-        return sorted;
-      }
-      default:
-        // BIG_DECIMAL, STRING, BYTES and the numeric types are all handled above. The only stored
-        // types that can reach here are non-scalar (STRUCT/MAP/LIST/OPEN_STRUCT) or UNKNOWN, which
-        // are never valid stored types for an OPEN_STRUCT key — fail loudly rather than write a
-        // segment with a corrupt dictionary that contains only the default value.
-        throw new IllegalStateException("Unsupported OPEN_STRUCT stored type for dictionary build: " + storedType);
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
@@ -20,7 +20,6 @@ package org.apache.pinot.segment.local.segment.creator.impl.openstruct;
 
 import java.io.File;
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -33,27 +32,32 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
-import org.apache.pinot.segment.local.io.util.PinotDataBitSet;
-import org.apache.pinot.segment.local.io.writer.impl.FixedBitSVForwardIndexWriter;
 import org.apache.pinot.segment.local.segment.creator.impl.BaseSegmentCreator;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentDictionaryCreator;
-import org.apache.pinot.segment.local.segment.creator.impl.fwd.SingleValueFixedByteRawIndexCreator;
 import org.apache.pinot.segment.local.segment.creator.impl.fwd.SingleValueVarByteRawIndexCreator;
-import org.apache.pinot.segment.local.segment.creator.impl.inv.OffHeapBitmapInvertedIndexCreator;
 import org.apache.pinot.segment.local.segment.creator.impl.nullvalue.NullValueVectorCreator;
 import org.apache.pinot.segment.local.segment.creator.impl.stats.AbstractColumnStatisticsCollector;
 import org.apache.pinot.segment.local.segment.creator.impl.stats.StatsCollectorUtil;
+import org.apache.pinot.segment.local.segment.index.dictionary.DictionaryIndexType;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
+import org.apache.pinot.segment.spi.creator.IndexCreationContext;
+import org.apache.pinot.segment.spi.index.DictionaryIndexConfig;
+import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
+import org.apache.pinot.segment.spi.index.ForwardIndexConfig;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.segment.spi.index.creator.ColumnarOpenStructIndexCreator;
+import org.apache.pinot.segment.spi.index.creator.DictionaryBasedInvertedIndexCreator;
+import org.apache.pinot.segment.spi.index.creator.ForwardIndexCreator;
 import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.IndexConfig;
+import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.OpenStructIndexConfig;
 import org.apache.pinot.spi.data.ComplexFieldSpec;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.OpenStructNaming;
-import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.PinotDataType;
 import org.roaringbitmap.RoaringBitmap;
@@ -73,7 +77,6 @@ import org.slf4j.LoggerFactory;
 public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OpenStructColumnSplitter.class);
-  private static final double NO_DICTIONARY_SIZE_RATIO_THRESHOLD = 0.85;
 
   private final File _indexDir;
   private final String _columnName;
@@ -84,7 +87,6 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
   // Per-key accumulation
   private final Map<String, RoaringBitmap> _presenceBitmaps = new HashMap<>();
   private final Map<String, List<Object>> _values = new HashMap<>();
-  private final Map<String, Long> _totalRawBytesPerKey = new HashMap<>();
   private final Map<String, DataType> _inferredTypes = new HashMap<>();
   private int _numDocs;
 
@@ -214,15 +216,6 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
           continue;
         }
         _values.get(key).add(coerced);
-
-        DataType storedType = valueType.getStoredType();
-        if (storedType == DataType.STRING || storedType == DataType.BYTES) {
-          byte[] rawBytes = storedType == DataType.BYTES ? (byte[]) coerced
-              : ((String) coerced).getBytes(StandardCharsets.UTF_8);
-          _totalRawBytesPerKey.merge(key, (long) rawBytes.length, Long::sum);
-        } else if (storedType == DataType.BIG_DECIMAL) {
-          _totalRawBytesPerKey.merge(key, (long) BigDecimalUtils.serialize((BigDecimal) coerced).length, Long::sum);
-        }
       }
     }
     _numDocs++;
@@ -274,13 +267,11 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
     DataType storedType = valueType.getStoredType();
     RoaringBitmap presence = _presenceBitmaps.get(key);
     List<Object> values = _values.get(key);
-    int numDocsForKey = presence.getCardinality();
 
-    // Synthetic field spec for the materialized child; its default-null-value matches the value stored
-    // for absent docs so column metadata stays consistent with on-disk content.
-    Object defaultValue = getDefaultValue(storedType);
+    // Synthetic field spec for the materialized child. Its natural Pinot dimension null value is the value
+    // stored for absent docs, so column metadata stays consistent with on-disk content.
     DimensionFieldSpec childFieldSpec = new DimensionFieldSpec(materializedCol, storedType, true);
-    childFieldSpec.setDefaultNullValue(defaultValue);
+    Object defaultValue = childFieldSpec.getDefaultNullValue();
 
     // Collect statistics the standard way: present docs contribute their value, absent docs the default
     // (absent docs are also marked in the null vector below).
@@ -292,70 +283,94 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
     }
     statsCollector.seal();
 
-    boolean useDictionary = shouldUseDictionary(key, storedType, statsCollector);
+    // Decide dictionary vs raw exactly as BaseSegmentCreator.createDictionaryForColumn, with standard
+    // default flags (optimizeDictionary off => dictionary unless explicitly disabled and not index-required).
     boolean enableInverted = _config.shouldEnableInvertedIndexForKey(key);
+    FieldIndexConfigs.Builder fieldIndexConfigsBuilder = new FieldIndexConfigs.Builder();
+    fieldIndexConfigsBuilder.add(StandardIndexes.dictionary(),
+        _config.shouldUseDictionaryForKey(key) ? DictionaryIndexConfig.DEFAULT : DictionaryIndexConfig.DISABLED);
+    if (enableInverted) {
+      fieldIndexConfigsBuilder.add(StandardIndexes.inverted(), IndexConfig.ENABLED);
+    }
+    FieldIndexConfigs fieldIndexConfigs = fieldIndexConfigsBuilder.build();
 
-    Object sortedDistinctArray = useDictionary ? statsCollector.getUniqueValuesSet() : null;
-    int cardinality = useDictionary ? statsCollector.getCardinality() : numDocsForKey;
-
-    int dictElementSize = 0;
-    SegmentDictionaryCreator dictCreator = null;
-    if (useDictionary) {
-      dictCreator = new SegmentDictionaryCreator(
-          materializedCol, storedType, new File(_indexDir,
-          materializedCol + V1Constants.Dict.FILE_EXTENSION), true);
-      dictCreator.build(sortedDistinctArray);
+    boolean useDictionary;
+    if (DictionaryIndexConfig.requiresDictionary(childFieldSpec, fieldIndexConfigs)) {
+      useDictionary = true;
+    } else if (fieldIndexConfigs.getConfig(StandardIndexes.dictionary()).isDisabled()) {
+      useDictionary = false;
+    } else {
+      useDictionary = DictionaryIndexType.ignoreDictionaryOverride(false, false,
+          IndexingConfig.DEFAULT_NO_DICTIONARY_SIZE_RATIO_THRESHOLD, null, childFieldSpec, fieldIndexConfigs,
+          statsCollector.getCardinality(), statsCollector.getTotalNumberOfEntries());
     }
 
+    // Dictionary built from the collector's sorted unique values (same as the standard pipeline).
+    int dictElementSize = 0;
+    SegmentDictionaryCreator dictCreator = null;
     try {
       if (useDictionary) {
-        int numBitsPerValue = PinotDataBitSet.getNumBitsPerValue(Math.max(cardinality - 1, 0));
-        int defaultDictId = dictCreator.indexOfSV(getDefaultValue(storedType));
+        dictCreator = new SegmentDictionaryCreator(materializedCol, storedType,
+            new File(_indexDir, materializedCol + V1Constants.Dict.FILE_EXTENSION), true);
+        dictCreator.build(statsCollector.getUniqueValuesSet());
+      }
 
-        FixedBitSVForwardIndexWriter fwdWriter = new FixedBitSVForwardIndexWriter(
-            new File(_indexDir, materializedCol + V1Constants.Indexes.UNSORTED_SV_FORWARD_INDEX_FILE_EXTENSION),
-            _numDocs, numBitsPerValue);
+      // Index-creation context built from the sealed collector (a ColumnShape) — no TableConfig required.
+      IndexCreationContext context =
+          new IndexCreationContext.Builder(_indexDir, null, statsCollector, useDictionary, false)
+              .withOnHeap(false).build();
+      ForwardIndexConfig forwardIndexConfig = new ForwardIndexConfig.Builder(
+          useDictionary ? FieldConfig.EncodingType.DICTIONARY : FieldConfig.EncodingType.RAW)
+          .withCompressionCodec(FieldConfig.CompressionCodec.LZ4).build();
+
+      ForwardIndexCreator forwardCreator;
+      try {
+        forwardCreator = StandardIndexes.forward().createIndexCreator(context, forwardIndexConfig);
+      } catch (IOException e) {
+        throw e;
+      } catch (Exception e) {
+        throw new IOException("Failed to create forward index creator for: " + materializedCol, e);
+      }
+      try {
+        DictionaryBasedInvertedIndexCreator invertedCreator;
+        try {
+          invertedCreator = (enableInverted && useDictionary)
+              ? StandardIndexes.inverted().createIndexCreator(context, IndexConfig.ENABLED) : null;
+        } catch (IOException e) {
+          throw e;
+        } catch (Exception e) {
+          throw new IOException("Failed to create inverted index creator for: " + materializedCol, e);
+        }
         try {
           int ordinal = 0;
           for (int docId = 0; docId < _numDocs; docId++) {
-            if (presence.contains(docId)) {
-              Object typedValue = values.get(ordinal++);
-              fwdWriter.putDictId(dictCreator.indexOfSV(typedValue));
-            } else {
-              fwdWriter.putDictId(defaultDictId);
+            Object value = presence.contains(docId) ? values.get(ordinal++) : defaultValue;
+            int dictId = useDictionary ? dictCreator.indexOfSV(value) : -1;
+            forwardCreator.add(value, dictId);
+            if (invertedCreator != null) {
+              invertedCreator.add(value, dictId);
             }
           }
+          forwardCreator.seal();
+          if (invertedCreator != null) {
+            invertedCreator.seal();
+          }
         } finally {
-          fwdWriter.close();
+          if (invertedCreator != null) {
+            invertedCreator.close();
+          }
         }
-      } else {
-        writeRawForwardIndex(materializedCol, storedType, presence, values);
+      } finally {
+        forwardCreator.close();
       }
 
-      if (enableInverted && useDictionary) {
-        FieldSpec fakeFieldSpec = new DimensionFieldSpec(materializedCol, storedType, true);
-        OffHeapBitmapInvertedIndexCreator invCreator = new OffHeapBitmapInvertedIndexCreator(
-            _indexDir, fakeFieldSpec, cardinality, _numDocs, _numDocs);
-        try {
-          int defaultDictId = dictCreator.indexOfSV(getDefaultValue(storedType));
-          int ordinal = 0;
-          for (int docId = 0; docId < _numDocs; docId++) {
-            if (presence.contains(docId)) {
-              Object typedValue = values.get(ordinal++);
-              invCreator.add(dictCreator.indexOfSV(typedValue));
-            } else {
-              invCreator.add(defaultDictId);
-            }
-          }
-          invCreator.seal();
-        } finally {
-          invCreator.close();
-        }
-      }
-    } finally {
+      // Seal the dictionary only after the index writes succeeded; capture its element size for metadata.
       if (dictCreator != null) {
         dictElementSize = dictCreator.getNumBytesPerEntry();
         dictCreator.seal();
+      }
+    } finally {
+      if (dictCreator != null) {
         dictCreator.close();
       }
     }
@@ -386,104 +401,6 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
       props.setProperty(V1Constants.MetadataKeys.Column.getKeyFor(materializedCol, "hasInvertedIndex"), true);
     }
     _materializedColumnMetadata.put(materializedCol, props);
-  }
-
-  private void writeRawForwardIndex(String materializedCol, DataType storedType,
-      RoaringBitmap presence, List<Object> values)
-      throws IOException {
-    Object defaultVal = getDefaultValue(storedType);
-    switch (storedType) {
-      case INT:
-      case LONG:
-      case FLOAT:
-      case DOUBLE: {
-        SingleValueFixedByteRawIndexCreator creator = new SingleValueFixedByteRawIndexCreator(
-            _indexDir, ChunkCompressionType.LZ4, materializedCol, _numDocs, storedType);
-        try {
-          int ordinal = 0;
-          for (int docId = 0; docId < _numDocs; docId++) {
-            Object val = presence.contains(docId) ? values.get(ordinal++) : defaultVal;
-            switch (storedType) {
-              case INT:
-                creator.putInt((Integer) val);
-                break;
-              case LONG:
-                creator.putLong((Long) val);
-                break;
-              case FLOAT:
-                creator.putFloat((Float) val);
-                break;
-              case DOUBLE:
-                creator.putDouble((Double) val);
-                break;
-              default:
-                break;
-            }
-          }
-          creator.seal();
-        } finally {
-          creator.close();
-        }
-        break;
-      }
-      case STRING: {
-        int maxLen = 1;
-        for (Object v : values) {
-          maxLen = Math.max(maxLen, ((String) v).getBytes(StandardCharsets.UTF_8).length);
-        }
-        SingleValueVarByteRawIndexCreator creator = new SingleValueVarByteRawIndexCreator(
-            _indexDir, ChunkCompressionType.LZ4, materializedCol, _numDocs, storedType, maxLen);
-        try {
-          int ordinal = 0;
-          for (int docId = 0; docId < _numDocs; docId++) {
-            creator.putString(presence.contains(docId) ? (String) values.get(ordinal++) : (String) defaultVal);
-          }
-          creator.seal();
-        } finally {
-          creator.close();
-        }
-        break;
-      }
-      case BYTES: {
-        int maxLen = 1;
-        for (Object v : values) {
-          maxLen = Math.max(maxLen, ((byte[]) v).length);
-        }
-        SingleValueVarByteRawIndexCreator creator = new SingleValueVarByteRawIndexCreator(
-            _indexDir, ChunkCompressionType.LZ4, materializedCol, _numDocs, storedType, maxLen);
-        try {
-          int ordinal = 0;
-          for (int docId = 0; docId < _numDocs; docId++) {
-            creator.putBytes(presence.contains(docId) ? (byte[]) values.get(ordinal++) : (byte[]) defaultVal);
-          }
-          creator.seal();
-        } finally {
-          creator.close();
-        }
-        break;
-      }
-      case BIG_DECIMAL: {
-        int maxLen = 1;
-        for (Object v : values) {
-          maxLen = Math.max(maxLen, BigDecimalUtils.serialize((BigDecimal) v).length);
-        }
-        SingleValueVarByteRawIndexCreator creator = new SingleValueVarByteRawIndexCreator(
-            _indexDir, ChunkCompressionType.LZ4, materializedCol, _numDocs, storedType, maxLen);
-        try {
-          int ordinal = 0;
-          for (int docId = 0; docId < _numDocs; docId++) {
-            creator.putBigDecimal(
-                presence.contains(docId) ? (BigDecimal) values.get(ordinal++) : (BigDecimal) defaultVal);
-          }
-          creator.seal();
-        } finally {
-          creator.close();
-        }
-        break;
-      }
-      default:
-        throw new IllegalStateException("Unsupported stored type for raw forward index: " + storedType);
-    }
   }
 
   private void writeSparseJsonColumn(List<String> sparseKeys)
@@ -576,77 +493,5 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
         V1Constants.MetadataKeys.Column.getKeyFor(_columnName, V1Constants.MetadataKeys.Column.HAS_SPARSE_COLUMN),
         hasSparseColumn);
     _materializedColumnMetadata.put(_columnName, props);
-  }
-
-  private boolean shouldUseDictionary(String key, DataType storedType,
-      AbstractColumnStatisticsCollector statsCollector) {
-    if (_config.shouldEnableInvertedIndexForKey(key)) {
-      return true;
-    }
-    if (!_config.shouldUseDictionaryForKey(key)) {
-      return false;
-    }
-    int cardinality = statsCollector.getCardinality();
-    if (cardinality == 0) {
-      return false;
-    }
-    int numBitsPerValue = PinotDataBitSet.getNumBitsPerValue(Math.max(cardinality - 1, 0));
-    long dictIdFwdSize = ((long) _numDocs * numBitsPerValue + Byte.SIZE - 1) / Byte.SIZE;
-    long rawSize;
-    long dictSize;
-    switch (storedType) {
-      case INT:
-        rawSize = (long) _numDocs * Integer.BYTES;
-        dictSize = (long) cardinality * Integer.BYTES;
-        break;
-      case LONG:
-        rawSize = (long) _numDocs * Long.BYTES;
-        dictSize = (long) cardinality * Long.BYTES;
-        break;
-      case FLOAT:
-        rawSize = (long) _numDocs * Float.BYTES;
-        dictSize = (long) cardinality * Float.BYTES;
-        break;
-      case DOUBLE:
-        rawSize = (long) _numDocs * Double.BYTES;
-        dictSize = (long) cardinality * Double.BYTES;
-        break;
-      case STRING:
-      case BYTES:
-      case BIG_DECIMAL: {
-        long totalRawBytes = _totalRawBytesPerKey.getOrDefault(key, 0L);
-        int longestElement = statsCollector.getLengthOfLongestElement();
-        rawSize = Integer.BYTES + (long) (_numDocs + 1) * Integer.BYTES + totalRawBytes;
-        // Conservative upper bound on the var-length dictionary: per-entry offset plus a payload
-        // bounded by the longest element (actual var-length payload is <= this).
-        dictSize = (long) cardinality * (Integer.BYTES + longestElement);
-        break;
-      }
-      default:
-        return true;
-    }
-    double ratio = (double) rawSize / (dictSize + dictIdFwdSize);
-    return ratio > NO_DICTIONARY_SIZE_RATIO_THRESHOLD;
-  }
-
-  private static Object getDefaultValue(DataType storedType) {
-    switch (storedType) {
-      case INT:
-        return 0;
-      case LONG:
-        return 0L;
-      case FLOAT:
-        return 0.0f;
-      case DOUBLE:
-        return 0.0;
-      case STRING:
-        return "";
-      case BYTES:
-        return new byte[0];
-      case BIG_DECIMAL:
-        return BigDecimal.ZERO;
-      default:
-        throw new IllegalStateException("Unsupported OPEN_STRUCT stored type for default value: " + storedType);
-    }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
@@ -39,16 +39,19 @@ import org.apache.pinot.segment.local.segment.creator.impl.nullvalue.NullValueVe
 import org.apache.pinot.segment.local.segment.creator.impl.stats.AbstractColumnStatisticsCollector;
 import org.apache.pinot.segment.local.segment.creator.impl.stats.StatsCollectorUtil;
 import org.apache.pinot.segment.local.segment.index.dictionary.DictionaryIndexType;
+import org.apache.pinot.segment.local.segment.index.openstruct.OpenStructSupportedIndexes;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
 import org.apache.pinot.segment.spi.creator.IndexCreationContext;
 import org.apache.pinot.segment.spi.index.DictionaryIndexConfig;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
+import org.apache.pinot.segment.spi.index.FieldIndexConfigsUtil;
 import org.apache.pinot.segment.spi.index.ForwardIndexConfig;
+import org.apache.pinot.segment.spi.index.IndexCreator;
+import org.apache.pinot.segment.spi.index.IndexService;
+import org.apache.pinot.segment.spi.index.IndexType;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.segment.spi.index.creator.ColumnarOpenStructIndexCreator;
-import org.apache.pinot.segment.spi.index.creator.DictionaryBasedInvertedIndexCreator;
-import org.apache.pinot.segment.spi.index.creator.ForwardIndexCreator;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.IndexConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
@@ -284,11 +287,37 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
     }
     statsCollector.seal();
 
+    // Build per-key index configuration from the key's FieldConfig (falling back to the default), then apply
+    // the OPEN_STRUCT inverted-on default. No TableConfig/Schema required.
+    FieldConfig keyFieldConfig = _config.getValueFieldConfig(key);
+    if (keyFieldConfig == null) {
+      keyFieldConfig = _config.getDefaultValueFieldConfig();
+    }
     boolean enableInverted = _config.shouldEnableInvertedIndexForKey(key);
-    boolean useDictionary = resolveUseDictionary(key, childFieldSpec, enableInverted, statsCollector);
+    FieldIndexConfigs configsForDecision = new FieldIndexConfigs.Builder(
+        FieldIndexConfigsUtil.fromFieldConfig(keyFieldConfig, childFieldSpec))
+        .add(StandardIndexes.inverted(), enableInverted ? IndexConfig.ENABLED : IndexConfig.DISABLED)
+        .build();
 
-    int dictElementSize = writeForwardAndInvertedIndexes(materializedCol, storedType, presence, values,
-        defaultValue, statsCollector, useDictionary, enableInverted);
+    boolean useDictionary = resolveUseDictionary(childFieldSpec, configsForDecision, statsCollector);
+
+    // Reconcile dictionary + forward encoding with the final decision (mirrors BaseSegmentCreator.adaptConfig);
+    // ForwardIndexCreatorFactory selects dict-vs-raw from the forward config's EncodingType. A compression codec
+    // applies only to the raw forward format (LZ4 preserves the dense child's current on-disk layout); attaching
+    // one to a dictionary-encoded forward is rejected by ForwardIndexType.validate.
+    ForwardIndexConfig.Builder forwardBuilder = new ForwardIndexConfig.Builder(
+        useDictionary ? FieldConfig.EncodingType.DICTIONARY : FieldConfig.EncodingType.RAW);
+    if (!useDictionary) {
+      forwardBuilder.withCompressionCodec(FieldConfig.CompressionCodec.LZ4);
+    }
+    FieldIndexConfigs fieldIndexConfigs = new FieldIndexConfigs.Builder(configsForDecision)
+        .add(StandardIndexes.dictionary(),
+            useDictionary ? DictionaryIndexConfig.DEFAULT : DictionaryIndexConfig.DISABLED)
+        .add(StandardIndexes.forward(), forwardBuilder.build())
+        .build();
+
+    int dictElementSize = writeColumnIndexes(materializedCol, storedType, presence, values,
+        defaultValue, statsCollector, useDictionary, fieldIndexConfigs, childFieldSpec);
 
     NullValueVectorCreator nullCreator = new NullValueVectorCreator(_indexDir, materializedCol);
     try {
@@ -323,16 +352,8 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
    * {@code BaseSegmentCreator.createDictionaryForColumn} with standard default flags (optimizeDictionary
    * off => dictionary unless explicitly disabled and not required by an enabled index).
    */
-  private boolean resolveUseDictionary(String key, FieldSpec childFieldSpec, boolean enableInverted,
+  private boolean resolveUseDictionary(FieldSpec childFieldSpec, FieldIndexConfigs fieldIndexConfigs,
       AbstractColumnStatisticsCollector statsCollector) {
-    FieldIndexConfigs.Builder fieldIndexConfigsBuilder = new FieldIndexConfigs.Builder();
-    fieldIndexConfigsBuilder.add(StandardIndexes.dictionary(),
-        _config.shouldUseDictionaryForKey(key) ? DictionaryIndexConfig.DEFAULT : DictionaryIndexConfig.DISABLED);
-    if (enableInverted) {
-      fieldIndexConfigsBuilder.add(StandardIndexes.inverted(), IndexConfig.ENABLED);
-    }
-    FieldIndexConfigs fieldIndexConfigs = fieldIndexConfigsBuilder.build();
-
     if (DictionaryIndexConfig.requiresDictionary(childFieldSpec, fieldIndexConfigs)) {
       return true;
     }
@@ -345,21 +366,15 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
   }
 
   /**
-   * Writes the dictionary (when used), forward index, and inverted index (when enabled and dictionary-encoded)
-   * for a materialized child column via the standard index-creator family, driven from a single per-doc loop.
-   * Returns the dictionary element size in bytes (0 when raw-encoded), for column metadata.
+   * Writes the dictionary (when used) plus all vetted, enabled indexes for a materialized child column through
+   * the standard index-creator family, driven from a single per-doc loop. Returns the dictionary element size in
+   * bytes (0 when raw-encoded), for column metadata. The dictionary is built separately because its build
+   * lifecycle is CUSTOM and it supplies the dictIds the per-row creators consume.
    */
-  // TODO(open_struct): only dictionary encoding and the inverted index are honored per key. A key's
-  // FieldConfig (OpenStructIndexConfig.valueFieldConfigs) can carry arbitrary indexes (text, range, bloom,
-  // json, fst, h3) via the modern `indexes` format, but those are silently dropped here. To support them,
-  // deserialize the per-key FieldConfig into a FieldIndexConfigs (FieldIndexConfigsUtil) and drive the
-  // standard multi-index creation loop (IndexService#getAllIndexes + IndexType#shouldCreateIndex), like
-  // BaseSegmentCreator, instead of hand-wiring only forward/dictionary/inverted creators.
-  private int writeForwardAndInvertedIndexes(String materializedCol, DataType storedType, RoaringBitmap presence,
+  private int writeColumnIndexes(String materializedCol, DataType storedType, RoaringBitmap presence,
       List<Object> values, Object defaultValue, AbstractColumnStatisticsCollector statsCollector,
-      boolean useDictionary, boolean enableInverted)
+      boolean useDictionary, FieldIndexConfigs fieldIndexConfigs, FieldSpec childFieldSpec)
       throws IOException {
-    // Dictionary built from the collector's sorted unique values (same as the standard pipeline).
     int dictElementSize = 0;
     SegmentDictionaryCreator dictCreator = null;
     try {
@@ -373,49 +388,38 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
       IndexCreationContext context =
           new IndexCreationContext.Builder(_indexDir, null, statsCollector, useDictionary, false)
               .withOnHeap(false).build();
-      ForwardIndexConfig forwardIndexConfig = new ForwardIndexConfig.Builder(
-          useDictionary ? FieldConfig.EncodingType.DICTIONARY : FieldConfig.EncodingType.RAW)
-          .withCompressionCodec(FieldConfig.CompressionCodec.LZ4).build();
 
-      ForwardIndexCreator forwardCreator;
+      List<IndexCreator> creators = new ArrayList<>();
       try {
-        forwardCreator = StandardIndexes.forward().createIndexCreator(context, forwardIndexConfig);
-      } catch (IOException e) {
-        throw e;
-      } catch (Exception e) {
-        throw new IOException("Failed to create forward index creator for: " + materializedCol, e);
-      }
-      try {
-        DictionaryBasedInvertedIndexCreator invertedCreator;
-        try {
-          invertedCreator = (enableInverted && useDictionary)
-              ? StandardIndexes.inverted().createIndexCreator(context, IndexConfig.ENABLED) : null;
-        } catch (IOException e) {
-          throw e;
-        } catch (Exception e) {
-          throw new IOException("Failed to create inverted index creator for: " + materializedCol, e);
+        for (IndexType<?, ?, ?> indexType : IndexService.getInstance().getAllIndexes()) {
+          if (indexType.getIndexBuildLifecycle() != IndexType.BuildLifecycle.DURING_SEGMENT_CREATION) {
+            continue;   // excludes dictionary (lifecycle CUSTOM), built separately above
+          }
+          if (!OpenStructSupportedIndexes.ALLOWED_PRETTY_NAMES.contains(indexType.getPrettyName())) {
+            continue;   // non-vetted indexes already rejected at table-config validation; defensive backstop
+          }
+          IndexCreator creator = createColumnIndexCreator(indexType, context, fieldIndexConfigs, materializedCol,
+              childFieldSpec);
+          if (creator != null) {
+            creators.add(creator);
+          }
         }
-        try {
-          int ordinal = 0;
-          for (int docId = 0; docId < _numDocs; docId++) {
-            Object value = presence.contains(docId) ? values.get(ordinal++) : defaultValue;
-            int dictId = useDictionary ? dictCreator.indexOfSV(value) : -1;
-            forwardCreator.add(value, dictId);
-            if (invertedCreator != null) {
-              invertedCreator.add(value, dictId);
-            }
+
+        int ordinal = 0;
+        for (int docId = 0; docId < _numDocs; docId++) {
+          Object value = presence.contains(docId) ? values.get(ordinal++) : defaultValue;
+          int dictId = useDictionary ? dictCreator.indexOfSV(value) : -1;
+          for (IndexCreator creator : creators) {
+            creator.add(value, dictId);
           }
-          forwardCreator.seal();
-          if (invertedCreator != null) {
-            invertedCreator.seal();
-          }
-        } finally {
-          if (invertedCreator != null) {
-            invertedCreator.close();
-          }
+        }
+        for (IndexCreator creator : creators) {
+          creator.seal();
         }
       } finally {
-        forwardCreator.close();
+        for (IndexCreator creator : creators) {
+          creator.close();
+        }
       }
 
       // Seal the dictionary only after the index writes succeeded; capture its element size for metadata.
@@ -429,6 +433,29 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
       }
     }
     return dictElementSize;
+  }
+
+  @Nullable
+  private static <C extends IndexConfig> IndexCreator createColumnIndexCreator(IndexType<C, ?, ?> indexType,
+      IndexCreationContext context, FieldIndexConfigs fieldIndexConfigs, String materializedCol,
+      FieldSpec childFieldSpec)
+      throws IOException {
+    // Materialized child columns exist in no schema/TableConfig, so the standard table-config-time validation
+    // never sees them. Run the index type's own guards here against the resolved child FieldSpec (e.g. range
+    // rejects a non-numeric column without a dictionary) so misconfigurations fail with the canonical message
+    // instead of crashing opaquely inside the creator. validate() internally no-ops when the index is disabled.
+    indexType.validate(fieldIndexConfigs, childFieldSpec, null);
+    C config = fieldIndexConfigs.getConfig(indexType);
+    if (!config.isEnabled() || !indexType.shouldCreateIndex(context, config)) {
+      return null;
+    }
+    try {
+      return indexType.createIndexCreator(context, config);
+    } catch (IOException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IOException("Failed to create " + indexType.getPrettyName() + " creator for: " + materializedCol, e);
+    }
   }
 
   private void writeSparseJsonColumn(List<String> sparseKeys)

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
@@ -58,6 +58,7 @@ import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.OpenStructNaming;
+import org.apache.pinot.spi.data.OpenStructTypeInference;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.PinotDataType;
 import org.roaringbitmap.RoaringBitmap;
@@ -196,7 +197,7 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
         DataType valueType = keySpec != null
             ? keySpec.getDataType()
             : _inferredTypes.computeIfAbsent(key, k -> {
-              DataType inferred = OpenStructNaming.inferDataType(rawValue);
+              DataType inferred = OpenStructTypeInference.inferDataType(rawValue);
               return inferred != null ? inferred : DataType.STRING;
             });
         if (!_presenceBitmaps.containsKey(key)) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitter.java
@@ -69,15 +69,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-/**
- * Splits an OPEN_STRUCT column into per-key materialized columns using standard Pinot index
- * creators. Dense keys become independent virtual columns; remaining keys go into a single
- * synthetic JSON column for sparse storage.
- *
- * <p>Lifecycle: instantiated by {@code BaseSegmentCreator} for OPEN_STRUCT columns. Receives
- * per-doc {@code Map<String, Object>} values via {@link #add(Map, int)}, accumulates in memory,
- * then on {@link #seal()} writes per-key column files using standard creators.
- */
+/// Splits an OPEN_STRUCT column into per-key materialized columns using standard Pinot index
+/// creators. Dense keys become independent virtual columns; remaining keys go into a single
+/// synthetic JSON column for sparse storage.
+///
+/// Lifecycle: instantiated by `BaseSegmentCreator` for OPEN_STRUCT columns. Receives
+/// per-doc `Map<String, Object>` values via [#add(Map, int)], accumulates in memory,
+/// then on [#seal()] writes per-key column files using standard creators.
 public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OpenStructColumnSplitter.class);
@@ -138,18 +136,14 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
     throw new UnsupportedOperationException("OPEN_STRUCT index is single-value only");
   }
 
-  /**
-   * Returns the resolved dense-key set after {@link #seal()} or {@link #classify()}.
-   * Returns an empty set before resolution.
-   */
+  /// Returns the resolved dense-key set after [#seal()] or [#classify()].
+  /// Returns an empty set before resolution.
   public Set<String> getResolvedDenseKeys() {
     return _resolvedDenseKeys != null ? Collections.unmodifiableSet(_resolvedDenseKeys) : Set.of();
   }
 
-  /**
-   * Resolves dense vs sparse keys without writing any files. Exposed for testing and for callers
-   * that need the classification independent of file output. {@link #seal()} calls this internally.
-   */
+  /// Resolves dense vs sparse keys without writing any files. Exposed for testing and for callers
+  /// that need the classification independent of file output. [#seal()] calls this internally.
   public Set<String> classify() {
     if (_resolvedDenseKeys != null) {
       return _resolvedDenseKeys;
@@ -347,11 +341,9 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
     _materializedColumnMetadata.put(materializedCol, props);
   }
 
-  /**
-   * Decides dictionary vs raw encoding for a materialized child column, mirroring the three steps of
-   * {@code BaseSegmentCreator.createDictionaryForColumn} with standard default flags (optimizeDictionary
-   * off => dictionary unless explicitly disabled and not required by an enabled index).
-   */
+  /// Decides dictionary vs raw encoding for a materialized child column, mirroring the three steps of
+  /// `BaseSegmentCreator.createDictionaryForColumn` with standard default flags (optimizeDictionary
+  /// off => dictionary unless explicitly disabled and not required by an enabled index).
   private boolean resolveUseDictionary(FieldSpec childFieldSpec, FieldIndexConfigs fieldIndexConfigs,
       AbstractColumnStatisticsCollector statsCollector) {
     if (DictionaryIndexConfig.requiresDictionary(childFieldSpec, fieldIndexConfigs)) {
@@ -365,12 +357,10 @@ public class OpenStructColumnSplitter implements ColumnarOpenStructIndexCreator 
         statsCollector.getCardinality(), statsCollector.getTotalNumberOfEntries());
   }
 
-  /**
-   * Writes the dictionary (when used) plus all vetted, enabled indexes for a materialized child column through
-   * the standard index-creator family, driven from a single per-doc loop. Returns the dictionary element size in
-   * bytes (0 when raw-encoded), for column metadata. The dictionary is built separately because its build
-   * lifecycle is CUSTOM and it supplies the dictIds the per-row creators consume.
-   */
+  /// Writes the dictionary (when used) plus all vetted, enabled indexes for a materialized child column through
+  /// the standard index-creator family, driven from a single per-doc loop. Returns the dictionary element size in
+  /// bytes (0 when raw-encoded), for column metadata. The dictionary is built separately because its build
+  /// lifecycle is CUSTOM and it supplies the dictIds the per-row creators consume.
   private int writeColumnIndexes(String materializedCol, DataType storedType, RoaringBitmap presence,
       List<Object> values, Object defaultValue, AbstractColumnStatisticsCollector statsCollector,
       boolean useDictionary, FieldIndexConfigs fieldIndexConfigs, FieldSpec childFieldSpec)

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -29,18 +29,24 @@ import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.segment.local.segment.index.loader.columnminmaxvalue.ColumnMinMaxValueGeneratorMode;
 import org.apache.pinot.segment.local.utils.TableConfigUtils;
+import org.apache.pinot.segment.spi.ColumnMetadata;
 import org.apache.pinot.segment.spi.creator.SegmentVersion;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigsUtil;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderRegistry;
 import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.IndexConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.MultiColumnTextIndexConfig;
+import org.apache.pinot.spi.config.table.OpenStructIndexConfig;
 import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.OpenStructNaming;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.TimestampIndexUtils;
@@ -406,6 +412,43 @@ public class IndexLoadingConfig {
 
   private <K, V> Map<K, V> unmodifiable(Map<K, V> map) {
     return map == null ? null : Collections.unmodifiableMap(map);
+  }
+
+  public void addOpenStructChildConfigs(SegmentMetadataImpl segmentMetadata) {
+    if (_indexConfigsByColName == null || _dirty) {
+      refreshIndexConfigs();
+    }
+    for (Map.Entry<String, ColumnMetadata> entry : segmentMetadata.getColumnMetadataMap().entrySet()) {
+      String childColumn = entry.getKey();
+      if (!childColumn.contains(OpenStructNaming.SEPARATOR) || _indexConfigsByColName.containsKey(childColumn)) {
+        continue;
+      }
+      if (OpenStructNaming.isSparseColumn(childColumn)) {
+        continue;
+      }
+      String parentColumn = OpenStructNaming.parseParentColumn(childColumn);
+      FieldIndexConfigs parentConfigs = _indexConfigsByColName.get(parentColumn);
+      if (parentConfigs == null) {
+        continue;
+      }
+      IndexConfig osConfig = parentConfigs.getConfig(StandardIndexes.openStruct());
+      if (!(osConfig instanceof OpenStructIndexConfig)) {
+        continue;
+      }
+      OpenStructIndexConfig openStructConfig = (OpenStructIndexConfig) osConfig;
+      String key = OpenStructNaming.parseKey(childColumn);
+      FieldConfig keyFieldConfig = openStructConfig.getValueFieldConfig(key);
+      if (keyFieldConfig == null) {
+        keyFieldConfig = openStructConfig.getDefaultValueFieldConfig();
+      }
+      FieldSpec childFieldSpec = entry.getValue().getFieldSpec();
+      boolean enableInverted = openStructConfig.shouldEnableInvertedIndexForKey(key);
+      FieldIndexConfigs childConfigs = new FieldIndexConfigs.Builder(
+          FieldIndexConfigsUtil.fromFieldConfig(keyFieldConfig, childFieldSpec))
+          .add(StandardIndexes.inverted(), enableInverted ? IndexConfig.ENABLED : IndexConfig.DISABLED)
+          .build();
+      _indexConfigsByColName.put(childColumn, childConfigs);
+    }
   }
 
   public void addKnownColumns(Set<String> columns) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessor.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessor.java
@@ -125,6 +125,11 @@ public class SegmentPreProcessor implements AutoCloseable {
       defaultColumnHandler.updateDefaultColumns();
       _segmentDirectory.reloadMetadata();
 
+      // Resolve per-key index configs for OPEN_STRUCT child columns so index handlers don't strip
+      // inverted/range indexes that the OpenStructColumnSplitter wrote during segment creation.
+      _indexLoadingConfig.addOpenStructChildConfigs(
+          (SegmentMetadataImpl) _segmentDirectory.getSegmentMetadata());
+
       // Update single-column indices, like inverted index, json index etc.
       List<IndexHandler> indexHandlers = new ArrayList<>();
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/ImmutableOpenStructDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/ImmutableOpenStructDataSource.java
@@ -1,0 +1,184 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.openstruct;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.pinot.segment.local.segment.index.datasource.BaseDataSource;
+import org.apache.pinot.segment.local.segment.index.datasource.ImmutableDataSource;
+import org.apache.pinot.segment.spi.Constants;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
+import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
+import org.apache.pinot.segment.spi.index.column.ColumnIndexContainer;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+
+
+/**
+ * Per-key {@link DataSource} accessor for sealed (immutable) segments with an OPEN_STRUCT column.
+ *
+ * <p>Always columnar — there is no blob branch. Every key that was dense enough during segment
+ * creation gets its own materialized {@link DataSource} (forward index + optional inverted index /
+ * dictionary). Keys that did not meet the density threshold are stored in an optional sparse
+ * column; the sparse {@link DataSource} is returned for any unmaterialized key lookup.
+ *
+ * <p>Use {@link #isMaterialized(String)} and {@link #isFullyMaterialized()} together to choose
+ * the query execution path:
+ * <ul>
+ *   <li>Materialized key → fast path via per-key DataSource (inverted/dictionary index available).
+ *   <li>Not materialized + not fully materialized → fall back to the sparse DataSource.
+ *   <li>Not materialized + fully materialized → key is definitively absent; short-circuit.
+ * </ul>
+ *
+ * <p>Thread-safety: immutable after construction; safe for concurrent reads.
+ */
+public class ImmutableOpenStructDataSource extends BaseDataSource implements OpenStructDataSource {
+  private final ComplexFieldSpec _fieldSpec;
+  private final Map<String, DataSource> _perKeyDataSources;
+  @Nullable
+  private final DataSource _sparseDataSource;
+
+  public ImmutableOpenStructDataSource(ComplexFieldSpec fieldSpec, Map<String, DataSource> perKeyDataSources,
+      @Nullable DataSource sparseDataSource, DataSourceMetadata dataSourceMetadata,
+      ColumnIndexContainer indexContainer) {
+    super(dataSourceMetadata, indexContainer);
+    _fieldSpec = fieldSpec;
+    _perKeyDataSources = perKeyDataSources;
+    _sparseDataSource = sparseDataSource;
+  }
+
+  /**
+   * Convenience constructor for segment-load time. Synthesizes a minimal {@link DataSourceMetadata}
+   * for the parent OPEN_STRUCT column (which has no on-disk presence of its own) and uses an empty
+   * {@link ColumnIndexContainer} — all real readers live on the per-key data sources.
+   */
+  public ImmutableOpenStructDataSource(ComplexFieldSpec fieldSpec, Map<String, DataSource> perKeyDataSources,
+      @Nullable DataSource sparseDataSource, int numDocs) {
+    this(fieldSpec, perKeyDataSources, sparseDataSource,
+        new ImmutableOpenStructDataSourceMetadata(fieldSpec, numDocs),
+        new ColumnIndexContainer.FromMap.Builder().build());
+  }
+
+  @Override
+  public ComplexFieldSpec getFieldSpec() {
+    return _fieldSpec;
+  }
+
+  @Override
+  @Nullable
+  public DataSource getDataSource(String key) {
+    DataSource ds = _perKeyDataSources.get(key);
+    return ds != null ? ds : _sparseDataSource;
+  }
+
+  @Override
+  public boolean isMaterialized(String key) {
+    return _perKeyDataSources.containsKey(key);
+  }
+
+  @Override
+  public boolean isFullyMaterialized() {
+    return _sparseDataSource == null;
+  }
+
+  @Override
+  public Map<String, DataSource> getDataSources() {
+    return _perKeyDataSources;
+  }
+
+  @Override
+  @Nullable
+  public DataSourceMetadata getDataSourceMetadata(String key) {
+    DataSource ds = _perKeyDataSources.get(key);
+    return ds != null ? ds.getDataSourceMetadata() : null;
+  }
+
+  @Override
+  @Nullable
+  public ColumnIndexContainer getIndexContainer(String key) {
+    DataSource ds = _perKeyDataSources.get(key);
+    return ds instanceof ImmutableDataSource immutableDs ? immutableDs.getIndexContainer() : null;
+  }
+
+  private static class ImmutableOpenStructDataSourceMetadata implements DataSourceMetadata {
+    private final FieldSpec _fieldSpec;
+    private final int _numDocs;
+
+    ImmutableOpenStructDataSourceMetadata(FieldSpec fieldSpec, int numDocs) {
+      _fieldSpec = fieldSpec;
+      _numDocs = numDocs;
+    }
+
+    @Override
+    public FieldSpec getFieldSpec() {
+      return _fieldSpec;
+    }
+
+    @Override
+    public boolean isSorted() {
+      return false;
+    }
+
+    @Override
+    public int getNumDocs() {
+      return _numDocs;
+    }
+
+    @Override
+    public int getNumValues() {
+      return _numDocs;
+    }
+
+    @Override
+    public int getMaxNumValuesPerMVEntry() {
+      return 0;
+    }
+
+    @Override
+    public int getCardinality() {
+      return Constants.UNKNOWN_CARDINALITY;
+    }
+
+    @Nullable
+    @Override
+    public Comparable getMinValue() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Comparable getMaxValue() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public PartitionFunction getPartitionFunction() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public java.util.Set<Integer> getPartitions() {
+      return null;
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/ImmutableOpenStructDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/ImmutableOpenStructDataSource.java
@@ -33,24 +33,20 @@ import org.apache.pinot.spi.data.FieldSpec;
 
 
 
-/**
- * Per-key {@link DataSource} accessor for sealed (immutable) segments with an OPEN_STRUCT column.
- *
- * <p>Always columnar — there is no blob branch. Every key that was dense enough during segment
- * creation gets its own materialized {@link DataSource} (forward index + optional inverted index /
- * dictionary). Keys that did not meet the density threshold are stored in an optional sparse
- * column; the sparse {@link DataSource} is returned for any unmaterialized key lookup.
- *
- * <p>Use {@link #isMaterialized(String)} and {@link #isFullyMaterialized()} together to choose
- * the query execution path:
- * <ul>
- *   <li>Materialized key → fast path via per-key DataSource (inverted/dictionary index available).
- *   <li>Not materialized + not fully materialized → fall back to the sparse DataSource.
- *   <li>Not materialized + fully materialized → key is definitively absent; short-circuit.
- * </ul>
- *
- * <p>Thread-safety: immutable after construction; safe for concurrent reads.
- */
+/// Per-key {@link DataSource} accessor for sealed (immutable) segments with an OPEN_STRUCT column.
+///
+/// Always columnar — there is no blob branch. Every key that was dense enough during segment
+/// creation gets its own materialized {@link DataSource} (forward index + optional inverted index /
+/// dictionary). Keys that did not meet the density threshold are stored in an optional sparse
+/// column; the sparse {@link DataSource} is returned for any unmaterialized key lookup.
+///
+/// Use [#isMaterialized(String)] and [#isFullyMaterialized()] together to choose
+/// the query execution path:
+/// - Materialized key → fast path via per-key DataSource (inverted/dictionary index available).
+/// - Not materialized + not fully materialized → fall back to the sparse DataSource.
+/// - Not materialized + fully materialized → key is definitively absent; short-circuit.
+///
+/// Thread-safety: immutable after construction; safe for concurrent reads.
 public class ImmutableOpenStructDataSource extends BaseDataSource implements OpenStructDataSource {
   private final ComplexFieldSpec _fieldSpec;
   private final Map<String, DataSource> _perKeyDataSources;
@@ -66,11 +62,9 @@ public class ImmutableOpenStructDataSource extends BaseDataSource implements Ope
     _sparseDataSource = sparseDataSource;
   }
 
-  /**
-   * Convenience constructor for segment-load time. Synthesizes a minimal {@link DataSourceMetadata}
-   * for the parent OPEN_STRUCT column (which has no on-disk presence of its own) and uses an empty
-   * {@link ColumnIndexContainer} — all real readers live on the per-key data sources.
-   */
+  /// Convenience constructor for segment-load time. Synthesizes a minimal {@link DataSourceMetadata}
+  /// for the parent OPEN_STRUCT column (which has no on-disk presence of its own) and uses an empty
+  /// {@link ColumnIndexContainer} — all real readers live on the per-key data sources.
   public ImmutableOpenStructDataSource(ComplexFieldSpec fieldSpec, Map<String, DataSource> perKeyDataSources,
       @Nullable DataSource sparseDataSource, int numDocs) {
     this(fieldSpec, perKeyDataSources, sparseDataSource,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/ImmutableOpenStructDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/ImmutableOpenStructDataSource.java
@@ -65,6 +65,10 @@ public class ImmutableOpenStructDataSource extends BaseDataSource implements Ope
   /// Convenience constructor for segment-load time. Synthesizes a minimal {@link DataSourceMetadata}
   /// for the parent OPEN_STRUCT column (which has no on-disk presence of its own) and uses an empty
   /// {@link ColumnIndexContainer} — all real readers live on the per-key data sources.
+  ///
+  /// The parent's {@code getForwardIndex()} / {@code getDictionary()} will return {@code null}.
+  /// Callers must use {@link #getDataSource(String)} for per-key access; whole-struct projection
+  /// ({@code SELECT open_struct_col}) is handled by the query layer, not the storage layer.
   public ImmutableOpenStructDataSource(ComplexFieldSpec fieldSpec, Map<String, DataSource> perKeyDataSources,
       @Nullable DataSource sparseDataSource, int numDocs) {
     this(fieldSpec, perKeyDataSources, sparseDataSource,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/ImmutableOpenStructDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/ImmutableOpenStructDataSource.java
@@ -32,6 +32,7 @@ import org.apache.pinot.spi.data.ComplexFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 
 
+
 /**
  * Per-key {@link DataSource} accessor for sealed (immutable) segments with an OPEN_STRUCT column.
  *

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableKeyColumn.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableKeyColumn.java
@@ -32,13 +32,11 @@ import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 
-/**
- * A single key's mutable column for an OPEN_STRUCT column: forward index (dictionary-encoded)
- * + presence bitmap tracking which docIds had this key set.
- *
- * Single-writer during ingestion; presence bitmap and forward index are not thread-safe for
- * concurrent writes.
- */
+/// A single key's mutable column for an OPEN_STRUCT column: forward index (dictionary-encoded)
+/// + presence bitmap tracking which docIds had this key set.
+///
+/// Single-writer during ingestion; presence bitmap and forward index are not thread-safe for
+/// concurrent writes.
 public class MutableKeyColumn implements Closeable {
   private static final int DEFAULT_AVG_STRING_LENGTH = 32;
   private static final int DEFAULT_ROWS_PER_CHUNK = 1000;
@@ -83,17 +81,17 @@ public class MutableKeyColumn implements Closeable {
     return _forwardIndex;
   }
 
-  /** Bitmap of docIds where this key was present (non-null). */
+  /// Bitmap of docIds where this key was present (non-null).
   public ImmutableRoaringBitmap getPresenceBitmap() {
     return _presenceBitmap;
   }
 
-  /** Number of documents where this key had a non-null value. */
+  /// Number of documents where this key had a non-null value.
   public int getNumNonNullDocs() {
     return _presenceBitmap.getCardinality();
   }
 
-  /** Distinct values in this key's dictionary, for cardinality estimation at seal time. */
+  /// Distinct values in this key's dictionary, for cardinality estimation at seal time.
   public Set<String> getDistinctValues() {
     int len = _dictionary.length();
     Set<String> result = new java.util.HashSet<>(len);
@@ -112,9 +110,7 @@ public class MutableKeyColumn implements Closeable {
     return _invertedIndex;
   }
 
-  /**
-   * Indexes {@code value} at {@code docId}. The value must already be coerced to the stored type.
-   */
+  /// Indexes `value` at `docId`. The value must already be coerced to the stored type.
   public void setValue(int docId, Object value) {
     _presenceBitmap.add(docId);
     int dictId = _dictionary.index(value);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableKeyColumn.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableKeyColumn.java
@@ -1,0 +1,146 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.openstruct;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Set;
+import org.apache.pinot.segment.local.realtime.impl.dictionary.MutableDictionaryFactory;
+import org.apache.pinot.segment.local.realtime.impl.forward.FixedByteSVMutableForwardIndex;
+import org.apache.pinot.segment.local.realtime.impl.invertedindex.RealtimeInvertedIndex;
+import org.apache.pinot.segment.spi.index.mutable.MutableDictionary;
+import org.apache.pinot.segment.spi.index.mutable.MutableForwardIndex;
+import org.apache.pinot.segment.spi.memory.PinotDataBufferMemoryManager;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+
+
+/**
+ * A single key's mutable column for an OPEN_STRUCT column: forward index (dictionary-encoded)
+ * + presence bitmap tracking which docIds had this key set.
+ *
+ * Single-writer during ingestion; presence bitmap and forward index are not thread-safe for
+ * concurrent writes.
+ */
+public class MutableKeyColumn implements Closeable {
+  private static final int DEFAULT_AVG_STRING_LENGTH = 32;
+  private static final int DEFAULT_ROWS_PER_CHUNK = 1000;
+
+  private final String _key;
+  private final DataType _storedType;
+  private final MutableForwardIndex _forwardIndex;
+  private final MutableRoaringBitmap _presenceBitmap;
+  private final MutableDictionary _dictionary;
+  private final RealtimeInvertedIndex _invertedIndex;
+
+  public MutableKeyColumn(String key, DataType storedType, PinotDataBufferMemoryManager memoryManager, int capacity) {
+    this(key, storedType, memoryManager, capacity, key);
+  }
+
+  public MutableKeyColumn(String key, DataType storedType, PinotDataBufferMemoryManager memoryManager, int capacity,
+      String allocationContext) {
+    _key = key;
+    _storedType = storedType;
+    _presenceBitmap = new MutableRoaringBitmap();
+    _invertedIndex = new RealtimeInvertedIndex();
+
+    int estimatedCardinality = Math.max(capacity / 100, 16);
+    int avgLength = storedType.isFixedWidth() ? storedType.size() : DEFAULT_AVG_STRING_LENGTH;
+    _dictionary = MutableDictionaryFactory.getMutableDictionary(
+        storedType, false, memoryManager, avgLength, estimatedCardinality,
+        allocationContext + ".dict");
+
+    _forwardIndex = new FixedByteSVMutableForwardIndex(true, DataType.INT,
+        DEFAULT_ROWS_PER_CHUNK, memoryManager, allocationContext + ".fwd");
+  }
+
+  public String getKey() {
+    return _key;
+  }
+
+  public DataType getStoredType() {
+    return _storedType;
+  }
+
+  public MutableForwardIndex getForwardIndex() {
+    return _forwardIndex;
+  }
+
+  /** Bitmap of docIds where this key was present (non-null). */
+  public ImmutableRoaringBitmap getPresenceBitmap() {
+    return _presenceBitmap;
+  }
+
+  /** Number of documents where this key had a non-null value. */
+  public int getNumNonNullDocs() {
+    return _presenceBitmap.getCardinality();
+  }
+
+  /** Distinct values in this key's dictionary, for cardinality estimation at seal time. */
+  public Set<String> getDistinctValues() {
+    int len = _dictionary.length();
+    Set<String> result = new java.util.HashSet<>(len);
+    for (int i = 0; i < len; i++) {
+      Object val = _dictionary.get(i);
+      result.add(val == null ? null : val.toString());
+    }
+    return result;
+  }
+
+  public MutableDictionary getDictionary() {
+    return _dictionary;
+  }
+
+  public RealtimeInvertedIndex getInvertedIndex() {
+    return _invertedIndex;
+  }
+
+  /**
+   * Indexes {@code value} at {@code docId}. The value must already be coerced to the stored type.
+   */
+  public void setValue(int docId, Object value) {
+    _presenceBitmap.add(docId);
+    int dictId = _dictionary.index(value);
+    _forwardIndex.setDictId(docId, dictId);
+    _invertedIndex.add(dictId, docId);
+  }
+
+  public Object getValue(int docId) {
+    // The forward index returns whatever bit pattern is at this offset, even for docs that were
+    // never written for this key. The presence bitmap is the source of truth — without this check,
+    // an absent doc would deserialize as if it held the first dictionary entry (dictId 0).
+    if (!_presenceBitmap.contains(docId)) {
+      return null;
+    }
+    int dictId = _forwardIndex.getDictId(docId, null);
+    if (dictId < 0 || dictId >= _dictionary.length()) {
+      return null;
+    }
+    return _dictionary.get(dictId);
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    _forwardIndex.close();
+    _dictionary.close();
+    _invertedIndex.close();
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructDataSource.java
@@ -1,0 +1,174 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.openstruct;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.pinot.segment.local.segment.index.datasource.BaseDataSource;
+import org.apache.pinot.segment.local.segment.index.datasource.ImmutableDataSource;
+import org.apache.pinot.segment.spi.ColumnMetadata;
+import org.apache.pinot.segment.spi.Constants;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
+import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
+import org.apache.pinot.segment.spi.index.IndexReader;
+import org.apache.pinot.segment.spi.index.IndexType;
+import org.apache.pinot.segment.spi.index.column.ColumnIndexContainer;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+
+
+/// Per-key {@link DataSource} accessor for mutable (consuming) segments with an OPEN_STRUCT column.
+///
+/// Always columnar — no blob branch. Per-key DataSources are synthesized on demand from the
+/// underlying {@link MutableOpenStructIndex}; mutable mode always holds every observed key, so
+/// {@link #isFullyMaterialized()} is unconditionally {@code true}.
+public class MutableOpenStructDataSource extends BaseDataSource implements OpenStructDataSource {
+  private final ComplexFieldSpec _fieldSpec;
+  private final MutableOpenStructIndex _index;
+  private final int _numDocs;
+
+  public MutableOpenStructDataSource(ComplexFieldSpec fieldSpec, MutableOpenStructIndex index, int numDocs) {
+    super(new MutableOpenStructDataSourceMetadata(fieldSpec, numDocs),
+        new ColumnIndexContainer.FromMap.Builder().build());
+    _fieldSpec = fieldSpec;
+    _index = index;
+    _numDocs = numDocs;
+  }
+
+  @Override
+  public ComplexFieldSpec getFieldSpec() {
+    return _fieldSpec;
+  }
+
+  @Override
+  @Nullable
+  public DataSource getDataSource(String key) {
+    Map<IndexType, IndexReader> indexes = _index.getIndexes(key);
+    if (indexes == null || indexes.isEmpty()) {
+      return null;
+    }
+    ColumnMetadata metadata = _index.getColumnMetadata(key);
+    return new ImmutableDataSource(metadata,
+        new ColumnIndexContainer.FromMap.Builder().withAll(indexes).build());
+  }
+
+  @Override
+  public boolean isMaterialized(String key) {
+    return _index.getKeyColumn(key) != null;
+  }
+
+  /// Mutable mode always holds every observed key in-memory; the sparse tier exists only after seal.
+  @Override
+  public boolean isFullyMaterialized() {
+    return true;
+  }
+
+  @Override
+  public Map<String, DataSource> getDataSources() {
+    Map<String, DataSource> result = new HashMap<>();
+    for (String key : _index.getKeys()) {
+      DataSource ds = getDataSource(key);
+      if (ds != null) {
+        result.put(key, ds);
+      }
+    }
+    return result;
+  }
+
+  @Override
+  @Nullable
+  public DataSourceMetadata getDataSourceMetadata(String key) {
+    DataSource ds = getDataSource(key);
+    return ds != null ? ds.getDataSourceMetadata() : null;
+  }
+
+  @Override
+  @Nullable
+  public ColumnIndexContainer getIndexContainer(String key) {
+    DataSource ds = getDataSource(key);
+    return ds instanceof ImmutableDataSource imm ? imm.getIndexContainer() : null;
+  }
+
+  private static class MutableOpenStructDataSourceMetadata implements DataSourceMetadata {
+    private final FieldSpec _fieldSpec;
+    private final int _numDocs;
+
+    MutableOpenStructDataSourceMetadata(FieldSpec fieldSpec, int numDocs) {
+      _fieldSpec = fieldSpec;
+      _numDocs = numDocs;
+    }
+
+    @Override
+    public FieldSpec getFieldSpec() {
+      return _fieldSpec;
+    }
+
+    @Override
+    public boolean isSorted() {
+      return false;
+    }
+
+    @Override
+    public int getNumDocs() {
+      return _numDocs;
+    }
+
+    @Override
+    public int getNumValues() {
+      return _numDocs;
+    }
+
+    @Override
+    public int getMaxNumValuesPerMVEntry() {
+      return 0;
+    }
+
+    @Override
+    public int getCardinality() {
+      return Constants.UNKNOWN_CARDINALITY;
+    }
+
+    @Override
+    @Nullable
+    public PartitionFunction getPartitionFunction() {
+      return null;
+    }
+
+    @Override
+    @Nullable
+    public java.util.Set<Integer> getPartitions() {
+      return null;
+    }
+
+    @Override
+    @Nullable
+    public Comparable<?> getMinValue() {
+      return null;
+    }
+
+    @Override
+    @Nullable
+    public Comparable<?> getMaxValue() {
+      return null;
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructDataSource.java
@@ -108,6 +108,12 @@ public class MutableOpenStructDataSource extends BaseDataSource implements OpenS
     return ds instanceof ImmutableDataSource imm ? imm.getIndexContainer() : null;
   }
 
+  @Override
+  @Nullable
+  public Map<String, Object> getMapValue(int docId) {
+    return _index.getMapValue(docId);
+  }
+
   private static class MutableOpenStructDataSourceMetadata implements DataSourceMetadata {
     private final FieldSpec _fieldSpec;
     private final int _numDocs;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructIndex.java
@@ -44,14 +44,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-/**
- * Manages per-key mutable columns for an OPEN_STRUCT column during real-time consumption.
- * Each discovered key gets its own {@link MutableKeyColumn} (dictionary-encoded forward index +
- * presence bitmap). Dense/sparse classification is deferred to seal time.
- *
- * <p>Single-writer for {@link #index}: the consuming thread calls this method. Readers may
- * concurrently read {@link #getKeys()} and {@link #getKeyColumns()} via the volatile map swap.
- */
+/// Manages per-key mutable columns for an OPEN_STRUCT column during real-time consumption.
+/// Each discovered key gets its own {@link MutableKeyColumn} (dictionary-encoded forward index +
+/// presence bitmap). Dense/sparse classification is deferred to seal time.
+///
+/// Single-writer for [#index]: the consuming thread calls this method. Readers may
+/// concurrently read [#getKeys()] and [#getKeyColumns()] via the volatile map swap.
 @SuppressWarnings("rawtypes")
 public class MutableOpenStructIndex implements OpenStructIndexReader<ForwardIndexReaderContext>, MutableIndex {
   private static final Logger LOGGER = LoggerFactory.getLogger(MutableOpenStructIndex.class);
@@ -86,10 +84,8 @@ public class MutableOpenStructIndex implements OpenStructIndexReader<ForwardInde
     throw new UnsupportedOperationException("OPEN_STRUCT does not support multi-value indexing");
   }
 
-  /**
-   * Indexes the OPEN_STRUCT value for the given document. {@code value} must be a
-   * {@code Map<String, Object>} or {@code null}; null and non-Map values are silently skipped.
-   */
+  /// Indexes the OPEN_STRUCT value for the given document. `value` must be a
+  /// `Map<String, Object>` or `null`; null and non-Map values are silently skipped.
   @SuppressWarnings("unchecked")
   public void index(int docId, @Nullable Object value) {
     if (!(value instanceof Map)) {
@@ -180,17 +176,17 @@ public class MutableOpenStructIndex implements OpenStructIndexReader<ForwardInde
     return newCol;
   }
 
-  /** Returns the set of keys discovered so far. */
+  /// Returns the set of keys discovered so far.
   public Set<String> getKeys() {
     return _keyColumns.keySet();
   }
 
-  /** Returns a snapshot of the per-key column map. */
+  /// Returns a snapshot of the per-key column map.
   public Map<String, MutableKeyColumn> getKeyColumns() {
     return _keyColumns;
   }
 
-  /** Returns the {@link MutableKeyColumn} for {@code key}, or {@code null} if not seen yet. */
+  /// Returns the {@link MutableKeyColumn} for `key`, or `null` if not seen yet.
   @Nullable
   public MutableKeyColumn getKeyColumn(String key) {
     return _keyColumns.get(key);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructIndex.java
@@ -23,6 +23,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
+import org.apache.pinot.common.metrics.ServerMeter;
+import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.segment.local.segment.index.map.SimpleColumnMetadata;
 import org.apache.pinot.segment.spi.ColumnMetadata;
@@ -158,8 +160,10 @@ public class MutableOpenStructIndex implements OpenStructIndexReader<ForwardInde
       PinotDataType destType = ColumnDataType.fromDataTypeSV(storedType).toPinotDataType();
       return destType.convert(rawValue, sourceType);
     } catch (Exception e) {
-      LOGGER.warn("OPEN_STRUCT '{}': coercion failed for key '{}' to {}. Skipping.",
-          _openStructColumn, key, storedType, e);
+      ServerMetrics serverMetrics = ServerMetrics.get();
+      if (serverMetrics != null) {
+        serverMetrics.addMeteredGlobalValue(ServerMeter.OPEN_STRUCT_TYPE_COERCION_FAILURES, 1);
+      }
       return null;
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructIndex.java
@@ -20,7 +20,6 @@ package org.apache.pinot.segment.local.segment.index.openstruct;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -60,20 +59,16 @@ public class MutableOpenStructIndex implements OpenStructIndexReader<ForwardInde
   private final String _openStructColumn;
   private final OpenStructIndexConfig _config;
   private final Map<String, FieldSpec> _childFieldSpecs;
-  private final int _maxDenseKeys;
   private final PinotDataBufferMemoryManager _memoryManager;
   private final int _capacity;
 
   // Volatile for lock-free reader access; writer always holds the consuming-thread lock.
   private volatile Map<String, MutableKeyColumn> _keyColumns = new HashMap<>();
-  private int _distinctKeyCount = 0;
-  private final Set<String> _droppedKeys = new HashSet<>();
 
   public MutableOpenStructIndex(String openStructColumn, ComplexFieldSpec fieldSpec,
       OpenStructIndexConfig config, PinotDataBufferMemoryManager memoryManager, int capacity) {
     _openStructColumn = openStructColumn;
     _config = config;
-    _maxDenseKeys = config.getMaxDenseKeys();
     _memoryManager = memoryManager;
     _capacity = capacity;
 
@@ -110,15 +105,11 @@ public class MutableOpenStructIndex implements OpenStructIndexReader<ForwardInde
 
       MutableKeyColumn keyCol = _keyColumns.get(key);
       if (keyCol == null) {
-        if (_maxDenseKeys >= 0 && _distinctKeyCount >= _maxDenseKeys) {
-          if (_droppedKeys.add(key)) {
-            LOGGER.warn("OPEN_STRUCT '{}' reached maxDenseKeys ({}).. Dropping '{}'.",
-                _openStructColumn, _maxDenseKeys, key);
-          }
-          continue;
-        }
-        // Resolve stored type and coerce BEFORE allocating a column. A first-row coercion failure
-        // would otherwise permanently consume a maxDenseKeys slot for a column that was never used.
+        // Mutable mode holds every observed key (see MutableOpenStructDataSource#isFullyMaterialized);
+        // dense/sparse classification (maxDenseKeys / denseKeys) is applied at seal time by the segment
+        // build, so no key is dropped during consumption.
+        // Resolve stored type and coerce BEFORE allocating a column so a first-row coercion failure
+        // does not allocate a column that was never usable.
         DataType resolvedType = resolveStoredType(key, rawValue);
         if (resolvedType == null) {
           continue;
@@ -178,9 +169,8 @@ public class MutableOpenStructIndex implements OpenStructIndexReader<ForwardInde
   }
 
   /// Allocates a new MutableKeyColumn for {@code key} with the resolved {@code storedType} and
-  /// publishes it via volatile copy-on-write. Increments the dense-key count.
+  /// publishes it via volatile copy-on-write.
   private MutableKeyColumn allocateKeyColumn(String key, DataType storedType) {
-    _distinctKeyCount++;
     String allocationContext = _openStructColumn + "$" + key;
     MutableKeyColumn newCol =
         new MutableKeyColumn(key, storedType, _memoryManager, _capacity, allocationContext);
@@ -204,6 +194,26 @@ public class MutableOpenStructIndex implements OpenStructIndexReader<ForwardInde
   @Nullable
   public MutableKeyColumn getKeyColumn(String key) {
     return _keyColumns.get(key);
+  }
+
+  /// Reconstructs the OPEN_STRUCT value for {@code docId} as a {@code Map<String, Object>} from the
+  /// per-key columns, including only keys present at that doc (presence-aware). Returns {@code null}
+  /// when no key is present. Used by the realtime seal path to re-feed the OPEN_STRUCT column into
+  /// the immutable segment build, where dense/sparse classification is (re)applied.
+  @Nullable
+  public Map<String, Object> getMapValue(int docId) {
+    Map<String, MutableKeyColumn> keyColumns = _keyColumns;
+    Map<String, Object> result = null;
+    for (Map.Entry<String, MutableKeyColumn> entry : keyColumns.entrySet()) {
+      Object value = entry.getValue().getValue(docId);
+      if (value != null) {
+        if (result == null) {
+          result = new HashMap<>();
+        }
+        result.put(entry.getKey(), value);
+      }
+    }
+    return result;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructIndex.java
@@ -1,0 +1,257 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.openstruct;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.segment.local.segment.index.map.SimpleColumnMetadata;
+import org.apache.pinot.segment.spi.ColumnMetadata;
+import org.apache.pinot.segment.spi.index.IndexReader;
+import org.apache.pinot.segment.spi.index.IndexType;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.segment.spi.index.mutable.MutableIndex;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
+import org.apache.pinot.segment.spi.index.reader.OpenStructIndexReader;
+import org.apache.pinot.segment.spi.memory.PinotDataBufferMemoryManager;
+import org.apache.pinot.spi.config.table.OpenStructIndexConfig;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.OpenStructNaming;
+import org.apache.pinot.spi.utils.PinotDataType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Manages per-key mutable columns for an OPEN_STRUCT column during real-time consumption.
+ * Each discovered key gets its own {@link MutableKeyColumn} (dictionary-encoded forward index +
+ * presence bitmap). Dense/sparse classification is deferred to seal time.
+ *
+ * <p>Single-writer for {@link #index}: the consuming thread calls this method. Readers may
+ * concurrently read {@link #getKeys()} and {@link #getKeyColumns()} via the volatile map swap.
+ */
+@SuppressWarnings("rawtypes")
+public class MutableOpenStructIndex implements OpenStructIndexReader<ForwardIndexReaderContext>, MutableIndex {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MutableOpenStructIndex.class);
+
+  private final String _openStructColumn;
+  private final OpenStructIndexConfig _config;
+  private final Map<String, FieldSpec> _childFieldSpecs;
+  private final int _maxDenseKeys;
+  private final PinotDataBufferMemoryManager _memoryManager;
+  private final int _capacity;
+
+  // Volatile for lock-free reader access; writer always holds the consuming-thread lock.
+  private volatile Map<String, MutableKeyColumn> _keyColumns = new HashMap<>();
+  private int _distinctKeyCount = 0;
+  private final Set<String> _droppedKeys = new HashSet<>();
+
+  public MutableOpenStructIndex(String openStructColumn, ComplexFieldSpec fieldSpec,
+      OpenStructIndexConfig config, PinotDataBufferMemoryManager memoryManager, int capacity) {
+    _openStructColumn = openStructColumn;
+    _config = config;
+    _maxDenseKeys = config.getMaxDenseKeys();
+    _memoryManager = memoryManager;
+    _capacity = capacity;
+
+    Map<String, FieldSpec> childFieldSpecs = fieldSpec.getChildFieldSpecs();
+    _childFieldSpecs = childFieldSpecs != null ? new HashMap<>(childFieldSpecs) : new HashMap<>();
+  }
+
+  @Override
+  public void add(Object value, int dictId, int docId) {
+    index(docId, value);
+  }
+
+  @Override
+  public void add(Object[] values, @Nullable int[] dictIds, int docId) {
+    throw new UnsupportedOperationException("OPEN_STRUCT does not support multi-value indexing");
+  }
+
+  /**
+   * Indexes the OPEN_STRUCT value for the given document. {@code value} must be a
+   * {@code Map<String, Object>} or {@code null}; null and non-Map values are silently skipped.
+   */
+  @SuppressWarnings("unchecked")
+  public void index(int docId, @Nullable Object value) {
+    if (!(value instanceof Map)) {
+      return;
+    }
+    Map<String, Object> map = (Map<String, Object>) value;
+    for (Map.Entry<String, Object> entry : map.entrySet()) {
+      String key = entry.getKey();
+      Object rawValue = entry.getValue();
+      if (rawValue == null) {
+        continue;
+      }
+
+      MutableKeyColumn keyCol = _keyColumns.get(key);
+      if (keyCol == null) {
+        if (_maxDenseKeys >= 0 && _distinctKeyCount >= _maxDenseKeys) {
+          if (_droppedKeys.add(key)) {
+            LOGGER.warn("OPEN_STRUCT '{}' reached maxDenseKeys ({}).. Dropping '{}'.",
+                _openStructColumn, _maxDenseKeys, key);
+          }
+          continue;
+        }
+        // Resolve stored type and coerce BEFORE allocating a column. A first-row coercion failure
+        // would otherwise permanently consume a maxDenseKeys slot for a column that was never used.
+        DataType resolvedType = resolveStoredType(key, rawValue);
+        if (resolvedType == null) {
+          continue;
+        }
+        Object coerced = tryCoerce(key, rawValue, resolvedType);
+        if (coerced == null) {
+          continue;
+        }
+        keyCol = allocateKeyColumn(key, resolvedType);
+        keyCol.setValue(docId, coerced);
+        continue;
+      }
+
+      DataType storedType = keyCol.getStoredType();
+      Object coerced = tryCoerce(key, rawValue, storedType);
+      if (coerced == null) {
+        continue;
+      }
+      keyCol.setValue(docId, coerced);
+    }
+  }
+
+  /// Resolves the stored type for a key without allocating any state. Returns null when the type
+  /// cannot be inferred (caller should skip the entry).
+  @Nullable
+  private DataType resolveStoredType(String key, Object rawValue) {
+    FieldSpec spec = _childFieldSpecs.get(key);
+    DataType valueType;
+    if (spec != null) {
+      valueType = spec.getDataType();
+    } else {
+      valueType = OpenStructNaming.inferDataType(rawValue);
+      if (valueType == null) {
+        LOGGER.warn("OPEN_STRUCT '{}': could not infer DataType for key '{}' from value of class '{}'."
+                + " Dropping the entry.",
+            _openStructColumn, key, rawValue.getClass().getName());
+        return null;
+      }
+    }
+    return valueType.getStoredType();
+  }
+
+  /// Coerces rawValue to storedType. Returns null on failure (logged at WARN); the caller drops
+  /// the entry. Note: a successful coerce of a "null"-shaped raw value would also return null —
+  /// but callers gate on rawValue != null before reaching here.
+  @Nullable
+  private Object tryCoerce(String key, Object rawValue, DataType storedType) {
+    try {
+      PinotDataType sourceType = PinotDataType.getSingleValueType(rawValue);
+      PinotDataType destType = ColumnDataType.fromDataTypeSV(storedType).toPinotDataType();
+      return destType.convert(rawValue, sourceType);
+    } catch (Exception e) {
+      LOGGER.warn("OPEN_STRUCT '{}': coercion failed for key '{}' to {}. Skipping.",
+          _openStructColumn, key, storedType, e);
+      return null;
+    }
+  }
+
+  /// Allocates a new MutableKeyColumn for {@code key} with the resolved {@code storedType} and
+  /// publishes it via volatile copy-on-write. Increments the dense-key count.
+  private MutableKeyColumn allocateKeyColumn(String key, DataType storedType) {
+    _distinctKeyCount++;
+    String allocationContext = _openStructColumn + "$" + key;
+    MutableKeyColumn newCol =
+        new MutableKeyColumn(key, storedType, _memoryManager, _capacity, allocationContext);
+    Map<String, MutableKeyColumn> updated = new HashMap<>(_keyColumns);
+    updated.put(key, newCol);
+    _keyColumns = updated;
+    return newCol;
+  }
+
+  /** Returns the set of keys discovered so far. */
+  public Set<String> getKeys() {
+    return _keyColumns.keySet();
+  }
+
+  /** Returns a snapshot of the per-key column map. */
+  public Map<String, MutableKeyColumn> getKeyColumns() {
+    return _keyColumns;
+  }
+
+  /** Returns the {@link MutableKeyColumn} for {@code key}, or {@code null} if not seen yet. */
+  @Nullable
+  public MutableKeyColumn getKeyColumn(String key) {
+    return _keyColumns.get(key);
+  }
+
+  @Override
+  public Map<IndexType, IndexReader> getIndexes(String key) {
+    MutableKeyColumn col = _keyColumns.get(key);
+    if (col == null) {
+      return Map.of();
+    }
+    return Map.of(
+        StandardIndexes.forward(), col.getForwardIndex(),
+        StandardIndexes.dictionary(), col.getDictionary(),
+        StandardIndexes.inverted(), col.getInvertedIndex());
+  }
+
+  @Nullable
+  @Override
+  public ColumnMetadata getColumnMetadata(String key) {
+    MutableKeyColumn col = _keyColumns.get(key);
+    if (col == null) {
+      return null;
+    }
+    FieldSpec spec = _childFieldSpecs.get(key);
+    if (spec == null) {
+      spec = new DimensionFieldSpec(key, col.getStoredType(), true);
+    }
+    return new SimpleColumnMetadata(spec, _capacity);
+  }
+
+  @Override
+  public boolean isDictionaryEncoded() {
+    return false;
+  }
+
+  @Override
+  public boolean isSingleValue() {
+    return true;
+  }
+
+  @Override
+  public DataType getStoredType() {
+    return DataType.OPEN_STRUCT;
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    for (MutableKeyColumn keyCol : _keyColumns.values()) {
+      keyCol.close();
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructIndex.java
@@ -39,7 +39,7 @@ import org.apache.pinot.spi.data.ComplexFieldSpec;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
-import org.apache.pinot.spi.data.OpenStructNaming;
+import org.apache.pinot.spi.data.OpenStructTypeInference;
 import org.apache.pinot.spi.utils.PinotDataType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -150,7 +150,7 @@ public class MutableOpenStructIndex implements OpenStructIndexReader<ForwardInde
     if (spec != null) {
       valueType = spec.getDataType();
     } else {
-      valueType = OpenStructNaming.inferDataType(rawValue);
+      valueType = OpenStructTypeInference.inferDataType(rawValue);
       if (valueType == null) {
         LOGGER.warn("OPEN_STRUCT '{}': could not infer DataType for key '{}' from value of class '{}'."
                 + " Dropping the entry.",

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/OpenStructIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/OpenStructIndexType.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.pinot.segment.local.segment.creator.impl.openstruct.OpenStructColumnSplitter;
 import org.apache.pinot.segment.spi.ColumnMetadata;
 import org.apache.pinot.segment.spi.creator.IndexCreationContext;
 import org.apache.pinot.segment.spi.index.AbstractIndexType;
@@ -124,16 +125,16 @@ public class OpenStructIndexType
 
   @Override
   public boolean shouldCreateIndex(IndexCreationContext context, OpenStructIndexConfig indexConfig) {
-    // Creator is wired in the storage-layer PR (PR 2b); returning true here with a null creator
-    // would NPE in SegmentColumnarIndexCreator.add(). Keep false until the real creator lands.
-    return false;
+    // The default OpenStructIndexConfig is auto-applied to every column; only build a creator for
+    // OPEN_STRUCT columns. Non-OPEN_STRUCT columns cannot meaningfully host this index.
+    return context.getFieldSpec().getDataType() == FieldSpec.DataType.OPEN_STRUCT;
   }
 
   @Override
   public ColumnarOpenStructIndexCreator createIndexCreator(IndexCreationContext context,
       OpenStructIndexConfig indexConfig) {
-    throw new UnsupportedOperationException(
-        "OPEN_STRUCT index creator is not yet available; shouldCreateIndex() must return false");
+    FieldSpec fieldSpec = context.getFieldSpec();
+    return new OpenStructColumnSplitter(context.getIndexDir(), fieldSpec.getName(), fieldSpec, indexConfig);
   }
 
   @Override
@@ -155,8 +156,8 @@ public class OpenStructIndexType
   @Nullable
   @Override
   public MutableIndex createMutableIndex(MutableIndexContext context, OpenStructIndexConfig config) {
-    // Mutable OPEN_STRUCT index is constructed by MutableSegmentImpl, not via this SPI path.
-    return null;
+    throw new UnsupportedOperationException("Mutable OPEN_STRUCT index is constructed by MutableSegmentImpl, "
+        + "not via this SPI path");
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentRecordReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentRecordReader.java
@@ -31,6 +31,8 @@ import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoa
 import org.apache.pinot.segment.local.segment.readers.sort.PinotSegmentSorter;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.MutableSegment;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
@@ -55,6 +57,9 @@ public class PinotSegmentRecordReader implements RecordReader {
   private ArrayList<PinotSegmentColumnReader> _columnReaders;
 
   private Map<String, PinotSegmentColumnReader> _columnReaderMap;
+  // OPEN_STRUCT parent columns have no forward index of their own (they expose per-key sub-columns),
+  // so they cannot be read via PinotSegmentColumnReader. Their per-doc value is reconstructed as a map.
+  private Map<String, OpenStructDataSource> _openStructDataSources;
   private int[] _sortedDocIds;
   private boolean _skipDefaultNullValues;
 
@@ -180,21 +185,16 @@ public class PinotSegmentRecordReader implements RecordReader {
       _columnReaderMap = new HashMap<>();
       _columnReaders = new ArrayList<>();
       _columnNames = new ArrayList<>();
+      _openStructDataSources = new HashMap<>();
       Set<String> columnsInSegment = _indexSegment.getPhysicalColumnNames();
       if (CollectionUtils.isEmpty(fieldsToRead)) {
         for (String column : columnsInSegment) {
-          PinotSegmentColumnReader reader = new PinotSegmentColumnReader(indexSegment, column);
-          _columnReaderMap.put(column, reader);
-          _columnNames.add(column);
-          _columnReaders.add(reader);
+          addColumnReader(column);
         }
       } else {
         for (String column : fieldsToRead) {
           if (columnsInSegment.contains(column)) {
-            PinotSegmentColumnReader reader = new PinotSegmentColumnReader(indexSegment, column);
-            _columnReaderMap.put(column, reader);
-            _columnNames.add(column);
-            _columnReaders.add(reader);
+            addColumnReader(column);
           } else {
             LOGGER.warn("Ignoring column: {} that does not exist in the segment", column);
           }
@@ -213,6 +213,23 @@ public class PinotSegmentRecordReader implements RecordReader {
 
       _skipDefaultNullValues = skipDefaultNullValues;
     }
+  }
+
+  /**
+   * Registers a reader for the given column. OPEN_STRUCT parent columns are tracked separately and
+   * reconstructed as maps at read time (they have no forward index of their own); all other columns
+   * use a {@link PinotSegmentColumnReader}.
+   */
+  private void addColumnReader(String column) {
+    DataSource dataSource = _indexSegment.getDataSourceNullable(column);
+    if (dataSource instanceof OpenStructDataSource) {
+      _openStructDataSources.put(column, (OpenStructDataSource) dataSource);
+      return;
+    }
+    PinotSegmentColumnReader reader = new PinotSegmentColumnReader(_indexSegment, column);
+    _columnReaderMap.put(column, reader);
+    _columnNames.add(column);
+    _columnReaders.add(reader);
   }
 
   /**
@@ -253,6 +270,14 @@ public class PinotSegmentRecordReader implements RecordReader {
         buffer.putDefaultNullValue(column, columnReader.getValue(docId));
       }
     }
+    for (Map.Entry<String, OpenStructDataSource> entry : _openStructDataSources.entrySet()) {
+      Map<String, Object> value = entry.getValue().getMapValue(docId);
+      // A null map means no key is present at this doc; leave the column unset so the OPEN_STRUCT
+      // build treats it as an absent/empty struct.
+      if (value != null) {
+        buffer.putValue(entry.getKey(), value);
+      }
+    }
   }
 
   public Object[] getRecordValues(int docId, int[] columnIndexes) {
@@ -286,6 +311,10 @@ public class PinotSegmentRecordReader implements RecordReader {
   //   - Currently there is no check on column existence
   //   - Null value is not handled (default null value is returned)
   public Object getValue(int docId, String column) {
+    OpenStructDataSource openStructDataSource = _openStructDataSources.get(column);
+    if (openStructDataSource != null) {
+      return openStructDataSource.getMapValue(docId);
+    }
     return _columnReaderMap.get(column).getValue(docId);
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitterTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitterTest.java
@@ -294,4 +294,78 @@ public class OpenStructColumnSplitterTest {
     s.seal();
     assertTrue(s.getMaterializedColumnMetadata().containsKey(OpenStructNaming.sparseColumnName("metrics")));
   }
+
+  @Test
+  public void testAbsentDocUsesDimensionNullDefault()
+      throws Exception {
+    // Absent docs now store the standard Pinot dimension null value (INT -> Integer.MIN_VALUE),
+    // so the column min reflects that default rather than the old metric-style 0.
+    OpenStructColumnSplitter s = new OpenStructColumnSplitter(_tempDir, "metrics", spec(),
+        config(0.5, -1, null));
+    for (int d = 0; d < 5; d++) {
+      s.add(Map.of("clicks", 10 + d), d);   // present: 10..14
+    }
+    for (int d = 5; d < 10; d++) {
+      s.add(Map.of(), d);                    // absent
+    }
+    s.seal();
+
+    String denseCol = OpenStructNaming.materializedColumnName("metrics", "clicks");
+    PropertiesConfiguration props = s.getMaterializedColumnMetadata().get(denseCol);
+    assertNotNull(props);
+    // Default (non-RAW) numeric key is dictionary-encoded.
+    assertEquals(props.getString(V1Constants.MetadataKeys.Column.getKeyFor(
+        denseCol, V1Constants.MetadataKeys.Column.HAS_DICTIONARY)), "true");
+    assertEquals(props.getString(V1Constants.MetadataKeys.Column.getKeyFor(
+        denseCol, V1Constants.MetadataKeys.Column.MIN_VALUE)), String.valueOf(Integer.MIN_VALUE));
+    assertEquals(props.getString(V1Constants.MetadataKeys.Column.getKeyFor(
+        denseCol, V1Constants.MetadataKeys.Column.MAX_VALUE)), "14");
+  }
+
+  @Test
+  public void testDenseDefaultKeyWritesDictionaryAndInvertedIndex()
+      throws Exception {
+    // Default keys are dictionary-encoded with an inverted index (both default on), now written via the
+    // standard ForwardIndexCreator and inverted index creator.
+    OpenStructColumnSplitter s = new OpenStructColumnSplitter(_tempDir, "metrics", spec(),
+        config(0.5, -1, null));
+    for (int d = 0; d < 10; d++) {
+      s.add(Map.of("tag", "v" + (d % 3)), d);
+    }
+    s.seal();
+
+    String denseCol = OpenStructNaming.materializedColumnName("metrics", "tag");
+    PropertiesConfiguration props = s.getMaterializedColumnMetadata().get(denseCol);
+    assertNotNull(props);
+    assertEquals(props.getString(V1Constants.MetadataKeys.Column.getKeyFor(
+        denseCol, V1Constants.MetadataKeys.Column.HAS_DICTIONARY)), "true");
+    assertEquals(props.getString(V1Constants.MetadataKeys.Column.getKeyFor(denseCol, "hasInvertedIndex")),
+        "true");
+    assertTrue(new File(_tempDir, denseCol + V1Constants.Dict.FILE_EXTENSION).exists());
+    assertTrue(new File(_tempDir,
+        denseCol + V1Constants.Indexes.BITMAP_INVERTED_INDEX_FILE_EXTENSION).exists());
+  }
+
+  @Test
+  public void testRawStringForwardIndexViaStandardCreator()
+      throws Exception {
+    // A RAW-configured key takes the standard raw var-byte forward index path (no dictionary).
+    FieldConfig rawConfig = new FieldConfig.Builder("note")
+        .withEncodingType(FieldConfig.EncodingType.RAW).build();
+    OpenStructIndexConfig cfg = new OpenStructIndexConfig(false, null, -1, null, 0.5, List.of(rawConfig));
+    OpenStructColumnSplitter s = new OpenStructColumnSplitter(_tempDir, "metrics", spec(), cfg);
+    for (int d = 0; d < 10; d++) {
+      s.add(Map.of("note", "n" + d), d);
+    }
+    s.seal();
+
+    String denseCol = OpenStructNaming.materializedColumnName("metrics", "note");
+    PropertiesConfiguration props = s.getMaterializedColumnMetadata().get(denseCol);
+    assertNotNull(props);
+    assertEquals(props.getString(V1Constants.MetadataKeys.Column.getKeyFor(
+        denseCol, V1Constants.MetadataKeys.Column.HAS_DICTIONARY)), "false");
+    assertFalse(new File(_tempDir, denseCol + V1Constants.Dict.FILE_EXTENSION).exists());
+    assertTrue(new File(_tempDir,
+        denseCol + V1Constants.Indexes.RAW_SV_FORWARD_INDEX_FILE_EXTENSION).exists());
+  }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitterTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitterTest.java
@@ -192,14 +192,14 @@ public class OpenStructColumnSplitterTest {
   @Test
   public void testBigDecimalScaleDistinctValuesNotCollapsed()
       throws Exception {
-    // 1.0 and 1.00 are equal by compareTo but distinct by equals. The dictionary lookup is
-    // equals-based, so they must remain separate dictionary entries. With the default (BigDecimal.ZERO)
-    // that is 3 distinct values; a compareTo-based dedup would wrongly collapse to 2 and silently
-    // mis-resolve forward-index dict ids.
+    // 1.0 and 1.00 are equal by compareTo but distinct by equals; they must stay separate dictionary
+    // entries. Doc 2 is absent, so the default (BigDecimal.ZERO) is also collected -> 3 distinct values.
+    // A compareTo-based dedup would wrongly collapse 1.0/1.00 and yield 2.
     OpenStructColumnSplitter s = new OpenStructColumnSplitter(_tempDir, "metrics", spec(),
         config(0.5, -1, null));
     s.add(Map.of("amount", new BigDecimal("1.0")), 0);
     s.add(Map.of("amount", new BigDecimal("1.00")), 1);
+    s.add(Map.of(), 2);
     s.seal();
 
     String denseCol = OpenStructNaming.materializedColumnName("metrics", "amount");

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitterTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitterTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.segment.creator.impl.openstruct;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.io.File;
 import java.math.BigDecimal;
 import java.nio.file.Files;
@@ -34,6 +35,7 @@ import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.OpenStructNaming;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -41,6 +43,7 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 
@@ -367,5 +370,45 @@ public class OpenStructColumnSplitterTest {
     assertFalse(new File(_tempDir, denseCol + V1Constants.Dict.FILE_EXTENSION).exists());
     assertTrue(new File(_tempDir,
         denseCol + V1Constants.Indexes.RAW_SV_FORWARD_INDEX_FILE_EXTENSION).exists());
+  }
+
+  @Test
+  public void testRangeAndBloomIndexesWrittenForKey()
+      throws Exception {
+    // An INT key configured with range + bloom must produce those index buffers via the generic loop.
+    JsonNode indexes = JsonUtils.stringToJsonNode("{\"range\": {}, \"bloom\": {}}");
+    FieldConfig keyConfig = new FieldConfig.Builder("clicks").withIndexes(indexes).build();
+    OpenStructIndexConfig cfg = new OpenStructIndexConfig(false, null, -1, null, 0.5, List.of(keyConfig));
+    OpenStructColumnSplitter s = new OpenStructColumnSplitter(_tempDir, "metrics", spec(), cfg);
+    for (int d = 0; d < 10; d++) {
+      s.add(Map.of("clicks", d), d);
+    }
+    s.seal();
+
+    String denseCol = OpenStructNaming.materializedColumnName("metrics", "clicks");
+    assertTrue(new File(_tempDir, denseCol + V1Constants.Indexes.BITMAP_RANGE_INDEX_FILE_EXTENSION).exists(),
+        "range index buffer should be written");
+    assertTrue(new File(_tempDir, denseCol + V1Constants.Indexes.BLOOM_FILTER_FILE_EXTENSION).exists(),
+        "bloom filter buffer should be written");
+  }
+
+  @Test
+  public void testRangeOnRawNonNumericKeyFailsWithCanonicalGuard()
+      throws Exception {
+    // A STRING key with RAW encoding + range resolves to raw (range does not require a dictionary), which the
+    // range creator cannot build. The splitter must surface the canonical RangeIndexType.validate guard
+    // (IllegalStateException) at build time rather than crashing opaquely inside the creator.
+    JsonNode indexes = JsonUtils.stringToJsonNode("{\"range\": {}}");
+    FieldConfig keyConfig = new FieldConfig.Builder("tag")
+        .withEncodingType(FieldConfig.EncodingType.RAW)
+        .withIndexes(indexes)
+        .build();
+    OpenStructIndexConfig cfg = new OpenStructIndexConfig(false, null, -1, null, 0.5, List.of(keyConfig));
+    OpenStructColumnSplitter s = new OpenStructColumnSplitter(_tempDir, "metrics", spec(), cfg);
+    for (int d = 0; d < 10; d++) {
+      s.add(Map.of("tag", "v" + d), d);
+    }
+
+    assertThrows(IllegalStateException.class, s::seal);
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitterTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitterTest.java
@@ -1,0 +1,164 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.creator.impl.openstruct;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.spi.config.table.OpenStructIndexConfig;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.OpenStructNaming;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+public class OpenStructColumnSplitterTest {
+
+  private File _tempDir;
+
+  @BeforeMethod
+  public void setUp()
+      throws Exception {
+    _tempDir = Files.createTempDirectory("OpenStructColumnSplitterTest").toFile();
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    FileUtils.deleteDirectory(_tempDir);
+  }
+
+  private ComplexFieldSpec spec() {
+    return new ComplexFieldSpec("metrics", DataType.OPEN_STRUCT, true, Map.of());
+  }
+
+  private OpenStructIndexConfig config(double minFillRate, int maxDenseKeys, Set<String> denseKeys) {
+    return new OpenStructIndexConfig(false, null, maxDenseKeys, denseKeys, minFillRate, null);
+  }
+
+  @Test
+  public void testClassifyByFillRate()
+      throws Exception {
+    OpenStructColumnSplitter s = new OpenStructColumnSplitter(_tempDir, "metrics", spec(),
+        config(0.5, -1, null));
+    for (int d = 0; d < 10; d++) {
+      Map<String, Object> doc = d < 7 ? Map.of("clicks", (long) d) : Map.of();
+      s.add(doc, d);
+    }
+    Set<String> dense = s.classify();
+    assertTrue(dense.contains("clicks"));
+  }
+
+  @Test
+  public void testExplicitDenseKeysAlwaysMaterialized()
+      throws Exception {
+    OpenStructColumnSplitter s = new OpenStructColumnSplitter(_tempDir, "metrics", spec(),
+        config(0.99, -1, Set.of("rare")));
+    s.add(Map.of("rare", "x"), 0);
+    for (int d = 1; d < 100; d++) {
+      s.add(Map.of(), d);
+    }
+    Set<String> dense = s.classify();
+    assertTrue(dense.contains("rare"));
+  }
+
+  @Test
+  public void testRareKeyDroppedFromDense()
+      throws Exception {
+    OpenStructColumnSplitter s = new OpenStructColumnSplitter(_tempDir, "metrics", spec(),
+        config(0.5, -1, null));
+    s.add(Map.of("rare", "x"), 0);
+    for (int d = 1; d < 100; d++) {
+      s.add(Map.of(), d);
+    }
+    Set<String> dense = s.classify();
+    assertFalse(dense.contains("rare"));
+  }
+
+  @Test
+  public void testMaxDenseKeysCap()
+      throws Exception {
+    OpenStructColumnSplitter s = new OpenStructColumnSplitter(_tempDir, "metrics", spec(),
+        config(0.1, 1, null));
+    for (int d = 0; d < 10; d++) {
+      s.add(Map.of("a", "x", "b", "y", "c", "z"), d);
+    }
+    Set<String> dense = s.classify();
+    assertEquals(dense.size(), 1);
+  }
+
+  @Test
+  public void testZeroDocsIsNoop()
+      throws Exception {
+    OpenStructColumnSplitter s = new OpenStructColumnSplitter(_tempDir, "metrics", spec(),
+        config(0.5, -1, null));
+    s.seal();
+    assertTrue(s.getResolvedDenseKeys().isEmpty());
+  }
+
+  @Test
+  public void testSealEmitsParentMetadataForDense()
+      throws Exception {
+    OpenStructColumnSplitter s = new OpenStructColumnSplitter(_tempDir, "metrics", spec(),
+        config(0.5, -1, null));
+    for (int d = 0; d < 10; d++) {
+      s.add(Map.of("clicks", (long) d), d);
+    }
+    s.seal();
+    String denseCol = OpenStructNaming.materializedColumnName("metrics", "clicks");
+    Map<String, PropertiesConfiguration> meta = s.getMaterializedColumnMetadata();
+    PropertiesConfiguration denseProps = meta.get(denseCol);
+    assertEquals(denseProps.getString(V1Constants.MetadataKeys.Column.getKeyFor(
+        denseCol, V1Constants.MetadataKeys.Column.PARENT_COLUMN)), "metrics");
+
+    PropertiesConfiguration parentProps = meta.get("metrics");
+    assertNotNull(parentProps);
+    assertEquals(parentProps.getString(V1Constants.MetadataKeys.Column.getKeyFor(
+        "metrics", V1Constants.MetadataKeys.Column.DATA_TYPE)), "OPEN_STRUCT");
+    assertEquals(parentProps.getString(V1Constants.MetadataKeys.Column.getKeyFor(
+        "metrics", V1Constants.MetadataKeys.Column.COLUMN_TYPE)), "COMPLEX");
+    assertEquals(parentProps.getString(V1Constants.MetadataKeys.Column.getKeyFor(
+        "metrics", V1Constants.MetadataKeys.Column.HAS_SPARSE_COLUMN)), "false");
+  }
+
+  @Test
+  public void testSparseJsonColumnWritten()
+      throws Exception {
+    OpenStructColumnSplitter s = new OpenStructColumnSplitter(_tempDir, "metrics", spec(),
+        config(0.9, -1, null));
+    s.add(Map.of("rare", "x"), 0);
+    for (int d = 1; d < 10; d++) {
+      s.add(Map.of(), d);
+    }
+    s.seal();
+    String sparseCol = OpenStructNaming.sparseColumnName("metrics");
+    assertTrue(s.getMaterializedColumnMetadata().containsKey(sparseCol));
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitterTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitterTest.java
@@ -19,14 +19,19 @@
 package org.apache.pinot.segment.local.segment.creator.impl.openstruct;
 
 import java.io.File;
+import java.math.BigDecimal;
 import java.nio.file.Files;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.OpenStructIndexConfig;
 import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.OpenStructNaming;
 import org.testng.annotations.AfterMethod;
@@ -160,5 +165,106 @@ public class OpenStructColumnSplitterTest {
     s.seal();
     String sparseCol = OpenStructNaming.sparseColumnName("metrics");
     assertTrue(s.getMaterializedColumnMetadata().containsKey(sparseCol));
+  }
+
+  @Test
+  public void testBigDecimalDictionaryRoundTrip()
+      throws Exception {
+    // Regression: an untyped key whose value is a BigDecimal used to crash seal() with
+    // IllegalStateException("Unsupported OPEN_STRUCT stored type for dictionary build: BIG_DECIMAL").
+    OpenStructColumnSplitter s = new OpenStructColumnSplitter(_tempDir, "metrics", spec(),
+        config(0.5, -1, null));
+    for (int d = 0; d < 10; d++) {
+      s.add(Map.of("amount", new BigDecimal("12.34").add(BigDecimal.valueOf(d))), d);
+    }
+    s.seal();
+
+    String denseCol = OpenStructNaming.materializedColumnName("metrics", "amount");
+    PropertiesConfiguration props = s.getMaterializedColumnMetadata().get(denseCol);
+    assertNotNull(props);
+    assertEquals(props.getString(V1Constants.MetadataKeys.Column.getKeyFor(
+        denseCol, V1Constants.MetadataKeys.Column.DATA_TYPE)), "BIG_DECIMAL");
+    assertEquals(props.getString(V1Constants.MetadataKeys.Column.getKeyFor(
+        denseCol, V1Constants.MetadataKeys.Column.HAS_DICTIONARY)), "true");
+    assertTrue(new File(_tempDir, denseCol + V1Constants.Dict.FILE_EXTENSION).exists());
+  }
+
+  @Test
+  public void testBigDecimalScaleDistinctValuesNotCollapsed()
+      throws Exception {
+    // 1.0 and 1.00 are equal by compareTo but distinct by equals. The dictionary lookup is
+    // equals-based, so they must remain separate dictionary entries. With the default (BigDecimal.ZERO)
+    // that is 3 distinct values; a compareTo-based dedup would wrongly collapse to 2 and silently
+    // mis-resolve forward-index dict ids.
+    OpenStructColumnSplitter s = new OpenStructColumnSplitter(_tempDir, "metrics", spec(),
+        config(0.5, -1, null));
+    s.add(Map.of("amount", new BigDecimal("1.0")), 0);
+    s.add(Map.of("amount", new BigDecimal("1.00")), 1);
+    s.seal();
+
+    String denseCol = OpenStructNaming.materializedColumnName("metrics", "amount");
+    PropertiesConfiguration props = s.getMaterializedColumnMetadata().get(denseCol);
+    assertNotNull(props);
+    assertEquals(props.getInt(V1Constants.MetadataKeys.Column.getKeyFor(
+        denseCol, V1Constants.MetadataKeys.Column.CARDINALITY)), 3);
+  }
+
+  @Test
+  public void testBigDecimalExplicitChildSpec()
+      throws Exception {
+    // A key declared BIG_DECIMAL in the schema bypasses inferDataType but must still seal.
+    Map<String, FieldSpec> children = Map.of(
+        "amount", new DimensionFieldSpec("amount", DataType.BIG_DECIMAL, true));
+    ComplexFieldSpec specWithChild = new ComplexFieldSpec("metrics", DataType.OPEN_STRUCT, true, children);
+    OpenStructColumnSplitter s = new OpenStructColumnSplitter(_tempDir, "metrics", specWithChild,
+        config(0.5, -1, null));
+    for (int d = 0; d < 10; d++) {
+      s.add(Map.of("amount", new BigDecimal("100.5")), d);
+    }
+    s.seal();
+
+    String denseCol = OpenStructNaming.materializedColumnName("metrics", "amount");
+    PropertiesConfiguration props = s.getMaterializedColumnMetadata().get(denseCol);
+    assertNotNull(props);
+    assertEquals(props.getString(V1Constants.MetadataKeys.Column.getKeyFor(
+        denseCol, V1Constants.MetadataKeys.Column.DATA_TYPE)), "BIG_DECIMAL");
+  }
+
+  @Test
+  public void testBigDecimalRawForwardIndex()
+      throws Exception {
+    // RAW-encoded BIG_DECIMAL key must take the raw var-byte forward index path, not the dictionary.
+    FieldConfig rawConfig = new FieldConfig.Builder("amount")
+        .withEncodingType(FieldConfig.EncodingType.RAW).build();
+    OpenStructIndexConfig cfg = new OpenStructIndexConfig(
+        false, null, -1, null, 0.5, List.of(rawConfig));
+    OpenStructColumnSplitter s = new OpenStructColumnSplitter(_tempDir, "metrics", spec(), cfg);
+    for (int d = 0; d < 10; d++) {
+      s.add(Map.of("amount", new BigDecimal("7.5").add(BigDecimal.valueOf(d))), d);
+    }
+    s.seal();
+
+    String denseCol = OpenStructNaming.materializedColumnName("metrics", "amount");
+    PropertiesConfiguration props = s.getMaterializedColumnMetadata().get(denseCol);
+    assertNotNull(props);
+    assertEquals(props.getString(V1Constants.MetadataKeys.Column.getKeyFor(
+        denseCol, V1Constants.MetadataKeys.Column.HAS_DICTIONARY)), "false");
+    assertFalse(new File(_tempDir, denseCol + V1Constants.Dict.FILE_EXTENSION).exists());
+    assertTrue(new File(_tempDir,
+        denseCol + V1Constants.Indexes.RAW_SV_FORWARD_INDEX_FILE_EXTENSION).exists());
+  }
+
+  @Test
+  public void testBigDecimalSparseKey()
+      throws Exception {
+    // A BIG_DECIMAL key below the fill-rate threshold goes to the sparse JSON column without crashing.
+    OpenStructColumnSplitter s = new OpenStructColumnSplitter(_tempDir, "metrics", spec(),
+        config(0.9, -1, null));
+    s.add(Map.of("rare", new BigDecimal("3.14159")), 0);
+    for (int d = 1; d < 10; d++) {
+      s.add(Map.of(), d);
+    }
+    s.seal();
+    assertTrue(s.getMaterializedColumnMetadata().containsKey(OpenStructNaming.sparseColumnName("metrics")));
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitterTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructColumnSplitterTest.java
@@ -154,6 +154,33 @@ public class OpenStructColumnSplitterTest {
   }
 
   @Test
+  public void testDenseColumnMetadataKeysPresent()
+      throws Exception {
+    OpenStructColumnSplitter s = new OpenStructColumnSplitter(_tempDir, "metrics", spec(),
+        config(0.5, -1, null));
+    for (int d = 0; d < 10; d++) {
+      s.add(Map.of("clicks", (long) d), d);
+    }
+    s.seal();
+    String denseCol = OpenStructNaming.materializedColumnName("metrics", "clicks");
+    PropertiesConfiguration p = s.getMaterializedColumnMetadata().get(denseCol);
+    assertNotNull(p);
+    assertEquals(p.getString(V1Constants.MetadataKeys.Column.getKeyFor(
+        denseCol, V1Constants.MetadataKeys.Column.DATA_TYPE)), "LONG");
+    assertEquals(p.getString(V1Constants.MetadataKeys.Column.getKeyFor(
+        denseCol, V1Constants.MetadataKeys.Column.COLUMN_TYPE)), "DIMENSION");
+    assertEquals(p.getString(V1Constants.MetadataKeys.Column.getKeyFor(
+        denseCol, V1Constants.MetadataKeys.Column.HAS_DICTIONARY)), "true");
+    assertEquals(p.getInt(V1Constants.MetadataKeys.Column.getKeyFor(
+        denseCol, V1Constants.MetadataKeys.Column.TOTAL_DOCS)), 10);
+    assertEquals(p.getInt(V1Constants.MetadataKeys.Column.getKeyFor(
+        denseCol, V1Constants.MetadataKeys.Column.CARDINALITY)), 10);
+    assertEquals(p.getString(V1Constants.MetadataKeys.Column.getKeyFor(
+        denseCol, V1Constants.MetadataKeys.Column.PARENT_COLUMN)), "metrics");
+    assertEquals(p.getString(V1Constants.MetadataKeys.Column.getKeyFor(denseCol, "hasNullValue")), "true");
+  }
+
+  @Test
   public void testSparseJsonColumnWritten()
       throws Exception {
     OpenStructColumnSplitter s = new OpenStructColumnSplitter(_tempDir, "metrics", spec(),

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructSegmentCreationTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/openstruct/OpenStructSegmentCreationTest.java
@@ -1,0 +1,157 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.creator.impl.openstruct;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.local.segment.store.SegmentLocalFSDirectory;
+import org.apache.pinot.segment.spi.ColumnMetadata;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
+import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.OpenStructIndexConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.OpenStructNaming;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+/// Drives [SegmentIndexCreationDriverImpl] over OPEN_STRUCT data to verify the full offline
+/// segment-build pipeline (transform → stats → creator → index) without a cluster.
+public class OpenStructSegmentCreationTest {
+
+  private static final String METRICS = "metrics";
+  private static final File TMP_DIR =
+      new File(FileUtils.getTempDirectory(), OpenStructSegmentCreationTest.class.getName());
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    FileUtils.deleteDirectory(TMP_DIR);
+  }
+
+  @Test
+  public void testOfflineSegmentBuildWithOpenStruct()
+      throws Exception {
+    Map<String, FieldSpec> children = new HashMap<>();
+    children.put("views", new DimensionFieldSpec("views", FieldSpec.DataType.LONG, true));
+    children.put("cpu", new DimensionFieldSpec("cpu", FieldSpec.DataType.DOUBLE, true));
+    children.put("host", new DimensionFieldSpec("host", FieldSpec.DataType.STRING, true));
+
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testOpenStruct")
+        .addField(new ComplexFieldSpec(METRICS, FieldSpec.DataType.OPEN_STRUCT, true, children))
+        .addSingleValueDimension("dim", FieldSpec.DataType.STRING)
+        .build();
+
+    OpenStructIndexConfig osConfig =
+        new OpenStructIndexConfig(false, null, 3, Set.of("views", "cpu", "host"), 0.5, List.of());
+
+    com.fasterxml.jackson.databind.node.ObjectNode indexes = JsonUtils.newObjectNode();
+    indexes.set("open_struct", JsonUtils.objectToJsonNode(osConfig));
+    FieldConfig metricsCfg = new FieldConfig.Builder(METRICS).withIndexes(indexes).build();
+
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testOpenStruct")
+        .setFieldConfigList(List.of(metricsCfg)).build();
+
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+    config.setOutDir(TMP_DIR.getAbsolutePath());
+    config.setSegmentName("testSegment");
+
+    int numRows = 100;
+    List<GenericRow> rows = new ArrayList<>(numRows);
+    for (int i = 0; i < numRows; i++) {
+      GenericRow row = new GenericRow();
+      Map<String, Object> metrics = new HashMap<>();
+      metrics.put("views", (long) i);
+      metrics.put("cpu", i * 0.5);
+      metrics.put("host", "host-" + (i % 5));
+      metrics.put("region", "region-" + (i % 4));
+      row.putValue(METRICS, metrics);
+      row.putValue("dim", "val-" + i);
+      rows.add(row);
+    }
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(config, new GenericRowRecordReader(rows));
+    driver.build();
+
+    File segmentDir = driver.getOutputDirectory();
+    SegmentMetadataImpl metadata = new SegmentMetadataImpl(segmentDir);
+
+    // Parent column present
+    ColumnMetadata parentMeta = metadata.getColumnMetadataFor(METRICS);
+    assertNotNull(parentMeta, "parent OPEN_STRUCT column missing");
+    assertEquals(parentMeta.getDataType(), FieldSpec.DataType.OPEN_STRUCT);
+
+    // Dense child columns present with correct types
+    String views = OpenStructNaming.materializedColumnName(METRICS, "views");
+    String cpu = OpenStructNaming.materializedColumnName(METRICS, "cpu");
+    String host = OpenStructNaming.materializedColumnName(METRICS, "host");
+    String sparse = OpenStructNaming.sparseColumnName(METRICS);
+
+    assertNotNull(metadata.getColumnMetadataFor(views), "dense child views missing");
+    assertNotNull(metadata.getColumnMetadataFor(cpu), "dense child cpu missing");
+    assertNotNull(metadata.getColumnMetadataFor(host), "dense child host missing");
+    assertEquals(metadata.getColumnMetadataFor(views).getDataType(), FieldSpec.DataType.LONG);
+    assertEquals(metadata.getColumnMetadataFor(cpu).getDataType(), FieldSpec.DataType.DOUBLE);
+    assertEquals(metadata.getColumnMetadataFor(host).getDataType(), FieldSpec.DataType.STRING);
+
+    // Sparse column present (region is not in denseKeys and budget is full)
+    assertNotNull(metadata.getColumnMetadataFor(sparse), "sparse column missing");
+
+    // region should NOT be materialized (forced sparse)
+    String region = OpenStructNaming.materializedColumnName(METRICS, "region");
+    assertFalse(metadata.getColumnMetadataMap().containsKey(region), "region must be sparse, not materialized");
+
+    // Verify index_map: dense children have forward index, parent does NOT
+    try (SegmentDirectory dir = new SegmentLocalFSDirectory(segmentDir, ReadMode.mmap);
+        SegmentDirectory.Reader reader = dir.createReader()) {
+      assertTrue(reader.hasIndexFor(views, StandardIndexes.forward()), "views must have forward");
+      assertTrue(reader.hasIndexFor(cpu, StandardIndexes.forward()), "cpu must have forward");
+      assertTrue(reader.hasIndexFor(host, StandardIndexes.forward()), "host must have forward");
+      assertTrue(reader.hasIndexFor(sparse, StandardIndexes.forward()), "sparse must have forward");
+      assertFalse(reader.hasIndexFor(METRICS, StandardIndexes.forward()), "parent must NOT have forward");
+    }
+
+    assertEquals(metadata.getTotalDocs(), numRows);
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/ImmutableOpenStructDataSourceTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/ImmutableOpenStructDataSourceTest.java
@@ -1,0 +1,200 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.openstruct;
+
+import java.util.Map;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
+import org.apache.pinot.segment.spi.index.column.ColumnIndexContainer;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+
+public class ImmutableOpenStructDataSourceTest {
+
+  private static ComplexFieldSpec openStructSpec(String name) {
+    ComplexFieldSpec spec = new ComplexFieldSpec(name, DataType.OPEN_STRUCT, true, Map.of());
+    return spec;
+  }
+
+  @Test
+  public void testGetDataSourceReturnsPerKeyDataSource() {
+    DataSource clicksDs = mock(DataSource.class);
+    DataSource sparseDs = mock(DataSource.class);
+    DataSourceMetadata meta = mock(DataSourceMetadata.class);
+    ColumnIndexContainer container = mock(ColumnIndexContainer.class);
+
+    ImmutableOpenStructDataSource ds = new ImmutableOpenStructDataSource(
+        openStructSpec("event"),
+        Map.of("clicks", clicksDs),
+        sparseDs,
+        meta,
+        container);
+
+    assertSame(ds.getDataSource("clicks"), clicksDs);
+    // absent key falls back to sparse
+    assertSame(ds.getDataSource("unknown"), sparseDs);
+  }
+
+  @Test
+  public void testIsMaterializedTrueOnlyForMaterializedKeys() {
+    DataSource clicksDs = mock(DataSource.class);
+    DataSourceMetadata meta = mock(DataSourceMetadata.class);
+    ColumnIndexContainer container = mock(ColumnIndexContainer.class);
+
+    ImmutableOpenStructDataSource ds = new ImmutableOpenStructDataSource(
+        openStructSpec("event"),
+        Map.of("clicks", clicksDs),
+        null,
+        meta,
+        container);
+
+    assertTrue(ds.isMaterialized("clicks"));
+    assertFalse(ds.isMaterialized("absent"));
+  }
+
+  @Test
+  public void testIsFullyMaterializedTrueWhenNoSparse() {
+    DataSourceMetadata meta = mock(DataSourceMetadata.class);
+    ColumnIndexContainer container = mock(ColumnIndexContainer.class);
+
+    ImmutableOpenStructDataSource ds = new ImmutableOpenStructDataSource(
+        openStructSpec("event"),
+        Map.of(),
+        null,
+        meta,
+        container);
+
+    assertTrue(ds.isFullyMaterialized());
+  }
+
+  @Test
+  public void testIsFullyMaterializedFalseWhenSparsePresent() {
+    DataSource sparseDs = mock(DataSource.class);
+    DataSourceMetadata meta = mock(DataSourceMetadata.class);
+    ColumnIndexContainer container = mock(ColumnIndexContainer.class);
+
+    ImmutableOpenStructDataSource ds = new ImmutableOpenStructDataSource(
+        openStructSpec("event"),
+        Map.of(),
+        sparseDs,
+        meta,
+        container);
+
+    assertFalse(ds.isFullyMaterialized());
+  }
+
+  @Test
+  public void testGetFieldSpecReturnsOpenStructView() {
+    DataSourceMetadata meta = mock(DataSourceMetadata.class);
+    ColumnIndexContainer container = mock(ColumnIndexContainer.class);
+
+    ImmutableOpenStructDataSource ds = new ImmutableOpenStructDataSource(
+        openStructSpec("event"),
+        Map.of(),
+        null,
+        meta,
+        container);
+
+    ComplexFieldSpec fieldSpec = ds.getFieldSpec();
+    assertNotNull(fieldSpec);
+    assertEquals(fieldSpec.getName(), "event");
+  }
+
+  @Test
+  public void testGetDataSourceMetadataByKeyReturnsDelegated() {
+    DataSource clicksDs = mock(DataSource.class);
+    DataSourceMetadata clicksMeta = mock(DataSourceMetadata.class);
+    DataSourceMetadata topMeta = mock(DataSourceMetadata.class);
+    ColumnIndexContainer container = mock(ColumnIndexContainer.class);
+
+    org.mockito.Mockito.when(clicksDs.getDataSourceMetadata()).thenReturn(clicksMeta);
+
+    ImmutableOpenStructDataSource ds = new ImmutableOpenStructDataSource(
+        openStructSpec("event"),
+        Map.of("clicks", clicksDs),
+        null,
+        topMeta,
+        container);
+
+    assertSame(ds.getDataSourceMetadata("clicks"), clicksMeta);
+    assertNull(ds.getDataSourceMetadata("absent"));
+  }
+
+  @Test
+  public void testGetDataSourcesReturnsPerKeyMap() {
+    DataSource clicksDs = mock(DataSource.class);
+    DataSourceMetadata meta = mock(DataSourceMetadata.class);
+    ColumnIndexContainer container = mock(ColumnIndexContainer.class);
+    Map<String, DataSource> perKeyMap = Map.of("clicks", clicksDs);
+
+    ImmutableOpenStructDataSource ds = new ImmutableOpenStructDataSource(
+        openStructSpec("event"),
+        perKeyMap,
+        null,
+        meta,
+        container);
+
+    assertEquals(ds.getDataSources(), perKeyMap);
+  }
+
+  @Test
+  public void testTopLevelMetadataAndContainerDelegated() {
+    DataSourceMetadata meta = mock(DataSourceMetadata.class);
+    ColumnIndexContainer container = mock(ColumnIndexContainer.class);
+
+    ImmutableOpenStructDataSource ds = new ImmutableOpenStructDataSource(
+        openStructSpec("event"),
+        Map.of(),
+        null,
+        meta,
+        container);
+
+    assertSame(ds.getDataSourceMetadata(), meta);
+    assertSame(ds.getIndexContainer(), container);
+  }
+
+  @Test
+  public void testConvenienceConstructorSynthesizesMetadata() {
+    DataSource clicksDs = mock(DataSource.class);
+    ImmutableOpenStructDataSource ds = new ImmutableOpenStructDataSource(
+        openStructSpec("event"),
+        Map.of("clicks", clicksDs),
+        null,
+        42);
+
+    DataSourceMetadata meta = ds.getDataSourceMetadata();
+    assertNotNull(meta);
+    assertEquals(meta.getNumDocs(), 42);
+    assertEquals(meta.getNumValues(), 42);
+    assertEquals(meta.getFieldSpec().getDataType(), DataType.OPEN_STRUCT);
+    assertNotNull(ds.getIndexContainer());
+    assertTrue(ds.isFullyMaterialized());
+    assertSame(ds.getDataSource("clicks"), clicksDs);
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructDataSourceTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructDataSourceTest.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.openstruct;
+
+import java.util.Map;
+import org.apache.pinot.segment.local.io.writer.impl.DirectMemoryManager;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.memory.PinotDataBufferMemoryManager;
+import org.apache.pinot.spi.config.table.OpenStructIndexConfig;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+public class MutableOpenStructDataSourceTest {
+
+  private PinotDataBufferMemoryManager _mm;
+
+  @BeforeMethod
+  public void setUp() {
+    _mm = new DirectMemoryManager("MutableOpenStructDataSourceTest");
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    _mm.close();
+  }
+
+  private ComplexFieldSpec spec() {
+    return new ComplexFieldSpec("metrics", DataType.OPEN_STRUCT, true, Map.of());
+  }
+
+  @Test
+  public void testGetDataSourcePerKey()
+      throws Exception {
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex("metrics", spec(),
+        OpenStructIndexConfig.DEFAULT, _mm, 100)) {
+      idx.index(0, Map.of("clicks", 5L));
+      MutableOpenStructDataSource ds = new MutableOpenStructDataSource(spec(), idx, 1);
+      DataSource clicks = ds.getDataSource("clicks");
+      assertNotNull(clicks);
+      assertTrue(ds.isMaterialized("clicks"));
+      assertTrue(ds.isFullyMaterialized()); // mutable always holds everything
+    }
+  }
+
+  @Test
+  public void testGetDataSourceForUnknownKey()
+      throws Exception {
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex("metrics", spec(),
+        OpenStructIndexConfig.DEFAULT, _mm, 100)) {
+      MutableOpenStructDataSource ds = new MutableOpenStructDataSource(spec(), idx, 0);
+      assertNull(ds.getDataSource("missing"));
+      assertFalse(ds.isMaterialized("missing"));
+    }
+  }
+
+  @Test
+  public void testGetDataSourcesReturnsAllKeys()
+      throws Exception {
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex("metrics", spec(),
+        OpenStructIndexConfig.DEFAULT, _mm, 100)) {
+      idx.index(0, Map.of("clicks", 5L, "country", "US"));
+      MutableOpenStructDataSource ds = new MutableOpenStructDataSource(spec(), idx, 1);
+      assertEquals(ds.getDataSources().size(), 2);
+    }
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructIndexTest.java
@@ -1,0 +1,160 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.openstruct;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.segment.local.io.writer.impl.DirectMemoryManager;
+import org.apache.pinot.segment.spi.memory.PinotDataBufferMemoryManager;
+import org.apache.pinot.spi.config.table.OpenStructIndexConfig;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+public class MutableOpenStructIndexTest {
+  private PinotDataBufferMemoryManager _memMgr;
+
+  @BeforeMethod
+  public void setUp() {
+    _memMgr = new DirectMemoryManager(MutableOpenStructIndexTest.class.getName());
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws IOException {
+    _memMgr.close();
+  }
+
+  private static ComplexFieldSpec openStructSpec() {
+    return new ComplexFieldSpec("metrics", DataType.OPEN_STRUCT, true, Map.of());
+  }
+
+  @Test
+  public void testAddAndGetKeys()
+      throws IOException {
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex(
+        "metrics", openStructSpec(), OpenStructIndexConfig.DEFAULT, _memMgr, 1000)) {
+
+      idx.index(0, Map.of("clicks", 42L, "impressions", 100L));
+      idx.index(1, Map.of("clicks", 7L, "revenue", "1.5"));
+
+      Set<String> keys = idx.getKeys();
+      assertTrue(keys.contains("clicks"), "Expected 'clicks' in keys");
+      assertTrue(keys.contains("impressions"), "Expected 'impressions' in keys");
+      assertTrue(keys.contains("revenue"), "Expected 'revenue' in keys");
+      assertEquals(keys.size(), 3);
+    }
+  }
+
+  @Test
+  public void testIndexNullIsNoop()
+      throws IOException {
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex(
+        "metrics", openStructSpec(), OpenStructIndexConfig.DEFAULT, _memMgr, 1000)) {
+
+      idx.index(0, null);
+
+      assertTrue(idx.getKeys().isEmpty(), "Expected no keys after indexing null");
+      assertNull(idx.getKeyColumn("clicks"));
+    }
+  }
+
+  @Test
+  public void testFillRateTracking()
+      throws IOException {
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex(
+        "metrics", openStructSpec(), OpenStructIndexConfig.DEFAULT, _memMgr, 1000)) {
+
+      for (int docId = 0; docId < 10; docId++) {
+        if (docId < 7) {
+          idx.index(docId, Map.of("clicks", (long) (docId + 1)));
+        } else {
+          // docs 7,8,9 have no "clicks" key
+          idx.index(docId, Map.of("impressions", 100L));
+        }
+      }
+
+      MutableKeyColumn clicksCol = idx.getKeyColumn("clicks");
+      assertNotNull(clicksCol, "Expected 'clicks' column to exist");
+      assertEquals(clicksCol.getNumNonNullDocs(), 7,
+          "Expected 7 non-null docs for 'clicks'");
+    }
+  }
+
+  @Test
+  public void testTypeInferenceFromValue()
+      throws IOException {
+    // No childFieldSpecs — type inference from rawValue
+    ComplexFieldSpec spec = new ComplexFieldSpec("metrics", DataType.OPEN_STRUCT, true, Map.of());
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex("metrics", spec,
+        OpenStructIndexConfig.DEFAULT, _memMgr, 100)) {
+      idx.index(0, java.util.Map.of("clicks", 5L));
+      assertEquals(idx.getKeyColumn("clicks").getStoredType(), DataType.LONG);
+      idx.index(1, java.util.Map.of("country", "US"));
+      assertEquals(idx.getKeyColumn("country").getStoredType(), DataType.STRING);
+    }
+  }
+
+  @Test
+  public void testImplementsOpenStructIndexReader() throws Exception {
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex("metrics", openStructSpec(),
+        OpenStructIndexConfig.DEFAULT, _memMgr, 100)) {
+      assertTrue(idx instanceof org.apache.pinot.segment.spi.index.reader.OpenStructIndexReader);
+    }
+  }
+
+  @Test
+  public void testGetIndexesReturnsForwardIndexForMaterializedKey() throws Exception {
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex("metrics", openStructSpec(),
+        OpenStructIndexConfig.DEFAULT, _memMgr, 100)) {
+      idx.index(0, Map.of("clicks", 5L));
+      Map<org.apache.pinot.segment.spi.index.IndexType, org.apache.pinot.segment.spi.index.IndexReader> indexes =
+          idx.getIndexes("clicks");
+      assertNotNull(indexes.get(org.apache.pinot.segment.spi.index.StandardIndexes.forward()));
+    }
+  }
+
+  @Test
+  public void testGetIndexesUnknownKeyReturnsEmpty() throws Exception {
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex("metrics", openStructSpec(),
+        OpenStructIndexConfig.DEFAULT, _memMgr, 100)) {
+      assertTrue(idx.getIndexes("missing").isEmpty());
+    }
+  }
+
+  @Test
+  public void testGetColumnMetadataReturnsKeyMetadata() throws Exception {
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex("metrics", openStructSpec(),
+        OpenStructIndexConfig.DEFAULT, _memMgr, 100)) {
+      idx.index(0, Map.of("clicks", 5L));
+      assertNotNull(idx.getColumnMetadata("clicks"));
+      assertEquals(idx.getColumnMetadata("clicks").getColumnName(), "clicks");
+      assertNull(idx.getColumnMetadata("absent"));
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This is PR 2b in the OPEN_STRUCT stack — the storage layer that makes `dataType: OPEN_STRUCT` columns ingestible, sealable, and queryable. Without it, declaring OPEN_STRUCT in a schema does nothing. It builds on the infrastructure/SPI pieces landed in PR 2a.

RFC: https://docs.google.com/document/d/14kPmjDTKbO8l0ql4rrN7I5Yki5pqMw6GeGmxxc9grsU/edit?tab=t.0

PR 1 (SPI + data model): #18368 — merged
PR 2a (SPI utilities, index registration, stats constructors): #18710 — merged

### Architecture

OPEN_STRUCT columns use a **two-tier columnar storage** model:

- **Dense tier** — keys with fill rate >= `denseKeyMinFillRate` (default 0.5) or explicitly listed in `denseKeys` are materialized as standard Pinot columns (`<column>$<key>`), each with its own forward index, dictionary, null vector, and optional per-key indexes (inverted, range, bloom).
- **Sparse tier** — remaining keys are packed into a single JSON column (`<column>$__sparse__`).

Dense keys reuse the entire standard column infrastructure — no bespoke binary format. New index types work on dense keys with zero custom code, and segment-level column pruning applies automatically.

### What this PR adds

**Segment creation (offline + realtime seal):**
- `OpenStructColumnSplitter` — the `ColumnarOpenStructIndexCreator` implementation. Receives per-doc `Map<String, Object>` values, accumulates stats per key, classifies dense vs sparse at seal time, then writes per-key column files using standard Pinot index creators. Supports per-key `FieldConfig` with inverted/range/bloom indexes and dictionary/RAW encoding.

**Mutable (consuming) path:**
- `MutableOpenStructIndex` — per-key in-memory state during consumption. Implements both `MutableIndex` and `OpenStructIndexReader` (dual-role: write-side index + read-side reader for queries against mutable segments). Creates a `MutableKeyColumn` per discovered key with dictionary-encoded forward index + presence bitmap + type tracking.
- `MutableKeyColumn` — per-key forward index + presence bitmap + three-level type resolution: declared child `FieldSpec` -> value-based inference via `OpenStructTypeInference` -> fallback to STRING.
- `MutableOpenStructDataSource` — exposes per-key `DataSource` views to the query engine during consumption, backed by the live `MutableOpenStructIndex`.

**Immutable (sealed) path:**
- `ImmutableOpenStructDataSource` — per-key `DataSource` accessor for sealed segments. Collects dense child `DataSource`s and sparse `DataSource` from the segment's column index containers. Provides `isMaterialized(key)` / `isFullyMaterialized()` for query-time fast-path selection.
- `ImmutableSegmentImpl` — modified to detect materialized child columns (via `ColumnMetadataImpl.isMaterializedChild()`), group them by parent, and construct `ImmutableOpenStructDataSource` for each OPEN_STRUCT parent.

**Pipeline wiring:**
- `MutableSegmentImpl` — routes OPEN_STRUCT values to the dedicated `MutableOpenStructIndex` instead of the standard per-IndexType loop. Marks OPEN_STRUCT as no-dictionary.
- `BaseSegmentCreator` / `SegmentColumnarIndexCreator` — wires `OpenStructColumnSplitter` into the offline segment-build pipeline; emits child column metadata into `metadata.properties`.
- `ImmutableSegmentLoader` — registers OPEN_STRUCT child columns for index loading.
- `SegmentPreProcessor` — preserves per-key inverted indexes through segment reload/preprocessing.
- `IndexLoadingConfig` — resolves per-key `FieldIndexConfigs` from the table config's OPEN_STRUCT field config.
- `PinotSegmentRecordReader` — reassembles OPEN_STRUCT from dense + sparse child columns when reading back segment records.
- `OpenStructIndexType` — `shouldCreateIndex()` now returns true; `createIndexCreator()` returns the real `OpenStructColumnSplitter`.

**Tests (~1,020 lines):**
- `OpenStructColumnSplitterTest` — unit tests for dense/sparse classification, per-key index matrix, type inference, BIG_DECIMAL support.
- `OpenStructSegmentCreationTest` — end-to-end segment creation through `SegmentColumnarIndexCreator`.
- `MutableOpenStructIndexTest` — mutable index lifecycle, key discovery, type coercion.
- `MutableOpenStructDataSourceTest` — mutable DataSource per-key access.
- `ImmutableOpenStructDataSourceTest` — immutable DataSource dense/sparse/absent key paths.
- `OpenStructIngestionCommitRealtimeTest` — REALTIME e2e: Kafka consume -> forceCommit -> validate committed segment's index_map, dense/sparse split, per-key indexes.
- `OpenStructIngestionCommitOfflineTest` — OFFLINE e2e: Avro RecordReader -> segment build -> validate index_map.
