### PR TITLE
[Arrow] Typed zero-boxing column-major build for single-value primitive columns

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnarBuildIntegrationTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnarBuildIntegrationTest.java
@@ -277,6 +277,94 @@ public class ArrowColumnarBuildIntegrationTest {
   }
 
   /**
+   * Type-mismatch fallback: the Arrow source stores {@code intCol} as a 64-bit integer (INT64) while the Pinot
+   * schema declares it {@code INT} (32-bit). On the column-major build the typed fast path must decline this
+   * column ({@code ColumnReader.isInt()} is false for a 64-bit reader) WITHOUT advancing the reader, so the shared
+   * Object path re-reads it from the start and coerces INT64 -&gt; INT exactly as the row-major
+   * {@code DataTypeTransformer} does. This exercises the {@code indexSingleValuePrimitive} per-case guard
+   * ({@code if (!columnReader.isInt()) return false;}), which is otherwise unexercised because every other
+   * column-major test pairs a numeric column with a matching-width source. {@code longCol} (INT64 -&gt; LONG) is a
+   * matching-width control that stays on the fast path. Asserts per-doc equivalence with the row-major segment
+   * built from the same file.
+   */
+  @Test
+  public void testSourceSchemaTypeMismatchInt64ToIntEquivalence()
+      throws Exception {
+    File arrowFile = writeInt64SourceArrowFileFixture("type-mismatch-int64.arrow");
+    org.apache.pinot.spi.data.Schema schema = int64SourceIntSchema();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
+
+    File rowMajorDir = _tempDir.resolve("rm-mismatch").toFile();
+    try (ArrowRecordReader reader = new ArrowRecordReader()) {
+      reader.init(arrowFile, null, null);
+      SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+      config.setOutDir(rowMajorDir.getAbsolutePath());
+      config.setSegmentName("rmMismatch");
+      SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+      driver.init(config, reader);
+      driver.build();
+    }
+
+    File columnarDir = _tempDir.resolve("col-mismatch").toFile();
+    try (ArrowFileColumnReaderFactory factory = new ArrowFileColumnReaderFactory(arrowFile)) {
+      SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+      config.setOutDir(columnarDir.getAbsolutePath());
+      config.setSegmentName("colMismatch");
+      SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+      driver.init(config, factory);
+      driver.build();
+    }
+
+    File rowMajorSeg = new File(rowMajorDir, "rmMismatch");
+    File columnarSeg = new File(columnarDir, "colMismatch");
+    assertSegmentMetadataEquivalence(rowMajorSeg, columnarSeg);
+    assertPerDocRecordEquivalence(rowMajorSeg, columnarSeg, new String[]{"intCol", "longCol"});
+  }
+
+  private org.apache.pinot.spi.data.Schema int64SourceIntSchema() {
+    org.apache.pinot.spi.data.Schema schema = new org.apache.pinot.spi.data.Schema();
+    schema.setSchemaName(TABLE_NAME);
+    // intCol is stored as INT64 in Arrow but declared INT here, forcing the typed fast path to decline and fall
+    // back to the coercing Object path. longCol stays INT64 -> LONG as a matching-width control column.
+    schema.addField(new DimensionFieldSpec("intCol", DataType.INT, true));
+    schema.addField(new DimensionFieldSpec("longCol", DataType.LONG, true));
+    return schema;
+  }
+
+  private File writeInt64SourceArrowFileFixture(String fileName)
+      throws IOException {
+    Field intField = new Field("intCol", FieldType.nullable(new ArrowType.Int(64, true)), null);
+    Field longField = new Field("longCol", FieldType.nullable(new ArrowType.Int(64, true)), null);
+    Schema arrowSchema = new Schema(Arrays.asList(intField, longField));
+
+    File out = _tempDir.resolve(fileName).toFile();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator);
+        FileOutputStream fos = new FileOutputStream(out);
+        FileChannel channel = fos.getChannel();
+        ArrowFileWriter writer = new ArrowFileWriter(root, null, channel)) {
+      BigIntVector intVec = (BigIntVector) root.getVector("intCol");
+      BigIntVector longVec = (BigIntVector) root.getVector("longCol");
+
+      intVec.allocateNew(ROW_COUNT);
+      longVec.allocateNew(ROW_COUNT);
+
+      for (int i = 0; i < ROW_COUNT; i++) {
+        intVec.set(i, i); // small values that fit in INT after INT64 -> INT coercion
+        longVec.set(i, 1_000_000_000_000L + i);
+      }
+      intVec.setValueCount(ROW_COUNT);
+      longVec.setValueCount(ROW_COUNT);
+      root.setRowCount(ROW_COUNT);
+
+      writer.start();
+      writer.writeBatch();
+      writer.end();
+    }
+    return out;
+  }
+
+  /**
    * Guardrail for any change that processes the Arrow source one record batch at a time: a segment
    * built from a multi-batch file must be byte-identical (same-path data CRC) and per-docId equal to
    * one built from a single-batch file carrying the same logical rows, and the naturally-ascending

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -152,11 +152,25 @@ public class SegmentColumnarIndexCreator extends BaseSegmentCreator {
     SegmentDictionaryCreator dictionaryCreator = _colIndexes.get(columnName).getDictionaryCreator();
 
     PinotDataType destDataType = PinotDataType.getPinotDataTypeForIngestion(fieldSpec);
-    Object reuseColumnValueToIndex;
 
     // Reset column reader to start from beginning
     columnReader.rewind();
 
+    // Typed fast path: for a single-value INT/LONG/FLOAT/DOUBLE column the reader can serve a primitive
+    // directly (ColumnReader.isInt()/...), the dictionary offers indexOfSV(primitive), and every index
+    // creator offers addInt/addLong/... (ForwardIndexCreator, CombinedInvertedIndexCreator and
+    // DictionaryBasedInvertedIndexCreator de-box; any other creator falls back to the boxing default).
+    // Driving the column through those eliminates the per-value Integer/Long/Float/Double box that
+    // next() -> indexOfSV(Object) -> add(Object, ...) incurs. Null docs (rare) and everything else
+    // (multi-value, BIG_DECIMAL/STRING/BYTES, BOOLEAN/TIMESTAMP coercion) fall through to the Object
+    // path below, which stays the single source of truth for null and type handling.
+    if (fieldSpec.isSingleValueField()
+        && indexSingleValuePrimitive(columnName, fieldSpec, destDataType, columnReader, dictionaryCreator,
+            creatorsByIndex, nullVec)) {
+      return;
+    }
+
+    Object reuseColumnValueToIndex;
     int docId = 0;
     while (columnReader.hasNext()) {
       Object rawValue = columnReader.next();
@@ -183,6 +197,118 @@ public class SegmentColumnarIndexCreator extends BaseSegmentCreator {
 
       docId++;
     }
+  }
+
+  /**
+   * Typed, allocation-free index write for a single-value primitive column. Returns {@code true} if it
+   * consumed the column (the reader served it as INT / LONG / FLOAT / DOUBLE directly), or {@code
+   * false} — without advancing the reader — if the caller should fall back to the Object path. Drives
+   * each value through {@code ColumnReader.nextInt()}/... -> {@code indexOfSV(primitive)} -> {@code
+   * IndexCreator.addInt(primitive, dictId)}, avoiding the box that {@code next() -> indexOfSV(Object) ->
+   * add(Object, ...)} incurs. Null docs (rare) are routed through the shared Object handling for exact
+   * parity, including whole-value-null marking in the null-value vector.
+   */
+  private boolean indexSingleValuePrimitive(String columnName, FieldSpec fieldSpec, PinotDataType destDataType,
+      ColumnReader columnReader, SegmentDictionaryCreator dictionaryCreator, List<IndexCreator> creatorsByIndex,
+      NullValueVectorCreator nullVec)
+      throws IOException {
+    int docId = 0;
+    switch (fieldSpec.getDataType()) {
+      case INT: {
+        if (!columnReader.isInt()) {
+          return false;
+        }
+        while (columnReader.hasNext()) {
+          if (columnReader.isNextNull()) {
+            indexSingleValueRow(dictionaryCreator,
+                normalizeNullRow(columnName, fieldSpec, destDataType, columnReader, nullVec, docId), creatorsByIndex);
+          } else {
+            int value = columnReader.nextInt();
+            int dictId = dictionaryCreator != null ? dictionaryCreator.indexOfSV(value) : -1;
+            for (IndexCreator creator : creatorsByIndex) {
+              creator.addInt(value, dictId);
+            }
+          }
+          docId++;
+        }
+        return true;
+      }
+      case LONG: {
+        if (!columnReader.isLong()) {
+          return false;
+        }
+        while (columnReader.hasNext()) {
+          if (columnReader.isNextNull()) {
+            indexSingleValueRow(dictionaryCreator,
+                normalizeNullRow(columnName, fieldSpec, destDataType, columnReader, nullVec, docId), creatorsByIndex);
+          } else {
+            long value = columnReader.nextLong();
+            int dictId = dictionaryCreator != null ? dictionaryCreator.indexOfSV(value) : -1;
+            for (IndexCreator creator : creatorsByIndex) {
+              creator.addLong(value, dictId);
+            }
+          }
+          docId++;
+        }
+        return true;
+      }
+      case FLOAT: {
+        if (!columnReader.isFloat()) {
+          return false;
+        }
+        while (columnReader.hasNext()) {
+          if (columnReader.isNextNull()) {
+            indexSingleValueRow(dictionaryCreator,
+                normalizeNullRow(columnName, fieldSpec, destDataType, columnReader, nullVec, docId), creatorsByIndex);
+          } else {
+            float value = columnReader.nextFloat();
+            int dictId = dictionaryCreator != null ? dictionaryCreator.indexOfSV(value) : -1;
+            for (IndexCreator creator : creatorsByIndex) {
+              creator.addFloat(value, dictId);
+            }
+          }
+          docId++;
+        }
+        return true;
+      }
+      case DOUBLE: {
+        if (!columnReader.isDouble()) {
+          return false;
+        }
+        while (columnReader.hasNext()) {
+          if (columnReader.isNextNull()) {
+            indexSingleValueRow(dictionaryCreator,
+                normalizeNullRow(columnName, fieldSpec, destDataType, columnReader, nullVec, docId), creatorsByIndex);
+          } else {
+            double value = columnReader.nextDouble();
+            int dictId = dictionaryCreator != null ? dictionaryCreator.indexOfSV(value) : -1;
+            for (IndexCreator creator : creatorsByIndex) {
+              creator.addDouble(value, dictId);
+            }
+          }
+          docId++;
+        }
+        return true;
+      }
+      default:
+        return false;
+    }
+  }
+
+  /**
+   * Read a whole-value-null doc on the typed fast path and resolve it exactly as the Object path does:
+   * read the raw value (an actual {@code null}, or a stored sentinel from a segment source), mark the
+   * null-value vector only for an actual {@code null}, and return the normalized value (the column
+   * default) for the shared single-value row helper to index.
+   */
+  private Object normalizeNullRow(String columnName, FieldSpec fieldSpec, PinotDataType destDataType,
+      ColumnReader columnReader, NullValueVectorCreator nullVec, int docId)
+      throws IOException {
+    Object rawValue = columnReader.next();
+    if (rawValue == null && nullVec != null) {
+      nullVec.setNull(docId);
+    }
+    return ColumnarValueNormalizer.normalize(columnName, fieldSpec, destDataType, rawValue);
   }
 
   private void indexColumnValue(PinotSegmentColumnReader colReader,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -32,6 +32,8 @@ import org.apache.pinot.spi.data.readers.ColumnReader;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.PinotDataType;
 import org.roaringbitmap.RoaringBitmap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -39,7 +41,15 @@ import org.roaringbitmap.RoaringBitmap;
  */
 // TODO: check resource leaks
 public class SegmentColumnarIndexCreator extends BaseSegmentCreator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentColumnarIndexCreator.class);
