### PR TITLE
Count multi-segment data managers in numSegmentsQueried

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/SingleTableExecutionInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/SingleTableExecutionInfo.java
@@ -210,7 +210,13 @@ public class SingleTableExecutionInfo implements TableExecutionInfo {
 
   @Override
   public int getNumSegmentsAcquired() {
-    return _segmentDataManagers.size();
+    // Count the physical segments each manager contributes, not the number of managers, so that a manager wrapping
+    // multiple segments (e.g. a group folded under one map entry) is reflected in numSegmentsQueried.
+    int numSegmentsAcquired = 0;
+    for (SegmentDataManager segmentDataManager : _segmentDataManagers) {
+      numSegmentsAcquired += segmentDataManager.getNumQueriedSegments();
+    }
+    return numSegmentsAcquired;
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/executor/SingleTableExecutionInfoTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/executor/SingleTableExecutionInfoTest.java
@@ -82,7 +82,34 @@ public class SingleTableExecutionInfoTest {
 
     // Acquired segment data managers list still tracks the duo once (one reference to release)
     assertEquals(info.getSegmentDataManagers().size(), 2);
+    // numSegmentsQueried counts the queried unit per manager: a duo reports 1 (it is one logical segment
+    // mid-commit), so single(1) + duo(1) == 2 even though three index segments are scanned.
     assertEquals(info.getNumSegmentsAcquired(), 2);
+  }
+
+  /**
+   * {@code numSegmentsQueried} (via {@link SingleTableExecutionInfo#getNumSegmentsAcquired()}) sums the
+   * {@link SegmentDataManager#getNumQueriedSegments()} of each acquired manager rather than counting managers, so a
+   * manager that folds multiple independently addressable segments under one map entry is reflected in the metric.
+   */
+  @Test
+  public void testGetNumSegmentsAcquiredSumsQueriedSegmentsPerManager()
+      throws TableNotFoundException {
+    SegmentDataManager single = mockImmutableSegmentDataManager("seg00");
+    // Simulate a manager that folds multiple segments under one map entry; no current SegmentDataManager
+    // reports more than 1, so the count is stubbed to exercise the summation.
+    SegmentDataManager multi = mockImmutableSegmentDataManager("multiSegmentMgr");
+    when(multi.getNumQueriedSegments()).thenReturn(5);
+
+    InstanceDataManager instanceDataManager =
+        mockInstanceDataManager(Arrays.asList(single, multi), /*isUpsertEnabled=*/ false);
+
+    SingleTableExecutionInfo info = SingleTableExecutionInfo.create(instanceDataManager, TABLE_NAME_WITH_TYPE,
+        Arrays.asList("seg00", "multiSegmentMgr"), null, mock(QueryContext.class));
+
+    // Two managers acquired, but they contribute 1 + 5 == 6 queried segments.
+    assertEquals(info.getSegmentDataManagers().size(), 2);
+    assertEquals(info.getNumSegmentsAcquired(), 6);
   }
 
   /**
@@ -168,6 +195,7 @@ public class SingleTableExecutionInfoTest {
     when(sdm.getSegmentName()).thenReturn(segmentName);
     when(sdm.getSegment()).thenReturn(segment);
     when(sdm.getReferenceCount()).thenReturn(1);
+    when(sdm.getNumQueriedSegments()).thenReturn(1);
     return sdm;
   }
 
@@ -177,6 +205,7 @@ public class SingleTableExecutionInfoTest {
     when(sdm.getSegmentName()).thenReturn(segmentName);
     when(sdm.getSegment()).thenReturn(segment);
     when(sdm.getReferenceCount()).thenReturn(1);
+    when(sdm.getNumQueriedSegments()).thenReturn(1);
     return sdm;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/SegmentDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/SegmentDataManager.java
@@ -83,6 +83,20 @@ public abstract class SegmentDataManager {
   }
 
   /**
+   * Number of physical segments this manager contributes to the per-query {@code numSegmentsQueried} metric.
+   * Defaults to 1 — a manager is one logical queried unit. A manager that folds multiple independently addressable
+   * segments under a single map entry overrides this to its member count, so the reported query cost stays
+   * comparable to querying the same segments unwrapped.
+   *
+   * <p>This is intentionally distinct from {@link #getSegments()}: a multi-segment manager that represents a single
+   * logical segment mid-transition (a still-consuming segment together with its committed immutable counterpart)
+   * keeps the default of 1.
+   */
+  public int getNumQueriedSegments() {
+    return 1;
+  }
+
+  /**
    * Offloads the segment from the metadata management (e.g. upsert metadata), but not releases the resources yet
    * because there might be queries still accessing the segment.
    */


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Changed getNumSegmentsAcquired to sum each manager's queried segments count instead of counting managers\.

```mermaid
flowchart TD
  N0["getNumSegmentsAcquired #40;F1#41;"]:::stModified
  N1["loop over #95;segmentDataManagers #40;F1#41;"]:::stModified
  N2["invoke getNumQueriedSegments #40;F1#41;"]:::stModified
  N3["accumulate sum #40;F1#41;"]:::stModified
  N4["return sum #40;F1#41;"]:::stModified
  N5["getNumQueriedSegments returns 1 #40;F2#41;"]:::stAdded
  N0 -->|"starts loop"| N1
  N1 -->|"each iteration"| N2
  N2 -->|"value used"| N3
  N3 -->|"continue loop"| N1
  N1 -->|"loop ends"| N4
  N2 -->|"call to method"| N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/query/executor/SingleTableExecutionInfo\.java — [before](https://github.com/apache/pinot/blob/474efb1c1bf881b6cdbc27787e31a4942737ae85/pinot-core/src/main/java/org/apache/pinot/core/query/executor/SingleTableExecutionInfo.java) · [after](https://github.com/apache/pinot/blob/59b360571e4112049b1faf86008f9cd619d82f47/pinot-core/src/main/java/org/apache/pinot/core/query/executor/SingleTableExecutionInfo.java)
- F2: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/data/manager/SegmentDataManager\.java — [before](https://github.com/apache/pinot/blob/474efb1c1bf881b6cdbc27787e31a4942737ae85/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/SegmentDataManager.java) · [after](https://github.com/apache/pinot/blob/59b360571e4112049b1faf86008f9cd619d82f47/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/SegmentDataManager.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjQ3NGVmYjFjMWJmODgxYjZjZGJjMjc3ODdlMzFhNDk0MjczN2FlODUiLCJjb250ZXh0X2hhc2giOiJmNjhjNDIzZDcwZmZlMmVmODUzYWI5MTg2YzkwOTVmYThjNWIzZTU2NWE2M2IxNWEyZmFkN2IyZGIwMzNjMDRhIiwiZ2VuZXJhdGVkX2F0IjoxNzg5Njk1Mjk4LCJoZWFkX3NoYSI6IjU5YjM2MDU3MWU0MTEyMDQ5YjFmYWY4NjAwOGY5Y2Q2MTlkODJmNDciLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI0NzRlZmIxYzFiZjg4MWI2Y2RiYzI3Nzg3ZTMxYTQ5NDI3MzdhZTg1IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature a46617668b632051c64439210b426d2e44e4dfaadc405f0a1cc2782b24f5f2a2 -->
<!-- pinot-pr-flow:end -->

`SingleTableExecutionInfo#getNumSegmentsAcquired()` counts data managers, so a manager that exposes multiple `IndexSegment`s under a single map entry (via `hasMultiSegments()` / `getSegments()`) under-reports `numSegmentsQueried` relative to `numSegmentsPrunedByServer` and `numSegmentsProcessed`, which are computed on the expanded index-segment list. On such a table `numSegmentsPruned` can exceed `numSegmentsQueried`.

This adds `SegmentDataManager#getNumQueriedSegments()` (default 1) and sums it across acquired managers. The default preserves existing behavior — including `DuoSegmentDataManager`, which represents one logical segment during the commit window and stays at 1. A manager that folds multiple independently addressable segments under one map entry overrides it to its member count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)