### PR TITLE
Fall back to cross-server send for SINGLETON exchange when workers diverge

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/MailboxAssignmentVisitor.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/MailboxAssignmentVisitor.java
@@ -55,84 +55,29 @@ public class MailboxAssignmentVisitor extends DefaultPostOrderTraversalVisitor<V
         int numSenders = senderServerMap.size();
         int numReceivers = receiverServerMap.size();
         if (sendNode.getDistributionType() == RelDistribution.Type.SINGLETON) {
-          // NOTE: We use SINGLETON to represent local exchange. The actual distribution type is determined by the
-          //       parallelism.
-          if (numSenders == numReceivers) {
-            // Send the data to the same instance (same worker id) with SINGLETON distribution type
-            for (int workerId = 0; workerId < numSenders; workerId++) {
-              QueryServerInstance senderServer = senderServerMap.get(workerId);
-              QueryServerInstance receiverServer = receiverServerMap.get(workerId);
-              Preconditions.checkState(senderServer.equals(receiverServer),
-                  "Got different server for SINGLETON distribution type for worker id: %s, sender: %s, receiver: %s",
-                  workerId, senderServer, receiverServer);
-              MailboxInfos mailboxInfos = new SharedMailboxInfos(
-                  new MailboxInfo(senderServer.getHostname(), senderServer.getQueryMailboxPort(), List.of(workerId)));
-              senderMailboxesMap.computeIfAbsent(workerId, k -> new HashMap<>()).put(receiverStageId, mailboxInfos);
-              receiverMailboxesMap.computeIfAbsent(workerId, k -> new HashMap<>()).put(senderStageId, mailboxInfos);
-            }
-          } else {
-            // Hash distribute the data to multiple receivers on the same server instance
+          // NOTE: We use SINGLETON to represent a local exchange. The actual distribution type is determined by the
+          //       parallelism: 1-to-1 when sender and receiver have the same number of workers, otherwise the data is
+          //       hash distributed to the parallel receivers on each server. computeDirectExchange handles the
+          //       co-location assumption and its cross-server fallback.
+          if (numSenders != numReceivers) {
+            // Local exchange with parallelism: hash distribute to the parallel receivers, so keys are required.
             // TODO: Support local exchange with parallelism but no key
             Preconditions.checkState(!sendNode.getKeys().isEmpty(), "Local exchange with parallelism requires keys");
             sendNode.setDistributionType(RelDistribution.Type.HASH_DISTRIBUTED);
-
             Preconditions.checkState(numReceivers % numSenders == 0,
                 "Number of receivers: %s should be a multiple of number of senders: %s for local exchange",
                 numReceivers, numSenders);
-            int parallelism = numReceivers / numSenders;
-            int receiverWorkerId = 0;
-            for (int senderWorkerId = 0; senderWorkerId < numSenders; senderWorkerId++) {
-              QueryServerInstance senderServer = senderServerMap.get(senderWorkerId);
-              QueryServerInstance receiverServer = receiverServerMap.get(receiverWorkerId);
-              Preconditions.checkState(senderServer.equals(receiverServer),
-                  "Got different server for local exchange, sender %s: %s, receiver %s: %s", senderWorkerId,
-                  senderServer, receiverWorkerId, receiverServer);
-              computeDirectExchangeWithParallelism(senderMailboxesMap, receiverMailboxesMap, senderStageId,
-                  receiverStageId, senderWorkerId, receiverWorkerId, senderServer, receiverServer, parallelism);
-              receiverWorkerId += parallelism;
-            }
           }
-        } else if (senderMetadata.isPrePartitioned() && isDirectExchangeCompatible(senderMetadata, receiverMetadata)) {
-          // Direct exchange possible:
-          // - Without parallelism:
-          //   Send the data to the worker with the same worker id (not necessary the same instance), 1-to-1 mapping
-          // - With parallelism:
-          //   Fanout based on parallelism from each sender workerID to sequentially increment receiver workerIDs
           int parallelism = numReceivers / numSenders;
-          if (parallelism == 1) {
-            // 1-to-1 mapping
-            for (int workerId = 0; workerId < numSenders; workerId++) {
-              QueryServerInstance senderServer = senderServerMap.get(workerId);
-              QueryServerInstance receiverServer = receiverServerMap.get(workerId);
-              List<Integer> workerIds = List.of(workerId);
-              MailboxInfos senderMailboxInfos;
-              MailboxInfos receiverMailboxInfos;
-              if (senderServer.equals(receiverServer)) {
-                senderMailboxInfos = new SharedMailboxInfos(
-                    new MailboxInfo(senderServer.getHostname(), senderServer.getQueryMailboxPort(), workerIds));
-                receiverMailboxInfos = senderMailboxInfos;
-              } else {
-                senderMailboxInfos = new MailboxInfos(
-                    new MailboxInfo(senderServer.getHostname(), senderServer.getQueryMailboxPort(), workerIds));
-                receiverMailboxInfos = new MailboxInfos(
-                    new MailboxInfo(receiverServer.getHostname(), receiverServer.getQueryMailboxPort(), workerIds));
-              }
-              senderMailboxesMap.computeIfAbsent(workerId, k -> new HashMap<>())
-                  .put(receiverStageId, receiverMailboxInfos);
-              receiverMailboxesMap.computeIfAbsent(workerId, k -> new HashMap<>())
-                  .put(senderStageId, senderMailboxInfos);
-            }
-          } else {
-            // 1-to-<parallelism> mapping
-            int receiverWorkerId = 0;
-            for (int senderWorkerId = 0; senderWorkerId < numSenders; senderWorkerId++) {
-              QueryServerInstance senderServer = senderServerMap.get(senderWorkerId);
-              QueryServerInstance receiverServer = receiverServerMap.get(receiverWorkerId);
-              computeDirectExchangeWithParallelism(senderMailboxesMap, receiverMailboxesMap, senderStageId,
-                  receiverStageId, senderWorkerId, receiverWorkerId, senderServer, receiverServer, parallelism);
-              receiverWorkerId += parallelism;
-            }
-          }
+          computeDirectExchange(senderMailboxesMap, receiverMailboxesMap, senderStageId, receiverStageId,
+              senderServerMap, receiverServerMap, numSenders, parallelism);
+        } else if (senderMetadata.isPrePartitioned() && isDirectExchangeCompatible(senderMetadata, receiverMetadata)) {
+          // Direct exchange: the data is already pre-partitioned, so send it 1-to-1 to the worker with the same worker
+          // id (with parallelism, fan out each sender worker to a contiguous range of receiver workers). The
+          // co-location handling is the same as SINGLETON, see computeDirectExchange.
+          int parallelism = numReceivers / numSenders;
+          computeDirectExchange(senderMailboxesMap, receiverMailboxesMap, senderStageId, receiverStageId,
+              senderServerMap, receiverServerMap, numSenders, parallelism);
         } else {
           // For other exchange types, send the data to all the instances in the receiver fragment
           // TODO: Add support for more exchange types
@@ -142,6 +87,70 @@ public class MailboxAssignmentVisitor extends DefaultPostOrderTraversalVisitor<V
       }
     }
     return null;
