### PR TITLE
Add best-effort mode for colocated-join routing of transiently-unavailable segments

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -255,7 +255,10 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
   /// Override to customize the [WorkerManager] used for multi-stage query engine worker assignment.
   protected WorkerManager createWorkerManager(String brokerId, String hostname, int port,
       RoutingManager routingManager) {
-    return new WorkerManager(brokerId, hostname, port, routingManager);
+    boolean colocatedJoinBestEffort = _brokerConf.getProperty(
+        CommonConstants.Broker.CONFIG_OF_COLOCATED_JOIN_BEST_EFFORT,
+        CommonConstants.Broker.DEFAULT_COLOCATED_JOIN_BEST_EFFORT);
+    return new WorkerManager(brokerId, hostname, port, routingManager, colocatedJoinBestEffort);
   }
 
   /// Override to supply a custom [SingleConnectionBrokerRequestHandler] subclass (e.g. one

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -825,6 +825,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
               "Found " + unavailableSegmentsInSubPlan + " unavailable segments for table " + tableName + ": "
                   + toSizeLimitedString(unavailableSegments, NUM_UNAVAILABLE_SEGMENTS_TO_LOG));
           brokerResponse.addException(errMsg);
+          _brokerMetrics.addMeteredTableValue(tableName, BrokerMeter.BROKER_RESPONSES_WITH_UNAVAILABLE_SEGMENTS, 1);
         }
       }
       requestContext.setNumUnavailableSegments(numUnavailableSegments);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManager.java
@@ -204,6 +204,9 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
     List<Pair<String, Integer>> unavailableSegments = new ArrayList<>();
     List<Triple<String, Integer, Integer>> segmentsReducingFullyReplicatedServers = new ArrayList<>();
     List<Map.Entry<String, SegmentInfo>> newSegmentInfoEntries = new ArrayList<>();
