### PR TITLE
Fix NPE in BaseServerStarter when IdealState.getInstanceStateMap returns null

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -409,8 +409,9 @@ public abstract class BaseServerStarter implements ServiceStartable {
       }
       if (checkRealtime && TableNameBuilder.isRealtimeTableResource(resourceName)) {
         for (String partitionName : idealState.getPartitionSet()) {
-          if (StateModel.SegmentStateModel.CONSUMING.equals(
-              idealState.getInstanceStateMap(partitionName).get(_instanceId))) {
+          Map<String, String> instanceStateMap = idealState.getInstanceStateMap(partitionName);
+          if (instanceStateMap != null && StateModel.SegmentStateModel.CONSUMING.equals(
+              instanceStateMap.get(_instanceId))) {
             consumingSegments.computeIfAbsent(resourceName, k -> new HashSet<>()).add(partitionName);
           }
         }
@@ -473,8 +474,9 @@ public abstract class BaseServerStarter implements ServiceStartable {
     }
     Set<String> consumingSegments = new HashSet<>();
     for (String partitionName : idealState.getPartitionSet()) {
-      if (StateModel.SegmentStateModel.CONSUMING.equals(
-          idealState.getInstanceStateMap(partitionName).get(_instanceId))) {
+      Map<String, String> instanceStateMap = idealState.getInstanceStateMap(partitionName);
+      if (instanceStateMap != null && StateModel.SegmentStateModel.CONSUMING.equals(
+          instanceStateMap.get(_instanceId))) {
         consumingSegments.add(partitionName);
       }
     }


### PR DESCRIPTION
## Description

`IdealState.getInstanceStateMap(partitionName)` can return `null` when a partition exists in the ideal-state partition set but has no instance assignments yet. Two call-sites in `BaseServerStarter` dereference this result directly to check for `CONSUMING` state:

1. `registerServiceStatusHandler` (line ~413) — iterates all realtime resources on server startup
2. `getConsumingSegments` (line ~477) — called to find consuming segments for a realtime table

Both cause a `NullPointerException` in transient cluster states (e.g. during reassignment or partial setup).

**Fix:** guard both call-sites with a null check before accessing the instance state, consistent with how the same pattern is handled in `ShowClusterInfoCommand` and `ZKOperator`.

## Related
Same family of fixes as #18697 (DebugResource), #18455 (HelixHelper), and the lead-controller EV fix.