### PR TITLE
Fix potential NPE in PinotNumReplicaChanger.updateIdealState

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/PinotNumReplicaChanger.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/PinotNumReplicaChanger.java
@@ -89,6 +89,9 @@ public class PinotNumReplicaChanger extends PinotZKChanger {
     Set<String> segmentIds = idealState.getPartitionSet();
     for (String segmentId : segmentIds) {
       Map<String, String> instanceStateMap = idealState.getInstanceStateMap(segmentId);
+      if (instanceStateMap == null) {
+        continue;
+      }
       if (instanceStateMap.size() > newNumReplicas) {
         Set<String> keys = instanceStateMap.keySet();
         while (instanceStateMap.size() > newNumReplicas) {


### PR DESCRIPTION
## Description
`IdealState.getInstanceStateMap(segmentId)` can return `null` when a partition exists in the ideal state but has no instance assignments. The previous code called `.size()` directly on the result without a null check, which would throw a `NullPointerException` during replica count changes.

## Fix
Add a null check on `instanceStateMap` and skip the segment if it is null — consistent with how this scenario is handled elsewhere in the codebase.

## Tests
No functional change for the normal (non-null) path. The null case is a defensive guard for an edge condition during cluster state transitions.

## Checklist
- [x] No new public APIs without documentation
- [x] Backward compatible change
- [x] Code follows existing patterns in the codebase