### PR TITLE
Make new segment expiration time configurable in SegmentPartitionMetadataManager

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
@@ -22,7 +22,6 @@ import java.time.Clock;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.model.ExternalView;
@@ -41,12 +40,6 @@ import org.apache.pinot.spi.config.table.TableConfig;
  * The instance selector selects server instances to serve the query based on the selected segments.
  */
 public interface InstanceSelector {
-  long NEW_SEGMENT_EXPIRATION_MILLIS = TimeUnit.MINUTES.toMillis(5);
-
-  static boolean isNewSegment(long creationTimeMs, long currentTimeMs) {
-    return isNewSegment(creationTimeMs, currentTimeMs, NEW_SEGMENT_EXPIRATION_MILLIS);
-  }
-
   static boolean isNewSegment(long creationTimeMs, long currentTimeMs, long newSegmentExpirationMillis) {
     return creationTimeMs > 0 && currentTimeMs - creationTimeMs <= newSegmentExpirationMillis;
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
@@ -138,6 +138,7 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
   private final ServerRoutingStatsManager _serverRoutingStatsManager;
   private final PinotConfiguration _pinotConfig;
   private final boolean _enablePartitionMetadataManager;
+  private final long _newSegmentExpirationMs;
   private final ExecutorService _executorService;
   @Nullable
   private Consumer<ServerInstance> _serverReenableCallback;
@@ -180,6 +181,9 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
     _enablePartitionMetadataManager =
         pinotConfig.getProperty(CommonConstants.Broker.CONFIG_OF_ENABLE_PARTITION_METADATA_MANAGER,
             CommonConstants.Broker.DEFAULT_ENABLE_PARTITION_METADATA_MANAGER);
+    _newSegmentExpirationMs = TimeUnit.SECONDS.toMillis(
+        pinotConfig.getProperty(CommonConstants.Broker.CONFIG_OF_NEW_SEGMENT_EXPIRATION_SECONDS,
+            CommonConstants.Broker.DEFAULT_VALUE_OF_NEW_SEGMENT_EXPIRATION_SECONDS));
     int processSegmentAssignmentChangeNumThreads =
         pinotConfig.getProperty(CommonConstants.Broker.CONFIG_OF_ROUTING_ASSIGNMENT_CHANGE_PROCESS_PARALLELISM,
             CommonConstants.Broker.DEFAULT_ROUTING_ASSIGNMENT_CHANGE_PROCESS_PARALLELISM);
@@ -807,9 +811,9 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
                 columnPartitionMap.entrySet().iterator().next();
             LOGGER.info("Enabling SegmentPartitionMetadataManager for table: {} on partition column: {}",
                 tableNameWithType, partitionConfig.getKey());
-            partitionMetadataManager =
-                new SegmentPartitionMetadataManager(tableNameWithType, partitionConfig.getKey(),
-                    partitionConfig.getValue().getFunctionName(), partitionConfig.getValue().getNumPartitions());
+            partitionMetadataManager = new SegmentPartitionMetadataManager(tableNameWithType, partitionConfig.getKey(),
+                partitionConfig.getValue().getFunctionName(), partitionConfig.getValue().getNumPartitions(),
+                _newSegmentExpirationMs);
           } else {
             LOGGER.warn(
                 "Cannot enable SegmentPartitionMetadataManager for table: {} with multiple partition columns: {}",

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManager.java
@@ -63,6 +63,7 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
   private final String _partitionColumn;
   private final String _partitionFunctionName;
   private final int _numPartitions;
+  private final long _newSegmentExpirationMs;
 
   // cache-able content, only follow changes if onlineSegments list (of ideal-state) is changed.
   private final Map<String, SegmentInfo> _segmentInfoMap = new HashMap<>();
@@ -72,11 +73,12 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
   private transient TablePartitionReplicatedServersInfo _tablePartitionReplicatedServersInfo;
 
   public SegmentPartitionMetadataManager(String tableNameWithType, String partitionColumn, String partitionFunctionName,
-      int numPartitions) {
+      int numPartitions, long newSegmentExpirationMs) {
     _tableNameWithType = tableNameWithType;
     _partitionColumn = partitionColumn;
     _partitionFunctionName = partitionFunctionName;
     _numPartitions = numPartitions;
+    _newSegmentExpirationMs = newSegmentExpirationMs;
   }
 
   @Override
@@ -215,7 +217,7 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
         continue;
       }
       // Process new segments in the end
-      if (InstanceSelector.isNewSegment(segmentInfo._creationTimeMs, currentTimeMs)) {
+      if (InstanceSelector.isNewSegment(segmentInfo._creationTimeMs, currentTimeMs, _newSegmentExpirationMs)) {
         newSegmentInfoEntries.add(entry);
         continue;
       }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
@@ -59,7 +59,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import static org.apache.pinot.broker.routing.instanceselector.InstanceSelector.NEW_SEGMENT_EXPIRATION_MILLIS;
 import static org.apache.pinot.spi.config.table.RoutingConfig.REPLICA_GROUP_INSTANCE_SELECTOR_TYPE;
 import static org.apache.pinot.spi.config.table.RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE;
 import static org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING;
@@ -70,7 +69,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -109,7 +110,10 @@ public class InstanceSelectorTest {
   private final static List<String> SEGMENTS =
       Arrays.asList("segment0", "segment1", "segment2", "segment3", "segment4", "segment5", "segment6", "segment7",
           "segment8", "segment9", "segment10", "segment11");
-  private final static InstanceSelectorConfig INSTANCE_SELECTOR_CONFIG = new InstanceSelectorConfig(false, 300, false);
+  private static final long NEW_SEGMENT_EXPIRATION_SECONDS = 300;
+  private static final long NEW_SEGMENT_EXPIRATION_MILLIS = TimeUnit.SECONDS.toMillis(NEW_SEGMENT_EXPIRATION_SECONDS);
+  private final static InstanceSelectorConfig INSTANCE_SELECTOR_CONFIG =
+      new InstanceSelectorConfig(false, NEW_SEGMENT_EXPIRATION_SECONDS, false);
 
   private void createSegments(List<Pair<String, Long>> segmentCreationTimeMsPairs) {
     List<String> segmentZKMetadataPaths = new ArrayList<>();

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManagerTest.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
@@ -83,16 +84,16 @@ public class SegmentPartitionMetadataManagerTest extends ControllerTest {
     IdealState idealState = new IdealState(OFFLINE_TABLE_NAME);
 
     SegmentPartitionMetadataManager partitionMetadataManager =
-        new SegmentPartitionMetadataManager(OFFLINE_TABLE_NAME, PARTITION_COLUMN, PARTITION_COLUMN_FUNC,
-            NUM_PARTITIONS);
+        new SegmentPartitionMetadataManager(OFFLINE_TABLE_NAME, PARTITION_COLUMN, PARTITION_COLUMN_FUNC, NUM_PARTITIONS,
+            TimeUnit.MINUTES.toMillis(5));
     SegmentZkMetadataFetcher segmentZkMetadataFetcher =
         new SegmentZkMetadataFetcher(OFFLINE_TABLE_NAME, _propertyStore);
     segmentZkMetadataFetcher.register(partitionMetadataManager);
 
     // Initial state should be all empty
     segmentZkMetadataFetcher.init(idealState, externalView, onlineSegments);
-    TablePartitionReplicatedServersInfo tablePartitionReplicatedServersInfo = partitionMetadataManager
-        .getTablePartitionReplicatedServersInfo();
+    TablePartitionReplicatedServersInfo tablePartitionReplicatedServersInfo =
+        partitionMetadataManager.getTablePartitionReplicatedServersInfo();
     assertEquals(tablePartitionReplicatedServersInfo.getPartitionInfoMap(),
         new TablePartitionReplicatedServersInfo.PartitionInfo[NUM_PARTITIONS]);
     assertTrue(tablePartitionReplicatedServersInfo.getSegmentsWithInvalidPartition().isEmpty());
@@ -149,8 +150,8 @@ public class SegmentPartitionMetadataManagerTest extends ControllerTest {
     setSegmentZKMetadata(segment0, PARTITION_COLUMN_FUNC, NUM_PARTITIONS, 0, 0L);
     segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
     tablePartitionReplicatedServersInfo = partitionMetadataManager.getTablePartitionReplicatedServersInfo();
-    TablePartitionReplicatedServersInfo.PartitionInfo[] partitionInfoMap = tablePartitionReplicatedServersInfo
-        .getPartitionInfoMap();
+    TablePartitionReplicatedServersInfo.PartitionInfo[] partitionInfoMap =
+        tablePartitionReplicatedServersInfo.getPartitionInfoMap();
     assertEquals(partitionInfoMap[0]._fullyReplicatedServers, Collections.singleton(SERVER_0));
     assertEquals(partitionInfoMap[0]._segments, Collections.singleton(segment0));
     assertNull(partitionInfoMap[1]);


### PR DESCRIPTION
## Summary

`SegmentPartitionMetadataManager` hardcoded the 5-minute new-segment expiration window by calling the 2-arg `InstanceSelector.isNewSegment(creationTimeMs, currentTimeMs)` overload, which always used the fixed `NEW_SEGMENT_EXPIRATION_MILLIS` constant.

This makes that window configurable by wiring it to the **existing** broker config `pinot.broker.new.segment.expiration.seconds` (`CONFIG_OF_NEW_SEGMENT_EXPIRATION_SECONDS`), which `InstanceSelector` already honors. Both the instance selector and the partition metadata manager now derive the new-segment window from the same config, so they stay aligned instead of one being fixed at 5 minutes while the other is tunable.

Changes:
- `BaseBrokerRoutingManager` reads `CONFIG_OF_NEW_SEGMENT_EXPIRATION_SECONDS` (defaulting to `DEFAULT_VALUE_OF_NEW_SEGMENT_EXPIRATION_SECONDS`, 5 min), converts to ms, and passes it to the `SegmentPartitionMetadataManager` constructor.
- `SegmentPartitionMetadataManager` takes the expiration as a constructor arg and uses the 3-arg `isNewSegment` overload.
- Removed the now-unused 2-arg `InstanceSelector.isNewSegment(long, long)` overload and the `NEW_SEGMENT_EXPIRATION_MILLIS` constant.
