### PR TITLE
Skip IdealState resource scan in instanceDropSafetyCheck for minions

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -4222,6 +4222,11 @@ public class PinotHelixResourceManager {
   /**
    * Utility to perform a safety check of the operation to drop an instance.
    * If the resource is not safe to drop the utility lists all the possible reasons.
+   * <p>The cluster-wide IdealState scan is skipped for minion instances: minions never appear in any
+   * resource IdealState (their task assignments live in the Helix Task Framework
+   * {@code JobContext}/{@code WorkflowContext}, not in IdealState), so the scan can only ever return
+   * empty for them. Skipping it avoids pulling every IdealState into the controller heap, which is a
+   * significant source of heap pressure when many minions are dropped in succession.
    * @param instanceName Pinot instance name
    * @return {@link OperationValidationResponse}
    */
@@ -4231,16 +4236,20 @@ public class PinotHelixResourceManager {
     if (_helixDataAccessor.getProperty(_keyBuilder.liveInstance(instanceName)) != null) {
       response.putIssue(OperationValidationResponse.ErrorCode.IS_ALIVE, instanceName);
     }
-    // Check if any ideal state includes the instance
-    getAllResources().forEach(resource -> {
-      IdealState idealState = _helixAdmin.getResourceIdealState(_helixClusterName, resource);
-      for (String partition : idealState.getPartitionSet()) {
-        if (idealState.getInstanceSet(partition).contains(instanceName)) {
-          response.putIssue(OperationValidationResponse.ErrorCode.CONTAINS_RESOURCE, instanceName, resource);
-          break;
+    // Check if any ideal state includes the instance. Minions never host any resource, so skip the
+    // expensive scan for them. Controllers/servers/brokers can host resources (e.g. controllers are
+    // participants in the lead controller resource), so the scan is still required for them.
+    if (!InstanceTypeUtils.isMinion(instanceName)) {
+      getAllResources().forEach(resource -> {
+        IdealState idealState = _helixAdmin.getResourceIdealState(_helixClusterName, resource);
+        for (String partition : idealState.getPartitionSet()) {
+          if (idealState.getInstanceSet(partition).contains(instanceName)) {
+            response.putIssue(OperationValidationResponse.ErrorCode.CONTAINS_RESOURCE, instanceName, resource);
+            break;
+          }
         }
-      }
-    });
+      });
+    }
     return response.setSafe(response.getIssues().isEmpty());
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerMinionDrainTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerMinionDrainTest.java
@@ -24,10 +24,12 @@ import java.util.List;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.controller.api.resources.OperationValidationResponse;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.spi.config.instance.Instance;
 import org.apache.pinot.spi.config.instance.InstanceType;
 import org.apache.pinot.spi.utils.CommonConstants.Helix;
+import org.mockito.Mockito;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -478,6 +480,69 @@ public class PinotHelixResourceManagerMinionDrainTest extends ControllerTest {
 
     // Cleanup
     _helixResourceManager.dropInstance(minionInstanceId);
+  }
+
+  @Test
+  public void testInstanceDropSafetyCheckSkipsResourceScanForMinion() {
+    // A minion never hosts any resource, so the drop safety check must skip the expensive cluster-wide
+    // IdealState scan entirely (getAllResources is never invoked) while still reporting it as safe.
+    String minionHost = "minion-test-safety.example.com";
+    int minionPort = 9530;
+    Instance minionInstance = new Instance(minionHost, minionPort, InstanceType.MINION,
+        Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+    assertTrue(_helixResourceManager.addInstance(minionInstance, false).isSuccessful());
+    String minionInstanceId = "Minion_" + minionHost + "_" + minionPort;
+
+    PinotHelixResourceManager spy = Mockito.spy(_helixResourceManager);
+    OperationValidationResponse response = spy.instanceDropSafetyCheck(minionInstanceId);
+
+    assertTrue(response.isSafe(), "Minion should be safe to drop: " + response.getIssues());
+    // The resource scan must be skipped for minions - this is the behavior under test.
+    Mockito.verify(spy, Mockito.never()).getAllResources();
+
+    // Cleanup
+    _helixResourceManager.dropInstance(minionInstanceId);
+  }
+
+  @Test
+  public void testInstanceDropSafetyCheckRunsResourceScanForNonMinion() {
+    // Non-minion instances can host resources, so the scan must still run. This locks the !isMinion
+    // guard: inverting it would skip the scan here and fail this verification.
+    String brokerHost = "broker-test-safety.example.com";
+    int brokerPort = 9531;
+    Instance brokerInstance = new Instance(brokerHost, brokerPort, InstanceType.BROKER,
+        Collections.singletonList(Helix.UNTAGGED_BROKER_INSTANCE), null, 0, 0, 0, 0, false);
+    assertTrue(_helixResourceManager.addInstance(brokerInstance, false).isSuccessful());
+    String brokerInstanceId = "Broker_" + brokerHost + "_" + brokerPort;
+
+    PinotHelixResourceManager spy = Mockito.spy(_helixResourceManager);
+    spy.instanceDropSafetyCheck(brokerInstanceId);
+
+    // The resource scan must run for non-minion instances.
+    Mockito.verify(spy, Mockito.atLeastOnce()).getAllResources();
+
+    // Cleanup
+    _helixResourceManager.dropInstance(brokerInstanceId);
+  }
+
+  @Test
+  public void testInstanceDropSafetyCheckFlagsLiveMinion()
+      throws Exception {
+    // The cheap liveness check must still apply to minions even though the resource scan is skipped:
+    // a live minion is reported as unsafe with an IS_ALIVE issue.
+    String minionHost = "minion-test-live.example.com";
+    int minionPort = 9532;
+    Instance minionInstance = new Instance(minionHost, minionPort, InstanceType.MINION,
+        Collections.singletonList(Helix.UNTAGGED_MINION_INSTANCE), null, 0, 0, 0, 0, false);
+    assertTrue(_helixResourceManager.addInstance(minionInstance, false).isSuccessful());
+    String minionInstanceId = "Minion_" + minionHost + "_" + minionPort;
+    createFakeMinionLiveInstance(minionInstanceId);
+
+    OperationValidationResponse response = _helixResourceManager.instanceDropSafetyCheck(minionInstanceId);
+    assertFalse(response.isSafe(), "Live minion should not be safe to drop");
+    assertTrue(response.getIssues().stream()
+            .anyMatch(issue -> issue.getCode() == OperationValidationResponse.ErrorCode.IS_ALIVE),
+        "Live minion drop safety check should produce an IS_ALIVE issue");
   }
 
   @AfterClass


### PR DESCRIPTION
## Description

`instanceDropSafetyCheck` (called by `dropInstance` and the `/instances/dropInstance/validate` endpoint) verifies an instance hosts no resource by scanning **every** resource's `IdealState` across the cluster. For minion instances this scan is pure waste:

- `getAllResources()` returns only table (`_OFFLINE`/`_REALTIME`) and broker resources.
- Minions never appear in any of those IdealStates — minion task assignments are managed by the Helix Task Framework in `JobContext`/`WorkflowContext`, not in IdealState.

So the scan can only ever return empty for a minion, yet each minion drop pulls every IdealState into the controller heap. When many minions are dropped in succession this creates significant heap pressure / GC churn on the controller.

## Change

- Gate the resource scan on `!InstanceTypeUtils.isMinion(instanceName)`.
- Keep the cheap `IS_ALIVE` liveness check (a single ZK read) for **all** instance types — a live minion is still reported as unsafe to drop.
- The scan remains in place for controllers/servers/brokers. This is deliberate: controllers are real participants in the `leadControllerResource` Helix resource and can legitimately match `CONTAINS_RESOURCE`, so the skip is scoped to minions only — not a broader "non-server" condition.

## Tests

Added to `PinotHelixResourceManagerMinionDrainTest`:
- `testInstanceDropSafetyCheckSkipsResourceScanForMinion` — spies the resource manager and verifies `getAllResources()` is **never** invoked for a minion (proves the scan is bypassed, not just result-equivalent).
- `testInstanceDropSafetyCheckRunsResourceScanForNonMinion` — verifies the scan **still runs** for a broker, locking the `!isMinion` guard against inversion.
- `testInstanceDropSafetyCheckFlagsLiveMinion` — verifies a live minion is still flagged `IS_ALIVE`.

All 15 tests in the class pass; spotless/checkstyle/license checks pass on `pinot-controller`.