### PR TITLE
Track segment replication state in SegmentPartitionMetadataManager to avoid partition routing failures

### DIFF
--- a/pinot-broker/pom.xml
+++ b/pinot-broker/pom.xml
@@ -80,6 +80,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-java-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-query-planner</artifactId>
       <type>test-jar</type>
       <scope>test</scope>

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManager.java
@@ -43,14 +43,21 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-/**
- * The {@code PartitionDataManager} manages partitions of a table. It manages
- *   1. all the online segments associated with the partition and their allocated servers
- *   2. all the replica of a specific segment.
- * It provides API to query
- *   1. For each partition ID, what are the servers that contains ALL segments belong to this partition ID.
- *   2. For each server, what are all the partition IDs and list of segments of those partition IDs on this server.
- */
+/// The `PartitionDataManager` manages partitions of a table. It manages
+///   1. all the online segments associated with the partition and their allocated servers
+///   2. all the replica of a specific segment.
+/// It provides API to query
+///   1. For each partition ID, what are the servers that contains ALL segments belong to this partition ID.
+///   2. For each server, what are all the partition IDs and list of segments of those partition IDs on this server.
+///
+/// When computing the fully replicated servers for a partition, segments that have not been fully replicated per
+/// their latest ideal assignment (newly pushed segments, new consuming segments, or segments uploaded under a new
+/// name to replace other segments) are excluded from the partition info until all their replicas become available,
+/// so that they don't reduce the fully replicated servers while loading. This protection is bounded by the configured
+/// new segment expiration time since the ideal assignment of the segment last changed; after that the segment is
+/// treated as a regular segment, so that a replica failing to load doesn't exclude the segment from being served
+/// forever. Segments without any available replica are also excluded because they cannot be served regardless of the
+/// server picked, and are reported via [TablePartitionReplicatedServersInfo#getUnavailableSegments()].
 public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchListener {
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentPartitionMetadataManager.class);
   private static final int INVALID_PARTITION_ID = -1;
@@ -83,12 +90,14 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
   @Override
   public void init(IdealState idealState, ExternalView externalView, List<String> onlineSegments,
       List<ZNRecord> znRecords) {
+    long currentTimeMs = System.currentTimeMillis();
     int numSegments = onlineSegments.size();
     for (int i = 0; i < numSegments; i++) {
       String segment = onlineSegments.get(i);
       ZNRecord znRecord = znRecords.get(i);
-      SegmentInfo segmentInfo = new SegmentInfo(getPartitionId(segment, znRecord), getCreationTimeMs(znRecord),
-          getOnlineServers(externalView, segment));
+      SegmentInfo segmentInfo = new SegmentInfo(getPartitionId(segment, znRecord), getCreationTimeMs(znRecord));
+      segmentInfo.updateServers(getOnlineServers(externalView, segment), idealState.getInstanceStateMap(segment),
+          currentTimeMs);
       _segmentInfoMap.put(segment, segmentInfo);
     }
     computeAllTablePartitionInfo();
@@ -124,6 +133,10 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
     return SegmentUtils.getSegmentCreationTimeMs(new SegmentZKMetadata(znRecord));
   }
 
