### PR TITLE
fix(upsert): skip expired metadata during upsert instead of comparing against it

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -378,6 +378,19 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
           if (currentRecordLocation != null) {
             // Existing primary key
             IndexSegment currentSegment = currentRecordLocation.getSegment();
+
+            // If existing metadata is expired per TTL, treat as new key
+            if (_metadataTTL > 0 && isOutOfMetadataTTL(
+                ((Number) currentRecordLocation.getComparisonValue()).doubleValue())) {
+              int currentDocId = currentRecordLocation.getDocId();
+              if (segment == currentSegment) {
+                replaceDocId(segment, validDocIds, queryableDocIds, currentDocId, newDocId, recordInfo);
+              } else {
+                replaceDocId(segment, validDocIds, queryableDocIds, currentSegment, currentDocId, newDocId, recordInfo);
+              }
+              return new RecordLocation(segment, newDocId, newComparisonValue);
+            }
+
             // Update the record location when the new comparison value is greater than or equal to the current value.
             // Update the record location when there is a tie to keep the newer record.
             if (newComparisonValue.compareTo(currentRecordLocation.getComparisonValue()) >= 0) {
@@ -423,7 +436,9 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
           // - New record is not out-of-order
           // - Previous record is not deleted
           if (!recordInfo.isDeleteRecord()
-              && recordInfo.getComparisonValue().compareTo(recordLocation.getComparisonValue()) >= 0) {
+              && recordInfo.getComparisonValue().compareTo(recordLocation.getComparisonValue()) >= 0
+              && !(_metadataTTL > 0 && isOutOfMetadataTTL(
+                  ((Number) recordLocation.getComparisonValue()).doubleValue()))) {
             IndexSegment currentSegment = recordLocation.getSegment();
             ThreadSafeMutableRoaringBitmap currentQueryableDocIds = currentSegment.getQueryableDocIds();
             int currentDocId = recordLocation.getDocId();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
@@ -266,6 +266,44 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
   }
 
   @Test
+  public void testAddRecordSkipsExpiredMetadata()
+      throws IOException {
+    _contextBuilder.setEnableSnapshot(true).setMetadataTTL(100);
+    ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
+        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, _contextBuilder.build());
+    Map<Object, ConcurrentMapPartitionUpsertMetadataManager.RecordLocation> recordLocationMap =
+        upsertMetadataManager._primaryKeyToRecordLocationMap;
+
+    // Add record for key 0 with comparison value 1000
+    ThreadSafeMutableRoaringBitmap validDocIds0 = new ThreadSafeMutableRoaringBitmap();
+    MutableSegment segment0 = mockMutableSegment(1, validDocIds0, null);
+    upsertMetadataManager.addRecord(segment0, new RecordInfo(makePrimaryKey(0), 0, Integer.valueOf(1000), false));
+    checkRecordLocationForTTL(recordLocationMap, 0, segment0, 0, 1000, HashFunction.NONE);
+    assertEquals(upsertMetadataManager.getWatermark(), 1000.0);
+
+    // Add record for key 1 with comparison value 1200 to advance watermark past TTL for key 0
+    // Threshold becomes 1200 - 100 = 1100; key 0's value 1000 < 1100 -> expired
+    upsertMetadataManager.addRecord(segment0, new RecordInfo(makePrimaryKey(1), 1, Integer.valueOf(1200), false));
+    assertEquals(upsertMetadataManager.getWatermark(), 1200.0);
+
+    // Add new record for key 0 with comparison value 900 (lower than the expired entry's 1000)
+    // Without the fix, this would be rejected as out-of-order. With the fix, it should be accepted.
+    ThreadSafeMutableRoaringBitmap validDocIds1 = new ThreadSafeMutableRoaringBitmap();
+    MutableSegment segment1 = mockMutableSegment(2, validDocIds1, null);
+    boolean result = upsertMetadataManager.addRecord(segment1,
+        new RecordInfo(makePrimaryKey(0), 0, Integer.valueOf(900), false));
+    assertTrue(result, "Record should be accepted when existing metadata is expired");
+    checkRecordLocationForTTL(recordLocationMap, 0, segment1, 0, 900, HashFunction.NONE);
+
+    // Verify the new record is queryable and the old record is invalidated
+    assertTrue(validDocIds1.contains(0), "New doc should be in validDocIds of new segment");
+    assertFalse(validDocIds0.contains(0), "Old doc should be removed from old segment's validDocIds");
+
+    upsertMetadataManager.stop();
+    upsertMetadataManager.close();
+  }
+
+  @Test
   public void testManageWatermark()
       throws IOException {
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

TTL check added to skip expired metadata during upsert, avoiding stale comparisons and merges\.

```mermaid
flowchart TD
  N0["TTL expiry check in doAddRecord #40;F1#41;"]:::stAdded
  N1["Replace doc ID and return new RecordLocation #40;F1#41;"]:::stAdded
  N2["Original comparison and update record location #40;F1#41;"]:::stUnchanged
  N3["Guard condition in doUpdateRecord #40;F1#41;"]:::stAdded
  N4["Partial upsert merge #40;read previous row and merge#41; #40;F1#41;"]:::stUnchanged
  N5["Skip merge when metadata expired #40;F1#41;"]:::stAdded
  N0 -->|"if expired"| N1
  N0 -->|"if not expired"| N2
  N3 -->|"if guard passes"| N4
  N3 -->|"if guard fails"| N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager\.java — [before](https://github.com/apache/pinot/blob/36934936ba425b7fe8b83893aedf065fe29dc848/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java) · [after](https://github.com/apache/pinot/blob/5085afb0e358ca0a8f783eff120124ae54a83847/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjM2OTM0OTM2YmE0MjViN2ZlOGI4Mzg5M2FlZGYwNjVmZTI5ZGM4NDgiLCJjb250ZXh0X2hhc2giOiJhNWVlNGFjYzVhM2UxNjNhODllYmI1Mzk2NDhmMWU1NGM4ZTRmNzVmMjI4MjJlMDA1MTUxZDA0YTQyODkyZDU2IiwiZ2VuZXJhdGVkX2F0IjoxNzg5Njk1NDg5LCJoZWFkX3NoYSI6IjUwODVhZmIwZTM1OGNhMGE4Zjc4M2VmZjEyMDEyNGFlNTRhODM4NDciLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI2YThlOTYxNTE3OWFhMGEwNzEwYzQ1ZjNkYTRiZjYxYTJjYmMzMGYyIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 61ae7cb14b162a8725f23969b663fdea15b2efb4b7a402bd340835f595a9d39a -->
<!-- pinot-pr-flow:end -->

### Problem

When `upsertMetadataTTL` is configured, expired metadata entries are only cleaned up at segment commit time (which can be hours apart for low-throughput tables). Records arriving after TTL expiry are still compared against stale metadata — a record with a lower comparison value gets rejected as out-of-order even though the existing entry is expired and should be irrelevant.

### Fix

Add an inline TTL expiry check in `doAddRecord()`. When the existing record's comparison value is below the TTL threshold (`largestSeenComparisonValue - metadataTTL`), skip the comparison entirely:
- The new record always wins regardless of its comparison value
- The old doc is invalidated via `replaceDocId` (no duplicate queryable rows)
- The map entry is replaced with a fresh `RecordLocation`

Also guard the partial upsert merge in `doUpdateRecord()` — skip reading the previous row when it's expired, preventing stale data from being merged into the new record.

### Changes

- `ConcurrentMapPartitionUpsertMetadataManager.doAddRecord()` — TTL check before comparison
- `ConcurrentMapPartitionUpsertMetadataManager.doUpdateRecord()` — TTL guard on partial upsert merge
- Test: expired metadata is skipped, lower comparison value accepted, old doc invalidated

### Not changed

- `ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes` — `metadataTTL` and `enableDeletedKeysCompactionConsistency` are mutually exclusive, so the check can never fire there
- `removeExpiredPrimaryKeys()` — lazy cleanup at segment commit continues as-is
