### PR TITLE
Add targetDocsPerChunk cap to VarByteChunkForwardIndexWriterV6 and wire it to table config

### DIFF
--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkVarByteV6TargetDocsPerChunk.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkVarByteV6TargetDocsPerChunk.java
@@ -1,0 +1,352 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Random;
+import java.util.TreeMap;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.io.writer.impl.VarByteChunkForwardIndexWriterV6;
+import org.apache.pinot.segment.local.segment.index.readers.forward.VarByteChunkForwardIndexReaderV4;
+import org.apache.pinot.segment.local.segment.index.readers.forward.VarByteChunkForwardIndexReaderV6;
+import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+/// Measures the storage-size / access-latency tradeoff of the `targetDocsPerChunk` cap added to
+/// [VarByteChunkForwardIndexWriterV6].
+///
+/// The cap flushes a chunk once it holds N documents even when the `chunkSize` byte budget is not
+/// exhausted. Smaller chunks shrink the compressor's dedup window (worse ratio, bigger index) but
+/// make a random point lookup decompress less data (lower latency). This benchmark sweeps the cap
+/// and reports both sides.
+///
+/// Storage size is not a JMH metric — it is recorded during trial setup and dumped by
+/// [#printSizes()] at JVM exit.
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(1)
+@Warmup(iterations = 2, time = 2)
+@Measurement(iterations = 3, time = 3)
+@State(Scope.Benchmark)
+public class BenchmarkVarByteV6TargetDocsPerChunk {
+
+  private static final File TARGET_DIR = new File(FileUtils.getTempDirectory(), "BenchmarkV6TargetDocsPerChunk");
+  /// Collected across all forked trials of this JVM, keyed by the parameter combination.
+  private static final Map<String, long[]> SIZES = new TreeMap<>();
+  private static final int NUM_RANDOM_LOOKUPS = 2_000;
+
+  static {
+    Runtime.getRuntime().addShutdownHook(new Thread(BenchmarkVarByteV6TargetDocsPerChunk::printSizes));
+  }
+
+  @Param("1000000")
+  int _numDocs;
+
+  /// Shape of the column being written. See [#generate()].
+  @Param({"LOW_CARD_URL", "HIGH_CARD_UUID", "JSON_LOG", "SKEWED_LOG"})
+  String _dataset;
+
+  @Param({"ZSTANDARD", "LZ4", "SNAPPY"})
+  ChunkCompressionType _compression;
+
+  /// Chunk byte budget. 1MB is the Pinot default `targetMaxChunkSize`.
+  @Param("1048576")
+  int _chunkSize;
+
+  /// -1 disables the cap (current behavior: byte-driven flush only).
+  @Param({"-1", "10", "50", "100", "250", "500", "1000", "5000", "20000"})
+  int _targetDocsPerChunk;
+
+  private byte[][] _values;
+  private File _file;
+  private PinotDataBuffer _buffer;
+  private VarByteChunkForwardIndexReaderV6 _reader;
+  private int[] _randomDocIds;
+  private int[] _selectiveDocIds;
+
+  @Setup(Level.Trial)
+  public void setup()
+      throws IOException {
+    FileUtils.forceMkdir(TARGET_DIR);
+    _values = generate();
+    _file = new File(TARGET_DIR, UUID.randomUUID().toString());
+    try (VarByteChunkForwardIndexWriterV6 writer = new VarByteChunkForwardIndexWriterV6(_file, _compression,
+        _chunkSize, _targetDocsPerChunk)) {
+      for (byte[] value : _values) {
+        writer.putBytes(value);
+      }
+    }
+    long rawBytes = 0;
+    for (byte[] value : _values) {
+      rawBytes += value.length;
+    }
+    synchronized (SIZES) {
+      SIZES.put(String.format("%-14s %-10s docsPerChunk=%-6d", _dataset, _compression, _targetDocsPerChunk),
+          new long[]{_file.length(), rawBytes});
+    }
+
+    _buffer = PinotDataBuffer.loadBigEndianFile(_file);
+    _reader = new VarByteChunkForwardIndexReaderV6(_buffer, FieldSpec.DataType.BYTES, true);
+
+    // Fixed seed so every parameter combination probes the same doc ids.
+    Random random = new Random(7);
+    _randomDocIds = new int[NUM_RANDOM_LOOKUPS];
+    for (int i = 0; i < NUM_RANDOM_LOOKUPS; i++) {
+      _randomDocIds[i] = random.nextInt(_numDocs);
+    }
+    _selectiveDocIds = new int[_numDocs / 100];
+    for (int i = 0; i < _selectiveDocIds.length; i++) {
+      _selectiveDocIds[i] = i * 100 + random.nextInt(100);
+    }
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown()
+      throws IOException {
+    if (_reader != null) {
+      _reader.close();
+    }
+    if (_buffer != null) {
+      _buffer.close();
+    }
+    FileUtils.deleteQuietly(_file);
+  }
+
+  /// Full sequential scan — every chunk is decompressed exactly once, so this isolates the
+  /// per-chunk overhead paid on a full-column scan.
+  @Benchmark
+  public void sequentialScan(Blackhole bh)
+      throws IOException {
+    try (VarByteChunkForwardIndexReaderV4.ReaderContext context = _reader.createContext()) {
+      for (int docId = 0; docId < _numDocs; docId++) {
+        bh.consume(_reader.getBytes(docId, context));
+      }
+    }
+  }
+
+  /// Uniformly random point lookups — the context caches only the last chunk, so nearly every
+  /// lookup decompresses a whole chunk. This is where a smaller chunk pays off.
+  @Benchmark
+  public void randomAccess(Blackhole bh)
+      throws IOException {
+    try (VarByteChunkForwardIndexReaderV4.ReaderContext context = _reader.createContext()) {
+      for (int docId : _randomDocIds) {
+        bh.consume(_reader.getBytes(docId, context));
+      }
+    }
+  }
+
+  /// Ascending doc ids at 1% selectivity — the realistic filtered-query pattern, where matches are
+  /// spread thinly but read in order. Sits between the two extremes above.
+  @Benchmark
+  public void selectiveAscendingScan(Blackhole bh)
+      throws IOException {
+    try (VarByteChunkForwardIndexReaderV4.ReaderContext context = _reader.createContext()) {
+      for (int docId : _selectiveDocIds) {
+        bh.consume(_reader.getBytes(docId, context));
+      }
+    }
+  }
+
+  private byte[][] generate() {
+    Random random = new Random(42);
+    byte[][] values = new byte[_numDocs][];
+    switch (_dataset) {
+      // Highly repetitive short strings: the case the cap is meant to help/hurt most.
+      case "LOW_CARD_URL": {
+        String[] dictionary = new String[200];
+        for (int i = 0; i < dictionary.length; i++) {
+          dictionary[i] = "https://www.example.com/catalog/category/" + i + "/item?ref=homepage&session=abc";
+        }
+        for (int i = 0; i < _numDocs; i++) {
+          values[i] = dictionary[random.nextInt(dictionary.length)].getBytes(StandardCharsets.UTF_8);
+        }
+        break;
+      }
+      // Effectively unique values: almost nothing for the compressor to dedup.
+      case "HIGH_CARD_UUID": {
+        for (int i = 0; i < _numDocs; i++) {
+          values[i] = new UUID(random.nextLong(), random.nextLong()).toString().getBytes(StandardCharsets.UTF_8);
+        }
+        break;
+      }
+      // Structurally repetitive but individually unique — the common real-world raw-string column.
+      case "JSON_LOG": {
+        String[] services = {"checkout", "search", "cart", "auth", "recommendation"};
+        String[] levels = {"INFO", "WARN", "ERROR", "DEBUG"};
+        for (int i = 0; i < _numDocs; i++) {
+          String json = "{\"ts\":" + (1700000000000L + i * 37L) + ",\"service\":\"" + services[random.nextInt(
+              services.length)] + "\",\"level\":\"" + levels[random.nextInt(levels.length)] + "\",\"latencyMs\":"
+              + random.nextInt(5000) + ",\"userId\":\"" + new UUID(random.nextLong(), random.nextLong())
+              + "\",\"message\":\"request completed successfully\"}";
+          values[i] = json.getBytes(StandardCharsets.UTF_8);
+        }
+        break;
+      }
+      // Short values with a handful of very large outliers. `maxLength` is then wildly
+      // unrepresentative of the average, which is what breaks the byte-derived docs-per-chunk path.
+      case "SKEWED_LOG": {
+        String[] services = {"checkout", "search", "cart", "auth", "recommendation"};
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < _numDocs; i++) {
+          if (random.nextInt(1000) == 0) {
+            sb.setLength(0);
+            // A stack trace / payload dump: ~50KB.
+            while (sb.length() < 50_000) {
+              sb.append("\tat org.apache.pinot.core.operator.filter.FilterOperator.getNextBlock(")
+                  .append(services[random.nextInt(services.length)]).append(".java:").append(random.nextInt(2000))
+                  .append(")\n");
+            }
+            values[i] = sb.toString().getBytes(StandardCharsets.UTF_8);
+          } else {
+            values[i] = ("service=" + services[random.nextInt(services.length)] + " status=200 latencyMs="
+                + random.nextInt(5000) + " region=us-east-1").getBytes(StandardCharsets.UTF_8);
+          }
+        }
+        break;
+      }
+      default:
+        throw new IllegalArgumentException("Unknown dataset: " + _dataset);
+    }
+    return values;
+  }
+
+  private static void printSizes() {
+    synchronized (SIZES) {
+      if (SIZES.isEmpty()) {
+        return;
+      }
+      System.out.println();
+      System.out.println("=== INDEX SIZE (targetDocsPerChunk sweep) ===");
+      System.out.printf("%-46s %14s %14s %8s%n", "config", "indexBytes", "rawBytes", "ratio");
+      for (Map.Entry<String, long[]> entry : SIZES.entrySet()) {
+        long indexBytes = entry.getValue()[0];
+        long rawBytes = entry.getValue()[1];
+        System.out.printf("%-46s %14d %14d %8.2f%n", entry.getKey(), indexBytes, rawBytes,
+            (double) rawBytes / indexBytes);
+      }
+      System.out.println("=== END INDEX SIZE ===");
+    }
+  }
+
+  /// Writes the index once per configuration and reports on-disk size plus the actual chunk
+  /// geometry. Much cheaper than a full JMH run, so it can cover the whole matrix.
+  ///
+  /// Two ways of bounding a chunk by document count are compared at the same nominal N:
+  /// - `byteDerived`: today's table-config path — `chunkSize = getDynamicTargetChunkSize(maxLength, N, 1MB)`,
+  ///   no hard cap. Docs per chunk only *approximates* N, and undershoots badly when
+  ///   `maxLength` exceeds the average value length.
+  /// - `hardCap`: this PR — `chunkSize = 1MB` with `targetDocsPerChunk = N`, giving exactly N docs per chunk.
+  private static void sizeSweep()
+      throws IOException {
+    FileUtils.forceMkdir(TARGET_DIR);
+    int numDocs = 1_000_000;
+    System.out.printf("%-14s %-10s %-11s %7s %11s %10s %10s %12s %8s%n", "dataset", "codec", "mode", "N", "chunkBytes",
+        "numChunks", "docsPerChk", "indexBytes", "ratio");
+    for (String dataset : new String[]{"LOW_CARD_URL", "HIGH_CARD_UUID", "JSON_LOG", "SKEWED_LOG"}) {
+      BenchmarkVarByteV6TargetDocsPerChunk gen = new BenchmarkVarByteV6TargetDocsPerChunk();
+      gen._numDocs = numDocs;
+      gen._dataset = dataset;
+      byte[][] values = gen.generate();
+      int maxLength = 0;
+      long rawBytes = 0;
+      for (byte[] value : values) {
+        maxLength = Math.max(maxLength, value.length);
+        rawBytes += value.length;
+      }
+      for (ChunkCompressionType codec : new ChunkCompressionType[]{
+          ChunkCompressionType.ZSTANDARD, ChunkCompressionType.LZ4, ChunkCompressionType.SNAPPY
+      }) {
+        for (int n : new int[]{10, 50, 100, 250, 500, 1000, 5000, 20000, -1}) {
+          // hardCap mode: full 1MB byte budget, chunk closed by doc count.
+          write(dataset, codec, "hardCap", n, 1024 * 1024, n, values, rawBytes, numDocs);
+          if (n > 0) {
+            // byteDerived mode: today's behavior — N only influences the byte budget, via
+            // ForwardIndexUtils#getDynamicTargetChunkSize.
+            int chunkSize = Math.max((int) Math.min((long) maxLength * n, 1024 * 1024), 4096);
+            write(dataset, codec, "byteDerived", n, chunkSize, DISABLED, values, rawBytes, numDocs);
+          }
+        }
+      }
+    }
+    FileUtils.deleteQuietly(TARGET_DIR);
+  }
+
+  private static final int DISABLED = VarByteChunkForwardIndexWriterV6.DISABLE_DOCS_PER_CHUNK;
+
+  private static void write(String dataset, ChunkCompressionType codec, String mode, int n, int chunkSize, int cap,
+      byte[][] values, long rawBytes, int numDocs)
+      throws IOException {
+    File file = new File(TARGET_DIR, UUID.randomUUID().toString());
+    try (VarByteChunkForwardIndexWriterV6 writer = new VarByteChunkForwardIndexWriterV6(file, codec, chunkSize, cap)) {
+      for (byte[] value : values) {
+        writer.putBytes(value);
+      }
+    }
+    long indexBytes = file.length();
+    int numChunks = countChunks(file);
+    System.out.printf("%-14s %-10s %-11s %7d %11d %10d %10d %12d %8.2f%n", dataset, codec, mode, n, chunkSize,
+        numChunks, numDocs / Math.max(numChunks, 1), indexBytes, (double) rawBytes / indexBytes);
+    FileUtils.deleteQuietly(file);
+  }
+
+  /// Recovers the chunk count from the V4-family file header, which is
+  /// `[version][targetChunkSize][compressionType][chunksStartOffset]` followed by an
+  /// 8-byte `[firstDocId][chunkStartOffset]` entry per chunk.
+  private static int countChunks(File file)
+      throws IOException {
+    try (PinotDataBuffer buffer = PinotDataBuffer.loadBigEndianFile(file)) {
+      int chunksStartOffset = buffer.getInt(3 * Integer.BYTES);
+      return (chunksStartOffset - 4 * Integer.BYTES) / (2 * Integer.BYTES);
+    }
+  }
+
+  public static void main(String[] args)
+      throws RunnerException, IOException {
+    if (args.length > 0 && args[0].equals("sizes")) {
+      sizeSweep();
+      return;
+    }
+    new Runner(new OptionsBuilder().include(BenchmarkVarByteV6TargetDocsPerChunk.class.getSimpleName()).build()).run();
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/VarByteChunkForwardIndexWriterV4.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/VarByteChunkForwardIndexWriterV4.java
@@ -126,7 +126,7 @@ public class VarByteChunkForwardIndexWriterV4 implements VarByteChunkWriter {
     Preconditions.checkState(_chunkOffset < (1L << 32),
         "exceeded 4GB of compressed chunks for: " + _dataBuffer.getName());
     int sizeRequired = Integer.BYTES + bytes.length;
-    if (_chunkBuffer.position() > _chunkBuffer.capacity() - sizeRequired) {
+    if (shouldStartNewChunk(sizeRequired)) {
       flushChunk();
       if (sizeRequired > _chunkBuffer.capacity() - Integer.BYTES) {
         writeHugeChunk(bytes);
@@ -136,6 +136,18 @@ public class VarByteChunkForwardIndexWriterV4 implements VarByteChunkWriter {
     _chunkBuffer.putInt(bytes.length);
     _chunkBuffer.put(bytes);
     _nextDocId++;
+  }
+
+  /// Returns whether the current chunk should be flushed before appending an entry that requires
+  /// `sizeRequired` bytes. V4 flushes only when the entry would overflow the chunk buffer.
+  /// Subclasses (e.g. V6) may override to add extra flush triggers such as a docs-per-chunk cap.
+  protected boolean shouldStartNewChunk(int sizeRequired) {
+    return _chunkBuffer.position() > _chunkBuffer.capacity() - sizeRequired;
+  }
+
+  /// Number of documents written into the chunk currently being accumulated (reset to 0 after each flush).
+  protected int getNumDocsInCurrentChunk() {
+    return _nextDocId - _docIdOffset;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/VarByteChunkForwardIndexWriterV6.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/VarByteChunkForwardIndexWriterV6.java
@@ -32,6 +32,12 @@ import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
 ///   Sizes compress dramatically better (e.g. 11x with ZSTD) because they are small, repetitive values.
 ///   The reader converts sizes back to offsets at read time with a single forward pass.
 /// - \*\*PASS_THROUGH\*\*: delta encoding provides no benefit, so V6 falls back to V4's offset-based header.
+/// ## Chunk boundaries
+/// A chunk is flushed whenever the next entry would overflow the `chunkSize`-byte chunk buffer
+/// (inherited V4 behavior). V6 additionally accepts a `targetDocsPerChunk` cap: when positive, a
+/// chunk is also flushed once it reaches that many documents, even if the byte buffer is not yet full.
+/// This lets callers bound a chunk by both byte size and document count. The cap defaults to `-1`
+/// (disabled), which preserves the original purely byte-driven behavior.
 ///
 /// @see VarByteChunkForwardIndexWriterV4
 /// @see VarByteChunkForwardIndexWriterV5
@@ -39,17 +45,42 @@ import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
 public class VarByteChunkForwardIndexWriterV6 extends VarByteChunkForwardIndexWriterV5 {
   public static final int VERSION = 6;
 
+  /// Sentinel meaning "no docs-per-chunk cap": chunks are bounded only by `chunkSize` bytes.
+  public static final int DISABLE_DOCS_PER_CHUNK = -1;
+
   private final boolean _deltaEncoding;
+  private final int _targetDocsPerChunk;
 
   public VarByteChunkForwardIndexWriterV6(File file, ChunkCompressionType compressionType, int chunkSize)
       throws IOException {
+    this(file, compressionType, chunkSize, DISABLE_DOCS_PER_CHUNK);
+  }
+
+  /// @param file output index file
+  /// @param compressionType chunk compression codec
+  /// @param chunkSize target uncompressed chunk size in bytes (the chunk buffer capacity)
+  /// @param targetDocsPerChunk flush a chunk once it holds this many documents, in addition to the
+  ///     byte-size limit; `-1` ([#DISABLE_DOCS_PER_CHUNK]) disables the cap and keeps the purely
+  ///     byte-driven behavior
+  public VarByteChunkForwardIndexWriterV6(File file, ChunkCompressionType compressionType, int chunkSize,
+      int targetDocsPerChunk)
+      throws IOException {
     super(file, compressionType, chunkSize);
     _deltaEncoding = compressionType != ChunkCompressionType.PASS_THROUGH;
+    _targetDocsPerChunk = targetDocsPerChunk;
   }
 
   @Override
   public int getVersion() {
     return VERSION;
+  }
+
+  /// Flushes a chunk when the byte buffer would overflow (V4 behavior) or, when a positive
+  /// `targetDocsPerChunk` is configured, once the current chunk reaches that many documents.
+  @Override
+  protected boolean shouldStartNewChunk(int sizeRequired) {
+    return super.shouldStartNewChunk(sizeRequired)
+        || (_targetDocsPerChunk > 0 && getNumDocsInCurrentChunk() >= _targetDocsPerChunk);
   }
 
   /// When compression is enabled, delta-encodes cumulative offsets into individual entry sizes

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/VarByteChunkForwardIndexWriterV6.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/VarByteChunkForwardIndexWriterV6.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 
 /// Forward index writer that extends [VarByteChunkForwardIndexWriterV5] and delta-encodes the chunk header
 /// when compression is enabled, writing individual entry sizes instead of cumulative byte offsets.
@@ -66,6 +68,8 @@ public class VarByteChunkForwardIndexWriterV6 extends VarByteChunkForwardIndexWr
       int targetDocsPerChunk)
       throws IOException {
     super(file, compressionType, chunkSize);
+    checkArgument(targetDocsPerChunk == DISABLE_DOCS_PER_CHUNK || targetDocsPerChunk > 0,
+        "targetDocsPerChunk must be -1 (disabled) or positive, got: %s", targetDocsPerChunk);
     _deltaEncoding = compressionType != ChunkCompressionType.PASS_THROUGH;
     _targetDocsPerChunk = targetDocsPerChunk;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/ForwardIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/ForwardIndexUtils.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.segment.local.segment.creator.impl.fwd;
 
+import org.apache.pinot.segment.local.io.writer.impl.VarByteChunkForwardIndexWriterV6;
+
 public class ForwardIndexUtils {
   private static final int TARGET_MIN_CHUNK_SIZE = 4 * 1024;
 
@@ -36,5 +38,21 @@ public class ForwardIndexUtils {
       return Math.max(targetMaxChunkSizeBytes, TARGET_MIN_CHUNK_SIZE);
     }
     return Math.max(Math.min(maxLength * targetDocsPerChunk, targetMaxChunkSizeBytes), TARGET_MIN_CHUNK_SIZE);
+  }
+
+  /// Get the hard per-chunk document cap to pass to [VarByteChunkForwardIndexWriterV6].
+  ///
+  /// [#getDynamicTargetChunkSize] only bounds a chunk by bytes, and it derives that bound from the column's
+  /// longest value. When the max length far exceeds the average length the derived size clamps to
+  /// targetMaxChunkSizeBytes and each chunk ends up holding far more documents than targetDocsPerChunk requested.
+  /// Enabling enforcement makes the writer additionally close a chunk at exactly targetDocsPerChunk documents.
+  ///
+  /// @param targetDocsPerChunk target number of documents to store per chunk
+  /// @param enforceTargetDocsPerChunk true to turn targetDocsPerChunk into a hard cap
+  /// @return targetDocsPerChunk when enforced and positive, otherwise
+  ///         [VarByteChunkForwardIndexWriterV6#DISABLE_DOCS_PER_CHUNK]
+  public static int getDocsPerChunkCap(int targetDocsPerChunk, boolean enforceTargetDocsPerChunk) {
+    return enforceTargetDocsPerChunk && targetDocsPerChunk > 0 ? targetDocsPerChunk
+        : VarByteChunkForwardIndexWriterV6.DISABLE_DOCS_PER_CHUNK;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueFixedByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueFixedByteRawIndexCreator.java
@@ -54,9 +54,20 @@ public class MultiValueFixedByteRawIndexCreator implements CompressionStatsTrack
       int totalDocs, DataType valueType, int maxNumberOfMultiValueElements, boolean deriveNumDocsPerChunk,
       int writerVersion, int targetMaxChunkSizeBytes, int targetDocsPerChunk)
       throws IOException {
+    this(baseIndexDir, compressionType, column, totalDocs, valueType, maxNumberOfMultiValueElements,
+        deriveNumDocsPerChunk, writerVersion, targetMaxChunkSizeBytes, targetDocsPerChunk,
+        ForwardIndexConfig.getDefaultEnforceTargetDocsPerChunk());
+  }
+
+  /// @param enforceTargetDocsPerChunk true to cap each chunk at exactly targetDocsPerChunk docs instead of only
+  ///                                  deriving the chunk byte size from it; supported by writer version 6 only
+  public MultiValueFixedByteRawIndexCreator(File baseIndexDir, ChunkCompressionType compressionType, String column,
+      int totalDocs, DataType valueType, int maxNumberOfMultiValueElements, boolean deriveNumDocsPerChunk,
+      int writerVersion, int targetMaxChunkSizeBytes, int targetDocsPerChunk, boolean enforceTargetDocsPerChunk)
+      throws IOException {
     this(new File(baseIndexDir, column + Indexes.RAW_MV_FORWARD_INDEX_FILE_EXTENSION), compressionType, totalDocs,
         valueType, maxNumberOfMultiValueElements, deriveNumDocsPerChunk, writerVersion, targetMaxChunkSizeBytes,
-        targetDocsPerChunk);
+        targetDocsPerChunk, enforceTargetDocsPerChunk);
   }
 
   public MultiValueFixedByteRawIndexCreator(File indexFile, ChunkCompressionType compressionType, int totalDocs,
@@ -70,6 +81,17 @@ public class MultiValueFixedByteRawIndexCreator implements CompressionStatsTrack
   public MultiValueFixedByteRawIndexCreator(File indexFile, ChunkCompressionType compressionType, int totalDocs,
       DataType valueType, int maxNumberOfMultiValueElements, boolean deriveNumDocsPerChunk, int writerVersion,
       int targetMaxChunkSizeBytes, int targetDocsPerChunk)
+      throws IOException {
+    this(indexFile, compressionType, totalDocs, valueType, maxNumberOfMultiValueElements, deriveNumDocsPerChunk,
+        writerVersion, targetMaxChunkSizeBytes, targetDocsPerChunk,
+        ForwardIndexConfig.getDefaultEnforceTargetDocsPerChunk());
+  }
+
+  /// @param enforceTargetDocsPerChunk true to cap each chunk at exactly targetDocsPerChunk docs instead of only
+  ///                                  deriving the chunk byte size from it; supported by writer version 6 only
+  public MultiValueFixedByteRawIndexCreator(File indexFile, ChunkCompressionType compressionType, int totalDocs,
+      DataType valueType, int maxNumberOfMultiValueElements, boolean deriveNumDocsPerChunk, int writerVersion,
+      int targetMaxChunkSizeBytes, int targetDocsPerChunk, boolean enforceTargetDocsPerChunk)
       throws IOException {
     if (writerVersion < VarByteChunkForwardIndexWriterV4.VERSION) {
       // Store the length followed by the values
@@ -85,7 +107,8 @@ public class MultiValueFixedByteRawIndexCreator implements CompressionStatsTrack
         int totalMaxLength = maxNumberOfMultiValueElements * valueType.getStoredType().size();
         int chunkSize =
             ForwardIndexUtils.getDynamicTargetChunkSize(totalMaxLength, targetDocsPerChunk, targetMaxChunkSizeBytes);
-        _indexWriter = new VarByteChunkForwardIndexWriterV6(indexFile, compressionType, chunkSize);
+        _indexWriter = new VarByteChunkForwardIndexWriterV6(indexFile, compressionType, chunkSize,
+            ForwardIndexUtils.getDocsPerChunkCap(targetDocsPerChunk, enforceTargetDocsPerChunk));
       } else if (writerVersion == VarByteChunkForwardIndexWriterV5.VERSION) {
         // Store only the values
         int totalMaxLength = maxNumberOfMultiValueElements * valueType.getStoredType().size();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueVarByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueVarByteRawIndexCreator.java
@@ -71,6 +71,27 @@ public class MultiValueVarByteRawIndexCreator implements CompressionStatsTrackin
       int totalDocs, DataType valueType, int writerVersion, int maxRowLengthInBytes, int maxNumberOfElements,
       int targetMaxChunkSizeBytes, int targetDocsPerChunk)
       throws IOException {
+    this(baseIndexDir, compressionType, column, totalDocs, valueType, writerVersion, maxRowLengthInBytes,
+        maxNumberOfElements, targetMaxChunkSizeBytes, targetDocsPerChunk,
+        ForwardIndexConfig.getDefaultEnforceTargetDocsPerChunk());
+  }
+
+  /// Create a var-byte raw index creator for the given column
+  ///
+  /// @param baseIndexDir Index directory
+  /// @param compressionType Type of compression to use
+  /// @param column Name of column to index
+  /// @param totalDocs Total number of documents to index
+  /// @param valueType Type of the values
+  /// @param maxRowLengthInBytes the size in bytes of the largest row, the chunk size cannot be smaller than this
+  /// @param maxNumberOfElements the maximum number of elements in a row
+  /// @param writerVersion writer format version
+  /// @param enforceTargetDocsPerChunk true to cap each chunk at exactly targetDocsPerChunk docs instead of only
+  ///                                  deriving the chunk byte size from it; supported by writer version 6 only
+  public MultiValueVarByteRawIndexCreator(File baseIndexDir, ChunkCompressionType compressionType, String column,
+      int totalDocs, DataType valueType, int writerVersion, int maxRowLengthInBytes, int maxNumberOfElements,
+      int targetMaxChunkSizeBytes, int targetDocsPerChunk, boolean enforceTargetDocsPerChunk)
+      throws IOException {
     File file = new File(baseIndexDir, column + Indexes.RAW_MV_FORWARD_INDEX_FILE_EXTENSION);
     // We will prepend the actual content with numElements and length array containing length of each element
     int totalMaxLength = getTotalRowStorageBytes(maxNumberOfElements, maxRowLengthInBytes);
@@ -83,7 +104,8 @@ public class MultiValueVarByteRawIndexCreator implements CompressionStatsTrackin
     } else if (writerVersion == VarByteChunkForwardIndexWriterV6.VERSION) {
       int chunkSize =
           ForwardIndexUtils.getDynamicTargetChunkSize(totalMaxLength, targetDocsPerChunk, targetMaxChunkSizeBytes);
-      _indexWriter = new VarByteChunkForwardIndexWriterV6(file, compressionType, chunkSize);
+      _indexWriter = new VarByteChunkForwardIndexWriterV6(file, compressionType, chunkSize,
+          ForwardIndexUtils.getDocsPerChunkCap(targetDocsPerChunk, enforceTargetDocsPerChunk));
     } else {
       int chunkSize =
           ForwardIndexUtils.getDynamicTargetChunkSize(totalMaxLength, targetDocsPerChunk, targetMaxChunkSizeBytes);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/SingleValueVarByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/SingleValueVarByteRawIndexCreator.java
@@ -72,6 +72,29 @@ public class SingleValueVarByteRawIndexCreator implements CompressionStatsTracki
       int totalDocs, DataType valueType, int maxLength, boolean deriveNumDocsPerChunk, int writerVersion,
       int targetMaxChunkSizeBytes, int targetDocsPerChunk)
       throws IOException {
+    this(baseIndexDir, compressionType, column, totalDocs, valueType, maxLength, deriveNumDocsPerChunk, writerVersion,
+        targetMaxChunkSizeBytes, targetDocsPerChunk, ForwardIndexConfig.getDefaultEnforceTargetDocsPerChunk());
+  }
+
+  /// Create a var-byte raw index creator for the given column
+  /// @param baseIndexDir Index directory
+  /// @param compressionType Type of compression to use
+  /// @param column Name of column to index
+  /// @param totalDocs Total number of documents to index
+  /// @param valueType Type of the values
+  /// @param maxLength length of longest entry (in bytes)
+  /// @param deriveNumDocsPerChunk true if writer should auto-derive the number of rows per chunk
+  /// @param writerVersion writer format version
+  /// @param targetMaxChunkSizeBytes target max chunk size in bytes, applicable only for V4 or when
+  ///                                deriveNumDocsPerChunk is true
+  /// @param targetDocsPerChunk target number of docs per chunk
+  /// @param enforceTargetDocsPerChunk true to cap each chunk at exactly targetDocsPerChunk docs instead of only
+  ///                                  deriving the chunk byte size from it; supported by writer version 6 only
+  /// @throws IOException
+  public SingleValueVarByteRawIndexCreator(File baseIndexDir, ChunkCompressionType compressionType, String column,
+      int totalDocs, DataType valueType, int maxLength, boolean deriveNumDocsPerChunk, int writerVersion,
+      int targetMaxChunkSizeBytes, int targetDocsPerChunk, boolean enforceTargetDocsPerChunk)
+      throws IOException {
     File file = new File(baseIndexDir, column + V1Constants.Indexes.RAW_SV_FORWARD_INDEX_FILE_EXTENSION);
     if (writerVersion < VarByteChunkForwardIndexWriterV4.VERSION) {
       int numDocsPerChunk =
@@ -81,7 +104,8 @@ public class SingleValueVarByteRawIndexCreator implements CompressionStatsTracki
     } else if (writerVersion == VarByteChunkForwardIndexWriterV6.VERSION) {
       int chunkSize =
           ForwardIndexUtils.getDynamicTargetChunkSize(maxLength, targetDocsPerChunk, targetMaxChunkSizeBytes);
-      _indexWriter = new VarByteChunkForwardIndexWriterV6(file, compressionType, chunkSize);
+      _indexWriter = new VarByteChunkForwardIndexWriterV6(file, compressionType, chunkSize,
+          ForwardIndexUtils.getDocsPerChunkCap(targetDocsPerChunk, enforceTargetDocsPerChunk));
     } else {
       int chunkSize =
           ForwardIndexUtils.getDynamicTargetChunkSize(maxLength, targetDocsPerChunk, targetMaxChunkSizeBytes);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexCreatorFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexCreatorFactory.java
@@ -94,14 +94,15 @@ public class ForwardIndexCreatorFactory {
         int writerVersion = indexConfig.getRawIndexWriterVersion();
         int targetMaxChunkSize = indexConfig.getTargetMaxChunkSizeBytes();
         int targetDocsPerChunk = indexConfig.getTargetDocsPerChunk();
+        boolean enforceTargetDocsPerChunk = indexConfig.isEnforceTargetDocsPerChunk();
         if (fieldSpec.isSingleValueField()) {
           creator = getRawIndexCreatorForSVColumn(indexDir, chunkCompressionType, columnName, storedType, numTotalDocs,
               context.getLengthOfLongestElement(), deriveNumDocsPerChunk, writerVersion, targetMaxChunkSize,
-              targetDocsPerChunk);
+              targetDocsPerChunk, enforceTargetDocsPerChunk);
         } else {
           creator = getRawIndexCreatorForMVColumn(indexDir, chunkCompressionType, columnName, storedType, numTotalDocs,
               context.getMaxNumberOfMultiValues(), deriveNumDocsPerChunk, writerVersion,
-              context.getMaxRowLengthInBytes(), targetMaxChunkSize, targetDocsPerChunk);
+              context.getMaxRowLengthInBytes(), targetMaxChunkSize, targetDocsPerChunk, enforceTargetDocsPerChunk);
         }
       }
       if (context.isCompressionStatsEnabled()
@@ -118,6 +119,17 @@ public class ForwardIndexCreatorFactory {
       String column, DataType storedType, int numTotalDocs, int lengthOfLongestEntry, boolean deriveNumDocsPerChunk,
       int writerVersion, int targetMaxChunkSize, int targetDocsPerChunk)
       throws IOException {
+    return getRawIndexCreatorForSVColumn(indexDir, compressionType, column, storedType, numTotalDocs,
+        lengthOfLongestEntry, deriveNumDocsPerChunk, writerVersion, targetMaxChunkSize, targetDocsPerChunk,
+        ForwardIndexConfig.getDefaultEnforceTargetDocsPerChunk());
+  }
+
+  /// Helper method to build the raw index creator for the column.
+  /// Assumes that column to be indexed is single valued.
+  public static ForwardIndexCreator getRawIndexCreatorForSVColumn(File indexDir, ChunkCompressionType compressionType,
+      String column, DataType storedType, int numTotalDocs, int lengthOfLongestEntry, boolean deriveNumDocsPerChunk,
+      int writerVersion, int targetMaxChunkSize, int targetDocsPerChunk, boolean enforceTargetDocsPerChunk)
+      throws IOException {
     switch (storedType) {
       case INT:
       case LONG:
@@ -130,7 +142,8 @@ public class ForwardIndexCreatorFactory {
       case BYTES:
       case MAP:
         return new SingleValueVarByteRawIndexCreator(indexDir, compressionType, column, numTotalDocs, storedType,
-            lengthOfLongestEntry, deriveNumDocsPerChunk, writerVersion, targetMaxChunkSize, targetDocsPerChunk);
+            lengthOfLongestEntry, deriveNumDocsPerChunk, writerVersion, targetMaxChunkSize, targetDocsPerChunk,
+            enforceTargetDocsPerChunk);
       default:
         throw new IllegalStateException("Unsupported stored type: " + storedType);
     }
@@ -143,19 +156,32 @@ public class ForwardIndexCreatorFactory {
       boolean deriveNumDocsPerChunk, int writerVersion, int maxRowLengthInBytes, int targetMaxChunkSize,
       int targetDocsPerChunk)
       throws IOException {
+    return getRawIndexCreatorForMVColumn(indexDir, compressionType, column, storedType, numTotalDocs,
+        maxNumberOfMultiValueElements, deriveNumDocsPerChunk, writerVersion, maxRowLengthInBytes, targetMaxChunkSize,
+        targetDocsPerChunk, ForwardIndexConfig.getDefaultEnforceTargetDocsPerChunk());
+  }
+
+  /// Helper method to build the raw index creator for the column.
+  /// Assumes that column to be indexed is multi-valued.
+  public static ForwardIndexCreator getRawIndexCreatorForMVColumn(File indexDir, ChunkCompressionType compressionType,
+      String column, DataType storedType, int numTotalDocs, int maxNumberOfMultiValueElements,
+      boolean deriveNumDocsPerChunk, int writerVersion, int maxRowLengthInBytes, int targetMaxChunkSize,
+      int targetDocsPerChunk, boolean enforceTargetDocsPerChunk)
+      throws IOException {
     switch (storedType) {
       case INT:
       case LONG:
       case FLOAT:
       case DOUBLE:
         return new MultiValueFixedByteRawIndexCreator(indexDir, compressionType, column, numTotalDocs, storedType,
-            maxNumberOfMultiValueElements, deriveNumDocsPerChunk, writerVersion, targetMaxChunkSize,
-            targetDocsPerChunk);
+            maxNumberOfMultiValueElements, deriveNumDocsPerChunk, writerVersion, targetMaxChunkSize, targetDocsPerChunk,
+            enforceTargetDocsPerChunk);
       case BIG_DECIMAL:
       case STRING:
       case BYTES:
         return new MultiValueVarByteRawIndexCreator(indexDir, compressionType, column, numTotalDocs, storedType,
-            writerVersion, maxRowLengthInBytes, maxNumberOfMultiValueElements, targetMaxChunkSize, targetDocsPerChunk);
+            writerVersion, maxRowLengthInBytes, maxNumberOfMultiValueElements, targetMaxChunkSize, targetDocsPerChunk,
+            enforceTargetDocsPerChunk);
       default:
         throw new IllegalStateException("Unsupported stored type: " + storedType);
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/EnforceTargetDocsPerChunkTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/EnforceTargetDocsPerChunkTest.java
@@ -1,0 +1,138 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.creator;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.segment.creator.impl.fwd.SingleValueVarByteRawIndexCreator;
+import org.apache.pinot.segment.local.segment.index.readers.forward.VarByteChunkForwardIndexReaderV4;
+import org.apache.pinot.segment.local.segment.index.readers.forward.VarByteChunkForwardIndexReaderV6;
+import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+/// Verifies that `enforceTargetDocsPerChunk` reaches the V6 writer through
+/// [SingleValueVarByteRawIndexCreator] and actually bounds a chunk by document count.
+///
+/// The interesting case is a column whose longest value dwarfs its average: the byte-size derivation
+/// `max(min(maxLength * targetDocsPerChunk, targetMaxChunkSizeBytes), 4KB)` clamps to
+/// `targetMaxChunkSizeBytes` and stops tracking `targetDocsPerChunk` at all. Enforcement restores it.
+public class EnforceTargetDocsPerChunkTest {
+  private static final int WRITER_VERSION = 6;
+  private static final int NUM_DOCS = 5000;
+  private static final int TARGET_DOCS_PER_CHUNK = 100;
+  private static final int TARGET_MAX_CHUNK_SIZE = 1024 * 1024;
+  private static final String COLUMN = "skewedColumn";
+
+  private File _indexDir;
+
+  @BeforeMethod
+  public void setUp()
+      throws IOException {
+    _indexDir = new File(FileUtils.getTempDirectory(), "EnforceTargetDocsPerChunkTest");
+    FileUtils.deleteQuietly(_indexDir);
+    FileUtils.forceMkdir(_indexDir);
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    FileUtils.deleteQuietly(_indexDir);
+  }
+
+  @Test
+  public void enforcedCapBoundsChunkByDocCount()
+      throws IOException {
+    String[] values = skewedValues();
+    write(values, true);
+    assertEquals(numChunks(), NUM_DOCS / TARGET_DOCS_PER_CHUNK, "Each chunk should hold exactly the target doc count");
+    assertRoundTrips(values);
+  }
+
+  @Test
+  public void withoutEnforcementByteDerivationIgnoresDocCount()
+      throws IOException {
+    String[] values = skewedValues();
+    write(values, false);
+    // maxLength * targetDocsPerChunk exceeds targetMaxChunkSize, so the chunk size clamps to 1MB and each chunk
+    // holds far more than TARGET_DOCS_PER_CHUNK docs.
+    int chunks = numChunks();
+    assertTrue(chunks < NUM_DOCS / TARGET_DOCS_PER_CHUNK,
+        "Expected fewer chunks than the doc-count target implies, got " + chunks);
+    assertRoundTrips(values);
+  }
+
+  /// Short values with a few large outliers, so `maxLength` is ~500x the average length.
+  private static String[] skewedValues() {
+    String[] values = new String[NUM_DOCS];
+    for (int i = 0; i < NUM_DOCS; i++) {
+      values[i] = i % 500 == 0 ? "x".repeat(50_000) : "short-value-" + i;
+    }
+    return values;
+  }
+
+  private void write(String[] values, boolean enforceTargetDocsPerChunk)
+      throws IOException {
+    int maxLength = 0;
+    for (String value : values) {
+      maxLength = Math.max(maxLength, value.getBytes(StandardCharsets.UTF_8).length);
+    }
+    try (SingleValueVarByteRawIndexCreator creator = new SingleValueVarByteRawIndexCreator(_indexDir,
+        ChunkCompressionType.ZSTANDARD, COLUMN, NUM_DOCS, DataType.STRING, maxLength, false, WRITER_VERSION,
+        TARGET_MAX_CHUNK_SIZE, TARGET_DOCS_PER_CHUNK, enforceTargetDocsPerChunk)) {
+      for (String value : values) {
+        creator.putString(value);
+      }
+    }
+  }
+
+  private File indexFile() {
+    return new File(_indexDir, COLUMN + V1Constants.Indexes.RAW_SV_FORWARD_INDEX_FILE_EXTENSION);
+  }
+
+  /// The V4-family header is `[version][targetChunkSize][compressionType][chunksStartOffset]` followed by an
+  /// 8-byte `[firstDocId][chunkStartOffset]` entry per chunk.
+  private int numChunks()
+      throws IOException {
+    try (PinotDataBuffer buffer = PinotDataBuffer.loadBigEndianFile(indexFile())) {
+      int chunksStartOffset = buffer.getInt(3 * Integer.BYTES);
+      return (chunksStartOffset - 4 * Integer.BYTES) / (2 * Integer.BYTES);
+    }
+  }
+
+  private void assertRoundTrips(String[] values)
+      throws IOException {
+    try (PinotDataBuffer buffer = PinotDataBuffer.loadBigEndianFile(indexFile());
+        VarByteChunkForwardIndexReaderV6 reader = new VarByteChunkForwardIndexReaderV6(buffer, DataType.STRING, true);
+        VarByteChunkForwardIndexReaderV4.ReaderContext context = reader.createContext()) {
+      for (int i = 0; i < values.length; i++) {
+        assertEquals(reader.getString(i, context), values[i], "Mismatch at docId " + i);
+      }
+    }
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/VarByteChunkV6Test.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/VarByteChunkV6Test.java
@@ -99,4 +99,46 @@ public class VarByteChunkV6Test extends VarByteChunkV5Test {
     FileUtils.deleteQuietly(v4FwdIndexFile);
     FileUtils.deleteQuietly(v6FwdIndexFile);
   }
+
+  /// A positive `targetDocsPerChunk` must cap each chunk at that many documents even when the byte
+  /// buffer is far from full, and values must still round-trip. The default (`-1`) keeps the original
+  /// byte-driven behavior, which is exercised by all the inherited read/write tests.
+  @Test
+  public void testTargetDocsPerChunkCapsChunk()
+      throws IOException {
+    int numDocs = 1000;
+    int docsPerChunk = 50;
+    // Large byte budget so flushing is driven purely by the docs-per-chunk cap, not the buffer size.
+    int chunkSize = 1 << 20;
+    File file = new File(FileUtils.getTempDirectory(), "v6test_docs_cap");
+    FileUtils.deleteQuietly(file);
+
+    String[] values = new String[numDocs];
+    try (VarByteChunkForwardIndexWriterV6 writer =
+        new VarByteChunkForwardIndexWriterV6(file, ChunkCompressionType.ZSTANDARD, chunkSize, docsPerChunk)) {
+      for (int i = 0; i < numDocs; i++) {
+        values[i] = "value_" + i;
+        writer.putString(values[i]);
+      }
+    }
+
+    try (PinotDataBuffer buffer = PinotDataBuffer.mapReadOnlyBigEndianFile(file)) {
+      // Chunk metadata starts at byte 16; each entry is 8 bytes. The metadata region ends at the offset
+      // stored at byte 12 (start of chunk data).
+      int numChunks = (buffer.getInt(12) - 16) / 8;
+      Assert.assertEquals(numChunks, (numDocs + docsPerChunk - 1) / docsPerChunk,
+          "Each chunk should hold exactly targetDocsPerChunk documents");
+    }
+
+    try (PinotDataBuffer buffer = PinotDataBuffer.mapReadOnlyBigEndianFile(file);
+        VarByteChunkForwardIndexReaderV6 reader =
+            new VarByteChunkForwardIndexReaderV6(buffer, FieldSpec.DataType.STRING, true);
+        VarByteChunkForwardIndexReaderV4.ReaderContext context = reader.createContext()) {
+      for (int i = 0; i < numDocs; i++) {
+        Assert.assertEquals(reader.getString(i, context), values[i]);
+      }
+    }
+
+    FileUtils.deleteQuietly(file);
+  }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/VarByteChunkV6Test.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/VarByteChunkV6Test.java
@@ -107,7 +107,8 @@ public class VarByteChunkV6Test extends VarByteChunkV5Test {
   public void testTargetDocsPerChunkCapsChunk()
       throws IOException {
     int numDocs = 1000;
-    int docsPerChunk = 50;
+    // 1000 is not a multiple of 30, so the last chunk holds a remainder (10 docs).
+    int docsPerChunk = 30;
     // Large byte budget so flushing is driven purely by the docs-per-chunk cap, not the buffer size.
     int chunkSize = 1 << 20;
     File file = new File(FileUtils.getTempDirectory(), "v6test_docs_cap");
@@ -123,11 +124,16 @@ public class VarByteChunkV6Test extends VarByteChunkV5Test {
     }
 
     try (PinotDataBuffer buffer = PinotDataBuffer.mapReadOnlyBigEndianFile(file)) {
-      // Chunk metadata starts at byte 16; each entry is 8 bytes. The metadata region ends at the offset
-      // stored at byte 12 (start of chunk data).
+      // Chunk metadata starts at byte 16; each 8-byte entry begins with the chunk's first docId (stored
+      // little-endian, MSB reserved for the huge-chunk flag). The region ends at the offset stored at byte 12.
       int numChunks = (buffer.getInt(12) - 16) / 8;
-      Assert.assertEquals(numChunks, (numDocs + docsPerChunk - 1) / docsPerChunk,
-          "Each chunk should hold exactly targetDocsPerChunk documents");
+      Assert.assertEquals(numChunks, (numDocs + docsPerChunk - 1) / docsPerChunk, "Unexpected chunk count");
+      // Each chunk must start exactly docsPerChunk docs after the previous one, so every chunk holds
+      // docsPerChunk docs and the last holds the remainder.
+      for (int chunk = 0; chunk < numChunks; chunk++) {
+        int firstDocId = Integer.reverseBytes(buffer.getInt(16 + chunk * 8)) & 0x7FFFFFFF;
+        Assert.assertEquals(firstDocId, chunk * docsPerChunk, "Unexpected start docId for chunk " + chunk);
+      }
     }
 
     try (PinotDataBuffer buffer = PinotDataBuffer.mapReadOnlyBigEndianFile(file);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexUtilsTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.segment.index.forward;
 
+import org.apache.pinot.segment.local.io.writer.impl.VarByteChunkForwardIndexWriterV6;
 import org.apache.pinot.segment.local.segment.creator.impl.fwd.ForwardIndexUtils;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -42,6 +43,22 @@ public class ForwardIndexUtilsTest {
         {100, -1, 1024 * 1024, 1024 * 1024}, // negative targetDocsPerChunk falls back to targetMaxChunkSizeBytes
         {2000, 1000, 1024 * 1024, 1024 * 1024}, // large maxValue limited by targetMaxChunkSizeBytes
         {100, -1, 1024, 4 * 1024} // tiny targetMaxChunkSizeBytes falls back to TARGET_MIN_CHUNK_SIZE
+    };
+  }
+
+  @Test(dataProvider = "docsPerChunkCapProvider")
+  public void testDocsPerChunkCap(Integer targetDocsPerChunk, Boolean enforce, Integer expectedCap) {
+    assertEquals(ForwardIndexUtils.getDocsPerChunkCap(targetDocsPerChunk, enforce), (int) expectedCap);
+  }
+
+  @DataProvider(name = "docsPerChunkCapProvider")
+  public Object[][] docsPerChunkCapProvider() {
+    int noCap = VarByteChunkForwardIndexWriterV6.DISABLE_DOCS_PER_CHUNK;
+    return new Object[][]{
+        {250, true, 250}, // enforced: the target becomes a hard cap
+        {250, false, noCap}, // not enforced: no cap, byte-driven flush only
+        {-1, true, noCap}, // enforcing a disabled target is still no cap
+        {0, true, noCap} // a zero target would stall the writer, so treat it as no cap
     };
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
@@ -40,6 +40,7 @@ public class ForwardIndexConfig extends IndexConfig {
   private static String _defaultTargetMaxChunkSize = "1MB";
   private static int _defaultTargetMaxChunkSizeBytes = 1024 * 1024;
   private static int _defaultTargetDocsPerChunk = 1000;
+  private static boolean _defaultEnforceTargetDocsPerChunk = false;
 
   public static int getDefaultRawWriterVersion() {
     return _defaultRawIndexWriterVersion;
@@ -70,6 +71,14 @@ public class ForwardIndexConfig extends IndexConfig {
     _defaultTargetDocsPerChunk = defaultTargetDocsPerChunk;
   }
 
+  public static boolean getDefaultEnforceTargetDocsPerChunk() {
+    return _defaultEnforceTargetDocsPerChunk;
+  }
+
+  public static void setDefaultEnforceTargetDocsPerChunk(boolean defaultEnforceTargetDocsPerChunk) {
+    _defaultEnforceTargetDocsPerChunk = defaultEnforceTargetDocsPerChunk;
+  }
+
   public static ForwardIndexConfig getDefault(EncodingType encodingType) {
     return new Builder(encodingType).build();
   }
@@ -86,6 +95,7 @@ public class ForwardIndexConfig extends IndexConfig {
   private final String _targetMaxChunkSize;
   private final int _targetMaxChunkSizeBytes;
   private final int _targetDocsPerChunk;
+  private final boolean _enforceTargetDocsPerChunk;
 
   @Nullable
   private final ChunkCompressionType _chunkCompressionType;
@@ -104,6 +114,7 @@ public class ForwardIndexConfig extends IndexConfig {
       @JsonProperty("rawIndexWriterVersion") @Nullable Integer rawIndexWriterVersion,
       @JsonProperty("targetMaxChunkSize") @Nullable String targetMaxChunkSize,
       @JsonProperty("targetDocsPerChunk") @Nullable Integer targetDocsPerChunk,
+      @JsonProperty("enforceTargetDocsPerChunk") @Nullable Boolean enforceTargetDocsPerChunk,
       @JsonProperty("configs") @Nullable Map<String, Object> configs) {
     super(disabled);
     // Backward-compat for legacy JSON that lacks `encodingType`: default to DICTIONARY (matches the historical
@@ -117,6 +128,10 @@ public class ForwardIndexConfig extends IndexConfig {
     _targetMaxChunkSizeBytes =
         targetMaxChunkSize == null ? _defaultTargetMaxChunkSizeBytes : (int) DataSizeUtils.toBytes(targetMaxChunkSize);
     _targetDocsPerChunk = targetDocsPerChunk == null ? _defaultTargetDocsPerChunk : targetDocsPerChunk;
+    _enforceTargetDocsPerChunk =
+        enforceTargetDocsPerChunk == null ? _defaultEnforceTargetDocsPerChunk : enforceTargetDocsPerChunk;
+    Preconditions.checkArgument(!_enforceTargetDocsPerChunk || _targetDocsPerChunk > 0,
+        "targetDocsPerChunk must be positive when enforceTargetDocsPerChunk is set, got: %s", _targetDocsPerChunk);
     _configs = configs != null ? configs : new HashMap<>();
     if (_compressionCodec != null) {
       switch (_compressionCodec) {
@@ -223,6 +238,19 @@ public class ForwardIndexConfig extends IndexConfig {
     return _targetDocsPerChunk;
   }
 
+  /// Whether [#getTargetDocsPerChunk()] is a hard per-chunk document cap rather than only an input to the
+  /// chunk byte-size derivation.
+  ///
+  /// By default `targetDocsPerChunk` only sizes the chunk buffer, via
+  /// `max(min(maxLength * targetDocsPerChunk, targetMaxChunkSizeBytes), 4KB)`. Because that derivation keys off
+  /// the column's *longest* value, a column whose max length far exceeds its average length clamps to
+  /// `targetMaxChunkSizeBytes` and ends up with far more documents per chunk than requested. Setting this flag
+  /// makes the writer close a chunk once it holds exactly `targetDocsPerChunk` documents, regardless of value
+  /// length. Only supported by raw index writer version 6.
+  public boolean isEnforceTargetDocsPerChunk() {
+    return _enforceTargetDocsPerChunk;
+  }
+
   @JsonIgnore
   public int getTargetMaxChunkSizeBytes() {
     return _targetMaxChunkSizeBytes;
@@ -265,13 +293,13 @@ public class ForwardIndexConfig extends IndexConfig {
     return _compressionCodec == that._compressionCodec && _deriveNumDocsPerChunk == that._deriveNumDocsPerChunk
         && _rawIndexWriterVersion == that._rawIndexWriterVersion && Objects.equals(_targetMaxChunkSize,
         that._targetMaxChunkSize) && _targetDocsPerChunk == that._targetDocsPerChunk
-        && _encodingType == that._encodingType;
+        && _enforceTargetDocsPerChunk == that._enforceTargetDocsPerChunk && _encodingType == that._encodingType;
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode(), _compressionCodec, _deriveNumDocsPerChunk, _rawIndexWriterVersion,
-        _targetMaxChunkSize, _targetDocsPerChunk, _encodingType);
+        _targetMaxChunkSize, _targetDocsPerChunk, _enforceTargetDocsPerChunk, _encodingType);
   }
 
   public static class Builder {
@@ -283,6 +311,7 @@ public class ForwardIndexConfig extends IndexConfig {
     private int _rawIndexWriterVersion = _defaultRawIndexWriterVersion;
     private String _targetMaxChunkSize = _defaultTargetMaxChunkSize;
     private int _targetDocsPerChunk = _defaultTargetDocsPerChunk;
+    private boolean _enforceTargetDocsPerChunk = _defaultEnforceTargetDocsPerChunk;
     private Map<String, Object> _configs = new HashMap<>();
 
     /// Constructs a builder with the given forward-index encoding. Callers should pass `FieldConfig.getEncodingType()`
@@ -306,6 +335,7 @@ public class ForwardIndexConfig extends IndexConfig {
       _rawIndexWriterVersion = other._rawIndexWriterVersion;
       _targetMaxChunkSize = other._targetMaxChunkSize;
       _targetDocsPerChunk = other._targetDocsPerChunk;
+      _enforceTargetDocsPerChunk = other._enforceTargetDocsPerChunk;
       _configs = other._configs;
     }
 
@@ -336,6 +366,11 @@ public class ForwardIndexConfig extends IndexConfig {
 
     public Builder withTargetDocsPerChunk(int targetDocsPerChunk) {
       _targetDocsPerChunk = targetDocsPerChunk;
+      return this;
+    }
+
+    public Builder withEnforceTargetDocsPerChunk(boolean enforceTargetDocsPerChunk) {
+      _enforceTargetDocsPerChunk = enforceTargetDocsPerChunk;
       return this;
     }
 
@@ -399,7 +434,7 @@ public class ForwardIndexConfig extends IndexConfig {
 
     public ForwardIndexConfig build() {
       return new ForwardIndexConfig(_disabled, _encodingType, _compressionCodec, null, null, _deriveNumDocsPerChunk,
-          _rawIndexWriterVersion, _targetMaxChunkSize, _targetDocsPerChunk, _configs);
+          _rawIndexWriterVersion, _targetMaxChunkSize, _targetDocsPerChunk, _enforceTargetDocsPerChunk, _configs);
     }
   }
 }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/ForwardIndexConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/ForwardIndexConfigTest.java
@@ -94,6 +94,48 @@ public class ForwardIndexConfigTest {
   }
 
   @Test
+  public void enforceTargetDocsPerChunkDefaultsToFalse()
+      throws JsonProcessingException {
+    ForwardIndexConfig config = JsonUtils.stringToObject("{\"targetDocsPerChunk\": \"250\"}", ForwardIndexConfig.class);
+
+    assertFalse(config.isEnforceTargetDocsPerChunk(), "Unexpected enforceTargetDocsPerChunk");
+  }
+
+  @Test
+  public void withEnforceTargetDocsPerChunk()
+      throws JsonProcessingException {
+    String confStr = "{\"targetDocsPerChunk\": \"250\", \"enforceTargetDocsPerChunk\": true}";
+    ForwardIndexConfig config = JsonUtils.stringToObject(confStr, ForwardIndexConfig.class);
+
+    assertTrue(config.isEnforceTargetDocsPerChunk(), "Unexpected enforceTargetDocsPerChunk");
+    assertEquals(config.getTargetDocsPerChunk(), 250, "Unexpected targetDocsPerChunk");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void enforceTargetDocsPerChunkRejectsNonPositiveTarget() {
+    new ForwardIndexConfig.Builder(FieldConfig.EncodingType.RAW).withTargetDocsPerChunk(-1)
+        .withEnforceTargetDocsPerChunk(true).build();
+  }
+
+  @Test
+  public void enforceTargetDocsPerChunkRejectsNonPositiveTargetFromJson() {
+    // Jackson wraps the constructor's IllegalArgumentException, so just assert the deserialization fails.
+    assertThrows(Exception.class,
+        () -> JsonUtils.stringToObject("{\"targetDocsPerChunk\": \"-1\", \"enforceTargetDocsPerChunk\": true}",
+            ForwardIndexConfig.class));
+  }
+
+  @Test
+  public void enforceTargetDocsPerChunkSurvivesBuilderCopy() {
+    ForwardIndexConfig config = new ForwardIndexConfig.Builder(FieldConfig.EncodingType.RAW).withTargetDocsPerChunk(250)
+        .withEnforceTargetDocsPerChunk(true).build();
+    ForwardIndexConfig copy = new ForwardIndexConfig.Builder(config).build();
+
+    assertTrue(copy.isEnforceTargetDocsPerChunk(), "Unexpected enforceTargetDocsPerChunk");
+    assertEquals(copy, config, "Copy should equal the original");
+  }
+
+  @Test
   public void withSomeData()
       throws JsonProcessingException {
     String confStr = "{\n"


### PR DESCRIPTION
## Summary

`VarByteChunkForwardIndexWriterV6` currently closes a chunk only when the next entry would
overflow the `chunkSize`-byte buffer. This PR lets a chunk additionally be bounded by document
count, and wires that control through to table config.

- New 4-arg constructor `VarByteChunkForwardIndexWriterV6(file, compressionType, chunkSize,
  targetDocsPerChunk)`. The existing 3-arg constructor delegates with `targetDocsPerChunk = -1`
  (`DISABLE_DOCS_PER_CHUNK`).
- When `targetDocsPerChunk > 0`, a chunk is flushed once it holds that many docs, even if the byte
  buffer isn't full; otherwise behavior is unchanged.
- The buffer-overflow flush predicate is extracted into a protected `shouldStartNewChunk(int)` hook
  in `VarByteChunkForwardIndexWriterV4` (mirroring the existing `writeChunkHeader` hook), so V6 adds
  the cap without duplicating `putBytes()`.
- New table-config option `enforceTargetDocsPerChunk` (default `false`) promotes the existing
  `targetDocsPerChunk` from a byte-size input into a hard per-chunk document cap.

## Motivation

The table-config `targetDocsPerChunk` does not actually control documents per chunk. It only
derives the chunk *byte* budget:

```
chunkSize = max(min(maxLength * targetDocsPerChunk, targetMaxChunkSize), 4KB)
```

Because that keys off the column's **longest** value, a column whose max length far exceeds its
average length clamps to `targetMaxChunkSize` and stops tracking the requested doc count entirely.

Measured on a 1M-doc column of short log lines (avg 106 B) with 0.1% ~50 KB stack traces
(max 50094 B), `targetMaxChunkSize=1MB`:

| `targetDocsPerChunk` | derived chunkBytes | actual docs/chunk |
|---|---|---|
| 50 | 1 MB (clamped) | 9345 |
| 250 | 1 MB (clamped) | 9345 |
| 1000 (the default) | 1 MB (clamped) | 9345 |
| 5000 | 1 MB (clamped) | 9345 |

Every setting yields the same 9,345 docs per chunk — the default overshoots its own nominal target
by more than 9x. With `enforceTargetDocsPerChunk: true` each setting yields exactly N.

Since a point lookup decompresses a whole chunk, docs-per-chunk is the dominant term in random
access latency, so losing control of it is expensive.

## Benchmark

`BenchmarkVarByteV6TargetDocsPerChunk` (added in this PR) sweeps the cap over index size,
sequential scan, 1%-selectivity ascending scan, and uniform random point lookups. 1M docs, ZSTD,
`chunkSize=1MB`, JDK 25, Apple Silicon.

**LOW_CARD_URL** (avg 73 B, 200 distinct values):

| N | docs/chunk | size | vs uncapped | random lookup | 1% asc scan | full scan |
|---|---|---|---|---|---|---|
| -1 | 13513 | 2.88 MB | 1.00x | 199.0 µs | 1.52 µs/doc | 26.1 ms |
| 50 | 50 | 5.93 MB | 2.06x | 3.45 µs | 3.33 | 77.3 |
| 250 | 250 | 3.76 MB | 1.31x | 6.85 µs | 2.62 | 37.2 |
| 1000 | 1000 | 3.24 MB | 1.12x | 17.8 µs | 1.78 | 29.4 |
| 5000 | 5000 | 2.97 MB | 1.03x | 79.5 µs | 1.57 | 26.0 |

**JSON_LOG** (avg 163 B, structurally repetitive, unique payloads):

| N | docs/chunk | size | vs uncapped | random lookup | 1% asc scan | full scan |
|---|---|---|---|---|---|---|
| -1 | 6250 | 34.26 MB | 1.00x | 495.3 µs | 7.98 µs/doc | 100.9 ms |
| 50 | 50 | 38.00 MB | 1.11x | 7.18 µs | 7.05 | 162.3 |
| 250 | 250 | 33.61 MB | 0.98x | 22.1 µs | 8.76 | 109.0 |
| 1000 | 1000 | 36.28 MB | 1.06x | 101.0 µs | 10.08 | 121.0 |
| 5000 | 5000 | 34.20 MB | 1.00x | 392.2 µs | 7.98 | 99.4 |

**SKEWED_LOG** (avg 106 B, max 50094 B):

| N | docs/chunk | size | vs uncapped | random lookup | 1% asc scan | full scan |
|---|---|---|---|---|---|---|
| -1 | 9345 | 8.15 MB | 1.00x | 335.9 µs | 3.56 µs/doc | 51.6 ms |
| 50 | 50 | 11.63 MB | 1.43x | 4.62 µs | 4.51 | 106.0 |
| 250 | 250 | 9.24 MB | 1.13x | 12.1 µs | 4.84 | 63.9 |
| 1000 | 1000 | 8.73 MB | 1.07x | 38.3 µs | 3.96 | 55.6 |
| 5000 | 5000 | 8.30 MB | 1.02x | 174.8 µs | 3.61 | 52.3 |

Takeaways:

- **Random point lookups scale ~linearly with docs/chunk.** Uncapped to N=250 is a 22–29x latency
  reduction across all three datasets.
- **The size cost at N=250 is small to nil**: 1.31x, 0.98x, 1.13x. Compression ratio is *not*
  monotonic in chunk size — JSON_LOG bottoms out at N=250–500, and HIGH_CARD_UUID at N=1000
  (18.83 MB vs 20.49 MB at N=5000). So there is a real tunable sweet spot rather than
  "larger is always smaller".
- **Small caps overshoot.** N=50 buys only 2–3x over N=250 on lookups but costs 1.11–2.06x size and
  1.5–3x on full scan.
- **This is a point-lookup optimization, not a general one.** The 1% ascending scan (the typical
  filtered-query shape) is flat-to-slightly-worse at every cap, since decompression already
  amortizes over ~135 values per uncapped chunk. Full scan regresses 8–43% at N=250.

N≈250 looks like a reasonable starting point for point-lookup-heavy columns.

Caveats: random-access error bars are wide at large chunk sizes (JSON_LOG uncapped: 495 ± 399 µs,
`Cnt=3`) — direction and order of magnitude are solid, exact values approximate. All measurements
are warm-buffer; on a server with mmap'd segments and cold pages, smaller chunks should also cut
read amplification, so the lookup win is likely understated. Latency swept on ZSTD only.

## Configuration

```json
{
  "fieldConfigList": [
    {
      "name": "myColumn",
      "encodingType": "RAW",
      "indexes": {
        "forward": {
          "compressionCodec": "ZSTANDARD",
          "rawIndexWriterVersion": 6,
          "targetMaxChunkSize": "1MB",
          "targetDocsPerChunk": 250,
          "enforceTargetDocsPerChunk": true
        }
      }
    }
  ]
}
```

- `rawIndexWriterVersion: 6` selects this writer. `enforceTargetDocsPerChunk` has no effect on
  earlier versions, which have no cap mechanism.
- Without `enforceTargetDocsPerChunk`, `targetDocsPerChunk` keeps its existing byte-size-derivation
  meaning exactly.
- `ForwardIndexConfig.setDefaultEnforceTargetDocsPerChunk` allows setting it cluster-wide, matching
  the existing `targetDocsPerChunk` pattern.
- Enforcement with a non-positive `targetDocsPerChunk` is rejected at config construction.

Note the chunk buffer is still allocated at `chunkSize` regardless of the cap, so a small cap
against a 1 MB `targetMaxChunkSize` leaves most of the buffer unused. Lower `targetMaxChunkSize`
alongside the cap; nothing auto-derives it.

## Constructor examples

```java
// Default (3-arg): byte-driven flush only — identical to the prior behavior.
new VarByteChunkForwardIndexWriterV6(file, ChunkCompressionType.ZSTANDARD, chunkSize);

// Cap each chunk at 1000 docs: flush at 1000 docs OR when the chunkSize buffer
// fills, whichever comes first.
new VarByteChunkForwardIndexWriterV6(file, ChunkCompressionType.ZSTANDARD, chunkSize, 1000);

// Explicitly disable the docs cap (equivalent to the 3-arg constructor).
new VarByteChunkForwardIndexWriterV6(file, ChunkCompressionType.ZSTANDARD, chunkSize,
    VarByteChunkForwardIndexWriterV6.DISABLE_DOCS_PER_CHUNK);
```

## Backward compatibility

- The defaults (`-1` at the writer, `enforceTargetDocsPerChunk: false` at the config) reproduce the
  exact current behavior. All pre-existing constructor and factory signatures are preserved as
  delegating overloads.
- The on-disk format and writer version (`6`) are unchanged.
- **The cap is a write-time decision only.** The chunk size lives in the index file header and the
  chunk boundaries in the per-chunk metadata, so readers derive all geometry from the segment and
  never consult table config. Retuning affects only newly built segments; segments with different
  geometries remain readable side by side, so the setting can be tuned over time without a reload.

## Testing

- `EnforceTargetDocsPerChunkTest` drives a skewed column (avg ~18 B, max 50 KB) through
  `SingleValueVarByteRawIndexCreator` and asserts enforcement yields exactly `numDocs / target`
  chunks while the unenforced path yields far fewer — pinning the gap the flag closes — plus a value
  round-trip on both paths.
- `VarByteChunkV6Test#testTargetDocsPerChunkCapsChunk` asserts each capped chunk holds exactly
  `targetDocsPerChunk` docs and that values round-trip.
- New `ForwardIndexConfigTest` cases cover the default, JSON round-trip, builder copy, and rejection
  of enforcement with a non-positive target; new `ForwardIndexUtilsTest` cases cover
  `getDocsPerChunkCap`.
- 2,735 tests pass across the forward-index creator/loader/writer suites in `pinot-segment-local`,
  plus 20 in `pinot-segment-spi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
