### PR TITLE
Fix NPE in DebugResource.debugBrokers when broker resource idealState/externalView is null

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/DebugResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/DebugResource.java
@@ -419,10 +419,16 @@ public class DebugResource {
     ExternalView externalView =
         helixDataAccessor.getProperty(helixDataAccessor.keyBuilder().externalView(BROKER_RESOURCE_INSTANCE));
 
-    for (Map.Entry<String, String> entry : idealState.getInstanceStateMap(tableNameWithType).entrySet()) {
+    Map<String, String> isStateMap = idealState != null ? idealState.getInstanceStateMap(tableNameWithType) : null;
+    if (isStateMap == null) {
+      return brokerDebugInfos;
+    }
+    Map<String, String> evStateMap =
+        externalView != null ? externalView.getStateMap(tableNameWithType) : null;
+    for (Map.Entry<String, String> entry : isStateMap.entrySet()) {
       String brokerName = entry.getKey();
       String isState = entry.getValue();
-      String evState = externalView.getStateMap(tableNameWithType).get(brokerName);
+      String evState = evStateMap != null ? evStateMap.get(brokerName) : null;
       if (verbosity > 0 || !isState.equals(evState)) {
         brokerDebugInfos.add(new TableDebugInfo.BrokerDebugInfo(brokerName, isState, evState));
       }


### PR DESCRIPTION
## Description

`DebugResource.debugBrokers()` fetches the broker resource ideal-state and external-view via `HelixDataAccessor.getProperty()`. Both calls can legitimately return `null` (e.g. during cluster initialisation or a controller leader transition), and `ExternalView.getStateMap()` itself can return `null` for a partition not yet tracked in the external-view.

The current code dereferences all three without null-checks, producing a `NullPointerException` on the `/debug/tables/{tableName}` endpoint in those transient states.

**Three NPE paths in `debugBrokers()`:**
1. `idealState.getInstanceStateMap(tableNameWithType)` — `idealState` may be `null`
2. `externalView.getStateMap(tableNameWithType)` — `externalView` may be `null`  
3. `.get(brokerName)` on the result of `getStateMap()` — that map may itself be `null`

**Fix:** guard all three call-sites and return an empty list when the ideal-state map is absent; treat a missing EV partition as a `null` `evState` — consistent with how `debugServers` already handles the same scenario (lines 357–358 of the same file).

## Related Issues / PRs

Follows the same pattern as #18455 (_Fix NPE in `HelixHelper.getOfflineInstanceFromExternalView` when `resourceExternalView` is null_).

## Checklist

- [x] No behaviour change on the happy path
- [x] Null-handling is consistent with the existing pattern in `debugServers`