### PR TITLE
Use total stream partition count for realtime partition function divisor

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -2023,29 +2023,32 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         ColumnPartitionConfig columnPartitionConfig = entry.getValue();
         String partitionFunctionName = columnPartitionConfig.getFunctionName();
 
-        // NOTE: Here we compare the number of partitions from the config and the stream, and log a warning and emit a
-        //       metric when they don't match, but use the one from the stream. The mismatch could happen when the
-        //       stream partitions are changed, but the table config has not been updated to reflect the change.
-        //       In such case, picking the number of partitions from the stream can keep the segment properly
-        //       partitioned as long as the partition function is not changed.
+        // NOTE: Here we compare the number of partitions from the config and the stream, and log a warning when they
+        //       don't match, but use the one from the stream. The mismatch could happen when the stream partitions are
+        //       changed, but the table config has not been updated to reflect the change. In such case, picking the
+        //       number of partitions from the stream can keep the segment properly partitioned as long as the
+        //       partition function is not changed.
         int numPartitions = columnPartitionConfig.getNumPartitions();
         try {
-          // TODO: currentPartitionGroupConsumptionStatus should be fetched from idealState + segmentZkMetadata,
-          //  so that we get back accurate partitionGroups info
-          //  However this is not an issue for Kafka, since partitionGroups never expire and every partitionGroup has
-          //  a single partition
-          //  Fix this before opening support for partitioning in Kinesis
-          int numPartitionGroups = _partitionMetadataProvider.computePartitionGroupMetadata(_clientId, _streamConfig,
-              Collections.emptyList(), /*maxWaitTimeMs=*/15000).size();
+          // Use the total stream partition count as the partition function divisor. The upstream producer hashed each
+          // key over the full partition count, so the divisor must match that count for the per-segment partition
+          // metadata (and the partition pruning that relies on it) to be correct. fetchPartitionCount() returns that
+          // full count; computePartitionGroupMetadata().size() does not - when the table consumes only a subset of
+          // stream partitions it returns the subset size, which is wrong here.
+          // TODO: This is correct for Kafka, where partition ids are a stable contiguous range. It does not make
+          //   partitioning work for Kinesis, where shards split/merge and ids are not a contiguous 0..N range -
+          //   fetchPartitionCount() returns the total shard count there. Fix this before opening support for
+          //   partitioning in Kinesis.
+          int numStreamPartitions = _partitionMetadataProvider.fetchPartitionCount(/*maxWaitTimeMs=*/10_000);
 
-          if (numPartitionGroups != numPartitions) {
-            _segmentLogger.info(
+          if (numStreamPartitions != numPartitions) {
+            _segmentLogger.warn(
                 "Number of stream partitions: {} does not match number of partitions in the partition config: {}, "
-                    + "using number of stream " + "partitions", numPartitionGroups, numPartitions);
-            numPartitions = numPartitionGroups;
+                    + "using number of stream " + "partitions", numStreamPartitions, numPartitions);
+            numPartitions = numStreamPartitions;
           }
         } catch (Exception e) {
-          _segmentLogger.warn("Failed to get number of stream partitions in 5s, "
+          _segmentLogger.error("Failed to get number of stream partitions in 10s, "
               + "using number of partitions in the partition config: {}", numPartitions, e);
           createPartitionMetadataProvider("Timeout getting number of stream partitions");
         }


### PR DESCRIPTION
## Summary

`RealtimeSegmentDataManager.setPartitionParameters` derived the partition function divisor (`numPartitions`) from `computePartitionGroupMetadata(clientId, streamConfig, emptyList(), timeoutMs).size()`. That call fetches and discards a `StreamPartitionMsgOffset` for every partition just to take the list size, and — more importantly — returns the wrong count in two cases:

- **Kafka partition-subset feature** (`stream.kafka.partition.ids`): the `KafkaStreamMetadataProvider` override returns the *subset* size, not the topic's full partition count. The subset path also preserves the original Kafka partition ids as the partition group ids, so a divisor equal to the subset size cannot even represent those ids (e.g. a subset `{5, 17, 42}` with divisor `3`). The per-segment partition metadata is then computed inconsistently and partition pruning can prune valid segments, returning wrong results.
- **Kinesis**: the override excludes expired shards, so `.size()` reflects active shards rather than the producer's hashing space.

The divisor must match the partition count the upstream producer hashed each key over. `fetchPartitionCount` returns exactly that with a single call, so switch to it. For Kafka it resolves via `partitionsFor(topic)`, i.e. the full topic partition count, independent of any configured subset.

Kinesis partitioning remains unsupported (shards split/merge and ids are not a contiguous `0..N` range); a `TODO` records this.

Also refreshed the stale surrounding comments (no metric is emitted on mismatch; it is now logged at `warn`), promoted the fetch-failure log to `error`, and aligned the failure log message with the actual timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
