### PR TITLE
Fix MutableJsonIndexImpl corrupting doc ID mapping on invalid UTF-16 strings

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/json/MutableJsonIndexImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/json/MutableJsonIndexImpl.java
@@ -24,6 +24,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -134,16 +135,26 @@ public class MutableJsonIndexImpl implements MutableJsonIndex {
         // Put both key and key-value into the posting list. Key is useful for checking if a key exists in the json.
         String key = entry.getKey();
         _postingListMap.computeIfAbsent(key, k -> {
-          _bytesSize += Utf8.encodedLength(key);
+          _bytesSize += estimateLength(key);
           return new RoaringBitmap();
         }).add(_nextFlattenedDocId);
         String keyValue = key + JsonIndexCreator.KEY_VALUE_SEPARATOR + entry.getValue();
         _postingListMap.computeIfAbsent(keyValue, k -> {
-          _bytesSize += Utf8.encodedLength(keyValue);
+          _bytesSize += estimateLength(keyValue);
           return new RoaringBitmap();
         }).add(_nextFlattenedDocId);
       }
       _nextFlattenedDocId++;
+    }
+  }
+
+  private static int estimateLength(String value) {
+    // Utf8.encodedLength counts bytes without allocating but throws on malformed strings (e.g. unpaired surrogates).
+    // _bytesSize is only a heuristic, so fall back to getBytes (which never throws) instead of failing.
+    try {
+      return Utf8.encodedLength(value);
+    } catch (IllegalArgumentException e) {
+      return value.getBytes(StandardCharsets.UTF_8).length;
     }
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/JsonIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/JsonIndexTest.java
@@ -100,6 +100,22 @@ public class JsonIndexTest implements PinotBuffersAfterMethodCheckRule {
   }
 
   @Test
+  public void testAddRecordWithUnpairedSurrogateDoesNotShiftDocIds()
+      throws IOException {
+    JsonIndexConfig jsonIndexConfig = getIndexConfig();
+    try (MutableJsonIndexImpl mutableJsonIndex =
+        new MutableJsonIndexImpl(jsonIndexConfig, "table__0__1", "col")) {
+      mutableJsonIndex.add("{\"name\":\"first\"}");
+      mutableJsonIndex.add("{\"name\":\"" + '\uD800' + "\"}");
+      mutableJsonIndex.add("{\"name\":\"third\"}");
+
+      assertDocIds(mutableJsonIndex, "name='first'", ids(0));
+      assertDocIds(mutableJsonIndex, "name='" + '\uD800' + "'", ids(1));
+      assertDocIds(mutableJsonIndex, "name='third'", ids(2));
+    }
+  }
+
+  @Test
   public void testSmallIndex()
       throws Exception {
     // @formatter: off


### PR DESCRIPTION
## Why

`MutableJsonIndexImpl#add` extends `_docIdMapping` for a document's flattened records, then builds the posting lists and increments `_nextFlattenedDocId`. While building those posting lists it maintains a running `_bytesSize` (a memory heuristic used to cap the mutable index) via Guava's `Utf8.encodedLength(...)`.

`Utf8.encodedLength` throws `IllegalArgumentException` when a string contains an unpaired UTF-16 surrogate. Because it's called inside `computeIfAbsent` — after `_docIdMapping` has already been extended but before `_nextFlattenedDocId` is incremented — a single malformed value aborts the build loop and leaves `_docIdMapping` and `_nextFlattenedDocId` permanently out of sync. `_nextDocId` still advances in the `finally` block, so every subsequent document's `json_match` result is silently shifted by one flattened doc id.

This behavior lasts until the segment is flushed. The non-mutable json indices do not estimate size, so its ids are in sync.

## Fix

Route the size accounting through an `estimateLength` helper that falls back to `String.getBytes(UTF_8).length` (which never throws — malformed input is replaced) when `Utf8.encodedLength` throws. `_bytesSize` is only a heuristic, so an approximate length for a malformed string is acceptable; aborting indexing is not.

## Testing

Added `testAddRecordWithUnpairedSurrogateDoesNotShiftDocIds`: indexes three records where the middle value is an unpaired surrogate (`\uD800`) and asserts `name='first'` → doc 0 and `name='third'` → doc 2. Fails before this change (doc ids shifted), passes after.

Fixes #18737