### PR TITLE
[deprecation] Block field-level forward encoding in table configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,34 @@ For faster builds it is recommended to use `./mvnw verify -Ppinot-fastdev`, whic
 
 More detailed instructions can be found at [Quick Demo](https://docs.pinot.apache.org/basics/getting-started/quick-start) section in the documentation.
 
+### Forward Index Encoding In Table Configs
+
+Set per-column forward index settings inside `fieldConfigList[].indexes.forward`. The older field-level
+`fieldConfigList[].encodingType`, `fieldConfigList[].compressionCodec`, and `fieldConfigList[].properties` forms are
+deprecated, and table create/update validation rejects them. Migrate existing configs before submitting them to the
+controller.
+
+Use this shape for new table configs:
+
+```json
+{
+  "fieldConfigList": [
+    {
+      "name": "message",
+      "indexes": {
+        "forward": {
+          "encodingType": "RAW",
+          "compressionCodec": "ZSTANDARD",
+          "rawIndexWriterVersion": 4
+        },
+        "text": {
+        }
+      }
+    }
+  ]
+}
+```
+
 ### macOS Build Requirements
 
 If you're building Pinot on macOS and encounter issues with the gRPC Java plugin during the build process, you may need to configure the protobuf Maven plugin to use a specific executable path. This is a known issue on macOS ARM (Apple Silicon) systems.

--- a/compatibility-verifier/README.md
+++ b/compatibility-verifier/README.md
@@ -21,6 +21,17 @@
 
 # Compatibility Regression Testing Scripts for Apache Pinot
 
+## Test suite table configs and deprecated fields
+
+Some compatibility-verifier table configs intentionally use deprecated field-level `FieldConfig` forms such as
+`fieldConfigList[].encodingType` and `fieldConfigList[].properties`. These configs are submitted to the older Pinot
+binary before the compatibility run upgrades to the newer binary, and older controllers do not understand the newer
+`fieldConfigList[].indexes.*` blocks.
+
+Those fixtures are not examples for configs submitted to a new controller. New-controller create/update validation
+rejects field-level `encodingType`, `compressionCodec`, and `properties`; production table configs should use the
+corresponding `fieldConfigList[].indexes.*` blocks.
+
 ## Usage
 
 ### Step 1: checkout source code and build targets for older commit and newer commit

--- a/compatibility-verifier/multi-stage-query-engine-test-suite/config/feature-test-1.json
+++ b/compatibility-verifier/multi-stage-query-engine-test-suite/config/feature-test-1.json
@@ -31,7 +31,9 @@
     "enableDefaultStarTree": false,
     "enableDynamicStarTreeCreation": false,
     "loadMode": "MMAP",
-    "noDictionaryColumns": ["textDim1"],
+    "noDictionaryColumns": [
+      "textDim1"
+    ],
     "nullHandlingEnabled": false,
     "sortedColumn": [],
     "streamConfigs": {}

--- a/compatibility-verifier/multi-stage-query-engine-test-suite/config/feature-test-2-realtime.json
+++ b/compatibility-verifier/multi-stage-query-engine-test-suite/config/feature-test-2-realtime.json
@@ -33,7 +33,9 @@
     "enableDefaultStarTree": false,
     "enableDynamicStarTreeCreation": false,
     "loadMode": "MMAP",
-    "noDictionaryColumns": [],
+    "noDictionaryColumns": [
+      "textDim1"
+    ],
     "nullHandlingEnabled": false,
     "segmentFormatVersion": "v3",
     "sortedColumn": [],

--- a/compatibility-verifier/sample-test-suite/config/feature-test-1.json
+++ b/compatibility-verifier/sample-test-suite/config/feature-test-1.json
@@ -31,7 +31,9 @@
     "enableDefaultStarTree": false,
     "enableDynamicStarTreeCreation": false,
     "loadMode": "MMAP",
-    "noDictionaryColumns": ["textDim1"],
+    "noDictionaryColumns": [
+      "textDim1"
+    ],
     "nullHandlingEnabled": false,
     "sortedColumn": [],
     "streamConfigs": {}

--- a/compatibility-verifier/sample-test-suite/config/feature-test-2-realtime.json
+++ b/compatibility-verifier/sample-test-suite/config/feature-test-2-realtime.json
@@ -33,7 +33,9 @@
     "enableDefaultStarTree": false,
     "enableDynamicStarTreeCreation": false,
     "loadMode": "MMAP",
-    "noDictionaryColumns": [],
+    "noDictionaryColumns": [
+      "textDim1"
+    ],
     "nullHandlingEnabled": false,
     "segmentFormatVersion": "v3",
     "sortedColumn": [],

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/MultiIndexingComponent.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/MultiIndexingComponent.tsx
@@ -188,7 +188,15 @@ export default function MultiIndexingComponent({
                         outputData.bloomFilterColumns.push(i.columnName);
                     break;
                     case "Text":
-                        fieldConfigList.push({"name":i.columnName, "encodingType":"RAW", "indexType":"TEXT"})
+                        fieldConfigList.push({
+                            "name": i.columnName,
+                            "indexType": "TEXT",
+                            "indexes": {
+                                "forward": {
+                                    "encodingType": "RAW"
+                                }
+                            }
+                        })
                     break;
                 }
             })

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableConfigsRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableConfigsRestletResourceTest.java
@@ -29,6 +29,7 @@ import org.apache.pinot.client.admin.PinotAdminClient;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConfigUtils;
 import org.apache.pinot.spi.config.TableConfigs;
+import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -608,6 +609,50 @@ public class TableConfigsRestletResourceTest extends ControllerTest {
       } else if (DEFAULT_INSTANCE.getHelixResourceManager().getSchema(tableName) != null) {
         adminClient.getSchemaClient().deleteSchema(tableName);
       }