+    // Transiently-unavailable (no online replica) segments, grouped by partition. Attached to their PartitionInfo at
+    // the end so that a single unavailable segment doesn't clear the partition's fully replicated servers.
+    Map<Integer, List<String>> unavailableSegmentsByPartition = new HashMap<>();
     long currentTimeMs = System.currentTimeMillis();
     for (Map.Entry<String, SegmentInfo> entry : _segmentInfoMap.entrySet()) {
       String segment = entry.getKey();
@@ -221,16 +224,13 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
       List<String> onlineServers = segmentInfo._onlineServers;
       PartitionInfo partitionInfo = partitionInfoMap[partitionId];
       if (onlineServers.isEmpty()) {
+        // A non-new segment with no online replica is transiently unavailable (e.g. during rebalance, LLC commit, or
+        // server restart). Record it as unavailable for the partition, but do NOT add it to the routable segment list
+        // and do NOT clear the fully replicated servers: a single unavailable segment must not make the whole
+        // partition unroutable. Best-effort colocated routing surfaces these segments as a non-fatal warning, while
+        // strict routing fails the query when a partition has any unavailable segment.
         unavailableSegments.add(Pair.of(segment, partitionId));
-        if (partitionInfo == null) {
-          List<String> segments = new ArrayList<>();
-          segments.add(segment);
-          partitionInfo = new PartitionInfo(new HashSet<>(), segments);
-          partitionInfoMap[partitionId] = partitionInfo;
-        } else {
-          partitionInfo._fullyReplicatedServers.clear();
-          partitionInfo._segments.add(segment);
-        }
+        unavailableSegmentsByPartition.computeIfAbsent(partitionId, k -> new ArrayList<>()).add(segment);
       } else {
         if (partitionInfo == null) {
           Set<String> fullyReplicatedServers = new HashSet<>(onlineServers);
@@ -302,6 +302,22 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
         int numSegments = excludedNewSegments.size();
         LOGGER.info("Excluded {} new segments: {}... without all replicas available in table: {}", numSegments,
             numSegments <= 10 ? excludedNewSegments : excludedNewSegments.subList(0, 10) + "...", _tableNameWithType);
+      }
+    }
+    // Attach transiently-unavailable segments to their partitions so that best-effort routing can surface them. A
+    // partition that still has at least one available segment keeps its fully replicated servers; a partition whose
+    // segments are ALL unavailable gets a PartitionInfo with no fully replicated servers and no routable segments
+    // (rather than being left null), so routing consumers handle it consistently: strict mode fails with an informative
+    // error and best-effort mode reports the unavailable segments. Such a fully-unavailable partition still cannot be
+    // colocated-routed (no server holds its data), so the query fails in both modes, but never silently.
+    for (Map.Entry<Integer, List<String>> entry : unavailableSegmentsByPartition.entrySet()) {
+      int partitionId = entry.getKey();
+      PartitionInfo partitionInfo = partitionInfoMap[partitionId];
+      if (partitionInfo != null) {
+        partitionInfo._unavailableSegments.addAll(entry.getValue());
+      } else {
+        partitionInfoMap[partitionId] =
+            new PartitionInfo(new HashSet<>(), new ArrayList<>(), new ArrayList<>(entry.getValue()));
       }
     }
     _tablePartitionReplicatedServersInfo =

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManagerTest.java
@@ -42,6 +42,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel.OFFLINE;
 import static org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE;
 import static org.testng.Assert.*;
 
@@ -283,6 +284,78 @@ public class SegmentPartitionMetadataManagerTest extends ControllerTest {
     assertEqualsNoOrder(partitionInfoMap[1]._segments.toArray(), new String[]{segment1, segment2});
     assertFalse(tablePartitionReplicatedServersInfo.getSegmentsWithInvalidPartition().isEmpty());
     assertEquals(tablePartitionReplicatedServersInfo.getSegmentsWithInvalidPartition().get(0), segmentInvalid);
+  }
+
+  /// A non-new segment that is temporarily OFFLINE on all of its servers (e.g. during rebalance, LLC commit, or server
+  /// restart) must NOT clear the partition's fully replicated servers. The partition stays routable for its available
+  /// segments, and the unavailable segment is recorded separately so that best-effort colocated routing can surface it.
+  @Test
+  public void testTransientlyUnavailableSegmentDoesNotClearFullyReplicatedServers() {
+    ExternalView externalView = new ExternalView(OFFLINE_TABLE_NAME);
+    Map<String, Map<String, String>> segmentAssignment = externalView.getRecord().getMapFields();
+    Set<String> onlineSegments = new HashSet<>();
+    IdealState idealState = new IdealState(OFFLINE_TABLE_NAME);
+
+    SegmentPartitionMetadataManager partitionMetadataManager =
+        new SegmentPartitionMetadataManager(OFFLINE_TABLE_NAME, PARTITION_COLUMN, PARTITION_COLUMN_FUNC,
+            NUM_PARTITIONS, TimeUnit.MINUTES.toMillis(5));
+    SegmentZkMetadataFetcher segmentZkMetadataFetcher =
+        new SegmentZkMetadataFetcher(OFFLINE_TABLE_NAME, _propertyStore);
+    segmentZkMetadataFetcher.register(partitionMetadataManager);
+    segmentZkMetadataFetcher.init(idealState, externalView, onlineSegments);
+
+    // Partition 1 has two segments, both fully replicated on SERVER_0.
+    String segment1 = "segment1";
+    String segment2 = "segment2";
+    onlineSegments.add(segment1);
+    onlineSegments.add(segment2);
+    segmentAssignment.put(segment1, Map.of(SERVER_0, ONLINE));
+    segmentAssignment.put(segment2, Map.of(SERVER_0, ONLINE));
+    setSegmentZKMetadata(segment1, PARTITION_COLUMN_FUNC, NUM_PARTITIONS, 1, 0L);
+    setSegmentZKMetadata(segment2, PARTITION_COLUMN_FUNC, NUM_PARTITIONS, 1, 0L);
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    TablePartitionReplicatedServersInfo info = partitionMetadataManager.getTablePartitionReplicatedServersInfo();
+    TablePartitionReplicatedServersInfo.PartitionInfo[] partitionInfoMap = info.getPartitionInfoMap();
+    assertEquals(partitionInfoMap[1]._fullyReplicatedServers, Set.of(SERVER_0));
+    assertEqualsNoOrder(partitionInfoMap[1]._segments.toArray(), new String[]{segment1, segment2});
+    assertTrue(partitionInfoMap[1]._unavailableSegments.isEmpty());
+
+    // segment2 goes OFFLINE on its only replica. Previously this cleared the partition's fully replicated servers
+    // (empty set), making colocated-join routing fail. Now SERVER_0 is preserved for the available segment1, segment2
+    // is dropped from the routable list, and recorded as unavailable.
+    segmentAssignment.put(segment2, Map.of(SERVER_0, OFFLINE));
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    info = partitionMetadataManager.getTablePartitionReplicatedServersInfo();
+    partitionInfoMap = info.getPartitionInfoMap();
+    assertEquals(partitionInfoMap[1]._fullyReplicatedServers, Set.of(SERVER_0));
+    assertEquals(partitionInfoMap[1]._segments, List.of(segment1));
+    assertEquals(partitionInfoMap[1]._unavailableSegments, List.of(segment2));
+    assertTrue(info.getSegmentsWithInvalidPartition().isEmpty());
+
+    // When segment2 comes back online, it returns to the routable list and is no longer unavailable.
+    segmentAssignment.put(segment2, Map.of(SERVER_0, ONLINE));
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    info = partitionMetadataManager.getTablePartitionReplicatedServersInfo();
+    partitionInfoMap = info.getPartitionInfoMap();
+    assertEquals(partitionInfoMap[1]._fullyReplicatedServers, Set.of(SERVER_0));
+    assertEqualsNoOrder(partitionInfoMap[1]._segments.toArray(), new String[]{segment1, segment2});
+    assertTrue(partitionInfoMap[1]._unavailableSegments.isEmpty());
+
+    // A partition whose only segment is unavailable keeps a PartitionInfo with no fully replicated servers and no
+    // routable segments (the dark segment is recorded as unavailable), so routing consumers fail non-silently in both
+    // modes rather than silently dropping the partition.
+    String segment0 = "segment0";
+    onlineSegments.add(segment0);
+    segmentAssignment.put(segment0, Map.of(SERVER_0, OFFLINE));
+    setSegmentZKMetadata(segment0, PARTITION_COLUMN_FUNC, NUM_PARTITIONS, 0, 0L);
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    info = partitionMetadataManager.getTablePartitionReplicatedServersInfo();
+    partitionInfoMap = info.getPartitionInfoMap();
+    assertNotNull(partitionInfoMap[0]);
+    assertTrue(partitionInfoMap[0]._fullyReplicatedServers.isEmpty());
+    assertTrue(partitionInfoMap[0]._segments.isEmpty());
+    assertEquals(partitionInfoMap[0]._unavailableSegments, List.of(segment0));
+    assertTrue(info.getSegmentsWithInvalidPartition().isEmpty());
   }
 
   private void setSegmentZKMetadata(String segment, String partitionFunction, int numPartitions, int partitionId,

--- a/pinot-core/src/main/java/org/apache/pinot/core/routing/TablePartitionReplicatedServersInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/routing/TablePartitionReplicatedServersInfo.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.routing;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -70,10 +71,20 @@ public class TablePartitionReplicatedServersInfo {
   public static class PartitionInfo {
     public final Set<String> _fullyReplicatedServers;
     public final List<String> _segments;
+    // Segments belonging to this partition that currently have no online replica on any server. They are excluded from
+    // {@link #_fullyReplicatedServers} and {@link #_segments} so that a single transiently-unavailable segment does not
+    // make the whole partition unroutable. Best-effort colocated routing surfaces these as a non-fatal warning, while
+    // strict routing fails the query when this list is non-empty.
+    public final List<String> _unavailableSegments;
 
     public PartitionInfo(Set<String> fullyReplicatedServers, List<String> segments) {
+      this(fullyReplicatedServers, segments, new ArrayList<>());
+    }
+
+    public PartitionInfo(Set<String> fullyReplicatedServers, List<String> segments, List<String> unavailableSegments) {
       _fullyReplicatedServers = fullyReplicatedServers;
       _segments = segments;
+      _unavailableSegments = unavailableSegments;
     }
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -57,6 +57,7 @@ import org.apache.pinot.query.planner.physical.DispatchablePlanMetadata;
 import org.apache.pinot.query.planner.plannode.MailboxSendNode;
 import org.apache.pinot.query.planner.plannode.PlanNode;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
@@ -80,12 +81,21 @@ public class WorkerManager {
   private final String _hostName;
   private final int _port;
   private final RoutingManager _routingManager;
+  // Default for colocated (partition-based) join routing when the COLOCATED_JOIN_BEST_EFFORT query option is not set.
+  // When true, partitions with transiently-unavailable segments are routed best-effort instead of failing the query.
+  private final boolean _colocatedJoinBestEffortDefault;
 
   public WorkerManager(String instanceId, String hostName, int port, RoutingManager routingManager) {
+    this(instanceId, hostName, port, routingManager, CommonConstants.Broker.DEFAULT_COLOCATED_JOIN_BEST_EFFORT);
+  }
+
+  public WorkerManager(String instanceId, String hostName, int port, RoutingManager routingManager,
+      boolean colocatedJoinBestEffortDefault) {
     _instanceId = instanceId;
     _hostName = hostName;
     _port = port;
     _routingManager = routingManager;
+    _colocatedJoinBestEffortDefault = colocatedJoinBestEffortDefault;
   }
 
   public String getInstanceId() {
@@ -966,13 +976,21 @@ public class WorkerManager {
 
     Map<Integer, QueryServerInstance> workerIdToServerInstanceMap = new HashMap<>();
     Map<Integer, Map<String, List<String>>> workerIdToSegmentsMap = new HashMap<>();
+    boolean bestEffort = resolveColocatedJoinBestEffort(context.getPlannerContext().getOptions());
+    Set<String> unavailableSegments = new HashSet<>();
     if (numPartitionsPerWorker == 1) {
       assignOnePartitionPerWorker(tableName, context.getRequestId(), partitionInfoMap, partitionsToKeep,
-          _routingManager.getEnabledServerInstanceMap(), workerIdToServerInstanceMap, workerIdToSegmentsMap);
+          _routingManager.getEnabledServerInstanceMap(), workerIdToServerInstanceMap, workerIdToSegmentsMap, bestEffort,
+          unavailableSegments);
     } else {
       assignMultiplePartitionsPerWorker(tableName, context.getRequestId(), numPartitionsPerWorker, partitionInfoMap,
           partitionsToKeep, _routingManager.getEnabledServerInstanceMap(), workerIdToServerInstanceMap,
-          workerIdToSegmentsMap);
+          workerIdToSegmentsMap, bestEffort, unavailableSegments);
+    }
+    // Surface best-effort dropped segments the same way the non-partitioned leaf path does, so the broker can attach a
+    // non-fatal "unavailable segments" warning to the response (suppressible via the ignoreMissingSegments option).
+    if (!unavailableSegments.isEmpty()) {
+      metadata.addUnavailableSegments(tableName, unavailableSegments);
     }
     metadata.setWorkerIdToServerInstanceMap(workerIdToServerInstanceMap);
     metadata.setWorkerIdToSegmentsMap(workerIdToSegmentsMap);
@@ -1037,7 +1055,8 @@ public class WorkerManager {
     for (int i = 0; i < partitionInfoMap.length; i++) {
       PartitionInfo partitionInfo = partitionInfoMap[i];
       if (partitionInfo != null && (containsAny(partitionInfo._offlineSegments, matchedSegments) || containsAny(
-          partitionInfo._realtimeSegments, matchedSegments))) {
+          partitionInfo._realtimeSegments, matchedSegments) || containsAny(partitionInfo._unavailableSegments,
+          matchedSegments))) {
         partitionsToKeep.add(i);
       }
     }
@@ -1069,12 +1088,38 @@ public class WorkerManager {
     return numPrunedSegments;
   }
 
+  private boolean resolveColocatedJoinBestEffort(Map<String, String> queryOptions) {
+    String optionValue = queryOptions.get(QueryOptionKey.COLOCATED_JOIN_BEST_EFFORT);
+    return optionValue != null ? Boolean.parseBoolean(optionValue) : _colocatedJoinBestEffortDefault;
+  }
+
+  /// Handles a partition's transiently-unavailable segments for colocated routing. In strict mode (default), a
+  /// partition with any unavailable segment fails the query to guarantee complete results (preserving the original
+  /// all-or-nothing behavior). In best-effort mode, the unavailable segments are collected so they can be surfaced as a
+  /// non-fatal warning while the partition's available segments are still routed to a fully replicated server.
+  private static void collectUnavailableSegments(String tableName, int partitionId, PartitionInfo partitionInfo,
+      boolean bestEffort, Set<String> unavailableSegments) {
+    List<String> partitionUnavailableSegments = partitionInfo._unavailableSegments;
+    if (partitionUnavailableSegments.isEmpty()) {
+      return;
+    }
+    int numUnavailable = partitionUnavailableSegments.size();
+    Preconditions.checkState(bestEffort,
+        "Failed to find fully replicated server for table: %s, partition: %s with %s unavailable segment(s): %s. Set "
+            + "query option '%s=true' to route the available segments instead of failing the query.", tableName,
+        partitionId, numUnavailable,
+        numUnavailable <= 10 ? partitionUnavailableSegments : partitionUnavailableSegments.subList(0, 10) + "...",
+        QueryOptionKey.COLOCATED_JOIN_BEST_EFFORT);
+    unavailableSegments.addAll(partitionUnavailableSegments);
+  }
+
   /// Pick one worker per partition for partitioned leaf stage. When `partitionsToKeep` is non-null (broker
   /// pruning is active), partitions absent from the set are pruned by the query filter and skipped.
   private void assignOnePartitionPerWorker(String tableName, long requestId, PartitionInfo[] partitionInfoMap,
       @Nullable Set<Integer> partitionsToKeep, Map<String, ServerInstance> enabledServerInstanceMap,
       Map<Integer, QueryServerInstance> workerIdToServerInstanceMap,
-      Map<Integer, Map<String, List<String>>> workerIdToSegmentsMap) {
+      Map<Integer, Map<String, List<String>>> workerIdToSegmentsMap, boolean bestEffort,
+      Set<String> unavailableSegments) {
     int numPartitions = partitionInfoMap.length;
     int workerId = 0;
     for (int i = 0; i < numPartitions; i++) {
@@ -1088,6 +1133,7 @@ public class WorkerManager {
       //       the leaf stage won't be able to directly return empty response.
       Preconditions.checkState(partitionInfo != null, "Failed to find any segment for table: %s, partition: %s",
           tableName, i);
+      collectUnavailableSegments(tableName, i, partitionInfo, bestEffort, unavailableSegments);
       // NOTE: Pick worker based on the request id plus the partition id (not a running counter) so that the same worker
       //       is picked across different table scans when the segments for the same partition are colocated, and so
       //       that skipping pruned partitions does not shift the server assignment of the surviving ones.
@@ -1111,7 +1157,8 @@ public class WorkerManager {
       PartitionInfo[] partitionInfoMap, @Nullable Set<Integer> partitionsToKeep,
       Map<String, ServerInstance> enabledServerInstanceMap,
       Map<Integer, QueryServerInstance> workerIdToServerInstanceMap,
-      Map<Integer, Map<String, List<String>>> workerIdToSegmentsMap) {
+      Map<Integer, Map<String, List<String>>> workerIdToSegmentsMap, boolean bestEffort,
+      Set<String> unavailableSegments) {
     int numPartitions = partitionInfoMap.length;
     assert numPartitions % numPartitionsPerWorker == 0;
     int numWorkers = numPartitions / numPartitionsPerWorker;
@@ -1129,6 +1176,7 @@ public class WorkerManager {
         if (partitionInfo == null) {
           continue;
         }
+        collectUnavailableSegments(tableName, j, partitionInfo, bestEffort, unavailableSegments);
         if (fullyReplicatedServers == null) {
           fullyReplicatedServers = new HashSet<>(partitionInfo._fullyReplicatedServers);
         } else {
@@ -1226,21 +1274,26 @@ public class WorkerManager {
             continue;
           }
           if (offlinePartitionInfo == null) {
-            partitionInfoMap[i] =
-                new PartitionInfo(realtimePartitionInfo._fullyReplicatedServers, null, realtimePartitionInfo._segments);
+            partitionInfoMap[i] = new PartitionInfo(realtimePartitionInfo._fullyReplicatedServers, null,
+                realtimePartitionInfo._segments, realtimePartitionInfo._unavailableSegments);
             continue;
           }
           if (realtimePartitionInfo == null) {
-            partitionInfoMap[i] =
-                new PartitionInfo(offlinePartitionInfo._fullyReplicatedServers, offlinePartitionInfo._segments, null);
+            partitionInfoMap[i] = new PartitionInfo(offlinePartitionInfo._fullyReplicatedServers,
+                offlinePartitionInfo._segments, null, offlinePartitionInfo._unavailableSegments);
             continue;
           }
           Set<String> fullyReplicatedServers = new HashSet<>(offlinePartitionInfo._fullyReplicatedServers);
           fullyReplicatedServers.retainAll(realtimePartitionInfo._fullyReplicatedServers);
           Preconditions.checkState(!fullyReplicatedServers.isEmpty(),
               "Failed to find fully replicated server for partition: %s in hybrid table: %s", i, tableName);
+          List<String> unavailableSegments =
+              new ArrayList<>(offlinePartitionInfo._unavailableSegments.size()
+                  + realtimePartitionInfo._unavailableSegments.size());
+          unavailableSegments.addAll(offlinePartitionInfo._unavailableSegments);
+          unavailableSegments.addAll(realtimePartitionInfo._unavailableSegments);
           partitionInfoMap[i] = new PartitionInfo(fullyReplicatedServers, offlinePartitionInfo._segments,
-              realtimePartitionInfo._segments);
+              realtimePartitionInfo._segments, unavailableSegments);
         }
         return new PartitionTableInfo(offlineTpi.getPartitionColumn(), offlineTpi.getPartitionFunctionName(),
             partitionInfoMap, timeBoundaryInfo);
@@ -1336,12 +1389,12 @@ public class WorkerManager {
         if (partitionInfo != null) {
           switch (tableType) {
             case OFFLINE:
-              workerPartitionInfoMap[i] =
-                  new PartitionInfo(partitionInfo._fullyReplicatedServers, partitionInfo._segments, null);
+              workerPartitionInfoMap[i] = new PartitionInfo(partitionInfo._fullyReplicatedServers,
+                  partitionInfo._segments, null, partitionInfo._unavailableSegments);
               break;
             case REALTIME:
-              workerPartitionInfoMap[i] =
-                  new PartitionInfo(partitionInfo._fullyReplicatedServers, null, partitionInfo._segments);
+              workerPartitionInfoMap[i] = new PartitionInfo(partitionInfo._fullyReplicatedServers, null,
+                  partitionInfo._segments, partitionInfo._unavailableSegments);
               break;
             default:
               throw new IllegalStateException("Unsupported table type: " + tableType);
@@ -1357,12 +1410,16 @@ public class WorkerManager {
     final Set<String> _fullyReplicatedServers;
     final List<String> _offlineSegments;
     final List<String> _realtimeSegments;
+    // Segments of this partition with no online replica, excluded from the routable segment lists above. Surfaced as a
+    // non-fatal warning in best-effort mode, or used to fail the query in strict mode.
+    final List<String> _unavailableSegments;
 
     PartitionInfo(Set<String> fullyReplicatedServers, @Nullable List<String> offlineSegments,
-        @Nullable List<String> realtimeSegments) {
+        @Nullable List<String> realtimeSegments, List<String> unavailableSegments) {
       _fullyReplicatedServers = fullyReplicatedServers;
       _offlineSegments = offlineSegments;
       _realtimeSegments = realtimeSegments;
+      _unavailableSegments = unavailableSegments;
     }
   }
 

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/routing/WorkerManagerTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/routing/WorkerManagerTest.java
@@ -59,6 +59,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 
 /// Tests for [WorkerManager].
@@ -1104,6 +1105,352 @@ public class WorkerManagerTest {
       }
     }
     assertTrue(anyT1Server, "Expected at least one T1 server to be used");
+  }
+
+  /// Colocated (partition-based) join routing over a partition that has a transiently-unavailable segment must fail in
+  /// strict mode (the default), preserving the original all-or-nothing behavior, and the error must point at the
+  /// best-effort query option.
+  @Test
+  public void testColocatedRoutingStrictModeFailsOnUnavailableSegment() {
+    QueryEnvironment queryEnvironment = createPartitionedQueryEnvironment(false);
+    String query = "SELECT * FROM testTable /*+ tableOptions(partition_function='hashcode', partition_key='col1', "
+        + "partition_size='1') */ LIMIT 10";
+    try (QueryEnvironment.CompiledQuery compiledQuery = queryEnvironment.compile(query)) {
+      compiledQuery.planQuery(0);
+      fail("Expected strict colocated routing to fail for a partition with an unavailable segment");
+    } catch (RuntimeException e) {
+      String messages = flattenMessages(e);
+      assertTrue(messages.contains("unavailable"), "Unexpected error: " + messages);
+      assertTrue(messages.contains(CommonConstants.Broker.Request.QueryOptionKey.COLOCATED_JOIN_BEST_EFFORT),
+          "Error should reference the best-effort option: " + messages);
+    }
+  }
+
+  /// With the best-effort query option set, colocated routing routes the partition's available segments and surfaces
+  /// the unavailable ones via the dispatchable plan (so the broker can attach a non-fatal warning) instead of failing.
+  @Test
+  public void testColocatedRoutingBestEffortModeSurfacesUnavailableSegment() {
+    QueryEnvironment queryEnvironment = createPartitionedQueryEnvironment(false);
+    String query = "SET colocatedJoinBestEffort=true; SELECT * FROM testTable /*+ tableOptions("
+        + "partition_function='hashcode', partition_key='col1', partition_size='1') */ LIMIT 10";
+    try (QueryEnvironment.CompiledQuery compiledQuery = queryEnvironment.compile(query)) {
+      DispatchableSubPlan dispatchableSubPlan = compiledQuery.planQuery(0).getQueryPlan();
+      assertNotNull(dispatchableSubPlan);
+      Set<String> allUnavailable = new HashSet<>();
+      dispatchableSubPlan.getTableToUnavailableSegmentsMap().values().forEach(allUnavailable::addAll);
+      assertTrue(allUnavailable.contains("darkSeg"),
+          "Best-effort routing should surface the unavailable segment, got: " + allUnavailable);
+    }
+  }
+
+  /// The best-effort default can also be set at the broker level (WorkerManager default) instead of per-query.
+  @Test
+  public void testColocatedRoutingBestEffortDefaultSurfacesUnavailableSegment() {
+    QueryEnvironment queryEnvironment = createPartitionedQueryEnvironment(true);
+    String query = "SELECT * FROM testTable /*+ tableOptions(partition_function='hashcode', partition_key='col1', "
+        + "partition_size='1') */ LIMIT 10";
+    try (QueryEnvironment.CompiledQuery compiledQuery = queryEnvironment.compile(query)) {
+      DispatchableSubPlan dispatchableSubPlan = compiledQuery.planQuery(0).getQueryPlan();
+      assertNotNull(dispatchableSubPlan);
+      Set<String> allUnavailable = new HashSet<>();
+      dispatchableSubPlan.getTableToUnavailableSegmentsMap().values().forEach(allUnavailable::addAll);
+      assertTrue(allUnavailable.contains("darkSeg"),
+          "Best-effort default should surface the unavailable segment, got: " + allUnavailable);
+    }
+  }
+
+  /// The multiple-partitions-per-worker path must also fail in strict mode when one of a worker's partitions has an
+  /// unavailable segment (covers `assignMultiplePartitionsPerWorker`).
+  @Test
+  public void testColocatedRoutingMultiplePartitionsPerWorkerStrictFails() {
+    ServerInstance server1 = getServerInstance("localhost", 1);
+    Map<String, ServerInstance> serverInstanceMap = Map.of(server1.getInstanceId(), server1);
+    TablePartitionReplicatedServersInfo tpi = buildFourPartitionTpi(server1.getInstanceId(), false);
+    QueryEnvironment queryEnvironment = createQueryEnvironment(serverInstanceMap,
+        new UnavailableSegmentRoutingManager(serverInstanceMap, "testTable_OFFLINE", tpi), false);
+    // 4 partitions, partition_size='2' => 2 workers, 2 partitions per worker.
+    String query = "SELECT * FROM testTable /*+ tableOptions(partition_function='hashcode', partition_key='col1', "
+        + "partition_size='2') */ LIMIT 10";
+    try (QueryEnvironment.CompiledQuery compiledQuery = queryEnvironment.compile(query)) {
+      compiledQuery.planQuery(0);
+      fail("Expected strict multi-partition-per-worker routing to fail on an unavailable segment");
+    } catch (RuntimeException e) {
+      assertTrue(flattenMessages(e).contains("unavailable"), "Unexpected error: " + flattenMessages(e));
+    }
+  }
+
+  /// The multiple-partitions-per-worker path must surface unavailable segments in best-effort mode rather than silently
+  /// dropping them.
+  @Test
+  public void testColocatedRoutingMultiplePartitionsPerWorkerBestEffortSurfacesUnavailableSegment() {
+    ServerInstance server1 = getServerInstance("localhost", 1);
+    Map<String, ServerInstance> serverInstanceMap = Map.of(server1.getInstanceId(), server1);
+    TablePartitionReplicatedServersInfo tpi = buildFourPartitionTpi(server1.getInstanceId(), false);
+    QueryEnvironment queryEnvironment = createQueryEnvironment(serverInstanceMap,
+        new UnavailableSegmentRoutingManager(serverInstanceMap, "testTable_OFFLINE", tpi), true);
+    String query = "SELECT * FROM testTable /*+ tableOptions(partition_function='hashcode', partition_key='col1', "
+        + "partition_size='2') */ LIMIT 10";
+    try (QueryEnvironment.CompiledQuery compiledQuery = queryEnvironment.compile(query)) {
+      DispatchableSubPlan dispatchableSubPlan = compiledQuery.planQuery(0).getQueryPlan();
+      assertTrue(unavailableSegmentsOf(dispatchableSubPlan).contains("dark0"),
+          "Best-effort multi-partition routing should surface the unavailable segment");
+    }
+  }
+
+  /// A partition whose segments are ALL unavailable cannot be colocated-routed (no server holds its data). Best-effort
+  /// mode must fail the query rather than silently drop the partition's rows from the colocated join.
+  @Test
+  public void testColocatedRoutingFullyUnavailablePartitionFailsInBestEffortMode() {
+    ServerInstance server1 = getServerInstance("localhost", 1);
+    Map<String, ServerInstance> serverInstanceMap = Map.of(server1.getInstanceId(), server1);
+    TablePartitionReplicatedServersInfo tpi = buildFourPartitionTpi(server1.getInstanceId(), true);
+    QueryEnvironment queryEnvironment = createQueryEnvironment(serverInstanceMap,
+        new UnavailableSegmentRoutingManager(serverInstanceMap, "testTable_OFFLINE", tpi), true);
+    String query = "SELECT * FROM testTable /*+ tableOptions(partition_function='hashcode', partition_key='col1', "
+        + "partition_size='2') */ LIMIT 10";
+    try (QueryEnvironment.CompiledQuery compiledQuery = queryEnvironment.compile(query)) {
+      compiledQuery.planQuery(0);
+      fail("Expected best-effort routing to fail (not silently drop) a fully-unavailable partition");
+    } catch (RuntimeException e) {
+      assertTrue(flattenMessages(e).contains("fully replicated server"), "Unexpected error: " + flattenMessages(e));
+    }
+  }
+
+  /// For a hybrid table, best-effort routing must surface unavailable segments from both the OFFLINE and REALTIME sides
+  /// (covers the hybrid merge in `calculatePartitionTableInfo`).
+  @Test
+  public void testColocatedRoutingHybridBestEffortSurfacesUnavailableFromBothTableTypes() {
+    ServerInstance server1 = getServerInstance("localhost", 1);
+    Map<String, ServerInstance> serverInstanceMap = Map.of(server1.getInstanceId(), server1);
+    TablePartitionReplicatedServersInfo offlineTpi =
+        new TablePartitionReplicatedServersInfo("testTable_OFFLINE", "col1", "hashcode", 1,
+            new TablePartitionReplicatedServersInfo.PartitionInfo[]{
+                buildPartitionInfo(Set.of(server1.getInstanceId()), List.of("offAvail"), List.of("offDark"))},
+            List.of());
+    TablePartitionReplicatedServersInfo realtimeTpi = new TablePartitionReplicatedServersInfo("testTable_REALTIME",
+        "col1", "hashcode", 1, new TablePartitionReplicatedServersInfo.PartitionInfo[]{
+        buildPartitionInfo(Set.of(server1.getInstanceId()), List.of("rtAvail"), List.of("rtDark"))}, List.of());
+    RoutingManager routingManager = new HybridPartitionedRoutingManager(serverInstanceMap,
+        Map.of("testTable_OFFLINE", offlineTpi, "testTable_REALTIME", realtimeTpi), new TimeBoundaryInfo("ts", "1000"));
+    QueryEnvironment queryEnvironment = createQueryEnvironment(serverInstanceMap, routingManager, true);
+    String query = "SELECT * FROM testTable /*+ tableOptions(partition_function='hashcode', partition_key='col1', "
+        + "partition_size='1') */ LIMIT 10";
+    try (QueryEnvironment.CompiledQuery compiledQuery = queryEnvironment.compile(query)) {
+      DispatchableSubPlan dispatchableSubPlan = compiledQuery.planQuery(0).getQueryPlan();
+      Set<String> unavailable = unavailableSegmentsOf(dispatchableSubPlan);
+      assertTrue(unavailable.contains("offDark") && unavailable.contains("rtDark"),
+          "Hybrid best-effort routing should surface unavailable segments from both table types, got: " + unavailable);
+    }
+  }
+
+  /// Builds a 4-partition OFFLINE [TablePartitionReplicatedServersInfo] on a single server. Partition 0 carries an
+  /// unavailable segment "dark0"; when `partition0FullyDark` is true it has no available segment or server.
+  private static TablePartitionReplicatedServersInfo buildFourPartitionTpi(String serverId,
+      boolean partition0FullyDark) {
+    TablePartitionReplicatedServersInfo.PartitionInfo[] infos =
+        new TablePartitionReplicatedServersInfo.PartitionInfo[4];
+    infos[0] = partition0FullyDark
+        ? buildPartitionInfo(Set.of(), List.of(), List.of("dark0"))
+        : buildPartitionInfo(Set.of(serverId), List.of("avail0"), List.of("dark0"));
+    infos[1] = buildPartitionInfo(Set.of(serverId), List.of("avail1"), List.of());
+    infos[2] = buildPartitionInfo(Set.of(serverId), List.of("avail2"), List.of());
+    infos[3] = buildPartitionInfo(Set.of(serverId), List.of("avail3"), List.of());
+    return new TablePartitionReplicatedServersInfo("testTable_OFFLINE", "col1", "hashcode", 4, infos, List.of());
+  }
+
+  /// Builds a [QueryEnvironment] for a single OFFLINE table partitioned into one partition whose only available segment
+  /// is "availSeg" on server1, with an additional transiently-unavailable segment "darkSeg".
+  private static QueryEnvironment createPartitionedQueryEnvironment(boolean bestEffortDefault) {
+    ServerInstance server1 = getServerInstance("localhost", 1);
+    Map<String, ServerInstance> serverInstanceMap = Map.of(server1.getInstanceId(), server1);
+    TablePartitionReplicatedServersInfo.PartitionInfo partitionInfo =
+        buildPartitionInfo(Set.of(server1.getInstanceId()), List.of("availSeg"), List.of("darkSeg"));
+    TablePartitionReplicatedServersInfo tpi = new TablePartitionReplicatedServersInfo("testTable_OFFLINE", "col1",
+        "hashcode", 1, new TablePartitionReplicatedServersInfo.PartitionInfo[]{partitionInfo}, List.of());
+    return createQueryEnvironment(serverInstanceMap,
+        new UnavailableSegmentRoutingManager(serverInstanceMap, "testTable_OFFLINE", tpi), bestEffortDefault);
+  }
+
+  private static TablePartitionReplicatedServersInfo.PartitionInfo buildPartitionInfo(Set<String> servers,
+      List<String> segments, List<String> unavailableSegments) {
+    return new TablePartitionReplicatedServersInfo.PartitionInfo(new HashSet<>(servers), new ArrayList<>(segments),
+        new ArrayList<>(unavailableSegments));
+  }
+
+  private static QueryEnvironment createQueryEnvironment(Map<String, ServerInstance> serverInstanceMap,
+      RoutingManager routingManager, boolean bestEffortDefault) {
+    Schema schema = getSchemaBuilder("testTable").build();
+    Map<String, String> tableNameMap = new HashMap<>();
+    tableNameMap.put("testTable_OFFLINE", "testTable_OFFLINE");
+    tableNameMap.put("testTable_REALTIME", "testTable_REALTIME");
+    tableNameMap.put("testTable", "testTable");
+    TableCache tableCache = mock(TableCache.class);
+    when(tableCache.getTableNameMap()).thenReturn(tableNameMap);
+    when(tableCache.getActualTableName(anyString())).thenAnswer(inv -> tableNameMap.get(inv.getArgument(0)));
+    when(tableCache.getSchema(anyString())).thenReturn(schema);
+    when(tableCache.getTableConfig("testTable_OFFLINE")).thenReturn(mock(TableConfig.class));
+    when(tableCache.getTableConfig("testTable_REALTIME")).thenReturn(mock(TableConfig.class));
+    WorkerManager workerManager =
+        new WorkerManager("Broker_localhost", "localhost", 3, routingManager, bestEffortDefault);
+    return new QueryEnvironment(CommonConstants.DEFAULT_DATABASE, tableCache, workerManager);
+  }
+
+  private static Set<String> unavailableSegmentsOf(DispatchableSubPlan dispatchableSubPlan) {
+    Set<String> allUnavailable = new HashSet<>();
+    dispatchableSubPlan.getTableToUnavailableSegmentsMap().values().forEach(allUnavailable::addAll);
+    return allUnavailable;
+  }
+
+  private static String flattenMessages(Throwable throwable) {
+    StringBuilder sb = new StringBuilder();
+    for (Throwable cause = throwable; cause != null; cause = cause.getCause()) {
+      if (cause.getMessage() != null) {
+        sb.append(cause.getMessage()).append('\n');
+      }
+    }
+    return sb.toString();
+  }
+
+  /// A RoutingManager that serves a single partitioned table via [TablePartitionReplicatedServersInfo], used to
+  /// exercise the colocated (partition-based) leaf assignment path.
+  private static class UnavailableSegmentRoutingManager implements RoutingManager {
+    private final Map<String, ServerInstance> _serverInstanceMap;
+    private final String _tableNameWithType;
+    private final TablePartitionReplicatedServersInfo _tablePartitionReplicatedServersInfo;
+
+    UnavailableSegmentRoutingManager(Map<String, ServerInstance> serverInstanceMap, String tableNameWithType,
+        TablePartitionReplicatedServersInfo tablePartitionReplicatedServersInfo) {
+      _serverInstanceMap = serverInstanceMap;
+      _tableNameWithType = tableNameWithType;
+      _tablePartitionReplicatedServersInfo = tablePartitionReplicatedServersInfo;
+    }
+
+    @Override
+    public Map<String, ServerInstance> getEnabledServerInstanceMap() {
+      return _serverInstanceMap;
+    }
+
+    @Nullable
+    @Override
+    public RoutingTable getRoutingTable(BrokerRequest brokerRequest, long requestId) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public RoutingTable getRoutingTable(BrokerRequest brokerRequest, String tableNameWithType, long requestId) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public List<String> getSegments(BrokerRequest brokerRequest) {
+      return List.of();
+    }
+
+    @Override
+    public boolean routingExists(String tableNameWithType) {
+      return _tableNameWithType.equals(tableNameWithType);
+    }
+
+    @Nullable
+    @Override
+    public TimeBoundaryInfo getTimeBoundaryInfo(String offlineTableName) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public TablePartitionInfo getTablePartitionInfo(String tableNameWithType) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public TablePartitionReplicatedServersInfo getTablePartitionReplicatedServersInfo(String tableNameWithType) {
+      return _tableNameWithType.equals(tableNameWithType) ? _tablePartitionReplicatedServersInfo : null;
+    }
+
+    @Override
+    public Set<String> getServingInstances(String tableNameWithType) {
+      return new HashSet<>(_serverInstanceMap.keySet());
+    }
+
+    @Override
+    public boolean isTableDisabled(String tableNameWithType) {
+      return false;
+    }
+  }
+
+  /// A RoutingManager that serves a hybrid partitioned table: it returns a [TablePartitionReplicatedServersInfo] for
+  /// both the OFFLINE and REALTIME table names and a non-null time boundary so the hybrid colocated path is taken.
+  private static class HybridPartitionedRoutingManager implements RoutingManager {
+    private final Map<String, ServerInstance> _serverInstanceMap;
+    private final Map<String, TablePartitionReplicatedServersInfo> _tpiByTable;
+    private final TimeBoundaryInfo _timeBoundaryInfo;
+
+    HybridPartitionedRoutingManager(Map<String, ServerInstance> serverInstanceMap,
+        Map<String, TablePartitionReplicatedServersInfo> tpiByTable, TimeBoundaryInfo timeBoundaryInfo) {
+      _serverInstanceMap = serverInstanceMap;
+      _tpiByTable = tpiByTable;
+      _timeBoundaryInfo = timeBoundaryInfo;
+    }
+
+    @Override
+    public Map<String, ServerInstance> getEnabledServerInstanceMap() {
+      return _serverInstanceMap;
+    }
+
+    @Nullable
+    @Override
+    public RoutingTable getRoutingTable(BrokerRequest brokerRequest, long requestId) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public RoutingTable getRoutingTable(BrokerRequest brokerRequest, String tableNameWithType, long requestId) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public List<String> getSegments(BrokerRequest brokerRequest) {
+      return List.of();
+    }
+
+    @Override
+    public boolean routingExists(String tableNameWithType) {
+      return _tpiByTable.containsKey(tableNameWithType);
+    }
+
+    @Nullable
+    @Override
+    public TimeBoundaryInfo getTimeBoundaryInfo(String offlineTableName) {
+      return _timeBoundaryInfo;
+    }
+
+    @Nullable
+    @Override
+    public TablePartitionInfo getTablePartitionInfo(String tableNameWithType) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public TablePartitionReplicatedServersInfo getTablePartitionReplicatedServersInfo(String tableNameWithType) {
+      return _tpiByTable.get(tableNameWithType);
+    }
+
+    @Override
+    public Set<String> getServingInstances(String tableNameWithType) {
+      return new HashSet<>(_serverInstanceMap.keySet());
+    }
+
+    @Override
+    public boolean isTableDisabled(String tableNameWithType) {
+      return false;
+    }
   }
 
   /// A RoutingManager that simulates two tenants of servers, where only one tenant serves the queried

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -539,6 +539,15 @@ public class CommonConstants {
     // This value can always be overridden by INFER_PARTITION_HINT query option
     public static final String CONFIG_OF_INFER_PARTITION_HINT = "pinot.broker.multistage.infer.partition.hint";
     public static final boolean DEFAULT_INFER_PARTITION_HINT = false;
+    // Whether colocated (partition-based) join routing tolerates partitions with transiently-unavailable segments by
+    // default. When false (default), a partition missing any segment fails the query (all-or-nothing) to guarantee
+    // complete results. When true, the available segments are still routed and the unavailable ones are surfaced as a
+    // non-fatal warning, matching single-stage routing semantics. Useful when frequent segment state transitions
+    // (e.g. rebalance, LLC commit, server restart) would otherwise fail colocated-join queries.
+    // This value can always be overridden by the COLOCATED_JOIN_BEST_EFFORT query option.
+    public static final String CONFIG_OF_COLOCATED_JOIN_BEST_EFFORT =
+        "pinot.broker.multistage.colocated.join.best.effort";
+    public static final boolean DEFAULT_COLOCATED_JOIN_BEST_EFFORT = false;
 
     /// Whether to use spools in multistage query engine by default.
     /// This value can always be overridden by [Request.QueryOptionKey#USE_SPOOLS] query option
@@ -787,6 +796,10 @@ public class CommonConstants {
         public static final String EXPLAIN_PLAN_VERBOSE = "explainPlanVerbose";
         public static final String USE_MULTISTAGE_ENGINE = "useMultistageEngine";
         public static final String INFER_PARTITION_HINT = "inferPartitionHint";
+        // Per-query override of CONFIG_OF_COLOCATED_JOIN_BEST_EFFORT. When true, colocated (partition-based) join
+        // routing tolerates partitions with transiently-unavailable segments: it routes the available segments and
+        // surfaces the unavailable ones as a non-fatal warning instead of failing the whole query.
+        public static final String COLOCATED_JOIN_BEST_EFFORT = "colocatedJoinBestEffort";
         public static final String ENABLE_NULL_HANDLING = "enableNullHandling";
         public static final String APPLICATION_NAME = "applicationName";
         public static final String USE_SPOOLS = "useSpools";


### PR DESCRIPTION
## Problem

Colocated (partition-based) join routing in the multi-stage engine is all-or-nothing. `SegmentPartitionMetadataManager` clears a partition's fully-replicated server set whenever **any** single segment is transiently `OFFLINE` in the ExternalView (segment rebalance, LLC segment commit, server restart). Once that set is empty, `WorkerManager` throws `Failed to find enabled fully replicated server` and fails the **entire** colocated-join query.

These transitions are frequent in production, so colocated-join queries fail intermittently for the duration of the transition window — tuning `pinot.helix.instance.state.maxStateTransitions` does not help, because the routing table is recomputed on every ExternalView change and will observe the momentary `OFFLINE` state regardless.

This is also inconsistent with single-stage routing, which serves the available segments and attaches a non-fatal `BROKER_SEGMENT_UNAVAILABLE` warning rather than failing the query (see `BaseSingleStageBrokerRequestHandler`).

## Change

Adds an **opt-in best-effort mode** that brings colocated-join routing in line with single-stage semantics:

- **`SegmentPartitionMetadataManager`** no longer clears the fully-replicated servers for a transiently-unavailable segment. It records the segment as unavailable (new `PartitionInfo._unavailableSegments`) and keeps routing the partition's available segments. A partition whose segments are **all** unavailable keeps an empty `PartitionInfo` (instead of `null`) so routing consumers fail non-silently rather than dropping it.
- **`WorkerManager`**:
  - **strict** (default): a partition with any unavailable segment fails fast with an informative error that names the unavailable segments and points at the option.
  - **best-effort**: the available segments are routed, and the unavailable ones are surfaced via the existing `DispatchablePlanMetadata.addUnavailableSegments(...)` channel, which the broker turns into a non-fatal `SERVER_SEGMENT_MISSING` warning plus the `BROKER_RESPONSES_WITH_UNAVAILABLE_SEGMENTS` metric (suppressible via `ignoreMissingSegments`) — exactly like single-stage.
- Controlled by the **`colocatedJoinBestEffort`** query option, which overrides the **`pinot.broker.multistage.colocated.join.best.effort`** broker config (default `false` = original strict behavior). This mirrors the existing `inferPartitionHint` option/config pair.

### Behavior

| Partition state | strict (default) | best-effort |
|---|---|---|
| all segments available | route (unchanged) | route (unchanged) |
| some segments transiently unavailable | **fail** (informative error) | **route available** + non-fatal warning + metric |
| all segments unavailable | fail | fail (non-silent — no server holds the data) |

A fully-unavailable partition still fails in both modes because it cannot be colocated-routed (the leaf stage cannot return an empty partition response), but it fails explicitly rather than silently dropping rows.

## Testing

- `WorkerManagerTest` (new cases): strict-fails-on-unavailable-segment; best-effort via query option; best-effort via broker-config default; multiple-partitions-per-worker (strict + best-effort); fully-unavailable-partition fails non-silently in best-effort mode; hybrid offline+realtime unavailable-segment merge.
- `SegmentPartitionMetadataManagerTest` (new case): a transiently-`OFFLINE` segment preserves the partition's fully-replicated servers and is recorded as unavailable; it returns to the routable list when it comes back online; a fully-unavailable partition keeps an empty `PartitionInfo`.

## Backward compatibility

Default `false` preserves the current strict all-or-nothing behavior — no behavior change unless the option/config is enabled. The new SPI field is added via an additive constructor overload (the existing 2-arg constructor is preserved).

## Notes

Opening as a **draft** for review and CI. A docs/release-note entry for the new query option and broker config will follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
