### PR TITLE
OPEN_STRUCT — SPI utilities, index registration, stats constructors (PR 2a/4)

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/AbstractColumnStatisticsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/AbstractColumnStatisticsCollector.java
@@ -56,13 +56,28 @@ public abstract class AbstractColumnStatisticsCollector implements ColumnStatist
   protected Comparable _previousValue = null;
 
   public AbstractColumnStatisticsCollector(String column, StatsCollectorConfig statsCollectorConfig) {
-    _fieldSpec = statsCollectorConfig.getFieldSpecForColumn(column);
-    Preconditions.checkArgument(_fieldSpec != null, "Failed to find column: %s", column);
-    _storedType = _fieldSpec.getDataType().getStoredType();
-    _sorted = _fieldSpec.isSingleValueField();
-    _fieldConfig = statsCollectorConfig.getFieldConfigForColumn(column);
-    _partitionFunction = statsCollectorConfig.getPartitionFunction(column);
-    _partitions = _partitionFunction != null ? new HashSet<>() : null;
+    this(getRequiredFieldSpec(column, statsCollectorConfig),
+        statsCollectorConfig.getFieldConfigForColumn(column),
+        statsCollectorConfig.getPartitionFunction(column));
+  }
+
+  /// Constructs a collector directly from a [FieldSpec], without a [StatsCollectorConfig]. Lets callers
+  /// that operate outside schema-driven segment generation (e.g. OPEN_STRUCT materialized child columns,
+  /// whose synthetic columns exist in no schema) reuse the standard stats collectors.
+  public AbstractColumnStatisticsCollector(FieldSpec fieldSpec, @Nullable FieldConfig fieldConfig,
+      @Nullable PartitionFunction partitionFunction) {
+    _fieldSpec = fieldSpec;
+    _storedType = fieldSpec.getDataType().getStoredType();
+    _sorted = fieldSpec.isSingleValueField();
+    _fieldConfig = fieldConfig;
+    _partitionFunction = partitionFunction;
+    _partitions = partitionFunction != null ? new HashSet<>() : null;
+  }
+
+  private static FieldSpec getRequiredFieldSpec(String column, StatsCollectorConfig statsCollectorConfig) {
+    FieldSpec fieldSpec = statsCollectorConfig.getFieldSpecForColumn(column);
+    Preconditions.checkArgument(fieldSpec != null, "Failed to find column: %s", column);
+    return fieldSpec;
   }
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/BigDecimalColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/BigDecimalColumnPreIndexStatsCollector.java
@@ -21,7 +21,11 @@ package org.apache.pinot.segment.local.segment.creator.impl.stats;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import java.math.BigDecimal;
 import java.util.Arrays;
