### PR TITLE
Fix typo: rename libthrift.verion property to libthrift.version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
     <snappy-java.version>1.1.10.8</snappy-java.version>
     <zstd-jni.version>1.5.7-10</zstd-jni.version>
     <lz4-java.version>1.11.0</lz4-java.version>
-    <libthrift.verion>0.23.0</libthrift.verion>
+    <libthrift.version>0.23.0</libthrift.version>
     <log4j.version>2.26.0</log4j.version>
     <slf4j.version>2.0.18</slf4j.version>
     <netty.version>4.1.135.Final</netty.version>
@@ -830,7 +830,7 @@
       <dependency>
         <groupId>org.apache.thrift</groupId>
         <artifactId>libthrift</artifactId>
-        <version>${libthrift.verion}</version>
+        <version>${libthrift.version}</version>
       </dependency>
       <dependency>
         <groupId>org.quartz-scheduler</groupId>


### PR DESCRIPTION
## Description

The Maven property for the libthrift dependency was declared as `libthrift.verion` (missing the `s`) and referenced under the same misspelling, so the build was not broken — but the property name is inconsistent with every other `*.version` property in the file.

**Change:** rename the property declaration and its single use-site from `libthrift.verion` to `libthrift.version`.

```xml
<!-- before -->
<libthrift.verion>0.23.0</libthrift.verion>
...
<version>${libthrift.verion}</version>

<!-- after -->
<libthrift.version>0.23.0</libthrift.version>
...
<version>${libthrift.version}</version>
```

## Checklist

- [x] Pure rename — no functional change
- [x] Both declaration and use-site updated together