### PR TITLE
[codex] Upgrade Jetty dependencies to 12

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -224,7 +224,7 @@ com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.21.1
 com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.21.1
 com.fasterxml.jackson.module:jackson-module-parameter-names:2.21.1
 com.fasterxml.jackson.module:jackson-module-scala_2.13:2.21.1
-com.fasterxml.woodstox:woodstox-core:7.1.1
+com.fasterxml.woodstox:woodstox-core:7.2.0
 com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.erosb:everit-json-schema:1.14.6
 com.github.jnr:jffi:1.3.14
@@ -414,7 +414,7 @@ org.apache.calcite:calcite-core:1.40.0
 org.apache.calcite:calcite-linq4j:1.40.0
 org.apache.commons:commons-collections4:4.5.0
 org.apache.commons:commons-compress:1.28.0
-org.apache.commons:commons-configuration2:2.13.0
+org.apache.commons:commons-configuration2:2.15.1
 org.apache.commons:commons-csv:1.14.1
 org.apache.commons:commons-lang3:3.20.0
 org.apache.commons:commons-math3:3.6.1
@@ -429,7 +429,6 @@ org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.5.0
 org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_25:1.5.0
 org.apache.hadoop:hadoop-annotations:3.4.3
 org.apache.hadoop:hadoop-auth:3.4.3
-org.apache.hadoop:hadoop-client-runtime:3.4.3
 org.apache.hadoop:hadoop-common:3.4.3
 org.apache.hadoop:hadoop-hdfs-client:3.4.3
 org.apache.hadoop:hadoop-hdfs:3.4.3
@@ -506,19 +505,10 @@ org.codehaus.groovy:groovy-all:2.4.21
 org.codehaus.jettison:jettison:1.5.4
 org.codehaus.plexus:plexus-classworlds:2.9.0
 org.conscrypt:conscrypt-openjdk-uber:2.5.2
-org.eclipse.jetty.websocket:websocket-api:9.4.58.v20250814
-org.eclipse.jetty.websocket:websocket-client:9.4.58.v20250814
-org.eclipse.jetty.websocket:websocket-common:9.4.58.v20250814
-org.eclipse.jetty:jetty-client:9.4.58.v20250814
-org.eclipse.jetty:jetty-http:9.4.58.v20250814
-org.eclipse.jetty:jetty-io:9.4.58.v20250814
-org.eclipse.jetty:jetty-security:9.4.58.v20250814
-org.eclipse.jetty:jetty-server:9.4.58.v20250814
-org.eclipse.jetty:jetty-servlet:9.4.58.v20250814
-org.eclipse.jetty:jetty-util-ajax:9.4.58.v20250814
-org.eclipse.jetty:jetty-webapp:9.4.58.v20250814
-org.eclipse.jetty:jetty-xml:9.4.58.v20250814
-org.eclipse.jetty:jetty-util:9.4.58.v20250814
+org.eclipse.jetty:jetty-http:12.0.35
+org.eclipse.jetty:jetty-io:12.0.35
+org.eclipse.jetty:jetty-server:12.0.35
+org.eclipse.jetty:jetty-util:12.0.35
 org.immutables:value-annotations:2.12.1
 org.javassist:javassist:3.30.2-GA
 org.jetbrains.kotlin:kotlin-reflect:2.3.10
@@ -623,7 +613,7 @@ com.thoughtworks.paranamer:paranamer:2.8.3
 BSD 2-Clause
 ------------
 com.github.luben:zstd-jni:1.5.7-7
-org.codehaus.woodstox:stax2-api:4.2.2
+org.codehaus.woodstox:stax2-api:4.3.0
 
 
 BSD 3-Clause

--- a/pinot-bom/pom.xml
+++ b/pinot-bom/pom.xml
@@ -311,6 +311,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.pinot</groupId>
+        <artifactId>pinot-hadoop-shaded-xml</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.pinot</groupId>
         <artifactId>pinot-orc</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/pinot-connectors/pinot-spark-3-connector/pom.xml
+++ b/pinot-connectors/pinot-spark-3-connector/pom.xml
@@ -86,6 +86,12 @@
       </activation>
       <dependencies>
         <dependency>
