### PR TITLE
Add query progress reporting for long-running queries

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
@@ -39,6 +39,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import javax.inject.Inject;
@@ -86,6 +87,7 @@ import org.apache.pinot.spi.auth.broker.RequesterIdentity;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.apache.pinot.spi.exception.QueryException;
+import org.apache.pinot.spi.query.QueryProgressStats;
 import org.apache.pinot.spi.trace.QueryFingerprint;
 import org.apache.pinot.spi.trace.RequestContext;
 import org.apache.pinot.spi.trace.RequestScope;
@@ -573,6 +575,63 @@ public class PinotClientRequest {
                   .entity(e.getMessage())
                   .build()));
     }
+  }
+
+  @GET
+  @Path("query/{id}/progress")
+  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_RUNNING_QUERY)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Get progress for a running query as identified by the id",
+      notes = "Progress is derived from processed work units over total work units. Single-stage work units are "
+          + "selected segments; multi-stage work units include selected segments and stage op-chains. Multi-stage "
+          + "responses may include labeled details for component-level progress.")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Success"),
+      @ApiResponse(code = 400, message = "Bad Request"),
+      @ApiResponse(code = 404, message = "Query not found on the requested broker"),
+      @ApiResponse(code = 500, message = "Internal server error")
+  })
+  public QueryProgressStats getQueryProgress(
+      @ApiParam(value = "Query id", required = true) @PathParam("id") String id,
+      @ApiParam(value = "Determines if query id is internal or provided by the client") @QueryParam("client")
+      @DefaultValue("false") boolean isClient,
+      @ApiParam(value = "Timeout for servers to respond the progress request") @QueryParam("timeoutMs")
+      @DefaultValue("1000") int timeoutMs) {
+    try {
+      if (timeoutMs <= 0) {
+        throw new BadRequestException("timeoutMs must be positive");
+      }
+      long reqId;
+      if (isClient) {
+        OptionalLong requestId = _requestHandler.getRequestIdByClientId(id);
+        if (!requestId.isPresent()) {
+          throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND)
+              .entity(String.format("Client query: %s not found on the broker", id))
+              .build());
+        }
+        reqId = requestId.getAsLong();
+      } else {
+        reqId = Long.parseLong(id);
+      }
+      QueryProgressStats progressStats =
+          _requestHandler.getQueryProgressStats(reqId, timeoutMs, _executor, _httpConnMgr);
+      if (progressStats != null) {
+        return progressStats;
+      }
+    } catch (NumberFormatException e) {
+      _brokerMetrics.addMeteredGlobalValue(BrokerMeter.BAD_REQUEST_EXCEPTIONS, 1L);
+      throw new BadRequestException(String.format("Invalid internal query id: %s", id), e);
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new WebApplicationException(Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+          .entity(String.format("Failed to get progress for query: %s on the broker due to error: %s", id,
+              e.getMessage()))
+          .build());
+    }
+    throw new WebApplicationException(
+        Response.status(Response.Status.NOT_FOUND).entity(String.format("Query: %s not found on the broker", id))
+            .build());
   }
 
   @DELETE

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -66,6 +66,7 @@ import org.apache.pinot.spi.eventlistener.query.BrokerQueryEventListener;
 import org.apache.pinot.spi.eventlistener.query.BrokerQueryEventListenerFactory;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
 import org.apache.pinot.spi.exception.QueryErrorCode;
+import org.apache.pinot.spi.query.QueryProgressStats;
 import org.apache.pinot.spi.trace.RequestContext;
 import org.apache.pinot.spi.utils.CommonConstants.Broker;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
@@ -97,6 +98,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   @Nullable
   protected final String _regexDictSizeThreshold;
   protected final boolean _enableQueryCancellation;
+  protected final boolean _enableQueryProgress;
   @Nullable
   protected final String _enableAutoRewriteAggregationType;
   @Nullable
@@ -106,6 +108,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   protected final Map<Long, String> _queriesById;
   /// Maps broker-generated query id to client-provided query id.
   protected final Map<Long, String> _clientQueryIds;
+  /// Reverse index for O(1) client-query-id lookup. A set preserves existing behavior when callers reuse an id.
+  protected final Map<String, Set<Long>> _requestIdsByClientQueryId;
 
   public BaseBrokerRequestHandler(PinotConfiguration config, String brokerId,
       BrokerRequestIdGenerator requestIdGenerator, RoutingManager routingManager,
@@ -131,6 +135,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     _regexDictSizeThreshold = config.getProperty(Broker.CONFIG_OF_BROKER_QUERY_REGEX_DICT_SIZE_THRESHOLD);
     _enableQueryCancellation = config.getProperty(Broker.CONFIG_OF_BROKER_ENABLE_QUERY_CANCELLATION,
         Broker.DEFAULT_BROKER_ENABLE_QUERY_CANCELLATION);
+    _enableQueryProgress = config.getProperty(Broker.CONFIG_OF_BROKER_QUERY_PROGRESS_ENABLED,
+        Broker.DEFAULT_BROKER_QUERY_PROGRESS_ENABLED);
     _enableAutoRewriteAggregationType =
         config.getProperty(Broker.CONFIG_OF_BROKER_QUERY_ENABLE_AUTO_REWRITE_AGGREGATION_TYPE);
     // Process-wide static because the SQL parser has no access to the broker config. Set here rather
@@ -138,12 +144,14 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     QueryOptionsUtils.setSqlQueryOptionValidationMode(SqlQueryOptionValidationMode.valueOf(
         config.getProperty(Broker.CONFIG_OF_BROKER_QUERY_OPTION_VALIDATION_MODE,
             Broker.DEFAULT_BROKER_QUERY_OPTION_VALIDATION_MODE).trim().toUpperCase(Locale.ROOT)));
-    if (_enableQueryCancellation) {
+    if (_enableQueryCancellation || _enableQueryProgress) {
       _queriesById = new ConcurrentHashMap<>();
       _clientQueryIds = new ConcurrentHashMap<>();
+      _requestIdsByClientQueryId = new ConcurrentHashMap<>();
     } else {
       _queriesById = null;
       _clientQueryIds = null;
+      _requestIdsByClientQueryId = null;
     }
   }
 
@@ -407,6 +415,14 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   }
 
   @Override
