### PR TITLE
Add an overridable table-config-change callback distinct from index-loading-config fetch

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -448,6 +448,13 @@ public abstract class BaseTableDataManager implements TableDataManager {
   }
 
   @Override
+  public void onTableConfigOrSchemaRefresh() {
+    // A genuine config/schema change: refresh the cached table config and schema from ZK. The returned index loading
+    // config is not needed here; the side effect of updating the cache is the contract of this callback.
+    fetchIndexLoadingConfig();
+  }
+
+  @Override
   public void addNewOnlineSegment(SegmentZKMetadata zkMetadata, IndexLoadingConfig indexLoadingConfig)
       throws Exception {
     _logger.info("Adding new ONLINE segment: {}", zkMetadata.getSegmentName());

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
@@ -80,6 +80,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
 
@@ -895,6 +896,30 @@ public class BaseTableDataManagerTest {
 
     assertTrue(dataDir.exists());
     assertEquals(new SegmentMetadataImpl(dataDir).getTotalDocs(), 5);
+  }
+
+  @Test
+  public void testOnTableConfigOrSchemaRefreshRefreshesCachedConfig()
+      throws Exception {
+    BaseTableDataManager tableDataManager = spy(createTableManager());
+    TableConfig refreshedConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setNumReplicas(2).build();
+    Schema refreshedSchema = new Schema.SchemaBuilder().setSchemaName(RAW_TABLE_NAME)
+        .addSingleValueDimension(STRING_COLUMN, DataType.STRING).build();
+    // Stand in for the ZK fetch fetchIndexLoadingConfig performs: its contract is to refresh the cached config/schema.
+    doAnswer(invocation -> {
+      tableDataManager.updateCachedTableConfigAndSchema(refreshedConfig, refreshedSchema);
+      return new IndexLoadingConfig();
+    }).when(tableDataManager).fetchIndexLoadingConfig();
+
+    assertSame(tableDataManager.getCachedTableConfigAndSchema().getLeft(), DEFAULT_TABLE_CONFIG);
+
+    tableDataManager.onTableConfigOrSchemaRefresh();
+
+    // The default callback refreshes the cache via the index-loading-config fetch.
+    verify(tableDataManager).fetchIndexLoadingConfig();
+    assertSame(tableDataManager.getCachedTableConfigAndSchema().getLeft(), refreshedConfig);
+    assertSame(tableDataManager.getCachedTableConfigAndSchema().getRight(), refreshedSchema);
   }
 
   // Has to be public class for the class loader to work.

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -351,6 +351,20 @@ public interface TableDataManager {
   void updateCachedTableConfigAndSchema(TableConfig config, Schema schema);
 
   /**
+   * Callback invoked when the table config or schema has actually changed (e.g. when a table config / schema refresh
+   * is delivered out of band, separate from any segment state transition or reload). This is distinct from
+   * {@link #fetchIndexLoadingConfig()}, which is also called incidentally during state transitions and reloads merely
+   * to obtain the index loading config; this callback is invoked only on a genuine config/schema change.
+   * <p>The default implementation refreshes the cached table config and schema (by fetching them from ZK), which
+   * preserves the historical behavior of the refresh path. Implementations that need to react to a config/schema
+   * change beyond refreshing the cache should override this method and additionally invoke {@code super}, or the
+   * default, to keep the cache refreshed.
+   */
+  default void onTableConfigOrSchemaRefresh() {
+    fetchIndexLoadingConfig();
+  }
+
+  /**
    * Interface to handle segment state transitions from CONSUMING to DROPPED
    *
    * @param segmentNameStr name of segment for which the state change is being handled

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentMessageHandlerFactory.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentMessageHandlerFactory.java
@@ -260,8 +260,9 @@ public class SegmentMessageHandlerFactory implements MessageHandlerFactory {
       try {
         TableDataManager tableDataManager = _instanceDataManager.getTableDataManager(_tableNameWithType);
         if (tableDataManager != null) {
-          // Update the table config and schema by fetching from ZK
-          tableDataManager.fetchIndexLoadingConfig();
+          // A genuine table config / schema change: notify the table data manager so it can refresh the cached config
+          // and schema (and react to the change) without going through the incidental index-loading-config fetch.
+          tableDataManager.onTableConfigOrSchemaRefresh();
         } else {
           _logger.warn("No data manager found for table: {}", _tableNameWithType);
         }


### PR DESCRIPTION
The server's table-config/schema refresh message handler called `fetchIndexLoadingConfig()` purely for its cache-refresh side effect, discarding the returned config. That same `fetchIndexLoadingConfig()` is also invoked incidentally during segment state transitions and reloads, so a table data manager had no way to distinguish "the config actually changed" from "an index loading config was fetched while a transition was in progress."

This adds a dedicated `onTableConfigOrSchemaRefresh()` callback on `TableDataManager`. The default implementation refreshes the cached table config and schema (preserving today's behavior), and the refresh message handler now invokes the callback instead of `fetchIndexLoadingConfig()`. The behavior of `fetchIndexLoadingConfig()` during transitions is unchanged. This gives implementations a hook that fires only on a genuine config/schema change.

## Testing
`BaseTableDataManagerTest#testOnTableConfigOrSchemaRefreshRefreshesCachedConfig` verifies the default callback refreshes the cached config/schema. Existing data-manager and server tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