+  private static boolean isServingState(String instanceState) {
+    return instanceState.equals(SegmentStateModel.ONLINE) || instanceState.equals(SegmentStateModel.CONSUMING);
+  }
+
   private static List<String> getOnlineServers(ExternalView externalView, String segment) {
     Map<String, String> instanceStateMap = externalView.getStateMap(segment);
     if (instanceStateMap == null) {
@@ -131,8 +144,7 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
     }
     List<String> onlineServers = new ArrayList<>(instanceStateMap.size());
     for (Map.Entry<String, String> entry : instanceStateMap.entrySet()) {
-      String instanceState = entry.getValue();
-      if (instanceState.equals(SegmentStateModel.ONLINE) || instanceState.equals(SegmentStateModel.CONSUMING)) {
+      if (isServingState(entry.getValue())) {
         onlineServers.add(entry.getKey());
       }
     }
@@ -147,23 +159,21 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
     for (int i = 0; i < numSegments; i++) {
       String segment = pulledSegments.get(i);
       ZNRecord znRecord = znRecords.get(i);
-      SegmentInfo segmentInfo = new SegmentInfo(getPartitionId(segment, znRecord), getCreationTimeMs(znRecord),
-          getOnlineServers(externalView, segment));
-      _segmentInfoMap.put(segment, segmentInfo);
+      _segmentInfoMap.put(segment, new SegmentInfo(getPartitionId(segment, znRecord), getCreationTimeMs(znRecord)));
     }
-    // Update online servers for all online segments
+    // Update online servers and replication state for all online segments
+    long currentTimeMs = System.currentTimeMillis();
     for (String segment : onlineSegments) {
       SegmentInfo segmentInfo = _segmentInfoMap.get(segment);
       if (segmentInfo == null) {
         // NOTE: This should not happen, but we still handle it gracefully by adding an invalid SegmentInfo
         LOGGER.error("Failed to find segment info for segment: {} in table: {} while handling assignment change",
             segment, _tableNameWithType);
-        segmentInfo =
-            new SegmentInfo(INVALID_PARTITION_ID, INVALID_CREATION_TIME_MS, getOnlineServers(externalView, segment));
+        segmentInfo = new SegmentInfo(INVALID_PARTITION_ID, INVALID_CREATION_TIME_MS);
         _segmentInfoMap.put(segment, segmentInfo);
-      } else {
-        segmentInfo._onlineServers = getOnlineServers(externalView, segment);
       }
+      segmentInfo.updateServers(getOnlineServers(externalView, segment), idealState.getInstanceStateMap(segment),
+          currentTimeMs);
     }
     _segmentInfoMap.keySet().retainAll(onlineSegments);
     computeAllTablePartitionInfo();
@@ -178,7 +188,7 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
       // NOTE: This should not happen, but we still handle it gracefully by adding an invalid SegmentInfo
       LOGGER.error("Failed to find segment info for segment: {} in table: {} while handling segment refresh", segment,
           _tableNameWithType);
-      segmentInfo = new SegmentInfo(partitionId, pushTimeMs, List.of());
+      segmentInfo = new SegmentInfo(partitionId, pushTimeMs);
       _segmentInfoMap.put(segment, segmentInfo);
     } else {
       segmentInfo._partitionId = partitionId;
@@ -205,7 +215,7 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
     List<String> segmentsWithInvalidPartition = new ArrayList<>();
     List<Pair<String, Integer>> unavailableSegments = new ArrayList<>();
     List<Triple<String, Integer, Integer>> segmentsReducingFullyReplicatedServers = new ArrayList<>();
-    List<Map.Entry<String, SegmentInfo>> newSegmentInfoEntries = new ArrayList<>();
+    List<Map.Entry<String, SegmentInfo>> pendingSegmentInfoEntries = new ArrayList<>();
     long currentTimeMs = System.currentTimeMillis();
     for (Map.Entry<String, SegmentInfo> entry : _segmentInfoMap.entrySet()) {
       String segment = entry.getKey();
@@ -215,24 +225,18 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
         segmentsWithInvalidPartition.add(segment);
         continue;
       }
-      // Process new segments in the end
-      if (InstanceSelector.isNewSegment(segmentInfo._creationTimeMs, currentTimeMs, _newSegmentExpirationMs)) {
-        newSegmentInfoEntries.add(entry);
+      // Process pending (not fully replicated yet) segments in the end
+      if (isPendingSegment(segmentInfo, currentTimeMs)) {
+        pendingSegmentInfoEntries.add(entry);
         continue;
       }
       List<String> onlineServers = segmentInfo._onlineServers;
       PartitionInfo partitionInfo = partitionInfoMap[partitionId];
       if (onlineServers.isEmpty()) {
+        // The segment has no available replica, thus it cannot be served regardless of the server picked. Exclude it
+        // from the partition info instead of clearing the fully replicated servers, which would fail all the queries
+        // on the partition without making the segment available.
         unavailableSegments.add(Pair.of(segment, partitionId));
-        if (partitionInfo == null) {
-          List<String> segments = new ArrayList<>();
-          segments.add(segment);
-          partitionInfo = new PartitionInfo(new HashSet<>(), segments);
-          partitionInfoMap[partitionId] = partitionInfo;
-        } else {
-          partitionInfo._fullyReplicatedServers.clear();
-          partitionInfo._segments.add(segment);
-        }
       } else {
         if (partitionInfo == null) {
           Set<String> fullyReplicatedServers = new HashSet<>(onlineServers);
@@ -266,18 +270,18 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
           numSegments, numSegments <= 10 ? segmentsReducingFullyReplicatedServers
               : segmentsReducingFullyReplicatedServers.subList(0, 10) + "...", _tableNameWithType);
     }
-    // Process new segments
-    if (!newSegmentInfoEntries.isEmpty()) {
-      List<String> excludedNewSegments = new ArrayList<>();
-      for (Map.Entry<String, SegmentInfo> entry : newSegmentInfoEntries) {
+    // Process pending segments
+    if (!pendingSegmentInfoEntries.isEmpty()) {
+      List<String> excludedPendingSegments = new ArrayList<>();
+      for (Map.Entry<String, SegmentInfo> entry : pendingSegmentInfoEntries) {
         String segment = entry.getKey();
         SegmentInfo segmentInfo = entry.getValue();
         int partitionId = segmentInfo._partitionId;
         List<String> onlineServers = segmentInfo._onlineServers;
         PartitionInfo partitionInfo = partitionInfoMap[partitionId];
         if (partitionInfo == null) {
-          // If the new segment is the first segment of a partition, treat it as regular segment if it has available
-          // replicas
+          // If the pending segment is the first segment of a partition, treat it as regular segment if it has
+          // available replicas
           if (!onlineServers.isEmpty()) {
             Set<String> fullyReplicatedServers = new HashSet<>(onlineServers);
             List<String> segments = new ArrayList<>();
@@ -285,30 +289,57 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
             partitionInfo = new PartitionInfo(fullyReplicatedServers, segments);
             partitionInfoMap[partitionId] = partitionInfo;
           } else {
-            excludedNewSegments.add(segment);
+            excludedPendingSegments.add(segment);
           }
         } else {
-          // If the new segment is not the first segment of a partition, add it only if it won't reduce the fully
-          // replicated servers. It is common that a new created segment (newly pushed, or a new consuming segment)
-          // doesn't have all the replicas available yet, and we want to exclude it from the partition info until all
-          // the replicas are available.
+          // If the pending segment is not the first segment of a partition, add it only if it won't reduce the fully
+          // replicated servers. It is common that a segment not fully replicated yet (newly pushed, a new consuming
+          // segment, or a segment uploaded under a new name to replace other segments) doesn't have all the replicas
+          // available, and we want to exclude it from the partition info until all the replicas are available.
           //noinspection SlowListContainsAll
           if (onlineServers.containsAll(partitionInfo._fullyReplicatedServers)) {
             partitionInfo._segments.add(segment);
           } else {
-            excludedNewSegments.add(segment);
+            excludedPendingSegments.add(segment);
           }
         }
       }
-      if (!excludedNewSegments.isEmpty()) {
-        int numSegments = excludedNewSegments.size();
-        LOGGER.info("Excluded {} new segments: {}... without all replicas available in table: {}", numSegments,
-            numSegments <= 10 ? excludedNewSegments : excludedNewSegments.subList(0, 10) + "...", _tableNameWithType);
+      if (!excludedPendingSegments.isEmpty()) {
+        int numSegments = excludedPendingSegments.size();
+        LOGGER.info("Excluded {} pending segments: {}... without all replicas available in table: {}", numSegments,
+            numSegments <= 10 ? excludedPendingSegments : excludedPendingSegments.subList(0, 10) + "...",
+            _tableNameWithType);
+      }
+    }
+    List<String> unavailableSegmentNames;
+    if (unavailableSegments.isEmpty()) {
+      unavailableSegmentNames = List.of();
+    } else {
+      unavailableSegmentNames = new ArrayList<>(unavailableSegments.size());
+      for (Pair<String, Integer> unavailableSegment : unavailableSegments) {
+        unavailableSegmentNames.add(unavailableSegment.getLeft());
       }
     }
     _tablePartitionReplicatedServersInfo =
         new TablePartitionReplicatedServersInfo(_tableNameWithType, _partitionColumn, _partitionFunctionName,
-            _numPartitions, partitionInfoMap, segmentsWithInvalidPartition);
+            _numPartitions, partitionInfoMap, segmentsWithInvalidPartition, unavailableSegmentNames);
+  }
+
+  /// Returns whether the segment is pending, i.e. it has not been fully replicated per its latest ideal assignment.
+  /// Pending segments (newly pushed segments, new consuming segments, or segments uploaded under a new name to
+  /// replace other segments) are excluded from the partition info if they would reduce the fully replicated servers,
+  /// until all their replicas become available. The pending state is bounded by the configured new segment expiration
+  /// time since the ideal assignment of the segment last changed, so that a replica failing to load doesn't exclude
+  /// the segment from being served forever. When the target servers cannot be determined from the ideal state, fall
+  /// back to the time based check on the segment creation time.
+  private boolean isPendingSegment(SegmentInfo segmentInfo, long currentTimeMs) {
+    if (segmentInfo._fullyReplicatedOnce) {
+      return false;
+    }
+    if (segmentInfo._numTargetServers > 0) {
+      return currentTimeMs - segmentInfo._targetServersUpdateTimeMs <= _newSegmentExpirationMs;
+    }
+    return InstanceSelector.isNewSegment(segmentInfo._creationTimeMs, currentTimeMs, _newSegmentExpirationMs);
   }
 
   private void computeTablePartitionInfo() {
@@ -345,12 +376,55 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
   private static class SegmentInfo {
     int _partitionId;
     long _creationTimeMs;
-    List<String> _onlineServers;
+    List<String> _onlineServers = List.of();
+    /// Number of target servers (servers with ONLINE/CONSUMING state in the ideal state). The target servers are
+    /// tracked as count and order-independent hash instead of the full server set to reduce the memory footprint.
+    int _numTargetServers;
+    /// Order-independent hash of the target servers, used together with the count to detect ideal assignment changes.
+    /// A hash collision can only delay the reset of the replication state, which is benign.
+    int _targetServersHash;
+    /// Time when the target servers were last changed, used to bound how long the segment can stay pending
+    long _targetServersUpdateTimeMs;
+    /// Whether the segment has been observed fully replicated (online servers covering the target servers from the
+    /// ideal state) at least once since its target servers last changed. Once fully replicated, losing a replica
+    /// reduces the fully replicated servers of the partition (queries are routed to the remaining replicas); before
+    /// that, the segment is excluded from the partition info to not reduce the fully replicated servers while its
+    /// replicas are still loading.
+    boolean _fullyReplicatedOnce;
 
-    SegmentInfo(int partitionId, long creationTimeMs, List<String> onlineServers) {
+    SegmentInfo(int partitionId, long creationTimeMs) {
       _partitionId = partitionId;
       _creationTimeMs = creationTimeMs;
+    }
+
+    void updateServers(List<String> onlineServers, @Nullable Map<String, String> targetInstanceStateMap,
+        long currentTimeMs) {
       _onlineServers = onlineServers;
+      int numTargetServers = 0;
+      int targetServersHash = 0;
+      boolean coversTargetServers = true;
+      if (targetInstanceStateMap != null) {
+        for (Map.Entry<String, String> entry : targetInstanceStateMap.entrySet()) {
+          if (isServingState(entry.getValue())) {
+            String server = entry.getKey();
+            numTargetServers++;
+            targetServersHash += server.hashCode();
+            if (coversTargetServers && !onlineServers.contains(server)) {
+              coversTargetServers = false;
+            }
+          }
+        }
+      }
+      // Recompute the replication state when the ideal assignment changes (e.g. rebalance)
+      if (numTargetServers != _numTargetServers || targetServersHash != _targetServersHash) {
+        _numTargetServers = numTargetServers;
+        _targetServersHash = targetServersHash;
+        _targetServersUpdateTimeMs = currentTimeMs;
+        _fullyReplicatedOnce = false;
+      }
+      if (!_fullyReplicatedOnce && numTargetServers > 0 && coversTargetServers) {
+        _fullyReplicatedOnce = true;
+      }
     }
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManagerTest.java
@@ -42,6 +42,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel.ERROR;
 import static org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE;
 import static org.testng.Assert.*;
 
@@ -55,6 +56,7 @@ public class SegmentPartitionMetadataManagerTest extends ControllerTest {
   private static final int NUM_PARTITIONS_ALT = 4;
   private static final String SERVER_0 = "server0";
   private static final String SERVER_1 = "server1";
+  private static final String SERVER_2 = "server2";
 
   private ZkClient _zkClient;
   private ZkHelixPropertyStore<ZNRecord> _propertyStore;
@@ -80,7 +82,8 @@ public class SegmentPartitionMetadataManagerTest extends ControllerTest {
     Map<String, Map<String, String>> segmentAssignment = externalView.getRecord().getMapFields();
     Map<String, String> onlineInstanceStateMap = Map.of(SERVER_0, ONLINE, SERVER_1, ONLINE);
     Set<String> onlineSegments = new HashSet<>();
-    // NOTE: Ideal state is not used in the current implementation.
+    // NOTE: The empty ideal state intentionally exercises the time based fallback path of the pending segment check,
+    //       where the target servers cannot be determined from the ideal state.
     IdealState idealState = new IdealState(OFFLINE_TABLE_NAME);
 
     SegmentPartitionMetadataManager partitionMetadataManager =
@@ -283,6 +286,153 @@ public class SegmentPartitionMetadataManagerTest extends ControllerTest {
     assertEqualsNoOrder(partitionInfoMap[1]._segments.toArray(), new String[]{segment1, segment2});
     assertFalse(tablePartitionReplicatedServersInfo.getSegmentsWithInvalidPartition().isEmpty());
     assertEquals(tablePartitionReplicatedServersInfo.getSegmentsWithInvalidPartition().get(0), segmentInvalid);
+  }
+
+  @Test
+  public void testReplicationStateTracking() {
+    ExternalView externalView = new ExternalView(OFFLINE_TABLE_NAME);
+    Map<String, Map<String, String>> externalViewAssignment = externalView.getRecord().getMapFields();
+    IdealState idealState = new IdealState(OFFLINE_TABLE_NAME);
+    Map<String, Map<String, String>> idealStateAssignment = idealState.getRecord().getMapFields();
+    Map<String, String> onlineInstanceStateMap = Map.of(SERVER_0, ONLINE, SERVER_1, ONLINE);
+    Set<String> onlineSegments = new HashSet<>();
+
+    SegmentPartitionMetadataManager partitionMetadataManager =
+        new SegmentPartitionMetadataManager(OFFLINE_TABLE_NAME, PARTITION_COLUMN, PARTITION_COLUMN_FUNC, NUM_PARTITIONS,
+            TimeUnit.MINUTES.toMillis(5));
+    SegmentZkMetadataFetcher segmentZkMetadataFetcher =
+        new SegmentZkMetadataFetcher(OFFLINE_TABLE_NAME, _propertyStore);
+    segmentZkMetadataFetcher.register(partitionMetadataManager);
+    segmentZkMetadataFetcher.init(idealState, externalView, onlineSegments);
+
+    // segmentA is fully replicated on both servers
+    String segmentA = "trackingSegmentA";
+    onlineSegments.add(segmentA);
+    idealStateAssignment.put(segmentA, onlineInstanceStateMap);
+    externalViewAssignment.put(segmentA, onlineInstanceStateMap);
+    setSegmentZKMetadata(segmentA, PARTITION_COLUMN_FUNC, NUM_PARTITIONS, 0, 0L);
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    TablePartitionReplicatedServersInfo tablePartitionReplicatedServersInfo =
+        partitionMetadataManager.getTablePartitionReplicatedServersInfo();
+    TablePartitionReplicatedServersInfo.PartitionInfo[] partitionInfoMap =
+        tablePartitionReplicatedServersInfo.getPartitionInfoMap();
+    assertEquals(partitionInfoMap[0]._fullyReplicatedServers, ImmutableSet.of(SERVER_0, SERVER_1));
+    assertEquals(partitionInfoMap[0]._segments, Collections.singleton(segmentA));
+
+    // segmentB is old by creation time, but has never been fully replicated per its ideal assignment (only ONLINE on
+    // SERVER_1 while assigned to both servers). It should be excluded from the partition info instead of reducing the
+    // fully replicated servers, regardless of its creation time.
+    String segmentB = "trackingSegmentB";
+    onlineSegments.add(segmentB);
+    idealStateAssignment.put(segmentB, onlineInstanceStateMap);
+    externalViewAssignment.put(segmentB, Map.of(SERVER_1, ONLINE));
+    setSegmentZKMetadata(segmentB, PARTITION_COLUMN_FUNC, NUM_PARTITIONS, 0, 0L);
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    tablePartitionReplicatedServersInfo = partitionMetadataManager.getTablePartitionReplicatedServersInfo();
+    partitionInfoMap = tablePartitionReplicatedServersInfo.getPartitionInfoMap();
+    assertEquals(partitionInfoMap[0]._fullyReplicatedServers, ImmutableSet.of(SERVER_0, SERVER_1));
+    assertEquals(partitionInfoMap[0]._segments, Collections.singleton(segmentA));
+    assertTrue(tablePartitionReplicatedServersInfo.getUnavailableSegments().isEmpty());
+
+    // Once segmentB becomes fully replicated, it should be included as a regular segment
+    externalViewAssignment.put(segmentB, onlineInstanceStateMap);
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    tablePartitionReplicatedServersInfo = partitionMetadataManager.getTablePartitionReplicatedServersInfo();
+    partitionInfoMap = tablePartitionReplicatedServersInfo.getPartitionInfoMap();
+    assertEquals(partitionInfoMap[0]._fullyReplicatedServers, ImmutableSet.of(SERVER_0, SERVER_1));
+    assertEqualsNoOrder(partitionInfoMap[0]._segments.toArray(), new String[]{segmentA, segmentB});
+
+    // Losing a replica after having been fully replicated should reduce the fully replicated servers, so that queries
+    // are routed to the remaining replica
+    externalViewAssignment.put(segmentB, Map.of(SERVER_0, ONLINE, SERVER_1, ERROR));
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    tablePartitionReplicatedServersInfo = partitionMetadataManager.getTablePartitionReplicatedServersInfo();
+    partitionInfoMap = tablePartitionReplicatedServersInfo.getPartitionInfoMap();
+    assertEquals(partitionInfoMap[0]._fullyReplicatedServers, Collections.singleton(SERVER_0));
+    assertEqualsNoOrder(partitionInfoMap[0]._segments.toArray(), new String[]{segmentA, segmentB});
+
+    // Losing all replicas should exclude the segment from the partition info and report it as unavailable, instead of
+    // clearing the fully replicated servers and failing all the queries on the partition
+    externalViewAssignment.put(segmentB, Map.of(SERVER_0, ERROR, SERVER_1, ERROR));
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    tablePartitionReplicatedServersInfo = partitionMetadataManager.getTablePartitionReplicatedServersInfo();
+    partitionInfoMap = tablePartitionReplicatedServersInfo.getPartitionInfoMap();
+    assertEquals(partitionInfoMap[0]._fullyReplicatedServers, ImmutableSet.of(SERVER_0, SERVER_1));
+    assertEquals(partitionInfoMap[0]._segments, Collections.singleton(segmentA));
+    assertEquals(tablePartitionReplicatedServersInfo.getUnavailableSegments(),
+        Collections.singletonList(segmentB));
+
+    // Recovering all replicas should include the segment back as a regular segment
+    externalViewAssignment.put(segmentB, onlineInstanceStateMap);
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    tablePartitionReplicatedServersInfo = partitionMetadataManager.getTablePartitionReplicatedServersInfo();
+    partitionInfoMap = tablePartitionReplicatedServersInfo.getPartitionInfoMap();
+    assertEquals(partitionInfoMap[0]._fullyReplicatedServers, ImmutableSet.of(SERVER_0, SERVER_1));
+    assertEqualsNoOrder(partitionInfoMap[0]._segments.toArray(), new String[]{segmentA, segmentB});
+    assertTrue(tablePartitionReplicatedServersInfo.getUnavailableSegments().isEmpty());
+
+    // Changing the ideal assignment (e.g. rebalance) should reset the replication state. While moving towards the new
+    // assignment, the segment should not reduce the fully replicated servers, but should still be included when its
+    // online servers cover them.
+    idealStateAssignment.put(segmentB, Map.of(SERVER_0, ONLINE, SERVER_2, ONLINE));
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    tablePartitionReplicatedServersInfo = partitionMetadataManager.getTablePartitionReplicatedServersInfo();
+    partitionInfoMap = tablePartitionReplicatedServersInfo.getPartitionInfoMap();
+    assertEquals(partitionInfoMap[0]._fullyReplicatedServers, ImmutableSet.of(SERVER_0, SERVER_1));
+    assertEqualsNoOrder(partitionInfoMap[0]._segments.toArray(), new String[]{segmentA, segmentB});
+
+    // Once the segment converges to the new assignment, it should reduce the fully replicated servers as a regular
+    // segment
+    externalViewAssignment.put(segmentB, Map.of(SERVER_0, ONLINE, SERVER_2, ONLINE));
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    tablePartitionReplicatedServersInfo = partitionMetadataManager.getTablePartitionReplicatedServersInfo();
+    partitionInfoMap = tablePartitionReplicatedServersInfo.getPartitionInfoMap();
+    assertEquals(partitionInfoMap[0]._fullyReplicatedServers, Collections.singleton(SERVER_0));
+    assertEqualsNoOrder(partitionInfoMap[0]._segments.toArray(), new String[]{segmentA, segmentB});
+  }
+
+  @Test
+  public void testPendingSegmentExpiration()
+      throws InterruptedException {
+    ExternalView externalView = new ExternalView(OFFLINE_TABLE_NAME);
+    Map<String, Map<String, String>> externalViewAssignment = externalView.getRecord().getMapFields();
+    IdealState idealState = new IdealState(OFFLINE_TABLE_NAME);
+    Map<String, Map<String, String>> idealStateAssignment = idealState.getRecord().getMapFields();
+    Map<String, String> onlineInstanceStateMap = Map.of(SERVER_0, ONLINE, SERVER_1, ONLINE);
+    Set<String> onlineSegments = new HashSet<>();
+
+    // Use 0 expiration time so that the pending state expires right away
+    SegmentPartitionMetadataManager partitionMetadataManager =
+        new SegmentPartitionMetadataManager(OFFLINE_TABLE_NAME, PARTITION_COLUMN, PARTITION_COLUMN_FUNC, NUM_PARTITIONS,
+            0L);
+    SegmentZkMetadataFetcher segmentZkMetadataFetcher =
+        new SegmentZkMetadataFetcher(OFFLINE_TABLE_NAME, _propertyStore);
+    segmentZkMetadataFetcher.register(partitionMetadataManager);
+    segmentZkMetadataFetcher.init(idealState, externalView, onlineSegments);
+
+    // segmentX is fully replicated on both servers; segmentY is assigned to both servers but only ONLINE on SERVER_1
+    String segmentX = "expirationSegmentX";
+    onlineSegments.add(segmentX);
+    idealStateAssignment.put(segmentX, onlineInstanceStateMap);
+    externalViewAssignment.put(segmentX, onlineInstanceStateMap);
+    setSegmentZKMetadata(segmentX, PARTITION_COLUMN_FUNC, NUM_PARTITIONS, 0, 0L);
+    String segmentY = "expirationSegmentY";
+    onlineSegments.add(segmentY);
+    idealStateAssignment.put(segmentY, onlineInstanceStateMap);
+    externalViewAssignment.put(segmentY, Map.of(SERVER_1, ONLINE));
+    setSegmentZKMetadata(segmentY, PARTITION_COLUMN_FUNC, NUM_PARTITIONS, 0, 0L);
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+
+    // After the pending state expires, segmentY should be treated as a regular segment and reduce the fully
+    // replicated servers, so that its data is still served from the available replica
+    Thread.sleep(10);
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    TablePartitionReplicatedServersInfo tablePartitionReplicatedServersInfo =
+        partitionMetadataManager.getTablePartitionReplicatedServersInfo();
+    TablePartitionReplicatedServersInfo.PartitionInfo[] partitionInfoMap =
+        tablePartitionReplicatedServersInfo.getPartitionInfoMap();
+    assertEquals(partitionInfoMap[0]._fullyReplicatedServers, Collections.singleton(SERVER_1));
+    assertEqualsNoOrder(partitionInfoMap[0]._segments.toArray(), new String[]{segmentX, segmentY});
   }
 
   private void setSegmentZKMetadata(String segment, String partitionFunction, int numPartitions, int partitionId,

--- a/pinot-core/src/main/java/org/apache/pinot/core/routing/TablePartitionReplicatedServersInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/routing/TablePartitionReplicatedServersInfo.java
@@ -33,16 +33,18 @@ public class TablePartitionReplicatedServersInfo {
   private final int _numPartitions;
   private final PartitionInfo[] _partitionInfoMap;
   private final List<String> _segmentsWithInvalidPartition;
+  private final List<String> _unavailableSegments;
 
   public TablePartitionReplicatedServersInfo(String tableNameWithType, String partitionColumn,
       String partitionFunctionName, int numPartitions, PartitionInfo[] partitionInfoMap,
-      List<String> segmentsWithInvalidPartition) {
+      List<String> segmentsWithInvalidPartition, List<String> unavailableSegments) {
     _tableNameWithType = tableNameWithType;
     _partitionColumn = partitionColumn;
     _partitionFunctionName = partitionFunctionName;
     _numPartitions = numPartitions;
     _partitionInfoMap = partitionInfoMap;
     _segmentsWithInvalidPartition = segmentsWithInvalidPartition;
+    _unavailableSegments = unavailableSegments;
   }
 
   public String getTableNameWithType() {
@@ -67,6 +69,12 @@ public class TablePartitionReplicatedServersInfo {
 
   public List<String> getSegmentsWithInvalidPartition() {
     return _segmentsWithInvalidPartition;
+  }
+
+  /// Returns the segments excluded from the partition info because they have no available replica, thus cannot be
+  /// served regardless of the server picked.
+  public List<String> getUnavailableSegments() {
+    return _unavailableSegments;
   }
 
   public static class PartitionInfo {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -968,6 +968,12 @@ public class WorkerManager {
     // verifies that the partition table obtained from routing manager is compatible with the hint options
     checkPartitionInfoMap(partitionTableInfo, tableName, partitionKey, partitionFunction, numWorkers);
 
+    // Attach unavailable segments (no available replica, excluded from the partition info) to the metadata so that
+    // they are reported in the query response
+    for (Map.Entry<String, List<String>> entry : partitionTableInfo._unavailableSegmentsByTable.entrySet()) {
+      metadata.addUnavailableSegments(entry.getKey(), entry.getValue());
+    }
+
     PartitionInfo[] partitionInfoMap = partitionTableInfo._partitionInfoMap;
     int numPartitions = partitionInfoMap.length;
     assert numPartitions % numWorkers == 0;
@@ -1264,8 +1270,11 @@ public class WorkerManager {
           partitionInfoMap[i] = new PartitionInfo(fullyReplicatedServers, offlinePartitionInfo._segments,
               realtimePartitionInfo._segments);
         }
+        Map<String, List<String>> unavailableSegmentsByTable =
+            new HashMap<>(PartitionTableInfo.getUnavailableSegmentsByTable(offlineTpi));
+        unavailableSegmentsByTable.putAll(PartitionTableInfo.getUnavailableSegmentsByTable(realtimeTpi));
         return new PartitionTableInfo(offlineTpi.getPartitionColumn(), offlineTpi.getPartitionFunctionName(),
-            partitionInfoMap, timeBoundaryInfo);
+            partitionInfoMap, timeBoundaryInfo, unavailableSegmentsByTable);
       } else if (offlineRoutingExists) {
         return getOfflinePartitionTableInfo(offlineTableName);
       } else {
@@ -1333,13 +1342,23 @@ public class WorkerManager {
     final PartitionInfo[] _partitionInfoMap;
     @Nullable
     final TimeBoundaryInfo _timeBoundaryInfo;
+    /// Unavailable segments (no available replica, excluded from the partition info) keyed by table name with type
+    final Map<String, List<String>> _unavailableSegmentsByTable;
 
     PartitionTableInfo(String partitionKey, String partitionFunction, PartitionInfo[] partitionInfoMap,
-        @Nullable TimeBoundaryInfo timeBoundaryInfo) {
+        @Nullable TimeBoundaryInfo timeBoundaryInfo, Map<String, List<String>> unavailableSegmentsByTable) {
       _partitionKey = partitionKey;
       _partitionFunction = partitionFunction;
       _partitionInfoMap = partitionInfoMap;
       _timeBoundaryInfo = timeBoundaryInfo;
+      _unavailableSegmentsByTable = unavailableSegmentsByTable;
+    }
+
+    static Map<String, List<String>> getUnavailableSegmentsByTable(
+        TablePartitionReplicatedServersInfo tablePartitionReplicatedServersInfo) {
+      List<String> unavailableSegments = tablePartitionReplicatedServersInfo.getUnavailableSegments();
+      return unavailableSegments.isEmpty() ? Map.of()
+          : Map.of(tablePartitionReplicatedServersInfo.getTableNameWithType(), unavailableSegments);
     }
 
     static PartitionTableInfo fromTablePartitionInfo(
@@ -1373,7 +1392,8 @@ public class WorkerManager {
         }
       }
       return new PartitionTableInfo(tablePartitionReplicatedServersInfo.getPartitionColumn(),
-          tablePartitionReplicatedServersInfo.getPartitionFunctionName(), workerPartitionInfoMap, null);
+          tablePartitionReplicatedServersInfo.getPartitionFunctionName(), workerPartitionInfoMap, null,
+          getUnavailableSegmentsByTable(tablePartitionReplicatedServersInfo));
     }
   }
 

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
@@ -326,7 +326,7 @@ public class QueryEnvironmentTestBase {
         }
         TablePartitionReplicatedServersInfo tablePartitionReplicatedServersInfo =
             new TablePartitionReplicatedServersInfo(tableNameWithType, partitionColumn, "Hashcode", numPartitions,
-                partitionIdToInfoMap, List.of());
+                partitionIdToInfoMap, List.of(), List.of());
         partitionInfoMap.put(tableNameWithType, tablePartitionReplicatedServersInfo);
       }
     }


### PR DESCRIPTION
## Problem

MSE queries on partitioned tables can fail with:

```
Failed to find enabled fully replicated server for table: X, partition: N
```

`SegmentPartitionMetadataManager` computes the per-partition fully replicated servers by intersecting the ExternalView ONLINE/CONSUMING server sets across all non-"new" segments. Two issues make this fragile:

1. **The "new segment" protection is purely time based** (`pinot.broker.new.segment.expiration.seconds`, made configurable in #18707). Segments that take longer than the window to become fully replicated (e.g. large upsert segments still downloading/preloading), and segments uploaded under a new name to replace other segments (e.g. via merge/rollup or compaction style tasks using the segment replacement protocol), start reducing the fully replicated servers the moment the window lapses — potentially down to the empty set, which fails **every** MSE query on the partition. Raising the config only moves the cliff.
2. **A segment with no available replica clears the partition's fully replicated servers** entirely. No server can serve such a segment regardless of which server is picked, so clearing the set turns one bad segment (all replicas in ERROR state, or a transient deletion race between EV/IS updates) into a full partition outage instead of a partial-data response.

## Fix

1. **Track per-segment replication state against the latest IdealState assignment** (the IdealState was already passed in but unused). A segment that has never been observed fully replicated per its current target assignment is "pending" and excluded from the partition info if it would reduce the fully replicated servers. The pending clock is keyed to when the segment's ideal assignment last changed (covering new segments, replaced segments, and rebalance moves alike), and is still bounded by `pinot.broker.new.segment.expiration.seconds` so a replica permanently failing to load cannot silently exclude a segment from being served forever. Once fully replicated, losing a replica reduces the fully replicated servers as before, so queries are routed to the remaining replicas. When target servers cannot be determined from the ideal state, the previous creation-time based check is used as fallback.
2. **Exclude unavailable segments instead of clearing the partition's fully replicated servers**, and report them in the query response as a `SERVER_SEGMENT_MISSING` exception via `DispatchablePlanMetadata#addUnavailableSegments` — the same mechanism the non-partitioned leaf stage uses, honoring the `ignoreMissingSegments` query option.
3. **Add the missing `pinot-java-client` test dependency to `pinot-broker`.** Since #17167 made `ControllerTest` reference `PinotAdminException` (test scoped in `pinot-controller`, thus not transitive), every `ControllerTest`-derived test class in `pinot-broker` failed to load and silently ran 0 tests in CI (`SegmentPartitionMetadataManagerTest`, `TimeBoundaryManagerTest`, `SegmentPrunerTest`, `SegmentZkMetadataFetcherTest`, `BrokerRoutingManagerConcurrencyTest`, `RemoteClusterBrokerRoutingManagerTest` — TestNG swallows the `NoClassDefFoundError` and reports `Tests run: 0`). With the dependency restored, all of them run and pass again.

## Testing

- New `testReplicationStateTracking`: never-replicated old segment is excluded instead of reducing the fully replicated servers; replica loss after full replication reduces the set; full replica loss excludes + reports the segment without clearing the set; recovery re-includes it; ideal assignment change resets the tracking.
- New `testPendingSegmentExpiration`: after the pending window lapses, the segment falls back to reducing the fully replicated servers so its data is still served from the available replica.
- Full `pinot-broker` (316 tests) and `pinot-query-planner` (1263 tests) suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)