### PR TITLE
Fix table rebalance to not drop the last serving replicas when proceeding on best-efforts without ExternalView convergence

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/RebalanceConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/RebalanceConfig.java
@@ -98,7 +98,11 @@ public class RebalanceConfig {
   // Whether to use best-efforts to rebalance (not fail the rebalance when the no-downtime contract cannot be achieved)
   // When using best-efforts to rebalance, the following scenarios won't fail the rebalance (will log warnings instead):
   // - Segment falls into ERROR state in ExternalView -> count ERROR state as good state
-  // - ExternalView has not converged within the maximum wait time -> continue to the next stage
+  // - ExternalView has not converged within the maximum wait time -> continue to the next stage for the segments that
+  //   can be moved without dropping the replicas actually serving them (ONLINE/CONSUMING in ExternalView) below the
+  //   minimum available replicas. Note that the rebalance still fails when no segment can be moved this way, because
+  //   making progress would require dropping the last serving replicas of the segments (causing query downtime); it
+  //   can be retried once the instances hosting the segments are healthy again
   @JsonProperty("bestEfforts")
   @ApiModelProperty(example = "false")
   private boolean _bestEfforts = false;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -927,7 +927,10 @@ public class PinotTableRestletResource {
           + "useful when servers are low on disk space, and we want to scale up the cluster and rebalance the table to "
           + "more servers.") @DefaultValue("false") @QueryParam("lowDiskMode") boolean lowDiskMode,
       @ApiParam(value = "Whether to use best-efforts to rebalance (not fail the rebalance when the no-downtime "
-          + "contract cannot be achieved)") @DefaultValue("false") @QueryParam("bestEfforts") boolean bestEfforts,
+          + "contract cannot be achieved). Segments in ERROR state and non-converged ExternalView do not fail the "
+          + "rebalance, but a segment is never moved if the move would drop the replicas actually serving it below "
+          + "minAvailableReplicas; the rebalance fails if no progress can be made this way")
+      @DefaultValue("false") @QueryParam("bestEfforts") boolean bestEfforts,
       @ApiParam(value = "How many maximum segment adds per server to update in the IdealState in each step. For "
           + "non-strict replica group based assignment, this number will be capped at the batchSizePerServer value "
           + "per rebalance step (some servers may get fewer segments). For strict replica group based assignment, "

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -922,7 +922,10 @@ public class PinotTableRestletResource {
           + "useful when servers are low on disk space, and we want to scale up the cluster and rebalance the table to "
           + "more servers.") @DefaultValue("false") @QueryParam("lowDiskMode") boolean lowDiskMode,
       @ApiParam(value = "Whether to use best-efforts to rebalance (not fail the rebalance when the no-downtime "
-          + "contract cannot be achieved)") @DefaultValue("false") @QueryParam("bestEfforts") boolean bestEfforts,
+          + "contract cannot be achieved). Segments in ERROR state and non-converged ExternalView do not fail the "
+          + "rebalance, but a segment is never moved if the move would drop the replicas actually serving it below "
+          + "minAvailableReplicas; the rebalance fails if no progress can be made this way")
+      @DefaultValue("false") @QueryParam("bestEfforts") boolean bestEfforts,
       @ApiParam(value = "How many maximum segment adds per server to update in the IdealState in each step. For "
           + "non-strict replica group based assignment, this number will be capped at the batchSizePerServer value "
           + "per rebalance step (some servers may get fewer segments). For strict replica group based assignment, "

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -601,10 +601,23 @@ public class TableRebalancer {
       }
       // Wait for ExternalView to converge before updating the next IdealState
       IdealState idealState;
+      // Non-null only when the wait gave up without convergence (best-efforts). In this case the instances in the
+      // current IdealState are not guaranteed to be serving the segments, and the next assignment calculation should
+      // not move a segment if doing so would drop the replicas actually serving it (ONLINE/CONSUMING in ExternalView)
+      // below the minimum available replicas. Note that this snapshot may be stale by the time the next assignment is
+      // calculated (e.g. after force-committing consuming segments); that is safe because a stale snapshot can only
+      // under-count the serving replicas and hold extra segments, which get moved in the following steps.
+      Map<String, Map<String, String>> nonConvergedExternalViewAssignment = null;
       try {
-        idealState = waitForExternalViewToConverge(tableNameWithType, lowDiskMode, bestEfforts, segmentsToMonitor,
-            externalViewCheckIntervalInMs, externalViewStabilizationTimeoutInMs, estimatedAverageSegmentSizeInBytes,
-            allSegmentsFromIdealState, tableRebalanceLogger);
+        Pair<IdealState, ExternalView> idealStateAndNonConvergedExternalView =
+            waitForExternalViewToConverge(tableNameWithType, lowDiskMode, bestEfforts, segmentsToMonitor,
+                externalViewCheckIntervalInMs, externalViewStabilizationTimeoutInMs,
+                estimatedAverageSegmentSizeInBytes, allSegmentsFromIdealState, tableRebalanceLogger);
+        idealState = idealStateAndNonConvergedExternalView.getLeft();
+        ExternalView nonConvergedExternalView = idealStateAndNonConvergedExternalView.getRight();
+        if (nonConvergedExternalView != null) {
+          nonConvergedExternalViewAssignment = nonConvergedExternalView.getRecord().getMapFields();
+        }
       } catch (Exception e) {
         String errorMsg = "Caught exception while waiting for ExternalView to converge, aborting the rebalance: "
             + e.getMessage();
@@ -710,7 +723,7 @@ public class TableRebalancer {
             nextAssignment =
                 getNextAssignment(currentAssignment, targetAssignment, minAvailableReplicas, enableStrictReplicaGroup,
                     lowDiskMode, batchSizePerServer, segmentPartitionIdMap, partitionIdFetcher, dataLossRiskAssessor,
-                    tableRebalanceLogger);
+                    nonConvergedExternalViewAssignment, tableRebalanceLogger);
           } catch (Exception e) {
             String errorMsg =
                 "Caught exception while calculating the next assignment, aborting the rebalance: " + e.getMessage();
@@ -775,11 +788,23 @@ public class TableRebalancer {
         nextAssignment =
             getNextAssignment(currentAssignment, targetAssignment, minAvailableReplicas, enableStrictReplicaGroup,
                 lowDiskMode, batchSizePerServer, segmentPartitionIdMap, partitionIdFetcher, dataLossRiskAssessor,
-                tableRebalanceLogger);
+                nonConvergedExternalViewAssignment, tableRebalanceLogger);
       } catch (Exception e) {
         String errorMsg =
             "Caught exception while calculating the next assignment, aborting the rebalance: " + e.getMessage();
         onReturnFailure(errorMsg, e, tableRebalanceLogger);
+        return new RebalanceResult(rebalanceJobId, RebalanceResult.Status.FAILED, errorMsg, instancePartitionsMap,
+            tierToInstancePartitionsMap, targetAssignment, preChecksResult, summaryResult);
+      }
+
+      // When the ExternalView did not converge (best-efforts) and no segment can be moved without dropping its last
+      // serving replicas, the rebalance cannot make progress without causing downtime. Abort instead of looping; the
+      // rebalance can be retried (e.g. by the next SegmentRelocator run) once the serving instances recover.
+      if (nonConvergedExternalViewAssignment != null && nextAssignment.equals(currentAssignment)) {
+        String errorMsg = "Rebalance cannot make progress without dropping the replicas actually serving the "
+            + "segments because ExternalView has not converged (best-efforts), aborting the rebalance. It can be "
+            + "retried once the instances hosting the segments are healthy again";
+        onReturnFailure(errorMsg, null, tableRebalanceLogger);
         return new RebalanceResult(rebalanceJobId, RebalanceResult.Status.FAILED, errorMsg, instancePartitionsMap,
             tierToInstancePartitionsMap, targetAssignment, preChecksResult, summaryResult);
       }
@@ -1441,10 +1466,14 @@ public class TableRebalancer {
     }
   }
 
