### PR TITLE
Add per-table OOM pre-kill pause fields to QueryConfig

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/QueryConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/QueryConfig.java
@@ -62,12 +62,33 @@ public class QueryConfig extends BaseJsonConfig {
 
   private final Long _maxEntriesScannedPostFilter;
 
+  // Per-table pre-OOM-kill query pause duration (ms). Null (the default) means the pause is disabled for this table —
+  // the field is omitted from serialized JSON by BaseJsonConfig's NON_NULL inclusion policy. A positive value pauses
+  // the queries for that many ms before killing them when the server hits panic-level heap pressure. A value of 0 is
+  // also treated as disabled and is allowed as an explicit opt-out signal.
+  private final Long _oomPreQueryKillPauseDurationMs;
+
+  // Per-table flag controlling whether the pre-OOM-kill pause is allowed at panic-level heap usage. Null (the default)
+  // means panic-level pause is disabled for this table — the field is omitted from serialized JSON. Pair with a
+  // positive _oomPreQueryKillPauseDurationMs to enable it.
+  private final Boolean _oomPanicAllowPreQueryKillPause;
 
   public QueryConfig(@Nullable Long timeoutMs, @Nullable Boolean disableGroovy,
       @Nullable Boolean useApproximateFunction, @Nullable Map<String, String> expressionOverrideMap,
       @Nullable Long maxQueryResponseSizeBytes, @Nullable Long maxServerResponseSizeBytes) {
     this(timeoutMs, disableGroovy, useApproximateFunction, expressionOverrideMap,
-        maxQueryResponseSizeBytes, maxServerResponseSizeBytes, null, null, null);
+        maxQueryResponseSizeBytes, maxServerResponseSizeBytes, null, null, null, null, null);
+  }
+
+  public QueryConfig(@Nullable Long timeoutMs, @Nullable Boolean disableGroovy,
+      @Nullable Boolean useApproximateFunction, @Nullable Map<String, String> expressionOverrideMap,
+      @Nullable Long maxQueryResponseSizeBytes, @Nullable Long maxServerResponseSizeBytes,
+      @Nullable Long maxEntriesScannedInFilter, @Nullable Long maxDocsScanned,
+      @Nullable Long maxEntriesScannedPostFilter) {
+    this(timeoutMs, disableGroovy, useApproximateFunction, expressionOverrideMap,
+        maxQueryResponseSizeBytes, maxServerResponseSizeBytes,
+        maxEntriesScannedInFilter, maxDocsScanned, maxEntriesScannedPostFilter,
+        null, null);
   }
 
   @JsonCreator