+  }
+
+  /// Wires the mailboxes for a direct exchange where sender worker `i` sends to receiver worker `i` (or, with
+  /// `parallelism` > 1, fans out to a contiguous range of `parallelism` receiver workers). Shared by the SINGLETON
+  /// (local exchange) and pre-partitioned exchange paths.
+  ///
+  /// Sender worker `i` and receiver worker `i` are normally co-located on the same server, because the receiver worker
+  /// map is derived from the sender's (see `WorkerManager#assignWorkersForLocalExchange`). When they are co-located the
+  /// data is exchanged in-process via a single shared local mailbox with no network hop.
+  ///
+  /// They are not guaranteed to be co-located, so this does not assert it. A colocated semi-join is the exception:
+  /// `PinotJoinToDynamicBroadcastRule` emits a SINGLETON `PIPELINE_BREAKER` exchange on the build side purely from the
+  /// `is_colocated_by_join_keys` hint, and the build (sender) leaf and join (receiver) leaf are routed independently
+  /// per table. During a rolling restart some segments are temporarily not queryable, so each side may reroute a
+  /// partition to a different replica, leaving worker `i` on different servers. Rather than failing the query, we fall
+  /// back to a cross-server send: the exchange stays correct because worker id still maps to the same partition on both
+  /// sides, and we only lose locality (one extra network hop) until routing re-stabilizes.
+  private void computeDirectExchange(Map<Integer, Map<Integer, MailboxInfos>> senderMailboxesMap,
+      Map<Integer, Map<Integer, MailboxInfos>> receiverMailboxesMap, Integer senderStageId, Integer receiverStageId,
+      Map<Integer, QueryServerInstance> senderServerMap, Map<Integer, QueryServerInstance> receiverServerMap,
+      int numSenders, int parallelism) {
+    if (parallelism == 1) {
+      // 1-to-1 mapping
+      for (int workerId = 0; workerId < numSenders; workerId++) {
+        QueryServerInstance senderServer = senderServerMap.get(workerId);
+        QueryServerInstance receiverServer = receiverServerMap.get(workerId);
+        List<Integer> workerIds = List.of(workerId);
+        MailboxInfos senderMailboxInfos;
+        MailboxInfos receiverMailboxInfos;
+        if (senderServer.equals(receiverServer)) {
+          // Co-located: share one local mailbox, exchanged in-process with no network hop.
+          MailboxInfos sharedMailboxInfos = new SharedMailboxInfos(
+              new MailboxInfo(senderServer.getHostname(), senderServer.getQueryMailboxPort(), workerIds));
+          senderMailboxInfos = sharedMailboxInfos;
+          receiverMailboxInfos = sharedMailboxInfos;
+        } else {
+          // Not co-located: cross-server send via separate sender and receiver mailboxes.
+          // TODO: Match the sender and receiver worker assignments upfront so co-located data never crosses the wire.
+          //   The sender and receiver leaves are routed independently per table today; co-routing them onto a shared
+          //   worker-to-server map (picking, per partition, a server that hosts the partition for both sides) would
+          //   keep this exchange local even during a rolling restart, falling back to a cross-server send only for
+          //   partitions that genuinely cannot be co-located. See PinotJoinToDynamicBroadcastRule and WorkerManager's
+          //   leaf worker assignment.
+          senderMailboxInfos = new MailboxInfos(
+              new MailboxInfo(senderServer.getHostname(), senderServer.getQueryMailboxPort(), workerIds));
+          receiverMailboxInfos = new MailboxInfos(
+              new MailboxInfo(receiverServer.getHostname(), receiverServer.getQueryMailboxPort(), workerIds));
+        }
+        senderMailboxesMap.computeIfAbsent(workerId, k -> new HashMap<>())
+            .put(receiverStageId, receiverMailboxInfos);
+        receiverMailboxesMap.computeIfAbsent(workerId, k -> new HashMap<>())
+            .put(senderStageId, senderMailboxInfos);
+      }
+    } else {
+      // 1-to-<parallelism> mapping
+      int receiverWorkerId = 0;
+      for (int senderWorkerId = 0; senderWorkerId < numSenders; senderWorkerId++) {
+        QueryServerInstance senderServer = senderServerMap.get(senderWorkerId);
+        QueryServerInstance receiverServer = receiverServerMap.get(receiverWorkerId);
+        computeDirectExchangeWithParallelism(senderMailboxesMap, receiverMailboxesMap, senderStageId,
+            receiverStageId, senderWorkerId, receiverWorkerId, senderServer, receiverServer, parallelism);
+        receiverWorkerId += parallelism;
+      }
+    }
   }
 
   private void computeDirectExchangeWithParallelism(Map<Integer, Map<Integer, MailboxInfos>> senderMailboxesMap,

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/MailboxAssignmentVisitorTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/MailboxAssignmentVisitorTest.java
@@ -21,12 +21,22 @@ package org.apache.pinot.query.planner.physical;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.pinot.calcite.rel.logical.PinotRelExchangeType;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.QueryEnvironmentTestBase;
+import org.apache.pinot.query.planner.plannode.MailboxSendNode;
 import org.apache.pinot.query.routing.MailboxInfo;
 import org.apache.pinot.query.routing.MailboxInfos;
+import org.apache.pinot.query.routing.QueryServerInstance;
+import org.apache.pinot.query.routing.SharedMailboxInfos;
 import org.apache.pinot.query.routing.WorkerMetadata;
+import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 
@@ -67,6 +77,93 @@ public class MailboxAssignmentVisitorTest extends QueryEnvironmentTestBase {
 
     DispatchableSubPlan subPlan = _queryEnvironment.planQuery(query);
     verifyAllMailboxInfosSorted(subPlan, query);
+  }
+
+  private static final int SENDER_STAGE = 1;
+  private static final int RECEIVER_STAGE = 0;
+
+  /// A SINGLETON local exchange where sender worker `i` and receiver worker `i` land on different servers (as can
+  /// happen for a colocated semi-join during a rolling restart) must not fail: it falls back to a cross-server send
+  /// for the diverged worker while keeping the co-located worker local.
+  @Test
+  public void testSingletonFallsBackToCrossServerWhenWorkersDiverge() {
+    // Worker 0 co-located on A; worker 1 diverged (sender on B, receiver on C).
+    DispatchablePlanMetadata sender = metadata(Map.of(0, server("A"), 1, server("B")));
+    DispatchablePlanMetadata receiver = metadata(Map.of(0, server("A"), 1, server("C")));
+    process(singletonSendNode(List.of()), sender, receiver);
+
+    Map<Integer, Map<Integer, MailboxInfos>> senderMailboxes = sender.getWorkerIdToMailboxesMap();
+    Map<Integer, Map<Integer, MailboxInfos>> receiverMailboxes = receiver.getWorkerIdToMailboxesMap();
+
+    // Worker 0 is co-located: a single shared local mailbox on host_A on both sides.
+    assertTrue(senderMailboxes.get(0).get(RECEIVER_STAGE) instanceof SharedMailboxInfos);
+    assertEquals(singleMailbox(senderMailboxes, 0, RECEIVER_STAGE).getHostname(), "host_A");
+    assertEquals(singleMailbox(receiverMailboxes, 0, SENDER_STAGE).getHostname(), "host_A");
+
+    // Worker 1 diverged: cross-server send, not a shared mailbox. The sender sends to the receiver's server (C) and
+    // the receiver reads from the sender's server (B).
+    assertFalse(senderMailboxes.get(1).get(RECEIVER_STAGE) instanceof SharedMailboxInfos);
+    assertEquals(singleMailbox(senderMailboxes, 1, RECEIVER_STAGE).getHostname(), "host_C");
+    assertEquals(singleMailbox(receiverMailboxes, 1, SENDER_STAGE).getHostname(), "host_B");
+  }
+
+  /// An unequal-but-non-multiple worker count (2 senders, 3 receivers) must be rejected rather than rounding the
+  /// parallelism down to 1 and silently dropping the extra receiver.
+  @Test(expectedExceptions = IllegalStateException.class,
+      expectedExceptionsMessageRegExp = ".*multiple of number of senders.*")
+  public void testSingletonRejectsNonMultipleReceiverCount() {
+    DispatchablePlanMetadata sender = metadata(Map.of(0, server("A"), 1, server("B")));
+    DispatchablePlanMetadata receiver = metadata(Map.of(0, server("A"), 1, server("B"), 2, server("C")));
+    process(singletonSendNode(List.of(0)), sender, receiver);
+  }
+
+  /// A SINGLETON local exchange with parallelism (more receivers than senders) does not assert co-location either: it
+  /// rewrites the distribution to HASH and fans each sender worker out to its receiver workers, even cross-server.
+  @Test
+  public void testSingletonWithParallelismAllowsCrossServer() {
+    // 1 sender on A, 2 receivers on B (parallelism 2), so the fan-out is cross-server.
+    DispatchablePlanMetadata sender = metadata(Map.of(0, server("A")));
+    DispatchablePlanMetadata receiver = metadata(Map.of(0, server("B"), 1, server("B")));
+    MailboxSendNode sendNode = singletonSendNode(List.of(0));
+    process(sendNode, sender, receiver);
+
+    assertEquals(sendNode.getDistributionType(), RelDistribution.Type.HASH_DISTRIBUTED);
+    MailboxInfo senderToReceiver = singleMailbox(sender.getWorkerIdToMailboxesMap(), 0, RECEIVER_STAGE);
+    assertEquals(senderToReceiver.getHostname(), "host_B");
+    assertEquals(senderToReceiver.getWorkerIds(), List.of(0, 1));
+    assertEquals(singleMailbox(receiver.getWorkerIdToMailboxesMap(), 0, SENDER_STAGE).getHostname(), "host_A");
+    assertEquals(singleMailbox(receiver.getWorkerIdToMailboxesMap(), 1, SENDER_STAGE).getHostname(), "host_A");
+  }
+
+  private static QueryServerInstance server(String id) {
+    return new QueryServerInstance(id, "host_" + id, 1, 1);
+  }
+
+  private static DispatchablePlanMetadata metadata(Map<Integer, QueryServerInstance> workerIdToServerInstanceMap) {
+    DispatchablePlanMetadata metadata = new DispatchablePlanMetadata();
+    metadata.setWorkerIdToServerInstanceMap(workerIdToServerInstanceMap);
+    return metadata;
+  }
+
+  private static MailboxSendNode singletonSendNode(List<Integer> keys) {
+    DataSchema dataSchema = new DataSchema(new String[]{"col"}, new ColumnDataType[]{ColumnDataType.INT});
+    return new MailboxSendNode(SENDER_STAGE, dataSchema, List.of(), RECEIVER_STAGE,
+        PinotRelExchangeType.PIPELINE_BREAKER, RelDistribution.Type.SINGLETON, keys, false, null, false, "absHashCode");
+  }
+
+  private static void process(MailboxSendNode sendNode, DispatchablePlanMetadata sender,
+      DispatchablePlanMetadata receiver) {
+    DispatchablePlanContext context = Mockito.mock(DispatchablePlanContext.class);
+    Mockito.when(context.getDispatchablePlanMetadataMap())
+        .thenReturn(Map.of(SENDER_STAGE, sender, RECEIVER_STAGE, receiver));
+    MailboxAssignmentVisitor.INSTANCE.process(sendNode, context);
+  }
+
+  private static MailboxInfo singleMailbox(Map<Integer, Map<Integer, MailboxInfos>> mailboxesMap, int workerId,
+      int stageId) {
+    List<MailboxInfo> mailboxInfos = mailboxesMap.get(workerId).get(stageId).getMailboxInfos();
+    assertEquals(mailboxInfos.size(), 1);
+    return mailboxInfos.get(0);
   }
 
   private void verifyAllMailboxInfosSorted(DispatchableSubPlan subPlan, String query) {


### PR DESCRIPTION
## Summary

`MailboxAssignmentVisitor` uses `SINGLETON` to represent a local exchange and asserts that sender worker `i` and receiver worker `i` are on the same server. For genuine local exchanges this holds by construction — the receiver worker map is copied from the sender via `WorkerManager#assignWorkersForLocalExchange`.

A colocated semi-join is the exception. `PinotJoinToDynamicBroadcastRule` emits a `SINGLETON` `PIPELINE_BREAKER` exchange on the build side purely from the `is_colocated_by_join_keys` hint, and the build (sender) leaf and join (receiver) leaf are routed independently per table. During a rolling restart, some segments are temporarily not queryable, so each side may reroute a partition to a different replica — leaving worker `i` on different servers and failing the query with:

```
IllegalStateException: Got different server for SINGLETON distribution type for worker id: ...
```

## Fix

Fall back to a cross-server send for the diverged workers instead of throwing, mirroring the behavior the pre-partitioned direct-exchange path already had. The exchange stays correct because worker id still maps to the same partition on both sides; only locality (one extra network hop) is lost until routing re-stabilizes.

Along the way:
- The 1-to-1 SINGLETON branch, the SINGLETON-with-parallelism branch, and the pre-partitioned branch all funnel through a single `computeDirectExchange` helper, removing the duplicated mailbox-wiring logic.
- The SINGLETON-with-parallelism branch no longer asserts co-location (it already wired the actual sender/receiver servers via `computeDirectExchangeWithParallelism`, so a cross-server send was already correct there).
- The local-exchange validation now gates on `numSenders != numReceivers` rather than the rounded-down `parallelism`, so an unequal-but-non-multiple count (e.g. 2 senders / 3 receivers) is still rejected instead of silently falling into the 1-to-1 path.

A `TODO` is left at the fallback site for a future optimization: matching the independently-routed sender/receiver worker assignments upfront so co-located data never has to cross the wire.
