### PR TITLE
Fix flaky testExplainPlanQueryV2 by masking scientific-notation rule timings

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -3569,7 +3569,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     // needed because both OfflineClusterIntegrationTest and MultiNodesOfflineClusterIntegrationTest run this test
     // case with different number of documents in the segment.
     response1 = response1.replaceAll("docs:[0-9]+", "docs:*")
-        .replaceAll("Time: \\d+\\.\\d+", "Time:*");
+        .replaceAll("Time: \\d+\\.\\d+(?:[eE][-+]?\\d+)?", "Time:*");
 
     JsonNode response1Json = JsonUtils.stringToJsonNode(response1);
     assertEquals(response1Json.get("dataSchema").get("columnNames").get(0).asText(), "SQL");
@@ -3605,7 +3605,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     // language=sql
     String query2 = "EXPLAIN PLAN WITHOUT IMPLEMENTATION FOR SELECT * FROM mytable WHERE FlightNum < 0";
     String response2 = postQuery(query2).get("resultTable").toString()
-        .replaceAll("Time: \\d+\\.\\d+", "Time: *");
+        .replaceAll("Time: \\d+\\.\\d+(?:[eE][-+]?\\d+)?", "Time: *");
 
     JsonNode response2Json = JsonUtils.stringToJsonNode(response2);
     assertEquals(response2Json.get("dataSchema").get("columnNames").get(0).asText(), "SQL");


### PR DESCRIPTION
## Problem

`OfflineClusterIntegrationTest#testExplainPlanQueryV2` is intermittently flaky. It compares the EXPLAIN output's "Rule Execution Times" section after masking each per-rule time with `*`, using the regex `Time: \d+\.\d+`.

Rule timings are rendered as `durationNanos / 1_000_000.0` (a `double`) via `Double.toString()` in `RuleTimingPlannerListener`. When a rule runs fast enough (sub-microsecond, i.e. `< 0.001` ms), `Double.toString()` switches to scientific notation such as `1.5E-4`. The old regex matches only the `1.5` mantissa and leaves the exponent behind, producing `Time:*E-4`, which no longer matches the expected `Time:*`:

```
expected: Rule: AggregateProjectPullUpConstants -> Time:*
found:    Rule: AggregateProjectPullUpConstants -> Time:*E-4
```

The rule list itself is correct/unchanged — only the time-masking is wrong. This is a pre-existing flake, unrelated to any Calcite version.

## Fix

Extend the masking regex to also strip an optional scientific-notation exponent, so both `1.5` and `1.5E-4` collapse to `*`:

```
Time: \d+\.\d+   ->   Time: \d+\.\d+(?:[eE][-+]?\d+)?
```

Applied to both occurrences in the test (the two responses asserted in the method).

## Testing

`./mvnw -pl pinot-integration-tests test -Dtest=OfflineClusterIntegrationTest#testExplainPlanQueryV2 -Dsurefire.failIfNoSpecifiedTests=false` passes.
