### PR TITLE
Type bool_and/bool_or intermediate result as BOOLEAN for consistency

### DIFF
--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
@@ -168,8 +168,9 @@ public enum AggregationFunctionType {
   STUNION("STUnion", ReturnTypes.VARBINARY, OperandTypes.BINARY, SqlTypeName.OTHER),
 
   // boolean aggregate functions
-  BOOLAND("boolAnd", ReturnTypes.BOOLEAN, OperandTypes.BOOLEAN, SqlTypeName.INTEGER),
-  BOOLOR("boolOr", ReturnTypes.BOOLEAN, OperandTypes.BOOLEAN, SqlTypeName.INTEGER),
+  // Intermediate result type is BOOLEAN, serialized through its stored type (INT).
+  BOOLAND("boolAnd", ReturnTypes.BOOLEAN, OperandTypes.BOOLEAN, SqlTypeName.BOOLEAN),
+  BOOLOR("boolOr", ReturnTypes.BOOLEAN, OperandTypes.BOOLEAN, SqlTypeName.BOOLEAN),
 
   // ExprMin and ExprMax
   // TODO: revisit support for ExprMin/Max count in V2, particularly plug query rewriter in the right place


### PR DESCRIPTION
## Description

`BOOLAND` / `BOOLOR` declare a `BOOLEAN` return type but override their
intermediate result type to `INTEGER`. This change aligns the intermediate result
type with the function's `BOOLEAN` type for consistency.

## Why it is non-breaking

- `ColumnDataType.BOOLEAN` is stored and serialized as `INT`, so the multi-stage
  intermediate exchange is byte-identical to `INTEGER`.
- The merge stage builds the aggregate call with an `ANY` operand type checker
  (`PinotAggregateExchangeNodeInsertRule`), so Calcite operand validation is
  unaffected.
- The single-stage (v1) engine derives the intermediate type from
  `AggregationFunction.getIntermediateResultColumnType()` (still `INT`) and is
  unaffected.

Verified against the multi-stage resource query tests (`ResourceBasedQueriesTest`):
identical results before and after (no behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
