### PR TITLE
Add WorkerManager extension points for customizing leaf-stage segment assignment

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -508,6 +508,7 @@ public class WorkerManager {
   }
 
   private void updateContextForLeafStage(DispatchablePlanMetadata metadata, DispatchablePlanContext context) {
+    filterLeafStageSegments(context, metadata);
     if (context.isUseLeafServerForIntermediateStage()) {
       Map<Integer, QueryServerInstance> workerIdToServerInstanceMap = metadata.getWorkerIdToServerInstanceMap();
       assert workerIdToServerInstanceMap != null;
@@ -735,6 +736,15 @@ public class WorkerManager {
 
     // TODO: Support unavailable segments and optional segments for replicated leaf stage
     metadata.setReplicatedSegments(segmentsMap);
+    filterReplicatedLeafStageSegments(context, metadata);
+  }
+
+  /** Extension point to filter the non-replicated leaf-stage per-worker segment assignment; no-op by default. */
+  protected void filterLeafStageSegments(DispatchablePlanContext context, DispatchablePlanMetadata metadata) {
+  }
+
+  /** Extension point to filter the replicated leaf-stage segments; no-op by default. */
+  protected void filterReplicatedLeafStageSegments(DispatchablePlanContext context, DispatchablePlanMetadata metadata) {
   }
 
   /**


### PR DESCRIPTION
## Description

Subclasses of `WorkerManager` can already customize multi-stage leaf-stage worker selection by overriding
`getCandidateServers` / `getCandidateServersForReplicatedLeaf`, but the per-worker **segment** assignment is finalized
internally with no extension point to adjust it.

This PR adds two `protected` no-op extension points, invoked once the leaf-stage segment assignment has been built:

- `filterLeafStageSegments(DispatchablePlanContext, DispatchablePlanMetadata)` — invoked from
  `updateContextForLeafStage`, which the non-partitioned, partitioned, and logical-table leaf paths all funnel through.
- `filterReplicatedLeafStageSegments(DispatchablePlanContext, DispatchablePlanMetadata)` — invoked from
  `setSegmentsForReplicatedLeafFragment` for the replicated (broadcast) leaf path.

A subclass can rewrite `DispatchablePlanMetadata#getWorkerIdToSegmentsMap()` / `#getReplicatedSegments()` through the
existing setters — for example to apply a custom segment-pruning policy — with access to the query options via
`DispatchablePlanContext#getPlannerContext().getOptions()`.

## Backward compatibility

Purely additive. Both hooks default to no-ops, so behavior is unchanged for the base `WorkerManager` and all existing
subclasses.

## Testing

Existing multi-stage planning / `WorkerManager` tests continue to pass; the hooks are no-ops by default.

## Release notes

No behavior change — new `protected` extension points only.