+    }
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testUpdateRejectsStoredLegacyFieldLevelConfigOptions()
+      throws Exception {
+    assertUpdateRejectsStoredLegacyFieldConfig("testUpdateRejectsLegacyEncodingType",
+        new FieldConfig("dimA", FieldConfig.EncodingType.RAW, null, null, null, null, null),
+        "FieldConfig.encodingType is deprecated for column: dimA. Use "
+            + "fieldConfigList[].indexes.forward.encodingType instead.");
+    assertUpdateRejectsStoredLegacyFieldConfig("testUpdateRejectsLegacyCompressionCodec",
+        new FieldConfig.Builder("dimA")
+            .withCompressionCodec(FieldConfig.CompressionCodec.SNAPPY)
+            .build(),
+        "FieldConfig.compressionCodec is deprecated for column: dimA. Use "
+            + "fieldConfigList[].indexes.forward.compressionCodec instead.");
+    assertUpdateRejectsStoredLegacyFieldConfig("testUpdateRejectsLegacyProperties",
+        new FieldConfig.Builder("dimA")
+            .withProperties(Map.of(FieldConfig.RAW_INDEX_WRITER_VERSION, "4"))
+            .build(),
+        "FieldConfig.properties is deprecated for column: dimA. Move these settings into the relevant "
+            + "fieldConfigList[].indexes.<indexName> block instead.");
+  }
+
+  private void assertUpdateRejectsStoredLegacyFieldConfig(String tableName, FieldConfig fieldConfig,
+      String expectedMessage)
+      throws Exception {
+    PinotAdminClient adminClient = getOrCreateAdminClient();
+    TableConfig offlineTableConfig = createOfflineTableConfig(tableName);
+    offlineTableConfig.setFieldConfigList(List.of(fieldConfig));
+    Schema schema = createDummySchema(tableName);
+    TableConfigs tableConfigs = new TableConfigs(tableName, schema, offlineTableConfig, null);
+
+    DEFAULT_INSTANCE.addDummySchema(tableName);
+    DEFAULT_INSTANCE.getHelixResourceManager().addTable(offlineTableConfig);
+    try {
+      String msg = Assert.expectThrows(Exception.class,
+              () -> adminClient.getTableClient()
+                  .updateTableConfigs(tableName, tableConfigs.toPrettyJsonString(), null, false, false))
+          .getMessage();
+      Assert.assertTrue(msg.contains(expectedMessage), msg);
+    } finally {
+      adminClient.getTableClient().deleteTableConfigs(tableName, null);
     }
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/TableIndexingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/TableIndexingTest.java
@@ -272,7 +272,6 @@ public class TableIndexingTest {
           schemaName.startsWith("raw") ? FieldConfig.EncodingType.RAW : FieldConfig.EncodingType.DICTIONARY;
 
       List<FieldConfig.IndexType> indexTypes = new ArrayList<>();
-      Map<String, String> properties = new HashMap<>();
       ObjectNode indexes = new ObjectNode(JsonNodeFactory.instance);
       TimestampConfig tstmpConfig = null;
       FieldConfig config = null; // table will be created from scratch for each run;
@@ -302,7 +301,11 @@ public class TableIndexingTest {
               "fieldConfigList":[
               {
                 "name":"text_col_1",
-                "encodingType":"DICTIONARY",
+                "indexes": {
+                  "forward": {
+                    "encodingType":"DICTIONARY"
+                  }
+                },
                 "indexType":"FST"
                 }
                 ]
@@ -315,8 +318,10 @@ public class TableIndexingTest {
               "fieldConfigList": [
                 {
                   "name": "location_st_point",
-                  "encodingType":"RAW", // this actually disables the dictionary
                   "indexes": {
+                    "forward": {
+                      "encodingType":"RAW"
+                    },
                     "h3": {
                       "resolutions": [13, 5, 6]
                     }
@@ -368,8 +373,12 @@ public class TableIndexingTest {
             "fieldConfigList":[
               {
                  "name":"text_col_1",
-                 "encodingType":"RAW",
-                 "indexTypes":["TEXT"]
+                 "indexTypes":["TEXT"],
+                 "indexes": {
+                   "forward": {
+                     "encodingType":"RAW"
+                   }
+                 }
               }
             ] */
           indexTypes.add(FieldConfig.IndexType.TEXT);
@@ -455,28 +464,37 @@ public class TableIndexingTest {
             /* vector
             "fieldConfigList": [
             {
-              "encodingType": "RAW",
-              "indexType": "VECTOR",
               "name": "embedding",
-              "properties": {
-                "vectorIndexType": "HNSW",
-                "vectorDimension": 1536,
-                "vectorDistanceFunction": "COSINE",
-                "version": 1
+              "indexes": {
+                "vector": {
+                  "vectorIndexType": "HNSW",
+                  "vectorDimension": 1536,
+                  "vectorDistanceFunction": "COSINE",
+                  "version": 1
+                },
+                "forward": {
+                  "encodingType": "RAW"
+                }
               }
             } */
-          indexTypes.add(FieldConfig.IndexType.VECTOR);
-          properties.put("vectorIndexType", "HNSW");
-          properties.put("vectorDimension", "1536");
-          properties.put("vectorDistanceFunction", "COSINE");
-          properties.put("version", "1");
+          ObjectNode vector = indexes.putObject("vector");
+          vector.put("vectorIndexType", "HNSW");
+          vector.put("vectorDimension", 1536);
+          vector.put("vectorDistanceFunction", "COSINE");
+          vector.put("version", 1);
           break;
         default:
           throw new IllegalArgumentException("Unexpected index type " + indexType);
       }
 
-      config =
-          new FieldConfig(field.getName(), encoding, null, indexTypes, null, tstmpConfig, indexes, properties, null);
+      ObjectNode forwardIndex = JsonUtils.newObjectNode();
+      forwardIndex.put("encodingType", encoding.name());
+      indexes.set("forward", forwardIndex);
+      config = new FieldConfig.Builder(field.getName())
+          .withIndexTypes(indexTypes)
+          .withTimestampConfig(tstmpConfig)
+          .withIndexes(indexes)
+          .build();
 
       tableConfig.getFieldConfigList().add(config);
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/ModeAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/ModeAggregationFunctionTest.java
@@ -19,9 +19,11 @@
 
 package org.apache.pinot.core.query.aggregation.function;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.PinotDataType;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -54,8 +56,12 @@ public class ModeAggregationFunctionTest extends AbstractAggregationFunctionTest
       FieldConfig.EncodingType encodingType =
           _dictionary ? FieldConfig.EncodingType.DICTIONARY : FieldConfig.EncodingType.RAW;
       return givenSingleNullableFieldTable(_dataType, nullHandlingEnabled, builder -> {
-        builder.withEncodingType(encodingType);
-        builder.withCompressionCodec(FieldConfig.CompressionCodec.PASS_THROUGH);
+        ObjectNode indexes = JsonUtils.newObjectNode();
+        ObjectNode forward = JsonUtils.newObjectNode();
+        forward.put("encodingType", encodingType.name());
+        forward.put("compressionCodec", FieldConfig.CompressionCodec.PASS_THROUGH.name());
+        indexes.set("forward", forward);
+        builder.withIndexes(indexes);
       });
     }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/ModeAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/ModeAggregationFunctionTest.java
@@ -19,9 +19,11 @@
 
 package org.apache.pinot.core.query.aggregation.function;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.config.table.FieldConfig;
-import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.PinotDataType;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -32,19 +34,20 @@ public class ModeAggregationFunctionTest extends AbstractAggregationFunctionTest
   @DataProvider(name = "scenarios")
   Object[] scenarios() {
     return new Object[] {
-        new Scenario(DataType.INT, true),
-        new Scenario(DataType.INT, false),
-        new Scenario(DataType.LONG, false),
-        new Scenario(DataType.FLOAT, false),
-        new Scenario(DataType.DOUBLE, false),
+        new Scenario(FieldSpec.DataType.INT, true),
+
+        new Scenario(FieldSpec.DataType.INT, false),
+        new Scenario(FieldSpec.DataType.LONG, false),
+        new Scenario(FieldSpec.DataType.FLOAT, false),
+        new Scenario(FieldSpec.DataType.DOUBLE, false),
     };
   }
 
   public class Scenario {
-    private final DataType _dataType;
+    private final FieldSpec.DataType _dataType;
     private final boolean _dictionary;
 
-    public Scenario(DataType dataType, boolean dictionary) {
+    public Scenario(FieldSpec.DataType dataType, boolean dictionary) {
       _dataType = dataType;
       _dictionary = dictionary;
     }
@@ -53,8 +56,12 @@ public class ModeAggregationFunctionTest extends AbstractAggregationFunctionTest
       FieldConfig.EncodingType encodingType =
           _dictionary ? FieldConfig.EncodingType.DICTIONARY : FieldConfig.EncodingType.RAW;
       return givenSingleNullableFieldTable(_dataType, nullHandlingEnabled, builder -> {
-        builder.withEncodingType(encodingType);
-        builder.withCompressionCodec(FieldConfig.CompressionCodec.PASS_THROUGH);
+        ObjectNode indexes = JsonUtils.newObjectNode();
+        ObjectNode forward = JsonUtils.newObjectNode();
+        forward.put("encodingType", encodingType.name());
+        forward.put("compressionCodec", FieldConfig.CompressionCodec.PASS_THROUGH.name());
+        indexes.set("forward", forward);
+        builder.withIndexes(indexes);
       });
     }
 
@@ -67,41 +74,51 @@ public class ModeAggregationFunctionTest extends AbstractAggregationFunctionTest
   @Test(dataProvider = "scenarios")
   void aggrWithoutNullAndEmptySegments(Scenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField", "null", "null")
-        .andOnSecondInstance("myField", "null", "null")
-        .whenQuery("select mode(myField) as mode from testTable")
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null"
+        ).whenQuery("select mode(myField) as mode from testTable")
         .thenResultIs("DOUBLE", aggrWithoutNullResult(scenario._dataType));
   }
 
   @Test(dataProvider = "scenarios")
   void aggrWithNullAndEmptySegments(Scenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField", "null", "null")
-        .andOnSecondInstance("myField", "null", "null")
-        .whenQuery("select mode(myField) as mode from testTable")
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null"
+        ).whenQuery("select mode(myField) as mode from testTable")
         .thenResultIs("DOUBLE", "null");
   }
 
-  String aggrWithoutNullResult(DataType dt) {
+  String aggrWithoutNullResult(FieldSpec.DataType dt) {
     switch (dt) {
-      case INT:
-        return "-2.147483648E9";
-      case LONG:
-        return "-9.223372036854776E18";
-      case FLOAT:
-        return "-Infinity";
-      case DOUBLE:
-        return "-Infinity";
-      default:
-        throw new IllegalArgumentException(dt.toString());
+      case INT: return "-2.147483648E9";
+      case LONG: return "-9.223372036854776E18";
+      case FLOAT: return "-Infinity";
+      case DOUBLE: return "-Infinity";
+      default: throw new IllegalArgumentException(dt.toString());
     }
   }
 
   @Test(dataProvider = "scenarios")
   void aggrWithoutNull(Scenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField", "null", "1", "null")
-        .andOnSecondInstance("myField", "null", "1", "null")
+        .onFirstInstance("myField",
+            "null",
+            "1",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null",
+            "1",
+            "null"
+        )
         .whenQuery("select mode(myField) as mode from testTable")
         .thenResultIs("DOUBLE", aggrWithoutNullResult(scenario._dataType));
   }
@@ -109,42 +126,55 @@ public class ModeAggregationFunctionTest extends AbstractAggregationFunctionTest
   @Test(dataProvider = "scenarios")
   void aggrWithNull(Scenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField", "null", "1", "null")
-        .andOnSecondInstance("myField", "null", "1", "null")
-        .whenQuery("select mode(myField) as mode from testTable")
+        .onFirstInstance("myField",
+            "null",
+            "1",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null",
+            "1",
+            "null"
+        ).whenQuery("select mode(myField) as mode from testTable")
         .thenResultIs("DOUBLE", "1");
   }
 
-  String aggrSvWithoutNullResult(DataType dt) {
+  String aggrSvWithoutNullResult(FieldSpec.DataType dt) {
     switch (dt) {
-      case INT:
-        return "-2.147483648E9";
-      case LONG:
-        return "-9.223372036854776E18";
-      case FLOAT:
-        return "-Infinity";
-      case DOUBLE:
-        return "-Infinity";
-      default:
-        throw new IllegalArgumentException(dt.toString());
+      case INT: return "-2.147483648E9";
+      case LONG: return "-9.223372036854776E18";
+      case FLOAT: return "-Infinity";
+      case DOUBLE: return "-Infinity";
+      default: throw new IllegalArgumentException(dt.toString());
     }
   }
 
   @Test(dataProvider = "scenarios")
   void aggrSvWithoutNull(Scenario scenario) {
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField", "null", "1", "null")
-        .andOnSecondInstance("myField", "null", "1", "null")
-        .whenQuery("select 'cte', mode(myField) as mode from testTable group by 'cte'")
+        .onFirstInstance("myField",
+            "null",
+            "1",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null",
+            "1",
+            "null"
+        ).whenQuery("select 'cte', mode(myField) as mode from testTable group by 'cte'")
         .thenResultIs("STRING | DOUBLE", "cte | " + aggrSvWithoutNullResult(scenario._dataType));
   }
 
   @Test(dataProvider = "scenarios")
   void aggrSvWithNull(Scenario scenario) {
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField", "null", "1", "null")
-        .andOnSecondInstance("myField", "null", "1", "null")
-        .whenQuery("select 'cte', mode(myField) as mode from testTable group by 'cte'")
+        .onFirstInstance("myField",
+            "null",
+            "1",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null",
+            "1",
+            "null"
+        ).whenQuery("select 'cte', mode(myField) as mode from testTable group by 'cte'")
         .thenResultIs("STRING | DOUBLE", "cte | 1");
   }
 
@@ -171,15 +201,19 @@ public class ModeAggregationFunctionTest extends AbstractAggregationFunctionTest
     }
 
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField", "null", "1", "2")
-        .andOnSecondInstance("myField", "null", "1", "2")
-        .whenQuery("select myField, mode(myField) as mode from testTable group by myField order by myField")
-        .thenResultIs(
-            pinotDataType + " | DOUBLE",
+        .onFirstInstance("myField",
+            "null",
+            "1",
+            "2"
+        ).andOnSecondInstance("myField",
+            "null",
+            "1",
+            "2"
+        ).whenQuery("select myField, mode(myField) as mode from testTable group by myField order by myField")
+        .thenResultIs(pinotDataType + " | DOUBLE",
             defaultNullValue + " | " + aggrSvWithoutNullResult(scenario._dataType),
             "1           | 1",
-            "2           | 2"
-        );
+            "2           | 2");
   }
 
   @Test(dataProvider = "scenarios")
@@ -187,29 +221,25 @@ public class ModeAggregationFunctionTest extends AbstractAggregationFunctionTest
     PinotDataType pinotDataType = PinotDataType.valueOf(scenario._dataType.name());
 
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField", "null", "1", "2")
-        .andOnSecondInstance("myField", "null", "1", "2")
-        .whenQuery("select myField, mode(myField) as mode from testTable group by myField order by myField")
-        .thenResultIs(
-            pinotDataType + " | DOUBLE",
-            "1 | 1",
-            "2 | 2",
-            "null | null"
-        );
+        .onFirstInstance("myField",
+            "null",
+            "1",
+            "2"
+        ).andOnSecondInstance("myField",
+            "null",
+            "1",
+            "2"
+        ).whenQuery("select myField, mode(myField) as mode from testTable group by myField order by myField")
+        .thenResultIs(pinotDataType + " | DOUBLE", "1 | 1", "2 | 2", "null | null");
   }
 
-  String aggrMvWithoutNullResult(DataType dt) {
+  String aggrMvWithoutNullResult(FieldSpec.DataType dt) {
     switch (dt) {
-      case INT:
-        return "-2.147483648E9";
-      case LONG:
-        return "-9.223372036854776E18";
-      case FLOAT:
-        return "-Infinity";
-      case DOUBLE:
-        return "-Infinity";
-      default:
-        throw new IllegalArgumentException(dt.toString());
+      case INT: return "-2.147483648E9";
+      case LONG: return "-9.223372036854776E18";
+      case FLOAT: return "-Infinity";
+      case DOUBLE: return "-Infinity";
+      default: throw new IllegalArgumentException(dt.toString());
     }
   }
 
@@ -217,9 +247,15 @@ public class ModeAggregationFunctionTest extends AbstractAggregationFunctionTest
   void aggrMvWithoutNull(Scenario scenario) {
     // TODO: This test is not actually exercising aggregateGroupByMV
     scenario.getDeclaringTable(false)
-        .onFirstInstance("myField", "null", "1", "null")
-        .andOnSecondInstance("myField", "null", "1", "null")
-        .whenQuery("select 'cte1' as cte1, 'cte2' as cte2, mode(myField) as mode from testTable group by cte1, cte2")
+        .onFirstInstance("myField",
+            "null",
+            "1",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null",
+            "1",
+            "null"
+        ).whenQuery("select 'cte1' as cte1, 'cte2' as cte2, mode(myField) as mode from testTable group by cte1, cte2")
         .thenResultIs("STRING | STRING | DOUBLE", "cte1 | cte2 | " + aggrMvWithoutNullResult(scenario._dataType));
   }
 
@@ -227,9 +263,15 @@ public class ModeAggregationFunctionTest extends AbstractAggregationFunctionTest
   void aggrMvWithNull(Scenario scenario) {
     // TODO: This test is not actually exercising aggregateGroupByMV
     scenario.getDeclaringTable(true)
-        .onFirstInstance("myField", "null", "1", "null")
-        .andOnSecondInstance("myField", "null", "1", "null")
-        .whenQuery("select 'cte1' as cte1, 'cte2' as cte2, mode(myField) as mode from testTable group by cte1, cte2")
+        .onFirstInstance("myField",
+            "null",
+            "1",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null",
+            "1",
+            "null"
+        ).whenQuery("select 'cte1' as cte1, 'cte2' as cte2, mode(myField) as mode from testTable group by cte1, cte2")
         .thenResultIs("STRING | STRING | DOUBLE", "cte1 | cte2 | 1");
   }
 }

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.integration.tests;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -140,6 +141,78 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   protected org.apache.pinot.client.Connection _pinotConnectionV2;
   protected Connection _h2Connection;
   protected QueryGenerator _queryGenerator;
+
+  protected static FieldConfig fieldConfigWithForwardEncoding(String column, FieldConfig.EncodingType encodingType,
+      List<FieldConfig.IndexType> indexTypes, FieldConfig.CompressionCodec compressionCodec,
+      Map<String, String> properties) {
+    ObjectNode indexes = indexesWithForwardEncoding(encodingType);
+    if (compressionCodec != null) {
+      withForwardCompression(indexes, compressionCodec);
+    }
+    if (properties != null) {
+      withForwardProperties(indexes, properties);
+    }
+    return fieldConfigBuilderWithForwardEncoding(column, encodingType)
+        .withIndexTypes(indexTypes)
+        .withIndexes(indexes)
+        .build();
+  }
+
+  protected static FieldConfig.Builder fieldConfigBuilderWithForwardEncoding(String column,
+      FieldConfig.EncodingType encodingType) {
+    return new FieldConfig.Builder(column).withIndexes(indexesWithForwardEncoding(encodingType));
+  }
+
+  protected static ObjectNode indexesWithForwardEncoding(FieldConfig.EncodingType encodingType) {
+    return withForwardEncoding(JsonUtils.newObjectNode(), encodingType);
+  }
+
+  protected static ObjectNode withForwardEncoding(JsonNode indexes, FieldConfig.EncodingType encodingType) {
+    ObjectNode indexesNode =
+        indexes != null && indexes.isObject() ? (ObjectNode) indexes.deepCopy() : JsonUtils.newObjectNode();
+    ObjectNode forward;
+    if (indexesNode.has("forward") && indexesNode.get("forward").isObject()) {
+      forward = (ObjectNode) indexesNode.get("forward");
+    } else {
+      forward = JsonUtils.newObjectNode();
+      indexesNode.set("forward", forward);
+    }
+    forward.put("encodingType", encodingType.name());
+    return indexesNode;
+  }
+
+  protected static void withForwardCompression(ObjectNode indexes, FieldConfig.CompressionCodec compressionCodec) {
+    forwardNode(indexes).put("compressionCodec", compressionCodec.name());
+  }
+
+  protected static void withForwardProperties(ObjectNode indexes, Map<String, String> properties) {
+    ObjectNode forward = forwardNode(indexes);
+    for (Map.Entry<String, String> entry : properties.entrySet()) {
+      switch (entry.getKey()) {
+        case FieldConfig.FORWARD_INDEX_DISABLED:
+          forward.put("disabled", Boolean.parseBoolean(entry.getValue()));
+          break;
+        case FieldConfig.DERIVE_NUM_DOCS_PER_CHUNK_RAW_INDEX_KEY:
+          forward.put("deriveNumDocsPerChunk", Boolean.parseBoolean(entry.getValue()));
+          break;
+        case FieldConfig.RAW_INDEX_WRITER_VERSION:
+          forward.put("rawIndexWriterVersion", Integer.parseInt(entry.getValue()));
+          break;
+        default:
+          forward.put(entry.getKey(), entry.getValue());
+          break;
+      }
+    }
+  }
+
+  protected static ObjectNode forwardNode(ObjectNode indexes) {
+    if (indexes.has("forward") && indexes.get("forward").isObject()) {
+      return (ObjectNode) indexes.get("forward");
+    }
+    ObjectNode forward = JsonUtils.newObjectNode();
+    indexes.set("forward", forward);
+    return forward;
+  }
 
   /// The following getters can be overridden to change default settings.
 

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.integration.tests;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -136,6 +137,78 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   protected org.apache.pinot.client.Connection _pinotConnectionV2;
   protected Connection _h2Connection;
   protected QueryGenerator _queryGenerator;
+
+  protected static FieldConfig fieldConfigWithForwardEncoding(String column, FieldConfig.EncodingType encodingType,
+      List<FieldConfig.IndexType> indexTypes, FieldConfig.CompressionCodec compressionCodec,
+      Map<String, String> properties) {
+    ObjectNode indexes = indexesWithForwardEncoding(encodingType);
+    if (compressionCodec != null) {
+      withForwardCompression(indexes, compressionCodec);
+    }
+    if (properties != null) {
+      withForwardProperties(indexes, properties);
+    }
+    return fieldConfigBuilderWithForwardEncoding(column, encodingType)
+        .withIndexTypes(indexTypes)
+        .withIndexes(indexes)
+        .build();
+  }
+
+  protected static FieldConfig.Builder fieldConfigBuilderWithForwardEncoding(String column,
+      FieldConfig.EncodingType encodingType) {
+    return new FieldConfig.Builder(column).withIndexes(indexesWithForwardEncoding(encodingType));
+  }
+
+  protected static ObjectNode indexesWithForwardEncoding(FieldConfig.EncodingType encodingType) {
+    return withForwardEncoding(JsonUtils.newObjectNode(), encodingType);
+  }
+
+  protected static ObjectNode withForwardEncoding(JsonNode indexes, FieldConfig.EncodingType encodingType) {
+    ObjectNode indexesNode =
+        indexes != null && indexes.isObject() ? (ObjectNode) indexes.deepCopy() : JsonUtils.newObjectNode();
+    ObjectNode forward;
+    if (indexesNode.has("forward") && indexesNode.get("forward").isObject()) {
+      forward = (ObjectNode) indexesNode.get("forward");
+    } else {
+      forward = JsonUtils.newObjectNode();
+      indexesNode.set("forward", forward);
+    }
+    forward.put("encodingType", encodingType.name());
+    return indexesNode;
+  }
+
+  protected static void withForwardCompression(ObjectNode indexes, FieldConfig.CompressionCodec compressionCodec) {
+    forwardNode(indexes).put("compressionCodec", compressionCodec.name());
+  }
+
+  protected static void withForwardProperties(ObjectNode indexes, Map<String, String> properties) {
+    ObjectNode forward = forwardNode(indexes);
+    for (Map.Entry<String, String> entry : properties.entrySet()) {
+      switch (entry.getKey()) {
+        case FieldConfig.FORWARD_INDEX_DISABLED:
+          forward.put("disabled", Boolean.parseBoolean(entry.getValue()));
+          break;
+        case FieldConfig.DERIVE_NUM_DOCS_PER_CHUNK_RAW_INDEX_KEY:
+          forward.put("deriveNumDocsPerChunk", Boolean.parseBoolean(entry.getValue()));
+          break;
+        case FieldConfig.RAW_INDEX_WRITER_VERSION:
+          forward.put("rawIndexWriterVersion", Integer.parseInt(entry.getValue()));
+          break;
+        default:
+          forward.put(entry.getKey(), entry.getValue());
+          break;
+      }
+    }
+  }
+
+  protected static ObjectNode forwardNode(ObjectNode indexes) {
+    if (indexes.has("forward") && indexes.get("forward").isObject()) {
+      return (ObjectNode) indexes.get("forward");
+    }
+    ObjectNode forward = JsonUtils.newObjectNode();
+    indexes.set("forward", forward);
+    return forward;
+  }
 
   /// The following getters can be overridden to change default settings.
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ErrorCodesIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ErrorCodesIntegrationTest.java
@@ -107,9 +107,8 @@ public abstract class ErrorCodesIntegrationTest extends BaseClusterIntegrationTe
 
   @Override
   protected List<FieldConfig> getFieldConfigs() {
-    return List.of(
-        new FieldConfig("DivAirports", FieldConfig.EncodingType.DICTIONARY, List.of(),
-            FieldConfig.CompressionCodec.MV_ENTRY_DICT, null));
+    return List.of(fieldConfigWithForwardEncoding("DivAirports", FieldConfig.EncodingType.DICTIONARY, List.of(),
+        FieldConfig.CompressionCodec.MV_ENTRY_DICT, null));
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageWithoutStatsIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageWithoutStatsIntegrationTest.java
@@ -115,9 +115,8 @@ public class MultiStageWithoutStatsIntegrationTest extends BaseClusterIntegratio
 
   @Override
   protected List<FieldConfig> getFieldConfigs() {
-    return List.of(
-        new FieldConfig("DivAirports", FieldConfig.EncodingType.DICTIONARY, List.of(),
-            FieldConfig.CompressionCodec.MV_ENTRY_DICT, null));
+    return List.of(fieldConfigWithForwardEncoding("DivAirports", FieldConfig.EncodingType.DICTIONARY, List.of(),
+        FieldConfig.CompressionCodec.MV_ENTRY_DICT, null));
   }
 
   /// This is a regression test. In older versions there were issues with stats in intersection queries.

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -187,9 +187,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   @Override
   protected List<FieldConfig> getFieldConfigs() {
     List<FieldConfig> fieldConfigs = new ArrayList<>();
-    fieldConfigs.add(
-        new FieldConfig("DivAirports", FieldConfig.EncodingType.DICTIONARY, List.of(), CompressionCodec.MV_ENTRY_DICT,
-            null));
+    fieldConfigs.add(fieldConfigWithForwardEncoding("DivAirports", FieldConfig.EncodingType.DICTIONARY, List.of(),
+        CompressionCodec.MV_ENTRY_DICT, null));
     return fieldConfigs;
   }
 
@@ -1539,8 +1538,9 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         .build();
     ObjectNode indexes = JsonUtils.newObjectNode();
     indexes.set("forward", forwardIndexConfig.toJsonNode());
-    FieldConfig fieldConfig =
-        new FieldConfig.Builder(column).withEncodingType(FieldConfig.EncodingType.RAW).withIndexes(indexes).build();
+    FieldConfig fieldConfig = new FieldConfig.Builder(column)
+        .withIndexes(withForwardEncoding(indexes, FieldConfig.EncodingType.RAW))
+        .build();
     fieldConfigs.add(fieldConfig);
     updateTableConfig(tableConfig);
     reloadAllSegments(SELECT_STAR_QUERY, false, numTotalDocs);
@@ -1562,8 +1562,9 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         .build();
     indexes = JsonUtils.newObjectNode();
     indexes.set("forward", forwardIndexConfig.toJsonNode());
-    fieldConfig =
-        new FieldConfig.Builder(column).withEncodingType(FieldConfig.EncodingType.RAW).withIndexes(indexes).build();
+    fieldConfig = new FieldConfig.Builder(column)
+        .withIndexes(withForwardEncoding(indexes, FieldConfig.EncodingType.RAW))
+        .build();
     fieldConfigs.set(fieldConfigs.size() - 1, fieldConfig);
     updateTableConfig(tableConfig);
     reloadAllSegments(SELECT_STAR_QUERY, false, numTotalDocs);
@@ -1578,8 +1579,9 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         .withCompressionCodec(CompressionCodec.SNAPPY)
         .build();
     indexes.set("forward", forwardIndexConfig.toJsonNode());
-    fieldConfig =
-        new FieldConfig.Builder(column).withEncodingType(FieldConfig.EncodingType.RAW).withIndexes(indexes).build();
+    fieldConfig = new FieldConfig.Builder(column)
+        .withIndexes(withForwardEncoding(indexes, FieldConfig.EncodingType.RAW))
+        .build();
     fieldConfigs.set(fieldConfigs.size() - 1, fieldConfig);
     updateTableConfig(tableConfig);
     reloadAllSegments(SELECT_STAR_QUERY, false, numTotalDocs);
@@ -1603,8 +1605,9 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         .withCompressionCodec(CompressionCodec.LZ4)
         .build();
     indexes.set("forward", forwardIndexConfig.toJsonNode());
-    fieldConfig =
-        new FieldConfig.Builder(column).withEncodingType(FieldConfig.EncodingType.RAW).withIndexes(indexes).build();
+    fieldConfig = new FieldConfig.Builder(column)
+        .withIndexes(withForwardEncoding(indexes, FieldConfig.EncodingType.RAW))
+        .build();
     fieldConfigs.add(fieldConfig);
     updateTableConfig(tableConfig);
     reloadAllSegments(SELECT_STAR_QUERY, false, numTotalDocs);
@@ -1924,12 +1927,10 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     noDictionaryColumns.add("NewAddedRawDerivedMVIntDimension");
     List<FieldConfig> fieldConfigList = tableConfig.getFieldConfigList();
     assertNotNull(fieldConfigList);
-    fieldConfigList.add(
-        new FieldConfig("NewAddedDerivedDivAirportSeqIDs", FieldConfig.EncodingType.DICTIONARY, List.of(),
-            CompressionCodec.MV_ENTRY_DICT, null));
-    fieldConfigList.add(
-        new FieldConfig("NewAddedDerivedDivAirportSeqIDsString", FieldConfig.EncodingType.DICTIONARY, List.of(),
-            CompressionCodec.MV_ENTRY_DICT, null));
+    fieldConfigList.add(fieldConfigWithForwardEncoding("NewAddedDerivedDivAirportSeqIDs",
+        FieldConfig.EncodingType.DICTIONARY, List.of(), CompressionCodec.MV_ENTRY_DICT, null));
+    fieldConfigList.add(fieldConfigWithForwardEncoding("NewAddedDerivedDivAirportSeqIDsString",
+        FieldConfig.EncodingType.DICTIONARY, List.of(), CompressionCodec.MV_ENTRY_DICT, null));
     updateTableConfig(tableConfig);
 
     // Query the new added columns without reload
@@ -3641,7 +3642,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     // needed because both OfflineClusterIntegrationTest and MultiNodesOfflineClusterIntegrationTest run this test
     // case with different number of documents in the segment.
     response1 = response1.replaceAll("docs:[0-9]+", "docs:*")
-        .replaceAll("Time: \\d+\\.\\d+(?:[eE][-+]?\\d+)?", "Time:*");
+        .replaceAll("Time: \\d+(?:\\.\\d+)?(?:[Ee][+-]?\\d+)?", "Time:*");
 
     JsonNode response1Json = JsonUtils.stringToJsonNode(response1);
     assertEquals(response1Json.get("dataSchema").get("columnNames").get(0).asText(), "SQL");
@@ -3677,7 +3678,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     // language=sql
     String query2 = "EXPLAIN PLAN WITHOUT IMPLEMENTATION FOR SELECT * FROM mytable WHERE FlightNum < 0";
     String response2 = postQuery(query2).get("resultTable").toString()
-        .replaceAll("Time: \\d+\\.\\d+(?:[eE][-+]?\\d+)?", "Time: *");
+        .replaceAll("Time: \\d+(?:\\.\\d+)?(?:[Ee][+-]?\\d+)?", "Time: *");
 
     JsonNode response2Json = JsonUtils.stringToJsonNode(response2);
     assertEquals(response2Json.get("dataSchema").get("columnNames").get(0).asText(), "SQL");

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -187,9 +187,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   @Override
   protected List<FieldConfig> getFieldConfigs() {
     List<FieldConfig> fieldConfigs = new ArrayList<>();
-    fieldConfigs.add(
-        new FieldConfig("DivAirports", FieldConfig.EncodingType.DICTIONARY, List.of(), CompressionCodec.MV_ENTRY_DICT,
-            null));
+    fieldConfigs.add(fieldConfigWithForwardEncoding("DivAirports", FieldConfig.EncodingType.DICTIONARY, List.of(),
+        CompressionCodec.MV_ENTRY_DICT, null));
     return fieldConfigs;
   }
 
@@ -1531,8 +1530,9 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         .build();
     ObjectNode indexes = JsonUtils.newObjectNode();
     indexes.set("forward", forwardIndexConfig.toJsonNode());
-    FieldConfig fieldConfig =
-        new FieldConfig.Builder(column).withEncodingType(FieldConfig.EncodingType.RAW).withIndexes(indexes).build();
+    FieldConfig fieldConfig = new FieldConfig.Builder(column)
+        .withIndexes(withForwardEncoding(indexes, FieldConfig.EncodingType.RAW))
+        .build();
     fieldConfigs.add(fieldConfig);
     updateTableConfig(tableConfig);
     reloadAllSegments(SELECT_STAR_QUERY, false, numTotalDocs);
@@ -1554,8 +1554,9 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         .build();
     indexes = JsonUtils.newObjectNode();
     indexes.set("forward", forwardIndexConfig.toJsonNode());
-    fieldConfig =
-        new FieldConfig.Builder(column).withEncodingType(FieldConfig.EncodingType.RAW).withIndexes(indexes).build();
+    fieldConfig = new FieldConfig.Builder(column)
+        .withIndexes(withForwardEncoding(indexes, FieldConfig.EncodingType.RAW))
+        .build();
     fieldConfigs.set(fieldConfigs.size() - 1, fieldConfig);
     updateTableConfig(tableConfig);
     reloadAllSegments(SELECT_STAR_QUERY, false, numTotalDocs);
@@ -1570,8 +1571,9 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         .withCompressionCodec(CompressionCodec.SNAPPY)
         .build();
     indexes.set("forward", forwardIndexConfig.toJsonNode());
-    fieldConfig =
-        new FieldConfig.Builder(column).withEncodingType(FieldConfig.EncodingType.RAW).withIndexes(indexes).build();
+    fieldConfig = new FieldConfig.Builder(column)
+        .withIndexes(withForwardEncoding(indexes, FieldConfig.EncodingType.RAW))
+        .build();
     fieldConfigs.set(fieldConfigs.size() - 1, fieldConfig);
     updateTableConfig(tableConfig);
     reloadAllSegments(SELECT_STAR_QUERY, false, numTotalDocs);
@@ -1595,8 +1597,9 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         .withCompressionCodec(CompressionCodec.LZ4)
         .build();
     indexes.set("forward", forwardIndexConfig.toJsonNode());
-    fieldConfig =
-        new FieldConfig.Builder(column).withEncodingType(FieldConfig.EncodingType.RAW).withIndexes(indexes).build();
+    fieldConfig = new FieldConfig.Builder(column)
+        .withIndexes(withForwardEncoding(indexes, FieldConfig.EncodingType.RAW))
+        .build();
     fieldConfigs.add(fieldConfig);
     updateTableConfig(tableConfig);
     reloadAllSegments(SELECT_STAR_QUERY, false, numTotalDocs);
@@ -1916,12 +1919,10 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     noDictionaryColumns.add("NewAddedRawDerivedMVIntDimension");
     List<FieldConfig> fieldConfigList = tableConfig.getFieldConfigList();
     assertNotNull(fieldConfigList);
-    fieldConfigList.add(
-        new FieldConfig("NewAddedDerivedDivAirportSeqIDs", FieldConfig.EncodingType.DICTIONARY, List.of(),
-            CompressionCodec.MV_ENTRY_DICT, null));
-    fieldConfigList.add(
-        new FieldConfig("NewAddedDerivedDivAirportSeqIDsString", FieldConfig.EncodingType.DICTIONARY, List.of(),
-            CompressionCodec.MV_ENTRY_DICT, null));
+    fieldConfigList.add(fieldConfigWithForwardEncoding("NewAddedDerivedDivAirportSeqIDs",
+        FieldConfig.EncodingType.DICTIONARY, List.of(), CompressionCodec.MV_ENTRY_DICT, null));
+    fieldConfigList.add(fieldConfigWithForwardEncoding("NewAddedDerivedDivAirportSeqIDsString",
+        FieldConfig.EncodingType.DICTIONARY, List.of(), CompressionCodec.MV_ENTRY_DICT, null));
     updateTableConfig(tableConfig);
 
     // Query the new added columns without reload
@@ -3561,7 +3562,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     // needed because both OfflineClusterIntegrationTest and MultiNodesOfflineClusterIntegrationTest run this test
     // case with different number of documents in the segment.
     response1 = response1.replaceAll("docs:[0-9]+", "docs:*")
-        .replaceAll("Time: \\d+\\.\\d+(?:[eE][-+]?\\d+)?", "Time:*");
+        .replaceAll("Time: \\d+(?:\\.\\d+)?(?:[Ee][+-]?\\d+)?", "Time:*");
 
     JsonNode response1Json = JsonUtils.stringToJsonNode(response1);
     assertEquals(response1Json.get("dataSchema").get("columnNames").get(0).asText(), "SQL");
@@ -3597,7 +3598,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     // language=sql
     String query2 = "EXPLAIN PLAN WITHOUT IMPLEMENTATION FOR SELECT * FROM mytable WHERE FlightNum < 0";
     String response2 = postQuery(query2).get("resultTable").toString()
-        .replaceAll("Time: \\d+\\.\\d+(?:[eE][-+]?\\d+)?", "Time: *");
+        .replaceAll("Time: \\d+(?:\\.\\d+)?(?:[Ee][+-]?\\d+)?", "Time: *");
 
     JsonNode response2Json = JsonUtils.stringToJsonNode(response2);
     assertEquals(response2Json.get("dataSchema").get("columnNames").get(0).asText(), "SQL");

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeToOfflineSegmentsMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeToOfflineSegmentsMinionClusterIntegrationTest.java
@@ -115,10 +115,11 @@ public class RealtimeToOfflineSegmentsMinionClusterIntegrationTest extends BaseC
     ingestionConfig.setTransformConfigs(
         List.of(new TransformConfig("ts", "fromEpochDays(DaysSinceEpoch)")));
     realtimeTableConfig.setIngestionConfig(ingestionConfig);
-    FieldConfig tsFieldConfig =
-        new FieldConfig("ts", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.TIMESTAMP, null, null,
-            new TimestampConfig(Arrays.asList(TimestampIndexGranularity.HOUR, TimestampIndexGranularity.DAY,
-                TimestampIndexGranularity.WEEK, TimestampIndexGranularity.MONTH)), null);
+    FieldConfig tsFieldConfig = fieldConfigBuilderWithForwardEncoding("ts", FieldConfig.EncodingType.DICTIONARY)
+        .withIndexTypes(List.of(FieldConfig.IndexType.TIMESTAMP))
+        .withTimestampConfig(new TimestampConfig(Arrays.asList(TimestampIndexGranularity.HOUR,
+            TimestampIndexGranularity.DAY, TimestampIndexGranularity.WEEK, TimestampIndexGranularity.MONTH)))
+        .build();
     realtimeTableConfig.setFieldConfigList(List.of(tsFieldConfig));
 
     Map<String, String> taskConfigs = new HashMap<>();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/StaleSegmentCheckIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/StaleSegmentCheckIntegrationTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.integration.tests;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -102,8 +103,11 @@ public class StaleSegmentCheckIntegrationTest extends BaseClusterIntegrationTest
   }
 
   private FieldConfig getH3FieldConfig() {
-    return new FieldConfig(H3_INDEX_COLUMN, FieldConfig.EncodingType.DICTIONARY, List.of(FieldConfig.IndexType.H3),
-        null, H3_INDEX_PROPERTIES);
+    ObjectNode indexes = indexesWithForwardEncoding(FieldConfig.EncodingType.DICTIONARY);
+    indexes.putObject("h3").putArray("resolution").add(Integer.parseInt(H3_INDEX_PROPERTIES.get("resolutions")));
+    return new FieldConfig.Builder(H3_INDEX_COLUMN)
+        .withIndexes(indexes)
+        .build();
   }
 
   @Override

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/CLPEncodingRealtimeTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/CLPEncodingRealtimeTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.integration.tests.custom;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -107,10 +108,9 @@ public class CLPEncodingRealtimeTest extends CustomDataQueryClusterIntegrationTe
 
   @Override
   protected List<FieldConfig> getFieldConfigs() {
-    List<FieldConfig> fieldConfigs = new ArrayList<>();
-    fieldConfigs.add(new FieldConfig.Builder("logLine").withEncodingType(FieldConfig.EncodingType.RAW)
-        .withCompressionCodec(_selectedCompressionCodec).build());
-    return fieldConfigs;
+    ObjectNode indexes = indexesWithForwardEncoding(FieldConfig.EncodingType.RAW);
+    withForwardCompression(indexes, _selectedCompressionCodec);
+    return List.of(new FieldConfig.Builder("logLine").withIndexes(indexes).build());
   }
 
   @Override

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/ConsumingSegmentTierOverrideRealtimeTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/ConsumingSegmentTierOverrideRealtimeTest.java
@@ -121,10 +121,9 @@ public class ConsumingSegmentTierOverrideRealtimeTest extends CustomDataQueryClu
 
   @Override
   protected List<FieldConfig> getFieldConfigs() {
-    return List.of(new FieldConfig.Builder(PROFILED_STRING_COLUMN)
-        .withEncodingType(FieldConfig.EncodingType.RAW)
-        .withTierOverwrites(jsonNode("{\"consuming\":{\"encodingType\":\"DICTIONARY\","
-            + "\"indexes\":{\"inverted\":{\"disabled\":false}}}}"))
+    return List.of(fieldConfigBuilderWithForwardEncoding(PROFILED_STRING_COLUMN, FieldConfig.EncodingType.RAW)
+        .withTierOverwrites(jsonNode("{\"consuming\":{\"indexes\":{\"forward\":{\"encodingType\":\"DICTIONARY\"},"
+            + "\"inverted\":{\"disabled\":false}}}}"))
         .build());
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/IvfFlatVectorTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/IvfFlatVectorTest.java
@@ -19,11 +19,11 @@
 package org.apache.pinot.integration.tests.custom;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericData;
 import org.apache.commons.lang3.StringUtils;
@@ -68,18 +68,19 @@ public class IvfFlatVectorTest extends CustomDataQueryClusterIntegrationTest {
 
   @Override
   public TableConfig createOfflineTableConfig() {
+    ObjectNode indexes = indexesWithForwardEncoding(FieldConfig.EncodingType.RAW);
+    ObjectNode vector = indexes.putObject("vector");
+    vector.put("vectorIndexType", "IVF_FLAT");
+    vector.put("vectorDimension", VECTOR_DIM_SIZE);
+    vector.put("vectorDistanceFunction", "EUCLIDEAN");
+    vector.put("version", 1);
+    vector.putObject("properties")
+        .put("nlist", String.valueOf(NLIST));
     return new TableConfigBuilder(TableType.OFFLINE)
         .setTableName(getTableName())
         .setFieldConfigList(List.of(
             new FieldConfig.Builder(VECTOR_COL)
-                .withIndexTypes(List.of(FieldConfig.IndexType.VECTOR))
-                .withEncodingType(FieldConfig.EncodingType.RAW)
-                .withProperties(Map.of(
-                    "vectorIndexType", "IVF_FLAT",
-                    "vectorDimension", String.valueOf(VECTOR_DIM_SIZE),
-                    "vectorDistanceFunction", "EUCLIDEAN",
-                    "nlist", String.valueOf(NLIST),
-                    "version", "1"))
+                .withIndexes(indexes)
                 .build()
         ))
         .build();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/IvfPqVectorTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/IvfPqVectorTest.java
@@ -19,11 +19,11 @@
 package org.apache.pinot.integration.tests.custom;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericData;
 import org.apache.commons.lang3.StringUtils;
@@ -65,19 +65,20 @@ public class IvfPqVectorTest extends CustomDataQueryClusterIntegrationTest {
 
   @Override
   protected List<FieldConfig> getFieldConfigs() {
+    ObjectNode indexes = indexesWithForwardEncoding(FieldConfig.EncodingType.RAW);
+    ObjectNode vector = indexes.putObject("vector");
+    vector.put("vectorIndexType", "IVF_PQ");
+    vector.put("vectorDimension", VECTOR_DIMENSION);
+    vector.put("vectorDistanceFunction", "EUCLIDEAN");
+    vector.put("version", 1);
+    vector.putObject("properties")
+        .put("nlist", String.valueOf(NLIST))
+        .put("pqM", String.valueOf(PQ_M))
+        .put("pqNbits", String.valueOf(PQ_NBITS))
+        .put("trainSampleSize", String.valueOf(TRAIN_SAMPLE_SIZE))
+        .put("trainingSeed", "7");
     return List.of(new FieldConfig.Builder(VECTOR_COL)
-        .withIndexTypes(List.of(FieldConfig.IndexType.VECTOR))
-        .withEncodingType(FieldConfig.EncodingType.RAW)
-        .withProperties(Map.of(
-            "vectorIndexType", "IVF_PQ",
-            "vectorDimension", String.valueOf(VECTOR_DIMENSION),
-            "vectorDistanceFunction", "EUCLIDEAN",
-            "version", "1",
-            "nlist", String.valueOf(NLIST),
-            "pqM", String.valueOf(PQ_M),
-            "pqNbits", String.valueOf(PQ_NBITS),
-            "trainSampleSize", String.valueOf(TRAIN_SAMPLE_SIZE),
-            "trainingSeed", "7"))
+        .withIndexes(indexes)
         .build());
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/MultiColumnTextIndicesTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/MultiColumnTextIndicesTest.java
@@ -136,20 +136,18 @@ public class MultiColumnTextIndicesTest extends CustomDataQueryClusterIntegratio
     }
 
     return Arrays.asList(
-        new FieldConfig.Builder(NULLABLE_TEXT_COL).withEncodingType(FieldConfig.EncodingType.RAW).build(),
-        new FieldConfig.Builder(NULLABLE_TEXT_COL_MV).withEncodingType(FieldConfig.EncodingType.RAW).build(),
-        new FieldConfig.Builder(TEXT_COL).withEncodingType(FieldConfig.EncodingType.RAW).build(),
-        new FieldConfig.Builder(TEXT_COL_CASE_SENSITIVE).withEncodingType(FieldConfig.EncodingType.RAW).build(),
-        new FieldConfig.Builder(TEXT_COL_MV).withEncodingType(FieldConfig.EncodingType.RAW).build(),
-        new FieldConfig.Builder(TEXT_COL_CASE_SENSITIVE_MV).withEncodingType(FieldConfig.EncodingType.RAW).build(),
-        new FieldConfig.Builder(DICT_TEXT_COL).withEncodingType(FieldConfig.EncodingType.DICTIONARY)
+        fieldConfigBuilderWithForwardEncoding(NULLABLE_TEXT_COL, FieldConfig.EncodingType.RAW).build(),
+        fieldConfigBuilderWithForwardEncoding(NULLABLE_TEXT_COL_MV, FieldConfig.EncodingType.RAW).build(),
+        fieldConfigBuilderWithForwardEncoding(TEXT_COL, FieldConfig.EncodingType.RAW).build(),
+        fieldConfigBuilderWithForwardEncoding(TEXT_COL_CASE_SENSITIVE, FieldConfig.EncodingType.RAW).build(),
+        fieldConfigBuilderWithForwardEncoding(TEXT_COL_MV, FieldConfig.EncodingType.RAW).build(),
+        fieldConfigBuilderWithForwardEncoding(TEXT_COL_CASE_SENSITIVE_MV, FieldConfig.EncodingType.RAW).build(),
+        new FieldConfig.Builder(DICT_TEXT_COL)
             .withIndexes(indexes)
             .build(), // column missing forward index can still be indexed if there's dictionary and inverted index
-        new FieldConfig.Builder(DICT_TEXT_COL_CASE_SENSITIVE).withEncodingType(FieldConfig.EncodingType.DICTIONARY)
-            .build(),
-        new FieldConfig.Builder(DICT_TEXT_COL_MV).withEncodingType(FieldConfig.EncodingType.DICTIONARY).build(),
-        new FieldConfig.Builder(DICT_TEXT_COL_CASE_SENSITIVE_MV).withEncodingType(FieldConfig.EncodingType.DICTIONARY)
-            .build());
+        new FieldConfig.Builder(DICT_TEXT_COL_CASE_SENSITIVE).build(),
+        new FieldConfig.Builder(DICT_TEXT_COL_MV).build(),
+        new FieldConfig.Builder(DICT_TEXT_COL_CASE_SENSITIVE_MV).build());
   }
 
   @Override

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/RawForwardIndexWithDictionaryTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/RawForwardIndexWithDictionaryTest.java
@@ -155,7 +155,7 @@ public class RawForwardIndexWithDictionaryTest extends CustomDataQueryClusterInt
 
   @Override
   protected List<String> getNoDictionaryColumns() {
-    // Forward-index encoding for the raw-dict columns is set via FieldConfig (RAW + explicit dictionary).
+    // Forward-index encoding for the raw-dict columns is set via fieldConfig.indexes.forward.
     return List.of();
   }
 
@@ -163,21 +163,21 @@ public class RawForwardIndexWithDictionaryTest extends CustomDataQueryClusterInt
   protected List<FieldConfig> getFieldConfigs() {
     ObjectNode dictionaryIndex = JsonUtils.newObjectNode();
     dictionaryIndex.set("dictionary", JsonUtils.newObjectNode());
-    FieldConfig rawDictString =
-        new FieldConfig(RAW_DICT_DIMENSION, FieldConfig.EncodingType.RAW, null, null, null, null, dictionaryIndex,
-            null, null);
-    FieldConfig rawDictInvString =
-        new FieldConfig(RAW_DICT_INV_DIMENSION, FieldConfig.EncodingType.RAW, null, null, null, null,
-            dictionaryIndex.deepCopy(), null, null);
-    FieldConfig rawDictInt =
-        new FieldConfig(RAW_DICT_INT_DIMENSION, FieldConfig.EncodingType.RAW, null, null, null, null,
-            dictionaryIndex.deepCopy(), null, null);
-    FieldConfig rawDictInvInt =
-        new FieldConfig(RAW_DICT_INV_INT_DIMENSION, FieldConfig.EncodingType.RAW, null, null, null, null,
-            dictionaryIndex.deepCopy(), null, null);
-    FieldConfig rawDictRangeInt =
-        new FieldConfig(RAW_DICT_RANGE_INT_DIMENSION, FieldConfig.EncodingType.RAW, null, null, null, null,
-            dictionaryIndex.deepCopy(), null, null);
+    FieldConfig rawDictString = new FieldConfig.Builder(RAW_DICT_DIMENSION)
+        .withIndexes(withForwardEncoding(dictionaryIndex, FieldConfig.EncodingType.RAW))
+        .build();
+    FieldConfig rawDictInvString = new FieldConfig.Builder(RAW_DICT_INV_DIMENSION)
+        .withIndexes(withForwardEncoding(dictionaryIndex, FieldConfig.EncodingType.RAW))
+        .build();
+    FieldConfig rawDictInt = new FieldConfig.Builder(RAW_DICT_INT_DIMENSION)
+        .withIndexes(withForwardEncoding(dictionaryIndex, FieldConfig.EncodingType.RAW))
+        .build();
+    FieldConfig rawDictInvInt = new FieldConfig.Builder(RAW_DICT_INV_INT_DIMENSION)
+        .withIndexes(withForwardEncoding(dictionaryIndex, FieldConfig.EncodingType.RAW))
+        .build();
+    FieldConfig rawDictRangeInt = new FieldConfig.Builder(RAW_DICT_RANGE_INT_DIMENSION)
+        .withIndexes(withForwardEncoding(dictionaryIndex, FieldConfig.EncodingType.RAW))
+        .build();
     return List.of(rawDictString, rawDictInvString, rawDictInt, rawDictInvInt, rawDictRangeInt);
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/TextIndicesTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/TextIndicesTest.java
@@ -92,14 +92,13 @@ public class TextIndicesTest extends CustomDataQueryClusterIntegrationTest {
       throw new RuntimeException(e);
     }
 
-    FieldConfig nullableTextConfig =
-        new FieldConfig(TEXT_COLUMN_NULL_NAME, FieldConfig.EncodingType.RAW, null, null, null, null, textColumnIndexes,
-            null,
-            null);
+    FieldConfig nullableTextConfig = new FieldConfig.Builder(TEXT_COLUMN_NULL_NAME)
+        .withIndexes(withForwardEncoding(textColumnIndexes, FieldConfig.EncodingType.RAW))
+        .build();
 
-    FieldConfig textColumnFieldConfig =
-        new FieldConfig(TEXT_COLUMN_NAME, FieldConfig.EncodingType.RAW, null, null, null, null, textColumnIndexes, null,
-            null);
+    FieldConfig textColumnFieldConfig = new FieldConfig.Builder(TEXT_COLUMN_NAME)
+        .withIndexes(withForwardEncoding(textColumnIndexes, FieldConfig.EncodingType.RAW))
+        .build();
 
     ObjectNode textColumnCaseSensitiveIndexes;
     try {
@@ -114,9 +113,9 @@ public class TextIndicesTest extends CustomDataQueryClusterIntegrationTest {
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }
-    FieldConfig textColumnCaseSensitiveFieldConfig =
-        new FieldConfig(TEXT_COLUMN_NAME_CASE_SENSITIVE, FieldConfig.EncodingType.RAW, null, null, null, null,
-            textColumnCaseSensitiveIndexes, null, null);
+    FieldConfig textColumnCaseSensitiveFieldConfig = new FieldConfig.Builder(TEXT_COLUMN_NAME_CASE_SENSITIVE)
+        .withIndexes(withForwardEncoding(textColumnCaseSensitiveIndexes, FieldConfig.EncodingType.RAW))
+        .build();
     return Arrays.asList(nullableTextConfig, textColumnFieldConfig, textColumnCaseSensitiveFieldConfig);
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/VectorTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/VectorTest.java
@@ -19,11 +19,11 @@
 package org.apache.pinot.integration.tests.custom;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.IntStream;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericData;
@@ -406,17 +406,17 @@ public class VectorTest extends CustomDataQueryClusterIntegrationTest {
 
   @Override
   public TableConfig createOfflineTableConfig() {
+    ObjectNode indexes = indexesWithForwardEncoding(FieldConfig.EncodingType.RAW);
+    ObjectNode vector = indexes.putObject("vector");
+    vector.put("vectorIndexType", "HNSW");
+    vector.put("vectorDimension", VECTOR_DIM_SIZE);
+    vector.put("vectorDistanceFunction", "COSINE");
+    vector.put("version", 1);
     return new TableConfigBuilder(TableType.OFFLINE)
         .setTableName(getTableName())
         .setFieldConfigList(List.of(
             new FieldConfig.Builder(VECTOR_1)
-                .withIndexTypes(List.of(FieldConfig.IndexType.VECTOR))
-                .withEncodingType(FieldConfig.EncodingType.RAW)
-                .withProperties(Map.of(
-                    "vectorIndexType", "HNSW",
-                    "vectorDimension", String.valueOf(VECTOR_DIM_SIZE),
-                    "vectorDistanceFunction", "COSINE",
-                    "version", "1"))
+                .withIndexes(indexes)
                 .build()
         ))
         .build();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/legacy/LegacyRawValueInvertedIndexMigrationIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/legacy/LegacyRawValueInvertedIndexMigrationIntegrationTest.java
@@ -137,8 +137,7 @@ public class LegacyRawValueInvertedIndexMigrationIntegrationTest extends BaseClu
     ObjectNode indexes = JsonUtils.newObjectNode();
     indexes.set("dictionary", JsonUtils.newObjectNode());
     FieldConfig categoryFieldConfig = new FieldConfig.Builder(CATEGORY_COLUMN)
-        .withEncodingType(FieldConfig.EncodingType.RAW)
-        .withIndexes(indexes)
+        .withIndexes(withForwardEncoding(indexes, FieldConfig.EncodingType.RAW))
         .build();
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName(tableName)

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
@@ -26,10 +26,10 @@ import com.google.common.collect.Maps;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -37,6 +37,7 @@ import javax.annotation.Nullable;
 import org.apache.pinot.segment.local.io.util.PinotDataBitSet;
 import org.apache.pinot.segment.local.realtime.impl.dictionary.MutableDictionaryFactory;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentDictionaryCreator;
+import org.apache.pinot.segment.local.segment.index.forward.ForwardIndexType;
 import org.apache.pinot.segment.local.segment.index.readers.BigDecimalDictionary;
 import org.apache.pinot.segment.local.segment.index.readers.BytesDictionary;
 import org.apache.pinot.segment.local.segment.index.readers.DoubleDictionary;
@@ -135,13 +136,13 @@ public class DictionaryIndexType
       }
       Map<String, DictionaryIndexConfig> result = new HashMap<>();
       for (FieldConfig fieldConfig : fieldConfigList) {
-        // encoding=RAW disables the dictionary unless an explicit dictionary config is given OR an
+        // RAW forward encoding disables the dictionary unless an explicit dictionary config is given OR an
         // index that requires a dictionary is enabled in the FieldConfig. In the latter case let the
         // dictionary fall through to its default-enabled state so the runtime can build it; the
         // auto-creation paths in BaseSegmentCreator/ForwardIndexHandler will produce a shared-dict +
-        // RAW forward index.
+        // RAW forward index. The forward block is canonical; field-level encoding is only a legacy fallback.
         FieldSpec fieldSpec = schema == null ? null : schema.getFieldSpecFor(fieldConfig.getName());
-        if (fieldConfig.getEncodingType() == FieldConfig.EncodingType.RAW
+        if (ForwardIndexType.getForwardEncodingType(fieldConfig) == FieldConfig.EncodingType.RAW
             && !hasExplicitDictionaryConfig(fieldConfig)
             && (fieldSpec == null || !hasIndexRequiringDictionary(fieldConfig, fieldSpec))) {
           result.put(fieldConfig.getName(), DictionaryIndexConfig.DISABLED);
@@ -176,11 +177,11 @@ public class DictionaryIndexType
   }
 
   /// True if any index enabled in the FieldConfig declares
-  /// [IndexType#requiresDictionary(FieldSpec, org.apache.pinot.spi.config.table.IndexConfig)] for the column.
-  /// Iterates over every registered IndexType, asks each whether it's enabled in this raw FieldConfig (legacy
-  /// `indexTypes` list or the `indexes` map without `disabled:true`), and consults `requiresDictionary` against the
-  /// IndexType's default config. (Built-in dict-requiring indexes — FST/IFST/INVERTED — return true unconditionally,
-  /// so the default config is sufficient.)
+  /// [IndexType#requiresDictionary(FieldSpec, IndexConfig)] for the column. Iterates over every
+  /// registered IndexType, asks each whether it's enabled in this raw FieldConfig (legacy `indexTypes`
+  /// list or the `indexes` map without `disabled:true`), and consults `requiresDictionary` against the
+  /// IndexType's default config. (Built-in dict-requiring indexes — FST/IFST/INVERTED — return true
+  /// unconditionally, so the default config is sufficient.)
   @SuppressWarnings({"rawtypes", "unchecked"})
   private static boolean hasIndexRequiringDictionary(FieldConfig fieldConfig, FieldSpec fieldSpec) {
     Set<String> enabledIds = enabledIndexIds(fieldConfig);
@@ -501,6 +502,7 @@ public class DictionaryIndexType
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   protected void handleIndexSpecificCleanup(TableConfig tableConfig) {
     IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
     List<String> noDictionaryColumns = indexingConfig.getNoDictionaryColumns() == null
@@ -510,14 +512,14 @@ public class DictionaryIndexType
         ? Lists.newArrayList()
         : tableConfig.getFieldConfigList();
 
-    List<FieldConfig> configsToUpdate = new ArrayList<>();
+    Set<FieldConfig> configsToUpdate = new LinkedHashSet<>();
     for (FieldConfig fieldConfig : fieldConfigList) {
-      // skip further computation of field configs which already has RAW encodingType
-      if (fieldConfig.getEncodingType() == FieldConfig.EncodingType.RAW) {
+      // Skip further computation for field configs whose canonical forward encoding is already RAW.
+      if (ForwardIndexType.getForwardEncodingType(fieldConfig) == FieldConfig.EncodingType.RAW) {
         noDictionaryColumns.remove(fieldConfig.getName());
         continue;
       }
-      // ensure encodingType is RAW on noDictionaryColumns
+      // Ensure forward encoding is RAW on noDictionaryColumns.
       if (noDictionaryColumns.remove(fieldConfig.getName())) {
         configsToUpdate.add(fieldConfig);
       }
@@ -528,7 +530,7 @@ public class DictionaryIndexType
         DictionaryIndexConfig indexConfig = JsonUtils.jsonNodeToObject(
             fieldConfig.getIndexes().get(getPrettyName()),
             DictionaryIndexConfig.class);
-        // ensure encodingType is RAW where dictionary index config has disabled = true
+        // Ensure forward encoding is RAW where dictionary index config has disabled = true.
         if (indexConfig.isDisabled()) {
           configsToUpdate.add(fieldConfig);
         }
@@ -537,10 +539,12 @@ public class DictionaryIndexType
       }
     }
 
-    // update the encodingType to RAW on the selected field configs
+    // Update the canonical forward encoding to RAW on the selected field configs.
     for (FieldConfig fieldConfig : configsToUpdate) {
+      // The cleanup rewrites legacy dictionary signals into the canonical forward block and clears the old field.
       FieldConfig.Builder builder = new FieldConfig.Builder(fieldConfig);
-      builder.withEncodingType(FieldConfig.EncodingType.RAW);
+      builder.withEncodingType(null).withIndexes(ForwardIndexType.withForwardEncoding(fieldConfig.getIndexes(),
+          FieldConfig.EncodingType.RAW));
       fieldConfigList.remove(fieldConfig);
       fieldConfigList.add(builder.build());
     }
@@ -548,7 +552,7 @@ public class DictionaryIndexType
     // create the missing field config for the remaining noDictionaryColumns
     for (String column : noDictionaryColumns) {
       FieldConfig.Builder builder = new FieldConfig.Builder(column);
-      builder.withEncodingType(FieldConfig.EncodingType.RAW);
+      builder.withIndexes(ForwardIndexType.withForwardEncoding(null, FieldConfig.EncodingType.RAW));
       fieldConfigList.add(builder.build());
     }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexType.java
@@ -72,6 +72,7 @@ public class ForwardIndexType extends AbstractIndexType<ForwardIndexConfig, Forw
   private static final Logger LOGGER = LoggerFactory.getLogger(ForwardIndexType.class);
 
   public static final String INDEX_DISPLAY_NAME = "forward";
+  public static final String ENCODING_TYPE_CONFIG_KEY = "encodingType";
   // For multi-valued column, forward-index.
   // Maximum number of multi-values per row. We assert on this.
   public static final int MAX_MULTI_VALUES_PER_ROW = 1000;
@@ -178,10 +179,12 @@ public class ForwardIndexType extends AbstractIndexType<ForwardIndexConfig, Forw
   }
 
   /// Resolves per-column [ForwardIndexConfig] in a single pass over [TableConfig], reconciling the legacy signals
-  /// (`indexingConfig.noDictionaryColumns`, `indexingConfig.noDictionaryConfig`, `fieldConfig.encodingType`,
-  /// `fieldConfig.compressionCodec`) with the modern `fieldConfig.indexes.forward` JSON block. The deserializer
-  /// fails fast on conflicting signals.
+  /// (`indexingConfig.noDictionaryColumns`, `indexingConfig.noDictionaryConfig`, deprecated
+  /// `fieldConfig.encodingType`, `fieldConfig.compressionCodec`) with the modern `fieldConfig.indexes.forward` JSON
+  /// block. When `indexes.forward.encodingType` is present, it is the canonical forward-index encoding and wins over
+  /// legacy top-level signals.
   @Override
+  @SuppressWarnings("deprecation")
   protected ColumnConfigDeserializer<ForwardIndexConfig> createDeserializer() {
     return (tableConfig, schema) -> {
       Map<String, ForwardIndexConfig> result = new HashMap<>();
@@ -211,12 +214,8 @@ public class ForwardIndexType extends AbstractIndexType<ForwardIndexConfig, Forw
             continue;
           }
 
-          // Resolve the forward-index encoding. `FieldConfig.encodingType` is never null (the FieldConfig constructor
-          // defaults it to DICTIONARY when unset), so the per-column override here is the legacy
-          // `noDictionaryColumns` / `noDictionaryConfig` membership — historically these may be set alongside a
-          // FieldConfig that left `encodingType` at the default DICTIONARY.
           FieldConfig.CompressionCodec fcCodec = fieldConfig.getCompressionCodec();
-          FieldConfig.EncodingType encodingType =
+          FieldConfig.EncodingType legacyEncodingType =
               inNoDictionaryList ? FieldConfig.EncodingType.RAW : fieldConfig.getEncodingType();
 
           JsonNode forwardIndexNode = fieldConfig.getIndexes().get(INDEX_DISPLAY_NAME);
@@ -224,14 +223,7 @@ public class ForwardIndexType extends AbstractIndexType<ForwardIndexConfig, Forw
             Preconditions.checkState(forwardIndexNode.isObject(), "Invalid forward index config for column: %s",
                 column);
 
-            // Conflict: encodingType mismatch between resolved FieldConfig encoding and indexes.forward.
-            JsonNode innerEncodingNode = forwardIndexNode.get("encodingType");
-            if (innerEncodingNode != null && !innerEncodingNode.isNull()) {
-              FieldConfig.EncodingType inner = FieldConfig.EncodingType.valueOf(innerEncodingNode.asText());
-              Preconditions.checkState(inner == encodingType,
-                  "Conflicting forward-index encoding for column: %s — FieldConfig.encodingType=%s but "
-                      + "indexes.forward.encodingType=%s", column, encodingType, inner);
-            }
+            JsonNode innerEncodingNode = forwardIndexNode.get(ENCODING_TYPE_CONFIG_KEY);
 
             // Conflict: compressionCodec mismatch between FieldConfig and indexes.forward.
             JsonNode innerCodecNode = forwardIndexNode.get("compressionCodec");
@@ -242,11 +234,10 @@ public class ForwardIndexType extends AbstractIndexType<ForwardIndexConfig, Forw
                       + "but indexes.forward.compressionCodec=%s", column, fcCodec, inner);
             }
 
-            // Inject the resolved encodingType / compressionCodec into the JSON when absent so the resulting
-            // ForwardIndexConfig always matches the column-level signals.
+            // Inject legacy encodingType / compressionCodec into the JSON only when the forward block omits them.
             ObjectNode configNode = (ObjectNode) forwardIndexNode.deepCopy();
             if (innerEncodingNode == null || innerEncodingNode.isNull()) {
-              configNode.put("encodingType", encodingType.name());
+              configNode.put(ENCODING_TYPE_CONFIG_KEY, legacyEncodingType.name());
             }
             if ((innerCodecNode == null || innerCodecNode.isNull()) && fcCodec != null) {
               configNode.put("compressionCodec", fcCodec.name());
@@ -257,7 +248,7 @@ public class ForwardIndexType extends AbstractIndexType<ForwardIndexConfig, Forw
               throw new UncheckedIOException(e);
             }
           } else {
-            result.put(column, createConfigFromFieldConfig(fieldConfig, encodingType));
+            result.put(column, createConfigFromFieldConfig(fieldConfig, legacyEncodingType));
           }
         }
       }
@@ -285,6 +276,39 @@ public class ForwardIndexType extends AbstractIndexType<ForwardIndexConfig, Forw
       builder.withLegacyProperties(properties);
     }
     return builder.build();
+  }
+
+  /// Returns the canonical forward-index encoding for `fieldConfig`.
+  ///
+  /// Prefer `fieldConfig.indexes.forward.encodingType` when present. Fall back to the deprecated field-level
+  /// `fieldConfig.encodingType` for legacy conversion paths that can still inspect configs before validation.
+  @SuppressWarnings("deprecation")
+  public static FieldConfig.EncodingType getForwardEncodingType(FieldConfig fieldConfig) {
+    JsonNode indexes = fieldConfig.getIndexes();
+    if (indexes != null && indexes.isObject()) {
+      JsonNode forward = indexes.get(INDEX_DISPLAY_NAME);
+      if (forward != null && forward.isObject()) {
+        JsonNode encodingType = forward.get(ENCODING_TYPE_CONFIG_KEY);
+        if (encodingType != null && !encodingType.isNull()) {
+          return FieldConfig.EncodingType.valueOf(encodingType.asText());
+        }
+      }
+    }
+    return fieldConfig.getEncodingType();
+  }
+
+  /// Returns a copy of `indexes` with `indexes.forward.encodingType` set to `encodingType`.
+  public static JsonNode withForwardEncoding(@Nullable JsonNode indexes, FieldConfig.EncodingType encodingType) {
+    ObjectNode indexesNode = indexes != null && indexes.isObject()
+        ? (ObjectNode) indexes.deepCopy()
+        : JsonUtils.newObjectNode();
+    JsonNode forward = indexesNode.get(INDEX_DISPLAY_NAME);
+    ObjectNode forwardNode = forward != null && forward.isObject()
+        ? (ObjectNode) forward.deepCopy()
+        : JsonUtils.newObjectNode();
+    forwardNode.put(ENCODING_TYPE_CONFIG_KEY, encodingType.name());
+    indexesNode.set(INDEX_DISPLAY_NAME, forwardNode);
+    return indexesNode;
   }
 
   public static ChunkCompressionType getDefaultCompressionType(FieldSpec.FieldType fieldType) {
@@ -320,7 +344,7 @@ public class ForwardIndexType extends AbstractIndexType<ForwardIndexConfig, Forw
 
   @Override
   public boolean shouldInvalidateOnDictionaryChange(FieldSpec fieldSpec, ForwardIndexConfig indexConfig) {
-    // The forward index encoding is reconciled with FieldConfig.encodingType independently of dictionary state
+    // The forward index encoding is reconciled with ForwardIndexConfig independently of dictionary state
     // (apache/pinot#18364), so adding or removing a dictionary alone does not change the on-disk forward index
     // layout — the existing forward index can be reused.
     return false;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexType.java
@@ -72,6 +72,7 @@ public class ForwardIndexType extends AbstractIndexType<ForwardIndexConfig, Forw
   private static final Logger LOGGER = LoggerFactory.getLogger(ForwardIndexType.class);
 
   public static final String INDEX_DISPLAY_NAME = "forward";
+  public static final String ENCODING_TYPE_CONFIG_KEY = "encodingType";
   private static final int NODICT_VARIABLE_WIDTH_ESTIMATED_AVERAGE_VALUE_LENGTH_DEFAULT = 100;
   private static final int NODICT_VARIABLE_WIDTH_ESTIMATED_NUMBER_OF_VALUES_DEFAULT = 100_000;
   //@formatter:off
@@ -175,10 +176,12 @@ public class ForwardIndexType extends AbstractIndexType<ForwardIndexConfig, Forw
   }
 
   /// Resolves per-column [ForwardIndexConfig] in a single pass over [TableConfig], reconciling the legacy signals
-  /// (`indexingConfig.noDictionaryColumns`, `indexingConfig.noDictionaryConfig`, `fieldConfig.encodingType`,
-  /// `fieldConfig.compressionCodec`) with the modern `fieldConfig.indexes.forward` JSON block. The deserializer
-  /// fails fast on conflicting signals.
+  /// (`indexingConfig.noDictionaryColumns`, `indexingConfig.noDictionaryConfig`, deprecated
+  /// `fieldConfig.encodingType`, `fieldConfig.compressionCodec`) with the modern `fieldConfig.indexes.forward` JSON
+  /// block. When `indexes.forward.encodingType` is present, it is the canonical forward-index encoding and wins over
+  /// legacy top-level signals.
   @Override
+  @SuppressWarnings("deprecation")
   protected ColumnConfigDeserializer<ForwardIndexConfig> createDeserializer() {
     return (tableConfig, schema) -> {
       Map<String, ForwardIndexConfig> result = new HashMap<>();
@@ -208,12 +211,8 @@ public class ForwardIndexType extends AbstractIndexType<ForwardIndexConfig, Forw
             continue;
           }
 
-          // Resolve the forward-index encoding. `FieldConfig.encodingType` is never null (the FieldConfig constructor
-          // defaults it to DICTIONARY when unset), so the per-column override here is the legacy
-          // `noDictionaryColumns` / `noDictionaryConfig` membership — historically these may be set alongside a
-          // FieldConfig that left `encodingType` at the default DICTIONARY.
           FieldConfig.CompressionCodec fcCodec = fieldConfig.getCompressionCodec();
-          FieldConfig.EncodingType encodingType =
+          FieldConfig.EncodingType legacyEncodingType =
               inNoDictionaryList ? FieldConfig.EncodingType.RAW : fieldConfig.getEncodingType();
 
           JsonNode forwardIndexNode = fieldConfig.getIndexes().get(INDEX_DISPLAY_NAME);
@@ -221,14 +220,7 @@ public class ForwardIndexType extends AbstractIndexType<ForwardIndexConfig, Forw
             Preconditions.checkState(forwardIndexNode.isObject(), "Invalid forward index config for column: %s",
                 column);
 
-            // Conflict: encodingType mismatch between resolved FieldConfig encoding and indexes.forward.
-            JsonNode innerEncodingNode = forwardIndexNode.get("encodingType");
-            if (innerEncodingNode != null && !innerEncodingNode.isNull()) {
-              FieldConfig.EncodingType inner = FieldConfig.EncodingType.valueOf(innerEncodingNode.asText());
-              Preconditions.checkState(inner == encodingType,
-                  "Conflicting forward-index encoding for column: %s — FieldConfig.encodingType=%s but "
-                      + "indexes.forward.encodingType=%s", column, encodingType, inner);
-            }
+            JsonNode innerEncodingNode = forwardIndexNode.get(ENCODING_TYPE_CONFIG_KEY);
 
             // Conflict: compressionCodec mismatch between FieldConfig and indexes.forward.
             JsonNode innerCodecNode = forwardIndexNode.get("compressionCodec");
@@ -239,11 +231,10 @@ public class ForwardIndexType extends AbstractIndexType<ForwardIndexConfig, Forw
                       + "but indexes.forward.compressionCodec=%s", column, fcCodec, inner);
             }
 
-            // Inject the resolved encodingType / compressionCodec into the JSON when absent so the resulting
-            // ForwardIndexConfig always matches the column-level signals.
+            // Inject legacy encodingType / compressionCodec into the JSON only when the forward block omits them.
             ObjectNode configNode = (ObjectNode) forwardIndexNode.deepCopy();
             if (innerEncodingNode == null || innerEncodingNode.isNull()) {
-              configNode.put("encodingType", encodingType.name());
+              configNode.put(ENCODING_TYPE_CONFIG_KEY, legacyEncodingType.name());
             }
             if ((innerCodecNode == null || innerCodecNode.isNull()) && fcCodec != null) {
               configNode.put("compressionCodec", fcCodec.name());
@@ -254,7 +245,7 @@ public class ForwardIndexType extends AbstractIndexType<ForwardIndexConfig, Forw
               throw new UncheckedIOException(e);
             }
           } else {
-            result.put(column, createConfigFromFieldConfig(fieldConfig, encodingType));
+            result.put(column, createConfigFromFieldConfig(fieldConfig, legacyEncodingType));
           }
         }
       }
@@ -282,6 +273,39 @@ public class ForwardIndexType extends AbstractIndexType<ForwardIndexConfig, Forw
       builder.withLegacyProperties(properties);
     }
     return builder.build();
+  }
+
+  /// Returns the canonical forward-index encoding for `fieldConfig`.
+  ///
+  /// Prefer `fieldConfig.indexes.forward.encodingType` when present. Fall back to the deprecated field-level
+  /// `fieldConfig.encodingType` for legacy conversion paths that can still inspect configs before validation.
+  @SuppressWarnings("deprecation")
+  public static FieldConfig.EncodingType getForwardEncodingType(FieldConfig fieldConfig) {
+    JsonNode indexes = fieldConfig.getIndexes();
+    if (indexes != null && indexes.isObject()) {
+      JsonNode forward = indexes.get(INDEX_DISPLAY_NAME);
+      if (forward != null && forward.isObject()) {
+        JsonNode encodingType = forward.get(ENCODING_TYPE_CONFIG_KEY);
+        if (encodingType != null && !encodingType.isNull()) {
+          return FieldConfig.EncodingType.valueOf(encodingType.asText());
+        }
+      }
+    }
+    return fieldConfig.getEncodingType();
+  }
+
+  /// Returns a copy of `indexes` with `indexes.forward.encodingType` set to `encodingType`.
+  public static JsonNode withForwardEncoding(@Nullable JsonNode indexes, FieldConfig.EncodingType encodingType) {
+    ObjectNode indexesNode = indexes != null && indexes.isObject()
+        ? (ObjectNode) indexes.deepCopy()
+        : JsonUtils.newObjectNode();
+    JsonNode forward = indexesNode.get(INDEX_DISPLAY_NAME);
+    ObjectNode forwardNode = forward != null && forward.isObject()
+        ? (ObjectNode) forward.deepCopy()
+        : JsonUtils.newObjectNode();
+    forwardNode.put(ENCODING_TYPE_CONFIG_KEY, encodingType.name());
+    indexesNode.set(INDEX_DISPLAY_NAME, forwardNode);
+    return indexesNode;
   }
 
   public static ChunkCompressionType getDefaultCompressionType(FieldSpec.FieldType fieldType) {
@@ -317,7 +341,7 @@ public class ForwardIndexType extends AbstractIndexType<ForwardIndexConfig, Forw
 
   @Override
   public boolean shouldInvalidateOnDictionaryChange(FieldSpec fieldSpec, ForwardIndexConfig indexConfig) {
-    // The forward index encoding is reconciled with FieldConfig.encodingType independently of dictionary state
+    // The forward index encoding is reconciled with ForwardIndexConfig independently of dictionary state
     // (apache/pinot#18364), so adding or removing a dictionary alone does not change the on-disk forward index
     // layout — the existing forward index can be reused.
     return false;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/VectorIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/VectorIndexUtils.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.lucene.codecs.lucene912.Lucene912Codec;
@@ -285,28 +286,30 @@ public class VectorIndexUtils {
 
   public static IndexWriterConfig getIndexWriterConfig(VectorIndexConfig vectorIndexConfig) {
     IndexWriterConfig indexWriterConfig = new IndexWriterConfig();
+    Map<String, String> properties =
+        vectorIndexConfig.getProperties() != null ? vectorIndexConfig.getProperties() : Map.of();
 
-    double maxBufferSizeMB = Double.parseDouble(vectorIndexConfig.getProperties()
+    double maxBufferSizeMB = Double.parseDouble(properties
         .getOrDefault("maxBufferSizeMB", String.valueOf(IndexWriterConfig.DEFAULT_RAM_BUFFER_SIZE_MB)));
-    boolean commit = Boolean.parseBoolean(vectorIndexConfig.getProperties()
+    boolean commit = Boolean.parseBoolean(properties
         .getOrDefault("commit", String.valueOf(IndexWriterConfig.DEFAULT_COMMIT_ON_CLOSE)));
-    boolean useCompoundFile = Boolean.parseBoolean(vectorIndexConfig.getProperties()
+    boolean useCompoundFile = Boolean.parseBoolean(properties
         .getOrDefault("useCompoundFile", String.valueOf(IndexWriterConfig.DEFAULT_USE_COMPOUND_FILE_SYSTEM)));
     indexWriterConfig.setRAMBufferSizeMB(maxBufferSizeMB);
     indexWriterConfig.setCommitOnClose(commit);
     indexWriterConfig.setUseCompoundFile(useCompoundFile);
 
-    int maxCon = Integer.parseInt(vectorIndexConfig.getProperties()
+    int maxCon = Integer.parseInt(properties
         .getOrDefault("maxCon", String.valueOf(Lucene99HnswVectorsFormat.DEFAULT_MAX_CONN)));
-    int beamWidth = Integer.parseInt(vectorIndexConfig.getProperties()
+    int beamWidth = Integer.parseInt(properties
         .getOrDefault("beamWidth", String.valueOf(Lucene99HnswVectorsFormat.DEFAULT_BEAM_WIDTH)));
-    int maxDimensions = Integer.parseInt(vectorIndexConfig.getProperties()
+    int maxDimensions = Integer.parseInt(properties
         .getOrDefault("maxDimensions", String.valueOf(HnswVectorsFormat.DEFAULT_MAX_DIMENSIONS)));
 
     HnswVectorsFormat knnVectorsFormat =
         new HnswVectorsFormat(maxCon, beamWidth, maxDimensions);
 
-    Lucene912Codec.Mode mode = Lucene912Codec.Mode.valueOf(vectorIndexConfig.getProperties()
+    Lucene912Codec.Mode mode = Lucene912Codec.Mode.valueOf(properties
         .getOrDefault("mode", Lucene912Codec.Mode.BEST_SPEED.name()));
     indexWriterConfig.setCodec(new HnswCodec(mode, knnVectorsFormat));
     return indexWriterConfig;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/VectorIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/VectorIndexUtils.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
@@ -325,28 +326,30 @@ public class VectorIndexUtils {
 
   public static IndexWriterConfig getIndexWriterConfig(VectorIndexConfig vectorIndexConfig) {
     IndexWriterConfig indexWriterConfig = new IndexWriterConfig();
+    Map<String, String> properties =
+        vectorIndexConfig.getProperties() != null ? vectorIndexConfig.getProperties() : Map.of();
 
-    double maxBufferSizeMB = Double.parseDouble(vectorIndexConfig.getProperties()
+    double maxBufferSizeMB = Double.parseDouble(properties
         .getOrDefault("maxBufferSizeMB", String.valueOf(IndexWriterConfig.DEFAULT_RAM_BUFFER_SIZE_MB)));
-    boolean commit = Boolean.parseBoolean(vectorIndexConfig.getProperties()
+    boolean commit = Boolean.parseBoolean(properties
         .getOrDefault("commit", String.valueOf(IndexWriterConfig.DEFAULT_COMMIT_ON_CLOSE)));
-    boolean useCompoundFile = Boolean.parseBoolean(vectorIndexConfig.getProperties()
+    boolean useCompoundFile = Boolean.parseBoolean(properties
         .getOrDefault("useCompoundFile", String.valueOf(IndexWriterConfig.DEFAULT_USE_COMPOUND_FILE_SYSTEM)));
     indexWriterConfig.setRAMBufferSizeMB(maxBufferSizeMB);
     indexWriterConfig.setCommitOnClose(commit);
     indexWriterConfig.setUseCompoundFile(useCompoundFile);
 
-    int maxCon = Integer.parseInt(vectorIndexConfig.getProperties()
+    int maxCon = Integer.parseInt(properties
         .getOrDefault("maxCon", String.valueOf(Lucene99HnswVectorsFormat.DEFAULT_MAX_CONN)));
-    int beamWidth = Integer.parseInt(vectorIndexConfig.getProperties()
+    int beamWidth = Integer.parseInt(properties
         .getOrDefault("beamWidth", String.valueOf(Lucene99HnswVectorsFormat.DEFAULT_BEAM_WIDTH)));
-    int maxDimensions = Integer.parseInt(vectorIndexConfig.getProperties()
+    int maxDimensions = Integer.parseInt(properties
         .getOrDefault("maxDimensions", String.valueOf(HnswVectorsFormat.DEFAULT_MAX_DIMENSIONS)));
 
     HnswVectorsFormat knnVectorsFormat =
         new HnswVectorsFormat(maxCon, beamWidth, maxDimensions);
 
-    Lucene912Codec.Mode mode = Lucene912Codec.Mode.valueOf(vectorIndexConfig.getProperties()
+    Lucene912Codec.Mode mode = Lucene912Codec.Mode.valueOf(properties
         .getOrDefault("mode", Lucene912Codec.Mode.BEST_SPEED.name()));
     indexWriterConfig.setCodec(new HnswCodec(mode, knnVectorsFormat));
     return indexWriterConfig;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -54,6 +54,7 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.index.DictionaryIndexConfig;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigsUtil;
+import org.apache.pinot.segment.spi.index.ForwardIndexConfig;
 import org.apache.pinot.segment.spi.index.IndexService;
 import org.apache.pinot.segment.spi.index.IndexType;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
@@ -63,7 +64,6 @@ import org.apache.pinot.spi.annotations.FunctionVolatility;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.DedupConfig;
 import org.apache.pinot.spi.config.table.FieldConfig;
-import org.apache.pinot.spi.config.table.FieldConfig.EncodingType;
 import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.MultiColumnTextIndexConfig;
@@ -1741,11 +1741,16 @@ public final class TableConfigUtils {
         String column = fieldConfig.getName();
         Preconditions.checkState(seenColumns.add(column), "Duplicate FieldConfig for column: %s", column);
         Preconditions.checkState(schema.hasColumn(column), "Failed to find column: %s in schema", column);
-
-        // Validate DELTA / DELTADELTA compression codecs compatibility
-        validateGorillaCompressionCodecIfPresent(fieldConfig, schema.getFieldSpecFor(column));
+        Preconditions.checkState(!fieldConfig.hasFieldLevelEncodingType(),
+            "FieldConfig.encodingType is deprecated for column: %s. Use fieldConfigList[].indexes.forward.encodingType "
+                + "instead.", column);
+        Preconditions.checkState(!fieldConfig.hasFieldLevelCompressionCodec(),
+            "FieldConfig.compressionCodec is deprecated for column: %s. Use "
+                + "fieldConfigList[].indexes.forward.compressionCodec instead.", column);
+        Preconditions.checkState(!fieldConfig.hasFieldLevelProperties(),
+            "FieldConfig.properties is deprecated for column: %s. Move these settings into the relevant "
+                + "fieldConfigList[].indexes.<indexName> block instead.", column);
       }
-      validateIndexingConfigAndFieldConfigListCompatibility(indexingConfig, fieldConfigs);
     }
 
     Map<String, FieldIndexConfigs> indexConfigsMap;
@@ -1760,6 +1765,7 @@ public final class TableConfigUtils {
       FieldSpec fieldSpec = schema.getFieldSpecFor(column);
       Preconditions.checkState(fieldSpec != null, "Failed to find column: %s in schema", column);
       FieldIndexConfigs indexConfigs = entry.getValue();
+      validateGorillaCompressionCodecIfPresent(indexConfigs.getConfig(StandardIndexes.forward()), fieldSpec, column);
       for (IndexType<?, ?, ?> indexType : allIndexes) {
         indexType.validate(indexConfigs, fieldSpec, tableConfig);
       }
@@ -1886,29 +1892,6 @@ public final class TableConfigUtils {
         for (String key : multiColTextIndex.getPerColumnProperties().get(column).keySet()) {
           Preconditions.checkState(MultiColumnTextMetadata.isValidPerColumnProperty(key),
               "Multi-column text index doesn't allow: %s as property for column: %s", key, column);
-        }
-      }
-    }
-  }
-
-  /// Validates compatibility across [IndexingConfig] and [FieldConfig]s, ensures that:
-  /// - Columns with DICTIONARY encoding type in [FieldConfig]s are not defined as no-dictionary in [IndexingConfig]
-  private static void validateIndexingConfigAndFieldConfigListCompatibility(IndexingConfig indexingConfig,
-      List<FieldConfig> fieldConfigs) {
-    Set<String> noDictionaryColumnsFromIndexingConfig = new HashSet<>();
-    if (indexingConfig.getNoDictionaryColumns() != null) {
-      noDictionaryColumnsFromIndexingConfig.addAll(indexingConfig.getNoDictionaryColumns());
-    }
-    if (indexingConfig.getNoDictionaryConfig() != null) {
-      noDictionaryColumnsFromIndexingConfig.addAll(indexingConfig.getNoDictionaryConfig().keySet());
-    }
-    if (!noDictionaryColumnsFromIndexingConfig.isEmpty()) {
-      for (FieldConfig fieldConfig : fieldConfigs) {
-        String column = fieldConfig.getName();
-        EncodingType encodingType = fieldConfig.getEncodingType();
-        if (encodingType == EncodingType.DICTIONARY) {
-          Preconditions.checkState(!noDictionaryColumnsFromIndexingConfig.contains(column),
-              "FieldConfig encoding type is different from indexingConfig for column: %s", column);
         }
       }
     }
@@ -2221,26 +2204,35 @@ public final class TableConfigUtils {
     return UPSERT_DEDUP_ALLOWED_ROUTING_STRATEGIES.stream().anyMatch(x -> x.equalsIgnoreCase(instanceSelectorType));
   }
 
-  /// Helper method to extract TableConfig in updated syntax from current TableConfig.
+  /// Helper method to extract [TableConfig] in updated syntax from current [TableConfig].
   ///
-  /// - Moves all index configs to FieldConfig.indexes
-  /// - Clean up index related configs from IndexingConfig and FieldConfig.IndexTypes
+  /// - Moves all index configs to `FieldConfig.indexes`
+  /// - Cleans up index related configs from [IndexingConfig] and deprecated field-level [FieldConfig] fields
   public static TableConfig createTableConfigFromOldFormat(TableConfig tableConfig, Schema schema) {
     TableConfig clone = new TableConfig(tableConfig);
     for (IndexType<?, ?, ?> indexType : IndexService.getInstance().getAllIndexes()) {
       // get all the index data in new format
       indexType.convertToNewFormat(clone, schema);
     }
-    // cleanup the indexTypes field from all FieldConfig items
+    // Clean up deprecated field-level config from all FieldConfig items.
     if (clone.getFieldConfigList() != null) {
       List<FieldConfig> cleanFieldConfigList = new ArrayList<>();
       for (FieldConfig fieldConfig : clone.getFieldConfigList()) {
-        cleanFieldConfigList.add(
-            new FieldConfig.Builder(fieldConfig).withIndexTypes(null).withProperties(null).build());
+        cleanFieldConfigList.add(clearDeprecatedFieldConfigOptions(fieldConfig));
       }
       clone.setFieldConfigList(cleanFieldConfigList);
     }
     return clone;
+  }
+
+  @SuppressWarnings("deprecation")
+  private static FieldConfig clearDeprecatedFieldConfigOptions(FieldConfig fieldConfig) {
+    return new FieldConfig.Builder(fieldConfig)
+        .withEncodingType(null)
+        .withIndexTypes(null)
+        .withCompressionCodec(null)
+        .withProperties(null)
+        .build();
   }
 
   public static boolean isCommitTimeCompactionEnabled(TableConfig tableConfig) {
@@ -2556,20 +2548,23 @@ public final class TableConfigUtils {
     return relevantTenants.contains(tenantName);
   }
 
-  private static void validateGorillaCompressionCodecIfPresent(FieldConfig fieldConfig, FieldSpec fieldSpec) {
-    if (fieldConfig.getCompressionCodec() == null) {
+  private static void validateGorillaCompressionCodecIfPresent(ForwardIndexConfig forwardIndexConfig,
+      FieldSpec fieldSpec, String column) {
+    FieldConfig.CompressionCodec compressionCodec =
+        forwardIndexConfig != null ? forwardIndexConfig.getCompressionCodec() : null;
+    if (compressionCodec == null) {
       return;
     }
-    switch (fieldConfig.getCompressionCodec()) {
+    switch (compressionCodec) {
       case DELTA:
       case DELTADELTA:
         Preconditions.checkState(fieldSpec.isSingleValueField(),
             "Compression codec %s can only be used on single-value columns, found multi-value column: %s",
-            fieldConfig.getCompressionCodec(), fieldConfig.getName());
+            compressionCodec, column);
         DataType storedType = fieldSpec.getDataType().getStoredType();
         Preconditions.checkState(storedType == DataType.INT || storedType == DataType.LONG,
             "Compression codec %s can only be used on INT/LONG data types, found %s for column: %s",
-            fieldConfig.getCompressionCodec(), storedType, fieldConfig.getName());
+            compressionCodec, storedType, column);
         break;
       default:
         // no-op for other codecs

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -54,6 +54,7 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.index.DictionaryIndexConfig;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigsUtil;
+import org.apache.pinot.segment.spi.index.ForwardIndexConfig;
 import org.apache.pinot.segment.spi.index.IndexService;
 import org.apache.pinot.segment.spi.index.IndexType;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
@@ -63,7 +64,6 @@ import org.apache.pinot.spi.annotations.FunctionVolatility;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.DedupConfig;
 import org.apache.pinot.spi.config.table.FieldConfig;
-import org.apache.pinot.spi.config.table.FieldConfig.EncodingType;
 import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.MultiColumnTextIndexConfig;
@@ -1778,11 +1778,16 @@ public final class TableConfigUtils {
         String column = fieldConfig.getName();
         Preconditions.checkState(seenColumns.add(column), "Duplicate FieldConfig for column: %s", column);
         Preconditions.checkState(schema.hasColumn(column), "Failed to find column: %s in schema", column);
-
-        // Validate DELTA / DELTADELTA compression codecs compatibility
-        validateGorillaCompressionCodecIfPresent(fieldConfig, schema.getFieldSpecFor(column));
+        Preconditions.checkState(!fieldConfig.hasFieldLevelEncodingType(),
+            "FieldConfig.encodingType is deprecated for column: %s. Use fieldConfigList[].indexes.forward.encodingType "
+                + "instead.", column);
+        Preconditions.checkState(!fieldConfig.hasFieldLevelCompressionCodec(),
+            "FieldConfig.compressionCodec is deprecated for column: %s. Use "
+                + "fieldConfigList[].indexes.forward.compressionCodec instead.", column);
+        Preconditions.checkState(!fieldConfig.hasFieldLevelProperties(),
+            "FieldConfig.properties is deprecated for column: %s. Move these settings into the relevant "
+                + "fieldConfigList[].indexes.<indexName> block instead.", column);
       }
-      validateIndexingConfigAndFieldConfigListCompatibility(indexingConfig, fieldConfigs);
     }
 
     Map<String, FieldIndexConfigs> indexConfigsMap;
@@ -1797,6 +1802,7 @@ public final class TableConfigUtils {
       FieldSpec fieldSpec = schema.getFieldSpecFor(column);
       Preconditions.checkState(fieldSpec != null, "Failed to find column: %s in schema", column);
       FieldIndexConfigs indexConfigs = entry.getValue();
+      validateGorillaCompressionCodecIfPresent(indexConfigs.getConfig(StandardIndexes.forward()), fieldSpec, column);
       for (IndexType<?, ?, ?> indexType : allIndexes) {
         indexType.validate(indexConfigs, fieldSpec, tableConfig);
       }
@@ -1924,29 +1930,6 @@ public final class TableConfigUtils {
         for (String key : multiColTextIndex.getPerColumnProperties().get(column).keySet()) {
           Preconditions.checkState(MultiColumnTextMetadata.isValidPerColumnProperty(key),
               "Multi-column text index doesn't allow: %s as property for column: %s", key, column);
-        }
-      }
-    }
-  }
-
-  /// Validates compatibility across [IndexingConfig] and [FieldConfig]s, ensures that:
-  /// - Columns with DICTIONARY encoding type in [FieldConfig]s are not defined as no-dictionary in [IndexingConfig]
-  private static void validateIndexingConfigAndFieldConfigListCompatibility(IndexingConfig indexingConfig,
-      List<FieldConfig> fieldConfigs) {
-    Set<String> noDictionaryColumnsFromIndexingConfig = new HashSet<>();
-    if (indexingConfig.getNoDictionaryColumns() != null) {
-      noDictionaryColumnsFromIndexingConfig.addAll(indexingConfig.getNoDictionaryColumns());
-    }
-    if (indexingConfig.getNoDictionaryConfig() != null) {
-      noDictionaryColumnsFromIndexingConfig.addAll(indexingConfig.getNoDictionaryConfig().keySet());
-    }
-    if (!noDictionaryColumnsFromIndexingConfig.isEmpty()) {
-      for (FieldConfig fieldConfig : fieldConfigs) {
-        String column = fieldConfig.getName();
-        EncodingType encodingType = fieldConfig.getEncodingType();
-        if (encodingType == EncodingType.DICTIONARY) {
-          Preconditions.checkState(!noDictionaryColumnsFromIndexingConfig.contains(column),
-              "FieldConfig encoding type is different from indexingConfig for column: %s", column);
         }
       }
     }
@@ -2274,26 +2257,35 @@ public final class TableConfigUtils {
     return UPSERT_DEDUP_ALLOWED_ROUTING_STRATEGIES.stream().anyMatch(x -> x.equalsIgnoreCase(instanceSelectorType));
   }
 
-  /// Helper method to extract TableConfig in updated syntax from current TableConfig.
+  /// Helper method to extract [TableConfig] in updated syntax from current [TableConfig].
   ///
-  /// - Moves all index configs to FieldConfig.indexes
-  /// - Clean up index related configs from IndexingConfig and FieldConfig.IndexTypes
+  /// - Moves all index configs to `FieldConfig.indexes`
+  /// - Cleans up index related configs from [IndexingConfig] and deprecated field-level [FieldConfig] fields
   public static TableConfig createTableConfigFromOldFormat(TableConfig tableConfig, Schema schema) {
     TableConfig clone = new TableConfig(tableConfig);
     for (IndexType<?, ?, ?> indexType : IndexService.getInstance().getAllIndexes()) {
       // get all the index data in new format
       indexType.convertToNewFormat(clone, schema);
     }
-    // cleanup the indexTypes field from all FieldConfig items
+    // Clean up deprecated field-level config from all FieldConfig items.
     if (clone.getFieldConfigList() != null) {
       List<FieldConfig> cleanFieldConfigList = new ArrayList<>();
       for (FieldConfig fieldConfig : clone.getFieldConfigList()) {
-        cleanFieldConfigList.add(
-            new FieldConfig.Builder(fieldConfig).withIndexTypes(null).withProperties(null).build());
+        cleanFieldConfigList.add(clearDeprecatedFieldConfigOptions(fieldConfig));
       }
       clone.setFieldConfigList(cleanFieldConfigList);
     }
     return clone;
+  }
+
+  @SuppressWarnings("deprecation")
+  private static FieldConfig clearDeprecatedFieldConfigOptions(FieldConfig fieldConfig) {
+    return new FieldConfig.Builder(fieldConfig)
+        .withEncodingType(null)
+        .withIndexTypes(null)
+        .withCompressionCodec(null)
+        .withProperties(null)
+        .build();
   }
 
   public static boolean isCommitTimeCompactionEnabled(TableConfig tableConfig) {
@@ -2609,20 +2601,23 @@ public final class TableConfigUtils {
     return relevantTenants.contains(tenantName);
   }
 
-  private static void validateGorillaCompressionCodecIfPresent(FieldConfig fieldConfig, FieldSpec fieldSpec) {
-    if (fieldConfig.getCompressionCodec() == null) {
+  private static void validateGorillaCompressionCodecIfPresent(ForwardIndexConfig forwardIndexConfig,
+      FieldSpec fieldSpec, String column) {
+    FieldConfig.CompressionCodec compressionCodec =
+        forwardIndexConfig != null ? forwardIndexConfig.getCompressionCodec() : null;
+    if (compressionCodec == null) {
       return;
     }
-    switch (fieldConfig.getCompressionCodec()) {
+    switch (compressionCodec) {
       case DELTA:
       case DELTADELTA:
         Preconditions.checkState(fieldSpec.isSingleValueField(),
             "Compression codec %s can only be used on single-value columns, found multi-value column: %s",
-            fieldConfig.getCompressionCodec(), fieldConfig.getName());
+            compressionCodec, column);
         DataType storedType = fieldSpec.getDataType().getStoredType();
         Preconditions.checkState(storedType == DataType.INT || storedType == DataType.LONG,
             "Compression codec %s can only be used on INT/LONG data types, found %s for column: %s",
-            fieldConfig.getCompressionCodec(), storedType, fieldConfig.getName());
+            compressionCodec, storedType, column);
         break;
       default:
         // no-op for other codecs

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverterTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverterTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.realtime.converter;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -71,6 +72,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
@@ -619,17 +621,19 @@ public class RealtimeSegmentConverterTest implements PinotBuffersAfterMethodChec
       throws Exception {
     File tmpDir = new File(TMP_DIR, "tmp_" + System.nanoTime());
 
-    Map<String, String> fieldConfigColumnProperties = new HashMap<>();
-    fieldConfigColumnProperties.put(FieldConfig.TEXT_INDEX_LUCENE_REUSE_MUTABLE_INDEX,
-        String.valueOf(reuseMutableIndex));
-    fieldConfigColumnProperties.put(FieldConfig.TEXT_INDEX_USE_AND_FOR_MULTI_TERM_QUERIES, "true");
+    ObjectNode indexes = JsonUtils.newObjectNode();
+    ObjectNode forward = JsonUtils.newObjectNode();
+    forward.put("encodingType", FieldConfig.EncodingType.RAW.name());
+    indexes.set("forward", forward);
+    ObjectNode text = JsonUtils.newObjectNode();
+    text.put("reuseMutableIndex", reuseMutableIndex);
+    text.put("useANDForMultiTermQueries", true);
     if (rawValueForTextIndex != null) {
-      fieldConfigColumnProperties.put(FieldConfig.TEXT_INDEX_RAW_VALUE, rawValueForTextIndex);
+      text.put("rawValue", rawValueForTextIndex);
     }
+    indexes.set("text", text);
     FieldConfig textIndexFieldConfig = new FieldConfig.Builder(STRING_COLUMN1)
-        .withEncodingType(FieldConfig.EncodingType.RAW)
-        .withIndexTypes(List.of(FieldConfig.IndexType.TEXT))
-        .withProperties(fieldConfigColumnProperties)
+        .withIndexes(indexes)
         .build();
     List<FieldConfig> fieldConfigList = List.of(textIndexFieldConfig);
     TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME)
@@ -742,8 +746,8 @@ public class RealtimeSegmentConverterTest implements PinotBuffersAfterMethodChec
 
         segmentFile.getRecord(docId, readRow);
 
-        // if rawValueForTextIndex is set and mutable index is reused, the forward index should return the dummy value
-        if (rawValueForTextIndex != null && reuseMutableIndex) {
+        // If rawValueForTextIndex is set, the converted forward index should return the dummy value.
+        if (rawValueForTextIndex != null) {
           assertEquals(readRow.getValue(STRING_COLUMN1), rawValueForTextIndex);
           assertEquals(readRow.getValue(DATE_TIME_COLUMN), row.getValue(DATE_TIME_COLUMN));
         } else {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/H3IndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/H3IndexTest.java
@@ -56,7 +56,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.apache.pinot.spi.config.table.FieldConfig.EncodingType.RAW;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
@@ -488,9 +487,12 @@ public class H3IndexTest implements PinotBuffersAfterMethodCheckRule {
       FieldConfig fieldConfig = _tableConfig.getFieldConfigList().stream()
           .filter(fc -> fc.getName().equals("location_st_point"))
           .collect(Collectors.toList()).get(0);
-      Assert.assertEquals(fieldConfig.getEncodingType(), RAW);
+      assertFalse(fieldConfig.hasFieldLevelEncodingType());
       assertTrue(fieldConfig.getIndexTypes().isEmpty());
       assertNull(fieldConfig.getProperties());
+      JsonNode forward = fieldConfig.getIndexes().get("forward");
+      assertNotNull(forward);
+      Assert.assertEquals(forward.get("encodingType").asText(), FieldConfig.EncodingType.RAW.name());
       JsonNode node = fieldConfig.getIndexes().get(H3IndexType.INDEX_DISPLAY_NAME);
       Assert.assertEquals(node.toString(), "{\"disabled\":false,\"resolution\":[5,6,13]}");
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexTypeTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexTypeTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.stream.Collectors;
 import org.apache.pinot.segment.local.segment.index.AbstractSerdeIndexContract;
+import org.apache.pinot.segment.local.segment.index.forward.ForwardIndexType;
 import org.apache.pinot.segment.spi.index.DictionaryIndexConfig;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
 import org.apache.pinot.segment.spi.index.IndexType;
@@ -121,6 +122,32 @@ public class DictionaryIndexTypeTest {
           + "    \"encodingType\": null\n"
           + "}");
       assertEquals(DictionaryIndexConfig.DEFAULT);
+    }
+
+    @Test
+    public void forwardEncodingOverridesRawFieldLevelEncoding()
+        throws IOException {
+      addFieldIndexConfig("{\n"
+          + "    \"name\": \"dimInt\",\n"
+          + "    \"encodingType\": \"RAW\",\n"
+          + "    \"indexes\" : {"
+          + "      \"forward\": { \"encodingType\": \"DICTIONARY\" }"
+          + "    }\n"
+          + "}");
+      assertEquals(DictionaryIndexConfig.DEFAULT);
+    }
+
+    @Test
+    public void forwardEncodingOverridesDictionaryFieldLevelEncoding()
+        throws IOException {
+      addFieldIndexConfig("{\n"
+          + "    \"name\": \"dimInt\",\n"
+          + "    \"encodingType\": \"DICTIONARY\",\n"
+          + "    \"indexes\" : {"
+          + "      \"forward\": { \"encodingType\": \"RAW\" }"
+          + "    }\n"
+          + "}");
+      assertEquals(DictionaryIndexConfig.DISABLED);
     }
 
     @Test
@@ -310,7 +337,7 @@ public class DictionaryIndexTypeTest {
       );
       convertToUpdatedFormat();
       FieldConfig fieldConfig = getFieldConfigByColumn("dimInt");
-      Assert.assertEquals(fieldConfig.getEncodingType(), FieldConfig.EncodingType.RAW);
+      assertForwardEncoding(fieldConfig, FieldConfig.EncodingType.RAW);
       postConversionAsserts();
     }
 
@@ -332,7 +359,7 @@ public class DictionaryIndexTypeTest {
       convertToUpdatedFormat();
 
       final FieldConfig fieldConfig = getFieldConfigByColumn("dimInt");
-      Assert.assertEquals(fieldConfig.getEncodingType(), FieldConfig.EncodingType.RAW);
+      assertForwardEncoding(fieldConfig, FieldConfig.EncodingType.RAW);
       assertNotNull(fieldConfig.getIndexes());
       assertTrue(fieldConfig.getIndexes().isObject());
       assertNotNull(fieldConfig.getIndexes().get("forward"));
@@ -368,8 +395,8 @@ public class DictionaryIndexTypeTest {
 
       final FieldConfig dimInt = getFieldConfigByColumn("dimInt");
       final FieldConfig dimStr = getFieldConfigByColumn("dimStr");
-      Assert.assertEquals(dimInt.getEncodingType(), FieldConfig.EncodingType.RAW);
-      Assert.assertEquals(dimStr.getEncodingType(), FieldConfig.EncodingType.RAW);
+      assertForwardEncoding(dimInt, FieldConfig.EncodingType.RAW);
+      assertForwardEncoding(dimStr, FieldConfig.EncodingType.RAW);
       assertNotNull(dimInt.getIndexes().get("forward"));
       assertNotNull(dimStr.getIndexes().get("forward"));
 
@@ -398,11 +425,11 @@ public class DictionaryIndexTypeTest {
       convertToUpdatedFormat();
 
       final FieldConfig dimInt = getFieldConfigByColumn("dimInt");
-      Assert.assertEquals(dimInt.getEncodingType(), FieldConfig.EncodingType.RAW);
+      assertForwardEncoding(dimInt, FieldConfig.EncodingType.RAW);
       assertNotNull(dimInt.getIndexes().get("forward"));
 
       final FieldConfig dimStr = getFieldConfigByColumn("dimStr");
-      Assert.assertEquals(dimStr.getEncodingType(), FieldConfig.EncodingType.RAW);
+      assertForwardEncoding(dimStr, FieldConfig.EncodingType.RAW);
 
       for (final String col : new String[]{"dimInt", "dimStr"}) {
         final long count = _tableConfig.getFieldConfigList().stream()
@@ -426,7 +453,7 @@ public class DictionaryIndexTypeTest {
       convertToUpdatedFormat();
 
       final FieldConfig fieldConfig = getFieldConfigByColumn("dimInt");
-      Assert.assertEquals(fieldConfig.getEncodingType(), FieldConfig.EncodingType.RAW);
+      assertForwardEncoding(fieldConfig, FieldConfig.EncodingType.RAW);
 
       final long count = _tableConfig.getFieldConfigList().stream()
           .filter(fc -> fc.getName().equals("dimInt"))
@@ -448,7 +475,7 @@ public class DictionaryIndexTypeTest {
       convertToUpdatedFormat();
 
       final FieldConfig fieldConfig = getFieldConfigByColumn("dimInt");
-      Assert.assertEquals(fieldConfig.getEncodingType(), FieldConfig.EncodingType.RAW);
+      assertForwardEncoding(fieldConfig, FieldConfig.EncodingType.RAW);
 
       final long count = _tableConfig.getFieldConfigList().stream()
           .filter(fc -> fc.getName().equals("dimInt"))
@@ -463,6 +490,14 @@ public class DictionaryIndexTypeTest {
       return _tableConfig.getFieldConfigList().stream()
           .filter(fc -> fc.getName().equals(column))
           .collect(Collectors.toList()).get(0);
+    }
+
+    private void assertForwardEncoding(FieldConfig fieldConfig, FieldConfig.EncodingType expected) {
+      assertNotNull(fieldConfig.getIndexes());
+      assertTrue(fieldConfig.getIndexes().isObject());
+      assertNotNull(fieldConfig.getIndexes().get(ForwardIndexType.INDEX_DISPLAY_NAME));
+      Assert.assertEquals(FieldConfig.EncodingType.valueOf(
+          fieldConfig.getIndexes().get(ForwardIndexType.INDEX_DISPLAY_NAME).get("encodingType").asText()), expected);
     }
 
     private void postConversionAsserts() {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexTypeTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexTypeTest.java
@@ -453,7 +453,7 @@ public class ForwardIndexTypeTest {
     }
 
     @Test
-    public void conflictingFieldConfigEncodingVsIndexesForward()
+    public void indexesForwardEncodingOverridesFieldConfigEncoding()
         throws IOException {
       addFieldIndexConfig(""
           + " {\n"
@@ -463,11 +463,22 @@ public class ForwardIndexTypeTest {
           + "      \"forward\": { \"encodingType\": \"DICTIONARY\" }"
           + "    }\n"
           + " }");
-      IllegalStateException ex = expectThrows(IllegalStateException.class,
-          () -> getActualConfig("dimInt", StandardIndexes.forward()));
-      assertTrue(ex.getMessage().contains("dimInt"), "message must name the column: " + ex.getMessage());
-      assertTrue(ex.getMessage().contains("encoding"),
-          "message must identify encoding as the conflicting field: " + ex.getMessage());
+      assertEquals(ForwardIndexConfig.getDefault(FieldConfig.EncodingType.DICTIONARY));
+    }
+
+    @Test
+    public void indexesForwardEncodingOverridesNoDictionaryColumns()
+        throws IOException {
+      _tableConfig.getIndexingConfig().setNoDictionaryColumns(
+          JsonUtils.stringToObject("[\"dimInt\"]", _stringListTypeRef));
+      addFieldIndexConfig(""
+          + " {\n"
+          + "    \"name\": \"dimInt\","
+          + "    \"indexes\" : {"
+          + "      \"forward\": { \"encodingType\": \"DICTIONARY\" }"
+          + "    }\n"
+          + " }");
+      assertEquals(ForwardIndexConfig.getDefault(FieldConfig.EncodingType.DICTIONARY));
     }
 
     @Test

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/IndexCombinationValidationTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/IndexCombinationValidationTest.java
@@ -18,15 +18,18 @@
  */
 package org.apache.pinot.segment.local.utils;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.FieldConfig.CompressionCodec;
 import org.apache.pinot.spi.config.table.FieldConfig.EncodingType;
 import org.apache.pinot.spi.config.table.FieldConfig.IndexType;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.TimestampConfig;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -67,7 +70,78 @@ public class IndexCombinationValidationTest {
   private static FieldConfig rawWithExplicitDict(String col, List<IndexType> indexes) {
     ObjectNode indexesNode = JsonUtils.newObjectNode();
     indexesNode.set("dictionary", JsonUtils.newObjectNode());
-    return new FieldConfig(col, EncodingType.RAW, null, indexes, null, null, indexesNode, null, null);
+    return fieldConfig(col, EncodingType.RAW, null, indexes, null, null, indexesNode, null, null);
+  }
+
+  private static FieldConfig fieldConfig(String name, EncodingType encodingType, IndexType indexType,
+      CompressionCodec compressionCodec, Map<String, String> properties) {
+    return fieldConfig(name, encodingType, indexType, null, compressionCodec, null, null, properties, null);
+  }
+
+  private static FieldConfig fieldConfig(String name, EncodingType encodingType, List<IndexType> indexTypes,
+      CompressionCodec compressionCodec, Map<String, String> properties) {
+    return fieldConfig(name, encodingType, null, indexTypes, compressionCodec, null, null, properties, null);
+  }
+
+  private static FieldConfig fieldConfig(String name, EncodingType encodingType, IndexType indexType,
+      List<IndexType> indexTypes, CompressionCodec compressionCodec, TimestampConfig timestampConfig,
+      JsonNode indexes, Map<String, String> properties, JsonNode tierOverwrites) {
+    ObjectNode indexesNode = withForwardEncoding(indexes, encodingType);
+    if (compressionCodec != null) {
+      withForwardCompression(indexesNode, compressionCodec);
+    }
+    if (properties != null) {
+      withForwardProperties(indexesNode, properties);
+    }
+    return new FieldConfig(name, null, indexType, indexTypes, null, timestampConfig, indexesNode, null,
+        tierOverwrites);
+  }
+
+  private static ObjectNode withForwardEncoding(JsonNode indexes, EncodingType encodingType) {
+    ObjectNode indexesNode =
+        indexes != null && indexes.isObject() ? (ObjectNode) indexes.deepCopy() : JsonUtils.newObjectNode();
+    ObjectNode forward;
+    if (indexesNode.has("forward") && indexesNode.get("forward").isObject()) {
+      forward = (ObjectNode) indexesNode.get("forward");
+    } else {
+      forward = JsonUtils.newObjectNode();
+      indexesNode.set("forward", forward);
+    }
+    forward.put("encodingType", encodingType.name());
+    return indexesNode;
+  }
+
+  private static void withForwardCompression(ObjectNode indexes, CompressionCodec compressionCodec) {
+    forwardNode(indexes).put("compressionCodec", compressionCodec.name());
+  }
+
+  private static void withForwardProperties(ObjectNode indexes, Map<String, String> properties) {
+    ObjectNode forward = forwardNode(indexes);
+    for (Map.Entry<String, String> entry : properties.entrySet()) {
+      switch (entry.getKey()) {
+        case FieldConfig.FORWARD_INDEX_DISABLED:
+          forward.put("disabled", Boolean.parseBoolean(entry.getValue()));
+          break;
+        case FieldConfig.DERIVE_NUM_DOCS_PER_CHUNK_RAW_INDEX_KEY:
+          forward.put("deriveNumDocsPerChunk", Boolean.parseBoolean(entry.getValue()));
+          break;
+        case FieldConfig.RAW_INDEX_WRITER_VERSION:
+          forward.put("rawIndexWriterVersion", Integer.parseInt(entry.getValue()));
+          break;
+        default:
+          forward.put(entry.getKey(), entry.getValue());
+          break;
+      }
+    }
+  }
+
+  private static ObjectNode forwardNode(ObjectNode indexes) {
+    if (indexes.has("forward") && indexes.get("forward").isObject()) {
+      return (ObjectNode) indexes.get("forward");
+    }
+    ObjectNode forward = JsonUtils.newObjectNode();
+    indexes.set("forward", forward);
+    return forward;
   }
 
   /// Validate and expect success.
@@ -130,7 +204,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testDictEncodedWithFstIndexPasses() {
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.DICTIONARY, List.of(IndexType.FST), null, null);
+    FieldConfig fc = fieldConfig(STR_COL, EncodingType.DICTIONARY, IndexType.FST, null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setFieldConfigList(List.of(fc)).build();
     assertValid(tc);
@@ -171,7 +245,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testRawWithFstIndexNoExplicitDictFails() {
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, List.of(IndexType.FST), null, null);
+    FieldConfig fc = fieldConfig(STR_COL, EncodingType.RAW, IndexType.FST, null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -182,7 +256,7 @@ public class IndexCombinationValidationTest {
   @Test
   public void testRawWithIfstIndexNoExplicitDictFails() {
     // IFSTIndexType.validate() fires: "Cannot create IFST index on column: <col> without dictionary"
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, List.of(IndexType.IFST), null, null);
+    FieldConfig fc = fieldConfig(STR_COL, EncodingType.RAW, IndexType.IFST, null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -193,7 +267,7 @@ public class IndexCombinationValidationTest {
   @Test
   public void testRawWithMultipleDictRequiringIndexesNoExplicitDictFails() {
     // Both inverted and FST require dictionary; at least one validator fires mentioning "dictionary"
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, null, List.of(IndexType.FST),
+    FieldConfig fc = fieldConfig(STR_COL, EncodingType.RAW, null, List.of(IndexType.FST),
         null, null, null, null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
@@ -212,7 +286,7 @@ public class IndexCombinationValidationTest {
   public void testRawWithExplicitDictAndInvertedIndexPasses() {
     ObjectNode indexes = JsonUtils.newObjectNode();
     indexes.set("dictionary", JsonUtils.newObjectNode());
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, null, null, null, null, indexes, null, null);
+    FieldConfig fc = fieldConfig(STR_COL, EncodingType.RAW, null, null, null, null, indexes, null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setInvertedIndexColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -238,7 +312,7 @@ public class IndexCombinationValidationTest {
   public void testRawWithExplicitDictAndInvertedPlusFstPasses() {
     ObjectNode indexes = JsonUtils.newObjectNode();
     indexes.set("dictionary", JsonUtils.newObjectNode());
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, null, List.of(IndexType.FST),
+    FieldConfig fc = fieldConfig(STR_COL, EncodingType.RAW, null, List.of(IndexType.FST),
         null, null, indexes, null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setInvertedIndexColumns(List.of(STR_COL))
@@ -251,7 +325,7 @@ public class IndexCombinationValidationTest {
   public void testRawWithExplicitDictAndInvertedIndexIntColumnPasses() {
     ObjectNode indexes = JsonUtils.newObjectNode();
     indexes.set("dictionary", JsonUtils.newObjectNode());
-    FieldConfig fc = new FieldConfig(INT_COL, EncodingType.RAW, null, null, null, null, indexes, null, null);
+    FieldConfig fc = fieldConfig(INT_COL, EncodingType.RAW, null, null, null, null, indexes, null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setInvertedIndexColumns(List.of(INT_COL))
         .setFieldConfigList(List.of(fc))
@@ -266,7 +340,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testRawWithTextIndexNoDictPasses() {
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, List.of(IndexType.TEXT), null, null);
+    FieldConfig fc = fieldConfig(STR_COL, EncodingType.RAW, IndexType.TEXT, null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -285,7 +359,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testRawWithJsonIndexStringColumnNoDictPasses() {
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, List.of(IndexType.JSON), null, null);
+    FieldConfig fc = fieldConfig(STR_COL, EncodingType.RAW, IndexType.JSON, null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -339,7 +413,7 @@ public class IndexCombinationValidationTest {
   public void testRawWithRangeIndexStringColumnWithExplicitDictPasses() {
     ObjectNode indexes = JsonUtils.newObjectNode();
     indexes.set("dictionary", JsonUtils.newObjectNode());
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, null, null, null, null, indexes, null, null);
+    FieldConfig fc = fieldConfig(STR_COL, EncodingType.RAW, null, null, null, null, indexes, null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setRangeIndexColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -373,7 +447,7 @@ public class IndexCombinationValidationTest {
   public void testRawMvWithInvertedIndexWithExplicitDictPasses() {
     ObjectNode indexes = JsonUtils.newObjectNode();
     indexes.set("dictionary", JsonUtils.newObjectNode());
-    FieldConfig fc = new FieldConfig(INT_MV_COL, EncodingType.RAW, null, null, null, null, indexes, null, null);
+    FieldConfig fc = fieldConfig(INT_MV_COL, EncodingType.RAW, null, null, null, null, indexes, null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setInvertedIndexColumns(List.of(INT_MV_COL))
         .setFieldConfigList(List.of(fc))
@@ -384,7 +458,7 @@ public class IndexCombinationValidationTest {
   @Test
   public void testFstIndexMvColumnFails() {
     // FST on MV column is never valid regardless of encoding
-    FieldConfig fc = new FieldConfig(INT_MV_COL, EncodingType.DICTIONARY, List.of(IndexType.FST), null, null);
+    FieldConfig fc = fieldConfig(INT_MV_COL, EncodingType.DICTIONARY, IndexType.FST, null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setFieldConfigList(List.of(fc))
         .build();
@@ -408,7 +482,7 @@ public class IndexCombinationValidationTest {
   @Test
   public void testMixedColumnsAllValidPasses() {
     // strCol: raw + text (no dict required); intCol: dict + inverted; floatCol: dict + range
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, List.of(IndexType.TEXT), null, null);
+    FieldConfig fc = fieldConfig(STR_COL, EncodingType.RAW, IndexType.TEXT, null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setInvertedIndexColumns(List.of(INT_COL))
@@ -423,7 +497,7 @@ public class IndexCombinationValidationTest {
     // strCol: raw + explicit dict + inverted (valid); intCol: raw + no dict + inverted → fails
     ObjectNode indexes = JsonUtils.newObjectNode();
     indexes.set("dictionary", JsonUtils.newObjectNode());
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, null, null, null, null, indexes, null, null);
+    FieldConfig fc = fieldConfig(STR_COL, EncodingType.RAW, null, null, null, null, indexes, null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(INT_COL))
         .setInvertedIndexColumns(Arrays.asList(STR_COL, INT_COL))
@@ -443,7 +517,7 @@ public class IndexCombinationValidationTest {
     ObjectNode fwdDisabled = JsonUtils.newObjectNode();
     fwdDisabled.put("disabled", true);
     indexes.set("forward", fwdDisabled);
-    FieldConfig fc = new FieldConfig(INT_COL, EncodingType.DICTIONARY, null,
+    FieldConfig fc = fieldConfig(INT_COL, EncodingType.DICTIONARY, null,
         null, null, null, indexes, null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setInvertedIndexColumns(List.of(INT_COL))
@@ -458,7 +532,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testRawWithLz4CodecPasses() {
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, null, CompressionCodec.LZ4, null);
+    FieldConfig fc = fieldConfig(STR_COL, EncodingType.RAW, (IndexType) null, CompressionCodec.LZ4, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -468,7 +542,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testRawWithSnappyCodecPasses() {
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, null, CompressionCodec.SNAPPY, null);
+    FieldConfig fc = fieldConfig(STR_COL, EncodingType.RAW, (IndexType) null, CompressionCodec.SNAPPY, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -478,7 +552,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testRawWithZstdCodecPasses() {
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, null, CompressionCodec.ZSTANDARD, null);
+    FieldConfig fc = fieldConfig(STR_COL, EncodingType.RAW, (IndexType) null, CompressionCodec.ZSTANDARD, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -489,7 +563,7 @@ public class IndexCombinationValidationTest {
   @Test
   public void testRawWithClpCodecStringColumnPasses() {
     // CLP codecs are valid for raw STRING columns
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, null, CompressionCodec.CLP, null);
+    FieldConfig fc = fieldConfig(STR_COL, EncodingType.RAW, (IndexType) null, CompressionCodec.CLP, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -500,7 +574,7 @@ public class IndexCombinationValidationTest {
   @Test
   public void testRawWithClpCodecNonStringColumnFails() {
     // CLP is only valid on STRING stored type
-    FieldConfig fc = new FieldConfig(INT_COL, EncodingType.RAW, null, CompressionCodec.CLP, null);
+    FieldConfig fc = fieldConfig(INT_COL, EncodingType.RAW, (IndexType) null, CompressionCodec.CLP, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(INT_COL))
         .setFieldConfigList(List.of(fc))
@@ -511,7 +585,7 @@ public class IndexCombinationValidationTest {
   @Test
   public void testDeltaDeltaCodecNonNumericColumnFails() {
     // DELTADELTA only valid on INT/LONG columns
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, null, CompressionCodec.DELTADELTA, null);
+    FieldConfig fc = fieldConfig(STR_COL, EncodingType.RAW, (IndexType) null, CompressionCodec.DELTADELTA, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -528,7 +602,7 @@ public class IndexCombinationValidationTest {
     // up with a RAW forward index alongside the standalone dictionary at segment-creation time.
     ObjectNode indexes = JsonUtils.newObjectNode();
     indexes.set("dictionary", JsonUtils.newObjectNode());
-    FieldConfig fc = new FieldConfig(INT_COL, EncodingType.RAW, null, null, CompressionCodec.DELTADELTA, null,
+    FieldConfig fc = fieldConfig(INT_COL, EncodingType.RAW, null, null, CompressionCodec.DELTADELTA, null,
         indexes, null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setFieldConfigList(List.of(fc))
@@ -542,7 +616,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testFstIndexNonStringColumnFails() {
-    FieldConfig fc = new FieldConfig(INT_COL, EncodingType.DICTIONARY, List.of(IndexType.FST), null, null);
+    FieldConfig fc = fieldConfig(INT_COL, EncodingType.DICTIONARY, IndexType.FST, null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setFieldConfigList(List.of(fc))
         .build();
@@ -551,7 +625,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testTextIndexNonStringColumnFails() {
-    FieldConfig fc = new FieldConfig(INT_COL, EncodingType.DICTIONARY, List.of(IndexType.TEXT), null, null);
+    FieldConfig fc = fieldConfig(INT_COL, EncodingType.DICTIONARY, IndexType.TEXT, null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setFieldConfigList(List.of(fc))
         .build();
@@ -561,7 +635,7 @@ public class IndexCombinationValidationTest {
   @Test
   public void testTextIndexStringColumnRawPasses() {
     // Text index does not require dictionary
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, List.of(IndexType.TEXT), null, null);
+    FieldConfig fc = fieldConfig(STR_COL, EncodingType.RAW, IndexType.TEXT, null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -571,7 +645,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testTextIndexStringColumnDictPasses() {
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.DICTIONARY, List.of(IndexType.TEXT), null, null);
+    FieldConfig fc = fieldConfig(STR_COL, EncodingType.DICTIONARY, IndexType.TEXT, null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setFieldConfigList(List.of(fc))
         .build();
@@ -580,7 +654,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testJsonIndexStringColumnRawPasses() {
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, List.of(IndexType.JSON), null, null);
+    FieldConfig fc = fieldConfig(STR_COL, EncodingType.RAW, IndexType.JSON, null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -590,7 +664,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testJsonIndexStringColumnDictPasses() {
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.DICTIONARY, List.of(IndexType.JSON), null, null);
+    FieldConfig fc = fieldConfig(STR_COL, EncodingType.DICTIONARY, IndexType.JSON, null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setFieldConfigList(List.of(fc))
         .build();
@@ -600,7 +674,7 @@ public class IndexCombinationValidationTest {
   @Test
   public void testJsonIndexIntColumnFails() {
     // JSON index not valid on non-STRING/non-MAP column
-    FieldConfig fc = new FieldConfig(INT_COL, EncodingType.DICTIONARY, List.of(IndexType.JSON), null, null);
+    FieldConfig fc = fieldConfig(INT_COL, EncodingType.DICTIONARY, IndexType.JSON, null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setFieldConfigList(List.of(fc))
         .build();
@@ -645,7 +719,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testErrorMessageNamesFstIndex() {
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, List.of(IndexType.FST), null, null);
+    FieldConfig fc = fieldConfig(STR_COL, EncodingType.RAW, IndexType.FST, null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigConsumingSegmentTierOverrideTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigConsumingSegmentTierOverrideTest.java
@@ -73,7 +73,8 @@ public class TableConfigConsumingSegmentTierOverrideTest {
     assertEquals(consumingConfig.getMultiColIndexConfig().getColumns(), List.of(PROFILED_COLUMN));
 
     assertEquals(tableConfig.getIndexingConfig().getNoDictionaryColumns(), List.of(PROFILED_COLUMN));
-    assertEquals(tableConfig.getFieldConfigList().get(0).getEncodingType(), FieldConfig.EncodingType.RAW);
+    assertEquals(tableConfig.getFieldConfigList().get(0).getIndexes().get("forward").get("encodingType").asText(),
+        FieldConfig.EncodingType.RAW.name());
   }
 
   @Test
@@ -168,9 +169,9 @@ public class TableConfigConsumingSegmentTierOverrideTest {
   private static FieldConfig profiledFieldConfigWithTierOverwrite(String tier)
       throws Exception {
     return new FieldConfig.Builder(PROFILED_COLUMN)
-        .withEncodingType(FieldConfig.EncodingType.RAW)
-        .withTierOverwrites(JsonUtils.stringToJsonNode("{\"" + tier + "\":{\"encodingType\":\"DICTIONARY\","
-            + "\"indexes\":{\"inverted\":{\"disabled\":false}}}}"))
+        .withIndexes(JsonUtils.stringToJsonNode("{\"forward\":{\"encodingType\":\"RAW\"}}"))
+        .withTierOverwrites(JsonUtils.stringToJsonNode("{\"" + tier
+            + "\":{\"indexes\":{\"forward\":{\"encodingType\":\"DICTIONARY\"},\"inverted\":{\"disabled\":false}}}}"))
         .build();
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -1431,6 +1431,7 @@ public class TableConfigUtilsTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testValidateFieldConfig() {
     Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
         .addDateTime(TIME_COLUMN, DataType.LONG, "1:HOURS:EPOCH", "1:HOURS")
@@ -1443,7 +1444,7 @@ public class TableConfigUtilsTest {
         .build();
 
     try {
-      FieldConfig fieldConfig = new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, null, null, null);
+      FieldConfig fieldConfig = fieldConfigWithForwardEncoding("myCol1", FieldConfig.EncodingType.RAW);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1451,8 +1452,44 @@ public class TableConfigUtilsTest {
     }
 
     try {
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, CompressionCodec.DELTADELTA, null, null);
+      FieldConfig fieldConfig = new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, null, null, null);
+      tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
+      TableConfigUtils.validate(tableConfig, schema);
+      fail("Should fail for deprecated field-level encoding type");
+    } catch (Exception e) {
+      assertEquals(e.getMessage(), "FieldConfig.encodingType is deprecated for column: myCol1. Use "
+          + "fieldConfigList[].indexes.forward.encodingType instead.");
+    }
+
+    try {
+      FieldConfig fieldConfig = new FieldConfig.Builder("myCol1")
+          .withCompressionCodec(CompressionCodec.SNAPPY)
+          .build();
+      tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
+      TableConfigUtils.validate(tableConfig, schema);
+      fail("Should fail for deprecated field-level compression codec");
+    } catch (Exception e) {
+      assertEquals(e.getMessage(), "FieldConfig.compressionCodec is deprecated for column: myCol1. Use "
+          + "fieldConfigList[].indexes.forward.compressionCodec instead.");
+    }
+
+    try {
+      FieldConfig fieldConfig = new FieldConfig.Builder("myCol1")
+          .withProperties(Map.of(FieldConfig.RAW_INDEX_WRITER_VERSION, "4"))
+          .build();
+      tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
+      TableConfigUtils.validate(tableConfig, schema);
+      fail("Should fail for deprecated field-level properties");
+    } catch (Exception e) {
+      assertEquals(e.getMessage(), "FieldConfig.properties is deprecated for column: myCol1. Move these settings into "
+          + "the relevant fieldConfigList[].indexes.<indexName> block instead.");
+    }
+
+    try {
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("myCol1", FieldConfig.EncodingType.RAW)
+          .withIndexes(withForwardCompression(indexesWithForwardEncoding(FieldConfig.EncodingType.RAW),
+              CompressionCodec.DELTADELTA))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1461,8 +1498,10 @@ public class TableConfigUtilsTest {
     }
 
     try {
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol2", FieldConfig.EncodingType.RAW, null, null, CompressionCodec.DELTADELTA, null, null);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("myCol2", FieldConfig.EncodingType.RAW)
+          .withIndexes(withForwardCompression(indexesWithForwardEncoding(FieldConfig.EncodingType.RAW),
+              CompressionCodec.DELTADELTA))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1471,31 +1510,30 @@ public class TableConfigUtilsTest {
     }
 
     try {
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol1", FieldConfig.EncodingType.DICTIONARY, List.of(FieldConfig.IndexType.FST), null,
-              null);
+      FieldConfig fieldConfig = fieldConfigWithForwardEncoding("myCol1", FieldConfig.EncodingType.DICTIONARY);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
-      fail("Should fail for with conflicting encoding type of myCol1");
+      fail("Should fail when forward DICTIONARY encoding conflicts with noDictionaryColumns");
     } catch (Exception e) {
-      assertEquals(e.getMessage(), "FieldConfig encoding type is different from indexingConfig for column: myCol1");
+      assertEquals(e.getMessage(), "Dictionary must be enabled for dictionary-encoded forward index column: myCol1");
     }
 
     // FST on RAW column is valid when explicit dictionary config is provided in indexes
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     ObjectNode rawFstIndexes = JsonUtils.newObjectNode();
     rawFstIndexes.set("dictionary", JsonUtils.newObjectNode());
-    FieldConfig rawFstFieldConfig =
-        new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, Arrays.asList(FieldConfig.IndexType.FST),
-            null, null, rawFstIndexes, null, null);
+    FieldConfig rawFstFieldConfig = new FieldConfig.Builder("myCol1")
+        .withIndexes(withForwardEncoding(rawFstIndexes, FieldConfig.EncodingType.RAW))
+        .withIndexTypes(Arrays.asList(FieldConfig.IndexType.FST))
+        .build();
     tableConfig.setFieldConfigList(Arrays.asList(rawFstFieldConfig));
     TableConfigUtils.validate(tableConfig, schema);
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     try {
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY, List.of(FieldConfig.IndexType.FST), null,
-              null);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("myCol2", FieldConfig.EncodingType.DICTIONARY)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.FST))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       fail("Should fail since FST index is enabled on multi value column");
@@ -1505,9 +1543,9 @@ public class TableConfigUtilsTest {
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     try {
-      FieldConfig fieldConfig =
-          new FieldConfig("intCol", FieldConfig.EncodingType.DICTIONARY, List.of(FieldConfig.IndexType.FST), null,
-              null);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("intCol", FieldConfig.EncodingType.DICTIONARY)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.FST))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       fail("Should fail since FST index is enabled on non String column");
@@ -1519,8 +1557,9 @@ public class TableConfigUtilsTest {
         .setNoDictionaryColumns(Arrays.asList("myCol2", "intCol"))
         .build();
     try {
-      FieldConfig fieldConfig =
-          new FieldConfig("intCol", FieldConfig.EncodingType.RAW, List.of(FieldConfig.IndexType.TEXT), null, null);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("intCol", FieldConfig.EncodingType.RAW)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.TEXT))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       fail("Should fail since TEXT index is enabled on non String column");
@@ -1532,8 +1571,9 @@ public class TableConfigUtilsTest {
         .setNoDictionaryColumns(Arrays.asList("myCol1"))
         .build();
     try {
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol21", FieldConfig.EncodingType.RAW, List.of(FieldConfig.IndexType.FST), null, null);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("myCol21", FieldConfig.EncodingType.RAW)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.FST))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       fail("Should fail since field name is not present in schema");
@@ -1543,8 +1583,11 @@ public class TableConfigUtilsTest {
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     try {
-      FieldConfig fieldConfig = new FieldConfig("intCol", FieldConfig.EncodingType.DICTIONARY, List.of(),
-          CompressionCodec.SNAPPY, null);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("intCol", FieldConfig.EncodingType.DICTIONARY)
+          .withIndexTypes(List.of())
+          .withIndexes(withForwardCompression(indexesWithForwardEncoding(FieldConfig.EncodingType.DICTIONARY),
+              CompressionCodec.SNAPPY))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       fail("Should fail since dictionary encoding does not support compression codec SNAPPY");
@@ -1554,8 +1597,11 @@ public class TableConfigUtilsTest {
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     try {
-      FieldConfig fieldConfig = new FieldConfig("intCol", FieldConfig.EncodingType.RAW, List.of(),
-          CompressionCodec.MV_ENTRY_DICT, null);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("intCol", FieldConfig.EncodingType.RAW)
+          .withIndexTypes(List.of())
+          .withIndexes(withForwardCompression(indexesWithForwardEncoding(FieldConfig.EncodingType.RAW),
+              CompressionCodec.MV_ENTRY_DICT))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       fail("Should fail since raw encoding does not support compression codec MV_ENTRY_DICT");
@@ -1569,10 +1615,9 @@ public class TableConfigUtilsTest {
     try {
       // Enable forward index disabled flag for a raw column. This should succeed as though the forward index cannot
       // be rebuilt without a dictionary, the constraint to have a dictionary has been lifted.
-      Map<String, String> fieldConfigProperties = new HashMap<>();
-      fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, null, null, fieldConfigProperties);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("myCol1", FieldConfig.EncodingType.RAW)
+          .withIndexes(indexesWithDisabledForwardIndex(FieldConfig.EncodingType.RAW))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1583,10 +1628,9 @@ public class TableConfigUtilsTest {
       // Enable forward index disabled flag for a column without inverted index. This should succeed as though the
       // forward index cannot be rebuilt without an inverted index, the constraint to have an inverted index has been
       // lifted.
-      Map<String, String> fieldConfigProperties = new HashMap<>();
-      fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY, null, null, null, null, fieldConfigProperties);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("myCol2", FieldConfig.EncodingType.DICTIONARY)
+          .withIndexes(indexesWithDisabledForwardIndex(FieldConfig.EncodingType.DICTIONARY))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1595,8 +1639,6 @@ public class TableConfigUtilsTest {
 
     try {
       // Enable forward index disabled flag for a column and verify that dictionary override options are not set.
-      Map<String, String> fieldConfigProperties = new HashMap<>();
-      fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
       tableConfig.getIndexingConfig().setOptimizeDictionaryForMetrics(true);
       tableConfig.getIndexingConfig().setOptimizeDictionaryForMetrics(true);
       TableConfigUtils.validate(tableConfig, schema);
@@ -1611,11 +1653,10 @@ public class TableConfigUtilsTest {
         .build();
     try {
       // Enable forward index disabled flag for a column with inverted index
-      Map<String, String> fieldConfigProperties = new HashMap<>();
-      fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.INVERTED, null, null,
-              null, fieldConfigProperties);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("myCol2", FieldConfig.EncodingType.DICTIONARY)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.INVERTED))
+          .withIndexes(indexesWithDisabledForwardIndex(FieldConfig.EncodingType.DICTIONARY))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1629,11 +1670,10 @@ public class TableConfigUtilsTest {
         .build();
     try {
       // Enable forward index disabled flag for a column with inverted index and is sorted
-      Map<String, String> fieldConfigProperties = new HashMap<>();
-      fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol1", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.INVERTED, null, null,
-              null, fieldConfigProperties);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("myCol1", FieldConfig.EncodingType.DICTIONARY)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.INVERTED))
+          .withIndexes(indexesWithDisabledForwardIndex(FieldConfig.EncodingType.DICTIONARY))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1647,12 +1687,10 @@ public class TableConfigUtilsTest {
         .build();
     try {
       // Enable forward index disabled flag for a multi-value column with inverted index and range index
-      Map<String, String> fieldConfigProperties = new HashMap<>();
-      fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.INVERTED,
-              Arrays.asList(FieldConfig.IndexType.INVERTED, FieldConfig.IndexType.RANGE), null, null,
-              fieldConfigProperties);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("myCol2", FieldConfig.EncodingType.DICTIONARY)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.INVERTED, FieldConfig.IndexType.RANGE))
+          .withIndexes(indexesWithDisabledForwardIndex(FieldConfig.EncodingType.DICTIONARY))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       fail("Should fail for MV myCol2 with forward index disabled but has range and inverted index");
@@ -1667,12 +1705,10 @@ public class TableConfigUtilsTest {
         .build();
     try {
       // Enable forward index disabled flag for a singe-value column with inverted index and range index v1
-      Map<String, String> fieldConfigProperties = new HashMap<>();
-      fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol1", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.INVERTED,
-              Arrays.asList(FieldConfig.IndexType.INVERTED, FieldConfig.IndexType.RANGE), null, null,
-              fieldConfigProperties);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("myCol1", FieldConfig.EncodingType.DICTIONARY)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.INVERTED, FieldConfig.IndexType.RANGE))
+          .withIndexes(indexesWithDisabledForwardIndex(FieldConfig.EncodingType.DICTIONARY))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       tableConfig.getIndexingConfig().setRangeIndexVersion(1);
       TableConfigUtils.validate(tableConfig, schema);
@@ -1689,11 +1725,10 @@ public class TableConfigUtilsTest {
         .build();
     try {
       // Enable forward index disabled flag for a column with inverted index and disable dictionary
-      Map<String, String> fieldConfigProperties = new HashMap<>();
-      fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol2", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.INVERTED, null, null, null,
-              fieldConfigProperties);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("myCol2", FieldConfig.EncodingType.RAW)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.INVERTED))
+          .withIndexes(indexesWithDisabledForwardIndex(FieldConfig.EncodingType.RAW))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       fail("Should not be able to disable dictionary but keep inverted index");
@@ -1705,10 +1740,9 @@ public class TableConfigUtilsTest {
     // producing a shared-dict + RAW forward index. No validation error expected.
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     {
-      FieldConfig fieldConfig =
-          new FieldConfig.Builder("myCol2").withIndexTypes(Arrays.asList(FieldConfig.IndexType.INVERTED))
-              .withEncodingType(FieldConfig.EncodingType.RAW)
-              .build();
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("myCol2", FieldConfig.EncodingType.RAW)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.INVERTED))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
     }
@@ -1718,11 +1752,10 @@ public class TableConfigUtilsTest {
         .build();
     try {
       // Enable forward index disabled flag for a column with FST index and disable dictionary
-      Map<String, String> fieldConfigProperties = new HashMap<>();
-      fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
-      FieldConfig fieldConfigWithFst =
-          new FieldConfig("myCol2", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.FST, null, null, null,
-              fieldConfigProperties);
+      FieldConfig fieldConfigWithFst = fieldConfigBuilderWithForwardEncoding("myCol2", FieldConfig.EncodingType.RAW)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.FST))
+          .withIndexes(indexesWithDisabledForwardIndex(FieldConfig.EncodingType.RAW))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfigWithFst));
       TableConfigUtils.validate(tableConfig, schema);
       fail("Should not be able to disable dictionary but keep FST index");
@@ -1739,11 +1772,10 @@ public class TableConfigUtilsTest {
         .build();
     try {
       // Enable forward index disabled flag for a column with FST index and disable dictionary
-      Map<String, String> fieldConfigProperties = new HashMap<>();
-      fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
-      FieldConfig fieldConfigWithRange =
-          new FieldConfig("intCol", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.RANGE, null, null, null,
-              fieldConfigProperties);
+      FieldConfig fieldConfigWithRange = fieldConfigBuilderWithForwardEncoding("intCol", FieldConfig.EncodingType.RAW)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.RANGE))
+          .withIndexes(indexesWithDisabledForwardIndex(FieldConfig.EncodingType.RAW))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfigWithRange));
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1758,13 +1790,12 @@ public class TableConfigUtilsTest {
         .build();
     try {
       // Enable forward index disabled flag for a column with inverted index index and disable dictionary
-      Map<String, String> fieldConfigProperties = new HashMap<>();
-      fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
       ObjectNode indexes = JsonUtils.newObjectNode();
       indexes.set("dictionary", JsonUtils.newObjectNode());
-      FieldConfig realtimeFieldConfig =
-          new FieldConfig("intCol", FieldConfig.EncodingType.RAW, null, Arrays.asList(FieldConfig.IndexType.INVERTED),
-              null, null, indexes, fieldConfigProperties, null);
+      FieldConfig realtimeFieldConfig = new FieldConfig.Builder("intCol")
+          .withIndexes(withForwardDisabled(withForwardEncoding(indexes, FieldConfig.EncodingType.RAW)))
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.INVERTED))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(realtimeFieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1775,9 +1806,9 @@ public class TableConfigUtilsTest {
     // and validation passes — the runtime builds a shared-dict + RAW forward index.
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     {
-      FieldConfig rawInvertedConfig =
-          new FieldConfig("intCol", FieldConfig.EncodingType.RAW,
-              Arrays.asList(FieldConfig.IndexType.INVERTED), null, null);
+      FieldConfig rawInvertedConfig = fieldConfigBuilderWithForwardEncoding("intCol", FieldConfig.EncodingType.RAW)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.INVERTED))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(rawInvertedConfig));
       TableConfigUtils.validate(tableConfig, schema);
     }
@@ -1787,9 +1818,10 @@ public class TableConfigUtilsTest {
     try {
       ObjectNode dictIndexes = JsonUtils.newObjectNode();
       dictIndexes.set("dictionary", JsonUtils.newObjectNode());
-      FieldConfig rawInvertedWithDictConfig =
-          new FieldConfig("intCol", FieldConfig.EncodingType.RAW, null,
-              Arrays.asList(FieldConfig.IndexType.INVERTED), null, null, dictIndexes, null, null);
+      FieldConfig rawInvertedWithDictConfig = new FieldConfig.Builder("intCol")
+          .withIndexes(withForwardEncoding(dictIndexes, FieldConfig.EncodingType.RAW))
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.INVERTED))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(rawInvertedWithDictConfig));
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1805,8 +1837,8 @@ public class TableConfigUtilsTest {
     final TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName(TABLE_NAME).build();
 
-    final FieldConfig fc1 = new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, null, null, null);
-    final FieldConfig fc2 = new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, null, null, null);
+    final FieldConfig fc1 = fieldConfigWithForwardEncoding("myCol1", FieldConfig.EncodingType.RAW);
+    final FieldConfig fc2 = fieldConfigWithForwardEncoding("myCol1", FieldConfig.EncodingType.RAW);
     tableConfig.setFieldConfigList(Arrays.asList(fc1, fc2));
 
     try {
@@ -1825,9 +1857,8 @@ public class TableConfigUtilsTest {
     final TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName(TABLE_NAME).build();
 
-    final FieldConfig fc1 = new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, null, null, null);
-    final FieldConfig fc2 =
-        new FieldConfig("myCol1", FieldConfig.EncodingType.DICTIONARY, null, null, null, null, null);
+    final FieldConfig fc1 = fieldConfigWithForwardEncoding("myCol1", FieldConfig.EncodingType.RAW);
+    final FieldConfig fc2 = fieldConfigWithForwardEncoding("myCol1", FieldConfig.EncodingType.DICTIONARY);
     tableConfig.setFieldConfigList(Arrays.asList(fc1, fc2));
 
     try {
@@ -1850,10 +1881,9 @@ public class TableConfigUtilsTest {
     final ObjectNode indexes = JsonNodeFactory.instance.objectNode();
     indexes.set("forward", JsonNodeFactory.instance.objectNode().put("compressionCodec", "ZSTANDARD"));
     final FieldConfig fc1 = new FieldConfig.Builder("myCol1")
-        .withEncodingType(FieldConfig.EncodingType.RAW)
-        .withIndexes(indexes)
+        .withIndexes(withForwardEncoding(indexes, FieldConfig.EncodingType.RAW))
         .build();
-    final FieldConfig fc2 = new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, null, null, null);
+    final FieldConfig fc2 = fieldConfigWithForwardEncoding("myCol1", FieldConfig.EncodingType.RAW);
     tableConfig.setFieldConfigList(Arrays.asList(fc1, fc2));
 
     try {
@@ -1873,9 +1903,8 @@ public class TableConfigUtilsTest {
     final TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName(TABLE_NAME).build();
 
-    final FieldConfig fc1 = new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, null, null, null);
-    final FieldConfig fc2 =
-        new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY, null, null, null, null, null);
+    final FieldConfig fc1 = fieldConfigWithForwardEncoding("myCol1", FieldConfig.EncodingType.RAW);
+    final FieldConfig fc2 = fieldConfigWithForwardEncoding("myCol2", FieldConfig.EncodingType.DICTIONARY);
     tableConfig.setFieldConfigList(Arrays.asList(fc1, fc2));
 
     try {
@@ -1893,7 +1922,7 @@ public class TableConfigUtilsTest {
     final TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName(TABLE_NAME).build();
 
-    final FieldConfig fc1 = new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, null, null, null);
+    final FieldConfig fc1 = fieldConfigWithForwardEncoding("myCol1", FieldConfig.EncodingType.RAW);
     tableConfig.setFieldConfigList(Arrays.asList(fc1));
 
     try {
@@ -1987,8 +2016,7 @@ public class TableConfigUtilsTest {
     TableConfig tableconfig3 = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).build();
     ObjectNode indexesNode = JsonNodeFactory.instance.objectNode();
     indexesNode.putObject("bloom");
-    FieldConfig fieldConfig =
-        new FieldConfig("MyCol", FieldConfig.EncodingType.DICTIONARY, null, null, null, null, indexesNode, null, null);
+    FieldConfig fieldConfig = new FieldConfig.Builder("MyCol").withIndexes(indexesNode).build();
     tableconfig3.setFieldConfigList(Arrays.asList(fieldConfig));
     assertThrows(IllegalStateException.class, () -> TableConfigUtils.validate(tableconfig3, schema));
   }
@@ -4031,7 +4059,7 @@ public class TableConfigUtilsTest {
   @Test
   public void testOverwriteTableConfigForTierFastPathReturnsSameInstance() {
     FieldConfig col1 = new FieldConfig.Builder("col1")
-        .withEncodingType(FieldConfig.EncodingType.DICTIONARY)
+        .withIndexes(indexesWithForwardEncoding(FieldConfig.EncodingType.DICTIONARY))
         .build();
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setFieldConfigList(List.of(col1))
@@ -4729,5 +4757,58 @@ public class TableConfigUtilsTest {
     } catch (IllegalStateException e) {
       assertTrue(e.getMessage().contains("metrics$v2"));
     }
+  }
+
+  private static FieldConfig fieldConfigWithForwardEncoding(String column, FieldConfig.EncodingType encodingType) {
+    return fieldConfigBuilderWithForwardEncoding(column, encodingType).build();
+  }
+
+  private static FieldConfig.Builder fieldConfigBuilderWithForwardEncoding(String column,
+      FieldConfig.EncodingType encodingType) {
+    return new FieldConfig.Builder(column).withIndexes(indexesWithForwardEncoding(encodingType));
+  }
+
+  private static ObjectNode indexesWithForwardEncoding(FieldConfig.EncodingType encodingType) {
+    return withForwardEncoding(JsonUtils.newObjectNode(), encodingType);
+  }
+
+  private static ObjectNode withForwardEncoding(ObjectNode indexes, FieldConfig.EncodingType encodingType) {
+    ObjectNode forward;
+    if (indexes.has("forward") && indexes.get("forward").isObject()) {
+      forward = (ObjectNode) indexes.get("forward");
+    } else {
+      forward = JsonUtils.newObjectNode();
+      indexes.set("forward", forward);
+    }
+    forward.put("encodingType", encodingType.name());
+    return indexes;
+  }
+
+  private static ObjectNode withForwardCompression(ObjectNode indexes, CompressionCodec compressionCodec) {
+    ObjectNode forward;
+    if (indexes.has("forward") && indexes.get("forward").isObject()) {
+      forward = (ObjectNode) indexes.get("forward");
+    } else {
+      forward = JsonUtils.newObjectNode();
+      indexes.set("forward", forward);
+    }
+    forward.put("compressionCodec", compressionCodec.name());
+    return indexes;
+  }
+
+  private static ObjectNode indexesWithDisabledForwardIndex(FieldConfig.EncodingType encodingType) {
+    return withForwardDisabled(indexesWithForwardEncoding(encodingType));
+  }
+
+  private static ObjectNode withForwardDisabled(ObjectNode indexes) {
+    ObjectNode forward;
+    if (indexes.has("forward") && indexes.get("forward").isObject()) {
+      forward = (ObjectNode) indexes.get("forward");
+    } else {
+      forward = JsonUtils.newObjectNode();
+      indexes.set("forward", forward);
+    }
+    forward.put("disabled", true);
+    return indexes;
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -1426,6 +1426,7 @@ public class TableConfigUtilsTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testValidateFieldConfig() {
     Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
         .addDateTime(TIME_COLUMN, DataType.LONG, "1:HOURS:EPOCH", "1:HOURS")
@@ -1438,7 +1439,7 @@ public class TableConfigUtilsTest {
         .build();
 
     try {
-      FieldConfig fieldConfig = new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, null, null, null);
+      FieldConfig fieldConfig = fieldConfigWithForwardEncoding("myCol1", FieldConfig.EncodingType.RAW);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1446,8 +1447,44 @@ public class TableConfigUtilsTest {
     }
 
     try {
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, CompressionCodec.DELTADELTA, null, null);
+      FieldConfig fieldConfig = new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, null, null, null);
+      tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
+      TableConfigUtils.validate(tableConfig, schema);
+      fail("Should fail for deprecated field-level encoding type");
+    } catch (Exception e) {
+      assertEquals(e.getMessage(), "FieldConfig.encodingType is deprecated for column: myCol1. Use "
+          + "fieldConfigList[].indexes.forward.encodingType instead.");
+    }
+
+    try {
+      FieldConfig fieldConfig = new FieldConfig.Builder("myCol1")
+          .withCompressionCodec(CompressionCodec.SNAPPY)
+          .build();
+      tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
+      TableConfigUtils.validate(tableConfig, schema);
+      fail("Should fail for deprecated field-level compression codec");
+    } catch (Exception e) {
+      assertEquals(e.getMessage(), "FieldConfig.compressionCodec is deprecated for column: myCol1. Use "
+          + "fieldConfigList[].indexes.forward.compressionCodec instead.");
+    }
+
+    try {
+      FieldConfig fieldConfig = new FieldConfig.Builder("myCol1")
+          .withProperties(Map.of(FieldConfig.RAW_INDEX_WRITER_VERSION, "4"))
+          .build();
+      tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
+      TableConfigUtils.validate(tableConfig, schema);
+      fail("Should fail for deprecated field-level properties");
+    } catch (Exception e) {
+      assertEquals(e.getMessage(), "FieldConfig.properties is deprecated for column: myCol1. Move these settings into "
+          + "the relevant fieldConfigList[].indexes.<indexName> block instead.");
+    }
+
+    try {
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("myCol1", FieldConfig.EncodingType.RAW)
+          .withIndexes(withForwardCompression(indexesWithForwardEncoding(FieldConfig.EncodingType.RAW),
+              CompressionCodec.DELTADELTA))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1456,8 +1493,10 @@ public class TableConfigUtilsTest {
     }
 
     try {
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol2", FieldConfig.EncodingType.RAW, null, null, CompressionCodec.DELTADELTA, null, null);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("myCol2", FieldConfig.EncodingType.RAW)
+          .withIndexes(withForwardCompression(indexesWithForwardEncoding(FieldConfig.EncodingType.RAW),
+              CompressionCodec.DELTADELTA))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1466,31 +1505,30 @@ public class TableConfigUtilsTest {
     }
 
     try {
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol1", FieldConfig.EncodingType.DICTIONARY, List.of(FieldConfig.IndexType.FST), null,
-              null);
+      FieldConfig fieldConfig = fieldConfigWithForwardEncoding("myCol1", FieldConfig.EncodingType.DICTIONARY);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
-      fail("Should fail for with conflicting encoding type of myCol1");
+      fail("Should fail when forward DICTIONARY encoding conflicts with noDictionaryColumns");
     } catch (Exception e) {
-      assertEquals(e.getMessage(), "FieldConfig encoding type is different from indexingConfig for column: myCol1");
+      assertEquals(e.getMessage(), "Dictionary must be enabled for dictionary-encoded forward index column: myCol1");
     }
 
     // FST on RAW column is valid when explicit dictionary config is provided in indexes
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     ObjectNode rawFstIndexes = JsonUtils.newObjectNode();
     rawFstIndexes.set("dictionary", JsonUtils.newObjectNode());
-    FieldConfig rawFstFieldConfig =
-        new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, Arrays.asList(FieldConfig.IndexType.FST),
-            null, null, rawFstIndexes, null, null);
+    FieldConfig rawFstFieldConfig = new FieldConfig.Builder("myCol1")
+        .withIndexes(withForwardEncoding(rawFstIndexes, FieldConfig.EncodingType.RAW))
+        .withIndexTypes(Arrays.asList(FieldConfig.IndexType.FST))
+        .build();
     tableConfig.setFieldConfigList(Arrays.asList(rawFstFieldConfig));
     TableConfigUtils.validate(tableConfig, schema);
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     try {
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY, List.of(FieldConfig.IndexType.FST), null,
-              null);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("myCol2", FieldConfig.EncodingType.DICTIONARY)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.FST))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       fail("Should fail since FST index is enabled on multi value column");
@@ -1500,9 +1538,9 @@ public class TableConfigUtilsTest {
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     try {
-      FieldConfig fieldConfig =
-          new FieldConfig("intCol", FieldConfig.EncodingType.DICTIONARY, List.of(FieldConfig.IndexType.FST), null,
-              null);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("intCol", FieldConfig.EncodingType.DICTIONARY)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.FST))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       fail("Should fail since FST index is enabled on non String column");
@@ -1514,8 +1552,9 @@ public class TableConfigUtilsTest {
         .setNoDictionaryColumns(Arrays.asList("myCol2", "intCol"))
         .build();
     try {
-      FieldConfig fieldConfig =
-          new FieldConfig("intCol", FieldConfig.EncodingType.RAW, List.of(FieldConfig.IndexType.TEXT), null, null);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("intCol", FieldConfig.EncodingType.RAW)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.TEXT))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       fail("Should fail since TEXT index is enabled on non String column");
@@ -1527,8 +1566,9 @@ public class TableConfigUtilsTest {
         .setNoDictionaryColumns(Arrays.asList("myCol1"))
         .build();
     try {
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol21", FieldConfig.EncodingType.RAW, List.of(FieldConfig.IndexType.FST), null, null);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("myCol21", FieldConfig.EncodingType.RAW)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.FST))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       fail("Should fail since field name is not present in schema");
@@ -1538,8 +1578,11 @@ public class TableConfigUtilsTest {
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     try {
-      FieldConfig fieldConfig = new FieldConfig("intCol", FieldConfig.EncodingType.DICTIONARY, List.of(),
-          CompressionCodec.SNAPPY, null);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("intCol", FieldConfig.EncodingType.DICTIONARY)
+          .withIndexTypes(List.of())
+          .withIndexes(withForwardCompression(indexesWithForwardEncoding(FieldConfig.EncodingType.DICTIONARY),
+              CompressionCodec.SNAPPY))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       fail("Should fail since dictionary encoding does not support compression codec SNAPPY");
@@ -1549,8 +1592,11 @@ public class TableConfigUtilsTest {
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     try {
-      FieldConfig fieldConfig = new FieldConfig("intCol", FieldConfig.EncodingType.RAW, List.of(),
-          CompressionCodec.MV_ENTRY_DICT, null);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("intCol", FieldConfig.EncodingType.RAW)
+          .withIndexTypes(List.of())
+          .withIndexes(withForwardCompression(indexesWithForwardEncoding(FieldConfig.EncodingType.RAW),
+              CompressionCodec.MV_ENTRY_DICT))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       fail("Should fail since raw encoding does not support compression codec MV_ENTRY_DICT");
@@ -1564,10 +1610,9 @@ public class TableConfigUtilsTest {
     try {
       // Enable forward index disabled flag for a raw column. This should succeed as though the forward index cannot
       // be rebuilt without a dictionary, the constraint to have a dictionary has been lifted.
-      Map<String, String> fieldConfigProperties = new HashMap<>();
-      fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, null, null, fieldConfigProperties);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("myCol1", FieldConfig.EncodingType.RAW)
+          .withIndexes(indexesWithDisabledForwardIndex(FieldConfig.EncodingType.RAW))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1578,10 +1623,9 @@ public class TableConfigUtilsTest {
       // Enable forward index disabled flag for a column without inverted index. This should succeed as though the
       // forward index cannot be rebuilt without an inverted index, the constraint to have an inverted index has been
       // lifted.
-      Map<String, String> fieldConfigProperties = new HashMap<>();
-      fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY, null, null, null, null, fieldConfigProperties);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("myCol2", FieldConfig.EncodingType.DICTIONARY)
+          .withIndexes(indexesWithDisabledForwardIndex(FieldConfig.EncodingType.DICTIONARY))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1590,8 +1634,6 @@ public class TableConfigUtilsTest {
 
     try {
       // Enable forward index disabled flag for a column and verify that dictionary override options are not set.
-      Map<String, String> fieldConfigProperties = new HashMap<>();
-      fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
       tableConfig.getIndexingConfig().setOptimizeDictionaryForMetrics(true);
       tableConfig.getIndexingConfig().setOptimizeDictionaryForMetrics(true);
       TableConfigUtils.validate(tableConfig, schema);
@@ -1606,11 +1648,10 @@ public class TableConfigUtilsTest {
         .build();
     try {
       // Enable forward index disabled flag for a column with inverted index
-      Map<String, String> fieldConfigProperties = new HashMap<>();
-      fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.INVERTED, null, null,
-              null, fieldConfigProperties);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("myCol2", FieldConfig.EncodingType.DICTIONARY)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.INVERTED))
+          .withIndexes(indexesWithDisabledForwardIndex(FieldConfig.EncodingType.DICTIONARY))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1624,11 +1665,10 @@ public class TableConfigUtilsTest {
         .build();
     try {
       // Enable forward index disabled flag for a column with inverted index and is sorted
-      Map<String, String> fieldConfigProperties = new HashMap<>();
-      fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol1", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.INVERTED, null, null,
-              null, fieldConfigProperties);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("myCol1", FieldConfig.EncodingType.DICTIONARY)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.INVERTED))
+          .withIndexes(indexesWithDisabledForwardIndex(FieldConfig.EncodingType.DICTIONARY))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1642,12 +1682,10 @@ public class TableConfigUtilsTest {
         .build();
     try {
       // Enable forward index disabled flag for a multi-value column with inverted index and range index
-      Map<String, String> fieldConfigProperties = new HashMap<>();
-      fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.INVERTED,
-              Arrays.asList(FieldConfig.IndexType.INVERTED, FieldConfig.IndexType.RANGE), null, null,
-              fieldConfigProperties);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("myCol2", FieldConfig.EncodingType.DICTIONARY)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.INVERTED, FieldConfig.IndexType.RANGE))
+          .withIndexes(indexesWithDisabledForwardIndex(FieldConfig.EncodingType.DICTIONARY))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       fail("Should fail for MV myCol2 with forward index disabled but has range and inverted index");
@@ -1662,12 +1700,10 @@ public class TableConfigUtilsTest {
         .build();
     try {
       // Enable forward index disabled flag for a singe-value column with inverted index and range index v1
-      Map<String, String> fieldConfigProperties = new HashMap<>();
-      fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol1", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.INVERTED,
-              Arrays.asList(FieldConfig.IndexType.INVERTED, FieldConfig.IndexType.RANGE), null, null,
-              fieldConfigProperties);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("myCol1", FieldConfig.EncodingType.DICTIONARY)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.INVERTED, FieldConfig.IndexType.RANGE))
+          .withIndexes(indexesWithDisabledForwardIndex(FieldConfig.EncodingType.DICTIONARY))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       tableConfig.getIndexingConfig().setRangeIndexVersion(1);
       TableConfigUtils.validate(tableConfig, schema);
@@ -1684,11 +1720,10 @@ public class TableConfigUtilsTest {
         .build();
     try {
       // Enable forward index disabled flag for a column with inverted index and disable dictionary
-      Map<String, String> fieldConfigProperties = new HashMap<>();
-      fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol2", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.INVERTED, null, null, null,
-              fieldConfigProperties);
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("myCol2", FieldConfig.EncodingType.RAW)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.INVERTED))
+          .withIndexes(indexesWithDisabledForwardIndex(FieldConfig.EncodingType.RAW))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       fail("Should not be able to disable dictionary but keep inverted index");
@@ -1700,10 +1735,9 @@ public class TableConfigUtilsTest {
     // producing a shared-dict + RAW forward index. No validation error expected.
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     {
-      FieldConfig fieldConfig =
-          new FieldConfig.Builder("myCol2").withIndexTypes(Arrays.asList(FieldConfig.IndexType.INVERTED))
-              .withEncodingType(FieldConfig.EncodingType.RAW)
-              .build();
+      FieldConfig fieldConfig = fieldConfigBuilderWithForwardEncoding("myCol2", FieldConfig.EncodingType.RAW)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.INVERTED))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
     }
@@ -1713,11 +1747,10 @@ public class TableConfigUtilsTest {
         .build();
     try {
       // Enable forward index disabled flag for a column with FST index and disable dictionary
-      Map<String, String> fieldConfigProperties = new HashMap<>();
-      fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
-      FieldConfig fieldConfigWithFst =
-          new FieldConfig("myCol2", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.FST, null, null, null,
-              fieldConfigProperties);
+      FieldConfig fieldConfigWithFst = fieldConfigBuilderWithForwardEncoding("myCol2", FieldConfig.EncodingType.RAW)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.FST))
+          .withIndexes(indexesWithDisabledForwardIndex(FieldConfig.EncodingType.RAW))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfigWithFst));
       TableConfigUtils.validate(tableConfig, schema);
       fail("Should not be able to disable dictionary but keep FST index");
@@ -1734,11 +1767,10 @@ public class TableConfigUtilsTest {
         .build();
     try {
       // Enable forward index disabled flag for a column with FST index and disable dictionary
-      Map<String, String> fieldConfigProperties = new HashMap<>();
-      fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
-      FieldConfig fieldConfigWithRange =
-          new FieldConfig("intCol", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.RANGE, null, null, null,
-              fieldConfigProperties);
+      FieldConfig fieldConfigWithRange = fieldConfigBuilderWithForwardEncoding("intCol", FieldConfig.EncodingType.RAW)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.RANGE))
+          .withIndexes(indexesWithDisabledForwardIndex(FieldConfig.EncodingType.RAW))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfigWithRange));
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1753,13 +1785,12 @@ public class TableConfigUtilsTest {
         .build();
     try {
       // Enable forward index disabled flag for a column with inverted index index and disable dictionary
-      Map<String, String> fieldConfigProperties = new HashMap<>();
-      fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
       ObjectNode indexes = JsonUtils.newObjectNode();
       indexes.set("dictionary", JsonUtils.newObjectNode());
-      FieldConfig realtimeFieldConfig =
-          new FieldConfig("intCol", FieldConfig.EncodingType.RAW, null, Arrays.asList(FieldConfig.IndexType.INVERTED),
-              null, null, indexes, fieldConfigProperties, null);
+      FieldConfig realtimeFieldConfig = new FieldConfig.Builder("intCol")
+          .withIndexes(withForwardDisabled(withForwardEncoding(indexes, FieldConfig.EncodingType.RAW)))
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.INVERTED))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(realtimeFieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1770,9 +1801,9 @@ public class TableConfigUtilsTest {
     // and validation passes — the runtime builds a shared-dict + RAW forward index.
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     {
-      FieldConfig rawInvertedConfig =
-          new FieldConfig("intCol", FieldConfig.EncodingType.RAW,
-              Arrays.asList(FieldConfig.IndexType.INVERTED), null, null);
+      FieldConfig rawInvertedConfig = fieldConfigBuilderWithForwardEncoding("intCol", FieldConfig.EncodingType.RAW)
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.INVERTED))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(rawInvertedConfig));
       TableConfigUtils.validate(tableConfig, schema);
     }
@@ -1782,9 +1813,10 @@ public class TableConfigUtilsTest {
     try {
       ObjectNode dictIndexes = JsonUtils.newObjectNode();
       dictIndexes.set("dictionary", JsonUtils.newObjectNode());
-      FieldConfig rawInvertedWithDictConfig =
-          new FieldConfig("intCol", FieldConfig.EncodingType.RAW, null,
-              Arrays.asList(FieldConfig.IndexType.INVERTED), null, null, dictIndexes, null, null);
+      FieldConfig rawInvertedWithDictConfig = new FieldConfig.Builder("intCol")
+          .withIndexes(withForwardEncoding(dictIndexes, FieldConfig.EncodingType.RAW))
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.INVERTED))
+          .build();
       tableConfig.setFieldConfigList(Arrays.asList(rawInvertedWithDictConfig));
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1800,8 +1832,8 @@ public class TableConfigUtilsTest {
     final TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName(TABLE_NAME).build();
 
-    final FieldConfig fc1 = new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, null, null, null);
-    final FieldConfig fc2 = new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, null, null, null);
+    final FieldConfig fc1 = fieldConfigWithForwardEncoding("myCol1", FieldConfig.EncodingType.RAW);
+    final FieldConfig fc2 = fieldConfigWithForwardEncoding("myCol1", FieldConfig.EncodingType.RAW);
     tableConfig.setFieldConfigList(Arrays.asList(fc1, fc2));
 
     try {
@@ -1820,9 +1852,8 @@ public class TableConfigUtilsTest {
     final TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName(TABLE_NAME).build();
 
-    final FieldConfig fc1 = new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, null, null, null);
-    final FieldConfig fc2 =
-        new FieldConfig("myCol1", FieldConfig.EncodingType.DICTIONARY, null, null, null, null, null);
+    final FieldConfig fc1 = fieldConfigWithForwardEncoding("myCol1", FieldConfig.EncodingType.RAW);
+    final FieldConfig fc2 = fieldConfigWithForwardEncoding("myCol1", FieldConfig.EncodingType.DICTIONARY);
     tableConfig.setFieldConfigList(Arrays.asList(fc1, fc2));
 
     try {
@@ -1845,10 +1876,9 @@ public class TableConfigUtilsTest {
     final ObjectNode indexes = JsonNodeFactory.instance.objectNode();
     indexes.set("forward", JsonNodeFactory.instance.objectNode().put("compressionCodec", "ZSTANDARD"));
     final FieldConfig fc1 = new FieldConfig.Builder("myCol1")
-        .withEncodingType(FieldConfig.EncodingType.RAW)
-        .withIndexes(indexes)
+        .withIndexes(withForwardEncoding(indexes, FieldConfig.EncodingType.RAW))
         .build();
-    final FieldConfig fc2 = new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, null, null, null);
+    final FieldConfig fc2 = fieldConfigWithForwardEncoding("myCol1", FieldConfig.EncodingType.RAW);
     tableConfig.setFieldConfigList(Arrays.asList(fc1, fc2));
 
     try {
@@ -1868,9 +1898,8 @@ public class TableConfigUtilsTest {
     final TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName(TABLE_NAME).build();
 
-    final FieldConfig fc1 = new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, null, null, null);
-    final FieldConfig fc2 =
-        new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY, null, null, null, null, null);
+    final FieldConfig fc1 = fieldConfigWithForwardEncoding("myCol1", FieldConfig.EncodingType.RAW);
+    final FieldConfig fc2 = fieldConfigWithForwardEncoding("myCol2", FieldConfig.EncodingType.DICTIONARY);
     tableConfig.setFieldConfigList(Arrays.asList(fc1, fc2));
 
     try {
@@ -1888,7 +1917,7 @@ public class TableConfigUtilsTest {
     final TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName(TABLE_NAME).build();
 
-    final FieldConfig fc1 = new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, null, null, null);
+    final FieldConfig fc1 = fieldConfigWithForwardEncoding("myCol1", FieldConfig.EncodingType.RAW);
     tableConfig.setFieldConfigList(Arrays.asList(fc1));
 
     try {
@@ -1982,8 +2011,7 @@ public class TableConfigUtilsTest {
     TableConfig tableconfig3 = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).build();
     ObjectNode indexesNode = JsonNodeFactory.instance.objectNode();
     indexesNode.putObject("bloom");
-    FieldConfig fieldConfig =
-        new FieldConfig("MyCol", FieldConfig.EncodingType.DICTIONARY, null, null, null, null, indexesNode, null, null);
+    FieldConfig fieldConfig = new FieldConfig.Builder("MyCol").withIndexes(indexesNode).build();
     tableconfig3.setFieldConfigList(Arrays.asList(fieldConfig));
     assertThrows(IllegalStateException.class, () -> TableConfigUtils.validate(tableconfig3, schema));
   }
@@ -3990,7 +4018,7 @@ public class TableConfigUtilsTest {
   @Test
   public void testOverwriteTableConfigForTierFastPathReturnsSameInstance() {
     FieldConfig col1 = new FieldConfig.Builder("col1")
-        .withEncodingType(FieldConfig.EncodingType.DICTIONARY)
+        .withIndexes(indexesWithForwardEncoding(FieldConfig.EncodingType.DICTIONARY))
         .build();
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setFieldConfigList(List.of(col1))
@@ -4638,5 +4666,58 @@ public class TableConfigUtilsTest {
     } catch (IllegalStateException e) {
       assertTrue(e.getMessage().contains("metrics$v2"));
     }
+  }
+
+  private static FieldConfig fieldConfigWithForwardEncoding(String column, FieldConfig.EncodingType encodingType) {
+    return fieldConfigBuilderWithForwardEncoding(column, encodingType).build();
+  }
+
+  private static FieldConfig.Builder fieldConfigBuilderWithForwardEncoding(String column,
+      FieldConfig.EncodingType encodingType) {
+    return new FieldConfig.Builder(column).withIndexes(indexesWithForwardEncoding(encodingType));
+  }
+
+  private static ObjectNode indexesWithForwardEncoding(FieldConfig.EncodingType encodingType) {
+    return withForwardEncoding(JsonUtils.newObjectNode(), encodingType);
+  }
+
+  private static ObjectNode withForwardEncoding(ObjectNode indexes, FieldConfig.EncodingType encodingType) {
+    ObjectNode forward;
+    if (indexes.has("forward") && indexes.get("forward").isObject()) {
+      forward = (ObjectNode) indexes.get("forward");
+    } else {
+      forward = JsonUtils.newObjectNode();
+      indexes.set("forward", forward);
+    }
+    forward.put("encodingType", encodingType.name());
+    return indexes;
+  }
+
+  private static ObjectNode withForwardCompression(ObjectNode indexes, CompressionCodec compressionCodec) {
+    ObjectNode forward;
+    if (indexes.has("forward") && indexes.get("forward").isObject()) {
+      forward = (ObjectNode) indexes.get("forward");
+    } else {
+      forward = JsonUtils.newObjectNode();
+      indexes.set("forward", forward);
+    }
+    forward.put("compressionCodec", compressionCodec.name());
+    return indexes;
+  }
+
+  private static ObjectNode indexesWithDisabledForwardIndex(FieldConfig.EncodingType encodingType) {
+    return withForwardDisabled(indexesWithForwardEncoding(encodingType));
+  }
+
+  private static ObjectNode withForwardDisabled(ObjectNode indexes) {
+    ObjectNode forward;
+    if (indexes.has("forward") && indexes.get("forward").isObject()) {
+      forward = (ObjectNode) indexes.get("forward");
+    } else {
+      forward = JsonUtils.newObjectNode();
+      indexes.set("forward", forward);
+    }
+    forward.put("disabled", true);
+    return indexes;
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/AbstractIndexType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/AbstractIndexType.java
@@ -129,7 +129,6 @@ public abstract class AbstractIndexType<C extends IndexConfig, IR extends IndexR
         JsonNode indexes = new ObjectMapper().createObjectNode().set(getPrettyName(), configValue.toJsonNode());
         FieldConfig.Builder builder = new FieldConfig.Builder(entry.getKey());
         builder.withIndexes(indexes);
-        builder.withEncodingType(FieldConfig.EncodingType.DICTIONARY);
         fieldConfigList.add(builder.build());
       }
     }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/FieldIndexConfigsUtil.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/FieldIndexConfigsUtil.java
@@ -58,7 +58,7 @@ public class FieldIndexConfigsUtil {
   }
 
   /// Builds a [FieldIndexConfigs] for a single column directly from one [FieldConfig], without a
-  /// `TableConfig` or `Schema`. The dictionary entry is derived from `fieldConfig.getEncodingType()`
+  /// `TableConfig` or `Schema`. The dictionary entry is derived from `fieldConfig.indexes.forward.encodingType`
   /// (RAW => disabled, otherwise default-enabled); every other index type is read from the modern
   /// `fieldConfig.getIndexes()` JSON (keyed by index pretty name), falling back to each type's default config.
   /// A `null` fieldConfig yields built-in defaults (dictionary enabled).
@@ -67,7 +67,7 @@ public class FieldIndexConfigsUtil {
   /// synthetic columns (e.g. OPEN_STRUCT materialized children) that exist in no schema.
   public static FieldIndexConfigs fromFieldConfig(@Nullable FieldConfig fieldConfig, FieldSpec fieldSpec) {
     FieldIndexConfigs.Builder builder = new FieldIndexConfigs.Builder();
-    boolean rawEncoded = fieldConfig != null && fieldConfig.getEncodingType() == FieldConfig.EncodingType.RAW;
+    boolean rawEncoded = isRawForwardEncoded(fieldConfig);
     builder.add(StandardIndexes.dictionary(),
         rawEncoded ? DictionaryIndexConfig.DISABLED : DictionaryIndexConfig.DEFAULT);
     JsonNode indexes = fieldConfig != null ? fieldConfig.getIndexes() : null;
@@ -78,6 +78,24 @@ public class FieldIndexConfigsUtil {
       addConfigFromIndexes(builder, indexType, indexes);
     }
     return builder.build();
+  }
+
+  @SuppressWarnings("deprecation")
+  private static boolean isRawForwardEncoded(@Nullable FieldConfig fieldConfig) {
+    if (fieldConfig == null) {
+      return false;
+    }
+    JsonNode indexes = fieldConfig.getIndexes();
+    JsonNode forward = indexes != null ? indexes.get("forward") : null;
+    if (forward != null && forward.isObject()) {
+      try {
+        return JsonUtils.jsonNodeToObject(forward, ForwardIndexConfig.class).getEncodingType()
+            == FieldConfig.EncodingType.RAW;
+      } catch (IOException e) {
+        throw new IllegalArgumentException("Failed to parse forward index config from FieldConfig", e);
+      }
+    }
+    return fieldConfig.getEncodingType() == FieldConfig.EncodingType.RAW;
   }
 
   private static <C extends IndexConfig> void addConfigFromIndexes(FieldIndexConfigs.Builder builder,

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
@@ -98,8 +98,8 @@ public class ForwardIndexConfig extends IndexConfig {
   private ForwardIndexConfig(@JsonProperty("disabled") @Nullable Boolean disabled,
       @JsonProperty("encodingType") @Nullable EncodingType encodingType,
       @JsonProperty("compressionCodec") @Nullable CompressionCodec compressionCodec,
-      @Deprecated @JsonProperty("chunkCompressionType") @Nullable ChunkCompressionType chunkCompressionType,
-      @Deprecated @JsonProperty("dictIdCompressionType") @Nullable DictIdCompressionType dictIdCompressionType,
+      @JsonProperty("chunkCompressionType") @Nullable ChunkCompressionType chunkCompressionType,
+      @JsonProperty("dictIdCompressionType") @Nullable DictIdCompressionType dictIdCompressionType,
       @JsonProperty("deriveNumDocsPerChunk") @Nullable Boolean deriveNumDocsPerChunk,
       @JsonProperty("rawIndexWriterVersion") @Nullable Integer rawIndexWriterVersion,
       @JsonProperty("targetMaxChunkSize") @Nullable String targetMaxChunkSize,
@@ -108,7 +108,7 @@ public class ForwardIndexConfig extends IndexConfig {
     super(disabled);
     // Backward-compat for legacy JSON that lacks `encodingType`: default to DICTIONARY (matches the historical
     // implicit behavior where ForwardIndexConfig had no encoding distinction). Programmatic callers must use
-    // Builder(EncodingType) and pass an explicit value, typically from FieldConfig.getEncodingType().
+    // Builder(EncodingType) and pass the resolved forward-index encoding.
     _encodingType = encodingType == null ? EncodingType.DICTIONARY : encodingType;
     _compressionCodec = getActualCompressionCodec(compressionCodec, chunkCompressionType, dictIdCompressionType);
     _deriveNumDocsPerChunk = Boolean.TRUE.equals(deriveNumDocsPerChunk);
@@ -285,8 +285,7 @@ public class ForwardIndexConfig extends IndexConfig {
     private int _targetDocsPerChunk = _defaultTargetDocsPerChunk;
     private Map<String, Object> _configs = new HashMap<>();
 
-    /// Constructs a builder with the given forward-index encoding. Callers should pass `FieldConfig.getEncodingType()`
-    /// so the forward-index encoding stays consistent with the column-level encoding.
+    /// Constructs a builder with the given forward-index encoding.
     public Builder(EncodingType encodingType) {
       _encodingType = Preconditions.checkNotNull(encodingType, "encodingType must not be null");
     }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
@@ -117,7 +117,7 @@ public class ForwardIndexConfig extends IndexConfig {
     super(disabled);
     // Backward-compat for legacy JSON that lacks `encodingType`: default to DICTIONARY (matches the historical
     // implicit behavior where ForwardIndexConfig had no encoding distinction). Programmatic callers must use
-    // Builder(EncodingType) and pass an explicit value, typically from FieldConfig.getEncodingType().
+    // Builder(EncodingType) and pass the resolved forward-index encoding.
     _encodingType = encodingType == null ? EncodingType.DICTIONARY : encodingType;
     _compressionCodec = getActualCompressionCodec(compressionCodec, chunkCompressionType, dictIdCompressionType);
     if (_compressionCodec != null && codecSpec != null) {
@@ -313,8 +313,7 @@ public class ForwardIndexConfig extends IndexConfig {
     private int _targetDocsPerChunk = _defaultTargetDocsPerChunk;
     private Map<String, Object> _configs = new HashMap<>();
 
-    /// Constructs a builder with the given forward-index encoding. Callers should pass `FieldConfig.getEncodingType()`
-    /// so the forward-index encoding stays consistent with the column-level encoding.
+    /// Constructs a builder with the given forward-index encoding.
     public Builder(EncodingType encodingType) {
       _encodingType = Preconditions.checkNotNull(encodingType, "encodingType must not be null");
     }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/IndexType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/IndexType.java
@@ -169,7 +169,7 @@ public interface IndexType<C extends IndexConfig, IR extends IndexReader, IC ext
   ///     (inverted, fst/ifst, range).
   ///   - Return `false` when the index is computed from raw column values and is therefore identical regardless of
   ///     dictionary presence (bloom, json, text, vector, h3, null-value, forward index — encoding is reconciled
-  ///     with FieldConfig.encodingType independently of dictionary state).
+  ///     with ForwardIndexConfig independently of dictionary state).
   ///   - The dictionary index type itself returns `false` — the dictionary *is* what is changing; its own rebuild
   ///     is driven by the dictionary handler, not by this hook.
   ///   - This must be a pure function of `fieldSpec` and `indexConfig`. Implementations should NOT short-circuit

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.spi.config.table;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NullNode;
@@ -72,11 +73,16 @@ public class FieldConfig extends BaseJsonConfig {
       "luceneNRTCachingDirectoryMaxBufferSizeMB";
 
   private final String _name;
+  @JsonProperty("encodingType")
+  @Nullable
+  @Deprecated
   private final EncodingType _encodingType;
   private final List<IndexType> _indexTypes;
   private final JsonNode _indexes;
   private final JsonNode _tierOverwrites;
+  @Deprecated
   private final CompressionCodec _compressionCodec;
+  @Deprecated
   private final Map<String, String> _properties;
   private final TimestampConfig _timestampConfig;
 
@@ -104,7 +110,7 @@ public class FieldConfig extends BaseJsonConfig {
       @JsonProperty(value = "tierOverwrites") @Nullable JsonNode tierOverwrites) {
     Preconditions.checkArgument(name != null, "'name' must be configured");
     _name = name;
-    _encodingType = encodingType == null ? EncodingType.DICTIONARY : encodingType;
+    _encodingType = encodingType;
     _indexTypes =
         indexTypes != null ? indexTypes : (indexType == null ? Lists.newArrayList() : Lists.newArrayList(indexType));
     _compressionCodec = compressionCodec;
@@ -190,8 +196,32 @@ public class FieldConfig extends BaseJsonConfig {
     return _name;
   }
 
+  /// Returns the legacy field-level forward-index encoding.
+  ///
+  /// Prefer configuring and reading `encodingType` from `indexes.forward`. This method keeps backward-compatible
+  /// defaulting for older configs: when the deprecated field-level value is absent, it returns `DICTIONARY`.
+  @JsonIgnore
+  @Deprecated
   public EncodingType getEncodingType() {
-    return _encodingType;
+    return _encodingType == null ? EncodingType.DICTIONARY : _encodingType;
+  }
+
+  /// Returns whether the deprecated field-level forward-index encoding was explicitly configured.
+  @JsonIgnore
+  public boolean hasFieldLevelEncodingType() {
+    return _encodingType != null;
+  }
+
+  /// Returns whether the deprecated field-level forward-index compression codec was explicitly configured.
+  @JsonIgnore
+  public boolean hasFieldLevelCompressionCodec() {
+    return _compressionCodec != null;
+  }
+
+  /// Returns whether the deprecated field-level index properties map was explicitly configured.
+  @JsonIgnore
+  public boolean hasFieldLevelProperties() {
+    return _properties != null;
   }
 
   @Nullable
@@ -213,6 +243,7 @@ public class FieldConfig extends BaseJsonConfig {
   }
 
   @Nullable
+  @Deprecated
   public CompressionCodec getCompressionCodec() {
     return _compressionCodec;
   }
@@ -223,6 +254,7 @@ public class FieldConfig extends BaseJsonConfig {
   }
 
   @Nullable
+  @Deprecated
   public Map<String, String> getProperties() {
     return _properties;
   }
@@ -262,6 +294,10 @@ public class FieldConfig extends BaseJsonConfig {
       return this;
     }
 
+    /// Sets the deprecated field-level forward-index encoding.
+    ///
+    /// Prefer `indexes.forward.encodingType` for new configs.
+    @Deprecated
     public Builder withEncodingType(EncodingType encodingType) {
       _encodingType = encodingType;
       return this;
@@ -272,11 +308,19 @@ public class FieldConfig extends BaseJsonConfig {
       return this;
     }
 
+    /// Sets the deprecated field-level forward-index compression codec.
+    ///
+    /// Prefer `indexes.forward.compressionCodec` for new configs.
+    @Deprecated
     public Builder withCompressionCodec(CompressionCodec compressionCodec) {
       _compressionCodec = compressionCodec;
       return this;
     }
 
+    /// Sets the deprecated field-level index properties map.
+    ///
+    /// Prefer the relevant `indexes.<indexName>` block for new configs.
+    @Deprecated
     public Builder withProperties(Map<String, String> properties) {
       _properties = properties;
       return this;

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/FieldConfigTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/FieldConfigTest.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.table;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+public class FieldConfigTest {
+  @Test
+  @SuppressWarnings("deprecation")
+  public void missingDeprecatedEncodingTypeDefaultsToDictionaryButDoesNotSerialize()
+      throws IOException {
+    FieldConfig fieldConfig = JsonUtils.stringToObject("{\"name\":\"col\"}", FieldConfig.class);
+
+    assertEquals(fieldConfig.getEncodingType(), FieldConfig.EncodingType.DICTIONARY);
+    assertFalse(fieldConfig.hasFieldLevelEncodingType());
+    assertFalse(fieldConfig.hasFieldLevelCompressionCodec());
+    assertFalse(fieldConfig.hasFieldLevelProperties());
+    assertFalse(fieldConfig.toJsonNode().has("encodingType"));
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void explicitDeprecatedEncodingTypeIsPreservedForBackwardCompatibility()
+      throws IOException {
+    FieldConfig fieldConfig = JsonUtils.stringToObject("{\"name\":\"col\",\"encodingType\":\"RAW\"}",
+        FieldConfig.class);
+    JsonNode jsonNode = fieldConfig.toJsonNode();
+
+    assertEquals(fieldConfig.getEncodingType(), FieldConfig.EncodingType.RAW);
+    assertTrue(fieldConfig.hasFieldLevelEncodingType());
+    assertEquals(jsonNode.get("encodingType").asText(), FieldConfig.EncodingType.RAW.name());
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void explicitDeprecatedCompressionCodecAndPropertiesArePreservedForBackwardCompatibility()
+      throws IOException {
+    FieldConfig fieldConfig = JsonUtils.stringToObject(
+        "{\"name\":\"col\",\"compressionCodec\":\"SNAPPY\",\"properties\":{\"rawIndexWriterVersion\":\"4\"}}",
+        FieldConfig.class);
+    JsonNode jsonNode = fieldConfig.toJsonNode();
+
+    assertEquals(fieldConfig.getCompressionCodec(), FieldConfig.CompressionCodec.SNAPPY);
+    assertTrue(fieldConfig.hasFieldLevelCompressionCodec());
+    assertEquals(fieldConfig.getProperties().get(FieldConfig.RAW_INDEX_WRITER_VERSION), "4");
+    assertTrue(fieldConfig.hasFieldLevelProperties());
+    assertEquals(jsonNode.get("compressionCodec").asText(), FieldConfig.CompressionCodec.SNAPPY.name());
+    assertEquals(jsonNode.get("properties").get(FieldConfig.RAW_INDEX_WRITER_VERSION).asText(), "4");
+  }
+}

--- a/pinot-tools/src/main/resources/conf/sample_offline_table_config.json
+++ b/pinot-tools/src/main/resources/conf/sample_offline_table_config.json
@@ -20,6 +20,18 @@
       "column2"
     ]
   },
+  "fieldConfigList": [
+    {
+      "name": "dim1",
+      "indexes": {
+        "forward": {
+          "encodingType": "RAW"
+        },
+        "text": {
+        }
+      }
+    }
+  ],
   "metadata": {
     "customConfigs": {
     }

--- a/pinot-tools/src/main/resources/examples/batch/airlineStats/airlineStats_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/airlineStats/airlineStats_offline_table_config.json
@@ -11,7 +11,6 @@
   "fieldConfigList": [
     {
       "name": "ts",
-      "encodingType": "DICTIONARY",
       "indexTypes": [
         "TIMESTAMP"
       ],
@@ -21,14 +20,21 @@
           "WEEK",
           "MONTH"
         ]
+      },
+      "indexes": {
+        "forward": {
+          "encodingType": "DICTIONARY"
+        }
       }
     },
     {
       "name": "ArrTimeBlk",
-      "encodingType": "DICTIONARY",
       "indexes": {
         "inverted": {
           "enabled": "true"
+        },
+        "forward": {
+          "encodingType": "DICTIONARY"
         }
       },
       "tierOverwrites": {

--- a/pinot-tools/src/main/resources/examples/batch/fineFoodReviews/fineFoodReviews_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/fineFoodReviews/fineFoodReviews_offline_table_config.json
@@ -5,42 +5,52 @@
     "segmentPushType": "APPEND",
     "replication": "1"
   },
-  "tenants": {
-  },
+  "tenants": {},
   "tableIndexConfig": {
     "loadMode": "MMAP",
-    "noDictionaryColumns": ["Text"],
-    "invertedIndexColumns": [
+    "noDictionaryColumns": [
+      "Text"
     ],
+    "invertedIndexColumns": [],
     "multiColumnTextIndexConfig": {
-      "columns": ["UserId", "ProductId", "Summary"]
+      "columns": [
+        "UserId",
+        "ProductId",
+        "Summary"
+      ]
     }
   },
   "metadata": {
-    "customConfigs": {
-    }
+    "customConfigs": {}
   },
   "fieldConfigList": [
     {
-      "encodingType": "RAW",
-      "indexType": "VECTOR",
       "name": "embedding",
-      "properties": {
-        "vectorIndexType": "HNSW",
-        "vectorDimension": 1536,
-        "vectorDistanceFunction": "COSINE",
-        "version": 1,
-        "commitDocs": "1"
+      "indexes": {
+        "vector": {
+          "vectorIndexType": "HNSW",
+          "vectorDimension": 1536,
+          "vectorDistanceFunction": "COSINE",
+          "version": 1,
+          "properties": {
+            "commitDocs": "1"
+          }
+        },
+        "forward": {
+          "encodingType": "RAW"
+        }
       }
     },
     {
       "name": "Text",
-      "encodingType": "RAW",
       "indexes": {
         "text": {
           "deriveNumDocsPerChunkForRawIndex": "true",
           "rawIndexWriterVersion": "3",
           "caseSensitive": "true"
+        },
+        "forward": {
+          "encodingType": "RAW"
         }
       }
     }

--- a/pinot-tools/src/main/resources/examples/batch/githubComplexTypeEvents/githubComplexTypeEvents_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/githubComplexTypeEvents/githubComplexTypeEvents_offline_table_config.json
@@ -1,8 +1,7 @@
 {
   "tableName": "githubComplexTypeEvents",
   "tableType": "OFFLINE",
-  "tenants": {
-  },
+  "tenants": {},
   "segmentsConfig": {
     "segmentPushType": "REFRESH",
     "replication": "1",
@@ -14,11 +13,13 @@
   "fieldConfigList": [
     {
       "name": "commits_url",
-      "encodingType": "RAW",
       "indexes": {
         "dictionary": {},
         "inverted": {
           "enabled": "true"
+        },
+        "forward": {
+          "encodingType": "RAW"
         }
       }
     }
@@ -49,7 +50,6 @@
     }
   },
   "metadata": {
-    "customConfigs": {
-    }
+    "customConfigs": {}
   }
 }

--- a/pinot-tools/src/main/resources/examples/batch/starbucksStores/starbucksStores_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/starbucksStores/starbucksStores_offline_table_config.json
@@ -7,15 +7,19 @@
     "segmentPushType": "APPEND",
     "replication": "1"
   },
-  "tenants": {
-  },
+  "tenants": {},
   "fieldConfigList": [
     {
       "name": "location_st_point",
-      "encodingType": "RAW",
-      "indexType": "H3",
-      "properties": {
-        "resolutions": "5"
+      "indexes": {
+        "h3": {
+          "resolution": [
+            5
+          ]
+        },
+        "forward": {
+          "encodingType": "RAW"
+        }
       }
     }
   ],
@@ -26,7 +30,6 @@
     ]
   },
   "metadata": {
-    "customConfigs": {
-    }
+    "customConfigs": {}
   }
 }

--- a/pinot-tools/src/main/resources/examples/stream/airlineStats/airlineStats_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/airlineStats/airlineStats_realtime_table_config.json
@@ -43,7 +43,6 @@
   "fieldConfigList": [
     {
       "name": "ts",
-      "encodingType": "DICTIONARY",
       "indexTypes": [
         "TIMESTAMP"
       ],
@@ -53,6 +52,11 @@
           "WEEK",
           "MONTH"
         ]
+      },
+      "indexes": {
+        "forward": {
+          "encodingType": "DICTIONARY"
+        }
       }
     }
   ],

--- a/pinot-tools/src/main/resources/examples/stream/fineFoodReviews/fineFoodReviews_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/fineFoodReviews/fineFoodReviews_realtime_table_config.json
@@ -8,13 +8,18 @@
     "retentionTimeValue": "5",
     "replication": "1"
   },
-  "tenants": {
-  },
+  "tenants": {},
   "tableIndexConfig": {
     "loadMode": "MMAP",
-    "noDictionaryColumns": ["Text"],
+    "noDictionaryColumns": [
+      "Text"
+    ],
     "multiColumnTextIndexConfig": {
-      "columns": ["UserId", "ProductId", "Summary"]
+      "columns": [
+        "UserId",
+        "ProductId",
+        "Summary"
+      ]
     }
   },
   "routing": {
@@ -45,30 +50,36 @@
     ]
   },
   "metadata": {
-    "customConfigs": {
-    }
+    "customConfigs": {}
   },
   "fieldConfigList": [
     {
-      "encodingType": "RAW",
-      "indexType": "VECTOR",
       "name": "embedding",
-      "properties": {
-        "vectorIndexType": "HNSW",
-        "vectorDimension": 1536,
-        "vectorDistanceFunction": "COSINE",
-        "version": 1,
-        "commitDocs": "1"
+      "indexes": {
+        "vector": {
+          "vectorIndexType": "HNSW",
+          "vectorDimension": 1536,
+          "vectorDistanceFunction": "COSINE",
+          "version": 1,
+          "properties": {
+            "commitDocs": "1"
+          }
+        },
+        "forward": {
+          "encodingType": "RAW"
+        }
       }
     },
     {
       "name": "Text",
-      "encodingType": "RAW",
       "indexes": {
         "text": {
           "deriveNumDocsPerChunkForRawIndex": "true",
           "rawIndexWriterVersion": "3",
           "caseSensitive": "false"
+        },
+        "forward": {
+          "encodingType": "RAW"
         }
       }
     }

--- a/pinot-tools/src/main/resources/examples/stream/fineFoodReviews_part_0/fineFoodReviews_part_0_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/fineFoodReviews_part_0/fineFoodReviews_part_0_realtime_table_config.json
@@ -8,13 +8,18 @@
     "retentionTimeValue": "5",
     "replication": "1"
   },
-  "tenants": {
-  },
+  "tenants": {},
   "tableIndexConfig": {
     "loadMode": "MMAP",
-    "noDictionaryColumns": ["Text"],
+    "noDictionaryColumns": [
+      "Text"
+    ],
     "multiColumnTextIndexConfig": {
-      "columns": ["UserId", "ProductId", "Summary"]
+      "columns": [
+        "UserId",
+        "ProductId",
+        "Summary"
+      ]
     }
   },
   "routing": {
@@ -46,30 +51,36 @@
     ]
   },
   "metadata": {
-    "customConfigs": {
-    }
+    "customConfigs": {}
   },
   "fieldConfigList": [
     {
-      "encodingType": "RAW",
-      "indexType": "VECTOR",
       "name": "embedding",
-      "properties": {
-        "vectorIndexType": "HNSW",
-        "vectorDimension": 1536,
-        "vectorDistanceFunction": "COSINE",
-        "version": 1,
-        "commitDocs": "1"
+      "indexes": {
+        "vector": {
+          "vectorIndexType": "HNSW",
+          "vectorDimension": 1536,
+          "vectorDistanceFunction": "COSINE",
+          "version": 1,
+          "properties": {
+            "commitDocs": "1"
+          }
+        },
+        "forward": {
+          "encodingType": "RAW"
+        }
       }
     },
     {
       "name": "Text",
-      "encodingType": "RAW",
       "indexes": {
         "text": {
           "deriveNumDocsPerChunkForRawIndex": "true",
           "rawIndexWriterVersion": "3",
           "caseSensitive": "false"
+        },
+        "forward": {
+          "encodingType": "RAW"
         }
       }
     }

--- a/pinot-tools/src/main/resources/examples/stream/fineFoodReviews_part_1/fineFoodReviews_part_1_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/fineFoodReviews_part_1/fineFoodReviews_part_1_realtime_table_config.json
@@ -8,13 +8,18 @@
     "retentionTimeValue": "5",
     "replication": "1"
   },
-  "tenants": {
-  },
+  "tenants": {},
   "tableIndexConfig": {
     "loadMode": "MMAP",
-    "noDictionaryColumns": ["Text"],
+    "noDictionaryColumns": [
+      "Text"
+    ],
     "multiColumnTextIndexConfig": {
-      "columns": ["UserId", "ProductId", "Summary"]
+      "columns": [
+        "UserId",
+        "ProductId",
+        "Summary"
+      ]
     }
   },
   "routing": {
@@ -46,30 +51,36 @@
     ]
   },
   "metadata": {
-    "customConfigs": {
-    }
+    "customConfigs": {}
   },
   "fieldConfigList": [
     {
-      "encodingType": "RAW",
-      "indexType": "VECTOR",
       "name": "embedding",
-      "properties": {
-        "vectorIndexType": "HNSW",
-        "vectorDimension": 1536,
-        "vectorDistanceFunction": "COSINE",
-        "version": 1,
-        "commitDocs": "1"
+      "indexes": {
+        "vector": {
+          "vectorIndexType": "HNSW",
+          "vectorDimension": 1536,
+          "vectorDistanceFunction": "COSINE",
+          "version": 1,
+          "properties": {
+            "commitDocs": "1"
+          }
+        },
+        "forward": {
+          "encodingType": "RAW"
+        }
       }
     },
     {
       "name": "Text",
-      "encodingType": "RAW",
       "indexes": {
         "text": {
           "deriveNumDocsPerChunkForRawIndex": "true",
           "rawIndexWriterVersion": "3",
           "caseSensitive": "false"
+        },
+        "forward": {
+          "encodingType": "RAW"
         }
       }
     }

--- a/pinot-tools/src/main/resources/examples/stream/meetupRsvp/meetupRsvp_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/meetupRsvp/meetupRsvp_realtime_table_config.json
@@ -27,7 +27,6 @@
   "fieldConfigList": [
     {
       "name": "mtime",
-      "encodingType": "DICTIONARY",
       "indexTypes": [
         "TIMESTAMP"
       ],
@@ -37,6 +36,11 @@
           "WEEK",
           "MONTH"
         ]
+      },
+      "indexes": {
+        "forward": {
+          "encodingType": "DICTIONARY"
+        }
       }
     }
   ],

--- a/pinot-tools/src/main/resources/examples/stream/upsertJsonMeetupRsvp/upsertJsonMeetupRsvp_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/upsertJsonMeetupRsvp/upsertJsonMeetupRsvp_realtime_table_config.json
@@ -28,7 +28,10 @@
       }
     },
     "multiColumnTextIndexConfig": {
-      "columns": ["visibility", "response"]
+      "columns": [
+        "visibility",
+        "response"
+      ]
     }
   },
   "instanceAssignmentConfigMap": {
@@ -88,31 +91,47 @@
   "fieldConfigList": [
     {
       "name": "event_json",
-      "encodingType": "RAW",
       "indexTypes": [
         "TEXT"
-      ]
+      ],
+      "indexes": {
+        "forward": {
+          "encodingType": "RAW"
+        }
+      }
     },
     {
       "name": "group_json",
-      "encodingType": "RAW",
       "indexTypes": [
         "TEXT"
-      ]
+      ],
+      "indexes": {
+        "forward": {
+          "encodingType": "RAW"
+        }
+      }
     },
     {
       "name": "member_json",
-      "encodingType": "RAW",
       "indexTypes": [
         "TEXT"
-      ]
+      ],
+      "indexes": {
+        "forward": {
+          "encodingType": "RAW"
+        }
+      }
     },
     {
       "name": "venue_json",
-      "encodingType": "RAW",
       "indexTypes": [
         "TEXT"
-      ]
+      ],
+      "indexes": {
+        "forward": {
+          "encodingType": "RAW"
+        }
+      }
     }
   ],
   "metadata": {

--- a/pinot-tools/src/main/resources/examples/stream/upsertMeetupRsvp/upsertMeetupRsvp_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/upsertMeetupRsvp/upsertMeetupRsvp_realtime_table_config.json
@@ -61,10 +61,15 @@
   "fieldConfigList": [
     {
       "name": "location",
-      "encodingType": "RAW",
-      "indexType": "H3",
-      "properties": {
-        "resolutions": "5"
+      "indexes": {
+        "h3": {
+          "resolution": [
+            5
+          ]
+        },
+        "forward": {
+          "encodingType": "RAW"
+        }
       }
     }
   ],

--- a/pinot-tools/src/main/resources/examples/stream/upsertPartialMeetupRsvp/upsertPartialMeetupRsvp_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/upsertPartialMeetupRsvp/upsertPartialMeetupRsvp_realtime_table_config.json
@@ -63,10 +63,15 @@
   "fieldConfigList": [
     {
       "name": "location",
-      "encodingType": "RAW",
-      "indexType": "H3",
-      "properties": {
-        "resolutions": "5"
+      "indexes": {
+        "h3": {
+          "resolution": [
+            5
+          ]
+        },
+        "forward": {
+          "encodingType": "RAW"
+        }
       }
     }
   ],


### PR DESCRIPTION
## Summary

Deprecates field-level `FieldConfig.encodingType` and makes `fieldConfig.indexes.forward.encodingType` the canonical forward-index encoding source.

This change now blocks table creation/update configs that still use `fieldConfigList[].encodingType`. Validation fails with a targeted message directing users to `fieldConfigList[].indexes.forward.encodingType`.

Compatibility retained internally:

- `fieldConfig.encodingType` still deserializes for backward-compatible `FieldConfig` reads.
- `FieldConfig#getEncodingType()` still returns `DICTIONARY` when the field is absent for existing callers.
- Legacy inputs such as `noDictionaryColumns`, `noDictionaryConfig`, and field-level `encodingType` remain fallback signals in index-conversion paths when no `indexes.forward.encodingType` is present.
- When `indexes.forward.encodingType` is present, it is authoritative over legacy no-dictionary and field-level encoding signals.

## User Manual

For new or updated table configs, configure forward-index encoding under the internal forward-index block:

```json
{
  "fieldConfigList": [
    {
      "name": "message",
      "indexes": {
        "forward": {
          "encodingType": "RAW",
          "compressionCodec": "ZSTANDARD"
        }
      }
    }
  ]
}
```

Do not use the deprecated field-level encoding form:

```json
{
  "fieldConfigList": [
    {
      "name": "message",
      "encodingType": "RAW"
    }
  ]
}
```

That form now fails table validation with:

```text
FieldConfig.encodingType is deprecated for column: message. Use fieldConfigList[].indexes.forward.encodingType instead.
```

## Sample Table Config

```json
{
  "tableName": "logs_OFFLINE",
  "tableType": "OFFLINE",
  "segmentsConfig": {
    "schemaName": "logs"
  },
  "tableIndexConfig": {},
  "fieldConfigList": [
    {
      "name": "logLine",
      "indexes": {
        "forward": {
          "encodingType": "RAW",
          "compressionCodec": "ZSTANDARD"
        },
        "text": {}
      }
    },
    {
      "name": "statusCode",
      "indexes": {
        "forward": {
          "encodingType": "DICTIONARY"
        },
        "inverted": {}
      }
    }
  ]
}
```

## Validation

- `./mvnw -pl pinot-segment-local -am -Dtest=TableConfigUtilsTest,TableConfigConsumingSegmentTierOverrideTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl pinot-segment-local -am -Dtest=TableConfigUtilsTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl pinot-segment-local -am -Dtest=ForwardIndexTypeTest,DictionaryIndexTypeTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl pinot-spi -Dtest=FieldConfigTest test`
- `./mvnw -pl pinot-segment-spi -Dtest=ForwardIndexConfigTest test`
- `./mvnw -pl pinot-spi -Dtest=FieldConfigTest,OpenStructIndexConfigTest test`
- `./mvnw spotless:apply -pl pinot-spi,pinot-segment-local`
- `./mvnw license:format -pl pinot-spi,pinot-segment-local`
- `./mvnw checkstyle:check -pl pinot-spi,pinot-segment-local`
- `./mvnw license:check -pl pinot-spi,pinot-segment-local`
- `./mvnw spotless:apply -pl pinot-spi,pinot-segment-spi,pinot-segment-local`
- `./mvnw checkstyle:check -pl pinot-spi,pinot-segment-spi,pinot-segment-local`
- `./mvnw license:format -pl pinot-spi,pinot-segment-spi,pinot-segment-local`
- `./mvnw license:check -pl pinot-spi,pinot-segment-spi,pinot-segment-local`

`license:check` passes with pre-existing unknown-extension warnings for Lucene binary test resources under `pinot-segment-local/src/test/resources/data/lucene_80_index`.
