### PR TITLE
Remove dead deprecated constant SegmentPrunerConfig.SEGMENT_PRUNER_NAMES_KEY

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/config/SegmentPrunerConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/config/SegmentPrunerConfig.java
@@ -28,9 +28,6 @@ import org.apache.pinot.spi.utils.CommonConstants.Server;
  * Config for SegmentPruner.
  */
 public class SegmentPrunerConfig {
-  @Deprecated
-  public static final String SEGMENT_PRUNER_NAMES_KEY = Server.CLASS;
-
   private final int _numSegmentPruners;
   private final List<String> _segmentPrunerNames;
   private final List<PinotConfiguration> _segmentPrunerConfigs;


### PR DESCRIPTION
## Description

`SegmentPrunerConfig.SEGMENT_PRUNER_NAMES_KEY` is a `@Deprecated` constant with **zero usages** anywhere in the codebase. It was an alias for `Server.CLASS` and was never referenced by any caller outside the class itself.

Remove the two-line dead constant.

## Checklist
- [x] Zero external usages confirmed via `grep`
- [x] No behaviour change