+          <groupId>org.apache.pinot</groupId>
+          <artifactId>pinot-hadoop-shaded-xml</artifactId>
+          <version>${project.version}</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
           <groupId>org.apache.spark</groupId>
           <artifactId>spark-sql_${scala.compat.version}</artifactId>
           <scope>provided</scope>
@@ -93,6 +99,10 @@
             <exclusion>
               <groupId>org.lz4</groupId>
               <artifactId>lz4-java</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>org.apache.hadoop</groupId>
+              <artifactId>hadoop-client-runtime</artifactId>
             </exclusion>
           </exclusions>
         </dependency>

--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -321,7 +321,17 @@
           <groupId>org.lz4</groupId>
           <artifactId>lz4-java</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-client-runtime</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-hadoop-shaded-xml</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/pom.xml
@@ -41,6 +41,12 @@
       <artifactId>pinot-batch-ingestion-spark-base</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-hadoop-shaded-xml</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.compat.version}</artifactId>
       <scope>provided</scope>
@@ -60,6 +66,10 @@
         <exclusion>
           <groupId>org.lz4</groupId>
           <artifactId>lz4-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-client-runtime</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pinot-plugins/pinot-input-format/pinot-hadoop-shaded-xml/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-hadoop-shaded-xml/pom.xml
@@ -1,0 +1,308 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>pinot-input-format</artifactId>
+    <groupId>org.apache.pinot</groupId>
+    <version>1.6.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>pinot-hadoop-shaded-xml</artifactId>
+  <name>Pinot Hadoop Shaded XML</name>
+  <url>https://pinot.apache.org/</url>
+
+  <properties>
+    <pinot.root>${basedir}/../../..</pinot.root>
+    <shade.phase.prop>process-classes</shade.phase.prop>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>commons-net</groupId>
+      <artifactId>commons-net</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.woodstox</groupId>
+      <artifactId>woodstox-core</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-configuration2</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-math3</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop.thirdparty</groupId>
+      <artifactId>hadoop-shaded-guava</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop.thirdparty</groupId>
+      <artifactId>hadoop-shaded-protobuf_3_25</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.woodstox</groupId>
+      <artifactId>stax2-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>clear-staged-relocated-hadoop-classes</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+            <configuration>
+              <excludeDefaultDirectories>true</excludeDefaultDirectories>
+              <filesets>
+                <fileset>
+                  <directory>${project.build.outputDirectory}/org/apache/hadoop</directory>
+                </fileset>
+                <fileset>
+                  <directory>${project.build.outputDirectory}/META-INF/services</directory>
+                </fileset>
+                <fileset>
+                  <directory>${project.build.outputDirectory}/META-INF/maven</directory>
+                </fileset>
+                <fileset>
+                  <directory>${project.build.outputDirectory}/META-INF/licenses-binary</directory>
+                </fileset>
+                <fileset>
+                  <directory>${project.build.outputDirectory}/assets</directory>
+                </fileset>
+                <fileset>
+                  <directory>${project.build.outputDirectory}</directory>
+                  <includes>
+                    <include>META-INF/NOTICE-binary</include>
+                    <include>PropertyList-1.0.dtd</include>
+                    <include>properties.dtd</include>
+                  </includes>
+                </fileset>
+              </filesets>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <forceCreation>true</forceCreation>
+        </configuration>
+        <executions>
+          <execution>
+            <id>create-main-artifact-before-shade</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>default-jar</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <configuration combine.self="override">
+          <outputFile>${project.build.directory}/${project.build.finalName}-relocated.jar</outputFile>
+          <shadedArtifactAttached>false</shadedArtifactAttached>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
+          <artifactSet>
+            <includes>
+              <include>com.fasterxml.woodstox:woodstox-core</include>
+              <include>commons-beanutils:commons-beanutils</include>
+              <include>commons-cli:commons-cli</include>
+              <include>commons-codec:commons-codec</include>
+              <include>commons-collections:commons-collections</include>
+              <include>commons-io:commons-io</include>
+              <include>commons-net:commons-net</include>
+              <include>org.apache.commons:commons-collections4</include>
+              <include>org.apache.commons:commons-compress</include>
+              <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava</include>
+              <include>org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_25</include>
+              <include>org.apache.commons:commons-configuration2</include>
+              <include>org.apache.commons:commons-lang3</include>
+              <include>org.apache.commons:commons-math3</include>
+              <include>org.apache.commons:commons-text</include>
+              <include>org.codehaus.woodstox:stax2-api</include>
+            </includes>
+          </artifactSet>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/*.SF</exclude>
+                <exclude>META-INF/*.DSA</exclude>
+                <exclude>META-INF/*.RSA</exclude>
+                <exclude>module-info.class</exclude>
+                <exclude>META-INF/versions/*/module-info.class</exclude>
+              </excludes>
+            </filter>
+          </filters>
+          <relocations>
+            <relocation>
+              <pattern>org.apache.commons.beanutils</pattern>
+              <shadedPattern>org.apache.hadoop.shaded.org.apache.commons.beanutils</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.commons.cli</pattern>
+              <shadedPattern>org.apache.hadoop.shaded.org.apache.commons.cli</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.commons.codec</pattern>
+              <shadedPattern>org.apache.hadoop.shaded.org.apache.commons.codec</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.commons.collections</pattern>
+              <shadedPattern>org.apache.hadoop.shaded.org.apache.commons.collections</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.commons.collections4</pattern>
+              <shadedPattern>org.apache.hadoop.shaded.org.apache.commons.collections4</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.commons.compress</pattern>
+              <shadedPattern>org.apache.hadoop.shaded.org.apache.commons.compress</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.commons.configuration2</pattern>
+              <shadedPattern>org.apache.hadoop.shaded.org.apache.commons.configuration2</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.commons.io</pattern>
+              <shadedPattern>org.apache.hadoop.shaded.org.apache.commons.io</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.commons.lang3</pattern>
+              <shadedPattern>org.apache.hadoop.shaded.org.apache.commons.lang3</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.commons.math3</pattern>
+              <shadedPattern>org.apache.hadoop.shaded.org.apache.commons.math3</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.commons.net</pattern>
+              <shadedPattern>org.apache.hadoop.shaded.org.apache.commons.net</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.commons.text</pattern>
+              <shadedPattern>org.apache.hadoop.shaded.org.apache.commons.text</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.ctc.wstx</pattern>
+              <shadedPattern>org.apache.hadoop.shaded.com.ctc.wstx</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.codehaus.stax2</pattern>
+              <shadedPattern>org.apache.hadoop.shaded.org.codehaus.stax2</shadedPattern>
+            </relocation>
+          </relocations>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>stage-relocated-hadoop-classes</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <!-- Reactor builds put target/classes, not the packaged jar, on downstream classpaths. -->
+                <unzip src="${project.build.directory}/${project.build.finalName}-relocated.jar"
+                       dest="${project.build.outputDirectory}" />
+                <jar destfile="${project.build.directory}/${project.build.finalName}.jar"
+                     basedir="${project.build.outputDirectory}"
+                     manifest="${project.build.outputDirectory}/META-INF/MANIFEST.MF" />
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/pinot-plugins/pinot-input-format/pinot-parquet/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/pom.xml
@@ -53,8 +53,9 @@
       <artifactId>bcprov-jdk18on</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-client-runtime</artifactId>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-hadoop-shaded-xml</artifactId>
