### PR TITLE
Refresh server table config cache on update

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2664,8 +2664,9 @@ public class PinotHelixResourceManager {
     // Assign instances
     assignInstances(tableConfig, false);
 
-    // Send update query quota message if quota is specified
+    // Refresh brokers and servers so in-memory table config caches observe the update.
     sendTableConfigRefreshMessage(tableNameWithType);
+    sendTableConfigSchemaRefreshMessage(tableNameWithType);
   }
 
   public void deleteUser(String username) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -66,6 +66,7 @@ import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConfigUtils;
 import org.apache.pinot.spi.config.instance.Instance;
 import org.apache.pinot.spi.config.instance.InstanceType;
+import org.apache.pinot.spi.config.table.QueryConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -100,9 +101,11 @@ import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
 
@@ -1049,6 +1052,40 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     retrievedSegmentZKMetadata = retrievedSegmentsZKMetadata.get(0);
     assertNull(retrievedSegmentZKMetadata.getTier());
     assertTrue(tierToSegmentsMap.isEmpty());
+  }
+
+  @Test
+  public void testUpdateTableConfigRefreshesBrokerAndServerCaches()
+      throws Exception {
+    String rawTableName = "tableConfigRefreshTest";
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(rawTableName);
+    addDummySchema(rawTableName);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(rawTableName)
+        .setBrokerTenant(BROKER_TENANT_NAME)
+        .setServerTenant(SERVER_TENANT_NAME)
+        .build();
+    waitForEVToDisappear(tableConfig.getTableName());
+    _helixResourceManager.addTable(tableConfig);
+
+    PinotHelixResourceManager resourceManager = spy(_helixResourceManager);
+    doNothing().when(resourceManager).sendTableConfigRefreshMessage(offlineTableName);
+    doNothing().when(resourceManager).sendTableConfigSchemaRefreshMessage(offlineTableName);
+
+    try {
+      TableConfig updatedTableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(rawTableName)
+          .setBrokerTenant(BROKER_TENANT_NAME)
+          .setServerTenant(SERVER_TENANT_NAME)
+          .setQueryConfig(new QueryConfig(10000L, null, null, null, null, null))
+          .build();
+
+      resourceManager.updateTableConfig(updatedTableConfig);
+
+      verify(resourceManager).sendTableConfigRefreshMessage(offlineTableName);
+      verify(resourceManager).sendTableConfigSchemaRefreshMessage(offlineTableName);
+    } finally {
+      _helixResourceManager.deleteOfflineTable(rawTableName);
+      deleteSchema(rawTableName);
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR makes table config updates refresh server-side cached table config/schema state in addition to the existing broker table config refresh.

Previously, updating a table config through the controller wrote the new config to ZK and notified brokers, but servers were not explicitly asked to refresh their cached table config/schema. Server features that read table config from the cached `TableDataManager` state could therefore continue using the old value until another operation caused the server cache to refresh.

## User-facing behavior

After a successful table config update, the controller now sends:

- table config refresh to brokers
- table config/schema refresh to servers

This means server-side features that depend on the cached table config can observe the updated table config through the normal Helix message path, without requiring a segment reload or another unrelated refresh operation.

## Example

Update a table config as usual:

```bash
curl -X PUT "http://<controller-host>:9000/tables/myTable_REALTIME" \
  -H "Content-Type: application/json" \
  -d @myTable_REALTIME.json
```

For example, if a realtime table config is changed to enable or disable a server-side ingestion feature under `ingestionConfig.streamIngestionConfig`, servers will receive the table config/schema refresh message after the update succeeds and refresh their cached table config.

## Validation

- `./mvnw -pl pinot-controller -Dtest=PinotHelixResourceManagerStatelessTest#testUpdateTableConfigRefreshesBrokerAndServerCaches test`
- `./mvnw spotless:apply -pl pinot-controller`
- `./mvnw license:format -pl pinot-controller`
- `./mvnw checkstyle:check -pl pinot-controller`
- `./mvnw license:check -pl pinot-controller`
- `./mvnw -pl pinot-controller -Dtest=PinotHelixResourceManagerStatelessTest test`
