### PR TITLE
[#18688] Remove AI co-author trailers from commit history

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "includeCoAuthoredBy": false
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,3 +1,7 @@
 {
-  "includeCoAuthoredBy": false
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,11 @@ repo. It is intentionally short and focused on day-to-day work.
 - Prefer imports over fully qualified class names (e.g., use `import com.foo.Bar` and refer to `Bar`, not `com.foo.Bar` inline).
 - Prefer targeted unit tests; use integration tests when behavior crosses roles.
 
+## Commit messages
+- Do not include `Co-authored-by` trailers that reference AI tools (e.g., Claude, Copilot).
+  - **Why**: These trailers propagate into squash-merge commits on GitHub, making the project history appear AI-authored rather than human-authored.
+  - **Fix**: Omit the `Co-authored-by` line entirely when committing.
+
 ## Checkstyle config
 - Checkstyle rules and related config files live under `config/`.
 - Use the Maven wrapper (`./mvnw` on Unix-like systems or `mvnw.cmd` on Windows) to run `spotless:apply` to format code and `checkstyle:check` to validate style.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,11 @@ Apache Pinot is a real-time distributed OLAP datastore for low-latency analytics
 - Prefer targeted unit tests; use integration tests when behavior crosses roles.
 - Avoid deprecated APIs in new code. If you must reference one (e.g., for backward-compat serialization or to test the deprecated path), justify it with a comment.
 
+## Commit messages
+- Do not include `Co-authored-by` trailers that reference AI tools (e.g., Claude, Copilot).
+  - **Why**: These trailers propagate into squash-merge commits on GitHub, making the project history appear AI-authored rather than human-authored.
+  - **Fix**: Omit the `Co-authored-by` line entirely when committing.
+
 ## Pre-commit checks
 Before pushing a commit, run the following checks on the affected modules and fix any failures:
 1. `./mvnw spotless:apply -pl <module>` — auto-format code.


### PR DESCRIPTION
@xiangfu0

## Problem

Recent commits in the Pinot history contain AI tool trailers:

```
Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
```

These appear in `git log`, GitHub commit pages, and blame views — making it look like AI merged or authored the code.

## Cause

AI coding tools (Claude Code, GitHub Copilot, etc.) automatically append `Co-authored-by` trailers to commit messages by default. When PRs are **squash-merged** on GitHub, all trailers from individual commits are combined into the final merge commit. The result: AI attribution is permanently baked into the project's main branch history.

## Fix

Two layers of defense:

1. **`.claude/settings.json`** — adds `"includeCoAuthoredBy": false` so Claude Code never appends the trailer, regardless of individual user configuration. This is the enforced, deterministic fix.

2. **`CLAUDE.md`** — adds a "Commit messages" section instructing AI tools (including non-Claude tools like Copilot, Cursor) not to include `Co-authored-by` trailers. This covers tools that don't read `settings.json`.

### Changes

**`.claude/settings.json`** (new file):
```json
{
  "includeCoAuthoredBy": false
}
```

**`CLAUDE.md`** (new section):
```markdown
## Commit messages
- Do not include `Co-authored-by` trailers that reference AI tools (e.g., Claude, Copilot).
  - **Why**: These trailers propagate into squash-merge commits on GitHub, making the
    project history appear AI-authored rather than human-authored.
  - **Fix**: Omit the `Co-authored-by` line entirely when committing.
```

Fixes #18688