+
   private int _nextDocId;
+
+  // Column-major build-path accounting, populated only by indexColumn(String, ColumnReader) and summarized
+  // once via logColumnMajorBuildPathSummary(). A fresh creator is instantiated per segment build, so these
+  // reset naturally; the row-major path never touches them.
+  private int _columnMajorTypedFastPathColumns;
+  private int _columnMajorObjectPathColumns;
 
   @Override
   public void indexRow(GenericRow row)
@@ -167,8 +177,13 @@ public class SegmentColumnarIndexCreator extends BaseSegmentCreator {
     if (fieldSpec.isSingleValueField()
         && indexSingleValuePrimitive(columnName, fieldSpec, destDataType, columnReader, dictionaryCreator,
             creatorsByIndex, nullVec)) {
+      _columnMajorTypedFastPathColumns++;
       return;
     }
+    // Multi-value columns, non-primitive single-value types, and fast-path primitives whose reader serves a
+    // different physical type all fall through to the Object path below (the single source of truth for null
+    // and type handling).
+    _columnMajorObjectPathColumns++;
 
     Object reuseColumnValueToIndex;
     int docId = 0;
@@ -200,13 +215,14 @@ public class SegmentColumnarIndexCreator extends BaseSegmentCreator {
   }
 
   /**
-   * Typed, allocation-free index write for a single-value primitive column. Returns {@code true} if it
-   * consumed the column (the reader served it as INT / LONG / FLOAT / DOUBLE directly), or {@code
-   * false} — without advancing the reader — if the caller should fall back to the Object path. Drives
-   * each value through {@code ColumnReader.nextInt()}/... -> {@code indexOfSV(primitive)} -> {@code
+   * Typed, allocation-free index write for a single-value primitive column. Returns {@code true} if it consumed
+   * the column (the reader served it as INT / LONG / FLOAT / DOUBLE directly). Otherwise it returns {@code false}
+   * — without advancing the reader — either because the column is not a fast-path primitive, or because it is
+   * one but the reader serves a different physical type, so the caller falls back to the Object path. Drives each
+   * value through {@code ColumnReader.nextInt()}/... -> {@code indexOfSV(primitive)} -> {@code
    * IndexCreator.addInt(primitive, dictId)}, avoiding the box that {@code next() -> indexOfSV(Object) ->
-   * add(Object, ...)} incurs. Null docs (rare) are routed through the shared Object handling for exact
-   * parity, including whole-value-null marking in the null-value vector.
+   * add(Object, ...)} incurs. Null docs (rare) are routed through the shared Object handling for exact parity,
+   * including whole-value-null marking in the null-value vector.
    */
   private boolean indexSingleValuePrimitive(String columnName, FieldSpec fieldSpec, PinotDataType destDataType,
       ColumnReader columnReader, SegmentDictionaryCreator dictionaryCreator, List<IndexCreator> creatorsByIndex,
@@ -309,6 +325,17 @@ public class SegmentColumnarIndexCreator extends BaseSegmentCreator {
       nullVec.setNull(docId);
     }
     return ColumnarValueNormalizer.normalize(columnName, fieldSpec, destDataType, rawValue);
+  }
+
+  /**
+   * Emit a single INFO line, once per column-major build after all columns are indexed, reporting how many
+   * single-value primitive columns took the typed allocation-free fast path versus the Object path (multi-value,
+   * non-primitive single-value, or a fast-path primitive whose source type did not match the schema).
+   */
+  void logColumnMajorBuildPathSummary() {
+    LOGGER.info("Column-major build path for segment {}: {} column(s) via typed single-value primitive fast path, "
+            + "{} column(s) via Object path",
+        getSegmentName(), _columnMajorTypedFastPathColumns, _columnMajorObjectPathColumns);
   }
 
   private void indexColumnValue(PinotSegmentColumnReader colReader,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -152,6 +152,13 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
    * Initialize the driver for columnar segment building using a ColumnReaderFactory.
    * This method sets up the driver to use column-wise input data access instead of row-wise.
    *
+   * <p>The column-major build this driver currently performs is two-pass — a statistics pass (which
+   * seals the dictionary) followed by an index pass — so each column's {@link ColumnReader} is read
+   * sequentially, {@code rewind()}ed, and read again. A factory supplied here must therefore return
+   * readers that support repeated {@code rewind()} and a full re-read; how it meets that (buffering all
+   * values, or re-reading a seekable/batch-bounded backing store) is the factory's own choice and sets
+   * the build's peak memory — this driver does not constrain it.
+   *
    * @param config Segment generator configuration
    * @param columnReaderFactory Factory for creating column readers
    * @throws Exception if initialization fails

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -556,6 +556,11 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
 
       LOGGER.info("Finished indexing using columnar approach in IndexCreator!");
       handlePostCreation();
+
+      if (_indexCreator instanceof SegmentColumnarIndexCreator) {
+        // Logged after seal so the final segment name is available; only reads accumulated counters.
+        ((SegmentColumnarIndexCreator) _indexCreator).logColumnMajorBuildPathSummary();
+      }
     } catch (Exception e) {
       try {
         _indexCreator.close();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/ColumnarSegmentPreIndexStatsContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/ColumnarSegmentPreIndexStatsContainer.java
@@ -132,6 +132,18 @@ public class ColumnarSegmentPreIndexStatsContainer implements SegmentPreIndexSta
     PinotDataType destDataType = PinotDataType.getPinotDataTypeForIngestion(fieldSpec);
     try {
       columnReader.rewind();
+      // Typed fast path: when the reader can serve a single-value column as a primitive directly
+      // (ColumnReader.isInt()/isLong()/...), read it with the type-specific accessor and feed the
+      // matching AbstractColumnStatisticsCollector.collect(primitive) overload. This avoids the
+      // Integer/Long/Float/Double box that next() -> collect(Object) incurs on every value, plus the
+      // per-value normalize() allocation. Anything the reader cannot type directly — multi-value,
+      // BIG_DECIMAL/STRING/BYTES, or a column needing coercion (BOOLEAN/TIMESTAMP) — falls through to
+      // the shared, normalize()-based Object path below, which stays the single source of truth for
+      // null and type handling.
+      if (fieldSpec.isSingleValueField()
+          && collectSingleValuePrimitive(columnName, fieldSpec, destDataType, columnReader, statsCollector)) {
+        return;
+      }
       while (columnReader.hasNext()) {
         statsCollector.collect(
             ColumnarValueNormalizer.normalize(columnName, fieldSpec, destDataType, columnReader.next()));
@@ -139,6 +151,94 @@ public class ColumnarSegmentPreIndexStatsContainer implements SegmentPreIndexSta
     } catch (IOException e) {
       throw new RuntimeException("Caught exception collecting stats for column: " + columnName, e);
     }
+  }
+
+  /**
+   * Typed, allocation-free stats collection for a single-value primitive column. Returns {@code true}
+   * if it consumed the column (the reader served it as INT / LONG / FLOAT / DOUBLE directly), or
+   * {@code false} — without advancing the reader — if the caller should fall back to the Object path.
+   *
+   * <p>A {@code null} value is collected as the column's default, pre-normalized once via {@link
+   * ColumnarValueNormalizer} so it matches the value the Object path would collect (segment metadata
+   * stays identical between the two paths). The reader's {@code isInt()} / {@code isLong()} / ...
+   * capability check guards each typed accessor, so a column the reader cannot type natively (e.g.
+   * BOOLEAN or TIMESTAMP read from a non-native vector) returns {@code false} here rather than risking
+   * a wrong typed read.
+   */
+  private static boolean collectSingleValuePrimitive(String columnName, FieldSpec fieldSpec,
+      PinotDataType destDataType, ColumnReader columnReader, AbstractColumnStatisticsCollector statsCollector)
+      throws IOException {
+    switch (fieldSpec.getDataType()) {
+      case INT: {
+        if (!columnReader.isInt()) {
+          return false;
+        }
+        while (columnReader.hasNext()) {
+          if (columnReader.isNextNull()) {
+            collectNull(columnName, fieldSpec, destDataType, columnReader, statsCollector);
+          } else {
+            statsCollector.collect(columnReader.nextInt());
+          }
+        }
+        return true;
+      }
+      case LONG: {
+        if (!columnReader.isLong()) {
+          return false;
+        }
+        while (columnReader.hasNext()) {
+          if (columnReader.isNextNull()) {
+            collectNull(columnName, fieldSpec, destDataType, columnReader, statsCollector);
+          } else {
+            statsCollector.collect(columnReader.nextLong());
+          }
+        }
+        return true;
+      }
+      case FLOAT: {
+        if (!columnReader.isFloat()) {
+          return false;
+        }
+        while (columnReader.hasNext()) {
+          if (columnReader.isNextNull()) {
+            collectNull(columnName, fieldSpec, destDataType, columnReader, statsCollector);
+          } else {
+            statsCollector.collect(columnReader.nextFloat());
+          }
+        }
+        return true;
+      }
+      case DOUBLE: {
+        if (!columnReader.isDouble()) {
+          return false;
+        }
+        while (columnReader.hasNext()) {
+          if (columnReader.isNextNull()) {
+            collectNull(columnName, fieldSpec, destDataType, columnReader, statsCollector);
+          } else {
+            statsCollector.collect(columnReader.nextDouble());
+          }
+        }
+        return true;
+      }
+      default:
+        return false;
+    }
+  }
+
+  /**
+   * Collect a null doc on the typed fast path by routing it through the same {@link
+   * ColumnarValueNormalizer#normalize} call {@code collectColumn} uses, so this path records exactly
+   * what the Object path would: a source that returns {@code null} at a null doc (e.g. Arrow) yields
+   * the column default, and one that surfaces a stored sentinel (e.g. a Pinot-segment reader) yields
+   * that sentinel — both identical to the Object path. Null docs are rare, so the box this incurs is
+   * immaterial; the non-null hot path stays primitive.
+   */
+  private static void collectNull(String columnName, FieldSpec fieldSpec, PinotDataType destDataType,
+      ColumnReader columnReader, AbstractColumnStatisticsCollector statsCollector)
+      throws IOException {
+    statsCollector.collect(
+        ColumnarValueNormalizer.normalize(columnName, fieldSpec, destDataType, columnReader.next()));
   }
 
   @Override


### PR DESCRIPTION
**TL;DR:** The column-major build added in #18638 removed per-row `GenericRow` materialization, but it still consumes every value through the generic `Object` path — so each primitive is **boxed twice**, once on the stats pass and once on the index pass. This PR adds a typed, boxing-free fast path for single-value `INT`/`LONG`/`FLOAT`/`DOUBLE` columns: `ColumnReader.nextInt()` → `collect(int)` / `indexOfSV(int)` → `IndexCreator.addInt(value, dictId)`. Purely additive; nulls, multi-value, and every other type fall back to the unchanged Object path. **No SPI changes, no new public API.** It also logs a one-line fast-path/Object-path column summary per build.

Tracks #18629. Builds on #18638 (column-major build) and the `ColumnReader` / `ColumnReaderFactory` SPI (#16727).

### Problem

#18629 set out to build a segment from a columnar source without "the per-row `GenericRow` allocation **and** per-primitive boxing." #18638 delivered the column-major path and removed the `GenericRow` allocation, but it routes values through the generic `Object` API:

```
columnReader.next()                         // Object — boxes the primitive
  -> ColumnarValueNormalizer.normalize(..)  // Object
  -> dictionaryCreator.indexOfSV(Object)    // boxed dictionary lookup
  -> creator.add(Object, dictId)            // unboxes again to write
```

So the per-primitive boxing #18629 aimed to remove is still on the hot path — and twice over, since `buildColumnar()` reads every column once for stats and once for indexing. (This is the follow-up requested in the #18638 review.)

### What this PR does

The `ColumnReader` SPI (#16727) already exposes typed accessors (`nextInt()`, `isInt()`, …) and the downstream sinks already have primitive overloads — `AbstractColumnStatisticsCollector.collect(int)`, `SegmentDictionaryCreator.indexOfSV(int)`, and `addInt(value, dictId)` on `ForwardIndexCreator` / `CombinedInvertedIndexCreator` / `DictionaryBasedInvertedIndexCreator`. They were simply never wired to the column-major build. This PR wires them:

- **Stats pass** (`ColumnarSegmentPreIndexStatsContainer`) — when the reader can serve a single-value column as a primitive (`isInt()`/`isLong()`/…), read with `nextInt()`/… and feed `collect(int)`/… directly.
- **Index pass** (`SegmentColumnarIndexCreator`) — same dispatch: `nextInt()` → `indexOfSV(int)` → `creator.addInt(value, dictId)` across the column's index creators (creators with no typed override keep the boxing default and stay correct).

Key choices:

- **Gated on the logical `FieldSpec` type** (`INT`/`LONG`/`FLOAT`/`DOUBLE`), so `BOOLEAN` (stored `INT`) and `TIMESTAMP` (stored `LONG`) — which require value coercion the typed read would skip — correctly stay on the Object path.
- **Null docs route through the existing Object path** for byte-for-byte parity, including null-value-vector marking and default substitution. The typed primitive accessor is only called when `isNextNull()` is false.
- **Multi-value and non-primitive types are unchanged.**

Net effect: for single-value primitive columns, neither build pass boxes — removing the remaining per-primitive boxing on both column reads.

### Potential saving

Each column is read twice (stats pass + index pass), so the Object path boxes every single-value primitive value `2 × N` times for an `N`-row column. The typed path avoids, per such column:

| Type | Garbage avoided |
|---|---|
| `INT` / `FLOAT` | `2 × N × 16 B` |
| `LONG` / `DOUBLE` | `2 × N × 24 B` |

Wrapper sizes assume a 64-bit JVM with compressed oops (`Integer` / `Long` skip the −128..127 cache). For example a 1M-row column eliminates ~32 MB (`INT` / `FLOAT`) or ~48 MB (`LONG` / `DOUBLE`) of short-lived allocation and `2 × N` boxing ops — allocation/GC pressure only; retained heap and segment size are unchanged.

### Scope

Single-value `INT`/`LONG`/`FLOAT`/`DOUBLE` only. The typed multi-value sinks (`addIntMV`, `nextIntMV` / `MultiValueResult`) already exist but are intentionally **not** wired here — the multi-value element-null contract is a distinct concern and is better handled on its own.

### Compatibility

Additive and behavior-preserving: **no SPI changes**, no new public API; the row-major path and the Object-path column-major fallback are untouched. The only non-fast-path edit documents the existing two-pass `rewind()` precondition on the `init(config, ColumnReaderFactory)` overload (the consumer that imposes it), leaving the `ColumnReaderFactory` SPI itself generic.

### Observability

Emits one INFO summary per column-major build — how many single-value primitive columns took the typed fast path vs. the Object-path fallback (multi-value, non-primitive single-value, or a fast-path primitive whose reader served a different physical type than the schema). Counts are incremented once per column where the path is chosen, so the summary can't drift from the path taken. No SPI or public-API change.

### Testing

The de-box is behavior-preserving (output-identical), so it's largely covered by the existing column-major equivalence suites; one new test is added for a previously-unexercised fallback:
- `ColumnarRowMajorEquivalenceTest` — column-major vs. row-major over single-value `INT`/`LONG`/`FLOAT`/`DOUBLE` with ~10% nulls, asserting per-doc value and min/max/cardinality equality (typed dispatch + null branch).
- The `pinot-arrow` column-major suite (e.g. `testRichMultiBatchEquivalence`, INT with nulls across batches) exercises the typed path via an Arrow source.
- **New —** `testSourceSchemaTypeMismatchInt64ToIntEquivalence` (`pinot-arrow`): an INT64 Arrow source declared as `INT` in the schema declines the fast path and coerces via the Object path; asserts byte-for-byte parity with row-major.

### References

Tracks #18629 · builds on #18638 · `ColumnReader` SPI #16727