-  private IdealState waitForExternalViewToConverge(String tableNameWithType, boolean lowDiskMode, boolean bestEfforts,
-      Set<String> segmentsToMonitor, long externalViewCheckIntervalInMs, long externalViewStabilizationTimeoutInMs,
-      long estimateAverageSegmentSizeInBytes, Set<String> allSegmentsFromIdealState,
-      Logger tableRebalanceLogger)
+  /// Waits for the ExternalView to converge to the IdealState. Returns a pair of the latest IdealState and the latest
+  /// ExternalView, where the ExternalView is `null` when it has converged, and non-null when the wait gave up
+  /// without convergence (best-efforts). The non-null ExternalView allows the caller to compute the next assignment
+  /// without assuming that all the instances in the current IdealState are actually serving the segments.
+  private Pair<IdealState, ExternalView> waitForExternalViewToConverge(String tableNameWithType, boolean lowDiskMode,
+      boolean bestEfforts, Set<String> segmentsToMonitor, long externalViewCheckIntervalInMs,
+      long externalViewStabilizationTimeoutInMs, long estimateAverageSegmentSizeInBytes,
+      Set<String> allSegmentsFromIdealState, Logger tableRebalanceLogger)
       throws InterruptedException, TimeoutException {
     long startTimeMs = System.currentTimeMillis();
     long endTimeMs = startTimeMs + externalViewStabilizationTimeoutInMs;
@@ -1481,7 +1510,7 @@ public class TableRebalancer {
               lowDiskMode, bestEfforts, segmentsToMonitor, tableRebalanceLogger)) {
             tableRebalanceLogger.info("ExternalView converged in {}ms, with {} extensions",
                 System.currentTimeMillis() - startTimeMs, extensionCount);
-            return idealState;
+            return Pair.of(idealState, null);
           }
           if (previousRemainingSegments < 0) {
             // initialize previousRemainingSegments
@@ -1515,7 +1544,7 @@ public class TableRebalancer {
           tableRebalanceLogger.warn("ExternalView has not made progress for the last {}ms, stop waiting after "
                   + "spending {}ms waiting ({} extensions), continuing the rebalance (best-efforts)",
               externalViewStabilizationTimeoutInMs, System.currentTimeMillis() - startTimeMs, extensionCount);
-          return idealState;
+          return Pair.of(idealState, externalView);
         }
         throw new TimeoutException(
             String.format("ExternalView has not made progress for the last %dms, timeout after spending %dms "
@@ -1662,7 +1691,20 @@ public class TableRebalancer {
       boolean lowDiskMode, int batchSizePerServer, Object2IntOpenHashMap<String> segmentPartitionIdMap,
       PartitionIdFetcher partitionIdFetcher, DataLossRiskAssessor dataLossRiskAssessor) {
     return getNextAssignment(currentAssignment, targetAssignment, minAvailableReplicas, enableStrictReplicaGroup,
-        lowDiskMode, batchSizePerServer, segmentPartitionIdMap, partitionIdFetcher, dataLossRiskAssessor, LOGGER);
+        lowDiskMode, batchSizePerServer, segmentPartitionIdMap, partitionIdFetcher, dataLossRiskAssessor, null,
+        LOGGER);
+  }
+
+  /// Uses the default LOGGER
+  @VisibleForTesting
+  static Map<String, Map<String, String>> getNextAssignment(Map<String, Map<String, String>> currentAssignment,
+      Map<String, Map<String, String>> targetAssignment, int minAvailableReplicas, boolean enableStrictReplicaGroup,
+      boolean lowDiskMode, int batchSizePerServer, Object2IntOpenHashMap<String> segmentPartitionIdMap,
+      PartitionIdFetcher partitionIdFetcher, DataLossRiskAssessor dataLossRiskAssessor,
+      @Nullable Map<String, Map<String, String>> nonConvergedExternalViewAssignment) {
+    return getNextAssignment(currentAssignment, targetAssignment, minAvailableReplicas, enableStrictReplicaGroup,
+        lowDiskMode, batchSizePerServer, segmentPartitionIdMap, partitionIdFetcher, dataLossRiskAssessor,
+        nonConvergedExternalViewAssignment, LOGGER);
   }
 
   /// Returns the next assignment for the table based on the current assignment and the target assignment with regard to
@@ -1684,33 +1726,88 @@ public class TableRebalancer {
   ///       instances. Special handling to check each group of assigned instances can be removed in that case. The
   ///       strict replica group routing can also be utilized for OFFLINE tables, thus StrictRealtimeSegmentAssignment
   ///       also needs to be made more generic for the OFFLINE case.
+  ///
+  /// The `nonConvergedExternalViewAssignment` is non-null only when the previous step's ExternalView did not
+  /// converge to the IdealState (best-efforts). In this case the instances in the current assignment are not guaranteed
+  /// to be actually serving the segments, so a segment is not moved if the move would drop the replicas actually
+  /// serving it (ONLINE/CONSUMING in ExternalView) below the minimum available replicas. This prevents the rebalance
+  /// from removing the last serving replica of a segment (causing query downtime) when the new replicas have not been
+  /// loaded yet, e.g. when relocating segments to another tier while the target servers are down or slow to load.
   private static Map<String, Map<String, String>> getNextAssignment(Map<String, Map<String, String>> currentAssignment,
       Map<String, Map<String, String>> targetAssignment, int minAvailableReplicas, boolean enableStrictReplicaGroup,
       boolean lowDiskMode, int batchSizePerServer, Object2IntOpenHashMap<String> segmentPartitionIdMap,
-      PartitionIdFetcher partitionIdFetcher, DataLossRiskAssessor dataLossRiskAssessor, Logger tableRebalanceLogger) {
+      PartitionIdFetcher partitionIdFetcher, DataLossRiskAssessor dataLossRiskAssessor,
+      @Nullable Map<String, Map<String, String>> nonConvergedExternalViewAssignment, Logger tableRebalanceLogger) {
     return enableStrictReplicaGroup
         ? getNextStrictReplicaGroupAssignment(currentAssignment, targetAssignment, minAvailableReplicas, lowDiskMode,
-        batchSizePerServer, segmentPartitionIdMap, partitionIdFetcher, dataLossRiskAssessor, tableRebalanceLogger)
+        batchSizePerServer, segmentPartitionIdMap, partitionIdFetcher, dataLossRiskAssessor,
+        nonConvergedExternalViewAssignment, tableRebalanceLogger)
         : getNextNonStrictReplicaGroupAssignment(currentAssignment, targetAssignment, minAvailableReplicas,
-            lowDiskMode, batchSizePerServer, dataLossRiskAssessor);
+            lowDiskMode, batchSizePerServer, dataLossRiskAssessor, nonConvergedExternalViewAssignment,
+            tableRebalanceLogger);
+  }
+
+  /// Returns true if the next assignment for a segment keeps enough replicas that are actually serving the segment
+  /// (ONLINE/CONSUMING in the ExternalView). Used when the previous step's ExternalView did not converge
+  /// (best-efforts), where an instance being in the current IdealState does not imply it is serving the segment.
+  ///
+  /// The requirement is capped at the number of replicas currently serving the segment, so a segment that is already
+  /// served by fewer replicas than the minimum (e.g. in ERROR state or hosted on dead instances) does not block the
+  /// rebalance from making progress: moving it cannot reduce the number of serving replicas below what it already is.
+  private static boolean isNextSingleSegmentAssignmentSafe(Map<String, String> nextInstanceStateMap,
+      Map<String, String> currentInstanceStateMap, @Nullable Map<String, String> externalViewInstanceStateMap,
+      int minAvailableReplicas) {
+    if (externalViewInstanceStateMap == null) {
+      // The segment does not exist in the ExternalView, so no instance is serving it. Moving it cannot reduce the
+      // number of serving replicas
+      return true;
+    }
+    int numServingReplicas = 0;
+    int numServingReplicasKept = 0;
+    for (String instance : currentInstanceStateMap.keySet()) {
+      String externalViewState = externalViewInstanceStateMap.get(instance);
+      if (SegmentStateModel.ONLINE.equals(externalViewState) || SegmentStateModel.CONSUMING.equals(externalViewState)) {
+        numServingReplicas++;
+        if (nextInstanceStateMap.containsKey(instance)) {
+          numServingReplicasKept++;
+        }
+      }
+    }
+    return numServingReplicasKept >= Math.min(minAvailableReplicas, numServingReplicas);
+  }
+
+  private static void logSegmentsNotMovedDueToNonConvergedExternalView(List<String> segmentsNotMoved,
+      Logger tableRebalanceLogger) {
+    if (!segmentsNotMoved.isEmpty()) {
+      int numSegmentsNotMoved = segmentsNotMoved.size();
+      tableRebalanceLogger.warn("Found {} segments that cannot be moved without dropping the replicas actually "
+              + "serving them because ExternalView has not converged (best-efforts), sampling {}: {}, keeping their "
+              + "current assignment", numSegmentsNotMoved, Math.min(numSegmentsNotMoved, 10),
+          segmentsNotMoved.subList(0, Math.min(numSegmentsNotMoved, 10)));
+    }
   }
 
   private static Map<String, Map<String, String>> getNextStrictReplicaGroupAssignment(
       Map<String, Map<String, String>> currentAssignment, Map<String, Map<String, String>> targetAssignment,
       int minAvailableReplicas, boolean lowDiskMode, int batchSizePerServer,
       Object2IntOpenHashMap<String> segmentPartitionIdMap, PartitionIdFetcher partitionIdFetcher,
-      DataLossRiskAssessor dataLossRiskAssessor, Logger tableRebalanceLogger) {
+      DataLossRiskAssessor dataLossRiskAssessor,
+      @Nullable Map<String, Map<String, String>> nonConvergedExternalViewAssignment, Logger tableRebalanceLogger) {
     Map<String, Map<String, String>> nextAssignment = new TreeMap<>();
     Map<String, Integer> numSegmentsToOffloadMap = getNumSegmentsToOffloadMap(currentAssignment, targetAssignment);
     Map<Pair<Set<String>, Set<String>>, Set<String>> assignmentMap = new HashMap<>();
     Map<Set<String>, Set<String>> availableInstancesMap = new HashMap<>();
     Map<String, Integer> serverToNumSegmentsAddedSoFar = new HashMap<>();
+    List<String> segmentsNotMovedDueToNonConvergedExternalView = new ArrayList<>();
 
     if (batchSizePerServer == RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER) {
       // Directly update the nextAssignment with anyServerExhaustedBatchSize = false and return if batching is disabled
       updateNextAssignmentForPartitionIdStrictReplicaGroup(currentAssignment, targetAssignment, nextAssignment,
           false, minAvailableReplicas, lowDiskMode, numSegmentsToOffloadMap, assignmentMap,
-          availableInstancesMap, serverToNumSegmentsAddedSoFar, dataLossRiskAssessor);
+          availableInstancesMap, serverToNumSegmentsAddedSoFar, dataLossRiskAssessor,
+          nonConvergedExternalViewAssignment, segmentsNotMovedDueToNonConvergedExternalView);
+      logSegmentsNotMovedDueToNonConvergedExternalView(segmentsNotMovedDueToNonConvergedExternalView,
+          tableRebalanceLogger);
       return nextAssignment;
     }
 
@@ -1755,10 +1852,13 @@ public class TableRebalancer {
         }
         updateNextAssignmentForPartitionIdStrictReplicaGroup(curAssignment, targetAssignment, nextAssignment,
             anyServerExhaustedBatchSize, minAvailableReplicas, lowDiskMode, numSegmentsToOffloadMap, assignmentMap,
-            availableInstancesMap, serverToNumSegmentsAddedSoFar, dataLossRiskAssessor);
+            availableInstancesMap, serverToNumSegmentsAddedSoFar, dataLossRiskAssessor,
+            nonConvergedExternalViewAssignment, segmentsNotMovedDueToNonConvergedExternalView);
       }
     }
 
