### PR TITLE
Fix strictReplicaGroup routing to not mark the whole instance group unavailable for segments not online anywhere

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
@@ -187,6 +187,11 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
    *   2. Compare online instances for old segments with instances in ideal state and gather the unavailable instances
    *   for each set of instances
    *   3. Exclude the unavailable instances from the online instances map for both old and new segment map
+   *
+   * As an exception, an old segment that is not online on any instance in the ideal state (e.g. it was just moved to
+   * a new set of instances by tier relocation/rebalance and is still being loaded on all of them) does not contribute
+   * to the unavailable instances because no instance selection can serve it; it is reported as unavailable
+   * individually instead, so that it doesn't take down all the other segments sharing the same instances.
    * </pre>
    */
   void updateSegmentMapsForUpsertTable(IdealState idealState, ExternalView externalView, Set<String> onlineSegments,
@@ -222,10 +227,28 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
     // Calculate the unavailable instances based on the old segments' online instances for each combination of instances
     // in the ideal state
     Map<Set<String>, Set<String>> unavailableInstancesMap = new HashMap<>();
+    List<String> segmentsNotOnlineAnywhere = null;
     for (Map.Entry<String, Set<String>> entry : oldSegmentToOnlineInstancesMap.entrySet()) {
       String segment = entry.getKey();
       Set<String> onlineInstances = entry.getValue();
       Map<String, String> idealStateInstanceStateMap = idealStateAssignment.get(segment);
+      // When a segment is not online on any instance in the ideal state (e.g. it was just moved to a new set of
+      // instances by tier relocation/rebalance and is still being loaded on all of them), no instance selection can
+      // serve it, so excluding instances for the whole group cannot help consistency. Marking all its instances
+      // unavailable would instead take down every other segment sharing the same instances (a production incident
+      // showed a whole tier of ~30k segments reported unavailable due to a few relocating segments). Skip it here;
+      // it gets an empty candidate list below and is reported unavailable individually.
+      if (onlineInstances.isEmpty()) {
+        if (segmentsNotOnlineAnywhere == null) {
+          segmentsNotOnlineAnywhere = new ArrayList<>();
+        }
+        segmentsNotOnlineAnywhere.add(segment);
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug("Found old segment: {} in table: {} not online on any instance (IS: {}, EV: {})", segment,
+              _tableNameWithType, idealStateInstanceStateMap, externalViewAssignment.get(segment));
+        }
+        continue;
+      }
       Set<String> instancesInIdealState = idealStateInstanceStateMap.keySet();
       Set<String> unavailableInstances =
           unavailableInstancesMap.computeIfAbsent(instancesInIdealState, k -> new HashSet<>());
@@ -240,6 +263,13 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
         }
       }
     }
