### PR TITLE
Add server-local memory guard to pause realtime ingestion under heap pressure

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -43,6 +43,10 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   LLC_SIMULTANEOUS_SEGMENT_BUILDS("llcSimultaneousSegmentBuilds", true),
   // Gauge to reflect whether pauseless is enabled or not
   PAUSELESS_CONSUMPTION_ENABLED("pauselessConsumptionEnabled", false),
+  // Server-global gauge (0/1) reflecting whether realtime ingestion is currently paused on this server due to JVM heap
+  // pressure (see RealtimeIngestionMemoryGuard). Lets dashboards/alerts distinguish a deliberate memory pause from a
+  // wedged consumer.
+  REALTIME_INGESTION_MEMORY_PAUSED("state", true),
   // Upsert metrics
   UPSERT_PRIMARY_KEYS_COUNT("upsertPrimaryKeysCount", false),
   // Dedup metrics

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -51,6 +51,10 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   REALTIME_CLP_UNENCODABLE("rows", false),
   REALTIME_CLP_ENCODED_NON_STRINGS("rows", false),
   REALTIME_CONSUMPTION_EXCEPTIONS("exceptions", true),
+  // Incremented once per pause check-interval that a consuming segment is parked by the server-local memory guard
+  // (RealtimeIngestionMemoryGuard) due to heap pressure or a primary-key cap. Reported per table so operators can see
+  // which tables are being throttled.
+  REALTIME_CONSUMPTION_PAUSED_MEMORY("count", false),
   REALTIME_MERGED_TEXT_IDX_TRUNCATED_DOCUMENT_SIZE("bytes", false),
   REALTIME_OFFSET_COMMITS("commits", true),
   REALTIME_OFFSET_COMMIT_EXCEPTIONS("exceptions", false),

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeIngestionMemoryGuard.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeIngestionMemoryGuard.java
@@ -1,0 +1,266 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.manager.realtime;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Locale;
+import java.util.function.LongSupplier;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.metrics.ServerGauge;
+import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.segment.local.dedup.PartitionDedupMetadataManager;
+import org.apache.pinot.segment.local.upsert.PartitionUpsertMetadataManager;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants.Server;
+import org.apache.pinot.spi.utils.ResourceUsageUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/// Server-local guard that pauses realtime ingestion when the JVM is under memory pressure, to protect the server from
+/// OOM. The dominant driver this targets is the on-heap upsert/dedup primary-key metadata, which grows with ingestion
+/// and is not freed by committing a consuming segment.
+///
+/// A single daemon thread samples the JVM heap every `checkIntervalMs` and maintains a `_heapPressure` flag with
+/// hysteresis: it flips to `true` once `usedHeap / maxHeap >= pauseRatio` and back to `false` once
+/// `usedHeap / maxHeap <= resumeRatio`. Realtime consumers consult [#shouldPauseConsumption] inside their consume loop
+/// and park (stop fetching from the stream) while it returns `true`, so memory stops growing; they resume
+/// automatically when heap recovers. This is server-local and self-healing — it does not involve the controller or
+/// ZooKeeper.
+///
+/// SCOPE / RESIDUAL EXPOSURE: the pause is applied only while a segment is in its open-ended `INITIAL_CONSUMING`
+/// phase. Segments catching up to a target offset (`CATCHING_UP` / `CONSUMING_TO_ONLINE`, e.g. right after a server
+/// restart or during lag recovery) are intentionally NOT paused, because stalling them would wedge the Helix
+/// CONSUMING -> ONLINE state transition (`CATCHING_UP` has no time bound). During catch-up the on-heap upsert/dedup
+/// metadata can still grow, so this guard dampens and delays OOM rather than guaranteeing prevention; it buys time for
+/// GC, segment commits, and TTL eviction. See [RealtimeSegmentDataManager#consumeLoop].
+///
+/// The [Mode] controls which tables are guarded ([Mode#ALL], [Mode#UPSERT_DEDUP_ONLY], or [Mode#DISABLED]). To avoid
+/// wedging ingestion if the sampler thread ever dies, the trigger fails open: if the last sample is older than a
+/// staleness threshold, [#shouldPauseConsumption] ignores the (possibly stuck) `_heapPressure` flag.
+///
+/// This class is a process-wide singleton (mirroring [RealtimeConsumptionRateManager]); it is initialized once from
+/// server config at startup via [#init] and read directly by [RealtimeSegmentDataManager]. It is thread-safe.
+public class RealtimeIngestionMemoryGuard {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeIngestionMemoryGuard.class);
+
+  /// Which realtime tables the guard applies to.
+  public enum Mode {
+    /// Pause consumption for any realtime table under memory pressure.
+    ALL,
+    /// Pause consumption only for upsert/dedup tables (whose on-heap metadata is the main OOM driver).
+    UPSERT_DEDUP_ONLY,
+    /// Guard is turned off; consumption is never paused.
+    DISABLED
+  }
+
+  private static final RealtimeIngestionMemoryGuard INSTANCE = new RealtimeIngestionMemoryGuard();
+
+  public static RealtimeIngestionMemoryGuard getInstance() {
+    return INSTANCE;
+  }
+
+  private final LongSupplier _usedHeapSupplier;
+  private final LongSupplier _maxHeapSupplier;
+  private final LongSupplier _clockMs;
+
+  // Configuration, set on init() and treated as effectively immutable afterwards.
+  private volatile Mode _mode = Mode.DISABLED;
+  private volatile double _pauseRatio = Server.DEFAULT_SERVER_CONSUMPTION_MEMORY_PAUSE_HEAP_RATIO;
+  private volatile double _resumeRatio = Server.DEFAULT_SERVER_CONSUMPTION_MEMORY_RESUME_HEAP_RATIO;
+  private volatile long _checkIntervalMs = Server.DEFAULT_SERVER_CONSUMPTION_MEMORY_CHECK_INTERVAL_MS;
+  private volatile long _staleThresholdMs = 5 * Server.DEFAULT_SERVER_CONSUMPTION_MEMORY_CHECK_INTERVAL_MS;
+
+  // Runtime state.
+  private volatile boolean _heapPressure = false;
+  private volatile long _lastSampleTimeMs = 0;
+  @Nullable
+  private volatile ServerMetrics _serverMetrics;
+  private boolean _initialized = false;
+
+  private RealtimeIngestionMemoryGuard() {
+    this(ResourceUsageUtils::getUsedHeapSize, ResourceUsageUtils::getMaxHeapSize, System::currentTimeMillis);
+  }
+
+  @VisibleForTesting
+  RealtimeIngestionMemoryGuard(LongSupplier usedHeapSupplier, LongSupplier maxHeapSupplier, LongSupplier clockMs) {
+    _usedHeapSupplier = usedHeapSupplier;
+    _maxHeapSupplier = maxHeapSupplier;
+    _clockMs = clockMs;
+  }
+
+  /// Initializes the guard from server config and, unless the mode is [Mode#DISABLED], starts the heap sampler thread.
+  /// Safe to call once at server startup; subsequent calls are ignored (the guard is configured once per process).
+  public synchronized void init(PinotConfiguration serverConfig, ServerMetrics serverMetrics) {
+    if (_initialized) {
+      LOGGER.warn("RealtimeIngestionMemoryGuard already initialized, ignoring re-init");
+      return;
+    }
+    _initialized = true;
+    _serverMetrics = serverMetrics;
+    applyConfig(serverConfig);
+
+    if (_mode == Mode.DISABLED) {
+      LOGGER.info("RealtimeIngestionMemoryGuard is disabled");
+      return;
+    }
+    LOGGER.info("Starting RealtimeIngestionMemoryGuard: mode={}, pauseHeapRatio={}, resumeHeapRatio={}, "
+            + "checkIntervalMs={}, maxHeapBytes={}", _mode, _pauseRatio, _resumeRatio, _checkIntervalMs,
+        _maxHeapSupplier.getAsLong());
+    // Daemon sampler: dies on JVM exit, so no explicit shutdown is needed (mirrors RealtimeConsumptionRateManager).
+    Thread samplerThread = new Thread(this::samplerLoop, "RealtimeIngestionMemoryGuard");
+    samplerThread.setDaemon(true);
+    samplerThread.start();
+  }
+
+  /// Parses and validates the guard configuration into the in-memory fields, without starting the sampler thread.
+  /// Visible for testing so the decision logic can be configured deterministically.
+  @VisibleForTesting
+  void applyConfig(PinotConfiguration serverConfig) {
+    _mode = parseMode(serverConfig.getProperty(Server.CONFIG_OF_SERVER_CONSUMPTION_MEMORY_PAUSE_MODE,
+        Server.DEFAULT_SERVER_CONSUMPTION_MEMORY_PAUSE_MODE));
+
+    double pauseRatio = serverConfig.getProperty(Server.CONFIG_OF_SERVER_CONSUMPTION_MEMORY_PAUSE_HEAP_RATIO,
+        Server.DEFAULT_SERVER_CONSUMPTION_MEMORY_PAUSE_HEAP_RATIO);
+    double resumeRatio = serverConfig.getProperty(Server.CONFIG_OF_SERVER_CONSUMPTION_MEMORY_RESUME_HEAP_RATIO,
+        Server.DEFAULT_SERVER_CONSUMPTION_MEMORY_RESUME_HEAP_RATIO);
+    // Require 0 < resumeRatio < pauseRatio <= 1.0 so the hysteresis band is well-formed; otherwise reject both and
+    // fall back to the defaults rather than silently consuming bad thresholds.
+    if (!(pauseRatio > 0.0 && pauseRatio <= 1.0 && resumeRatio > 0.0 && resumeRatio < pauseRatio)) {
+      LOGGER.warn("Invalid heap usage ratios (pause={}, resume={}); falling back to defaults (pause={}, resume={})",
+          pauseRatio, resumeRatio, Server.DEFAULT_SERVER_CONSUMPTION_MEMORY_PAUSE_HEAP_RATIO,
+          Server.DEFAULT_SERVER_CONSUMPTION_MEMORY_RESUME_HEAP_RATIO);
+      pauseRatio = Server.DEFAULT_SERVER_CONSUMPTION_MEMORY_PAUSE_HEAP_RATIO;
+      resumeRatio = Server.DEFAULT_SERVER_CONSUMPTION_MEMORY_RESUME_HEAP_RATIO;
+    }
+    _pauseRatio = pauseRatio;
+    _resumeRatio = resumeRatio;
+
+    long checkIntervalMs = serverConfig.getProperty(Server.CONFIG_OF_SERVER_CONSUMPTION_MEMORY_CHECK_INTERVAL_MS,
+        Server.DEFAULT_SERVER_CONSUMPTION_MEMORY_CHECK_INTERVAL_MS);
+    if (checkIntervalMs <= 0) {
+      LOGGER.warn("Invalid check interval {}ms; falling back to default {}ms", checkIntervalMs,
+          Server.DEFAULT_SERVER_CONSUMPTION_MEMORY_CHECK_INTERVAL_MS);
+      checkIntervalMs = Server.DEFAULT_SERVER_CONSUMPTION_MEMORY_CHECK_INTERVAL_MS;
+    }
+    _checkIntervalMs = checkIntervalMs;
+    // Treat the heap-pressure flag as stale (and so fail open) if the sampler has not refreshed it for several check
+    // intervals, which indicates the sampler thread has died.
+    _staleThresholdMs = 5 * checkIntervalMs;
+  }
+
+  private static Mode parseMode(String modeStr) {
+    try {
+      return Mode.valueOf(modeStr.trim().toUpperCase(Locale.ENGLISH));
+    } catch (IllegalArgumentException e) {
+      LOGGER.warn("Invalid {} value '{}'; falling back to default '{}'",
+          Server.CONFIG_OF_SERVER_CONSUMPTION_MEMORY_PAUSE_MODE, modeStr,
+          Server.DEFAULT_SERVER_CONSUMPTION_MEMORY_PAUSE_MODE);
+      return Mode.valueOf(Server.DEFAULT_SERVER_CONSUMPTION_MEMORY_PAUSE_MODE);
+    }
+  }
+
+  private void samplerLoop() {
+    while (true) {
+      try {
+        sampleOnce();
+      } catch (Throwable t) {
+        LOGGER.warn("Error while sampling heap usage in RealtimeIngestionMemoryGuard", t);
+      }
+      try {
+        Thread.sleep(_checkIntervalMs);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return;
+      }
+    }
+  }
+
+  /// Samples heap usage once and updates the [#_heapPressure] flag using hysteresis. Visible for testing so the
+  /// decision logic can be driven deterministically without the sampler thread.
+  @VisibleForTesting
+  void sampleOnce() {
+    long maxHeap = _maxHeapSupplier.getAsLong();
+    long usedHeap = _usedHeapSupplier.getAsLong();
+    if (maxHeap <= 0) {
+      // Cannot compute a ratio without a heap max; leave the pressure state and heartbeat untouched so that, if this
+      // persists, the staleness check in shouldPauseConsumption() fails open rather than honoring a stuck flag.
+      return;
+    }
+    // Refresh the heartbeat only after a usable sample so a live-but-blind sampler cannot keep a stuck flag "fresh".
+    _lastSampleTimeMs = _clockMs.getAsLong();
+    double ratio = (double) usedHeap / maxHeap;
+    boolean previous = _heapPressure;
+    boolean next = previous;
+    if (!previous && ratio >= _pauseRatio) {
+      next = true;
+    } else if (previous && ratio <= _resumeRatio) {
+      next = false;
+    }
+    if (next != previous) {
+      _heapPressure = next;
+      ServerMetrics serverMetrics = _serverMetrics;
+      if (serverMetrics != null) {
+        serverMetrics.setValueOfGlobalGauge(ServerGauge.REALTIME_INGESTION_MEMORY_PAUSED, next ? 1L : 0L);
+      }
+      if (next) {
+        LOGGER.warn("Pausing realtime ingestion due to heap pressure: usedHeap={} bytes, maxHeap={} bytes, "
+            + "ratio={} >= pauseRatio={}", usedHeap, maxHeap, ratio, _pauseRatio);
+      } else {
+        LOGGER.info("Resuming realtime ingestion: usedHeap={} bytes, maxHeap={} bytes, ratio={} <= resumeRatio={}",
+            usedHeap, maxHeap, ratio, _resumeRatio);
+      }
+    }
+  }
+
+  /// Returns `true` if the consumer for a partition with the given (nullable) upsert/dedup metadata managers should
+  /// currently pause consumption. The caller passes its own metadata managers (either may be `null` for non-upsert,
+  /// non-dedup tables); the guard derives table eligibility from them.
+  ///
+  /// This is called from the consume loop and must be cheap: it reads volatile flags only.
+  public boolean shouldPauseConsumption(@Nullable PartitionUpsertMetadataManager upsertMetadataManager,
+      @Nullable PartitionDedupMetadataManager dedupMetadataManager) {
+    Mode mode = _mode;
+    if (mode == Mode.DISABLED) {
+      return false;
+    }
+    if (mode == Mode.UPSERT_DEDUP_ONLY && upsertMetadataManager == null && dedupMetadataManager == null) {
+      return false;
+    }
+    // Fail open if the sampler heartbeat is stale (sampler thread presumed dead) so a stuck flag can never wedge
+    // ingestion.
+    return _heapPressure && (_clockMs.getAsLong() - _lastSampleTimeMs) <= _staleThresholdMs;
+  }
+
+  /// Returns the configured sampling / pause re-check interval in milliseconds. Used by a parked consumer as its sleep
+  /// quantum between pause re-checks.
+  long getCheckIntervalMs() {
+    return _checkIntervalMs;
+  }
+
+  @VisibleForTesting
+  Mode getMode() {
+    return _mode;
+  }
+
+  @VisibleForTesting
+  boolean isHeapPressure() {
+    return _heapPressure;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -346,6 +346,10 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   private final SegmentCommitterFactory _segmentCommitterFactory;
   private final ConsumptionRateLimiter _partitionRateLimiter;
   private final ConsumptionRateLimiter _serverRateLimiter;
+  // Server-local guard that parks this consumer when the server is under heap pressure, to protect against OOM.
+  // Defaults to the process-wide singleton; no-op unless enabled via server config.
+  // Non-final only so tests can inject a deterministic guard via setIngestionMemoryGuard().
+  private RealtimeIngestionMemoryGuard _ingestionMemoryGuard = RealtimeIngestionMemoryGuard.getInstance();
 
   private final StreamPartitionMsgOffset _latestStreamOffsetAtStartupTime;
   private final CompletionMode _segmentCompletionMode;
@@ -483,7 +487,37 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         .create(_currentOffset);  // so that we always update the metric when we enter this method.
 
     _segmentLogger.info("Starting consumption loop start offset {}, finalOffset {}", _currentOffset, _finalOffset);
+    boolean wasPausedForMemory = false;
     while (!_shouldStop && !endCriteriaReached()) {
+      // Server memory guard: while the server is under heap pressure, park this consumer instead of fetching more
+      // messages, so memory stops growing; resume automatically once the
+      // pressure clears. Only applies in INITIAL_CONSUMING - the catch-up states (CATCHING_UP / CONSUMING_TO_ONLINE)
+      // must keep making progress to complete the Helix transition. The sleep sits above the fetchMessages try-block
+      // so that an interrupt from stop() terminates the thread promptly instead of being misclassified as a transient
+      // stream error. endCriteriaReached() is still evaluated every iteration, so force-commit, time-limit and
+      // end-of-partition all continue to take precedence over the pause.
+      if (_state == State.INITIAL_CONSUMING && _ingestionMemoryGuard.shouldPauseConsumption(
+          _partitionUpsertMetadataManager, _partitionDedupMetadataManager)) {
+        if (!wasPausedForMemory) {
+          _segmentLogger.warn("Pausing consumption due to server memory pressure");
+          wasPausedForMemory = true;
+        }
+        _serverMetrics.addMeteredTableValue(_clientId, ServerMeter.REALTIME_CONSUMPTION_PAUSED_MEMORY, 1L);
+        try {
+          Thread.sleep(_ingestionMemoryGuard.getCheckIntervalMs());
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          break;
+        }
+        continue;
+      }
+      if (wasPausedForMemory) {
+        _segmentLogger.info("Resuming consumption after server memory pressure cleared");
+        // Reset the idle timer so the paused duration is not counted as stream-idle time, which would otherwise
+        // trigger a spurious stream-consumer recreation on the first post-resume empty batch.
+        _idleTimer.markStreamCreated();
+        wasPausedForMemory = false;
+      }
       _serverMetrics.setValueOfTableGauge(_clientId, ServerGauge.LLC_PARTITION_CONSUMING, 1);
       // Consume for the next readTime ms, or we get to final offset, whichever happens earlier,
       // Update _currentOffset upon return from this method
@@ -761,6 +795,11 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   @VisibleForTesting
   boolean canAddMore() {
     return _realtimeSegment.canAddMore();
+  }
+
+  @VisibleForTesting
+  void setIngestionMemoryGuard(RealtimeIngestionMemoryGuard ingestionMemoryGuard) {
+    _ingestionMemoryGuard = ingestionMemoryGuard;
   }
 
   public class PartitionConsumer implements Runnable {

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeIngestionMemoryGuardTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeIngestionMemoryGuardTest.java
@@ -1,0 +1,195 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.manager.realtime;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.pinot.segment.local.dedup.PartitionDedupMetadataManager;
+import org.apache.pinot.segment.local.upsert.PartitionUpsertMetadataManager;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants.Server;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+public class RealtimeIngestionMemoryGuardTest {
+  private static final long MAX_HEAP = 1000L;
+
+  private RealtimeIngestionMemoryGuard newGuard(AtomicLong usedHeap, AtomicLong clockMs) {
+    return new RealtimeIngestionMemoryGuard(usedHeap::get, () -> MAX_HEAP, clockMs::get);
+  }
+
+  private PinotConfiguration config(Map<String, Object> overrides) {
+    Map<String, Object> map = new HashMap<>(overrides);
+    return new PinotConfiguration(map);
+  }
+
+  private Map<String, Object> baseConfig(String mode) {
+    Map<String, Object> map = new HashMap<>();
+    map.put(Server.CONFIG_OF_SERVER_CONSUMPTION_MEMORY_PAUSE_MODE, mode);
+    map.put(Server.CONFIG_OF_SERVER_CONSUMPTION_MEMORY_PAUSE_HEAP_RATIO, 0.85);
+    map.put(Server.CONFIG_OF_SERVER_CONSUMPTION_MEMORY_RESUME_HEAP_RATIO, 0.75);
+    return map;
+  }
+
+  @Test
+  public void testHeapPressureHysteresis() {
+    AtomicLong usedHeap = new AtomicLong(0);
+    AtomicLong clock = new AtomicLong(1000);
+    RealtimeIngestionMemoryGuard guard = newGuard(usedHeap, clock);
+    guard.applyConfig(config(baseConfig("ALL")));
+
+    // Just below pause ratio (0.849 < 0.85) -> no pressure
+    usedHeap.set(849);
+    guard.sampleOnce();
+    assertFalse(guard.isHeapPressure());
+
+    // Exactly at the pause ratio (0.85, inclusive) -> pressure
+    usedHeap.set(850);
+    guard.sampleOnce();
+    assertTrue(guard.isHeapPressure());
+
+    // In the hysteresis band (between resume and pause ratios) -> stays paused
+    usedHeap.set(800);
+    guard.sampleOnce();
+    assertTrue(guard.isHeapPressure());
+
+    // Just above the resume ratio (0.751 > 0.75) -> stays paused
+    usedHeap.set(751);
+    guard.sampleOnce();
+    assertTrue(guard.isHeapPressure());
+
+    // Exactly at the resume ratio (0.75, inclusive) -> resumes
+    usedHeap.set(750);
+    guard.sampleOnce();
+    assertFalse(guard.isHeapPressure());
+  }
+
+  @Test
+  public void testUnknownMaxHeapDoesNotPause() {
+    AtomicLong usedHeap = new AtomicLong(950);
+    AtomicLong clock = new AtomicLong(1000);
+    // maxHeap reported as 0 (unknown) -> cannot compute a ratio, must not flip to pressure or throw
+    RealtimeIngestionMemoryGuard guard = new RealtimeIngestionMemoryGuard(usedHeap::get, () -> 0L, clock::get);
+    guard.applyConfig(config(baseConfig("ALL")));
+    guard.sampleOnce();
+    assertFalse(guard.isHeapPressure());
+    assertFalse(guard.shouldPauseConsumption(null, null));
+  }
+
+  @Test
+  public void testDisabledModeNeverPauses() {
+    AtomicLong usedHeap = new AtomicLong(950);
+    AtomicLong clock = new AtomicLong(1000);
+    RealtimeIngestionMemoryGuard guard = newGuard(usedHeap, clock);
+    guard.applyConfig(config(baseConfig("DISABLED")));
+    guard.sampleOnce();
+
+    PartitionUpsertMetadataManager upsert = mock(PartitionUpsertMetadataManager.class);
+    assertFalse(guard.shouldPauseConsumption(upsert, null));
+    assertFalse(guard.shouldPauseConsumption(null, null));
+  }
+
+  @Test
+  public void testUpsertDedupOnlyModeEligibility() {
+    AtomicLong usedHeap = new AtomicLong(950);
+    AtomicLong clock = new AtomicLong(1000);
+    RealtimeIngestionMemoryGuard guard = newGuard(usedHeap, clock);
+    guard.applyConfig(config(baseConfig("UPSERT_DEDUP_ONLY")));
+    guard.sampleOnce();
+    assertTrue(guard.isHeapPressure());
+
+    PartitionUpsertMetadataManager upsert = mock(PartitionUpsertMetadataManager.class);
+    PartitionDedupMetadataManager dedup = mock(PartitionDedupMetadataManager.class);
+
+    // Upsert or dedup tables are eligible and pause under heap pressure
+    assertTrue(guard.shouldPauseConsumption(upsert, null));
+    assertTrue(guard.shouldPauseConsumption(null, dedup));
+    // Non-upsert, non-dedup table is not eligible in this mode
+    assertFalse(guard.shouldPauseConsumption(null, null));
+  }
+
+  @Test
+  public void testAllModePausesAnyTable() {
+    AtomicLong usedHeap = new AtomicLong(950);
+    AtomicLong clock = new AtomicLong(1000);
+    RealtimeIngestionMemoryGuard guard = newGuard(usedHeap, clock);
+    guard.applyConfig(config(baseConfig("ALL")));
+    guard.sampleOnce();
+    assertTrue(guard.isHeapPressure());
+
+    // A plain realtime table (no upsert/dedup managers) pauses under heap pressure in ALL mode
+    assertTrue(guard.shouldPauseConsumption(null, null));
+  }
+
+  @Test
+  public void testFailOpenOnStaleHeartbeat() {
+    AtomicLong usedHeap = new AtomicLong(950);
+    AtomicLong clock = new AtomicLong(1000);
+    RealtimeIngestionMemoryGuard guard = newGuard(usedHeap, clock);
+    guard.applyConfig(config(baseConfig("ALL")));
+    guard.sampleOnce();
+    assertTrue(guard.isHeapPressure());
+    assertTrue(guard.shouldPauseConsumption(null, null));
+
+    // Advance the clock beyond the staleness threshold (5 * checkInterval). The sampler has not refreshed, so the
+    // guard must fail open and stop pausing even though the (stuck) pressure flag is still true.
+    clock.addAndGet(5 * Server.DEFAULT_SERVER_CONSUMPTION_MEMORY_CHECK_INTERVAL_MS + 1);
+    assertTrue(guard.isHeapPressure());
+    assertFalse(guard.shouldPauseConsumption(null, null));
+  }
+
+  @Test
+  public void testInvalidRatiosFallBackToDefaults() {
+    AtomicLong usedHeap = new AtomicLong(0);
+    AtomicLong clock = new AtomicLong(1000);
+    RealtimeIngestionMemoryGuard guard = newGuard(usedHeap, clock);
+    Map<String, Object> cfg = baseConfig("ALL");
+    // resume >= pause is invalid (no hysteresis band) -> the default 0.85/0.75 band must be used instead.
+    cfg.put(Server.CONFIG_OF_SERVER_CONSUMPTION_MEMORY_PAUSE_HEAP_RATIO, 0.5);
+    cfg.put(Server.CONFIG_OF_SERVER_CONSUMPTION_MEMORY_RESUME_HEAP_RATIO, 0.9);
+    guard.applyConfig(config(cfg));
+
+    // 0.80 is above the rejected pause ratio (0.5) but below the default (0.85): no pressure proves the default is in
+    // effect.
+    usedHeap.set(800);
+    guard.sampleOnce();
+    assertFalse(guard.isHeapPressure());
+    // 0.86 crosses the default pause ratio.
+    usedHeap.set(860);
+    guard.sampleOnce();
+    assertTrue(guard.isHeapPressure());
+  }
+
+  @Test
+  public void testInvalidModeFallsBackToDefault() {
+    AtomicLong usedHeap = new AtomicLong(0);
+    AtomicLong clock = new AtomicLong(1000);
+    RealtimeIngestionMemoryGuard guard = newGuard(usedHeap, clock);
+    Map<String, Object> cfg = baseConfig("NOT_A_MODE");
+    guard.applyConfig(config(cfg));
+
+    assertEquals(guard.getMode().name(), Server.DEFAULT_SERVER_CONSUMPTION_MEMORY_PAUSE_MODE);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
@@ -70,7 +70,10 @@ import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
@@ -861,6 +864,80 @@ public class RealtimeSegmentDataManagerTest {
           FakeStreamConfigUtils.SEGMENT_FLUSH_THRESHOLD_ROWS);
       Assert.assertEquals(segmentDataManager.getSegment().getSegmentMetadata().getTotalDocs(),
           FakeStreamConfigUtils.SEGMENT_FLUSH_THRESHOLD_ROWS);
+    }
+  }
+
+  /**
+   * Verifies the server memory guard integration in the consume loop: while in INITIAL_CONSUMING the consumer parks
+   * (stops fetching) as long as the guard reports memory pressure, then resumes and indexes all rows once the pressure
+   * clears.
+   */
+  @Test
+  public void testConsumptionPausesAndResumesUnderMemoryPressure()
+      throws Exception {
+    TimeSupplier timeSupplier = new TimeSupplier();
+    try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager(true, timeSupplier,
+        String.valueOf(FakeStreamConfigUtils.SEGMENT_FLUSH_THRESHOLD_ROWS), "10m", null)) {
+      segmentDataManager._stubConsumeLoop = false;
+      segmentDataManager._state.set(segmentDataManager, RealtimeSegmentDataManager.State.INITIAL_CONSUMING);
+
+      // Guard reports memory pressure for the first few consume-loop iterations, then clears.
+      RealtimeIngestionMemoryGuard mockGuard = mock(RealtimeIngestionMemoryGuard.class);
+      when(mockGuard.shouldPauseConsumption(any(), any())).thenReturn(true, true, true, false);
+      segmentDataManager.setIngestionMemoryGuard(mockGuard);
+
+      RealtimeSegmentDataManager.PartitionConsumer consumer = segmentDataManager.createPartitionConsumer();
+      final LongMsgOffset endOffset =
+          new LongMsgOffset(START_OFFSET_VALUE + FakeStreamConfigUtils.SEGMENT_FLUSH_THRESHOLD_ROWS);
+      segmentDataManager._consumeOffsets.add(endOffset);
+      segmentDataManager._responses.add(new SegmentCompletionProtocol.Response(
+          new SegmentCompletionProtocol.Response.Params().withStatus(
+                  SegmentCompletionProtocol.ControllerResponseStatus.COMMIT)
+              .withStreamPartitionMsgOffset(endOffset.toString())));
+
+      consumer.run();
+
+      // The guard was consulted, and despite the initial pauses consumption resumed and indexed every row.
+      verify(mockGuard, atLeast(1)).shouldPauseConsumption(any(), any());
+      Assert.assertEquals(segmentDataManager.getSegment().getNumDocsIndexed(),
+          FakeStreamConfigUtils.SEGMENT_FLUSH_THRESHOLD_ROWS);
+    }
+  }
+
+  /**
+   * Verifies that the memory guard is NOT consulted while catching up (CATCHING_UP). Pausing during catch-up would
+   * stall the Helix CONSUMING -> ONLINE transition, so the guard must only apply in INITIAL_CONSUMING.
+   */
+  @Test
+  public void testConsumptionNotPausedWhileCatchingUp()
+      throws Exception {
+    TimeSupplier timeSupplier = new TimeSupplier();
+    try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager(true, timeSupplier,
+        String.valueOf(FakeStreamConfigUtils.SEGMENT_FLUSH_THRESHOLD_ROWS * 2), "10m", null)) {
+      segmentDataManager._stubConsumeLoop = false;
+      segmentDataManager._state.set(segmentDataManager, RealtimeSegmentDataManager.State.CATCHING_UP);
+      final LongMsgOffset finalOffset =
+          new LongMsgOffset(START_OFFSET_VALUE + FakeStreamConfigUtils.SEGMENT_FLUSH_THRESHOLD_ROWS);
+      Field finalOffsetField = RealtimeSegmentDataManager.class.getDeclaredField("_finalOffset");
+      finalOffsetField.setAccessible(true);
+      finalOffsetField.set(segmentDataManager, finalOffset);
+
+      // Even though the guard would report pressure, the consume loop must never ask it while catching up.
+      RealtimeIngestionMemoryGuard mockGuard = mock(RealtimeIngestionMemoryGuard.class);
+      when(mockGuard.shouldPauseConsumption(any(), any())).thenReturn(true);
+      segmentDataManager.setIngestionMemoryGuard(mockGuard);
+
+      RealtimeSegmentDataManager.PartitionConsumer consumer = segmentDataManager.createPartitionConsumer();
+      segmentDataManager._responses.add(new SegmentCompletionProtocol.Response(
+          new SegmentCompletionProtocol.Response.Params().withStatus(
+                  SegmentCompletionProtocol.ControllerResponseStatus.COMMIT)
+              .withStreamPartitionMsgOffset(finalOffset.toString())));
+
+      consumer.run();
+
+      verify(mockGuard, never()).shouldPauseConsumption(any(), any());
+      Assert.assertEquals(((LongMsgOffset) segmentDataManager.getCurrentOffset()).getOffset(),
+          START_OFFSET_VALUE + FakeStreamConfigUtils.SEGMENT_FLUSH_THRESHOLD_ROWS);
     }
   }
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -85,6 +85,7 @@ import org.apache.pinot.common.version.PinotVersion;
 import org.apache.pinot.core.common.datatable.DataTableBuilderFactory;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeConsumptionRateManager;
+import org.apache.pinot.core.data.manager.realtime.RealtimeIngestionMemoryGuard;
 import org.apache.pinot.core.data.manager.realtime.ServerRateLimitConfigChangeListener;
 import org.apache.pinot.core.instance.context.ServerContext;
 import org.apache.pinot.core.query.scheduler.QuerySchedulerThreadPoolConfigChangeListener;
@@ -789,6 +790,11 @@ public abstract class BaseServerStarter implements ServiceStartable {
     PinotClusterConfigChangeListener serverRateLimitConfigChangeListener =
         new ServerRateLimitConfigChangeListener(_serverMetrics);
     _clusterConfigChangeHandler.registerClusterConfigChangeListener(serverRateLimitConfigChangeListener);
+
+    // Initialize the server-local realtime ingestion memory guard, which pauses realtime consumption when the JVM is
+    // under heap pressure to protect the server from OOM. On by default (scoped to upsert/dedup tables); tunable and
+    // disableable via pinot.server.consumption.memory.* configs.
+    RealtimeIngestionMemoryGuard.getInstance().init(_serverConf, _serverMetrics);
 
     initSegmentFetcher(_serverConf);
     StateModelFactory<?> stateModelFactory =

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1546,6 +1546,29 @@ public class CommonConstants {
     // Default to 0.0 (no limit)
     public static final double DEFAULT_SERVER_CONSUMPTION_RATE_LIMIT = 0.0;
 
+    // Configs for the server-local realtime ingestion memory guard (RealtimeIngestionMemoryGuard). When the JVM heap
+    // crosses the pause threshold, realtime consumers are parked (stop fetching from the stream) until heap recovers
+    // below the resume threshold, protecting the server from OOM (primarily driven by on-heap upsert/dedup primary-key
+    // metadata). It is server-local and self-healing.
+    // Mode controls which tables are guarded: ALL | UPSERT_DEDUP_ONLY | DISABLED. On by default, scoped to the
+    // upsert/dedup tables whose on-heap metadata is the main OOM driver.
+    public static final String CONFIG_OF_SERVER_CONSUMPTION_MEMORY_PAUSE_MODE =
+        "pinot.server.consumption.memory.pause.mode";
+    public static final String DEFAULT_SERVER_CONSUMPTION_MEMORY_PAUSE_MODE = "UPSERT_DEDUP_ONLY";
+    // Pause consumption when usedHeap / maxHeap >= this ratio
+    public static final String CONFIG_OF_SERVER_CONSUMPTION_MEMORY_PAUSE_HEAP_RATIO =
+        "pinot.server.consumption.memory.pause.heap.usage.ratio";
+    public static final double DEFAULT_SERVER_CONSUMPTION_MEMORY_PAUSE_HEAP_RATIO = 0.85;
+    // Resume consumption when usedHeap / maxHeap <= this ratio (must be strictly less than the pause ratio to provide
+    // hysteresis; otherwise the configured values are rejected and the defaults are used)
+    public static final String CONFIG_OF_SERVER_CONSUMPTION_MEMORY_RESUME_HEAP_RATIO =
+        "pinot.server.consumption.memory.resume.heap.usage.ratio";
+    public static final double DEFAULT_SERVER_CONSUMPTION_MEMORY_RESUME_HEAP_RATIO = 0.75;
+    // Heap sampling / pause re-check interval in milliseconds
+    public static final String CONFIG_OF_SERVER_CONSUMPTION_MEMORY_CHECK_INTERVAL_MS =
+        "pinot.server.consumption.memory.check.interval.ms";
+    public static final long DEFAULT_SERVER_CONSUMPTION_MEMORY_CHECK_INTERVAL_MS = 1000L;
+
     public static final String CONFIG_OF_MMAP_DEFAULT_ADVICE = "pinot.server.mmap.advice.default";
     public static final String PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY = "pinot.server.segment.fetcher";
 


### PR DESCRIPTION
## Summary

Realtime servers consuming **upsert/dedup** tables hold large **on-heap** primary-key metadata (`ConcurrentMapPartitionUpsertMetadataManager`'s key→record-location maps). Under sustained ingestion these grow unbounded and OOM the server JVM, taking down every table on that host. Today the only throttles are controller-driven (disk-based `ResourceUtilizationManager` + whole-table `PauseState`, slow and ZK-mediated) and the per-query OOM accountant (off by default, kills queries — not ingestion). There is no fast, **server-local** mechanism that halts ingestion when heap is about to OOM.

This PR adds **`RealtimeIngestionMemoryGuard`**, a server-local, self-healing guard (mirroring the existing `RealtimeConsumptionRateManager` singleton). A daemon thread samples JVM heap; when usage crosses a tunable ratio, realtime consumers **park** inside their consume loop (stop fetching from the stream, so memory stops growing) and **resume automatically** once heap recovers. No controller/ZK involvement.

## Design

- **Trigger:** global heap-usage ratio with hysteresis — pause once `usedHeap/maxHeap >= pauseRatio`, resume once `<= resumeRatio`.
- **Mode** `ALL` / `UPSERT_DEDUP_ONLY` / `DISABLED` controls which tables are guarded.
- **Pause point:** only while a segment is in `INITIAL_CONSUMING`. Catch-up states (`CATCHING_UP` / `CONSUMING_TO_ONLINE`) are intentionally **not** paused, because stalling them would wedge the Helix CONSUMING→ONLINE transition.
- **Safety:** the park sleep sits above the fetch and is interrupt-safe (prompt `stop()`); end-criteria are still evaluated every iteration so force-commit/time-limit/end-of-partition keep precedence; the idle timer is reset on resume; and the trigger **fails open** if the sampler thread ever dies, so it can never wedge ingestion.

### Configuration (server-level, prefix `pinot.server.consumption.memory.`)

| Key | Default | Meaning |
|---|---|---|
| `pause.mode` | `UPSERT_DEDUP_ONLY` | `ALL` / `UPSERT_DEDUP_ONLY` / `DISABLED` |
| `pause.heap.usage.ratio` | `0.85` | pause when usedHeap/maxHeap ≥ this |
| `resume.heap.usage.ratio` | `0.75` | resume when usedHeap/maxHeap ≤ this (hysteresis) |
| `check.interval.ms` | `1000` | heap sampling / pause re-check interval |

### Metrics
- `ServerGauge.REALTIME_INGESTION_MEMORY_PAUSED` (global 0/1)
- `ServerMeter.REALTIME_CONSUMPTION_PAUSED_MEMORY` (per-table, counts pause cycles) — lets dashboards/alerts tell "deliberately paused" from "wedged".

## Limitation (by design)
Pausing halts memory **growth** and buys time for GC, segment commits, and TTL eviction; it does **not** by itself reclaim already-allocated upsert primary-key metadata (committing a consuming segment does not free it). This is the right primitive for "stop ingestion to prevent OOM", documented in the guard's Javadoc.

## Backward compatibility / release note
**This feature is ON by default** (mode `UPSERT_DEDUP_ONLY`): on upgrade, servers will pause upsert/dedup realtime consumption when heap usage exceeds 0.85, resuming below 0.75. Set `pinot.server.consumption.memory.pause.mode=DISABLED` to turn it off, or `ALL` for whole-server coverage. No public API or wire-format changes.

## Testing
- `RealtimeIngestionMemoryGuardTest` (8 tests): hysteresis incl. exact boundaries, mode/eligibility matrix, fail-open on stale heartbeat, unknown-max-heap, and config validation fallback.
- `RealtimeSegmentDataManagerTest` (2 new tests): consume loop pauses then resumes under simulated pressure in `INITIAL_CONSUMING`, and the guard is **not** consulted while `CATCHING_UP`.
- spotless / checkstyle / license clean on all touched modules.
