### PR TITLE
Fix typos in comments, Javadoc, and log messages

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
@@ -190,7 +190,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
         && pauseStatus.getReasonCode().equals(PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED)) {
       // The table was previously paused due to exceeding resource utilization, but the current status cannot be
       // determined. To be safe, leave it as paused and once the status is available take the correct action
-      LOGGER.warn("Resource utilization limit could not be determined for for table: {}, and it is paused, leave it as "
+      LOGGER.warn("Resource utilization limit could not be determined for table: {}, and it is paused, leave it as "
           + "paused", tableNameWithType);
       return false;
     }

--- a/pinot-plugins/pinot-metrics/pinot-dropwizard/src/test/java/org/apache/pinot/plugin/metrics/dropwizard/prometheus/DropwizardBrokerPrometheusMetricsTest.java
+++ b/pinot-plugins/pinot-metrics/pinot-dropwizard/src/test/java/org/apache/pinot/plugin/metrics/dropwizard/prometheus/DropwizardBrokerPrometheusMetricsTest.java
@@ -31,7 +31,7 @@ import org.testng.annotations.Test;
 
 
 /**
- * Disabling tests as Pinot currently uses Yammer and these tests fail for for {@link DropwizardMetricsFactory}
+ * Disabling tests as Pinot currently uses Yammer and these tests fail for {@link DropwizardMetricsFactory}
  */
 @Test(enabled = false) // enabled=false on class level doesn't seem to work in intellij
 public class DropwizardBrokerPrometheusMetricsTest extends BrokerPrometheusMetricsTest {

--- a/pinot-plugins/pinot-metrics/pinot-dropwizard/src/test/java/org/apache/pinot/plugin/metrics/dropwizard/prometheus/DropwizardControllerPrometheusMetricsTest.java
+++ b/pinot-plugins/pinot-metrics/pinot-dropwizard/src/test/java/org/apache/pinot/plugin/metrics/dropwizard/prometheus/DropwizardControllerPrometheusMetricsTest.java
@@ -29,7 +29,7 @@ import org.testng.annotations.Test;
 
 
 /**
- * Disabling tests as Pinot currently uses Yammer and these tests fail for for {@link DropwizardMetricsFactory}
+ * Disabling tests as Pinot currently uses Yammer and these tests fail for {@link DropwizardMetricsFactory}
  */
 @Test(enabled = false) // enabled=false on class level doesn't seem to work in intellij
 public class DropwizardControllerPrometheusMetricsTest extends ControllerPrometheusMetricsTest {

--- a/pinot-plugins/pinot-metrics/pinot-dropwizard/src/test/java/org/apache/pinot/plugin/metrics/dropwizard/prometheus/DropwizardMinionPrometheusMetricsTest.java
+++ b/pinot-plugins/pinot-metrics/pinot-dropwizard/src/test/java/org/apache/pinot/plugin/metrics/dropwizard/prometheus/DropwizardMinionPrometheusMetricsTest.java
@@ -29,7 +29,7 @@ import org.testng.annotations.Test;
 
 
 /**
- * Disabling tests as Pinot currently uses Yammer and these tests fail for for {@link DropwizardMetricsFactory}
+ * Disabling tests as Pinot currently uses Yammer and these tests fail for {@link DropwizardMetricsFactory}
  */
 @Test(enabled = false) // enabled=false on class level doesn't seem to work in intellij
 public class DropwizardMinionPrometheusMetricsTest extends MinionPrometheusMetricsTest {

--- a/pinot-plugins/pinot-metrics/pinot-dropwizard/src/test/java/org/apache/pinot/plugin/metrics/dropwizard/prometheus/DropwizardServerPrometheusMetricsTest.java
+++ b/pinot-plugins/pinot-metrics/pinot-dropwizard/src/test/java/org/apache/pinot/plugin/metrics/dropwizard/prometheus/DropwizardServerPrometheusMetricsTest.java
@@ -31,7 +31,7 @@ import org.testng.annotations.Test;
 
 
 /**
- * Disabling tests as Pinot currently uses Yammer and these tests fail for for {@link DropwizardMetricsFactory}
+ * Disabling tests as Pinot currently uses Yammer and these tests fail for {@link DropwizardMetricsFactory}
  */
 @Test(enabled = false) // enabled=false on class level doesn't seem to work in intellij
 public class DropwizardServerPrometheusMetricsTest extends ServerPrometheusMetricsTest {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  * Provides a configuration abstraction for Pinot to decouple services from configuration sources and frameworks.
  * </p>
  * <p>
- * Pinot services may retreived configurations from PinotConfiguration independently from any source of configuration.
+ * Pinot services may retrieve configurations from PinotConfiguration independently from any source of configuration.
  * {@link PinotConfiguration} currently supports configuration loaded from the following sources :
  *
  * <ul>

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/env/VersionedPropertyConfigTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/env/VersionedPropertyConfigTest.java
@@ -107,7 +107,7 @@ public class VersionedPropertyConfigTest {
 
   @Test
   //Test requires 'segment-metadata-without-version-header.properties' sample segment metadata file in resources folder
-  public void testOldSegmentMetadataBackwardCompatability()
+  public void testOldSegmentMetadataBackwardCompatibility()
       throws ConfigurationException {
     File oldSegmentProperties = new File(
         Objects.requireNonNull(


### PR DESCRIPTION
## Summary

Comment-only and test-only spelling fixes:

| File | Typo | Fix |
|------|------|-----|
| `PinotConfiguration.java` | `retreived` | `retrieve` |
| `RealtimeSegmentValidationManager.java` | `for for table` | `for table` |
| `VersionedPropertyConfigTest.java` | `BackwardCompatability` | `BackwardCompatibility` |
| `Dropwizard*PrometheusMetricsTest.java` (×4) | `tests fail for for` | `tests fail for` |

No logic changes.

## Test plan
- [ ] No behavior change; comment and test-name fixes only