### PR TITLE
Add dictionary-based TEXT index option (buildOnDictionary)

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/TextMatchDictIdPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/TextMatchDictIdPredicateEvaluatorFactory.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.filter.predicate;
+
+import org.apache.pinot.common.request.context.predicate.TextMatchPredicate;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.segment.spi.index.reader.TextIndexReader;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+
+
+/// Factory for TEXT_MATCH predicate evaluators backed by a dictionary-based text index (see
+/// [TextIndexReader#isBuildOnDictionary()]). The text index returns the matching dictionary ids, which the
+/// standard dictionary-based filter operators (inverted index / scan) resolve to document ids. This mirrors
+/// [FSTBasedRegexpPredicateEvaluatorFactory].
+public class TextMatchDictIdPredicateEvaluatorFactory {
+  private TextMatchDictIdPredicateEvaluatorFactory() {
+  }
+
+  /// Creates a predicate evaluator that matches the TEXT_MATCH query using the dictionary-based text index.
+  ///
+  /// @param textMatchPredicate TEXT_MATCH predicate to evaluate
+  /// @param textIndexReader dictionary-based text index reader
+  /// @param dictionary dictionary for the column
+  /// @return predicate evaluator
+  public static BaseDictionaryBasedPredicateEvaluator newDictIdBasedEvaluator(TextMatchPredicate textMatchPredicate,
+      TextIndexReader textIndexReader, Dictionary dictionary) {
+    return new TextMatchDictIdPredicateEvaluator(textMatchPredicate, textIndexReader, dictionary);
+  }
+
+  private static class TextMatchDictIdPredicateEvaluator extends BaseDictionaryBasedPredicateEvaluator {
+    final ImmutableRoaringBitmap _matchingDictIdBitmap;
+
+    public TextMatchDictIdPredicateEvaluator(TextMatchPredicate textMatchPredicate, TextIndexReader textIndexReader,
+        Dictionary dictionary) {
+      super(textMatchPredicate, dictionary);
+      _matchingDictIdBitmap = textIndexReader.getDictIds(textMatchPredicate.getValue());
+      int numMatchingDictIds = _matchingDictIdBitmap.getCardinality();
+      if (numMatchingDictIds == 0) {
+        _alwaysFalse = true;
+      } else if (dictionary.length() == numMatchingDictIds) {
+        _alwaysTrue = true;
+      }
+    }
+
+    @Override
+    protected int[] calculateMatchingDictIds() {
+      return _matchingDictIdBitmap.toArray();
+    }
+
+    @Override
+    public boolean applySV(int dictId) {
+      return _matchingDictIdBitmap.contains(dictId);
+    }
+
+    @Override
+    public int applySV(int limit, int[] docIds, int[] values) {
+      // reimplemented here to ensure applySV can be inlined
+      int matches = 0;
+      for (int i = 0; i < limit; i++) {
+        int value = values[i];
+        if (applySV(value)) {
+          docIds[matches++] = docIds[i];
+        }
+      }
+      return matches;
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -55,6 +55,7 @@ import org.apache.pinot.core.operator.filter.VectorSearchStrategy;
 import org.apache.pinot.core.operator.filter.VectorSimilarityFilterOperator;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluatorProvider;
+import org.apache.pinot.core.operator.filter.predicate.TextMatchDictIdPredicateEvaluatorFactory;
 import org.apache.pinot.core.operator.transform.function.ItemTransformFunction;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.IndexSegment;
@@ -286,6 +287,19 @@ public class FilterPlanNode implements PlanNode {
 
               Preconditions.checkState(textIndexReader != null,
                   "Cannot apply TEXT_MATCH on column: %s without text index", column);
+
+              if (textIndexReader.isBuildOnDictionary()) {
+                // Dictionary-based text index: search returns matching dictIds, resolved to docIds by the standard
+                // dictionary-based filter operators (inverted index / scan), exactly like FST/REGEXP_LIKE.
+                TextMatchPredicate textMatchPredicate = (TextMatchPredicate) predicate;
+                Preconditions.checkState(textMatchPredicate.getOptions() == null,
+                    "TEXT_MATCH options are not supported for a dictionary-based text index on column: %s", column);
+                predicateEvaluator = TextMatchDictIdPredicateEvaluatorFactory.newDictIdBasedEvaluator(
+                    textMatchPredicate, textIndexReader, dataSource.getDictionary());
+                _predicateEvaluators.add(Pair.of(predicate, predicateEvaluator));
+                return FilterOperatorUtils.getLeafFilterOperator(_queryContext, predicateEvaluator, dataSource,
+                    numDocs);
+              }
 
               if (textIndexReader.isMultiColumn()) {
                 return new TextMatchFilterOperator(column, textIndexReader, (TextMatchPredicate) predicate, numDocs);

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -55,6 +55,7 @@ import org.apache.pinot.core.operator.filter.VectorSearchStrategy;
 import org.apache.pinot.core.operator.filter.VectorSimilarityFilterOperator;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluatorProvider;
+import org.apache.pinot.core.operator.filter.predicate.TextMatchDictIdPredicateEvaluatorFactory;
 import org.apache.pinot.core.operator.transform.function.ItemTransformFunction;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.IndexSegment;
@@ -305,6 +306,19 @@ public class FilterPlanNode implements PlanNode {
 
               Preconditions.checkState(textIndexReader != null,
                   "Cannot apply TEXT_MATCH on column: %s without text index", column);
+
+              if (textIndexReader.isBuildOnDictionary()) {
+                // Dictionary-based text index: search returns matching dictIds, resolved to docIds by the standard
+                // dictionary-based filter operators (inverted index / scan), exactly like FST/REGEXP_LIKE.
+                TextMatchPredicate textMatchPredicate = (TextMatchPredicate) predicate;
+                Preconditions.checkState(textMatchPredicate.getOptions() == null,
+                    "TEXT_MATCH options are not supported for a dictionary-based text index on column: %s", column);
+                predicateEvaluator = TextMatchDictIdPredicateEvaluatorFactory.newDictIdBasedEvaluator(
+                    textMatchPredicate, textIndexReader, dataSource.getDictionary());
+                _predicateEvaluators.add(Pair.of(predicate, predicateEvaluator));
+                return FilterOperatorUtils.getLeafFilterOperator(_queryContext, predicateEvaluator, dataSource,
+                    numDocs);
+              }
 
               if (textIndexReader.isMultiColumn()) {
                 return new TextMatchFilterOperator(column, textIndexReader, (TextMatchPredicate) predicate, numDocs);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DictionaryBasedTextIndexQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DictionaryBasedTextIndexQueriesTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.queries;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +49,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -284,6 +286,38 @@ public class DictionaryBasedTextIndexQueriesTest extends BaseQueriesTest {
       dictBased.destroy();
       _indexSegment = null;
     }
+  }
+
+  @Test
+  public void segmentWithoutPersistedFlagReadsAsPerRow()
+      throws Exception {
+    // Build a per-row segment, then strip the buildOnDictionary key from its persisted properties to simulate a
+    // segment written before this feature existed.
+    buildAndLoad("preFeature", false).destroy();
+    for (File propsFile : FileUtils.listFiles(new File(INDEX_DIR, "preFeature"), new String[]{"properties"}, true)) {
+      if (propsFile.getName().equals("lucene.properties")) {
+        List<String> kept = new ArrayList<>();
+        for (String line : FileUtils.readLines(propsFile, StandardCharsets.UTF_8)) {
+          if (!line.contains(FieldConfig.TEXT_INDEX_BUILD_ON_DICTIONARY)) {
+            kept.add(line);
+          }
+        }
+        FileUtils.writeLines(propsFile, kept);
+      }
+    }
+
+    // Reload under a table config that turns buildOnDictionary ON. The segment self-describes, so it must still be
+    // read as per-row (the build mode comes from the segment, not the live table config).
+    ImmutableSegment segment = ImmutableSegmentLoader.load(new File(INDEX_DIR, "preFeature"),
+        new IndexLoadingConfig(tableConfig(true), SCHEMA));
+    _indexSegment = segment;
+    _indexSegments = List.of(segment);
+    assertFalse(segment.getDataSource(SV_COL).getTextIndex().isBuildOnDictionary(),
+        "A segment whose persisted properties lack the flag must be read as per-row, regardless of table config");
+    assertEquals(count("SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + SV_COL + ", 'apple')"),
+        NUM_ROWS / SV_TOKENS.length);
+    segment.destroy();
+    _indexSegment = null;
   }
 
   private static long countMv(int mod) {

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DictionaryBasedTextIndexQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DictionaryBasedTextIndexQueriesTest.java
@@ -121,7 +121,13 @@ public class DictionaryBasedTextIndexQueriesTest extends BaseQueriesTest {
   }
 
   private TableConfig tableConfig(boolean buildOnDictionary) {
-    Map<String, String> props = Map.of(FieldConfig.TEXT_INDEX_BUILD_ON_DICTIONARY, Boolean.toString(buildOnDictionary));
+    return tableConfig(buildOnDictionary, false);
+  }
+
+  private TableConfig tableConfig(boolean buildOnDictionary, boolean storeInSegmentFile) {
+    Map<String, String> props = Map.of(
+        FieldConfig.TEXT_INDEX_BUILD_ON_DICTIONARY, Boolean.toString(buildOnDictionary),
+        "storeInSegmentFile", Boolean.toString(storeInSegmentFile));
     List<FieldConfig> fieldConfigs = List.of(
         new FieldConfig(SV_COL, EncodingType.DICTIONARY, List.of(IndexType.TEXT), null, props),
         new FieldConfig(MV_COL, EncodingType.DICTIONARY, List.of(IndexType.TEXT), null, props));
@@ -130,7 +136,12 @@ public class DictionaryBasedTextIndexQueriesTest extends BaseQueriesTest {
 
   private ImmutableSegment buildAndLoad(String segmentName, boolean buildOnDictionary)
       throws Exception {
-    TableConfig tableConfig = tableConfig(buildOnDictionary);
+    return buildAndLoad(segmentName, buildOnDictionary, false);
+  }
+
+  private ImmutableSegment buildAndLoad(String segmentName, boolean buildOnDictionary, boolean storeInSegmentFile)
+      throws Exception {
+    TableConfig tableConfig = tableConfig(buildOnDictionary, storeInSegmentFile);
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, SCHEMA);
     config.setOutDir(INDEX_DIR.getPath());
     config.setTableName(TABLE_NAME);
@@ -286,6 +297,44 @@ public class DictionaryBasedTextIndexQueriesTest extends BaseQueriesTest {
       dictBased.destroy();
       _indexSegment = null;
     }
+  }
+
+  @Test
+  public void dictionaryBasedTextMatchWithStoreInSegmentFile()
+      throws Exception {
+    // storeInSegmentFile packs the Lucene index into the segment's single file, exercising the buffer-based reader
+    // path (LuceneTextIndexReader buffer constructor + buffer property overlay) in dictionary mode.
+    ImmutableSegment perRow = buildAndLoad("perRowSif", false, true);
+    _indexSegment = perRow;
+    _indexSegments = List.of(perRow);
+    long svCount = count("SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + SV_COL + ", 'apple')");
+    long mvCount = count("SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + MV_COL + ", 'green')");
+    perRow.destroy();
+
+    ImmutableSegment dictBased = buildAndLoad("dictSif", true, true);
+    _indexSegment = dictBased;
+    _indexSegments = List.of(dictBased);
+    assertTrue(dictBased.getDataSource(SV_COL).getTextIndex().isBuildOnDictionary(),
+        "store-in-segment-file segment should still self-describe as dictionary-based");
+    assertEquals(count("SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + SV_COL + ", 'apple')"), svCount);
+    assertEquals(count("SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + MV_COL + ", 'green')"), mvCount);
+    dictBased.destroy();
+    _indexSegment = null;
+  }
+
+  @Test
+  public void dictionaryBasedTextMatchMatchingAllValues()
+      throws Exception {
+    // Matching every distinct dictionary value exercises the always-true short-circuit in the dict-id evaluator.
+    ImmutableSegment dictBased = buildAndLoad("dictAll", true);
+    _indexSegment = dictBased;
+    _indexSegments = List.of(dictBased);
+    // MV distinct values are {fruit, red, green, blue}; OR-ing all of them matches every distinct dictId, so every
+    // row matches.
+    assertEquals(count("SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + MV_COL
+        + ", 'fruit OR red OR green OR blue')"), NUM_ROWS);
+    dictBased.destroy();
+    _indexSegment = null;
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DictionaryBasedTextIndexQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DictionaryBasedTextIndexQueriesTest.java
@@ -1,0 +1,298 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.FieldConfig.EncodingType;
+import org.apache.pinot.spi.config.table.FieldConfig.IndexType;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+
+/// Verifies that a dictionary-based TEXT index (`buildOnDictionary = true`) returns the same `TEXT_MATCH`
+/// results as the default per-row TEXT index, for both single-value and multi-value STRING columns. The
+/// dictionary-based index returns matching dictIds that are resolved to docIds by the standard dictionary-based
+/// filter operators; this test confirms that resolution is correct end-to-end.
+public class DictionaryBasedTextIndexQueriesTest extends BaseQueriesTest {
+  private static final File INDEX_DIR =
+      new File(FileUtils.getTempDirectory(), DictionaryBasedTextIndexQueriesTest.class.getSimpleName());
+  private static final String TABLE_NAME = "testTable";
+  private static final String SV_COL = "SV_TEXT";
+  private static final String MV_COL = "MV_TEXT";
+  private static final String INT_COL = "INT_COL";
+  private static final int NUM_ROWS = 1000;
+
+  // SV value cycles over 5 distinct tokens; MV value pairs a constant token with a cycling token.
+  private static final String[] SV_TOKENS = {"apple", "banana", "cherry", "date", "elderberry"};
+  private static final String[] MV_TOKENS = {"red", "green", "blue"};
+
+  private static final Schema SCHEMA = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+      .addSingleValueDimension(SV_COL, FieldSpec.DataType.STRING)
+      .addMultiValueDimension(MV_COL, FieldSpec.DataType.STRING)
+      .addMetric(INT_COL, FieldSpec.DataType.INT)
+      .build();
+
+  private IndexSegment _indexSegment;
+  private List<IndexSegment> _indexSegments;
+
+  @Override
+  protected String getFilter() {
+    return "";
+  }
+
+  @Override
+  protected IndexSegment getIndexSegment() {
+    return _indexSegment;
+  }
+
+  @Override
+  protected List<IndexSegment> getIndexSegments() {
+    return _indexSegments;
+  }
+
+  @BeforeClass
+  public void setUp() {
+    FileUtils.deleteQuietly(INDEX_DIR);
+  }
+
+  @AfterClass
+  public void tearDown() {
+    if (_indexSegment != null) {
+      _indexSegment.destroy();
+    }
+    FileUtils.deleteQuietly(INDEX_DIR);
+  }
+
+  private static List<GenericRow> createTestData() {
+    List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      GenericRow row = new GenericRow();
+      row.putValue(SV_COL, SV_TOKENS[i % SV_TOKENS.length]);
+      row.putValue(MV_COL, new String[]{"fruit", MV_TOKENS[i % MV_TOKENS.length]});
+      row.putValue(INT_COL, i);
+      rows.add(row);
+    }
+    return rows;
+  }
+
+  private TableConfig tableConfig(boolean buildOnDictionary) {
+    Map<String, String> props = Map.of(FieldConfig.TEXT_INDEX_BUILD_ON_DICTIONARY, Boolean.toString(buildOnDictionary));
+    List<FieldConfig> fieldConfigs = List.of(
+        new FieldConfig(SV_COL, EncodingType.DICTIONARY, List.of(IndexType.TEXT), null, props),
+        new FieldConfig(MV_COL, EncodingType.DICTIONARY, List.of(IndexType.TEXT), null, props));
+    return new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setFieldConfigList(fieldConfigs).build();
+  }
+
+  private ImmutableSegment buildAndLoad(String segmentName, boolean buildOnDictionary)
+      throws Exception {
+    TableConfig tableConfig = tableConfig(buildOnDictionary);
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, SCHEMA);
+    config.setOutDir(INDEX_DIR.getPath());
+    config.setTableName(TABLE_NAME);
+    config.setSegmentName(segmentName);
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    try (RecordReader recordReader = new GenericRowRecordReader(createTestData())) {
+      driver.init(config, recordReader);
+      driver.build();
+    }
+    return ImmutableSegmentLoader.load(new File(INDEX_DIR, segmentName),
+        new IndexLoadingConfig(tableConfig, SCHEMA));
+  }
+
+  private long count(String query) {
+    AggregationResultsBlock block = (AggregationResultsBlock) ((Operator) getOperator(query)).nextBlock();
+    return ((Number) block.getResults().get(0)).longValue();
+  }
+
+  @Test
+  public void dictionaryBasedTextMatchEqualsPerRow()
+      throws Exception {
+    String[] queries = {
+        "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + SV_COL + ", 'apple')",
+        "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + SV_COL + ", 'cherry')",
+        "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + SV_COL + ", 'missing')",
+        "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + MV_COL + ", 'fruit')",
+        "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + MV_COL + ", 'green')",
+        "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + MV_COL + ", 'red OR blue')"
+    };
+    // Expected counts derived from the deterministic data generator.
+    long[] expected = {
+        NUM_ROWS / SV_TOKENS.length,          // 'apple' -> i % 5 == 0
+        NUM_ROWS / SV_TOKENS.length,          // 'cherry' -> i % 5 == 2
+        0,                                    // not present
+        NUM_ROWS,                             // 'fruit' present in every MV row
+        countMv(1),                           // 'green' -> i % 3 == 1
+        countMv(0) + countMv(2)               // 'red' (i%3==0) OR 'blue' (i%3==2)
+    };
+
+    // Per-row index results (the reference) ...
+    ImmutableSegment perRow = buildAndLoad("perRow", false);
+    _indexSegment = perRow;
+    _indexSegments = List.of(perRow);
+    long[] perRowCounts = new long[queries.length];
+    for (int i = 0; i < queries.length; i++) {
+      perRowCounts[i] = count(queries[i]);
+      assertEquals(perRowCounts[i], expected[i], "Per-row count mismatch for: " + queries[i]);
+    }
+    perRow.destroy();
+
+    // ... must equal the dictionary-based index results.
+    ImmutableSegment dictBased = buildAndLoad("dictBased", true);
+    _indexSegment = dictBased;
+    _indexSegments = List.of(dictBased);
+    for (int i = 0; i < queries.length; i++) {
+      assertEquals(count(queries[i]), perRowCounts[i], "Dictionary-based count mismatch for: " + queries[i]);
+    }
+    dictBased.destroy();
+    _indexSegment = null;
+  }
+
+  @Test
+  public void dictionaryBasedIndexIsSmallerForLowCardinality()
+      throws Exception {
+    // The SV column has only 5 distinct values across 1000 rows, so the dictionary-based text index (5 Lucene docs)
+    // must be smaller than the per-row text index (1000 Lucene docs).
+    ImmutableSegment perRow = buildAndLoad("perRowSize", false);
+    long perRowSize = FileUtils.sizeOfDirectory(new File(INDEX_DIR, "perRowSize"));
+    perRow.destroy();
+    ImmutableSegment dictBased = buildAndLoad("dictSize", true);
+    long dictSize = FileUtils.sizeOfDirectory(new File(INDEX_DIR, "dictSize"));
+    dictBased.destroy();
+    _indexSegment = null;
+    assertTrue(dictSize < perRowSize,
+        "Expected dictionary-based segment (" + dictSize + ") < per-row segment (" + perRowSize + ")");
+  }
+
+  @Test
+  public void reloadBuildsDictionaryBasedTextIndex()
+      throws Exception {
+    // Build a segment with NO text index (dictionary-encoded columns only) ...
+    TableConfig noTextConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(noTextConfig, SCHEMA);
+    config.setOutDir(INDEX_DIR.getPath());
+    config.setTableName(TABLE_NAME);
+    config.setSegmentName("reload");
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    try (RecordReader recordReader = new GenericRowRecordReader(createTestData())) {
+      driver.init(config, recordReader);
+      driver.build();
+    }
+
+    // ... then reload with a buildOnDictionary text index, which the SegmentPreProcessor (TextIndexHandler) builds
+    // by looping the dictionary.
+    ImmutableSegment segment = ImmutableSegmentLoader.load(new File(INDEX_DIR, "reload"),
+        new IndexLoadingConfig(tableConfig(true), SCHEMA));
+    _indexSegment = segment;
+    _indexSegments = List.of(segment);
+
+    assertTrue(segment.getDataSource(SV_COL).getTextIndex().isBuildOnDictionary(),
+        "Reloaded text index should be dictionary-based");
+    assertEquals(count("SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + SV_COL + ", 'apple')"),
+        NUM_ROWS / SV_TOKENS.length);
+    assertEquals(count("SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + MV_COL + ", 'green')"),
+        countMv(1));
+    assertEquals(count("SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + MV_COL + ", 'fruit')"), NUM_ROWS);
+
+    segment.destroy();
+    _indexSegment = null;
+  }
+
+  @Test
+  public void buildOnDictionaryRequiresDictionaryEncoding()
+      throws Exception {
+    // A raw (non-dictionary) column with buildOnDictionary=true must fail the build, protecting the docId==dictId
+    // invariant.
+    Map<String, String> props = Map.of(FieldConfig.TEXT_INDEX_BUILD_ON_DICTIONARY, "true");
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setNoDictionaryColumns(List.of(SV_COL))
+        .setFieldConfigList(List.of(new FieldConfig(SV_COL, EncodingType.RAW, List.of(IndexType.TEXT), null, props)))
+        .build();
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, SCHEMA);
+    config.setOutDir(INDEX_DIR.getPath());
+    config.setTableName(TABLE_NAME);
+    config.setSegmentName("raw");
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    try (RecordReader recordReader = new GenericRowRecordReader(createTestData())) {
+      driver.init(config, recordReader);
+      driver.build();
+      fail("Expected build to fail for buildOnDictionary on a raw-encoded column");
+    } catch (Exception e) {
+      assertTrue(ExceptionUtils.getStackTrace(e).contains("buildOnDictionary"),
+          "Expected a buildOnDictionary dictionary-required failure, got: " + e);
+    }
+  }
+
+  @Test
+  public void dictionaryBasedTextMatchRejectsOptions()
+      throws Exception {
+    ImmutableSegment dictBased = buildAndLoad("dictOptions", true);
+    _indexSegment = dictBased;
+    _indexSegments = List.of(dictBased);
+    try {
+      // TEXT_MATCH options are not supported by the dictionary-based path (getDictIds takes only the query value).
+      getOperator(
+          "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + SV_COL + ", 'apple', 'parser=CLASSIC')");
+      fail("Expected TEXT_MATCH with options to be rejected for a dictionary-based text index");
+    } catch (Exception e) {
+      assertTrue(ExceptionUtils.getStackTrace(e).contains("options are not supported"),
+          "Expected an options-not-supported failure, got: " + e);
+    } finally {
+      dictBased.destroy();
+      _indexSegment = null;
+    }
+  }
+
+  private static long countMv(int mod) {
+    long count = 0;
+    for (int i = 0; i < NUM_ROWS; i++) {
+      if (i % MV_TOKENS.length == mod) {
+        count++;
+      }
+    }
+    return count;
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/LuceneTextIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/LuceneTextIndexCreator.java
@@ -66,6 +66,9 @@ public class LuceneTextIndexCreator extends AbstractTextIndexCreator {
   private final TextIndexConfig _config;
   private final File _indexFile;
   private final boolean _reuseMutableIndex;
+  // When true, the index is built over the column dictionary (one document per distinct value, fed via add(String)),
+  // so the per-row IndexCreator entry points (add(Object, int) / add(Object[], int[])) are no-ops.
+  private final boolean _buildOnDictionary;
   private Directory _indexDirectory;
   private IndexWriter _indexWriter;
   private int _nextDocId = 0;
@@ -115,6 +118,10 @@ public class LuceneTextIndexCreator extends AbstractTextIndexCreator {
     _combineAndCleanupFiles = combineAndCleanupFiles;
     _segmentDirectory = segmentIndexDir;
     _config = config;
+    // Dictionary-based indexing only applies to immutable segments (commit == true): offline creation and the
+    // realtime-to-offline conversion. A consuming (mutable) segment has no immutable dictionary, so it always builds
+    // the per-row index regardless of the flag.
+    _buildOnDictionary = config.isBuildOnDictionary() && commit;
     String luceneAnalyzerClass = config.getLuceneAnalyzerClass();
     try {
       // segment generation is always in V1 and later we convert (as part of post creation processing)
@@ -145,7 +152,10 @@ public class LuceneTextIndexCreator extends AbstractTextIndexCreator {
       // 1. Not the realtime index, i.e. commit is set to true
       // 2. Happens during realtime segment conversion
       // 3. Mutable segment not compacted
-      _reuseMutableIndex = config.isReuseMutableIndex() && commit && realtimeConversion && !mutableSegmentCompacted;
+      // 4. Not a dictionary-based index: the mutable index is per-row, so a dictionary-based immutable index must be
+      //    rebuilt from the sealed dictionary rather than reusing the mutable index.
+      _reuseMutableIndex = config.isReuseMutableIndex() && commit && realtimeConversion && !mutableSegmentCompacted
+          && !_buildOnDictionary;
       if (_reuseMutableIndex) {
         LOGGER.info("Reusing the realtime lucene index for segment {} and column {}", segmentIndexDir, column);
         indexWriterConfig.setOpenMode(IndexWriterConfig.OpenMode.CREATE_OR_APPEND);
@@ -287,6 +297,23 @@ public class LuceneTextIndexCreator extends AbstractTextIndexCreator {
     } finally {
       indexReader.close();
     }
+  }
+
+  @Override
+  public void add(Object value, int dictId) {
+    // In dictionary mode the index is built once from the dictionary (via add(String)); ignore the per-row callbacks.
+    if (_buildOnDictionary) {
+      return;
+    }
+    super.add(value, dictId);
+  }
+
+  @Override
+  public void add(Object[] values, @Nullable int[] dictIds) {
+    if (_buildOnDictionary) {
+      return;
+    }
+    super.add(values, dictIds);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/TextIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/TextIndexHandler.java
@@ -234,7 +234,15 @@ public class TextIndexHandler extends BaseIndexHandler {
         _fieldIndexConfigs.get(columnMetadata.getColumnName()), columnMetadata);
         ForwardIndexReaderContext readerContext = forwardIndexReader.createContext();
         TextIndexCreator textIndexCreator = StandardIndexes.text().createIndexCreator(context, config)) {
-      if (columnMetadata.isSingleValue()) {
+      if (config.isBuildOnDictionary()) {
+        // Dictionary-based text index: build one Lucene document per distinct value (Lucene docId == dictId),
+        // independent of single/multi-value. Mirrors FSTIndexHandler. Requires a dictionary (validated upstream).
+        try (Dictionary dictionary = DictionaryIndexType.read(segmentWriter, columnMetadata)) {
+          for (int dictId = 0; dictId < dictionary.length(); dictId++) {
+            textIndexCreator.add(dictionary.getStringValue(dictId));
+          }
+        }
+      } else if (columnMetadata.isSingleValue()) {
         processSVField(segmentWriter, hasDictionary, forwardIndexReader, readerContext, textIndexCreator, numDocs,
             columnMetadata);
       } else {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/TextIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/TextIndexHandler.java
@@ -233,7 +233,15 @@ public class TextIndexHandler extends BaseIndexHandler {
         _fieldIndexConfigs.get(columnMetadata.getColumnName()), columnMetadata);
         ForwardIndexReaderContext readerContext = forwardIndexReader.createContext();
         TextIndexCreator textIndexCreator = StandardIndexes.text().createIndexCreator(context, config)) {
-      if (columnMetadata.isSingleValue()) {
+      if (config.isBuildOnDictionary()) {
+        // Dictionary-based text index: build one Lucene document per distinct value (Lucene docId == dictId),
+        // independent of single/multi-value. Mirrors FSTIndexHandler. Requires a dictionary (validated upstream).
+        try (Dictionary dictionary = DictionaryIndexType.read(segmentWriter, columnMetadata)) {
+          for (int dictId = 0; dictId < dictionary.length(); dictId++) {
+            textIndexCreator.add(dictionary.getStringValue(dictId));
+          }
+        }
+      } else if (columnMetadata.isSingleValue()) {
         processSVField(segmentWriter, hasDictionary, forwardIndexReader, readerContext, textIndexCreator, numDocs,
             columnMetadata);
       } else {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/LuceneTextIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/LuceneTextIndexReader.java
@@ -342,10 +342,11 @@ public class LuceneTextIndexReader implements TextIndexReader {
       builder.withDocIdTranslatorMode(docIdTranslatorMode);
     }
 
-    String buildOnDictionary = properties.getProperty(FieldConfig.TEXT_INDEX_BUILD_ON_DICTIONARY);
-    if (buildOnDictionary != null) {
-      builder.withBuildOnDictionary(Boolean.parseBoolean(buildOnDictionary));
-    }
+    // The build mode is intrinsic to the segment: default to false when the property is absent (segments written
+    // before this feature are always per-row). Must NOT keep the live table-config value, otherwise a per-row segment
+    // could be misread as dictionary-based after the flag is flipped on.
+    builder.withBuildOnDictionary(
+        Boolean.parseBoolean(properties.getProperty(FieldConfig.TEXT_INDEX_BUILD_ON_DICTIONARY)));
 
     return builder.build();
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/LuceneTextIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/LuceneTextIndexReader.java
@@ -70,6 +70,11 @@ public class LuceneTextIndexReader implements TextIndexReader {
   private final String _column;
   private final DocIdTranslator _docIdTranslator;
   private final Analyzer _analyzer;
+  // When true, this index was built over the column dictionary (one Lucene doc per distinct value, Lucene docId ==
+  // dictId). Derived from the persisted segment properties, NOT the live table config, so a table holding a mix of
+  // dictionary-based and per-row text segments reads each correctly. In this mode searches return dictIds via
+  // getDictIds(), and the doc-id translator is a no-op (Lucene docId already equals dictId).
+  private final boolean _buildOnDictionary;
   private boolean _useANDForMultiTermQueries = false;
   private final String _queryParserClass;
   private Constructor<QueryParserBase> _queryParserClassConstructor;
@@ -101,7 +106,11 @@ public class LuceneTextIndexReader implements TextIndexReader {
         config = TextIndexUtils.getUpdatedConfigFromPropertiesFile(propertiesFile, config);
       }
 
-      _docIdTranslator = prepareDocIdTranslator(indexDir, _column, numDocs, _indexSearcher, config, indexFile);
+      _buildOnDictionary = config.isBuildOnDictionary();
+      // In dictionary mode the Lucene docId equals the dictId (entries are added in dictId order and the index is
+      // force-merged to a single segment), so no docId mapping is needed.
+      _docIdTranslator = _buildOnDictionary ? NoOpDocIdTranslator.INSTANCE
+          : prepareDocIdTranslator(indexDir, _column, numDocs, _indexSearcher, config, indexFile);
       _analyzer = TextIndexUtils.getAnalyzer(config);
       _queryParserClass = config.getLuceneQueryParserClass();
       _queryParserClassConstructor =
@@ -165,12 +174,18 @@ public class LuceneTextIndexReader implements TextIndexReader {
       if (config.isEnablePrefixSuffixMatchingInPhraseQueries()) {
         _enablePrefixSuffixMatchingInPhraseQueries = true;
       }
-      PinotDataBuffer docIdMappingBuffer = LuceneTextIndexBufferReader.extractDocIdMappingBuffer(indexBuffer, column);
-      // Initialize docId translator
-      long startTime = System.currentTimeMillis();
-      _docIdTranslator = createDocIdTranslator(docIdMappingBuffer, config, numDocs);
-      LOGGER.info("Time taken to create docIdTranslator for column {}: {} ms", column,
-          System.currentTimeMillis() - startTime);
+      _buildOnDictionary = config.isBuildOnDictionary();
+      if (_buildOnDictionary) {
+        // In dictionary mode the Lucene docId equals the dictId, so no docId mapping is needed.
+        _docIdTranslator = NoOpDocIdTranslator.INSTANCE;
+      } else {
+        PinotDataBuffer docIdMappingBuffer = LuceneTextIndexBufferReader.extractDocIdMappingBuffer(indexBuffer, column);
+        // Initialize docId translator
+        long startTime = System.currentTimeMillis();
+        _docIdTranslator = createDocIdTranslator(docIdMappingBuffer, config, numDocs);
+        LOGGER.info("Time taken to create docIdTranslator for column {}: {} ms", column,
+            System.currentTimeMillis() - startTime);
+      }
       // Initialize analyzer and query parser
       _analyzer = TextIndexUtils.getAnalyzer(config);
       _queryParserClass = config.getLuceneQueryParserClass();
@@ -206,8 +221,18 @@ public class LuceneTextIndexReader implements TextIndexReader {
   }
 
   @Override
+  public boolean isBuildOnDictionary() {
+    return _buildOnDictionary;
+  }
+
+  @Override
   public ImmutableRoaringBitmap getDictIds(String searchQuery) {
-    throw new UnsupportedOperationException("");
+    if (_buildOnDictionary) {
+      // In dictionary mode the Lucene docId equals the dictId, so the matching "doc ids" are the matching dict ids.
+      return getDocIdsWithoutOptions(searchQuery);
+    }
+    throw new UnsupportedOperationException(
+        "getDictIds is only supported when the text index is built on the dictionary for column: " + _column);
   }
 
   @Deprecated
@@ -315,6 +340,11 @@ public class LuceneTextIndexReader implements TextIndexReader {
     String docIdTranslatorMode = properties.getProperty(FieldConfig.TEXT_INDEX_LUCENE_DOC_ID_TRANSLATOR_MODE);
     if (docIdTranslatorMode != null) {
       builder.withDocIdTranslatorMode(docIdTranslatorMode);
+    }
+
+    String buildOnDictionary = properties.getProperty(FieldConfig.TEXT_INDEX_BUILD_ON_DICTIONARY);
+    if (buildOnDictionary != null) {
+      builder.withBuildOnDictionary(Boolean.parseBoolean(buildOnDictionary));
     }
 
     return builder.build();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexConfigBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexConfigBuilder.java
@@ -97,6 +97,11 @@ public class TextIndexConfigBuilder extends TextIndexConfig.AbstractBuilder {
       if (textIndexProperties.get("storeInSegmentFile") != null) {
         withStoreInSegmentFile(Boolean.parseBoolean(textIndexProperties.get("storeInSegmentFile")));
       }
+
+      if (textIndexProperties.get(FieldConfig.TEXT_INDEX_BUILD_ON_DICTIONARY) != null) {
+        withBuildOnDictionary(
+            Boolean.parseBoolean(textIndexProperties.get(FieldConfig.TEXT_INDEX_BUILD_ON_DICTIONARY)));
+      }
     }
     return this;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexType.java
@@ -32,6 +32,7 @@ import org.apache.pinot.segment.local.segment.index.loader.invertedindex.TextInd
 import org.apache.pinot.segment.local.segment.index.readers.text.LuceneTextIndexReader;
 import org.apache.pinot.segment.spi.ColumnMetadata;
 import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.segment.spi.creator.ColumnStatistics;
 import org.apache.pinot.segment.spi.creator.IndexCreationContext;
 import org.apache.pinot.segment.spi.index.AbstractIndexType;
 import org.apache.pinot.segment.spi.index.ColumnConfigDeserializer;
@@ -86,6 +87,10 @@ public class TextIndexType extends AbstractIndexType<TextIndexConfig, TextIndexR
     if (textIndexConfig.isEnabled()) {
       Preconditions.checkState(fieldSpec.getDataType().getStoredType() == FieldSpec.DataType.STRING,
           "Cannot create TEXT index on column: %s of stored type other than STRING", fieldSpec.getName());
+      if (textIndexConfig.isBuildOnDictionary()) {
+        Preconditions.checkState(indexConfigs.getConfig(StandardIndexes.dictionary()).isEnabled(),
+            "buildOnDictionary TEXT index requires a dictionary-encoded column: %s", fieldSpec.getName());
+      }
     }
   }
 
@@ -105,6 +110,25 @@ public class TextIndexType extends AbstractIndexType<TextIndexConfig, TextIndexR
       throws IOException {
     Preconditions.checkState(context.getFieldSpec().getDataType().getStoredType() == FieldSpec.DataType.STRING,
         "Text index is currently only supported on STRING type columns");
+    if (indexConfig.isBuildOnDictionary()) {
+      Preconditions.checkState(context.hasDictionary(),
+          "buildOnDictionary TEXT index requires a dictionary-encoded column: %s", context.getFieldSpec().getName());
+      LuceneTextIndexCreator creator = new LuceneTextIndexCreator(context, indexConfig);
+      // Columnar segment-creation / realtime-conversion path: build one Lucene document per distinct dictionary value
+      // (Lucene docId == dictId). On the reload path ColumnStatistics is null and TextIndexHandler feeds the
+      // dictionary values via add(String) instead.
+      ColumnStatistics columnStatistics = context.getColumnStatistics();
+      if (columnStatistics != null) {
+        Object uniqueValues = columnStatistics.getUniqueValuesSet();
+        Preconditions.checkState(uniqueValues instanceof String[],
+            "Expected String[] dictionary values for dictionary-based TEXT index on column: %s",
+            context.getFieldSpec().getName());
+        for (String value : (String[]) uniqueValues) {
+          creator.add(value);
+        }
+      }
+      return creator;
+    }
     return new LuceneTextIndexCreator(context, indexConfig);
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/TextIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/TextIndexUtils.java
@@ -388,6 +388,9 @@ public class TextIndexUtils {
     properties.setProperty(FieldConfig.TEXT_INDEX_LUCENE_ANALYZER_CLASS_ARG_TYPES, escapedLuceneAnalyzerClassArgTypes);
     properties.setProperty(FieldConfig.TEXT_INDEX_LUCENE_QUERY_PARSER_CLASS, config.getLuceneQueryParserClass());
     properties.setProperty(FieldConfig.TEXT_INDEX_LUCENE_DOC_ID_TRANSLATOR_MODE, config.getDocIdTranslatorMode());
+    // Persist the build mode so the reader self-describes (a table may hold a mix of dictionary-based and per-row
+    // text segments; reads must not depend on the live table config).
+    properties.setProperty(FieldConfig.TEXT_INDEX_BUILD_ON_DICTIONARY, config.isBuildOnDictionary());
 
     File propertiesFile = new File(indexDir, V1Constants.Indexes.LUCENE_TEXT_INDEX_PROPERTIES_FILE);
     CommonsConfigurationUtils.saveToFile(properties, propertiesFile);
@@ -424,6 +427,9 @@ public class TextIndexUtils {
         .withLuceneAnalyzerClassArgTypes(recoveredLuceneAnalyzerClassArgTypes)
         .withLuceneQueryParserClass(properties.getString(FieldConfig.TEXT_INDEX_LUCENE_QUERY_PARSER_CLASS))
         .withDocIdTranslatorMode(properties.getString(FieldConfig.TEXT_INDEX_LUCENE_DOC_ID_TRANSLATOR_MODE))
+        // Default to the existing config value when the property is absent (segments written before this feature).
+        .withBuildOnDictionary(properties.getBoolean(FieldConfig.TEXT_INDEX_BUILD_ON_DICTIONARY,
+            config.isBuildOnDictionary()))
         .build();
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/TextIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/TextIndexUtils.java
@@ -481,9 +481,10 @@ public class TextIndexUtils {
         .withLuceneAnalyzerClassArgTypes(recoveredLuceneAnalyzerClassArgTypes)
         .withLuceneQueryParserClass(properties.getString(FieldConfig.TEXT_INDEX_LUCENE_QUERY_PARSER_CLASS))
         .withDocIdTranslatorMode(properties.getString(FieldConfig.TEXT_INDEX_LUCENE_DOC_ID_TRANSLATOR_MODE))
-        // Default to the existing config value when the property is absent (segments written before this feature).
-        .withBuildOnDictionary(properties.getBoolean(FieldConfig.TEXT_INDEX_BUILD_ON_DICTIONARY,
-            config.isBuildOnDictionary()))
+        // The build mode is intrinsic to the segment: default to false when the property is absent (segments written
+        // before this feature are always per-row). Must NOT fall back to the live table config, otherwise a per-row
+        // segment could be misread as dictionary-based after the flag is flipped on.
+        .withBuildOnDictionary(properties.getBoolean(FieldConfig.TEXT_INDEX_BUILD_ON_DICTIONARY, false))
         .build();
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/TextIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/TextIndexUtils.java
@@ -442,6 +442,9 @@ public class TextIndexUtils {
     properties.setProperty(FieldConfig.TEXT_INDEX_LUCENE_ANALYZER_CLASS_ARG_TYPES, escapedLuceneAnalyzerClassArgTypes);
     properties.setProperty(FieldConfig.TEXT_INDEX_LUCENE_QUERY_PARSER_CLASS, config.getLuceneQueryParserClass());
     properties.setProperty(FieldConfig.TEXT_INDEX_LUCENE_DOC_ID_TRANSLATOR_MODE, config.getDocIdTranslatorMode());
+    // Persist the build mode so the reader self-describes (a table may hold a mix of dictionary-based and per-row
+    // text segments; reads must not depend on the live table config).
+    properties.setProperty(FieldConfig.TEXT_INDEX_BUILD_ON_DICTIONARY, config.isBuildOnDictionary());
 
     File propertiesFile = new File(indexDir, V1Constants.Indexes.LUCENE_TEXT_INDEX_PROPERTIES_FILE);
     CommonsConfigurationUtils.saveToFile(properties, propertiesFile);
@@ -478,6 +481,9 @@ public class TextIndexUtils {
         .withLuceneAnalyzerClassArgTypes(recoveredLuceneAnalyzerClassArgTypes)
         .withLuceneQueryParserClass(properties.getString(FieldConfig.TEXT_INDEX_LUCENE_QUERY_PARSER_CLASS))
         .withDocIdTranslatorMode(properties.getString(FieldConfig.TEXT_INDEX_LUCENE_DOC_ID_TRANSLATOR_MODE))
+        // Default to the existing config value when the property is absent (segments written before this feature).
+        .withBuildOnDictionary(properties.getBoolean(FieldConfig.TEXT_INDEX_BUILD_ON_DICTIONARY,
+            config.isBuildOnDictionary()))
         .build();
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/TextIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/TextIndexUtils.java
@@ -427,9 +427,10 @@ public class TextIndexUtils {
         .withLuceneAnalyzerClassArgTypes(recoveredLuceneAnalyzerClassArgTypes)
         .withLuceneQueryParserClass(properties.getString(FieldConfig.TEXT_INDEX_LUCENE_QUERY_PARSER_CLASS))
         .withDocIdTranslatorMode(properties.getString(FieldConfig.TEXT_INDEX_LUCENE_DOC_ID_TRANSLATOR_MODE))
-        // Default to the existing config value when the property is absent (segments written before this feature).
-        .withBuildOnDictionary(properties.getBoolean(FieldConfig.TEXT_INDEX_BUILD_ON_DICTIONARY,
-            config.isBuildOnDictionary()))
+        // The build mode is intrinsic to the segment: default to false when the property is absent (segments written
+        // before this feature are always per-row). Must NOT fall back to the live table config, otherwise a per-row
+        // segment could be misread as dictionary-based after the flag is flipped on.
+        .withBuildOnDictionary(properties.getBoolean(FieldConfig.TEXT_INDEX_BUILD_ON_DICTIONARY, false))
         .build();
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
@@ -142,6 +142,24 @@ public class TextIndexConfig extends IndexConfig {
          LUCENE_INDEX_DEFAULT_BUILD_ON_DICTIONARY);
   }
 
+  /**
+   * Retained for binary compatibility (pre-{@code buildOnDictionary}). Delegates to the canonical constructor with
+   * {@code buildOnDictionary} defaulted to false.
+   */
+  public TextIndexConfig(Boolean disabled, @Nullable Object rawValueForTextIndex, boolean enableQueryCache,
+      boolean useANDForMultiTermQueries, List<String> stopWordsInclude, List<String> stopWordsExclude,
+      Boolean luceneUseCompoundFile, Integer luceneMaxBufferSizeMB, String luceneAnalyzerClass,
+      Object luceneAnalyzerClassArgs, Object luceneAnalyzerClassArgTypes, String luceneQueryParserClass,
+      Boolean enablePrefixSuffixMatchingInPhraseQueries, Boolean reuseMutableIndex,
+      Integer luceneNRTCachingDirectoryMaxBufferSizeMB, Boolean useLogByteSizeMergePolicy,
+      DocIdTranslatorMode docIdTranslatorMode, Boolean caseSensitive, Boolean storeInSegmentFile) {
+    this(disabled, rawValueForTextIndex, enableQueryCache, useANDForMultiTermQueries, stopWordsInclude,
+        stopWordsExclude, luceneUseCompoundFile, luceneMaxBufferSizeMB, luceneAnalyzerClass, luceneAnalyzerClassArgs,
+        luceneAnalyzerClassArgTypes, luceneQueryParserClass, enablePrefixSuffixMatchingInPhraseQueries,
+        reuseMutableIndex, luceneNRTCachingDirectoryMaxBufferSizeMB, useLogByteSizeMergePolicy, docIdTranslatorMode,
+        caseSensitive, storeInSegmentFile, LUCENE_INDEX_DEFAULT_BUILD_ON_DICTIONARY);
+  }
+
   @JsonCreator
   public TextIndexConfig(@JsonProperty("disabled") Boolean disabled,
       @JsonProperty("rawValue") @Nullable Object rawValueForTextIndex,

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
@@ -142,10 +142,8 @@ public class TextIndexConfig extends IndexConfig {
          LUCENE_INDEX_DEFAULT_BUILD_ON_DICTIONARY);
   }
 
-  /**
-   * Retained for binary compatibility (pre-{@code buildOnDictionary}). Delegates to the canonical constructor with
-   * {@code buildOnDictionary} defaulted to false.
-   */
+  /// Retained for binary compatibility (pre-`buildOnDictionary`). Delegates to the canonical constructor with
+  /// `buildOnDictionary` defaulted to false.
   public TextIndexConfig(Boolean disabled, @Nullable Object rawValueForTextIndex, boolean enableQueryCache,
       boolean useANDForMultiTermQueries, List<String> stopWordsInclude, List<String> stopWordsExclude,
       Boolean luceneUseCompoundFile, Integer luceneMaxBufferSizeMB, String luceneAnalyzerClass,
@@ -341,12 +339,10 @@ public class TextIndexConfig extends IndexConfig {
     return _storeInSegmentFile;
   }
 
-  /**
-   * Whether the Lucene text index is built over the column's dictionary (one document per distinct value, with the
-   * Lucene docId equal to the dictId) instead of one document per row. When enabled, {@code TEXT_MATCH} returns
-   * matching dictIds that are resolved to docIds through the dictionary-based filter operators. Requires a
-   * dictionary-encoded column and is only applied to immutable segments. Defaults to false.
-   */
+  /// Whether the Lucene text index is built over the column's dictionary (one document per distinct value, with the
+  /// Lucene docId equal to the dictId) instead of one document per row. When enabled, `TEXT_MATCH` returns
+  /// matching dictIds that are resolved to docIds through the dictionary-based filter operators. Requires a
+  /// dictionary-encoded column and is only applied to immutable segments. Defaults to false.
   public boolean isBuildOnDictionary() {
     return _buildOnDictionary;
   }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
@@ -42,6 +42,7 @@ public class TextIndexConfig extends IndexConfig {
   private static final DocIdTranslatorMode LUCENE_TRANSLATOR_MODE = null;
   private static final boolean LUCENE_INDEX_DEFAULT_CASE_SENSITIVE_INDEX = false;
   private static final boolean LUCENE_INDEX_DEFAULT_STORE_IN_SEGMENT_FILE = false;
+  private static final boolean LUCENE_INDEX_DEFAULT_BUILD_ON_DICTIONARY = false;
 
   // keep in sync with constructor!
   private static final List<String> PROPERTY_NAMES = List.of(
@@ -49,13 +50,14 @@ public class TextIndexConfig extends IndexConfig {
       "luceneUseCompoundFile", "luceneMaxBufferSizeMB", "luceneAnalyzerClass", "luceneAnalyzerClassArgs",
       "luceneAnalyzerClassArgTypes", "luceneQueryParserClass", "enablePrefixSuffixMatchingInPhraseQueries",
       "reuseMutableIndex", "luceneNRTCachingDirectoryMaxBufferSizeMB", "useLogByteSizeMergePolicy",
-      "docIdTranslatorMode", "caseSensitive", "storeInSegmentFile"
+      "docIdTranslatorMode", "caseSensitive", "storeInSegmentFile", "buildOnDictionary"
   );
 
   public static final TextIndexConfig DISABLED =
       new TextIndexConfig(true, null, false, false, List.of(), List.of(), false,
           LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB, null, null, null, null, false, false, 0, false, null,
-          LUCENE_INDEX_DEFAULT_CASE_SENSITIVE_INDEX, LUCENE_INDEX_DEFAULT_STORE_IN_SEGMENT_FILE);
+          LUCENE_INDEX_DEFAULT_CASE_SENSITIVE_INDEX, LUCENE_INDEX_DEFAULT_STORE_IN_SEGMENT_FILE,
+          LUCENE_INDEX_DEFAULT_BUILD_ON_DICTIONARY);
 
   @Nullable
   private final Object _rawValueForTextIndex;
@@ -76,6 +78,7 @@ public class TextIndexConfig extends IndexConfig {
   private final DocIdTranslatorMode _docIdTranslatorMode;
   private final boolean _caseSensitive;
   private final boolean _storeInSegmentFile;
+  private final boolean _buildOnDictionary;
 
   public enum DocIdTranslatorMode {
     // build and keep mapping
@@ -111,7 +114,8 @@ public class TextIndexConfig extends IndexConfig {
         luceneAnalyzerClassArgs, luceneAnalyzerClassArgTypes, luceneQueryParserClass,
         enablePrefixSuffixMatchingInPhraseQueries, reuseMutableIndex,
         luceneNRTCachingDirectoryMaxBufferSizeMB, useLogByteSizeMergePolicy, docIdTranslatorMode,
-        LUCENE_INDEX_DEFAULT_CASE_SENSITIVE_INDEX, LUCENE_INDEX_DEFAULT_STORE_IN_SEGMENT_FILE);
+        LUCENE_INDEX_DEFAULT_CASE_SENSITIVE_INDEX, LUCENE_INDEX_DEFAULT_STORE_IN_SEGMENT_FILE,
+        LUCENE_INDEX_DEFAULT_BUILD_ON_DICTIONARY);
   }
 
   /// @deprecated Use the new constructor with storeInSegmentFile parameter instead.
@@ -134,7 +138,8 @@ public class TextIndexConfig extends IndexConfig {
          enablePrefixSuffixPhraseMatching != null ? enablePrefixSuffixPhraseMatching : false,
          false, 0, false, docIdTranslatorMode,
          enablePrefixSuffixMatchingKey != null ? enablePrefixSuffixMatchingKey : false,
-         storeInSegmentFile != null ? storeInSegmentFile : false);
+         storeInSegmentFile != null ? storeInSegmentFile : false,
+         LUCENE_INDEX_DEFAULT_BUILD_ON_DICTIONARY);
   }
 
   @JsonCreator
@@ -156,7 +161,8 @@ public class TextIndexConfig extends IndexConfig {
       @JsonProperty("useLogByteSizeMergePolicy") Boolean useLogByteSizeMergePolicy,
       @JsonProperty("docIdTranslatorMode") DocIdTranslatorMode docIdTranslatorMode,
       @JsonProperty("caseSensitive") Boolean caseSensitive,
-      @JsonProperty("storeInSegmentFile") Boolean storeInSegmentFile) {
+      @JsonProperty("storeInSegmentFile") Boolean storeInSegmentFile,
+      @JsonProperty("buildOnDictionary") Boolean buildOnDictionary) {
     super(disabled);
     _rawValueForTextIndex = rawValueForTextIndex;
     _enableQueryCache = enableQueryCache;
@@ -191,6 +197,7 @@ public class TextIndexConfig extends IndexConfig {
     _docIdTranslatorMode = docIdTranslatorMode == null ? LUCENE_TRANSLATOR_MODE : docIdTranslatorMode;
     _caseSensitive = caseSensitive == null ? LUCENE_INDEX_DEFAULT_CASE_SENSITIVE_INDEX : caseSensitive;
     _storeInSegmentFile = storeInSegmentFile == null ? LUCENE_INDEX_DEFAULT_STORE_IN_SEGMENT_FILE : storeInSegmentFile;
+    _buildOnDictionary = buildOnDictionary == null ? LUCENE_INDEX_DEFAULT_BUILD_ON_DICTIONARY : buildOnDictionary;
   }
 
   /// Parses the input value to a List of Strings.
@@ -316,6 +323,16 @@ public class TextIndexConfig extends IndexConfig {
     return _storeInSegmentFile;
   }
 
+  /**
+   * Whether the Lucene text index is built over the column's dictionary (one document per distinct value, with the
+   * Lucene docId equal to the dictId) instead of one document per row. When enabled, {@code TEXT_MATCH} returns
+   * matching dictIds that are resolved to docIds through the dictionary-based filter operators. Requires a
+   * dictionary-encoded column and is only applied to immutable segments. Defaults to false.
+   */
+  public boolean isBuildOnDictionary() {
+    return _buildOnDictionary;
+  }
+
   public static abstract class AbstractBuilder {
     @Nullable
     protected Object _rawValueForTextIndex;
@@ -338,6 +355,7 @@ public class TextIndexConfig extends IndexConfig {
     protected DocIdTranslatorMode _docIdTranslatorMode = LUCENE_TRANSLATOR_MODE;
     protected boolean _caseSensitive = LUCENE_INDEX_DEFAULT_CASE_SENSITIVE_INDEX;
     protected boolean _storeInSegmentFile = LUCENE_INDEX_DEFAULT_STORE_IN_SEGMENT_FILE;
+    protected boolean _buildOnDictionary = LUCENE_INDEX_DEFAULT_BUILD_ON_DICTIONARY;
 
     public AbstractBuilder() {
     }
@@ -362,6 +380,7 @@ public class TextIndexConfig extends IndexConfig {
       _docIdTranslatorMode = other._docIdTranslatorMode;
       _caseSensitive = other._caseSensitive;
       _storeInSegmentFile = other._storeInSegmentFile;
+      _buildOnDictionary = other._buildOnDictionary;
     }
 
     public TextIndexConfig build() {
@@ -371,7 +390,7 @@ public class TextIndexConfig extends IndexConfig {
           CsvParser.serialize(_luceneAnalyzerClassArgTypes, true, false),
           _luceneQueryParserClass, _enablePrefixSuffixMatchingInPhraseQueries, _reuseMutableIndex,
           _luceneNRTCachingDirectoryMaxBufferSizeMB, _useLogByteSizeMergePolicy, _docIdTranslatorMode, _caseSensitive,
-          _storeInSegmentFile);
+          _storeInSegmentFile, _buildOnDictionary);
     }
 
     public abstract AbstractBuilder withProperties(@Nullable Map<String, String> textIndexProperties);
@@ -471,6 +490,11 @@ public class TextIndexConfig extends IndexConfig {
       _storeInSegmentFile = storeInSegmentFile;
       return this;
     }
+
+    public AbstractBuilder withBuildOnDictionary(boolean buildOnDictionary) {
+      _buildOnDictionary = buildOnDictionary;
+      return this;
+    }
   }
 
   @Override
@@ -501,7 +525,8 @@ public class TextIndexConfig extends IndexConfig {
         && Objects.equals(_luceneAnalyzerClassArgs, that._luceneAnalyzerClassArgs)
         && Objects.equals(_luceneAnalyzerClassArgTypes, that._luceneAnalyzerClassArgTypes)
         && Objects.equals(_luceneQueryParserClass, that._luceneQueryParserClass)
-        && _caseSensitive == that._caseSensitive && _storeInSegmentFile == that._storeInSegmentFile;
+        && _caseSensitive == that._caseSensitive && _storeInSegmentFile == that._storeInSegmentFile
+        && _buildOnDictionary == that._buildOnDictionary;
   }
 
   @Override
@@ -511,7 +536,7 @@ public class TextIndexConfig extends IndexConfig {
         _luceneMaxBufferSizeMB, _luceneAnalyzerClass, _luceneAnalyzerClassArgs, _luceneAnalyzerClassArgTypes,
         _luceneQueryParserClass, _enablePrefixSuffixMatchingInPhraseQueries, _reuseMutableIndex,
         _luceneNRTCachingDirectoryMaxBufferSizeMB, _useLogByteSizeMergePolicy, _docIdTranslatorMode, _caseSensitive,
-        _storeInSegmentFile);
+        _storeInSegmentFile, _buildOnDictionary);
   }
 
   public static boolean isProperty(String prop) {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/TextIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/TextIndexReader.java
@@ -48,6 +48,13 @@ public interface TextIndexReader extends IndexReader {
     return false;
   }
 
+  /// Whether this text index was built over the column dictionary (one entry per distinct value) rather than per row.
+  /// When true, [#getDictIds(String)] returns matching dictionary ids (resolved to docIds by the dictionary-based
+  /// filter operators) and [#getDocIds(String)] is not used. Defaults to false (per-row index).
+  default boolean isBuildOnDictionary() {
+    return false;
+  }
+
   /// Returns the number of documents that are searchable in the index. For near-realtime indexes
   /// (e.g. Lucene on consuming segments), this may be less than the total segment doc count because
   /// recently ingested documents may not yet be visible to the index searcher. For offline/completed

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/TextIndexConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/TextIndexConfigTest.java
@@ -92,6 +92,21 @@ public class TextIndexConfigTest {
   }
 
   @Test
+  public void withBuildOnDictionary()
+      throws JsonProcessingException {
+    // Defaults to false when absent.
+    assertFalse(JsonUtils.stringToObject("{}", TextIndexConfig.class).isBuildOnDictionary(),
+        "buildOnDictionary should default to false");
+
+    // Parses from JSON and survives a full serialize/deserialize round-trip (mirrors how the segment persists it).
+    TextIndexConfig config = JsonUtils.stringToObject("{\"buildOnDictionary\": true}", TextIndexConfig.class);
+    assertTrue(config.isBuildOnDictionary(), "Unexpected buildOnDictionary");
+    TextIndexConfig roundTripped =
+        JsonUtils.stringToObject(JsonUtils.objectToString(config), TextIndexConfig.class);
+    assertTrue(roundTripped.isBuildOnDictionary(), "buildOnDictionary not preserved across round-trip");
+  }
+
+  @Test
   public void withSomeData()
       throws JsonProcessingException {
     String confStr = "{\n"

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/TextIndexConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/TextIndexConfigTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.segment.spi.index;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.List;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
@@ -104,6 +105,17 @@ public class TextIndexConfigTest {
     TextIndexConfig roundTripped =
         JsonUtils.stringToObject(JsonUtils.objectToString(config), TextIndexConfig.class);
     assertTrue(roundTripped.isBuildOnDictionary(), "buildOnDictionary not preserved across round-trip");
+
+    // buildOnDictionary participates in equals/hashCode.
+    TextIndexConfig off = JsonUtils.stringToObject("{\"buildOnDictionary\": false}", TextIndexConfig.class);
+    assertNotEquals(config, off, "Configs differing only by buildOnDictionary must not be equal");
+    assertEquals(config, JsonUtils.stringToObject("{\"buildOnDictionary\": true}", TextIndexConfig.class));
+
+    // The pre-buildOnDictionary constructor (retained for binary compatibility) defaults the flag to false.
+    TextIndexConfig legacy = new TextIndexConfig(false, null, false, false, List.of(),
+        List.of(), true, 500, null, null, null, null, false, false, 0, false, null, false,
+        false);
+    assertFalse(legacy.isBuildOnDictionary(), "Legacy constructor should default buildOnDictionary to false");
   }
 
   @Test

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -70,6 +70,9 @@ public class FieldConfig extends BaseJsonConfig {
   public static final String TEXT_INDEX_LUCENE_REUSE_MUTABLE_INDEX = "reuseMutableIndex";
   public static final String TEXT_INDEX_LUCENE_NRT_CACHING_DIRECTORY_BUFFER_SIZE =
       "luceneNRTCachingDirectoryMaxBufferSizeMB";
+  // When true, the Lucene text index is built over the column dictionary (one document per distinct value) instead of
+  // one document per row. Requires a dictionary-encoded column; applied to immutable segments only. Defaults to false.
+  public static final String TEXT_INDEX_BUILD_ON_DICTIONARY = "buildOnDictionary";
 
   private final String _name;
   private final EncodingType _encodingType;


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Query flow for dictionary\-based TEXT\_MATCH: check index mode, create evaluator, get matching dictIds from index\.

```mermaid
flowchart TD
  N0["FilterPlanNode #40;F2#41; #40;F2#41;"]:::stModified
  N1["TextMatchDictIdPredicateEvaluatorFactory #40;F1#41; #40;F1#41;"]:::stAdded
  N2["TextMatchDictIdPredicateEvaluator #40;F1#41; #40;F1#41;"]:::stAdded
  N3["LuceneTextIndexReader #40;F5#41; #40;F5#41;"]:::stModified
  N0 -->|"check isBuildOnDictionary#40;#41;"| N3
  N0 -->|"create evaluator via factory"| N1
  N1 -->|"return new evaluator"| N2
  N2 -->|"call getDictIds#40;query#41;"| N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/TextMatchDictIdPredicateEvaluatorFactory\.java — [after](https://github.com/apache/pinot/blob/d68ab4382b8c4dfe89c45781b78451355a1564a4/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/TextMatchDictIdPredicateEvaluatorFactory.java)
- F2: pinot\-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java) · [after](https://github.com/apache/pinot/blob/d68ab4382b8c4dfe89c45781b78451355a1564a4/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java)
- F5: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/LuceneTextIndexReader\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/LuceneTextIndexReader.java) · [after](https://github.com/apache/pinot/blob/d68ab4382b8c4dfe89c45781b78451355a1564a4/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/LuceneTextIndexReader.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImU2Nzg3ZTE3ODY0NWZkM2M1YTg4N2UyYWJhN2UwZGU4MzQzY2Q1MjQiLCJjb250ZXh0X2hhc2giOiJkN2ZlZDIxY2NiMGRhNDJmMjI3ZTIzZWRmZmMzMDkxMTcwNjM1NTU5NzgxNmQzNDk4MzFhOTRiMjYwNDYyNGJmIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MjgxNzMxLCJoZWFkX3NoYSI6ImQ2OGFiNDM4MmI4YzRkZmU4OWM0NTc4MWI3ODQ1MTM1NWExNTY0YTQiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJlNjc4N2UxNzg2NDVmZDNjNWE4ODdlMmFiYTdlMGRlODM0M2NkNTI0IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature c4f1027db657e0be155a6c0210eafcb09b104785c7be21091ade9257b1f96c13 -->
<!-- pinot-pr-flow:end -->

## Description

Adds an opt-in **`buildOnDictionary`** flag (default **false**) for the Lucene **TEXT** index. When enabled on a dictionary-encoded `STRING` column, the Lucene index is built over the column **dictionary** — one document per distinct value, with the Lucene docId equal to the dictId — instead of one document per row.

This makes the text index size scale with **cardinality** rather than **row count**, which is a large win for low/medium-cardinality text columns, while keeping the full Lucene query surface. `TEXT_MATCH` returns the matching dictIds, which are resolved to docIds through the existing dictionary-based filter operators (inverted index / scan) — mirroring the FST / `REGEXP_LIKE` path.

Existing behavior is unchanged when the flag is off.

### Design (mirrors the FST dictionary pattern)

- **Config:** `FieldConfig.TEXT_INDEX_BUILD_ON_DICTIONARY` + `TextIndexConfig.isBuildOnDictionary()` (default false), parsed in `TextIndexConfigBuilder`.
- **Creation:** `TextIndexType.createIndexCreator` feeds the sorted dictionary values to a dictionary-mode `LuceneTextIndexCreator` (the per-row `add()` becomes a no-op). Dictionary mode is gated to `commit == true`, so **consuming (realtime) segments keep building per-row** and the dictionary-based index is produced on seal/convert and on offline ingestion. Reload is handled by `TextIndexHandler` looping the dictionary, mirroring `FSTIndexHandler`.
- **Self-describing segments (mixed-table safe):** the build mode is persisted into the segment's `lucene.properties`, and the reader derives its mode from the **segment**, not the live table config. A table holding a **mix** of dictionary-based and per-row text segments (e.g. during rollout) reads each correctly. The table-config flag governs **creation only**.
- **Reader:** `LuceneTextIndexReader` serves `getDictIds()` in dictionary mode and uses a no-op docId translator (Lucene docId already equals dictId).
- **Query:** new `TextMatchDictIdPredicateEvaluatorFactory`; `FilterPlanNode` routes a dictionary-based `TEXT_MATCH` through `FilterOperatorUtils` to the standard scan/inverted operators. **Single-value and multi-value** STRING columns supported.
- **Validation (hard failure):** `buildOnDictionary` on a non-dictionary-encoded column is rejected at table-config validation and again by a creation-time precondition.

### Limitations / follow-ups

- `TEXT_MATCH` **options** are not supported in dictionary mode (the dictionary lookup takes only the query value) — such queries are rejected rather than silently ignored.
- Realtime consuming segments always build the per-row index; the dictionary-based index is produced when the segment is sealed/converted.

## Upgrade Notes

Opt-in and default-off, so no behavior change on upgrade. The build mode is recorded per segment, so a table can hold a mix of dictionary-based and per-row text segments during a rolling enablement and each is read correctly. Flipping the flag triggers a text-index rebuild on segment reload.

## Testing

`DictionaryBasedTextIndexQueriesTest` (new):
- dictionary-based `TEXT_MATCH` results equal the per-row index for SV and MV columns, including `OR` and zero-match queries;
- reload builds the dictionary-based index from the dictionary;
- the dictionary-based segment is smaller than per-row for a low-cardinality column;
- a non-dictionary column with `buildOnDictionary=true` fails the build;
- `TEXT_MATCH` with options is rejected for a dictionary-based index.

`TextIndexConfigTest`: round-trips the new flag.

Regression (all green): per-row `TextSearchQueriesTest`, `FSTBasedRegexpLikeQueriesTest`, `IFSTBasedRegexpLikeQueriesTest`, and segment-local `LuceneTextIndexCreatorTest` / `TextIndexTest` / `LuceneTextIndexConfigReloadTest` / `TextIndexUtilsTest`. `spotless` / `license` / `checkstyle` clean.

## Labels
`feature`, `text-index`
