### PR TITLE
Fix NPE in PinotLeadControllerRestletResource when partition state map is null

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotLeadControllerRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotLeadControllerRestletResource.java
@@ -172,6 +172,11 @@ public class PinotLeadControllerRestletResource {
     Map<String, String> partitionStateMap = leadControllerResourceExternalView.getStateMap(partitionName);
 
     // Gets master host from partition map. Returns null if no master found.
+    if (partitionStateMap == null) {
+      LOGGER.warn("Partition state map for partition: {} is null in lead controller resource external view",
+          partitionName);
+      return null;
+    }
     for (Map.Entry<String, String> entry : partitionStateMap.entrySet()) {
       if (MasterSlaveSMD.States.MASTER.name().equals(entry.getValue())) {
         // Found the controller in master state.


### PR DESCRIPTION
## Description

`getParticipantInstanceIdFromExternalView` in `PinotLeadControllerRestletResource` guards against a null `ExternalView`, but immediately dereferences the result of `ExternalView.getStateMap(partitionName)` without a null check. `getStateMap` can return `null` when a partition has not yet been assigned in the lead controller resource external view (e.g. during controller initialisation or a leader transition), causing a `NullPointerException`.

**Fix:** add a null check with a `WARN` log before iterating the partition state map, returning `null` (no leader found) — consistent with the existing null-EV guard pattern in the same method.

## Related
Same family of fixes as #18697 (DebugResource), #18455 (HelixHelper).