### PR TITLE
Bound FST regexp traversal and fall back to scan when the limit is exceeded

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -720,6 +720,15 @@ public class QueryOptionsUtils {
     return uncheckedParseInt(QueryOptionKey.REGEX_DICT_SIZE_THRESHOLD, regexDictSizeThreshold);
   }
 
+  /// Cap on the number of FST paths visited per FST/IFST-backed REGEXP_LIKE evaluation before falling back to the
+  /// dictionary-scan evaluator. Returns `null` if the query option is not set, in which case the caller defaults the
+  /// cap to the column cardinality.
+  @Nullable
+  public static Integer getFstRegexpTraversalLimit(Map<String, String> queryOptions) {
+    String fstRegexpTraversalLimit = queryOptions.get(QueryOptionKey.FST_REGEXP_TRAVERSAL_LIMIT);
+    return uncheckedParseInt(QueryOptionKey.FST_REGEXP_TRAVERSAL_LIMIT, fstRegexpTraversalLimit);
+  }
+
   // --- Vector search query option accessors ---
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/FSTBasedRegexpPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/FSTBasedRegexpPredicateEvaluatorFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.operator.filter.predicate;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.predicate.RegexpLikePredicate;
 import org.apache.pinot.common.utils.RegexpPatternConverterUtils;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
@@ -33,17 +34,26 @@ public class FSTBasedRegexpPredicateEvaluatorFactory {
   }
 
   /**
-   * Creates a predicate evaluator which matches the regexp query pattern using FST Index available.
+   * Creates a predicate evaluator which matches the regexp query pattern using the available FST index, bounding the
+   * traversal to {@code maxTraversalPaths}.
    *
    * @param regexpLikePredicate REGEXP_LIKE predicate to evaluate
    * @param fstIndexReader FST Index reader
    * @param dictionary Dictionary for the column
-   * @return Predicate evaluator
+   * @param maxTraversalPaths cap on FST paths visited before the walk is abandoned
+   * @return Predicate evaluator, or {@code null} if the traversal exceeded the limit (the caller should fall back to
+   *         a scan-based evaluator)
    */
+  @Nullable
   public static BaseDictionaryBasedPredicateEvaluator newFSTBasedEvaluator(RegexpLikePredicate regexpLikePredicate,
-      TextIndexReader fstIndexReader, Dictionary dictionary) {
-    return new FSTBasedRegexpPredicateEvaluatorFactory.FSTBasedRegexpPredicateEvaluator(regexpLikePredicate,
-        fstIndexReader, dictionary);
+      TextIndexReader fstIndexReader, Dictionary dictionary, int maxTraversalPaths) {
+    String searchQuery = RegexpPatternConverterUtils.regexpLikeToLuceneRegExp(regexpLikePredicate.getValue());
+    ImmutableRoaringBitmap matchingDictIds = fstIndexReader.getDictIds(searchQuery, maxTraversalPaths);
+    if (matchingDictIds == null) {
+      // Traversal limit exceeded; signal the caller to fall back to a scan-based evaluator.
+      return null;
+    }
+    return new FSTBasedRegexpPredicateEvaluator(regexpLikePredicate, dictionary, matchingDictIds);
   }
 
   /**
@@ -52,11 +62,10 @@ public class FSTBasedRegexpPredicateEvaluatorFactory {
   private static class FSTBasedRegexpPredicateEvaluator extends BaseDictIdBasedRegexpLikePredicateEvaluator {
     final ImmutableRoaringBitmap _matchingDictIdBitmap;
 
-    public FSTBasedRegexpPredicateEvaluator(RegexpLikePredicate regexpLikePredicate, TextIndexReader fstIndexReader,
-        Dictionary dictionary) {
+    public FSTBasedRegexpPredicateEvaluator(RegexpLikePredicate regexpLikePredicate, Dictionary dictionary,
+        ImmutableRoaringBitmap matchingDictIds) {
       super(regexpLikePredicate, dictionary);
-      String searchQuery = RegexpPatternConverterUtils.regexpLikeToLuceneRegExp(regexpLikePredicate.getValue());
-      _matchingDictIdBitmap = fstIndexReader.getDictIds(searchQuery);
+      _matchingDictIdBitmap = matchingDictIds;
       int numMatchingDictIds = _matchingDictIdBitmap.getCardinality();
       if (numMatchingDictIds == 0) {
         _alwaysFalse = true;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/IFSTBasedRegexpPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/IFSTBasedRegexpPredicateEvaluatorFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.operator.filter.predicate;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.predicate.RegexpLikePredicate;
 import org.apache.pinot.common.utils.RegexpPatternConverterUtils;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
@@ -33,26 +34,35 @@ public class IFSTBasedRegexpPredicateEvaluatorFactory {
   }
 
   /**
-   * Create a new instance of IFST based REGEXP_LIKE predicate evaluator for case-insensitive matching.
+   * Create a new instance of IFST based REGEXP_LIKE predicate evaluator for case-insensitive matching, bounding the
+   * traversal to {@code maxTraversalPaths}.
    *
    * @param regexpLikePredicate REGEXP_LIKE predicate to evaluate
    * @param ifstIndexReader IFST index reader
    * @param dictionary Dictionary for the column
-   * @return IFST based REGEXP_LIKE predicate evaluator
+   * @param maxTraversalPaths cap on FST paths visited before the walk is abandoned
+   * @return IFST based REGEXP_LIKE predicate evaluator, or {@code null} if the traversal exceeded the limit (the
+   *         caller should fall back to a scan-based evaluator)
    */
