### PR TITLE
Migrate toServerRoutingInstance(boolean) callers to RoutingType enum

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/routing/ImplicitHybridTableRouteInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/routing/ImplicitHybridTableRouteInfo.java
@@ -273,7 +273,8 @@ public class ImplicitHybridTableRouteInfo implements TableRouteInfo {
   private Map<ServerRoutingInstance, InstanceRequest> getRequestMapFromRoutingTable(TableType tableType,
       Map<ServerInstance, SegmentsToQuery> routingTable, BrokerRequest brokerRequest, long requestId, String brokerId,
       boolean preferTls) {
-    ServerInstance.RoutingType routingType = preferTls ? ServerInstance.RoutingType.NETTY_TLS : ServerInstance.RoutingType.NETTY;
+    ServerInstance.RoutingType routingType =
+        preferTls ? ServerInstance.RoutingType.NETTY_TLS : ServerInstance.RoutingType.NETTY;
     Map<ServerRoutingInstance, InstanceRequest> requestMap = new HashMap<>();
     for (Map.Entry<ServerInstance, SegmentsToQuery> entry : routingTable.entrySet()) {
       ServerRoutingInstance serverRoutingInstance = entry.getKey().toServerRoutingInstance(tableType, routingType);

--- a/pinot-core/src/main/java/org/apache/pinot/core/routing/ImplicitHybridTableRouteInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/routing/ImplicitHybridTableRouteInfo.java
@@ -273,9 +273,10 @@ public class ImplicitHybridTableRouteInfo implements TableRouteInfo {
   private Map<ServerRoutingInstance, InstanceRequest> getRequestMapFromRoutingTable(TableType tableType,
       Map<ServerInstance, SegmentsToQuery> routingTable, BrokerRequest brokerRequest, long requestId, String brokerId,
       boolean preferTls) {
+    ServerInstance.RoutingType routingType = preferTls ? ServerInstance.RoutingType.NETTY_TLS : ServerInstance.RoutingType.NETTY;
     Map<ServerRoutingInstance, InstanceRequest> requestMap = new HashMap<>();
     for (Map.Entry<ServerInstance, SegmentsToQuery> entry : routingTable.entrySet()) {
-      ServerRoutingInstance serverRoutingInstance = entry.getKey().toServerRoutingInstance(tableType, preferTls);
+      ServerRoutingInstance serverRoutingInstance = entry.getKey().toServerRoutingInstance(tableType, routingType);
       InstanceRequest instanceRequest = getInstanceRequest(requestId, brokerId, brokerRequest, entry.getValue());
       requestMap.put(serverRoutingInstance, instanceRequest);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/routing/LogicalTableRouteInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/routing/LogicalTableRouteInfo.java
@@ -98,13 +98,14 @@ public class LogicalTableRouteInfo implements TableRouteInfo {
 
     Map<ServerRoutingInstance, InstanceRequest> requestMap = new HashMap<>();
 
+    ServerInstance.RoutingType routingType = preferTls ? ServerInstance.RoutingType.NETTY_TLS : ServerInstance.RoutingType.NETTY;
     for (Map.Entry<ServerInstance, List<TableSegmentsInfo>> entry : offlineTableRouteInfo.entrySet()) {
-      requestMap.put(entry.getKey().toServerRoutingInstance(TableType.OFFLINE, preferTls),
+      requestMap.put(entry.getKey().toServerRoutingInstance(TableType.OFFLINE, routingType),
           getInstanceRequest(requestId, brokerId, _offlineBrokerRequest, entry.getValue()));
     }
 
     for (Map.Entry<ServerInstance, List<TableSegmentsInfo>> entry : realtimeTableRouteInfo.entrySet()) {
-      requestMap.put(entry.getKey().toServerRoutingInstance(TableType.REALTIME, preferTls),
+      requestMap.put(entry.getKey().toServerRoutingInstance(TableType.REALTIME, routingType),
           getInstanceRequest(requestId, brokerId, _realtimeBrokerRequest, entry.getValue()));
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/routing/LogicalTableRouteInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/routing/LogicalTableRouteInfo.java
@@ -98,7 +98,8 @@ public class LogicalTableRouteInfo implements TableRouteInfo {
 
     Map<ServerRoutingInstance, InstanceRequest> requestMap = new HashMap<>();
 
-    ServerInstance.RoutingType routingType = preferTls ? ServerInstance.RoutingType.NETTY_TLS : ServerInstance.RoutingType.NETTY;
+    ServerInstance.RoutingType routingType =
+        preferTls ? ServerInstance.RoutingType.NETTY_TLS : ServerInstance.RoutingType.NETTY;
     for (Map.Entry<ServerInstance, List<TableSegmentsInfo>> entry : offlineTableRouteInfo.entrySet()) {
       requestMap.put(entry.getKey().toServerRoutingInstance(TableType.OFFLINE, routingType),
           getInstanceRequest(requestId, brokerId, _offlineBrokerRequest, entry.getValue()));

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
@@ -151,9 +151,9 @@ public class QueryRouter {
 
   public boolean hasChannel(ServerInstance serverInstance) {
     if (_serverChannelsTls != null) {
-      return _serverChannelsTls.hasChannel(serverInstance.toServerRoutingInstance(TableType.OFFLINE, true));
+      return _serverChannelsTls.hasChannel(serverInstance.toServerRoutingInstance(TableType.OFFLINE, ServerInstance.RoutingType.NETTY_TLS));
     } else {
-      return _serverChannels.hasChannel(serverInstance.toServerRoutingInstance(TableType.OFFLINE, false));
+      return _serverChannels.hasChannel(serverInstance.toServerRoutingInstance(TableType.OFFLINE, ServerInstance.RoutingType.NETTY));
     }
   }
 
@@ -163,9 +163,9 @@ public class QueryRouter {
   public boolean connect(ServerInstance serverInstance) {
     try {
       if (_serverChannelsTls != null) {
-        _serverChannelsTls.connect(serverInstance.toServerRoutingInstance(TableType.OFFLINE, true));
+        _serverChannelsTls.connect(serverInstance.toServerRoutingInstance(TableType.OFFLINE, ServerInstance.RoutingType.NETTY_TLS));
       } else {
-        _serverChannels.connect(serverInstance.toServerRoutingInstance(TableType.OFFLINE, false));
+        _serverChannels.connect(serverInstance.toServerRoutingInstance(TableType.OFFLINE, ServerInstance.RoutingType.NETTY));
       }
       return true;
     } catch (Exception e) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
@@ -151,9 +151,11 @@ public class QueryRouter {
 
   public boolean hasChannel(ServerInstance serverInstance) {
     if (_serverChannelsTls != null) {
-      return _serverChannelsTls.hasChannel(serverInstance.toServerRoutingInstance(TableType.OFFLINE, ServerInstance.RoutingType.NETTY_TLS));
+      return _serverChannelsTls.hasChannel(
+          serverInstance.toServerRoutingInstance(TableType.OFFLINE, ServerInstance.RoutingType.NETTY_TLS));
     } else {
-      return _serverChannels.hasChannel(serverInstance.toServerRoutingInstance(TableType.OFFLINE, ServerInstance.RoutingType.NETTY));
+      return _serverChannels.hasChannel(
+          serverInstance.toServerRoutingInstance(TableType.OFFLINE, ServerInstance.RoutingType.NETTY));
     }
   }
 
@@ -163,9 +165,11 @@ public class QueryRouter {
   public boolean connect(ServerInstance serverInstance) {
     try {
       if (_serverChannelsTls != null) {
-        _serverChannelsTls.connect(serverInstance.toServerRoutingInstance(TableType.OFFLINE, ServerInstance.RoutingType.NETTY_TLS));
+        _serverChannelsTls.connect(
+            serverInstance.toServerRoutingInstance(TableType.OFFLINE, ServerInstance.RoutingType.NETTY_TLS));
       } else {
-        _serverChannels.connect(serverInstance.toServerRoutingInstance(TableType.OFFLINE, ServerInstance.RoutingType.NETTY));
+        _serverChannels.connect(
+            serverInstance.toServerRoutingInstance(TableType.OFFLINE, ServerInstance.RoutingType.NETTY));
       }
       return true;
     } catch (Exception e) {


### PR DESCRIPTION
## Description

`ServerInstance.toServerRoutingInstance(TableType, boolean preferNettyTls)` is `@Deprecated` in favour of `toServerRoutingInstance(TableType, RoutingType)`. This PR migrates all three production call-sites to the typed overload.

### Changes

| File | Before | After |
|---|---|---|
| `QueryRouter` | `toServerRoutingInstance(…, true/false)` | `toServerRoutingInstance(…, NETTY_TLS / NETTY)` |
| `ImplicitHybridTableRouteInfo` | `toServerRoutingInstance(…, preferTls)` | resolve `RoutingType` once before loop, pass enum |
| `LogicalTableRouteInfo` | `toServerRoutingInstance(…, preferTls)` | same pattern |

`GrpcBrokerRequestHandler` already uses `RoutingType.GRPC` and is unaffected.

The deprecated overload and its test coverage in `QueryRoutingTest` are left for a follow-up removal PR once all callers are migrated.

## Checklist
- [x] No behaviour change — `true → NETTY_TLS`, `false → NETTY`
- [x] Consistent with `GrpcBrokerRequestHandler` which already uses the new API