### PR TITLE
Make adaptive routing variables runtime adjustable

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ExponentialMovingAverage.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ExponentialMovingAverage.java
@@ -21,6 +21,7 @@ package org.apache.pinot.common.utils;
 
 import com.google.common.base.Preconditions;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -32,14 +33,18 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public class ExponentialMovingAverage {
-  private final double _alpha;
-  private final long _autoDecayWindowMs;
+  private volatile double _alpha;
+  private volatile long _autoDecayWindowMs;
 
   private final long _warmUpDurationMs;
   private final long _initializationTimeMs;
 
   private volatile double _average;
-  private long _lastUpdatedTimeMs;
+  private volatile long _lastUpdatedTimeMs;
+  @Nullable
+  private final ScheduledExecutorService _periodicTaskExecutor;
+  @Nullable
+  private volatile ScheduledFuture<?> _autoDecayFuture;
 
   /**
    * Constructor
@@ -52,12 +57,12 @@ public class ExponentialMovingAverage {
    * @param warmUpDurationMs     The initial duration after initialization during which new incoming values are ignored
    *                             in the average calculation.
    * @param avgInitializationVal The default value to initialize for average.
-   * @param periodicTaskExecutor Executor to schedule periodic tasks like autoDecay.
+   * @param periodicTaskExecutor Executor to schedule periodic tasks like autoDecay; can be null only while auto-decay
+   *                             is disabled.
    */
   public ExponentialMovingAverage(double alpha, long autoDecayWindowMs, long warmUpDurationMs,
       double avgInitializationVal, @Nullable ScheduledExecutorService periodicTaskExecutor) {
-    Preconditions.checkState(alpha >= 0.0 && alpha <= 1.0, "Alpha should be between 0 and 1");
-    _alpha = alpha;
+    _alpha = validateAlpha(alpha);
     Preconditions.checkState(warmUpDurationMs >= 0, "warmUpDurationMs is negative.");
     _warmUpDurationMs = warmUpDurationMs;
     Preconditions.checkState(avgInitializationVal >= 0.0, "avgInitializationVal is negative.");
@@ -65,20 +70,9 @@ public class ExponentialMovingAverage {
 
     _initializationTimeMs = System.currentTimeMillis();
     _lastUpdatedTimeMs = 0;
+    _periodicTaskExecutor = periodicTaskExecutor;
     _autoDecayWindowMs = autoDecayWindowMs;
-
-    if (_autoDecayWindowMs > 0) {
-      // Schedule a task to automatically decay the average if updates are not performed in the last _autoDecayWindowMs.
-      Preconditions.checkState(periodicTaskExecutor != null);
-      periodicTaskExecutor.scheduleAtFixedRate(new Runnable() {
-        @Override
-        public void run() {
-          if (_lastUpdatedTimeMs > 0 && (System.currentTimeMillis() - _lastUpdatedTimeMs) > _autoDecayWindowMs) {
-            compute(0.0);
-          }
-        }
-      }, 0, _autoDecayWindowMs, TimeUnit.MILLISECONDS);
-    }
+    scheduleAutoDecayTask();
   }
 
   /**
@@ -86,6 +80,32 @@ public class ExponentialMovingAverage {
    */
   public double getAverage() {
     return _average;
+  }
+
+  /**
+   * Updates the alpha (smoothing factor) used for subsequent EMA computations.
+   * @param alpha new alpha value between 0 and 1.
+   */
+  public synchronized void setAlpha(double alpha) {
+    _alpha = validateAlpha(alpha);
+  }
+
+  /**
+   * Updates the auto-decay window. Cancels any existing periodic decay task, then reschedules only if the new window is
+   * positive. A value &lt;= 0 disables auto-decay. Throws if enabling auto-decay without a periodic task executor.
+   * @param autoDecayWindowMs new auto-decay window in milliseconds; &lt;= 0 disables auto-decay.
+   */
+  public synchronized void setAutoDecayWindowMs(long autoDecayWindowMs) {
+    if (autoDecayWindowMs == _autoDecayWindowMs) {
+      return;
+    }
+    if (autoDecayWindowMs > 0) {
+      Preconditions.checkState(_periodicTaskExecutor != null,
+          "periodicTaskExecutor must not be null when autoDecayWindowMs is positive");
+    }
+    _autoDecayWindowMs = autoDecayWindowMs;
+    cancelAutoDecayTask();
+    scheduleAutoDecayTask();
   }
 
   /**
@@ -104,5 +124,39 @@ public class ExponentialMovingAverage {
 
     _average = value * _alpha + _average * (1 - _alpha);
     return _average;
+  }
+
+  /**
+   * Validates and returns an EWMA alpha value.
+   */
+  public static double validateAlpha(double alpha) {
+    Preconditions.checkArgument(alpha >= 0.0 && alpha <= 1.0, "Alpha should be between 0 and 1");
+    return alpha;
+  }
+
+  private void scheduleAutoDecayTask() {
+    if (_autoDecayWindowMs <= 0) {
+      return;
+    }
+    Preconditions.checkState(_periodicTaskExecutor != null,
+        "periodicTaskExecutor must not be null when autoDecayWindowMs is positive");
+    _autoDecayFuture = _periodicTaskExecutor.scheduleAtFixedRate(new Runnable() {
+      @Override
+      public void run() {
+        synchronized (ExponentialMovingAverage.this) {
+          if (_autoDecayWindowMs > 0 && _lastUpdatedTimeMs > 0
+              && (System.currentTimeMillis() - _lastUpdatedTimeMs) > _autoDecayWindowMs) {
+            compute(0.0);
+          }
+        }
+      }
+    }, 0, _autoDecayWindowMs, TimeUnit.MILLISECONDS);
+  }
+
+  private void cancelAutoDecayTask() {
+    if (_autoDecayFuture != null) {
+      _autoDecayFuture.cancel(false);
+      _autoDecayFuture = null;
+    }
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/ExponentialMovingAverageTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/ExponentialMovingAverageTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.common.utils;
 import java.util.Random;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -113,5 +114,19 @@ public class ExponentialMovingAverageTest {
       Thread.sleep(100);
       assertEquals(average.getAverage(), currAvg);
     }
+  }
+
+  @Test
+  public void testNullExecutorCannotEnableAutoDecay() {
+    ExponentialMovingAverage average = new ExponentialMovingAverage(1.0, -1, 0, 0.0, null);
+    average.compute(10.0);
+    assertEquals(average.getAverage(), 10.0);
+
+    IllegalStateException exception = Assert.expectThrows(IllegalStateException.class,
+        () -> average.setAutoDecayWindowMs(10));
+    assertEquals(exception.getMessage(), "periodicTaskExecutor must not be null when autoDecayWindowMs is positive");
+
+    average.compute(20.0);
+    assertEquals(average.getAverage(), 20.0);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsEntry.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsEntry.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.ExponentialMovingAverage;
 
 
@@ -37,24 +38,24 @@ public class ServerRoutingStatsEntry {
 
   // Fields related to number of in-flight requests.
   private volatile int _numInFlightRequests;
-  private final ExponentialMovingAverage _inFlighRequestsEMA;
+  private final ExponentialMovingAverage _inFlightRequestsEMA;
 
   // Fields related to latency
   private final ExponentialMovingAverage _latencyMsEMA;
 
   // Hybrid score exponent.
-  private final int _hybridScoreExponent;
+  private volatile int _hybridScoreExponent;
 
   // Hybrid score queue size floor (added to A+B before exponentiation to avoid score collapsing to 0 when idle).
   private final int _hybridScoreQueueFloor;
 
   public ServerRoutingStatsEntry(String serverInstanceId, double alphaEMA, long autoDecayWindowMsEMA,
       long warmupDurationMsEMA, double avgInitializationValEMA, int scoreExponent, int queueFloor,
-      ScheduledExecutorService periodicTaskExecutor) {
+      @Nullable ScheduledExecutorService periodicTaskExecutor) {
     _serverInstanceId = serverInstanceId;
     _serverLock = new ReentrantReadWriteLock();
 
-    _inFlighRequestsEMA =
+    _inFlightRequestsEMA =
         new ExponentialMovingAverage(alphaEMA, autoDecayWindowMsEMA, warmupDurationMsEMA, avgInitializationValEMA,
             periodicTaskExecutor);
     _latencyMsEMA =
@@ -81,7 +82,7 @@ public class ServerRoutingStatsEntry {
   }
 
   public Double getInFlightRequestsEMA() {
-    return _inFlighRequestsEMA.getAverage();
+    return _inFlightRequestsEMA.getAverage();
   }
 
   public Double getLatencyEMA() {
@@ -90,13 +91,13 @@ public class ServerRoutingStatsEntry {
 
   @JsonProperty("hybridScore")
   public double computeHybridScore() {
-    double estimatedQSize = _hybridScoreQueueFloor + _numInFlightRequests + _inFlighRequestsEMA.getAverage();
+    double estimatedQSize = _hybridScoreQueueFloor + _numInFlightRequests + _inFlightRequestsEMA.getAverage();
     return Math.pow(estimatedQSize, _hybridScoreExponent) * _latencyMsEMA.getAverage();
   }
 
   public void updateNumInFlightRequestsForQuerySubmission() {
     ++_numInFlightRequests;
-    _inFlighRequestsEMA.compute(_numInFlightRequests);
+    _inFlightRequestsEMA.compute(_numInFlightRequests);
   }
 
   public void updateNumInFlightRequestsForResponseArrival() {
@@ -105,5 +106,29 @@ public class ServerRoutingStatsEntry {
 
   public void updateLatency(double latencyMs) {
     _latencyMsEMA.compute(latencyMs);
+  }
+
+  /**
+   * Updates the hybrid score exponent used in {@link #computeHybridScore()}.
+   */
+  public void setHybridScoreExponent(int exponent) {
+    _hybridScoreExponent = exponent;
+  }
+
+  /**
+   * Updates the EWMA alpha (smoothing factor) on both the in-flight requests and latency EMAs.
+   */
+  public void setAlpha(double alpha) {
+    ExponentialMovingAverage.validateAlpha(alpha);
+    _inFlightRequestsEMA.setAlpha(alpha);
+    _latencyMsEMA.setAlpha(alpha);
+  }
+
+  /**
+   * Updates the auto-decay window on both the in-flight requests and latency EMAs.
+   */
+  public void setAutoDecayWindowMs(long autoDecayWindowMs) {
+    _inFlightRequestsEMA.setAutoDecayWindowMs(autoDecayWindowMs);
+    _latencyMsEMA.setAutoDecayWindowMs(autoDecayWindowMs);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
@@ -32,11 +32,13 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.metrics.BrokerGauge;
 import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.utils.ExponentialMovingAverage;
 import org.apache.pinot.spi.config.provider.PinotClusterConfigChangeListener;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.query.QueryExecutionContext.QueryType;
@@ -73,11 +75,11 @@ public class ServerRoutingStatsManager implements PinotClusterConfigChangeListen
   // ScheduledExecutorServer for processing periodic tasks like decay.
   private ScheduledExecutorService _periodicTaskExecutor;
 
-  private double _alpha;
-  private long _autoDecayWindowMs;
+  private volatile double _alpha;
+  private volatile long _autoDecayWindowMs;
   private long _warmupDurationMs;
   private double _avgInitializationVal;
-  private int _hybridScoreExponent;
+  private volatile int _hybridScoreExponent;
   private int _hybridScoreQueueFloor;
   private volatile boolean _enableStatsMetricExport;
   private volatile long _statsMetricExportIntervalMs;
@@ -98,8 +100,9 @@ public class ServerRoutingStatsManager implements PinotClusterConfigChangeListen
 
     LOGGER.info("Initializing ServerRoutingStatsManager for Adaptive Server Selection.");
 
-    _alpha = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA,
-        AdaptiveServerSelector.DEFAULT_EWMA_ALPHA);
+    double configuredAlpha = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA,
+            AdaptiveServerSelector.DEFAULT_EWMA_ALPHA);
+    _alpha = ExponentialMovingAverage.validateAlpha(configuredAlpha);
     _autoDecayWindowMs = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_AUTODECAY_WINDOW_MS,
         AdaptiveServerSelector.DEFAULT_AUTODECAY_WINDOW_MS);
     _warmupDurationMs = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_WARMUP_DURATION_MS,
@@ -134,12 +137,15 @@ public class ServerRoutingStatsManager implements PinotClusterConfigChangeListen
 
   @Override
   public void onChange(Set<String> changedConfigs, Map<String, String> clusterConfigs) {
+    if (!_isEnabled) {
+      return;
+    }
     if (changedConfigs.contains(AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT)) {
       String value = clusterConfigs.get(AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT);
       if (value != null) {
         _enableStatsMetricExport = Boolean.parseBoolean(value);
       } else {
-        // Key was removed from cluster config — fall back to the static broker config value.
+        // Key was removed from cluster config; fall back to the static broker config value.
         _enableStatsMetricExport = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT,
             AdaptiveServerSelector.DEFAULT_ENABLE_STATS_METRIC_EXPORT);
       }
@@ -149,32 +155,108 @@ public class ServerRoutingStatsManager implements PinotClusterConfigChangeListen
       }
     }
     if (changedConfigs.contains(AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS)) {
-      String value = clusterConfigs.get(AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS);
-      long newIntervalMs;
-      if (value != null) {
-        try {
-          newIntervalMs = Long.parseLong(value);
-        } catch (NumberFormatException e) {
-          LOGGER.warn("Invalid value '{}' for config '{}'; ignoring interval change", value,
-              AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS);
-          return;
-        }
-        if (newIntervalMs <= 0) {
-          LOGGER.warn("Non-positive value {} for config '{}'; ignoring interval change", newIntervalMs,
-              AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS);
-          return;
-        }
-      } else {
-        newIntervalMs = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS,
-            AdaptiveServerSelector.DEFAULT_STATS_METRIC_EXPORT_INTERVAL_MS);
+      setStatsMetricExportIntervalMs(clusterConfigs);
+    }
+    if (changedConfigs.contains(AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT)) {
+      setHybridScoreExponent(clusterConfigs);
+    }
+    if (changedConfigs.contains(AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA)) {
+      setAlpha(clusterConfigs);
+    }
+    if (changedConfigs.contains(AdaptiveServerSelector.CONFIG_OF_AUTODECAY_WINDOW_MS)) {
+      setAutoDecayWindowMs(clusterConfigs);
+    }
+  }
+
+  private void setStatsMetricExportIntervalMs(Map<String, String> clusterConfigs) {
+    String value = clusterConfigs.get(AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS);
+    long newIntervalMs;
+    if (value != null) {
+      try {
+        newIntervalMs = Long.parseLong(value);
+      } catch (NumberFormatException e) {
+        LOGGER.warn("Invalid value '{}' for config '{}'; ignoring interval change", value,
+            AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS);
+        return;
       }
-      if (newIntervalMs != _statsMetricExportIntervalMs) {
-        _statsMetricExportIntervalMs = newIntervalMs;
-        _metricExportFuture.cancel(false);
-        _metricExportFuture = _periodicTaskExecutor.scheduleAtFixedRate(this::exportStatsAsMetrics,
-            newIntervalMs, newIntervalMs, TimeUnit.MILLISECONDS);
-        LOGGER.info("Rescheduled adaptive server routing stats metric export with new interval {}ms.", newIntervalMs);
+      if (newIntervalMs <= 0) {
+        LOGGER.warn("Non-positive value {} for config '{}'; ignoring interval change", newIntervalMs,
+            AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS);
+        return;
       }
+    } else {
+      newIntervalMs = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS,
+          AdaptiveServerSelector.DEFAULT_STATS_METRIC_EXPORT_INTERVAL_MS);
+    }
+    if (newIntervalMs != _statsMetricExportIntervalMs) {
+      _statsMetricExportIntervalMs = newIntervalMs;
+      _metricExportFuture.cancel(false);
+      _metricExportFuture = _periodicTaskExecutor.scheduleAtFixedRate(this::exportStatsAsMetrics,
+          newIntervalMs, newIntervalMs, TimeUnit.MILLISECONDS);
+      LOGGER.info("Rescheduled adaptive server routing stats metric export with new interval {}ms.", newIntervalMs);
+    }
+  }
+
+  private void setHybridScoreExponent(Map<String, String> clusterConfigs) {
+    String value = clusterConfigs.get(AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT);
+    int newExponent;
+    try {
+      newExponent = value != null ? Integer.parseInt(value)
+          : _config.getProperty(AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT,
+              AdaptiveServerSelector.DEFAULT_HYBRID_SCORE_EXPONENT);
+    } catch (NumberFormatException e) {
+      LOGGER.warn("Invalid value for {}: '{}', ignoring.",
+          AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT, value);
+      return;
+    }
+    if (newExponent < 0) {
+      LOGGER.warn("Invalid value for {}: '{}', ignoring.",
+          AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT, value);
+      return;
+    }
+    if (newExponent != _hybridScoreExponent) {
+      _hybridScoreExponent = newExponent;
+      updateAllEntries(entry -> entry.setHybridScoreExponent(newExponent));
+      LOGGER.info("Updated hybrid score exponent to {} and propagated to all entries.", newExponent);
+    }
+  }
+
+  private void setAlpha(Map<String, String> clusterConfigs) {
+    String value = clusterConfigs.get(AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA);
+    double newAlpha;
+    try {
+      double configuredAlpha = value != null ? Double.parseDouble(value)
+          : _config.getProperty(AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA,
+              AdaptiveServerSelector.DEFAULT_EWMA_ALPHA);
+      newAlpha = ExponentialMovingAverage.validateAlpha(configuredAlpha);
+    } catch (IllegalArgumentException e) {
+      LOGGER.warn("Invalid value for {}: '{}', ignoring.",
+          AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA, value);
+      return;
+    }
+    if (Double.compare(newAlpha, _alpha) != 0) {
+      _alpha = newAlpha;
+      updateAllEntries(entry -> entry.setAlpha(newAlpha));
+      LOGGER.info("Updated EWMA alpha to {} and propagated to all entries.", _alpha);
+    }
+  }
+
+  private void setAutoDecayWindowMs(Map<String, String> clusterConfigs) {
+    String value = clusterConfigs.get(AdaptiveServerSelector.CONFIG_OF_AUTODECAY_WINDOW_MS);
+    long newWindowMs;
+    try {
+      newWindowMs = value != null ? Long.parseLong(value)
+          : _config.getProperty(AdaptiveServerSelector.CONFIG_OF_AUTODECAY_WINDOW_MS,
+              AdaptiveServerSelector.DEFAULT_AUTODECAY_WINDOW_MS);
+    } catch (NumberFormatException e) {
+      LOGGER.warn("Invalid value for {}: '{}', ignoring.",
+          AdaptiveServerSelector.CONFIG_OF_AUTODECAY_WINDOW_MS, value);
+      return;
+    }
+    if (newWindowMs != _autoDecayWindowMs) {
+      _autoDecayWindowMs = newWindowMs;
+      updateAllEntries(entry -> entry.setAutoDecayWindowMs(newWindowMs));
+      LOGGER.info("Updated autodecay window to {}ms and propagated to all entries.", newWindowMs);
     }
   }
 
@@ -187,6 +269,10 @@ public class ServerRoutingStatsManager implements PinotClusterConfigChangeListen
     return _statsMetricExportIntervalMs;
   }
 
+  long getAutoDecayWindowMs() {
+    return _autoDecayWindowMs;
+  }
+
   public void shutDown() {
     // As the stats are not persistent, shutdown need not wait for task termination.
     if (!_isEnabled) {
@@ -195,7 +281,12 @@ public class ServerRoutingStatsManager implements PinotClusterConfigChangeListen
 
     LOGGER.info("Shutting down ServerRoutingStatsManager.");
     _isEnabled = false;
-    _executorService.shutdownNow();
+    if (_executorService != null) {
+      _executorService.shutdownNow();
+    }
+    if (_periodicTaskExecutor != null) {
+      _periodicTaskExecutor.shutdownNow();
+    }
   }
 
   public int getQueueSize() {
@@ -500,6 +591,33 @@ public class ServerRoutingStatsManager implements PinotClusterConfigChangeListen
       return stats.computeHybridScore();
     } finally {
       stats.getServerReadLock().unlock();
+    }
+  }
+
+  /**
+   * Applies the given action to every existing {@link ServerRoutingStatsEntry} in both the SSE and MSE stats maps.
+   *
+   * Note: there is a narrow race where an entry created via computeIfAbsent concurrently with this iteration may
+   * not be visited. The only problematic ordering (entry reads old value, then updateAllEntries misses it) requires
+   * the computeIfAbsent to begin before the volatile write, which is unlikely because a config change and a server
+   * addition would have to occur at the same time.
+   */
+  private void updateAllEntries(Consumer<ServerRoutingStatsEntry> action) {
+    for (ServerRoutingStatsEntry entry : _serverQueryStatsMap.values()) {
+      entry.getServerWriteLock().lock();
+      try {
+        action.accept(entry);
+      } finally {
+        entry.getServerWriteLock().unlock();
+      }
+    }
+    for (ServerRoutingStatsEntry entry : _mseServerQueryStatsMap.values()) {
+      entry.getServerWriteLock().lock();
+      try {
+        action.accept(entry);
+      } finally {
+        entry.getServerWriteLock().unlock();
+      }
     }
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
@@ -693,6 +693,286 @@ public class ServerRoutingStatsManagerTest {
     assertEquals(mseList.get(0).getRight().intValue(), 1);
   }
 
+  @Test
+  public void testDynamicHybridScoreExponentChange() {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_COLLECTION, true);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA, 1.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AUTODECAY_WINDOW_MS, -1);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_WARMUP_DURATION_MS, 0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AVG_INITIALIZATION_VAL, 0.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT, 3);
+    ServerRoutingStatsManager manager = new ServerRoutingStatsManager(new PinotConfiguration(properties),
+        _brokerMetrics);
+    manager.init();
+
+    int requestId = 0;
+    // Submit + respond to build up stats: numInFlight=0, inFlightEMA=1, latencyEMA=10.
+    manager.recordStatsForQuerySubmission(requestId++, "server1");
+    waitForStatsUpdate(manager, requestId);
+    manager.recordStatsUponResponseArrival(requestId++, "server1", 10);
+    waitForStatsUpdate(manager, requestId);
+
+    // With exponent=3: (0+1)^3 * 10 = 10
+    assertEquals(manager.fetchHybridScoreForServer("server1"), 10.0);
+
+    // Change exponent to 2 at runtime.
+    manager.onChange(
+        Set.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT),
+        Map.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT, "2"));
+
+    // With exponent=2: (0+1)^2 * 10 = 10
+    assertEquals(manager.fetchHybridScoreForServer("server1"), 10.0);
+
+    // Submit another query so numInFlight=1, inFlightEMA=1, latencyEMA=10.
+    manager.recordStatsForQuerySubmission(requestId++, "server1");
+    waitForStatsUpdate(manager, requestId);
+
+    // With exponent=2: (1+1)^2 * 10 = 40
+    assertEquals(manager.fetchHybridScoreForServer("server1"), 40.0);
+
+    // With exponent=3 that would have been (1+1)^3 * 10 = 80. Verify by switching back.
+    manager.onChange(
+        Set.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT),
+        Map.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT, "3"));
+    assertEquals(manager.fetchHybridScoreForServer("server1"), 80.0);
+
+    // Invalid negative exponent should be ignored.
+    manager.onChange(
+        Set.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT),
+        Map.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT, "-1"));
+    assertEquals(manager.fetchHybridScoreForServer("server1"), 80.0);
+  }
+
+  @Test
+  public void testDynamicEwmaAlphaChange() {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_COLLECTION, true);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA, 1.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AUTODECAY_WINDOW_MS, -1);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_WARMUP_DURATION_MS, 0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AVG_INITIALIZATION_VAL, 0.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT, 3);
+    ServerRoutingStatsManager manager = new ServerRoutingStatsManager(new PinotConfiguration(properties),
+        _brokerMetrics);
+    manager.init();
+
+    int requestId = 0;
+    // With alpha=1.0, EMA = latest value. Record latency=100.
+    manager.recordStatsForQuerySubmission(requestId++, "server1");
+    waitForStatsUpdate(manager, requestId);
+    manager.recordStatsUponResponseArrival(requestId++, "server1", 100);
+    waitForStatsUpdate(manager, requestId);
+    assertEquals(manager.fetchEMALatencyForServer("server1"), 100.0);
+
+    // Change alpha to 0.5 at runtime.
+    manager.onChange(
+        Set.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA),
+        Map.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA, "0.5"));
+
+    // Record latency=200. New EMA = 200*0.5 + 100*0.5 = 150.
+    manager.recordStatsForQuerySubmission(requestId++, "server1");
+    waitForStatsUpdate(manager, requestId);
+    manager.recordStatsUponResponseArrival(requestId++, "server1", 200);
+    waitForStatsUpdate(manager, requestId);
+    assertEquals(manager.fetchEMALatencyForServer("server1"), 150.0);
+
+    // Newly created entries also use the updated alpha.
+    manager.recordStatsForQuerySubmission(requestId++, "server2");
+    waitForStatsUpdate(manager, requestId);
+    manager.recordStatsUponResponseArrival(requestId++, "server2", 80);
+    waitForStatsUpdate(manager, requestId);
+    // alpha=0.5: EMA = 80*0.5 + 0*0.5 = 40
+    assertEquals(manager.fetchEMALatencyForServer("server2"), 40.0);
+  }
+
+  @Test
+  public void testDynamicAlphaRejectsInvalid() {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_COLLECTION, true);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA, 0.5);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AUTODECAY_WINDOW_MS, -1);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_WARMUP_DURATION_MS, 0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AVG_INITIALIZATION_VAL, 0.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT, 3);
+    ServerRoutingStatsManager manager = new ServerRoutingStatsManager(new PinotConfiguration(properties),
+        _brokerMetrics);
+    manager.init();
+
+    int requestId = 0;
+    manager.recordStatsForQuerySubmission(requestId++, "server1");
+    waitForStatsUpdate(manager, requestId);
+    manager.recordStatsUponResponseArrival(requestId++, "server1", 100);
+    waitForStatsUpdate(manager, requestId);
+
+    // alpha=0 is valid (freezes EMA at current value).
+    manager.onChange(
+        Set.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA),
+        Map.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA, "0.0"));
+
+    // With alpha=0: EMA = 200*0 + prevEMA*1 = prevEMA (unchanged).
+    // Previous EMA = 100*0.5 + 0*0.5 = 50.
+    manager.recordStatsForQuerySubmission(requestId++, "server1");
+    waitForStatsUpdate(manager, requestId);
+    manager.recordStatsUponResponseArrival(requestId++, "server1", 200);
+    waitForStatsUpdate(manager, requestId);
+    assertEquals(manager.fetchEMALatencyForServer("server1"), 50.0);
+
+    // Attempting to set alpha > 1 should be silently ignored (logged as warning).
+    manager.onChange(
+        Set.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA),
+        Map.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA, "1.5"));
+
+    // Verify manager is still functional — new entries should be created with the last valid alpha (0.0).
+    manager.recordStatsForQuerySubmission(requestId++, "server2");
+    waitForStatsUpdate(manager, requestId);
+    manager.recordStatsUponResponseArrival(requestId++, "server2", 50);
+    waitForStatsUpdate(manager, requestId);
+    // alpha=0 freezes EMA at init value (0.0), so latency stays at 0.
+    assertEquals(manager.fetchEMALatencyForServer("server2"), 0.0);
+
+    // Attempting to set alpha < 0 should be silently ignored.
+    manager.onChange(
+        Set.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA),
+        Map.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA, "-0.1"));
+  }
+
+  @Test
+  public void testDynamicAutoDecayWindowChange() {
+    // Start with a short autodecay window so the periodic task IS scheduled.
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_COLLECTION, true);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA, 1.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AUTODECAY_WINDOW_MS, 50);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_WARMUP_DURATION_MS, 0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AVG_INITIALIZATION_VAL, 0.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT, 3);
+    ServerRoutingStatsManager manager = new ServerRoutingStatsManager(new PinotConfiguration(properties),
+        _brokerMetrics);
+    manager.init();
+
+    int requestId = 0;
+    manager.recordStatsForQuerySubmission(requestId++, "server1");
+    waitForStatsUpdate(manager, requestId);
+    manager.recordStatsUponResponseArrival(requestId++, "server1", 100);
+    waitForStatsUpdate(manager, requestId);
+    assertEquals(manager.fetchEMALatencyForServer("server1"), 100.0);
+
+    TestUtils.waitForCondition(aVoid -> manager.fetchEMALatencyForServer("server1") == 0.0,
+        10L, 5000, "Expected latency EMA to decay with the initial auto-decay window");
+
+    // Change autodecay window to a very large value so decay threshold is never met.
+    manager.onChange(
+        Set.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AUTODECAY_WINDOW_MS),
+        Map.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AUTODECAY_WINDOW_MS, "999999"));
+    assertEquals(manager.getAutoDecayWindowMs(), 999999);
+
+    manager.recordStatsForQuerySubmission(requestId++, "server1");
+    waitForStatsUpdate(manager, requestId);
+    manager.recordStatsUponResponseArrival(requestId++, "server1", 100);
+    waitForStatsUpdate(manager, requestId);
+    assertEquals(manager.fetchEMALatencyForServer("server1"), 100.0);
+  }
+
+  @Test
+  public void testDynamicAutoDecayWindowChangeFromDisabled() {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_COLLECTION, true);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA, 1.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AUTODECAY_WINDOW_MS, -1);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_WARMUP_DURATION_MS, 0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AVG_INITIALIZATION_VAL, 0.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT, 3);
+    ServerRoutingStatsManager manager = new ServerRoutingStatsManager(new PinotConfiguration(properties),
+        _brokerMetrics);
+    manager.init();
+
+    int requestId = 0;
+    manager.recordStatsForQuerySubmission(requestId++, "server1");
+    waitForStatsUpdate(manager, requestId);
+    manager.recordStatsUponResponseArrival(requestId++, "server1", 100);
+    waitForStatsUpdate(manager, requestId);
+    assertEquals(manager.fetchEMALatencyForServer("server1"), 100.0);
+
+    manager.onChange(
+        Set.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AUTODECAY_WINDOW_MS),
+        Map.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AUTODECAY_WINDOW_MS, "50"));
+
+    TestUtils.waitForCondition(aVoid -> manager.fetchEMALatencyForServer("server1") == 0.0,
+        10L, 5000, "Expected latency EMA to decay after enabling auto-decay at runtime");
+  }
+
+  @Test
+  public void testDynamicChangePropagatesBothSseAndMse() {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_COLLECTION, true);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA, 1.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AUTODECAY_WINDOW_MS, -1);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_WARMUP_DURATION_MS, 0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AVG_INITIALIZATION_VAL, 0.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT, 3);
+    ServerRoutingStatsManager manager = new ServerRoutingStatsManager(new PinotConfiguration(properties),
+        _brokerMetrics);
+    manager.init();
+
+    int requestId = 0;
+
+    // Create entries in both SSE and MSE maps.
+    try (QueryThreadContext ignored = QueryThreadContext.openForSseTest()) {
+      manager.recordStatsForQuerySubmission(requestId++, "server1");
+    }
+    try (QueryThreadContext ignored = QueryThreadContext.openForMseTest()) {
+      manager.recordStatsForQuerySubmission(requestId++, "server1");
+    }
+    waitForStatsUpdate(manager, requestId);
+
+    try (QueryThreadContext ignored = QueryThreadContext.openForSseTest()) {
+      manager.recordStatsUponResponseArrival(requestId++, "server1", 10);
+    }
+    try (QueryThreadContext ignored = QueryThreadContext.openForMseTest()) {
+      manager.recordStatsUponResponseArrival(requestId++, "server1", 20);
+    }
+    waitForStatsUpdate(manager, requestId);
+
+    // With exponent=3: SSE=(0+1)^3*10=10, MSE=(0+1)^3*20=20.
+    try (QueryThreadContext ignored = QueryThreadContext.openForSseTest()) {
+      assertEquals(manager.fetchHybridScoreForServer("server1"), 10.0);
+    }
+    try (QueryThreadContext ignored = QueryThreadContext.openForMseTest()) {
+      assertEquals(manager.fetchHybridScoreForServer("server1"), 20.0);
+    }
+
+    // Change exponent to 1. Both maps should be updated.
+    manager.onChange(
+        Set.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT),
+        Map.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT, "1"));
+
+    // With exponent=1: SSE=(0+1)^1*10=10, MSE=(0+1)^1*20=20.
+    try (QueryThreadContext ignored = QueryThreadContext.openForSseTest()) {
+      assertEquals(manager.fetchHybridScoreForServer("server1"), 10.0);
+    }
+    try (QueryThreadContext ignored = QueryThreadContext.openForMseTest()) {
+      assertEquals(manager.fetchHybridScoreForServer("server1"), 20.0);
+    }
+
+    // Submit more queries so numInFlight=1, inFlightEMA=1 for both.
+    try (QueryThreadContext ignored = QueryThreadContext.openForSseTest()) {
+      manager.recordStatsForQuerySubmission(requestId++, "server1");
+    }
+    try (QueryThreadContext ignored = QueryThreadContext.openForMseTest()) {
+      manager.recordStatsForQuerySubmission(requestId++, "server1");
+    }
+    waitForStatsUpdate(manager, requestId);
+
+    // With exponent=1: SSE=(1+1)^1*10=20, MSE=(1+1)^1*20=40.
+    try (QueryThreadContext ignored = QueryThreadContext.openForSseTest()) {
+      assertEquals(manager.fetchHybridScoreForServer("server1"), 20.0);
+    }
+    try (QueryThreadContext ignored = QueryThreadContext.openForMseTest()) {
+      assertEquals(manager.fetchHybridScoreForServer("server1"), 40.0);
+    }
+  }
+
   private void assertStatsNullForInstance(ServerRoutingStatsManager manager, String instanceId) {
     Integer numInFlightReq = manager.fetchNumInFlightRequestsForServer(instanceId);
     assertNull(numInFlightReq);


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Config change triggers manager to update parameter and propagate to all entries; entries update state directly \(exponent\) or via EMA setters \(alpha/autodecay\)\.

```mermaid
flowchart TD
  N0["ServerRoutingStatsManager#46;onChange #40;F3#41;"]:::stModified
  N1["ServerRoutingStatsManager#46;setAlpha #40;F3#41;"]:::stModified
  N2["ServerRoutingStatsManager#46;updateAllEntries #40;F3#41;"]:::stModified
  N3["ServerRoutingStatsEntry#46;setAlpha #40;F2#41;"]:::stModified
  N4["ExponentialMovingAverage#46;setAlpha #40;F1#41;"]:::stModified
  N0 --> N1
  N1 --> N2
  N2 --> N3
  N3 --> N4
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-common/src/main/java/org/apache/pinot/common/utils/ExponentialMovingAverage\.java — [before](https://github.com/apache/pinot/blob/a0d00297153b58d0fe79f1146bef51668abcbc3c/pinot-common/src/main/java/org/apache/pinot/common/utils/ExponentialMovingAverage.java) · [after](https://github.com/apache/pinot/blob/c8d5cee856c6bfebcdf02d256640c43e819c2513/pinot-common/src/main/java/org/apache/pinot/common/utils/ExponentialMovingAverage.java)
- F2: pinot\-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsEntry\.java — [before](https://github.com/apache/pinot/blob/a0d00297153b58d0fe79f1146bef51668abcbc3c/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsEntry.java) · [after](https://github.com/apache/pinot/blob/c8d5cee856c6bfebcdf02d256640c43e819c2513/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsEntry.java)
- F3: pinot\-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager\.java — [before](https://github.com/apache/pinot/blob/a0d00297153b58d0fe79f1146bef51668abcbc3c/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java) · [after](https://github.com/apache/pinot/blob/c8d5cee856c6bfebcdf02d256640c43e819c2513/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImEwZDAwMjk3MTUzYjU4ZDBmZTc5ZjExNDZiZWY1MTY2OGFiY2JjM2MiLCJjb250ZXh0X2hhc2giOiI1ODA5MWZiZDczZDQyOGQ0MDYwN2JmMDI4Mzg5MGE4MDJmY2FmOWMwMzVmZDBhMTc5MTIxNmE1YjI4YmY4ZjA4IiwiZ2VuZXJhdGVkX2F0IjoxNzg4OTE4MDU1LCJoZWFkX3NoYSI6ImM4ZDVjZWU4NTZjNmJmZWJjZGYwMmQyNTY2NDBjNDNlODE5YzI1MTMiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJhMGQwMDI5NzE1M2I1OGQwZmU3OWYxMTQ2YmVmNTE2NjhhYmNiYzNjIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature bd0f70ee0551397840ed5695299e74d7d779f6fa70e62746ca46650e965880dc -->
<!-- pinot-pr-flow:end -->

### Summary

Makes three adaptive routing parameters adjustable at runtime via cluster config changes:
- `hybrid.score.exponent` — the exponent used in the hybrid score formula `(O+A+B)^N * C`
- `ewma.alpha` — the smoothing factor for exponential moving averages (latency and in-flight requests)
- `autodecay.window.ms` — the time threshold after which EMA values auto-decay toward zero

When any of these configs change, the new value is propagated to all existing `ServerRoutingStatsEntry` instances in both the SSE and MSE stats maps. New entries created after the change also use the updated values.

### Motivation
Make it easier to tune adaptive routing!

### Testing
We've deployed this internally and used it to tune all three variables. 

The testing we did before merging internally:

Deployed to a QA cluster. 

```
curl -X POST localhost:9000/cluster/configs -H "Content-Type: application/json" -d '{"pinot.broker.adaptive.server.selector.ewma.alpha": "0"}'
{"status":"Updated cluster config."}
```
<img width="1482" height="458" alt="image" src="https://github.com/user-attachments/assets/194a890f-8e43-4337-909b-5400fb761635" />


```
curl -X POST localhost:9000/cluster/configs -H "Content-Type: application/json" -d '{"pinot.broker.adaptive.server.selector.hybrid.score.exponent": "0"}'
{"status":"Updated cluster config."}
```
Harder to prove it worked, but we do see `Updated EWMA alpha to 0.0 and propagated to all entries.` in the logs. 

```
curl -X POST localhost:9000/cluster/configs -H "Content-Type: application/json" -d '{"pinot.broker.adaptive.server.selector.autodecay.window.ms": "100000"}'
{"status":"Updated cluster config."}
```
<img width="1476" height="520" alt="image" src="https://github.com/user-attachments/assets/d0581026-4684-402e-b6b3-8cfd032b6ad0" />

We can see the stats stay high for a lot longer before they drop down.