### PR TITLE
Add spool query cases to multi-stage engine resource tests

### DIFF
--- a/pinot-query-runtime/src/test/resources/queries/Spool.json
+++ b/pinot-query-runtime/src/test/resources/queries/Spool.json
@@ -31,6 +31,21 @@
         "description": "Simplest spool",
         "sql": "SET timeoutMs=10000; SET useSpools=true; SELECT * FROM {tbl1} as a1 JOIN {tbl2} as b ON a1.strCol1 = b.strCol1 JOIN {tbl1} as a2 ON a2.strCol1 = b.strCol1",
         "h2Sql": "SELECT * FROM {tbl1} as a1 JOIN {tbl2} as b ON a1.strCol1 = b.strCol1 JOIN {tbl1} as a2 ON a2.strCol1 = b.strCol1"
+      },
+      {
+        "description": "Spool reused by three downstream stages (table scanned once, joined three times)",
+        "sql": "SET timeoutMs=10000; SET useSpools=true; SELECT a1.intCol1, a2.intCol1, a3.intCol1 FROM {tbl1} as a1 JOIN {tbl1} as a2 ON a1.strCol1 = a2.strCol1 JOIN {tbl1} as a3 ON a1.strCol1 = a3.strCol1",
+        "h2Sql": "SELECT a1.intCol1, a2.intCol1, a3.intCol1 FROM {tbl1} as a1 JOIN {tbl1} as a2 ON a1.strCol1 = a2.strCol1 JOIN {tbl1} as a3 ON a1.strCol1 = a3.strCol1"
+      },
+      {
+        "description": "Spool of an aggregated stage reused by a self join",
+        "sql": "SET timeoutMs=10000; SET useSpools=true; WITH g AS (SELECT strCol1, SUM(intCol1) AS s FROM {tbl1} GROUP BY strCol1) SELECT a.strCol1, a.s, b.s FROM g a JOIN g b ON a.strCol1 = b.strCol1",
+        "h2Sql": "WITH g AS (SELECT strCol1, SUM(intCol1) AS s FROM {tbl1} GROUP BY strCol1) SELECT a.strCol1, a.s, b.s FROM g a JOIN g b ON a.strCol1 = b.strCol1"
+      },
+      {
+        "description": "Spool of an aggregated stage reused by both arms of a UNION ALL",
+        "sql": "SET timeoutMs=10000; SET useSpools=true; WITH g AS (SELECT strCol1, SUM(intCol1) AS s FROM {tbl1} GROUP BY strCol1) SELECT strCol1, s FROM g UNION ALL SELECT strCol1, s FROM g",
+        "h2Sql": "WITH g AS (SELECT strCol1, SUM(intCol1) AS s FROM {tbl1} GROUP BY strCol1) SELECT strCol1, s FROM g UNION ALL SELECT strCol1, s FROM g"
       }
     ]
   }


### PR DESCRIPTION
## Summary

`Spool.json` in the multi-stage `ResourceBasedQueriesTest` previously covered a single spool shape (a table scanned once and joined twice). This adds three more so the spool (`useSpools=true`) reuse path is exercised across common reuse patterns:

- a stage reused by **three** downstream stages (one scan, joined three times);
- an **aggregated** stage reused by a self join;
- an aggregated stage reused by both arms of a **UNION ALL**.

Each query has an `h2Sql` equivalent, so the results are validated against H2.

## Testing

`mvn -pl pinot-query-runtime test -Dtest=ResourceBasedQueriesTest -Dpinot.fileFilter=Spool` — all spool cases pass.