### PR TITLE
[bugfix] Re-seek Kafka consumer after unprocessed prefetched batch

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConsumer.java
@@ -63,6 +63,12 @@ public class KafkaPartitionLevelConsumer extends KafkaPartitionLevelConnectionHa
   // (and KafkaPartitionLevelConsumerTest.testConsumer) does exercise arbitrary
   // re-seeks, so we preserve that behaviour.
   private long _lastFetchStartOffset = Long.MIN_VALUE;
+  // Whether the previous successful poll returned any records from Kafka. When the caller
+  // repeats the same startOffset after a non-empty fetch, the records may have been fetched
+  // but not processed by RealtimeSegmentDataManager because an end criterion fired before
+  // index 0. In that case we must re-seek and replay the batch instead of continuing from
+  // _nextReadOffset.
+  private boolean _lastFetchReturnedRecords;
   // Cached true iff stream.kafka.isolation.level == read_committed. Computed once at
   // construction (the value is final per consumer) and reused on every fetch instead of
   // re-resolving the StreamConfig each time.
@@ -85,27 +91,32 @@ public class KafkaPartitionLevelConsumer extends KafkaPartitionLevelConnectionHa
     }
     // Seek when:
     //   (a) we have not yet positioned the consumer (initial state), OR
-    //   (b) the caller passed a startOffset different from the previous call AND
-    //       different from the consumer's current _nextReadOffset (i.e. a fresh
-    //       caller-requested seek that doesn't already match where we are).
-    // We do NOT seek when the caller passed the SAME startOffset as the previous call --
-    // that is the read_committed empty-poll case, where RealtimeSegmentDataManager.
-    // _currentOffset didn't advance on our last empty batch and so calls us with the same
-    // startOffset again. Seeking back to that startOffset would undo the consumer's
-    // progress through the filtered (aborted) region and wedge consumption forever; this
-    // was the dominant CI flake mode for ExactlyOnceKafkaRealtimeClusterIntegrationTest.
-    boolean explicitNewStartOffset = startOffset != _lastFetchStartOffset && startOffset != _nextReadOffset;
-    if (_nextReadOffset < 0 || explicitNewStartOffset) {
+    //   (b) the caller-requested startOffset differs from _nextReadOffset, except for
+    //       the repeated-startOffset-after-empty-fetch case described below.
+    //
+    // We only suppress a re-seek when the caller passed the same startOffset after the
+    // previous successful fetch returned zero records. That is the read_committed
+    // empty-poll case: RealtimeSegmentDataManager._currentOffset did not advance, but
+    // KafkaConsumer.position() may have advanced through aborted records. Seeking back to
+    // startOffset would undo that progress and wedge consumption forever.
+    //
+    // If the previous poll returned records, a repeated startOffset means the caller did
+    // not process them (for example, the segment time limit fired before index 0). We must
+    // seek back and replay those records; otherwise CATCH_UP can skip an already-fetched
+    // batch and falsely report data loss.
+    boolean repeatedStartOffsetAfterEmptyFetch = startOffset == _lastFetchStartOffset && !_lastFetchReturnedRecords;
+    if (_nextReadOffset < 0 || (startOffset != _nextReadOffset && !repeatedStartOffsetAfterEmptyFetch)) {
       if (LOGGER.isDebugEnabled()) {
         LOGGER.debug("Seeking to offset: {}", startOffset);
       }
       _consumer.seek(_topicPartition, startOffset);
       _nextReadOffset = startOffset;
     }
-    _lastFetchStartOffset = startOffset;
 
     ConsumerRecords<Bytes, Bytes> consumerRecords = _consumer.poll(Duration.ofMillis(timeoutMs));
     List<ConsumerRecord<Bytes, Bytes>> records = consumerRecords.records(_topicPartition);
+    _lastFetchStartOffset = startOffset;
+    _lastFetchReturnedRecords = !records.isEmpty();
     List<BytesStreamMessage> filteredRecords = new ArrayList<>(records.size());
     long firstOffset = -1;
     StreamMessageMetadata lastMessageMetadata = null;

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/test/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConsumerSeekTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/test/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConsumerSeekTest.java
@@ -1,0 +1,130 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.kafka30;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.pinot.plugin.stream.kafka.KafkaMessageBatch;
+import org.apache.pinot.plugin.stream.kafka.KafkaStreamConfigProperties;
+import org.apache.pinot.spi.stream.LongMsgOffset;
+import org.apache.pinot.spi.stream.StreamConfig;
+import org.testng.annotations.Test;
+
+import static org.apache.kafka.clients.consumer.ConsumerRecord.NULL_CHECKSUM;
+import static org.apache.kafka.common.record.LegacyRecord.NO_TIMESTAMP;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+
+/// Regression tests for [KafkaPartitionLevelConsumer] seek decisions.
+public class KafkaPartitionLevelConsumerSeekTest {
+  private static final String TOPIC = "test-topic";
+  private static final TopicPartition TOPIC_PARTITION = new TopicPartition(TOPIC, 0);
+
+  @Test
+  public void testRepeatedStartOffsetAfterNonEmptyFetchSeeksAgain() {
+    Consumer<Bytes, Bytes> mockConsumer = mock(Consumer.class);
+    ConsumerRecords<Bytes, Bytes> consumerRecords = records(record(291L));
+    when(mockConsumer.poll(any(Duration.class))).thenReturn(consumerRecords, consumerRecords);
+
+    KafkaPartitionLevelConsumer consumer = createConsumerWithMock(getStreamConfig(null), mockConsumer);
+    KafkaMessageBatch firstBatch = consumer.fetchMessages(new LongMsgOffset(291L), 10000);
+    KafkaMessageBatch repeatedBatch = consumer.fetchMessages(new LongMsgOffset(291L), 10000);
+
+    assertEquals(firstBatch.getOffsetOfNextBatch().toString(), "292");
+    assertEquals(repeatedBatch.getFirstMessageOffset().toString(), "291");
+    verify(mockConsumer, times(2)).seek(TOPIC_PARTITION, 291L);
+  }
+
+  @Test
+  public void testRepeatedStartOffsetAfterReadCommittedEmptyFetchDoesNotSeekAgain() {
+    Consumer<Bytes, Bytes> mockConsumer = mock(Consumer.class);
+    ConsumerRecords<Bytes, Bytes> emptyRecords =
+        new ConsumerRecords<>(Map.of(TOPIC_PARTITION, List.<ConsumerRecord<Bytes, Bytes>>of()));
+    when(mockConsumer.poll(any(Duration.class))).thenReturn(emptyRecords, records(record(100L)));
+    when(mockConsumer.position(eq(TOPIC_PARTITION), any(Duration.class))).thenReturn(100L);
+
+    KafkaPartitionLevelConsumer consumer =
+        createConsumerWithMock(getStreamConfig(
+            KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_ISOLATION_LEVEL_READ_COMMITTED), mockConsumer);
+    KafkaMessageBatch emptyBatch = consumer.fetchMessages(new LongMsgOffset(0L), 10000);
+    KafkaMessageBatch nextBatch = consumer.fetchMessages(new LongMsgOffset(0L), 10000);
+
+    assertEquals(emptyBatch.getMessageCount(), 0);
+    assertEquals(emptyBatch.getOffsetOfNextBatch().toString(), "100");
+    assertEquals(nextBatch.getFirstMessageOffset().toString(), "100");
+    verify(mockConsumer, times(1)).seek(TOPIC_PARTITION, 0L);
+  }
+
+  private static KafkaPartitionLevelConsumer createConsumerWithMock(StreamConfig streamConfig,
+      Consumer<Bytes, Bytes> mockConsumer) {
+    class FakeKafkaPartitionLevelConsumer extends KafkaPartitionLevelConsumer {
+      FakeKafkaPartitionLevelConsumer(String clientId, StreamConfig streamConfig, int partition) {
+        super(clientId, streamConfig, partition);
+      }
+
+      @Override
+      protected Consumer<Bytes, Bytes> createConsumer(Properties consumerProp) {
+        return mockConsumer;
+      }
+    }
+    return new FakeKafkaPartitionLevelConsumer("clientId-test", streamConfig, 0);
+  }
+
+  private static ConsumerRecords<Bytes, Bytes> records(ConsumerRecord<Bytes, Bytes> record) {
+    return new ConsumerRecords<>(Map.of(TOPIC_PARTITION, List.of(record)));
+  }
+
+  private static ConsumerRecord<Bytes, Bytes> record(long offset) {
+    return new ConsumerRecord<>(TOPIC, 0, offset, NO_TIMESTAMP, TimestampType.NO_TIMESTAMP_TYPE, NULL_CHECKSUM, 3, 5,
+        bytes("key"), bytes("value"));
+  }
+
+  private static Bytes bytes(String value) {
+    return new Bytes(value.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static StreamConfig getStreamConfig(String isolationLevel) {
+    Map<String, String> streamConfigMap = new HashMap<>();
+    streamConfigMap.put("streamType", "kafka");
+    streamConfigMap.put("stream.kafka.topic.name", TOPIC);
+    streamConfigMap.put("stream.kafka.broker.list", "localhost:9092");
+    streamConfigMap.put("stream.kafka.consumer.factory.class.name", KafkaConsumerFactory.class.getName());
+    streamConfigMap.put("stream.kafka.decoder.class.name", "decoderClass");
+    if (isolationLevel != null) {
+      streamConfigMap.put("stream.kafka.isolation.level", isolationLevel);
+    }
+    return new StreamConfig("tableName_REALTIME", streamConfigMap);
+  }
+}

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/main/java/org/apache/pinot/plugin/stream/kafka40/KafkaPartitionLevelConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/main/java/org/apache/pinot/plugin/stream/kafka40/KafkaPartitionLevelConsumer.java
@@ -63,6 +63,12 @@ public class KafkaPartitionLevelConsumer extends KafkaPartitionLevelConnectionHa
   // (and KafkaPartitionLevelConsumerTest.testConsumer) does exercise arbitrary
   // re-seeks, so we preserve that behaviour.
   private long _lastFetchStartOffset = Long.MIN_VALUE;
+  // Whether the previous successful poll returned any records from Kafka. When the caller
+  // repeats the same startOffset after a non-empty fetch, the records may have been fetched
+  // but not processed by RealtimeSegmentDataManager because an end criterion fired before
+  // index 0. In that case we must re-seek and replay the batch instead of continuing from
+  // _nextReadOffset.
+  private boolean _lastFetchReturnedRecords;
   // Cached true iff stream.kafka.isolation.level == read_committed. Computed once at
   // construction (the value is final per consumer) and reused on every fetch instead of
   // re-resolving the StreamConfig each time.
@@ -85,27 +91,32 @@ public class KafkaPartitionLevelConsumer extends KafkaPartitionLevelConnectionHa
     }
     // Seek when:
     //   (a) we have not yet positioned the consumer (initial state), OR
-    //   (b) the caller passed a startOffset different from the previous call AND
-    //       different from the consumer's current _nextReadOffset (i.e. a fresh
-    //       caller-requested seek that doesn't already match where we are).
-    // We do NOT seek when the caller passed the SAME startOffset as the previous call --
-    // that is the read_committed empty-poll case, where RealtimeSegmentDataManager.
-    // _currentOffset didn't advance on our last empty batch and so calls us with the same
-    // startOffset again. Seeking back to that startOffset would undo the consumer's
-    // progress through the filtered (aborted) region and wedge consumption forever; this
-    // was the dominant CI flake mode for ExactlyOnceKafkaRealtimeClusterIntegrationTest.
-    boolean explicitNewStartOffset = startOffset != _lastFetchStartOffset && startOffset != _nextReadOffset;
-    if (_nextReadOffset < 0 || explicitNewStartOffset) {
+    //   (b) the caller-requested startOffset differs from _nextReadOffset, except for
+    //       the repeated-startOffset-after-empty-fetch case described below.
+    //
+    // We only suppress a re-seek when the caller passed the same startOffset after the
+    // previous successful fetch returned zero records. That is the read_committed
+    // empty-poll case: RealtimeSegmentDataManager._currentOffset did not advance, but
+    // KafkaConsumer.position() may have advanced through aborted records. Seeking back to
+    // startOffset would undo that progress and wedge consumption forever.
+    //
+    // If the previous poll returned records, a repeated startOffset means the caller did
+    // not process them (for example, the segment time limit fired before index 0). We must
+    // seek back and replay those records; otherwise CATCH_UP can skip an already-fetched
+    // batch and falsely report data loss.
+    boolean repeatedStartOffsetAfterEmptyFetch = startOffset == _lastFetchStartOffset && !_lastFetchReturnedRecords;
+    if (_nextReadOffset < 0 || (startOffset != _nextReadOffset && !repeatedStartOffsetAfterEmptyFetch)) {
       if (LOGGER.isDebugEnabled()) {
         LOGGER.debug("Seeking to offset: {}", startOffset);
       }
       _consumer.seek(_topicPartition, startOffset);
       _nextReadOffset = startOffset;
     }
-    _lastFetchStartOffset = startOffset;
 
     ConsumerRecords<Bytes, Bytes> consumerRecords = _consumer.poll(Duration.ofMillis(timeoutMs));
     List<ConsumerRecord<Bytes, Bytes>> records = consumerRecords.records(_topicPartition);
+    _lastFetchStartOffset = startOffset;
+    _lastFetchReturnedRecords = !records.isEmpty();
     List<BytesStreamMessage> filteredRecords = new ArrayList<>(records.size());
     long firstOffset = -1;
     StreamMessageMetadata lastMessageMetadata = null;

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/test/java/org/apache/pinot/plugin/stream/kafka40/KafkaPartitionLevelConsumerSeekTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/test/java/org/apache/pinot/plugin/stream/kafka40/KafkaPartitionLevelConsumerSeekTest.java
@@ -1,0 +1,130 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.kafka40;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.pinot.plugin.stream.kafka.KafkaMessageBatch;
+import org.apache.pinot.plugin.stream.kafka.KafkaStreamConfigProperties;
+import org.apache.pinot.spi.stream.LongMsgOffset;
+import org.apache.pinot.spi.stream.StreamConfig;
+import org.testng.annotations.Test;
+
+import static org.apache.kafka.common.record.RecordBatch.NO_TIMESTAMP;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+
+/// Regression tests for [KafkaPartitionLevelConsumer] seek decisions.
+public class KafkaPartitionLevelConsumerSeekTest {
+  private static final String TOPIC = "test-topic";
+  private static final TopicPartition TOPIC_PARTITION = new TopicPartition(TOPIC, 0);
+
+  @Test
+  public void testRepeatedStartOffsetAfterNonEmptyFetchSeeksAgain() {
+    Consumer<Bytes, Bytes> mockConsumer = mock(Consumer.class);
+    ConsumerRecords<Bytes, Bytes> consumerRecords = records(record(291L));
+    when(mockConsumer.poll(any(Duration.class))).thenReturn(consumerRecords, consumerRecords);
+
+    KafkaPartitionLevelConsumer consumer = createConsumerWithMock(getStreamConfig(null), mockConsumer);
+    KafkaMessageBatch firstBatch = consumer.fetchMessages(new LongMsgOffset(291L), 10000);
+    KafkaMessageBatch repeatedBatch = consumer.fetchMessages(new LongMsgOffset(291L), 10000);
+
+    assertEquals(firstBatch.getOffsetOfNextBatch().toString(), "292");
+    assertEquals(repeatedBatch.getFirstMessageOffset().toString(), "291");
+    verify(mockConsumer, times(2)).seek(TOPIC_PARTITION, 291L);
+  }
+
+  @Test
+  public void testRepeatedStartOffsetAfterReadCommittedEmptyFetchDoesNotSeekAgain() {
+    Consumer<Bytes, Bytes> mockConsumer = mock(Consumer.class);
+    ConsumerRecords<Bytes, Bytes> emptyRecords =
+        new ConsumerRecords<>(Map.of(TOPIC_PARTITION, List.<ConsumerRecord<Bytes, Bytes>>of()));
+    when(mockConsumer.poll(any(Duration.class))).thenReturn(emptyRecords, records(record(100L)));
+    when(mockConsumer.position(eq(TOPIC_PARTITION), any(Duration.class))).thenReturn(100L);
+
+    KafkaPartitionLevelConsumer consumer =
+        createConsumerWithMock(getStreamConfig(
+            KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_ISOLATION_LEVEL_READ_COMMITTED), mockConsumer);
+    KafkaMessageBatch emptyBatch = consumer.fetchMessages(new LongMsgOffset(0L), 10000);
+    KafkaMessageBatch nextBatch = consumer.fetchMessages(new LongMsgOffset(0L), 10000);
+
+    assertEquals(emptyBatch.getMessageCount(), 0);
+    assertEquals(emptyBatch.getOffsetOfNextBatch().toString(), "100");
+    assertEquals(nextBatch.getFirstMessageOffset().toString(), "100");
+    verify(mockConsumer, times(1)).seek(TOPIC_PARTITION, 0L);
+  }
+
+  private static KafkaPartitionLevelConsumer createConsumerWithMock(StreamConfig streamConfig,
+      Consumer<Bytes, Bytes> mockConsumer) {
+    class FakeKafkaPartitionLevelConsumer extends KafkaPartitionLevelConsumer {
+      FakeKafkaPartitionLevelConsumer(String clientId, StreamConfig streamConfig, int partition) {
+        super(clientId, streamConfig, partition);
+      }
+
+      @Override
+      protected Consumer<Bytes, Bytes> createConsumer(Properties consumerProp) {
+        return mockConsumer;
+      }
+    }
+    return new FakeKafkaPartitionLevelConsumer("clientId-test", streamConfig, 0);
+  }
+
+  private static ConsumerRecords<Bytes, Bytes> records(ConsumerRecord<Bytes, Bytes> record) {
+    return new ConsumerRecords<>(Map.of(TOPIC_PARTITION, List.of(record)));
+  }
+
+  private static ConsumerRecord<Bytes, Bytes> record(long offset) {
+    return new ConsumerRecord<>(TOPIC, 0, offset, NO_TIMESTAMP, TimestampType.NO_TIMESTAMP_TYPE, 3, 5, bytes("key"),
+        bytes("value"), new RecordHeaders(), null);
+  }
+
+  private static Bytes bytes(String value) {
+    return new Bytes(value.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static StreamConfig getStreamConfig(String isolationLevel) {
+    Map<String, String> streamConfigMap = new HashMap<>();
+    streamConfigMap.put("streamType", "kafka");
+    streamConfigMap.put("stream.kafka.topic.name", TOPIC);
+    streamConfigMap.put("stream.kafka.broker.list", "localhost:9092");
+    streamConfigMap.put("stream.kafka.consumer.factory.class.name", KafkaConsumerFactory.class.getName());
+    streamConfigMap.put("stream.kafka.decoder.class.name", "decoderClass");
+    if (isolationLevel != null) {
+      streamConfigMap.put("stream.kafka.isolation.level", isolationLevel);
+    }
+    return new StreamConfig("tableName_REALTIME", streamConfigMap);
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #18663.

This updates `KafkaPartitionLevelConsumer` for both Kafka 3.x and Kafka 4.x so repeated caller offsets only skip re-seek after an empty fetch. If the previous Kafka poll returned records but `RealtimeSegmentDataManager` did not process them, the consumer now re-seeks to the caller's start offset and replays that batch.

## Root cause

#18337 intentionally skipped re-seek when Pinot called `fetchMessages()` again with the same start offset, so `read_committed` consumers could preserve progress through broker-filtered aborted records after an empty poll.

That same seek-skip is unsafe after a non-empty poll. When a realtime segment hits an end criterion before processing index 0, Kafka has already advanced the consumer position, but Pinot's `_currentOffset` has not advanced. A later `CATCH_UP` call with the same start offset then polls from the advanced Kafka position, falsely surfacing as message loss / past max offset.

## User manual

No table config change is required. Existing realtime tables continue using the same stream config. Tables using the default `read_uncommitted` isolation and tables explicitly using `read_committed` both keep their existing behavior; the fix only changes how the consumer repositions after a repeated caller offset.

## Sample table config

For transactional Kafka topics where Pinot should ignore aborted records, keep using `read_committed` as before:

```json
{
  "tableName": "events_REALTIME",
  "tableType": "REALTIME",
  "segmentsConfig": {
    "timeColumnName": "ts",
    "timeType": "MILLISECONDS",
    "replication": "1"
  },
  "streamConfigs": {
    "streamType": "kafka",
    "stream.kafka.topic.name": "events",
    "stream.kafka.broker.list": "localhost:9092",
    "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
    "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder",
    "stream.kafka.isolation.level": "read_committed"
  }
}
```

## Review

Reviewed with the Pinot PR review checklist: production safety, backward compatibility, correctness, state management, performance, architecture, testing, naming, and process. No remaining findings.

## Tests

- `./mvnw -pl pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0,pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0 -Dtest=KafkaPartitionLevelConsumerSeekTest test`
- `./mvnw spotless:apply checkstyle:check license:format license:check -pl pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0,pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0`
- `git diff --check`

Note: full `KafkaPartitionLevelConsumerTest` was also attempted. Kafka 3.x passed locally; Kafka 4.x requires Docker/Testcontainers and this environment has no Docker socket.