+      <version>${project.version}</version>
       <scope>${hadoop.dependencies.scope}</scope>
     </dependency>
     <dependency>

--- a/pinot-plugins/pinot-input-format/pom.xml
+++ b/pinot-plugins/pinot-input-format/pom.xml
@@ -44,6 +44,7 @@
     <module>pinot-confluent-avro</module>
     <module>pinot-confluent-json</module>
     <module>pinot-confluent-protobuf</module>
+    <module>pinot-hadoop-shaded-xml</module>
     <module>pinot-orc</module>
     <module>pinot-json</module>
     <module>pinot-parquet</module>

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,7 @@
     <fastutil.version>8.5.18</fastutil.version>
     <disruptor.version>4.0.0</disruptor.version>
     <snakeyaml.version>2.6</snakeyaml.version>
+    <hadoop-shaded-guava.version>1.5.0</hadoop-shaded-guava.version>
     <hadoop-shaded-protobuf_3_25.version>1.5.0</hadoop-shaded-protobuf_3_25.version>
     <clearspring-stream-lib.version>2.9.8</clearspring-stream-lib.version>
     <datasketches-java.version>6.2.0</datasketches-java.version>
@@ -233,6 +234,7 @@
 
     <!-- Apache Commons Libraries -->
     <commons-lang3.version>3.20.0</commons-lang3.version>
