### PR TITLE
Optimize JSON index doc id mapping

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/json/MutableJsonIndexImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/json/MutableJsonIndexImpl.java
@@ -28,9 +28,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.annotation.Nullable;
@@ -50,6 +52,7 @@ import org.apache.pinot.common.request.context.predicate.RegexpLikePredicate;
 import org.apache.pinot.common.utils.SegmentUtils;
 import org.apache.pinot.common.utils.regex.Matcher;
 import org.apache.pinot.common.utils.regex.Pattern;
+import org.apache.pinot.segment.local.segment.index.json.JsonIndexUtils;
 import org.apache.pinot.segment.spi.index.creator.JsonIndexCreator;
 import org.apache.pinot.segment.spi.index.mutable.MutableJsonIndex;
 import org.apache.pinot.spi.config.table.JsonIndexConfig;
@@ -74,6 +77,7 @@ public class MutableJsonIndexImpl implements MutableJsonIndex {
   private final String _segmentName;
   private final String _columnName;
   private final TreeMap<String, RoaringBitmap> _postingListMap;
+  private final TreeMap<String, MutableRoaringBitmap> _docIdPostingListMap;
   private final IntList _docIdMapping;
   private final long _maxBytesSize;
   private final ReentrantReadWriteLock.ReadLock _readLock;
@@ -83,12 +87,15 @@ public class MutableJsonIndexImpl implements MutableJsonIndex {
   private int _nextDocId;
   private int _nextFlattenedDocId;
   private long _bytesSize;
+  private long _docIdPostingListBytesSize;
+  private boolean _docIdMappingIdentity = true;
 
   public MutableJsonIndexImpl(JsonIndexConfig jsonIndexConfig, String segmentName, String columnName) {
     _jsonIndexConfig = jsonIndexConfig;
     _segmentName = segmentName;
     _columnName = columnName;
     _postingListMap = new TreeMap<>();
+    _docIdPostingListMap = new TreeMap<>();
     _docIdMapping = new IntArrayList();
     _maxBytesSize = jsonIndexConfig.getMaxBytesSize() == null ? Long.MAX_VALUE : jsonIndexConfig.getMaxBytesSize();
 
@@ -124,9 +131,17 @@ public class MutableJsonIndexImpl implements MutableJsonIndex {
     int numRecords = records.size();
     Preconditions.checkState(_nextFlattenedDocId + numRecords >= 0, "Got more than %s flattened records",
         Integer.MAX_VALUE);
+    boolean wasDocIdMappingIdentity = _docIdMappingIdentity;
+    if (numRecords != 1 || _nextFlattenedDocId != _nextDocId) {
+      _docIdMappingIdentity = false;
+      if (wasDocIdMappingIdentity) {
+        initializeDocIdPostingListMap();
+      }
+    }
     for (int i = 0; i < numRecords; i++) {
       _docIdMapping.add(_nextDocId);
     }
+    Set<String> directDocIdValues = null;
     // TODO: Consider storing tuples as the key of the posting list so that the strings can be reused, and the hashcode
     //       can be cached.
     for (Map<String, String> record : records) {
@@ -142,8 +157,25 @@ public class MutableJsonIndexImpl implements MutableJsonIndex {
           _bytesSize += Utf8.encodedLength(keyValue);
           return new RoaringBitmap();
         }).add(_nextFlattenedDocId);
+        if (JsonIndexUtils.isDirectDocIdIndexEligibleKey(key)) {
+          if (directDocIdValues == null) {
+            directDocIdValues = new HashSet<>();
+          }
+          directDocIdValues.add(key);
+          directDocIdValues.add(keyValue);
+        }
       }
       _nextFlattenedDocId++;
+    }
+    if (!_docIdMappingIdentity && directDocIdValues != null) {
+      for (String value : directDocIdValues) {
+        MutableRoaringBitmap docIds = _docIdPostingListMap.computeIfAbsent(value, k -> {
+          _docIdPostingListBytesSize += Utf8.encodedLength(k);
+          return new MutableRoaringBitmap();
+        });
+        docIds.add(_nextDocId);
+        _docIdPostingListBytesSize += Integer.BYTES;
+      }
     }
   }
 
@@ -170,20 +202,24 @@ public class MutableJsonIndexImpl implements MutableJsonIndex {
   private MutableRoaringBitmap getMatchingDocIds(FilterContext filter) {
     _readLock.lock();
     try {
+      if (canEvaluateWithDocIdIndex(filter, true)) {
+        MutableRoaringBitmap directDocIds = getMatchingDocIdsFromDocIdIndex(filter);
+        if (directDocIds != null) {
+          return directDocIds;
+        }
+      }
+
       Predicate predicate = filter.getPredicate();
       if (predicate != null && isExclusive(predicate.getType())) {
         // Handle exclusive predicate separately because the flip can only be applied to the unflattened doc ids in
         // order to get the correct result, and it cannot be nested
         LazyBitmap flattenedDocIds = getMatchingFlattenedDocIds(predicate);
-        MutableRoaringBitmap matchingDocIds = new MutableRoaringBitmap();
-        flattenedDocIds.forEach(flattenedDocId -> matchingDocIds.add(_docIdMapping.getInt(flattenedDocId)));
+        MutableRoaringBitmap matchingDocIds = toDocIdBitmap(flattenedDocIds);
         matchingDocIds.flip(0, (long) _nextDocId);
         return matchingDocIds;
       } else {
         LazyBitmap flattenedDocIds = getMatchingFlattenedDocIds(filter);
-        MutableRoaringBitmap matchingDocIds = new MutableRoaringBitmap();
-        flattenedDocIds.forEach(flattenedDocId -> matchingDocIds.add(_docIdMapping.getInt(flattenedDocId)));
-        return matchingDocIds;
+        return toDocIdBitmap(flattenedDocIds);
       }
     } finally {
       _readLock.unlock();
@@ -195,6 +231,256 @@ public class MutableJsonIndexImpl implements MutableJsonIndex {
    */
   private boolean isExclusive(Predicate.Type predicateType) {
     return predicateType == Predicate.Type.IS_NULL;
+  }
+
+  private MutableRoaringBitmap toDocIdBitmap(LazyBitmap flattenedDocIds) {
+    MutableRoaringBitmap matchingDocIds = new MutableRoaringBitmap();
+    if (_docIdMappingIdentity) {
+      flattenedDocIds.forEach(matchingDocIds::add);
+    } else {
+      flattenedDocIds.forEach(flattenedDocId -> matchingDocIds.add(_docIdMapping.getInt(flattenedDocId)));
+    }
+    return matchingDocIds;
+  }
+
+  @Nullable
+  private MutableRoaringBitmap getMatchingDocIdsFromDocIdIndex(FilterContext filter) {
+    switch (filter.getType()) {
+      case AND: {
+        List<FilterContext> filters = filter.getChildren();
+        MutableRoaringBitmap matchingDocIds = getMatchingDocIdsFromDocIdIndex(filters.get(0));
+        if (matchingDocIds == null) {
+          return null;
+        }
+        for (int i = 1, numFilters = filters.size(); i < numFilters; i++) {
+          if (matchingDocIds.isEmpty()) {
+            return matchingDocIds;
+          }
+          FilterContext childFilter = filters.get(i);
+          Predicate childPredicate = childFilter.getPredicate();
+          if (childPredicate != null && isExclusive(childPredicate.getType())) {
+            return null;
+          }
+          MutableRoaringBitmap childDocIds = getMatchingDocIdsFromDocIdIndex(childFilter);
+          if (childDocIds == null) {
+            return null;
+          }
+          matchingDocIds.and(childDocIds);
+        }
+        return matchingDocIds;
+      }
+      case OR: {
+        List<FilterContext> filters = filter.getChildren();
+        MutableRoaringBitmap matchingDocIds = getMatchingDocIdsFromDocIdIndex(filters.get(0));
+        if (matchingDocIds == null) {
+          return null;
+        }
+        for (int i = 1, numFilters = filters.size(); i < numFilters; i++) {
+          FilterContext childFilter = filters.get(i);
+          Predicate childPredicate = childFilter.getPredicate();
+          if (childPredicate != null && isExclusive(childPredicate.getType())) {
+            return null;
+          }
+          MutableRoaringBitmap childDocIds = getMatchingDocIdsFromDocIdIndex(childFilter);
+          if (childDocIds == null) {
+            return null;
+          }
+          matchingDocIds.or(childDocIds);
+        }
+        return matchingDocIds;
+      }
+      case PREDICATE:
+        return getMatchingDocIdsFromDocIdIndex(filter.getPredicate());
+      default:
+        throw new IllegalStateException();
+    }
+  }
+
+  private boolean canEvaluateWithDocIdIndex(FilterContext filter, boolean allowExclusivePredicate) {
+    if (_docIdMappingIdentity) {
+      return false;
+    }
+    switch (filter.getType()) {
+      case AND:
+      case OR:
+        for (FilterContext childFilter : filter.getChildren()) {
+          if (!canEvaluateWithDocIdIndex(childFilter, false)) {
+            return false;
+          }
+        }
+        return true;
+      case PREDICATE: {
+        Predicate predicate = filter.getPredicate();
+        return (allowExclusivePredicate || !isExclusive(predicate.getType()))
+            && normalizeDirectDocIdIndexKey(predicate) != null;
+      }
+      default:
+        throw new IllegalStateException();
+    }
+  }
+
+  @Nullable
+  private MutableRoaringBitmap getMatchingDocIdsFromDocIdIndex(Predicate predicate) {
+    String key = normalizeDirectDocIdIndexKey(predicate);
+    if (key == null) {
+      return null;
+    }
+
+    switch (predicate.getType()) {
+      case EQ: {
+        String value = ((EqPredicate) predicate).getValue();
+        return getDirectDocIds(key + JsonIndexCreator.KEY_VALUE_SEPARATOR + value);
+      }
+
+      case NOT_EQ: {
+        MutableRoaringBitmap result = getDirectDocIds(key);
+        String value = ((NotEqPredicate) predicate).getValue();
+        result.andNot(getDirectDocIds(key + JsonIndexCreator.KEY_VALUE_SEPARATOR + value));
+        return result;
+      }
+
+      case IN: {
+        StringBuilder buffer = new StringBuilder(key);
+        buffer.append(JsonIndexCreator.KEY_VALUE_SEPARATOR);
+        int pos = buffer.length();
+        MutableRoaringBitmap result = new MutableRoaringBitmap();
+        List<String> values = ((InPredicate) predicate).getValues();
+        for (String value : values) {
+          buffer.setLength(pos);
+          buffer.append(value);
+          result.or(getDirectDocIds(buffer.toString()));
+        }
+        return result;
+      }
+
+      case NOT_IN: {
+        MutableRoaringBitmap result = getDirectDocIds(key);
+        StringBuilder buffer = new StringBuilder(key);
+        buffer.append(JsonIndexCreator.KEY_VALUE_SEPARATOR);
+        int pos = buffer.length();
+        List<String> values = ((NotInPredicate) predicate).getValues();
+        for (String value : values) {
+          if (result.isEmpty()) {
+            return result;
+          }
+          buffer.setLength(pos);
+          buffer.append(value);
+          result.andNot(getDirectDocIds(buffer.toString()));
+        }
+        return result;
+      }
+
+      case IS_NOT_NULL:
+        return getDirectDocIds(key);
+
+      case IS_NULL: {
+        MutableRoaringBitmap result = getDirectDocIds(key);
+        result.flip(0, (long) _nextDocId);
+        return result;
+      }
+
+      case REGEXP_LIKE: {
+        Map<String, MutableRoaringBitmap> subMap = getMatchingDocIdKeysMap(key);
+        if (subMap.isEmpty()) {
+          return new MutableRoaringBitmap();
+        }
+        Pattern pattern = ((RegexpLikePredicate) predicate).getPattern();
+        Matcher matcher = pattern.matcher("");
+        MutableRoaringBitmap result = new MutableRoaringBitmap();
+        StringBuilder value = new StringBuilder();
+        int valueStart = key.length() + 1;
+        for (Map.Entry<String, MutableRoaringBitmap> entry : subMap.entrySet()) {
+          String keyValue = entry.getKey();
+          value.setLength(0);
+          value.append(keyValue, valueStart, keyValue.length());
+          if (matcher.reset(value).matches()) {
+            result.or(entry.getValue());
+          }
+        }
+        return result;
+      }
+
+      case RANGE: {
+        Map<String, MutableRoaringBitmap> subMap = getMatchingDocIdKeysMap(key);
+        if (subMap.isEmpty()) {
+          return new MutableRoaringBitmap();
+        }
+        RangePredicate rangePredicate = (RangePredicate) predicate;
+        FieldSpec.DataType rangeDataType = rangePredicate.getRangeDataType();
+        if (rangeDataType.isNumeric()) {
+          rangeDataType = FieldSpec.DataType.DOUBLE;
+        } else {
+          rangeDataType = FieldSpec.DataType.STRING;
+        }
+        boolean lowerUnbounded = rangePredicate.getLowerBound().equals(RangePredicate.UNBOUNDED);
+        boolean upperUnbounded = rangePredicate.getUpperBound().equals(RangePredicate.UNBOUNDED);
+        boolean lowerInclusive = lowerUnbounded || rangePredicate.isLowerInclusive();
+        boolean upperInclusive = upperUnbounded || rangePredicate.isUpperInclusive();
+        Object lowerBound = lowerUnbounded ? null : rangeDataType.convert(rangePredicate.getLowerBound());
+        Object upperBound = upperUnbounded ? null : rangeDataType.convert(rangePredicate.getUpperBound());
+        MutableRoaringBitmap result = new MutableRoaringBitmap();
+        int valueStart = key.length() + 1;
+        for (Map.Entry<String, MutableRoaringBitmap> entry : subMap.entrySet()) {
+          String value = entry.getKey().substring(valueStart);
+          Object valueObj = rangeDataType.convert(value);
+          boolean lowerCompareResult =
+              lowerUnbounded || (lowerInclusive ? rangeDataType.compare(valueObj, lowerBound) >= 0
+                  : rangeDataType.compare(valueObj, lowerBound) > 0);
+          boolean upperCompareResult =
+              upperUnbounded || (upperInclusive ? rangeDataType.compare(valueObj, upperBound) <= 0
+                  : rangeDataType.compare(valueObj, upperBound) < 0);
+          if (lowerCompareResult && upperCompareResult) {
+            result.or(entry.getValue());
+          }
+        }
+        return result;
+      }
+
+      default:
+        throw new IllegalStateException("Unsupported json_match predicate type: " + predicate);
+    }
+  }
+
+  @Nullable
+  private String normalizeDirectDocIdIndexKey(Predicate predicate) {
+    ExpressionContext lhs = predicate.getLhs();
+    if (lhs.getType() != ExpressionContext.Type.IDENTIFIER) {
+      return null;
+    }
+
+    String key = lhs.getIdentifier();
+    if (key.indexOf('[') >= 0) {
+      return null;
+    }
+    if (key.startsWith("$")) {
+      key = key.substring(1);
+    } else {
+      key = JsonUtils.KEY_SEPARATOR + key;
+    }
+
+    Pair<String, LazyBitmap> pair = getKeyAndFlattenedDocIds(key);
+    if (pair.getRight() != null) {
+      return null;
+    }
+    key = pair.getLeft();
+    return JsonIndexUtils.isDirectDocIdIndexEligibleKey(key) ? key : null;
+  }
+
+  private MutableRoaringBitmap getDirectDocIds(String key) {
+    MutableRoaringBitmap docIds = _docIdPostingListMap.get(key);
+    return docIds != null ? docIds.clone() : new MutableRoaringBitmap();
+  }
+
+  private void initializeDocIdPostingListMap() {
+    for (Map.Entry<String, RoaringBitmap> entry : _postingListMap.entrySet()) {
+      if (JsonIndexUtils.isDirectDocIdIndexEligibleValue(entry.getKey())) {
+        MutableRoaringBitmap docIds = new MutableRoaringBitmap();
+        entry.getValue().forEach((IntConsumer) docIds::add);
+        _docIdPostingListMap.put(entry.getKey(), docIds);
+        _docIdPostingListBytesSize += Utf8.encodedLength(entry.getKey());
+        _docIdPostingListBytesSize += (long) docIds.getCardinality() * Integer.BYTES;
+      }
+    }
   }
 
   /** This class allows delaying of cloning posting list bitmap for as long as possible
@@ -547,6 +833,9 @@ public class MutableJsonIndexImpl implements MutableJsonIndex {
   public void convertFlattenedDocIdsToDocIds(Map<String, RoaringBitmap> valueToFlattenedDocIds) {
     _readLock.lock();
     try {
+      if (_docIdMappingIdentity) {
+        return;
+      }
       valueToFlattenedDocIds.replaceAll((key, value) -> {
         RoaringBitmap docIds = new RoaringBitmap();
         value.forEach((IntConsumer) flattenedDocId -> docIds.add(_docIdMapping.getInt(flattenedDocId)));
@@ -676,6 +965,11 @@ public class MutableJsonIndexImpl implements MutableJsonIndex {
         key + JsonIndexCreator.KEY_VALUE_SEPARATOR_NEXT_CHAR, false);
   }
 
+  private Map<String, MutableRoaringBitmap> getMatchingDocIdKeysMap(String key) {
+    return _docIdPostingListMap.subMap(key + JsonIndexCreator.KEY_VALUE_SEPARATOR, false,
+        key + JsonIndexCreator.KEY_VALUE_SEPARATOR_NEXT_CHAR, false);
+  }
+
   @Override
   public String[][] getValuesMV(int[] docIds, int length, Map<String, RoaringBitmap> valueToMatchingFlattenedDocs) {
     String[][] result = new String[length][];
@@ -695,7 +989,7 @@ public class MutableJsonIndexImpl implements MutableJsonIndex {
         String value = entry.getKey();
         RoaringBitmap matchingFlattenedDocIds = entry.getValue();
         matchingFlattenedDocIds.forEach((IntConsumer) flattenedDocId -> {
-          int docId = _docIdMapping.getInt(flattenedDocId);
+          int docId = _docIdMappingIdentity ? flattenedDocId : _docIdMapping.getInt(flattenedDocId);
           if (docIdToPos.containsKey(docId)) {
             docIdToFlattenedDocIdsAndValues.get(docIdToPos.get(docId)).add(Pair.of(value, flattenedDocId));
           }
@@ -728,7 +1022,7 @@ public class MutableJsonIndexImpl implements MutableJsonIndex {
         String value = entry.getKey();
         RoaringBitmap matchingDocIds = entry.getValue();
 
-        if (isFlattenedDocIds) {
+        if (isFlattenedDocIds && !_docIdMappingIdentity) {
           matchingDocIds.forEach((IntConsumer) flattenedDocId -> {
             int docId = _docIdMapping.getInt(flattenedDocId);
             if (docIdMask.contains(docId)) {
@@ -758,19 +1052,24 @@ public class MutableJsonIndexImpl implements MutableJsonIndex {
 
   @Override
   public boolean canAddMore() {
-    return _bytesSize < _maxBytesSize;
+    return getEstimatedBytesSize() < _maxBytesSize;
   }
 
   @Override
   public void close() {
     try {
       String tableName = SegmentUtils.getTableNameFromSegmentName(_segmentName);
+      long estimatedBytesSize = getEstimatedBytesSize();
       _serverMetrics.addMeteredTableValue(tableName, _columnName, ServerMeter.MUTABLE_JSON_INDEX_MEMORY_USAGE,
-          _bytesSize);
+          estimatedBytesSize);
     } catch (Exception e) {
       LOGGER.warn(
           "Caught exception while updating mutable json index memory usage for segment: {}, column: {}, value: {}",
-          _segmentName, _columnName, _bytesSize, e);
+          _segmentName, _columnName, getEstimatedBytesSize(), e);
     }
+  }
+
+  private long getEstimatedBytesSize() {
+    return _bytesSize + _docIdPostingListBytesSize;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/json/BaseJsonIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/json/BaseJsonIndexCreator.java
@@ -32,38 +32,56 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.io.util.VarLengthValueWriter;
+import org.apache.pinot.segment.local.segment.creator.impl.inv.BitmapInvertedIndexWriter;
 import org.apache.pinot.segment.local.segment.index.json.JsonIndexType;
+import org.apache.pinot.segment.local.segment.index.json.JsonIndexUtils;
+import org.apache.pinot.segment.local.segment.index.readers.BitmapInvertedIndexReader;
+import org.apache.pinot.segment.local.segment.index.readers.StringDictionary;
 import org.apache.pinot.segment.local.utils.MetricUtils;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.index.creator.JsonIndexCreator;
 import org.apache.pinot.segment.spi.memory.CleanerUtil;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.spi.config.table.JsonIndexConfig;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.roaringbitmap.Container;
+import org.roaringbitmap.IntConsumer;
 import org.roaringbitmap.RoaringBitmap;
 import org.roaringbitmap.RoaringBitmapWriter;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 
-/**
- * Base implementation of the json index creator.
- * <p>Header format:
- * <ul>
- *   <li>Version (int)</li>
- *   <li>Max value length (int)</li>
- *   <li>Dictionary file length (long)</li>
- *   <li>Inverted index file length (long)</li>
- *   <li>Doc id mapping file length (long)</li>
- * </ul>
- */
+
+/// Base implementation of the json index creator.
+///
+/// Header format:
+///
+/// - Version (`int`)
+/// - Max value length (`int`)
+/// - Dictionary file length (`long`)
+/// - Inverted index file length (`long`)
+/// - Doc id mapping file length (`long`)
+///
+/// V2 keeps the doc-id mapping and can append an optional direct-doc-id sidecar after it. A non-zero sidecar stores a
+/// direct-doc-id dictionary and inverted index for scalar paths. Older V2 readers ignore the trailing sidecar and keep
+/// using the flattened-doc-id dictionary.
+///
+/// V3 is used only when flattened doc ids are identical to real doc ids. It stores the same dictionary and inverted
+/// index encoding as V2, omits the identity doc-id mapping, and appends a zero-length sidecar marker.
 public abstract class BaseJsonIndexCreator implements JsonIndexCreator {
   // NOTE: V1 is deprecated because it does not support top-level value, top-level array and nested array
   public static final int VERSION_1 = 1;
   public static final int VERSION_2 = 2;
+  public static final int VERSION_3 = 3;
   public static final int HEADER_LENGTH = 32;
 
   static final String TEMP_DIR_SUFFIX = ".json.idx.tmp";
   static final String DICTIONARY_FILE_NAME = "dictionary.buf";
   static final String INVERTED_INDEX_FILE_NAME = "inverted.index.buf";
+  static final String DIRECT_DOC_ID_DICTIONARY_FILE_NAME = "direct_doc_id_dictionary.buf";
+  static final String DIRECT_DOC_ID_INVERTED_INDEX_FILE_NAME = "direct_doc_id_inverted.index.buf";
+  public static final int DIRECT_DOC_ID_INDEX_HEADER_LENGTH = Long.BYTES * 2;
 
   final String _tableNameWithType;
   final boolean _continueOnError;
@@ -72,12 +90,15 @@ public abstract class BaseJsonIndexCreator implements JsonIndexCreator {
   final File _tempDir;
   final File _dictionaryFile;
   final File _invertedIndexFile;
+  final File _directDocIdDictionaryFile;
+  final File _directDocIdInvertedIndexFile;
   final IntList _numFlattenedRecordsList = new IntArrayList();
   final Map<String, RoaringBitmapWriter<RoaringBitmap>> _postingListMap = new TreeMap<>();
   final RoaringBitmapWriter.Wizard<Container, RoaringBitmap> _bitmapWriterWizard = RoaringBitmapWriter.writer();
 
   int _nextFlattenedDocId;
   int _maxValueLength;
+  boolean _docIdMappingIdentity = true;
 
   BaseJsonIndexCreator(File indexDir, String columnName, String tableNameWithType, boolean continueOnError,
       JsonIndexConfig jsonIndexConfig)
@@ -94,6 +115,8 @@ public abstract class BaseJsonIndexCreator implements JsonIndexCreator {
     }
     _dictionaryFile = new File(_tempDir, DICTIONARY_FILE_NAME);
     _invertedIndexFile = new File(_tempDir, INVERTED_INDEX_FILE_NAME);
+    _directDocIdDictionaryFile = new File(_tempDir, DIRECT_DOC_ID_DICTIONARY_FILE_NAME);
+    _directDocIdInvertedIndexFile = new File(_tempDir, DIRECT_DOC_ID_INVERTED_INDEX_FILE_NAME);
   }
 
   @Override
@@ -149,6 +172,9 @@ public abstract class BaseJsonIndexCreator implements JsonIndexCreator {
     int numRecords = records.size();
     Preconditions.checkState(_nextFlattenedDocId + numRecords >= 0, "Got more than %s flattened records",
         Integer.MAX_VALUE);
+    if (numRecords != 1 || _nextFlattenedDocId != _numFlattenedRecordsList.size()) {
+      _docIdMappingIdentity = false;
+    }
     _numFlattenedRecordsList.add(numRecords);
     for (Map<String, String> record : records) {
       for (Map.Entry<String, String> entry : record.entrySet()) {
@@ -180,12 +206,17 @@ public abstract class BaseJsonIndexCreator implements JsonIndexCreator {
    */
   void generateIndexFile()
       throws IOException {
+    boolean hasDirectDocIdIndex = generateDirectDocIdIndexFiles();
     ByteBuffer headerBuffer = ByteBuffer.allocate(HEADER_LENGTH);
-    headerBuffer.putInt(VERSION_2);
+    boolean omitDocIdMapping = _docIdMappingIdentity;
+    headerBuffer.putInt(omitDocIdMapping ? VERSION_3 : VERSION_2);
     headerBuffer.putInt(_maxValueLength);
     long dictionaryFileLength = _dictionaryFile.length();
     long invertedIndexFileLength = _invertedIndexFile.length();
-    long docIdMappingFileLength = (long) _nextFlattenedDocId << 2;
+    long docIdMappingFileLength = omitDocIdMapping ? 0 : (long) _nextFlattenedDocId << 2;
+    boolean hasDirectDocIdIndexHeader = omitDocIdMapping || hasDirectDocIdIndex;
+    long directDocIdDictionaryFileLength = hasDirectDocIdIndex ? _directDocIdDictionaryFile.length() : 0;
+    long directDocIdInvertedIndexFileLength = hasDirectDocIdIndex ? _directDocIdInvertedIndexFile.length() : 0;
     headerBuffer.putLong(dictionaryFileLength);
     headerBuffer.putLong(invertedIndexFileLength);
     headerBuffer.putLong(docIdMappingFileLength);
@@ -193,30 +224,128 @@ public abstract class BaseJsonIndexCreator implements JsonIndexCreator {
 
     try (FileChannel indexFileChannel = new RandomAccessFile(_indexFile, "rw").getChannel();
         FileChannel dictionaryFileChannel = new RandomAccessFile(_dictionaryFile, "r").getChannel();
-        FileChannel invertedIndexFileChannel = new RandomAccessFile(_invertedIndexFile, "r").getChannel()) {
+        FileChannel invertedIndexFileChannel = new RandomAccessFile(_invertedIndexFile, "r").getChannel();
+        FileChannel directDocIdDictionaryFileChannel = hasDirectDocIdIndex
+            ? new RandomAccessFile(_directDocIdDictionaryFile, "r").getChannel() : null;
+        FileChannel directDocIdInvertedIndexFileChannel = hasDirectDocIdIndex
+            ? new RandomAccessFile(_directDocIdInvertedIndexFile, "r").getChannel() : null) {
       indexFileChannel.write(headerBuffer);
       org.apache.pinot.common.utils.FileUtils.transferBytes(dictionaryFileChannel, 0, dictionaryFileLength,
           indexFileChannel);
       org.apache.pinot.common.utils.FileUtils.transferBytes(invertedIndexFileChannel, 0, invertedIndexFileLength,
           indexFileChannel);
 
-      // Write the doc id mapping to the index file
-      ByteBuffer docIdMappingBuffer =
-          indexFileChannel.map(FileChannel.MapMode.READ_WRITE, indexFileChannel.position(), docIdMappingFileLength)
-              .order(ByteOrder.LITTLE_ENDIAN);
-      int numDocs = _numFlattenedRecordsList.size();
-      for (int i = 0; i < numDocs; i++) {
-        int numRecords = _numFlattenedRecordsList.getInt(i);
-        for (int j = 0; j < numRecords; j++) {
-          docIdMappingBuffer.putInt(i);
+      // Write the doc id mapping to the index file.
+      long docIdMappingStartOffset = indexFileChannel.position();
+      if (!omitDocIdMapping) {
+        ByteBuffer docIdMappingBuffer =
+            indexFileChannel.map(FileChannel.MapMode.READ_WRITE, docIdMappingStartOffset, docIdMappingFileLength)
+                .order(ByteOrder.LITTLE_ENDIAN);
+        int numDocs = _numFlattenedRecordsList.size();
+        for (int i = 0; i < numDocs; i++) {
+          int numRecords = _numFlattenedRecordsList.getInt(i);
+          for (int j = 0; j < numRecords; j++) {
+            docIdMappingBuffer.putInt(i);
+          }
+        }
+        if (CleanerUtil.UNMAP_SUPPORTED) {
+          CleanerUtil.BufferCleaner cleaner = CleanerUtil.getCleaner();
+          cleaner.freeBuffer(docIdMappingBuffer);
         }
       }
-      if (CleanerUtil.UNMAP_SUPPORTED) {
-        CleanerUtil.BufferCleaner cleaner = CleanerUtil.getCleaner();
-        cleaner.freeBuffer(docIdMappingBuffer);
+      indexFileChannel.position(docIdMappingStartOffset + docIdMappingFileLength);
+      if (hasDirectDocIdIndexHeader) {
+        ByteBuffer directDocIdHeaderBuffer = ByteBuffer.allocate(DIRECT_DOC_ID_INDEX_HEADER_LENGTH);
+        directDocIdHeaderBuffer.putLong(directDocIdDictionaryFileLength);
+        directDocIdHeaderBuffer.putLong(directDocIdInvertedIndexFileLength);
+        directDocIdHeaderBuffer.position(0);
+        indexFileChannel.write(directDocIdHeaderBuffer);
+        if (hasDirectDocIdIndex) {
+          org.apache.pinot.common.utils.FileUtils.transferBytes(directDocIdDictionaryFileChannel, 0,
+              directDocIdDictionaryFileLength, indexFileChannel);
+          org.apache.pinot.common.utils.FileUtils.transferBytes(directDocIdInvertedIndexFileChannel, 0,
+              directDocIdInvertedIndexFileLength, indexFileChannel);
+        }
       }
+      indexFileChannel.truncate(indexFileChannel.position());
       indexFileChannel.force(true);
     }
+  }
+
+  private boolean generateDirectDocIdIndexFiles()
+      throws IOException {
+    if (_docIdMappingIdentity) {
+      return false;
+    }
+
+    try (PinotDataBuffer dictionaryBuffer = PinotDataBuffer.mapReadOnlyBigEndianFile(_dictionaryFile);
+        PinotDataBuffer invertedIndexBuffer = PinotDataBuffer.mapReadOnlyBigEndianFile(_invertedIndexFile)) {
+      StringDictionary dictionary = new StringDictionary(dictionaryBuffer, 0, _maxValueLength);
+      int numDirectDocIdPostingLists = countDirectDocIdPostingLists(dictionary);
+      if (numDirectDocIdPostingLists == 0) {
+        return false;
+      }
+
+      BitmapInvertedIndexReader invertedIndex =
+          new BitmapInvertedIndexReader(invertedIndexBuffer, dictionary.length());
+      int[] flattenedDocIdUpperBounds = buildFlattenedDocIdUpperBounds();
+      try (VarLengthValueWriter dictionaryWriter =
+          new VarLengthValueWriter(_directDocIdDictionaryFile, numDirectDocIdPostingLists);
+          BitmapInvertedIndexWriter invertedIndexWriter =
+              new BitmapInvertedIndexWriter(_directDocIdInvertedIndexFile, numDirectDocIdPostingLists)) {
+        byte[] dictBuffer = dictionary.getBuffer();
+        for (int dictId = 0, length = dictionary.length(); dictId < length; dictId++) {
+          String value = dictionary.getStringValue(dictId, dictBuffer);
+          if (JsonIndexUtils.isDirectDocIdIndexEligibleValue(value)) {
+            byte[] valueBytes = value.getBytes(UTF_8);
+            dictionaryWriter.add(valueBytes);
+            RoaringBitmap docIds = new RoaringBitmap();
+            invertedIndex.getDocIds(dictId)
+                .forEach((IntConsumer) flattenedDocId -> docIds.add(getDocId(flattenedDocId,
+                    flattenedDocIdUpperBounds)));
+            invertedIndexWriter.add(docIds);
+          }
+        }
+      }
+      return true;
+    }
+  }
+
+  private int countDirectDocIdPostingLists(StringDictionary dictionary) {
+    int count = 0;
+    byte[] dictBuffer = dictionary.getBuffer();
+    for (int dictId = 0, length = dictionary.length(); dictId < length; dictId++) {
+      if (JsonIndexUtils.isDirectDocIdIndexEligibleValue(dictionary.getStringValue(dictId, dictBuffer))) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private int[] buildFlattenedDocIdUpperBounds() {
+    int numDocs = _numFlattenedRecordsList.size();
+    int[] flattenedDocIdUpperBounds = new int[numDocs];
+    int flattenedDocIdUpperBound = 0;
+    for (int docId = 0; docId < numDocs; docId++) {
+      flattenedDocIdUpperBound += _numFlattenedRecordsList.getInt(docId);
+      flattenedDocIdUpperBounds[docId] = flattenedDocIdUpperBound;
+    }
+    return flattenedDocIdUpperBounds;
+  }
+
+  private static int getDocId(int flattenedDocId, int[] flattenedDocIdUpperBounds) {
+    int target = flattenedDocId + 1;
+    int low = 0;
+    int high = flattenedDocIdUpperBounds.length;
+    while (low < high) {
+      int mid = (low + high) >>> 1;
+      if (flattenedDocIdUpperBounds[mid] < target) {
+        low = mid + 1;
+      } else {
+        high = mid;
+      }
+    }
+    return low;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/json/JsonIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/json/JsonIndexUtils.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.json;
+
+import org.apache.pinot.segment.spi.index.creator.JsonIndexCreator;
+import org.apache.pinot.spi.utils.JsonUtils;
+
+
+/// Utility methods shared by JSON index writers and readers.
+public final class JsonIndexUtils {
+  private JsonIndexUtils() {
+  }
+
+  public static boolean isDirectDocIdIndexEligibleKey(String key) {
+    return key.isEmpty() || (!key.endsWith(JsonUtils.KEY_SEPARATOR)
+        && !key.contains(JsonUtils.KEY_SEPARATOR + JsonUtils.KEY_SEPARATOR)
+        && !key.contains(JsonUtils.ARRAY_INDEX_KEY));
+  }
+
+  public static boolean isDirectDocIdIndexEligibleValue(String value) {
+    int separatorIndex = value.indexOf(JsonIndexCreator.KEY_VALUE_SEPARATOR);
+    String key = separatorIndex >= 0 ? value.substring(0, separatorIndex) : value;
+    return isDirectDocIdIndexEligibleKey(key);
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/json/ImmutableJsonIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/json/ImmutableJsonIndexReader.java
@@ -49,6 +49,7 @@ import org.apache.pinot.common.request.context.predicate.RegexpLikePredicate;
 import org.apache.pinot.common.utils.regex.Matcher;
 import org.apache.pinot.common.utils.regex.Pattern;
 import org.apache.pinot.segment.local.segment.creator.impl.inv.json.BaseJsonIndexCreator;
+import org.apache.pinot.segment.local.segment.index.json.JsonIndexUtils;
 import org.apache.pinot.segment.local.segment.index.readers.BitmapInvertedIndexReader;
 import org.apache.pinot.segment.local.segment.index.readers.StringDictionary;
 import org.apache.pinot.segment.spi.index.creator.JsonIndexCreator;
@@ -76,6 +77,15 @@ public class ImmutableJsonIndexReader implements JsonIndexReader {
   private final BitmapInvertedIndexReader _invertedIndex;
   private final long _numFlattenedDocs;
   private final PinotDataBuffer _docIdMapping;
+  @Nullable
+  private final StringDictionary _directDocIdDictionary;
+  @Nullable
+  private final BitmapInvertedIndexReader _directDocIdInvertedIndex;
+  private volatile int _docIdMappingIdentityState;
+
+  private static final int DOC_ID_MAPPING_IDENTITY_UNKNOWN = 0;
+  private static final int DOC_ID_MAPPING_IDENTITY_TRUE = 1;
+  private static final int DOC_ID_MAPPING_IDENTITY_FALSE = 2;
 
   // empty bitmap used to limit creation of new empty mutable bitmaps
   private static final ImmutableRoaringBitmap EMPTY_BITMAP;
@@ -99,8 +109,8 @@ public class ImmutableJsonIndexReader implements JsonIndexReader {
   public ImmutableJsonIndexReader(PinotDataBuffer dataBuffer, int numDocs) {
     _numDocs = numDocs;
     _version = dataBuffer.getInt(0);
-    Preconditions.checkState(_version == BaseJsonIndexCreator.VERSION_1 || _version == BaseJsonIndexCreator.VERSION_2,
-        "Unsupported json index version: %s", _version);
+    Preconditions.checkState(_version == BaseJsonIndexCreator.VERSION_1 || _version == BaseJsonIndexCreator.VERSION_2
+        || _version == BaseJsonIndexCreator.VERSION_3, "Unsupported json index version: %s", _version);
 
     int maxValueLength = dataBuffer.getInt(4);
     long dictionaryLength = dataBuffer.getLong(8);
@@ -116,8 +126,49 @@ public class ImmutableJsonIndexReader implements JsonIndexReader {
     _invertedIndex = new BitmapInvertedIndexReader(
         dataBuffer.view(dictionaryEndOffset, invertedIndexEndOffset, ByteOrder.BIG_ENDIAN), _dictionary.length());
     long docIdMappingEndOffset = invertedIndexEndOffset + docIdMappingLength;
-    _numFlattenedDocs = (docIdMappingLength / Integer.BYTES);
+    boolean omittedIdentityDocIdMapping = _version == BaseJsonIndexCreator.VERSION_3;
+    Preconditions.checkState(!omittedIdentityDocIdMapping || docIdMappingLength == 0,
+        "V3 json index must omit the identity doc id mapping, got mapping length: %s", docIdMappingLength);
+    _numFlattenedDocs = omittedIdentityDocIdMapping ? _numDocs : (docIdMappingLength / Integer.BYTES);
     _docIdMapping = dataBuffer.view(invertedIndexEndOffset, docIdMappingEndOffset, ByteOrder.LITTLE_ENDIAN);
+    _docIdMappingIdentityState =
+        omittedIdentityDocIdMapping ? DOC_ID_MAPPING_IDENTITY_TRUE
+            : (_numFlattenedDocs == _numDocs ? DOC_ID_MAPPING_IDENTITY_UNKNOWN : DOC_ID_MAPPING_IDENTITY_FALSE);
+    long directDocIdIndexHeaderEndOffset =
+        docIdMappingEndOffset + BaseJsonIndexCreator.DIRECT_DOC_ID_INDEX_HEADER_LENGTH;
+    if (dataBuffer.size() >= directDocIdIndexHeaderEndOffset) {
+      long directDocIdDictionaryLength = dataBuffer.getLong(docIdMappingEndOffset);
+      long directDocIdInvertedIndexLength = dataBuffer.getLong(docIdMappingEndOffset + Long.BYTES);
+      long directDocIdDictionaryStartOffset = directDocIdIndexHeaderEndOffset;
+      long directDocIdDictionaryEndOffset = directDocIdDictionaryStartOffset + directDocIdDictionaryLength;
+      long directDocIdInvertedIndexEndOffset = directDocIdDictionaryEndOffset + directDocIdInvertedIndexLength;
+      Preconditions.checkState(directDocIdInvertedIndexEndOffset == dataBuffer.size(),
+          "Invalid direct doc id json index section: expected end offset: %s, actual size: %s",
+          directDocIdInvertedIndexEndOffset, dataBuffer.size());
+      if (directDocIdDictionaryLength == 0 && directDocIdInvertedIndexLength == 0) {
+        _docIdMappingIdentityState = DOC_ID_MAPPING_IDENTITY_TRUE;
+        _directDocIdDictionary = null;
+        _directDocIdInvertedIndex = null;
+      } else {
+        _docIdMappingIdentityState = DOC_ID_MAPPING_IDENTITY_FALSE;
+        _directDocIdDictionary = new StringDictionary(
+            dataBuffer.view(directDocIdDictionaryStartOffset, directDocIdDictionaryEndOffset, ByteOrder.BIG_ENDIAN), 0,
+            maxValueLength);
+        _directDocIdInvertedIndex = new BitmapInvertedIndexReader(
+            dataBuffer.view(directDocIdDictionaryEndOffset, directDocIdInvertedIndexEndOffset, ByteOrder.BIG_ENDIAN),
+            _directDocIdDictionary.length());
+      }
+    } else {
+      Preconditions.checkState(dataBuffer.size() == docIdMappingEndOffset,
+          "Invalid json index size: expected doc id mapping end offset: %s, actual size: %s", docIdMappingEndOffset,
+          dataBuffer.size());
+      _directDocIdDictionary = null;
+      _directDocIdInvertedIndex = null;
+    }
+  }
+
+  private boolean isJsonPathIndexVersion() {
+    return _version == BaseJsonIndexCreator.VERSION_2 || _version == BaseJsonIndexCreator.VERSION_3;
   }
 
   @Override
@@ -141,20 +192,24 @@ public class ImmutableJsonIndexReader implements JsonIndexReader {
   }
 
   private MutableRoaringBitmap getMatchingDocIds(FilterContext filter) {
+    if (canEvaluateWithDocIdIndex(filter, true)) {
+      MutableRoaringBitmap directDocIds = getMatchingDocIdsFromDocIdIndex(filter);
+      if (directDocIds != null) {
+        return directDocIds;
+      }
+    }
+
     Predicate predicate = filter.getPredicate();
     if (predicate != null && isExclusive(predicate.getType())) {
       // Handle exclusive predicate separately because the flip can only be applied to the unflattened doc ids in order
       // to get the correct result, and it cannot be nested
       ImmutableRoaringBitmap flattenedDocIds = getMatchingFlattenedDocIds(predicate);
-      MutableRoaringBitmap resultDocIds = new MutableRoaringBitmap();
-      flattenedDocIds.forEach((IntConsumer) flattenedDocId -> resultDocIds.add(getDocId(flattenedDocId)));
+      MutableRoaringBitmap resultDocIds = toDocIdBitmap(flattenedDocIds);
       resultDocIds.flip(0, _numDocs);
       return resultDocIds;
     } else {
       ImmutableRoaringBitmap flattenedDocIds = getMatchingFlattenedDocIds(filter);
-      MutableRoaringBitmap resultDocIds = new MutableRoaringBitmap();
-      flattenedDocIds.forEach((IntConsumer) flattenedDocId -> resultDocIds.add(getDocId(flattenedDocId)));
-      return resultDocIds;
+      return toDocIdBitmap(flattenedDocIds);
     }
   }
 
@@ -163,6 +218,300 @@ public class ImmutableJsonIndexReader implements JsonIndexReader {
    */
   private boolean isExclusive(Predicate.Type predicateType) {
     return predicateType == Predicate.Type.IS_NULL;
+  }
+
+  private boolean isDocIdMappingIdentity() {
+    int docIdMappingIdentityState = _docIdMappingIdentityState;
+    if (docIdMappingIdentityState == DOC_ID_MAPPING_IDENTITY_TRUE) {
+      return true;
+    }
+    if (docIdMappingIdentityState == DOC_ID_MAPPING_IDENTITY_FALSE) {
+      return false;
+    }
+    if (_numFlattenedDocs != _numDocs) {
+      _docIdMappingIdentityState = DOC_ID_MAPPING_IDENTITY_FALSE;
+      return false;
+    }
+    for (int docId = 0; docId < _numDocs; docId++) {
+      if (getDocId(docId) != docId) {
+        _docIdMappingIdentityState = DOC_ID_MAPPING_IDENTITY_FALSE;
+        return false;
+      }
+    }
+    _docIdMappingIdentityState = DOC_ID_MAPPING_IDENTITY_TRUE;
+    return true;
+  }
+
+  private MutableRoaringBitmap toDocIdBitmap(ImmutableRoaringBitmap flattenedDocIds) {
+    if (isDocIdMappingIdentity()) {
+      return flattenedDocIds.toMutableRoaringBitmap();
+    }
+    MutableRoaringBitmap resultDocIds = new MutableRoaringBitmap();
+    flattenedDocIds.forEach((IntConsumer) flattenedDocId -> resultDocIds.add(getDocId(flattenedDocId)));
+    return resultDocIds;
+  }
+
+  @Nullable
+  private MutableRoaringBitmap getMatchingDocIdsFromDocIdIndex(FilterContext filter) {
+    switch (filter.getType()) {
+      case AND: {
+        List<FilterContext> filters = filter.getChildren();
+        MutableRoaringBitmap matchingDocIds = getMatchingDocIdsFromDocIdIndex(filters.get(0));
+        if (matchingDocIds == null) {
+          return null;
+        }
+        for (int i = 1, numFilters = filters.size(); i < numFilters; i++) {
+          if (matchingDocIds.isEmpty()) {
+            return matchingDocIds;
+          }
+          FilterContext childFilter = filters.get(i);
+          Predicate childPredicate = childFilter.getPredicate();
+          if (childPredicate != null && isExclusive(childPredicate.getType())) {
+            return null;
+          }
+          MutableRoaringBitmap childDocIds = getMatchingDocIdsFromDocIdIndex(childFilter);
+          if (childDocIds == null) {
+            return null;
+          }
+          matchingDocIds.and(childDocIds);
+        }
+        return matchingDocIds;
+      }
+      case OR: {
+        List<FilterContext> filters = filter.getChildren();
+        MutableRoaringBitmap matchingDocIds = getMatchingDocIdsFromDocIdIndex(filters.get(0));
+        if (matchingDocIds == null) {
+          return null;
+        }
+        for (int i = 1, numFilters = filters.size(); i < numFilters; i++) {
+          FilterContext childFilter = filters.get(i);
+          Predicate childPredicate = childFilter.getPredicate();
+          if (childPredicate != null && isExclusive(childPredicate.getType())) {
+            return null;
+          }
+          MutableRoaringBitmap childDocIds = getMatchingDocIdsFromDocIdIndex(childFilter);
+          if (childDocIds == null) {
+            return null;
+          }
+          matchingDocIds.or(childDocIds);
+        }
+        return matchingDocIds;
+      }
+      case PREDICATE:
+        return getMatchingDocIdsFromDocIdIndex(filter.getPredicate());
+      default:
+        throw new IllegalStateException();
+    }
+  }
+
+  private boolean canEvaluateWithDocIdIndex(FilterContext filter, boolean allowExclusivePredicate) {
+    switch (filter.getType()) {
+      case AND:
+      case OR:
+        for (FilterContext childFilter : filter.getChildren()) {
+          if (!canEvaluateWithDocIdIndex(childFilter, false)) {
+            return false;
+          }
+        }
+        return true;
+      case PREDICATE: {
+        Predicate predicate = filter.getPredicate();
+        return (allowExclusivePredicate || !isExclusive(predicate.getType()))
+            && normalizeDirectDocIdIndexKey(predicate) != null
+            && (_directDocIdDictionary != null || isDocIdMappingIdentity());
+      }
+      default:
+        throw new IllegalStateException();
+    }
+  }
+
+  @Nullable
+  private MutableRoaringBitmap getMatchingDocIdsFromDocIdIndex(Predicate predicate) {
+    String key = normalizeDirectDocIdIndexKey(predicate);
+    if (key == null) {
+      return null;
+    }
+    StringDictionary dictionary = getDirectDocIdDictionary();
+    BitmapInvertedIndexReader invertedIndex = getDirectDocIdInvertedIndex();
+
+    switch (predicate.getType()) {
+      case EQ: {
+        String value = ((EqPredicate) predicate).getValue();
+        int dictId = dictionary.indexOf(key + JsonIndexCreator.KEY_VALUE_SEPARATOR + value);
+        return dictId >= 0 ? getDirectDocIds(invertedIndex, dictId) : new MutableRoaringBitmap();
+      }
+
+      case NOT_EQ: {
+        int allValuesDictId = dictionary.indexOf(key);
+        if (allValuesDictId < 0) {
+          return new MutableRoaringBitmap();
+        }
+        MutableRoaringBitmap result = getDirectDocIds(invertedIndex, allValuesDictId);
+        String value = ((NotEqPredicate) predicate).getValue();
+        int dictId = dictionary.indexOf(key + JsonIndexCreator.KEY_VALUE_SEPARATOR + value);
+        if (dictId >= 0) {
+          result.andNot(getDirectDocIds(invertedIndex, dictId));
+        }
+        return result;
+      }
+
+      case IN: {
+        StringBuilder buffer = new StringBuilder(key);
+        buffer.append(JsonIndexCreator.KEY_VALUE_SEPARATOR);
+        int pos = buffer.length();
+        MutableRoaringBitmap result = new MutableRoaringBitmap();
+        List<String> values = ((InPredicate) predicate).getValues();
+        for (String value : values) {
+          buffer.setLength(pos);
+          buffer.append(value);
+          int dictId = dictionary.indexOf(buffer.toString());
+          if (dictId >= 0) {
+            result.or(getDirectDocIds(invertedIndex, dictId));
+          }
+        }
+        return result;
+      }
+
+      case NOT_IN: {
+        int allValuesDictId = dictionary.indexOf(key);
+        if (allValuesDictId < 0) {
+          return new MutableRoaringBitmap();
+        }
+        MutableRoaringBitmap result = getDirectDocIds(invertedIndex, allValuesDictId);
+        StringBuilder buffer = new StringBuilder(key);
+        buffer.append(JsonIndexCreator.KEY_VALUE_SEPARATOR);
+        int pos = buffer.length();
+        List<String> values = ((NotInPredicate) predicate).getValues();
+        for (String value : values) {
+          if (result.isEmpty()) {
+            return result;
+          }
+          buffer.setLength(pos);
+          buffer.append(value);
+          int dictId = dictionary.indexOf(buffer.toString());
+          if (dictId >= 0) {
+            result.andNot(getDirectDocIds(invertedIndex, dictId));
+          }
+        }
+        return result;
+      }
+
+      case IS_NOT_NULL: {
+        int dictId = dictionary.indexOf(key);
+        return dictId >= 0 ? getDirectDocIds(invertedIndex, dictId) : new MutableRoaringBitmap();
+      }
+
+      case IS_NULL: {
+        int dictId = dictionary.indexOf(key);
+        MutableRoaringBitmap result =
+            dictId >= 0 ? getDirectDocIds(invertedIndex, dictId) : new MutableRoaringBitmap();
+        result.flip(0, _numDocs);
+        return result;
+      }
+
+      case REGEXP_LIKE: {
+        int[] dictIds = getDictIdRangeForKey(key, dictionary);
+        if (dictIds[0] < 0) {
+          return new MutableRoaringBitmap();
+        }
+        Pattern pattern = ((RegexpLikePredicate) predicate).getPattern();
+        Matcher matcher = pattern.matcher("");
+        MutableRoaringBitmap result = new MutableRoaringBitmap();
+        byte[] dictBuffer = dictionary.getBuffer();
+        StringBuilder value = new StringBuilder();
+        int valueStart = key.length() + 1;
+        for (int dictId = dictIds[0]; dictId < dictIds[1]; dictId++) {
+          String keyValue = dictionary.getStringValue(dictId, dictBuffer);
+          value.setLength(0);
+          value.append(keyValue, valueStart, keyValue.length());
+          if (matcher.reset(value).matches()) {
+            result.or(getDirectDocIds(invertedIndex, dictId));
+          }
+        }
+        return result;
+      }
+
+      case RANGE: {
+        int[] dictIds = getDictIdRangeForKey(key, dictionary);
+        if (dictIds[0] < 0) {
+          return new MutableRoaringBitmap();
+        }
+        RangePredicate rangePredicate = (RangePredicate) predicate;
+        FieldSpec.DataType rangeDataType = rangePredicate.getRangeDataType();
+        if (rangeDataType.isNumeric()) {
+          rangeDataType = FieldSpec.DataType.DOUBLE;
+        } else {
+          rangeDataType = FieldSpec.DataType.STRING;
+        }
+        boolean lowerUnbounded = rangePredicate.getLowerBound().equals(RangePredicate.UNBOUNDED);
+        boolean upperUnbounded = rangePredicate.getUpperBound().equals(RangePredicate.UNBOUNDED);
+        boolean lowerInclusive = lowerUnbounded || rangePredicate.isLowerInclusive();
+        boolean upperInclusive = upperUnbounded || rangePredicate.isUpperInclusive();
+        Object lowerBound = lowerUnbounded ? null : rangeDataType.convert(rangePredicate.getLowerBound());
+        Object upperBound = upperUnbounded ? null : rangeDataType.convert(rangePredicate.getUpperBound());
+        MutableRoaringBitmap result = new MutableRoaringBitmap();
+        byte[] dictBuffer = dictionary.getBuffer();
+        int valueStart = key.length() + 1;
+        for (int dictId = dictIds[0]; dictId < dictIds[1]; dictId++) {
+          String value = dictionary.getStringValue(dictId, dictBuffer).substring(valueStart);
+          Object valueObj = rangeDataType.convert(value);
+          boolean lowerCompareResult =
+              lowerUnbounded || (lowerInclusive ? rangeDataType.compare(valueObj, lowerBound) >= 0
+                  : rangeDataType.compare(valueObj, lowerBound) > 0);
+          boolean upperCompareResult =
+              upperUnbounded || (upperInclusive ? rangeDataType.compare(valueObj, upperBound) <= 0
+                  : rangeDataType.compare(valueObj, upperBound) < 0);
+          if (lowerCompareResult && upperCompareResult) {
+            result.or(getDirectDocIds(invertedIndex, dictId));
+          }
+        }
+        return result;
+      }
+
+      default:
+        throw new IllegalStateException("Unsupported json_match predicate type: " + predicate);
+    }
+  }
+
+  @Nullable
+  private String normalizeDirectDocIdIndexKey(Predicate predicate) {
+    if (!isJsonPathIndexVersion()) {
+      return null;
+    }
+
+    ExpressionContext lhs = predicate.getLhs();
+    if (lhs.getType() != ExpressionContext.Type.IDENTIFIER) {
+      return null;
+    }
+
+    String key = lhs.getIdentifier();
+    if (key.indexOf('[') >= 0) {
+      return null;
+    }
+    if (key.startsWith("$")) {
+      key = key.substring(1);
+    } else {
+      key = JsonUtils.KEY_SEPARATOR + key;
+    }
+
+    Pair<String, ImmutableRoaringBitmap> pair = getKeyAndFlattenedDocIds(key);
+    if (pair.getRight() != null) {
+      return null;
+    }
+    key = pair.getLeft();
+    return JsonIndexUtils.isDirectDocIdIndexEligibleKey(key) ? key : null;
+  }
+
+  private StringDictionary getDirectDocIdDictionary() {
+    return _directDocIdDictionary != null ? _directDocIdDictionary : _dictionary;
+  }
+
+  private BitmapInvertedIndexReader getDirectDocIdInvertedIndex() {
+    return _directDocIdInvertedIndex != null ? _directDocIdInvertedIndex : _invertedIndex;
+  }
+
+  private MutableRoaringBitmap getDirectDocIds(BitmapInvertedIndexReader invertedIndex, int dictId) {
+    return invertedIndex.getDocIds(dictId).toMutableRoaringBitmap();
   }
 
   private static ImmutableRoaringBitmap and(ImmutableRoaringBitmap target, ImmutableRoaringBitmap other) {
@@ -266,7 +615,7 @@ public class ImmutableJsonIndexReader implements JsonIndexReader {
     // - JSONPath format (e.g. "$.a[1].b"='abc', "$[0]"=1, "$"='abc')
     // - Legacy format (e.g. "a[1].b"='abc')
     String key = lhs.getIdentifier();
-    if (_version == BaseJsonIndexCreator.VERSION_2) {
+    if (isJsonPathIndexVersion()) {
       if (key.startsWith("$")) {
         key = key.substring(1);
       } else {
@@ -471,10 +820,16 @@ public class ImmutableJsonIndexReader implements JsonIndexReader {
   }
 
   private int getDocId(int flattenedDocId) {
+    if (_docIdMappingIdentityState == DOC_ID_MAPPING_IDENTITY_TRUE) {
+      return flattenedDocId;
+    }
     return _docIdMapping.getInt((long) flattenedDocId << 2);
   }
 
   public void convertFlattenedDocIdsToDocIds(Map<String, RoaringBitmap> valueToFlattenedDocIds) {
+    if (isDocIdMappingIdentity()) {
+      return;
+    }
     valueToFlattenedDocIds.replaceAll((key, value) -> {
       RoaringBitmap docIds = new RoaringBitmap();
       value.forEach((IntConsumer) flattenedDocId -> docIds.add(getDocId(flattenedDocId)));
@@ -505,7 +860,7 @@ public class ImmutableJsonIndexReader implements JsonIndexReader {
     // Support 2 formats:
     // - JSONPath format (e.g. "$.a[1].b"='abc', "$[0]"=1, "$"='abc')
     // - Legacy format (e.g. "a[1].b"='abc')
-    if (_version == BaseJsonIndexCreator.VERSION_2) {
+    if (isJsonPathIndexVersion()) {
       if (jsonPathKey.startsWith("$")) {
         jsonPathKey = jsonPathKey.substring(1);
       } else {
@@ -555,7 +910,7 @@ public class ImmutableJsonIndexReader implements JsonIndexReader {
   @Override
   public Set<String> getMatchingDistinctValues(String jsonPathKey, @Nullable String filterString) {
     // Normalize the path key (same logic as getMatchingFlattenedDocsMap)
-    if (_version == BaseJsonIndexCreator.VERSION_2) {
+    if (isJsonPathIndexVersion()) {
       if (jsonPathKey.startsWith("$")) {
         jsonPathKey = jsonPathKey.substring(1);
       } else {
@@ -709,7 +1064,7 @@ public class ImmutableJsonIndexReader implements JsonIndexReader {
       return null;
     }
     String key = lhs.getIdentifier();
-    if (_version == BaseJsonIndexCreator.VERSION_2) {
+    if (isJsonPathIndexVersion()) {
       if (key.startsWith("$")) {
         key = key.substring(1);
       } else {
@@ -737,7 +1092,7 @@ public class ImmutableJsonIndexReader implements JsonIndexReader {
   }
 
   private String denormalizeKey(String normalizedKey) {
-    if (_version == BaseJsonIndexCreator.VERSION_2) {
+    if (isJsonPathIndexVersion()) {
       return "$" + normalizedKey;
     } else {
       return "$." + normalizedKey;
@@ -757,11 +1112,12 @@ public class ImmutableJsonIndexReader implements JsonIndexReader {
       docIdToPos.put(docIds[i], i);
     }
 
+    boolean docIdMappingIdentity = isDocIdMappingIdentity();
     for (Map.Entry<String, RoaringBitmap> entry : valueToMatchingFlattenedDocs.entrySet()) {
       String value = entry.getKey();
       RoaringBitmap matchingFlattenedDocIds = entry.getValue();
       matchingFlattenedDocIds.forEach((IntConsumer) flattenedDocId -> {
-        int docId = getDocId(flattenedDocId);
+        int docId = docIdMappingIdentity ? flattenedDocId : getDocId(flattenedDocId);
         if (docIdToPos.containsKey(docId)) {
           docIdToFlattenedDocIdsAndValues.get(docIdToPos.get(docId)).add(Pair.of(value, flattenedDocId));
         }
@@ -786,10 +1142,11 @@ public class ImmutableJsonIndexReader implements JsonIndexReader {
     Int2ObjectOpenHashMap<String> docIdToValues = new Int2ObjectOpenHashMap<>(docIds.length);
     RoaringBitmap docIdMask = RoaringBitmap.bitmapOf(docIds);
 
+    boolean docIdMappingIdentity = isDocIdMappingIdentity();
     for (Map.Entry<String, RoaringBitmap> entry : valueToMatchingDocs.entrySet()) {
       String value = entry.getKey();
       RoaringBitmap matchingDocIds = entry.getValue();
-      if (isFlattenedDocIds) {
+      if (isFlattenedDocIds && !docIdMappingIdentity) {
         matchingDocIds.forEach((IntConsumer) flattenedDocId -> {
           int docId = getDocId(flattenedDocId);
           if (docIdMask.contains(docId)) {
@@ -818,15 +1175,22 @@ public class ImmutableJsonIndexReader implements JsonIndexReader {
    * For a JSON key path, returns an int array of the range [min, max] spanning all values for the JSON key path
    */
   private int[] getDictIdRangeForKey(String key) {
+    return getDictIdRangeForKey(key, _dictionary);
+  }
+
+  /**
+   * For a JSON key path, returns an int array of the range [min, max] spanning all values for the JSON key path
+   */
+  private int[] getDictIdRangeForKey(String key, StringDictionary dictionary) {
     // json_index uses \0 as the separator (or \u0000 in unicode)
     // therefore, use the unicode char \u0001 to get the range of dict entries that have this prefix
 
     // get min for key
-    int indexOfMin = _dictionary.indexOf(key);
+    int indexOfMin = dictionary.indexOf(key);
     if (indexOfMin == -1) {
       return new int[]{-1, -1}; // if key does not exist, immediately return
     }
-    int indexOfMax = _dictionary.insertionIndexOf(key + JsonIndexCreator.KEY_VALUE_SEPARATOR_NEXT_CHAR);
+    int indexOfMax = dictionary.insertionIndexOf(key + JsonIndexCreator.KEY_VALUE_SEPARATOR_NEXT_CHAR);
 
     int minDictId = indexOfMin + 1; // skip the index of the key only
     int maxDictId = -1 * indexOfMax - 1; // undo the binary search
@@ -846,7 +1210,7 @@ public class ImmutableJsonIndexReader implements JsonIndexReader {
   private Pair<String, ImmutableRoaringBitmap> getKeyAndFlattenedDocIds(String key) {
     ImmutableRoaringBitmap matchingDocIds = null;
 
-    if (_version == BaseJsonIndexCreator.VERSION_2) {
+    if (isJsonPathIndexVersion()) {
       // Process the array index within the key if exists
       // E.g. "[*]"=1 -> "."='1'
       // E.g. "[0]"=1 -> ".$index"='0' && "."='1'

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/JsonIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/JsonIndexTest.java
@@ -33,6 +33,7 @@ import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.PinotBuffersAfterMethodCheckRule;
 import org.apache.pinot.segment.local.realtime.impl.json.MutableJsonIndexImpl;
+import org.apache.pinot.segment.local.segment.creator.impl.inv.json.BaseJsonIndexCreator;
 import org.apache.pinot.segment.local.segment.creator.impl.inv.json.OffHeapJsonIndexCreator;
 import org.apache.pinot.segment.local.segment.creator.impl.inv.json.OnHeapJsonIndexCreator;
 import org.apache.pinot.segment.local.segment.index.json.JsonIndexType;
@@ -164,6 +165,8 @@ public class JsonIndexTest implements PinotBuffersAfterMethodCheckRule {
         JsonIndexReader onHeapReader = new ImmutableJsonIndexReader(onHeapBuffer, records.length);
         JsonIndexReader offHeapReader = new ImmutableJsonIndexReader(offHeapBuffer, records.length);
         MutableJsonIndexImpl mutableJsonIndex = new MutableJsonIndexImpl(jsonIndexConfig, "table__0__1", "col")) {
+      assertDirectDocIdSidecar(onHeapBuffer);
+      assertDirectDocIdSidecar(offHeapBuffer);
       for (String record : records) {
         mutableJsonIndex.add(record);
       }
@@ -260,6 +263,87 @@ public class JsonIndexTest implements PinotBuffersAfterMethodCheckRule {
     }
   }
 
+  @Test
+  public void testScalarOnlyImmutableJsonIndexUsesIdentityMarker()
+      throws Exception {
+    String[] records = new String[]{
+        "{\"name\":\"adam\",\"age\":20,\"score\":1.25,\"dir\":\"downstream\"}",
+        "{\"name\":\"bob\",\"age\":25,\"score\":1.94,\"dir\":\"upstream\"}",
+        "{\"name\":\"charles\",\"age\":30,\"score\":0.90}",
+        "{\"name\":\"david\",\"age\":35,\"score\":0.9999,\"dir\":\"side\"}"
+    };
+    JsonIndexConfig jsonIndexConfig = getIndexConfig();
+
+    createIndex(true, jsonIndexConfig, records);
+    File onHeapIndexFile = new File(INDEX_DIR, ON_HEAP_COLUMN_NAME + V1Constants.Indexes.JSON_INDEX_FILE_EXTENSION);
+    assertTrue(onHeapIndexFile.exists());
+
+    createIndex(false, jsonIndexConfig, records);
+    File offHeapIndexFile = new File(INDEX_DIR, OFF_HEAP_COLUMN_NAME + V1Constants.Indexes.JSON_INDEX_FILE_EXTENSION);
+    assertTrue(offHeapIndexFile.exists());
+
+    try (PinotDataBuffer onHeapBuffer = PinotDataBuffer.mapReadOnlyBigEndianFile(onHeapIndexFile);
+        PinotDataBuffer offHeapBuffer = PinotDataBuffer.mapReadOnlyBigEndianFile(offHeapIndexFile);
+        JsonIndexReader onHeapReader = new ImmutableJsonIndexReader(onHeapBuffer, records.length);
+        JsonIndexReader offHeapReader = new ImmutableJsonIndexReader(offHeapBuffer, records.length);
+        MutableJsonIndexImpl mutableJsonIndex = new MutableJsonIndexImpl(jsonIndexConfig, "table__0__1", "col")) {
+      assertOmittedDocIdMappingIdentityMarker(onHeapBuffer);
+      assertOmittedDocIdMappingIdentityMarker(offHeapBuffer);
+      for (String record : records) {
+        mutableJsonIndex.add(record);
+      }
+
+      JsonIndexReader[] indexReaders = new JsonIndexReader[]{onHeapReader, offHeapReader, mutableJsonIndex};
+      for (JsonIndexReader reader : indexReaders) {
+        assertDocIds(reader, "\"$.dir\" = 'downstream'", ids(0));
+        assertDocIds(reader, "\"$.dir\" IN ('downstream', 'side')", ids(0, 3));
+        assertDocIds(reader, "\"$.age\" >= 25", ids(1, 2, 3));
+        assertDocIds(reader, "REGEXP_LIKE(\"$.name\", '.*a.*')", ids(0, 2, 3));
+        assertDocIds(reader, "\"$.dir\" IS NULL", ids(2));
+        assertDocIds(reader, "\"$.dir\" IS NOT NULL", ids(0, 1, 3));
+      }
+    }
+  }
+
+  @Test
+  public void testScalarPathUsesDocIdsWhenOtherPathHasArrays()
+      throws Exception {
+    String[] records = new String[]{
+        "{\"dir\":\"downstream\",\"tags\":[\"a\",\"b\"]}",
+        "{\"dir\":\"upstream\",\"tags\":[\"a\"]}",
+        "{\"tags\":[\"a\",\"b\",\"c\"]}",
+        "{\"dir\":\"side\",\"metadata\":{\"values\":[1,2]}}"
+    };
+    JsonIndexConfig jsonIndexConfig = getIndexConfig();
+
+    createIndex(true, jsonIndexConfig, records);
+    File onHeapIndexFile = new File(INDEX_DIR, ON_HEAP_COLUMN_NAME + V1Constants.Indexes.JSON_INDEX_FILE_EXTENSION);
+    assertTrue(onHeapIndexFile.exists());
+
+    createIndex(false, jsonIndexConfig, records);
+    File offHeapIndexFile = new File(INDEX_DIR, OFF_HEAP_COLUMN_NAME + V1Constants.Indexes.JSON_INDEX_FILE_EXTENSION);
+    assertTrue(offHeapIndexFile.exists());
+
+    try (PinotDataBuffer onHeapBuffer = PinotDataBuffer.mapReadOnlyBigEndianFile(onHeapIndexFile);
+        PinotDataBuffer offHeapBuffer = PinotDataBuffer.mapReadOnlyBigEndianFile(offHeapIndexFile);
+        JsonIndexReader onHeapReader = new ImmutableJsonIndexReader(onHeapBuffer, records.length);
+        JsonIndexReader offHeapReader = new ImmutableJsonIndexReader(offHeapBuffer, records.length);
+        MutableJsonIndexImpl mutableJsonIndex = new MutableJsonIndexImpl(jsonIndexConfig, "table__0__1", "col")) {
+      for (String record : records) {
+        mutableJsonIndex.add(record);
+      }
+      JsonIndexReader[] indexReaders = new JsonIndexReader[]{onHeapReader, offHeapReader, mutableJsonIndex};
+      for (JsonIndexReader reader : indexReaders) {
+        assertDocIds(reader, "\"$.dir\" = 'downstream'", ids(0));
+        assertDocIds(reader, "\"$.dir\" != 'upstream'", ids(0, 3));
+        assertDocIds(reader, "\"$.dir\" IN ('downstream', 'side')", ids(0, 3));
+        assertDocIds(reader, "\"$.dir\" NOT IN ('upstream', 'side')", ids(0));
+        assertDocIds(reader, "\"$.dir\" IS NULL", ids(2));
+        assertDocIds(reader, "\"$.dir\" IS NOT NULL", ids(0, 1, 3));
+      }
+    }
+  }
+
   private int[] empty() {
     return new int[0];
   }
@@ -275,6 +359,31 @@ public class JsonIndexTest implements PinotBuffersAfterMethodCheckRule {
     } catch (AssertionError ae) {
       throw new AssertionError(" index: " + indexReader.getClass().getSimpleName() + " " + ae.getMessage(), ae);
     }
+  }
+
+  private void assertOmittedDocIdMappingIdentityMarker(PinotDataBuffer buffer) {
+    assertEquals(buffer.getInt(0), BaseJsonIndexCreator.VERSION_3);
+    long dictionaryLength = buffer.getLong(8);
+    long invertedIndexLength = buffer.getLong(16);
+    long docIdMappingLength = buffer.getLong(24);
+    assertEquals(docIdMappingLength, 0L);
+    long docIdMappingEndOffset =
+        BaseJsonIndexCreator.HEADER_LENGTH + dictionaryLength + invertedIndexLength + docIdMappingLength;
+    assertEquals(buffer.size(), docIdMappingEndOffset + BaseJsonIndexCreator.DIRECT_DOC_ID_INDEX_HEADER_LENGTH);
+    assertEquals(buffer.getLong(docIdMappingEndOffset), 0L);
+    assertEquals(buffer.getLong(docIdMappingEndOffset + Long.BYTES), 0L);
+  }
+
+  private void assertDirectDocIdSidecar(PinotDataBuffer buffer) {
+    assertEquals(buffer.getInt(0), BaseJsonIndexCreator.VERSION_2);
+    long dictionaryLength = buffer.getLong(8);
+    long invertedIndexLength = buffer.getLong(16);
+    long docIdMappingLength = buffer.getLong(24);
+    assertTrue(docIdMappingLength > 0);
+    long docIdMappingEndOffset =
+        BaseJsonIndexCreator.HEADER_LENGTH + dictionaryLength + invertedIndexLength + docIdMappingLength;
+    assertTrue(buffer.getLong(docIdMappingEndOffset) > 0);
+    assertTrue(buffer.getLong(docIdMappingEndOffset + Long.BYTES) > 0);
   }
 
   @Test

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/JsonIndexQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/JsonIndexQuickStart.java
@@ -42,6 +42,11 @@ public class JsonIndexQuickStart extends Quickstart {
     printStatus(Color.YELLOW, "Most contributed repos by 'LombiqBot'");
     printStatus(Color.CYAN, "Query : " + q1);
     printStatus(Color.YELLOW, prettyPrintResponse(runner.runQuery(q1)));
+
+    String q2 = "select count(*) from githubEvents where json_match(actor, '\"$.login\"!=''LombiqBot''')";
+    printStatus(Color.YELLOW, "Events from actors other than 'LombiqBot'");
+    printStatus(Color.CYAN, "Query : " + q2);
+    printStatus(Color.YELLOW, prettyPrintResponse(runner.runQuery(q2)));
     printStatus(Color.GREEN, "***************************************************");
   }
 


### PR DESCRIPTION
## Summary
- skip flattened-doc-id to segment-doc-id translation when the JSON index mapping is identity
- emit JSON index V3 for immutable scalar-only JSON indexes so the identity doc-id mapping is omitted from disk
- keep a direct doc-id bitmap path for realtime JSON index predicates and immutable scalar paths whose JSON paths cannot expand through arrays
- fall back to flattened-doc evaluation for array paths to preserve same-array-element semantics

## User Manual
No table config changes are required. Existing JSON index configurations continue to work. Queries using `JSON_MATCH` or `jsonExtractIndex` can benefit automatically when a predicate targets a scalar/object JSON path that does not require array-element correlation.

When every indexed JSON document flattens to exactly one record, new immutable segments write JSON index V3 and omit the identity flattened-doc-id to real-doc-id mapping. JSON documents with arrays keep the compatible V2 layout and add a scalar-path direct-doc-id sidecar when useful.

Sample table config snippet:
```json
{
  "tableIndexConfig": {
    "jsonIndexConfigs": {
      "payload": {}
    }
  }
}
```

Sample queries:
```sql
SELECT COUNT(*)
FROM myTable
WHERE JSON_MATCH(payload, '"$.eventType" = ''click''');

SELECT COUNT(*)
FROM myTable
WHERE JSON_MATCH(payload, '"$.dir" != ''upstream''');

SELECT jsonExtractIndex(payload, '$.eventType', 'STRING')
FROM myTable
WHERE JSON_MATCH(payload, '"$.country" = ''US''');
```

Array predicates still use flattened-doc semantics:
```sql
SELECT COUNT(*)
FROM myTable
WHERE JSON_MATCH(payload, '"$.items[*].sku" = ''abc'' AND "$.items[*].qty" > 1');
```

## Benchmark
Local harness: `.bench-compare/JsonDocIdFastPathBench.java`, JDK 21, baseline `dd6520c726`, current `2fd1c3bcb1`, 10 warmups / 30 measured iterations.

| Scenario | Predicate | Baseline avg | Current avg | Speedup | Baseline index | Current index | Storage reduction |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| scalar dir-only, 1M rows | `"$.dir" != 'upstream'` | 4.260707 ms | 0.302997 ms | 14.1x | 4,256,550 B | 256,566 B | 16.59x |
| scalar dir-only, 1M rows | `"$.dir" IS NOT NULL` | 5.014949 ms | 0.078740 ms | 63.7x | 4,256,550 B | 256,566 B | 16.59x |
| scalar + extra fields, 1M rows | `"$.dir" != 'upstream'` | 4.230829 ms | 0.257292 ms | 16.4x | 7,282,779 B | 3,282,795 B | 2.22x |
| array length 32, 50k rows | `"$.dir" != 'upstream'` | 7.862618 ms | 0.151867 ms | 51.8x | 12,856,486 B | 12,881,206 B | 1.00x |
| array length 128, 50k rows | `"$.dir" != 'upstream'` | 31.125785 ms | 0.100103 ms | 310.9x | 51,454,913 B | 51,479,633 B | 1.00x |
| array length 128, 50k rows | `"$.dir" IS NOT NULL` | 33.870899 ms | 0.068719 ms | 492.9x | 51,454,913 B | 51,479,633 B | 1.00x |

Notes: V3 removes the identity doc-id mapping bytes entirely (`4,000,000 B -> 0 B` for the 1M-row scalar cases). Total index-size reduction depends on the remaining dictionary/inverted-index payload. Array scenarios keep the V2 mapping for compatibility and add a 24,720 B direct-doc-id sidecar in this benchmark.

## Tests
- `./mvnw -pl pinot-segment-local -Dtest=JsonIndexTest test`
- `./mvnw -pl pinot-tools -DskipTests compile`
- `./mvnw spotless:apply -pl pinot-segment-local,pinot-tools`
- `./mvnw checkstyle:check -pl pinot-segment-local,pinot-tools`
- `./mvnw license:format -pl pinot-segment-local,pinot-tools`
- `./mvnw license:check -pl pinot-segment-local,pinot-tools`
- `git diff --check`
