### PR TITLE
Fix query console blank page when result contains a MAP (complex) column

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Table.tsx
+++ b/pinot-controller/src/main/resources/app/components/Table.tsx
@@ -556,7 +556,10 @@ export default function CustomizedTables({
               {styleCell(cellData.value)}
             </Tooltip>
         );
-      } else if(has(cellData, 'value') && cellData.value) {
+      } else if (has(cellData, 'value')) {
+        // Render via the value path whenever the key is present, including falsy values
+        // (0, false, null, ''). styleCell safely coerces any type, so we no longer fall
+        // through to dumping the whole {value: ...} object for a falsy value.
         return styleCell(cellData.value);
       } else {
           // Fall back to a stringified representation. toDisplayString guards against

--- a/pinot-controller/src/main/resources/app/components/Table.tsx
+++ b/pinot-controller/src/main/resources/app/components/Table.tsx
@@ -89,6 +89,26 @@ staticSortFunctions.set("Estimated Size", sortBytes);
 staticSortFunctions.set("Reported Size", sortBytes);
 staticSortFunctions.set("Status", sortCellValue);
 
+// Safely coerce an arbitrary cell value to a string for display. Most cells are strings, but
+// complex column types (e.g. MAP, which the broker serializes as an object) arrive as non-strings.
+// JSON.stringify can itself throw (circular references, BigInt) or return undefined (functions,
+// symbols), so both are guarded — the results view has no error boundary, and any throw here
+// white-screens the whole page.
+const toDisplayString = (value: any): string => {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (value === null || value === undefined) {
+    return String(value);
+  }
+  try {
+    const json = JSON.stringify(value);
+    return json === undefined ? String(value) : json;
+  } catch (e) {
+    return '<DATA COULD NOT BE PARSED TO DISPLAY>';
+  }
+};
+
 const StyledTableRow = withStyles((theme) =>
   createStyles({
     root: {
@@ -414,7 +434,10 @@ export default function CustomizedTables({
     };
   }, [search, timeoutId, filterSearchResults]);
 
-  const styleCell = (str: string) => {
+  const styleCell = (cellValue: any) => {
+    // Coerce to a string first so the String methods below (toLowerCase/search/replace) never
+    // throw on a non-string cell value (e.g. a MAP column) and crash the whole results view.
+    const str = toDisplayString(cellValue);
     if (str.toLowerCase() === 'good' || str.toLowerCase() === 'healthy' || str.toLowerCase() === 'online' || str.toLowerCase() === 'alive' || str.toLowerCase() === 'true') {
           return (
             <StyledChip
@@ -536,14 +559,9 @@ export default function CustomizedTables({
       } else if(has(cellData, 'value') && cellData.value) {
         return styleCell(cellData.value);
       } else {
-          try {
-            const stringifiedJSON = JSON.stringify(cellData)
-            return stringifiedJSON
-          } catch(e) {
-            // If the data is corrupted and not recognizable by JSON.stringify, fallback to below error message instead
-            // of crashing the whole page for the user.
-            return '<DATA COULD NOT BE PARSED TO DISPLAY>'
-          }
+          // Fall back to a stringified representation. toDisplayString guards against
+          // JSON.stringify throwing (e.g. corrupted/circular data) so we never crash the page.
+          return toDisplayString(cellData);
       }
     }
     return styleCell(cellData.toString());


### PR DESCRIPTION
## Problem

The query console (controller web UI) renders a **blank page** whenever a result set includes a `MAP`-typed column.

Repro: `SELECT * FROM <table>` where the table has a `MAP` column. The broker serializes a MAP cell as an object, e.g.:

```json
{"value":{"container.image.name":"...", "k8s.pod.name":"...", ...}}
```

In [`Table.tsx`](https://github.com/apache/pinot/blob/master/pinot-controller/src/main/resources/app/components/Table.tsx), `makeCell` treats any object with a truthy `value` key as an internal "rich cell" (`{value, tooltip, component}`, where `value` is a status **string**) and calls `styleCell(cellData.value)`. For a MAP column, `cellData.value` is itself an **object**, so `styleCell`'s first statement `str.toLowerCase()` throws:

```
TypeError: str.toLowerCase is not a function
```

This is thrown during React render, and there is no error boundary, so the entire results view unmounts and the page goes blank.

## Fix

Add a single guarded `toDisplayString` helper that coerces any non-string cell value to a string before the `String` methods run, shared by both `styleCell` and `makeCell`. It also guards `JSON.stringify` against throwing (circular references, `BigInt`) or returning `undefined` (functions, symbols), so the renderer never throws on an unexpected cell value.

After the fix, a MAP column renders its contents as JSON text instead of blanking the page; scalar/array columns are unaffected.

## Notes

- Root cause is the column **type** (`MAP`), not any particular column name.
- The controller frontend currently has no JS test harness, so no unit test is added; the change is a defensive coercion with no behavior change for existing string/array cells.