+  @Nullable
   public static BaseDictionaryBasedPredicateEvaluator newIFSTBasedEvaluator(RegexpLikePredicate regexpLikePredicate,
-      TextIndexReader ifstIndexReader, Dictionary dictionary) {
-    return new IFSTBasedRegexpPredicateEvaluator(regexpLikePredicate, ifstIndexReader, dictionary);
+      TextIndexReader ifstIndexReader, Dictionary dictionary, int maxTraversalPaths) {
+    String searchQuery = RegexpPatternConverterUtils.regexpLikeToLuceneRegExp(regexpLikePredicate.getValue());
+    ImmutableRoaringBitmap matchingDictIds = ifstIndexReader.getDictIds(searchQuery, maxTraversalPaths);
+    if (matchingDictIds == null) {
+      // Traversal limit exceeded; signal the caller to fall back to a scan-based evaluator.
+      return null;
+    }
+    return new IFSTBasedRegexpPredicateEvaluator(regexpLikePredicate, dictionary, matchingDictIds);
   }
 
   private static class IFSTBasedRegexpPredicateEvaluator extends BaseDictIdBasedRegexpLikePredicateEvaluator {
     final ImmutableRoaringBitmap _matchingDictIdBitmap;
 
-    public IFSTBasedRegexpPredicateEvaluator(RegexpLikePredicate regexpLikePredicate,
-        TextIndexReader ifstIndexReader, Dictionary dictionary) {
+    public IFSTBasedRegexpPredicateEvaluator(RegexpLikePredicate regexpLikePredicate, Dictionary dictionary,
+        ImmutableRoaringBitmap matchingDictIds) {
       super(regexpLikePredicate, dictionary);
-      String searchQuery = RegexpPatternConverterUtils.regexpLikeToLuceneRegExp(regexpLikePredicate.getValue());
-      _matchingDictIdBitmap = ifstIndexReader.getDictIds(searchQuery);
+      _matchingDictIdBitmap = matchingDictIds;
       int numMatchingDictIds = _matchingDictIdBitmap.getCardinality();
       if (numMatchingDictIds == 0) {
         _alwaysFalse = true;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateEvaluatorProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateEvaluatorProvider.java
@@ -27,6 +27,7 @@ import org.apache.pinot.common.request.context.predicate.NotInPredicate;
 import org.apache.pinot.common.request.context.predicate.Predicate;
 import org.apache.pinot.common.request.context.predicate.RangePredicate;
 import org.apache.pinot.common.request.context.predicate.RegexpLikePredicate;
+import org.apache.pinot.common.utils.config.QueryOptionsUtils;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
@@ -87,17 +88,26 @@ public class PredicateEvaluatorProvider {
                 dataType);
           case REGEXP_LIKE: {
             // Prefer FST/IFST text index when present on the data source; otherwise fall back to the generic
-            // dict-based evaluator (dict-id scan or eager dict iteration).
+            // dict-based evaluator (dict-id scan or eager dict iteration). A broad pattern (e.g. a leading '.*') over
+            // a high-cardinality column can make the FST walk allocate without bound, so the walk is capped: when it
+            // exceeds the traversal limit the factory returns null and we fall back to the same scan evaluator
+            // (correct, and often cheaper for broad patterns). Selective patterns visit a small subtree and never
+            // trip the cap.
             RegexpLikePredicate regexpLike = (RegexpLikePredicate) predicate;
             if (dataSource != null) {
+              int maxTraversalPaths = getFstRegexpTraversalLimit(queryContext, dictionary);
+              BaseDictionaryBasedPredicateEvaluator fstEvaluator = null;
               if (regexpLike.isCaseInsensitive() && dataSource.getIFSTIndex() != null) {
-                return IFSTBasedRegexpPredicateEvaluatorFactory.newIFSTBasedEvaluator(regexpLike,
-                    dataSource.getIFSTIndex(), dictionary);
+                fstEvaluator = IFSTBasedRegexpPredicateEvaluatorFactory.newIFSTBasedEvaluator(regexpLike,
+                    dataSource.getIFSTIndex(), dictionary, maxTraversalPaths);
+              } else if (!regexpLike.isCaseInsensitive() && dataSource.getFSTIndex() != null) {
+                fstEvaluator = FSTBasedRegexpPredicateEvaluatorFactory.newFSTBasedEvaluator(regexpLike,
+                    dataSource.getFSTIndex(), dictionary, maxTraversalPaths);
               }
-              if (!regexpLike.isCaseInsensitive() && dataSource.getFSTIndex() != null) {
-                return FSTBasedRegexpPredicateEvaluatorFactory.newFSTBasedEvaluator(regexpLike,
-                    dataSource.getFSTIndex(), dictionary);
+              if (fstEvaluator != null) {
+                return fstEvaluator;
               }
+              // No FST/IFST index, or the walk exceeded the traversal limit; fall back to the scan evaluator below.
             }
             return RegexpLikePredicateEvaluatorFactory.newDictionaryBasedEvaluator(regexpLike, dictionary, dataType,
                 queryContext);
@@ -129,6 +139,21 @@ public class PredicateEvaluatorProvider {
       // Exception here is caused by mismatch between the column data type and the predicate value in the query
       throw new BadQueryRequestException(e);
     }
+  }
+
+  /// Resolves the per-evaluation cap on FST paths visited by an FST/IFST-backed REGEXP_LIKE walk. The
+  /// `fstRegexpTraversalLimit` query option overrides it with an absolute value when set (a non-positive value
+  /// disables the cap, which the matcher normalizes to an unbounded walk); otherwise it defaults to the column
+  /// cardinality, so a non-pruning pattern that would walk the whole FST falls back to a scan while selective
+  /// patterns stay on the FST.
+  private static int getFstRegexpTraversalLimit(@Nullable QueryContext queryContext, Dictionary dictionary) {
+    if (queryContext != null) {
+      Integer limit = QueryOptionsUtils.getFstRegexpTraversalLimit(queryContext.getQueryOptions());
+      if (limit != null) {
+        return limit;
+      }
+    }
+    return dictionary.length();
   }
 
   /// Returns the column dictionary if the planner can actually use it for filtering this specific predicate, otherwise

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/FilterPlanNodeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/FilterPlanNodeTest.java
@@ -269,6 +269,8 @@ public class FilterPlanNodeTest {
     TextIndexReader reader = Mockito.mock(TextIndexReader.class);
     ImmutableRoaringBitmap emptyBitmap = ImmutableRoaringBitmap.bitmapOf();
     when(reader.getDictIds(Mockito.anyString())).thenReturn(emptyBitmap);
+    // FST/IFST regexp evaluators call the bounded overload; stub it too so the mock returns a real bitmap.
+    when(reader.getDictIds(Mockito.anyString(), Mockito.anyInt())).thenReturn(emptyBitmap);
     return reader;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FSTBasedRegexpLikeQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FSTBasedRegexpLikeQueriesTest.java
@@ -98,6 +98,19 @@ public class FSTBasedRegexpLikeQueriesTest extends BaseFSTBasedRegexpLikeQueries
   }
 
   @Test
+  public void testFSTBasedRegexLikeFallsBackToScanOnTraversalLimit() {
+    // With a tiny FST traversal budget the FST walk is abandoned mid-flight and the query falls back to the
+    // dictionary-scan evaluator, which must produce identical results to the FST path.
+    String query = "SELECT INT_COL, URL_COL FROM MyTable WHERE REGEXP_LIKE(DOMAIN_NAMES, 'www.domain1.*') LIMIT 50000";
+    testInnerSegmentSelectionQuery(query, 256, null);
+    testInnerSegmentSelectionQuery("SET fstRegexpTraversalLimit = 1; " + query, 256, null);
+
+    query = "SELECT INT_COL, URL_COL FROM MyTable WHERE REGEXP_LIKE(URL_COL, '.*domain1.*') LIMIT 50000";
+    testInnerSegmentSelectionQuery(query, 512, null);
+    testInnerSegmentSelectionQuery("SET fstRegexpTraversalLimit = 1; " + query, 512, null);
+  }
+
+  @Test
   public void testLikeOperator() {
     String query = "SELECT INT_COL, URL_COL FROM MyTable WHERE DOMAIN_NAMES LIKE 'www.dom_in1.com' LIMIT 50000";
     testInnerSegmentSelectionQuery(query, 64, null);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/LuceneFSTIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/LuceneFSTIndexReader.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.segment.local.segment.index.readers;
 
 import java.io.IOException;
+import javax.annotation.Nullable;
 import org.apache.lucene.util.fst.FST;
 import org.apache.lucene.util.fst.OffHeapFSTStore;
 import org.apache.lucene.util.fst.PositiveIntOutputs;
@@ -59,9 +60,18 @@ public class LuceneFSTIndexReader implements TextIndexReader {
 
   @Override
   public ImmutableRoaringBitmap getDictIds(String searchQuery) {
+    return getDictIds(searchQuery, Integer.MAX_VALUE);
+  }
+
+  @Override
+  @Nullable
+  public ImmutableRoaringBitmap getDictIds(String searchQuery, int maxTraversalPaths) {
     try {
       MutableRoaringBitmap dictIds = new MutableRoaringBitmap();
-      RegexpMatcher.regexMatch(searchQuery, _fst, dictIds::add);
+      // Returns null when the walk is stopped at the traversal limit, signaling the caller to fall back to scan.
+      if (!RegexpMatcher.regexMatch(searchQuery, _fst, dictIds::add, maxTraversalPaths)) {
+        return null;
+      }
       return dictIds.toImmutableRoaringBitmap();
     } catch (QueryException ex) {
       // Let query termination exceptions (timeout, OOM-protection kill) propagate as-is.

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/LuceneIFSTIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/LuceneIFSTIndexReader.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.segment.local.segment.index.readers;
 
 import java.io.IOException;
+import javax.annotation.Nullable;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.fst.ByteSequenceOutputs;
 import org.apache.lucene.util.fst.FST;
@@ -60,9 +61,18 @@ public class LuceneIFSTIndexReader implements TextIndexReader {
 
   @Override
   public ImmutableRoaringBitmap getDictIds(String searchQuery) {
+    return getDictIds(searchQuery, Integer.MAX_VALUE);
+  }
+
+  @Override
+  @Nullable
+  public ImmutableRoaringBitmap getDictIds(String searchQuery, int maxTraversalPaths) {
     try {
       MutableRoaringBitmap dictIds = new MutableRoaringBitmap();
-      RegexpMatcherCaseInsensitive.regexMatch(searchQuery, _ifst, dictIds::add);
+      // Returns null when the walk is stopped at the traversal limit, signaling the caller to fall back to scan.
+      if (!RegexpMatcherCaseInsensitive.regexMatch(searchQuery, _ifst, dictIds::add, maxTraversalPaths)) {
+        return null;
+      }
       return dictIds.toImmutableRoaringBitmap();
     } catch (QueryException ex) {
       // Let query termination exceptions (timeout, OOM-protection kill) propagate as-is.

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/fst/RegexpMatcher.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/fst/RegexpMatcher.java
@@ -53,7 +53,17 @@ public class RegexpMatcher {
   /// this class materializing the full result set in memory.
   public static void regexMatch(String regexQuery, FST<Long> fst, IntConsumer dictIdConsumer)
       throws IOException {
-    new RegexpMatcher(regexQuery, fst).regexMatchOnFST(dictIdConsumer);
+    regexMatch(regexQuery, fst, dictIdConsumer, Integer.MAX_VALUE);
+  }
+
+  /// Same as [#regexMatch(String, FST, IntConsumer)] but stops the walk once `maxPaths` FST paths have been visited,
+  /// so a broad pattern over a high-cardinality column cannot allocate without bound. Returns `true` if the walk
+  /// completed (all matches emitted), or `false` if it was stopped at the limit (the emitted values are partial and
+  /// should be discarded, with the caller falling back to a scan). A non-positive `maxPaths` disables the cap, so the
+  /// walk runs unbounded.
+  public static boolean regexMatch(String regexQuery, FST<Long> fst, IntConsumer dictIdConsumer, int maxPaths)
+      throws IOException {
+    return new RegexpMatcher(regexQuery, fst).regexMatchOnFST(dictIdConsumer, maxPaths);
   }
 
   // Matches "input" string with _regexQuery Automaton.
@@ -79,9 +89,19 @@ public class RegexpMatcher {
   /// for query termination (timeout or OOM-protection kill) to remain interruptible.
   public void regexMatchOnFST(IntConsumer dictIdConsumer)
       throws IOException {
+    regexMatchOnFST(dictIdConsumer, Integer.MAX_VALUE);
+  }
+
+  /// Same as [#regexMatchOnFST(IntConsumer)] but stops once `maxPaths` FST paths have been visited. Returns `true` if
+  /// the walk completed, or `false` if it was stopped at the limit (partial results emitted). A non-positive
+  /// `maxPaths` disables the cap (unbounded walk).
+  public boolean regexMatchOnFST(IntConsumer dictIdConsumer, int maxPaths)
+      throws IOException {
     if (_automaton.getNumStates() == 0) {
-      return;
+      return true;
     }
+    // A non-positive limit means "unbounded"; normalize so the per-iteration check never trips spuriously.
+    int pathLimit = maxPaths <= 0 ? Integer.MAX_VALUE : maxPaths;
 
     // Automaton start state and FST start node is added to the stack.
     List<Path<Long>> stack = new ArrayList<>();
@@ -93,6 +113,10 @@ public class RegexpMatcher {
     Transition t = new Transition();
     int numPathsProcessed = 0;
     while (!stack.isEmpty()) {
+      if (numPathsProcessed >= pathLimit) {
+        // Pattern too broad for the FST index; signal the caller to fall back to a scan-based evaluator.
+        return false;
+      }
       QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numPathsProcessed++,
           "RegexpMatcher#regexMatchOnFST");
       Path<Long> path = stack.remove(stack.size() - 1);
@@ -124,6 +148,7 @@ public class RegexpMatcher {
         }
       }
     }
+    return true;
   }
 
   public static final class Path<T> {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/fst/RegexpMatcherCaseInsensitive.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/fst/RegexpMatcherCaseInsensitive.java
@@ -55,7 +55,16 @@ public class RegexpMatcherCaseInsensitive {
   /// collect them without this class materializing the full result set in memory.
   public static void regexMatch(String regexQuery, FST<BytesRef> ifst, IntConsumer dictIdConsumer)
       throws IOException {
-    new RegexpMatcherCaseInsensitive(regexQuery, ifst).regexMatchOnFST(dictIdConsumer);
+    regexMatch(regexQuery, ifst, dictIdConsumer, Integer.MAX_VALUE);
+  }
+
+  /// Same as [#regexMatch(String, FST, IntConsumer)] but stops the walk once `maxPaths` FST paths have been visited.
+  /// Returns `true` if the walk completed (all matches emitted), or `false` if it was stopped at the limit (the
+  /// emitted values are partial and should be discarded, with the caller falling back to a scan). A non-positive
+  /// `maxPaths` disables the cap, so the walk runs unbounded.
+  public static boolean regexMatch(String regexQuery, FST<BytesRef> ifst, IntConsumer dictIdConsumer, int maxPaths)
+      throws IOException {
+    return new RegexpMatcherCaseInsensitive(regexQuery, ifst).regexMatchOnFST(dictIdConsumer, maxPaths);
   }
 
   // Matches "input" string with _regexQuery Automaton (case-insensitive).
@@ -81,9 +90,19 @@ public class RegexpMatcherCaseInsensitive {
   /// for query termination (timeout or OOM-protection kill) to remain interruptible.
   public void regexMatchOnFST(IntConsumer dictIdConsumer)
       throws IOException {
+    regexMatchOnFST(dictIdConsumer, Integer.MAX_VALUE);
+  }
+
+  /// Same as [#regexMatchOnFST(IntConsumer)] but stops once `maxPaths` FST paths have been visited. Returns `true` if
+  /// the walk completed, or `false` if it was stopped at the limit (partial results emitted). A non-positive
+  /// `maxPaths` disables the cap (unbounded walk).
+  public boolean regexMatchOnFST(IntConsumer dictIdConsumer, int maxPaths)
+      throws IOException {
     if (_automaton.getNumStates() == 0) {
-      return;
+      return true;
     }
+    // A non-positive limit means "unbounded"; normalize so the per-iteration check never trips spuriously.
+    int pathLimit = maxPaths <= 0 ? Integer.MAX_VALUE : maxPaths;
 
     // Automaton start state and FST start node is added to the stack.
     List<Path<BytesRef>> stack = new ArrayList<>();
@@ -95,6 +114,10 @@ public class RegexpMatcherCaseInsensitive {
     Transition t = new Transition();
     int numPathsProcessed = 0;
     while (!stack.isEmpty()) {
+      if (numPathsProcessed >= pathLimit) {
+        // Pattern too broad for the FST index; signal the caller to fall back to a scan-based evaluator.
+        return false;
+      }
       QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numPathsProcessed++,
           "RegexpMatcherCaseInsensitive#regexMatchOnFST");
       Path<BytesRef> path = stack.remove(stack.size() - 1);
@@ -139,6 +162,7 @@ public class RegexpMatcherCaseInsensitive {
         }
       }
     }
+    return true;
   }
 
   public static final class Path<T> {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/fst/FSTBuilderTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/fst/FSTBuilderTest.java
@@ -39,6 +39,8 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
@@ -128,6 +130,43 @@ public class FSTBuilderTest implements PinotBuffersAfterMethodCheckRule {
     } finally {
       // Clear the interrupt flag in case the matcher did not consume it
       Thread.interrupted();
+    }
+  }
+
+  @Test
+  public void testRegexMatchTraversalLimit()
+      throws IOException {
+    SortedMap<String, Integer> x = new TreeMap<>();
+    for (int i = 0; i < 1000; i++) {
+      x.put(String.format("key-%06d", i), i);
+    }
+    FST<Long> fst = FSTBuilder.buildFST(x);
+    File outputFile = new File(TEMP_DIR, "test_traversal_limit.lucene");
+    try (FileOutputStream outputStream = new FileOutputStream(outputFile);
+        OutputStreamDataOutput dataOutput = new OutputStreamDataOutput(outputStream)) {
+      fst.save(dataOutput, dataOutput);
+    }
+
+    int cardinality = 1000;
+    try (PinotDataBuffer dataBuffer = PinotDataBuffer.loadBigEndianFile(outputFile);
+        LuceneFSTIndexReader reader = new LuceneFSTIndexReader(dataBuffer)) {
+      // A broad walk exceeds a tiny path budget and is abandoned: the matcher reports incomplete (false) and the
+      // reader returns null to signal the caller to fall back to a scan.
+      assertFalse(RegexpMatcher.regexMatch(".*", fst, new MutableRoaringBitmap()::add, 10));
+      assertNull(reader.getDictIds(".*", 10));
+
+      // Unbounded (or a cap above the full-walk path count) completes and returns all entries.
+      assertEquals(reader.getDictIds(".*", Integer.MAX_VALUE).getCardinality(), cardinality);
+
+      // With the cap at the column cardinality (the provider's default), a non-pruning '.*' walk visits more than
+      // `cardinality` FST paths, so it trips and falls back (null); a selective prefix visits a small subtree and
+      // stays on the FST.
+      assertNull(reader.getDictIds(".*", cardinality));
+      assertEquals(reader.getDictIds("key-000001", cardinality).getCardinality(), 1);
+
+      // A non-positive limit disables the cap (unbounded walk).
+      assertEquals(reader.getDictIds(".*", 0).getCardinality(), cardinality);
+      assertEquals(reader.getDictIds(".*", -1).getCardinality(), cardinality);
     }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/fst/IFSTBuilderTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/fst/IFSTBuilderTest.java
@@ -42,6 +42,8 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
@@ -143,6 +145,43 @@ public class IFSTBuilderTest implements PinotBuffersAfterMethodCheckRule {
     } finally {
       // Clear the interrupt flag in case the matcher did not consume it
       Thread.interrupted();
+    }
+  }
+
+  @Test
+  public void testRegexMatchTraversalLimit()
+      throws IOException {
+    SortedMap<String, Integer> x = new TreeMap<>();
+    for (int i = 0; i < 1000; i++) {
+      x.put(String.format("key-%06d", i), i);
+    }
+    FST<BytesRef> ifst = IFSTBuilder.buildIFST(x);
+    File outputFile = new File(TEMP_DIR, "test_traversal_limit_case_insensitive.lucene");
+    try (FileOutputStream outputStream = new FileOutputStream(outputFile);
+        OutputStreamDataOutput dataOutput = new OutputStreamDataOutput(outputStream)) {
+      ifst.save(dataOutput, dataOutput);
+    }
+
+    int cardinality = 1000;
+    try (PinotDataBuffer dataBuffer = PinotDataBuffer.loadBigEndianFile(outputFile);
+        LuceneIFSTIndexReader reader = new LuceneIFSTIndexReader(dataBuffer)) {
+      // A broad walk exceeds a tiny path budget and is abandoned: the matcher reports incomplete (false) and the
+      // reader returns null to signal the caller to fall back to a scan.
+      assertFalse(RegexpMatcherCaseInsensitive.regexMatch(".*", ifst, new MutableRoaringBitmap()::add, 10));
+      assertNull(reader.getDictIds(".*", 10));
+
+      // Unbounded (or a cap above the full-walk path count) completes and returns all entries.
+      assertEquals(reader.getDictIds(".*", Integer.MAX_VALUE).getCardinality(), cardinality);
+
+      // With the cap at the column cardinality (the provider's default), a non-pruning '.*' walk visits more than
+      // `cardinality` FST paths, so it trips and falls back (null); a selective prefix visits a small subtree and
+      // stays on the FST.
+      assertNull(reader.getDictIds(".*", cardinality));
+      assertEquals(reader.getDictIds("key-000001", cardinality).getCardinality(), 1);
+
+      // A non-positive limit disables the cap (unbounded walk).
+      assertEquals(reader.getDictIds(".*", 0).getCardinality(), cardinality);
+      assertEquals(reader.getDictIds(".*", -1).getCardinality(), cardinality);
     }
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/TextIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/TextIndexReader.java
@@ -31,6 +31,21 @@ public interface TextIndexReader extends IndexReader {
   ImmutableRoaringBitmap getDictIds(String searchQuery);
 
   /**
+   * Returns the matching dictionary ids for the given search query, bounding the work performed (e.g. the number of
+   * FST paths visited by a regexp walk) to {@code maxTraversalPaths}. Implementations that can exceed a safe memory
+   * footprint for broad queries should honor this bound by aborting once it is reached and returning {@code null},
+   * which signals the caller to fall back to a scan-based evaluator (rather than failing the query). The default
+   * implementation ignores the bound and delegates to {@link #getDictIds(String)}, which is correct for readers
+   * whose work is already bounded.
+   *
+   * @return the matching dictionary ids, or {@code null} if the bounded traversal was aborted before completing
+   */
+  @Nullable
+  default ImmutableRoaringBitmap getDictIds(String searchQuery, int maxTraversalPaths) {
+    return getDictIds(searchQuery);
+  }
+
+  /**
    * Returns the matching document ids for the given search query.
    * This is the legacy entry point retained for backward compatibility.
    */

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -887,6 +887,15 @@ public class CommonConstants {
         //   during the scan
         public static final String REGEX_DICT_SIZE_THRESHOLD = "regexDictSizeThreshold";
 
+        // When evaluating a REGEXP_LIKE predicate backed by an FST/IFST index, bound the number of FST paths visited
+        // during the automaton-over-FST walk. Once the limit is reached the FST evaluation is abandoned and the query
+        // falls back to the dictionary-scan evaluator (correct, and often cheaper for broad patterns). When unset, the
+        // limit defaults to the column cardinality (dictionary length): a non-pruning pattern (e.g. a leading '.*')
+        // walks the whole FST (~cardinality paths) and so falls back to scan, while selective prefix/fuzzy patterns
+        // visit only a small subtree and stay on the FST. A positive value overrides this with an absolute cap; a
+        // non-positive value disables the cap (unbounded traversal).
+        public static final String FST_REGEXP_TRAVERSAL_LIMIT = "fstRegexpTraversalLimit";
+
         public static final String DROP_RESULTS = "dropResults";
 
         // Exclude virtual columns (columns starting with '$') from table schema


### PR DESCRIPTION
## Problem

A `REGEXP_LIKE` backed by an **FST/IFST index** walks the query automaton over the FST. A pattern that does not prune — anything with a leading `.*` — gives the prefix walk nothing to descend into, so it traverses essentially the whole FST (~cardinality paths) and allocates proportionally. A single such query is fine, but a burst of them saturates server heap (the EpicGames OOM). The companion fix #18754 (merged) removed the retained-result overhead and made the walk interruptible; this PR bounds the walk itself.

Benchmarks (default `java.util.regex` scan, 500K keys × 40 chars): for broad patterns the dictionary scan is faster and allocates ~190× less than the FST walk, while for selective prefix/fuzzy patterns the FST is ~1600× faster. So the right move is to **cap the FST work and fall back to scan only when the walk is actually broad**.

## Approach

The matcher reports completion instead of throwing — no exception is used as control flow:

- `RegexpMatcher` / `RegexpMatcherCaseInsensitive` return `false` once `maxPaths` FST paths have been visited (walk abandoned), or `true` if it completed.
- `TextIndexReader` gains a backward-compatible `@Nullable getDictIds(String, int maxTraversalPaths)` default method (delegates to the single-arg version, so other readers are unaffected). The two Lucene readers return `null` when the walk is abandoned.
- The FST/IFST predicate factories return `null` on `null`, and `PredicateEvaluatorProvider` falls back to the existing dictionary-scan evaluator — correct, and typically far cheaper in memory for broad patterns. Selective patterns visit a small subtree, never trip the cap, and keep the FST's large speed advantage.

### Default cap = column cardinality

The `fstRegexpTraversalLimit` query option overrides the cap with an absolute value (non-positive disables it); **when unset it defaults to the column cardinality** (dictionary length). This is the natural, self-tuning unit: an experiment across cardinalities shows a selective query visits paths proportional to its *match count* (≈150 paths for 100 matches, independent of cardinality), while a non-pruning `.*` walk visits ≈1.1× the cardinality. So capping at cardinality makes a non-pruning pattern fall back to scan (where scan is the better tool anyway) while every selective prefix/fuzzy query stays on the FST — at any column size, with no magic constant.

| cardinality | pattern | matches | paths visited |
|---|---|---|---|
| 1M | `.*` (matchAll) | 1,000,000 | 1,111,145 |
| 1M | `.*<rare-suffix>` (leading `.*`) | 100 | 1,111,145 |
| 1M | selective prefix | 100 | 149 |
| 1M | exact | 1 | 41 |

No on-disk format change; the SPI addition is a default method (rolling-upgrade safe); the new query option is additive.

## Testing

- **Matcher / reader** (`FSTBuilderTest`, `IFSTBuilderTest`): a tiny budget abandons the walk (matcher returns `false`, reader returns `null`); an unbounded walk completes; a cap equal to the cardinality makes a `.*` walk fall back (`null`) while a selective prefix stays on the FST; a non-positive cap disables the bound.
- **End-to-end** (`FSTBasedRegexpLikeQueriesTest`): a query with `fstRegexpTraversalLimit = 1` forces the scan fallback and returns results **identical** to the FST path (256 and 512 rows), proving fallback correctness.