+import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.creator.StatsCollectorConfig;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
 
 
@@ -38,6 +42,11 @@ public class BigDecimalColumnPreIndexStatsCollector extends AbstractColumnStatis
 
   public BigDecimalColumnPreIndexStatsCollector(String column, StatsCollectorConfig statsCollectorConfig) {
     super(column, statsCollectorConfig);
+  }
+
+  public BigDecimalColumnPreIndexStatsCollector(FieldSpec fieldSpec, @Nullable FieldConfig fieldConfig,
+      @Nullable PartitionFunction partitionFunction) {
+    super(fieldSpec, fieldConfig, partitionFunction);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/BytesColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/BytesColumnPreIndexStatsCollector.java
@@ -21,7 +21,11 @@ package org.apache.pinot.segment.local.segment.creator.impl.stats;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import java.util.Arrays;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.creator.StatsCollectorConfig;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.utils.ByteArray;
 
 
@@ -38,6 +42,11 @@ public class BytesColumnPreIndexStatsCollector extends AbstractColumnStatisticsC
 
   public BytesColumnPreIndexStatsCollector(String column, StatsCollectorConfig statsCollectorConfig) {
     super(column, statsCollectorConfig);
+  }
+
+  public BytesColumnPreIndexStatsCollector(FieldSpec fieldSpec, @Nullable FieldConfig fieldConfig,
+      @Nullable PartitionFunction partitionFunction) {
+    super(fieldSpec, fieldConfig, partitionFunction);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/DoubleColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/DoubleColumnPreIndexStatsCollector.java
@@ -21,7 +21,11 @@ package org.apache.pinot.segment.local.segment.creator.impl.stats;
 import it.unimi.dsi.fastutil.doubles.DoubleOpenHashSet;
 import it.unimi.dsi.fastutil.doubles.DoubleSet;
 import java.util.Arrays;
+import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.creator.StatsCollectorConfig;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.data.FieldSpec;
 
 
 public class DoubleColumnPreIndexStatsCollector extends AbstractColumnStatisticsCollector {
@@ -32,6 +36,11 @@ public class DoubleColumnPreIndexStatsCollector extends AbstractColumnStatistics
 
   public DoubleColumnPreIndexStatsCollector(String column, StatsCollectorConfig statsCollectorConfig) {
     super(column, statsCollectorConfig);
+  }
+
+  public DoubleColumnPreIndexStatsCollector(FieldSpec fieldSpec, @Nullable FieldConfig fieldConfig,
+      @Nullable PartitionFunction partitionFunction) {
+    super(fieldSpec, fieldConfig, partitionFunction);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/FloatColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/FloatColumnPreIndexStatsCollector.java
@@ -21,7 +21,11 @@ package org.apache.pinot.segment.local.segment.creator.impl.stats;
 import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
 import it.unimi.dsi.fastutil.floats.FloatSet;
 import java.util.Arrays;
+import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.creator.StatsCollectorConfig;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.data.FieldSpec;
 
 
 public class FloatColumnPreIndexStatsCollector extends AbstractColumnStatisticsCollector {
@@ -32,6 +36,11 @@ public class FloatColumnPreIndexStatsCollector extends AbstractColumnStatisticsC
 
   public FloatColumnPreIndexStatsCollector(String column, StatsCollectorConfig statsCollectorConfig) {
     super(column, statsCollectorConfig);
+  }
+
+  public FloatColumnPreIndexStatsCollector(FieldSpec fieldSpec, @Nullable FieldConfig fieldConfig,
+      @Nullable PartitionFunction partitionFunction) {
+    super(fieldSpec, fieldConfig, partitionFunction);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/IntColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/IntColumnPreIndexStatsCollector.java
@@ -21,7 +21,11 @@ package org.apache.pinot.segment.local.segment.creator.impl.stats;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.Arrays;
+import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.creator.StatsCollectorConfig;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.data.FieldSpec;
 
 
 public class IntColumnPreIndexStatsCollector extends AbstractColumnStatisticsCollector {
@@ -32,6 +36,11 @@ public class IntColumnPreIndexStatsCollector extends AbstractColumnStatisticsCol
 
   public IntColumnPreIndexStatsCollector(String column, StatsCollectorConfig statsCollectorConfig) {
     super(column, statsCollectorConfig);
+  }
+
+  public IntColumnPreIndexStatsCollector(FieldSpec fieldSpec, @Nullable FieldConfig fieldConfig,
+      @Nullable PartitionFunction partitionFunction) {
+    super(fieldSpec, fieldConfig, partitionFunction);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/LongColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/LongColumnPreIndexStatsCollector.java
@@ -21,7 +21,11 @@ package org.apache.pinot.segment.local.segment.creator.impl.stats;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import java.util.Arrays;
+import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.creator.StatsCollectorConfig;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.data.FieldSpec;
 
 
 public class LongColumnPreIndexStatsCollector extends AbstractColumnStatisticsCollector {
@@ -32,6 +36,11 @@ public class LongColumnPreIndexStatsCollector extends AbstractColumnStatisticsCo
 
   public LongColumnPreIndexStatsCollector(String column, StatsCollectorConfig statsCollectorConfig) {
     super(column, statsCollectorConfig);
+  }
+
+  public LongColumnPreIndexStatsCollector(FieldSpec fieldSpec, @Nullable FieldConfig fieldConfig,
+      @Nullable PartitionFunction partitionFunction) {
+    super(fieldSpec, fieldConfig, partitionFunction);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/StatsCollectorUtil.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/StatsCollectorUtil.java
@@ -18,10 +18,12 @@
  */
 package org.apache.pinot.segment.local.segment.creator.impl.stats;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.segment.local.utils.ClusterConfigForTable;
 import org.apache.pinot.segment.spi.creator.StatsCollectorConfig;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 
 
@@ -43,7 +45,9 @@ public final class StatsCollectorUtil {
   public static AbstractColumnStatisticsCollector createStatsCollector(String columnName, FieldSpec fieldSpec,
       FieldIndexConfigs indexConfig, StatsCollectorConfig statsCollectorConfig) {
     boolean dictionaryEnabled = indexConfig.getConfig(StandardIndexes.dictionary()).isEnabled();
-    if (!dictionaryEnabled && fieldSpec.getDataType().getStoredType() != FieldSpec.DataType.MAP) {
+    FieldSpec.DataType storedType = fieldSpec.getDataType().getStoredType();
+    if (!dictionaryEnabled && storedType != FieldSpec.DataType.MAP
+        && storedType != FieldSpec.DataType.OPEN_STRUCT) {
       if (ClusterConfigForTable.useOptimizedNoDictCollector(statsCollectorConfig.getTableConfig())) {
         return new NoDictColumnStatisticsCollector(columnName, statsCollectorConfig);
       }
@@ -64,9 +68,36 @@ public final class StatsCollectorUtil {
       case BYTES:
         return new BytesColumnPreIndexStatsCollector(columnName, statsCollectorConfig);
       case MAP:
+      case OPEN_STRUCT:
         return new MapColumnPreIndexStatsCollector(columnName, statsCollectorConfig);
       default:
         throw new IllegalStateException("Unsupported data type: " + fieldSpec.getDataType());
+    }
+  }
+
+  /// Creates a scalar stats collector directly from a [FieldSpec], for callers without a
+  /// [StatsCollectorConfig]/[Schema] (e.g. OPEN_STRUCT materialized child columns). Skips the
+  /// no-dictionary-optimization branch, which requires a TableConfig that synthetic columns lack.
+  public static AbstractColumnStatisticsCollector createStatsCollector(FieldSpec fieldSpec,
+      @Nullable FieldConfig fieldConfig) {
+    switch (fieldSpec.getDataType().getStoredType()) {
+      case INT:
+        return new IntColumnPreIndexStatsCollector(fieldSpec, fieldConfig, null);
+      case LONG:
+        return new LongColumnPreIndexStatsCollector(fieldSpec, fieldConfig, null);
+      case FLOAT:
+        return new FloatColumnPreIndexStatsCollector(fieldSpec, fieldConfig, null);
+      case DOUBLE:
+        return new DoubleColumnPreIndexStatsCollector(fieldSpec, fieldConfig, null);
+      case BIG_DECIMAL:
+        return new BigDecimalColumnPreIndexStatsCollector(fieldSpec, fieldConfig, null);
+      case STRING:
+        return new StringColumnPreIndexStatsCollector(fieldSpec, fieldConfig, null);
+      case BYTES:
+        return new BytesColumnPreIndexStatsCollector(fieldSpec, fieldConfig, null);
+      default:
+        throw new IllegalStateException("Unsupported stored type for OPEN_STRUCT child: "
+            + fieldSpec.getDataType().getStoredType());
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/StringColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/StringColumnPreIndexStatsCollector.java
@@ -27,7 +27,9 @@ import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.creator.StatsCollectorConfig;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 
@@ -45,6 +47,14 @@ public class StringColumnPreIndexStatsCollector extends AbstractColumnStatistics
 
   public StringColumnPreIndexStatsCollector(String column, StatsCollectorConfig statsCollectorConfig) {
     super(column, statsCollectorConfig);
+    if (_fieldConfig != null && _fieldConfig.getCompressionCodec() == FieldConfig.CompressionCodec.CLP) {
+      _clpStatsCollector = new CLPStatsCollector();
+    }
+  }
+
+  public StringColumnPreIndexStatsCollector(FieldSpec fieldSpec, @Nullable FieldConfig fieldConfig,
+      @Nullable PartitionFunction partitionFunction) {
+    super(fieldSpec, fieldConfig, partitionFunction);
     if (_fieldConfig != null && _fieldConfig.getCompressionCodec() == FieldConfig.CompressionCodec.CLP) {
       _clpStatsCollector = new CLPStatsCollector();
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexType.java
@@ -297,6 +297,11 @@ public class ForwardIndexType extends AbstractIndexType<ForwardIndexConfig, Forw
   }
 
   @Override
+  public boolean shouldCreateIndex(IndexCreationContext context, ForwardIndexConfig indexConfig) {
+    return context.getFieldSpec().getDataType() != FieldSpec.DataType.OPEN_STRUCT;
+  }
+
+  @Override
   public ForwardIndexCreator createIndexCreator(IndexCreationContext context, ForwardIndexConfig indexConfig)
       throws Exception {
     return ForwardIndexCreatorFactory.createIndexCreator(context, indexConfig);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/OpenStructIndexPlugin.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/OpenStructIndexPlugin.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.openstruct;
+
+import com.google.auto.service.AutoService;
+import org.apache.pinot.segment.spi.index.IndexPlugin;
+
+
+/// {@link IndexPlugin} that registers {@link OpenStructIndexType} via `@AutoService`.
+@AutoService(IndexPlugin.class)
+public class OpenStructIndexPlugin implements IndexPlugin<OpenStructIndexType> {
+  public static final OpenStructIndexType INSTANCE = new OpenStructIndexType();
+
+  @Override
+  public OpenStructIndexType getIndexType() {
+    return INSTANCE;
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/OpenStructIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/OpenStructIndexType.java
@@ -157,8 +157,8 @@ public class OpenStructIndexType
   @Nullable
   @Override
   public MutableIndex createMutableIndex(MutableIndexContext context, OpenStructIndexConfig config) {
-    throw new UnsupportedOperationException("Mutable OPEN_STRUCT index is constructed by MutableSegmentImpl, "
-        + "not via this SPI path");
+    // Mutable OPEN_STRUCT index is constructed by MutableSegmentImpl, not via this SPI path.
+    return null;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/OpenStructIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/OpenStructIndexType.java
@@ -1,0 +1,184 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.openstruct;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.pinot.segment.spi.ColumnMetadata;
+import org.apache.pinot.segment.spi.creator.IndexCreationContext;
+import org.apache.pinot.segment.spi.index.AbstractIndexType;
+import org.apache.pinot.segment.spi.index.ColumnConfigDeserializer;
+import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
+import org.apache.pinot.segment.spi.index.IndexConfigDeserializer;
+import org.apache.pinot.segment.spi.index.IndexHandler;
+import org.apache.pinot.segment.spi.index.IndexReaderFactory;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.segment.spi.index.creator.ColumnarOpenStructIndexCreator;
+import org.apache.pinot.segment.spi.index.mutable.MutableIndex;
+import org.apache.pinot.segment.spi.index.mutable.provider.MutableIndexContext;
+import org.apache.pinot.segment.spi.index.reader.OpenStructIndexReader;
+import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.OpenStructIndexConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+
+
+/// Index type for the OPEN_STRUCT index on OPEN_STRUCT columns.
+///
+/// The OPEN_STRUCT index has no reader of its own — per-key materialized columns are loaded by
+/// the standard `PhysicalColumnIndexContainer` and served via standard index readers. This
+/// type exists for SPI registration, config deserialization, and validation.
+public class OpenStructIndexType
+    extends AbstractIndexType<OpenStructIndexConfig, OpenStructIndexReader, ColumnarOpenStructIndexCreator> {
+
+  public static final String INDEX_DISPLAY_NAME = "open_struct";
+  private static final List<String> EXTENSIONS = Collections.singletonList(".open_struct.idx");
+
+  protected OpenStructIndexType() {
+    super(StandardIndexes.OPEN_STRUCT_ID);
+  }
+
+  @Override
+  public Class<OpenStructIndexConfig> getIndexConfigClass() {
+    return OpenStructIndexConfig.class;
+  }
+
+  @Override
+  public OpenStructIndexConfig getDefaultConfig() {
+    return OpenStructIndexConfig.DEFAULT;
+  }
+
+  @Override
+  public void validate(FieldIndexConfigs indexConfigs, FieldSpec fieldSpec, TableConfig tableConfig) {
+    // The default OpenStructIndexConfig is auto-applied to every column; only enforce on OPEN_STRUCT
+    // fields. Non-OPEN_STRUCT columns cannot meaningfully opt in to this index.
+    if (fieldSpec.getDataType() != FieldSpec.DataType.OPEN_STRUCT) {
+      return;
+    }
+    OpenStructIndexConfig config = indexConfigs.getConfig(this);
+    if (config.isEnabled()) {
+      Preconditions.checkState(fieldSpec.isSingleValueField(),
+          "OPEN_STRUCT index can only be created on single-value columns, but column '%s' is multi-value",
+          fieldSpec.getName());
+      validatePerKeyIndexes(config);
+    }
+  }
+
+  private void validatePerKeyIndexes(OpenStructIndexConfig config) {
+    List<FieldConfig> fieldConfigs = new ArrayList<>();
+    if (config.getValueFieldConfigs() != null) {
+      fieldConfigs.addAll(config.getValueFieldConfigs());
+    }
+    if (config.getDefaultValueFieldConfig() != null) {
+      fieldConfigs.add(config.getDefaultValueFieldConfig());
+    }
+    for (FieldConfig fieldConfig : fieldConfigs) {
+      JsonNode indexes = fieldConfig.getIndexes();
+      if (indexes == null) {
+        continue;
+      }
+      Iterator<String> indexNames = indexes.fieldNames();
+      while (indexNames.hasNext()) {
+        String indexName = indexNames.next();
+        Preconditions.checkState(OpenStructSupportedIndexes.ALLOWED_PRETTY_NAMES.contains(indexName),
+            "OPEN_STRUCT key '%s' declares unsupported index '%s'; supported indexes are %s",
+            fieldConfig.getName(), indexName, OpenStructSupportedIndexes.ALLOWED_PRETTY_NAMES);
+      }
+    }
+  }
+
+  @Override
+  public String getPrettyName() {
+    return INDEX_DISPLAY_NAME;
+  }
+
+  @Override
+  protected ColumnConfigDeserializer<OpenStructIndexConfig> createDeserializerForLegacyConfigs() {
+    // OPEN_STRUCT is net-new; no legacy FieldConfig.properties path to migrate.
+    return IndexConfigDeserializer.fromIndexTypes(FieldConfig.IndexType.OPEN_STRUCT,
+        (tableConfig, fieldConfig) -> OpenStructIndexConfig.DEFAULT);
+  }
+
+  @Override
+  public boolean shouldCreateIndex(IndexCreationContext context, OpenStructIndexConfig indexConfig) {
+    // The default OpenStructIndexConfig is auto-applied to every column; only build a creator for
+    // OPEN_STRUCT columns. Non-OPEN_STRUCT columns cannot meaningfully host this index.
+    return context.getFieldSpec().getDataType() == FieldSpec.DataType.OPEN_STRUCT;
+  }
+
+  @Override
+  public ColumnarOpenStructIndexCreator createIndexCreator(IndexCreationContext context,
+      OpenStructIndexConfig indexConfig) {
+    // Creator is wired in the storage-layer PR (PR 2b); this infra PR registers the index type
+    // but does not yet support segment creation for OPEN_STRUCT columns.
+    return null;
+  }
+
+  @Override
+  protected IndexReaderFactory<OpenStructIndexReader> createReaderFactory() {
+    return new NoOpReaderFactory();
+  }
+
+  @Override
+  public List<String> getFileExtensions(@Nullable ColumnMetadata columnMetadata) {
+    return EXTENSIONS;
+  }
+
+  @Override
+  public IndexHandler createIndexHandler(SegmentDirectory segmentDirectory,
+      Map<String, FieldIndexConfigs> configsByCol, Schema schema, TableConfig tableConfig) {
+    return IndexHandler.NoOp.INSTANCE;
+  }
+
+  @Nullable
+  @Override
+  public MutableIndex createMutableIndex(MutableIndexContext context, OpenStructIndexConfig config) {
+    throw new UnsupportedOperationException("Mutable OPEN_STRUCT index is constructed by MutableSegmentImpl, "
+        + "not via this SPI path");
+  }
+
+  @Override
+  public boolean shouldInvalidateOnDictionaryChange(FieldSpec fieldSpec, OpenStructIndexConfig indexConfig) {
+    return false;
+  }
+
+  @Override
+  public boolean requiresDictionary(FieldSpec fieldSpec, OpenStructIndexConfig indexConfig) {
+    return false;
+  }
+
+  /// Reader factory that always returns null. The OPEN_STRUCT index has no reader of its own —
+  /// materialized columns are loaded independently by the standard column loading infrastructure.
+  private static class NoOpReaderFactory implements IndexReaderFactory<OpenStructIndexReader> {
+    @Nullable
+    @Override
+    public OpenStructIndexReader createIndexReader(SegmentDirectory.Reader segmentReader,
+        FieldIndexConfigs fieldIndexConfigs, ColumnMetadata metadata) {
+      return null;
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/OpenStructIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/OpenStructIndexType.java
@@ -125,17 +125,16 @@ public class OpenStructIndexType
 
   @Override
   public boolean shouldCreateIndex(IndexCreationContext context, OpenStructIndexConfig indexConfig) {
-    // The default OpenStructIndexConfig is auto-applied to every column; only build a creator for
-    // OPEN_STRUCT columns. Non-OPEN_STRUCT columns cannot meaningfully host this index.
-    return context.getFieldSpec().getDataType() == FieldSpec.DataType.OPEN_STRUCT;
+    // Creator is wired in the storage-layer PR (PR 2b); returning true here with a null creator
+    // would NPE in SegmentColumnarIndexCreator.add(). Keep false until the real creator lands.
+    return false;
   }
 
   @Override
   public ColumnarOpenStructIndexCreator createIndexCreator(IndexCreationContext context,
       OpenStructIndexConfig indexConfig) {
-    // Creator is wired in the storage-layer PR (PR 2b); this infra PR registers the index type
-    // but does not yet support segment creation for OPEN_STRUCT columns.
-    return null;
+    throw new UnsupportedOperationException(
+        "OPEN_STRUCT index creator is not yet available; shouldCreateIndex() must return false");
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/OpenStructSupportedIndexes.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/OpenStructSupportedIndexes.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.openstruct;
+
+import java.util.Set;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
+
+
+/// The set of index types (by pretty name) supported on OPEN_STRUCT materialized child columns. A key's
+/// `FieldConfig` may declare only these; non-vetted indexes are rejected at table-config validation.
+/// `dictionary` is built structurally (lifecycle CUSTOM); `forward` is always written.
+public final class OpenStructSupportedIndexes {
+  private OpenStructSupportedIndexes() {
+  }
+
+  public static final Set<String> ALLOWED_PRETTY_NAMES = Set.of(
+      StandardIndexes.forward().getPrettyName(),
+      StandardIndexes.dictionary().getPrettyName(),
+      StandardIndexes.inverted().getPrettyName(),
+      StandardIndexes.range().getPrettyName(),
+      StandardIndexes.bloomFilter().getPrettyName());
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -1605,17 +1605,17 @@ public final class TableConfigUtils {
     validateMultiColumnTextIndex(indexingConfig.getMultiColumnTextIndexConfig());
 
     // OPEN_STRUCT materialized child columns use a reserved separator '$' in their name. When any
-    // schema field is OPEN_STRUCT, reject user columns whose names contain '$' to prevent naming
-    // collisions with future per-key materialized columns (col$key) or the sparse column
-    // (col$__sparse__). This validation runs here (with full schema access) rather than per-field
-    // because each OpenStructIndexType.validate() call only sees one field at a time.
+    // schema field is OPEN_STRUCT, reject ALL columns (including OPEN_STRUCT parents themselves)
+    // whose names contain '$'. This prevents naming collisions: a parent named 'a$b' would produce
+    // children 'a$b$key', which parseParentColumn() would misparse as parent 'a' and key 'b$key'.
+    // This validation runs here (with full schema access) rather than per-field because each
+    // OpenStructIndexType.validate() call only sees one field at a time.
     boolean anyOpenStruct = schema.getAllFieldSpecs().stream()
         .anyMatch(fs -> fs.getDataType() == DataType.OPEN_STRUCT);
     if (anyOpenStruct) {
       for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
         Preconditions.checkState(
-            fieldSpec.getDataType() == DataType.OPEN_STRUCT
-                || !OpenStructNaming.isMaterializedOpenStructColumn(fieldSpec.getName()),
+            !OpenStructNaming.isMaterializedOpenStructColumn(fieldSpec.getName()),
             "Schema column '%s' contains reserved OPEN_STRUCT separator '%s'",
             fieldSpec.getName(), OpenStructNaming.SEPARATOR);
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -93,6 +93,7 @@ import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.OpenStructNaming;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.function.FunctionEvaluator;
 import org.apache.pinot.spi.ingestion.batch.BatchConfig;
@@ -1602,6 +1603,23 @@ public final class TableConfigUtils {
     }
 
     validateMultiColumnTextIndex(indexingConfig.getMultiColumnTextIndexConfig());
+
+    // OPEN_STRUCT materialized child columns use a reserved separator '$' in their name. When any
+    // schema field is OPEN_STRUCT, reject user columns whose names contain '$' to prevent naming
+    // collisions with future per-key materialized columns (col$key) or the sparse column
+    // (col$__sparse__). This validation runs here (with full schema access) rather than per-field
+    // because each OpenStructIndexType.validate() call only sees one field at a time.
+    boolean anyOpenStruct = schema.getAllFieldSpecs().stream()
+        .anyMatch(fs -> fs.getDataType() == DataType.OPEN_STRUCT);
+    if (anyOpenStruct) {
+      for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
+        Preconditions.checkState(
+            fieldSpec.getDataType() == DataType.OPEN_STRUCT
+                || !OpenStructNaming.isMaterializedOpenStructColumn(fieldSpec.getName()),
+            "Schema column '%s' contains reserved OPEN_STRUCT separator '%s'",
+            fieldSpec.getName(), OpenStructNaming.SEPARATOR);
+      }
+    }
 
     // Star-tree index config is not managed by FieldIndexConfigs, and we need to validate it separately.
     List<StarTreeIndexConfig> starTreeIndexConfigs = indexingConfig.getStarTreeIndexConfigs();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/stats/StatsCollectorUtilFieldSpecTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/stats/StatsCollectorUtilFieldSpecTest.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.creator.impl.stats;
+
+import java.math.BigDecimal;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class StatsCollectorUtilFieldSpecTest {
+
+  @Test
+  public void testCreateIntCollectorFromFieldSpec() {
+    DimensionFieldSpec spec = new DimensionFieldSpec("c", DataType.INT, true);
+    AbstractColumnStatisticsCollector collector = StatsCollectorUtil.createStatsCollector(spec, null);
+    collector.collect(5);
+    collector.collect(5);
+    collector.collect(2);
+    collector.seal();
+    assertEquals(collector.getCardinality(), 2);
+    assertEquals(collector.getMinValue(), 2);
+    assertEquals(collector.getMaxValue(), 5);
+  }
+
+  @Test
+  public void testCreateBigDecimalCollectorFromFieldSpec() {
+    DimensionFieldSpec spec = new DimensionFieldSpec("c", DataType.BIG_DECIMAL, true);
+    AbstractColumnStatisticsCollector collector = StatsCollectorUtil.createStatsCollector(spec, null);
+    collector.collect(new BigDecimal("1.0"));
+    collector.collect(new BigDecimal("1.00"));
+    collector.seal();
+    // 1.0 and 1.00 are distinct under equals (BigDecimalColumnPreIndexStatsCollector uses ObjectOpenHashSet).
+    assertEquals(collector.getCardinality(), 2);
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/OpenStructIndexTypeTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/OpenStructIndexTypeTest.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.openstruct;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.OpenStructIndexConfig;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertThrows;
+
+
+public class OpenStructIndexTypeTest {
+
+  @Test
+  public void testServiceLoaderResolves() {
+    assertNotNull(StandardIndexes.openStruct(),
+        "StandardIndexes.openStruct() should resolve via OpenStructIndexPlugin");
+  }
+
+  @Test
+  public void testIndexIdMatches() {
+    assertEquals(StandardIndexes.openStruct().getId(), StandardIndexes.OPEN_STRUCT_ID);
+  }
+
+  @Test
+  public void testSingletonInstance() {
+    assertSame(StandardIndexes.openStruct(), OpenStructIndexPlugin.INSTANCE);
+  }
+
+  @Test
+  public void testValidateRejectsUnsupportedPerKeyIndex()
+      throws Exception {
+    // 'h3' is not in the OPEN_STRUCT vetted subset; declaring it on a key must fail validation.
+    JsonNode indexes = JsonUtils.stringToJsonNode("{\"h3\": {}}");
+    FieldConfig keyConfig = new FieldConfig.Builder("loc").withIndexes(indexes).build();
+    // First constructor arg is `disabled` — pass false so the config is enabled and validation runs.
+    OpenStructIndexConfig config = new OpenStructIndexConfig(false, null, -1, null, 0.5, List.of(keyConfig));
+    FieldIndexConfigs fieldIndexConfigs =
+        new FieldIndexConfigs.Builder().add(StandardIndexes.openStruct(), config).build();
+    FieldSpec openStructSpec = new ComplexFieldSpec("payload", FieldSpec.DataType.OPEN_STRUCT, true, Map.of());
+
+    assertThrows(IllegalStateException.class,
+        () -> StandardIndexes.openStruct().validate(fieldIndexConfigs, openStructSpec, null));
+  }
+
+  @Test
+  public void testValidateAllowsVettedPerKeyIndexes()
+      throws Exception {
+    JsonNode indexes = JsonUtils.stringToJsonNode("{\"range\": {}, \"bloom\": {}, \"inverted\": {}}");
+    FieldConfig keyConfig = new FieldConfig.Builder("clicks").withIndexes(indexes).build();
+    OpenStructIndexConfig config = new OpenStructIndexConfig(false, null, -1, null, 0.5, List.of(keyConfig));
+    FieldIndexConfigs fieldIndexConfigs =
+        new FieldIndexConfigs.Builder().add(StandardIndexes.openStruct(), config).build();
+    FieldSpec openStructSpec = new ComplexFieldSpec("payload", FieldSpec.DataType.OPEN_STRUCT, true, Map.of());
+
+    // Must not throw.
+    StandardIndexes.openStruct().validate(fieldIndexConfigs, openStructSpec, null);
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -4346,4 +4346,42 @@ public class TableConfigUtilsTest {
         .setTaskConfig(new org.apache.pinot.spi.config.table.TableTaskConfig(buildMaterializedViewTaskMap(definedSql)))
         .build();
   }
+
+  @Test
+  public void testValidateOpenStructSeparatorInColumnNames() {
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
+
+    // Valid: no '$' in any column name — OPEN_STRUCT and regular column both clean.
+    Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+        .addSingleValueDimension("event_type", FieldSpec.DataType.STRING)
+        .addOpenStruct("payload", Map.of())
+        .build();
+    TableConfigUtils.validate(tableConfig, schema);
+
+    // Invalid: non-OPEN_STRUCT column contains '$'.
+    Schema schemaWithDollarInNonOpenStruct = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+        .addSingleValueDimension("event$type", FieldSpec.DataType.STRING)
+        .addOpenStruct("payload", Map.of())
+        .build();
+    try {
+      TableConfigUtils.validate(tableConfig, schemaWithDollarInNonOpenStruct);
+      fail("Should fail when a non-OPEN_STRUCT column contains the reserved '$' separator");
+    } catch (IllegalStateException e) {
+      assertTrue(e.getMessage().contains("event$type"));
+    }
+
+    // Invalid: OPEN_STRUCT parent name itself contains '$'. Without this check, a parent named
+    // 'metrics$v2' would produce children 'metrics$v2$key', and parseParentColumn() would split
+    // on the first '$' and return 'metrics' instead of 'metrics$v2', corrupting the name mapping.
+    Schema schemaWithDollarInOpenStructParent = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+        .addSingleValueDimension("event_type", FieldSpec.DataType.STRING)
+        .addOpenStruct("metrics$v2", Map.of())
+        .build();
+    try {
+      TableConfigUtils.validate(tableConfig, schemaWithDollarInOpenStructParent);
+      fail("Should fail when an OPEN_STRUCT parent column name contains the reserved '$' separator");
+    } catch (IllegalStateException e) {
+      assertTrue(e.getMessage().contains("metrics$v2"));
+    }
+  }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
@@ -178,6 +178,9 @@ public class V1Constants {
       //   parentColumn = metrics
       public static final String PARENT_COLUMN = "parentColumn";
 
+      // Whether this OPEN_STRUCT column has a sparse column for keys not materialized as dense.
+      public static final String HAS_SPARSE_COLUMN = "hasSparseColumn";
+
       /// Partition function, all optional
       public static final String PARTITION_FUNCTION = "partitionFunction";
       public static final String NUM_PARTITIONS = "numPartitions";

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/OpenStructDataSource.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/OpenStructDataSource.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.segment.spi.datasource;
 
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.index.column.ColumnIndexContainer;
 import org.apache.pinot.spi.data.ComplexFieldSpec;
 
@@ -61,4 +62,13 @@ public interface OpenStructDataSource extends DataSource {
 
   /// Returns the ColumnIndexContainer for the given key's values.
   ColumnIndexContainer getIndexContainer(String key);
+
+  /// Reconstructs the full OPEN_STRUCT value for {@code docId} as a {@code Map<String, Object>}, or
+  /// {@code null} when no key is present at that doc. Used by the realtime seal path to re-feed the
+  /// OPEN_STRUCT column into the immutable segment build.
+  @Nullable
+  default Map<String, Object> getMapValue(int docId) {
+    throw new UnsupportedOperationException(
+        "Per-doc OPEN_STRUCT map reconstruction is not supported by this implementation");
+  }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/FieldIndexConfigsUtil.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/FieldIndexConfigsUtil.java
@@ -19,14 +19,20 @@
 
 package org.apache.pinot.segment.spi.index;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Sets;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.IndexConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.JsonUtils;
 
 
 public class FieldIndexConfigsUtil {
@@ -49,6 +55,46 @@ public class FieldIndexConfigsUtil {
 
     return builderMap.entrySet().stream()
         .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().build()));
+  }
+
+  /// Builds a {@link FieldIndexConfigs} for a single column directly from one {@link FieldConfig}, without a
+  /// `TableConfig` or `Schema`. The dictionary entry is derived from `fieldConfig.getEncodingType()`
+  /// (RAW => disabled, otherwise default-enabled); every other index type is read from the modern
+  /// `fieldConfig.getIndexes()` JSON (keyed by index pretty name), falling back to each type's default config.
+  /// A `null` fieldConfig yields built-in defaults (dictionary enabled).
+  ///
+  /// This reads only the modern `indexes` format and never legacy `IndexingConfig` lists, so it suits
+  /// synthetic columns (e.g. OPEN_STRUCT materialized children) that exist in no schema.
+  public static FieldIndexConfigs fromFieldConfig(@Nullable FieldConfig fieldConfig, FieldSpec fieldSpec) {
+    FieldIndexConfigs.Builder builder = new FieldIndexConfigs.Builder();
+    boolean rawEncoded = fieldConfig != null && fieldConfig.getEncodingType() == FieldConfig.EncodingType.RAW;
+    builder.add(StandardIndexes.dictionary(),
+        rawEncoded ? DictionaryIndexConfig.DISABLED : DictionaryIndexConfig.DEFAULT);
+    JsonNode indexes = fieldConfig != null ? fieldConfig.getIndexes() : null;
+    for (IndexType<?, ?, ?> indexType : IndexService.getInstance().getAllIndexes()) {
+      if (indexType.getId().equals(StandardIndexes.DICTIONARY_ID)) {
+        continue;
+      }
+      addConfigFromIndexes(builder, indexType, indexes);
+    }
+    return builder.build();
+  }
+
+  private static <C extends IndexConfig> void addConfigFromIndexes(FieldIndexConfigs.Builder builder,
+      IndexType<C, ?, ?> indexType, @Nullable JsonNode indexes) {
+    JsonNode node = indexes != null ? indexes.get(indexType.getPrettyName()) : null;
+    C config;
+    if (node != null) {
+      try {
+        config = JsonUtils.jsonNodeToObject(node, indexType.getIndexConfigClass());
+      } catch (IOException e) {
+        throw new IllegalArgumentException(
+            "Failed to parse '" + indexType.getPrettyName() + "' index config from FieldConfig", e);
+      }
+    } else {
+      config = indexType.getDefaultConfig();
+    }
+    builder.add(indexType, config);
   }
 
   @FunctionalInterface

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/FieldIndexConfigsUtilTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/FieldIndexConfigsUtilTest.java
@@ -1,0 +1,189 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.index;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.segment.spi.ColumnMetadata;
+import org.apache.pinot.segment.spi.creator.IndexCreationContext;
+import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.IndexConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+public class FieldIndexConfigsUtilTest {
+
+  private static final FieldSpec INT_SPEC = new DimensionFieldSpec("x", FieldSpec.DataType.INT, true);
+
+  private IndexService _originalIndexService;
+  private StubIndexType _dictType;
+  private StubIndexType _rangeType;
+  private StubIndexType _bloomType;
+
+  @BeforeMethod
+  public void setUp() {
+    _originalIndexService = IndexService.getInstance();
+    _dictType = new StubIndexType(StandardIndexes.DICTIONARY_ID, StandardIndexes.DICTIONARY_ID);
+    _rangeType = new StubIndexType(StandardIndexes.RANGE_ID, "range");
+    _bloomType = new StubIndexType(StandardIndexes.BLOOM_FILTER_ID, "bloom");
+    installIndexService(_dictType, _rangeType, _bloomType);
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    IndexService.setInstance(_originalIndexService);
+  }
+
+  @Test
+  public void testParsesIndexesAndRawEncoding()
+      throws Exception {
+    JsonNode indexes = JsonUtils.stringToJsonNode("{\"range\": {}, \"bloom\": {}}");
+    FieldConfig fc = new FieldConfig.Builder("x")
+        .withEncodingType(FieldConfig.EncodingType.RAW)
+        .withIndexes(indexes)
+        .build();
+
+    FieldIndexConfigs configs = FieldIndexConfigsUtil.fromFieldConfig(fc, INT_SPEC);
+
+    // RAW encoding disables the dictionary — verify via the stored DictionaryIndexConfig constant.
+    IndexConfig dictConfig = configs.getConfig(_dictType);
+    assertTrue(dictConfig.isDisabled(), "RAW => dictionary disabled");
+
+    // range and bloom should be enabled because the JSON contained their pretty-name keys.
+    IndexConfig rangeConfig = configs.getConfig(_rangeType);
+    assertTrue(rangeConfig.isEnabled(), "range config from JSON should be enabled");
+
+    IndexConfig bloomConfig = configs.getConfig(_bloomType);
+    assertTrue(bloomConfig.isEnabled(), "bloom config from JSON should be enabled");
+  }
+
+  @Test
+  public void testNullFieldConfigUsesDictionaryDefault() {
+    FieldIndexConfigs configs = FieldIndexConfigsUtil.fromFieldConfig(null, INT_SPEC);
+    // null fieldConfig => dictionary should use DictionaryIndexConfig.DEFAULT (not disabled)
+    IndexConfig dictConfig = configs.getConfig(_dictType);
+    assertFalse(dictConfig.isDisabled(), "null => dictionary enabled");
+  }
+
+  private void installIndexService(StubIndexType... types) {
+    Set<IndexPlugin<?>> plugins = new HashSet<>();
+    int priority = 0;
+    for (StubIndexType type : types) {
+      final int p = priority++;
+      final StubIndexType t = type;
+      plugins.add(new IndexPlugin<StubIndexType>() {
+        @Override
+        public StubIndexType getIndexType() {
+          return t;
+        }
+
+        @Override
+        public int getPriority() {
+          return p;
+        }
+      });
+    }
+    IndexService.setInstance(new IndexService(plugins));
+  }
+
+  private static final class StubIndexType implements IndexType<IndexConfig, IndexReader, IndexCreator> {
+    private final String _id;
+    private final String _prettyName;
+
+    StubIndexType(String id, String prettyName) {
+      _id = id;
+      _prettyName = prettyName;
+    }
+
+    @Override
+    public String getId() {
+      return _id;
+    }
+
+    @Override
+    public String getPrettyName() {
+      return _prettyName;
+    }
+
+    @Override
+    public Class<IndexConfig> getIndexConfigClass() {
+      return IndexConfig.class;
+    }
+
+    @Override
+    public IndexConfig getDefaultConfig() {
+      return IndexConfig.DISABLED;
+    }
+
+    @Override
+    public Map<String, IndexConfig> getConfig(TableConfig tableConfig, Schema schema) {
+      return Map.of();
+    }
+
+    @Override
+    public IndexCreator createIndexCreator(IndexCreationContext context, IndexConfig indexConfig) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public IndexReaderFactory<IndexReader> getReaderFactory() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> getFileExtensions(@Nullable ColumnMetadata columnMetadata) {
+      return List.of();
+    }
+
+    @Override
+    public IndexHandler createIndexHandler(SegmentDirectory segmentDirectory,
+        Map<String, FieldIndexConfigs> configsByCol, Schema schema, TableConfig tableConfig) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean requiresDictionary(FieldSpec fieldSpec, IndexConfig indexConfig) {
+      return false;
+    }
+
+    @Override
+    public boolean shouldInvalidateOnDictionaryChange(FieldSpec fieldSpec, IndexConfig indexConfig) {
+      return false;
+    }
+
+    @Override
+    public void convertToNewFormat(TableConfig tableConfig, Schema schema) {
+    }
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/OpenStructNaming.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/OpenStructNaming.java
@@ -36,4 +36,41 @@ public final class OpenStructNaming {
   public static String sparseColumnName(String openStructColumn) {
     return openStructColumn + SEPARATOR + SPARSE_SUFFIX;
   }
+
+  /// Returns true if the given column name is a materialized OPEN_STRUCT child column
+  /// (dense materialized key or the sparse JSON column).
+  public static boolean isMaterializedOpenStructColumn(String columnName) {
+    return columnName.indexOf(SEPARATOR.charAt(0)) > 0;
+  }
+
+  /// Returns true if the given column name is the sparse JSON column for some
+  /// OPEN_STRUCT parent.
+  public static boolean isSparseColumn(String columnName) {
+    int sep = columnName.indexOf(SEPARATOR.charAt(0));
+    return sep > 0 && SPARSE_SUFFIX.equals(columnName.substring(sep + 1));
+  }
+
+  /// Returns the parent OPEN_STRUCT column name for a materialized child column.
+  /// Throws IllegalArgumentException if the input is not a materialized child column.
+  public static String parseParentColumn(String materializedColumnName) {
+    int sep = materializedColumnName.indexOf(SEPARATOR.charAt(0));
+    if (sep <= 0) {
+      throw new IllegalArgumentException("Not a materialized OPEN_STRUCT column: " + materializedColumnName);
+    }
+    return materializedColumnName.substring(0, sep);
+  }
+
+  /// Returns the key portion of a materialized dense column name. Throws
+  /// IllegalArgumentException for the sparse column or non-materialized names.
+  public static String parseKey(String materializedColumnName) {
+    int sep = materializedColumnName.indexOf(SEPARATOR.charAt(0));
+    if (sep <= 0) {
+      throw new IllegalArgumentException("Not a materialized OPEN_STRUCT column: " + materializedColumnName);
+    }
+    String key = materializedColumnName.substring(sep + 1);
+    if (SPARSE_SUFFIX.equals(key)) {
+      throw new IllegalArgumentException("Sparse column has no key: " + materializedColumnName);
+    }
+    return key;
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/OpenStructTypeInference.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/OpenStructTypeInference.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.data;
+
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.utils.PinotDataType;
+
+
+/// Infers the {@link FieldSpec.DataType} for an OPEN_STRUCT key from raw ingested values when the key has
+/// no declared child {@link FieldSpec}. This is OPEN_STRUCT-specific policy (it keeps TIMESTAMP, folds
+/// DATE/TIME/UUID to STRING, widens BYTE/CHARACTER/SHORT to INT, and returns {@code null} for values that
+/// cannot be represented as a stored column type), distinct from the JSON-node-based inference in
+/// {@code JsonUtils.valueOf}.
+public final class OpenStructTypeInference {
+  private OpenStructTypeInference() {
+  }
+
+  /// Infers the {@link FieldSpec.DataType} from a raw ingested value. Returns {@code null} when the value
+  /// cannot be represented as a stored column type; callers decide whether to drop the entry or fall back
+  /// to a default (e.g. STRING).
+  @Nullable
+  public static FieldSpec.DataType inferDataType(Object rawValue) {
+    switch (PinotDataType.getSingleValueType(rawValue)) {
+      case INTEGER:
+      case BYTE:
+      case CHARACTER:
+      case SHORT:
+        return FieldSpec.DataType.INT;
+      case LONG:
+        return FieldSpec.DataType.LONG;
+      case FLOAT:
+        return FieldSpec.DataType.FLOAT;
+      case DOUBLE:
+        return FieldSpec.DataType.DOUBLE;
+      case BIG_DECIMAL:
+        return FieldSpec.DataType.BIG_DECIMAL;
+      case BOOLEAN:
+        return FieldSpec.DataType.BOOLEAN;
+      case TIMESTAMP:
+        return FieldSpec.DataType.TIMESTAMP;
+      case STRING:
+      case DATE:
+      case TIME:
+      case UUID:
+        return FieldSpec.DataType.STRING;
+      case BYTES:
+        return FieldSpec.DataType.BYTES;
+      default:
+        return null;
+    }
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/PinotDataType.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/PinotDataType.java
@@ -1981,6 +1981,11 @@ public enum PinotDataType {
           return MAP;
         }
         throw new IllegalStateException("There is no multi-value type for MAP");
+      case OPEN_STRUCT:
+        if (fieldSpec.isSingleValueField()) {
+          return MAP;
+        }
+        throw new IllegalStateException("There is no multi-value type for OPEN_STRUCT");
       default:
         throw new IllegalStateException("Unsupported data type: " + dataType);
     }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/OpenStructNamingTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/OpenStructNamingTest.java
@@ -21,17 +21,55 @@ package org.apache.pinot.spi.data;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 
 public class OpenStructNamingTest {
 
   @Test
   public void testMaterializedColumnName() {
-    assertEquals(OpenStructNaming.materializedColumnName("metrics", "tenancy"), "metrics$tenancy");
+    assertEquals(OpenStructNaming.materializedColumnName("metrics", "clicks"), "metrics$clicks");
   }
 
   @Test
   public void testSparseColumnName() {
     assertEquals(OpenStructNaming.sparseColumnName("metrics"), "metrics$__sparse__");
+  }
+
+  @Test
+  public void testIsMaterializedOpenStructColumn() {
+    assertTrue(OpenStructNaming.isMaterializedOpenStructColumn("metrics$clicks"));
+    assertTrue(OpenStructNaming.isMaterializedOpenStructColumn("metrics$__sparse__"));
+    assertFalse(OpenStructNaming.isMaterializedOpenStructColumn("metrics"));
+    assertFalse(OpenStructNaming.isMaterializedOpenStructColumn("plain_column"));
+  }
+
+  @Test
+  public void testIsSparseColumn() {
+    assertTrue(OpenStructNaming.isSparseColumn("metrics$__sparse__"));
+    assertFalse(OpenStructNaming.isSparseColumn("metrics$clicks"));
+    assertFalse(OpenStructNaming.isSparseColumn("metrics"));
+  }
+
+  @Test
+  public void testParseParentColumn() {
+    assertEquals(OpenStructNaming.parseParentColumn("metrics$clicks"), "metrics");
+    assertEquals(OpenStructNaming.parseParentColumn("metrics$__sparse__"), "metrics");
+  }
+
+  @Test
+  public void testParseKey() {
+    assertEquals(OpenStructNaming.parseKey("metrics$clicks"), "clicks");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testParseKeyRejectsSparse() {
+    OpenStructNaming.parseKey("metrics$__sparse__");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testParseKeyRejectsNonMaterialized() {
+    OpenStructNaming.parseKey("metrics");
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/OpenStructTypeInferenceTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/OpenStructTypeInferenceTest.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.data;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class OpenStructTypeInferenceTest {
+
+  @DataProvider(name = "inferenceCases")
+  public Object[][] inferenceCases() {
+    return new Object[][]{
+        // Integral types all widen to INT.
+        {42, DataType.INT},
+        {(byte) 1, DataType.INT},
+        {'a', DataType.INT},
+        {(short) 7, DataType.INT},
+        {42L, DataType.LONG},
+        {3.14f, DataType.FLOAT},
+        {3.14d, DataType.DOUBLE},
+        {new BigDecimal("1.23"), DataType.BIG_DECIMAL},
+        {true, DataType.BOOLEAN},
+        {new Timestamp(0L), DataType.TIMESTAMP},
+        {"hello", DataType.STRING},
+        // Temporal and UUID values fold to STRING.
+        {LocalDate.of(2026, 6, 2), DataType.STRING},
+        {LocalTime.of(12, 0), DataType.STRING},
+        {UUID.randomUUID(), DataType.STRING},
+        {new byte[]{1, 2, 3}, DataType.BYTES},
+        // Unrepresentable values return null so callers can drop or default.
+        {Map.of("k", "v"), null},
+        {new Object(), null},
+    };
+  }
+
+  @Test(dataProvider = "inferenceCases")
+  public void testInferDataType(Object rawValue, DataType expected) {
+    assertEquals(OpenStructTypeInference.inferDataType(rawValue), expected);
+  }
+}


### PR DESCRIPTION
OPEN_STRUCT infrastructure — SPI utilities, index registration, stats constructors (PR 2/4)

---

## Summary

This is **PR 2a** in the OPEN_STRUCT stack — the infrastructure/setup slice split from #18643 (storage layer) to make review more manageable. It adds foundational pieces that the ingestion/load pipeline (PR 2b) builds on.

RFC: https://docs.google.com/document/d/14kPmjDTKbO8l0ql4rrN7I5Yki5pqMw6GeGmxxc9grsU/edit?tab=t.0

PR 1 (SPI + data model): #18368 — merged

### What's in this PR

**SPI utilities (pinot-spi):**
- `OpenStructTypeInference` — value→DataType inference for OPEN_STRUCT keys (TIMESTAMP retained; DATE/TIME/UUID → STRING; Byte/Short → INT; unrepresentable → null)
- `OpenStructNaming` — `isMaterializedOpenStructColumn()`, `parseParentColumn()`, `parseKey()` name-based child column detection helpers
- `PinotDataType` — OPEN_STRUCT→MAP ingestion coercion in `getPinotDataTypeForIngestion()`

**SPI utilities (pinot-segment-spi):**
- `FieldIndexConfigsUtil.fromFieldConfig()` — builds `FieldIndexConfigs` from a single `FieldConfig` without requiring a `TableConfig`/`Schema`, enabling per-key index resolution for synthetic materialized children
- `V1Constants` — `PARENT_COLUMN`, `HAS_SPARSE_COLUMN` metadata keys
- `OpenStructDataSource` — default `getMapValue(docId)` SPI method

**Index registration (pinot-segment-local):**
- `OpenStructIndexType` + `OpenStructIndexPlugin` — `@AutoService(IndexPlugin.class)` registration, per-key index validation against vetted allowlist, no-op reader factory, no-op index handler
- `OpenStructSupportedIndexes` — vetted allowlist of per-key index types (forward, dictionary, inverted, range, bloom)

**Stats collector infrastructure:**
- `AbstractColumnStatisticsCollector` — new `(FieldSpec, FieldConfig, PartitionFunction)` constructor for creating collectors without `StatsCollectorConfig`/`Schema`
- 7 scalar collectors (`Int`, `Long`, `Float`, `Double`, `BigDecimal`, `String`, `Bytes`) — delegating FieldSpec constructors
- `StatsCollectorUtil` — OPEN_STRUCT cases + `createStatsCollector(FieldSpec, FieldConfig)` overload

**Wiring hooks:**
- `ForwardIndexType` — `shouldCreateIndex()` returns false for OPEN_STRUCT parent columns
- `TableConfigUtils` — rejects user columns containing the reserved `$` separator when any field is OPEN_STRUCT

### What's NOT in this PR (deferred to PR 2b)

- Mutable path: `MutableOpenStructIndex`, `MutableKeyColumn`, `MutableOpenStructDataSource`
- Seal path: `OpenStructColumnSplitter` (the core dense/sparse classification and materialization)
- Immutable path: `ImmutableOpenStructDataSource`, segment load wiring
- All wiring into `MutableSegmentImpl`, `ImmutableSegmentImpl`, `BaseSegmentCreator`, `SegmentColumnarIndexCreator`, etc.
- Integration tests

### Backward compatibility

- Zero behavior change for existing schemas and segments
- OPEN_STRUCT is opt-in at schema authoring time
- The `$` column name restriction applies only to schemas containing at least one OPEN_STRUCT field

## Test plan

- [x] `OpenStructTypeInferenceTest` — value→DataType mapping for all input types including widening, folding, and unrepresentable
- [x] `OpenStructNamingTest` — materialized/sparse column naming, `isMaterializedOpenStructColumn`, `parseParentColumn` parsing
- [x] `FieldIndexConfigsUtilTest` — `fromFieldConfig` with dictionary/raw encoding, inverted/range/bloom indexes, default fallback
- [x] `StatsCollectorUtilFieldSpecTest` — FieldSpec-based collector factory for all scalar types
- [x] `OpenStructIndexTypeTest` — index registration, no-op handler, config extraction, per-key index validation
