### PR TITLE
Fix potential NPE in PinotHelixResourceManager tenant deletability checks

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1538,6 +1538,9 @@ public class PinotHelixResourceManager {
     Set<String> taggedInstances = new HashSet<>(HelixHelper.getInstancesWithTag(_helixZkManager, brokerTag));
     String brokerName = Helix.BROKER_RESOURCE_INSTANCE;
     IdealState brokerIdealState = _helixAdmin.getResourceIdealState(_helixClusterName, brokerName);
+    if (brokerIdealState == null) {
+      return true;
+    }
     for (String partition : brokerIdealState.getPartitionSet()) {
       for (String instance : brokerIdealState.getInstanceSet(partition)) {
         if (taggedInstances.contains(instance)) {
@@ -1558,6 +1561,9 @@ public class PinotHelixResourceManager {
         continue;
       }
       IdealState tableIdealState = _helixAdmin.getResourceIdealState(_helixClusterName, resourceName);
+      if (tableIdealState == null) {
+        continue;
+      }
       for (String partition : tableIdealState.getPartitionSet()) {
         for (String instance : tableIdealState.getInstanceSet(partition)) {
           if (taggedInstances.contains(instance)) {


### PR DESCRIPTION
## Description

`HelixAdmin.getResourceIdealState()` can return `null` in two methods within tenant-deletability checks:

### `isBrokerTenantDeletable`
The broker resource IdealState is fetched using `BROKER_RESOURCE_INSTANCE`. During cluster initialization or in edge cases (e.g., cluster not fully set up), this can be `null`. The previous code called `brokerIdealState.getPartitionSet()` directly, which would throw a `NullPointerException`.

### `isServerTenantDeletable`
The method iterates over all resources via `getAllResources()` and then fetches each resource's IdealState. There is a TOCTOU race: a table resource can be concurrently deleted between `getAllResources()` and `getResourceIdealState()`, returning `null`. The previous code called `tableIdealState.getPartitionSet()` directly, which would throw a `NullPointerException`.

## Fix

- **`isBrokerTenantDeletable`**: Guard null `brokerIdealState` by returning `true` (safe default — no broker resource means no brokers are assigned to this tenant)
- **`isServerTenantDeletable`**: Guard null `tableIdealState` with `continue` (consistent with how concurrent deletions are handled elsewhere in the codebase — see `getServerToSegmentsMap`, `getServers`)

## Tests

No functional behavior change for the normal (non-null) path. The null guards are defensive fixes for edge cases during cluster state transitions.

## Checklist

- [x] No new public APIs without documentation
- [x] Backward compatible change
- [x] Code follows existing patterns in the codebase