### PR TITLE
Parse-once for JSON-index ingestion: cache the parsed Map and flatten it directly

### DIFF
--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkJsonFlatten.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkJsonFlatten.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.spi.config.table.JsonIndexConfig;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.MapUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+/// Compares the cost of building the JSON index input for a realtime row from a re-serialized JSON **string**
+/// (the current path: `DataTypeTransformer` serializes the Map, then the JSON index re-parses it) versus from the
+/// already-parsed **Map** (the parse-once cache: the index flattens the Map directly via `valueToTree`).
+///
+/// - `flattenFromString` - current per-row index cost (`stringToJsonNode` + flatten).
+/// - `flattenFromMap` - parse-once cost (`valueToTree` + flatten), the re-parse avoided.
+/// - `serializeMap` - the Map to String serialization that stays (the forward index stores it).
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(1)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 8, time = 1)
+public class BenchmarkJsonFlatten {
+
+  // A representative structured log line (nested "log" object, ids, an array) similar to the zomato `message` field.
+  private static final String MESSAGE_JSON =
+      "{\"x_gr_trace_id\":\"a1b2c3d4-e5f6-7890-abcd-ef1234567890\","
+          + "\"user_id\":\"user-99174432\","
+          + "\"path\":\"/retail_purchase_order/modules/serialized_inventory.py\","
+          + "\"status\":\"500\",\"event\":\"request.error\",\"level\":\"ERROR\","
+          + "\"stream\":\"stderr\",\"time\":\"2026-06-12T10:31:13.123456789Z\","
+          + "\"msg\":\"File \\\"/retail_purchase_order/modules/serialized_inventory.py\\\", line 222, in "
+          + "create_integration_partner_entries\","
+          + "\"log\":{\"msg\":\"create_integration_partner_entries failed\",\"message\":\"partner missing\","
+          + "\"level\":\"error\",\"logger\":\"retail.purchase_order.serialized_inventory\",\"line\":222},"
+          + "\"http\":{\"method\":\"POST\",\"status_code\":500,\"duration_ms\":1843,\"host\":\"api-internal\"},"
+          + "\"tags\":[\"retail\",\"purchase_order\",\"serialized_inventory\",\"prod\"]}";
+
+  private Map<String, Object> _messageMap;
+  private JsonIndexConfig _config;
+
+  @Setup
+  public void setup()
+      throws Exception {
+    _messageMap = JsonUtils.stringToObject(MESSAGE_JSON, Map.class);
+    _config = new JsonIndexConfig();
+    _config.setMaxLevels(2);
+  }
+
+  @Benchmark
+  public Object flattenFromString()
+      throws Exception {
+    return JsonUtils.flatten(MESSAGE_JSON, _config);
+  }
+
+  @Benchmark
+  public Object flattenFromMap()
+      throws Exception {
+    return JsonUtils.flattenParsed(_messageMap, _config);
+  }
+
+  @Benchmark
+  public Object serializeMap() {
+    return MapUtils.toString(_messageMap);
+  }
+
+  public static void main(String[] args)
+      throws Exception {
+    new Runner(new OptionsBuilder().include(BenchmarkJsonFlatten.class.getSimpleName()).build()).run();
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -62,6 +62,7 @@ import org.apache.pinot.segment.local.realtime.impl.dictionary.SameValueMutableD
 import org.apache.pinot.segment.local.realtime.impl.forward.FixedByteMVMutableForwardIndex;
 import org.apache.pinot.segment.local.realtime.impl.forward.SameValueMutableForwardIndex;
 import org.apache.pinot.segment.local.realtime.impl.invertedindex.MultiColumnRealtimeLuceneTextIndex;
+import org.apache.pinot.segment.local.realtime.impl.json.MutableJsonIndexImpl;
 import org.apache.pinot.segment.local.realtime.impl.nullvalue.MutableNullValueVector;
 import org.apache.pinot.segment.local.segment.index.datasource.MutableDataSource;
 import org.apache.pinot.segment.local.segment.index.dictionary.DictionaryIndexType;
@@ -926,6 +927,17 @@ public class MutableSegmentImpl implements MutableSegment {
         for (Map.Entry<IndexType, MutableIndex> indexEntry : indexContainer._mutableIndexes.entrySet()) {
           try {
             MutableIndex mutableIndex = indexEntry.getValue();
+            if (mutableIndex instanceof MutableJsonIndexImpl) {
+              // Feed the JSON index the parsed value cached by the DataTypeTransformer (if any), so it flattens the
+              // document directly instead of re-parsing the string this column was serialized into for the forward
+              // index. This is intentionally scoped to Pinot's built-in JSON index implementation.
+              Object parsedValue = row.getParsedJsonValue(column);
+              if (parsedValue != null) {
+                ((MutableJsonIndexImpl) mutableIndex).addParsed(parsedValue);
+                updateIndexCapacityThresholdBreached(mutableIndex, indexEntry.getKey(), column);
+                continue;
+              }
+            }
             mutableIndex.add(value, dictId, docId);
             updateIndexCapacityThresholdBreached(mutableIndex, indexEntry.getKey(), column);
           } catch (Exception e) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -61,6 +61,7 @@ import org.apache.pinot.segment.local.realtime.impl.dictionary.BaseOffHeapMutabl
 import org.apache.pinot.segment.local.realtime.impl.dictionary.SameValueMutableDictionary;
 import org.apache.pinot.segment.local.realtime.impl.forward.SameValueMutableForwardIndex;
 import org.apache.pinot.segment.local.realtime.impl.invertedindex.MultiColumnRealtimeLuceneTextIndex;
+import org.apache.pinot.segment.local.realtime.impl.json.MutableJsonIndexImpl;
 import org.apache.pinot.segment.local.realtime.impl.nullvalue.MutableNullValueVector;
 import org.apache.pinot.segment.local.segment.index.datasource.MutableDataSource;
 import org.apache.pinot.segment.local.segment.index.dictionary.DictionaryIndexType;
@@ -952,6 +953,17 @@ public class MutableSegmentImpl implements MutableSegment {
         for (Map.Entry<IndexType, MutableIndex> indexEntry : indexContainer._mutableIndexes.entrySet()) {
           try {
             MutableIndex mutableIndex = indexEntry.getValue();
+            if (mutableIndex instanceof MutableJsonIndexImpl) {
+              // Feed the JSON index the parsed value cached by the DataTypeTransformer (if any), so it flattens the
+              // document directly instead of re-parsing the string this column was serialized into for the forward
+              // index. This is intentionally scoped to Pinot's built-in JSON index implementation.
+              Object parsedValue = row.getParsedJsonValue(column);
+              if (parsedValue != null) {
+                ((MutableJsonIndexImpl) mutableIndex).addParsed(parsedValue);
+                updateIndexCapacityThresholdBreached(mutableIndex, indexEntry.getKey(), column);
+                continue;
+              }
+            }
             mutableIndex.add(value, dictId, docId);
             updateIndexCapacityThresholdBreached(mutableIndex, indexEntry.getKey(), column);
           } catch (Exception e) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/json/MutableJsonIndexImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/json/MutableJsonIndexImpl.java
@@ -114,6 +114,24 @@ public class MutableJsonIndexImpl implements MutableJsonIndex {
     }
   }
 
+  /// Indexes an already-parsed JSON document (e.g. a Map cached on the GenericRow), flattening it directly via
+  /// {@link JsonUtils#flattenParsed} instead of re-parsing the string the document was serialized into for the
+  /// forward index.
+  public void addParsed(Object parsedValue)
+      throws IOException {
+    try {
+      List<Map<String, String>> flattenedRecords = JsonUtils.flattenParsed(parsedValue, _jsonIndexConfig);
+      _writeLock.lock();
+      try {
+        addFlattenedRecords(flattenedRecords);
+      } finally {
+        _writeLock.unlock();
+      }
+    } finally {
+      _nextDocId++;
+    }
+  }
+
   /// Adds the flattened records for the next document.
   private void addFlattenedRecords(List<Map<String, String>> records) {
     int numRecords = records.size();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/DataTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/DataTypeTransformer.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.segment.local.recordtransformer;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -27,12 +29,16 @@ import java.util.UUID;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.ThrottledLogger;
 import org.apache.pinot.segment.local.utils.DataTypeTransformerUtils;
+import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
+import org.apache.pinot.segment.spi.index.FieldIndexConfigsUtil;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.recordtransformer.RecordTransformer;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.PinotDataType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,6 +57,11 @@ public class DataTypeTransformer implements RecordTransformer {
   private static final Logger LOGGER = LoggerFactory.getLogger(DataTypeTransformer.class);
 
   private final Map<String, PinotDataType> _dataTypes;
+  /// JSON-typed columns that have a JSON index. For these the parsed value is cached on the row (before it is
+  /// serialized to a string for the forward index) so the JSON index can flatten it directly instead of re-parsing.
+  /// Computed once here so we only pay for the cache when a JSON index will actually consume the parsed value. Empty
+  /// for the source-field usage, which runs before indexing.
+  private final Set<String> _jsonCacheColumns;
   private final boolean _continueOnError;
   private final ThrottledLogger _throttledLogger;
   // UUID primary key columns for upsert/dedup tables; non-null and non-empty when applicable.
@@ -64,18 +75,20 @@ public class DataTypeTransformer implements RecordTransformer {
   /// Creates a [DataTypeTransformer] that converts the (non-virtual) schema columns to the data types defined in the
   /// [Schema].
   public DataTypeTransformer(TableConfig tableConfig, Schema schema) {
-    this(tableConfig, extractSchemaDataTypes(schema), schema);
+    this(tableConfig, extractSchemaDataTypes(schema), schema, computeJsonCacheColumns(tableConfig, schema));
   }
 
   /// Creates a [DataTypeTransformer] that converts the given columns to the provided [PinotDataType]s. This is useful
   /// for fixing the data types of source fields before other transformers (such as [ExpressionTransformer]) consume
   /// them.
   public DataTypeTransformer(TableConfig tableConfig, Map<String, PinotDataType> dataTypes) {
-    this(tableConfig, dataTypes, null);
+    this(tableConfig, dataTypes, null, Set.of());
   }
 
-  private DataTypeTransformer(TableConfig tableConfig, Map<String, PinotDataType> dataTypes, @Nullable Schema schema) {
+  private DataTypeTransformer(TableConfig tableConfig, Map<String, PinotDataType> dataTypes,
+      @Nullable Schema schema, Set<String> jsonCacheColumns) {
     _dataTypes = dataTypes;
+    _jsonCacheColumns = jsonCacheColumns;
     IngestionConfig ingestionConfig = tableConfig.getIngestionConfig();
     _continueOnError = ingestionConfig != null && ingestionConfig.isContinueOnError();
     _throttledLogger = new ThrottledLogger(LOGGER, ingestionConfig);
@@ -116,6 +129,29 @@ public class DataTypeTransformer implements RecordTransformer {
     return _dataTypes.isEmpty();
   }
 
+  /// Returns the JSON-typed columns that have an (enabled) JSON index, i.e. the columns worth caching the parsed value
+  /// for. If the index configs cannot be resolved, returns an empty set and the optimization is disabled (the JSON
+  /// index simply re-parses the serialized string, as before).
+  private static Set<String> computeJsonCacheColumns(TableConfig tableConfig, Schema schema) {
+    Set<String> columns = new HashSet<>();
+    try {
+      Map<String, FieldIndexConfigs> indexConfigsByColumn =
+          FieldIndexConfigsUtil.createIndexConfigsByColName(tableConfig, schema);
+      for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
+        if (!fieldSpec.isVirtualColumn() && fieldSpec.getDataType() == FieldSpec.DataType.JSON) {
+          FieldIndexConfigs configs = indexConfigsByColumn.get(fieldSpec.getName());
+          if (configs != null && configs.getConfig(StandardIndexes.json()).isEnabled()) {
+            columns.add(fieldSpec.getName());
+          }
+        }
+      }
+    } catch (Exception e) {
+      LOGGER.warn("Failed to compute JSON parse-once cache columns; disabling the optimization", e);
+      return Set.of();
+    }
+    return columns;
+  }
+
   @Override
   public Set<String> getInputColumns() {
     return _dataTypes.keySet();
@@ -131,8 +167,39 @@ public class DataTypeTransformer implements RecordTransformer {
             && value instanceof CharSequence) {
           validateCanonicalUuidPrimaryKey(column, value.toString());
         }
-        value = DataTypeTransformerUtils.transformValue(column, value, entry.getValue());
+        // For a JSON column with a JSON index, cache the parsed value so the index flattens it directly instead of
+        // re-parsing the string the value is serialized into for the forward index. The parsed value is cached AFTER
+        // the forward value is written (below), because putValue invalidates the parsed-JSON cache: a later transformer
+        // that rewrites the value (e.g. sanitization trimming an over-length JSON string) must not leave a stale node.
+        Object parsedToCache = null;
+        if (value != null && !_jsonCacheColumns.isEmpty() && _jsonCacheColumns.contains(column)) {
+          if (value instanceof Map || value instanceof List || value instanceof JsonNode) {
+            // Already-parsed JSON: serialize it for the forward index (below) and cache the parsed value for the index.
+            parsedToCache = value;
+            value = DataTypeTransformerUtils.transformValue(column, value, entry.getValue());
+          } else if (value instanceof String) {
+            // The column value is JSON text. The JSON conversion parses it (preserving BigDecimal) and re-serializes it
+            // to the canonical string for the forward index; the JSON index then re-parses that string. Parse it once
+            // here instead: reuse the node's canonical string for the forward index and cache the node for the index.
+            JsonNode parsed = tryParseJson((String) value);
+            if (parsed != null) {
+              parsedToCache = parsed;
+              // parsed.toString() equals PinotDataType.JSON.convert(value) for well-formed JSON (byte-identical).
+              value = parsed.toString();
+            } else {
+              // Not well-formed JSON: the normal conversion wraps it as a JSON string.
+              value = DataTypeTransformerUtils.transformValue(column, value, entry.getValue());
+            }
+          } else {
+            value = DataTypeTransformerUtils.transformValue(column, value, entry.getValue());
+          }
+        } else {
+          value = DataTypeTransformerUtils.transformValue(column, value, entry.getValue());
+        }
         record.putValue(column, value);
+        if (parsedToCache != null) {
+          record.putParsedJsonValue(column, parsedToCache);
+        }
       } catch (Exception e) {
         if (!_continueOnError) {
           throw new RuntimeException("Caught exception while transforming data type for column: " + column, e);
@@ -176,6 +243,19 @@ public class DataTypeTransformer implements RecordTransformer {
               + (canonical != null ? ": '" + canonical + "'" : " (8-4-4-4-12 dashed lowercase)") + ". "
               + "UUID primary keys must be in canonical lowercase form to ensure consistent Kafka partition "
               + "routing. Non-canonical values cause silent dedup failures in multi-partition realtime tables.");
+    }
+  }
+
+  /// Parses JSON text the way [PinotDataType]'s JSON conversion does (preserving `BigDecimal` floats so the
+  /// canonical string is byte-identical), or returns `null` if the text is not well-formed JSON so the caller
+  /// falls back to the normal conversion (which wraps a non-JSON string as a JSON string).
+  @Nullable
+  private static JsonNode tryParseJson(String jsonText) {
+    try {
+      return JsonUtils.stringToJsonNodeWithBigDecimal(jsonText);
+    } catch (IOException e) {
+      // Not well-formed JSON; let the caller fall back to the normal conversion (which wraps it as a JSON string).
+      return null;
     }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/IndexingFailureTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/IndexingFailureTest.java
@@ -31,6 +31,7 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.stream.StreamMessageMetadata;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -136,5 +137,22 @@ public class IndexingFailureTest implements PinotBuffersAfterMethodCheckRule {
     // null string value skipped
     verify(_serverMetrics, times(1)).addMeteredTableValue(matches("DICTIONARY-indexingError$"),
         eq(ServerMeter.INDEXING_FAILURES), eq(1L));
+  }
+
+  @Test
+  public void testJsonIndexUsesParsedCache()
+      throws IOException {
+    GenericRow row = new GenericRow();
+    row.putValue(INT_COL, 0);
+    row.putValue(STRING_COL, "a");
+    row.putValue(JSON_COL, "not valid json");
+    row.putParsedJsonValue(JSON_COL, JsonUtils.stringToJsonNode("{\"cached\":\"value\"}"));
+
+    _mutableSegment.index(row, METADATA);
+
+    assertEquals(_mutableSegment.getDataSource(JSON_COL).getJsonIndex().getMatchingDocIds("cached = 'value'"),
+        ImmutableRoaringBitmap.bitmapOf(0));
+    verify(_serverMetrics, never()).addMeteredTableValue(matches("indexingError$"), eq(ServerMeter.INDEXING_FAILURES),
+        anyLong());
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/DataTypeTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/DataTypeTransformerTest.java
@@ -18,7 +18,9 @@
  */
 package org.apache.pinot.segment.local.recordtransformer;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,11 +38,104 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertEqualsNoOrder;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 
 public class DataTypeTransformerTest {
   private static final String COLUMN = "testColumn";
+
+  /// The JSON parse-once cache: for a JSON column with a JSON index, the DataTypeTransformer caches the parsed Map on
+  /// the row (so the index can flatten it directly) and still serializes the column value to a string. For a JSON
+  /// column without a JSON index, nothing is cached.
+  @Test
+  public void testJsonParseOnceCache() {
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension("jsonCol", FieldSpec.DataType.JSON).build();
+    Map<String, Object> doc = new HashMap<>();
+    doc.put("a", 1);
+    doc.put("b", "x");
+
+    TableConfig withIndex = new TableConfigBuilder(TableType.OFFLINE).setTableName("t")
+        .setJsonIndexColumns(Collections.singletonList("jsonCol")).build();
+    GenericRow indexed = new GenericRow();
+    indexed.putValue("jsonCol", doc);
+    new DataTypeTransformer(withIndex, schema).transform(indexed);
+    // The column value is serialized for the forward index...
+    assertTrue(indexed.getValue("jsonCol") instanceof String);
+    // ...and the parsed Map is cached for the JSON index to flatten directly.
+    assertEquals(indexed.getParsedJsonValue("jsonCol"), doc);
+
+    // No JSON index on the column -> no caching (the index, if any, would re-parse as before).
+    TableConfig noIndex = new TableConfigBuilder(TableType.OFFLINE).setTableName("t").build();
+    GenericRow unindexed = new GenericRow();
+    unindexed.putValue("jsonCol", doc);
+    new DataTypeTransformer(noIndex, schema).transform(unindexed);
+    assertTrue(unindexed.getValue("jsonCol") instanceof String);
+    assertNull(unindexed.getParsedJsonValue("jsonCol"));
+  }
+
+  /// The common case: a JSON column is fed as JSON text (e.g. a stringified log payload). With a JSON index, the
+  /// transformer parses it once, caches the JsonNode for the index, and the forward-index string is byte-identical to
+  /// the normal conversion. A non-JSON string falls through to the normal conversion with nothing cached.
+  @Test
+  public void testJsonParseOnceCacheFromString() {
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension("jsonCol", FieldSpec.DataType.JSON).build();
+    TableConfig withIndex = new TableConfigBuilder(TableType.OFFLINE).setTableName("t")
+        .setJsonIndexColumns(Collections.singletonList("jsonCol")).build();
+    TableConfig noIndex = new TableConfigBuilder(TableType.OFFLINE).setTableName("t").build();
+
+    // Includes a fractional number (BigDecimal canonicalization) and an integer to cover both flatten paths.
+    for (String json : new String[]{"{\"b\":\"x\",\"a\":1}", "{\"bd\":1234567890.5,\"n\":42}"}) {
+      // Reference: the same column without a JSON index serializes via the normal PinotDataType conversion.
+      GenericRow reference = new GenericRow();
+      reference.putValue("jsonCol", json);
+      new DataTypeTransformer(noIndex, schema).transform(reference);
+      assertNull(reference.getParsedJsonValue("jsonCol"));
+
+      GenericRow row = new GenericRow();
+      row.putValue("jsonCol", json);
+      new DataTypeTransformer(withIndex, schema).transform(row);
+      // Forward-index value is byte-identical to the normal conversion...
+      assertEquals(row.getValue("jsonCol"), reference.getValue("jsonCol"));
+      // ...and the parsed node is cached for the JSON index to flatten directly.
+      assertTrue(row.getParsedJsonValue("jsonCol") instanceof JsonNode);
+    }
+
+    // A non-JSON string is not cached and is serialized exactly as the normal conversion would.
+    GenericRow nonJsonReference = new GenericRow();
+    nonJsonReference.putValue("jsonCol", "not json");
+    new DataTypeTransformer(noIndex, schema).transform(nonJsonReference);
+    GenericRow nonJson = new GenericRow();
+    nonJson.putValue("jsonCol", "not json");
+    new DataTypeTransformer(withIndex, schema).transform(nonJson);
+    assertEquals(nonJson.getValue("jsonCol"), nonJsonReference.getValue("jsonCol"));
+    assertNull(nonJson.getParsedJsonValue("jsonCol"));
+  }
+
+  /// A transformer that runs after DataTypeTransformer and rewrites a JSON column's value must not leave a stale parsed
+  /// node cached: SanitizationTransformer trims an over-length JSON string, which has to invalidate the cache so the
+  /// JSON index re-parses the trimmed forward value instead of flattening the original (full) document.
+  @Test
+  public void testParsedJsonCacheInvalidatedBySanitization() {
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension("jsonCol", FieldSpec.DataType.JSON).build();
+    FieldSpec jsonSpec = schema.getFieldSpecFor("jsonCol");
+    jsonSpec.setMaxLength(8);
+    jsonSpec.setMaxLengthExceedStrategy(FieldSpec.MaxLengthExceedStrategy.TRIM_LENGTH);
+    TableConfig withIndex = new TableConfigBuilder(TableType.OFFLINE).setTableName("t")
+        .setJsonIndexColumns(Collections.singletonList("jsonCol")).build();
+
+    GenericRow row = new GenericRow();
+    row.putValue("jsonCol", "{\"a\":\"averylongvalue\",\"b\":2}");
+    new DataTypeTransformer(withIndex, schema).transform(row);
+    // After type transformation the full parsed node is cached for the JSON index.
+    assertTrue(row.getParsedJsonValue("jsonCol") instanceof JsonNode);
+
+    // Sanitization trims the forward-index string; the stale node must be dropped so the index re-parses the trimmed
+    // value (which the forward index now holds) rather than flattening the full document.
+    new SanitizationTransformer(schema).transform(row);
+    assertTrue(((String) row.getValue("jsonCol")).length() <= 8);
+    assertNull(row.getParsedJsonValue("jsonCol"));
+  }
 
   @Test
   public void testStandardize() {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/JsonIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/JsonIndexTest.java
@@ -96,6 +96,57 @@ public class JsonIndexTest implements PinotBuffersAfterMethodCheckRule {
     FileUtils.deleteDirectory(INDEX_DIR);
   }
 
+  /// The realtime parse-once path must build an identical index: indexing each document via `addParsed(Map)`
+  /// (the cache path) must yield the same matching docIds as `add(String)` (the re-parse path) for every filter.
+  @Test
+  public void testMutableJsonIndexParsedMatchesString()
+      throws Exception {
+    String[] docs = {
+        "{\"name\":\"adam\",\"age\":20,\"addresses\":[{\"country\":\"us\"},{\"country\":\"ca\"}]}",
+        "{\"name\":\"bob\",\"age\":30,\"tags\":[\"x\",\"y\"],\"active\":true}",
+        "{\"name\":\"carol\",\"nested\":{\"a\":1,\"b\":\"z\"}}"
+    };
+    JsonIndexConfig config = new JsonIndexConfig();
+    try (MutableJsonIndexImpl fromString = new MutableJsonIndexImpl(config, "table__0__0", "col");
+        MutableJsonIndexImpl fromParsed = new MutableJsonIndexImpl(config, "table__0__0", "col")) {
+      for (String doc : docs) {
+        fromString.add(doc);
+        fromParsed.addParsed(JsonUtils.stringToObject(doc, Map.class));
+      }
+      for (String filter : new String[]{
+          "name='adam'", "name='bob'", "name='carol'", "age='20'", "age='30'", "active='true'", "name='nobody'"}) {
+        assertEquals(fromParsed.getMatchingDocIds(filter), fromString.getMatchingDocIds(filter), "filter: " + filter);
+      }
+    }
+  }
+
+  /// The JSON-text fast path: a column fed as JSON text is parsed once into a JsonNode (with BigDecimal, as
+  /// PinotDataType does) and that node is fed to the index via `addParsed`. It must yield the same matching docIds
+  /// as re-parsing the serialized string. The docs include a fractional number to exercise the DecimalNode fallback.
+  @Test
+  public void testMutableJsonIndexParsedNodeMatchesString()
+      throws Exception {
+    String[] docs = {
+        "{\"name\":\"adam\",\"age\":20,\"score\":98.6,\"addresses\":[{\"country\":\"us\"},{\"country\":\"ca\"}]}",
+        "{\"name\":\"bob\",\"age\":30,\"tags\":[\"x\",\"y\"],\"active\":true}",
+        "{\"name\":\"carol\",\"nested\":{\"a\":1,\"b\":\"z\"}}"
+    };
+    JsonIndexConfig config = new JsonIndexConfig();
+    try (MutableJsonIndexImpl fromString = new MutableJsonIndexImpl(config, "table__0__0", "col");
+        MutableJsonIndexImpl fromParsed = new MutableJsonIndexImpl(config, "table__0__0", "col")) {
+      for (String doc : docs) {
+        // The forward index stores the canonical string (node.toString()); the index re-parses it on the string path.
+        String canonical = JsonUtils.stringToJsonNodeWithBigDecimal(doc).toString();
+        fromString.add(canonical);
+        fromParsed.addParsed(JsonUtils.stringToJsonNodeWithBigDecimal(doc));
+      }
+      for (String filter : new String[]{
+          "name='adam'", "name='bob'", "name='carol'", "age='20'", "score='98.6'", "active='true'", "name='nobody'"}) {
+        assertEquals(fromParsed.getMatchingDocIds(filter), fromString.getMatchingDocIds(filter), "filter: " + filter);
+      }
+    }
+  }
+
   @Test
   public void testAddRecordWithUnpairedSurrogateDoesNotShiftDocIds()
       throws IOException {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow.java
@@ -66,6 +66,11 @@ public class GenericRow implements Serializable {
   private final Set<String> _nullValueFields = new HashSet<>();
   private boolean _incomplete;
   private boolean _sanitized;
+  /// Transient, per-row cache of already-parsed JSON values (column -> {@code Map}/{@code List}/{@code JsonNode}).
+  /// Populated by the DataTypeTransformer for columns that feed a JSON index, so the index can flatten the parsed
+  /// value directly instead of re-parsing the string the document was just serialized into. Not part of the row's
+  /// value, equality, copy, or serialized state - purely an ingestion-time optimization that is cleared per row.
+  private transient Map<String, Object> _parsedJsonCache;
 
   /// Initializes the generic row from the given generic row (shallow copy). The row should be new created or cleared
   /// before calling this method.
@@ -193,22 +198,52 @@ public class GenericRow implements Serializable {
   /// Sets the value for the given field.
   public void putValue(String fieldName, @Nullable Object value) {
     _fieldToValueMap.put(fieldName, value);
+    invalidateParsedJsonValue(fieldName);
   }
 
   /// Sets the values per the given map from fields to values.
   public void putValues(Map<String, Object> fieldToValueMap) {
     _fieldToValueMap.putAll(fieldToValueMap);
+    if (_parsedJsonCache != null) {
+      _parsedJsonCache.keySet().removeAll(fieldToValueMap.keySet());
+    }
   }
 
   /// Removes the value for the given field.
   public Object removeValue(String fieldName) {
+    invalidateParsedJsonValue(fieldName);
     return _fieldToValueMap.remove(fieldName);
+  }
+
+  /// Caches an already-parsed JSON value for the given field so a downstream JSON index can flatten it directly
+  /// instead of re-parsing the serialized string. See {@link #_parsedJsonCache}.
+  public void putParsedJsonValue(String fieldName, Object parsedValue) {
+    if (_parsedJsonCache == null) {
+      _parsedJsonCache = new HashMap<>();
+    }
+    _parsedJsonCache.put(fieldName, parsedValue);
+  }
+
+  /// Returns the cached already-parsed JSON value for the given field, or {@code null} if none was cached.
+  @Nullable
+  public Object getParsedJsonValue(String fieldName) {
+    return _parsedJsonCache != null ? _parsedJsonCache.get(fieldName) : null;
+  }
+
+  /// Drops any cached parsed JSON value for the given field. Invoked whenever the field's value is overwritten or
+  /// removed so a downstream JSON index never flattens a parsed node that no longer matches the serialized value (for
+  /// example after a sanitization transformer trims an over-length JSON string). See {@link #_parsedJsonCache}.
+  private void invalidateParsedJsonValue(String fieldName) {
+    if (_parsedJsonCache != null) {
+      _parsedJsonCache.remove(fieldName);
+    }
   }
 
   /// Sets the `defaultNullValue` for the given `nullField`.
   public void putDefaultNullValue(String fieldName, Object defaultNullValue) {
     _fieldToValueMap.put(fieldName, defaultNullValue);
     _nullValueFields.add(fieldName);
+    invalidateParsedJsonValue(fieldName);
   }
 
   /// Marks a field as `null`.
@@ -235,6 +270,9 @@ public class GenericRow implements Serializable {
   public void clear() {
     _fieldToValueMap.clear();
     _nullValueFields.clear();
+    if (_parsedJsonCache != null) {
+      _parsedJsonCache.clear();
+    }
     _incomplete = false;
     _sanitized = false;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
@@ -783,6 +783,115 @@ public class JsonUtils {
     }
   }
 
+  /// Flattens an already-parsed JSON value ({@link Map} / {@link List} / {@link JsonNode}) for the JSON index, avoiding
+  /// the string tokenization that {@link #flatten(String, JsonIndexConfig)} performs. Used by the realtime JSON index
+  /// when the source value is already a parsed object (e.g. cached on the `GenericRow` before it is serialized to a
+  /// string for the forward index), so the document is parsed once at ingestion instead of being serialized and
+  /// re-parsed here. The result must match {@link #flatten(String, JsonIndexConfig)} on the serialized form (both go
+  /// through `DEFAULT_MAPPER`). A {@link String} input is delegated to {@link #flatten(String, JsonIndexConfig)}.
+  public static List<Map<String, String>> flattenParsed(Object jsonValue, JsonIndexConfig jsonIndexConfig)
+      throws IOException {
+    if (jsonValue instanceof String) {
+      return flatten((String) jsonValue, jsonIndexConfig);
+    }
+    JsonNode jsonNode = jsonValue instanceof JsonNode ? (JsonNode) jsonValue : DEFAULT_MAPPER.valueToTree(jsonValue);
+    int classification = classifyForFlatten(jsonNode);
+    if (classification == FLATTEN_UNSAFE) {
+      // A leaf renders differently than the string path (e.g. a Float or byte[] from a non-JSON RecordReader). Fall
+      // back to serialize+reparse so the flattened records are byte-for-byte identical. Rare: the JSON decoders never
+      // produce these types.
+      return flatten(objectToString(jsonValue), jsonIndexConfig);
+    }
+    try {
+      // A DecimalNode (a BigDecimal float, e.g. from stringToJsonNodeWithBigDecimal) renders its plain value, but the
+      // string path re-parses it: an integral value becomes an int/long, a fractional one a double (possibly in
+      // scientific notation). Re-parse just those leaves the same way so flatten matches, without re-tokenizing the
+      // whole document as the serialize+reparse fallback would.
+      JsonNode toFlatten =
+          classification == FLATTEN_SAFE_WITH_BIG_DECIMAL ? normalizeBigDecimalNodes(jsonNode) : jsonNode;
+      return JsonUtils.flatten(toFlatten, jsonIndexConfig);
+    } catch (Exception e) {
+      if (jsonIndexConfig.getSkipInvalidJson()) {
+        return SKIPPED_FLATTENED_RECORD;
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  private static final int FLATTEN_UNSAFE = 0;
+  private static final int FLATTEN_SAFE = 1;
+  private static final int FLATTEN_SAFE_WITH_BIG_DECIMAL = 2;
+
+  /// Classifies whether a parsed value can be flattened directly so the records are byte-for-byte identical to
+  /// flattening its serialized string (both paths render each leaf via {@link JsonNode#asText()}). {@code Integer},
+  /// {@code Long}, {@code Double} and {@code BigInteger} nodes render identically to the string path
+  /// ({@link #FLATTEN_SAFE}); a {@code DecimalNode} (a {@code BigDecimal} float) renders its plain value while the
+  /// string path re-parses it (an integral value as an int/long, a fractional one as a double), so it is re-parsed the
+  /// same way first ({@link #FLATTEN_SAFE_WITH_BIG_DECIMAL}, e.g. {@code "2.0"} -> {@code "2"},
+  /// {@code "1234567890.5"} -> {@code "1.2345678905E9"}); a {@code FloatNode} or a binary / POJO node does not
+  /// round-trip and forces the serialize+reparse fallback ({@link #FLATTEN_UNSAFE}). The JSON decoders only produce
+  /// String / Integer / Long / Double / BigInteger / BigDecimal, so a parsed {@link JsonNode} is never
+  /// {@code FLATTEN_UNSAFE}; the fallback only applies to Float / byte[] leaves from a non-JSON RecordReader.
+  private static int classifyForFlatten(JsonNode node) {
+    switch (node.getNodeType()) {
+      case NUMBER:
+        if (node.isFloat()) {
+          return FLATTEN_UNSAFE;
+        }
+        return node.isBigDecimal() ? FLATTEN_SAFE_WITH_BIG_DECIMAL : FLATTEN_SAFE;
+      case OBJECT:
+      case ARRAY: {
+        int result = FLATTEN_SAFE;
+        for (JsonNode child : node) {
+          int childClassification = classifyForFlatten(child);
+          if (childClassification == FLATTEN_UNSAFE) {
+            return FLATTEN_UNSAFE;
+          }
+          if (childClassification == FLATTEN_SAFE_WITH_BIG_DECIMAL) {
+            result = FLATTEN_SAFE_WITH_BIG_DECIMAL;
+          }
+        }
+        return result;
+      }
+      case STRING:
+      case BOOLEAN:
+      case NULL:
+        return FLATTEN_SAFE;
+      default:
+        // BINARY, POJO, MISSING
+        return FLATTEN_UNSAFE;
+    }
+  }
+
+  /// Returns a copy of the tree with every {@code DecimalNode} re-parsed the way the string path does (serialize via
+  /// {@code toString}, parse with the default reader), so {@link #flatten}'s {@code asText()} is identical -- whether
+  /// the value renders as an integer, a double, or in scientific notation -- while sharing all other leaf nodes. Only
+  /// called when the tree actually contains a {@code BigDecimal} node. Using {@code doubleValue()} instead would be
+  /// wrong: an integral decimal ({@code 2.0}) re-parses to an integer ({@code "2"}, not {@code "2.0"}) and values past
+  /// 2^53 would lose precision.
+  private static JsonNode normalizeBigDecimalNodes(JsonNode node)
+      throws IOException {
+    if (node.isBigDecimal()) {
+      return stringToJsonNode(node.toString());
+    }
+    if (node.isObject()) {
+      ObjectNode result = JsonNodeFactory.instance.objectNode();
+      for (Map.Entry<String, JsonNode> field : node.properties()) {
+        result.set(field.getKey(), normalizeBigDecimalNodes(field.getValue()));
+      }
+      return result;
+    }
+    if (node.isArray()) {
+      ArrayNode result = JsonNodeFactory.instance.arrayNode(node.size());
+      for (JsonNode child : node) {
+        result.add(normalizeBigDecimalNodes(child));
+      }
+      return result;
+    }
+    return node;
+  }
+
   /// Generates the JsonSchemaTreeNode tree from the given json index config indexPaths to represent which path we
   /// should flatten/index in the json record.
   /// @param jsonIndexConfig

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/GenericRowTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/GenericRowTest.java
@@ -168,4 +168,40 @@ public class GenericRowTest {
     second.putDefaultNullValue("one", null);
     Assert.assertEquals(first, second);
   }
+
+  @Test
+  public void testParsedJsonValueInvalidatedOnValueChange() {
+    // The parse-once cache must not outlive the value it mirrors: overwriting or removing a field drops its cached
+    // parsed JSON node, so a downstream JSON index never flattens content the serialized value no longer holds.
+    GenericRow row = new GenericRow();
+    row.putValue("j", "{\"a\":1}");
+    row.putParsedJsonValue("j", "parsed-node");
+    Assert.assertNotNull(row.getParsedJsonValue("j"));
+
+    // putValue (e.g. a sanitization transformer trimming the JSON string) invalidates the now-stale node.
+    row.putValue("j", "{\"a\":");
+    Assert.assertNull(row.getParsedJsonValue("j"));
+
+    // putValues invalidates the overwritten keys.
+    row.putParsedJsonValue("j", "parsed-node");
+    HashMap<String, Object> values = new HashMap<>();
+    values.put("j", "x");
+    row.putValues(values);
+    Assert.assertNull(row.getParsedJsonValue("j"));
+
+    // putDefaultNullValue invalidates.
+    row.putParsedJsonValue("j", "parsed-node");
+    row.putDefaultNullValue("j", "default");
+    Assert.assertNull(row.getParsedJsonValue("j"));
+
+    // removeValue invalidates.
+    row.putParsedJsonValue("k", "parsed-node");
+    row.removeValue("k");
+    Assert.assertNull(row.getParsedJsonValue("k"));
+
+    // clear() drops everything for row reuse.
+    row.putParsedJsonValue("m", "parsed-node");
+    row.clear();
+    Assert.assertNull(row.getParsedJsonValue("m"));
+  }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/JsonUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/JsonUtilsTest.java
@@ -22,12 +22,16 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableSet;
 import java.io.File;
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -43,12 +47,86 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertEqualsNoOrder;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 
 public class JsonUtilsTest {
   private static final String JSON_FILE = "json_util_test.json";
+
+  /// The parse-once index path: `flattenParsed(parsedValue)` must produce the same flattened records as the old
+  /// serialize-then-reparse path (the records are a set, so order is ignored). Covers diverse leaf types - including
+  /// non-Jackson types (Float / BigInteger / BigDecimal / large long) that a non-JSON RecordReader could place on a
+  /// JSON column - plus nested objects/arrays, a top-level list, null, and empty containers, across maxLevels.
+  @Test
+  public void testFlattenParsedValueMatchesString()
+      throws Exception {
+    Map<String, Object> nested = new HashMap<>();
+    nested.put("a", "x");
+    nested.put("arr", Arrays.asList(1, 2, 3));
+    Map<String, Object> doc = new HashMap<>();
+    doc.put("s", "line 1\nline 2 \"quoted\" é");
+    doc.put("i", 7);
+    doc.put("lng", 9007199254740993L);
+    doc.put("f", 0.1f);
+    doc.put("d", 3.140625);
+    doc.put("bd", new BigDecimal("1234567890.5"));
+    doc.put("bi", new BigInteger("123456789012345678901234567890"));
+    doc.put("bool", true);
+    doc.put("nul", null);
+    doc.put("obj", nested);
+    doc.put("arrObj", Arrays.asList(Collections.singletonMap("k", "v1"), Collections.singletonMap("k", "v2")));
+    doc.put("empty", new HashMap<>());
+    // The old path serialized the Map (objectToString) and re-parsed it; flattenParsed must match that.
+    String oldPathInput = JsonUtils.objectToString(doc);
+
+    for (int maxLevels : new int[]{-1, 1, 2, 3}) {
+      JsonIndexConfig config = new JsonIndexConfig();
+      config.setMaxLevels(maxLevels);
+      List<Map<String, String>> fromParsed = JsonUtils.flattenParsed(doc, config);
+      List<Map<String, String>> fromString = JsonUtils.flatten(oldPathInput, config);
+      assertEqualsNoOrder(fromParsed.toArray(), fromString.toArray(),
+          "flattenParsed(Map) must match serialize+reparse at maxLevels=" + maxLevels);
+    }
+
+    // Top-level list input (the cache stores List values too).
+    List<Object> topList = Arrays.asList(Collections.singletonMap("k", "a"), Collections.singletonMap("k", "b"));
+    JsonIndexConfig config = new JsonIndexConfig();
+    assertEqualsNoOrder(JsonUtils.flattenParsed(topList, config).toArray(),
+        JsonUtils.flatten(JsonUtils.objectToString(topList), config).toArray());
+  }
+
+  @Test
+  public void testFlattenParsedJsonNodeMatchesString()
+      throws Exception {
+    // A JSON column fed as text (the common case) is parsed once and the JsonNode is cached for the JSON index. The
+    // node is parsed with BigDecimal (matching PinotDataType's JSON canonicalization), so flattenParsed(node) must
+    // match flatten(node.toString()) -- the string the forward index stores and the index used to re-parse.
+    String noDecimal = "{\"s\":\"a\\nb \\\"q\\\"\",\"i\":7,\"lng\":9007199254740993,"
+        + "\"bi\":123456789012345678901234567890,\"bool\":true,\"nul\":null,"
+        + "\"obj\":{\"a\":\"x\",\"arr\":[1,2,3]},\"arr\":[{\"k\":\"v1\"},{\"k\":\"v2\"}]}";
+    // Numbers parse to DecimalNode under BigDecimal, which can render differently than the re-parsed string path: a
+    // fractional value as a double (e.g. "1234567890.5" -> "1.2345678905E9") and an INTEGRAL-valued decimal as an
+    // integer ("2.0" -> "2", not "2.0"; past 2^53 the integer must be preserved exactly). flattenParsed re-parses each
+    // DecimalNode the same way, so it must still match -- across integral, large-magnitude, tiny, high-precision,
+    // exponent, negative, >2^53, nested and array values.
+    String withDecimal = "{\"f\":0.1,\"d\":3.140625,\"bd\":1234567890.5,\"tiny\":0.0000001,"
+        + "\"prec\":3.141592653589793238462643383279,\"neg\":-9876543210.125,\"exp\":1.5e10,"
+        + "\"whole\":2.0,\"negWhole\":-5.0,\"zero\":0.0,\"expWhole\":1.5e1,\"bigWhole\":9007199254740993.0,"
+        + "\"arr\":[0.5,123456.789,2,1234567890.5,7.0,-100.00],\"nested\":{\"x\":98765.4321,\"w\":42.0},"
+        + "\"i\":42,\"s\":\"hi\"}";
+    for (String json : new String[]{noDecimal, withDecimal}) {
+      JsonNode node = JsonUtils.stringToJsonNodeWithBigDecimal(json);
+      for (int maxLevels : new int[]{-1, 1, 2, 3}) {
+        JsonIndexConfig config = new JsonIndexConfig();
+        config.setMaxLevels(maxLevels);
+        assertEqualsNoOrder(JsonUtils.flattenParsed(node, config).toArray(),
+            JsonUtils.flatten(node.toString(), config).toArray(),
+            "flattenParsed(JsonNode) must match flatten(node.toString()) for " + json + " at maxLevels=" + maxLevels);
+      }
+    }
+  }
 
   @Test
   public void testFlatten()


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Parse\-once flow: cache parsed JSON in GenericRow, use it directly in JSON index to avoid re\-parsing\.

```mermaid
flowchart TD
  N0["DataTypeTransformer#46;transform #40;F4#41;"]:::stModified
  N1["GenericRow#46;putParsedJsonValue #47; cache #40;F5#41;"]:::stModified
  N2["MutableSegmentImpl#46;addNewRow #40;indexing#41; #40;F2#41;"]:::stModified
  N3["MutableJsonIndexImpl#46;addParsed #40;F3#41;"]:::stModified
  N4["JsonUtils#46;flattenParsed #40;F6#41;"]:::stModified
  N5["JsonUtils#46;flatten #40;on JsonNode#41; #40;F6#41;"]:::stUnchanged
  N0 -->|"caches parsed JSON"| N1
  N1 -->|"provides cached value"| N2
  N2 -->|"calls addParsed when cache present"| N3
  N3 -->|"delegates flattening"| N4
  N4 -->|"flattens JsonNode"| N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F2: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java) · [after](https://github.com/apache/pinot/blob/cf6b73f11c9eb5149c4d137c5d3afc789e6f8364/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java)
- F3: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/json/MutableJsonIndexImpl\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/json/MutableJsonIndexImpl.java) · [after](https://github.com/apache/pinot/blob/cf6b73f11c9eb5149c4d137c5d3afc789e6f8364/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/json/MutableJsonIndexImpl.java)
- F4: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/DataTypeTransformer\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/DataTypeTransformer.java) · [after](https://github.com/apache/pinot/blob/cf6b73f11c9eb5149c4d137c5d3afc789e6f8364/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/DataTypeTransformer.java)
- F5: pinot\-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow.java) · [after](https://github.com/apache/pinot/blob/cf6b73f11c9eb5149c4d137c5d3afc789e6f8364/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow.java)
- F6: pinot\-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java) · [after](https://github.com/apache/pinot/blob/cf6b73f11c9eb5149c4d137c5d3afc789e6f8364/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImU2Nzg3ZTE3ODY0NWZkM2M1YTg4N2UyYWJhN2UwZGU4MzQzY2Q1MjQiLCJjb250ZXh0X2hhc2giOiIyYTc3OWIyYjFmYzRmYzU0YzFjYWI3NjY0MDIwOWM1MWQ2YmExMzVjNDI5ZDY4OTVjYWFkMTc1NzU4MWEwN2RhIiwiZ2VuZXJhdGVkX2F0IjoxNzg4OTAzMDk3LCJoZWFkX3NoYSI6ImNmNmI3M2YxMWM5ZWI1MTQ5YzRkMTM3YzVkM2FmYzc4OWU2ZjgzNjQiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJlNjc4N2UxNzg2NDVmZDNjNWE4ODdlMmFiYTdlMGRlODM0M2NkNTI0IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 816e3ae6a33e64356fd736be6c11b8fc017d202bfb01f5c6b97afafcf858594e -->
<!-- pinot-pr-flow:end -->

## What

A `dataType: JSON` column with a JSON index currently pays a **serialize -> re-parse round-trip** per row: `DataTypeTransformer` serializes the parsed JSON value to the forward-index string, and the mutable JSON index then re-parses that same string before flattening it.

This PR keeps a transient parsed-value cache on the `GenericRow` for JSON columns that have Pinot's built-in `json` index enabled, then feeds that cached value directly to `MutableJsonIndexImpl`:

- `GenericRow` stores a transient per-row parsed JSON cache. It is not part of row value/equality/copy/serialized state and is invalidated when the column value changes.
- `DataTypeTransformer` populates the cache only for `dataType: JSON` columns with the built-in JSON index enabled.
- `MutableSegmentImpl` passes the cached parsed value to `MutableJsonIndexImpl.addParsed(...)` when present; otherwise indexing uses the existing string path.
- `JsonUtils.flattenParsed(Object, JsonIndexConfig)` flattens a parsed `Map` / `List` / `JsonNode` while preserving the old string-path output.
- `BenchmarkJsonFlatten` now runs the same benchmark over multiple payload sizes (`330`, `2900`, `8000` bytes).

## User Manual / Sample Config

No new table config is introduced. Existing realtime tables with JSON columns and Pinot's built-in JSON index benefit automatically.

```json
{
  "tableName": "logs_REALTIME",
  "tableType": "REALTIME",
  "indexingConfig": {
    "jsonIndexColumns": ["payload"]
  }
}
```

The optimization is intentionally scoped to the built-in `json` index implementation. Plugin/custom JSON-like indexes continue to receive the serialized string path.

## Behavior-preserving

- `flattenParsed` is tested to produce the same flattened records as `flatten(String, JsonIndexConfig)` on the serialized form, including nested objects/arrays, top-level arrays, `JsonNode`, `BigDecimal`, `BigInteger`, floats, nulls, max levels, and JSON index matching.
- For leaf values that do not round-trip identically through Jackson's tree model, `flattenParsed` falls back to serialize+reparse so the JSON index output remains identical to today's behavior.
- Cached parsed values are invalidated when a row value is overwritten, removed, default-null-filled, bulk-updated, cleared, or sanitized after type transformation.
- `IndexingFailureTest#testJsonIndexUsesParsedCache` covers the segment-level path where a cached `JsonNode` is indexed via `MutableSegmentImpl`.

## Performance (`BenchmarkJsonFlatten`)

Validated with the checked-in JMH benchmark on JDK 21:

```text
-wi 3 -i 5 -f 1 -w 2s -r 2s
```

The benchmark isolates JSON flatten/index-input cost and separately measures `serializeMap`, which still remains because the forward index stores the serialized JSON string. The last column combines `serializeMap` with flattening as a harmonic throughput estimate for the full Map-input path.

| payload | re-parse flatten | parsed flatten | serialize map | flatten-only gain | estimated serialize+flatten gain |
|---|---:|---:|---:|---:|---:|
| ~330 B | 314 ops/ms | 588 ops/ms | 872 ops/ms | 1.87x | 1.52x |
| ~2.9 KB | 83 ops/ms | 535 ops/ms | 265 ops/ms | 6.44x | 2.80x |
| ~8 KB | 69 ops/ms | 226 ops/ms | 260 ops/ms | 3.26x | 2.21x |


The local machine was noisy, but the payload-size trend is consistent: avoiding the string re-tokenization is most valuable as payload size grows.

## API Surface

No `MutableJsonIndex` SPI change remains after review simplification. The additive public surface is limited to:

- `GenericRow` parsed JSON cache accessors.
- `JsonUtils.flattenParsed(Object, JsonIndexConfig)`.
- `MutableJsonIndexImpl.addParsed(Object)` as an implementation method used by `MutableSegmentImpl`.

## Validation

- `GITHUB_ACTIONS=true ./mvnw -pl pinot-spi,pinot-segment-local -am -Dtest=JsonUtilsTest,GenericRowTest,DataTypeTransformerTest,JsonIndexTest,IndexingFailureTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `GITHUB_ACTIONS=true ./mvnw -pl pinot-segment-local -am -Dtest=IndexingFailureTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `GITHUB_ACTIONS=true ./mvnw spotless:apply -pl pinot-segment-local,pinot-spi,pinot-perf`
- `GITHUB_ACTIONS=true ./mvnw checkstyle:check -pl pinot-segment-local,pinot-spi,pinot-perf`
- `GITHUB_ACTIONS=true ./mvnw license:format -pl pinot-segment-local,pinot-spi,pinot-perf`
- `GITHUB_ACTIONS=true ./mvnw license:check -pl pinot-segment-local,pinot-spi,pinot-perf`