+  @Nullable
+  public QueryProgressStats getQueryProgressStats(long queryId, int timeoutMs, Executor executor,
+      HttpClientConnectionManager connMgr)
+      throws Exception {
+    return null;
+  }
+
+  @Override
   public boolean cancelQuery(long queryId, int timeoutMs, Executor executor, HttpClientConnectionManager connMgr,
       Map<String, Integer> serverResponses)
       throws Exception {
@@ -434,10 +450,14 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
   @Override
   public OptionalLong getRequestIdByClientId(String clientQueryId) {
-    return _clientQueryIds.entrySet().stream()
-        .filter(e -> clientQueryId.equals(e.getValue()))
-        .mapToLong(Map.Entry::getKey)
-        .findFirst();
+    if (!isQueryTrackingEnabled()) {
+      return OptionalLong.empty();
+    }
+    Set<Long> requestIds = _requestIdsByClientQueryId.get(clientQueryId);
+    if (requestIds == null) {
+      return OptionalLong.empty();
+    }
+    return requestIds.stream().mapToLong(Long::longValue).findFirst();
   }
 
   @Nullable
@@ -450,10 +470,12 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   ///   But right now the semantics are not clear. For example, while MSE calls this method once, SSE calls it once per
   ///   query AND subquery, which means this method is called multiple times for the same query.
   protected void onQueryStart(long requestId, @Nullable String clientRequestId, String query, Object... extras) {
-    if (isQueryCancellationEnabled()) {
+    if (isQueryTrackingEnabled()) {
       _queriesById.put(requestId, query);
       if (StringUtils.isNotBlank(clientRequestId)) {
         _clientQueryIds.put(requestId, clientRequestId);
+        _requestIdsByClientQueryId.computeIfAbsent(clientRequestId, ignored -> ConcurrentHashMap.newKeySet())
+            .add(requestId);
         LOGGER.debug("Keep track of running query: {} (with client id {})", requestId, clientRequestId);
       } else {
         LOGGER.debug("Keep track of running query: {}", requestId);
@@ -462,14 +484,28 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   }
 
   protected void onQueryFinish(long requestId) {
-    if (isQueryCancellationEnabled()) {
+    if (isQueryTrackingEnabled()) {
       _queriesById.remove(requestId);
-      _clientQueryIds.remove(requestId);
+      String clientRequestId = _clientQueryIds.remove(requestId);
+      if (clientRequestId != null) {
+        _requestIdsByClientQueryId.computeIfPresent(clientRequestId, (ignored, requestIds) -> {
+          requestIds.remove(requestId);
+          return requestIds.isEmpty() ? null : requestIds;
+        });
+      }
       LOGGER.debug("Remove track of running query: {}", requestId);
     }
   }
 
   protected boolean isQueryCancellationEnabled() {
     return _enableQueryCancellation;
+  }
+
+  protected boolean isQueryProgressEnabled() {
+    return _enableQueryProgress;
+  }
+
+  protected boolean isQueryTrackingEnabled() {
+    return _enableQueryCancellation || _enableQueryProgress;
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -63,6 +63,7 @@ import org.apache.pinot.spi.eventlistener.query.BrokerQueryEventListener;
 import org.apache.pinot.spi.eventlistener.query.BrokerQueryEventListenerFactory;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
 import org.apache.pinot.spi.exception.QueryErrorCode;
+import org.apache.pinot.spi.query.QueryProgressStats;
 import org.apache.pinot.spi.trace.RequestContext;
 import org.apache.pinot.spi.utils.CommonConstants.Broker;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
@@ -94,6 +95,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   @Nullable
   protected final String _regexDictSizeThreshold;
   protected final boolean _enableQueryCancellation;
+  protected final boolean _enableQueryProgress;
   @Nullable
   protected final String _enableAutoRewriteAggregationType;
   @Nullable
@@ -103,6 +105,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   protected final Map<Long, String> _queriesById;
   /// Maps broker-generated query id to client-provided query id.
   protected final Map<Long, String> _clientQueryIds;
+  /// Reverse index for O(1) client-query-id lookup. A set preserves existing behavior when callers reuse an id.
+  protected final Map<String, Set<Long>> _requestIdsByClientQueryId;
 
   public BaseBrokerRequestHandler(PinotConfiguration config, String brokerId,
       BrokerRequestIdGenerator requestIdGenerator, RoutingManager routingManager,
@@ -128,14 +132,18 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     _regexDictSizeThreshold = config.getProperty(Broker.CONFIG_OF_BROKER_QUERY_REGEX_DICT_SIZE_THRESHOLD);
     _enableQueryCancellation = config.getProperty(Broker.CONFIG_OF_BROKER_ENABLE_QUERY_CANCELLATION,
         Broker.DEFAULT_BROKER_ENABLE_QUERY_CANCELLATION);
+    _enableQueryProgress = config.getProperty(Broker.CONFIG_OF_BROKER_QUERY_PROGRESS_ENABLED,
+        Broker.DEFAULT_BROKER_QUERY_PROGRESS_ENABLED);
     _enableAutoRewriteAggregationType =
         config.getProperty(Broker.CONFIG_OF_BROKER_QUERY_ENABLE_AUTO_REWRITE_AGGREGATION_TYPE);
-    if (_enableQueryCancellation) {
+    if (_enableQueryCancellation || _enableQueryProgress) {
       _queriesById = new ConcurrentHashMap<>();
       _clientQueryIds = new ConcurrentHashMap<>();
+      _requestIdsByClientQueryId = new ConcurrentHashMap<>();
     } else {
       _queriesById = null;
       _clientQueryIds = null;
+      _requestIdsByClientQueryId = null;
     }
   }
 
@@ -399,6 +407,14 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   }
 
   @Override
+  @Nullable
+  public QueryProgressStats getQueryProgressStats(long queryId, int timeoutMs, Executor executor,
+      HttpClientConnectionManager connMgr)
+      throws Exception {
+    return null;
+  }
+
+  @Override
   public boolean cancelQuery(long queryId, int timeoutMs, Executor executor, HttpClientConnectionManager connMgr,
       Map<String, Integer> serverResponses)
       throws Exception {
@@ -426,10 +442,14 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
   @Override
   public OptionalLong getRequestIdByClientId(String clientQueryId) {
-    return _clientQueryIds.entrySet().stream()
-        .filter(e -> clientQueryId.equals(e.getValue()))
-        .mapToLong(Map.Entry::getKey)
-        .findFirst();
+    if (!isQueryTrackingEnabled()) {
+      return OptionalLong.empty();
+    }
+    Set<Long> requestIds = _requestIdsByClientQueryId.get(clientQueryId);
+    if (requestIds == null) {
+      return OptionalLong.empty();
+    }
+    return requestIds.stream().mapToLong(Long::longValue).findFirst();
   }
 
   @Nullable
@@ -442,10 +462,12 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   ///   But right now the semantics are not clear. For example, while MSE calls this method once, SSE calls it once per
   ///   query AND subquery, which means this method is called multiple times for the same query.
   protected void onQueryStart(long requestId, @Nullable String clientRequestId, String query, Object... extras) {
-    if (isQueryCancellationEnabled()) {
+    if (isQueryTrackingEnabled()) {
       _queriesById.put(requestId, query);
       if (StringUtils.isNotBlank(clientRequestId)) {
         _clientQueryIds.put(requestId, clientRequestId);
+        _requestIdsByClientQueryId.computeIfAbsent(clientRequestId, ignored -> ConcurrentHashMap.newKeySet())
+            .add(requestId);
         LOGGER.debug("Keep track of running query: {} (with client id {})", requestId, clientRequestId);
       } else {
         LOGGER.debug("Keep track of running query: {}", requestId);
@@ -454,14 +476,28 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   }
 
   protected void onQueryFinish(long requestId) {
-    if (isQueryCancellationEnabled()) {
+    if (isQueryTrackingEnabled()) {
       _queriesById.remove(requestId);
-      _clientQueryIds.remove(requestId);
+      String clientRequestId = _clientQueryIds.remove(requestId);
+      if (clientRequestId != null) {
+        _requestIdsByClientQueryId.computeIfPresent(clientRequestId, (ignored, requestIds) -> {
+          requestIds.remove(requestId);
+          return requestIds.isEmpty() ? null : requestIds;
+        });
+      }
       LOGGER.debug("Remove track of running query: {}", requestId);
     }
   }
 
   protected boolean isQueryCancellationEnabled() {
     return _enableQueryCancellation;
+  }
+
+  protected boolean isQueryProgressEnabled() {
+    return _enableQueryProgress;
+  }
+
+  protected boolean isQueryTrackingEnabled() {
+    return _enableQueryCancellation || _enableQueryProgress;
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -125,6 +125,7 @@ import org.apache.pinot.spi.exception.DatabaseConflictException;
 import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.apache.pinot.spi.exception.QueryException;
 import org.apache.pinot.spi.query.QueryExecutionContext;
+import org.apache.pinot.spi.query.QueryProgressStats;
 import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.trace.QueryFingerprint;
 import org.apache.pinot.spi.trace.RequestContext;
@@ -132,6 +133,7 @@ import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.spi.utils.DataSizeUtils;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.sql.FilterKind;
 import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
@@ -208,7 +210,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
         _config.getProperty(CommonConstants.Helix.ENABLE_DISTINCT_COUNT_BITMAP_OVERRIDE_KEY, false);
     _queryResponseLimit =
         config.getProperty(Broker.CONFIG_OF_BROKER_QUERY_RESPONSE_LIMIT, Broker.DEFAULT_BROKER_QUERY_RESPONSE_LIMIT);
-    if (isQueryCancellationEnabled()) {
+    if (isQueryTrackingEnabled()) {
       _serversById = new ConcurrentHashMap<>();
     } else {
       _serversById = null;
@@ -283,7 +285,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
 
   @VisibleForTesting
   Set<ServerInstance> getRunningServers(long requestId) {
-    Preconditions.checkState(isQueryCancellationEnabled(), "Query cancellation is not enabled on broker");
+    Preconditions.checkState(isQueryTrackingEnabled(), "Query tracking is not enabled on broker");
     QueryServers queryServers = _serversById.get(requestId);
     return queryServers != null ? queryServers._servers : Set.of();
   }
@@ -291,7 +293,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
   @Override
   protected void onQueryFinish(long requestId) {
     super.onQueryFinish(requestId);
-    if (isQueryCancellationEnabled()) {
+    if (isQueryTrackingEnabled()) {
       _serversById.remove(requestId);
     }
   }
@@ -305,14 +307,12 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       return false;
     }
 
-    // TODO: Use different global query id for OFFLINE and REALTIME table after releasing 0.12.0. See QueryIdUtils for
-    //       details
-    String globalQueryId = getGlobalQueryId(queryId);
-    List<Pair<String, String>> serverUrls = new ArrayList<>();
-    for (ServerInstance serverInstance : queryServers._servers) {
-      // TODO: how should we add the cid here? Maybe as a query param?
-      //  we can get the cid from QueryThreadContext
-      serverUrls.add(Pair.of(String.format("%s/query/%s", serverInstance.getAdminEndpoint(), globalQueryId), null));
+    List<Pair<String, String>> serverUrls = new ArrayList<>(queryServers.numServerRequests());
+    for (Map.Entry<Long, Set<ServerInstance>> entry : queryServers._serversByRequestId.entrySet()) {
+      String globalQueryId = getGlobalQueryId(entry.getKey());
+      for (ServerInstance serverInstance : entry.getValue()) {
+        serverUrls.add(Pair.of(String.format("%s/query/%s", serverInstance.getAdminEndpoint(), globalQueryId), null));
+      }
     }
     LOGGER.debug("Cancelling the query: {} via server urls: {}", _queryLogger.redactQuery(queryServers._query),
         serverUrls);
@@ -352,6 +352,78 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       throw new Exception("Unexpected responses from servers: " + StringUtils.join(errMsgs, ","));
     }
     return true;
+  }
+
+  @Override
+  @Nullable
+  public QueryProgressStats getQueryProgressStats(long queryId, int timeoutMs, Executor executor,
+      HttpClientConnectionManager connMgr)
+      throws Exception {
+    if (!isQueryProgressEnabled()) {
+      return null;
+    }
+    QueryServers queryServers = _serversById.get(queryId);
+    if (queryServers == null) {
+      return null;
+    }
+
+    List<String> serverUrls = new ArrayList<>(queryServers.numServerRequests());
+    for (Map.Entry<Long, Set<ServerInstance>> entry : queryServers._serversByRequestId.entrySet()) {
+      String globalQueryId = getGlobalQueryId(entry.getKey());
+      for (ServerInstance serverInstance : entry.getValue()) {
+        serverUrls.add(String.format("%s/query/%s/progress", serverInstance.getAdminEndpoint(), globalQueryId));
+      }
+    }
+    if (serverUrls.isEmpty()) {
+      return null;
+    }
+
+    CompletionService<MultiHttpRequestResponse> completionService =
+        new MultiHttpRequest(executor, connMgr).executeGet(serverUrls, null, timeoutMs);
+    List<QueryProgressStats> serverProgressStats = new ArrayList<>(serverUrls.size());
+    List<String> errMsgs = new ArrayList<>(serverUrls.size());
+    for (int i = 0; i < serverUrls.size(); i++) {
+      MultiHttpRequestResponse httpRequestResponse = null;
+      URI uri = null;
+      try {
+        httpRequestResponse = completionService.take().get();
+        uri = httpRequestResponse.getURI();
+        int status = httpRequestResponse.getResponse().getCode();
+        if (status == 200) {
+          String responseString = EntityUtils.toString(httpRequestResponse.getResponse().getEntity());
+          serverProgressStats.add(JsonUtils.stringToObject(responseString, QueryProgressStats.class));
+        } else if (status != 404) {
+          String responseString = EntityUtils.toString(httpRequestResponse.getResponse().getEntity());
+          throw new Exception(
+              String.format("Unexpected status=%d and response='%s' from uri='%s'", status, responseString, uri));
+        }
+      } catch (Exception e) {
+        LOGGER.debug("Failed to get progress for query id: {} from uri: {}", queryId, uri, e);
+        errMsgs.add(e.getMessage());
+      } finally {
+        if (httpRequestResponse != null) {
+          httpRequestResponse.close();
+        }
+      }
+    }
+    return aggregateSingleStageProgressStats(serverProgressStats, serverUrls.size(), errMsgs);
+  }
+
+  @Nullable
+  static QueryProgressStats aggregateSingleStageProgressStats(List<QueryProgressStats> serverProgressStats,
+      int numServers, List<String> errMsgs)
+      throws Exception {
+    if (!serverProgressStats.isEmpty()) {
+      List<QueryProgressStats> progressStats = new ArrayList<>(serverProgressStats);
+      for (int i = serverProgressStats.size(); i < numServers; i++) {
+        progressStats.add(QueryProgressStats.unknown("Server", true));
+      }
+      return QueryProgressStats.aggregate(progressStats);
+    }
+    if (!errMsgs.isEmpty()) {
+      throw new Exception("Unexpected responses from servers: " + StringUtils.join(errMsgs, ","));
+    }
+    return null;
   }
 
   @Override
@@ -986,7 +1058,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       }
     }
     BrokerResponseNative brokerResponse;
-    if (isQueryCancellationEnabled()) {
+    if (isQueryTrackingEnabled()) {
       // Start to track the running query for cancellation just before sending it out to servers to avoid any
       // potential failures that could happen before sending it out, like failures to calculate the routing table etc.
       // TODO: Even tracking the query as late as here, a potential race condition between calling cancel API and
@@ -997,7 +1069,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       //       servers takes time, but will address later if needed.
       String clientRequestId = extractClientRequestId(sqlNodeAndOptions);
       onQueryStart(requestId, clientRequestId, query,
-          new QueryServers(query, offlineExecutionServers, realtimeExecutionServers));
+          new QueryServers(query, requestId, offlineExecutionServers, realtimeExecutionServers));
       try {
         brokerResponse = processBrokerRequest(requestId, brokerRequest, serverBrokerRequest, routeInfo,
             remainingTimeMs, serverStats, requestContext);
@@ -1467,7 +1539,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
   @Override
   protected void onQueryStart(long requestId, @Nullable String clientRequestId, String query, Object... extras) {
     super.onQueryStart(requestId, clientRequestId, query, extras);
-    if (isQueryCancellationEnabled() && extras.length > 0 && extras[0] instanceof QueryServers) {
+    if (isQueryTrackingEnabled() && extras.length > 0 && extras[0] instanceof QueryServers) {
       _serversById.put(requestId, (QueryServers) extras[0]);
     }
   }
@@ -1656,9 +1728,10 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       }
 
       // Pass false for queryWasLogged to avoid logging subqueries separately
+      long subqueryRequestId = _requestIdGenerator.get();
       BrokerResponse response =
-          doHandleRequest(requestId, subquery, sqlNodeAndOptions, jsonRequest, requesterIdentity, requestContext,
-              httpHeaders, accessControl, false);
+          doHandleRequest(subqueryRequestId, subquery, sqlNodeAndOptions, jsonRequest, requesterIdentity,
+              requestContext, httpHeaders, accessControl, false);
       if (response.getExceptionsSize() != 0) {
         throw new RuntimeException("Caught exception while executing subquery: " + subquery);
       }
@@ -2571,17 +2644,13 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
     }
 
     long materializedViewRequestId = _requestIdGenerator.get();
-    if (isQueryCancellationEnabled()) {
-      /// Track the union of base + MV server sets against the user's `requestId`.  Cancel will
-      /// be sent under the user's global query id; the MV-side servers may already have
-      /// finished by the time cancel fires, but they would not be reached by global-id cancel
-      /// anyway (they ran under `materializedViewRequestId`).  Improving per-sub-request cancel
-      /// is out of scope for this PR — see the TODO in `handleCancel` for the eventual fix.
-      Set<ServerInstance> offlineUnion =
-          unionServers(hybridBaseRoute.getOfflineExecutionServers(), viewRouteInfo.getOfflineExecutionServers());
-      Set<ServerInstance> realtimeUnion =
-          unionServers(hybridBaseRoute.getRealtimeExecutionServers(), viewRouteInfo.getRealtimeExecutionServers());
-      onQueryStart(requestId, clientRequestId, query, new QueryServers(query, offlineUnion, realtimeUnion));
+    if (isQueryTrackingEnabled()) {
+      QueryServers queryServers = new QueryServers(query);
+      queryServers.addRequest(requestId, hybridBaseRoute.getOfflineExecutionServers(),
+          hybridBaseRoute.getRealtimeExecutionServers());
+      queryServers.addRequest(materializedViewRequestId, viewRouteInfo.getOfflineExecutionServers(),
+          viewRouteInfo.getRealtimeExecutionServers());
+      onQueryStart(requestId, clientRequestId, query, queryServers);
       try {
         return processMaterializedViewSplitBrokerRequest(requestId, materializedViewRequestId, reduceBrokerRequest,
             hybridBaseRoute, viewRouteInfo, timeoutMs, serverStats, requestContext);
@@ -2763,19 +2832,36 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
   }
 
   /// Helper class to track the query plaintext and the requested servers.
-  private static class QueryServers {
+  @VisibleForTesting
+  static class QueryServers {
     final String _query;
     final Set<ServerInstance> _servers = new HashSet<>();
+    final Map<Long, Set<ServerInstance>> _serversByRequestId = new HashMap<>();
 
-    QueryServers(String query, @Nullable Set<ServerInstance> offlineExecutionServers,
-        @Nullable Set<ServerInstance> realtimeExecutionServers) {
+    QueryServers(String query) {
       _query = query;
+    }
+
+    QueryServers(String query, long requestId, @Nullable Set<ServerInstance> offlineExecutionServers,
+        @Nullable Set<ServerInstance> realtimeExecutionServers) {
+      this(query);
+      addRequest(requestId, offlineExecutionServers, realtimeExecutionServers);
+    }
+
+    void addRequest(long requestId, @Nullable Set<ServerInstance> offlineExecutionServers,
+        @Nullable Set<ServerInstance> realtimeExecutionServers) {
+      Set<ServerInstance> requestServers = _serversByRequestId.computeIfAbsent(requestId, ignored -> new HashSet<>());
       if (offlineExecutionServers != null) {
-        _servers.addAll(offlineExecutionServers);
+        requestServers.addAll(offlineExecutionServers);
       }
       if (realtimeExecutionServers != null) {
-        _servers.addAll(realtimeExecutionServers);
+        requestServers.addAll(realtimeExecutionServers);
       }
+      _servers.addAll(requestServers);
+    }
+
+    int numServerRequests() {
+      return _serversByRequestId.values().stream().mapToInt(Set::size).sum();
     }
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -122,6 +122,7 @@ import org.apache.pinot.spi.exception.DatabaseConflictException;
 import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.apache.pinot.spi.exception.QueryException;
 import org.apache.pinot.spi.query.QueryExecutionContext;
+import org.apache.pinot.spi.query.QueryProgressStats;
 import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.trace.QueryFingerprint;
 import org.apache.pinot.spi.trace.RequestContext;
@@ -129,6 +130,7 @@ import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.spi.utils.DataSizeUtils;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.sql.FilterKind;
 import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
@@ -200,7 +202,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
         _config.getProperty(CommonConstants.Helix.ENABLE_DISTINCT_COUNT_BITMAP_OVERRIDE_KEY, false);
     _queryResponseLimit =
         config.getProperty(Broker.CONFIG_OF_BROKER_QUERY_RESPONSE_LIMIT, Broker.DEFAULT_BROKER_QUERY_RESPONSE_LIMIT);
-    if (isQueryCancellationEnabled()) {
+    if (isQueryTrackingEnabled()) {
       _serversById = new ConcurrentHashMap<>();
     } else {
       _serversById = null;
@@ -275,7 +277,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
 
   @VisibleForTesting
   Set<ServerInstance> getRunningServers(long requestId) {
-    Preconditions.checkState(isQueryCancellationEnabled(), "Query cancellation is not enabled on broker");
+    Preconditions.checkState(isQueryTrackingEnabled(), "Query tracking is not enabled on broker");
     QueryServers queryServers = _serversById.get(requestId);
     return queryServers != null ? queryServers._servers : Set.of();
   }
@@ -283,7 +285,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
   @Override
   protected void onQueryFinish(long requestId) {
     super.onQueryFinish(requestId);
-    if (isQueryCancellationEnabled()) {
+    if (isQueryTrackingEnabled()) {
       _serversById.remove(requestId);
     }
   }
@@ -297,14 +299,12 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       return false;
     }
 
-    // TODO: Use different global query id for OFFLINE and REALTIME table after releasing 0.12.0. See QueryIdUtils for
-    //       details
-    String globalQueryId = getGlobalQueryId(queryId);
-    List<Pair<String, String>> serverUrls = new ArrayList<>();
-    for (ServerInstance serverInstance : queryServers._servers) {
-      // TODO: how should we add the cid here? Maybe as a query param?
-      //  we can get the cid from QueryThreadContext
-      serverUrls.add(Pair.of(String.format("%s/query/%s", serverInstance.getAdminEndpoint(), globalQueryId), null));
+    List<Pair<String, String>> serverUrls = new ArrayList<>(queryServers.numServerRequests());
+    for (Map.Entry<Long, Set<ServerInstance>> entry : queryServers._serversByRequestId.entrySet()) {
+      String globalQueryId = getGlobalQueryId(entry.getKey());
+      for (ServerInstance serverInstance : entry.getValue()) {
+        serverUrls.add(Pair.of(String.format("%s/query/%s", serverInstance.getAdminEndpoint(), globalQueryId), null));
+      }
     }
     LOGGER.debug("Cancelling the query: {} via server urls: {}", _queryLogger.redactQuery(queryServers._query),
         serverUrls);
@@ -343,6 +343,78 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       throw new Exception("Unexpected responses from servers: " + StringUtils.join(errMsgs, ","));
     }
     return true;
+  }
+
+  @Override
+  @Nullable
+  public QueryProgressStats getQueryProgressStats(long queryId, int timeoutMs, Executor executor,
+      HttpClientConnectionManager connMgr)
+      throws Exception {
+    if (!isQueryProgressEnabled()) {
+      return null;
+    }
+    QueryServers queryServers = _serversById.get(queryId);
+    if (queryServers == null) {
+      return null;
+    }
+
+    List<String> serverUrls = new ArrayList<>(queryServers.numServerRequests());
+    for (Map.Entry<Long, Set<ServerInstance>> entry : queryServers._serversByRequestId.entrySet()) {
+      String globalQueryId = getGlobalQueryId(entry.getKey());
+      for (ServerInstance serverInstance : entry.getValue()) {
+        serverUrls.add(String.format("%s/query/%s/progress", serverInstance.getAdminEndpoint(), globalQueryId));
+      }
+    }
+    if (serverUrls.isEmpty()) {
+      return null;
+    }
+
+    CompletionService<MultiHttpRequestResponse> completionService =
+        new MultiHttpRequest(executor, connMgr).executeGet(serverUrls, null, timeoutMs);
+    List<QueryProgressStats> serverProgressStats = new ArrayList<>(serverUrls.size());
+    List<String> errMsgs = new ArrayList<>(serverUrls.size());
+    for (int i = 0; i < serverUrls.size(); i++) {
+      MultiHttpRequestResponse httpRequestResponse = null;
+      URI uri = null;
+      try {
+        httpRequestResponse = completionService.take().get();
+        uri = httpRequestResponse.getURI();
+        int status = httpRequestResponse.getResponse().getCode();
+        if (status == 200) {
+          String responseString = EntityUtils.toString(httpRequestResponse.getResponse().getEntity());
+          serverProgressStats.add(JsonUtils.stringToObject(responseString, QueryProgressStats.class));
+        } else if (status != 404) {
+          String responseString = EntityUtils.toString(httpRequestResponse.getResponse().getEntity());
+          throw new Exception(
+              String.format("Unexpected status=%d and response='%s' from uri='%s'", status, responseString, uri));
+        }
+      } catch (Exception e) {
+        LOGGER.debug("Failed to get progress for query id: {} from uri: {}", queryId, uri, e);
+        errMsgs.add(e.getMessage());
+      } finally {
+        if (httpRequestResponse != null) {
+          httpRequestResponse.close();
+        }
+      }
+    }
+    return aggregateSingleStageProgressStats(serverProgressStats, serverUrls.size(), errMsgs);
+  }
+
+  @Nullable
+  static QueryProgressStats aggregateSingleStageProgressStats(List<QueryProgressStats> serverProgressStats,
+      int numServers, List<String> errMsgs)
+      throws Exception {
+    if (!serverProgressStats.isEmpty()) {
+      List<QueryProgressStats> progressStats = new ArrayList<>(serverProgressStats);
+      for (int i = serverProgressStats.size(); i < numServers; i++) {
+        progressStats.add(QueryProgressStats.unknown("Server", true));
+      }
+      return QueryProgressStats.aggregate(progressStats);
+    }
+    if (!errMsgs.isEmpty()) {
+      throw new Exception("Unexpected responses from servers: " + StringUtils.join(errMsgs, ","));
+    }
+    return null;
   }
 
   @Override
@@ -949,7 +1021,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       }
     }
     BrokerResponseNative brokerResponse;
-    if (isQueryCancellationEnabled()) {
+    if (isQueryTrackingEnabled()) {
       // Start to track the running query for cancellation just before sending it out to servers to avoid any
       // potential failures that could happen before sending it out, like failures to calculate the routing table etc.
       // TODO: Even tracking the query as late as here, a potential race condition between calling cancel API and
@@ -960,7 +1032,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       //       servers takes time, but will address later if needed.
       String clientRequestId = extractClientRequestId(sqlNodeAndOptions);
       onQueryStart(requestId, clientRequestId, query,
-          new QueryServers(query, offlineExecutionServers, realtimeExecutionServers));
+          new QueryServers(query, requestId, offlineExecutionServers, realtimeExecutionServers));
       try {
         brokerResponse = processBrokerRequest(requestId, brokerRequest, serverBrokerRequest, routeInfo,
             remainingTimeMs, serverStats, requestContext);
@@ -1422,7 +1494,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
   @Override
   protected void onQueryStart(long requestId, @Nullable String clientRequestId, String query, Object... extras) {
     super.onQueryStart(requestId, clientRequestId, query, extras);
-    if (isQueryCancellationEnabled() && extras.length > 0 && extras[0] instanceof QueryServers) {
+    if (isQueryTrackingEnabled() && extras.length > 0 && extras[0] instanceof QueryServers) {
       _serversById.put(requestId, (QueryServers) extras[0]);
     }
   }
@@ -1611,9 +1683,10 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       }
 
       // Pass false for queryWasLogged to avoid logging subqueries separately
+      long subqueryRequestId = _requestIdGenerator.get();
       BrokerResponse response =
-          doHandleRequest(requestId, subquery, sqlNodeAndOptions, jsonRequest, requesterIdentity, requestContext,
-              httpHeaders, accessControl, false);
+          doHandleRequest(subqueryRequestId, subquery, sqlNodeAndOptions, jsonRequest, requesterIdentity,
+              requestContext, httpHeaders, accessControl, false);
       if (response.getExceptionsSize() != 0) {
         throw new RuntimeException("Caught exception while executing subquery: " + subquery);
       }
@@ -2482,17 +2555,13 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
     }
 
     long materializedViewRequestId = _requestIdGenerator.get();
-    if (isQueryCancellationEnabled()) {
-      /// Track the union of base + MV server sets against the user's `requestId`.  Cancel will
-      /// be sent under the user's global query id; the MV-side servers may already have
-      /// finished by the time cancel fires, but they would not be reached by global-id cancel
-      /// anyway (they ran under `materializedViewRequestId`).  Improving per-sub-request cancel
-      /// is out of scope for this PR — see the TODO in `handleCancel` for the eventual fix.
-      Set<ServerInstance> offlineUnion =
-          unionServers(hybridBaseRoute.getOfflineExecutionServers(), viewRouteInfo.getOfflineExecutionServers());
-      Set<ServerInstance> realtimeUnion =
-          unionServers(hybridBaseRoute.getRealtimeExecutionServers(), viewRouteInfo.getRealtimeExecutionServers());
-      onQueryStart(requestId, clientRequestId, query, new QueryServers(query, offlineUnion, realtimeUnion));
+    if (isQueryTrackingEnabled()) {
+      QueryServers queryServers = new QueryServers(query);
+      queryServers.addRequest(requestId, hybridBaseRoute.getOfflineExecutionServers(),
+          hybridBaseRoute.getRealtimeExecutionServers());
+      queryServers.addRequest(materializedViewRequestId, viewRouteInfo.getOfflineExecutionServers(),
+          viewRouteInfo.getRealtimeExecutionServers());
+      onQueryStart(requestId, clientRequestId, query, queryServers);
       try {
         return processMaterializedViewSplitBrokerRequest(requestId, materializedViewRequestId, reduceBrokerRequest,
             hybridBaseRoute, viewRouteInfo, timeoutMs, serverStats, requestContext);
@@ -2674,19 +2743,36 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
   }
 
   /// Helper class to track the query plaintext and the requested servers.
-  private static class QueryServers {
+  @VisibleForTesting
+  static class QueryServers {
     final String _query;
     final Set<ServerInstance> _servers = new HashSet<>();
+    final Map<Long, Set<ServerInstance>> _serversByRequestId = new HashMap<>();
 
-    QueryServers(String query, @Nullable Set<ServerInstance> offlineExecutionServers,
-        @Nullable Set<ServerInstance> realtimeExecutionServers) {
+    QueryServers(String query) {
       _query = query;
+    }
+
+    QueryServers(String query, long requestId, @Nullable Set<ServerInstance> offlineExecutionServers,
+        @Nullable Set<ServerInstance> realtimeExecutionServers) {
+      this(query);
+      addRequest(requestId, offlineExecutionServers, realtimeExecutionServers);
+    }
+
+    void addRequest(long requestId, @Nullable Set<ServerInstance> offlineExecutionServers,
+        @Nullable Set<ServerInstance> realtimeExecutionServers) {
+      Set<ServerInstance> requestServers = _serversByRequestId.computeIfAbsent(requestId, ignored -> new HashSet<>());
       if (offlineExecutionServers != null) {
-        _servers.addAll(offlineExecutionServers);
+        requestServers.addAll(offlineExecutionServers);
       }
       if (realtimeExecutionServers != null) {
-        _servers.addAll(realtimeExecutionServers);
+        requestServers.addAll(realtimeExecutionServers);
       }
+      _servers.addAll(requestServers);
+    }
+
+    int numServerRequests() {
+      return _serversByRequestId.values().stream().mapToInt(Set::size).sum();
     }
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandler.java
@@ -31,6 +31,7 @@ import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.pinot.common.response.BrokerResponse;
 import org.apache.pinot.spi.auth.broker.RequesterIdentity;
 import org.apache.pinot.spi.exception.QueryException;
+import org.apache.pinot.spi.query.QueryProgressStats;
 import org.apache.pinot.spi.trace.RequestContext;
 import org.apache.pinot.spi.trace.RequestScope;
 import org.apache.pinot.spi.trace.Tracing;
@@ -77,6 +78,14 @@ public interface BrokerRequestHandler {
   }
 
   Map<Long, String> getRunningQueries();
+
+  /// Returns progress for a running query, or `null` if the query is not running or progress is disabled. Single-stage
+  /// progress uses selected segments as work units. Multi-stage progress also includes stage op-chains and may contain
+  /// component detail rows.
+  @Nullable
+  QueryProgressStats getQueryProgressStats(long queryId, int timeoutMs, Executor executor,
+      HttpClientConnectionManager connMgr)
+      throws Exception;
 
   /// Cancel a query as identified by the queryId. This method is non-blocking so the query may still run for a while
   /// after calling this method. This cancel method can be called multiple times.

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
@@ -35,6 +35,7 @@ import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.spi.auth.broker.RequesterIdentity;
 import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.apache.pinot.spi.exception.QueryException;
+import org.apache.pinot.spi.query.QueryProgressStats;
 import org.apache.pinot.spi.trace.RequestContext;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request;
 import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
@@ -155,6 +156,22 @@ public class BrokerRequestHandlerDelegate implements BrokerRequestHandler {
       queries.putAll(_multiStageBrokerRequestHandler.getRunningQueries());
     }
     return queries;
+  }
+
+  @Override
+  @Nullable
+  public QueryProgressStats getQueryProgressStats(long queryId, int timeoutMs, Executor executor,
+      HttpClientConnectionManager connMgr)
+      throws Exception {
+    // Both engines share the same request ID generator, so the query will have unique IDs across the two engines.
+    if (_multiStageBrokerRequestHandler != null) {
+      QueryProgressStats mseProgressStats =
+          _multiStageBrokerRequestHandler.getQueryProgressStats(queryId, timeoutMs, executor, connMgr);
+      if (mseProgressStats != null) {
+        return mseProgressStats;
+      }
+    }
+    return _singleStageBrokerRequestHandler.getQueryProgressStats(queryId, timeoutMs, executor, connMgr);
   }
 
   @Override

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -33,6 +33,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -100,6 +101,7 @@ import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.apache.pinot.spi.exception.QueryException;
 import org.apache.pinot.spi.metrics.PinotMeter;
 import org.apache.pinot.spi.query.QueryExecutionContext;
+import org.apache.pinot.spi.query.QueryProgressStats;
 import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.trace.QueryFingerprint;
 import org.apache.pinot.spi.trace.RequestContext;
@@ -136,6 +138,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
   private final WorkerManager _multiClusterWorkerManager;
   private final MailboxService _mailboxService;
   private final QueryDispatcher _queryDispatcher;
+  private final Map<Long, QueryExecutionContext> _executionContextsById;
   @Nullable
   private final ServerRoutingStatsManager _serverRoutingStatsManager;
   private final boolean _explainAskingServerDefault;
@@ -210,9 +213,10 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
         CommonConstants.Broker.DEFAULT_STREAM_STATS_DRAIN_MS);
     _mailboxService = new MailboxService(hostname, port, InstanceType.BROKER, config, tlsConfig);
     _queryDispatcher =
-        new QueryDispatcher(_mailboxService, failureDetector, tlsConfig, isQueryCancellationEnabled(), cancelTimeout,
-            dispatchKeepAliveTimeMs, dispatchKeepAliveTimeoutMs, dispatchKeepAliveWithoutCalls, _streamStatsDefault,
-            streamStatsDrainMs);
+        new QueryDispatcher(_mailboxService, failureDetector, tlsConfig, isQueryCancellationEnabled(),
+            isQueryProgressEnabled(), cancelTimeout, dispatchKeepAliveTimeMs, dispatchKeepAliveTimeoutMs,
+            dispatchKeepAliveWithoutCalls, _streamStatsDefault, streamStatsDrainMs);
+    _executionContextsById = new ConcurrentHashMap<>();
     LOGGER.info("Initialized MultiStageBrokerRequestHandler on host: {}, port: {} with broker id: {}, timeout: {}ms, "
             + "query log max length: {}, query log max rate: {}, query cancellation enabled: {}", hostname, port,
         _brokerId, _brokerTimeoutMs, _queryLogger.getMaxQueryLengthToLog(), _queryLogger.getLogRateLimit(),
@@ -282,6 +286,40 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
   public void shutDown() {
     _queryCompileExecutor.shutdown();
     _queryDispatcher.shutdown();
+  }
+
+  @Override
+  @Nullable
+  public QueryProgressStats getQueryProgressStats(long queryId, int timeoutMs, Executor executor,
+      HttpClientConnectionManager connMgr) {
+    if (!isQueryProgressEnabled()) {
+      return null;
+    }
+    QueryExecutionContext executionContext = _executionContextsById.get(queryId);
+    if (executionContext == null) {
+      return null;
+    }
+    List<QueryProgressStats> progressStatsList = new ArrayList<>(2);
+    List<QueryProgressStats> details = new ArrayList<>(4);
+    QueryProgressStats brokerProgressStats = executionContext.getProgressStats().withLabel("Broker");
+    progressStatsList.add(brokerProgressStats);
+    details.add(brokerProgressStats);
+    QueryProgressStats serverProgressStats = _queryDispatcher.getQueryProgressStats(queryId, timeoutMs);
+    if (serverProgressStats != null) {
+      progressStatsList.add(serverProgressStats);
+      if (serverProgressStats.getDetails().isEmpty()) {
+        details.add(serverProgressStats.withLabel("Servers"));
+      } else {
+        details.addAll(serverProgressStats.getDetails());
+      }
+    }
+    return QueryProgressStats.aggregate(progressStatsList).withLabel("Query").withDetails(details);
+  }
+
+  @Override
+  protected void onQueryFinish(long requestId) {
+    super.onQueryFinish(requestId);
+    _executionContextsById.remove(requestId);
   }
 
   @Override
@@ -729,6 +767,11 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
 
     try {
       String clientRequestId = extractClientRequestId(query.getSqlNodeAndOptions());
+      QueryExecutionContext executionContext = QueryThreadContext.get().getExecutionContext();
+      executionContext.addTotalWorkUnits(1);
+      if (isQueryProgressEnabled()) {
+        _executionContextsById.put(requestId, executionContext);
+      }
       onQueryStart(requestId, clientRequestId, query.getTextQuery());
       long executionStartTimeNs = System.nanoTime();
 
@@ -739,6 +782,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       if (allLeafStagesEmpty) {
         try {
           queryResults = QueryDispatcher.runReducer(dispatchableSubPlan, query.getOptions(), _mailboxService);
+          executionContext.incrementProcessedWorkUnits();
         } catch (QueryException e) {
           // Re-throw typed errors (auth, validation, etc.) so they propagate with their
           // original error codes, matching the dispatch branch behavior.
@@ -764,6 +808,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
         try {
           queryResults = _queryDispatcher.submitAndReduce(requestContext, dispatchableSubPlan,
               timer.getRemainingTimeMs(), query.getOptions(), _serverRoutingStatsManager);
+          executionContext.incrementProcessedWorkUnits();
         } catch (QueryException e) {
           throw e;
         } catch (Throwable t) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -33,6 +33,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -100,6 +101,7 @@ import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.apache.pinot.spi.exception.QueryException;
 import org.apache.pinot.spi.metrics.PinotMeter;
 import org.apache.pinot.spi.query.QueryExecutionContext;
+import org.apache.pinot.spi.query.QueryProgressStats;
 import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.trace.QueryFingerprint;
 import org.apache.pinot.spi.trace.RequestContext;
@@ -136,6 +138,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
   private final WorkerManager _multiClusterWorkerManager;
   private final MailboxService _mailboxService;
   private final QueryDispatcher _queryDispatcher;
+  private final Map<Long, QueryExecutionContext> _executionContextsById;
   @Nullable
   private final ServerRoutingStatsManager _serverRoutingStatsManager;
   private final boolean _explainAskingServerDefault;
@@ -212,9 +215,10 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
         CommonConstants.Broker.DEFAULT_STREAM_STATS_DRAIN_MS);
     _mailboxService = new MailboxService(hostname, port, InstanceType.BROKER, config, tlsConfig);
     _queryDispatcher =
-        new QueryDispatcher(_mailboxService, failureDetector, tlsConfig, isQueryCancellationEnabled(), cancelTimeout,
-            dispatchKeepAliveTimeMs, dispatchKeepAliveTimeoutMs, dispatchKeepAliveWithoutCalls, _streamStatsDefault,
-            streamStatsDrainMs);
+        new QueryDispatcher(_mailboxService, failureDetector, tlsConfig, isQueryCancellationEnabled(),
+            isQueryProgressEnabled(), cancelTimeout, dispatchKeepAliveTimeMs, dispatchKeepAliveTimeoutMs,
+            dispatchKeepAliveWithoutCalls, _streamStatsDefault, streamStatsDrainMs);
+    _executionContextsById = new ConcurrentHashMap<>();
     LOGGER.info("Initialized MultiStageBrokerRequestHandler on host: {}, port: {} with broker id: {}, timeout: {}ms, "
             + "query log max length: {}, query log max rate: {}, query cancellation enabled: {}", hostname, port,
         _brokerId, _brokerTimeoutMs, _queryLogger.getMaxQueryLengthToLog(), _queryLogger.getLogRateLimit(),
@@ -289,6 +293,40 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
   public void shutDown() {
     _queryCompileExecutor.shutdown();
     _queryDispatcher.shutdown();
+  }
+
+  @Override
+  @Nullable
+  public QueryProgressStats getQueryProgressStats(long queryId, int timeoutMs, Executor executor,
+      HttpClientConnectionManager connMgr) {
+    if (!isQueryProgressEnabled()) {
+      return null;
+    }
+    QueryExecutionContext executionContext = _executionContextsById.get(queryId);
+    if (executionContext == null) {
+      return null;
+    }
+    List<QueryProgressStats> progressStatsList = new ArrayList<>(2);
+    List<QueryProgressStats> details = new ArrayList<>(4);
+    QueryProgressStats brokerProgressStats = executionContext.getProgressStats().withLabel("Broker");
+    progressStatsList.add(brokerProgressStats);
+    details.add(brokerProgressStats);
+    QueryProgressStats serverProgressStats = _queryDispatcher.getQueryProgressStats(queryId, timeoutMs);
+    if (serverProgressStats != null) {
+      progressStatsList.add(serverProgressStats);
+      if (serverProgressStats.getDetails().isEmpty()) {
+        details.add(serverProgressStats.withLabel("Servers"));
+      } else {
+        details.addAll(serverProgressStats.getDetails());
+      }
+    }
+    return QueryProgressStats.aggregate(progressStatsList).withLabel("Query").withDetails(details);
+  }
+
+  @Override
+  protected void onQueryFinish(long requestId) {
+    super.onQueryFinish(requestId);
+    _executionContextsById.remove(requestId);
   }
 
   @Override
@@ -740,6 +778,11 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
 
     try {
       String clientRequestId = extractClientRequestId(query.getSqlNodeAndOptions());
+      QueryExecutionContext executionContext = QueryThreadContext.get().getExecutionContext();
+      executionContext.addTotalWorkUnits(1);
+      if (isQueryProgressEnabled()) {
+        _executionContextsById.put(requestId, executionContext);
+      }
       onQueryStart(requestId, clientRequestId, query.getTextQuery());
       long executionStartTimeNs = System.nanoTime();
 
@@ -750,6 +793,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       if (allLeafStagesEmpty) {
         try {
           queryResults = QueryDispatcher.runReducer(dispatchableSubPlan, query.getOptions(), _mailboxService);
+          executionContext.incrementProcessedWorkUnits();
         } catch (QueryException e) {
           // Re-throw typed errors (auth, validation, etc.) so they propagate with their
           // original error codes, matching the dispatch branch behavior.
@@ -775,6 +819,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
         try {
           queryResults = _queryDispatcher.submitAndReduce(requestContext, dispatchableSubPlan,
               timer.getRemainingTimeMs(), query.getOptions(), _serverRoutingStatsManager);
+          executionContext.incrementProcessedWorkUnits();
         } catch (QueryException e) {
           throw e;
         } catch (Throwable t) {

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandlerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandlerTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.broker.requesthandler;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -25,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.broker.api.AccessControl;
@@ -40,6 +43,8 @@ import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.response.BrokerResponse;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.routing.RoutingTable;
 import org.apache.pinot.core.routing.SegmentsToQuery;
 import org.apache.pinot.core.routing.TableRouteInfo;
@@ -67,11 +72,15 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.eventlistener.query.BrokerQueryEventListenerFactory;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
+import org.apache.pinot.spi.query.QueryProgressStats;
 import org.apache.pinot.spi.trace.LoggerConstants;
 import org.apache.pinot.spi.trace.RequestContext;
+import org.apache.pinot.spi.trace.RequestScope;
+import org.apache.pinot.spi.trace.Tracing;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker;
 import org.apache.pinot.spi.utils.CommonConstants.Query.Range;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.sql.FilterKind;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
@@ -95,6 +104,35 @@ public class BaseSingleStageBrokerRequestHandlerTest {
   @AfterMethod
   public void cleanupMdc() {
     MDC.clear();
+  }
+
+  @Test
+  public void testSingleStageProgressMarksPartialServerResponsesUnknown()
+      throws Exception {
+    QueryProgressStats progressStats = BaseSingleStageBrokerRequestHandler.aggregateSingleStageProgressStats(
+        List.of(new QueryProgressStats(4, 10, 4, 10, false)), 2, List.of("timeout"));
+
+    Assert.assertEquals(progressStats.getProcessedWorkUnits(), 4);
+    Assert.assertEquals(progressStats.getTotalWorkUnits(), -1);
+    Assert.assertEquals(progressStats.getProcessedSegments(), 4);
+    Assert.assertEquals(progressStats.getTotalSegmentsToProcess(), -1);
+    Assert.assertEquals(progressStats.getProgressPercent(), -1.0);
+    Assert.assertTrue(progressStats.isEstimated());
+    Assert.assertTrue(progressStats.getDetails().isEmpty());
+  }
+
+  @Test
+  public void testMaterializedViewProgressTracksSubRequestIds() {
+    ServerInstance baseServer = new ServerInstance(new InstanceConfig("baseServer_9000"));
+    ServerInstance viewServer = new ServerInstance(new InstanceConfig("viewServer_9000"));
+    BaseSingleStageBrokerRequestHandler.QueryServers queryServers =
+        new BaseSingleStageBrokerRequestHandler.QueryServers("query", 11L, Set.of(baseServer), null);
+
+    queryServers.addRequest(12L, Set.of(viewServer), null);
+
+    Assert.assertEquals(queryServers._serversByRequestId.get(11L), Set.of(baseServer));
+    Assert.assertEquals(queryServers._serversByRequestId.get(12L), Set.of(viewServer));
+    Assert.assertEquals(queryServers.numServerRequests(), 2);
   }
 
   @Test
@@ -358,6 +396,114 @@ public class BaseSingleStageBrokerRequestHandlerTest {
     Assert.assertEquals(servers.iterator().next().getInstanceId(), "server01_9000");
     Assert.assertEquals(servers.iterator().next().getAdminEndpoint(), "http://server01:8097");
     latch.countDown();
+  }
+
+  @Test
+  public void testInSubqueryUsesDistinctRequestIdForTracking()
+      throws Exception {
+    String tableName = "myTable_OFFLINE";
+    String rawTableName = "myTable";
+    String clientQueryId = "client-subquery-progress";
+
+    TableCache tableCache = mock(TableCache.class);
+    TableConfig tableCfg = mock(TableConfig.class);
+    when(tableCache.getActualTableName(anyString())).thenReturn(tableName);
+    Schema schema = new Schema.SchemaBuilder()
+        .setSchemaName(rawTableName)
+        .addSingleValueDimension("airlineID", DataType.INT)
+        .addSingleValueDimension("Carrier", DataType.STRING)
+        .build();
+    when(tableCache.getSchema(rawTableName)).thenReturn(schema);
+    when(tableCache.getColumnNameMap(rawTableName)).thenReturn(
+        Map.of("airlineID", "airlineID", "Carrier", "Carrier"));
+    TenantConfig tenant = new TenantConfig("tier_BROKER", "tier_SERVER", null);
+    when(tableCfg.getTenantConfig()).thenReturn(tenant);
+    when(tableCache.getTableConfig(tableName)).thenReturn(tableCfg);
+
+    BrokerRoutingManager routingManager = mock(BrokerRoutingManager.class);
+    when(routingManager.routingExists(tableName)).thenReturn(true);
+    when(routingManager.getQueryTimeoutMs(tableName)).thenReturn(10000L);
+    RoutingTable rt = mock(RoutingTable.class);
+    when(rt.getServerInstanceToSegmentsMap()).thenReturn(Map.of(new ServerInstance(new InstanceConfig("server01_9000")),
+        new SegmentsToQuery(List.of("segment01"), List.of())));
+    when(routingManager.getRoutingTable(any(), Mockito.anyLong())).thenReturn(rt);
+
+    QueryQuotaManager queryQuotaManager = mock(QueryQuotaManager.class);
+    when(queryQuotaManager.acquire(anyString())).thenReturn(true);
+    when(queryQuotaManager.acquireDatabase(anyString())).thenReturn(true);
+    when(queryQuotaManager.acquireApplication(anyString())).thenReturn(true);
+
+    BrokerMetrics.register(mock(BrokerMetrics.class));
+    PinotConfiguration config = new PinotConfiguration();
+    BrokerQueryEventListenerFactory.init(config);
+
+    AtomicInteger processCallCount = new AtomicInteger();
+    List<Long> requestIds = new ArrayList<>();
+    BaseSingleStageBrokerRequestHandler requestHandler =
+        new BaseSingleStageBrokerRequestHandler(config, "testBrokerId", new BrokerRequestIdGenerator(), routingManager,
+            new AllowAllAccessControlFactory(), queryQuotaManager, tableCache,
+            ThreadAccountantUtils.getNoOpAccountant(), null, null) {
+          @Override
+          public void start() {
+          }
+
+          @Override
+          public void shutDown() {
+          }
+
+          @Override
+          protected BrokerResponseNative processBrokerRequest(long requestId, BrokerRequest originalBrokerRequest,
+              BrokerRequest serverBrokerRequest, TableRouteInfo route, long timeoutMs, ServerStats serverStats,
+              RequestContext requestContext) {
+            int callCount = processCallCount.incrementAndGet();
+            requestIds.add(requestId);
+            Assert.assertEquals(getRequestIdByClientId(clientQueryId).getAsLong(), requestId);
+            Assert.assertEquals(getRunningServers(requestId).size(), 1);
+
+            if (callCount == 1) {
+              BrokerResponseNative response = BrokerResponseNative.empty();
+              response.setResultTable(new ResultTable(
+                  new DataSchema(new String[]{"idSet"}, new DataSchema.ColumnDataType[]{
+                      DataSchema.ColumnDataType.STRING
+                  }),
+                  List.<Object[]>of(new Object[]{"serialized-id-set"})));
+              return response;
+            }
+
+            Assert.assertEquals(callCount, 2);
+            Assert.assertNotEquals(requestId, requestIds.get(0).longValue());
+            Assert.assertFalse(getRunningQueries().containsKey(requestIds.get(0)));
+            Assert.assertTrue(getRunningQueries().containsKey(requestId));
+            Assert.assertTrue(getRunningQueries().get(requestId).contains("IN_SUBQUERY"));
+            return BrokerResponseNative.empty();
+          }
+
+          @Override
+          protected BrokerResponseNative processMaterializedViewSplitBrokerRequest(long requestId,
+              long materializedViewRequestId, BrokerRequest originalBrokerRequest, TableRouteInfo baseRoute,
+              TableRouteInfo materializedViewRoute, long timeoutMs, ServerStats serverStats,
+              RequestContext requestContext)
+              throws Exception {
+            throw new UnsupportedOperationException("Not implemented in test");
+          }
+        };
+
+    String sql = "SELECT COUNT(*) FROM myTable_OFFLINE WHERE "
+        + "IN_SUBQUERY(airlineID, 'SELECT ID_SET(airlineID) FROM myTable_OFFLINE WHERE Carrier = ''AA''') = 1";
+    ObjectNode request = JsonUtils.newObjectNode();
+    request.put(CommonConstants.Broker.Request.SQL, sql);
+    request.put(CommonConstants.Broker.Request.QUERY_OPTIONS,
+        CommonConstants.Broker.Request.QueryOptionKey.CLIENT_QUERY_ID + "=" + clientQueryId);
+    try (RequestScope requestContext = Tracing.getTracer().createRequestScope()) {
+      requestContext.setRequestArrivalTimeMillis(System.currentTimeMillis());
+      requestHandler.handleRequest(request, null, null, requestContext, null);
+    }
+
+    Assert.assertEquals(processCallCount.get(), 2);
+    Assert.assertTrue(requestHandler.getRunningQueries().isEmpty());
+    Assert.assertFalse(requestHandler.getRequestIdByClientId(clientQueryId).isPresent());
+    Assert.assertTrue(requestHandler.getRunningServers(requestIds.get(0)).isEmpty());
+    Assert.assertTrue(requestHandler.getRunningServers(requestIds.get(1)).isEmpty());
   }
 
   @Test

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandlerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandlerTest.java
@@ -18,8 +18,10 @@
  */
 package org.apache.pinot.broker.requesthandler;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.sun.net.httpserver.HttpServer;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -30,6 +32,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.helix.model.InstanceConfig;
@@ -46,6 +49,8 @@ import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.response.BrokerResponse;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.routing.RoutingTable;
 import org.apache.pinot.core.routing.SegmentsToQuery;
 import org.apache.pinot.core.routing.TableRouteInfo;
@@ -73,11 +78,15 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.eventlistener.query.BrokerQueryEventListenerFactory;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
+import org.apache.pinot.spi.query.QueryProgressStats;
 import org.apache.pinot.spi.trace.LoggerConstants;
 import org.apache.pinot.spi.trace.RequestContext;
+import org.apache.pinot.spi.trace.RequestScope;
+import org.apache.pinot.spi.trace.Tracing;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker;
 import org.apache.pinot.spi.utils.CommonConstants.Query.Range;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.sql.FilterKind;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
@@ -101,6 +110,35 @@ public class BaseSingleStageBrokerRequestHandlerTest {
   @AfterMethod
   public void cleanupMdc() {
     MDC.clear();
+  }
+
+  @Test
+  public void testSingleStageProgressMarksPartialServerResponsesUnknown()
+      throws Exception {
+    QueryProgressStats progressStats = BaseSingleStageBrokerRequestHandler.aggregateSingleStageProgressStats(
+        List.of(new QueryProgressStats(4, 10, 4, 10, false)), 2, List.of("timeout"));
+
+    Assert.assertEquals(progressStats.getProcessedWorkUnits(), 4);
+    Assert.assertEquals(progressStats.getTotalWorkUnits(), -1);
+    Assert.assertEquals(progressStats.getProcessedSegments(), 4);
+    Assert.assertEquals(progressStats.getTotalSegmentsToProcess(), -1);
+    Assert.assertEquals(progressStats.getProgressPercent(), -1.0);
+    Assert.assertTrue(progressStats.isEstimated());
+    Assert.assertTrue(progressStats.getDetails().isEmpty());
+  }
+
+  @Test
+  public void testMaterializedViewProgressTracksSubRequestIds() {
+    ServerInstance baseServer = new ServerInstance(new InstanceConfig("baseServer_9000"));
+    ServerInstance viewServer = new ServerInstance(new InstanceConfig("viewServer_9000"));
+    BaseSingleStageBrokerRequestHandler.QueryServers queryServers =
+        new BaseSingleStageBrokerRequestHandler.QueryServers("query", 11L, Set.of(baseServer), null);
+
+    queryServers.addRequest(12L, Set.of(viewServer), null);
+
+    Assert.assertEquals(queryServers._serversByRequestId.get(11L), Set.of(baseServer));
+    Assert.assertEquals(queryServers._serversByRequestId.get(12L), Set.of(viewServer));
+    Assert.assertEquals(queryServers.numServerRequests(), 2);
   }
 
   @Test
@@ -403,6 +441,114 @@ public class BaseSingleStageBrokerRequestHandlerTest {
         }
       }
     }
+  }
+
+  @Test
+  public void testInSubqueryUsesDistinctRequestIdForTracking()
+      throws Exception {
+    String tableName = "myTable_OFFLINE";
+    String rawTableName = "myTable";
+    String clientQueryId = "client-subquery-progress";
+
+    TableCache tableCache = mock(TableCache.class);
+    TableConfig tableCfg = mock(TableConfig.class);
+    when(tableCache.getActualTableName(anyString())).thenReturn(tableName);
+    Schema schema = new Schema.SchemaBuilder()
+        .setSchemaName(rawTableName)
+        .addSingleValueDimension("airlineID", DataType.INT)
+        .addSingleValueDimension("Carrier", DataType.STRING)
+        .build();
+    when(tableCache.getSchema(rawTableName)).thenReturn(schema);
+    when(tableCache.getColumnNameMap(rawTableName)).thenReturn(
+        Map.of("airlineID", "airlineID", "Carrier", "Carrier"));
+    TenantConfig tenant = new TenantConfig("tier_BROKER", "tier_SERVER", null);
+    when(tableCfg.getTenantConfig()).thenReturn(tenant);
+    when(tableCache.getTableConfig(tableName)).thenReturn(tableCfg);
+
+    BrokerRoutingManager routingManager = mock(BrokerRoutingManager.class);
+    when(routingManager.routingExists(tableName)).thenReturn(true);
+    when(routingManager.getQueryTimeoutMs(tableName)).thenReturn(10000L);
+    RoutingTable rt = mock(RoutingTable.class);
+    when(rt.getServerInstanceToSegmentsMap()).thenReturn(Map.of(new ServerInstance(new InstanceConfig("server01_9000")),
+        new SegmentsToQuery(List.of("segment01"), List.of())));
+    when(routingManager.getRoutingTable(any(), Mockito.anyLong())).thenReturn(rt);
+
+    QueryQuotaManager queryQuotaManager = mock(QueryQuotaManager.class);
+    when(queryQuotaManager.acquire(anyString())).thenReturn(true);
+    when(queryQuotaManager.acquireDatabase(anyString())).thenReturn(true);
+    when(queryQuotaManager.acquireApplication(anyString())).thenReturn(true);
+
+    BrokerMetrics.register(mock(BrokerMetrics.class));
+    PinotConfiguration config = new PinotConfiguration();
+    BrokerQueryEventListenerFactory.init(config);
+
+    AtomicInteger processCallCount = new AtomicInteger();
+    List<Long> requestIds = new ArrayList<>();
+    BaseSingleStageBrokerRequestHandler requestHandler =
+        new BaseSingleStageBrokerRequestHandler(config, "testBrokerId", new BrokerRequestIdGenerator(), routingManager,
+            new AllowAllAccessControlFactory(), queryQuotaManager, tableCache,
+            ThreadAccountantUtils.getNoOpAccountant(), null, null) {
+          @Override
+          public void start() {
+          }
+
+          @Override
+          public void shutDown() {
+          }
+
+          @Override
+          protected BrokerResponseNative processBrokerRequest(long requestId, BrokerRequest originalBrokerRequest,
+              BrokerRequest serverBrokerRequest, TableRouteInfo route, long timeoutMs, ServerStats serverStats,
+              RequestContext requestContext) {
+            int callCount = processCallCount.incrementAndGet();
+            requestIds.add(requestId);
+            Assert.assertEquals(getRequestIdByClientId(clientQueryId).getAsLong(), requestId);
+            Assert.assertEquals(getRunningServers(requestId).size(), 1);
+
+            if (callCount == 1) {
+              BrokerResponseNative response = BrokerResponseNative.empty();
+              response.setResultTable(new ResultTable(
+                  new DataSchema(new String[]{"idSet"}, new DataSchema.ColumnDataType[]{
+                      DataSchema.ColumnDataType.STRING
+                  }),
+                  List.<Object[]>of(new Object[]{"serialized-id-set"})));
+              return response;
+            }
+
+            Assert.assertEquals(callCount, 2);
+            Assert.assertNotEquals(requestId, requestIds.get(0).longValue());
+            Assert.assertFalse(getRunningQueries().containsKey(requestIds.get(0)));
+            Assert.assertTrue(getRunningQueries().containsKey(requestId));
+            Assert.assertTrue(getRunningQueries().get(requestId).contains("IN_SUBQUERY"));
+            return BrokerResponseNative.empty();
+          }
+
+          @Override
+          protected BrokerResponseNative processMaterializedViewSplitBrokerRequest(long requestId,
+              long materializedViewRequestId, BrokerRequest originalBrokerRequest, TableRouteInfo baseRoute,
+              TableRouteInfo materializedViewRoute, long timeoutMs, ServerStats serverStats,
+              RequestContext requestContext)
+              throws Exception {
+            throw new UnsupportedOperationException("Not implemented in test");
+          }
+        };
+
+    String sql = "SELECT COUNT(*) FROM myTable_OFFLINE WHERE "
+        + "IN_SUBQUERY(airlineID, 'SELECT ID_SET(airlineID) FROM myTable_OFFLINE WHERE Carrier = ''AA''') = 1";
+    ObjectNode request = JsonUtils.newObjectNode();
+    request.put(CommonConstants.Broker.Request.SQL, sql);
+    request.put(CommonConstants.Broker.Request.QUERY_OPTIONS,
+        CommonConstants.Broker.Request.QueryOptionKey.CLIENT_QUERY_ID + "=" + clientQueryId);
+    try (RequestScope requestContext = Tracing.getTracer().createRequestScope()) {
+      requestContext.setRequestArrivalTimeMillis(System.currentTimeMillis());
+      requestHandler.handleRequest(request, null, null, requestContext, null);
+    }
+
+    Assert.assertEquals(processCallCount.get(), 2);
+    Assert.assertTrue(requestHandler.getRunningQueries().isEmpty());
+    Assert.assertFalse(requestHandler.getRequestIdByClientId(clientQueryId).isPresent());
+    Assert.assertTrue(requestHandler.getRunningServers(requestIds.get(0)).isEmpty());
+    Assert.assertTrue(requestHandler.getRunningServers(requestIds.get(1)).isEmpty());
   }
 
   @Test

--- a/pinot-clients/pinot-cli/README.md
+++ b/pinot-clients/pinot-cli/README.md
@@ -89,6 +89,7 @@ pinot-clients/pinot-cli/target/pinot-cli-*-executable.jar \
 - `--history-file` Path to history file for interactive mode (default: `~/.pinot_history`)
 - `--config` Path to a properties file with defaults (see Configuration below)
 - `--debug` Print stack traces and timing diagnostics to stderr
+- `--progress-interval-ms` Query progress polling interval in milliseconds. Use `0` to disable progress polling (default: `1000`)
 
 ### Output formats
 
@@ -114,7 +115,7 @@ Supported keys in the properties file (CLI flags take precedence):
 - `server` (maps to `--url`)
 - `user`, `password`
 - `output-format`, `output-format-interactive`, `output`
-- `pager`, `history-file`, `debug`
+- `pager`, `history-file`, `debug`, `progress-interval-ms`
 - `headers.*` (e.g., `headers.Authorization=Bearer <token>`) -> becomes extra headers
 - Any other key is forwarded as a session option (equivalent to `--set key=value`)
 
@@ -128,6 +129,7 @@ pager=less -SRFXK
 history-file=/Users/alice/.pinot_history
 headers.Authorization=Bearer abc123
 debug=true
+progress-interval-ms=1000
 timeoutMs=60000
 ```
 
@@ -163,8 +165,99 @@ pinot-clients/pinot-cli/target/pinot-cli-*-executable.jar \
   --execute "SELECT col1, col2 FROM myTable LIMIT 3;"
 ```
 
+## Query progress
+
+Pinot exposes query progress for long-running queries through the controller, and
+both the query console and CLI can show the progress while the query is in the
+`RUNNING` state.
+
+The query console automatically attaches a client query id, polls query progress,
+and shows a numeric progress bar while the query is running. The percentage is
+derived from processed work units divided by total work units. For V1 queries,
+work units are based on server segment processing. For V2 queries, work units are
+estimated from the multi-stage operators and stage progress.
+
+The CLI enables progress polling by default for interactive terminals. It updates
+the status at the bottom of the terminal and clears it before printing query
+results. Single-stage queries render one compact progress line. Multi-stage
+queries render the aggregate query progress plus component progress rows when
+the progress response includes them. Redirected output does not print progress
+updates.
+
+Tune the refresh interval:
+
+```bash
+pinot-clients/pinot-cli/target/pinot-cli-*-executable.jar \
+  -u jdbc:pinot://localhost:9000 \
+  --progress-interval-ms=2000 \
+  --execute "SELECT COUNT(*) FROM baseballStats"
+```
+
+Disable CLI progress polling:
+
+```bash
+pinot-clients/pinot-cli/target/pinot-cli-*-executable.jar \
+  -u jdbc:pinot://localhost:9000 \
+  --progress-interval-ms=0 \
+  --execute "SELECT COUNT(*) FROM baseballStats"
+```
+
+Sample V1 query using the quickstart `baseballStats` table:
+
+```sql
+SELECT playerName, SUM(runs), SUM(hits), SUM(homeRuns)
+FROM baseballStats
+GROUP BY playerName
+ORDER BY SUM(hits) DESC
+LIMIT 1000;
+```
+
+Sample V2 query using the quickstart `baseballStats` table:
+
+```bash
+pinot-clients/pinot-cli/target/pinot-cli-*-executable.jar \
+  -u jdbc:pinot://localhost:9000 \
+  --set useMultistageEngine=true \
+  --set maxRowsInJoin=10000000 \
+  --progress-interval-ms=1000 \
+  --execute "SELECT COUNT(*) FROM baseballStats a JOIN baseballStats b ON a.yearID = b.yearID"
+```
+
+### Cluster configuration and polling cost
+
+Query progress tracking is enabled by default. It can be disabled independently
+on brokers and servers:
+
+```properties
+# Broker configuration
+pinot.broker.query.progress.enabled=true
+
+# Server configuration
+pinot.server.query.progress.enabled=true
+```
+
+Set both values to `false` when query progress is not needed and the tracking
+overhead should be removed. Query cancellation remains independently controlled
+by its existing broker and server settings.
+
+Each UI or CLI heartbeat calls the controller. The controller checks live
+brokers, and the broker that owns the query checks its participating servers.
+Broker discovery is cached briefly at the controller, but the broker-to-server
+requests occur for every heartbeat. The one-second default gives responsive
+feedback for individual users; use a two- or five-second CLI interval when many
+long-running queries are monitored concurrently.
+
+The CLI progress request reuses the JDBC URL scheme and authentication headers,
+including Basic authentication from `--user` and `--password`, URL properties,
+and `headers.*` configuration. An explicitly supplied `clientQueryId` query
+option is preserved instead of being replaced by a generated value.
+
+Progress is best effort during a rolling upgrade. Older servers that do not
+implement the progress RPC are shown as unknown components; query execution is
+unaffected. Upgrade controllers and brokers before relying on the client-facing
+progress endpoint across the cluster.
+
 ## Notes
 
 - CLI arguments take precedence over config file values.
 - Pager is only used in interactive mode. Batch mode prints directly to stdout.
-

--- a/pinot-clients/pinot-cli/src/main/java/org/apache/pinot/cli/PinotCli.java
+++ b/pinot-clients/pinot-cli/src/main/java/org/apache/pinot/cli/PinotCli.java
@@ -21,7 +21,11 @@ package org.apache.pinot.cli;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -30,6 +34,8 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLWarning;
 import java.sql.Statement;
 import java.time.Duration;
 import java.time.Instant;
@@ -40,11 +46,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import org.apache.pinot.client.utils.DriverUtils;
+import org.apache.pinot.spi.query.QueryProgressStats;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
@@ -107,6 +117,10 @@ public class PinotCli implements Callable<Integer> {
   @CommandLine.Option(names = {"--debug"}, description = "Enable debug output and stack traces")
   private boolean _debug = false;
 
+  @CommandLine.Option(names = {"--progress-interval-ms"},
+      description = "Query progress polling interval in milliseconds. Use 0 to disable. (default: 1000)")
+  private Integer _progressIntervalMs;
+
   @CommandLine.Option(names = {"--set"}, description = "Query option key=value (repeatable)")
   private final Map<String, String> _options = new LinkedHashMap<>();
 
@@ -119,6 +133,11 @@ public class PinotCli implements Callable<Integer> {
   public Integer call()
       throws Exception {
     loadConfigDefaults();
+    if (_progressIntervalMs == null) {
+      _progressIntervalMs = 1000;
+    } else if (_progressIntervalMs < 0) {
+      throw new IllegalArgumentException("progress interval must be non-negative");
+    }
     Properties props = new Properties();
     if (_user != null) {
       props.setProperty("user", _user);
@@ -130,6 +149,13 @@ public class PinotCli implements Callable<Integer> {
     for (Map.Entry<String, String> e : _headers.entrySet()) {
       props.setProperty("headers." + e.getKey(), e.getValue());
     }
+    props.putAll(DriverUtils.getURLParams(_jdbcUrl));
+    for (String name : props.stringPropertyNames()) {
+      if (name.startsWith("headers.")) {
+        _headers.put(name.substring("headers.".length()), props.getProperty(name));
+      }
+    }
+    DriverUtils.handleAuth(props, _headers);
     // query options are passed as properties; PinotConnection will convert to SET statements
     for (Map.Entry<String, String> e : _options.entrySet()) {
       props.setProperty(e.getKey(), e.getValue());
@@ -270,16 +296,30 @@ public class PinotCli implements Callable<Integer> {
 
   private void executeAndRender(Connection conn, String sql)
       throws SQLException {
-    String composed = prefixSessionOptions(sql);
+    boolean progressEnabled = _progressIntervalMs > 0 && isInteractiveProgressEnabled();
+    String configuredClientQueryId = getQueryOption("clientQueryId");
+    String generatedClientQueryId = progressEnabled && configuredClientQueryId == null
+        ? "pinotcli" + UUID.randomUUID().toString().replace("-", "") : null;
+    String clientQueryId = configuredClientQueryId != null ? configuredClientQueryId : generatedClientQueryId;
+    String composed = prefixSessionOptions(sql, generatedClientQueryId);
     Instant start = Instant.now();
-    Progress progress = new Progress();
-    ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
-    ScheduledFuture<?> spinner = scheduler.scheduleAtFixedRate(() -> progress.tick(), 0, 120, TimeUnit.MILLISECONDS);
+    Progress progress = null;
+    ScheduledExecutorService scheduler = null;
+    ScheduledFuture<?> spinner = null;
+    if (progressEnabled) {
+      progress = new Progress(getControllerProgressUrl(clientQueryId), _headers);
+      Progress progressMonitor = progress;
+      scheduler = Executors.newSingleThreadScheduledExecutor();
+      spinner = scheduler.scheduleWithFixedDelay(progressMonitor::tick, 0, _progressIntervalMs, TimeUnit.MILLISECONDS);
+    }
     try (Statement stmt = conn.createStatement()) {
       boolean hasResult = stmt.execute(composed);
+      if (progress != null) {
+        spinner = stopProgress(spinner, progress);
+      }
       if (!hasResult) {
         System.out.println("OK");
-        printSqlWarnings(stmt.getWarnings());
+        printSqlWarnings(stmt);
         return;
       }
       try (ResultSet rs = stmt.getResultSet()) {
@@ -294,7 +334,7 @@ public class PinotCli implements Callable<Integer> {
           out = System.out;
         }
         int rows = render(rs, format, out, getTerminalWidthIfInteractive());
-        printSqlWarnings(rs.getWarnings());
+        printSqlWarnings(rs);
         if (usePager && buffer != null) {
           page(buffer.toString());
         }
@@ -305,11 +345,26 @@ public class PinotCli implements Callable<Integer> {
         }
       }
     } finally {
-      spinner.cancel(true);
-      scheduler.shutdownNow();
-      progress.clear();
+      if (progress != null) {
+        spinner = stopProgress(spinner, progress);
+      }
+      if (scheduler != null) {
+        scheduler.shutdownNow();
+      }
       _overrideFormat = null;
     }
+  }
+
+  private static boolean isInteractiveProgressEnabled() {
+    return System.console() != null;
+  }
+
+  private static ScheduledFuture<?> stopProgress(ScheduledFuture<?> spinner, Progress progress) {
+    if (spinner != null) {
+      spinner.cancel(true);
+      progress.clear();
+    }
+    return null;
   }
 
   private int render(ResultSet rs, OutputFormat format, Appendable out, int terminalWidth)
@@ -381,16 +436,39 @@ public class PinotCli implements Callable<Integer> {
     return renderAlignedFromResultSet(rs, out);
   }
 
-  private String prefixSessionOptions(String sql) {
-    if (_options.isEmpty()) {
+  private String prefixSessionOptions(String sql, String clientQueryId) {
+    if (_options.isEmpty() && clientQueryId == null) {
       return sql;
     }
     StringBuilder sb = new StringBuilder();
     for (Map.Entry<String, String> e : _options.entrySet()) {
       sb.append("SET ").append(e.getKey()).append("=").append(e.getValue()).append(";\n");
     }
+    if (clientQueryId != null) {
+      sb.append("SET clientQueryId='").append(clientQueryId).append("';\n");
+    }
     sb.append(sql);
     return sb.toString();
+  }
+
+  private String getQueryOption(String optionName) {
+    for (Map.Entry<String, String> entry : _options.entrySet()) {
+      if (optionName.equalsIgnoreCase(entry.getKey())) {
+        return entry.getValue();
+      }
+    }
+    return null;
+  }
+
+  private String getControllerProgressUrl(String clientQueryId) {
+    try {
+      String scheme = DriverUtils.getURLParams(_jdbcUrl).getOrDefault("scheme", "http");
+      String encodedClientQueryId = URLEncoder.encode(clientQueryId, StandardCharsets.UTF_8).replace("+", "%20");
+      return String.format("%s://%s/clientQuery/%s/progress?timeoutMs=%d", scheme,
+          DriverUtils.getControllerFromURL(_jdbcUrl), encodedClientQueryId, Progress.REQUEST_TIMEOUT_MS);
+    } catch (Exception e) {
+      return null;
+    }
   }
 
   private int renderAlignedFromResultSet(ResultSet rs, Appendable out)
@@ -815,7 +893,7 @@ public class PinotCli implements Callable<Integer> {
     }
     try {
       Terminal t = TerminalBuilder.builder().system(true).build();
-      return t.getWidth();
+      return t.getSize().getColumns();
     } catch (IOException e) {
       return -1;
     }
@@ -913,6 +991,9 @@ public class PinotCli implements Callable<Integer> {
     if (!_debug && p.getProperty("debug") != null) {
       _debug = Boolean.parseBoolean(p.getProperty("debug"));
     }
+    if (_progressIntervalMs == null) {
+      _progressIntervalMs = Integer.parseInt(p.getProperty("progress-interval-ms", "1000"));
+    }
     // headers.* and arbitrary options
     for (String name : p.stringPropertyNames()) {
       if (name.startsWith("headers.")) {
@@ -935,7 +1016,8 @@ public class PinotCli implements Callable<Integer> {
           || name.equals("output-format-interactive")
           || name.equals("pager")
           || name.equals("history-file")
-          || name.equals("debug")) {
+          || name.equals("debug")
+          || name.equals("progress-interval-ms")) {
         continue;
       }
       // don't override explicit --set
@@ -981,6 +1063,7 @@ public class PinotCli implements Callable<Integer> {
     System.out.println("Roles: " + (_roles.isEmpty() ? "(none)" : String.join(",", _roles)) + " (client-side)");
     System.out.println("Output (batch): " + (_outputFormat == null ? _output : _outputFormat));
     System.out.println("Output (interactive): " + _outputFormatInteractive);
+    System.out.println("Progress interval: " + _progressIntervalMs + " ms");
     if (_pager != null) {
       System.out.println("Pager: " + _pager);
     }
@@ -992,12 +1075,30 @@ public class PinotCli implements Callable<Integer> {
     }
   }
 
-  private void printSqlWarnings(java.sql.SQLWarning warn) {
+  private void printSqlWarnings(Statement stmt)
+      throws SQLException {
+    try {
+      printSqlWarnings(stmt.getWarnings());
+    } catch (SQLFeatureNotSupportedException e) {
+      // Some Pinot JDBC result implementations do not surface warnings.
+    }
+  }
+
+  private void printSqlWarnings(ResultSet rs)
+      throws SQLException {
+    try {
+      printSqlWarnings(rs.getWarnings());
+    } catch (SQLFeatureNotSupportedException e) {
+      // Some Pinot JDBC result implementations do not surface warnings.
+    }
+  }
+
+  private void printSqlWarnings(SQLWarning warn) {
     if (warn == null) {
       return;
     }
     System.err.println("Warnings:");
-    for (java.sql.SQLWarning w = warn; w != null; w = w.getNextWarning()) {
+    for (SQLWarning w = warn; w != null; w = w.getNextWarning()) {
       System.err.println(
           "  " + w.getMessage() + (w.getSQLState() != null ? (" [SQLState=" + w.getSQLState() + "]") : ""));
     }
@@ -1013,21 +1114,165 @@ public class PinotCli implements Callable<Integer> {
     }
   }
 
-  private static final class Progress {
-    private final char[] _spin = new char[]{'|', '/', '-', '\\'};
-    private int _idx = 0;
-    private final long _start = System.currentTimeMillis();
+  static final class Progress {
+    private static final int BAR_WIDTH = 28;
+    static final int REQUEST_TIMEOUT_MS = 1000;
+    private static final int CLIENT_TIMEOUT_MS = REQUEST_TIMEOUT_MS + 1000;
 
-    synchronized void tick() {
-      long elapsed = System.currentTimeMillis() - _start;
-      System.err.print("\r[" + _spin[_idx] + "] Executing... " + elapsed + " ms");
-      System.err.flush();
-      _idx = (_idx + 1) % _spin.length;
+    private final String _progressUrl;
+    private final Map<String, String> _headers;
+    private final long _start = System.currentTimeMillis();
+    private final Object _renderLock = new Object();
+    private volatile boolean _stopped;
+    private volatile HttpURLConnection _activeConnection;
+    private int _renderedLines;
+
+    Progress(String progressUrl, Map<String, String> headers) {
+      _progressUrl = progressUrl;
+      _headers = new LinkedHashMap<>(headers);
     }
 
-    synchronized void clear() {
-      System.err.print("\r\033[K");
-      System.err.flush();
+    void tick() {
+      if (_stopped) {
+        return;
+      }
+      long elapsed = System.currentTimeMillis() - _start;
+      QueryProgressStats progressStats = fetchProgress();
+      synchronized (_renderLock) {
+        if (_stopped) {
+          return;
+        }
+        if (progressStats != null) {
+          writeProgress(formatProgress(progressStats, elapsed));
+        } else {
+          writeProgress(formatElapsed(elapsed));
+        }
+        System.err.flush();
+      }
+    }
+
+    void clear() {
+      _stopped = true;
+      HttpURLConnection activeConnection = _activeConnection;
+      if (activeConnection != null) {
+        activeConnection.disconnect();
+      }
+      synchronized (_renderLock) {
+        clearRenderedLines();
+        System.err.flush();
+      }
+    }
+
+    private void writeProgress(String progress) {
+      clearRenderedLines();
+      System.err.print("\r");
+      String[] lines = progress.split("\n", -1);
+      for (int i = 0; i < lines.length; i++) {
+        if (i > 0) {
+          System.err.print("\n");
+        }
+        System.err.print(lines[i] + "\033[K");
+      }
+      _renderedLines = lines.length;
+    }
+
+    private void clearRenderedLines() {
+      if (_renderedLines == 0) {
+        return;
+      }
+      for (int i = 0; i < _renderedLines; i++) {
+        System.err.print("\r\033[K");
+        if (i < _renderedLines - 1) {
+          System.err.print("\033[A");
+        }
+      }
+      _renderedLines = 0;
+    }
+
+    private QueryProgressStats fetchProgress() {
+      if (_progressUrl == null) {
+        return null;
+      }
+      HttpURLConnection conn = null;
+      try {
+        conn = (HttpURLConnection) URI.create(_progressUrl).toURL().openConnection();
+        _activeConnection = conn;
+        if (_stopped) {
+          return null;
+        }
+        conn.setRequestMethod("GET");
+        conn.setConnectTimeout(CLIENT_TIMEOUT_MS);
+        conn.setReadTimeout(CLIENT_TIMEOUT_MS);
+        _headers.forEach(conn::setRequestProperty);
+        if (conn.getResponseCode() != HttpURLConnection.HTTP_OK) {
+          return null;
+        }
+        try (InputStream inputStream = conn.getInputStream()) {
+          String response = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+          return JsonUtils.stringToObject(response, QueryProgressStats.class);
+        }
+      } catch (Exception e) {
+        return null;
+      } finally {
+        if (conn != null) {
+          if (_activeConnection == conn) {
+            _activeConnection = null;
+          }
+          conn.disconnect();
+        }
+      }
+    }
+
+    static String formatElapsed(long elapsedMs) {
+      return "[----------------------------]   ?.?% 0/? " + elapsedMs + " ms";
+    }
+
+    static String formatProgress(QueryProgressStats progressStats, long elapsedMs) {
+      if (progressStats.getDetails().isEmpty()) {
+        return formatProgressRow(null, 0, progressStats, elapsedMs);
+      }
+      List<QueryProgressStats> rows = new ArrayList<>(progressStats.getDetails().size() + 1);
+      rows.add(progressStats);
+      rows.addAll(progressStats.getDetails());
+      List<String> labels = new ArrayList<>(rows.size());
+      int labelWidth = 0;
+      for (int i = 0; i < rows.size(); i++) {
+        QueryProgressStats row = rows.get(i);
+        String label = row.getLabel() != null ? row.getLabel() : i == 0 ? "Query" : "Progress " + i;
+        labels.add(label);
+        labelWidth = Math.max(labelWidth, label.length());
+      }
+      labelWidth = Math.min(labelWidth, 24);
+      StringBuilder builder = new StringBuilder();
+      for (int i = 0; i < rows.size(); i++) {
+        if (i > 0) {
+          builder.append('\n');
+        }
+        builder.append(formatProgressRow(labels.get(i), labelWidth, rows.get(i), i == 0 ? elapsedMs : -1));
+      }
+      return builder.toString();
+    }
+
+    private static String formatProgressRow(String label, int labelWidth, QueryProgressStats progressStats,
+        long elapsedMs) {
+      double percent = progressStats.getProgressPercent();
+      String prefix = labelWidth > 0 ? String.format("%-" + labelWidth + "s ", abbreviate(label, labelWidth)) : "";
+      String suffix = elapsedMs >= 0 ? " " + elapsedMs + " ms" : "";
+      if (percent < 0) {
+        return String.format("%s[----------------------------]   ?.?%% %d/?%s", prefix,
+            progressStats.getProcessedWorkUnits(), suffix);
+      }
+      int filled = Math.max(0, Math.min(BAR_WIDTH, (int) Math.round(percent * BAR_WIDTH / 100.0)));
+      String bar = "#".repeat(filled) + "-".repeat(BAR_WIDTH - filled);
+      return String.format("%s[%s] %5.1f%% %d/%d%s", prefix, bar, percent, progressStats.getProcessedWorkUnits(),
+          progressStats.getTotalWorkUnits(), suffix);
+    }
+
+    private static String abbreviate(String value, int maxLength) {
+      if (value == null || value.length() <= maxLength) {
+        return value;
+      }
+      return value.substring(0, maxLength - 1) + "~";
     }
   }
 

--- a/pinot-clients/pinot-cli/src/test/java/org/apache/pinot/cli/PinotCliProgressTest.java
+++ b/pinot-clients/pinot-cli/src/test/java/org/apache/pinot/cli/PinotCliProgressTest.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.cli;
+
+import java.util.List;
+import org.apache.pinot.spi.query.QueryProgressStats;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+public class PinotCliProgressTest {
+  @Test
+  public void testSingleStageProgressUsesOneLine() {
+    String output = PinotCli.Progress.formatProgress(new QueryProgressStats(5, 10), 123);
+
+    assertFalse(output.contains("\n"));
+    assertTrue(output.contains("50.0%"));
+    assertTrue(output.contains("5/10"));
+    assertTrue(output.endsWith("123 ms"));
+  }
+
+  @Test
+  public void testMultiStageProgressUsesAggregateAndDetailRows() {
+    QueryProgressStats broker = new QueryProgressStats("Broker", 1, 2, 0, -1, true);
+    QueryProgressStats server = new QueryProgressStats("Server server-1", 3, 6, 2, 4, true);
+    QueryProgressStats query = QueryProgressStats.aggregate(List.of(broker, server)).withLabel("Query")
+        .withDetails(List.of(broker, server));
+
+    String[] lines = PinotCli.Progress.formatProgress(query, 250).split("\n");
+
+    assertEquals(lines.length, 3);
+    assertTrue(lines[0].startsWith("Query"));
+    assertTrue(lines[0].endsWith("250 ms"));
+    assertTrue(lines[1].startsWith("Broker"));
+    assertTrue(lines[2].startsWith("Server server-1"));
+  }
+
+  @Test
+  public void testUnknownProgressShowsUnknownDenominator() {
+    String output = PinotCli.Progress.formatProgress(QueryProgressStats.unknown("Server", true), 50);
+
+    assertTrue(output.contains("?.?%"));
+    assertTrue(output.contains("0/?"));
+  }
+}

--- a/pinot-common/src/main/proto/worker.proto
+++ b/pinot-common/src/main/proto/worker.proto
@@ -29,6 +29,8 @@ service PinotQueryWorker {
 
   rpc Cancel(CancelRequest) returns (CancelResponse);
 
+  rpc GetQueryProgress(QueryProgressRequest) returns (QueryProgressResponse);
+
   rpc Explain(QueryRequest) returns (stream ExplainResponse);
 
   // Long-lived bidi RPC used by the "stream" stats-reporting mode (S3-variant).
@@ -48,6 +50,24 @@ message CancelResponse {
   // Deprecated: always empty since the stream-stats push feature was introduced; per-opchain stats
   // now flow via OpChainComplete on the SubmitWithStream bidi RPC and are no longer collected on cancel.
   map<int32, bytes> statsByStage = 1;
+}
+
+message QueryProgressRequest {
+  int64 requestId = 1;
+}
+
+message QueryProgressResponse {
+  QueryProgress progress = 1;
+}
+
+message QueryProgress {
+  int64 processedWorkUnits = 1;
+  int64 totalWorkUnits = 2;
+  int64 processedSegments = 3;
+  int64 totalSegmentsToProcess = 4;
+  bool estimated = 5;
+  string label = 6;
+  repeated QueryProgress details = 7;
 }
 
 // QueryRequest is the dispatched content for all query stages to a physical worker.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRunningQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRunningQueryResource.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.controller.api.resources;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiKeyAuthDefinition;
 import io.swagger.annotations.ApiOperation;
@@ -36,7 +38,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -58,9 +62,11 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.net.URIBuilder;
 import org.apache.hc.core5.util.Timeout;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.common.http.MultiHttpRequest;
+import org.apache.pinot.common.http.MultiHttpRequestBufferedResponse;
 import org.apache.pinot.common.http.MultiHttpRequestResponse;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.access.AccessType;
@@ -69,6 +75,7 @@ import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.core.auth.Actions;
 import org.apache.pinot.core.auth.Authorize;
 import org.apache.pinot.core.auth.TargetType;
+import org.apache.pinot.spi.query.QueryProgressStats;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,6 +97,14 @@ import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_K
 @Path("/")
 public class PinotRunningQueryResource {
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotRunningQueryResource.class);
+  private static final int BROKER_PROGRESS_REQUEST_TIMEOUT_OVERHEAD_MS = 250;
+  private static final int PROGRESS_BROKER_CACHE_EXPIRATION_SECONDS = 5;
+  private static final int PROGRESS_BROKER_CACHE_MAX_DATABASES = 1_000;
+  private static final String DEFAULT_DATABASE_CACHE_KEY = "";
+
+  private final Cache<String, Map<String, InstanceInfo>> _progressBrokers = CacheBuilder.newBuilder()
+      .maximumSize(PROGRESS_BROKER_CACHE_MAX_DATABASES)
+      .expireAfterWrite(PROGRESS_BROKER_CACHE_EXPIRATION_SECONDS, TimeUnit.SECONDS).build();
 
   @Inject
   PinotHelixResourceManager _pinotHelixResourceManager;
@@ -304,6 +319,44 @@ public class PinotRunningQueryResource {
   }
 
   @GET
+  @Path("clientQuery/{clientQueryId}/progress")
+  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_RUNNING_QUERY)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Get progress for a query as identified by the clientQueryId",
+      notes = "Polls all live brokers and returns the first matching running query progress. No progress is returned "
+          + "if no broker is currently tracking the given clientQueryId. Multi-stage responses may include labeled "
+          + "details for component-level progress.")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error"),
+      @ApiResponse(code = 404, message = "Query not found on any broker")
+  })
+  public QueryProgressStats getClientQueryProgress(
+      @ApiParam(value = "ClientQueryId provided by the client", required = true)
+      @PathParam("clientQueryId") String clientQueryId,
+      @ApiParam(value = "Timeout for brokers and servers to respond the progress request") @QueryParam("timeoutMs")
+      @DefaultValue("1000") int timeoutMs, @Context HttpHeaders httpHeaders) {
+    try {
+      if (timeoutMs <= 0) {
+        throw new WebApplicationException(
+            Response.status(Response.Status.BAD_REQUEST).entity("timeoutMs must be positive").build());
+      }
+      Map<String, InstanceInfo> brokers = getProgressBrokers(httpHeaders.getHeaderString(DATABASE));
+      QueryProgressStats progressStats =
+          getClientQueryProgress(brokers, clientQueryId, timeoutMs, createRequestHeaders(httpHeaders));
+      if (progressStats != null) {
+        return progressStats;
+      }
+      throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND)
+          .entity(String.format("Client query: %s not found on any broker", clientQueryId)).build());
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new WebApplicationException(Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+          .entity("Failed to get query progress due to error: " + e.getMessage()).build());
+    }
+  }
+
+  @GET
   @Path("/queries")
   @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_RUNNING_QUERY)
   @Produces(MediaType.APPLICATION_JSON)
@@ -371,6 +424,80 @@ public class PinotRunningQueryResource {
     return queriesByBroker;
   }
 
+  @Nullable
+  private QueryProgressStats getClientQueryProgress(Map<String, InstanceInfo> brokers, String clientQueryId,
+      int timeoutMs, Map<String, String> requestHeaders)
+      throws Exception {
+    String protocol = _controllerConf.getControllerBrokerProtocol();
+    int portOverride = _controllerConf.getControllerBrokerPortOverride();
+    List<String> brokerUrls = new ArrayList<>();
+    for (InstanceInfo broker : brokers.values()) {
+      int port = portOverride > 0 ? portOverride : broker.getPort();
+      brokerUrls.add(new URIBuilder().setScheme(protocol).setHost(broker.getHost()).setPort(port)
+          .setPathSegments("query", clientQueryId, "progress").addParameter("client", "true")
+          .addParameter("timeoutMs", Integer.toString(timeoutMs)).build().toString());
+    }
+    if (brokerUrls.isEmpty()) {
+      return null;
+    }
+    LOGGER.debug("Getting query progress via broker urls: {}", brokerUrls);
+    List<String> errMsgs = new ArrayList<>(brokerUrls.size());
+    int brokerRequestTimeoutMs = timeoutMs > Integer.MAX_VALUE - BROKER_PROGRESS_REQUEST_TIMEOUT_OVERHEAD_MS
+        ? Integer.MAX_VALUE : timeoutMs + BROKER_PROGRESS_REQUEST_TIMEOUT_OVERHEAD_MS;
+    long collectionTimeoutNanos = TimeUnit.MILLISECONDS.toNanos(brokerRequestTimeoutMs);
+    long collectionStartNanos = System.nanoTime();
+    int notFoundResponses = 0;
+    int receivedResponses = 0;
+    try (MultiHttpRequest.BufferedRequestExecution execution =
+        new MultiHttpRequest(_executor, _httpConnMgr).executeGetBuffered(brokerUrls, requestHeaders,
+            timeoutMs)) {
+      for (int i = 0; i < brokerUrls.size(); i++) {
+        URI uri = null;
+        try {
+          long remainingNanos = collectionTimeoutNanos - (System.nanoTime() - collectionStartNanos);
+          if (remainingNanos <= 0) {
+            break;
+          }
+          Future<MultiHttpRequestBufferedResponse> responseFuture =
+              execution.poll(remainingNanos, TimeUnit.NANOSECONDS);
+          if (responseFuture == null) {
+            break;
+          }
+          receivedResponses++;
+          MultiHttpRequestBufferedResponse response = responseFuture.get();
+          uri = response.getURI();
+          int status = response.getStatusCode();
+          String responseString = response.getResponseBody();
+          if (status == 200) {
+            if (responseString == null) {
+              throw new Exception("Empty response from uri='" + uri + "'");
+            }
+            return JsonUtils.stringToObject(responseString, QueryProgressStats.class);
+          } else if (status == 404) {
+            notFoundResponses++;
+          } else {
+            throw new Exception(
+                String.format("Unexpected status=%d and response='%s' from uri='%s'", status, responseString, uri));
+          }
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw e;
+        } catch (Exception e) {
+          LOGGER.debug("Failed to get progress for client query id: {} from uri: {}", clientQueryId, uri, e);
+          errMsgs.add(String.valueOf(e.getMessage()));
+        }
+      }
+    }
+    int timedOutResponses = brokerUrls.size() - receivedResponses;
+    if (timedOutResponses > 0) {
+      errMsgs.add("Timed out waiting for " + timedOutResponses + " broker response(s)");
+    }
+    if (notFoundResponses == 0 && !errMsgs.isEmpty()) {
+      throw new Exception("Unexpected responses from brokers: " + StringUtils.join(errMsgs, ","));
+    }
+    return null;
+  }
+
   private static String getInstanceKey(InstanceInfo info) {
     return info.getHost() + ":" + info.getPort();
   }
@@ -393,6 +520,17 @@ public class PinotRunningQueryResource {
         _pinotHelixResourceManager.getTableToLiveBrokersMapping(database);
     Map<String, InstanceInfo> brokers = new HashMap<>();
     tableBrokers.values().forEach(list -> list.forEach(info -> brokers.putIfAbsent(getInstanceKey(info), info)));
+    return brokers;
+  }
+
+  private Map<String, InstanceInfo> getProgressBrokers(String database) {
+    String cacheKey = database != null ? database : DEFAULT_DATABASE_CACHE_KEY;
+    Map<String, InstanceInfo> brokers = _progressBrokers.getIfPresent(cacheKey);
+    if (brokers != null) {
+      return brokers;
+    }
+    brokers = Map.copyOf(getBrokers(database));
+    _progressBrokers.put(cacheKey, brokers);
     return brokers;
   }
 }

--- a/pinot-controller/src/main/resources/app/Models.ts
+++ b/pinot-controller/src/main/resources/app/Models.ts
@@ -292,6 +292,17 @@ export type SQLResult = {
   realtimeTotalCpuTimeNs: number;
 };
 
+export type QueryProgressStats = {
+  label?: string;
+  processedWorkUnits: number;
+  totalWorkUnits: number;
+  processedSegments: number;
+  totalSegmentsToProcess: number;
+  estimated: boolean;
+  progressPercent: number;
+  details?: QueryProgressStats[];
+};
+
 export interface TimeseriesData {
   metric: Record<string, string>;
   values: [number, number][];

--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -20,10 +20,21 @@
 
 import React, {useEffect, useState} from 'react';
 import {makeStyles} from '@material-ui/core/styles';
-import {Box, Button, ButtonGroup, Checkbox, FormControl, Grid, Input, InputLabel, Typography} from '@material-ui/core';
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  Checkbox,
+  FormControl,
+  Grid,
+  Input,
+  InputLabel,
+  LinearProgress,
+  Typography
+} from '@material-ui/core';
 import Alert from '@material-ui/lab/Alert';
 import FileCopyIcon from '@material-ui/icons/FileCopy';
-import {SqlException, TableData} from 'Models';
+import {QueryProgressStats, SqlException, TableData} from 'Models';
 import {UnControlled as CodeMirror} from 'react-codemirror2';
 import 'codemirror/lib/codemirror.css';
 import 'codemirror/theme/material.css';
@@ -50,6 +61,7 @@ import {useHistory, useLocation} from 'react-router-dom';
 import sqlFormatter from '@sqltools/formatter';
 import {FlamegraphMode, FlameGraphQueryStageStats} from '../components/Query/FlamegraphQueryStageStats';
 import {VisualizeQueryStageStats} from '../components/Query/VisualizeQueryStageStats';
+import {getClientQueryProgress} from '../requests';
 
 enum ResultViewType {
   TABULAR = 'tabular',
@@ -64,6 +76,7 @@ enum ErrorViewType {
 }
 
 const QUERY_BOOTSTRAP_TIMEOUT_MS = 3000;
+const QUERY_PROGRESS_POLL_INTERVAL_MS = 1000;
 const EMPTY_TABLE_LIST = {
   columns: ['Tables'],
   records: [],
@@ -71,6 +84,30 @@ const EMPTY_TABLE_LIST = {
 const EMPTY_LOGICAL_TABLE_LIST = {
   columns: ['Logical Tables'],
   records: [],
+};
+
+const getQueryProgressRows = (queryProgress: QueryProgressStats | null): Array<QueryProgressStats | null> => {
+  if (!queryProgress) {
+    return [null];
+  }
+  return queryProgress.details?.length ? [queryProgress, ...queryProgress.details] : [queryProgress];
+};
+
+const getProgressPercent = (queryProgress: QueryProgressStats | null): number => {
+  return queryProgress ? Math.max(0, Math.min(100, queryProgress.progressPercent)) : 0;
+};
+
+const formatProgressPercent = (queryProgress: QueryProgressStats | null): string => {
+  if (!queryProgress) {
+    return '0.0%';
+  }
+  return queryProgress.progressPercent >= 0 ? `${queryProgress.progressPercent.toFixed(1)}%` : '?.?%';
+};
+
+const formatProgressUnits = (queryProgress: QueryProgressStats | null): string => {
+  const processedWorkUnits = queryProgress?.processedWorkUnits || 0;
+  const totalWorkUnits = queryProgress && queryProgress.totalWorkUnits >= 0 ? queryProgress.totalWorkUnits : '?';
+  return `${processedWorkUnits}/${totalWorkUnits}`;
 };
 
 const useStyles = makeStyles((theme) => ({
@@ -126,6 +163,37 @@ const useStyles = makeStyles((theme) => ({
   },
   timeoutControl: {
     bottom: 10
+  },
+  queryProgress: {
+    margin: '8px 0 20px 0',
+  },
+  queryProgressRows: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 6,
+  },
+  queryProgressRow: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(96px, 160px) 1fr',
+    columnGap: 12,
+    alignItems: 'center',
+  },
+  queryProgressLine: {
+    minWidth: 0,
+  },
+  queryProgressLabel: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  queryProgressNumbers: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    marginBottom: 4,
+  },
+  queryProgressBar: {
+    height: 8,
+    borderRadius: 4,
   }
 }));
 
@@ -254,9 +322,12 @@ const QueryPage = () => {
   });
 
   const queryExecuted = React.useRef(false);
+  const queryRunGeneration = React.useRef(0);
+  const queryProgressTimer = React.useRef<number | null>(null);
   const [boolFlag, setBoolFlag] = useState(false);
 
   const [copyMsg, showCopyMsg] = React.useState(false);
+  const [queryProgress, setQueryProgress] = React.useState<QueryProgressStats | null>(null);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setChecked({ ...checked, [event.target.name]: event.target.checked });
@@ -340,9 +411,19 @@ const QueryPage = () => {
     setInputQuery(formatted);
   };
 
+  const createClientQueryId = () => {
+    return `query-console-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  };
+
   const handleRunNow = async (query?: string) => {
-    setQueryLoader(true);
+    if (queryExecuted.current) {
+      return;
+    }
     queryExecuted.current = true;
+    const runGeneration = ++queryRunGeneration.current;
+    setQueryLoader(true);
+    setQueryProgress(null);
+    const clientQueryId = createClientQueryId();
     let params;
     let queryOptions = [];
     if(queryTimeout){
@@ -351,6 +432,7 @@ const QueryPage = () => {
     if(checked.useMSE){
       queryOptions.push(`useMultistageEngine=true`);
     }
+    queryOptions.push(`clientQueryId=${clientQueryId}`);
     const finalQuery = `${query || inputQuery.trim()}`;
     params = JSON.stringify({
       sql: `${finalQuery}`,
@@ -371,15 +453,46 @@ const QueryPage = () => {
       })
     }
 
-    const results = await PinotMethodUtils.getQueryResults(params);
-    setResultError(results.exceptions || []);
-    setResultData(results.result || { columns: [], records: [] });
-    setQueryStats(results.queryStats || { columns: QUERY_STATS_COLUMNS, records: [] });
-    setOutputResult(JSON.stringify(results.data, null, 2) || '');
-    setStageStats(results?.data?.stageStats || {});
-    setWarnings(extractWarnings(results));
-    setQueryLoader(false);
-    queryExecuted.current = false;
+    let progressStopped = false;
+    const pollQueryProgress = async () => {
+      try {
+        const response = await getClientQueryProgress(clientQueryId, QUERY_PROGRESS_POLL_INTERVAL_MS);
+        if (!progressStopped && queryRunGeneration.current === runGeneration) {
+          setQueryProgress(response.data);
+        }
+      } catch (error) {
+        // The query might not be registered yet, or may already have completed.
+      } finally {
+        if (!progressStopped && queryRunGeneration.current === runGeneration) {
+          queryProgressTimer.current = window.setTimeout(pollQueryProgress, QUERY_PROGRESS_POLL_INTERVAL_MS);
+        }
+      }
+    };
+    queryProgressTimer.current = window.setTimeout(pollQueryProgress, QUERY_PROGRESS_POLL_INTERVAL_MS);
+
+    try {
+      const results = await PinotMethodUtils.getQueryResults(params);
+      if (queryRunGeneration.current !== runGeneration) {
+        return;
+      }
+      setResultError(results.exceptions || []);
+      setResultData(results.result || { columns: [], records: [] });
+      setQueryStats(results.queryStats || { columns: QUERY_STATS_COLUMNS, records: [] });
+      setOutputResult(JSON.stringify(results.data, null, 2) || '');
+      setStageStats(results?.data?.stageStats || {});
+      setWarnings(extractWarnings(results));
+    } finally {
+      progressStopped = true;
+      if (queryProgressTimer.current !== null) {
+        window.clearTimeout(queryProgressTimer.current);
+        queryProgressTimer.current = null;
+      }
+      if (queryRunGeneration.current === runGeneration) {
+        setQueryProgress(null);
+        setQueryLoader(false);
+        queryExecuted.current = false;
+      }
+    }
   };
 
   const extractWarnings = (result) => {
@@ -508,6 +621,12 @@ const QueryPage = () => {
       handleRunNow(inputQuery);
     }
     return () => {
+      queryRunGeneration.current++;
+      queryExecuted.current = false;
+      if (queryProgressTimer.current !== null) {
+        window.clearTimeout(queryProgressTimer.current);
+        queryProgressTimer.current = null;
+      }
       cancelFetchData();
     };
   }, []);
@@ -669,6 +788,7 @@ const QueryPage = () => {
                     variant="contained"
                     color="primary"
                     onClick={() => handleRunNow()}
+                    disabled={queryLoader}
                     endIcon={<span style={{fontSize: '0.8em', lineHeight: 1}}>{navigator.platform.includes('Mac') ? '⌘↵' : 'Ctrl+↵'}</span>}
                 >
                   Run Query
@@ -677,7 +797,41 @@ const QueryPage = () => {
             </Grid>
 
             {queryLoader ? (
-              <AppLoader />
+              <Box className={classes.queryProgress}>
+                <Box className={classes.queryProgressRows}>
+                  {getQueryProgressRows(queryProgress).map((progress, index, rows) => {
+                    const showLabel = rows.length > 1;
+                    const label = progress?.label || (index === 0 ? 'Query' : `Progress ${index + 1}`);
+                    return (
+                      <Box
+                        className={showLabel ? classes.queryProgressRow : classes.queryProgressLine}
+                        key={`${label}-${index}`}
+                      >
+                        {showLabel && (
+                          <Typography className={classes.queryProgressLabel} variant="body2">
+                            {label}
+                          </Typography>
+                        )}
+                        <Box className={classes.queryProgressLine}>
+                          <Box className={classes.queryProgressNumbers}>
+                            <Typography variant="body2">
+                              {formatProgressPercent(progress)}
+                            </Typography>
+                            <Typography variant="body2">
+                              {formatProgressUnits(progress)}
+                            </Typography>
+                          </Box>
+                          <LinearProgress
+                            className={classes.queryProgressBar}
+                            variant={progress && progress.progressPercent >= 0 ? 'determinate' : 'indeterminate'}
+                            value={getProgressPercent(progress)}
+                          />
+                        </Box>
+                      </Box>
+                    );
+                  })}
+                </Box>
+              </Box>
             ) : (
               <>
                 {queryStats.columns.length ? (

--- a/pinot-controller/src/main/resources/app/requests/index.ts
+++ b/pinot-controller/src/main/resources/app/requests/index.ts
@@ -27,6 +27,7 @@ import {
   TableName,
   TableSize,
   IdealState,
+  QueryProgressStats,
   QueryTables,
   TableSchema,
   SQLResult,
@@ -298,6 +299,14 @@ export const getTableSchema = (name: string): Promise<AxiosResponse<TableSchema>
 
 export const getQueryResult = (params: Object): Promise<AxiosResponse<SQLResult>> =>
   transformApi.post(`/sql`, params, {headers});
+
+export const getClientQueryProgress = (
+  clientQueryId: string,
+  timeoutMs = 1000
+): Promise<AxiosResponse<QueryProgressStats>> =>
+  baseApiWithErrors.get(`/clientQuery/${encodeURIComponent(clientQueryId)}/progress`, {
+    params: { timeoutMs },
+  });
 
 export const getTimeSeriesQueryResult = (params: Object): Promise<AxiosResponse<any>> =>
   transformApi.post(`/query/timeseries`, params);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
@@ -196,6 +196,13 @@ public abstract class BaseCombineOperator<T extends BaseResultsBlock> extends Ba
     return Math.min(_numTasks, ResourceManager.DEFAULT_QUERY_WORKER_THREADS);
   }
 
+  protected void markSegmentProcessed() {
+    QueryThreadContext threadContext = QueryThreadContext.getIfAvailable();
+    if (threadContext != null) {
+      threadContext.getExecutionContext().incrementProcessedSegments();
+    }
+  }
+
   /// Start the combine operator process. This will spin up multiple threads to process data segments in parallel.
   protected void startProcess() {
     Tracing.activeRecording().setNumTasks(_numTasks);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseSingleBlockCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseSingleBlockCombineOperator.java
@@ -106,6 +106,7 @@ public abstract class BaseSingleBlockCombineOperator<T extends BaseResultsBlock>
           ((AcquireReleaseColumnsSegmentOperator) operator).release();
         }
       }
+      markSegmentProcessed();
       _blockingQueue.offer(resultsBlock);
       // When query is satisfied, skip processing the remaining segments
       if (_resultsBlockMerger.isQuerySatisfied(resultsBlock)) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
@@ -162,6 +162,7 @@ public class GroupByCombineOperator extends BaseSingleBlockCombineOperator<Group
             _indexedTable.upsert(intermediateResult._key, intermediateResult._record);
           }
         }
+        markSegmentProcessed();
       } catch (RuntimeException e) {
         throw wrapOperatorException(operator, e);
       } finally {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/MinMaxValueBasedSelectionOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/MinMaxValueBasedSelectionOrderByCombineOperator.java
@@ -142,6 +142,7 @@ public class MinMaxValueBasedSelectionOrderByCombineOperator
     int operatorId;
     while (_processingException.get() == null && (operatorId = _nextOperatorId.getAndIncrement()) < _numOperators) {
       if (operatorId >= _endOperatorId.get()) {
+        markSegmentProcessed();
         _blockingQueue.offer(EMPTY_RESULTS_BLOCK);
         continue;
       }
@@ -174,6 +175,7 @@ public class MinMaxValueBasedSelectionOrderByCombineOperator
             int result = minMaxValueContext._minValue.compareTo(boundaryValue);
             if (result > 0 || (result == 0 && numOrderByExpressions == 1)) {
               _endOperatorId.set(operatorId);
+              markSegmentProcessed();
               _blockingQueue.offer(EMPTY_RESULTS_BLOCK);
               continue;
             }
@@ -185,6 +187,7 @@ public class MinMaxValueBasedSelectionOrderByCombineOperator
             int result = minMaxValueContext._maxValue.compareTo(boundaryValue);
             if (result < 0 || (result == 0 && numOrderByExpressions == 1)) {
               _endOperatorId.set(operatorId);
+              markSegmentProcessed();
               _blockingQueue.offer(EMPTY_RESULTS_BLOCK);
               continue;
             }
@@ -228,6 +231,7 @@ public class MinMaxValueBasedSelectionOrderByCombineOperator
         }
       }
       threadBoundaryValue = boundaryValue;
+      markSegmentProcessed();
       _blockingQueue.offer(resultsBlock);
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SequentialSortedGroupByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SequentialSortedGroupByCombineOperator.java
@@ -107,6 +107,7 @@ public class SequentialSortedGroupByCombineOperator extends BaseSingleBlockCombi
           ((AcquireReleaseColumnsSegmentOperator) operator).release();
         }
       }
+      markSegmentProcessed();
       _blockingQueue.offer(resultsBlock);
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SortedGroupByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SortedGroupByCombineOperator.java
@@ -142,10 +142,12 @@ public class SortedGroupByCombineOperator extends BaseSingleBlockCombineOperator
         //   pair-wise is used when numOperators >= numAvailableCores.
         if (_numOperators == 1) {
           _waitingRecords.set(GroupByUtils.getAndPopulateSortedRecords(resultsBlock));
+          markSegmentProcessed();
           break;
         }
         Object waitingObject = _waitingRecords.getAndUpdate(v -> v == null ? resultsBlock : null);
         if (waitingObject == null) {
+          markSegmentProcessed();
           continue;
         }
         SortedRecords records = GroupByUtils.getAndPopulateSortedRecords(resultsBlock);
@@ -171,6 +173,7 @@ public class SortedGroupByCombineOperator extends BaseSingleBlockCombineOperator
           }
           checkTerminationAndSampleUsage();
         }
+        markSegmentProcessed();
       } catch (RuntimeException e) {
         throw wrapOperatorException(operator, e);
       } finally {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/BaseStreamingCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/BaseStreamingCombineOperator.java
@@ -110,6 +110,7 @@ public abstract class BaseStreamingCombineOperator<T extends BaseResultsBlock> e
     Object tracker = createQuerySatisfiedTracker();
     while (_processingException.get() == null && (operatorId = _nextOperatorId.getAndIncrement()) < _numOperators) {
       Operator<T> operator = _operators.get(operatorId);
+      boolean querySatisfied = false;
       try {
         if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
           ((AcquireReleaseColumnsSegmentOperator) operator).acquire();
@@ -119,8 +120,7 @@ public abstract class BaseStreamingCombineOperator<T extends BaseResultsBlock> e
           addResultsBlock(resultsBlock);
           // When query is satisfied, skip processing the remaining segments
           if (isQuerySatisfied(resultsBlock, tracker)) {
-            _nextOperatorId.set(_numOperators);
-            return;
+            querySatisfied = true;
           }
         } else {
           T resultsBlock;
@@ -129,8 +129,8 @@ public abstract class BaseStreamingCombineOperator<T extends BaseResultsBlock> e
             addResultsBlock(resultsBlock);
             // When query is satisfied, skip processing the remaining segments
             if (isQuerySatisfied(resultsBlock, tracker)) {
-              _nextOperatorId.set(_numOperators);
-              return;
+              querySatisfied = true;
+              break;
             }
           }
         }
@@ -140,6 +140,11 @@ public abstract class BaseStreamingCombineOperator<T extends BaseResultsBlock> e
         if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
           ((AcquireReleaseColumnsSegmentOperator) operator).release();
         }
+      }
+      markSegmentProcessed();
+      if (querySatisfied) {
+        _nextOperatorId.set(_numOperators);
+        return;
       }
       // offer the LAST_RESULTS_BLOCK indicate finish of the current operator.
       addResultsBlock(LAST_RESULTS_BLOCK);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -334,6 +334,10 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
 
     TableExecutionInfo.SelectedSegmentsInfo selectedSegmentsInfo =
         executionInfo.getSelectedSegmentsInfo(queryContext, timerContext, executorService, _segmentPrunerService);
+    QueryThreadContext threadContext = QueryThreadContext.getIfAvailable();
+    if (threadContext != null) {
+      threadContext.getExecutionContext().addTotalSegmentsToProcess(selectedSegmentsInfo.getNumSelectedSegments());
+    }
     // Account for resource usage in pruning, given that it can be expensive for large segment lists.
     QueryThreadContext.checkTerminationAndSampleUsage("Server segment pruning");
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -338,6 +338,10 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
 
     TableExecutionInfo.SelectedSegmentsInfo selectedSegmentsInfo =
         executionInfo.getSelectedSegmentsInfo(queryContext, timerContext, executorService, _segmentPrunerService);
+    QueryThreadContext threadContext = QueryThreadContext.getIfAvailable();
+    if (threadContext != null) {
+      threadContext.getExecutionContext().addTotalSegmentsToProcess(selectedSegmentsInfo.getNumSelectedSegments());
+    }
     // Account for resource usage in pruning, given that it can be expensive for large segment lists.
     QueryThreadContext.checkTerminationAndSampleUsage("Server segment pruning");
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/ServerQueryRequest.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/ServerQueryRequest.java
@@ -75,6 +75,9 @@ public class ServerQueryRequest {
   // Timing information for different phases of query execution
   private final TimerContext _timerContext;
 
+  @Nullable
+  private QueryExecutionContext _executionContext;
+
   /// This is called from the Netty server to create a ServerQueryRequest from the InstanceRequest
   public ServerQueryRequest(InstanceRequest instanceRequest, ServerMetrics serverMetrics, long queryArrivalTimeMs) {
     this(instanceRequest, serverMetrics, queryArrivalTimeMs, false);
@@ -261,7 +264,22 @@ public class ServerQueryRequest {
     return _timerContext;
   }
 
+  public synchronized QueryExecutionContext getOrCreateExecutionContext(String instanceId) {
+    if (_executionContext == null) {
+      _executionContext = createExecutionContext(instanceId);
+    }
+    return _executionContext;
+  }
+
+  public synchronized void setExecutionContext(QueryExecutionContext executionContext) {
+    _executionContext = executionContext;
+  }
+
   public QueryExecutionContext toExecutionContext(String instanceId) {
+    return getOrCreateExecutionContext(instanceId);
+  }
+
+  private QueryExecutionContext createExecutionContext(String instanceId) {
     Map<String, String> queryOptions = _queryContext.getQueryOptions();
     long startTimeMs = _timerContext.getQueryArrivalTimeMs();
     Long timeoutMs = QueryOptionsUtils.getTimeoutMs(queryOptions);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/ServerQueryRequest.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/ServerQueryRequest.java
@@ -74,6 +74,9 @@ public class ServerQueryRequest {
   // Timing information for different phases of query execution
   private final TimerContext _timerContext;
 
+  @Nullable
+  private QueryExecutionContext _executionContext;
+
   /// This is called from the Netty server to create a ServerQueryRequest from the InstanceRequest
   public ServerQueryRequest(InstanceRequest instanceRequest, ServerMetrics serverMetrics, long queryArrivalTimeMs) {
     this(instanceRequest, serverMetrics, queryArrivalTimeMs, false);
@@ -238,7 +241,22 @@ public class ServerQueryRequest {
     return _timerContext;
   }
 
+  public synchronized QueryExecutionContext getOrCreateExecutionContext(String instanceId) {
+    if (_executionContext == null) {
+      _executionContext = createExecutionContext(instanceId);
+    }
+    return _executionContext;
+  }
+
+  public synchronized void setExecutionContext(QueryExecutionContext executionContext) {
+    _executionContext = executionContext;
+  }
+
   public QueryExecutionContext toExecutionContext(String instanceId) {
+    return getOrCreateExecutionContext(instanceId);
+  }
+
+  private QueryExecutionContext createExecutionContext(String instanceId) {
     Map<String, String> queryOptions = _queryContext.getQueryOptions();
     long startTimeMs = _timerContext.getQueryArrivalTimeMs();
     Long timeoutMs = QueryOptionsUtils.getTimeoutMs(queryOptions);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
@@ -118,7 +118,7 @@ public abstract class QueryScheduler {
   /// @return serialized query response
   @Nullable
   protected byte[] processQueryAndSerialize(ServerQueryRequest queryRequest, ExecutorService executorService) {
-    QueryExecutionContext executionContext = queryRequest.toExecutionContext(_instanceId);
+    QueryExecutionContext executionContext = queryRequest.getOrCreateExecutionContext(_instanceId);
     _latestQueryTime.accumulate(executionContext.getStartTimeMs());
     try (QueryThreadContext ignore = QueryThreadContext.open(executionContext, _threadAccountant)) {
       InstanceResponseBlock instanceResponse;

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ChannelHandlerFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ChannelHandlerFactory.java
@@ -88,6 +88,13 @@ public class ChannelHandlerFactory {
     return new InstanceRequestHandler(instanceName, config, queryScheduler, accessControl, threadAccountant);
   }
 
+  public static ChannelHandler getInstanceRequestHandler(String instanceName, PinotConfiguration config,
+      QueryScheduler queryScheduler, AccessControl accessControl, ThreadAccountant threadAccountant,
+      QueryProgressTracker queryProgressTracker) {
+    return new InstanceRequestHandler(instanceName, config, queryScheduler, accessControl, threadAccountant,
+        queryProgressTracker);
+  }
+
   public static ChannelHandler getDirectOOMHandler(QueryRouter queryRouter, ServerRoutingInstance serverRoutingInstance,
       ConcurrentHashMap<ServerRoutingInstance, ServerChannels.ServerChannel> serverToChannelMap,
       ConcurrentHashMap<SocketChannel, Boolean> allChannels, ServerSocketChannel serverSocketChannel) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/InstanceRequestHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/InstanceRequestHandler.java
@@ -52,6 +52,7 @@ import org.apache.pinot.spi.accounting.ThreadAccountant;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.apache.pinot.spi.query.QueryExecutionContext;
+import org.apache.pinot.spi.query.QueryProgressStats;
 import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.CommonConstants.Server;
@@ -86,14 +87,21 @@ public class InstanceRequestHandler extends SimpleChannelInboundHandler<ByteBuf>
   private final AccessControl _accessControl;
   private final ThreadAccountant _threadAccountant;
   private final ConcurrentHashMap<String, QueryExecutionContext> _executionContexts;
+  private final QueryProgressTracker _queryProgressTracker;
   private final ServerMetrics _serverMetrics = ServerMetrics.get();
 
   public InstanceRequestHandler(String instanceName, PinotConfiguration config, QueryScheduler queryScheduler,
       AccessControl accessControl, ThreadAccountant threadAccountant) {
+    this(instanceName, config, queryScheduler, accessControl, threadAccountant, new QueryProgressTracker(config));
+  }
+
+  public InstanceRequestHandler(String instanceName, PinotConfiguration config, QueryScheduler queryScheduler,
+      AccessControl accessControl, ThreadAccountant threadAccountant, QueryProgressTracker queryProgressTracker) {
     _instanceName = instanceName;
     _queryScheduler = queryScheduler;
     _accessControl = accessControl;
     _threadAccountant = threadAccountant;
+    _queryProgressTracker = queryProgressTracker;
 
     if (config.getProperty(Server.CONFIG_OF_ENABLE_QUERY_CANCELLATION, Server.DEFAULT_ENABLE_QUERY_CANCELLATION)) {
       _executionContexts = new ConcurrentHashMap<>();
@@ -152,34 +160,36 @@ public class InstanceRequestHandler extends SimpleChannelInboundHandler<ByteBuf>
   /// If query cancellation is enabled, the query future is tracked as well.
   @VisibleForTesting
   void submitQuery(ServerQueryRequest queryRequest, ChannelHandlerContext ctx, long queryArrivalTimeMs) {
-    QueryExecutionContext executionContext = queryRequest.toExecutionContext(_instanceName);
+    QueryExecutionContext executionContext = queryRequest.getOrCreateExecutionContext(_instanceName);
     try (QueryThreadContext ignore = QueryThreadContext.open(executionContext, _threadAccountant)) {
       ListenableFuture<byte[]> future = _queryScheduler.submit(queryRequest);
+      String queryId = queryRequest.getQueryId();
       if (_executionContexts != null) {
-        String queryId = queryRequest.getQueryId();
         // Track the running query for cancellation.
         if (LOGGER.isDebugEnabled()) {
           LOGGER.debug("Keep track of running query: {}", queryId);
         }
         _executionContexts.put(queryId, executionContext);
       }
-      Futures.addCallback(future, createCallback(queryRequest, ctx, queryArrivalTimeMs),
+      _queryProgressTracker.register(queryId, executionContext);
+      Futures.addCallback(future, createCallback(queryRequest, executionContext, ctx, queryArrivalTimeMs),
           MoreExecutors.directExecutor());
     }
   }
 
-  private FutureCallback<byte[]> createCallback(ServerQueryRequest queryRequest, ChannelHandlerContext ctx,
-      long queryArrivalTimeMs) {
+  private FutureCallback<byte[]> createCallback(ServerQueryRequest queryRequest, QueryExecutionContext executionContext,
+      ChannelHandlerContext ctx, long queryArrivalTimeMs) {
     return new FutureCallback<>() {
       @Override
       public void onSuccess(@Nullable byte[] responseBytes) {
+        String queryId = queryRequest.getQueryId();
         if (_executionContexts != null) {
-          String queryId = queryRequest.getQueryId();
           if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Remove track of running query: {} on success", queryId);
           }
-          _executionContexts.remove(queryId);
+          _executionContexts.remove(queryId, executionContext);
         }
+        _queryProgressTracker.complete(queryId, executionContext, responseBytes != null);
         long requestId = queryRequest.getRequestId();
         String tableNameWithType = queryRequest.getTableNameWithType();
         if (responseBytes != null) {
@@ -194,13 +204,14 @@ public class InstanceRequestHandler extends SimpleChannelInboundHandler<ByteBuf>
 
       @Override
       public void onFailure(Throwable t) {
+        String queryId = queryRequest.getQueryId();
         if (_executionContexts != null) {
-          String queryId = queryRequest.getQueryId();
           if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Remove track of running query: {} on failure", queryId);
           }
-          _executionContexts.remove(queryId);
+          _executionContexts.remove(queryId, executionContext);
         }
+        _queryProgressTracker.complete(queryId, executionContext, false);
         // Send exception response.
         Exception e;
         if (t instanceof Exception) {
@@ -256,6 +267,11 @@ public class InstanceRequestHandler extends SimpleChannelInboundHandler<ByteBuf>
   public Set<String> getRunningQueryIds() {
     Preconditions.checkState(_executionContexts != null, "Query cancellation is not enabled on server");
     return new HashSet<>(_executionContexts.keySet());
+  }
+
+  @Nullable
+  public QueryProgressStats getQueryProgressStats(String queryId) {
+    return _queryProgressTracker.getProgressStats(queryId);
   }
 
   /// Send an exception back to broker as response to the query request.

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryProgressTracker.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryProgressTracker.java
@@ -1,0 +1,112 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.transport;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import java.time.Duration;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.query.QueryExecutionContext;
+import org.apache.pinot.spi.query.QueryProgressStats;
+import org.apache.pinot.spi.utils.CommonConstants.Server;
+
+
+/// Server-wide progress registry shared by every single-stage query transport.
+///
+/// Active contexts are removed conditionally so a late completion cannot remove a newer execution that reused the
+/// same query id. Completed snapshots are retained briefly because one server can finish while the broker is still
+/// reducing results or waiting for other servers.
+public final class QueryProgressTracker {
+  private static final int COMPLETED_PROGRESS_STATS_CACHE_SIZE = 10_000;
+  private static final Duration COMPLETED_PROGRESS_STATS_CACHE_EXPIRATION = Duration.ofMinutes(10);
+
+  @Nullable
+  private final ConcurrentHashMap<String, QueryExecutionContext> _executionContexts;
+  @Nullable
+  private final Cache<String, QueryProgressStats> _completedProgressStats;
+
+  public QueryProgressTracker(PinotConfiguration config) {
+    this(config.getProperty(Server.CONFIG_OF_QUERY_PROGRESS_ENABLED, Server.DEFAULT_QUERY_PROGRESS_ENABLED));
+  }
+
+  public QueryProgressTracker(boolean enabled) {
+    if (enabled) {
+      _executionContexts = new ConcurrentHashMap<>();
+      _completedProgressStats = CacheBuilder.newBuilder().maximumSize(COMPLETED_PROGRESS_STATS_CACHE_SIZE)
+          .expireAfterWrite(COMPLETED_PROGRESS_STATS_CACHE_EXPIRATION).build();
+    } else {
+      _executionContexts = null;
+      _completedProgressStats = null;
+    }
+  }
+
+  public boolean isEnabled() {
+    return _executionContexts != null;
+  }
+
+  public void register(String queryId, QueryExecutionContext executionContext) {
+    if (_executionContexts == null) {
+      return;
+    }
+    _completedProgressStats.invalidate(queryId);
+    _executionContexts.put(queryId, executionContext);
+  }
+
+  public void complete(String queryId, QueryExecutionContext executionContext, boolean successful) {
+    if (_executionContexts == null) {
+      return;
+    }
+    QueryProgressStats progressStats = executionContext.getProgressStats();
+    if (successful && progressStats != null) {
+      progressStats = asCompleted(progressStats);
+    }
+    QueryProgressStats completedProgressStats = progressStats;
+    _executionContexts.computeIfPresent(queryId, (ignored, currentExecutionContext) -> {
+      if (currentExecutionContext != executionContext) {
+        return currentExecutionContext;
+      }
+      if (completedProgressStats != null) {
+        _completedProgressStats.put(queryId, completedProgressStats);
+      }
+      return null;
+    });
+  }
+
+  @Nullable
+  public QueryProgressStats getProgressStats(String queryId) {
+    if (_executionContexts == null) {
+      return null;
+    }
+    QueryExecutionContext executionContext = _executionContexts.get(queryId);
+    return executionContext != null ? executionContext.getProgressStats()
+        : _completedProgressStats.getIfPresent(queryId);
+  }
+
+  private static QueryProgressStats asCompleted(QueryProgressStats progressStats) {
+    long totalWorkUnits = progressStats.getTotalWorkUnits();
+    long processedWorkUnits = totalWorkUnits >= 0 ? totalWorkUnits : progressStats.getProcessedWorkUnits();
+    long totalSegmentsToProcess = progressStats.getTotalSegmentsToProcess();
+    long processedSegments = totalSegmentsToProcess >= 0
+        ? totalSegmentsToProcess : progressStats.getProcessedSegments();
+    return new QueryProgressStats(progressStats.getLabel(), processedWorkUnits, totalWorkUnits, processedSegments,
+        totalSegmentsToProcess, progressStats.isEstimated()).withDetails(progressStats.getDetails());
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
@@ -60,6 +60,7 @@ import org.apache.pinot.core.query.executor.QueryExecutor;
 import org.apache.pinot.core.query.logger.ServerQueryLogger;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.scheduler.resources.ResourceManager;
+import org.apache.pinot.core.transport.QueryProgressTracker;
 import org.apache.pinot.server.access.AccessControl;
 import org.apache.pinot.server.access.GrpcRequesterIdentity;
 import org.apache.pinot.spi.accounting.ThreadAccountant;
@@ -86,6 +87,7 @@ public class GrpcQueryServer extends PinotQueryServerGrpc.PinotQueryServerImplBa
   private final ExecutorService _executorService;
   private final AccessControl _accessControl;
   private final ThreadAccountant _threadAccountant;
+  private final QueryProgressTracker _queryProgressTracker;
   // Memory allocator and throttling configuration
   private final PooledByteBufAllocator _bufAllocator;
   private final long _memoryThresholdBytes;
@@ -115,6 +117,13 @@ public class GrpcQueryServer extends PinotQueryServerGrpc.PinotQueryServerImplBa
 
   public GrpcQueryServer(String instanceId, int port, GrpcConfig config, TlsConfig tlsConfig,
       QueryExecutor queryExecutor, AccessControl accessControl, ThreadAccountant threadAccountant) {
+    this(instanceId, port, config, tlsConfig, queryExecutor, accessControl, threadAccountant,
+        new QueryProgressTracker(false));
+  }
+
+  public GrpcQueryServer(String instanceId, int port, GrpcConfig config, TlsConfig tlsConfig,
+      QueryExecutor queryExecutor, AccessControl accessControl, ThreadAccountant threadAccountant,
+      QueryProgressTracker queryProgressTracker) {
     _instanceId = instanceId;
     _executorService = QueryThreadContext.contextAwareExecutorService(
         Executors.newFixedThreadPool(config.isQueryWorkerThreadsSet()
@@ -171,6 +180,7 @@ public class GrpcQueryServer extends PinotQueryServerGrpc.PinotQueryServerImplBa
 
     _accessControl = accessControl;
     _threadAccountant = threadAccountant;
+    _queryProgressTracker = queryProgressTracker;
     LOGGER.info("Initialized GrpcQueryServer on port: {} with numWorkerThreads: {}", port,
         ResourceManager.DEFAULT_QUERY_WORKER_THREADS);
   }
@@ -272,6 +282,9 @@ public class GrpcQueryServer extends PinotQueryServerGrpc.PinotQueryServerImplBa
 
     // Process the query
     QueryExecutionContext executionContext = queryRequest.toExecutionContext(_instanceId);
+    String queryId = queryRequest.getQueryId();
+    _queryProgressTracker.register(queryId, executionContext);
+    boolean successful = false;
     try (QueryThreadContext ignore = QueryThreadContext.open(executionContext, _threadAccountant)) {
       InstanceResponseBlock instanceResponse;
       try {
@@ -302,6 +315,7 @@ public class GrpcQueryServer extends PinotQueryServerGrpc.PinotQueryServerImplBa
       responseObserver.onNext(serverResponse);
       _serverMetrics.addMeteredGlobalValue(ServerMeter.GRPC_BYTES_SENT, serverResponse.getSerializedSize());
       responseObserver.onCompleted();
+      successful = true;
       _serverMetrics.addTimedTableValue(queryRequest.getTableNameWithType(), ServerTimer.GRPC_QUERY_EXECUTION_MS,
           System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
 
@@ -309,6 +323,8 @@ public class GrpcQueryServer extends PinotQueryServerGrpc.PinotQueryServerImplBa
       if (_queryLogger != null) {
         _queryLogger.logQuery(queryRequest, instanceResponse, "GrpcQueryServer");
       }
+    } finally {
+      _queryProgressTracker.complete(queryId, executionContext, successful);
     }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/streaming/StreamingGroupByCombineOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/streaming/StreamingGroupByCombineOperatorTest.java
@@ -49,6 +49,7 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.utils.CommonConstants.Server;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
@@ -432,6 +433,33 @@ public class StreamingGroupByCombineOperatorTest {
     }
     // Per segment, the total over all rows is sum over g of 2 * (g + 1) = 2550
     assertEquals(groupSums.get(null), NUM_SEGMENTS * 2550.0, 0.001, "Incorrect rollup total");
+  }
+
+  @Test
+  public void testTracksProcessedSegments() {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT groupColumn, COUNT(*) FROM testTable GROUP BY groupColumn");
+    queryContext.setEndTimeMs(System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS);
+    ExecutorService executor = QueryThreadContext.contextAwareExecutorService(Executors.newCachedThreadPool());
+
+    try (QueryThreadContext threadContext = QueryThreadContext.openForSseTest()) {
+      StreamingGroupByCombineOperator combineOperator =
+          new StreamingGroupByCombineOperator(buildOperators(queryContext), queryContext, executor, 10);
+      combineOperator.start();
+      try {
+        BaseResultsBlock block = combineOperator.nextBlock();
+        while (!(block instanceof MetadataResultsBlock)) {
+          assertNull(block.getErrorMessages());
+          block = combineOperator.nextBlock();
+        }
+      } finally {
+        combineOperator.stop();
+      }
+
+      assertEquals(threadContext.getExecutionContext().getProgressStats().getProcessedSegments(), NUM_SEGMENTS);
+    } finally {
+      executor.shutdownNow();
+    }
   }
 
   private List<Operator> buildOperators(QueryContext queryContext) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/streaming/StreamingGroupByCombineOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/streaming/StreamingGroupByCombineOperatorTest.java
@@ -51,6 +51,7 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.utils.CommonConstants.Server;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
@@ -475,6 +476,33 @@ public class StreamingGroupByCombineOperatorTest {
       planNodes.add(PLAN_MAKER.makeSegmentPlanNode(new SegmentContext(indexSegment), queryContext));
     }
     return new CombinePlanNode(planNodes, queryContext, EXECUTOR, block -> { }).run();
+  }
+
+  @Test
+  public void testTracksProcessedSegments() {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT groupColumn, COUNT(*) FROM testTable GROUP BY groupColumn");
+    queryContext.setEndTimeMs(System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS);
+    ExecutorService executor = QueryThreadContext.contextAwareExecutorService(Executors.newCachedThreadPool());
+
+    try (QueryThreadContext threadContext = QueryThreadContext.openForSseTest()) {
+      StreamingGroupByCombineOperator combineOperator =
+          new StreamingGroupByCombineOperator(buildOperators(queryContext), queryContext, executor, 10);
+      combineOperator.start();
+      try {
+        BaseResultsBlock block = combineOperator.nextBlock();
+        while (!(block instanceof MetadataResultsBlock)) {
+          assertNull(block.getErrorMessages());
+          block = combineOperator.nextBlock();
+        }
+      } finally {
+        combineOperator.stop();
+      }
+
+      assertEquals(threadContext.getExecutionContext().getProgressStats().getProcessedSegments(), NUM_SEGMENTS);
+    } finally {
+      executor.shutdownNow();
+    }
   }
 
   private List<Operator> buildOperators(QueryContext queryContext) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/InstanceRequestHandlerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/InstanceRequestHandlerTest.java
@@ -40,6 +40,7 @@ import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.metrics.PinotMetricUtils;
 import org.apache.pinot.spi.metrics.PinotMetricsRegistry;
 import org.apache.pinot.spi.query.QueryExecutionContext;
+import org.apache.pinot.spi.query.QueryProgressStats;
 import org.apache.pinot.util.TestUtils;
 import org.mockito.ArgumentCaptor;
 import org.testng.annotations.BeforeClass;
@@ -83,7 +84,7 @@ public class InstanceRequestHandlerTest {
       when(query.getTableNameWithType()).thenReturn("testTable_OFFLINE");
       QueryExecutionContext executionContext = mock(QueryExecutionContext.class);
       when(executionContext.getCid()).thenReturn(queryId);
-      when(query.toExecutionContext(any())).thenReturn(executionContext);
+      when(query.getOrCreateExecutionContext(any())).thenReturn(executionContext);
       ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
       ChannelFuture chFu = mock(ChannelFuture.class);
       when(ctx.writeAndFlush(any())).thenReturn(chFu);
@@ -103,6 +104,44 @@ public class InstanceRequestHandlerTest {
     assertFalse(handler.cancelQuery("unknown"));
   }
 
+  @Test
+  public void testCompletedProgressStatsRetained()
+      throws InterruptedException {
+    PinotConfiguration config = new PinotConfiguration();
+    CountDownLatch queryFinishLatch = new CountDownLatch(1);
+    QueryScheduler queryScheduler = createQueryScheduler(config, queryFinishLatch, new byte[]{1});
+    InstanceRequestHandler handler =
+        new InstanceRequestHandler("server01", config, queryScheduler, mock(AccessControl.class),
+            ThreadAccountantUtils.getNoOpAccountant());
+
+    ServerQueryRequest query = mock(ServerQueryRequest.class);
+    when(query.getQueryId()).thenReturn("test-query");
+    when(query.getTableNameWithType()).thenReturn("testTable_OFFLINE");
+    when(query.getRequestId()).thenReturn(1L);
+    QueryExecutionContext executionContext = mock(QueryExecutionContext.class);
+    when(executionContext.getCid()).thenReturn("test-query");
+    when(executionContext.getProgressStats()).thenReturn(new QueryProgressStats(1, 3, 1, 3, false));
+    when(query.getOrCreateExecutionContext(any())).thenReturn(executionContext);
+
+    ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+    ChannelFuture chFu = mock(ChannelFuture.class);
+    when(ctx.writeAndFlush(any())).thenReturn(chFu);
+
+    handler.submitQuery(query, ctx, System.currentTimeMillis());
+    assertEquals(handler.getQueryProgressStats("test-query").getProcessedWorkUnits(), 1);
+
+    queryFinishLatch.countDown();
+    TestUtils.waitForCondition((aVoid) -> handler.getRunningQueryIds().isEmpty(), 10_000L,
+        "Timed out waiting for query to finish");
+
+    QueryProgressStats completedProgressStats = handler.getQueryProgressStats("test-query");
+    assertEquals(completedProgressStats.getProcessedWorkUnits(), 3);
+    assertEquals(completedProgressStats.getTotalWorkUnits(), 3);
+    assertEquals(completedProgressStats.getProcessedSegments(), 3);
+    assertEquals(completedProgressStats.getTotalSegmentsToProcess(), 3);
+    assertEquals(completedProgressStats.getProgressPercent(), 100.0);
+  }
+
   @SuppressWarnings("unchecked")
   @Test
   public void testWriteFailureClosesChannel()
@@ -120,7 +159,7 @@ public class InstanceRequestHandlerTest {
     when(query.getRequestId()).thenReturn(1L);
     QueryExecutionContext executionContext = mock(QueryExecutionContext.class);
     when(executionContext.getCid()).thenReturn("test-query");
-    when(query.toExecutionContext(any())).thenReturn(executionContext);
+    when(query.getOrCreateExecutionContext(any())).thenReturn(executionContext);
 
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     ChannelFuture writeFuture = mock(ChannelFuture.class);
@@ -145,6 +184,11 @@ public class InstanceRequestHandlerTest {
   }
 
   private QueryScheduler createQueryScheduler(PinotConfiguration config, CountDownLatch queryFinishLatch) {
+    return createQueryScheduler(config, queryFinishLatch, null);
+  }
+
+  private QueryScheduler createQueryScheduler(PinotConfiguration config, CountDownLatch queryFinishLatch,
+      byte[] responseBytes) {
     ResourceManager resourceManager = new UnboundedResourceManager(config);
     return new QueryScheduler(config, "serverId", mock(QueryExecutor.class), ThreadAccountantUtils.getNoOpAccountant(),
         new LongAccumulator(Long::max, 0), resourceManager) {
@@ -153,7 +197,7 @@ public class InstanceRequestHandlerTest {
         // Create a FutureTask does nothing but waits to be cancelled and trigger callbacks.
         ListenableFutureTask<byte[]> task = ListenableFutureTask.create(() -> {
           queryFinishLatch.await();
-          return null;
+          return responseBytes;
         });
         resourceManager.getQueryRunners().submit(task);
         return task;

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryProgressTrackerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryProgressTrackerTest.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.transport;
+
+import org.apache.pinot.spi.query.QueryExecutionContext;
+import org.apache.pinot.spi.query.QueryProgressStats;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+
+
+public class QueryProgressTrackerTest {
+  @Test
+  public void testTracksActiveAndCompletedProgress() {
+    QueryProgressTracker tracker = new QueryProgressTracker(true);
+    QueryExecutionContext executionContext = QueryExecutionContext.forSseTest();
+    executionContext.addTotalSegmentsToProcess(3);
+    executionContext.incrementProcessedSegments();
+
+    tracker.register("query", executionContext);
+    QueryProgressStats active = tracker.getProgressStats("query");
+    assertEquals(active.getProcessedSegments(), 1);
+    assertEquals(active.getTotalSegmentsToProcess(), 3);
+
+    tracker.complete("query", executionContext, true);
+    QueryProgressStats completed = tracker.getProgressStats("query");
+    assertEquals(completed.getProcessedSegments(), 3);
+    assertEquals(completed.getProcessedWorkUnits(), 3);
+    assertEquals(completed.getProgressPercent(), 100.0);
+  }
+
+  @Test
+  public void testCompletedProgressClampsProcessedCountsToKnownTotals() {
+    QueryProgressTracker tracker = new QueryProgressTracker(true);
+    QueryExecutionContext executionContext = QueryExecutionContext.forSseTest();
+    executionContext.addTotalSegmentsToProcess(1);
+    executionContext.incrementProcessedSegments();
+    executionContext.incrementProcessedSegments();
+
+    tracker.register("query", executionContext);
+    tracker.complete("query", executionContext, true);
+
+    QueryProgressStats completed = tracker.getProgressStats("query");
+    assertEquals(completed.getProcessedSegments(), 1);
+    assertEquals(completed.getTotalSegmentsToProcess(), 1);
+    assertEquals(completed.getProcessedWorkUnits(), 1);
+    assertEquals(completed.getTotalWorkUnits(), 1);
+  }
+
+  @Test
+  public void testLateCompletionDoesNotRemoveReusedQueryId() {
+    QueryProgressTracker tracker = new QueryProgressTracker(true);
+    QueryExecutionContext first = QueryExecutionContext.forSseTest();
+    QueryExecutionContext second = QueryExecutionContext.forSseTest();
+    second.addTotalSegmentsToProcess(5);
+
+    tracker.register("query", first);
+    tracker.register("query", second);
+    tracker.complete("query", second, true);
+    tracker.complete("query", first, false);
+
+    QueryProgressStats progressStats = tracker.getProgressStats("query");
+    assertEquals(progressStats.getProcessedSegments(), 5);
+    assertEquals(progressStats.getTotalSegmentsToProcess(), 5);
+  }
+
+  @Test
+  public void testDisabledTrackerIsNoOp() {
+    QueryProgressTracker tracker = new QueryProgressTracker(false);
+    QueryExecutionContext executionContext = QueryExecutionContext.forSseTest();
+
+    tracker.register("query", executionContext);
+    tracker.complete("query", executionContext, true);
+
+    assertFalse(tracker.isEnabled());
+    assertNull(tracker.getProgressStats("query"));
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -71,6 +71,7 @@ import org.apache.pinot.spi.executor.ExecutorServiceUtils;
 import org.apache.pinot.spi.executor.HardLimitExecutor;
 import org.apache.pinot.spi.executor.MetricsExecutor;
 import org.apache.pinot.spi.query.QueryExecutionContext;
+import org.apache.pinot.spi.query.QueryProgressStats;
 import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.query.QueryThreadExceedStrategy;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
@@ -588,6 +589,11 @@ public class QueryRunner {
 
   public void unregisterOpChainCompletionListener(long requestId) {
     _opChainScheduler.unregisterCompletionListener(requestId);
+  }
+
+  @Nullable
+  public QueryProgressStats getQueryProgressStats(long requestId) {
+    return _opChainScheduler.getQueryProgressStats(requestId);
   }
 
   public StagePlan explainQuery(WorkerMetadata workerMetadata, StagePlan stagePlan,

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
@@ -52,7 +52,9 @@ import org.apache.pinot.spi.exception.QueryException;
 import org.apache.pinot.spi.exception.TerminationException;
 import org.apache.pinot.spi.metrics.PinotMeter;
 import org.apache.pinot.spi.query.QueryExecutionContext;
+import org.apache.pinot.spi.query.QueryProgressStats;
 import org.apache.pinot.spi.query.QueryThreadContext;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,6 +65,8 @@ public class OpChainSchedulerService {
   private static final Logger LOGGER = LoggerFactory.getLogger(OpChainSchedulerService.class);
   private static final int NUM_QUERY_LOCKS = 1 << 10; // 1024 locks
   private static final int QUERY_LOCK_MASK = NUM_QUERY_LOCKS - 1;
+  private static final int COMPLETED_PROGRESS_STATS_CACHE_SIZE = 10_000;
+  private static final int COMPLETED_PROGRESS_STATS_CACHE_EXPIRATION_MINUTES = 10;
 
   private final String _instanceId;
   /// This [ExecutorService] must be wrapped with [QueryThreadContext#contextAwareExecutorService].
@@ -84,23 +88,27 @@ public class OpChainSchedulerService {
   /// BEFORE calling compute() so that register()'s read lock cannot overlap with the eviction window.
   private final ConcurrentMap<Long, QueryExecutionContext> _executionContextByRequest = new ConcurrentHashMap<>();
   private final ConcurrentMap<Long, AtomicInteger> _activeOpChainsByRequest = new ConcurrentHashMap<>();
+  @Nullable
+  private final Cache<Long, QueryProgressStats> _completedProgressStats;
 
   public OpChainSchedulerService(String instanceId, ExecutorService executorService, PinotConfiguration config) {
     this(instanceId, executorService,
         config.getProperty(MultiStageQueryRunner.KEY_OF_CANCELLED_QUERY_CACHE_SIZE,
             MultiStageQueryRunner.DEFAULT_OF_CANCELLED_QUERY_CACHE_SIZE),
         config.getProperty(MultiStageQueryRunner.KEY_OF_CANCELLED_QUERY_CACHE_EXPIRE_MS,
-            MultiStageQueryRunner.DEFAULT_OF_CANCELLED_QUERY_CACHE_EXPIRE_MS));
+            MultiStageQueryRunner.DEFAULT_OF_CANCELLED_QUERY_CACHE_EXPIRE_MS),
+        config.getProperty(CommonConstants.Server.CONFIG_OF_QUERY_PROGRESS_ENABLED,
+            CommonConstants.Server.DEFAULT_QUERY_PROGRESS_ENABLED));
   }
 
   @VisibleForTesting
   public OpChainSchedulerService(ExecutorService executorService) {
     this("testServer", executorService, MultiStageQueryRunner.DEFAULT_OF_CANCELLED_QUERY_CACHE_SIZE,
-        MultiStageQueryRunner.DEFAULT_OF_CANCELLED_QUERY_CACHE_EXPIRE_MS);
+        MultiStageQueryRunner.DEFAULT_OF_CANCELLED_QUERY_CACHE_EXPIRE_MS, true);
   }
 
   private OpChainSchedulerService(String instanceId, ExecutorService executorService, int cancelledQueryCacheSize,
-      long cancelledQueryCacheExpireMs) {
+      long cancelledQueryCacheExpireMs, boolean enableQueryProgress) {
     _instanceId = instanceId;
     _executorService = executorService;
     _queryLocks = new ReadWriteLock[NUM_QUERY_LOCKS];
@@ -111,6 +119,10 @@ public class OpChainSchedulerService {
         .maximumSize(cancelledQueryCacheSize)
         .expireAfterWrite(cancelledQueryCacheExpireMs, TimeUnit.MILLISECONDS)
         .build();
+    _completedProgressStats = enableQueryProgress
+        ? CacheBuilder.newBuilder().maximumSize(COMPLETED_PROGRESS_STATS_CACHE_SIZE)
+            .expireAfterWrite(COMPLETED_PROGRESS_STATS_CACHE_EXPIRATION_MINUTES, TimeUnit.MINUTES).build()
+        : null;
   }
 
   public void register(OpChain operatorChain) {
@@ -162,6 +174,9 @@ public class OpChainSchedulerService {
     // that observes count==0 and removes the context entry cannot race with a new putIfAbsent arriving between the
     // counter update and the context-map update.
     _activeOpChainsByRequest.compute(requestId, (k, v) -> {
+      if (_completedProgressStats != null) {
+        _completedProgressStats.invalidate(requestId);
+      }
       _executionContextByRequest.putIfAbsent(requestId, executionContext);
       if (v == null) {
         return new AtomicInteger(1);
@@ -203,6 +218,7 @@ public class OpChainSchedulerService {
     Futures.addCallback(listenableFutureTask, new FutureCallback<>() {
       @Override
       public void onSuccess(Void result) {
+        executionContext.incrementProcessedWorkUnits();
         _metrics.onOpChainFinished(rootOperator);
         decrementActiveOpChains(requestId);
         notifyCompletionListener(opChainId, operatorChain, statsRef.get(), null);
@@ -212,6 +228,7 @@ public class OpChainSchedulerService {
       @Override
       public void onFailure(Throwable t) {
         String logMsg = "Failed to execute operator chain: " + t.getMessage();
+        executionContext.incrementProcessedWorkUnits();
         _metrics.onOpChainFinished(rootOperator);
         if (t instanceof QueryException) {
           switch (((QueryException) t).getErrorCode()) {
@@ -248,14 +265,28 @@ public class OpChainSchedulerService {
     }
   }
 
+  @Nullable
+  public QueryProgressStats getQueryProgressStats(long requestId) {
+    if (_completedProgressStats == null) {
+      return null;
+    }
+    QueryExecutionContext executionContext = _executionContextByRequest.get(requestId);
+    return executionContext != null ? executionContext.getProgressStats()
+        : _completedProgressStats.getIfPresent(requestId);
+  }
+
   private void decrementActiveOpChains(long requestId) {
-    // Use compute() so the "decrement-to-zero → remove" step is atomic with a concurrent registerInternal()
+    // Use compute() so the "decrement-to-zero -> remove" step is atomic with a concurrent registerInternal()
     // that would otherwise interleave a putIfAbsent + increment between our remove() calls.
     _activeOpChainsByRequest.compute(requestId, (k, counter) -> {
       if (counter == null) {
         return null;
       }
       if (counter.decrementAndGet() <= 0) {
+        QueryExecutionContext executionContext = _executionContextByRequest.get(requestId);
+        if (executionContext != null && _completedProgressStats != null) {
+          _completedProgressStats.put(requestId, executionContext.getProgressStats());
+        }
         _executionContextByRequest.remove(requestId);
         return null;
       }
@@ -322,6 +353,9 @@ public class OpChainSchedulerService {
       // putIfAbsent() on _executionContextByRequest.
       _activeOpChainsByRequest.compute(requestId, (k, counter) -> {
         ctxRef.set(_executionContextByRequest.remove(requestId));
+        if (_completedProgressStats != null) {
+          _completedProgressStats.invalidate(requestId);
+        }
         return null; // unconditionally evict the counter on cancel
       });
       _cancelledQueryCache.put(requestId, Boolean.TRUE);
@@ -338,6 +372,11 @@ public class OpChainSchedulerService {
 
   private ReadWriteLock getQueryLock(long requestId) {
     return _queryLocks[(int) (requestId & QUERY_LOCK_MASK)];
+  }
+
+  @VisibleForTesting
+  boolean hasRunningExecutionContext(long requestId) {
+    return _executionContextByRequest.containsKey(requestId);
   }
 
   private static class Metrics {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
@@ -54,7 +54,9 @@ import org.apache.pinot.spi.exception.QueryException;
 import org.apache.pinot.spi.exception.TerminationException;
 import org.apache.pinot.spi.metrics.PinotMeter;
 import org.apache.pinot.spi.query.QueryExecutionContext;
+import org.apache.pinot.spi.query.QueryProgressStats;
 import org.apache.pinot.spi.query.QueryThreadContext;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,6 +67,8 @@ public class OpChainSchedulerService {
   private static final Logger LOGGER = LoggerFactory.getLogger(OpChainSchedulerService.class);
   private static final int NUM_QUERY_LOCKS = 1 << 10; // 1024 locks
   private static final int QUERY_LOCK_MASK = NUM_QUERY_LOCKS - 1;
+  private static final int COMPLETED_PROGRESS_STATS_CACHE_SIZE = 10_000;
+  private static final int COMPLETED_PROGRESS_STATS_CACHE_EXPIRATION_MINUTES = 10;
 
   private final String _instanceId;
   /// This [ExecutorService] must be wrapped with [QueryThreadContext#contextAwareExecutorService].
@@ -92,6 +96,8 @@ public class OpChainSchedulerService {
   /// when the forEach observes the cache entry.
   private final ConcurrentMap<Long, QueryExecutionContext> _executionContextByRequest = new ConcurrentHashMap<>();
   private final ConcurrentMap<Long, AtomicInteger> _activeOpChainsByRequest = new ConcurrentHashMap<>();
+  @Nullable
+  private final Cache<Long, QueryProgressStats> _completedProgressStats;
 
   public OpChainSchedulerService(String instanceId, ExecutorService executorService, PinotConfiguration config) {
     this(instanceId, executorService, config.getProperty(MultiStageQueryRunner.KEY_OF_OP_STATS_CACHE_SIZE,
@@ -101,7 +107,9 @@ public class OpChainSchedulerService {
         config.getProperty(MultiStageQueryRunner.KEY_OF_CANCELLED_QUERY_CACHE_SIZE,
             MultiStageQueryRunner.DEFAULT_OF_CANCELLED_QUERY_CACHE_SIZE),
         config.getProperty(MultiStageQueryRunner.KEY_OF_CANCELLED_QUERY_CACHE_EXPIRE_MS,
-            MultiStageQueryRunner.DEFAULT_OF_CANCELLED_QUERY_CACHE_EXPIRE_MS));
+            MultiStageQueryRunner.DEFAULT_OF_CANCELLED_QUERY_CACHE_EXPIRE_MS),
+        config.getProperty(CommonConstants.Server.CONFIG_OF_QUERY_PROGRESS_ENABLED,
+            CommonConstants.Server.DEFAULT_QUERY_PROGRESS_ENABLED));
   }
 
   @VisibleForTesting
@@ -109,11 +117,12 @@ public class OpChainSchedulerService {
     this("testServer", executorService, MultiStageQueryRunner.DEFAULT_OF_OP_STATS_CACHE_SIZE,
         MultiStageQueryRunner.DEFAULT_OF_OP_STATS_CACHE_EXPIRE_MS,
         MultiStageQueryRunner.DEFAULT_OF_CANCELLED_QUERY_CACHE_SIZE,
-        MultiStageQueryRunner.DEFAULT_OF_CANCELLED_QUERY_CACHE_EXPIRE_MS);
+        MultiStageQueryRunner.DEFAULT_OF_CANCELLED_QUERY_CACHE_EXPIRE_MS, true);
   }
 
   private OpChainSchedulerService(String instanceId, ExecutorService executorService, int opStatsCacheSize,
-      long opStatsCacheExpireMs, int cancelledQueryCacheSize, long cancelledQueryCacheExpireMs) {
+      long opStatsCacheExpireMs, int cancelledQueryCacheSize, long cancelledQueryCacheExpireMs,
+      boolean enableQueryProgress) {
     _instanceId = instanceId;
     _executorService = executorService;
     _opChainCache = CacheBuilder.newBuilder()
@@ -129,6 +138,10 @@ public class OpChainSchedulerService {
         .maximumSize(cancelledQueryCacheSize)
         .expireAfterWrite(cancelledQueryCacheExpireMs, TimeUnit.MILLISECONDS)
         .build();
+    _completedProgressStats = enableQueryProgress
+        ? CacheBuilder.newBuilder().maximumSize(COMPLETED_PROGRESS_STATS_CACHE_SIZE)
+            .expireAfterWrite(COMPLETED_PROGRESS_STATS_CACHE_EXPIRATION_MINUTES, TimeUnit.MINUTES).build()
+        : null;
   }
 
   public void register(OpChain operatorChain) {
@@ -181,6 +194,9 @@ public class OpChainSchedulerService {
     // that observes count==0 and removes the context entry cannot race with a new putIfAbsent arriving between the
     // counter update and the context-map update.
     _activeOpChainsByRequest.compute(requestId, (k, v) -> {
+      if (_completedProgressStats != null) {
+        _completedProgressStats.invalidate(requestId);
+      }
       _executionContextByRequest.putIfAbsent(requestId, executionContext);
       if (v == null) {
         return new AtomicInteger(1);
@@ -223,6 +239,7 @@ public class OpChainSchedulerService {
     Futures.addCallback(listenableFutureTask, new FutureCallback<>() {
       @Override
       public void onSuccess(Void result) {
+        executionContext.incrementProcessedWorkUnits();
         _metrics.onOpChainFinished(rootOperator);
         decrementActiveOpChains(requestId);
         notifyCompletionListener(opChainId, operatorChain, statsRef.get(), null);
@@ -232,6 +249,7 @@ public class OpChainSchedulerService {
       @Override
       public void onFailure(Throwable t) {
         String logMsg = "Failed to execute operator chain: " + t.getMessage();
+        executionContext.incrementProcessedWorkUnits();
         _metrics.onOpChainFinished(rootOperator);
         if (t instanceof QueryException) {
           switch (((QueryException) t).getErrorCode()) {
@@ -271,14 +289,28 @@ public class OpChainSchedulerService {
     }
   }
 
+  @Nullable
+  public QueryProgressStats getQueryProgressStats(long requestId) {
+    if (_completedProgressStats == null) {
+      return null;
+    }
+    QueryExecutionContext executionContext = _executionContextByRequest.get(requestId);
+    return executionContext != null ? executionContext.getProgressStats()
+        : _completedProgressStats.getIfPresent(requestId);
+  }
+
   private void decrementActiveOpChains(long requestId) {
-    // Use compute() so the "decrement-to-zero → remove" step is atomic with a concurrent registerInternal()
+    // Use compute() so the "decrement-to-zero -> remove" step is atomic with a concurrent registerInternal()
     // that would otherwise interleave a putIfAbsent + increment between our remove() calls.
     _activeOpChainsByRequest.compute(requestId, (k, counter) -> {
       if (counter == null) {
         return null;
       }
       if (counter.decrementAndGet() <= 0) {
+        QueryExecutionContext executionContext = _executionContextByRequest.get(requestId);
+        if (executionContext != null && _completedProgressStats != null) {
+          _completedProgressStats.put(requestId, executionContext.getProgressStats());
+        }
         _executionContextByRequest.remove(requestId);
         return null;
       }
@@ -345,6 +377,9 @@ public class OpChainSchedulerService {
       // putIfAbsent() on _executionContextByRequest.
       _activeOpChainsByRequest.compute(requestId, (k, counter) -> {
         ctxRef.set(_executionContextByRequest.remove(requestId));
+        if (_completedProgressStats != null) {
+          _completedProgressStats.invalidate(requestId);
+        }
         return null; // unconditionally evict the counter on cancel
       });
       _cancelledQueryCache.put(requestId, Boolean.TRUE);
@@ -390,6 +425,11 @@ public class OpChainSchedulerService {
 
   private ReadWriteLock getQueryLock(long requestId) {
     return _queryLocks[(int) (requestId & QUERY_LOCK_MASK)];
+  }
+
+  @VisibleForTesting
+  boolean hasRunningExecutionContext(long requestId) {
+    return _executionContextByRequest.containsKey(requestId);
   }
 
   private static class Metrics {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
@@ -58,6 +58,8 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.query.QueryExecutionContext;
+import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
@@ -124,8 +126,16 @@ public class ServerPlanRequestUtils {
     }
     int numRequests = instanceRequests.size();
     List<ServerQueryRequest> serverQueryRequests = new ArrayList<>(numRequests);
+    QueryThreadContext threadContext = QueryThreadContext.getIfAvailable();
+    QueryExecutionContext queryExecutionContext =
+        threadContext != null ? threadContext.getExecutionContext() : null;
     for (InstanceRequest instanceRequest : instanceRequests) {
-      serverQueryRequests.add(new ServerQueryRequest(instanceRequest, ServerMetrics.get(), queryArrivalTimeMs, true));
+      ServerQueryRequest serverQueryRequest =
+          new ServerQueryRequest(instanceRequest, ServerMetrics.get(), queryArrivalTimeMs, true);
+      if (queryExecutionContext != null) {
+        serverQueryRequest.setExecutionContext(queryExecutionContext);
+      }
+      serverQueryRequests.add(serverQueryRequest);
     }
     serverContext.setServerQueryRequests(serverQueryRequests);
     // 3. Compile the OpChain

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
@@ -57,6 +57,8 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.query.QueryExecutionContext;
+import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
@@ -125,8 +127,16 @@ public class ServerPlanRequestUtils {
     }
     int numRequests = instanceRequests.size();
     List<ServerQueryRequest> serverQueryRequests = new ArrayList<>(numRequests);
+    QueryThreadContext threadContext = QueryThreadContext.getIfAvailable();
+    QueryExecutionContext queryExecutionContext =
+        threadContext != null ? threadContext.getExecutionContext() : null;
     for (InstanceRequest instanceRequest : instanceRequests) {
-      serverQueryRequests.add(new ServerQueryRequest(instanceRequest, ServerMetrics.get(), queryArrivalTimeMs, true));
+      ServerQueryRequest serverQueryRequest =
+          new ServerQueryRequest(instanceRequest, ServerMetrics.get(), queryArrivalTimeMs, true);
+      if (queryExecutionContext != null) {
+        serverQueryRequest.setExecutionContext(queryExecutionContext);
+      }
+      serverQueryRequests.add(serverQueryRequest);
     }
     serverContext.setServerQueryRequests(serverQueryRequests);
     // 3. Compile the OpChain

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/DispatchClient.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/DispatchClient.java
@@ -144,6 +144,14 @@ class DispatchClient {
     _dispatchStub.withDeadline(deadline).cancel(cancelRequest, observer);
   }
 
+  public void getQueryProgress(long requestId, QueryServerInstance virtualServer, Deadline deadline,
+      Consumer<AsyncResponse<Worker.QueryProgressResponse>> callback) {
+    Worker.QueryProgressRequest queryProgressRequest =
+        Worker.QueryProgressRequest.newBuilder().setRequestId(requestId).build();
+    StreamObserver<Worker.QueryProgressResponse> observer = new LastValueDispatchObserver<>(virtualServer, callback);
+    _dispatchStub.withDeadline(deadline).getQueryProgress(queryProgressRequest, observer);
+  }
+
   public void explain(Worker.QueryRequest request, QueryServerInstance virtualServer, Deadline deadline,
       Consumer<AsyncResponse<List<Worker.ExplainResponse>>> callback) {
     _dispatchStub.withDeadline(deadline).explain(request, new AllValuesDispatchObserver<>(virtualServer, callback));

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/DispatchClient.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/DispatchClient.java
@@ -186,6 +186,14 @@ class DispatchClient {
     _dispatchStub.withDeadline(deadline).cancel(cancelRequest, observer);
   }
 
+  public void getQueryProgress(long requestId, QueryServerInstance virtualServer, Deadline deadline,
+      Consumer<AsyncResponse<Worker.QueryProgressResponse>> callback) {
+    Worker.QueryProgressRequest queryProgressRequest =
+        Worker.QueryProgressRequest.newBuilder().setRequestId(requestId).build();
+    StreamObserver<Worker.QueryProgressResponse> observer = new LastValueDispatchObserver<>(virtualServer, callback);
+    _dispatchStub.withDeadline(deadline).getQueryProgress(queryProgressRequest, observer);
+  }
+
   public void explain(Worker.QueryRequest request, QueryServerInstance virtualServer, Deadline deadline,
       Consumer<AsyncResponse<List<Worker.ExplainResponse>>> callback) {
     _dispatchStub.withDeadline(deadline).explain(request, new AllValuesDispatchObserver<>(virtualServer, callback));

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -28,6 +28,7 @@ import io.grpc.Deadline;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -89,6 +90,7 @@ import org.apache.pinot.query.service.dispatch.streaming.StreamingQuerySession;
 import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.apache.pinot.spi.exception.QueryException;
 import org.apache.pinot.spi.query.QueryExecutionContext;
+import org.apache.pinot.spi.query.QueryProgressStats;
 import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.trace.RequestContext;
 import org.apache.pinot.spi.utils.CommonConstants;
@@ -127,6 +129,8 @@ public class QueryDispatcher {
   private final DispatchClient.KeepAliveConfig _keepAliveConfig;
   // maps broker-generated query id to the set of servers that the query was dispatched to
   private final Map<Long, Set<QueryServerInstance>> _serversByQuery;
+  private final boolean _enableCancellation;
+  private final boolean _enableProgress;
   private final FailureDetector _failureDetector;
   private final Duration _cancelTimeout;
   /// Cluster-level default for stream-stats mode. Used as the fallback in [#submitAndReduce] when the query
@@ -135,7 +139,7 @@ public class QueryDispatcher {
 
   public QueryDispatcher(MailboxService mailboxService, FailureDetector failureDetector, @Nullable TlsConfig tlsConfig,
       boolean enableCancellation, Duration cancelTimeout) {
-    this(mailboxService, failureDetector, tlsConfig, enableCancellation, cancelTimeout,
+    this(mailboxService, failureDetector, tlsConfig, enableCancellation, enableCancellation, cancelTimeout,
         DispatchClient.KeepAliveConfig.DISABLED, false, CommonConstants.Broker.DEFAULT_STREAM_STATS_DRAIN_MS);
   }
 
@@ -144,14 +148,22 @@ public class QueryDispatcher {
   public QueryDispatcher(MailboxService mailboxService, FailureDetector failureDetector, @Nullable TlsConfig tlsConfig,
       boolean enableCancellation, Duration cancelTimeout, int keepAliveTimeMs, int keepAliveTimeoutMs,
       boolean keepAliveWithoutCalls, boolean streamStatsDefault, long statsDrainMs) {
-    this(mailboxService, failureDetector, tlsConfig, enableCancellation, cancelTimeout,
+    this(mailboxService, failureDetector, tlsConfig, enableCancellation, enableCancellation, cancelTimeout,
+        new DispatchClient.KeepAliveConfig(keepAliveTimeMs, keepAliveTimeoutMs, keepAliveWithoutCalls),
+        streamStatsDefault, statsDrainMs);
+  }
+
+  public QueryDispatcher(MailboxService mailboxService, FailureDetector failureDetector, @Nullable TlsConfig tlsConfig,
+      boolean enableCancellation, boolean enableProgress, Duration cancelTimeout, int keepAliveTimeMs,
+      int keepAliveTimeoutMs, boolean keepAliveWithoutCalls, boolean streamStatsDefault, long statsDrainMs) {
+    this(mailboxService, failureDetector, tlsConfig, enableCancellation, enableProgress, cancelTimeout,
         new DispatchClient.KeepAliveConfig(keepAliveTimeMs, keepAliveTimeoutMs, keepAliveWithoutCalls),
         streamStatsDefault, statsDrainMs);
   }
 
   private QueryDispatcher(MailboxService mailboxService, FailureDetector failureDetector, @Nullable TlsConfig tlsConfig,
-      boolean enableCancellation, Duration cancelTimeout, DispatchClient.KeepAliveConfig keepAliveConfig,
-      boolean streamStatsDefault, long statsDrainMs) {
+      boolean enableCancellation, boolean enableProgress, Duration cancelTimeout,
+      DispatchClient.KeepAliveConfig keepAliveConfig, boolean streamStatsDefault, long statsDrainMs) {
     _cancelTimeout = cancelTimeout;
     _statsDrainMs = statsDrainMs;
     _mailboxService = mailboxService;
@@ -162,8 +174,10 @@ public class QueryDispatcher {
     _keepAliveConfig = keepAliveConfig;
     _failureDetector = failureDetector;
     _streamStatsDefault = streamStatsDefault;
+    _enableCancellation = enableCancellation;
+    _enableProgress = enableProgress;
 
-    if (enableCancellation) {
+    if (enableCancellation || enableProgress) {
       _serversByQuery = new ConcurrentHashMap<>();
     } else {
       _serversByQuery = null;
@@ -239,7 +253,7 @@ public class QueryDispatcher {
           statsManager.recordStatsUponResponseArrival(requestId, server.getInstanceId(), -1);
         }
       }
-      if (isQueryCancellationEnabled()) {
+      if (isQueryTrackingEnabled()) {
         _serversByQuery.remove(requestId);
       }
     }
@@ -329,7 +343,7 @@ public class QueryDispatcher {
           statsManager.recordStatsUponResponseArrival(requestId, server.getInstanceId(), -1);
         }
       }
-      if (isQueryCancellationEnabled()) {
+      if (isQueryTrackingEnabled()) {
         _serversByQuery.remove(requestId);
       }
     }
@@ -390,7 +404,7 @@ public class QueryDispatcher {
       }
     }, deadline, ackQueue);
 
-    if (isQueryCancellationEnabled()) {
+    if (isQueryTrackingEnabled()) {
       _serversByQuery.put(requestId, serversOut);
     }
   }
@@ -585,7 +599,7 @@ public class QueryDispatcher {
                     serverInstance, response.getMetadataOrDefault(ServerResponseStatus.STATUS_ERROR, "null")));
           }
         });
-    if (isQueryCancellationEnabled()) {
+    if (isQueryTrackingEnabled()) {
       _serversByQuery.put(requestId, serversOut);
     }
   }
@@ -613,6 +627,10 @@ public class QueryDispatcher {
   }
 
   private boolean isQueryCancellationEnabled() {
+    return _enableCancellation;
+  }
+
+  private boolean isQueryTrackingEnabled() {
     return _serversByQuery != null;
   }
 
@@ -803,7 +821,7 @@ public class QueryDispatcher {
         LOGGER.warn("Caught exception while cancelling query: {} on server: {}", requestId, queryServerInstance, t);
       }
     }
-    if (isQueryCancellationEnabled()) {
+    if (isQueryTrackingEnabled()) {
       _serversByQuery.remove(requestId);
     }
     return true;
@@ -831,6 +849,86 @@ public class QueryDispatcher {
 
   private static String toHostnamePortKey(String hostname, int port) {
     return String.format("%s_%d", hostname, port);
+  }
+
+  @Nullable
+  public QueryProgressStats getQueryProgressStats(long requestId, int timeoutMs) {
+    if (!_enableProgress) {
+      return null;
+    }
+    Set<QueryServerInstance> servers = _serversByQuery.get(requestId);
+    if (servers == null || servers.isEmpty()) {
+      return null;
+    }
+
+    Deadline deadline = Deadline.after(timeoutMs, TimeUnit.MILLISECONDS);
+    SendRequest<Long, Worker.QueryProgressResponse> sendRequest = DispatchClient::getQueryProgress;
+    BlockingQueue<AsyncResponse<Worker.QueryProgressResponse>> dispatchCallbacks =
+        dispatch(sendRequest, new HashSet<>(servers), deadline, serverInstance -> requestId);
+    Set<QueryServerInstance> pendingServers = new HashSet<>(servers);
+    List<QueryProgressStats> details = new ArrayList<>(servers.size());
+    int numResponses = 0;
+    while (!deadline.isExpired() && numResponses < servers.size()) {
+      try {
+        AsyncResponse<Worker.QueryProgressResponse> response =
+            dispatchCallbacks.poll(Math.max(1, deadline.timeRemaining(TimeUnit.MILLISECONDS)), TimeUnit.MILLISECONDS);
+        if (response == null) {
+          LOGGER.debug("No progress response from server for query: {}", requestId);
+          continue;
+        }
+        numResponses++;
+        QueryServerInstance serverInstance = response.getServerInstance();
+        pendingServers.remove(serverInstance);
+        if (response.getThrowable() != null) {
+          LOGGER.debug("Failed to get progress for query: {} from server: {}", requestId, serverInstance,
+              response.getThrowable());
+          details.add(unknownServerProgress(serverInstance));
+          continue;
+        }
+        Worker.QueryProgressResponse queryProgressResponse = response.getResponse();
+        if (queryProgressResponse != null && queryProgressResponse.hasProgress()) {
+          details.add(toProgressStats(queryProgressResponse.getProgress(), getServerProgressLabel(serverInstance)));
+        } else {
+          details.add(unknownServerProgress(serverInstance));
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        LOGGER.debug("Interrupted while getting progress for query: {}", requestId, e);
+        break;
+      }
+    }
+    if (deadline.isExpired()) {
+      LOGGER.debug("Timed out waiting for progress response for query: {}", requestId);
+    }
+    for (QueryServerInstance serverInstance : pendingServers) {
+      details.add(unknownServerProgress(serverInstance));
+    }
+    details.sort(Comparator.comparing(QueryProgressStats::getLabel, Comparator.nullsFirst(String::compareTo)));
+    return details.isEmpty() ? null : QueryProgressStats.aggregate(details).withLabel("Servers").withDetails(details);
+  }
+
+  private static QueryProgressStats unknownServerProgress(QueryServerInstance serverInstance) {
+    return QueryProgressStats.unknown(getServerProgressLabel(serverInstance), true);
+  }
+
+  private static String getServerProgressLabel(QueryServerInstance serverInstance) {
+    String instanceId = serverInstance.getInstanceId();
+    if (instanceId != null && !instanceId.isEmpty()) {
+      return "Server " + instanceId;
+    }
+    return String.format("Server %s:%d", serverInstance.getHostname(), serverInstance.getQueryServicePort());
+  }
+
+  @VisibleForTesting
+  static QueryProgressStats toProgressStats(Worker.QueryProgress queryProgress,
+      @Nullable String label) {
+    List<QueryProgressStats> details = new ArrayList<>(queryProgress.getDetailsCount());
+    for (Worker.QueryProgress detail : queryProgress.getDetailsList()) {
+      details.add(toProgressStats(detail, detail.getLabel().isEmpty() ? null : detail.getLabel()));
+    }
+    return new QueryProgressStats(label, queryProgress.getProcessedWorkUnits(), queryProgress.getTotalWorkUnits(),
+        queryProgress.getProcessedSegments(), queryProgress.getTotalSegmentsToProcess(), queryProgress.getEstimated(),
+        details);
   }
 
   @Nullable

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -28,6 +28,7 @@ import io.grpc.Deadline;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -90,6 +91,7 @@ import org.apache.pinot.query.service.dispatch.streaming.StreamingQuerySession;
 import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.apache.pinot.spi.exception.QueryException;
 import org.apache.pinot.spi.query.QueryExecutionContext;
+import org.apache.pinot.spi.query.QueryProgressStats;
 import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.trace.RequestContext;
 import org.apache.pinot.spi.utils.CommonConstants;
@@ -128,6 +130,8 @@ public class QueryDispatcher {
   private final GrpcKeepAliveConfig _keepAliveConfig;
   // maps broker-generated query id to the set of servers that the query was dispatched to
   private final Map<Long, Set<QueryServerInstance>> _serversByQuery;
+  private final boolean _enableCancellation;
+  private final boolean _enableProgress;
   private final FailureDetector _failureDetector;
   private final Duration _cancelTimeout;
   /// Cluster-level default for stream-stats mode. Used as the fallback in [#submitAndReduce] when the query
@@ -136,7 +140,7 @@ public class QueryDispatcher {
 
   public QueryDispatcher(MailboxService mailboxService, FailureDetector failureDetector, @Nullable TlsConfig tlsConfig,
       boolean enableCancellation, Duration cancelTimeout) {
-    this(mailboxService, failureDetector, tlsConfig, enableCancellation, cancelTimeout,
+    this(mailboxService, failureDetector, tlsConfig, enableCancellation, enableCancellation, cancelTimeout,
         GrpcKeepAliveConfig.DISABLED, false, CommonConstants.Broker.DEFAULT_STREAM_STATS_DRAIN_MS);
   }
 
@@ -145,14 +149,22 @@ public class QueryDispatcher {
   public QueryDispatcher(MailboxService mailboxService, FailureDetector failureDetector, @Nullable TlsConfig tlsConfig,
       boolean enableCancellation, Duration cancelTimeout, int keepAliveTimeMs, int keepAliveTimeoutMs,
       boolean keepAliveWithoutCalls, boolean streamStatsDefault, long statsDrainMs) {
-    this(mailboxService, failureDetector, tlsConfig, enableCancellation, cancelTimeout,
+    this(mailboxService, failureDetector, tlsConfig, enableCancellation, enableCancellation, cancelTimeout,
+        new GrpcKeepAliveConfig(keepAliveTimeMs, keepAliveTimeoutMs, keepAliveWithoutCalls),
+        streamStatsDefault, statsDrainMs);
+  }
+
+  public QueryDispatcher(MailboxService mailboxService, FailureDetector failureDetector, @Nullable TlsConfig tlsConfig,
+      boolean enableCancellation, boolean enableProgress, Duration cancelTimeout, int keepAliveTimeMs,
+      int keepAliveTimeoutMs, boolean keepAliveWithoutCalls, boolean streamStatsDefault, long statsDrainMs) {
+    this(mailboxService, failureDetector, tlsConfig, enableCancellation, enableProgress, cancelTimeout,
         new GrpcKeepAliveConfig(keepAliveTimeMs, keepAliveTimeoutMs, keepAliveWithoutCalls),
         streamStatsDefault, statsDrainMs);
   }
 
   private QueryDispatcher(MailboxService mailboxService, FailureDetector failureDetector, @Nullable TlsConfig tlsConfig,
-      boolean enableCancellation, Duration cancelTimeout, GrpcKeepAliveConfig keepAliveConfig,
-      boolean streamStatsDefault, long statsDrainMs) {
+      boolean enableCancellation, boolean enableProgress, Duration cancelTimeout,
+      GrpcKeepAliveConfig keepAliveConfig, boolean streamStatsDefault, long statsDrainMs) {
     _cancelTimeout = cancelTimeout;
     _statsDrainMs = statsDrainMs;
     _mailboxService = mailboxService;
@@ -163,8 +175,10 @@ public class QueryDispatcher {
     _keepAliveConfig = keepAliveConfig;
     _failureDetector = failureDetector;
     _streamStatsDefault = streamStatsDefault;
+    _enableCancellation = enableCancellation;
+    _enableProgress = enableProgress;
 
-    if (enableCancellation) {
+    if (enableCancellation || enableProgress) {
       _serversByQuery = new ConcurrentHashMap<>();
     } else {
       _serversByQuery = null;
@@ -240,7 +254,7 @@ public class QueryDispatcher {
           statsManager.recordStatsUponResponseArrival(requestId, server.getInstanceId(), -1);
         }
       }
-      if (isQueryCancellationEnabled()) {
+      if (isQueryTrackingEnabled()) {
         _serversByQuery.remove(requestId);
       }
     }
@@ -330,7 +344,7 @@ public class QueryDispatcher {
           statsManager.recordStatsUponResponseArrival(requestId, server.getInstanceId(), -1);
         }
       }
-      if (isQueryCancellationEnabled()) {
+      if (isQueryTrackingEnabled()) {
         _serversByQuery.remove(requestId);
       }
     }
@@ -391,7 +405,7 @@ public class QueryDispatcher {
       }
     }, deadline, ackQueue);
 
-    if (isQueryCancellationEnabled()) {
+    if (isQueryTrackingEnabled()) {
       _serversByQuery.put(requestId, serversOut);
     }
   }
@@ -586,7 +600,7 @@ public class QueryDispatcher {
                     serverInstance, response.getMetadataOrDefault(ServerResponseStatus.STATUS_ERROR, "null")));
           }
         });
-    if (isQueryCancellationEnabled()) {
+    if (isQueryTrackingEnabled()) {
       _serversByQuery.put(requestId, serversOut);
     }
   }
@@ -614,6 +628,10 @@ public class QueryDispatcher {
   }
 
   private boolean isQueryCancellationEnabled() {
+    return _enableCancellation;
+  }
+
+  private boolean isQueryTrackingEnabled() {
     return _serversByQuery != null;
   }
 
@@ -804,7 +822,7 @@ public class QueryDispatcher {
         LOGGER.warn("Caught exception while cancelling query: {} on server: {}", requestId, queryServerInstance, t);
       }
     }
-    if (isQueryCancellationEnabled()) {
+    if (isQueryTrackingEnabled()) {
       _serversByQuery.remove(requestId);
     }
     return true;
@@ -832,6 +850,86 @@ public class QueryDispatcher {
 
   private static String toHostnamePortKey(String hostname, int port) {
     return String.format("%s_%d", hostname, port);
+  }
+
+  @Nullable
+  public QueryProgressStats getQueryProgressStats(long requestId, int timeoutMs) {
+    if (!_enableProgress) {
+      return null;
+    }
+    Set<QueryServerInstance> servers = _serversByQuery.get(requestId);
+    if (servers == null || servers.isEmpty()) {
+      return null;
+    }
+
+    Deadline deadline = Deadline.after(timeoutMs, TimeUnit.MILLISECONDS);
+    SendRequest<Long, Worker.QueryProgressResponse> sendRequest = DispatchClient::getQueryProgress;
+    BlockingQueue<AsyncResponse<Worker.QueryProgressResponse>> dispatchCallbacks =
+        dispatch(sendRequest, new HashSet<>(servers), deadline, serverInstance -> requestId);
+    Set<QueryServerInstance> pendingServers = new HashSet<>(servers);
+    List<QueryProgressStats> details = new ArrayList<>(servers.size());
+    int numResponses = 0;
+    while (!deadline.isExpired() && numResponses < servers.size()) {
+      try {
+        AsyncResponse<Worker.QueryProgressResponse> response =
+            dispatchCallbacks.poll(Math.max(1, deadline.timeRemaining(TimeUnit.MILLISECONDS)), TimeUnit.MILLISECONDS);
+        if (response == null) {
+          LOGGER.debug("No progress response from server for query: {}", requestId);
+          continue;
+        }
+        numResponses++;
+        QueryServerInstance serverInstance = response.getServerInstance();
+        pendingServers.remove(serverInstance);
+        if (response.getThrowable() != null) {
+          LOGGER.debug("Failed to get progress for query: {} from server: {}", requestId, serverInstance,
+              response.getThrowable());
+          details.add(unknownServerProgress(serverInstance));
+          continue;
+        }
+        Worker.QueryProgressResponse queryProgressResponse = response.getResponse();
+        if (queryProgressResponse != null && queryProgressResponse.hasProgress()) {
+          details.add(toProgressStats(queryProgressResponse.getProgress(), getServerProgressLabel(serverInstance)));
+        } else {
+          details.add(unknownServerProgress(serverInstance));
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        LOGGER.debug("Interrupted while getting progress for query: {}", requestId, e);
+        break;
+      }
+    }
+    if (deadline.isExpired()) {
+      LOGGER.debug("Timed out waiting for progress response for query: {}", requestId);
+    }
+    for (QueryServerInstance serverInstance : pendingServers) {
+      details.add(unknownServerProgress(serverInstance));
+    }
+    details.sort(Comparator.comparing(QueryProgressStats::getLabel, Comparator.nullsFirst(String::compareTo)));
+    return details.isEmpty() ? null : QueryProgressStats.aggregate(details).withLabel("Servers").withDetails(details);
+  }
+
+  private static QueryProgressStats unknownServerProgress(QueryServerInstance serverInstance) {
+    return QueryProgressStats.unknown(getServerProgressLabel(serverInstance), true);
+  }
+
+  private static String getServerProgressLabel(QueryServerInstance serverInstance) {
+    String instanceId = serverInstance.getInstanceId();
+    if (instanceId != null && !instanceId.isEmpty()) {
+      return "Server " + instanceId;
+    }
+    return String.format("Server %s:%d", serverInstance.getHostname(), serverInstance.getQueryServicePort());
+  }
+
+  @VisibleForTesting
+  static QueryProgressStats toProgressStats(Worker.QueryProgress queryProgress,
+      @Nullable String label) {
+    List<QueryProgressStats> details = new ArrayList<>(queryProgress.getDetailsCount());
+    for (Worker.QueryProgress detail : queryProgress.getDetailsList()) {
+      details.add(toProgressStats(detail, detail.getLabel().isEmpty() ? null : detail.getLabel()));
+    }
+    return new QueryProgressStats(label, queryProgress.getProcessedWorkUnits(), queryProgress.getTotalWorkUnits(),
+        queryProgress.getProcessedSegments(), queryProgress.getTotalSegmentsToProcess(), queryProgress.getEstimated(),
+        details);
   }
 
   @Nullable

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
@@ -69,6 +69,7 @@ import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.executor.ExecutorServiceUtils;
 import org.apache.pinot.spi.executor.MetricsExecutor;
 import org.apache.pinot.spi.query.QueryExecutionContext;
+import org.apache.pinot.spi.query.QueryProgressStats;
 import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
@@ -316,6 +317,10 @@ public class QueryServer extends PinotQueryWorkerGrpc.PinotQueryWorkerImplBase {
     long requestId = executionContext.getRequestId();
     List<CompletableFuture<Void>> startedWorkers = new ArrayList<>();
     List<Worker.StagePlan> protoStagePlans = request.getStagePlanList();
+    int opChainCount = protoStagePlans.stream()
+        .mapToInt(stagePlan -> stagePlan.getStageMetadata().getWorkerMetadataCount())
+        .sum();
+    executionContext.addTotalWorkUnits(opChainCount);
     for (Worker.StagePlan protoStagePlan : protoStagePlans) {
       StagePlan stagePlan = deserializePlan(requestId, protoStagePlan);
       StageMetadata stageMetadata = stagePlan.getStageMetadata();
@@ -854,6 +859,39 @@ public class QueryServer extends PinotQueryWorkerGrpc.PinotQueryWorkerImplBase {
     // we always return completed even if cancel attempt fails, server will self clean up in this case.
     responseObserver.onNext(Worker.CancelResponse.getDefaultInstance());
     responseObserver.onCompleted();
+  }
+
+  @Override
+  public void getQueryProgress(Worker.QueryProgressRequest request,
+      StreamObserver<Worker.QueryProgressResponse> responseObserver) {
+    long requestId = request.getRequestId();
+    Worker.QueryProgressResponse.Builder builder = Worker.QueryProgressResponse.newBuilder();
+    try {
+      QueryProgressStats progressStats = _queryRunner.getQueryProgressStats(requestId);
+      if (progressStats != null) {
+        builder.setProgress(toProtoProgress(progressStats));
+      }
+    } catch (Throwable t) {
+      LOGGER.error("Caught exception while getting progress for request: {}", requestId, t);
+    }
+    responseObserver.onNext(builder.build());
+    responseObserver.onCompleted();
+  }
+
+  private static Worker.QueryProgress toProtoProgress(QueryProgressStats progressStats) {
+    Worker.QueryProgress.Builder builder = Worker.QueryProgress.newBuilder()
+        .setProcessedWorkUnits(progressStats.getProcessedWorkUnits())
+        .setTotalWorkUnits(progressStats.getTotalWorkUnits())
+        .setProcessedSegments(progressStats.getProcessedSegments())
+        .setTotalSegmentsToProcess(progressStats.getTotalSegmentsToProcess())
+        .setEstimated(progressStats.isEstimated());
+    if (progressStats.getLabel() != null) {
+      builder.setLabel(progressStats.getLabel());
+    }
+    for (QueryProgressStats detail : progressStats.getDetails()) {
+      builder.addDetails(toProtoProgress(detail));
+    }
+    return builder.build();
   }
 
   // Collects sender stage IDs from all MailboxReceiveNodes in the plan tree via BFS,

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerServiceTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerServiceTest.java
@@ -39,9 +39,13 @@ import org.apache.pinot.query.runtime.operator.MultiStageOperator;
 import org.apache.pinot.query.runtime.operator.OpChain;
 import org.apache.pinot.query.runtime.plan.MultiStageQueryStats;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.exception.QueryCancelledException;
 import org.apache.pinot.spi.executor.ExecutorServiceUtils;
+import org.apache.pinot.spi.query.QueryExecutionContext;
+import org.apache.pinot.spi.query.QueryProgressStats;
 import org.apache.pinot.spi.query.QueryThreadContext;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.AfterClass;
@@ -53,6 +57,7 @@ import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -147,6 +152,89 @@ public class OpChainSchedulerServiceTest {
     }
 
     assertTrue(latch.await(10, TimeUnit.SECONDS), "expected await to be called in less than 10 seconds");
+  }
+
+  @Test
+  public void shouldTrackProgressForActiveRequest()
+      throws InterruptedException {
+    CountDownLatch operatorAClosed = new CountDownLatch(1);
+    CountDownLatch operatorBStarted = new CountDownLatch(1);
+    CountDownLatch operatorBCanFinish = new CountDownLatch(1);
+    CountDownLatch operatorBClosed = new CountDownLatch(1);
+    MultiStageOperator operatorB = Mockito.mock(MultiStageOperator.class);
+    Mockito.when(operatorB.copyStatMaps()).thenAnswer(inv -> new StatMap<>(MailboxSendOperator.StatKey.class));
+
+    Mockito.when(_operatorA.nextBlock()).thenReturn(SuccessMseBlock.INSTANCE);
+    Mockito.doAnswer(inv -> {
+      operatorAClosed.countDown();
+      return null;
+    }).when(_operatorA).close();
+
+    Mockito.when(operatorB.nextBlock()).thenAnswer(inv -> {
+      operatorBStarted.countDown();
+      assertTrue(operatorBCanFinish.await(10, TimeUnit.SECONDS), "expected operatorB to be released");
+      return SuccessMseBlock.INSTANCE;
+    });
+    Mockito.doAnswer(inv -> {
+      operatorBClosed.countDown();
+      return null;
+    }).when(operatorB).close();
+
+    OpChainSchedulerService schedulerService = new OpChainSchedulerService(_executor);
+    try (QueryThreadContext ignore = QueryThreadContext.openForMseTest()) {
+      QueryExecutionContext executionContext = QueryThreadContext.get().getExecutionContext();
+      executionContext.addTotalWorkUnits(2);
+      schedulerService.register(getChain(_operatorA, 0));
+      schedulerService.register(getChain(operatorB, 1));
+    }
+
+    assertTrue(operatorAClosed.await(10, TimeUnit.SECONDS), "expected operatorA to finish");
+    assertTrue(operatorBStarted.await(10, TimeUnit.SECONDS), "expected operatorB to start");
+    QueryProgressStats progressStats = schedulerService.getQueryProgressStats(123L);
+    assertEquals(progressStats.getProcessedWorkUnits(), 1);
+    assertEquals(progressStats.getTotalWorkUnits(), 2);
+    assertEquals(progressStats.getProgressPercent(), 50.0);
+    assertTrue(schedulerService.hasRunningExecutionContext(123L));
+
+    operatorBCanFinish.countDown();
+    assertTrue(operatorBClosed.await(10, TimeUnit.SECONDS), "expected operatorB to finish");
+    QueryProgressStats completedProgressStats = schedulerService.getQueryProgressStats(123L);
+    assertEquals(completedProgressStats.getProcessedWorkUnits(), 2);
+    assertEquals(completedProgressStats.getTotalWorkUnits(), 2);
+    assertEquals(completedProgressStats.getProgressPercent(), 100.0);
+    assertEquals(schedulerService.activeRequestCount(), 0);
+  }
+
+  @Test
+  public void shouldDisableProgressWithoutDisablingQueryTracking()
+      throws InterruptedException {
+    CountDownLatch operatorStarted = new CountDownLatch(1);
+    CountDownLatch operatorCanFinish = new CountDownLatch(1);
+    CountDownLatch operatorClosed = new CountDownLatch(1);
+    Mockito.when(_operatorA.nextBlock()).thenAnswer(inv -> {
+      operatorStarted.countDown();
+      assertTrue(operatorCanFinish.await(10, TimeUnit.SECONDS), "expected operator to be released");
+      return SuccessMseBlock.INSTANCE;
+    });
+    Mockito.doAnswer(inv -> {
+      operatorClosed.countDown();
+      return null;
+    }).when(_operatorA).close();
+    PinotConfiguration config = new PinotConfiguration(
+        Map.of(CommonConstants.Server.CONFIG_OF_QUERY_PROGRESS_ENABLED, false));
+    OpChainSchedulerService schedulerService = new OpChainSchedulerService("testServer", _executor, config);
+    try (QueryThreadContext ignore = QueryThreadContext.openForMseTest()) {
+      schedulerService.register(getChain(_operatorA));
+    }
+
+    try {
+      assertTrue(operatorStarted.await(10, TimeUnit.SECONDS), "expected operator to start");
+      assertTrue(schedulerService.hasRunningExecutionContext(123L));
+      assertNull(schedulerService.getQueryProgressStats(123L));
+    } finally {
+      operatorCanFinish.countDown();
+    }
+    assertTrue(operatorClosed.await(10, TimeUnit.SECONDS), "expected operator to finish");
   }
 
   @Test

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
@@ -46,6 +46,7 @@ import org.apache.pinot.query.testutils.QueryTestUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.metrics.PinotMetricUtils;
 import org.apache.pinot.spi.metrics.PinotMetricsRegistry;
+import org.apache.pinot.spi.query.QueryProgressStats;
 import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.trace.DefaultRequestContext;
 import org.apache.pinot.spi.trace.RequestContext;
@@ -66,6 +67,22 @@ public class QueryDispatcherTest extends QueryTestSet {
 
   private QueryEnvironment _queryEnvironment;
   private QueryDispatcher _queryDispatcher;
+
+  @Test
+  public void testConvertsNestedQueryProgressPayload() {
+    Worker.QueryProgress detail = Worker.QueryProgress.newBuilder().setLabel("Stage 1")
+        .setProcessedWorkUnits(2).setTotalWorkUnits(4).setProcessedSegments(1).setTotalSegmentsToProcess(2)
+        .setEstimated(true).build();
+    Worker.QueryProgress progress = Worker.QueryProgress.newBuilder().setProcessedWorkUnits(3).setTotalWorkUnits(6)
+        .setProcessedSegments(1).setTotalSegmentsToProcess(2).setEstimated(true).addDetails(detail).build();
+
+    QueryProgressStats progressStats = QueryDispatcher.toProgressStats(progress, "Server server-1");
+
+    Assert.assertEquals(progressStats.getLabel(), "Server server-1");
+    Assert.assertEquals(progressStats.getProgressPercent(), 50.0);
+    Assert.assertEquals(progressStats.getDetails().size(), 1);
+    Assert.assertEquals(progressStats.getDetails().get(0).getLabel(), "Stage 1");
+  }
 
   @BeforeClass
   public void setUp()

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/server/QueryServerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/server/QueryServerTest.java
@@ -59,6 +59,7 @@ import org.apache.pinot.spi.accounting.ThreadAccountantUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.metrics.PinotMetricUtils;
 import org.apache.pinot.spi.query.QueryExecutionContext;
+import org.apache.pinot.spi.query.QueryProgressStats;
 import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.trace.LoggerConstants;
 import org.apache.pinot.spi.utils.CommonConstants;
@@ -230,6 +231,32 @@ public class QueryServerTest extends QueryTestSet {
     assertTrue(responseHolder[0].getMetadataMap()
             .containsKey(CommonConstants.Query.Response.ServerResponseStatus.STATUS_ERROR),
         "Malformed metadata should still return an error response");
+  }
+
+  @Test
+  public void testGetQueryProgressReturnsNestedProgressPayload() {
+    Map.Entry<Integer, QueryRunner> queryRunnerEntry = _queryRunnerMap.entrySet().iterator().next();
+    int port = queryRunnerEntry.getKey();
+    QueryRunner queryRunner = queryRunnerEntry.getValue();
+    QueryProgressStats detail = new QueryProgressStats("Stage 1", 2, 4, 1, 2, true);
+    QueryProgressStats progressStats = new QueryProgressStats("Server", 3, 6, 1, 2, true)
+        .withDetails(List.of(detail));
+    when(queryRunner.getQueryProgressStats(42L)).thenReturn(progressStats);
+    ManagedChannel channel = ManagedChannelBuilder.forAddress("localhost", port).usePlaintext().build();
+    try {
+      Worker.QueryProgressResponse response = PinotQueryWorkerGrpc.newBlockingStub(channel)
+          .withDeadline(Deadline.after(10, TimeUnit.SECONDS))
+          .getQueryProgress(Worker.QueryProgressRequest.newBuilder().setRequestId(42L).build());
+
+      assertTrue(response.hasProgress());
+      assertEquals(response.getProgress().getProcessedWorkUnits(), 3L);
+      assertEquals(response.getProgress().getTotalWorkUnits(), 6L);
+      assertEquals(response.getProgress().getDetailsCount(), 1);
+      assertEquals(response.getProgress().getDetails(0).getLabel(), "Stage 1");
+    } finally {
+      channel.shutdownNow();
+      reset(queryRunner);
+    }
   }
 
   @Test(dataProvider = "testSql")

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/QueryResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/QueryResource.java
@@ -27,6 +27,8 @@ import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import javax.inject.Inject;
 import javax.ws.rs.DELETE;
@@ -41,6 +43,7 @@ import javax.ws.rs.core.Response;
 import org.apache.pinot.core.query.utils.QueryIdUtils;
 import org.apache.pinot.core.transport.InstanceRequestHandler;
 import org.apache.pinot.server.starter.ServerInstance;
+import org.apache.pinot.spi.query.QueryProgressStats;
 
 import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_KEY;
 
@@ -85,6 +88,53 @@ public class QueryResource {
     } catch (Exception e) {
       throw new WebApplicationException(Response.status(Response.Status.INTERNAL_SERVER_ERROR)
           .entity(String.format("Failed to cancel query: %s on the server due to error: %s", queryId, e.getMessage()))
+          .build());
+    }
+    throw new WebApplicationException(
+        Response.status(Response.Status.NOT_FOUND).entity(String.format("Query: %s not found on the server", queryId))
+            .build());
+  }
+
+  @GET
+  @Path("/query/{queryId}/progress")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Get progress for a query running on the server",
+      notes = "Progress is derived from processed work units over total work units. For server-side single-stage "
+          + "requests, work units map to selected segments.")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error"),
+      @ApiResponse(code = 404, message = "Query not found running on the server")
+  })
+  public QueryProgressStats getQueryProgress(
+      @ApiParam(value = "QueryId as in the format of <brokerId>_<requestId> or <brokerId>_<requestId>_(O|R)",
+          required = true)
+      @PathParam("queryId") String queryId) {
+    try {
+      if (QueryIdUtils.hasTypeSuffix(queryId)) {
+        QueryProgressStats progressStats = _serverInstance.getQueryProgressStats(queryId);
+        if (progressStats != null) {
+          return progressStats;
+        }
+      } else {
+        List<QueryProgressStats> progressStatsList = new ArrayList<>(2);
+        QueryProgressStats offlineProgressStats =
+            _serverInstance.getQueryProgressStats(QueryIdUtils.withOfflineSuffix(queryId));
+        if (offlineProgressStats != null) {
+          progressStatsList.add(offlineProgressStats);
+        }
+        QueryProgressStats realtimeProgressStats =
+            _serverInstance.getQueryProgressStats(QueryIdUtils.withRealtimeSuffix(queryId));
+        if (realtimeProgressStats != null) {
+          progressStatsList.add(realtimeProgressStats);
+        }
+        if (!progressStatsList.isEmpty()) {
+          return QueryProgressStats.aggregate(progressStatsList);
+        }
+      }
+    } catch (Exception e) {
+      throw new WebApplicationException(Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+          .entity(String.format("Failed to get progress for query: %s on the server due to error: %s", queryId,
+              e.getMessage()))
           .build());
     }
     throw new WebApplicationException(

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
@@ -40,6 +40,7 @@ import org.apache.pinot.core.query.scheduler.QueryScheduler;
 import org.apache.pinot.core.query.scheduler.QuerySchedulerFactory;
 import org.apache.pinot.core.transport.ChannelHandlerFactory;
 import org.apache.pinot.core.transport.InstanceRequestHandler;
+import org.apache.pinot.core.transport.QueryProgressTracker;
 import org.apache.pinot.core.transport.QueryServer;
 import org.apache.pinot.core.transport.grpc.GrpcQueryServer;
 import org.apache.pinot.query.runtime.KeepPipelineBreakerStatsPredicate;
@@ -55,6 +56,7 @@ import org.apache.pinot.server.worker.WorkerQueryServer;
 import org.apache.pinot.spi.accounting.ThreadAccountant;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.plugin.PluginManager;
+import org.apache.pinot.spi.query.QueryProgressStats;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,6 +81,7 @@ public class ServerInstance {
   private final GrpcQueryServer _grpcQueryServer;
   private final WorkerQueryServer _workerQueryServer;
   private final ChannelHandler _instanceRequestHandler;
+  private final QueryProgressTracker _queryProgressTracker;
   private final ServerMetrics _serverMetrics = ServerMetrics.get();
 
   private boolean _dataManagerStarted = false;
@@ -94,6 +97,7 @@ public class ServerInstance {
     _helixManager = helixManager;
     _threadAccountant = threadAccountant;
     _reloadJobStatusCache = requireNonNull(reloadJobStatusCache, "reloadJobStatusCache cannot be null");
+    _queryProgressTracker = new QueryProgressTracker(serverConf.getPinotConfig());
 
     if (segmentOperationsThrottlerSet != null) {
       // Initialize the metrics for the throttler so it picks up the newly registered ServerMetrics object
@@ -146,7 +150,7 @@ public class ServerInstance {
       LOGGER.info("Initializing Netty query server on port: {}", nettyPort);
       instanceRequestHandler =
           ChannelHandlerFactory.getInstanceRequestHandler(helixManager.getInstanceName(), serverConf.getPinotConfig(),
-              _queryScheduler, new AllowAllAccessFactory().create(), threadAccountant);
+              _queryScheduler, new AllowAllAccessFactory().create(), threadAccountant, _queryProgressTracker);
       _nettyQueryServer = new QueryServer(nettyPort, nettyConfig, instanceRequestHandler);
     } else {
       _nettyQueryServer = null;
@@ -156,7 +160,7 @@ public class ServerInstance {
       LOGGER.info("Initializing TLS-secured Netty query server on port: {}", nettySecPort);
       instanceRequestHandler =
           ChannelHandlerFactory.getInstanceRequestHandler(helixManager.getInstanceName(), serverConf.getPinotConfig(),
-              _queryScheduler, accessControl, threadAccountant);
+              _queryScheduler, accessControl, threadAccountant, _queryProgressTracker);
       _nettyTlsQueryServer = new QueryServer(nettySecPort, nettyConfig, tlsConfig, instanceRequestHandler);
     } else {
       _nettyTlsQueryServer = null;
@@ -170,7 +174,7 @@ public class ServerInstance {
           : null;
       _grpcQueryServer =
           new GrpcQueryServer(instanceName, grpcPort, GrpcConfig.buildGrpcQueryConfig(serverConf.getPinotConfig()),
-              actualTslConfig, _queryExecutor, accessControl, threadAccountant);
+              actualTslConfig, _queryExecutor, accessControl, threadAccountant, _queryProgressTracker);
     } else {
       _grpcQueryServer = null;
     }
@@ -299,6 +303,11 @@ public class ServerInstance {
     Preconditions.checkState(_instanceRequestHandler instanceof InstanceRequestHandler,
         "Unexpected type of instance request handler");
     return (InstanceRequestHandler) _instanceRequestHandler;
+  }
+
+  @Nullable
+  public QueryProgressStats getQueryProgressStats(String queryId) {
+    return _queryProgressTracker.getProgressStats(queryId);
   }
 
   public HelixManager getHelixManager() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/query/QueryExecutionContext.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/query/QueryExecutionContext.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import org.apache.pinot.spi.exception.QueryErrorCode;
@@ -65,6 +66,10 @@ public class QueryExecutionContext {
   private final List<Future<?>> _tasks = new ArrayList<>();
 
   private volatile TerminationException _terminateException;
+  private final AtomicLong _processedWorkUnits = new AtomicLong();
+  private final AtomicLong _totalWorkUnits = new AtomicLong(-1);
+  private final AtomicLong _processedSegments = new AtomicLong();
+  private final AtomicLong _totalSegmentsToProcess = new AtomicLong(-1);
 
   /// Per-query scan cost accumulators for scan-based killing, tracking cumulative scan cost across all segments.
   @Nullable
@@ -183,6 +188,30 @@ public class QueryExecutionContext {
 
   public String getQueryHash() {
     return _queryHash;
+  }
+
+  public void addTotalSegmentsToProcess(long totalSegmentsToProcess) {
+    _totalSegmentsToProcess.updateAndGet(
+        currentTotal -> currentTotal < 0 ? totalSegmentsToProcess : currentTotal + totalSegmentsToProcess);
+    addTotalWorkUnits(totalSegmentsToProcess);
+  }
+
+  public void incrementProcessedSegments() {
+    _processedSegments.incrementAndGet();
+    incrementProcessedWorkUnits();
+  }
+
+  public void addTotalWorkUnits(long totalWorkUnits) {
+    _totalWorkUnits.updateAndGet(currentTotal -> currentTotal < 0 ? totalWorkUnits : currentTotal + totalWorkUnits);
+  }
+
+  public void incrementProcessedWorkUnits() {
+    _processedWorkUnits.incrementAndGet();
+  }
+
+  public QueryProgressStats getProgressStats() {
+    return new QueryProgressStats(_processedWorkUnits.get(), _totalWorkUnits.get(), _processedSegments.get(),
+        _totalSegmentsToProcess.get(), _queryType != QueryType.SSE);
   }
 
   /// Adds a task to the execution context. If the query has been terminated, cancels the task immediately without

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/query/QueryExecutionContext.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/query/QueryExecutionContext.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import org.apache.pinot.spi.exception.QueryErrorCode;
@@ -68,6 +69,10 @@ public class QueryExecutionContext {
   private final List<Future<?>> _tasks = new ArrayList<>();
 
   private volatile TerminationException _terminateException;
+  private final AtomicLong _processedWorkUnits = new AtomicLong();
+  private final AtomicLong _totalWorkUnits = new AtomicLong(-1);
+  private final AtomicLong _processedSegments = new AtomicLong();
+  private final AtomicLong _totalSegmentsToProcess = new AtomicLong(-1);
 
   /// Per-query scan cost accumulators for scan-based killing, tracking cumulative scan cost across all segments.
   @Nullable
@@ -207,6 +212,30 @@ public class QueryExecutionContext {
 
   public String getQueryHash() {
     return _queryHash;
+  }
+
+  public void addTotalSegmentsToProcess(long totalSegmentsToProcess) {
+    _totalSegmentsToProcess.updateAndGet(
+        currentTotal -> currentTotal < 0 ? totalSegmentsToProcess : currentTotal + totalSegmentsToProcess);
+    addTotalWorkUnits(totalSegmentsToProcess);
+  }
+
+  public void incrementProcessedSegments() {
+    _processedSegments.incrementAndGet();
+    incrementProcessedWorkUnits();
+  }
+
+  public void addTotalWorkUnits(long totalWorkUnits) {
+    _totalWorkUnits.updateAndGet(currentTotal -> currentTotal < 0 ? totalWorkUnits : currentTotal + totalWorkUnits);
+  }
+
+  public void incrementProcessedWorkUnits() {
+    _processedWorkUnits.incrementAndGet();
+  }
+
+  public QueryProgressStats getProgressStats() {
+    return new QueryProgressStats(_processedWorkUnits.get(), _totalWorkUnits.get(), _processedSegments.get(),
+        _totalSegmentsToProcess.get(), _queryType != QueryType.SSE);
   }
 
   /// Adds a task to the execution context. If the query has been terminated, cancels the task immediately without

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/query/QueryProgressStats.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/query/QueryProgressStats.java
@@ -1,0 +1,168 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.query;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collection;
+import java.util.List;
+import javax.annotation.Nullable;
+
+
+/// Progress for a running query.
+///
+/// The progress percentage is derived from processed work units over total work units. For single-stage queries, work
+/// units map to selected segments. For multi-stage queries, work units include selected segments and stage op-chains,
+/// because non-leaf stages can still be running after all leaf segments have been scanned. A negative percentage means
+/// the denominator is not known yet. Optional detail rows let multi-stage queries expose component-level progress while
+/// keeping single-stage responses compact.
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public final class QueryProgressStats {
+  @Nullable
+  private final String _label;
+  private final long _processedWorkUnits;
+  private final long _totalWorkUnits;
+  private final long _processedSegments;
+  private final long _totalSegmentsToProcess;
+  private final boolean _estimated;
+  private final double _progressPercent;
+  private final List<QueryProgressStats> _details;
+
+  @JsonCreator
+  public QueryProgressStats(@JsonProperty("label") @Nullable String label,
+      @JsonProperty("processedWorkUnits") @Nullable Long processedWorkUnits,
+      @JsonProperty("totalWorkUnits") @Nullable Long totalWorkUnits,
+      @JsonProperty("processedSegments") @Nullable Long processedSegments,
+      @JsonProperty("totalSegmentsToProcess") @Nullable Long totalSegmentsToProcess,
+      @JsonProperty("estimated") @Nullable Boolean estimated,
+      @JsonProperty("details") @Nullable List<QueryProgressStats> details) {
+    _label = label;
+    _processedSegments = processedSegments != null ? processedSegments : 0;
+    _totalSegmentsToProcess = totalSegmentsToProcess != null ? totalSegmentsToProcess : -1;
+    _processedWorkUnits = processedWorkUnits != null ? processedWorkUnits : _processedSegments;
+    _totalWorkUnits = totalWorkUnits != null ? totalWorkUnits : _totalSegmentsToProcess;
+    _estimated = estimated != null && estimated;
+    _details = details != null ? List.copyOf(details) : List.of();
+    if (_totalWorkUnits < 0) {
+      _progressPercent = -1.0;
+    } else if (_totalWorkUnits == 0) {
+      _progressPercent = 100.0;
+    } else {
+      _progressPercent = Math.min(100.0, _processedWorkUnits * 100.0 / _totalWorkUnits);
+    }
+  }
+
+  public QueryProgressStats(@Nullable Long processedWorkUnits, @Nullable Long totalWorkUnits,
+      @Nullable Long processedSegments, @Nullable Long totalSegmentsToProcess, @Nullable Boolean estimated) {
+    this(null, processedWorkUnits, totalWorkUnits, processedSegments, totalSegmentsToProcess, estimated, null);
+  }
+
+  public QueryProgressStats(long processedSegments, long totalSegmentsToProcess) {
+    this(processedSegments, totalSegmentsToProcess, processedSegments, totalSegmentsToProcess, false);
+  }
+
+  public QueryProgressStats(long processedWorkUnits, long totalWorkUnits, long processedSegments,
+      long totalSegmentsToProcess, boolean estimated) {
+    this(Long.valueOf(processedWorkUnits), Long.valueOf(totalWorkUnits), Long.valueOf(processedSegments),
+        Long.valueOf(totalSegmentsToProcess), Boolean.valueOf(estimated));
+  }
+
+  public QueryProgressStats(String label, long processedWorkUnits, long totalWorkUnits, long processedSegments,
+      long totalSegmentsToProcess, boolean estimated) {
+    this(label, Long.valueOf(processedWorkUnits), Long.valueOf(totalWorkUnits), Long.valueOf(processedSegments),
+        Long.valueOf(totalSegmentsToProcess), Boolean.valueOf(estimated), null);
+  }
+
+  public static QueryProgressStats unknown(String label, boolean estimated) {
+    return new QueryProgressStats(label, 0, -1, 0, -1, estimated);
+  }
+
+  public static QueryProgressStats aggregate(Collection<QueryProgressStats> progressStats) {
+    long processedWorkUnits = 0;
+    long totalWorkUnits = 0;
+    long processedSegments = 0;
+    long totalSegmentsToProcess = 0;
+    boolean hasUnknownWorkTotal = false;
+    boolean hasUnknownSegmentTotal = false;
+    boolean estimated = false;
+    for (QueryProgressStats progress : progressStats) {
+      processedWorkUnits += progress.getProcessedWorkUnits();
+      if (progress.getTotalWorkUnits() >= 0) {
+        totalWorkUnits += progress.getTotalWorkUnits();
+      } else {
+        hasUnknownWorkTotal = true;
+      }
+      processedSegments += progress.getProcessedSegments();
+      if (progress.getTotalSegmentsToProcess() >= 0) {
+        totalSegmentsToProcess += progress.getTotalSegmentsToProcess();
+      } else {
+        hasUnknownSegmentTotal = true;
+      }
+      estimated |= progress.isEstimated();
+    }
+    return new QueryProgressStats(processedWorkUnits, hasUnknownWorkTotal ? -1 : totalWorkUnits, processedSegments,
+        hasUnknownSegmentTotal ? -1 : totalSegmentsToProcess, estimated);
+  }
+
+  public QueryProgressStats withLabel(String label) {
+    return new QueryProgressStats(label, _processedWorkUnits, _totalWorkUnits, _processedSegments,
+        _totalSegmentsToProcess, _estimated, _details);
+  }
+
+  public QueryProgressStats withDetails(List<QueryProgressStats> details) {
+    return new QueryProgressStats(_label, _processedWorkUnits, _totalWorkUnits, _processedSegments,
+        _totalSegmentsToProcess, _estimated, details);
+  }
+
+  @Nullable
+  public String getLabel() {
+    return _label;
+  }
+
+  public long getProcessedWorkUnits() {
+    return _processedWorkUnits;
+  }
+
+  public long getTotalWorkUnits() {
+    return _totalWorkUnits;
+  }
+
+  public long getProcessedSegments() {
+    return _processedSegments;
+  }
+
+  public long getTotalSegmentsToProcess() {
+    return _totalSegmentsToProcess;
+  }
+
+  public boolean isEstimated() {
+    return _estimated;
+  }
+
+  public double getProgressPercent() {
+    return _progressPercent;
+  }
+
+  public List<QueryProgressStats> getDetails() {
+    return _details;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -403,6 +403,8 @@ public class CommonConstants {
         "pinot.broker.query.regex.dict.size.threshold";
     public static final String CONFIG_OF_BROKER_ENABLE_QUERY_CANCELLATION = "pinot.broker.enable.query.cancellation";
     public static final boolean DEFAULT_BROKER_ENABLE_QUERY_CANCELLATION = true;
+    public static final String CONFIG_OF_BROKER_QUERY_PROGRESS_ENABLED = "pinot.broker.query.progress.enabled";
+    public static final boolean DEFAULT_BROKER_QUERY_PROGRESS_ENABLED = true;
     public static final String CONFIG_OF_BROKER_ENABLE_QUERY_FINGERPRINTING =
         "pinot.broker.enable.query.fingerprinting";
     public static final boolean DEFAULT_BROKER_ENABLE_QUERY_FINGERPRINTING = false;
@@ -1542,6 +1544,8 @@ public class CommonConstants {
     public static final String DEFAULT_SERVER_QUERY_REGEX_CLASS = "JAVA_UTIL";
     public static final String CONFIG_OF_ENABLE_QUERY_CANCELLATION = "pinot.server.enable.query.cancellation";
     public static final boolean DEFAULT_ENABLE_QUERY_CANCELLATION = true;
+    public static final String CONFIG_OF_QUERY_PROGRESS_ENABLED = "pinot.server.query.progress.enabled";
+    public static final boolean DEFAULT_QUERY_PROGRESS_ENABLED = true;
     public static final String CONFIG_OF_NETTY_SERVER_ENABLED = "pinot.server.netty.enabled";
     public static final boolean DEFAULT_NETTY_SERVER_ENABLED = true;
     public static final String CONFIG_OF_ENABLE_GRPC_SERVER = "pinot.server.grpc.enable";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -392,6 +392,8 @@ public class CommonConstants {
         "pinot.broker.query.regex.dict.size.threshold";
     public static final String CONFIG_OF_BROKER_ENABLE_QUERY_CANCELLATION = "pinot.broker.enable.query.cancellation";
     public static final boolean DEFAULT_BROKER_ENABLE_QUERY_CANCELLATION = true;
+    public static final String CONFIG_OF_BROKER_QUERY_PROGRESS_ENABLED = "pinot.broker.query.progress.enabled";
+    public static final boolean DEFAULT_BROKER_QUERY_PROGRESS_ENABLED = true;
     public static final String CONFIG_OF_BROKER_ENABLE_QUERY_FINGERPRINTING =
         "pinot.broker.enable.query.fingerprinting";
     public static final boolean DEFAULT_BROKER_ENABLE_QUERY_FINGERPRINTING = false;
@@ -1479,6 +1481,8 @@ public class CommonConstants {
     public static final String DEFAULT_SERVER_QUERY_REGEX_CLASS = "JAVA_UTIL";
     public static final String CONFIG_OF_ENABLE_QUERY_CANCELLATION = "pinot.server.enable.query.cancellation";
     public static final boolean DEFAULT_ENABLE_QUERY_CANCELLATION = true;
+    public static final String CONFIG_OF_QUERY_PROGRESS_ENABLED = "pinot.server.query.progress.enabled";
+    public static final boolean DEFAULT_QUERY_PROGRESS_ENABLED = true;
     public static final String CONFIG_OF_NETTY_SERVER_ENABLED = "pinot.server.netty.enabled";
     public static final boolean DEFAULT_NETTY_SERVER_ENABLED = true;
     public static final String CONFIG_OF_ENABLE_GRPC_SERVER = "pinot.server.grpc.enable";

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/query/QueryProgressStatsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/query/QueryProgressStatsTest.java
@@ -1,0 +1,168 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.query;
+
+import java.util.List;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class QueryProgressStatsTest {
+
+  @Test
+  public void testProgressPercent() {
+    QueryProgressStats progressStats = new QueryProgressStats(3, 10);
+    assertEquals(progressStats.getProcessedWorkUnits(), 3);
+    assertEquals(progressStats.getTotalWorkUnits(), 10);
+    assertEquals(progressStats.getProcessedSegments(), 3);
+    assertEquals(progressStats.getTotalSegmentsToProcess(), 10);
+    assertEquals(progressStats.getProgressPercent(), 30.0);
+
+    assertEquals(new QueryProgressStats(0, 0).getProgressPercent(), 100.0);
+    assertEquals(new QueryProgressStats(1, -1).getProgressPercent(), -1.0);
+    assertEquals(new QueryProgressStats(12, 10).getProgressPercent(), 100.0);
+  }
+
+  @Test
+  public void testAggregate() {
+    QueryProgressStats progressStats = QueryProgressStats.aggregate(List.of(
+        new QueryProgressStats(5, 20, 3, 10, true),
+        new QueryProgressStats(15, 60, 7, 30, false)));
+
+    assertEquals(progressStats.getProcessedWorkUnits(), 20);
+    assertEquals(progressStats.getTotalWorkUnits(), 80);
+    assertEquals(progressStats.getProcessedSegments(), 10);
+    assertEquals(progressStats.getTotalSegmentsToProcess(), 40);
+    assertEquals(progressStats.getProgressPercent(), 25.0);
+    assertEquals(progressStats.isEstimated(), true);
+  }
+
+  @Test
+  public void testAggregateWithUnknownTotal() {
+    QueryProgressStats progressStats = QueryProgressStats.aggregate(List.of(
+        new QueryProgressStats(3, 10),
+        new QueryProgressStats(1, -1)));
+
+    assertEquals(progressStats.getProcessedWorkUnits(), 4);
+    assertEquals(progressStats.getTotalWorkUnits(), -1);
+    assertEquals(progressStats.getProcessedSegments(), 4);
+    assertEquals(progressStats.getTotalSegmentsToProcess(), -1);
+    assertEquals(progressStats.getProgressPercent(), -1.0);
+  }
+
+  @Test
+  public void testAggregateWithUnknownDetailKeepsUnknownTotal() {
+    QueryProgressStats progressStats = QueryProgressStats.aggregate(List.of(
+        new QueryProgressStats("Server A", 10, 10, 0, -1, true),
+        QueryProgressStats.unknown("Server B", true))).withLabel("Servers");
+
+    assertEquals(progressStats.getLabel(), "Servers");
+    assertEquals(progressStats.getProcessedWorkUnits(), 10);
+    assertEquals(progressStats.getTotalWorkUnits(), -1);
+    assertEquals(progressStats.getProgressPercent(), -1.0);
+    assertEquals(progressStats.isEstimated(), true);
+  }
+
+  @Test
+  public void testJsonRoundTrip()
+      throws Exception {
+    QueryProgressStats progressStats = new QueryProgressStats(6, 12, 4, 8, true);
+    QueryProgressStats deserialized =
+        JsonUtils.stringToObject(JsonUtils.objectToString(progressStats), QueryProgressStats.class);
+
+    assertEquals(deserialized.getProcessedWorkUnits(), 6);
+    assertEquals(deserialized.getTotalWorkUnits(), 12);
+    assertEquals(deserialized.getProcessedSegments(), 4);
+    assertEquals(deserialized.getTotalSegmentsToProcess(), 8);
+    assertEquals(deserialized.getProgressPercent(), 50.0);
+    assertEquals(deserialized.isEstimated(), true);
+  }
+
+  @Test
+  public void testJsonRoundTripWithDetails()
+      throws Exception {
+    QueryProgressStats brokerProgressStats = new QueryProgressStats("Broker", 1, 2, 0, -1, true);
+    QueryProgressStats serverProgressStats = new QueryProgressStats("Server a", 3, 6, 2, 4, true);
+    QueryProgressStats progressStats = QueryProgressStats.aggregate(List.of(brokerProgressStats, serverProgressStats))
+        .withLabel("Query").withDetails(List.of(brokerProgressStats, serverProgressStats));
+
+    QueryProgressStats deserialized =
+        JsonUtils.stringToObject(JsonUtils.objectToString(progressStats), QueryProgressStats.class);
+
+    assertEquals(deserialized.getLabel(), "Query");
+    assertEquals(deserialized.getProcessedWorkUnits(), 4);
+    assertEquals(deserialized.getTotalWorkUnits(), 8);
+    assertEquals(deserialized.getDetails().size(), 2);
+    assertEquals(deserialized.getDetails().get(0).getLabel(), "Broker");
+    assertEquals(deserialized.getDetails().get(0).getProcessedWorkUnits(), 1);
+    assertEquals(deserialized.getDetails().get(1).getLabel(), "Server a");
+    assertEquals(deserialized.getDetails().get(1).getTotalSegmentsToProcess(), 4);
+  }
+
+  @Test
+  public void testJsonRoundTripWithSegmentOnlyPayload()
+      throws Exception {
+    QueryProgressStats deserialized = JsonUtils.stringToObject(
+        "{\"processedSegments\":4,\"totalSegmentsToProcess\":8}", QueryProgressStats.class);
+
+    assertEquals(deserialized.getProcessedWorkUnits(), 4);
+    assertEquals(deserialized.getTotalWorkUnits(), 8);
+    assertEquals(deserialized.getProcessedSegments(), 4);
+    assertEquals(deserialized.getTotalSegmentsToProcess(), 8);
+    assertEquals(deserialized.getProgressPercent(), 50.0);
+    assertEquals(deserialized.isEstimated(), false);
+  }
+
+  @Test
+  public void testExecutionContextAccumulatesSegmentTotals() {
+    QueryExecutionContext executionContext = QueryExecutionContext.forSseTest();
+    assertEquals(executionContext.getProgressStats().getTotalSegmentsToProcess(), -1);
+
+    executionContext.addTotalSegmentsToProcess(2);
+    executionContext.incrementProcessedSegments();
+    executionContext.addTotalSegmentsToProcess(3);
+
+    QueryProgressStats progressStats = executionContext.getProgressStats();
+    assertEquals(progressStats.getProcessedWorkUnits(), 1);
+    assertEquals(progressStats.getTotalWorkUnits(), 5);
+    assertEquals(progressStats.getProcessedSegments(), 1);
+    assertEquals(progressStats.getTotalSegmentsToProcess(), 5);
+    assertEquals(progressStats.getProgressPercent(), 20.0);
+  }
+
+  @Test
+  public void testExecutionContextAccumulatesWorkUnits() {
+    QueryExecutionContext executionContext = QueryExecutionContext.forMseTest();
+    assertEquals(executionContext.getProgressStats().getTotalWorkUnits(), -1);
+
+    executionContext.addTotalWorkUnits(2);
+    executionContext.incrementProcessedWorkUnits();
+    executionContext.addTotalWorkUnits(3);
+
+    QueryProgressStats progressStats = executionContext.getProgressStats();
+    assertEquals(progressStats.getProcessedWorkUnits(), 1);
+    assertEquals(progressStats.getTotalWorkUnits(), 5);
+    assertEquals(progressStats.getProcessedSegments(), 0);
+    assertEquals(progressStats.getTotalSegmentsToProcess(), -1);
+    assertEquals(progressStats.getProgressPercent(), 20.0);
+    assertEquals(progressStats.isEstimated(), true);
+  }
+}


### PR DESCRIPTION
## Summary

Adds end-to-end progress reporting for long-running V1 (single-stage) and V2 (multi-stage) queries. Progress is represented as processed work units over total work units and is available through the controller API, Query Console, and Pinot CLI.

## How it works

- Clients attach a `clientQueryId` and poll `GET /clientQuery/{clientQueryId}/progress` on the controller while the query is running.
- V1 progress uses successfully processed server segments over total segments. Missing or non-responsive server data remains unknown so a partial response cannot report a false 100%.
- V2 progress aggregates multi-stage operator-chain work and returns labeled detail rows for participating components.
- Active and recently completed progress snapshots are retained briefly so the final poll can show completion without extending query lifetime.
- Query tracking is shared by HTTP, TLS, and gRPC server transports and remains independent from query cancellation.

## User experience

- Query Console shows a numeric bar during `RUNNING`, guards overlapping runs, and stops polling when the query completes or the view unmounts.
- Pinot CLI updates only the bottom terminal region and clears it before results are printed.
- V1/simple responses render one CLI line. V2 responses with details render an aggregate bar plus labeled component bars.
- CLI polling is enabled only for interactive terminals. Redirected output and logs remain clean.
- `--progress-interval-ms=0` disables polling; `1000` ms is the default, with `2000` or `5000` ms recommended for higher monitoring concurrency.

The [Pinot CLI manual](https://github.com/apache/pinot/blob/2b9cc00a2466aa9d489bacea643fab2c53fc8a30/pinot-clients/pinot-cli/README.md#query-progress) includes V1 and V2 quickstart queries, CLI/config-file examples, authentication behavior, polling cost, and rolling-upgrade guidance.

## Configuration

Progress tracking is enabled by default and can be controlled independently:

```properties
# Broker configuration
pinot.broker.query.progress.enabled=true

# Server configuration
pinot.server.query.progress.enabled=true
```

Each heartbeat fans out controller to brokers and the owning broker to participating servers. Broker discovery is cached briefly at the controller, but server progress is queried on every heartbeat. Older nodes are handled on a best-effort basis and appear as unknown components during rolling upgrades; query execution is unaffected.

## Screenshot

Adaptive V2 progress in Query Console:

![Query console adaptive MSE progress rows showing Query, Broker, Server, and unknown Server bars](https://gist.githubusercontent.com/xiangfu0/e9d703c161d5cc048d0ab05c77cac144/raw/90c7484b78bd10e28e1e206b15bae271f2d345bd/pinot-query-progress-ui.png)

The screenshot is externally hosted and is not committed to this PR.

## Validation

- Query runtime: `QueryServerTest`, `QueryDispatcherTest`, and `OpChainSchedulerServiceTest` (168 tests)
- Core: `InstanceRequestHandlerTest`, `QueryProgressTrackerTest`, and `StreamingGroupByCombineOperatorTest` (11 tests)
- Broker: `BaseSingleStageBrokerRequestHandlerTest` (26 tests), including materialized-view request routing
- CLI: `PinotCliProgressTest` (3 tests covering one-line V1, multi-line V2, and unknown totals)
- SPI: `QueryProgressStatsTest` (9 tests)
- Controller Query Console: clean `npm ci` and Vite production build
- Strict affected-reactor `test-compile` with `-Xlint:all`: 31 modules, 448 Maven goals
- `spotless:apply`, `checkstyle:check`, `license:format`, and `license:check` passed on all affected modules
- Full PR `git diff --check` passed