+    if (segmentsNotOnlineAnywhere != null) {
+      int numSegmentsNotOnlineAnywhere = segmentsNotOnlineAnywhere.size();
+      LOGGER.warn("Found {} old segments not online on any instance in table: {}, sampling {}: {}, counting them as "
+              + "unavailable without excluding instances for their groups", numSegmentsNotOnlineAnywhere,
+          _tableNameWithType, Math.min(numSegmentsNotOnlineAnywhere, 10),
+          segmentsNotOnlineAnywhere.subList(0, Math.min(numSegmentsNotOnlineAnywhere, 10)));
+    }
 
     // Iterate over the maps and exclude the unavailable instances
     for (Map.Entry<String, Set<String>> entry : oldSegmentToOnlineInstancesMap.entrySet()) {
@@ -248,7 +278,8 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
       Set<String> onlineInstances = entry.getValue();
       Map<String, String> idealStateInstanceStateMap = idealStateAssignment.get(segment);
 
-      Set<String> unavailableInstances = unavailableInstancesMap.get(idealStateInstanceStateMap.keySet());
+      Set<String> unavailableInstances =
+          unavailableInstancesMap.getOrDefault(idealStateInstanceStateMap.keySet(), Collections.emptySet());
       List<SegmentInstanceCandidate> candidates = new ArrayList<>(onlineInstances.size());
       int idealStateReplicaId = 0;
       for (String instance : convertToSortedMap(idealStateInstanceStateMap).keySet()) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
@@ -34,7 +34,11 @@ import org.apache.helix.model.IdealState;
  * partition are never served from multiple different instances. The instances in a replica-group should have all the
  * online segments (segments with ONLINE/CONSUMING instances in the ideal state and selected by the pre-selector)
  * available (ONLINE/CONSUMING in the external view) in order to serve queries. If any segment is unavailable in the
- * replica-group, we mark the whole replica-group down and not serve queries with this replica-group.
+ * replica-group, we mark the whole replica-group down and not serve queries with this replica-group. As an exception,
+ * a segment that is unavailable in every replica-group (e.g. being loaded on all the new instances right after tier
+ * relocation/rebalance moved it) does not mark any replica-group down because no routing choice can serve it; it is
+ * reported as unavailable individually instead, so that it doesn't take down all the other segments sharing the same
+ * instances.
  *
  * The selection algorithm is the same as {@link ReplicaGroupInstanceSelector}, and will always evenly distribute the
  * traffic to all replica-groups that have all online segments available.

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
@@ -1218,8 +1218,8 @@ public class InstanceSelectorTest {
       assertEquals(selectionResult.getUnavailableSegments(), Arrays.asList(segment0, segment1));
 
       // Change the ERROR instance of segment0 to ONLINE, segment0 should be available
-      // (Note that for StrictReplicaGroupInstanceSelector, segment1 but it is old so it will mark instance down for
-      // segment0)
+      // (Note that for StrictReplicaGroupInstanceSelector, segment1 is old but it is not online on any instance, so
+      // it is counted as unavailable individually without marking instances down for segment0)
       // {
       //   segment0: {
       //     (disabled) instance: OFFLINE,
@@ -1237,8 +1237,8 @@ public class InstanceSelectorTest {
       assertEquals(selectionResult.getSegmentToInstanceMap().size(), 1);
       assertEquals(selectionResult.getUnavailableSegments(), Collections.singletonList(segment1));
       selectionResult = strictReplicaGroupInstanceSelector.select(brokerRequest, segments, 0);
-      assertTrue(selectionResult.getSegmentToInstanceMap().isEmpty());
-      assertEquals(selectionResult.getUnavailableSegments(), Arrays.asList(segment0, segment1));
+      assertEquals(selectionResult.getSegmentToInstanceMap().size(), 1);
+      assertEquals(selectionResult.getUnavailableSegments(), Collections.singletonList(segment1));
 
       // Disable the ONLINE instance, both segments should be unavailable
       // {
@@ -1285,6 +1285,85 @@ public class InstanceSelectorTest {
       assertTrue(selectionResult.getSegmentToInstanceMap().isEmpty());
       assertEquals(selectionResult.getUnavailableSegments(), Arrays.asList(segment0, segment1));
     }
+  }
+
+  /**
+   * Regression test for a segment relocation scenario: an old segment that just got moved to a new set of instances
+   * (e.g. by tier relocation) is not ONLINE on any of them yet. Such a segment cannot be served from anywhere, so it
+   * should be reported as unavailable individually instead of marking the instances unavailable for the whole group,
+   * which would take down all the other segments hosted by the same instances.
+   */
+  @Test
+  public void testStrictReplicaGroupSegmentNotOnlineAnywhereDoesNotMarkGroupDown() {
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
+    StrictReplicaGroupInstanceSelector strictReplicaGroupInstanceSelector = new StrictReplicaGroupInstanceSelector();
+
+    String instance0 = "instance0";
+    String instance1 = "instance1";
+    Set<String> enabledInstances = new HashSet<>(Arrays.asList(instance0, instance1));
+
+    String segment0 = "segment0";
+    String segment1 = "segment1";
+    String relocatedSegment = "segment2";
+    List<String> segments = Arrays.asList(segment0, segment1, relocatedSegment);
+
+    // All the segments are assigned to the same instances in the ideal state. The external view shows segment0 and
+    // segment1 ONLINE on instance0 only (instance1 is restarting and has no entries), and the relocated segment not
+    // ONLINE anywhere (still being loaded on both instances).
+    IdealState idealState = new IdealState(TABLE_NAME);
+    Map<String, Map<String, String>> idealStateSegmentAssignment = idealState.getRecord().getMapFields();
+    Map<String, String> idealStateInstanceStateMap = new TreeMap<>();
+    idealStateInstanceStateMap.put(instance0, ONLINE);
+    idealStateInstanceStateMap.put(instance1, ONLINE);
+    for (String segment : segments) {
+      idealStateSegmentAssignment.put(segment, idealStateInstanceStateMap);
+    }
+    ExternalView externalView = new ExternalView(TABLE_NAME);
+    Map<String, Map<String, String>> externalViewSegmentAssignment = externalView.getRecord().getMapFields();
+    Map<String, String> externalViewInstanceStateMap = new TreeMap<>();
+    externalViewInstanceStateMap.put(instance0, ONLINE);
+    externalViewSegmentAssignment.put(segment0, externalViewInstanceStateMap);
+    externalViewSegmentAssignment.put(segment1, externalViewInstanceStateMap);
+    Set<String> onlineSegments = new HashSet<>(segments);
+
+    strictReplicaGroupInstanceSelector.init(_tableConfig, propertyStore, brokerMetrics, null, Clock.systemUTC(),
+        INSTANCE_SELECTOR_CONFIG, enabledInstances, EMPTY_SERVER_MAP, idealState, externalView, onlineSegments);
+    BrokerRequest brokerRequest = mock(BrokerRequest.class);
+    PinotQuery pinotQuery = mock(PinotQuery.class);
+    when(brokerRequest.getPinotQuery()).thenReturn(pinotQuery);
+    when(pinotQuery.getQueryOptions()).thenReturn(null);
+
+    // The relocated segment should be unavailable, but segment0 and segment1 should still be served from instance0
+    InstanceSelector.SelectionResult selectionResult =
+        strictReplicaGroupInstanceSelector.select(brokerRequest, segments, 0);
+    Map<String, String> expectedSegmentToInstanceMap = new HashMap<>();
+    expectedSegmentToInstanceMap.put(segment0, instance0);
+    expectedSegmentToInstanceMap.put(segment1, instance0);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedSegmentToInstanceMap);
+    assertEquals(selectionResult.getUnavailableSegments(), Collections.singletonList(relocatedSegment));
+
+    // Once the relocated segment is loaded on instance0, all the segments should be served from instance0
+    Map<String, String> relocatedSegmentExternalViewInstanceStateMap = new TreeMap<>();
+    relocatedSegmentExternalViewInstanceStateMap.put(instance0, ONLINE);
+    externalViewSegmentAssignment.put(relocatedSegment, relocatedSegmentExternalViewInstanceStateMap);
+    strictReplicaGroupInstanceSelector.onAssignmentChange(idealState, externalView, onlineSegments);
+    selectionResult = strictReplicaGroupInstanceSelector.select(brokerRequest, segments, 0);
+    expectedSegmentToInstanceMap.put(relocatedSegment, instance0);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedSegmentToInstanceMap);
+    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
+
+    // If a segment is ONLINE on some instance (instance1 here) but missing on another (instance0), the strict
+    // replica-group guarantee should still mark the instance missing the segment as unavailable for the whole group
+    Map<String, String> partiallyOnlineExternalViewInstanceStateMap = new TreeMap<>();
+    partiallyOnlineExternalViewInstanceStateMap.put(instance1, ONLINE);
+    externalViewSegmentAssignment.put(relocatedSegment, partiallyOnlineExternalViewInstanceStateMap);
+    strictReplicaGroupInstanceSelector.onAssignmentChange(idealState, externalView, onlineSegments);
+    selectionResult = strictReplicaGroupInstanceSelector.select(brokerRequest, segments, 0);
+    // instance0 is unavailable because it misses the relocated segment, and instance1 is unavailable because it
+    // misses segment0 and segment1, so all the segments should be unavailable
+    assertTrue(selectionResult.getSegmentToInstanceMap().isEmpty());
+    assertEquals(new HashSet<>(selectionResult.getUnavailableSegments()), new HashSet<>(segments));
   }
 
   @Test(dataProvider = "selectorType")
