### PR TITLE
Delete orphan destination segments when cleaning up zombie lineage entries

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/lineage/DefaultLineageManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/lineage/DefaultLineageManager.java
@@ -117,9 +117,14 @@ public class DefaultLineageManager implements LineageManager {
         Set<String> destinationSegments = new HashSet<>(lineageEntry.getSegmentsTo());
         destinationSegments.retainAll(segmentsForTable);
         if (destinationSegments.isEmpty()) {
-          // If the lineage state is 'IN_PROGRESS or REVERTED' and source segments are already removed, it is safe
-          // to clean up the lineage entry. Deleting lineage will allow the task scheduler to re-schedule the source
-          // segments to be merged again.
+          // If the lineage state is 'IN_PROGRESS or REVERTED' and the destination segments are no longer in the
+          // ideal state, it is safe to clean up the lineage entry. Deleting lineage will allow the task scheduler
+          // to re-schedule the source segments to be merged again.
+          // A destination segment may still have a znode lingering in the property store even though it never
+          // reached (or has already left) the ideal state — e.g. a crash between creating the destination metadata
+          // and the ideal-state update. Schedule the destination segments for deletion so such orphans are reaped
+          // along with the lineage entry. Names that have no znode are a no-op in the deletion path.
+          segmentsToDelete.addAll(lineageEntry.getSegmentsTo());
           lineageEntryIterator.remove();
         } else {
           // If the lineage state is 'IN_PROGRESS', it is safe to delete all segments from 'segmentsTo'

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/SegmentLineageCleanupTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/SegmentLineageCleanupTest.java
@@ -26,6 +26,8 @@ import org.apache.pinot.common.lineage.LineageEntry;
 import org.apache.pinot.common.lineage.LineageEntryState;
 import org.apache.pinot.common.lineage.SegmentLineage;
 import org.apache.pinot.common.lineage.SegmentLineageAccessHelper;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.LeadControllerManager;
@@ -46,6 +48,7 @@ import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 
 public class SegmentLineageCleanupTest {
@@ -160,6 +163,23 @@ public class SegmentLineageCleanupTest {
     segmentLineage =
         SegmentLineageAccessHelper.getSegmentLineage(_resourceManager.getPropertyStore(), OFFLINE_TABLE_NAME);
     assertEquals(segmentLineage.getLineageEntryIds().size(), 1);
+
+    // Validate that reaping a zombie IN_PROGRESS entry also deletes a destination znode that never reached the
+    // ideal state. The prior pass kept entry "1" because "merged_1" was still in the ideal state. Plant a
+    // property-store znode for "merged_2" — which was never added to the ideal state — to mimic a crash between
+    // destination-metadata creation and the ideal-state update. Now neither destination is in the ideal state, so
+    // the entry must be reaped and the orphan znode deleted along with it.
+    ZKMetadataProvider.setSegmentZKMetadata(_resourceManager.getPropertyStore(), OFFLINE_TABLE_NAME,
+        new SegmentZKMetadata("merged_2"));
+    assertTrue(_resourceManager.getSegmentsFromPropertyStore(OFFLINE_TABLE_NAME).contains("merged_2"));
+    _retentionManager.processTable(OFFLINE_TABLE_NAME);
+    segmentLineage =
+        SegmentLineageAccessHelper.getSegmentLineage(_resourceManager.getPropertyStore(), OFFLINE_TABLE_NAME);
+    assertEquals(segmentLineage.getLineageEntryIds().size(), 0);
+    // Segment znode deletion is asynchronous, so wait for the orphan to disappear from the property store.
+    TestUtils.waitForCondition(
+        aVoid -> !_resourceManager.getSegmentsFromPropertyStore(OFFLINE_TABLE_NAME).contains("merged_2"), 60_000L,
+        "Orphan destination znode absent from the ideal state must be reaped when the zombie entry is cleaned up");
   }
 
   private void verifySegmentsDeleted(int expectedNumRemainingSegments) {


### PR DESCRIPTION
## What

When the retention manager cleans up a zombie `IN_PROGRESS` or `REVERTED`
segment-lineage entry whose destination segments are no longer in the ideal
state, it removed the lineage entry but left the destination segments' ZK
metadata behind in the property store.

This can happen, for example, when the controller crashes between writing the
destination segment metadata and updating the ideal state — the orphan znodes
are then never reclaimed.

## Change

`DefaultLineageManager.updateLineageForRetention` now schedules the entry's
`segmentsTo` for deletion when it reaps such an entry, so the orphan znodes are
cleaned up together with the lineage entry.

This is safe:
- The branch only triggers when none of the destination segments are in the
  ideal state, so no queryable segment is touched.
- Segment names with no znode are a no-op in the deletion path.

## Testing

Extended `SegmentLineageCleanupTest` to plant an orphan destination znode that
never reached the ideal state and assert it is reaped when the zombie entry is
cleaned up. `DefaultLineageManagerTest` and `SegmentLineageCleanupTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
