### PR TITLE
Fix controller UI crash on instance listing pages when instance names lack type prefix

### DIFF
--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -191,7 +191,9 @@ const getAllInstances = () => {
 
     data.instances.forEach((instance) => {
       const instanceType =  instance.split('_')[0].toUpperCase();
-      instanceTypeToInstancesMap[instanceType].push(instance);
+      if (instanceTypeToInstancesMap[instanceType]) {
+        instanceTypeToInstancesMap[instanceType].push(instance);
+      }
     });
 
     return instanceTypeToInstancesMap;


### PR DESCRIPTION
## Summary

The `#/minions`, `#/servers`, `#/brokers`, and `#/controllers` pages crash with `TypeError: Cannot read properties of undefined (reading 'push')` when the `/instances` API returns instance names without the expected `Type_` prefix (e.g. bare UUIDs like `a1b2c3d4-e5f6-7890-abcd-ef1234567890`).

`getAllInstances()` in `PinotMethodUtils.ts` splits instance names on `_` and uses the first segment as a key into a fixed map of `{CONTROLLER, BROKER, SERVER, MINION}`. When the instance name has no recognized prefix, the lookup returns `undefined` and `.push()` throws.

The fix skips instances whose name prefix doesn't match a known instance type.

## Validation

Validated locally by:
1. Starting a batch quickstart cluster
2. Registering a bare-UUID instance directly in ZooKeeper via `PUT /zk/put`
3. Confirming `GET /instances` returns the bare UUID alongside prefixed instances
4. Confirming the UI crashes without the fix (TypeError in console, page stuck on loader)
5. Confirming the UI renders correctly with the fix applied (bare-UUID instance silently skipped)

## Test plan
- [x] Local quickstart with injected bare-UUID instance
- [x] Verified crash reproduces without fix
- [x] Verified page loads with fix