+    <commons-collections.version>3.2.2</commons-collections.version>
     <commons-collections4.version>4.5.0</commons-collections4.version>
     <commons-text.version>1.15.0</commons-text.version>
     <commons-compress.version>1.28.0</commons-compress.version>
@@ -301,7 +303,7 @@
     <jettison.version>1.5.5</jettison.version>
     <nimbus-jose-jwt.version>10.9</nimbus-jose-jwt.version>
     <dnsjava.version>3.6.5</dnsjava.version>
-    <eclipse.jetty.version>9.4.58.v20250814</eclipse.jetty.version>
+    <eclipse.jetty.version>12.0.35</eclipse.jetty.version>
     <woodstox.version>7.2.0</woodstox.version>
     <curator.version>5.9.0</curator.version>
     <javassist.version>3.31.0-GA</javassist.version>
@@ -920,6 +922,11 @@
         <version>${commons-lang3.version}</version>
       </dependency>
       <dependency>
+        <groupId>commons-collections</groupId>
+        <artifactId>commons-collections</artifactId>
+        <version>${commons-collections.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-collections4</artifactId>
         <version>${commons-collections4.version}</version>
@@ -1161,6 +1168,22 @@
         <scope>provided</scope>
         <exclusions>
           <exclusion>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-webapp</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
           </exclusion>
@@ -1197,6 +1220,10 @@
         <scope>provided</scope>
         <exclusions>
           <exclusion>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util-ajax</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-core</artifactId>
           </exclusion>
@@ -1216,6 +1243,18 @@
         <version>${hadoop.version}</version>
         <scope>provided</scope>
         <exclusions>
+          <exclusion>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-webapp</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>websocket-client</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-reload4j</artifactId>
@@ -1260,6 +1299,10 @@
             <groupId>ch.qos.reload4j</groupId>
             <artifactId>reload4j</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>websocket-client</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -1270,21 +1313,14 @@
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
-        <artifactId>hadoop-client-runtime</artifactId>
-        <version>${hadoop.version}</version>
-        <scope>provided</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-client-api</artifactId>
         <version>${hadoop.version}</version>
         <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop.thirdparty</groupId>
+        <artifactId>hadoop-shaded-guava</artifactId>
+        <version>${hadoop-shaded-guava.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop.thirdparty</groupId>
@@ -1721,27 +1757,35 @@
         <artifactId>dnsjava</artifactId>
         <version>${dnsjava.version}</version>
       </dependency>
-      <!-- Eclipse jetty dependencies in Hadoop/Spark/Pulsar -->
+      <!-- Eclipse Jetty dependencies. Jetty 12 uses renamed EE/websocket artifacts; Hadoop's Jetty 9 transitive
+      artifacts are excluded at their dependency edges instead of being mapped to incompatible coordinates. -->
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId>
-        <artifactId>websocket-client</artifactId>
+        <artifactId>jetty-websocket-jetty-client</artifactId>
         <version>${eclipse.jetty.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-servlet</artifactId>
+        <groupId>org.eclipse.jetty.ee8</groupId>
+        <artifactId>jetty-ee8-servlet</artifactId>
         <version>${eclipse.jetty.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-webapp</artifactId>
+        <groupId>org.eclipse.jetty.ee8</groupId>
+        <artifactId>jetty-ee8-webapp</artifactId>
         <version>${eclipse.jetty.version}</version>
       </dependency>
 
-      <!-- jetty bom -->
+      <!-- Jetty BOMs -->
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-bom</artifactId>
+        <version>${eclipse.jetty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee8</groupId>
+        <artifactId>jetty-ee8-bom</artifactId>
         <version>${eclipse.jetty.version}</version>
         <type>pom</type>
         <scope>import</scope>
@@ -2168,6 +2212,12 @@
                       <exclude>org.bouncycastle:bcprov-jdk15on</exclude>
                       <!-- Use at.yawk.lz4:lz4-java -->
                       <exclude>org.lz4:lz4-java</exclude>
+                      <!-- Embeds relocated Jetty 9 classes; use pinot-hadoop-shaded-xml for Hadoop shaded classes. -->
+                      <exclude>org.apache.hadoop:hadoop-client-runtime</exclude>
+                      <!-- Jetty 9/10/11 are not allowed; use Jetty 12+ coordinates or exclude transitive server bits. -->
+                      <exclude>org.eclipse.jetty:*:(,12.0.35)</exclude>
+                      <exclude>org.eclipse.jetty.ee8:*:(,12.0.35)</exclude>
+                      <exclude>org.eclipse.jetty.websocket:*:(,12.0.35)</exclude>
                     </excludes>
                   </bannedDependencies>
                 </rules>


### PR DESCRIPTION
## Summary
- upgrade managed Jetty coordinates from 9.4.x to Jetty 12.0.35, including Jetty EE8 compatibility artifacts used by optional Hadoop/Spark/Pulsar dependency paths
- ban Jetty < 12 and `hadoop-client-runtime` in Maven enforcer rules so the vulnerable Jetty 9 runtime cannot re-enter transitively
- add `pinot-input-format/pinot-hadoop-shaded-xml` as a small shaded support artifact for Hadoop-relocated Commons/Woodstox/Guava/Protobuf classes that were previously embedded in `hadoop-client-runtime`
- update binary license inventory for the Jetty 12 and Woodstox/StAX dependency versions

## User Manual / Compatibility
- No Pinot table config, ingestion config, or query syntax changes are required.
- Existing Hadoop, Spark, Parquet, HDFS, and Pulsar plugin users should keep using the same plugin coordinates and table configs. The change is internal to the managed dependency graph.
- Sample table config/query: not applicable for this security dependency migration. Pinot service HTTP endpoints still use Grizzly/Jersey, not Jetty.

## Tests
- `./mvnw -pl pinot-plugins/pinot-input-format/pinot-hadoop-shaded-xml package -DskipTests`
- verified helper jar contains Hadoop-relocated `Configuration`, `UnmodifiableMap`, Guava `Maps`, and Protobuf `Message` classes
- `rm -rf pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/target && ./mvnw -pl pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3 -am -Dtest=SparkSegmentGenerationJobRunnerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl pinot-tools,pinot-connectors/pinot-spark-3-connector,pinot-integration-tests,pinot-plugins/pinot-file-system/pinot-hdfs,pinot-plugins/pinot-input-format/pinot-orc,pinot-plugins/pinot-input-format/pinot-parquet,pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop,pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3,pinot-plugins/pinot-stream-ingestion/pinot-pulsar -am dependency:tree -Dincludes=org.apache.hadoop:hadoop-client-runtime,org.eclipse.jetty,org.eclipse.jetty.websocket,org.eclipse.jetty.ee8 -DskipTests`
- `./mvnw -B -ntp -T1C enforcer:enforce -DskipTests`
- `./mvnw -B -ntp -T1C enforcer:enforce -Pdependency-verifier -DskipTests`
- `./mvnw spotless:apply -pl .,pinot-bom,pinot-plugins,pinot-plugins/pinot-input-format,pinot-plugins/pinot-input-format/pinot-hadoop-shaded-xml,pinot-plugins/pinot-input-format/pinot-parquet,pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3,pinot-connectors/pinot-spark-3-connector,pinot-integration-tests`
- `./mvnw license:format -pl .,pinot-bom,pinot-plugins,pinot-plugins/pinot-input-format,pinot-plugins/pinot-input-format/pinot-hadoop-shaded-xml,pinot-plugins/pinot-input-format/pinot-parquet,pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3,pinot-connectors/pinot-spark-3-connector,pinot-integration-tests`
- `./mvnw checkstyle:check -pl .,pinot-bom,pinot-plugins,pinot-plugins/pinot-input-format,pinot-plugins/pinot-input-format/pinot-hadoop-shaded-xml,pinot-plugins/pinot-input-format/pinot-parquet,pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3,pinot-connectors/pinot-spark-3-connector,pinot-integration-tests`
- `./mvnw license:check -pl .,pinot-bom,pinot-plugins,pinot-plugins/pinot-input-format,pinot-plugins/pinot-input-format/pinot-hadoop-shaded-xml,pinot-plugins/pinot-input-format/pinot-parquet,pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3,pinot-connectors/pinot-spark-3-connector,pinot-integration-tests`