@@ -1443,15 +1522,12 @@ public class InstanceSelectorTest {
     assertTrue(selectionResult.getUnavailableSegments().isEmpty());
 
     // Advance the clock to make newSeg to old segment and we see newSeg is reported as unavailable segment.
+    // Note that even for strict replica-group routing, newSeg is not online on any instance, so it doesn't mark
+    // instances unavailable for the whole group, and oldSeg is still served.
     _mutableClock.fastForward(Duration.ofMillis(NEW_SEGMENT_EXPIRATION_MILLIS + 10));
     selector = createTestInstanceSelector(selectorType, enabledInstances, idealState, externalView, onlineSegments);
     selectionResult = selector.select(_brokerRequest, Lists.newArrayList(onlineSegments), requestId);
-    if (STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE.equals(selectorType)) {
-      expectedResult = Map.of();
-      assertEquals(selectionResult.getUnavailableSegments(), List.of(newSeg, oldSeg));
-    } else {
-      assertEquals(selectionResult.getUnavailableSegments(), List.of(newSeg));
-    }
+    assertEquals(selectionResult.getUnavailableSegments(), List.of(newSeg));
     assertEquals(selectionResult.getSegmentToInstanceMap(), expectedResult);
     assertTrue(selectionResult.getOptionalSegmentToInstanceMap().isEmpty());
   }
