### PR TITLE
Check query termination while building the combine operator in CombinePlanNode

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
@@ -40,8 +40,9 @@ import org.apache.pinot.core.query.executor.ResultsBlockStreamer;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextUtils;
 import org.apache.pinot.core.util.QueryMultiThreadingUtils;
-import org.apache.pinot.spi.exception.BadQueryRequestException;
 import org.apache.pinot.spi.exception.QueryCancelledException;
+import org.apache.pinot.spi.exception.QueryException;
+import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.trace.InvocationRecording;
 import org.apache.pinot.spi.trace.InvocationScope;
 import org.apache.pinot.spi.trace.Tracing;
@@ -90,34 +91,36 @@ public class CombinePlanNode implements PlanNode {
     recording.setNumChildren(numPlanNodes);
     List<Operator> operators = new ArrayList<>(numPlanNodes);
 
-    if (numPlanNodes <= TARGET_NUM_PLANS_PER_THREAD) {
-      // Small number of plan nodes, run them sequentially
+    int numTasks = QueryMultiThreadingUtils.getNumTasks(numPlanNodes, TARGET_NUM_PLANS_PER_THREAD,
+        _queryContext.getMaxExecutionThreads());
+    recording.setNumTasks(numTasks);
+    if (numTasks == 1) {
+      // Single task, run all plan nodes sequentially on the current thread. The per-plan-node termination check below
+      // honors the query deadline and cancellation, so there is no need to offload to a separate thread.
       for (PlanNode planNode : _planNodes) {
+        // Building a plan node can be expensive (e.g. FST/IFST regexp processing), so check for query termination
+        // between plan nodes to avoid wasting resources on a cancelled or timed-out query.
+        QueryThreadContext.checkTerminationAndSampleUsage("CombinePlanNode");
         operators.add(planNode.run());
       }
     } else {
-      // Large number of plan nodes, run them in parallel
-      // NOTE: Even if we get single executor thread, still run it using a separate thread so that the timeout can be
-      //       honored
-      int numTasks = QueryMultiThreadingUtils.getNumTasks(numPlanNodes, TARGET_NUM_PLANS_PER_THREAD,
-          _queryContext.getMaxExecutionThreads());
-      recording.setNumTasks(numTasks);
+      // Multiple tasks, run them in parallel
       QueryMultiThreadingUtils.runTasksWithDeadline(numTasks, index -> {
         List<Operator> ops = new ArrayList<>();
         for (int i = index; i < numPlanNodes; i += numTasks) {
+          // Building a plan node can be expensive (e.g. FST/IFST regexp processing), so check for query termination
+          // between plan nodes to avoid wasting resources on a cancelled or timed-out query.
+          QueryThreadContext.checkTerminationAndSampleUsage("CombinePlanNode");
           ops.add(_planNodes.get(i).run());
         }
         return ops;
-      }, taskRes -> {
-        if (taskRes != null) {
-          operators.addAll(taskRes);
-        }
-      }, e -> {
+      }, operators::addAll, e -> {
         // Future object will throw ExecutionException for execution exception, need to check the cause to determine
-        // whether it is caused by bad query
+        // how to surface it. Preserve QueryException (e.g. termination/timeout from checkTerminationAndSampleUsage,
+        // BadQueryRequestException) so the original error code is not lost behind a generic RuntimeException.
         Throwable cause = e.getCause();
-        if (cause instanceof BadQueryRequestException) {
-          throw (BadQueryRequestException) cause;
+        if (cause instanceof QueryException) {
+          throw (QueryException) cause;
         }
         if (e instanceof InterruptedException) {
           throw new QueryCancelledException("Cancelled while running CombinePlanNode", e);

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/CombinePlanNodeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/CombinePlanNodeTest.java
@@ -31,11 +31,19 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.apache.pinot.spi.exception.BadQueryRequestException;
 import org.apache.pinot.spi.exception.QueryCancelledException;
+import org.apache.pinot.spi.exception.QueryErrorCode;
+import org.apache.pinot.spi.exception.TerminationException;
+import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.utils.CommonConstants.Server;
 import org.apache.pinot.util.TestUtils;
-import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 
 public class CombinePlanNodeTest {
@@ -63,7 +71,7 @@ public class CombinePlanNodeTest {
       _queryContext.setEndTimeMs(System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS);
       CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, _queryContext, _executorService, null);
       combinePlanNode.run();
-      Assert.assertEquals(numPlans, count.get());
+      assertEquals(numPlans, count.get());
     }
   }
 
@@ -89,12 +97,66 @@ public class CombinePlanNodeTest {
     try {
       combinePlanNode.run();
     } catch (RuntimeException e) {
-      Assert.assertTrue(e.getCause() instanceof TimeoutException);
-      Assert.assertFalse(notInterrupted.get());
+      assertTrue(e.getCause() instanceof TimeoutException);
+      assertFalse(notInterrupted.get());
       return;
     }
     // Fail.
-    Assert.fail();
+    fail();
+  }
+
+  /**
+   * Tests that query termination is checked while building the combine operator, so a terminated query stops before
+   * running the plan nodes. With a small number of plan nodes the combine operator is built sequentially on the
+   * calling thread (numTasks == 1), so it observes the QueryThreadContext set up on this thread.
+   */
+  @Test
+  public void testTerminationCheckedDuringPlanning() {
+    try (QueryThreadContext threadContext = QueryThreadContext.openForSseTest()) {
+      threadContext.getExecutionContext().terminate(QueryErrorCode.QUERY_CANCELLATION, "terminated for test");
+      AtomicInteger count = new AtomicInteger();
+      List<PlanNode> planNodes = new ArrayList<>();
+      for (int i = 0; i < 5; i++) {
+        planNodes.add(() -> {
+          count.incrementAndGet();
+          return null;
+        });
+      }
+      _queryContext.setEndTimeMs(System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS);
+      CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, _queryContext, _executorService, null);
+      try {
+        combinePlanNode.run();
+        fail("Should have thrown TerminationException");
+      } catch (TerminationException e) {
+        assertEquals(e.getErrorCode(), QueryErrorCode.QUERY_CANCELLATION);
+        // Termination is checked before running any plan node
+        assertEquals(count.get(), 0);
+      }
+    }
+  }
+
+  /**
+   * Tests that a QueryException thrown while building a plan node in parallel mode is surfaced as-is with its error
+   * code preserved, instead of being wrapped in a generic RuntimeException.
+   */
+  @Test
+  public void testQueryExceptionPreservedInParallel() {
+    List<PlanNode> planNodes = new ArrayList<>();
+    for (int i = 0; i < 20; i++) {
+      planNodes.add(() -> {
+        throw new BadQueryRequestException("Bad query for test");
+      });
+    }
+    _queryContext.setEndTimeMs(System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS);
+    // Force parallel execution (numTasks > 1) regardless of the number of available processors
+    _queryContext.setMaxExecutionThreads(2);
+    CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, _queryContext, _executorService, null);
+    try {
+      combinePlanNode.run();
+      fail("Should have thrown BadQueryRequestException");
+    } catch (BadQueryRequestException e) {
+      assertEquals(e.getErrorCode(), QueryErrorCode.QUERY_VALIDATION);
+    }
   }
 
   @Test
@@ -110,11 +172,11 @@ public class CombinePlanNodeTest {
     try {
       combinePlanNode.run();
     } catch (RuntimeException e) {
-      Assert.assertEquals(e.getCause().getMessage(), "java.lang.RuntimeException: Inner exception message.");
+      assertEquals(e.getCause().getMessage(), "java.lang.RuntimeException: Inner exception message.");
       return;
     }
     // Fail.
-    Assert.fail();
+    fail();
   }
 
   @Test
@@ -156,7 +218,7 @@ public class CombinePlanNodeTest {
       // waiting can be cancelled as below.
       future.cancel(true);
     } catch (Exception e) {
-      Assert.fail();
+      fail();
     } finally {
       combineExecutor.shutdownNow();
     }


### PR DESCRIPTION
## Summary

Building a plan node can be expensive (e.g. FST/IFST regexp processing), but `CombinePlanNode.getCombineOperator()` did not check for query termination while constructing the operators. A cancelled or timed-out query would keep building every plan node before bailing out, wasting CPU and holding segment references.

This PR adds termination checks to the operator-construction phase and tightens the related exception handling:

- **Per-plan-node termination check.** Both the sequential and parallel construction paths now call `QueryThreadContext.checkTerminationAndSampleUsage("CombinePlanNode")` between plan nodes, so a cancelled or timed-out query stops promptly and the construction work is sampled into the query's resource accountant.
- **Run inline when `numTasks == 1`.** Instead of always offloading to the executor for large plan-node counts, the operators are built sequentially on the current thread when only a single task would be scheduled (small plan-node count, or a single execution thread). The per-plan-node check now honors the deadline inline, so the separate-thread hop (previously needed only so the timeout could be honored) is no longer required. This also folds the old `numPlanNodes <= TARGET_NUM_PLANS_PER_THREAD` sequential branch into the same condition.
- **Preserve `QueryException` from parallel workers.** The parallel error handler now rethrows any `QueryException` cause (which subsumes the previous `BadQueryRequestException` special-case and covers the termination/timeout exceptions) instead of wrapping it in a generic `RuntimeException`, so the original error code reaches the caller. This matches how `BaseCombineOperator` already classifies worker exceptions.

The termination check is wired through the same `QueryThreadContext` path that `ServerQueryExecutorV1Impl` already uses during server query planning, and the new exceptions are handled by the existing top-level catch in `ServerQueryExecutorV1Impl` (mapped to `QUERY_CANCELLATION` / the preserved error code).