+    logSegmentsNotMovedDueToNonConvergedExternalView(segmentsNotMovedDueToNonConvergedExternalView,
+        tableRebalanceLogger);
     checkIfAnyServersAssignedMoreSegmentsThanBatchSize(batchSizePerServer, serverToNumSegmentsAddedSoFar,
         tableRebalanceLogger);
     return nextAssignment;
@@ -1770,11 +1870,40 @@ public class TableRebalancer {
       boolean lowDiskMode, Map<String, Integer> numSegmentsToOffloadMap,
       Map<Pair<Set<String>, Set<String>>, Set<String>> assignmentMap,
       Map<Set<String>, Set<String>> availableInstancesMap, Map<String, Integer> serverToNumSegmentsAddedSoFar,
-      DataLossRiskAssessor dataLossRiskAssessor) {
+      DataLossRiskAssessor dataLossRiskAssessor,
+      @Nullable Map<String, Map<String, String>> nonConvergedExternalViewAssignment,
+      List<String> segmentsNotMovedDueToNonConvergedExternalView) {
     if (anyServerExhaustedBatchSize) {
       // Exhausted the batch size for at least 1 server, just copy over the remaining segments as is
       nextAssignment.putAll(currentAssignment);
     } else {
+      // When the previous step's ExternalView did not converge (best-efforts), pre-scan the segments to find the
+      // (current instances, target instances) pairs for which the move is unsafe for at least one segment. The check
+      // is done at the granularity of the pair rather than per segment because all the segments assigned to the same
+      // pair (in particular all the segments of the same partition for strict replica group routing) must be moved
+      // together to stay on the same set of instances: moving only the safe segments would split them across
+      // different instance sets and break the strict replica group routing consistency.
+      Set<Pair<Set<String>, Set<String>>> unsafeAssignmentKeys = Set.of();
+      if (nonConvergedExternalViewAssignment != null) {
+        unsafeAssignmentKeys = new HashSet<>();
+        for (Map.Entry<String, Map<String, String>> entry : currentAssignment.entrySet()) {
+          String segmentName = entry.getKey();
+          Map<String, String> currentInstanceStateMap = entry.getValue();
+          Map<String, String> targetInstanceStateMap = targetAssignment.get(segmentName);
+          Pair<Set<String>, Set<String>> assignmentKey =
+              Pair.of(currentInstanceStateMap.keySet(), targetInstanceStateMap.keySet());
+          if (unsafeAssignmentKeys.contains(assignmentKey)) {
+            continue;
+          }
+          SingleSegmentAssignment assignment =
+              getNextSingleSegmentAssignment(currentInstanceStateMap, targetInstanceStateMap, minAvailableReplicas,
+                  lowDiskMode, numSegmentsToOffloadMap, assignmentMap);
+          if (!isNextSingleSegmentAssignmentSafe(assignment._instanceStateMap, currentInstanceStateMap,
+              nonConvergedExternalViewAssignment.get(segmentName), minAvailableReplicas)) {
+            unsafeAssignmentKeys.add(assignmentKey);
+          }
+        }
+      }
       // Process all the partitionIds even if segmentsAddedSoFar becomes larger than batchSizePerServer
       // Can only do bestEfforts w.r.t. StrictReplicaGroup since a whole partition must be moved together for
       // maintaining consistency
@@ -1782,6 +1911,15 @@ public class TableRebalancer {
         String segmentName = entry.getKey();
         Map<String, String> currentInstanceStateMap = entry.getValue();
         Map<String, String> targetInstanceStateMap = targetAssignment.get(segmentName);
+        if (!unsafeAssignmentKeys.isEmpty() && unsafeAssignmentKeys.contains(
+            Pair.of(currentInstanceStateMap.keySet(), targetInstanceStateMap.keySet()))) {
+          // The move would drop the replicas actually serving some segment assigned to the same instances below the
+          // minimum available replicas (the new replicas have not been loaded yet), keep the current assignment for
+          // all the segments assigned to these instances
+          nextAssignment.put(segmentName, currentInstanceStateMap);
+          segmentsNotMovedDueToNonConvergedExternalView.add(segmentName);
+          continue;
+        }
         SingleSegmentAssignment assignment =
             getNextSingleSegmentAssignment(currentInstanceStateMap, targetInstanceStateMap, minAvailableReplicas,
                 lowDiskMode, numSegmentsToOffloadMap, assignmentMap);
@@ -1998,11 +2136,13 @@ public class TableRebalancer {
   private static Map<String, Map<String, String>> getNextNonStrictReplicaGroupAssignment(
       Map<String, Map<String, String>> currentAssignment, Map<String, Map<String, String>> targetAssignment,
       int minAvailableReplicas, boolean lowDiskMode, int batchSizePerServer,
-      DataLossRiskAssessor dataLossRiskAssessor) {
+      DataLossRiskAssessor dataLossRiskAssessor,
+      @Nullable Map<String, Map<String, String>> nonConvergedExternalViewAssignment, Logger tableRebalanceLogger) {
     Map<String, Integer> serverToNumSegmentsAddedSoFar = new HashMap<>();
     Map<String, Map<String, String>> nextAssignment = new TreeMap<>();
     Map<String, Integer> numSegmentsToOffloadMap = getNumSegmentsToOffloadMap(currentAssignment, targetAssignment);
     Map<Pair<Set<String>, Set<String>>, Set<String>> assignmentMap = new HashMap<>();
+    List<String> segmentsNotMovedDueToNonConvergedExternalView = new ArrayList<>();
     for (Map.Entry<String, Map<String, String>> entry : currentAssignment.entrySet()) {
       String segmentName = entry.getKey();
       Map<String, String> currentInstanceStateMap = entry.getValue();
@@ -2010,6 +2150,14 @@ public class TableRebalancer {
       Map<String, String> nextInstanceStateMap =
           getNextSingleSegmentAssignment(currentInstanceStateMap, targetInstanceStateMap, minAvailableReplicas,
               lowDiskMode, numSegmentsToOffloadMap, assignmentMap)._instanceStateMap;
+      if (nonConvergedExternalViewAssignment != null && !isNextSingleSegmentAssignmentSafe(nextInstanceStateMap,
+          currentInstanceStateMap, nonConvergedExternalViewAssignment.get(segmentName), minAvailableReplicas)) {
+        // The move would drop the replicas actually serving the segment below the minimum available replicas (the
+        // new replicas have not been loaded yet), keep the current assignment for this segment
+        nextAssignment.put(segmentName, currentInstanceStateMap);
+        segmentsNotMovedDueToNonConvergedExternalView.add(segmentName);
+        continue;
+      }
       Set<String> serversAddedForSegment = getServersAddedInSingleSegmentAssignment(currentInstanceStateMap,
           nextInstanceStateMap);
       boolean anyServerExhaustedBatchSize = false;
@@ -2041,6 +2189,8 @@ public class TableRebalancer {
         }
       }
     }
+    logSegmentsNotMovedDueToNonConvergedExternalView(segmentsNotMovedDueToNonConvergedExternalView,
+        tableRebalanceLogger);
     return nextAssignment;
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
+import org.apache.helix.model.ExternalView;
 import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.common.assignment.InstancePartitionsUtils;
 import org.apache.pinot.common.restlet.resources.DiskUsageInfo;
@@ -64,6 +65,7 @@ import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.Enablement;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.util.TestUtils;
 import org.mockito.Mockito;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -2451,6 +2453,108 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertFalse(moving.contains("segment1"));
     assertFalse(moving.contains("segment3"));
     assertFalse(moving.contains("segment4"));
+  }
+
+  /// Tests that a best-efforts rebalance does not drop the replicas actually serving the segments when the
+  /// ExternalView cannot converge because the target servers cannot load the segments (e.g. down or restarting):
+  /// the segments keep their current assignment and the rebalance fails (to be retried later) instead of making the
+  /// segments unavailable. This simulates relocating all the segments to a disjoint set of servers (e.g. moving them
+  /// to another tier or tenant) while the target servers are down.
+  @Test
+  public void testBestEffortsRebalanceDoesNotDropServingReplicas()
+      throws Exception {
+    int numServers = 2;
+    String initialServerPrefix = "bestEfforts_initialServer_";
+    String newServerPrefix = "bestEfforts_newServer_";
+    for (int i = 0; i < numServers; i++) {
+      addFakeServerInstanceToAutoJoinHelixCluster(initialServerPrefix + i, true);
+    }
+
+    String rawTableName = "bestEffortsTestTable";
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(rawTableName);
+    addDummySchema(rawTableName);
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(rawTableName).setNumReplicas(numServers).build();
+    _helixResourceManager.addTable(tableConfig);
+    int numSegments = 4;
+    for (int i = 0; i < numSegments; i++) {
+      _helixResourceManager.addNewSegment(offlineTableName,
+          SegmentMetadataMockUtils.mockSegmentMetadata(rawTableName, SEGMENT_NAME_PREFIX + i), null);
+    }
+    Map<String, Map<String, String>> initialAssignment =
+        _helixResourceManager.getTableIdealState(offlineTableName).getRecord().getMapFields();
+    // Wait for the ExternalView to converge to the initial assignment
+    TestUtils.waitForCondition(aVoid -> {
+      ExternalView externalView = _helixAdmin.getResourceExternalView(getHelixClusterName(), offlineTableName);
+      return externalView != null && externalView.getRecord().getMapFields().equals(initialAssignment);
+    }, 60_000L, "Failed to converge the ExternalView to the initial assignment");
+
+    // Add new servers with stopped participants (they cannot load segments), and untag the initial servers so that
+    // the target assignment moves all the segments to the new servers
+    for (int i = 0; i < numServers; i++) {
+      String instanceId = newServerPrefix + i;
+      addFakeServerInstanceToAutoJoinHelixCluster(instanceId, true);
+      stopFakeInstance(instanceId);
+    }
+    for (int i = 0; i < numServers; i++) {
+      _helixAdmin.removeInstanceTag(getHelixClusterName(), initialServerPrefix + i,
+          TagNameUtils.getOfflineTagForTenant(null));
+    }
+
+    TableRebalancer tableRebalancer = new TableRebalancer(_helixManager);
+    RebalanceConfig rebalanceConfig = new RebalanceConfig();
+    rebalanceConfig.setBestEfforts(true);
+    rebalanceConfig.setExternalViewCheckIntervalInMs(100L);
+    rebalanceConfig.setExternalViewStabilizationTimeoutInMs(2_000L);
+    RebalanceResult rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+
+    // The rebalance should fail without dropping the initial servers (the only ones actually serving the segments)
+    // from the IdealState, so every segment should still have at least one serving replica
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.FAILED);
+    assertTrue(rebalanceResult.getDescription().contains("cannot make progress"), rebalanceResult.getDescription());
+    Map<String, Map<String, String>> currentAssignment =
+        _helixResourceManager.getTableIdealState(offlineTableName).getRecord().getMapFields();
+    ExternalView externalView = _helixAdmin.getResourceExternalView(getHelixClusterName(), offlineTableName);
+    assertNotNull(externalView);
+    Map<String, Map<String, String>> externalViewAssignment = externalView.getRecord().getMapFields();
+    for (int i = 0; i < numSegments; i++) {
+      String segmentName = SEGMENT_NAME_PREFIX + i;
+      Map<String, String> instanceStateMap = currentAssignment.get(segmentName);
+      assertNotNull(instanceStateMap);
+      Map<String, String> externalViewInstanceStateMap = externalViewAssignment.get(segmentName);
+      assertNotNull(externalViewInstanceStateMap);
+      boolean hasServingReplica = false;
+      for (Map.Entry<String, String> instanceStateEntry : externalViewInstanceStateMap.entrySet()) {
+        if (ONLINE.equals(instanceStateEntry.getValue()) && instanceStateMap.containsKey(
+            instanceStateEntry.getKey())) {
+          hasServingReplica = true;
+          break;
+        }
+      }
+      assertTrue(hasServingReplica, "Segment: " + segmentName + " does not have any serving replica");
+    }
+
+    // Restart the new servers and rebalance again, the rebalance should succeed and all the segments should be moved
+    // to the new servers
+    for (int i = 0; i < numServers; i++) {
+      addFakeServerInstanceToAutoJoinHelixCluster(newServerPrefix + i, true);
+    }
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
+    Map<String, Map<String, String>> finalAssignment =
+        _helixResourceManager.getTableIdealState(offlineTableName).getRecord().getMapFields();
+    for (Map<String, String> instanceStateMap : finalAssignment.values()) {
+      for (String instance : instanceStateMap.keySet()) {
+        assertTrue(instance.startsWith(newServerPrefix), "Found segment not moved to the new servers: " + instance);
+      }
+    }
+
+    // Clean up
+    _helixResourceManager.deleteOfflineTable(rawTableName);
+    for (int i = 0; i < numServers; i++) {
+      stopAndDropFakeInstance(initialServerPrefix + i);
+      stopAndDropFakeInstance(newServerPrefix + i);
+    }
   }
 
   @AfterClass

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
+import org.apache.helix.model.ExternalView;
 import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.common.assignment.InstancePartitionsUtils;
 import org.apache.pinot.common.restlet.resources.DiskUsageInfo;
@@ -64,6 +65,7 @@ import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.Enablement;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.util.TestUtils;
 import org.mockito.Mockito;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -2456,6 +2458,108 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertFalse(moving.contains("segment1"));
     assertFalse(moving.contains("segment3"));
     assertFalse(moving.contains("segment4"));
+  }
+
+  /// Tests that a best-efforts rebalance does not drop the replicas actually serving the segments when the
+  /// ExternalView cannot converge because the target servers cannot load the segments (e.g. down or restarting):
+  /// the segments keep their current assignment and the rebalance fails (to be retried later) instead of making the
+  /// segments unavailable. This simulates relocating all the segments to a disjoint set of servers (e.g. moving them
+  /// to another tier or tenant) while the target servers are down.
+  @Test
+  public void testBestEffortsRebalanceDoesNotDropServingReplicas()
+      throws Exception {
+    int numServers = 2;
+    String initialServerPrefix = "bestEfforts_initialServer_";
+    String newServerPrefix = "bestEfforts_newServer_";
+    for (int i = 0; i < numServers; i++) {
+      addFakeServerInstanceToAutoJoinHelixCluster(initialServerPrefix + i, true);
+    }
+
+    String rawTableName = "bestEffortsTestTable";
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(rawTableName);
+    addDummySchema(rawTableName);
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(rawTableName).setNumReplicas(numServers).build();
+    _helixResourceManager.addTable(tableConfig);
+    int numSegments = 4;
+    for (int i = 0; i < numSegments; i++) {
+      _helixResourceManager.addNewSegment(offlineTableName,
+          SegmentMetadataMockUtils.mockSegmentMetadata(rawTableName, SEGMENT_NAME_PREFIX + i), null);
+    }
+    Map<String, Map<String, String>> initialAssignment =
+        _helixResourceManager.getTableIdealState(offlineTableName).getRecord().getMapFields();
+    // Wait for the ExternalView to converge to the initial assignment
+    TestUtils.waitForCondition(aVoid -> {
+      ExternalView externalView = _helixAdmin.getResourceExternalView(getHelixClusterName(), offlineTableName);
+      return externalView != null && externalView.getRecord().getMapFields().equals(initialAssignment);
+    }, 60_000L, "Failed to converge the ExternalView to the initial assignment");
+
+    // Add new servers with stopped participants (they cannot load segments), and untag the initial servers so that
+    // the target assignment moves all the segments to the new servers
+    for (int i = 0; i < numServers; i++) {
+      String instanceId = newServerPrefix + i;
+      addFakeServerInstanceToAutoJoinHelixCluster(instanceId, true);
+      stopFakeInstance(instanceId);
+    }
+    for (int i = 0; i < numServers; i++) {
+      _helixAdmin.removeInstanceTag(getHelixClusterName(), initialServerPrefix + i,
+          TagNameUtils.getOfflineTagForTenant(null));
+    }
+
+    TableRebalancer tableRebalancer = new TableRebalancer(_helixManager);
+    RebalanceConfig rebalanceConfig = new RebalanceConfig();
+    rebalanceConfig.setBestEfforts(true);
+    rebalanceConfig.setExternalViewCheckIntervalInMs(100L);
+    rebalanceConfig.setExternalViewStabilizationTimeoutInMs(2_000L);
+    RebalanceResult rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+
+    // The rebalance should fail without dropping the initial servers (the only ones actually serving the segments)
+    // from the IdealState, so every segment should still have at least one serving replica
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.FAILED);
+    assertTrue(rebalanceResult.getDescription().contains("cannot make progress"), rebalanceResult.getDescription());
+    Map<String, Map<String, String>> currentAssignment =
+        _helixResourceManager.getTableIdealState(offlineTableName).getRecord().getMapFields();
+    ExternalView externalView = _helixAdmin.getResourceExternalView(getHelixClusterName(), offlineTableName);
+    assertNotNull(externalView);
+    Map<String, Map<String, String>> externalViewAssignment = externalView.getRecord().getMapFields();
+    for (int i = 0; i < numSegments; i++) {
+      String segmentName = SEGMENT_NAME_PREFIX + i;
+      Map<String, String> instanceStateMap = currentAssignment.get(segmentName);
+      assertNotNull(instanceStateMap);
+      Map<String, String> externalViewInstanceStateMap = externalViewAssignment.get(segmentName);
+      assertNotNull(externalViewInstanceStateMap);
+      boolean hasServingReplica = false;
+      for (Map.Entry<String, String> instanceStateEntry : externalViewInstanceStateMap.entrySet()) {
+        if (ONLINE.equals(instanceStateEntry.getValue()) && instanceStateMap.containsKey(
+            instanceStateEntry.getKey())) {
+          hasServingReplica = true;
+          break;
+        }
+      }
+      assertTrue(hasServingReplica, "Segment: " + segmentName + " does not have any serving replica");
+    }
+
+    // Restart the new servers and rebalance again, the rebalance should succeed and all the segments should be moved
+    // to the new servers
+    for (int i = 0; i < numServers; i++) {
+      addFakeServerInstanceToAutoJoinHelixCluster(newServerPrefix + i, true);
+    }
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
+    Map<String, Map<String, String>> finalAssignment =
+        _helixResourceManager.getTableIdealState(offlineTableName).getRecord().getMapFields();
+    for (Map<String, String> instanceStateMap : finalAssignment.values()) {
+      for (String instance : instanceStateMap.keySet()) {
+        assertTrue(instance.startsWith(newServerPrefix), "Found segment not moved to the new servers: " + instance);
+      }
+    }
+
+    // Clean up
+    _helixResourceManager.deleteOfflineTable(rawTableName);
+    for (int i = 0; i < numServers; i++) {
+      stopAndDropFakeInstance(initialServerPrefix + i);
+      stopAndDropFakeInstance(newServerPrefix + i);
+    }
   }
 
   @AfterClass

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
@@ -866,6 +866,149 @@ public class TableRebalancerTest {
     assertEquals(nextAssignment, targetAssignment);
   }
 
+  /// Tests the next assignment calculation when the previous step's ExternalView did not converge (best-efforts).
+  /// This simulates relocating segments from a hot tier to a cold tier: the previous step added the cold instances
+  /// ("coldA", "coldB") to the IdealState while keeping one hot instance ("hot1"), but the ExternalView shows that
+  /// the cold instances have not loaded the segments yet (e.g. "coldB" is down and "coldA" is still loading). The
+  /// next assignment should not drop "hot1" (the only instance actually serving the segments) until at least one
+  /// cold instance has the segments ONLINE.
+  @Test
+  public void testNextAssignmentWithNonConvergedExternalView() {
+    // Current assignment (intermediate step of the relocation):
+    Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
+    currentAssignment.put("segment1",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("hot1", "coldA", "coldB"), ONLINE));
+    currentAssignment.put("segment2",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("hot1", "coldA", "coldB"), ONLINE));
+
+    // Target assignment (cold tier only):
+    Map<String, Map<String, String>> targetAssignment = new TreeMap<>();
+    targetAssignment.put("segment1",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("coldA", "coldB"), ONLINE));
+    targetAssignment.put("segment2",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("coldA", "coldB"), ONLINE));
+
+    // ExternalView: segments are only served by "hot1" ("coldA" is still loading, "coldB" is down with no entries)
+    Map<String, Map<String, String>> externalViewAssignment = new TreeMap<>();
+    externalViewAssignment.put("segment1",
+        SegmentAssignmentUtils.getInstanceStateMap(List.of("hot1"), ONLINE));
+    externalViewAssignment.put("segment2",
+        SegmentAssignmentUtils.getInstanceStateMap(List.of("hot1"), ONLINE));
+
+    for (boolean enableStrictReplicaGroup : Arrays.asList(false, true)) {
+      // Without the ExternalView (previous step converged), the next assignment should reach the target assignment
+      Map<String, Map<String, String>> nextAssignment =
+          TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 1, enableStrictReplicaGroup, false,
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+              DEFAULT_DATA_LOSS_RISK_ASSESSOR);
+      assertEquals(nextAssignment, targetAssignment);
+
+      // With the non-converged ExternalView, the segments should not be moved because the move would drop "hot1",
+      // the only instance actually serving them
+      nextAssignment =
+          TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 1, enableStrictReplicaGroup, false,
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+              DEFAULT_DATA_LOSS_RISK_ASSESSOR, externalViewAssignment);
+      assertEquals(nextAssignment, currentAssignment);
+
+      // Same with server-level segment batching enabled (exercises the batched code paths)
+      nextAssignment =
+          TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 1, enableStrictReplicaGroup, false,
+              1, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER, DEFAULT_DATA_LOSS_RISK_ASSESSOR,
+              externalViewAssignment);
+      assertEquals(nextAssignment, currentAssignment);
+
+      // Once "coldA" has loaded segment1 (but not segment2), segment1 should be moved while segment2 should not for
+      // non-strict replica group. For strict replica group, segments assigned to the same instances must be moved
+      // together to keep them on the same set of instances (e.g. segments of the same partition must be served from
+      // the same instances for strict replica group routing), so neither segment should be moved.
+      Map<String, Map<String, String>> partiallyLoadedExternalViewAssignment = new TreeMap<>(externalViewAssignment);
+      partiallyLoadedExternalViewAssignment.put("segment1",
+          SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("hot1", "coldA"), ONLINE));
+      nextAssignment =
+          TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 1, enableStrictReplicaGroup, false,
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+              DEFAULT_DATA_LOSS_RISK_ASSESSOR, partiallyLoadedExternalViewAssignment);
+      if (enableStrictReplicaGroup) {
+        assertEquals(nextAssignment, currentAssignment);
+      } else {
+        assertEquals(nextAssignment.get("segment1"), targetAssignment.get("segment1"));
+        assertEquals(nextAssignment.get("segment2"), currentAssignment.get("segment2"));
+      }
+
+      // Same with server-level segment batching enabled (exercises the batched code paths)
+      nextAssignment =
+          TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 1, enableStrictReplicaGroup, false,
+              1, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER, DEFAULT_DATA_LOSS_RISK_ASSESSOR,
+              partiallyLoadedExternalViewAssignment);
+      if (enableStrictReplicaGroup) {
+        assertEquals(nextAssignment, currentAssignment);
+      } else {
+        assertEquals(nextAssignment.get("segment1"), targetAssignment.get("segment1"));
+        assertEquals(nextAssignment.get("segment2"), currentAssignment.get("segment2"));
+      }
+
+      // Once both cold instances have loaded the segments, the next assignment should reach the target assignment
+      Map<String, Map<String, String>> loadedExternalViewAssignment = new TreeMap<>();
+      loadedExternalViewAssignment.put("segment1",
+          SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("hot1", "coldA", "coldB"), ONLINE));
+      loadedExternalViewAssignment.put("segment2",
+          SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("hot1", "coldA", "coldB"), ONLINE));
+      nextAssignment =
+          TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 1, enableStrictReplicaGroup, false,
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+              DEFAULT_DATA_LOSS_RISK_ASSESSOR, loadedExternalViewAssignment);
+      assertEquals(nextAssignment, targetAssignment);
+
+      // Same with server-level segment batching enabled (exercises the batched code paths)
+      nextAssignment =
+          TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 1, enableStrictReplicaGroup, false,
+              1, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER, DEFAULT_DATA_LOSS_RISK_ASSESSOR,
+              loadedExternalViewAssignment);
+      assertEquals(nextAssignment, targetAssignment);
+
+      // Segments in ERROR state on the current instances do not block the move because they are not serving anyway
+      // (moving them cannot reduce the number of serving replicas)
+      Map<String, Map<String, String>> errorExternalViewAssignment = new TreeMap<>();
+      errorExternalViewAssignment.put("segment1",
+          SegmentAssignmentUtils.getInstanceStateMap(List.of("hot1"), ERROR));
+      errorExternalViewAssignment.put("segment2",
+          SegmentAssignmentUtils.getInstanceStateMap(List.of("hot1"), ERROR));
+      nextAssignment =
+          TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 1, enableStrictReplicaGroup, false,
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+              DEFAULT_DATA_LOSS_RISK_ASSESSOR, errorExternalViewAssignment);
+      assertEquals(nextAssignment, targetAssignment);
+
+      // Segments missing from the ExternalView entirely do not block the move either
+      nextAssignment =
+          TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 1, enableStrictReplicaGroup, false,
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+              DEFAULT_DATA_LOSS_RISK_ASSESSOR, new TreeMap<>());
+      assertEquals(nextAssignment, targetAssignment);
+
+      // CONSUMING replicas count as serving: segments served by "hot1" in CONSUMING state should not be moved
+      Map<String, Map<String, String>> consumingExternalViewAssignment = new TreeMap<>();
+      consumingExternalViewAssignment.put("segment1",
+          SegmentAssignmentUtils.getInstanceStateMap(List.of("hot1"), CONSUMING));
+      consumingExternalViewAssignment.put("segment2",
+          SegmentAssignmentUtils.getInstanceStateMap(List.of("hot1"), CONSUMING));
+      nextAssignment =
+          TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 1, enableStrictReplicaGroup, false,
+              RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+              DEFAULT_DATA_LOSS_RISK_ASSESSOR, consumingExternalViewAssignment);
+      assertEquals(nextAssignment, currentAssignment);
+    }
+
+    // With minimum available replicas set to 0 (downtime allowed), the non-converged ExternalView should not block
+    // the move
+    Map<String, Map<String, String>> nextAssignment =
+        TableRebalancer.getNextAssignment(currentAssignment, targetAssignment, 0, false, false,
+            RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER, new Object2IntOpenHashMap<>(), DUMMY_PARTITION_FETCHER,
+            DEFAULT_DATA_LOSS_RISK_ASSESSOR, externalViewAssignment);
+    assertEquals(nextAssignment, targetAssignment);
+  }
+
   @Test
   public void testAssignmentWithLowDiskMode() {
     // Current assignment:


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Best\-efforts rebalance uses ExternalView to avoid dropping last serving replicas; fails if no safe move\.

```mermaid
flowchart TD
  N0["Wait for ExternalView#59; set nonConvergedExternalViewAssignment if non#45;null #40;F1#41;"]:::stModified
  N1["Branch on enableStrictReplicaGroup #40;F1#41;"]:::stModified
  N2["Strict replica group#58; compute unsafe keys #40;if non#45;converged EV#41; and skip unsafe #40;F1#41;"]:::stModified
  N3["Non#45;strict replica group#58; skip segment if #33;isNextSingleSegmentAssignmentSafe #40;F1#41;"]:::stModified
  N4["Helper#58; isNextSingleSegmentAssignmentSafe #45; check if move keeps enough serving #40;F1#41;"]:::stModified
  N5["If non#45;converged EV and no progress #40;nextAssignment#61;#61;currentAssignment#41; #45;#62; FAIL #40;F1#41;"]:::stModified
  N0 --> N1
  N1 --> N2
  N1 --> N3
  N2 --> N4
  N3 --> N4
  N2 --> N5
  N3 --> N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

Partial evidence: 0 file patches omitted; 1 truncated.

<details>
<summary>Diff evidence</summary>

- F1: pinot\-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java) · [after](https://github.com/apache/pinot/blob/c7e9c05804b4bb69f7f32daa787394e270944c9c/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImU2Nzg3ZTE3ODY0NWZkM2M1YTg4N2UyYWJhN2UwZGU4MzQzY2Q1MjQiLCJjb250ZXh0X2hhc2giOiJjOGJhMmQ1MWJjNDE3NmM3MWY0NDA4ZGIyYmM0ZTQwNmMyYjRiMTAyN2UxNWRkYzdhOTUyM2M0ZmU3NWVkNmNiIiwiZ2VuZXJhdGVkX2F0IjoxNzg4OTAwOTQzLCJoZWFkX3NoYSI6ImM3ZTljMDU4MDRiNGJiNjlmN2YzMmRhYTc4NzM5NGUyNzA5NDRjOWMiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJlNjc4N2UxNzg2NDVmZDNjNWE4ODdlMmFiYTdlMGRlODM0M2NkNTI0IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature edeb20dec12adb2e59a1624844a47e1b05a5204597ff23928ee87f0927b79507 -->
<!-- pinot-pr-flow:end -->

## Problem

`TableRebalancer` enforces `minAvailableReplicas` against the **IdealState only**: when computing the next assignment, an instance counts as "available" for a segment merely because it appears in both the current and next IdealState (`SingleSegmentAssignment._availableInstances`). This is sound only because each incremental step waits for the ExternalView to converge before the next step — which is exactly the assumption that `bestEfforts=true` breaks: when the EV stabilization wait times out without progress, the rebalancer proceeds to the next step anyway.

In that situation, the rebalancer can remove the **last replica actually serving a segment** from the IdealState while the new replicas are still loading (or their servers are down), leaving the segment ONLINE nowhere.

This caused a production incident with tiered storage: during a cold-tier server pool restart (~3.5h reload), the hourly `SegmentRelocator` (which uses `bestEfforts=true` by default, with the EV stabilization timeout capped at the task interval) kept relocating segments hot → cold. Each run timed out waiting for the down replica group, force-advanced the IdealState, and dropped the hot-tier replicas while no cold server had loaded the segments. Under `strictReplicaGroup` routing the brokers then reported the **entire cold tier (~29.5k segments) unavailable** for ~1 minute every hour:

```
29562 segments unavailable, sampling 10: [...], with routing policy: strictReplicaGroup [realtime]
```

## Fix

When the EV stabilization wait gives up without convergence (best-efforts), the wait now returns the last-seen ExternalView, and the next assignment calculation uses it to keep `minAvailableReplicas` in terms of replicas **actually serving** each segment (ONLINE/CONSUMING in EV):

- A segment is not moved if the move would drop its serving replicas below `min(minAvailableReplicas, numServingReplicas)`. Capping at `numServingReplicas` means already-degraded segments (ERROR everywhere, hosted on dead instances, or absent from EV) never block the rebalance — moving them cannot reduce serving replicas below what they already are, so best-efforts still powers through ERROR states and dead-server evacuation.
- For strict replica group assignment, the check is enforced per `(currentInstances, targetInstances)` group, not per segment: all segments sharing the same instance pair (in particular all segments of a partition) are held together, so the IdealState never splits a partition across instance sets (which would break strict replica group routing consistency for upsert tables).
- If **no** segment can be moved safely, the rebalance now returns `FAILED` instead of looping or silently causing downtime. It can be retried (e.g. the next `SegmentRelocator` run) once the serving instances recover.
- When the EV converges normally (the common case), behavior is **completely unchanged** — the EV is not consulted at all.

## bestEfforts semantic change

Previously, `bestEfforts=true` + non-converged EV meant "continue to the next stage" unconditionally — including dropping the last serving replicas (query downtime, silently). Now it means "continue for the segments that can be moved without dropping their serving replicas below the minimum; fail if none can". The `RebalanceConfig` comment and the REST `@ApiParam` doc are updated accordingly. ERROR-state handling is unchanged (still counted as good state / powered through).

## Testing

- `TableRebalancerTest.testNextAssignmentWithNonConvergedExternalView`: unit test of the gating for strict and non-strict replica group, batched and non-batched, covering: hold when target replicas not loaded; per-segment moves for non-strict vs whole-group moves for strict when partially loaded; progress when loaded; no blocking for ERROR-everywhere / EV-absent segments; CONSUMING counts as serving; `minAvailableReplicas=0` (downtime) unaffected.
- `TableRebalancerClusterStatelessTest.testBestEffortsRebalanceDoesNotDropServingReplicas`: end-to-end reproduction of the incident shape — moving all segments to a disjoint set of servers whose participants are down; asserts the rebalance returns `FAILED` with every segment still having a serving replica in the IdealState, then completes with `DONE` once the target servers come back.
- Full `TableRebalancerTest`, `TableRebalancerClusterStatelessTest`, `RebalanceCheckerTest`, `DataLossRiskAssessorTest` pass.