@@ -79,7 +100,9 @@ public class QueryConfig extends BaseJsonConfig {
       @JsonProperty("maxServerResponseSizeBytes") @Nullable Long maxServerResponseSizeBytes,
       @JsonProperty("maxEntriesScannedInFilter") @Nullable Long maxEntriesScannedInFilter,
       @JsonProperty("maxDocsScanned") @Nullable Long maxDocsScanned,
-      @JsonProperty("maxEntriesScannedPostFilter") @Nullable Long maxEntriesScannedPostFilter) {
+      @JsonProperty("maxEntriesScannedPostFilter") @Nullable Long maxEntriesScannedPostFilter,
+      @JsonProperty("oomPreQueryKillPauseDurationMs") @Nullable Long oomPreQueryKillPauseDurationMs,
+      @JsonProperty("oomPanicAllowPreQueryKillPause") @Nullable Boolean oomPanicAllowPreQueryKillPause) {
     Preconditions.checkArgument(timeoutMs == null || timeoutMs > 0, "Invalid 'timeoutMs': %s", timeoutMs);
     Preconditions.checkArgument(maxQueryResponseSizeBytes == null || maxQueryResponseSizeBytes > 0,
         "Invalid 'maxQueryResponseSizeBytes': %s", maxQueryResponseSizeBytes);
@@ -91,6 +114,9 @@ public class QueryConfig extends BaseJsonConfig {
         "Invalid 'maxDocsScanned': %s", maxDocsScanned);
     Preconditions.checkArgument(maxEntriesScannedPostFilter == null || maxEntriesScannedPostFilter > 0,
         "Invalid 'maxEntriesScannedPostFilter': %s", maxEntriesScannedPostFilter);
+    Preconditions.checkArgument(oomPreQueryKillPauseDurationMs == null || oomPreQueryKillPauseDurationMs >= 0,
+        "Invalid 'oomPreQueryKillPauseDurationMs': %s (must be >= 0; 0 disables the pause for this table)",
+        oomPreQueryKillPauseDurationMs);
 
     _timeoutMs = timeoutMs;
     _disableGroovy = disableGroovy;
@@ -101,6 +127,8 @@ public class QueryConfig extends BaseJsonConfig {
     _maxEntriesScannedInFilter = maxEntriesScannedInFilter;
     _maxDocsScanned = maxDocsScanned;
     _maxEntriesScannedPostFilter = maxEntriesScannedPostFilter;
+    _oomPreQueryKillPauseDurationMs = oomPreQueryKillPauseDurationMs;
+    _oomPanicAllowPreQueryKillPause = oomPanicAllowPreQueryKillPause;
   }
 
   @Nullable
@@ -155,5 +183,17 @@ public class QueryConfig extends BaseJsonConfig {
   @JsonProperty("maxEntriesScannedPostFilter")
   public Long getMaxEntriesScannedPostFilter() {
     return _maxEntriesScannedPostFilter;
+  }
+
+  @Nullable
+  @JsonProperty("oomPreQueryKillPauseDurationMs")
+  public Long getOomPreQueryKillPauseDurationMs() {
+    return _oomPreQueryKillPauseDurationMs;
+  }
+
+  @Nullable
+  @JsonProperty("oomPanicAllowPreQueryKillPause")
+  public Boolean getOomPanicAllowPreQueryKillPause() {
+    return _oomPanicAllowPreQueryKillPause;
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/QueryConfigOomPauseTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/QueryConfigOomPauseTest.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.table;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+public class QueryConfigOomPauseTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @Test
+  public void testOomPauseFieldsDefaultToNull() {
+    QueryConfig config = new QueryConfig(null, null, null, null, null, null, null, null, null);
+    assertNull(config.getOomPreQueryKillPauseDurationMs());
+    assertNull(config.getOomPanicAllowPreQueryKillPause());
+  }
+
+  @Test
+  public void testOomPauseFieldsSetExplicitly() {
+    QueryConfig config = new QueryConfig(null, null, null, null, null, null, null, null, null, 3000L, true);
+    assertEquals(config.getOomPreQueryKillPauseDurationMs(), Long.valueOf(3000L));
+    assertEquals(config.getOomPanicAllowPreQueryKillPause(), Boolean.TRUE);
+  }
+
+  @Test
+  public void testOomPauseDisabledExplicitlyByZero() {
+    QueryConfig config = new QueryConfig(null, null, null, null, null, null, null, null, null, 0L, false);
+    assertEquals(config.getOomPreQueryKillPauseDurationMs(), Long.valueOf(0L));
+    assertEquals(config.getOomPanicAllowPreQueryKillPause(), Boolean.FALSE);
+  }
+
+  @Test
+  public void testJsonRoundTripWithOomPauseFields()
+      throws Exception {
+    QueryConfig config = new QueryConfig(30000L, null, null, null, null, null, null, null, null, 3000L, true);
+
+    String json = OBJECT_MAPPER.writeValueAsString(config);
+    assertTrue(json.contains("\"oomPreQueryKillPauseDurationMs\":3000"), "json missing oomPreQueryKillPauseDurationMs");
+    assertTrue(json.contains("\"oomPanicAllowPreQueryKillPause\":true"), "json missing oomPanicAllowPreQueryKillPause");
+
+    QueryConfig deserialized = OBJECT_MAPPER.readValue(json, QueryConfig.class);
+    assertEquals(deserialized.getOomPreQueryKillPauseDurationMs(), Long.valueOf(3000L));
+    assertEquals(deserialized.getOomPanicAllowPreQueryKillPause(), Boolean.TRUE);
+  }
+
+  @Test
+  public void testJsonDeserializationWithoutOomPauseFieldsPreservesNull()
+      throws Exception {
+    String json = "{\"timeoutMs\": 5000}";
+    QueryConfig config = OBJECT_MAPPER.readValue(json, QueryConfig.class);
+    assertEquals(config.getTimeoutMs(), Long.valueOf(5000L));
+    assertNull(config.getOomPreQueryKillPauseDurationMs());
+    assertNull(config.getOomPanicAllowPreQueryKillPause());
+  }
+
+  @Test
+  public void testJsonDeserializationWithOnlyOomPauseFields()
+      throws Exception {
+    String json = "{\"oomPreQueryKillPauseDurationMs\": 3000, \"oomPanicAllowPreQueryKillPause\": true}";
+    QueryConfig config = OBJECT_MAPPER.readValue(json, QueryConfig.class);
+    assertNull(config.getTimeoutMs());
+    assertEquals(config.getOomPreQueryKillPauseDurationMs(), Long.valueOf(3000L));
+    assertEquals(config.getOomPanicAllowPreQueryKillPause(), Boolean.TRUE);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testNegativeOomPauseDurationThrows() {
+    new QueryConfig(null, null, null, null, null, null, null, null, null, -1L, null);
+  }
+
+  @Test
+  public void testZeroOomPauseDurationAllowedAsDisableSignal() {
+    // Zero is a valid "disable pause for this table" signal — the accountant treats <= 0 as disabled.
+    QueryConfig config = new QueryConfig(null, null, null, null, null, null, null, null, null, 0L, null);
+    assertEquals(config.getOomPreQueryKillPauseDurationMs(), Long.valueOf(0L));
+  }
+}


### PR DESCRIPTION
## Summary

Adds two nullable fields to `tableConfig.queryConfig` so operators can opt individual tables in or out of the pre-OOM-kill query pause behavior independently of the server-instance defaults:

- `oomPreQueryKillPauseDurationMs` (`Long`)
- `oomPanicAllowPreQueryKillPause` (`Boolean`)

Both default to `null`. Because `BaseJsonConfig` is annotated `@JsonInclude(NON_NULL)`, existing table configs serialize byte-for-byte identically — no field rename, no enum extension, no protocol change.

## Motivation

The existing OOM pre-kill pause configs (`pinot.server.query.accounting.oom.pre.query.kill.pause.duration.ms` and `oom.panic.allow.pre.query.kill.pause`) are read once at server startup into `QueryMonitorConfig` and apply JVM-wide. That's fine for dedicated servers, but on mixed-tenant servers the pause behavior leaks to every co-hosted table. For workloads that read large objects from object storage on the query path (e.g. external / Iceberg-backed tables), the pause gives in-flight work a chance to release memory before the kill — but co-hosted tables with smaller working sets don't necessarily want that pause.

Per-table opt-in lets the table author decide. The server-instance defaults remain the fallback for any table that doesn't override.

## Tests

New `QueryConfigOomPauseTest` covers:
- Default-null state.
- Explicit positive and zero values (zero as the opt-out signal).
- JSON round-trip with the fields set.
- JSON deserialization with the fields absent or set in isolation.
- Negative-value rejection via `Preconditions.checkArgument`.