@@ -1511,12 +1587,9 @@ public class InstanceSelectorTest {
     externalView = createExternalView(externalViewMap);
     selector.onAssignmentChange(idealState, externalView, onlineSegments);
     selectionResult = selector.select(_brokerRequest, Lists.newArrayList(onlineSegments), requestId);
-    if (selectorType == STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE) {
-      expectedResult = Map.of();
-      assertEquals(selectionResult.getUnavailableSegments(), List.of(oldSeg, newSeg));
-    } else {
-      assertEquals(selectionResult.getUnavailableSegments(), List.of(newSeg));
-    }
+    // Note that even for strict replica-group routing, segment1 is not online on any instance, so it doesn't mark
+    // instances unavailable for the whole group, and segment0 is still served.
+    assertEquals(selectionResult.getUnavailableSegments(), List.of(newSeg));
     assertEquals(selectionResult.getSegmentToInstanceMap(), expectedResult);
 
     // Get segment1 back online in instance1
@@ -1602,12 +1675,9 @@ public class InstanceSelectorTest {
 
     selector.onAssignmentChange(idealState, externalView, onlineSegments);
     selectionResult = selector.select(_brokerRequest, Lists.newArrayList(onlineSegments), requestId);
-    if (selectorType == STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE) {
-      expectedBalancedInstanceSelectorResult = Map.of();
-      assertEquals(selectionResult.getUnavailableSegments(), List.of(oldSeg, newSeg));
-    } else {
-      assertEquals(selectionResult.getUnavailableSegments(), List.of(newSeg));
-    }
+    // Note that even for strict replica-group routing, segment1 is not online on any instance, so it doesn't mark
+    // instances unavailable for the whole group, and segment0 is still served.
+    assertEquals(selectionResult.getUnavailableSegments(), List.of(newSeg));
     assertEquals(selectionResult.getSegmentToInstanceMap(), expectedBalancedInstanceSelectorResult);
   }
 
@@ -1680,15 +1750,13 @@ public class InstanceSelectorTest {
     assertTrue(selectionResult.getUnavailableSegments().isEmpty());
 
     // Advance the clock to make newSeg to old segment.
-    // On state update, all segments become unavailable.
+    // On state update, newSeg becomes unavailable. Note that even for strict replica-group routing, newSeg is not
+    // online on any instance, so it doesn't mark instances unavailable for the whole group, and the old segments are
+    // still served.
     _mutableClock.fastForward(Duration.ofMillis(NEW_SEGMENT_EXPIRATION_MILLIS + 10));
     selector.onAssignmentChange(idealState, externalView, onlineSegments);
     selectionResult = selector.select(_brokerRequest, Lists.newArrayList(onlineSegments), requestId);
-    if (selectorType == STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE) {
-      assertEquals(selectionResult.getUnavailableSegments(), List.of(oldSeg0, oldSeg1, newSeg));
-    } else {
-      assertEquals(selectionResult.getUnavailableSegments(), List.of(newSeg));
-    }
+    assertEquals(selectionResult.getUnavailableSegments(), List.of(newSeg));
   }
 
   // Test that on instance change, we exclude not enabled instance from serving for new segments.


### PR DESCRIPTION
## Problem

In strict replica-group routing (`StrictReplicaGroupInstanceSelector`, and `ReplicaGroupInstanceSelector` for upsert/dedup tables), when an old segment is missing (not ONLINE/CONSUMING in ExternalView) on an instance, that instance is marked unavailable **for every segment sharing the same ideal state instance set**. This is correct when the segment is available on some other instance in the group: it forces the whole group to route to an instance that has all the segments.

However, when a segment is not online on **any** instance in its instance set, this logic marks **all** instances of the group unavailable, taking down every other segment hosted by the same instances — even though excluding instances cannot make the missing segment servable and provides no consistency benefit.

This caused a production incident: during tier relocation while one cold-tier replica group was restarting, a `bestEfforts` rebalance advanced the IdealState past ExternalView convergence, leaving a handful of relocating segments ONLINE nowhere for ~1 minute. Those few segments poisoned both cold instances of every instance group, and the broker reported the **entire cold tier (~29.5k segments) unavailable**:

```
29562 segments unavailable, sampling 10: [...], with routing policy: strictReplicaGroup [realtime]
```

The same mechanism also lets a single corrupt segment (ERROR on all replicas) black out a whole replica-group set.

## Fix

In `updateSegmentMapsForUpsertTable`, an old segment with no online instance within its ideal state instance set no longer contributes to the unavailable-instance computation for its group. It gets an empty candidate list and is reported as unavailable **individually**, while all other segments on those instances keep serving.

The strict replica-group guarantee is unchanged for any segment that is available on at least one instance: instances missing such a segment are still excluded for the whole group, so all served segments of a group are still served from a consistent instance (verified by the last phase of the new regression test).

## Behavior change

Before: a segment unavailable everywhere caused **all** segments sharing its instance set to be reported unavailable, and the query served no rows from any of them.

After: only the truly unservable segment is reported unavailable; the rest of the group keeps serving.

This applies to `StrictReplicaGroupInstanceSelector` (all tables) and `ReplicaGroupInstanceSelector` (upsert/dedup tables), since both share `updateSegmentMapsForUpsertTable`. For upsert tables this means a query can now return rows from the remaining segments of a partition while the nowhere-online segment is reported unavailable; records whose latest version lives in that segment may surface earlier versions. Note that in both the old and the new behavior the query response carries a `BROKER_SEGMENT_UNAVAILABLE` exception, so clients that treat partial results as failures are unaffected. Given that the previous behavior also returned partial (more incomplete) results with the same exception, this is shipped without a config gate.

## Testing

- New regression test `testStrictReplicaGroupSegmentNotOnlineAnywhereDoesNotMarkGroupDown` covering: (1) the incident scenario (relocated segment not online anywhere does not take down the group), (2) recovery once the segment loads, and (3) the preserved group-down behavior for a segment that is online on one instance but missing on another.
- Updated existing test expectations that codified the old blackout behavior (each with explanatory comments).
- Full `pinot-broker` module test suite passes.
