### PR TITLE
Add latency tracking for MSE adaptive routing

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/datatable/StatMap.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datatable/StatMap.java
@@ -280,7 +280,7 @@ public class StatMap<K extends Enum<K> & StatMap.Key> {
             if (key.includeDefaultInJson()) {
               node.put(key.getStatName(), false);
             }
-          } else {
+          } else if (key.includeInJson()) {
             node.put(key.getStatName(), (boolean) value);
           }
           break;
@@ -289,7 +289,7 @@ public class StatMap<K extends Enum<K> & StatMap.Key> {
             if (key.includeDefaultInJson()) {
               node.put(key.getStatName(), 0);
             }
-          } else {
+          } else if (key.includeInJson()) {
             node.put(key.getStatName(), (int) value);
           }
           break;
@@ -298,7 +298,7 @@ public class StatMap<K extends Enum<K> & StatMap.Key> {
             if (key.includeDefaultInJson()) {
               node.put(key.getStatName(), 0L);
             }
-          } else {
+          } else if (key.includeInJson()) {
             node.put(key.getStatName(), (long) value);
           }
           break;
@@ -307,7 +307,7 @@ public class StatMap<K extends Enum<K> & StatMap.Key> {
             if (key.includeDefaultInJson()) {
               node.put(key.getStatName(), "");
             }
-          } else {
+          } else if (key.includeInJson()) {
             node.put(key.getStatName(), (String) value);
           }
           break;
