### PR TITLE
Allow intermediate transform columns not in the schema when consumed by another transform

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -668,7 +668,11 @@ public final class TableConfigUtils {
         Set<String> transformInputColumns = new HashSet<>();
         for (TransformConfig transformConfig : transformConfigs) {
           String transformFunction = transformConfig.getTransformFunction();
-          if (transformFunction != null) {
+          // Skip Groovy expressions when Groovy is disabled: do not compile them just to collect arguments (the main
+          // loop below rejects Groovy without compiling). Such a config is rejected anyway, so these columns are not
+          // needed as valid intermediate targets.
+          if (transformFunction != null
+              && !(_disableGroovy && FunctionEvaluatorFactory.isGroovyExpression(transformFunction))) {
             try {
               transformInputColumns.addAll(
                   FunctionEvaluatorFactory.getExpressionEvaluator(transformFunction).getArguments());

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -658,6 +658,25 @@ public final class TableConfigUtils {
       // Transform configs
       List<TransformConfig> transformConfigs = ingestionConfig.getTransformConfigs();
       if (transformConfigs != null) {
+        // Pre-pass: collect every column referenced as a transform-function argument. A transform whose destination
+        // is not in the schema is still valid when another transform consumes it as an input - i.e. it is an
+        // intermediate ("derived") column. This enables chained / parse-once transforms, e.g.
+        //   message_obj = jsonExtractObject(message)              // intermediate, not in the schema
+        //   level       = JSONPATHSTRING(message_obj, '$.level')  // consumes the intermediate
+        // The intermediate is materialized in the record during transformation and dropped before indexing (only
+        // schema columns are indexed). Unreferenced non-schema destinations still fail below (typo protection).
+        Set<String> transformInputColumns = new HashSet<>();
+        for (TransformConfig transformConfig : transformConfigs) {
+          String transformFunction = transformConfig.getTransformFunction();
+          if (transformFunction != null) {
+            try {
+              transformInputColumns.addAll(
+                  FunctionEvaluatorFactory.getExpressionEvaluator(transformFunction).getArguments());
+            } catch (Exception ignore) {
+              // Invalid functions are reported with a descriptive error in the main loop below.
+            }
+          }
+        }
         Set<String> transformColumns = new HashSet<>();
         for (TransformConfig transformConfig : transformConfigs) {
           String columnName = transformConfig.getColumnName();
@@ -669,10 +688,12 @@ public final class TableConfigUtils {
           if (!transformColumns.add(columnName)) {
             throw new IllegalStateException("Duplicate transform config found for column '" + columnName + "'");
           }
-          Preconditions.checkState(schema.hasColumn(columnName) || aggregationSourceColumns.contains(columnName),
+          Preconditions.checkState(
+              schema.hasColumn(columnName) || aggregationSourceColumns.contains(columnName)
+                  || transformInputColumns.contains(columnName),
               "The destination column '" + columnName
-                  + "' of the transform function must be present in the schema or as a source column for "
-                  + "aggregations");
+                  + "' of the transform function must be present in the schema, be consumed as the input of another "
+                  + "transform function, or be a source column for aggregations");
           FunctionEvaluator expressionEvaluator;
           if (_disableGroovy && FunctionEvaluatorFactory.isGroovyExpression(transformFunction)) {
             throw new IllegalStateException(

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -533,6 +533,25 @@ public class TableConfigUtilsTest {
     } catch (IllegalStateException e) {
       // expected
     }
+
+    // multi-hop chain whose LEAF is a non-schema column consumed by nothing - still fails. Typo protection holds
+    // across a chain: 'intermediateCol' is allowed (consumed by 'danglingLeaf'), but 'danglingLeaf' itself is not in
+    // the schema and is referenced by nothing, so validation fails on it.
+    ingestionConfig.setTransformConfigs(Arrays.asList(new TransformConfig("intermediateCol", "reverse(anotherCol)"),
+        new TransformConfig("danglingLeaf", "lower(intermediateCol)")));
+    try {
+      TableConfigUtils.validate(tableConfig, schema);
+      fail("Should fail: chain leaf 'danglingLeaf' is not in the schema and is consumed by nothing");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+
+    // a 2-node cycle among non-schema columns passes this validation (each is referenced by the other), consistent
+    // with cycles among schema columns - TableConfigUtils does not do cycle detection; a cycle is caught later by
+    // ExpressionTransformer's topological sort at ingestion time.
+    ingestionConfig.setTransformConfigs(Arrays.asList(new TransformConfig("cycleA", "reverse(cycleB)"),
+        new TransformConfig("cycleB", "lower(cycleA)")));
+    TableConfigUtils.validate(tableConfig, schema);
     ingestionConfig.setTransformConfigs(null);
 
     // invalid field name in schema with matching prefix from complexConfigType's prefixesToRename

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -513,6 +513,28 @@ public class TableConfigUtilsTest {
         new TransformConfig("myCol", "lower(transformedCol)")));
     TableConfigUtils.validate(tableConfig, schema);
 
+    // intermediate column NOT in the schema but consumed as the input of another transform - should pass.
+    // Enables chained / parse-once transforms (e.g. obj = jsonExtractObject(col); field = JSONPATHSTRING(obj, ...)).
+    ingestionConfig.setTransformConfigs(Arrays.asList(new TransformConfig("intermediateCol", "reverse(anotherCol)"),
+        new TransformConfig("myCol", "lower(intermediateCol)")));
+    TableConfigUtils.validate(tableConfig, schema);
+
+    // same as above but the consumer is listed BEFORE the producer - the check is order-independent, should pass
+    ingestionConfig.setTransformConfigs(Arrays.asList(new TransformConfig("myCol", "lower(intermediateCol)"),
+        new TransformConfig("intermediateCol", "reverse(anotherCol)")));
+    TableConfigUtils.validate(tableConfig, schema);
+
+    // destination column NOT in the schema and NOT consumed by any other transform - should fail (typo protection)
+    ingestionConfig.setTransformConfigs(
+        Collections.singletonList(new TransformConfig("notInSchemaCol", "reverse(anotherCol)")));
+    try {
+      TableConfigUtils.validate(tableConfig, schema);
+      fail("Should fail: destination column not in schema and not consumed by another transform");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    ingestionConfig.setTransformConfigs(null);
+
     // invalid field name in schema with matching prefix from complexConfigType's prefixesToRename
     ingestionConfig.setTransformConfigs(null);
     ingestionConfig.setComplexTypeConfig(


### PR DESCRIPTION
## Problem

`TableConfigUtils.validateIngestionConfig` rejects any transform whose destination column is absent from the schema:

```
The destination column 'container_obj' of the transform function must be present in the schema or as a source column for aggregations
```

This blocks **chained / "parse-once" transforms**, where an intermediate column is parsed/computed once and consumed by several downstream transforms but is never itself stored. This is the key pattern for efficiently extracting many fields from a JSON-string column on the ingestion path:

```jsonc
{"columnName": "message_obj", "transformFunction": "jsonExtractObject(message)"}          // intermediate
{"columnName": "level",       "transformFunction": "JSONPATHSTRING(message_obj, '$.level', null)"}
{"columnName": "msg_time",    "transformFunction": "JSONPATHSTRING(message_obj, '$.time',  null)"}
```
Without an intermediate, `message` is re-parsed once per extracted field; with one, it is parsed once (a ~2x ingestion-transform speedup on a JSON-heavy log table).

## The runtime already supports this

`ExpressionTransformer` builds an evaluator for **every** transform config regardless of schema membership, topologically sorts them by argument dependency, and materializes each result into the `GenericRow`. Columns absent from the schema are simply dropped before indexing (only schema columns are indexed). So intermediate columns already work end-to-end — **only the config validation was rejecting them.**

## Change

Relax the check to also accept a destination column that is **referenced as the input of another transform function**. A pre-pass collects all transform-function argument columns; the destination check then passes if the column is in the schema, an aggregation source, **or** consumed by another transform.

Destinations that are neither in the schema, an aggregation source, nor consumed by another transform still fail — so an unreferenced (fat-fingered) destination is still caught. The narrowed guarantee: the *leaf* of a transform chain must still be a real (schema/agg) column; only a non-schema column that genuinely feeds another transform is now allowed.

## Testing

`TableConfigUtilsTest#validateIngestionConfig` gains cases for: (a) an intermediate column not in the schema consumed by another transform → passes; (b) the same with consumer listed before producer (order-independent) → passes; (c) a non-schema destination referenced by nothing → still fails. Verified locally that a config with `message_obj`/`container_obj` intermediates now validates, and an unreferenced non-schema destination is still rejected.

## Backward compatibility

Backward-compatible: every config that validated before still validates; only previously-rejected chained-transform configs now pass. No config-key / SPI / wire-format change.