### PR TITLE
Add tenant label to table-scoped broker and server metrics

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/broker.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/broker.yml
@@ -18,14 +18,6 @@ rules:
     table: "$3$5"
     tableType: "$6"
     tenant: "$7"
-# Meters/timers that accept rawTableName + tenant
-- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.((\\w+)\\.)?(\\w+)\\.tenant\\.(\\w+)\\.(\\w+)\"?><>(\\w+)"
-  name: "pinot_$1_$6_$7"
-  cache: true
-  labels:
-    database: "$3"
-    table: "$2$4"
-    tenant: "$5"
 # === End tenant-aware rules ===
 
 # Meters/timers that accept tableNameWithType

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/broker.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/broker.yml
@@ -1,4 +1,33 @@
 rules:
+# === Tenant-aware rules (must precede non-tenant rules to match first) ===
+# Meters/timers that accept tableNameWithType + tenant
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.((\\w+)\\.)?(\\w+)_(OFFLINE|REALTIME)\\.tenant\\.(\\w+)\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$7_$8"
+  cache: true
+  labels:
+    database: "$3"
+    table: "$2$4"
+    tableType: "$5"
+    tenant: "$6"
+# Gauges that accept tableNameWithType + tenant
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.((\\w+)\\.)?(\\w+)_(OFFLINE|REALTIME)\\.tenant\\.(\\w+)\\\"?><>(\\w+)"
+  name: "pinot_$1_$2_$8"
+  cache: true
+  labels:
+    database: "$4"
+    table: "$3$5"
+    tableType: "$6"
+    tenant: "$7"
+# Meters/timers that accept rawTableName + tenant
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.((\\w+)\\.)?(\\w+)\\.tenant\\.(\\w+)\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$6_$7"
+  cache: true
+  labels:
+    database: "$3"
+    table: "$2$4"
+    tenant: "$5"
+# === End tenant-aware rules ===
+
 # Meters/timers that accept tableNameWithType
 - pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.((\\w+)\\.)?(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)"
   name: "pinot_$1_$6_$7"

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
@@ -97,14 +97,6 @@ rules:
     database: "$2"
     table: "$1$3"
     tableType: "$4"
-# Meters/timers that accept rawTableName + tenant
-- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.server\\.((\\w+)\\.)?(\\w+)\\.tenant\\.(\\w+)\\.(\\w+)\"?><>(\\w+)"
-  name: "pinot_server_$5_$6"
-  cache: true
-  labels:
-    database: "$2"
-    table: "$1$3"
-    tenant: "$4"
 # Meters/timers that accept rawTableName
 - pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.server\\.((\\w+)\\.)?(\\w+)\\.(\\w+)\"?><>(\\w+)"
   name: "pinot_server_$4_$5"

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
@@ -1,4 +1,35 @@
 rules:
+# === Tenant-aware rules (must precede non-tenant rules to match first) ===
+# Gauges that accept tableNameWithType + tenant
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.((\\w+)\\.)?(\\w+)_(OFFLINE|REALTIME)\\.tenant\\.(\\w+)\\\"?><>(\\w+)"
+  name: "pinot_$1_$2_$8"
+  cache: true
+  labels:
+    database: "$4"
+    table: "$3$5"
+    tableType: "$6"
+    tenant: "$7"
+# Gauges that accept tableNameWithType + partitionId + tenant
+- pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ServerMetrics\", name=\"pinot\\.server\\.(\\w+)\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.tenant\\.(\\w+)\\.(\\w+)\"><>(\\w+)"
+  name: "pinot_server_$1_$8"
+  cache: true
+  labels:
+    database: "$3"
+    table: "$2$4"
+    tableType: "$5"
+    tenant: "$6"
+    partition: "$7"
+# Meters/timers that accept tableNameWithType + tenant
+- pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ServerMetrics\", name=\"pinot\\.server\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.tenant\\.(\\w+)\\.(\\w+)\"><>(\\w+)"
+  name: "pinot_server_$6_$7"
+  cache: true
+  labels:
+    database: "$2"
+    table: "$1$3"
+    tableType: "$4"
+    tenant: "$5"
+# === End tenant-aware rules ===
+
 # Gauges that accept tableNameWithType
 - pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.((\\w+)\\.)?(\\w+)_(OFFLINE|REALTIME)\\\"?><>(\\w+)"
   name: "pinot_$1_$2_$7"