@@ -500,6 +500,10 @@ public class StatMap<K extends Enum<K> & StatMap.Key> {
 
     default boolean includeDefaultInJson() {
       return false;
+    }
+
+    default boolean includeInJson() {
+      return true;
     }
 
     static int minPositive(int value1, int value2) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerGauge.java
@@ -75,6 +75,8 @@ public enum BrokerGauge implements AbstractMetrics.Gauge {
    * Per-server adaptive routing stats exported as metrics (MSE / multi-stage engine).
    */
   ADAPTIVE_SERVER_MSE_NUM_IN_FLIGHT_REQUESTS("adaptiveServerMseNumInFlightRequests", false),
+  ADAPTIVE_SERVER_MSE_LATENCY_EMA("adaptiveServerMseLatencyEma", false),
+  ADAPTIVE_SERVER_MSE_HYBRID_SCORE("adaptiveServerMseHybridScore", false),
 
   /**
    * The queue size of ServerRoutingStatsManager main executor service.

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
@@ -29,7 +29,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.metrics.BrokerGauge;
@@ -452,19 +451,17 @@ public class ServerRoutingStatsManager {
           BrokerGauge.ADAPTIVE_SERVER_NUM_IN_FLIGHT_REQUESTS,
           BrokerGauge.ADAPTIVE_SERVER_LATENCY_EMA,
           BrokerGauge.ADAPTIVE_SERVER_HYBRID_SCORE);
-      // TODO: Export MSE latency stats once we support it
       exportStatsForMap(_mseServerQueryStatsMap, "server.",
           BrokerGauge.ADAPTIVE_SERVER_MSE_NUM_IN_FLIGHT_REQUESTS,
-          null,
-          null);
+          BrokerGauge.ADAPTIVE_SERVER_MSE_LATENCY_EMA,
+          BrokerGauge.ADAPTIVE_SERVER_MSE_HYBRID_SCORE);
     } catch (Exception e) {
       LOGGER.error("Exception caught while exporting routing stats as metrics.", e);
     }
   }
 
   private void exportStatsForMap(ConcurrentHashMap<String, ServerRoutingStatsEntry> statsMap, String tagPrefix,
-      BrokerGauge numInFlightGauge, @Nullable BrokerGauge latencyEmaGauge,
-      @Nullable BrokerGauge hybridScoreGauge) {
+      BrokerGauge numInFlightGauge, BrokerGauge latencyEmaGauge, BrokerGauge hybridScoreGauge) {
     for (Map.Entry<String, ServerRoutingStatsEntry> entry : statsMap.entrySet()) {
       String serverInstanceId = entry.getKey();
       ServerRoutingStatsEntry stats = entry.getValue();
@@ -484,12 +481,8 @@ public class ServerRoutingStatsManager {
 
       String tag = tagPrefix + serverInstanceId;
       _brokerMetrics.setValueOfGlobalGauge(numInFlightGauge, tag, numInFlightRequests);
-      if (latencyEmaGauge != null) {
-        _brokerMetrics.setValueOfGlobalGauge(latencyEmaGauge, tag, (long) latencyEma);
-      }
-      if (hybridScoreGauge != null) {
-        _brokerMetrics.setValueOfGlobalGauge(hybridScoreGauge, tag, (long) hybridScore);
-      }
+      _brokerMetrics.setValueOfGlobalGauge(latencyEmaGauge, tag, (long) latencyEma);
+      _brokerMetrics.setValueOfGlobalGauge(hybridScoreGauge, tag, (long) hybridScore);
     }
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanContext.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanContext.java
@@ -207,9 +207,18 @@ public class DispatchablePlanContext {
       if (dispatchablePlanMetadata.getTimeBoundaryInfo() != null) {
         dispatchablePlanFragment.setTimeBoundaryInfo(dispatchablePlanMetadata.getTimeBoundaryInfo());
       }
+
+      PlanFragment planFrag = dispatchablePlanFragment.getPlanFragment();
+      PlanNode root = planFrag != null ? planFrag.getFragmentRoot() : null;
+      FragmentType fragmentType = FragmentType.classify(root,
+          !dispatchablePlanMetadata.getScannedTables().isEmpty(), _dispatchablePlanMetadataMap);
+      if (fragmentType != null) {
+        dispatchablePlanFragment.setFragmentType(fragmentType);
+      }
     }
     return dispatchablePlanFragmentMap;
   }
+
 
   private Map<Integer, DispatchablePlanFragment> createDispatchablePlanFragmentMap(PlanFragment planFragmentRoot) {
     HashMap<Integer, DispatchablePlanFragment> result =

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanFragment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanFragment.java
@@ -49,6 +49,9 @@ public class DispatchablePlanFragment {
   // used for passing custom properties to build StageMetadata on the server.
   private final Map<String, String> _customProperties;
 
+  // Broker-only classification — not shipped to servers.
+  private FragmentType _fragmentType;
+
   public DispatchablePlanFragment(PlanFragment planFragment) {
     this(planFragment, new ArrayList<>(), new HashMap<>(), new HashMap<>());
   }
@@ -131,5 +134,13 @@ public class DispatchablePlanFragment {
 
   public Set<QueryServerInstance> getServerInstances() {
     return _serverInstanceToWorkerIdMap.keySet();
+  }
+
+  public FragmentType getFragmentType() {
+    return _fragmentType;
+  }
+
+  public void setFragmentType(FragmentType fragmentType) {
+    _fragmentType = fragmentType;
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/FragmentType.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/FragmentType.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.physical;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.pinot.query.planner.plannode.MailboxReceiveNode;
+import org.apache.pinot.query.planner.plannode.MailboxSendNode;
+import org.apache.pinot.query.planner.plannode.PlanNode;
+
+
+public enum FragmentType {
+  // Scans a fact table; non-SINGLETON sender
+  LEAF,
+  // Dim-table leaf via SINGLETON exchange, with a leaf upstream sender
+  SINGLETON_LEAF,
+  // Non-scanning stage (join, agg, sort); timings reflect upstream cascade delays
+  INTERMEDIATE;
+
+  public static FragmentType classify(PlanNode root, boolean hasScannedTable,
+      Map<Integer, DispatchablePlanMetadata> metadataMap) {
+    if (!(root instanceof MailboxSendNode)) {
+      return null;
+    }
+    if (!hasScannedTable) {
+      return INTERMEDIATE;
+    }
+    List<Integer> singletonSenderStageIds = getSingletonReceiveSenderStageIds(root);
+    if (singletonSenderStageIds.isEmpty()) {
+      return LEAF;
+    }
+    boolean allSendersAreLeaves = singletonSenderStageIds.stream().allMatch(senderStageId -> {
+      DispatchablePlanMetadata senderMeta = metadataMap.get(senderStageId);
+      return senderMeta != null && !senderMeta.getScannedTables().isEmpty();
+    });
+    return allSendersAreLeaves ? SINGLETON_LEAF : INTERMEDIATE;
+  }
+
+  static List<Integer> getSingletonReceiveSenderStageIds(PlanNode node) {
+    List<Integer> result = new ArrayList<>();
+    collectSingletonReceiveSenderStageIds(node, result);
+    return result;
+  }
+
+  private static void collectSingletonReceiveSenderStageIds(PlanNode node, List<Integer> result) {
+    if (node instanceof MailboxReceiveNode) {
+      MailboxReceiveNode receiveNode = (MailboxReceiveNode) node;
+      if (receiveNode.getDistributionType() == RelDistribution.Type.SINGLETON) {
+        result.add(receiveNode.getSenderStageId());
+      }
+    }
+    for (PlanNode input : node.getInputs()) {
+      collectSingletonReceiveSenderStageIds(input, result);
+    }
+  }
+}

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/FragmentTypeTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/FragmentTypeTest.java
@@ -1,0 +1,177 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.physical;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.pinot.calcite.rel.logical.PinotRelExchangeType;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.query.planner.plannode.FilterNode;
+import org.apache.pinot.query.planner.plannode.MailboxReceiveNode;
+import org.apache.pinot.query.planner.plannode.MailboxSendNode;
+import org.apache.pinot.query.planner.plannode.PlanNode;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+
+public class FragmentTypeTest {
+
+  private static final DataSchema SCHEMA = new DataSchema(
+      new String[]{"col1"}, new ColumnDataType[]{ColumnDataType.INT});
+
+  @Test
+  public void testNonMailboxSendRootReturnsNull() {
+    PlanNode filterNode = new FilterNode(0, SCHEMA, null, List.of(), null);
+    assertNull(FragmentType.classify(filterNode, true, Map.of()));
+  }
+
+  @Test
+  public void testNullRootReturnsNull() {
+    assertNull(FragmentType.classify(null, true, Map.of()));
+  }
+
+  @Test
+  public void testNoScannedTableReturnsIntermediate() {
+    MailboxSendNode sendNode = new MailboxSendNode(0, SCHEMA, List.of(),
+        1, PinotRelExchangeType.STREAMING, RelDistribution.Type.HASH_DISTRIBUTED,
+        List.of(0), false, null, false, "murmur");
+    assertEquals(FragmentType.classify(sendNode, false, Map.of()), FragmentType.INTERMEDIATE);
+  }
+
+  @Test
+  public void testLeafWithNoSingletonReceive() {
+    // A send node with no receive children (pure leaf scan)
+    MailboxSendNode sendNode = new MailboxSendNode(1, SCHEMA, List.of(),
+        0, PinotRelExchangeType.STREAMING, RelDistribution.Type.HASH_DISTRIBUTED,
+        List.of(0), false, null, false, "murmur");
+    assertEquals(FragmentType.classify(sendNode, true, Map.of()), FragmentType.LEAF);
+  }
+
+  @Test
+  public void testLeafWithNonSingletonReceive() {
+    // A receive node with HASH distribution (not SINGLETON) should not affect LEAF classification
+    MailboxReceiveNode receiveNode = new MailboxReceiveNode(1, SCHEMA, 2,
+        PinotRelExchangeType.STREAMING, RelDistribution.Type.HASH_DISTRIBUTED,
+        List.of(0), null, false, false, null);
+    MailboxSendNode sendNode = new MailboxSendNode(1, SCHEMA, List.of(receiveNode),
+        0, PinotRelExchangeType.STREAMING, RelDistribution.Type.HASH_DISTRIBUTED,
+        List.of(0), false, null, false, "murmur");
+    assertEquals(FragmentType.classify(sendNode, true, Map.of()), FragmentType.LEAF);
+  }
+
+  @Test
+  public void testSingletonLeafWhenSenderIsLeaf() {
+    // Stage 1 has a SINGLETON receive from stage 2, and stage 2 has scanned tables
+    MailboxReceiveNode receiveNode = new MailboxReceiveNode(1, SCHEMA, 2,
+        PinotRelExchangeType.STREAMING, RelDistribution.Type.SINGLETON,
+        null, null, false, false, null);
+    MailboxSendNode sendNode = new MailboxSendNode(1, SCHEMA, List.of(receiveNode),
+        0, PinotRelExchangeType.STREAMING, RelDistribution.Type.HASH_DISTRIBUTED,
+        List.of(0), false, null, false, "murmur");
+
+    Map<Integer, DispatchablePlanMetadata> metadataMap = new HashMap<>();
+    DispatchablePlanMetadata senderMeta = new DispatchablePlanMetadata();
+    senderMeta.addScannedTable("dimTable");
+    metadataMap.put(2, senderMeta);
+
+    assertEquals(FragmentType.classify(sendNode, true, metadataMap), FragmentType.SINGLETON_LEAF);
+  }
+
+  @Test
+  public void testIntermediateWhenSingletonSenderHasNoScannedTables() {
+    // Stage 1 has a SINGLETON receive from stage 2, but stage 2 has no scanned tables
+    MailboxReceiveNode receiveNode = new MailboxReceiveNode(1, SCHEMA, 2,
+        PinotRelExchangeType.STREAMING, RelDistribution.Type.SINGLETON,
+        null, null, false, false, null);
+    MailboxSendNode sendNode = new MailboxSendNode(1, SCHEMA, List.of(receiveNode),
+        0, PinotRelExchangeType.STREAMING, RelDistribution.Type.HASH_DISTRIBUTED,
+        List.of(0), false, null, false, "murmur");
+
+    Map<Integer, DispatchablePlanMetadata> metadataMap = new HashMap<>();
+    DispatchablePlanMetadata senderMeta = new DispatchablePlanMetadata();
+    metadataMap.put(2, senderMeta);
+
+    assertEquals(FragmentType.classify(sendNode, true, metadataMap), FragmentType.INTERMEDIATE);
+  }
+
+  @Test
+  public void testIntermediateWhenSingletonSenderMetadataMissing() {
+    // Stage 1 has a SINGLETON receive from stage 2, but stage 2 metadata is null
+    MailboxReceiveNode receiveNode = new MailboxReceiveNode(1, SCHEMA, 2,
+        PinotRelExchangeType.STREAMING, RelDistribution.Type.SINGLETON,
+        null, null, false, false, null);
+    MailboxSendNode sendNode = new MailboxSendNode(1, SCHEMA, List.of(receiveNode),
+        0, PinotRelExchangeType.STREAMING, RelDistribution.Type.HASH_DISTRIBUTED,
+        List.of(0), false, null, false, "murmur");
+
+    assertEquals(FragmentType.classify(sendNode, true, Map.of()), FragmentType.INTERMEDIATE);
+  }
+
+  @Test
+  public void testMultipleSingletonReceivesAllLeaves() {
+    // Two SINGLETON receives, both senders have scanned tables
+    MailboxReceiveNode receive1 = new MailboxReceiveNode(1, SCHEMA, 2,
+        PinotRelExchangeType.STREAMING, RelDistribution.Type.SINGLETON,
+        null, null, false, false, null);
+    MailboxReceiveNode receive2 = new MailboxReceiveNode(1, SCHEMA, 3,
+        PinotRelExchangeType.STREAMING, RelDistribution.Type.SINGLETON,
+        null, null, false, false, null);
+    MailboxSendNode sendNode = new MailboxSendNode(1, SCHEMA, List.of(receive1, receive2),
+        0, PinotRelExchangeType.STREAMING, RelDistribution.Type.HASH_DISTRIBUTED,
+        List.of(0), false, null, false, "murmur");
+
+    Map<Integer, DispatchablePlanMetadata> metadataMap = new HashMap<>();
+    DispatchablePlanMetadata meta2 = new DispatchablePlanMetadata();
+    meta2.addScannedTable("dim1");
+    metadataMap.put(2, meta2);
+    DispatchablePlanMetadata meta3 = new DispatchablePlanMetadata();
+    meta3.addScannedTable("dim2");
+    metadataMap.put(3, meta3);
+
+    assertEquals(FragmentType.classify(sendNode, true, metadataMap), FragmentType.SINGLETON_LEAF);
+  }
+
+  @Test
+  public void testMultipleSingletonReceivesOnlyOneIsLeaf() {
+    // Two SINGLETON receives; one sender has scanned tables, the other does not
+    MailboxReceiveNode receive1 = new MailboxReceiveNode(1, SCHEMA, 2,
+        PinotRelExchangeType.STREAMING, RelDistribution.Type.SINGLETON,
+        null, null, false, false, null);
+    MailboxReceiveNode receive2 = new MailboxReceiveNode(1, SCHEMA, 3,
+        PinotRelExchangeType.STREAMING, RelDistribution.Type.SINGLETON,
+        null, null, false, false, null);
+    MailboxSendNode sendNode = new MailboxSendNode(1, SCHEMA, List.of(receive1, receive2),
+        0, PinotRelExchangeType.STREAMING, RelDistribution.Type.HASH_DISTRIBUTED,
+        List.of(0), false, null, false, "murmur");
+
+    Map<Integer, DispatchablePlanMetadata> metadataMap = new HashMap<>();
+    DispatchablePlanMetadata meta2 = new DispatchablePlanMetadata();
+    meta2.addScannedTable("dim1");
+    metadataMap.put(2, meta2);
+    DispatchablePlanMetadata meta3 = new DispatchablePlanMetadata();
+    metadataMap.put(3, meta3);
+
+    assertEquals(FragmentType.classify(sendNode, true, metadataMap), FragmentType.INTERMEDIATE);
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java
@@ -88,7 +88,11 @@ public abstract class BaseMailboxReceiveOperator extends MultiStageOperator {
         asyncStreams.add(asyncStream);
         _receivingStats.add(asyncStream._mailbox.getStatMap());
       }
-      Map<Object, String> streamIdToSenderKey = buildStreamIdToSenderKey(mailboxInfos, asyncStreams);
+      boolean collectTiming = "true".equals(
+          context.getOpChainMetadata().get(AdaptiveRoutingUpstreamTimings.COLLECT_UPSTREAM_TIMING_KEY));
+      Map<Object, String> streamIdToSenderKey = collectTiming
+          ? buildStreamIdToSenderKey(mailboxInfos, asyncStreams)
+          : Map.of();
       _multiConsumer = new BlockingMultiStreamConsumer.OfMseBlock(
           context, asyncStreams, _senderStageId, streamIdToSenderKey);
     } else {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java
@@ -20,7 +20,9 @@ package org.apache.pinot.query.runtime.operator;
 
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.pinot.common.datatable.StatMap;
@@ -28,13 +30,17 @@ import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.mailbox.ReceivingMailbox;
 import org.apache.pinot.query.planner.physical.MailboxIdUtils;
 import org.apache.pinot.query.planner.plannode.MailboxReceiveNode;
+import org.apache.pinot.query.routing.MailboxInfo;
 import org.apache.pinot.query.routing.MailboxInfos;
 import org.apache.pinot.query.runtime.blocks.MseBlock;
 import org.apache.pinot.query.runtime.operator.utils.AsyncStream;
 import org.apache.pinot.query.runtime.operator.utils.BlockingMultiStreamConsumer;
 import org.apache.pinot.query.runtime.plan.MultiStageQueryStats;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+import org.apache.pinot.query.service.dispatch.AdaptiveRoutingUpstreamTimings;
 import org.apache.pinot.spi.query.QueryThreadContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -47,8 +53,11 @@ import org.apache.pinot.spi.query.QueryThreadContext;
  * When exchangeType is non-Singleton, we pull from each instance in round-robin way to get matched mailbox content.
  */
 public abstract class BaseMailboxReceiveOperator extends MultiStageOperator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BaseMailboxReceiveOperator.class);
+
   protected final MailboxService _mailboxService;
   protected final RelDistribution.Type _distributionType;
+  protected final int _senderStageId;
   protected final List<String> _mailboxIds;
   protected final BlockingMultiStreamConsumer.OfMseBlock _multiConsumer;
   protected final List<StatMap<ReceivingMailbox.StatKey>> _receivingStats;
@@ -63,11 +72,11 @@ public abstract class BaseMailboxReceiveOperator extends MultiStageOperator {
     _distributionType = distributionType;
 
     long requestId = context.getRequestId();
-    int senderStageId = node.getSenderStageId();
-    MailboxInfos mailboxInfos = context.getWorkerMetadata().getMailboxInfosMap().get(senderStageId);
+    _senderStageId = node.getSenderStageId();
+    MailboxInfos mailboxInfos = context.getWorkerMetadata().getMailboxInfosMap().get(_senderStageId);
     if (mailboxInfos != null) {
       _mailboxIds =
-          MailboxIdUtils.toMailboxIds(requestId, senderStageId, mailboxInfos.getMailboxInfos(), context.getStageId(),
+          MailboxIdUtils.toMailboxIds(requestId, _senderStageId, mailboxInfos.getMailboxInfos(), context.getStageId(),
               context.getWorkerId());
       int numMailboxes = _mailboxIds.size();
       List<ReadMailboxAsyncStream> asyncStreams = new ArrayList<>(numMailboxes);
@@ -79,12 +88,14 @@ public abstract class BaseMailboxReceiveOperator extends MultiStageOperator {
         asyncStreams.add(asyncStream);
         _receivingStats.add(asyncStream._mailbox.getStatMap());
       }
-      _multiConsumer = new BlockingMultiStreamConsumer.OfMseBlock(context, asyncStreams, senderStageId);
+      Map<Object, String> streamIdToSenderKey = buildStreamIdToSenderKey(mailboxInfos, asyncStreams);
+      _multiConsumer = new BlockingMultiStreamConsumer.OfMseBlock(
+          context, asyncStreams, _senderStageId, streamIdToSenderKey);
     } else {
       // TODO: Revisit if we should throw exception here.
       _mailboxIds = List.of();
       _receivingStats = List.of();
-      _multiConsumer = new BlockingMultiStreamConsumer.OfMseBlock(context, List.of(), senderStageId);
+      _multiConsumer = new BlockingMultiStreamConsumer.OfMseBlock(context, List.of(), _senderStageId);
     }
     _statMap.merge(StatKey.FAN_IN, _mailboxIds.size());
   }
@@ -124,12 +135,32 @@ public abstract class BaseMailboxReceiveOperator extends MultiStageOperator {
 
   @Override
   public StatMap<StatKey> copyStatMaps() {
-    return new StatMap<>(_statMap);
+    StatMap<StatKey> copy = new StatMap<>(_statMap);
+    // Flush partial timing data so that the timeout/cancellation path (where onEos() never ran)
+    // still captures timings for senders whose EOS did arrive. In the normal path onEos() has
+    // already merged the same data into _statMap, so this is idempotent via the Math::max merger.
+    mergeSenderTimingsInto(copy);
+    return copy;
   }
 
   protected void onEos() {
     for (StatMap<ReceivingMailbox.StatKey> receivingStats : _receivingStats) {
       addReceivingStats(receivingStats);
+    }
+    mergeSenderTimingsInto(_statMap);
+    LOGGER.debug("==[UPSTREAM_TIMING]== stage {} onEos: merged sender timings", _senderStageId);
+  }
+
+  /**
+   * Encodes per-sender elapsed-time data from the multi-consumer and merges it into {@code target}.
+   */
+  private void mergeSenderTimingsInto(StatMap<StatKey> target) {
+    Map<String, Long> senderElapsedMs = _multiConsumer.getSenderElapsedMs();
+    if (!senderElapsedMs.isEmpty()) {
+      String encoded = AdaptiveRoutingUpstreamTimings.encode(senderElapsedMs);
+      if (encoded != null) {
+        target.merge(StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS, encoded);
+      }
     }
   }
 
@@ -148,6 +179,27 @@ public abstract class BaseMailboxReceiveOperator extends MultiStageOperator {
     _statMap.merge(StatKey.EMITTED_ROWS, numRows);
     _statMap.merge(StatKey.ALLOCATED_MEMORY_BYTES, memoryUsedBytes);
     _statMap.merge(StatKey.GC_TIME_MS, gcTimeMs);
+  }
+
+  /**
+   * Builds a map from stream ID to sender key (hostname|mailboxPort) for per-sender elapsed-time tracking.
+   * Iterates {@link MailboxInfos} and {@code asyncStreams} in parallel (same order as
+   * {@link MailboxIdUtils#toMailboxIds}), mapping each stream's ID to its server's sender key.
+   */
+  private static Map<Object, String> buildStreamIdToSenderKey(MailboxInfos mailboxInfos,
+      List<? extends AsyncStream<?>> asyncStreams) {
+    Map<Object, String> streamIdToSenderKey = new HashMap<>(asyncStreams.size());
+    int i = 0;
+    for (MailboxInfo info : mailboxInfos.getMailboxInfos()) {
+      String key = AdaptiveRoutingUpstreamTimings.senderKey(info.getHostname(), info.getPort());
+      for (int ignored : info.getWorkerIds()) {
+        streamIdToSenderKey.put(asyncStreams.get(i).getId(), key);
+        i++;
+      }
+    }
+    Preconditions.checkState(i == asyncStreams.size(),
+        "MailboxInfos worker count (%s) does not match asyncStreams size (%s)", i, asyncStreams.size());
+    return streamIdToSenderKey;
   }
 
   private void addReceivingStats(StatMap<ReceivingMailbox.StatKey> from) {
@@ -266,7 +318,35 @@ public abstract class BaseMailboxReceiveOperator extends MultiStageOperator {
     /**
      * Time spent on GC while this operator or its children in the same stage were running.
      */
-    GC_TIME_MS(StatMap.Type.LONG);
+    GC_TIME_MS(StatMap.Type.LONG),
+    /**
+     * Per-upstream-sender wall-clock elapsed time (consumer construction -> EOS arrival),
+     * encoded as a semicolon-separated list of {@code "hostname|mailboxPort=elapsedMs"} pairs.
+     *
+     * <p>Populated by every {@link BaseMailboxReceiveOperator}. Elapsed time is anchored to consumer
+     * construction (after pipeline breakers), avoiding cross-host clock skew. When multiple workers on
+     * the same stage contribute stats for the same sender, the merge function takes the maximum elapsed
+     * time so the slowest observation is preserved for the same sending server.
+     *
+     * <p>On the broker side, {@code QueryDispatcher#extractMaxTimingsPerInstance} reads this stat and calls
+     * {@link org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsManager
+     *     #recordStatsUponResponseArrival}
+     * for servers that the broker did not track directly (e.g. S2 in a join query routed through S1).
+     * Senders with no observed timing are omitted from the encoding.
+     */
+    UPSTREAM_SERVER_RESPONSE_TIMES_MS(StatMap.Type.STRING) {
+      @Override
+      public String merge(@Nullable String value1, @Nullable String value2) {
+        return AdaptiveRoutingUpstreamTimings.mergeEncodings(value1, value2);
+      }
+
+      @Override
+      public boolean includeInJson() {
+        // Excluded from stage stats in the query response because the encoded timing string can be large
+        // (one entry per upstream sender). It is only needed broker-side for adaptive routing.
+        return false;
+      }
+    };
 
     private final StatMap.Type _type;
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java
@@ -140,10 +140,10 @@ public abstract class BaseMailboxReceiveOperator extends MultiStageOperator {
   @Override
   public StatMap<StatKey> copyStatMaps() {
     StatMap<StatKey> copy = new StatMap<>(_statMap);
-    // Flush partial timing data so that the timeout/cancellation path (where onEos() never ran)
-    // still captures timings for senders whose EOS did arrive. In the normal path onEos() has
-    // already merged the same data into _statMap, so this is idempotent via the Math::max merger.
-    mergeSenderTimingsInto(copy);
+    // On the cancel/timeout path (where onEos() never ran), include ALL known senders:
+    // completed senders get their actual measured latency, pending senders get the current
+    // wall-clock elapsed time so the adaptive selector can identify slow servers.
+    mergeSenderTimingsInto(copy, _multiConsumer.getSenderElapsedMsIncludingPending());
     return copy;
   }
 
@@ -151,15 +151,14 @@ public abstract class BaseMailboxReceiveOperator extends MultiStageOperator {
     for (StatMap<ReceivingMailbox.StatKey> receivingStats : _receivingStats) {
       addReceivingStats(receivingStats);
     }
-    mergeSenderTimingsInto(_statMap);
+    mergeSenderTimingsInto(_statMap, _multiConsumer.getSenderElapsedMs());
     LOGGER.debug("==[UPSTREAM_TIMING]== stage {} onEos: merged sender timings", _senderStageId);
   }
 
   /**
-   * Encodes per-sender elapsed-time data from the multi-consumer and merges it into {@code target}.
+   * Encodes per-sender elapsed-time data and merges it into {@code target}.
    */
-  private void mergeSenderTimingsInto(StatMap<StatKey> target) {
-    Map<String, Long> senderElapsedMs = _multiConsumer.getSenderElapsedMs();
+  private void mergeSenderTimingsInto(StatMap<StatKey> target, Map<String, Long> senderElapsedMs) {
     if (!senderElapsedMs.isEmpty()) {
       String encoded = AdaptiveRoutingUpstreamTimings.encode(senderElapsedMs);
       if (encoded != null) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/BlockingMultiStreamConsumer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/BlockingMultiStreamConsumer.java
@@ -18,11 +18,15 @@
  */
 package org.apache.pinot.query.runtime.operator.utils;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.pinot.query.mailbox.ReceivingMailbox;
@@ -92,10 +96,12 @@ public abstract class BlockingMultiStreamConsumer<E> implements AutoCloseable {
    *
    * It is guaranteed that the received element is an EOS as defined by {@link #isSuccess(Object)}.
    * No more messages are going to be read from that mailbox.
+   * The {@code completedStream} is the stream that just sent its EOS and has already been removed from
+   * {@link #_mailboxes}.
    *
    * This method is called by the consumer thread.
    */
-  protected abstract void onMailboxSuccess(E element);
+  protected abstract void onMailboxSuccess(E element, AsyncStream<E> completedStream);
 
   /**
    * This method is called whenever a timeout is reached while reading an element.
@@ -277,7 +283,7 @@ public abstract class BlockingMultiStreamConsumer<E> implements AutoCloseable {
         LOGGER.debug("==[RECEIVE]== EOS received : " + _id + " in mailbox: " + removed.getId()
             + " (mailboxes alive: " + ids + ")");
       }
-      onMailboxSuccess(block);
+      onMailboxSuccess(block, removed);
 
       block = readBlockOrNull();
     }
@@ -345,13 +351,35 @@ public abstract class BlockingMultiStreamConsumer<E> implements AutoCloseable {
     @Nullable
     private MultiStageQueryStats _stats;
     private final int _senderStageId;
+    private final long _startTimeMs;
+    private final LongSupplier _clock;
+    // Maps senderKey (hostname|mailboxPort) -> max elapsed time (ms) seen for that sender
+    private final Map<String, Long> _senderElapsedMs = new ConcurrentHashMap<>();
+    // Maps stream ID -> sender key (hostname|mailboxPort)
+    private final Map<Object, String> _streamIdToSenderKey;
 
     public OfMseBlock(OpChainExecutionContext context,
         List<? extends AsyncStream<ReceivingMailbox.MseBlockWithStats>> asyncProducers, int senderStageId) {
+      this(context, asyncProducers, senderStageId, Map.of());
+    }
+
+    public OfMseBlock(OpChainExecutionContext context,
+        List<? extends AsyncStream<ReceivingMailbox.MseBlockWithStats>> asyncProducers, int senderStageId,
+        Map<Object, String> streamIdToSenderKey) {
+      this(context, asyncProducers, senderStageId, streamIdToSenderKey, System::currentTimeMillis);
+    }
+
+    @VisibleForTesting
+    OfMseBlock(OpChainExecutionContext context,
+        List<? extends AsyncStream<ReceivingMailbox.MseBlockWithStats>> asyncProducers, int senderStageId,
+        Map<Object, String> streamIdToSenderKey, LongSupplier clock) {
       super(context.getId(), context.getPassiveDeadlineMs(), asyncProducers);
       _stageId = context.getStageId();
       _stats = MultiStageQueryStats.emptyStats(context.getStageId());
       _senderStageId = senderStageId;
+      _streamIdToSenderKey = streamIdToSenderKey;
+      _clock = clock;
+      _startTimeMs = clock.getAsLong();
     }
 
     @Override
@@ -365,8 +393,27 @@ public abstract class BlockingMultiStreamConsumer<E> implements AutoCloseable {
     }
 
     @Override
-    protected void onMailboxSuccess(ReceivingMailbox.MseBlockWithStats element) {
+    protected void onMailboxSuccess(ReceivingMailbox.MseBlockWithStats element,
+        AsyncStream<ReceivingMailbox.MseBlockWithStats> completedStream) {
       mergeStats(element);
+      String senderKey = _streamIdToSenderKey.get(completedStream.getId());
+      if (senderKey == null) {
+        LOGGER.warn("==[UPSTREAM_TIMING]== stage {} stream {} has no senderKey mapping, skipping timing",
+            _senderStageId, completedStream.getId());
+        return;
+      }
+      long elapsedMs = _clock.getAsLong() - _startTimeMs;
+      _senderElapsedMs.merge(senderKey, elapsedMs, Math::max);
+      LOGGER.debug("==[UPSTREAM_TIMING]== stage {} sender {} EOS at {}ms since receiver start",
+          _senderStageId, senderKey, elapsedMs);
+    }
+
+    /**
+     * Returns the per-sender timing map (senderKey -> max elapsedMs since consumer construction).
+     * May be empty if no timing data was collected.
+     */
+    public Map<String, Long> getSenderElapsedMs() {
+      return Collections.unmodifiableMap(_senderElapsedMs);
     }
 
     @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/BlockingMultiStreamConsumer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/BlockingMultiStreamConsumer.java
@@ -396,6 +396,9 @@ public abstract class BlockingMultiStreamConsumer<E> implements AutoCloseable {
     protected void onMailboxSuccess(ReceivingMailbox.MseBlockWithStats element,
         AsyncStream<ReceivingMailbox.MseBlockWithStats> completedStream) {
       mergeStats(element);
+      if (_streamIdToSenderKey.isEmpty()) {
+        return;
+      }
       String senderKey = _streamIdToSenderKey.get(completedStream.getId());
       if (senderKey == null) {
         LOGGER.warn("==[UPSTREAM_TIMING]== stage {} stream {} has no senderKey mapping, skipping timing",

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/BlockingMultiStreamConsumer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/BlockingMultiStreamConsumer.java
@@ -21,6 +21,7 @@ package org.apache.pinot.query.runtime.operator.utils;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -417,6 +418,22 @@ public abstract class BlockingMultiStreamConsumer<E> implements AutoCloseable {
      */
     public Map<String, Long> getSenderElapsedMs() {
       return Collections.unmodifiableMap(_senderElapsedMs);
+    }
+
+    /**
+     * Returns per-sender timing with pending (non-completing) senders injected at the current
+     * wall-clock elapsed time. Completed senders retain their actual measured latency.
+     */
+    public Map<String, Long> getSenderElapsedMsIncludingPending() {
+      if (_streamIdToSenderKey.isEmpty()) {
+        return Collections.unmodifiableMap(_senderElapsedMs);
+      }
+      long elapsedMs = _clock.getAsLong() - _startTimeMs;
+      Map<String, Long> result = new HashMap<>(_senderElapsedMs);
+      for (String senderKey : _streamIdToSenderKey.values()) {
+        result.putIfAbsent(senderKey, elapsedMs);
+      }
+      return Collections.unmodifiableMap(result);
     }
 
     @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/AdaptiveRoutingStageClassification.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/AdaptiveRoutingStageClassification.java
@@ -126,6 +126,10 @@ final class AdaptiveRoutingStageClassification {
     // Exclude stages contaminated by non-leaf/SINGLETON senders.
     trustedStageIds.removeAll(stagesReceivingFromNonLeaf);
 
+    // Stage 0 (the broker reducer) is always trusted: its sender timings are measured directly
+    // by the multi-consumer, not propagated through intermediate stages.
+    trustedStageIds.add(0);
+
     LOGGER.debug("==[UPSTREAM_TIMING]== classifyStages: trustedStageIds={} trackedServers={} "
         + "senderKeyToInstanceId.size={}", trustedStageIds, trackedServers.size(), senderKeyToInstanceId.size());
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/AdaptiveRoutingStageClassification.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/AdaptiveRoutingStageClassification.java
@@ -18,18 +18,14 @@
  */
 package org.apache.pinot.query.service.dispatch;
 
-import com.google.common.annotations.VisibleForTesting;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.calcite.rel.RelDistribution;
 import org.apache.pinot.query.planner.PlanFragment;
 import org.apache.pinot.query.planner.physical.DispatchablePlanFragment;
 import org.apache.pinot.query.planner.physical.DispatchableSubPlan;
-import org.apache.pinot.query.planner.plannode.MailboxReceiveNode;
+import org.apache.pinot.query.planner.physical.FragmentType;
 import org.apache.pinot.query.planner.plannode.MailboxSendNode;
 import org.apache.pinot.query.planner.plannode.PlanNode;
 import org.apache.pinot.query.routing.QueryServerInstance;
@@ -70,18 +66,17 @@ final class AdaptiveRoutingStageClassification {
   }
 
   /**
-   * Classification of plan fragments into consulted stages and tracked servers.
+   * Derives trusted stages and tracked servers from pre-computed roles set at planning time.
+   *
+   * <p>For pure leaves: their receivers are trusted (unless also receiving from a non-leaf).
+   * For SINGLETON leaf trusted: the stage itself is trusted.
+   * Contamination filter: any stage that receives from a non-leaf is excluded from trusted.
    */
   static AdaptiveRoutingStageClassification classify(DispatchableSubPlan plan) {
     Map<String, String> senderKeyToInstanceId = new HashMap<>();
-    Set<Integer> leafStageIds = new HashSet<>();
     Set<Integer> trustedStageIds = new HashSet<>();
     Set<String> trackedServers = new HashSet<>();
-    // Stages that receive from any non-leaf stage. Their timing is unreliable: the non-leaf sender
-    // may have waited for a slow upstream (cascade), inflating per-sender timings at the receiver.
     Set<Integer> stagesReceivingFromNonLeaf = new HashSet<>();
-    // Deferred: SINGLETON leaf stages pending "is sender also a leaf?" resolution.
-    List<int[]> pendingSingletonLeaves = new ArrayList<>();
 
     for (DispatchablePlanFragment fragment : plan.getQueryStagesWithoutRoot()) {
       Set<QueryServerInstance> fragmentServers = fragment.getServerInstanceToWorkerIdMap().keySet();
@@ -90,81 +85,50 @@ final class AdaptiveRoutingStageClassification {
         senderKeyToInstanceId.putIfAbsent(key, server.getInstanceId());
       }
 
+      FragmentType role = fragment.getFragmentType();
       PlanFragment planFragment = fragment.getPlanFragment();
       PlanNode fragmentRoot = planFragment != null ? planFragment.getFragmentRoot() : null;
+      MailboxSendNode sendNode = fragmentRoot instanceof MailboxSendNode ? (MailboxSendNode) fragmentRoot : null;
 
-      if (fragment.getTableName() == null) {
-        // Non-leaf intermediate stage — mark its receivers as contaminated.
-        if (fragmentRoot instanceof MailboxSendNode) {
-          for (int receiverStageId : ((MailboxSendNode) fragmentRoot).getReceiverStageIds()) {
-            stagesReceivingFromNonLeaf.add(receiverStageId);
+      if (role == FragmentType.LEAF) {
+        // Leaf: receivers are trusted, servers are tracked.
+        if (sendNode != null) {
+          for (int receiverStageId : sendNode.getReceiverStageIds()) {
+            trustedStageIds.add(receiverStageId);
           }
-        }
-        continue;
-      }
-
-      if (!(fragmentRoot instanceof MailboxSendNode)) {
-        continue;
-      }
-      MailboxSendNode sendNode = (MailboxSendNode) fragmentRoot;
-      leafStageIds.add(sendNode.getStageId());
-
-      int singletonSenderStageId = getSingletonReceiveSenderStageId(fragmentRoot);
-      if (singletonSenderStageId >= 0) {
-        // SINGLETON leaf: mark its receivers as contaminated, defer consultation decision
-        // until we know whether the sender is also a leaf.
-        for (int receiverStageId : sendNode.getReceiverStageIds()) {
-          stagesReceivingFromNonLeaf.add(receiverStageId);
-        }
-        pendingSingletonLeaves.add(new int[]{sendNode.getStageId(), singletonSenderStageId});
-      } else {
-        // Pure leaf: its receivers are consulted and its servers are tracked for EMA updates.
-        for (int receiverStageId : sendNode.getReceiverStageIds()) {
-          trustedStageIds.add(receiverStageId);
         }
         for (QueryServerInstance server : fragmentServers) {
           trackedServers.add(server.getInstanceId());
         }
+      } else if (role == FragmentType.SINGLETON_LEAF) {
+        // SINGLETON leaf with leaf sender: this stage's own stats are trusted.
+        trustedStageIds.add(planFragment.getFragmentId());
+        // Its receivers are contaminated (SINGLETON cascade).
+        if (sendNode != null) {
+          for (int receiverStageId : sendNode.getReceiverStageIds()) {
+            stagesReceivingFromNonLeaf.add(receiverStageId);
+          }
+        }
+      } else if (role == FragmentType.INTERMEDIATE && sendNode != null) {
+        // Intermediate stage: its receivers are contaminated by cascade delays.
+        for (int receiverStageId : sendNode.getReceiverStageIds()) {
+          stagesReceivingFromNonLeaf.add(receiverStageId);
+        }
+      } else if (role == null && sendNode != null) {
+        LOGGER.debug("Stage {} has null FragmentType; treating as INTERMEDIATE",
+            planFragment != null ? planFragment.getFragmentId() : "unknown");
+        for (int receiverStageId : sendNode.getReceiverStageIds()) {
+          stagesReceivingFromNonLeaf.add(receiverStageId);
+        }
       }
     }
 
-    // Resolve deferred SINGLETON leaves: only consult if their sender is also a leaf.
-    for (int[] pair : pendingSingletonLeaves) {
-      if (leafStageIds.contains(pair[1])) {
-        trustedStageIds.add(pair[0]);
-      }
-    }
-
-    // Exclude stages that receive from any non-leaf stage. Non-leaf senders may carry cascade
-    // delay from slow upstream servers, inflating per-sender timings at the receiver.
+    // Exclude stages contaminated by non-leaf/SINGLETON senders.
     trustedStageIds.removeAll(stagesReceivingFromNonLeaf);
 
-    LOGGER.debug("==[UPSTREAM_TIMING]== classifyStages: leafStageIds={} trustedStageIds={} "
-        + "trackedServers={} senderKeyToInstanceId.size={}", leafStageIds, trustedStageIds,
-        trackedServers.size(), senderKeyToInstanceId.size());
+    LOGGER.debug("==[UPSTREAM_TIMING]== classifyStages: trustedStageIds={} trackedServers={} "
+        + "senderKeyToInstanceId.size={}", trustedStageIds, trackedServers.size(), senderKeyToInstanceId.size());
 
     return new AdaptiveRoutingStageClassification(senderKeyToInstanceId, trustedStageIds, trackedServers);
-  }
-
-  /**
-   * Returns the sender stage ID of the first {@link MailboxReceiveNode} with
-   * {@link RelDistribution.Type#SINGLETON} distribution found in the plan subtree rooted at {@code node},
-   * or {@code -1} if none is found.
-   */
-  @VisibleForTesting
-  static int getSingletonReceiveSenderStageId(PlanNode node) {
-    if (node instanceof MailboxReceiveNode) {
-      MailboxReceiveNode receiveNode = (MailboxReceiveNode) node;
-      if (receiveNode.getDistributionType() == RelDistribution.Type.SINGLETON) {
-        return receiveNode.getSenderStageId();
-      }
-    }
-    for (PlanNode input : node.getInputs()) {
-      int result = getSingletonReceiveSenderStageId(input);
-      if (result >= 0) {
-        return result;
-      }
-    }
-    return -1;
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/AdaptiveRoutingStageClassification.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/AdaptiveRoutingStageClassification.java
@@ -1,0 +1,170 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.service.dispatch;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.pinot.query.planner.PlanFragment;
+import org.apache.pinot.query.planner.physical.DispatchablePlanFragment;
+import org.apache.pinot.query.planner.physical.DispatchableSubPlan;
+import org.apache.pinot.query.planner.plannode.MailboxReceiveNode;
+import org.apache.pinot.query.planner.plannode.MailboxSendNode;
+import org.apache.pinot.query.planner.plannode.PlanNode;
+import org.apache.pinot.query.routing.QueryServerInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Classifies a query plan's stages for upstream timing extraction.
+ *
+ * <p>Two kinds of stages are consulted:
+ * <ul>
+ *   <li><b>Pure leaf receivers</b>: stages that directly receive from a non-SINGLETON leaf.</li>
+ *   <li><b>SINGLETON leaf stages receiving from another leaf</b>: a leaf stage that both scans a
+ *       dim table and receives all upstream data via a SINGLETON exchange, but ONLY when its upstream
+ *       sender stage is also a leaf.</li>
+ * </ul>
+ *
+ * <p>Only pure leaf servers (non-SINGLETON) are eligible for EMA updates. Intermediate and
+ * SINGLETON leaf servers are excluded because their timings reflect cascade delays from upstream
+ * rather than their own scan performance.
+ */
+final class AdaptiveRoutingStageClassification {
+  private static final Logger LOGGER = LoggerFactory.getLogger(AdaptiveRoutingStageClassification.class);
+
+  /** Maps "hostname|mailboxPort" -> instanceId for all known servers. */
+  final Map<String, String> _senderKeyToInstanceId;
+  /** Stage IDs whose UPSTREAM_SERVER_RESPONSE_TIMES_MS we trust. */
+  final Set<Integer> _trustedStageIds;
+  /** Instance IDs of pure leaf servers eligible for EMA updates in the fallback path. */
+  final Set<String> _trackedServers;
+
+  private AdaptiveRoutingStageClassification(Map<String, String> senderKeyToInstanceId, Set<Integer> trustedStageIds,
+      Set<String> trackedServers) {
+    _senderKeyToInstanceId = senderKeyToInstanceId;
+    _trustedStageIds = trustedStageIds;
+    _trackedServers = trackedServers;
+  }
+
+  /**
+   * Classification of plan fragments into consulted stages and tracked servers.
+   */
+  static AdaptiveRoutingStageClassification classify(DispatchableSubPlan plan) {
+    Map<String, String> senderKeyToInstanceId = new HashMap<>();
+    Set<Integer> leafStageIds = new HashSet<>();
+    Set<Integer> trustedStageIds = new HashSet<>();
+    Set<String> trackedServers = new HashSet<>();
+    // Stages that receive from any non-leaf stage. Their timing is unreliable: the non-leaf sender
+    // may have waited for a slow upstream (cascade), inflating per-sender timings at the receiver.
+    Set<Integer> stagesReceivingFromNonLeaf = new HashSet<>();
+    // Deferred: SINGLETON leaf stages pending "is sender also a leaf?" resolution.
+    List<int[]> pendingSingletonLeaves = new ArrayList<>();
+
+    for (DispatchablePlanFragment fragment : plan.getQueryStagesWithoutRoot()) {
+      Set<QueryServerInstance> fragmentServers = fragment.getServerInstanceToWorkerIdMap().keySet();
+      for (QueryServerInstance server : fragmentServers) {
+        String key = AdaptiveRoutingUpstreamTimings.senderKey(server.getHostname(), server.getQueryMailboxPort());
+        senderKeyToInstanceId.putIfAbsent(key, server.getInstanceId());
+      }
+
+      PlanFragment planFragment = fragment.getPlanFragment();
+      PlanNode fragmentRoot = planFragment != null ? planFragment.getFragmentRoot() : null;
+
+      if (fragment.getTableName() == null) {
+        // Non-leaf intermediate stage — mark its receivers as contaminated.
+        if (fragmentRoot instanceof MailboxSendNode) {
+          for (int receiverStageId : ((MailboxSendNode) fragmentRoot).getReceiverStageIds()) {
+            stagesReceivingFromNonLeaf.add(receiverStageId);
+          }
+        }
+        continue;
+      }
+
+      if (!(fragmentRoot instanceof MailboxSendNode)) {
+        continue;
+      }
+      MailboxSendNode sendNode = (MailboxSendNode) fragmentRoot;
+      leafStageIds.add(sendNode.getStageId());
+
+      int singletonSenderStageId = getSingletonReceiveSenderStageId(fragmentRoot);
+      if (singletonSenderStageId >= 0) {
+        // SINGLETON leaf: mark its receivers as contaminated, defer consultation decision
+        // until we know whether the sender is also a leaf.
+        for (int receiverStageId : sendNode.getReceiverStageIds()) {
+          stagesReceivingFromNonLeaf.add(receiverStageId);
+        }
+        pendingSingletonLeaves.add(new int[]{sendNode.getStageId(), singletonSenderStageId});
+      } else {
+        // Pure leaf: its receivers are consulted and its servers are tracked for EMA updates.
+        for (int receiverStageId : sendNode.getReceiverStageIds()) {
+          trustedStageIds.add(receiverStageId);
+        }
+        for (QueryServerInstance server : fragmentServers) {
+          trackedServers.add(server.getInstanceId());
+        }
+      }
+    }
+
+    // Resolve deferred SINGLETON leaves: only consult if their sender is also a leaf.
+    for (int[] pair : pendingSingletonLeaves) {
+      if (leafStageIds.contains(pair[1])) {
+        trustedStageIds.add(pair[0]);
+      }
+    }
+
+    // Exclude stages that receive from any non-leaf stage. Non-leaf senders may carry cascade
+    // delay from slow upstream servers, inflating per-sender timings at the receiver.
+    trustedStageIds.removeAll(stagesReceivingFromNonLeaf);
+
+    LOGGER.debug("==[UPSTREAM_TIMING]== classifyStages: leafStageIds={} trustedStageIds={} "
+        + "trackedServers={} senderKeyToInstanceId.size={}", leafStageIds, trustedStageIds,
+        trackedServers.size(), senderKeyToInstanceId.size());
+
+    return new AdaptiveRoutingStageClassification(senderKeyToInstanceId, trustedStageIds, trackedServers);
+  }
+
+  /**
+   * Returns the sender stage ID of the first {@link MailboxReceiveNode} with
+   * {@link RelDistribution.Type#SINGLETON} distribution found in the plan subtree rooted at {@code node},
+   * or {@code -1} if none is found.
+   */
+  @VisibleForTesting
+  static int getSingletonReceiveSenderStageId(PlanNode node) {
+    if (node instanceof MailboxReceiveNode) {
+      MailboxReceiveNode receiveNode = (MailboxReceiveNode) node;
+      if (receiveNode.getDistributionType() == RelDistribution.Type.SINGLETON) {
+        return receiveNode.getSenderStageId();
+      }
+    }
+    for (PlanNode input : node.getInputs()) {
+      int result = getSingletonReceiveSenderStageId(input);
+      if (result >= 0) {
+        return result;
+      }
+    }
+    return -1;
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/AdaptiveRoutingUpstreamTimings.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/AdaptiveRoutingUpstreamTimings.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.service.dispatch;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Holds per-upstream-sender timing data for adaptive routing, encoded for transport via StatMap STRING keys.
+ *
+ * <p>Format: {@code "key1=elapsedMs1;key2=elapsedMs2"}
+ * <ul>
+ *   <li>Entries are separated by {@code ';'}</li>
+ *   <li>Key and value are separated by {@code '='}</li>
+ *   <li>Keys are of the form {@code "hostname|mailboxPort"} (pipe cannot appear in DNS names or port numbers)</li>
+ *   <li>elapsedMs values are non-negative longs</li>
+ * </ul>
+ *
+ * <p>This encoding is used in
+ * {@link org.apache.pinot.query.runtime.operator.BaseMailboxReceiveOperator.StatKey#UPSTREAM_SERVER_RESPONSE_TIMES_MS}.
+ */
+public class AdaptiveRoutingUpstreamTimings {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AdaptiveRoutingUpstreamTimings.class);
+
+  static final char ENTRY_SEPARATOR = ';';
+  static final char KV_SEPARATOR = '=';
+
+  private AdaptiveRoutingUpstreamTimings() {
+  }
+
+  /**
+   * Returns the key used to identify a sender in the timing map, given its hostname and mailbox port.
+   * <p>The {@code '|'} separator is chosen because it cannot appear in DNS hostnames or port numbers.
+   */
+  public static String senderKey(String hostname, int mailboxPort) {
+    return hostname + "|" + mailboxPort;
+  }
+
+  /**
+   * Encode a map of senderKey -> elapsedMs into a string. Entries are sorted by key so the
+   * output is deterministic and easy to diff.
+   *
+   * @return encoded string, or {@code null} if the map is empty (null = absent in StatMap)
+   */
+  @Nullable
+  public static String encode(Map<String, Long> timings) {
+    if (timings.isEmpty()) {
+      return null;
+    }
+    StringBuilder sb = new StringBuilder();
+    for (Map.Entry<String, Long> entry : new TreeMap<>(timings).entrySet()) {
+      if (sb.length() > 0) {
+        sb.append(ENTRY_SEPARATOR);
+      }
+      sb.append(entry.getKey()).append(KV_SEPARATOR).append(entry.getValue());
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Decode a string (possibly null) into a mutable map of senderKey -> elapsedMs.
+   */
+  public static Map<String, Long> decode(@Nullable String encoded) {
+    Map<String, Long> result = new HashMap<>();
+    if (encoded == null || encoded.isEmpty()) {
+      return result;
+    }
+    String[] entries = encoded.split(String.valueOf(ENTRY_SEPARATOR));
+    for (String entry : entries) {
+      int eq = entry.indexOf(KV_SEPARATOR);
+      if (eq > 0) {
+        String key = entry.substring(0, eq);
+        try {
+          long value = Long.parseLong(entry.substring(eq + 1));
+          result.put(key, value);
+        } catch (NumberFormatException e) {
+          LOGGER.warn("Skipping malformed timing entry '{}': {}", entry, e.getMessage());
+        }
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Merge two encoded timing strings, taking the max elapsedMs per senderKey.
+   * Either or both arguments may be null (treated as empty).
+   */
+  @Nullable
+  public static String mergeEncodings(@Nullable String enc1, @Nullable String enc2) {
+    Map<String, Long> merged = decode(enc1);
+    Map<String, Long> incoming = decode(enc2);
+    for (Map.Entry<String, Long> entry : incoming.entrySet()) {
+      merged.merge(entry.getKey(), entry.getValue(), Math::max);
+    }
+    return encode(merged);
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/AdaptiveRoutingUpstreamTimings.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/AdaptiveRoutingUpstreamTimings.java
@@ -20,7 +20,6 @@ package org.apache.pinot.query.service.dispatch;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.TreeMap;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,6 +43,8 @@ public class AdaptiveRoutingUpstreamTimings {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AdaptiveRoutingUpstreamTimings.class);
 
+  public static final String COLLECT_UPSTREAM_TIMING_KEY = "collectUpstreamTiming";
+
   static final char ENTRY_SEPARATOR = ';';
   static final char KV_SEPARATOR = '=';
 
@@ -59,8 +60,7 @@ public class AdaptiveRoutingUpstreamTimings {
   }
 
   /**
-   * Encode a map of senderKey -> elapsedMs into a string. Entries are sorted by key so the
-   * output is deterministic and easy to diff.
+   * Encode a map of senderKey -> elapsedMs into a string.
    *
    * @return encoded string, or {@code null} if the map is empty (null = absent in StatMap)
    */
@@ -70,7 +70,7 @@ public class AdaptiveRoutingUpstreamTimings {
       return null;
     }
     StringBuilder sb = new StringBuilder();
-    for (Map.Entry<String, Long> entry : new TreeMap<>(timings).entrySet()) {
+    for (Map.Entry<String, Long> entry : timings.entrySet()) {
       if (sb.length() > 0) {
         sb.append(ENTRY_SEPARATOR);
       }
@@ -87,18 +87,24 @@ public class AdaptiveRoutingUpstreamTimings {
     if (encoded == null || encoded.isEmpty()) {
       return result;
     }
-    String[] entries = encoded.split(String.valueOf(ENTRY_SEPARATOR));
-    for (String entry : entries) {
-      int eq = entry.indexOf(KV_SEPARATOR);
-      if (eq > 0) {
-        String key = entry.substring(0, eq);
+    int start = 0;
+    int len = encoded.length();
+    while (start < len) {
+      int end = encoded.indexOf(ENTRY_SEPARATOR, start);
+      if (end < 0) {
+        end = len;
+      }
+      int eq = encoded.indexOf(KV_SEPARATOR, start);
+      if (eq > start && eq < end) {
+        String key = encoded.substring(start, eq);
         try {
-          long value = Long.parseLong(entry.substring(eq + 1));
+          long value = Long.parseLong(encoded.substring(eq + 1, end));
           result.put(key, value);
         } catch (NumberFormatException e) {
-          LOGGER.warn("Skipping malformed timing entry '{}': {}", entry, e.getMessage());
+          LOGGER.warn("Skipping malformed timing entry '{}': {}", encoded.substring(start, end), e.getMessage());
         }
       }
+      start = end + 1;
     }
     return result;
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -105,6 +105,22 @@ import org.slf4j.LoggerFactory;
  * {@code QueryDispatcher} dispatch a query to different workers.
  */
 public class QueryDispatcher {
+
+  static final class CancelOutcome {
+    static final CancelOutcome NONE = new CancelOutcome(null, Set.of());
+
+    @Nullable final MultiStageQueryStats _stats;
+    final Set<String> _respondingServerIds;
+
+    CancelOutcome(@Nullable MultiStageQueryStats stats, Set<String> respondingServerIds) {
+      _stats = stats;
+      _respondingServerIds = respondingServerIds;
+    }
+
+    boolean wasAttempted() {
+      return !_respondingServerIds.isEmpty();
+    }
+  }
   private static final Logger LOGGER = LoggerFactory.getLogger(QueryDispatcher.class);
   private static final String PINOT_BROKER_QUERY_DISPATCHER_FORMAT = "multistage-query-dispatch-%d";
 
@@ -203,17 +219,18 @@ public class QueryDispatcher {
     long requestId = context.getRequestId();
     Set<QueryServerInstance> servers = new HashSet<>();
     Set<QueryServerInstance> incrementedServers = new HashSet<>();
-    Set<String> decrementedServers = new HashSet<>();
     long submitTimeMs = _clock.getAsLong();
     QueryResult result = null;
+    CancelOutcome cancelOutcome = CancelOutcome.NONE;
 
     AdaptiveRoutingStageClassification classification = null;
     if (statsManager != null) {
       classification = AdaptiveRoutingStageClassification.classify(dispatchableSubPlan);
+      dispatchableSubPlan.getQueryStageMap().get(0).getCustomProperties()
+          .put(AdaptiveRoutingUpstreamTimings.COLLECT_UPSTREAM_TIMING_KEY, "true");
       for (DispatchablePlanFragment fragment : dispatchableSubPlan.getQueryStagesWithoutRoot()) {
         int stageId = fragment.getPlanFragment().getFragmentId();
         if (classification._trustedStageIds.contains(stageId)) {
-          // Safe to mutate: plan is fresh per request (not cached) and this runs before submit() serializes.
           fragment.getCustomProperties().put(AdaptiveRoutingUpstreamTimings.COLLECT_UPSTREAM_TIMING_KEY, "true");
         }
       }
@@ -232,11 +249,13 @@ public class QueryDispatcher {
       }
       result = runReducer(dispatchableSubPlan, queryOptions, _mailboxService);
       if (result.getProcessingException() != null) {
-        cancel(requestId);
+        cancel(requestId, servers);
       }
       return result;
     } catch (Exception ex) {
-      result = tryRecover(context.getRequestId(), servers, ex);
+      Pair<QueryResult, CancelOutcome> recovered = tryRecover(context.getRequestId(), servers, ex);
+      result = recovered.getLeft();
+      cancelOutcome = recovered.getRight();
       return result;
     } catch (Throwable e) {
       // TODO: Consider always cancel when it returns (early terminate)
@@ -244,38 +263,16 @@ public class QueryDispatcher {
       throw e;
     } finally {
       if (statsManager != null) {
-        Set<String> trackedServers = Set.of();
+        Map<String, Long> knownTimings = Map.of();
         if (result != null && !incrementedServers.isEmpty() && !classification._trustedStageIds.isEmpty()) {
           try {
-            Map<String, Long> maxTimings = extractMaxTimingsPerInstance(result, classification, requestId);
-            for (Map.Entry<String, Long> entry : maxTimings.entrySet()) {
-              String instanceId = entry.getKey();
-              if (decrementedServers.add(instanceId)) {
-                LOGGER.debug("==[UPSTREAM_TIMING]== request {} recording indirect sender {} latency={}ms",
-                    requestId, instanceId, entry.getValue());
-                statsManager.recordStatsUponResponseArrival(requestId, instanceId, entry.getValue());
-              }
-            }
-            trackedServers = classification._trackedServers;
+            knownTimings = extractMaxTimingsPerInstance(result, classification, requestId, cancelOutcome);
           } catch (Exception e) {
             LOGGER.warn("Failed to apply upstream timings for request {}", requestId, e);
           }
         }
-        if (decrementedServers.isEmpty()) {
-          // Fallback 1: if we received no partial timings, avoid marking all servers with the full elapsed time.
-          for (QueryServerInstance server : incrementedServers) {
-            statsManager.recordStatsUponResponseArrival(requestId, server.getInstanceId(), -1L);
-          }
-        } else {
-          // Fallback 2: if we received partial timings, mark remaining leaf servers with the full elapsed time.
-          long elapsedMs = _clock.getAsLong() - submitTimeMs;
-          for (QueryServerInstance server : incrementedServers) {
-            String id = server.getInstanceId();
-            if (!decrementedServers.contains(id)) {
-              statsManager.recordStatsUponResponseArrival(requestId, id, trackedServers.contains(id) ? elapsedMs : -1L);
-            }
-          }
-        }
+        recordPerServerLatencies(statsManager, requestId, incrementedServers, classification, knownTimings,
+            cancelOutcome, _clock.getAsLong() - submitTimeMs);
       }
       if (isQueryCancellationEnabled()) {
         _serversByQuery.remove(requestId);
@@ -283,11 +280,35 @@ public class QueryDispatcher {
     }
   }
 
+  private static void recordPerServerLatencies(ServerRoutingStatsManager statsManager, long requestId,
+      Set<QueryServerInstance> incrementedServers, AdaptiveRoutingStageClassification classification,
+      Map<String, Long> knownTimings, CancelOutcome cancelOutcome, long elapsedMs) {
+    for (QueryServerInstance server : incrementedServers) {
+      String id = server.getInstanceId();
+      long latency;
+      if (knownTimings.containsKey(id)) {
+        // Tier 1: actual upstream timing extracted — use it for tracked (leaf) servers, -1 otherwise.
+        latency = classification._trackedServers.contains(id) ? knownTimings.get(id) : -1L;
+      } else if (classification._trackedServers.contains(id) && !knownTimings.isEmpty()) {
+        // Tier 2: tracked leaf server whose timing is missing while other servers had data — mark degraded.
+        latency = elapsedMs;
+      } else if (cancelOutcome.wasAttempted() && !cancelOutcome._respondingServerIds.contains(id)) {
+        // Tier 3: cancel was attempted but this server didn't respond — mark degraded.
+        latency = elapsedMs;
+      } else {
+        // Tier 4: no timing data, but server is responsive (or cancel wasn't attempted).
+        latency = -1L;
+      }
+      LOGGER.debug("==[UPSTREAM_TIMING]== request {} recording server {} latency={}ms", requestId, id, latency);
+      statsManager.recordStatsUponResponseArrival(requestId, id, latency);
+    }
+  }
+
   /// Tries to recover from an exception thrown during query dispatching.
   ///
   /// [QueryException] and [TimeoutException] are handled by returning a [QueryResult] with the error code and stats,
   /// while other exceptions are not known, so they are directly rethrown.
-  private QueryResult tryRecover(long requestId, Set<QueryServerInstance> servers, Exception ex)
+  private Pair<QueryResult, CancelOutcome> tryRecover(long requestId, Set<QueryServerInstance> servers, Exception ex)
       throws Exception {
     if (servers.isEmpty()) {
       throw ex;
@@ -308,12 +329,12 @@ public class QueryDispatcher {
     // in case of known exceptions (timeout or query exception), we need can build here the erroneous QueryResult
     // that include the stats.
     LOGGER.warn("Query failed with a known exception. Trying to cancel the other opchains");
-    MultiStageQueryStats stats = cancelWithStats(requestId, servers);
-    if (stats == null) {
+    CancelOutcome outcome = cancelWithStats(requestId, servers);
+    if (outcome._stats == null) {
       throw ex;
     }
     QueryProcessingException processingException = new QueryProcessingException(errorCode, ex.getMessage());
-    return new QueryResult(processingException, stats, 0L);
+    return Pair.of(new QueryResult(processingException, outcome._stats, 0L), outcome);
   }
 
   public List<PlanNode> explain(RequestContext context, DispatchablePlanFragment fragment, long timeoutMs,
@@ -408,7 +429,8 @@ public class QueryDispatcher {
    */
   @VisibleForTesting
   static Map<String, Long> extractMaxTimingsPerInstance(QueryResult result,
-      AdaptiveRoutingStageClassification classification, long requestId) {
+      AdaptiveRoutingStageClassification classification, long requestId,
+      CancelOutcome cancelOutcome) {
     Map<String, Long> maxTimingPerInstance = new HashMap<>();
     List<MultiStageQueryStats.StageStats.Closed> queryStatsList = result.getQueryStats();
     for (int stageIdx = 0; stageIdx < queryStatsList.size(); stageIdx++) {
@@ -416,39 +438,54 @@ public class QueryDispatcher {
         continue;
       }
       MultiStageQueryStats.StageStats.Closed stageStats = queryStatsList.get(stageIdx);
-      if (stageStats == null) {
-        continue;
+      if (stageStats != null) {
+        extractTimingsFromStage(stageStats, stageIdx, classification, requestId, maxTimingPerInstance);
       }
-      final int stage = stageIdx;
-      stageStats.forEach((opType, statMap) -> {
-        if (opType != MultiStageOperator.Type.MAILBOX_RECEIVE) {
-          return;
+    }
+    if (cancelOutcome._stats != null) {
+      MultiStageQueryStats cancelStats = cancelOutcome._stats;
+      for (int stageId = cancelStats.getCurrentStageId() + 1; stageId <= cancelStats.getMaxStageId(); stageId++) {
+        if (!classification._trustedStageIds.contains(stageId)) {
+          continue;
         }
-        @SuppressWarnings("unchecked")
-        StatMap<BaseMailboxReceiveOperator.StatKey> receiveStats =
-            (StatMap<BaseMailboxReceiveOperator.StatKey>) statMap;
-        String encoded =
-            receiveStats.getString(BaseMailboxReceiveOperator.StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS);
-        if (encoded == null) {
-          LOGGER.debug("==[UPSTREAM_TIMING]== request {} consulted stage {} MAILBOX_RECEIVE has null timing",
-              requestId, stage);
-          return;
+        MultiStageQueryStats.StageStats.Closed stageStats = cancelStats.getUpstreamStageStats(stageId);
+        if (stageStats != null) {
+          extractTimingsFromStage(stageStats, stageId, classification, requestId, maxTimingPerInstance);
         }
-        LOGGER.debug("==[UPSTREAM_TIMING]== request {} consulted stage {} encoded timing: {}",
-            requestId, stage, encoded);
-        Map<String, Long> timings = AdaptiveRoutingUpstreamTimings.decode(encoded);
-        for (Map.Entry<String, Long> entry : timings.entrySet()) {
-          String instanceId = classification._senderKeyToInstanceId.get(entry.getKey());
-          if (instanceId != null) {
-            maxTimingPerInstance.merge(instanceId, entry.getValue(), Math::max);
-          } else {
-            LOGGER.debug("==[UPSTREAM_TIMING]== request {} senderKey={} not found in known servers, skipping",
-                requestId, entry.getKey());
-          }
-        }
-      });
+      }
     }
     return maxTimingPerInstance;
+  }
+
+  private static void extractTimingsFromStage(MultiStageQueryStats.StageStats.Closed stageStats, int stageIdx,
+      AdaptiveRoutingStageClassification classification, long requestId, Map<String, Long> maxTimingPerInstance) {
+    stageStats.forEach((opType, statMap) -> {
+      if (opType != MultiStageOperator.Type.MAILBOX_RECEIVE) {
+        return;
+      }
+      @SuppressWarnings("unchecked")
+      StatMap<BaseMailboxReceiveOperator.StatKey> receiveStats =
+          (StatMap<BaseMailboxReceiveOperator.StatKey>) statMap;
+      String encoded =
+          receiveStats.getString(BaseMailboxReceiveOperator.StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS);
+      if (encoded == null) {
+        LOGGER.debug("==[UPSTREAM_TIMING]== request {} consulted stage {} MAILBOX_RECEIVE has null timing",
+              requestId, stageIdx);
+        return;
+      }
+      LOGGER.debug("==[UPSTREAM_TIMING]== request {} consulted stage {} encoded timing: {}",
+            requestId, stageIdx, encoded);
+      Map<String, Long> timings = AdaptiveRoutingUpstreamTimings.decode(encoded);
+      for (Map.Entry<String, Long> entry : timings.entrySet()) {
+        String instanceId = classification._senderKeyToInstanceId.get(entry.getKey());
+        if (instanceId != null) {
+          maxTimingPerInstance.merge(instanceId, entry.getValue(), Math::max);
+        } else {
+          LOGGER.debug("==[UPSTREAM_TIMING]== request {} senderKey={} not found in known servers, skipping",
+              requestId, entry.getKey());
+        }
+      }
+    });
   }
 
 
@@ -646,9 +683,9 @@ public class QueryDispatcher {
   }
 
   @Nullable
-  private MultiStageQueryStats cancelWithStats(long requestId, @Nullable Set<QueryServerInstance> servers) {
+  private CancelOutcome cancelWithStats(long requestId, @Nullable Set<QueryServerInstance> servers) {
     if (servers == null) {
-      return null;
+      return CancelOutcome.NONE;
     }
 
     Deadline deadline = Deadline.after(_cancelTimeout.toMillis(), TimeUnit.MILLISECONDS);
@@ -656,11 +693,13 @@ public class QueryDispatcher {
     BlockingQueue<AsyncResponse<Worker.CancelResponse>> dispatchCallbacks =
         dispatch(sendRequest, servers, deadline, serverInstance -> requestId);
 
+    Set<String> respondedServerIds = new HashSet<>();
     MultiStageQueryStats stats = MultiStageQueryStats.emptyStats(0);
     StatMap<BaseMailboxReceiveOperator.StatKey> rootStats = new StatMap<>(BaseMailboxReceiveOperator.StatKey.class);
     stats.getCurrentStats().addLastOperator(MultiStageOperator.Type.MAILBOX_RECEIVE, rootStats);
     try {
       processResults(requestId, servers.size(), (response, server) -> {
+        respondedServerIds.add(server.getInstanceId());
         Map<Integer, ByteString> statsByStage = response.getStatsByStageMap();
         for (Map.Entry<Integer, ByteString> entry : statsByStage.entrySet()) {
           try (InputStream is = entry.getValue().newInput(); DataInputStream dis = new DataInputStream(is)) {
@@ -671,12 +710,12 @@ public class QueryDispatcher {
           }
         }
       }, deadline, dispatchCallbacks);
-      return stats;
+      return new CancelOutcome(stats, respondedServerIds);
     } catch (InterruptedException e) {
       throw QueryErrorCode.INTERNAL.asException("Interrupted while waiting for cancel response", e);
     } catch (TimeoutException e) {
       LOGGER.debug("Timed out waiting for cancel response", e);
-      return stats;
+      return new CancelOutcome(stats, respondedServerIds);
     }
   }
 
@@ -735,8 +774,14 @@ public class QueryDispatcher {
         workerMetadata.size());
 
     StageMetadata stageMetadata = new StageMetadata(0, workerMetadata, stagePlan.getCustomProperties());
+    Map<String, String> opChainMetadata = new HashMap<>(queryOptions);
+    String collectTiming = stagePlan.getCustomProperties()
+        .get(AdaptiveRoutingUpstreamTimings.COLLECT_UPSTREAM_TIMING_KEY);
+    if (collectTiming != null) {
+      opChainMetadata.put(AdaptiveRoutingUpstreamTimings.COLLECT_UPSTREAM_TIMING_KEY, collectTiming);
+    }
     OpChainExecutionContext opChainExecutionContext =
-        OpChainExecutionContext.fromQueryContext(mailboxService, queryOptions, stageMetadata, workerMetadata.get(0),
+        OpChainExecutionContext.fromQueryContext(mailboxService, opChainMetadata, stageMetadata, workerMetadata.get(0),
             null, true, true);
 
     PairList<Integer, String> resultFields = subPlan.getQueryResultFields();

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -207,6 +207,18 @@ public class QueryDispatcher {
     long submitTimeMs = _clock.getAsLong();
     QueryResult result = null;
 
+    AdaptiveRoutingStageClassification classification = null;
+    if (statsManager != null) {
+      classification = AdaptiveRoutingStageClassification.classify(dispatchableSubPlan);
+      for (DispatchablePlanFragment fragment : dispatchableSubPlan.getQueryStagesWithoutRoot()) {
+        int stageId = fragment.getPlanFragment().getFragmentId();
+        if (classification._trustedStageIds.contains(stageId)) {
+          // Safe to mutate: plan is fresh per request (not cached) and this runs before submit() serializes.
+          fragment.getCustomProperties().put(AdaptiveRoutingUpstreamTimings.COLLECT_UPSTREAM_TIMING_KEY, "true");
+        }
+      }
+    }
+
     try {
       submit(requestId, dispatchableSubPlan, timeoutMs, servers, queryOptions);
       // The SSE engine increments before `submit`, but here we increment after because `submit` populates
@@ -233,11 +245,8 @@ public class QueryDispatcher {
     } finally {
       if (statsManager != null) {
         Set<String> trackedServers = Set.of();
-        if (result != null && !incrementedServers.isEmpty()) {
+        if (result != null && !incrementedServers.isEmpty() && !classification._trustedStageIds.isEmpty()) {
           try {
-            // Gather all the timings we fully received.
-            AdaptiveRoutingStageClassification classification =
-                AdaptiveRoutingStageClassification.classify(dispatchableSubPlan);
             Map<String, Long> maxTimings = extractMaxTimingsPerInstance(result, classification, requestId);
             for (Map.Entry<String, Long> entry : maxTimings.entrySet()) {
               String instanceId = entry.getKey();
@@ -391,6 +400,7 @@ public class QueryDispatcher {
   private boolean isQueryCancellationEnabled() {
     return _serversByQuery != null;
   }
+
 
   /**
    * Extracts the maximum observed latency per instance from consulted stages' stats.

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -47,6 +47,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.LongSupplier;
 import javax.annotation.Nullable;
 import org.apache.calcite.runtime.PairList;
 import org.apache.commons.lang3.tuple.Pair;
@@ -119,11 +120,13 @@ public class QueryDispatcher {
   private final Map<Long, Set<QueryServerInstance>> _serversByQuery;
   private final FailureDetector _failureDetector;
   private final Duration _cancelTimeout;
+  // Injectable for tests that need to manipulate time (e.g. to simulate a timeout without actually waiting).
+  private final LongSupplier _clock;
 
   public QueryDispatcher(MailboxService mailboxService, FailureDetector failureDetector, @Nullable TlsConfig tlsConfig,
       boolean enableCancellation, Duration cancelTimeout) {
     this(mailboxService, failureDetector, tlsConfig, enableCancellation, cancelTimeout,
-        DispatchClient.KeepAliveConfig.DISABLED);
+        DispatchClient.KeepAliveConfig.DISABLED, System::currentTimeMillis);
   }
 
   /// Overload that accepts gRPC keep-alive settings for broker dispatch channels. A non-positive `keepAliveTimeMs`
@@ -132,11 +135,20 @@ public class QueryDispatcher {
       boolean enableCancellation, Duration cancelTimeout, int keepAliveTimeMs, int keepAliveTimeoutMs,
       boolean keepAliveWithoutCalls) {
     this(mailboxService, failureDetector, tlsConfig, enableCancellation, cancelTimeout,
-        new DispatchClient.KeepAliveConfig(keepAliveTimeMs, keepAliveTimeoutMs, keepAliveWithoutCalls));
+        new DispatchClient.KeepAliveConfig(keepAliveTimeMs, keepAliveTimeoutMs, keepAliveWithoutCalls),
+        System::currentTimeMillis);
+  }
+
+  @VisibleForTesting
+  QueryDispatcher(MailboxService mailboxService, FailureDetector failureDetector, @Nullable TlsConfig tlsConfig,
+      boolean enableCancellation, Duration cancelTimeout, LongSupplier clock) {
+    this(mailboxService, failureDetector, tlsConfig, enableCancellation, cancelTimeout,
+        DispatchClient.KeepAliveConfig.DISABLED, clock);
   }
 
   private QueryDispatcher(MailboxService mailboxService, FailureDetector failureDetector, @Nullable TlsConfig tlsConfig,
-      boolean enableCancellation, Duration cancelTimeout, DispatchClient.KeepAliveConfig keepAliveConfig) {
+      boolean enableCancellation, Duration cancelTimeout, DispatchClient.KeepAliveConfig keepAliveConfig,
+      LongSupplier clock) {
     _cancelTimeout = cancelTimeout;
     _mailboxService = mailboxService;
     _executorService = Executors.newFixedThreadPool(2 * Runtime.getRuntime().availableProcessors(),
@@ -145,6 +157,7 @@ public class QueryDispatcher {
     _clientGrpcSslContext = initClientSslContext(tlsConfig);
     _keepAliveConfig = keepAliveConfig;
     _failureDetector = failureDetector;
+    _clock = clock;
 
     if (enableCancellation) {
       _serversByQuery = new ConcurrentHashMap<>();
@@ -175,22 +188,25 @@ public class QueryDispatcher {
   /// in-flight request statistics into {@code statsManager} for use by the adaptive query router.
   /// When {@code statsManager} is non-null:
   /// <ul>
-  ///   <li>Each leaf server is registered as having one more in-flight request via
-  ///       {@link ServerRoutingStatsManager#recordStatsForQuerySubmission} after the fan-out begins.</li>
-  ///   <li>After the full fan-out completes (or fails), each server is decremented via
-  ///       {@link ServerRoutingStatsManager#recordStatsUponResponseArrival} with {@code latency = -1}
-  ///       (no latency is recorded at this stage).</li>
+  ///   <li>Each submitted server is registered as having one more in-flight request via
+  ///       {@link ServerRoutingStatsManager#recordStatsForQuerySubmission} after the fan-out succeeds.</li>
+  ///   <li>For servers that reported leaf-stage timing via {@code UPSTREAM_SERVER_RESPONSE_TIMES_MS} stats,
+  ///       {@link ServerRoutingStatsManager#recordStatsUponResponseArrival} is called with measured elapsed time.
+  ///   <li>For all submitted servers not already recorded by the upstream timing extraction
+  ///       (e.g. intermediate-stage servers, or any server when the reduce phase fails),
+  ///       the finally block calls {@code recordStatsUponResponseArrival} with the total wall-clock
+  ///       elapsed time since dispatch.</li>
   /// </ul>
-  /// TODO: Replace the coarse end-of-fanout decrement with per-sender arrival once per-sender EOS
-  ///       interception is in place, and record real leaf-stage latency at that point.
   public QueryResult submitAndReduce(RequestContext context, DispatchableSubPlan dispatchableSubPlan, long timeoutMs,
       Map<String, String> queryOptions, @Nullable ServerRoutingStatsManager statsManager)
       throws Exception {
     long requestId = context.getRequestId();
     Set<QueryServerInstance> servers = new HashSet<>();
-    // Tracks servers where recordStatsForQuerySubmission was actually called, so the finally block only
-    // decrements servers that were incremented — guarding against a partial failure in submit().
     Set<QueryServerInstance> incrementedServers = new HashSet<>();
+    Set<String> decrementedServers = new HashSet<>();
+    long submitTimeMs = _clock.getAsLong();
+    QueryResult result = null;
+
     try {
       submit(requestId, dispatchableSubPlan, timeoutMs, servers, queryOptions);
       // The SSE engine increments before `submit`, but here we increment after because `submit` populates
@@ -202,21 +218,54 @@ public class QueryDispatcher {
           incrementedServers.add(server);
         }
       }
-      QueryResult result = runReducer(dispatchableSubPlan, queryOptions, _mailboxService);
+      result = runReducer(dispatchableSubPlan, queryOptions, _mailboxService);
       if (result.getProcessingException() != null) {
         cancel(requestId);
       }
       return result;
     } catch (Exception ex) {
-      return tryRecover(context.getRequestId(), servers, ex);
+      result = tryRecover(context.getRequestId(), servers, ex);
+      return result;
     } catch (Throwable e) {
       // TODO: Consider always cancel when it returns (early terminate)
       cancel(requestId);
       throw e;
     } finally {
       if (statsManager != null) {
-        for (QueryServerInstance server : incrementedServers) {
-          statsManager.recordStatsUponResponseArrival(requestId, server.getInstanceId(), -1);
+        Set<String> trackedServers = Set.of();
+        if (result != null && !incrementedServers.isEmpty()) {
+          try {
+            // Gather all the timings we fully received.
+            AdaptiveRoutingStageClassification classification =
+                AdaptiveRoutingStageClassification.classify(dispatchableSubPlan);
+            Map<String, Long> maxTimings = extractMaxTimingsPerInstance(result, classification, requestId);
+            for (Map.Entry<String, Long> entry : maxTimings.entrySet()) {
+              String instanceId = entry.getKey();
+              if (decrementedServers.add(instanceId)) {
+                LOGGER.debug("==[UPSTREAM_TIMING]== request {} recording indirect sender {} latency={}ms",
+                    requestId, instanceId, entry.getValue());
+                statsManager.recordStatsUponResponseArrival(requestId, instanceId, entry.getValue());
+              }
+            }
+            trackedServers = classification._trackedServers;
+          } catch (Exception e) {
+            LOGGER.warn("Failed to apply upstream timings for request {}", requestId, e);
+          }
+        }
+        if (decrementedServers.isEmpty()) {
+          // Fallback 1: if we received no partial timings, avoid marking all servers with the full elapsed time.
+          for (QueryServerInstance server : incrementedServers) {
+            statsManager.recordStatsUponResponseArrival(requestId, server.getInstanceId(), -1L);
+          }
+        } else {
+          // Fallback 2: if we received partial timings, mark remaining leaf servers with the full elapsed time.
+          long elapsedMs = _clock.getAsLong() - submitTimeMs;
+          for (QueryServerInstance server : incrementedServers) {
+            String id = server.getInstanceId();
+            if (!decrementedServers.contains(id)) {
+              statsManager.recordStatsUponResponseArrival(requestId, id, trackedServers.contains(id) ? elapsedMs : -1L);
+            }
+          }
         }
       }
       if (isQueryCancellationEnabled()) {
@@ -342,6 +391,56 @@ public class QueryDispatcher {
   private boolean isQueryCancellationEnabled() {
     return _serversByQuery != null;
   }
+
+  /**
+   * Extracts the maximum observed latency per instance from consulted stages' stats.
+   * Takes the maximum when the same server appears in multiple consulted stages.
+   */
+  @VisibleForTesting
+  static Map<String, Long> extractMaxTimingsPerInstance(QueryResult result,
+      AdaptiveRoutingStageClassification classification, long requestId) {
+    Map<String, Long> maxTimingPerInstance = new HashMap<>();
+    List<MultiStageQueryStats.StageStats.Closed> queryStatsList = result.getQueryStats();
+    for (int stageIdx = 0; stageIdx < queryStatsList.size(); stageIdx++) {
+      if (!classification._trustedStageIds.contains(stageIdx)) {
+        continue;
+      }
+      MultiStageQueryStats.StageStats.Closed stageStats = queryStatsList.get(stageIdx);
+      if (stageStats == null) {
+        continue;
+      }
+      final int stage = stageIdx;
+      stageStats.forEach((opType, statMap) -> {
+        if (opType != MultiStageOperator.Type.MAILBOX_RECEIVE) {
+          return;
+        }
+        @SuppressWarnings("unchecked")
+        StatMap<BaseMailboxReceiveOperator.StatKey> receiveStats =
+            (StatMap<BaseMailboxReceiveOperator.StatKey>) statMap;
+        String encoded =
+            receiveStats.getString(BaseMailboxReceiveOperator.StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS);
+        if (encoded == null) {
+          LOGGER.debug("==[UPSTREAM_TIMING]== request {} consulted stage {} MAILBOX_RECEIVE has null timing",
+              requestId, stage);
+          return;
+        }
+        LOGGER.debug("==[UPSTREAM_TIMING]== request {} consulted stage {} encoded timing: {}",
+            requestId, stage, encoded);
+        Map<String, Long> timings = AdaptiveRoutingUpstreamTimings.decode(encoded);
+        for (Map.Entry<String, Long> entry : timings.entrySet()) {
+          String instanceId = classification._senderKeyToInstanceId.get(entry.getKey());
+          if (instanceId != null) {
+            maxTimingPerInstance.merge(instanceId, entry.getValue(), Math::max);
+          } else {
+            LOGGER.debug("==[UPSTREAM_TIMING]== request {} senderKey={} not found in known servers, skipping",
+                requestId, entry.getKey());
+          }
+        }
+      });
+    }
+    return maxTimingPerInstance;
+  }
+
 
   private <E> void execute(long requestId, Set<DispatchablePlanFragment> stagePlans, long timeoutMs,
       Map<String, String> queryOptions, SendRequest<Worker.QueryRequest, E> sendRequest,

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.query.runtime.operator;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -40,6 +41,7 @@ import org.apache.pinot.query.runtime.blocks.MseBlock;
 import org.apache.pinot.query.runtime.operator.MultiStageOperator.Type;
 import org.apache.pinot.query.runtime.plan.MultiStageQueryStats;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+import org.apache.pinot.query.service.dispatch.AdaptiveRoutingUpstreamTimings;
 import org.apache.pinot.segment.spi.memory.DataBuffer;
 import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.mockito.Mock;
@@ -288,8 +290,10 @@ public class MailboxReceiveOperatorTest {
 
     // Use a short deadline so the test does not take too long waiting for the slow sender.
     long shortDeadlineMs = System.currentTimeMillis() + 500L;
+    Map<String, String> metadata = new HashMap<>();
+    metadata.put(AdaptiveRoutingUpstreamTimings.COLLECT_UPSTREAM_TIMING_KEY, "true");
     try (MailboxReceiveOperator operator = getOperator(_stageMetadataBoth, RelDistribution.Type.HASH_DISTRIBUTED,
-        shortDeadlineMs)) {
+        shortDeadlineMs, metadata)) {
       MseBlock block = operator.nextBlock();
       // The operator times out waiting for mailbox 2.
       assertTrue(block.isError(), "Expected a timeout error block");
@@ -308,7 +312,13 @@ public class MailboxReceiveOperatorTest {
 
   private MailboxReceiveOperator getOperator(StageMetadata stageMetadata, RelDistribution.Type distributionType,
       long deadlineMs) {
-    OpChainExecutionContext context = OperatorTestUtil.getOpChainContext(_mailboxService, deadlineMs, stageMetadata);
+    return getOperator(stageMetadata, distributionType, deadlineMs, Map.of());
+  }
+
+  private MailboxReceiveOperator getOperator(StageMetadata stageMetadata, RelDistribution.Type distributionType,
+      long deadlineMs, Map<String, String> opChainMetadata) {
+    OpChainExecutionContext context =
+        OperatorTestUtil.getOpChainContext(_mailboxService, deadlineMs, stageMetadata, opChainMetadata);
     MailboxReceiveNode node = mock(MailboxReceiveNode.class);
     when(node.getDistributionType()).thenReturn(distributionType);
     when(node.getSenderStageId()).thenReturn(1);

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
@@ -55,6 +55,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
@@ -261,6 +262,47 @@ public class MailboxReceiveOperatorTest {
       MultiStageQueryStats stats = operator.calculateStats();
       MultiStageQueryStats.StageStats.Closed upstreamStats = stats.getUpstreamStageStats(1);
       assertNull(upstreamStats, "Upstream stats should be null in case of error merging stats");
+    }
+  }
+
+  /**
+   * Verifies that {@link BaseMailboxReceiveOperator#copyStatMaps()} includes per-sender timing for
+   * senders whose EOS arrived before the query was cancelled or timed out, even when {@code onEos()}
+   * was never called (because a slow sender never completed).
+   *
+   * <p>This is the timeout path fix: fast-server timings are "trapped" in
+   * {@code _multiConsumer._senderElapsedMs} until {@code onEos()} fires, but on timeout
+   * {@code onEos()} never fires.  {@code copyStatMaps()} must flush the partial map so that
+   * {@code applyUpstreamTimingsFromStats} can exempt those fast servers from the full elapsed-time
+   * penalty in the {@code finally} block.
+   */
+  @Test
+  public void copyStatMapsIncludesPartialTimingWhenSlowSenderNeverCompletes() {
+    // mailbox 1 (fast sender): returns EOS immediately.
+    // mailbox 2 (slow sender): never returns data; the operator will time out waiting for it.
+    when(_mailboxService.getReceivingMailbox(eq(MAILBOX_ID_1))).thenReturn(_mailbox1);
+    when(_mailbox1.poll()).thenReturn(OperatorTestUtil.eosWithEmptyStats());
+
+    when(_mailboxService.getReceivingMailbox(eq(MAILBOX_ID_2))).thenReturn(_mailbox2);
+    // _mailbox2.poll() returns null by default (slow sender never completes).
+
+    // Use a short deadline so the test does not take too long waiting for the slow sender.
+    long shortDeadlineMs = System.currentTimeMillis() + 500L;
+    try (MailboxReceiveOperator operator = getOperator(_stageMetadataBoth, RelDistribution.Type.HASH_DISTRIBUTED,
+        shortDeadlineMs)) {
+      MseBlock block = operator.nextBlock();
+      // The operator times out waiting for mailbox 2.
+      assertTrue(block.isError(), "Expected a timeout error block");
+
+      // onEos() was NOT called (only one of two senders completed), so _statMap has no timing.
+      // copyStatMaps() must flush partial timing from _multiConsumer._senderElapsedMs.
+      StatMap<BaseMailboxReceiveOperator.StatKey> stats = operator.copyStatMaps();
+      String encoded = stats.getString(BaseMailboxReceiveOperator.StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS);
+      assertNotNull(encoded, "copyStatMaps() should include partial timing for fast sender that already sent EOS");
+      // The sender key is derived from the MailboxInfo hostname/port ("localhost", 1234).
+      String expectedKey = "localhost|1234";
+      assertTrue(encoded.contains(expectedKey),
+          "Encoded timing '" + encoded + "' should contain the sender key '" + expectedKey + "'");
     }
   }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorTestUtil.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorTestUtil.java
@@ -110,7 +110,12 @@ public class OperatorTestUtil {
 
   public static OpChainExecutionContext getOpChainContext(MailboxService mailboxService, long deadlineMs,
       StageMetadata stageMetadata) {
-    return new OpChainExecutionContext(mailboxService, 0, "cid", deadlineMs, deadlineMs, "brokerId", Map.of(),
+    return getOpChainContext(mailboxService, deadlineMs, stageMetadata, Map.of());
+  }
+
+  public static OpChainExecutionContext getOpChainContext(MailboxService mailboxService, long deadlineMs,
+      StageMetadata stageMetadata, Map<String, String> opChainMetadata) {
+    return new OpChainExecutionContext(mailboxService, 0, "cid", deadlineMs, deadlineMs, "brokerId", opChainMetadata,
         stageMetadata, stageMetadata.getWorkerMetadataList().get(0), null, true, true);
   }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/utils/BlockingMultiStreamConsumerUpstreamTimingTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/utils/BlockingMultiStreamConsumerUpstreamTimingTest.java
@@ -119,4 +119,105 @@ public class BlockingMultiStreamConsumerUpstreamTimingTest {
           "Unmapped stream must not produce a timing entry");
     }
   }
+
+  /**
+   * Full timeout: no senders complete. getSenderElapsedMsIncludingPending() injects elapsed time for all.
+   * Does not call readMseBlockBlocking() — simulates the state at cancel time when no EOS arrived.
+   */
+  @Test
+  public void testIncludingPendingFullTimeout() {
+    AtomicLong clock = new AtomicLong(0L);
+    String keyA = AdaptiveRoutingUpstreamTimings.senderKey("host-a", 8442);
+    String keyB = AdaptiveRoutingUpstreamTimings.senderKey("host-b", 8442);
+    String keyC = AdaptiveRoutingUpstreamTimings.senderKey("host-c", 8442);
+
+    AsyncStream<ReceivingMailbox.MseBlockWithStats> streamA = mockStream("mailbox-A");
+    AsyncStream<ReceivingMailbox.MseBlockWithStats> streamB = mockStream("mailbox-B");
+    AsyncStream<ReceivingMailbox.MseBlockWithStats> streamC = mockStream("mailbox-C");
+
+    List<StatMap<ReceivingMailbox.StatKey>> stats = List.of(
+        new StatMap<>(ReceivingMailbox.StatKey.class),
+        new StatMap<>(ReceivingMailbox.StatKey.class),
+        new StatMap<>(ReceivingMailbox.StatKey.class));
+
+    try (QueryThreadContext ignored = QueryThreadContext.openForMseTest()) {
+      Map<Object, String> streamIdToSenderKey = new HashMap<>();
+      streamIdToSenderKey.put("mailbox-A", keyA);
+      streamIdToSenderKey.put("mailbox-B", keyB);
+      streamIdToSenderKey.put("mailbox-C", keyC);
+
+      BlockingMultiStreamConsumer.OfMseBlock consumer = new BlockingMultiStreamConsumer.OfMseBlock(
+          createContext(),
+          new ArrayList<>(List.of(streamA, streamB, streamC)),
+          /* senderStageId= */ 2,
+          List.of("host-a", "host-b", "host-c"),
+          stats,
+          streamIdToSenderKey,
+          clock::get);
+
+      // No reads performed — no EOS received
+      assertTrue(consumer.getSenderElapsedMs().isEmpty());
+
+      // Simulate time passing (as if timeout occurred at 9800ms)
+      clock.set(9800L);
+
+      Map<String, Long> timings = consumer.getSenderElapsedMsIncludingPending();
+      assertEquals(timings.size(), 3);
+      assertEquals((long) timings.get(keyA), 9800L);
+      assertEquals((long) timings.get(keyB), 9800L);
+      assertEquals((long) timings.get(keyC), 9800L);
+    }
+  }
+
+  /**
+   * All senders complete normally. getSenderElapsedMsIncludingPending matches getSenderElapsedMs
+   * even when called later (putIfAbsent is a no-op for already-recorded senders).
+   */
+  @Test
+  public void testIncludingPendingAllComplete() {
+    AtomicLong clock = new AtomicLong(0L);
+    String keyA = AdaptiveRoutingUpstreamTimings.senderKey("host-a", 8442);
+    String keyB = AdaptiveRoutingUpstreamTimings.senderKey("host-b", 8442);
+
+    AsyncStream<ReceivingMailbox.MseBlockWithStats> streamA = mockStream("mailbox-A");
+    AsyncStream<ReceivingMailbox.MseBlockWithStats> streamB = mockStream("mailbox-B");
+
+    when(streamA.poll()).thenAnswer(inv -> {
+      clock.set(50L);
+      return eos();
+    });
+    when(streamB.poll()).thenAnswer(inv -> {
+      clock.set(80L);
+      return eos();
+    });
+
+    List<StatMap<ReceivingMailbox.StatKey>> stats = List.of(
+        new StatMap<>(ReceivingMailbox.StatKey.class),
+        new StatMap<>(ReceivingMailbox.StatKey.class));
+
+    try (QueryThreadContext ignored = QueryThreadContext.openForMseTest()) {
+      Map<Object, String> streamIdToSenderKey = new HashMap<>();
+      streamIdToSenderKey.put("mailbox-A", keyA);
+      streamIdToSenderKey.put("mailbox-B", keyB);
+
+      BlockingMultiStreamConsumer.OfMseBlock consumer = new BlockingMultiStreamConsumer.OfMseBlock(
+          createContext(),
+          new ArrayList<>(List.of(streamA, streamB)),
+          /* senderStageId= */ 2,
+          List.of("host-a", "host-b"),
+          stats,
+          streamIdToSenderKey,
+          clock::get);
+
+      consumer.readMseBlockBlocking();
+
+      // Both completed — includingPending should preserve actual latencies even at later clock
+      clock.set(5000L);
+      Map<String, Long> base = consumer.getSenderElapsedMs();
+      Map<String, Long> withPending = consumer.getSenderElapsedMsIncludingPending();
+      assertEquals(withPending, base, "When all senders completed, includingPending equals base");
+      assertEquals((long) withPending.get(keyA), 50L);
+      assertEquals((long) withPending.get(keyB), 80L);
+    }
+  }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/utils/BlockingMultiStreamConsumerUpstreamTimingTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/utils/BlockingMultiStreamConsumerUpstreamTimingTest.java
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.utils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.pinot.query.mailbox.MailboxService;
+import org.apache.pinot.query.mailbox.ReceivingMailbox;
+import org.apache.pinot.query.routing.StageMetadata;
+import org.apache.pinot.query.routing.WorkerMetadata;
+import org.apache.pinot.query.runtime.blocks.SuccessMseBlock;
+import org.apache.pinot.query.runtime.operator.OperatorTestUtil;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+import org.apache.pinot.query.service.dispatch.AdaptiveRoutingUpstreamTimings;
+import org.apache.pinot.spi.query.QueryThreadContext;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Tests per-sender elapsed-time tracking in {@link BlockingMultiStreamConsumer.OfMseBlock}.
+ */
+public class BlockingMultiStreamConsumerUpstreamTimingTest {
+
+  @SuppressWarnings("unchecked")
+  private AsyncStream<ReceivingMailbox.MseBlockWithStats> mockStream(String id) {
+    AsyncStream<ReceivingMailbox.MseBlockWithStats> stream = mock(AsyncStream.class);
+    when(stream.getId()).thenReturn(id);
+    doNothing().when(stream).addOnNewDataListener(any());
+    return stream;
+  }
+
+  private static ReceivingMailbox.MseBlockWithStats eos() {
+    return new ReceivingMailbox.MseBlockWithStats(SuccessMseBlock.INSTANCE, List.of());
+  }
+
+  private OpChainExecutionContext createContext() {
+    MailboxService mailboxService = mock(MailboxService.class);
+    when(mailboxService.getHostname()).thenReturn("localhost");
+    when(mailboxService.getPort()).thenReturn(1234);
+    StageMetadata stageMetadata = new StageMetadata(0,
+        List.of(new WorkerMetadata(0, Map.of(), Map.of())), Map.of());
+    return OperatorTestUtil.getOpChainContext(mailboxService, Long.MAX_VALUE, stageMetadata);
+  }
+
+  /**
+   * Covers: per-sender tracking, max-dedup for duplicate sender keys, and no-op for unmapped streams.
+   *
+   * <p>Three streams: A (fast), A-worker1 (slow, same sender key as A), and C (no sender key mapping).
+   * Verifies: A gets max of both workers (700ms), C produces no entry.
+   */
+  @Test
+  public void testPerSenderElapsedTimeWithMaxDedupAndUnmappedStream() {
+    AtomicLong clock = new AtomicLong(0L);
+
+    AsyncStream<ReceivingMailbox.MseBlockWithStats> streamA0 = mockStream("mailbox-A-w0");
+    AsyncStream<ReceivingMailbox.MseBlockWithStats> streamA1 = mockStream("mailbox-A-w1");
+    AsyncStream<ReceivingMailbox.MseBlockWithStats> streamC = mockStream("mailbox-C");
+
+    String keyA = AdaptiveRoutingUpstreamTimings.senderKey("host-a", 8442);
+
+    when(streamA0.poll()).thenAnswer(inv -> {
+      clock.set(100L);
+      return eos();
+    });
+    when(streamA1.poll()).thenAnswer(inv -> {
+      clock.set(700L);
+      return eos();
+    });
+    when(streamC.poll()).thenAnswer(inv -> {
+      clock.set(500L);
+      return eos();
+    });
+
+    try (QueryThreadContext ignored = QueryThreadContext.openForMseTest()) {
+      Map<Object, String> streamIdToSenderKey = new HashMap<>();
+      streamIdToSenderKey.put("mailbox-A-w0", keyA);
+      streamIdToSenderKey.put("mailbox-A-w1", keyA);
+      // mailbox-C deliberately NOT mapped -> tests null-guard path
+
+      BlockingMultiStreamConsumer.OfMseBlock consumer = new BlockingMultiStreamConsumer.OfMseBlock(
+          createContext(),
+          new ArrayList<>(List.of(streamA0, streamA1, streamC)),
+          /* senderStageId= */ 2,
+          streamIdToSenderKey,
+          clock::get);
+
+      consumer.readMseBlockBlocking();
+
+      Map<String, Long> timings = consumer.getSenderElapsedMs();
+      assertEquals(timings.size(), 1, "Only keyA should be recorded (keyC has no mapping)");
+      assertEquals((long) timings.get(keyA), 700L, "Should keep max across workers (700 > 100)");
+      assertTrue(!timings.containsKey(AdaptiveRoutingUpstreamTimings.senderKey("host-c", 8442)),
+          "Unmapped stream must not produce a timing entry");
+    }
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/utils/BlockingMultiStreamConsumerUpstreamTimingTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/utils/BlockingMultiStreamConsumerUpstreamTimingTest.java
@@ -135,11 +135,6 @@ public class BlockingMultiStreamConsumerUpstreamTimingTest {
     AsyncStream<ReceivingMailbox.MseBlockWithStats> streamB = mockStream("mailbox-B");
     AsyncStream<ReceivingMailbox.MseBlockWithStats> streamC = mockStream("mailbox-C");
 
-    List<StatMap<ReceivingMailbox.StatKey>> stats = List.of(
-        new StatMap<>(ReceivingMailbox.StatKey.class),
-        new StatMap<>(ReceivingMailbox.StatKey.class),
-        new StatMap<>(ReceivingMailbox.StatKey.class));
-
     try (QueryThreadContext ignored = QueryThreadContext.openForMseTest()) {
       Map<Object, String> streamIdToSenderKey = new HashMap<>();
       streamIdToSenderKey.put("mailbox-A", keyA);
@@ -150,8 +145,6 @@ public class BlockingMultiStreamConsumerUpstreamTimingTest {
           createContext(),
           new ArrayList<>(List.of(streamA, streamB, streamC)),
           /* senderStageId= */ 2,
-          List.of("host-a", "host-b", "host-c"),
-          stats,
           streamIdToSenderKey,
           clock::get);
 
@@ -191,10 +184,6 @@ public class BlockingMultiStreamConsumerUpstreamTimingTest {
       return eos();
     });
 
-    List<StatMap<ReceivingMailbox.StatKey>> stats = List.of(
-        new StatMap<>(ReceivingMailbox.StatKey.class),
-        new StatMap<>(ReceivingMailbox.StatKey.class));
-
     try (QueryThreadContext ignored = QueryThreadContext.openForMseTest()) {
       Map<Object, String> streamIdToSenderKey = new HashMap<>();
       streamIdToSenderKey.put("mailbox-A", keyA);
@@ -204,8 +193,6 @@ public class BlockingMultiStreamConsumerUpstreamTimingTest {
           createContext(),
           new ArrayList<>(List.of(streamA, streamB)),
           /* senderStageId= */ 2,
-          List.of("host-a", "host-b"),
-          stats,
           streamIdToSenderKey,
           clock::get);
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/AdaptiveRoutingUpstreamTimingsTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/AdaptiveRoutingUpstreamTimingsTest.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.service.dispatch;
+
+import java.util.Map;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class AdaptiveRoutingUpstreamTimingsTest {
+
+  @Test
+  public void testEncodeMultipleEntriesSortedByKey() {
+    Map<String, Long> timings = new java.util.LinkedHashMap<>();
+    timings.put("host-z|8442", 300L);
+    timings.put("host-a|8442", 100L);
+    timings.put("host-m|8442", 200L);
+    assertEquals(AdaptiveRoutingUpstreamTimings.encode(timings), "host-a|8442=100;host-m|8442=200;host-z|8442=300");
+  }
+
+  @Test
+  public void testRoundTrip() {
+    Map<String, Long> original = Map.of("host-a|8442", 100L, "host-b|8442", 200L, "host-c|8442", 300L);
+    String encoded = AdaptiveRoutingUpstreamTimings.encode(original);
+    assertEquals(AdaptiveRoutingUpstreamTimings.decode(encoded), original);
+  }
+
+  @Test
+  public void testMergeEncodingsTakesMax() {
+    String enc1 = AdaptiveRoutingUpstreamTimings.encode(Map.of("host-a|8442", 100L, "host-b|8442", 50L));
+    String enc2 = AdaptiveRoutingUpstreamTimings.encode(Map.of("host-a|8442", 80L, "host-b|8442", 200L));
+    Map<String, Long> merged = AdaptiveRoutingUpstreamTimings.decode(
+        AdaptiveRoutingUpstreamTimings.mergeEncodings(enc1, enc2));
+    assertEquals(merged, Map.of("host-a|8442", 100L, "host-b|8442", 200L));
+  }
+
+  @Test
+  public void testMergeEncodingsDisjointKeys() {
+    String enc1 = AdaptiveRoutingUpstreamTimings.encode(Map.of("host-a|8442", 100L));
+    String enc2 = AdaptiveRoutingUpstreamTimings.encode(Map.of("host-b|8442", 200L));
+    Map<String, Long> merged = AdaptiveRoutingUpstreamTimings.decode(
+        AdaptiveRoutingUpstreamTimings.mergeEncodings(enc1, enc2));
+    assertEquals(merged, Map.of("host-a|8442", 100L, "host-b|8442", 200L));
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/AdaptiveRoutingUpstreamTimingsTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/AdaptiveRoutingUpstreamTimingsTest.java
@@ -27,12 +27,14 @@ import static org.testng.Assert.assertEquals;
 public class AdaptiveRoutingUpstreamTimingsTest {
 
   @Test
-  public void testEncodeMultipleEntriesSortedByKey() {
+  public void testEncodeMultipleEntriesRoundTrips() {
     Map<String, Long> timings = new java.util.LinkedHashMap<>();
     timings.put("host-z|8442", 300L);
     timings.put("host-a|8442", 100L);
     timings.put("host-m|8442", 200L);
-    assertEquals(AdaptiveRoutingUpstreamTimings.encode(timings), "host-a|8442=100;host-m|8442=200;host-z|8442=300");
+    String encoded = AdaptiveRoutingUpstreamTimings.encode(timings);
+    assertEquals(AdaptiveRoutingUpstreamTimings.decode(encoded), Map.of(
+        "host-z|8442", 300L, "host-a|8442", 100L, "host-m|8442", 200L));
   }
 
   @Test

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherApplyUpstreamTimingsTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherApplyUpstreamTimingsTest.java
@@ -1,0 +1,568 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.service.dispatch;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.pinot.calcite.rel.logical.PinotRelExchangeType;
+import org.apache.pinot.common.datatable.StatMap;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsManager;
+import org.apache.pinot.query.planner.PlanFragment;
+import org.apache.pinot.query.planner.physical.DispatchablePlanFragment;
+import org.apache.pinot.query.planner.physical.DispatchableSubPlan;
+import org.apache.pinot.query.planner.plannode.MailboxReceiveNode;
+import org.apache.pinot.query.planner.plannode.MailboxSendNode;
+import org.apache.pinot.query.routing.QueryServerInstance;
+import org.apache.pinot.query.runtime.operator.BaseMailboxReceiveOperator;
+import org.apache.pinot.query.runtime.operator.MultiStageOperator;
+import org.apache.pinot.query.runtime.plan.MultiStageQueryStats;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+/**
+ * Unit tests for upstream timing extraction via {@link AdaptiveRoutingStageClassification#classify} and
+ * {@link QueryDispatcher#extractMaxTimingsPerInstance}.
+ *
+ * <p>Each test constructs a {@link QueryDispatcher.QueryResult} with hand-crafted
+ * {@code UPSTREAM_SERVER_RESPONSE_TIMES_MS} stats and a matching {@link DispatchableSubPlan},
+ * then asserts that {@link ServerRoutingStatsManager#recordStatsUponResponseArrival} is (or is not)
+ * called with the expected arguments.
+ *
+ * <p>Two kinds of stages are consulted: direct pure-leaf receivers ({@code stagesReceivingFromLeaves},
+ * including stage 0 for 2-stage queries), and SINGLETON leaf stages themselves
+ * ({@code singletonLeafStageIds}). All other stages — including receivers of SINGLETON leaf stages —
+ * are excluded to prevent SINGLETON cascade contamination.
+ * See {@link AdaptiveRoutingStageClassification} for details.
+ */
+public class QueryDispatcherApplyUpstreamTimingsTest {
+
+  private static final long REQUEST_ID = 42L;
+  private static final int MAILBOX_PORT = 8442;
+  private static final ResultTable EMPTY_RESULT =
+      new ResultTable(new DataSchema(new String[]{}, new DataSchema.ColumnDataType[]{}), List.of());
+
+  /**
+   * Mirrors the 3-step sequence in QueryDispatcher's finally block: classify -> extract -> record.
+   * Returns the classification so tests can inspect _trackedServers.
+   */
+  private static AdaptiveRoutingStageClassification applyUpstreamTimingsFromStats(QueryDispatcher.QueryResult result,
+      DispatchableSubPlan plan, ServerRoutingStatsManager statsManager, long requestId,
+      Set<String> recordedInstanceIds) {
+    AdaptiveRoutingStageClassification classification = AdaptiveRoutingStageClassification.classify(plan);
+    Map<String, Long> maxTimings = QueryDispatcher.extractMaxTimingsPerInstance(result, classification, requestId);
+    for (Map.Entry<String, Long> entry : maxTimings.entrySet()) {
+      if (recordedInstanceIds.add(entry.getKey())) {
+        statsManager.recordStatsUponResponseArrival(requestId, entry.getKey(), entry.getValue());
+      }
+    }
+    return classification;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Builds a QueryResult whose stage-1 stats contain a MAILBOX_RECEIVE operator with
+   * UPSTREAM_SERVER_RESPONSE_TIMES_MS set to {@code encoded}.
+   */
+  private static QueryDispatcher.QueryResult resultWithStage1Timing(String encoded) {
+    StatMap<BaseMailboxReceiveOperator.StatKey> receiveStats =
+        new StatMap<>(BaseMailboxReceiveOperator.StatKey.class);
+    receiveStats.merge(BaseMailboxReceiveOperator.StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS, encoded);
+
+    MultiStageQueryStats.StageStats.Closed stage1 = new MultiStageQueryStats.StageStats.Closed(
+        List.of(MultiStageOperator.Type.MAILBOX_RECEIVE), List.of(receiveStats));
+
+    MultiStageQueryStats mqStats = MultiStageQueryStats.emptyStats(0);
+    mqStats.mergeUpstream(1, stage1);
+    return new QueryDispatcher.QueryResult(EMPTY_RESULT, mqStats, 0L);
+  }
+
+  /**
+   * Builds a leaf {@link DispatchablePlanFragment} mock: has a non-null table name (leaf stage)
+   * and a plan root that advertises {@code receiverStageId} as its receiver.
+   */
+  private static DispatchablePlanFragment leafFragment(int receiverStageId, QueryServerInstance... servers) {
+    return leafFragmentWithStageId(0, receiverStageId, servers);
+  }
+
+  private static DispatchablePlanFragment leafFragmentWithStageId(int stageId, int receiverStageId,
+      QueryServerInstance... servers) {
+    DispatchablePlanFragment fragment = mock(DispatchablePlanFragment.class);
+    Map.Entry<QueryServerInstance, List<Integer>>[] entries = new Map.Entry[servers.length];
+    for (int i = 0; i < servers.length; i++) {
+      entries[i] = Map.entry(servers[i], List.of(i));
+    }
+    when(fragment.getServerInstanceToWorkerIdMap()).thenReturn(Map.ofEntries(entries));
+    when(fragment.getTableName()).thenReturn("testTable");
+
+    MailboxSendNode sendNode = mock(MailboxSendNode.class);
+    when(sendNode.getStageId()).thenReturn(stageId);
+    when(sendNode.getReceiverStageIds()).thenReturn(List.of(receiverStageId));
+    PlanFragment planFragment = mock(PlanFragment.class);
+    when(planFragment.getFragmentRoot()).thenReturn(sendNode);
+    when(fragment.getPlanFragment()).thenReturn(planFragment);
+    return fragment;
+  }
+
+  /**
+   * Builds a non-leaf {@link DispatchablePlanFragment} mock: has a null table name (intermediate stage).
+   * Used to populate the senderKey -> instanceId lookup without contributing leaf-stage receiver info.
+   */
+  private static DispatchablePlanFragment nonLeafFragment(QueryServerInstance... servers) {
+    DispatchablePlanFragment fragment = mock(DispatchablePlanFragment.class);
+    Map.Entry<QueryServerInstance, List<Integer>>[] entries = new Map.Entry[servers.length];
+    for (int i = 0; i < servers.length; i++) {
+      entries[i] = Map.entry(servers[i], List.of(i));
+    }
+    when(fragment.getServerInstanceToWorkerIdMap()).thenReturn(Map.ofEntries(entries));
+    when(fragment.getTableName()).thenReturn(null);
+    return fragment;
+  }
+
+  /**
+   * Wraps one or more fragments into a {@link DispatchableSubPlan} mock.
+   */
+  private static DispatchableSubPlan planWith(DispatchablePlanFragment... fragments) {
+    DispatchableSubPlan plan = mock(DispatchableSubPlan.class);
+    TreeSet<DispatchablePlanFragment> fragmentSet = new TreeSet<>(Comparator.comparingInt(System::identityHashCode));
+    fragmentSet.addAll(Arrays.asList(fragments));
+    when(plan.getQueryStagesWithoutRoot()).thenReturn(fragmentSet);
+    return plan;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tests
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testRecordsRealLatencyForKnownIndirectSender() {
+    // Stage-1 stats encode that host-a took 600ms. The plan knows host-a as "instance-a" via a
+    // leaf fragment that sends to Stage 1.
+    QueryServerInstance server = new QueryServerInstance("instance-a", "host-a", 9000, MAILBOX_PORT);
+    String encoded = AdaptiveRoutingUpstreamTimings.senderKey("host-a", MAILBOX_PORT) + "=600";
+
+    ServerRoutingStatsManager stats = mock(ServerRoutingStatsManager.class);
+    Set<String> recorded = new HashSet<>();
+
+    applyUpstreamTimingsFromStats(
+        resultWithStage1Timing(encoded), planWith(leafFragment(1, server)), stats, REQUEST_ID, recorded);
+
+    verify(stats).recordStatsUponResponseArrival(REQUEST_ID, "instance-a", 600L);
+    Assert.assertTrue(recorded.contains("instance-a"), "instance-a should be added to recordedInstanceIds");
+  }
+
+  @Test
+  public void testSkipsUnknownSenderKey() {
+    // Stage stats reference a host that isn't in the plan — should not be recorded.
+    QueryServerInstance server = new QueryServerInstance("instance-a", "host-a", 9000, MAILBOX_PORT);
+    String encoded = AdaptiveRoutingUpstreamTimings.senderKey("host-unknown", MAILBOX_PORT) + "=300";
+
+    ServerRoutingStatsManager stats = mock(ServerRoutingStatsManager.class);
+
+    applyUpstreamTimingsFromStats(
+        resultWithStage1Timing(encoded), planWith(leafFragment(1, server)), stats, REQUEST_ID, new HashSet<>());
+
+    verify(stats, never()).recordStatsUponResponseArrival(REQUEST_ID, "instance-a", 300L);
+  }
+
+
+  @Test
+  public void testMultipleStagesAndSendersAllProcessed() {
+    // Stage 1 receives from leaf-A (host-a); stage 2 receives from leaf-B (host-b). Both recorded.
+    QueryServerInstance serverA = new QueryServerInstance("instance-a", "host-a", 9000, MAILBOX_PORT);
+    QueryServerInstance serverB = new QueryServerInstance("instance-b", "host-b", 9000, MAILBOX_PORT);
+
+    StatMap<BaseMailboxReceiveOperator.StatKey> s1Stats =
+        new StatMap<>(BaseMailboxReceiveOperator.StatKey.class);
+    s1Stats.merge(BaseMailboxReceiveOperator.StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS,
+        AdaptiveRoutingUpstreamTimings.senderKey("host-a", MAILBOX_PORT) + "=500");
+
+    StatMap<BaseMailboxReceiveOperator.StatKey> s2Stats =
+        new StatMap<>(BaseMailboxReceiveOperator.StatKey.class);
+    s2Stats.merge(BaseMailboxReceiveOperator.StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS,
+        AdaptiveRoutingUpstreamTimings.senderKey("host-b", MAILBOX_PORT) + "=250");
+
+    MultiStageQueryStats mqStats = MultiStageQueryStats.emptyStats(0);
+    mqStats.mergeUpstream(1, new MultiStageQueryStats.StageStats.Closed(
+        List.of(MultiStageOperator.Type.MAILBOX_RECEIVE), List.of(s1Stats)));
+    mqStats.mergeUpstream(2, new MultiStageQueryStats.StageStats.Closed(
+        List.of(MultiStageOperator.Type.MAILBOX_RECEIVE), List.of(s2Stats)));
+
+    QueryDispatcher.QueryResult result = new QueryDispatcher.QueryResult(EMPTY_RESULT, mqStats, 0L);
+    ServerRoutingStatsManager stats = mock(ServerRoutingStatsManager.class);
+    Set<String> recorded = new HashSet<>();
+
+    // Two leaf fragments: leaf-A sends to Stage 1, leaf-B sends to Stage 2.
+    applyUpstreamTimingsFromStats(result,
+        planWith(leafFragment(1, serverA), leafFragment(2, serverB)), stats, REQUEST_ID, recorded);
+
+    verify(stats).recordStatsUponResponseArrival(REQUEST_ID, "instance-a", 500L);
+    verify(stats).recordStatsUponResponseArrival(REQUEST_ID, "instance-b", 250L);
+    Assert.assertTrue(recorded.containsAll(List.of("instance-a", "instance-b")));
+  }
+
+  @Test
+  public void testIntermediateStageTimingsIgnored() {
+    // Stage 0 (broker) has inflated timings for all 3 servers (in their Stage 1 intermediate role).
+    // Stage 1 (intermediate) has accurate leaf timings for all 3 servers (in their Stage 2 leaf role).
+    //
+    // The plan has a leaf fragment (Stage 2) that sends to Stage 1 as its receiver.
+    // Stage 1 is consulted because it is a pure-leaf receiver (in stagesReceivingFromLeaves).
+    // Stage 0 is excluded because it is not a leaf receiver (the leaf sends to stage 1, not stage 0)
+    // and is not in singletonLeafStageIds.
+    QueryServerInstance serverA = new QueryServerInstance("instance-a", "host-a", 9000, MAILBOX_PORT);
+    QueryServerInstance serverB = new QueryServerInstance("instance-b", "host-b", 9000, MAILBOX_PORT);
+    QueryServerInstance serverC = new QueryServerInstance("instance-c", "host-c", 9000, MAILBOX_PORT);
+
+    // Stage 0 (broker reduce): all 3 servers reported as ~600ms (inflated, each waited for slow server-c)
+    StatMap<BaseMailboxReceiveOperator.StatKey> stage0ReceiveStats =
+        new StatMap<>(BaseMailboxReceiveOperator.StatKey.class);
+    stage0ReceiveStats.merge(BaseMailboxReceiveOperator.StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS,
+        AdaptiveRoutingUpstreamTimings.senderKey("host-a", MAILBOX_PORT) + "=600;"
+        + AdaptiveRoutingUpstreamTimings.senderKey("host-b", MAILBOX_PORT) + "=600;"
+        + AdaptiveRoutingUpstreamTimings.senderKey("host-c", MAILBOX_PORT) + "=600");
+
+    // Stage 1 (intermediate receivers): true per-leaf timings: fast servers at 50ms, slow at 600ms
+    StatMap<BaseMailboxReceiveOperator.StatKey> stage1ReceiveStats =
+        new StatMap<>(BaseMailboxReceiveOperator.StatKey.class);
+    stage1ReceiveStats.merge(BaseMailboxReceiveOperator.StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS,
+        AdaptiveRoutingUpstreamTimings.senderKey("host-a", MAILBOX_PORT) + "=50;"
+        + AdaptiveRoutingUpstreamTimings.senderKey("host-b", MAILBOX_PORT) + "=50;"
+        + AdaptiveRoutingUpstreamTimings.senderKey("host-c", MAILBOX_PORT) + "=600");
+    MultiStageQueryStats.StageStats.Closed stage1Closed = new MultiStageQueryStats.StageStats.Closed(
+        List.of(MultiStageOperator.Type.MAILBOX_RECEIVE), List.of(stage1ReceiveStats));
+
+    MultiStageQueryStats mqStats = MultiStageQueryStats.emptyStats(0);
+    mqStats.getCurrentStats().addLastOperator(MultiStageOperator.Type.MAILBOX_RECEIVE, stage0ReceiveStats);
+    mqStats.mergeUpstream(1, stage1Closed);
+    QueryDispatcher.QueryResult result = new QueryDispatcher.QueryResult(EMPTY_RESULT, mqStats, 0L);
+
+    // Plan: leaf fragment (Stage 2) sends to Stage 1; non-leaf fragment (Stage 1) holds the servers.
+    // Both fragments list servers A/B/C so senderKeyToInstanceId is fully populated.
+    ServerRoutingStatsManager stats = mock(ServerRoutingStatsManager.class);
+    Set<String> recorded = new HashSet<>();
+
+    applyUpstreamTimingsFromStats(result,
+        planWith(leafFragment(1, serverA, serverB, serverC), nonLeafFragment(serverA, serverB, serverC)),
+        stats, REQUEST_ID, recorded);
+
+    // Accurate leaf timings must be recorded for fast servers.
+    verify(stats).recordStatsUponResponseArrival(REQUEST_ID, "instance-a", 50L);
+    verify(stats).recordStatsUponResponseArrival(REQUEST_ID, "instance-b", 50L);
+    verify(stats).recordStatsUponResponseArrival(REQUEST_ID, "instance-c", 600L);
+    // Inflated Stage 0 observations must never reach the stats manager.
+    verify(stats, never()).recordStatsUponResponseArrival(REQUEST_ID, "instance-a", 600L);
+    verify(stats, never()).recordStatsUponResponseArrival(REQUEST_ID, "instance-b", 600L);
+  }
+
+  @Test
+  public void testSameServerInMultipleLeafStagesTakesMax() {
+    // Server A participates in two leaf stages: Stage 3 (50ms) and Stage 5 (300ms).
+    // Both leaf fragments send to different receivers (Stage 2 and Stage 4 respectively).
+    // The maximum of the two leaf observations (300ms) should be recorded.
+    QueryServerInstance serverA = new QueryServerInstance("instance-a", "host-a", 9000, MAILBOX_PORT);
+
+    StatMap<BaseMailboxReceiveOperator.StatKey> stage2Stats =
+        new StatMap<>(BaseMailboxReceiveOperator.StatKey.class);
+    stage2Stats.merge(BaseMailboxReceiveOperator.StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS,
+        AdaptiveRoutingUpstreamTimings.senderKey("host-a", MAILBOX_PORT) + "=50");
+
+    StatMap<BaseMailboxReceiveOperator.StatKey> stage4Stats =
+        new StatMap<>(BaseMailboxReceiveOperator.StatKey.class);
+    stage4Stats.merge(BaseMailboxReceiveOperator.StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS,
+        AdaptiveRoutingUpstreamTimings.senderKey("host-a", MAILBOX_PORT) + "=300");
+
+    MultiStageQueryStats mqStats = MultiStageQueryStats.emptyStats(0);
+    mqStats.mergeUpstream(2, new MultiStageQueryStats.StageStats.Closed(
+        List.of(MultiStageOperator.Type.MAILBOX_RECEIVE), List.of(stage2Stats)));
+    mqStats.mergeUpstream(4, new MultiStageQueryStats.StageStats.Closed(
+        List.of(MultiStageOperator.Type.MAILBOX_RECEIVE), List.of(stage4Stats)));
+
+    QueryDispatcher.QueryResult result = new QueryDispatcher.QueryResult(EMPTY_RESULT, mqStats, 0L);
+    ServerRoutingStatsManager stats = mock(ServerRoutingStatsManager.class);
+    Set<String> recorded = new HashSet<>();
+
+    // Two leaf fragments for server A: one sends to Stage 2, another sends to Stage 4.
+    applyUpstreamTimingsFromStats(result,
+        planWith(leafFragment(2, serverA), leafFragment(4, serverA)), stats, REQUEST_ID, recorded);
+
+    // The max of the two leaf observations (300ms) should be the single recorded value.
+    verify(stats).recordStatsUponResponseArrival(REQUEST_ID, "instance-a", 300L);
+  }
+
+  /**
+   * Builds a "mixed" leaf fragment: {@code getTableName()} is non-null (scans a dim table), but the plan
+   * subtree also contains a {@link MailboxReceiveNode} with the given {@code receiveDistribution}. This
+   * mirrors the lookup-join pattern where a stage both receives all upstream data via a SINGLETON exchange
+   * and scans an inline dimension table.
+   *
+   * @param leafStageId  the stage ID of this leaf fragment itself (used as the SINGLETON leaf stage ID
+   *                     when {@code receiveDistribution} is SINGLETON)
+   * @param receiverStageId  the stage ID that this leaf sends its output to
+   */
+  private static DispatchablePlanFragment mixedLeafFragment(int leafStageId, int receiverStageId,
+      RelDistribution.Type receiveDistribution, QueryServerInstance... servers) {
+    return mixedLeafFragment(leafStageId, receiverStageId, receiveDistribution, 98, servers);
+  }
+
+  private static DispatchablePlanFragment mixedLeafFragment(int leafStageId, int receiverStageId,
+      RelDistribution.Type receiveDistribution, int senderStageId, QueryServerInstance... servers) {
+    DispatchablePlanFragment fragment = mock(DispatchablePlanFragment.class);
+    Map.Entry<QueryServerInstance, List<Integer>>[] entries = new Map.Entry[servers.length];
+    for (int i = 0; i < servers.length; i++) {
+      entries[i] = Map.entry(servers[i], List.of(i));
+    }
+    when(fragment.getServerInstanceToWorkerIdMap()).thenReturn(Map.ofEntries(entries));
+    when(fragment.getTableName()).thenReturn("dimTable");
+
+    // A real MailboxReceiveNode with the given distribution type, representing the upstream receive.
+    MailboxReceiveNode receiveNode = new MailboxReceiveNode(
+        /*stageId=*/99, new DataSchema(new String[]{}, new DataSchema.ColumnDataType[]{}),
+        senderStageId, PinotRelExchangeType.getDefaultExchangeType(),
+        receiveDistribution, null, null, false, false, null);
+
+    // A mock MailboxSendNode whose subtree contains the receive node.
+    MailboxSendNode sendNode = mock(MailboxSendNode.class);
+    when(sendNode.getStageId()).thenReturn(leafStageId);
+    when(sendNode.getReceiverStageIds()).thenReturn(List.of(receiverStageId));
+    when(sendNode.getInputs()).thenReturn(List.of(receiveNode));
+
+    PlanFragment planFragment = mock(PlanFragment.class);
+    when(planFragment.getFragmentRoot()).thenReturn(sendNode);
+    when(fragment.getPlanFragment()).thenReturn(planFragment);
+    return fragment;
+  }
+
+  @Test
+  public void testMixedLeafWithSingletonReceiveIsSkipped() {
+    // A fragment that has getTableName() != null (dim table scan) AND a SINGLETON MailboxReceiveNode
+    // (lookup-join pattern). Stage 1 is not consulted (the 800ms timing is never recorded).
+    // The SINGLETON stage's server is NOT in _trackedServers, so the caller's finally block records
+    // it at -1 (not at wall-clock) to avoid cascade contamination.
+    QueryServerInstance server = new QueryServerInstance("instance-a", "host-a", 9000, MAILBOX_PORT);
+    String encoded = AdaptiveRoutingUpstreamTimings.senderKey("host-a", MAILBOX_PORT) + "=800";
+
+    ServerRoutingStatsManager stats = mock(ServerRoutingStatsManager.class);
+    Set<String> recorded = new HashSet<>();
+
+    // Stage 1 has timing, but the only "leaf" fragment is a mixed stage (leafStageId=2) with
+    // SINGLETON receive that sends to stage 1.
+    AdaptiveRoutingStageClassification classification = applyUpstreamTimingsFromStats(
+        resultWithStage1Timing(encoded),
+        planWith(mixedLeafFragment(2, 1, RelDistribution.Type.SINGLETON, server)),
+        stats, REQUEST_ID, recorded);
+
+    // Stage 1 (receiver) is not consulted — the inflated 800ms timing is never recorded.
+    verify(stats, never()).recordStatsUponResponseArrival(REQUEST_ID, "instance-a", 800L);
+    // No -1 pre-recording inside applyUpstreamTimingsFromStats — that's the caller's job.
+    verify(stats, never()).recordStatsUponResponseArrival(REQUEST_ID, "instance-a", -1L);
+    // But the server is NOT in trackedServers, so the caller's fallback will record -1.
+    Assert.assertFalse(classification._trackedServers.contains("instance-a"),
+        "instance-a must NOT be in trackedServers so the finally block records -1");
+  }
+
+
+  @Test
+  public void testPureLeavesStillRecordedWhenMixedLeafAlsoPresent() {
+    // When a query has both a pure leaf (fact table) and a mixed leaf (inline dim with SINGLETON receive),
+    // the pure leaf timing is still recorded correctly. The mixed leaf is silently skipped.
+    QueryServerInstance server = new QueryServerInstance("instance-a", "host-a", 9000, MAILBOX_PORT);
+
+    // Stage 1 receives from the pure leaf (will be in stagesReceivingFromLeaves).
+    // Stage 2 receives from the mixed leaf (must be excluded).
+    StatMap<BaseMailboxReceiveOperator.StatKey> stage1Stats =
+        new StatMap<>(BaseMailboxReceiveOperator.StatKey.class);
+    stage1Stats.merge(BaseMailboxReceiveOperator.StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS,
+        AdaptiveRoutingUpstreamTimings.senderKey("host-a", MAILBOX_PORT) + "=90");
+
+    StatMap<BaseMailboxReceiveOperator.StatKey> stage2Stats =
+        new StatMap<>(BaseMailboxReceiveOperator.StatKey.class);
+    stage2Stats.merge(BaseMailboxReceiveOperator.StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS,
+        AdaptiveRoutingUpstreamTimings.senderKey("host-a", MAILBOX_PORT) + "=950");
+
+    MultiStageQueryStats mqStats = MultiStageQueryStats.emptyStats(0);
+    mqStats.mergeUpstream(1, new MultiStageQueryStats.StageStats.Closed(
+        List.of(MultiStageOperator.Type.MAILBOX_RECEIVE), List.of(stage1Stats)));
+    mqStats.mergeUpstream(2, new MultiStageQueryStats.StageStats.Closed(
+        List.of(MultiStageOperator.Type.MAILBOX_RECEIVE), List.of(stage2Stats)));
+
+    QueryDispatcher.QueryResult result = new QueryDispatcher.QueryResult(EMPTY_RESULT, mqStats, 0L);
+    ServerRoutingStatsManager stats = mock(ServerRoutingStatsManager.class);
+    Set<String> recorded = new HashSet<>();
+
+    applyUpstreamTimingsFromStats(result,
+        planWith(leafFragment(1, server), mixedLeafFragment(3, 2, RelDistribution.Type.SINGLETON, server)),
+        stats, REQUEST_ID, recorded);
+
+    // Pure leaf timing (90ms) recorded, NOT the inflated mixed-leaf timing (950ms).
+    verify(stats).recordStatsUponResponseArrival(REQUEST_ID, "instance-a", 90L);
+    verify(stats, never()).recordStatsUponResponseArrival(REQUEST_ID, "instance-a", 950L);
+  }
+
+  /**
+   * Models the 10-stage canary case where all leaf stages are "mixed" SINGLETON lookup-join stages,
+   * so {@code stagesReceivingFromLeaves} is empty. The slow server is identified by its slow network
+   * sends: stage-4 SINGLETON workers at remote servers record the slow server's stage-5 data as
+   * arriving late. Stage 4 (the SINGLETON leaf stage itself) is in {@code singletonLeafStageIds}
+   * and is directly consulted, giving clean per-server upstream-send timings.
+   */
+  @Test
+  public void testSingletonLeafStageItselfIsConsultedWhenSenderIsLeaf() {
+    QueryServerInstance impacted = new QueryServerInstance("impacted", "host-impacted", 9000, MAILBOX_PORT);
+    QueryServerInstance normal = new QueryServerInstance("normal", "host-normal", 9000, MAILBOX_PORT);
+
+    // Stage 4 (the SINGLETON leaf stage) receives from stage 5 (a pure leaf scan stage).
+    // It records stage-5 leaf senders' timings: the impacted server's data took 911ms to arrive;
+    // the normal server's data arrived in 2ms.
+    StatMap<BaseMailboxReceiveOperator.StatKey> stage4Stats =
+        new StatMap<>(BaseMailboxReceiveOperator.StatKey.class);
+    stage4Stats.merge(BaseMailboxReceiveOperator.StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS,
+        AdaptiveRoutingUpstreamTimings.senderKey("host-impacted", MAILBOX_PORT) + "=911;"
+        + AdaptiveRoutingUpstreamTimings.senderKey("host-normal", MAILBOX_PORT) + "=2");
+
+    MultiStageQueryStats mqStats = MultiStageQueryStats.emptyStats(0);
+    mqStats.mergeUpstream(4, new MultiStageQueryStats.StageStats.Closed(
+        List.of(MultiStageOperator.Type.MAILBOX_RECEIVE), List.of(stage4Stats)));
+    QueryDispatcher.QueryResult result = new QueryDispatcher.QueryResult(EMPTY_RESULT, mqStats, 0L);
+
+    // SINGLETON mixed leaf at stageId=4, sends to receiver stage 3, receives from stage 5 (a leaf).
+    // singletonLeafStageIds = {4}; stagesReceivingFromLeaves = {}.
+    // Stage 5 is a pure leaf (fact table scan) running on the same servers.
+    DispatchablePlanFragment mixedLeaf =
+        mixedLeafFragment(4, 3, RelDistribution.Type.SINGLETON, /*senderStageId=*/5, impacted, normal);
+    DispatchablePlanFragment senderLeaf = leafFragmentWithStageId(5, 4, impacted, normal);
+    DispatchablePlanFragment intermediate = nonLeafFragment(impacted, normal);
+
+    ServerRoutingStatsManager stats = mock(ServerRoutingStatsManager.class);
+    Set<String> recorded = new HashSet<>();
+
+    applyUpstreamTimingsFromStats(
+        result, planWith(mixedLeaf, senderLeaf, intermediate), stats, REQUEST_ID, recorded);
+
+    // Stage 4 is in singletonLeafStageIds (sender stage 5 is a leaf) -> consulted.
+    // Correct per-server send timings recorded.
+    verify(stats).recordStatsUponResponseArrival(REQUEST_ID, "impacted", 911L);
+    verify(stats).recordStatsUponResponseArrival(REQUEST_ID, "normal", 2L);
+    Assert.assertTrue(recorded.containsAll(List.of("impacted", "normal")));
+  }
+
+
+  /**
+   * Covers the relay/intermediate-server contamination case (e.g. a SINGLETON relay stage-1 server
+   * like {@code 055f50e85c4876db1} that waits for a slow upstream and therefore has an inflated
+   * wall-clock elapsed time).  The intermediate server must NOT be in {@code _trackedServers} so
+   * the caller's finally block records it at -1 (not at wall-clock).
+   *
+   * <p>Topology: leaf (stage 2) sends non-SINGLETON to stage 1 (intermediate relay). Stage 1's
+   * UPSTREAM_SERVER_RESPONSE_TIMES_MS gives accurate leaf timings. The relay server runs only the
+   * intermediate stage ({@code nonLeafFragment}) and must NOT have a real latency recorded for it.
+   */
+  @Test
+  public void testIntermediateRelayServerNotInTrackedServers() {
+    QueryServerInstance leafServer = new QueryServerInstance("leaf-instance", "host-leaf", 9000, MAILBOX_PORT);
+    QueryServerInstance relayServer = new QueryServerInstance("relay-instance", "host-relay", 9000, MAILBOX_PORT);
+
+    // Stage 1 (intermediate relay) records leaf server timing accurately.
+    String encoded = AdaptiveRoutingUpstreamTimings.senderKey("host-leaf", MAILBOX_PORT) + "=80";
+
+    ServerRoutingStatsManager stats = mock(ServerRoutingStatsManager.class);
+    Set<String> recorded = new HashSet<>();
+
+    // leaf fragment sends to stage 1; relay server is in a non-leaf intermediate fragment.
+    AdaptiveRoutingStageClassification classification = applyUpstreamTimingsFromStats(
+        resultWithStage1Timing(encoded),
+        planWith(leafFragment(1, leafServer), nonLeafFragment(relayServer)),
+        stats, REQUEST_ID, recorded);
+
+    // Leaf server gets its real latency recorded.
+    verify(stats).recordStatsUponResponseArrival(REQUEST_ID, "leaf-instance", 80L);
+    // Relay server is NOT recorded by applyUpstreamTimingsFromStats — the caller's finally block
+    // will handle it (not in trackedServers, so it records -1).
+    verify(stats, never()).recordStatsUponResponseArrival(REQUEST_ID, "relay-instance", -1L);
+    Assert.assertFalse(recorded.contains("relay-instance"),
+        "relay-instance must NOT be in recordedInstanceIds (handled by caller)");
+    Assert.assertFalse(classification._trackedServers.contains("relay-instance"),
+        "relay-instance must NOT be in trackedServers so the finally block records -1");
+  }
+
+  /**
+   * Verifies that a SINGLETON leaf stage whose sender is an intermediate (non-leaf) stage is NOT
+   * consulted. This prevents cascade-contaminated timings from being attributed to intermediate
+   * servers. Example: stage 2 is a SINGLETON leaf (dim join) that receives from stage 3 (an
+   * intermediate hash-distribution stage running on multiple servers). If stage 3 servers wait for
+   * a slow upstream, their delivery to stage 2 is delayed. Reading stage 2's timing would wrongly
+   * attribute that cascade delay to those intermediate servers.
+   */
+  @Test
+  public void testSingletonLeafReceivingFromIntermediateNotConsulted() {
+    QueryServerInstance serverA = new QueryServerInstance("server-a", "host-a", 9000, MAILBOX_PORT);
+    QueryServerInstance serverB = new QueryServerInstance("server-b", "host-b", 9000, MAILBOX_PORT);
+
+    // Stage 2 (SINGLETON leaf) records timing for its stage-3 upstream senders. These timings
+    // are cascade-contaminated: serverA took 600ms because it waited for a slow upstream.
+    StatMap<BaseMailboxReceiveOperator.StatKey> stage2Stats =
+        new StatMap<>(BaseMailboxReceiveOperator.StatKey.class);
+    stage2Stats.merge(BaseMailboxReceiveOperator.StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS,
+        AdaptiveRoutingUpstreamTimings.senderKey("host-a", MAILBOX_PORT) + "=600;"
+        + AdaptiveRoutingUpstreamTimings.senderKey("host-b", MAILBOX_PORT) + "=10");
+
+    MultiStageQueryStats mqStats = MultiStageQueryStats.emptyStats(0);
+    mqStats.mergeUpstream(2, new MultiStageQueryStats.StageStats.Closed(
+        List.of(MultiStageOperator.Type.MAILBOX_RECEIVE), List.of(stage2Stats)));
+    QueryDispatcher.QueryResult result = new QueryDispatcher.QueryResult(EMPTY_RESULT, mqStats, 0L);
+
+    // Stage 2 is a SINGLETON leaf that receives from stage 3, but stage 3 is NOT a leaf
+    // (it's an intermediate stage). So stage 2 must NOT be consulted.
+    DispatchablePlanFragment singletonLeaf =
+        mixedLeafFragment(2, 1, RelDistribution.Type.SINGLETON, /*senderStageId=*/3, serverA, serverB);
+    DispatchablePlanFragment intermediate = nonLeafFragment(serverA, serverB);
+
+    ServerRoutingStatsManager stats = mock(ServerRoutingStatsManager.class);
+    Set<String> recorded = new HashSet<>();
+
+    AdaptiveRoutingStageClassification classification = applyUpstreamTimingsFromStats(
+        result, planWith(singletonLeaf, intermediate), stats, REQUEST_ID, recorded);
+
+    // Stage 2 is NOT consulted (sender stage 3 is not a leaf) -> contaminated timings never recorded.
+    verify(stats, never()).recordStatsUponResponseArrival(REQUEST_ID, "server-a", 600L);
+    verify(stats, never()).recordStatsUponResponseArrival(REQUEST_ID, "server-b", 10L);
+    // No -1 pre-recording inside applyUpstreamTimingsFromStats. Caller handles via trackedServers check.
+    verify(stats, never()).recordStatsUponResponseArrival(REQUEST_ID, "server-a", -1L);
+    verify(stats, never()).recordStatsUponResponseArrival(REQUEST_ID, "server-b", -1L);
+    // Neither server is in trackedServers, so the caller's fallback will suppress them.
+    Assert.assertFalse(classification._trackedServers.contains("server-a"));
+    Assert.assertFalse(classification._trackedServers.contains("server-b"));
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherApplyUpstreamTimingsTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherApplyUpstreamTimingsTest.java
@@ -76,8 +76,16 @@ public class QueryDispatcherApplyUpstreamTimingsTest {
   private static AdaptiveRoutingStageClassification applyUpstreamTimingsFromStats(QueryDispatcher.QueryResult result,
       DispatchableSubPlan plan, ServerRoutingStatsManager statsManager, long requestId,
       Set<String> recordedInstanceIds) {
+    return applyUpstreamTimingsFromStats(result, plan, statsManager, requestId, recordedInstanceIds,
+        QueryDispatcher.CancelOutcome.NONE);
+  }
+
+  private static AdaptiveRoutingStageClassification applyUpstreamTimingsFromStats(QueryDispatcher.QueryResult result,
+      DispatchableSubPlan plan, ServerRoutingStatsManager statsManager, long requestId,
+      Set<String> recordedInstanceIds, QueryDispatcher.CancelOutcome cancelOutcome) {
     AdaptiveRoutingStageClassification classification = AdaptiveRoutingStageClassification.classify(plan);
-    Map<String, Long> maxTimings = QueryDispatcher.extractMaxTimingsPerInstance(result, classification, requestId);
+    Map<String, Long> maxTimings = QueryDispatcher.extractMaxTimingsPerInstance(
+        result, classification, requestId, cancelOutcome);
     for (Map.Entry<String, Long> entry : maxTimings.entrySet()) {
       if (recordedInstanceIds.add(entry.getKey())) {
         statsManager.recordStatsUponResponseArrival(requestId, entry.getKey(), entry.getValue());
@@ -240,26 +248,20 @@ public class QueryDispatcherApplyUpstreamTimingsTest {
 
   @Test
   public void testIntermediateStageTimingsIgnored() {
-    // Stage 0 (broker) has inflated timings for all 3 servers (in their Stage 1 intermediate role).
-    // Stage 1 (intermediate) has accurate leaf timings for all 3 servers (in their Stage 2 leaf role).
+    // Stage 1 (leaf receiver) has accurate per-leaf timings for all 3 servers.
+    // Stage 0 (broker) has no timing data (it receives from the intermediate, not from leaves).
     //
     // The plan has a leaf fragment (Stage 2) that sends to Stage 1 as its receiver.
-    // Stage 1 is consulted because it is a pure-leaf receiver (in stagesReceivingFromLeaves).
-    // Stage 0 is excluded because it is not a leaf receiver (the leaf sends to stage 1, not stage 0)
-    // and is not in singletonLeafStageIds.
+    // Stage 1 is consulted because it is a pure-leaf receiver.
     QueryServerInstance serverA = new QueryServerInstance("instance-a", "host-a", 9000, MAILBOX_PORT);
     QueryServerInstance serverB = new QueryServerInstance("instance-b", "host-b", 9000, MAILBOX_PORT);
     QueryServerInstance serverC = new QueryServerInstance("instance-c", "host-c", 9000, MAILBOX_PORT);
 
-    // Stage 0 (broker reduce): all 3 servers reported as ~600ms (inflated, each waited for slow server-c)
+    // Stage 0 (broker reduce): no timing data — it receives from the intermediate, not leaves.
     StatMap<BaseMailboxReceiveOperator.StatKey> stage0ReceiveStats =
         new StatMap<>(BaseMailboxReceiveOperator.StatKey.class);
-    stage0ReceiveStats.merge(BaseMailboxReceiveOperator.StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS,
-        AdaptiveRoutingUpstreamTimings.senderKey("host-a", MAILBOX_PORT) + "=600;"
-        + AdaptiveRoutingUpstreamTimings.senderKey("host-b", MAILBOX_PORT) + "=600;"
-        + AdaptiveRoutingUpstreamTimings.senderKey("host-c", MAILBOX_PORT) + "=600");
 
-    // Stage 1 (intermediate receivers): true per-leaf timings: fast servers at 50ms, slow at 600ms
+    // Stage 1 (leaf receiver): true per-leaf timings: fast servers at 50ms, slow at 600ms
     StatMap<BaseMailboxReceiveOperator.StatKey> stage1ReceiveStats =
         new StatMap<>(BaseMailboxReceiveOperator.StatKey.class);
     stage1ReceiveStats.merge(BaseMailboxReceiveOperator.StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS,
@@ -283,13 +285,10 @@ public class QueryDispatcherApplyUpstreamTimingsTest {
         planWith(leafFragment(1, serverA, serverB, serverC), nonLeafFragment(serverA, serverB, serverC)),
         stats, REQUEST_ID, recorded);
 
-    // Accurate leaf timings must be recorded for fast servers.
+    // Accurate leaf timings from Stage 1 must be recorded.
     verify(stats).recordStatsUponResponseArrival(REQUEST_ID, "instance-a", 50L);
     verify(stats).recordStatsUponResponseArrival(REQUEST_ID, "instance-b", 50L);
     verify(stats).recordStatsUponResponseArrival(REQUEST_ID, "instance-c", 600L);
-    // Inflated Stage 0 observations must never reach the stats manager.
-    verify(stats, never()).recordStatsUponResponseArrival(REQUEST_ID, "instance-a", 600L);
-    verify(stats, never()).recordStatsUponResponseArrival(REQUEST_ID, "instance-b", 600L);
   }
 
   @Test
@@ -522,5 +521,117 @@ public class QueryDispatcherApplyUpstreamTimingsTest {
     verify(stats, never()).recordStatsUponResponseArrival(REQUEST_ID, "server-b", -1L);
     Assert.assertFalse(classification._trackedServers.contains("server-a"));
     Assert.assertFalse(classification._trackedServers.contains("server-b"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Cancel stats tests
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testCancelStatsProvideTimingsForStagesMissingFromResult() {
+    // Stage 1 timings come from the normal query result. Stage 2 timings come only from cancelStats
+    // (the broker didn't see stage 2 during normal reduce because the query was cancelled early).
+    QueryServerInstance serverA = new QueryServerInstance("instance-a", "host-a", 9000, MAILBOX_PORT);
+    QueryServerInstance serverB = new QueryServerInstance("instance-b", "host-b", 9000, MAILBOX_PORT);
+
+    // Normal result has stage 1 timing for server A.
+    StatMap<BaseMailboxReceiveOperator.StatKey> stage1Stats =
+        new StatMap<>(BaseMailboxReceiveOperator.StatKey.class);
+    stage1Stats.merge(BaseMailboxReceiveOperator.StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS,
+        AdaptiveRoutingUpstreamTimings.senderKey("host-a", MAILBOX_PORT) + "=100");
+
+    MultiStageQueryStats mqStats = MultiStageQueryStats.emptyStats(0);
+    mqStats.mergeUpstream(1, new MultiStageQueryStats.StageStats.Closed(
+        List.of(MultiStageOperator.Type.MAILBOX_RECEIVE), List.of(stage1Stats)));
+    QueryDispatcher.QueryResult result = new QueryDispatcher.QueryResult(EMPTY_RESULT, mqStats, 0L);
+
+    // Cancel stats have stage 2 timing for server B (gathered during cancel).
+    StatMap<BaseMailboxReceiveOperator.StatKey> cancelStage2Stats =
+        new StatMap<>(BaseMailboxReceiveOperator.StatKey.class);
+    cancelStage2Stats.merge(BaseMailboxReceiveOperator.StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS,
+        AdaptiveRoutingUpstreamTimings.senderKey("host-b", MAILBOX_PORT) + "=450");
+    MultiStageQueryStats cancelStats = MultiStageQueryStats.emptyStats(0);
+    cancelStats.mergeUpstream(2, new MultiStageQueryStats.StageStats.Closed(
+        List.of(MultiStageOperator.Type.MAILBOX_RECEIVE), List.of(cancelStage2Stats)));
+
+    // Plan: leaf-A sends to stage 1, leaf-B sends to stage 2.
+    ServerRoutingStatsManager stats = mock(ServerRoutingStatsManager.class);
+    Set<String> recorded = new HashSet<>();
+
+    applyUpstreamTimingsFromStats(result,
+        planWith(leafFragment(1, serverA), leafFragment(2, serverB)),
+        stats, REQUEST_ID, recorded, new QueryDispatcher.CancelOutcome(cancelStats, Set.of()));
+
+    verify(stats).recordStatsUponResponseArrival(REQUEST_ID, "instance-a", 100L);
+    verify(stats).recordStatsUponResponseArrival(REQUEST_ID, "instance-b", 450L);
+    Assert.assertTrue(recorded.containsAll(List.of("instance-a", "instance-b")));
+  }
+
+  @Test
+  public void testCancelStatsMergedWithResultTakingMax() {
+    // Same server appears in both the normal result (stage 1) and cancelStats (stage 2).
+    // extractMaxTimingsPerInstance should take the max across both sources.
+    QueryServerInstance server = new QueryServerInstance("instance-a", "host-a", 9000, MAILBOX_PORT);
+
+    // Normal result: stage 1 reports server at 200ms.
+    StatMap<BaseMailboxReceiveOperator.StatKey> stage1Stats =
+        new StatMap<>(BaseMailboxReceiveOperator.StatKey.class);
+    stage1Stats.merge(BaseMailboxReceiveOperator.StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS,
+        AdaptiveRoutingUpstreamTimings.senderKey("host-a", MAILBOX_PORT) + "=200");
+
+    MultiStageQueryStats mqStats = MultiStageQueryStats.emptyStats(0);
+    mqStats.mergeUpstream(1, new MultiStageQueryStats.StageStats.Closed(
+        List.of(MultiStageOperator.Type.MAILBOX_RECEIVE), List.of(stage1Stats)));
+    QueryDispatcher.QueryResult result = new QueryDispatcher.QueryResult(EMPTY_RESULT, mqStats, 0L);
+
+    // Cancel stats: stage 2 reports same server at 700ms.
+    StatMap<BaseMailboxReceiveOperator.StatKey> cancelStage2Stats =
+        new StatMap<>(BaseMailboxReceiveOperator.StatKey.class);
+    cancelStage2Stats.merge(BaseMailboxReceiveOperator.StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS,
+        AdaptiveRoutingUpstreamTimings.senderKey("host-a", MAILBOX_PORT) + "=700");
+    MultiStageQueryStats cancelStats = MultiStageQueryStats.emptyStats(0);
+    cancelStats.mergeUpstream(2, new MultiStageQueryStats.StageStats.Closed(
+        List.of(MultiStageOperator.Type.MAILBOX_RECEIVE), List.of(cancelStage2Stats)));
+
+    // Plan: leaf sends to both stage 1 and stage 2.
+    ServerRoutingStatsManager stats = mock(ServerRoutingStatsManager.class);
+    Set<String> recorded = new HashSet<>();
+
+    applyUpstreamTimingsFromStats(result,
+        planWith(leafFragment(1, server), leafFragment(2, server)),
+        stats, REQUEST_ID, recorded, new QueryDispatcher.CancelOutcome(cancelStats, Set.of()));
+
+    // Max of 200 and 700 -> 700ms.
+    verify(stats).recordStatsUponResponseArrival(REQUEST_ID, "instance-a", 700L);
+  }
+
+  @Test
+  public void testCancelStatsUntrustedStagesSkipped() {
+    // Cancel stats contain timings for a non-trusted stage (intermediate). These should be ignored.
+    QueryServerInstance server = new QueryServerInstance("instance-a", "host-a", 9000, MAILBOX_PORT);
+
+    // Empty normal result (no upstream stage stats).
+    MultiStageQueryStats mqStats = MultiStageQueryStats.emptyStats(0);
+    QueryDispatcher.QueryResult result = new QueryDispatcher.QueryResult(EMPTY_RESULT, mqStats, 0L);
+
+    // Cancel stats have stage 1 timing, but stage 1 is NOT a trusted stage (no leaf sends to it).
+    StatMap<BaseMailboxReceiveOperator.StatKey> cancelStage1Stats =
+        new StatMap<>(BaseMailboxReceiveOperator.StatKey.class);
+    cancelStage1Stats.merge(BaseMailboxReceiveOperator.StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS,
+        AdaptiveRoutingUpstreamTimings.senderKey("host-a", MAILBOX_PORT) + "=500");
+    MultiStageQueryStats cancelStats = MultiStageQueryStats.emptyStats(0);
+    cancelStats.mergeUpstream(1, new MultiStageQueryStats.StageStats.Closed(
+        List.of(MultiStageOperator.Type.MAILBOX_RECEIVE), List.of(cancelStage1Stats)));
+
+    // Plan: only a non-leaf fragment (no leaf sends to stage 1).
+    ServerRoutingStatsManager stats = mock(ServerRoutingStatsManager.class);
+    Set<String> recorded = new HashSet<>();
+
+    applyUpstreamTimingsFromStats(result,
+        planWith(nonLeafFragment(server)),
+        stats, REQUEST_ID, recorded, new QueryDispatcher.CancelOutcome(cancelStats, Set.of()));
+
+    verify(stats, never()).recordStatsUponResponseArrival(REQUEST_ID, "instance-a", 500L);
+    Assert.assertTrue(recorded.isEmpty());
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherApplyUpstreamTimingsTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherApplyUpstreamTimingsTest.java
@@ -25,8 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import org.apache.calcite.rel.RelDistribution;
-import org.apache.pinot.calcite.rel.logical.PinotRelExchangeType;
 import org.apache.pinot.common.datatable.StatMap;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
@@ -34,7 +32,7 @@ import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsMa
 import org.apache.pinot.query.planner.PlanFragment;
 import org.apache.pinot.query.planner.physical.DispatchablePlanFragment;
 import org.apache.pinot.query.planner.physical.DispatchableSubPlan;
-import org.apache.pinot.query.planner.plannode.MailboxReceiveNode;
+import org.apache.pinot.query.planner.physical.FragmentType;
 import org.apache.pinot.query.planner.plannode.MailboxSendNode;
 import org.apache.pinot.query.routing.QueryServerInstance;
 import org.apache.pinot.query.runtime.operator.BaseMailboxReceiveOperator;
@@ -109,10 +107,6 @@ public class QueryDispatcherApplyUpstreamTimingsTest {
     return new QueryDispatcher.QueryResult(EMPTY_RESULT, mqStats, 0L);
   }
 
-  /**
-   * Builds a leaf {@link DispatchablePlanFragment} mock: has a non-null table name (leaf stage)
-   * and a plan root that advertises {@code receiverStageId} as its receiver.
-   */
   private static DispatchablePlanFragment leafFragment(int receiverStageId, QueryServerInstance... servers) {
     return leafFragmentWithStageId(0, receiverStageId, servers);
   }
@@ -125,29 +119,40 @@ public class QueryDispatcherApplyUpstreamTimingsTest {
       entries[i] = Map.entry(servers[i], List.of(i));
     }
     when(fragment.getServerInstanceToWorkerIdMap()).thenReturn(Map.ofEntries(entries));
-    when(fragment.getTableName()).thenReturn("testTable");
+    when(fragment.getFragmentType()).thenReturn(FragmentType.LEAF);
 
     MailboxSendNode sendNode = mock(MailboxSendNode.class);
-    when(sendNode.getStageId()).thenReturn(stageId);
     when(sendNode.getReceiverStageIds()).thenReturn(List.of(receiverStageId));
     PlanFragment planFragment = mock(PlanFragment.class);
+    when(planFragment.getFragmentId()).thenReturn(stageId);
     when(planFragment.getFragmentRoot()).thenReturn(sendNode);
     when(fragment.getPlanFragment()).thenReturn(planFragment);
     return fragment;
   }
 
-  /**
-   * Builds a non-leaf {@link DispatchablePlanFragment} mock: has a null table name (intermediate stage).
-   * Used to populate the senderKey -> instanceId lookup without contributing leaf-stage receiver info.
-   */
   private static DispatchablePlanFragment nonLeafFragment(QueryServerInstance... servers) {
+    return nonLeafFragmentWithReceivers(List.of(), servers);
+  }
+
+  private static DispatchablePlanFragment nonLeafFragmentWithReceivers(List<Integer> receiverStageIds,
+      QueryServerInstance... servers) {
     DispatchablePlanFragment fragment = mock(DispatchablePlanFragment.class);
     Map.Entry<QueryServerInstance, List<Integer>>[] entries = new Map.Entry[servers.length];
     for (int i = 0; i < servers.length; i++) {
       entries[i] = Map.entry(servers[i], List.of(i));
     }
     when(fragment.getServerInstanceToWorkerIdMap()).thenReturn(Map.ofEntries(entries));
-    when(fragment.getTableName()).thenReturn(null);
+    when(fragment.getFragmentType()).thenReturn(FragmentType.INTERMEDIATE);
+
+    if (!receiverStageIds.isEmpty()) {
+      MailboxSendNode sendNode = mock(MailboxSendNode.class);
+      when(sendNode.getReceiverStageIds()).thenReturn(receiverStageIds);
+      PlanFragment planFragment = mock(PlanFragment.class);
+      when(planFragment.getFragmentRoot()).thenReturn(sendNode);
+      when(fragment.getPlanFragment()).thenReturn(planFragment);
+    } else {
+      when(fragment.getPlanFragment()).thenReturn(null);
+    }
     return fragment;
   }
 
@@ -322,44 +327,26 @@ public class QueryDispatcherApplyUpstreamTimingsTest {
     verify(stats).recordStatsUponResponseArrival(REQUEST_ID, "instance-a", 300L);
   }
 
-  /**
-   * Builds a "mixed" leaf fragment: {@code getTableName()} is non-null (scans a dim table), but the plan
-   * subtree also contains a {@link MailboxReceiveNode} with the given {@code receiveDistribution}. This
-   * mirrors the lookup-join pattern where a stage both receives all upstream data via a SINGLETON exchange
-   * and scans an inline dimension table.
-   *
-   * @param leafStageId  the stage ID of this leaf fragment itself (used as the SINGLETON leaf stage ID
-   *                     when {@code receiveDistribution} is SINGLETON)
-   * @param receiverStageId  the stage ID that this leaf sends its output to
-   */
-  private static DispatchablePlanFragment mixedLeafFragment(int leafStageId, int receiverStageId,
-      RelDistribution.Type receiveDistribution, QueryServerInstance... servers) {
-    return mixedLeafFragment(leafStageId, receiverStageId, receiveDistribution, 98, servers);
+  private static DispatchablePlanFragment singletonLeafFragment(int leafStageId, boolean timingTrusted,
+      QueryServerInstance... servers) {
+    return singletonLeafFragment(leafStageId, timingTrusted, List.of(), servers);
   }
 
-  private static DispatchablePlanFragment mixedLeafFragment(int leafStageId, int receiverStageId,
-      RelDistribution.Type receiveDistribution, int senderStageId, QueryServerInstance... servers) {
+  private static DispatchablePlanFragment singletonLeafFragment(int leafStageId, boolean timingTrusted,
+      List<Integer> receiverStageIds, QueryServerInstance... servers) {
     DispatchablePlanFragment fragment = mock(DispatchablePlanFragment.class);
     Map.Entry<QueryServerInstance, List<Integer>>[] entries = new Map.Entry[servers.length];
     for (int i = 0; i < servers.length; i++) {
       entries[i] = Map.entry(servers[i], List.of(i));
     }
     when(fragment.getServerInstanceToWorkerIdMap()).thenReturn(Map.ofEntries(entries));
-    when(fragment.getTableName()).thenReturn("dimTable");
+    when(fragment.getFragmentType()).thenReturn(
+        timingTrusted ? FragmentType.SINGLETON_LEAF : FragmentType.INTERMEDIATE);
 
-    // A real MailboxReceiveNode with the given distribution type, representing the upstream receive.
-    MailboxReceiveNode receiveNode = new MailboxReceiveNode(
-        /*stageId=*/99, new DataSchema(new String[]{}, new DataSchema.ColumnDataType[]{}),
-        senderStageId, PinotRelExchangeType.getDefaultExchangeType(),
-        receiveDistribution, null, null, false, false, null);
-
-    // A mock MailboxSendNode whose subtree contains the receive node.
     MailboxSendNode sendNode = mock(MailboxSendNode.class);
-    when(sendNode.getStageId()).thenReturn(leafStageId);
-    when(sendNode.getReceiverStageIds()).thenReturn(List.of(receiverStageId));
-    when(sendNode.getInputs()).thenReturn(List.of(receiveNode));
-
+    when(sendNode.getReceiverStageIds()).thenReturn(receiverStageIds);
     PlanFragment planFragment = mock(PlanFragment.class);
+    when(planFragment.getFragmentId()).thenReturn(leafStageId);
     when(planFragment.getFragmentRoot()).thenReturn(sendNode);
     when(fragment.getPlanFragment()).thenReturn(planFragment);
     return fragment;
@@ -367,28 +354,23 @@ public class QueryDispatcherApplyUpstreamTimingsTest {
 
   @Test
   public void testMixedLeafWithSingletonReceiveIsSkipped() {
-    // A fragment that has getTableName() != null (dim table scan) AND a SINGLETON MailboxReceiveNode
-    // (lookup-join pattern). Stage 1 is not consulted (the 800ms timing is never recorded).
-    // The SINGLETON stage's server is NOT in _trackedServers, so the caller's finally block records
-    // it at -1 (not at wall-clock) to avoid cascade contamination.
+    // A SINGLETON leaf fragment (dim table lookup-join). Its receiver stage 1 is NOT trusted
+    // (SINGLETON receivers are contaminated). Its servers are NOT tracked.
     QueryServerInstance server = new QueryServerInstance("instance-a", "host-a", 9000, MAILBOX_PORT);
     String encoded = AdaptiveRoutingUpstreamTimings.senderKey("host-a", MAILBOX_PORT) + "=800";
 
     ServerRoutingStatsManager stats = mock(ServerRoutingStatsManager.class);
     Set<String> recorded = new HashSet<>();
 
-    // Stage 1 has timing, but the only "leaf" fragment is a mixed stage (leafStageId=2) with
-    // SINGLETON receive that sends to stage 1.
+    // SINGLETON leaf (stageId=2), not timing-trusted (sender is not a leaf in this test).
     AdaptiveRoutingStageClassification classification = applyUpstreamTimingsFromStats(
         resultWithStage1Timing(encoded),
-        planWith(mixedLeafFragment(2, 1, RelDistribution.Type.SINGLETON, server)),
+        planWith(singletonLeafFragment(2, false, server)),
         stats, REQUEST_ID, recorded);
 
     // Stage 1 (receiver) is not consulted — the inflated 800ms timing is never recorded.
     verify(stats, never()).recordStatsUponResponseArrival(REQUEST_ID, "instance-a", 800L);
-    // No -1 pre-recording inside applyUpstreamTimingsFromStats — that's the caller's job.
     verify(stats, never()).recordStatsUponResponseArrival(REQUEST_ID, "instance-a", -1L);
-    // But the server is NOT in trackedServers, so the caller's fallback will record -1.
     Assert.assertFalse(classification._trackedServers.contains("instance-a"),
         "instance-a must NOT be in trackedServers so the finally block records -1");
   }
@@ -396,12 +378,12 @@ public class QueryDispatcherApplyUpstreamTimingsTest {
 
   @Test
   public void testPureLeavesStillRecordedWhenMixedLeafAlsoPresent() {
-    // When a query has both a pure leaf (fact table) and a mixed leaf (inline dim with SINGLETON receive),
-    // the pure leaf timing is still recorded correctly. The mixed leaf is silently skipped.
+    // When a query has both a pure leaf (fact table) and a SINGLETON leaf (dim lookup),
+    // the pure leaf timing is still recorded correctly. The SINGLETON leaf is silently skipped.
     QueryServerInstance server = new QueryServerInstance("instance-a", "host-a", 9000, MAILBOX_PORT);
 
-    // Stage 1 receives from the pure leaf (will be in stagesReceivingFromLeaves).
-    // Stage 2 receives from the mixed leaf (must be excluded).
+    // Stage 1 receives from the pure leaf (trusted receiver).
+    // Stage 2 receives from the SINGLETON leaf (not trusted).
     StatMap<BaseMailboxReceiveOperator.StatKey> stage1Stats =
         new StatMap<>(BaseMailboxReceiveOperator.StatKey.class);
     stage1Stats.merge(BaseMailboxReceiveOperator.StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS,
@@ -422,30 +404,22 @@ public class QueryDispatcherApplyUpstreamTimingsTest {
     ServerRoutingStatsManager stats = mock(ServerRoutingStatsManager.class);
     Set<String> recorded = new HashSet<>();
 
+    // Pure leaf sends to stage 1 (trusted). SINGLETON leaf (stage 3) has no trusted receivers.
     applyUpstreamTimingsFromStats(result,
-        planWith(leafFragment(1, server), mixedLeafFragment(3, 2, RelDistribution.Type.SINGLETON, server)),
+        planWith(leafFragment(1, server), singletonLeafFragment(3, false, server)),
         stats, REQUEST_ID, recorded);
 
-    // Pure leaf timing (90ms) recorded, NOT the inflated mixed-leaf timing (950ms).
+    // Pure leaf timing (90ms) recorded, NOT the inflated SINGLETON timing (950ms).
     verify(stats).recordStatsUponResponseArrival(REQUEST_ID, "instance-a", 90L);
     verify(stats, never()).recordStatsUponResponseArrival(REQUEST_ID, "instance-a", 950L);
   }
 
-  /**
-   * Models the 10-stage canary case where all leaf stages are "mixed" SINGLETON lookup-join stages,
-   * so {@code stagesReceivingFromLeaves} is empty. The slow server is identified by its slow network
-   * sends: stage-4 SINGLETON workers at remote servers record the slow server's stage-5 data as
-   * arriving late. Stage 4 (the SINGLETON leaf stage itself) is in {@code singletonLeafStageIds}
-   * and is directly consulted, giving clean per-server upstream-send timings.
-   */
   @Test
   public void testSingletonLeafStageItselfIsConsultedWhenSenderIsLeaf() {
     QueryServerInstance impacted = new QueryServerInstance("impacted", "host-impacted", 9000, MAILBOX_PORT);
     QueryServerInstance normal = new QueryServerInstance("normal", "host-normal", 9000, MAILBOX_PORT);
 
     // Stage 4 (the SINGLETON leaf stage) receives from stage 5 (a pure leaf scan stage).
-    // It records stage-5 leaf senders' timings: the impacted server's data took 911ms to arrive;
-    // the normal server's data arrived in 2ms.
     StatMap<BaseMailboxReceiveOperator.StatKey> stage4Stats =
         new StatMap<>(BaseMailboxReceiveOperator.StatKey.class);
     stage4Stats.merge(BaseMailboxReceiveOperator.StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS,
@@ -457,11 +431,9 @@ public class QueryDispatcherApplyUpstreamTimingsTest {
         List.of(MultiStageOperator.Type.MAILBOX_RECEIVE), List.of(stage4Stats)));
     QueryDispatcher.QueryResult result = new QueryDispatcher.QueryResult(EMPTY_RESULT, mqStats, 0L);
 
-    // SINGLETON mixed leaf at stageId=4, sends to receiver stage 3, receives from stage 5 (a leaf).
-    // singletonLeafStageIds = {4}; stagesReceivingFromLeaves = {}.
-    // Stage 5 is a pure leaf (fact table scan) running on the same servers.
-    DispatchablePlanFragment mixedLeaf =
-        mixedLeafFragment(4, 3, RelDistribution.Type.SINGLETON, /*senderStageId=*/5, impacted, normal);
+    // SINGLETON leaf at stageId=4, marked TIMING_TRUSTED (sender stage 5 is a leaf).
+    // Stage 5 is a pure leaf running on the same servers.
+    DispatchablePlanFragment singletonLeaf = singletonLeafFragment(4, true, impacted, normal);
     DispatchablePlanFragment senderLeaf = leafFragmentWithStageId(5, 4, impacted, normal);
     DispatchablePlanFragment intermediate = nonLeafFragment(impacted, normal);
 
@@ -469,10 +441,9 @@ public class QueryDispatcherApplyUpstreamTimingsTest {
     Set<String> recorded = new HashSet<>();
 
     applyUpstreamTimingsFromStats(
-        result, planWith(mixedLeaf, senderLeaf, intermediate), stats, REQUEST_ID, recorded);
+        result, planWith(singletonLeaf, senderLeaf, intermediate), stats, REQUEST_ID, recorded);
 
-    // Stage 4 is in singletonLeafStageIds (sender stage 5 is a leaf) -> consulted.
-    // Correct per-server send timings recorded.
+    // Stage 4 is TIMING_TRUSTED -> its stats are consulted.
     verify(stats).recordStatsUponResponseArrival(REQUEST_ID, "impacted", 911L);
     verify(stats).recordStatsUponResponseArrival(REQUEST_ID, "normal", 2L);
     Assert.assertTrue(recorded.containsAll(List.of("impacted", "normal")));
@@ -517,21 +488,12 @@ public class QueryDispatcherApplyUpstreamTimingsTest {
         "relay-instance must NOT be in trackedServers so the finally block records -1");
   }
 
-  /**
-   * Verifies that a SINGLETON leaf stage whose sender is an intermediate (non-leaf) stage is NOT
-   * consulted. This prevents cascade-contaminated timings from being attributed to intermediate
-   * servers. Example: stage 2 is a SINGLETON leaf (dim join) that receives from stage 3 (an
-   * intermediate hash-distribution stage running on multiple servers). If stage 3 servers wait for
-   * a slow upstream, their delivery to stage 2 is delayed. Reading stage 2's timing would wrongly
-   * attribute that cascade delay to those intermediate servers.
-   */
   @Test
   public void testSingletonLeafReceivingFromIntermediateNotConsulted() {
     QueryServerInstance serverA = new QueryServerInstance("server-a", "host-a", 9000, MAILBOX_PORT);
     QueryServerInstance serverB = new QueryServerInstance("server-b", "host-b", 9000, MAILBOX_PORT);
 
-    // Stage 2 (SINGLETON leaf) records timing for its stage-3 upstream senders. These timings
-    // are cascade-contaminated: serverA took 600ms because it waited for a slow upstream.
+    // Stage 2 (SINGLETON leaf) records timing for its stage-3 upstream senders.
     StatMap<BaseMailboxReceiveOperator.StatKey> stage2Stats =
         new StatMap<>(BaseMailboxReceiveOperator.StatKey.class);
     stage2Stats.merge(BaseMailboxReceiveOperator.StatKey.UPSTREAM_SERVER_RESPONSE_TIMES_MS,
@@ -543,10 +505,8 @@ public class QueryDispatcherApplyUpstreamTimingsTest {
         List.of(MultiStageOperator.Type.MAILBOX_RECEIVE), List.of(stage2Stats)));
     QueryDispatcher.QueryResult result = new QueryDispatcher.QueryResult(EMPTY_RESULT, mqStats, 0L);
 
-    // Stage 2 is a SINGLETON leaf that receives from stage 3, but stage 3 is NOT a leaf
-    // (it's an intermediate stage). So stage 2 must NOT be consulted.
-    DispatchablePlanFragment singletonLeaf =
-        mixedLeafFragment(2, 1, RelDistribution.Type.SINGLETON, /*senderStageId=*/3, serverA, serverB);
+    // Stage 2 is a SINGLETON leaf. NOT timing-trusted (sender stage 3 is intermediate, not a leaf).
+    DispatchablePlanFragment singletonLeaf = singletonLeafFragment(2, false, serverA, serverB);
     DispatchablePlanFragment intermediate = nonLeafFragment(serverA, serverB);
 
     ServerRoutingStatsManager stats = mock(ServerRoutingStatsManager.class);
@@ -555,13 +515,11 @@ public class QueryDispatcherApplyUpstreamTimingsTest {
     AdaptiveRoutingStageClassification classification = applyUpstreamTimingsFromStats(
         result, planWith(singletonLeaf, intermediate), stats, REQUEST_ID, recorded);
 
-    // Stage 2 is NOT consulted (sender stage 3 is not a leaf) -> contaminated timings never recorded.
+    // Stage 2 is NOT consulted (not timing-trusted) -> contaminated timings never recorded.
     verify(stats, never()).recordStatsUponResponseArrival(REQUEST_ID, "server-a", 600L);
     verify(stats, never()).recordStatsUponResponseArrival(REQUEST_ID, "server-b", 10L);
-    // No -1 pre-recording inside applyUpstreamTimingsFromStats. Caller handles via trackedServers check.
     verify(stats, never()).recordStatsUponResponseArrival(REQUEST_ID, "server-a", -1L);
     verify(stats, never()).recordStatsUponResponseArrival(REQUEST_ID, "server-b", -1L);
-    // Neither server is in trackedServers, so the caller's fallback will suppress them.
     Assert.assertFalse(classification._trackedServers.contains("server-a"));
     Assert.assertFalse(classification._trackedServers.contains("server-b"));
   }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
 import org.apache.pinot.common.failuredetector.FailureDetector;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.proto.Worker;
@@ -258,6 +259,40 @@ public class QueryDispatcherTest extends QueryTestSet {
   }
 
   @Test
+  public void testStatsManagerRecordsSubmissionAndArrivalForDispatchedServers()
+      throws Exception {
+    // Clock ticks by tickMs on each call: submitTimeMs = 1000, then elapsedMs = 1100 - 1000 = 100.
+    final long tickMs = 100L;
+    AtomicLong fakeClockMs = new AtomicLong(1_000L);
+    QueryDispatcher dispatcher = newDispatcher(() -> fakeClockMs.getAndAdd(tickMs));
+
+    ServerRoutingStatsManager statsManager = Mockito.mock(ServerRoutingStatsManager.class);
+    String sql = "SELECT * FROM a";
+    long requestId = REQUEST_ID_GEN.getAndIncrement();
+    RequestContext context = new DefaultRequestContext();
+    context.setRequestId(requestId);
+    DispatchableSubPlan plan = _queryEnvironment.planQuery(sql);
+
+    Set<String> expectedInstanceIds = getExpectedInstanceIds(plan);
+    try {
+      try (QueryThreadContext ignore = QueryThreadContext.openForMseTest()) {
+        dispatcher.submitAndReduce(context, plan, 10_000L, Map.of(), statsManager);
+      } catch (NullPointerException e) {
+        // expected: reduce phase fails with mocked MailboxService
+      }
+      for (String instanceId : expectedInstanceIds) {
+        Mockito.verify(statsManager).recordStatsForQuerySubmission(requestId, instanceId);
+        // No indirect timing was extracted (mocked MailboxService -> no real stats), so
+        // decrementedServers is empty -> all servers get -1 (no EMA update, just decrement in-flight).
+        Mockito.verify(statsManager).recordStatsUponResponseArrival(
+            Mockito.eq(requestId), Mockito.eq(instanceId), Mockito.eq(-1L));
+      }
+    } finally {
+      dispatcher.shutdown();
+    }
+  }
+
+  @Test
   public void testRealStatsManagerInflightReturnsToZero()
       throws Exception {
     Map<String, Object> properties = new HashMap<>();
@@ -288,14 +323,7 @@ public class QueryDispatcherTest extends QueryTestSet {
     RequestContext context = new DefaultRequestContext();
     context.setRequestId(requestId);
     DispatchableSubPlan plan = _queryEnvironment.planQuery(sql);
-
-    Set<String> expectedInstanceIds = new HashSet<>();
-    for (DispatchablePlanFragment fragment : plan.getQueryStagesWithoutRoot()) {
-      for (QueryServerInstance server : fragment.getServerInstanceToWorkerIdMap().keySet()) {
-        expectedInstanceIds.add(server.getInstanceId());
-      }
-    }
-    Assert.assertFalse(expectedInstanceIds.isEmpty());
+    Set<String> expectedInstanceIds = getExpectedInstanceIds(plan);
 
     try (QueryThreadContext ignore = QueryThreadContext.openForMseTest()) {
       _queryDispatcher.submitAndReduce(context, plan, 10_000L, Map.of(), statsManager);
@@ -320,5 +348,97 @@ public class QueryDispatcherTest extends QueryTestSet {
     }
 
     statsManager.shutDown();
+  }
+
+  @Test
+  public void testNoStatsRecordedWhenAdaptiveRoutingDisabled()
+      throws Exception {
+    // When statsManager is null (adaptive routing disabled), submitAndReduce must not
+    // dereference it — the null guards in submitAndReduce must prevent any NPE from the
+    // stats path. Any exception thrown here should come from the mocked MailboxService
+    // (reduce phase), not from a null statsManager dereference.
+    String sql = "SELECT * FROM a";
+    long requestId = REQUEST_ID_GEN.getAndIncrement();
+    RequestContext context = new DefaultRequestContext();
+    context.setRequestId(requestId);
+    DispatchableSubPlan plan = _queryEnvironment.planQuery(sql);
+
+    try (QueryThreadContext ignore = QueryThreadContext.openForMseTest()) {
+      _queryDispatcher.submitAndReduce(context, plan, 10_000L, Map.of(), null);
+    } catch (NullPointerException e) {
+      // Acceptable: reduce phase NPEs because MailboxService is mocked.
+      // Verify the NPE did NOT originate from the stats-manager null-guard path.
+      for (StackTraceElement frame : e.getStackTrace()) {
+        Assert.assertFalse(
+            frame.getMethodName().contains("recordStats") || frame.getMethodName().contains("applyUpstreamTimings"),
+            "NPE must not originate from stats recording path, but got: " + frame);
+      }
+    }
+  }
+
+  /**
+   * When {@code submit()} throws {@link TimeoutException} (one server never ACKs the dispatch),
+   * {@code submitAndReduce()} must catch it via {@code tryRecover()} and return a failed
+   * {@code QueryResult} — not propagate the exception.
+   *
+   * <p>Because {@code submit()} threw before the submission-stats loop ran, {@code incrementedServers}
+   * is empty and the {@code !incrementedServers.isEmpty()} guard skips {@code applyUpstreamTimingsFromStats}
+   * entirely — so {@code statsManager} receives zero interactions.
+   */
+  @Test
+  public void testSubmitAndReduceReturnsResultWhenSubmitTimesOut()
+      throws Exception {
+    // One server hangs on submit so processResults() times out after the short deadline.
+    QueryServer hangingServer = _queryServerMap.values().iterator().next();
+    CountDownLatch neverClosingLatch = new CountDownLatch(1);
+    Mockito.doAnswer(invocationOnMock -> {
+      neverClosingLatch.await();
+      StreamObserver<Worker.QueryResponse> observer = invocationOnMock.getArgument(1);
+      observer.onCompleted();
+      return null;
+    }).when(hangingServer).submit(Mockito.any(), Mockito.any());
+
+    ServerRoutingStatsManager statsManager = Mockito.mock(ServerRoutingStatsManager.class);
+    String sql = "SELECT * FROM a";
+    long requestId = REQUEST_ID_GEN.getAndIncrement();
+    RequestContext context = new DefaultRequestContext();
+    context.setRequestId(requestId);
+    DispatchableSubPlan plan = _queryEnvironment.planQuery(sql);
+
+    try {
+      QueryDispatcher.QueryResult result;
+      try (QueryThreadContext ignore = QueryThreadContext.openForMseTest()) {
+        // submit() times out because hangingServer never ACKs -> tryRecover() handles TimeoutException
+        // and returns a failed QueryResult instead of propagating the exception.
+        result = _queryDispatcher.submitAndReduce(context, plan, 200L, Map.of(), statsManager);
+      }
+      Assert.assertNotNull(result.getProcessingException(),
+          "Expected a processing exception in the result when submit times out");
+    } finally {
+      neverClosingLatch.countDown();
+      Mockito.reset(hangingServer);
+    }
+
+    // submit() threw before recordStatsForQuerySubmission ran -> incrementedServers is empty.
+    // applyUpstreamTimingsFromStats finds no timing data (servers had not started the query),
+    // and the fallback loop iterates an empty incrementedServers set. No statsManager interactions.
+    Mockito.verifyNoInteractions(statsManager);
+  }
+
+  /** Creates a local {@link QueryDispatcher} wired to the shared query servers with an injected clock. */
+  private QueryDispatcher newDispatcher(LongSupplier clock) {
+    return new QueryDispatcher(Mockito.mock(MailboxService.class), Mockito.mock(FailureDetector.class), null, true,
+        Duration.ofSeconds(1), clock);
+  }
+
+  private Set<String> getExpectedInstanceIds(DispatchableSubPlan plan) {
+    Set<String> expectedInstanceIds = new HashSet<>();
+    for (DispatchablePlanFragment fragment : plan.getQueryStagesWithoutRoot()) {
+      for (QueryServerInstance server : fragment.getServerInstanceToWorkerIdMap().keySet()) {
+        expectedInstanceIds.add(server.getInstanceId());
+      }
+    }
+    Assert.assertFalse(expectedInstanceIds.isEmpty());
+    return expectedInstanceIds;
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
@@ -394,15 +394,17 @@ public class QueryDispatcherTest extends QueryTestSet {
   @Test
   public void testSubmitAndReduceReturnsResultWhenSubmitTimesOut()
       throws Exception {
-    // One server hangs on submit so processResults() times out after the short deadline.
-    QueryServer hangingServer = _queryServerMap.values().iterator().next();
+    // All servers hang on submit so processResults() times out after the short deadline.
     CountDownLatch neverClosingLatch = new CountDownLatch(1);
-    Mockito.doAnswer(invocationOnMock -> {
-      neverClosingLatch.await();
-      StreamObserver<Worker.QueryResponse> observer = invocationOnMock.getArgument(1);
-      observer.onCompleted();
-      return null;
-    }).when(hangingServer).submit(Mockito.any(), Mockito.any());
+    List<QueryServer> allServers = new ArrayList<>(_queryServerMap.values());
+    for (QueryServer server : allServers) {
+      Mockito.doAnswer(invocationOnMock -> {
+        neverClosingLatch.await();
+        StreamObserver<Worker.QueryResponse> observer = invocationOnMock.getArgument(1);
+        observer.onCompleted();
+        return null;
+      }).when(server).submit(Mockito.any(), Mockito.any());
+    }
 
     ServerRoutingStatsManager statsManager = Mockito.mock(ServerRoutingStatsManager.class);
     String sql = "SELECT * FROM a";
@@ -412,17 +414,24 @@ public class QueryDispatcherTest extends QueryTestSet {
     DispatchableSubPlan plan = _queryEnvironment.planQuery(sql);
 
     try {
-      QueryDispatcher.QueryResult result;
       try (QueryThreadContext ignore = QueryThreadContext.openForMseTest()) {
-        // submit() times out because hangingServer never ACKs -> tryRecover() handles TimeoutException
-        // and returns a failed QueryResult instead of propagating the exception.
-        result = _queryDispatcher.submitAndReduce(context, plan, 200L, Map.of(), statsManager);
+        // submit() times out because all servers never ACK -> tryRecover() handles TimeoutException.
+        // Depending on whether cancelWithStats succeeds, this either returns a QueryResult with a
+        // processing exception or throws a RuntimeException wrapping the cancel failure.
+        QueryDispatcher.QueryResult result =
+            _queryDispatcher.submitAndReduce(context, plan, 200L, Map.of(), statsManager);
+        Assert.assertNotNull(result.getProcessingException(),
+            "Expected a processing exception in the result when submit times out");
       }
-      Assert.assertNotNull(result.getProcessingException(),
-          "Expected a processing exception in the result when submit times out");
+    } catch (RuntimeException e) {
+      // Cancel phase may also throw if the hanging servers don't respond to the cancel RPC.
+      Assert.assertTrue(e.getMessage().contains("Error dispatching query"),
+          "Expected dispatch error from cancel phase, got: " + e.getMessage());
     } finally {
       neverClosingLatch.countDown();
-      Mockito.reset(hangingServer);
+      for (QueryServer server : allServers) {
+        Mockito.reset(server);
+      }
     }
 
     // submit() threw before recordStatsForQuerySubmission ran -> incrementedServers is empty.

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
@@ -258,6 +258,12 @@ public class QueryDispatcherTest extends QueryTestSet {
     Mockito.reset(failingQueryServer);
   }
 
+  /**
+   * When no indirect timing is extracted (e.g. reduce phase fails before stats propagate), the
+   * finally block must still decrement in-flight for all submitted servers. With no known timings
+   * and no cancel attempted, all servers fall into Tier 4 (no timing data, server responsive)
+   * and get -1 (decrement only, no EMA update) rather than the contaminated wall-clock.
+   */
   @Test
   public void testStatsManagerRecordsSubmissionAndArrivalForDispatchedServers()
       throws Exception {
@@ -283,7 +289,7 @@ public class QueryDispatcherTest extends QueryTestSet {
       for (String instanceId : expectedInstanceIds) {
         Mockito.verify(statsManager).recordStatsForQuerySubmission(requestId, instanceId);
         // No indirect timing was extracted (mocked MailboxService -> no real stats), so
-        // decrementedServers is empty -> all servers get -1 (no EMA update, just decrement in-flight).
+        // knownTimings is empty -> all servers get -1 (Tier 4: no timing data).
         Mockito.verify(statsManager).recordStatsUponResponseArrival(
             Mockito.eq(requestId), Mockito.eq(instanceId), Mockito.eq(-1L));
       }
@@ -382,8 +388,8 @@ public class QueryDispatcherTest extends QueryTestSet {
    * {@code QueryResult} — not propagate the exception.
    *
    * <p>Because {@code submit()} threw before the submission-stats loop ran, {@code incrementedServers}
-   * is empty and the {@code !incrementedServers.isEmpty()} guard skips {@code applyUpstreamTimingsFromStats}
-   * entirely — so {@code statsManager} receives zero interactions.
+   * is empty and the finally block's tiered latency recorder has nothing to update, so
+   * {@code statsManager} receives zero interactions.
    */
   @Test
   public void testSubmitAndReduceReturnsResultWhenSubmitTimesOut()
@@ -420,8 +426,8 @@ public class QueryDispatcherTest extends QueryTestSet {
     }
 
     // submit() threw before recordStatsForQuerySubmission ran -> incrementedServers is empty.
-    // applyUpstreamTimingsFromStats finds no timing data (servers had not started the query),
-    // and the fallback loop iterates an empty incrementedServers set. No statsManager interactions.
+    // The finally block's tiered latency recorder iterates an empty incrementedServers set,
+    // so statsManager receives no interactions.
     Mockito.verifyNoInteractions(statsManager);
   }
 


### PR DESCRIPTION
https://github.com/apache/pinot/pull/18553 added in-flight request tracking for MSE in the adaptive routing stats. This PR adds per-server latency. It looks very large, but much of it is tests, and some new files were introduced, which comes with a certain amount of boilerplate in Java.

**1. The planner marks stages as needing timing**. It assigns `FragmentType`s and then the dispatcher uses those to turn those roles into timing collection in `AdaptiveRoutingStageClassification.java`. it always enables collection on stage 0, and otherwise only on trusted stages that either directly receive from pure leaves or are singleton-leaf stages themselves, while excluding stages fed by non-leaf senders so their timings do not include upstream cascade delay.

**2. Stages track their elapsed time and return it as `UPSTREAM_SERVER_RESPONSE_TIMES_MS` stat** (`BaseMailboxReceiveOperator`, `BlockingMultiStreamConsumer`, `AdaptiveRoutingUpstreamTimings`)

Each `BaseMailboxReceiveOperator` tracks per-sender wall-clock elapsed time (from when its `BlockingMultiStreamConsumer.OfMseBlock` is constructed until each sender's EOS arrives). The start time is captured at consumer construction time, not at query start, to avoid pipeline-breaker inflation: if a pipeline breaker on this stage blocks for 1000ms waiting on a slow sender, fast senders' EOS blocks sit unconsumed in their queues during that time, and measuring from query start would report ~1000ms for all of them.

These per-sender timings are encoded as `"hostname|port=elapsedMs;..."` in a new `UPSTREAM_SERVER_RESPONSE_TIMES_MS` stat key on `BaseMailboxReceiveOperator.StatKey` and propagated up through the query stats. A serialized string is used because it is more straightforward than adding a Map type to the `StatKey` system.

**3. Broker reads leaf-server timings** and resolves `hostname|mailboxPort` sender keys to full instance IDs and accumulates the maximum observed latency per instance across all trusted stages. A `decrementedServers` set prevents double-recording.

**4. Query timeout:** on query cancellation (e.g. reaching the timeout), we try to cancel with stats. We preserve completed timings and inject elapsed time for pending senders. 

### Testing

**1. Performance impact**:  We ran some performance tests and saw no impact. 

**2. Manually with tc**

Choose a server that we want to induce latency on. `ssh` to that server and:

```
sudo tc qdisc add dev ens5 root handle 1: prio
sudo tc qdisc add dev ens5 parent 1:3 handle 30: netem delay 1200ms

sudo tc filter add dev ens5 protocol ip parent 1:0 prio 3 u32 \
  match ip dport 8442 0xffff flowid 1:3
```

We induced latency only for MSE to validate that adaptive routing can be influenced by only MSE queries.

To reset the latency

```
sudo tc qdisc del dev ens5 root # cleanup
```

We saw the score spike for the targetted servers. 
**3. Chaos Agent**
We kicked off a chaos agent run that does
1. 90s of 600ms **MSE latency**
2. 30s with no faults
3. 90s of 600ms **SSE latency**
4. 90s with no faults
5. 90s of 1200ms **MSE latency**
6. 30s with no faults
7. 90s of 1200ms **SSE latency**

(query timeout is 1s). 

<img width="1462" height="916" alt="image" src="https://github.com/user-attachments/assets/42fea0fc-b2ed-4070-be6b-9e60f7446a40" />