@@ -66,6 +97,14 @@ rules:
     database: "$2"
     table: "$1$3"
     tableType: "$4"
+# Meters/timers that accept rawTableName + tenant
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.server\\.((\\w+)\\.)?(\\w+)\\.tenant\\.(\\w+)\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_server_$5_$6"
+  cache: true
+  labels:
+    database: "$2"
+    table: "$1$3"
+    tenant: "$4"
 # Meters/timers that accept rawTableName
 - pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.server\\.((\\w+)\\.)?(\\w+)\\.(\\w+)\"?><>(\\w+)"
   name: "pinot_server_$4_$5"

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
@@ -719,6 +719,8 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
       TableConfig tableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, tableNameWithType);
       Preconditions.checkState(tableConfig != null, "Failed to find table config for table: %s", tableNameWithType);
 
+      _brokerMetrics.registerTableTenant(tableNameWithType, tableConfig.getTenantConfig().getBroker());
+
       String idealStatePath = getIdealStatePath(tableNameWithType);
       IdealState idealState = getIdealState(idealStatePath);
       Preconditions.checkState(idealState != null, "Failed to find ideal state for table: %s", tableNameWithType);
@@ -970,6 +972,7 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
 
       if (_routingEntryMap.remove(tableNameWithType) != null) {
         LOGGER.info("Removed routing for table: {}", tableNameWithType);
+        _brokerMetrics.unregisterTableTenant(tableNameWithType);
 
         // Remove time boundary manager for the offline part routing if the removed routing is the real-time part of a
         // hybrid table

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
@@ -68,6 +68,11 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
   // Table level metrics are still emitted for allowed tables even if emitting table level metrics is disabled
   private final Set<String> _allowedTables;
 
+  // Maps tableNameWithType (or raw table name) to the tenant name for that table.
+  // When populated, table-scoped metrics include a ".tenant.{tenantName}" suffix so the
+  // Prometheus JMX exporter can extract it as a label.
+  private final Map<String, String> _tableTenantMap = new ConcurrentHashMap<>();
+
   public AbstractMetrics(String metricPrefix, PinotMetricsRegistry metricsRegistry, Class clazz) {
     this(metricPrefix, metricsRegistry, clazz, true, Collections.emptySet());
   }
@@ -824,6 +829,43 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
   protected abstract G[] getGauges();
 
   protected String getTableName(String tableName) {
-    return _isTableLevelMetricsEnabled || _allowedTables.contains(tableName) ? tableName : "allTables";
+    if (!_isTableLevelMetricsEnabled && !_allowedTables.contains(tableName)) {
+      return "allTables";
+    }
+    String tenant = _tableTenantMap.get(tableName);
+    if (tenant != null) {
+      return tableName + ".tenant." + tenant;
+    }
+    return tableName;
+  }
+
+  /**
+   * Registers a tenant mapping for a table so that table-scoped metrics include
+   * the tenant as an additional label dimension in Prometheus.
+   *
+   * @param tableNameWithType the table name (with or without type suffix)
+   * @param tenantName the tenant name from the table's TenantConfig
+   */
+  public void registerTableTenant(String tableNameWithType, String tenantName) {
+    if (tableNameWithType != null && tenantName != null && !tenantName.isEmpty()) {
+      _tableTenantMap.put(tableNameWithType, sanitizeTenantName(tenantName));
+    }
+  }
+
+  private static String sanitizeTenantName(String tenantName) {
+    // Replace non-word characters with underscore to ensure the tenant name is safe for
+    // JMX metric names and can be matched by \\w+ in Prometheus exporter regex patterns.
+    return tenantName.replaceAll("\\W+", "_");
+  }
+
+  /**
+   * Removes the tenant mapping for a table (e.g. when a table is dropped).
+   *
+   * @param tableNameWithType the table name (with or without type suffix)
+   */
+  public void unregisterTableTenant(String tableNameWithType) {
+    if (tableNameWithType != null) {
+      _tableTenantMap.remove(tableNameWithType);
+    }
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/AbstractMetricsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/AbstractMetricsTest.java
@@ -74,6 +74,13 @@ public abstract class AbstractMetricsTest {
     return new ControllerMetrics(buildRegistry());
   }
 
+  protected ServerMetrics buildServerMetrics() {
+    PinotConfiguration config = new PinotConfiguration();
+    config.setProperty(CONFIG_OF_METRICS_FACTORY_CLASS_NAME, metricsFactoryClassName());
+    PinotMetricUtils.init(config);
+    return new ServerMetrics(buildRegistry());
+  }
+
   /**
    * Tear down the PinotMetricUtils static factory after each subclass finishes. The factory installs a
    * {@link org.apache.pinot.spi.metrics.PinotJmxReporter}; leaving it registered can cause cross-test JMX collisions
@@ -419,10 +426,7 @@ public abstract class AbstractMetricsTest {
 
   @Test
   public void testTableTenantRegistration() {
-    PinotConfiguration config = new PinotConfiguration();
-    config.setProperty(CONFIG_OF_METRICS_FACTORY_CLASS_NAME, metricsFactoryClassName());
-    PinotMetricUtils.init(config);
-    ServerMetrics serverMetrics = new ServerMetrics(buildRegistry());
+    ServerMetrics serverMetrics = buildServerMetrics();
     MetricsInspector inspector = createInspector(serverMetrics.getMetricsRegistry());
     String tableNameWithType = "myTable_REALTIME";
     String tenantName = "analytics";
@@ -452,10 +456,7 @@ public abstract class AbstractMetricsTest {
 
   @Test
   public void testTableTenantRegistrationWithNullOrEmpty() {
-    PinotConfiguration config = new PinotConfiguration();
-    config.setProperty(CONFIG_OF_METRICS_FACTORY_CLASS_NAME, metricsFactoryClassName());
-    PinotMetricUtils.init(config);
-    ServerMetrics serverMetrics = new ServerMetrics(buildRegistry());
+    ServerMetrics serverMetrics = buildServerMetrics();
 
     // null tenant should not throw or register
     serverMetrics.registerTableTenant("myTable_OFFLINE", null);
@@ -468,16 +469,13 @@ public abstract class AbstractMetricsTest {
 
   @Test
   public void testTableTenantGaugeMetrics() {
-    PinotConfiguration config = new PinotConfiguration();
-    config.setProperty(CONFIG_OF_METRICS_FACTORY_CLASS_NAME, metricsFactoryClassName());
-    PinotMetricUtils.init(config);
-    ServerMetrics serverMetrics = new ServerMetrics(buildRegistry());
+    ServerMetrics serverMetrics = buildServerMetrics();
     String tableNameWithType = "events_OFFLINE";
     String tenantName = "platformTenant";
 
     serverMetrics.registerTableTenant(tableNameWithType, tenantName);
 
-    serverMetrics.setOrUpdateTableGauge(tableNameWithType, ServerGauge.SEGMENT_COUNT, 42L);
+    serverMetrics.setValueOfTableGauge(tableNameWithType, ServerGauge.SEGMENT_COUNT, 42L);
     String expectedGaugeName =
         ServerGauge.SEGMENT_COUNT.getGaugeName() + "." + tableNameWithType + ".tenant." + tenantName;
     Long gaugeValue = serverMetrics.getGaugeValue(expectedGaugeName);

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/AbstractMetricsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/AbstractMetricsTest.java
@@ -416,4 +416,72 @@ public abstract class AbstractMetricsTest {
     Assert.assertEquals(
         getGaugeValue(controllerMetrics, ControllerGauge.VERSION.getGaugeName() + "." + table), 10);
   }
+
+  @Test
+  public void testTableTenantRegistration() {
+    PinotConfiguration config = new PinotConfiguration();
+    config.setProperty(CONFIG_OF_METRICS_FACTORY_CLASS_NAME, metricsFactoryClassName());
+    PinotMetricUtils.init(config);
+    ServerMetrics serverMetrics = new ServerMetrics(buildRegistry());
+    MetricsInspector inspector = createInspector(serverMetrics.getMetricsRegistry());
+    String tableNameWithType = "myTable_REALTIME";
+    String tenantName = "analytics";
+
+    // Without tenant registered, metric name uses plain table name
+    serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.QUERIES, 1);
+    PinotMetricName metricWithoutTenant = inspector.lastMetric();
+    Assert.assertTrue(metricWithoutTenant.toString().contains(tableNameWithType));
+    Assert.assertFalse(metricWithoutTenant.toString().contains("tenant"));
+
+    // Register tenant
+    serverMetrics.registerTableTenant(tableNameWithType, tenantName);
+
+    // With tenant registered, metric name includes tenant segment
+    serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.QUERIES, 1);
+    PinotMetricName metricWithTenant = inspector.lastMetric();
+    Assert.assertTrue(metricWithTenant.toString().contains(tableNameWithType + ".tenant." + tenantName));
+
+    // Unregister tenant
+    serverMetrics.unregisterTableTenant(tableNameWithType);
+
+    // After unregister, metric name no longer includes tenant
+    serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.QUERIES_KILLED, 1);
+    PinotMetricName metricAfterUnregister = inspector.lastMetric();
+    Assert.assertFalse(metricAfterUnregister.toString().contains("tenant"));
+  }
+
+  @Test
+  public void testTableTenantRegistrationWithNullOrEmpty() {
+    PinotConfiguration config = new PinotConfiguration();
+    config.setProperty(CONFIG_OF_METRICS_FACTORY_CLASS_NAME, metricsFactoryClassName());
+    PinotMetricUtils.init(config);
+    ServerMetrics serverMetrics = new ServerMetrics(buildRegistry());
+
+    // null tenant should not throw or register
+    serverMetrics.registerTableTenant("myTable_OFFLINE", null);
+    serverMetrics.registerTableTenant("myTable_OFFLINE", "");
+    serverMetrics.registerTableTenant(null, "tenant1");
+
+    // unregister null should not throw
+    serverMetrics.unregisterTableTenant(null);
+  }
+
+  @Test
+  public void testTableTenantGaugeMetrics() {
+    PinotConfiguration config = new PinotConfiguration();
+    config.setProperty(CONFIG_OF_METRICS_FACTORY_CLASS_NAME, metricsFactoryClassName());
+    PinotMetricUtils.init(config);
+    ServerMetrics serverMetrics = new ServerMetrics(buildRegistry());
+    String tableNameWithType = "events_OFFLINE";
+    String tenantName = "platformTenant";
+
+    serverMetrics.registerTableTenant(tableNameWithType, tenantName);
+
+    serverMetrics.setOrUpdateTableGauge(tableNameWithType, ServerGauge.SEGMENT_COUNT, 42L);
+    String expectedGaugeName =
+        ServerGauge.SEGMENT_COUNT.getGaugeName() + "." + tableNameWithType + ".tenant." + tenantName;
+    Long gaugeValue = serverMetrics.getGaugeValue(expectedGaugeName);
+    Assert.assertNotNull(gaugeValue);
+    Assert.assertEquals(gaugeValue.longValue(), 42L);
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -234,6 +234,9 @@ public abstract class BaseTableDataManager implements TableDataManager {
         .build();
     updateCachedTableConfigAndSchema(tableConfig, schema);
 
+    String serverTenant = tableConfig.getTenantConfig().getServer();
+    _serverMetrics.registerTableTenant(_tableNameWithType, serverTenant);
+
     _peerDownloadScheme = tableConfig.getValidationConfig().getPeerSegmentDownloadScheme();
     if (_peerDownloadScheme == null) {
       _peerDownloadScheme = instanceDataManagerConfig.getSegmentPeerDownloadScheme();
@@ -306,6 +309,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
     }
     _logger.info("Shutting down table data manager");
     _shutDown = true;
+    _serverMetrics.unregisterTableTenant(_tableNameWithType);
     doShutdown();
     _logger.info("Shut down table data manager");
   }
@@ -434,6 +438,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
     IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig(_instanceDataManagerConfig, tableConfig, schema);
     indexLoadingConfig.setTableDataDir(_tableDataDir);
     updateCachedTableConfigAndSchema(tableConfig, schema);
+    _serverMetrics.registerTableTenant(_tableNameWithType, tableConfig.getTenantConfig().getServer());
     return indexLoadingConfig;
   }
 


### PR DESCRIPTION
## Summary

- Adds a `tenant` label to table-scoped Prometheus metrics for brokers and servers, enabling Grafana dashboards to group/filter metrics by tenant.
- The tenant name is sourced from each table's `TenantConfig` (broker tenant for broker metrics, server tenant for server metrics).
- This is a purely additive change — existing Grafana queries and dashboards that don't reference the `tenant` label continue to work without modification.

## Design

A tenant registry (`ConcurrentHashMap<String, String>`) is added to `AbstractMetrics`. When a table's tenant is registered, the `getTableName()` method appends `.tenant.{tenantName}` to the metric name key. The JMX Prometheus exporter YAML configs have new, higher-priority regex rules that capture this segment as a `tenant` label.

**Metric name format:**
- Without tenant (unchanged): `pinot.server.{table}_{type}.{metric}`
- With tenant: `pinot.server.{table}_{type}.tenant.{tenantName}.{metric}`

**What gets the tenant label (table is known when metric is updated):**
- Query path: latency / errors / throttle counts per table (broker and server)
- Ingestion / consumption per table
- Segment / table gauges: rows, segments, freshness

**What does NOT get a tenant label (instance-only, no table context):**
- JVM: heap, GC, threads
- Process / Helix: ZK session, reconnects
- Host: CPU load, disk free
- Global counters: connection pool totals, generic errors with no table in context

## Changes

| File | Purpose |
|---|---|
| `AbstractMetrics.java` | Add `_tableTenantMap`, `registerTableTenant()`, `unregisterTableTenant()`, modify `getTableName()` |
| `BaseTableDataManager.java` | Register server tenant on init/refresh, unregister on shutdown |
| `BaseBrokerRoutingManager.java` | Register broker tenant on buildRouting, unregister on removeRouting |
| `server.yml` / `broker.yml` | Add tenant-aware JMX exporter regex rules before existing catch-all patterns |
| `AbstractMetricsTest.java` | Unit tests for tenant registration, null handling, gauge metrics |

## Backward Compatibility

- **Existing dashboards won't break**: `tenant` is a new additive label. PromQL queries that don't specify `tenant` continue to match all series.
- **Tables without tenant config**: metrics are identical to before (no `.tenant.` segment, no label).
- **Wire protocols/serialization**: no changes.
- **Metric names in Prometheus**: unchanged — only the label set is enriched.

## Test plan

- [x] Unit tests for tenant registration (with/without tenant, null/empty handling, gauge metrics)
- [ ] Manual verification: start broker+server with multi-tenant table configs, confirm `tenant` label appears in Prometheus scrape output
- [ ] Verify existing metrics (tables without explicit tenant) are unchanged in Prometheus output
- [ ] Confirm existing Grafana queries return same results after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)