### PR TITLE
Rename PinotDataType.INTEGER to INT for naming consistency

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionUtils.java
@@ -37,8 +37,8 @@ public class FunctionUtils {
 
   // Types allowed as the function parameter (in the function signature) for type conversion
   private static final Map<Class<?>, PinotDataType> PARAMETER_TYPE_MAP = new HashMap<>() {{
-      put(int.class, PinotDataType.INTEGER);
-      put(Integer.class, PinotDataType.INTEGER);
+      put(int.class, PinotDataType.INT);
+      put(Integer.class, PinotDataType.INT);
       put(long.class, PinotDataType.LONG);
       put(Long.class, PinotDataType.LONG);
       put(float.class, PinotDataType.FLOAT);

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DataTypeConversionFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DataTypeConversionFunctions.java
@@ -62,10 +62,10 @@ public class DataTypeConversionFunctions {
       case "DECIMAL":
         targetDataType = BIG_DECIMAL;
         break;
-      case "INT":
+      case "INTEGER":
       case "UTINYINT":
       case "USMALLINT":
-        targetDataType = INTEGER;
+        targetDataType = INT;
         break;
       case "VARBINARY":
         targetDataType = BYTES;
@@ -81,9 +81,9 @@ public class DataTypeConversionFunctions {
         }
         break;
     }
-    if (sourceType == STRING && (targetDataType == INTEGER || targetDataType == LONG)) {
+    if (sourceType == STRING && (targetDataType == INT || targetDataType == LONG)) {
       String stringValue = value.toString().trim();
-      if (targetDataType == INTEGER) {
+      if (targetDataType == INT) {
         try {
           return Integer.parseInt(stringValue);
         } catch (NumberFormatException e) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
@@ -71,7 +71,7 @@ public class LiteralContext {
       case INT_VALUE:
         _type = DataType.INT;
         _value = literal.getIntValue();
-        _pinotDataType = PinotDataType.INTEGER;
+        _pinotDataType = PinotDataType.INT;
         break;
       case LONG_VALUE:
         _type = DataType.LONG;
@@ -159,7 +159,7 @@ public class LiteralContext {
         Preconditions.checkState(singleValue, "Boolean array is not supported");
         return PinotDataType.BOOLEAN;
       case INT:
-        return singleValue ? PinotDataType.INTEGER : PinotDataType.PRIMITIVE_INT_ARRAY;
+        return singleValue ? PinotDataType.INT : PinotDataType.PRIMITIVE_INT_ARRAY;
       case LONG:
         return singleValue ? PinotDataType.LONG : PinotDataType.PRIMITIVE_LONG_ARRAY;
       case FLOAT:

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
@@ -954,7 +954,7 @@ public class DataSchema {
     public PinotDataType toPinotDataType() {
       switch (this) {
         case INT:
-          return PinotDataType.INTEGER;
+          return PinotDataType.INT;
         case LONG:
           return PinotDataType.LONG;
         case FLOAT:

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/FunctionUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/FunctionUtilsTest.java
@@ -38,7 +38,7 @@ public class FunctionUtilsTest {
   @Test
   public void testGetArgumentType() {
     // Single values delegated to PinotDataType.getSingleValueType
-    assertEquals(FunctionUtils.getArgumentType(1), PinotDataType.INTEGER);
+    assertEquals(FunctionUtils.getArgumentType(1), PinotDataType.INT);
     assertEquals(FunctionUtils.getArgumentType(1L), PinotDataType.LONG);
     assertEquals(FunctionUtils.getArgumentType(1.0f), PinotDataType.FLOAT);
     assertEquals(FunctionUtils.getArgumentType(1.0d), PinotDataType.DOUBLE);
@@ -80,7 +80,7 @@ public class FunctionUtilsTest {
   @Test
   public void testGetArgumentTypeForReferenceArrays() {
     // Reference arrays sample first non-null element via PinotDataType.getMultiValueType
-    assertEquals(FunctionUtils.getArgumentType(new Integer[]{1}), PinotDataType.INTEGER_ARRAY);
+    assertEquals(FunctionUtils.getArgumentType(new Integer[]{1}), PinotDataType.INT_ARRAY);
     assertEquals(FunctionUtils.getArgumentType(new Long[]{1L}), PinotDataType.LONG_ARRAY);
     assertEquals(FunctionUtils.getArgumentType(new Float[]{1.0f}), PinotDataType.FLOAT_ARRAY);
     assertEquals(FunctionUtils.getArgumentType(new Double[]{1.0d}), PinotDataType.DOUBLE_ARRAY);
@@ -117,8 +117,8 @@ public class FunctionUtilsTest {
   @Test
   public void testGetParameterType() {
     // Scalars
-    assertEquals(FunctionUtils.getParameterType(int.class), PinotDataType.INTEGER);
-    assertEquals(FunctionUtils.getParameterType(Integer.class), PinotDataType.INTEGER);
+    assertEquals(FunctionUtils.getParameterType(int.class), PinotDataType.INT);
+    assertEquals(FunctionUtils.getParameterType(Integer.class), PinotDataType.INT);
     assertEquals(FunctionUtils.getParameterType(boolean.class), PinotDataType.BOOLEAN);
     assertEquals(FunctionUtils.getParameterType(Boolean.class), PinotDataType.BOOLEAN);
     assertEquals(FunctionUtils.getParameterType(Timestamp.class), PinotDataType.TIMESTAMP);

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/DataTypeConversionFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/DataTypeConversionFunctionsTest.java
@@ -81,6 +81,15 @@ public class DataTypeConversionFunctionsTest {
   }
 
   @Test
+  public void testCastToIntegerLiteral() {
+    // `INTEGER` was the PinotDataType enum name before it was renamed to `INT`. It is kept as an explicit cast literal
+    // for backward compatibility so existing `CAST(x AS INTEGER)` queries keep working; both literals resolve to INT.
+    assertEquals(DataTypeConversionFunctions.cast(10L, "INTEGER"), 10);
+    assertEquals(DataTypeConversionFunctions.cast(10L, "INT"), 10);
+    assertEquals(DataTypeConversionFunctions.cast("10.0", "INTEGER"), 10);
+  }
+
+  @Test
   public void testHexDecimalToLong() {
     assertEquals(hexDecimalToLong("0"), 0L);
     assertEquals(hexDecimalToLong("1"), 1L);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapper.java
@@ -103,7 +103,7 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
             break;
           case INT:
             _scalarArguments[i] =
-                parameterTypes[i].convert(literalTransformFunction.getIntLiteral(), PinotDataType.INTEGER);
+                parameterTypes[i].convert(literalTransformFunction.getIntLiteral(), PinotDataType.INT);
             break;
           case LONG:
             _scalarArguments[i] =
@@ -383,7 +383,7 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
       PinotDataType parameterType = parameterTypes[_nonLiteralIndices[i]];
       TransformFunction transformFunction = _nonLiteralFunctions[i];
       switch (parameterType) {
-        case INTEGER:
+        case INT:
           _nonLiteralValues[i] = ArrayUtils.toObject(transformFunction.transformToIntValuesSV(valueBlock));
           break;
         case LONG:

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunctionTest.java
@@ -207,7 +207,7 @@ public class AvgAggregationFunctionTest extends AbstractAggregationFunctionTest 
                 + "group by key "
                 + "order by key")
         .thenResultIs(
-            "INTEGER | DOUBLE",
+            "INT | DOUBLE",
             "5   |  3",
             "6   |  2",
             "7   |  1"
@@ -241,7 +241,7 @@ public class AvgAggregationFunctionTest extends AbstractAggregationFunctionTest 
                 + "group by key1, key2 "
                 + "order by key1, key2")
         .thenResultIs(
-            "INTEGER | INTEGER | LONG",
+            "INT | INT | LONG",
             "5   |  3  |  2",
             "6   |  2  |  2",
             "7   |  1  |  2"

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunctionTest.java
@@ -45,7 +45,7 @@ public class CountAggregationFunctionTest extends AbstractAggregationFunctionTes
             new Object[] {null}
         )
         .whenQuery("select myField from testTable order by myField")
-        .thenResultIs("INTEGER",
+        .thenResultIs("INT",
             "-2147483648",
             "1",
             "2"
@@ -65,7 +65,7 @@ public class CountAggregationFunctionTest extends AbstractAggregationFunctionTes
             new Object[] {null}
         )
         .whenQuery("select myField from testTable order by myField")
-        .thenResultIs("INTEGER",
+        .thenResultIs("INT",
             "1",
             "2",
             "null"
@@ -87,7 +87,7 @@ public class CountAggregationFunctionTest extends AbstractAggregationFunctionTes
             "null"
         )
         .whenQuery("select myField, COUNT(myField) from testTable group by myField order by myField")
-        .thenResultIs("INTEGER | LONG",
+        .thenResultIs("INT | LONG",
             "-2147483648 | 1",
             "1           | 1",
             "2           | 1"
@@ -111,7 +111,7 @@ public class CountAggregationFunctionTest extends AbstractAggregationFunctionTes
         )
         .whenQuery("select myField, COUNT(myField) from testTable group by myField order by myField")
         .thenResultIs(
-            "INTEGER | LONG",
+            "INT | LONG",
             "1    | 1",
             "2    | 1",
             "null | 0"
@@ -133,7 +133,7 @@ public class CountAggregationFunctionTest extends AbstractAggregationFunctionTes
             "null"
         )
         .whenQuery("select myField, COUNT(*) from testTable group by myField order by myField")
-        .thenResultIs("INTEGER | LONG",
+        .thenResultIs("INT | LONG",
             "-2147483648 | 1",
             "1    | 1",
             "2    | 1"
@@ -155,7 +155,7 @@ public class CountAggregationFunctionTest extends AbstractAggregationFunctionTes
             "null"
         )
         .whenQuery("select myField, COUNT(*) from testTable group by myField order by myField")
-        .thenResultIs("INTEGER | LONG",
+        .thenResultIs("INT | LONG",
             "1    | 1",
             "2    | 1",
             "null | 1"

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctAggregationFunctionTest.java
@@ -49,7 +49,7 @@ public class DistinctAggregationFunctionTest extends AbstractAggregationFunction
             "null",
             "null"
         ).whenQuery("select count(distinct myField) from testTable")
-        .thenResultIs("INTEGER", "1");
+        .thenResultIs("INT", "1");
   }
 
   @Test(dataProvider = "scenarios")
@@ -64,7 +64,7 @@ public class DistinctAggregationFunctionTest extends AbstractAggregationFunction
             "null",
             "null"
         ).whenQuery("select count(distinct myField) from testTable")
-        .thenResultIs("INTEGER", "0");
+        .thenResultIs("INT", "0");
   }
 
   @Test(dataProvider = "scenarios")
@@ -79,7 +79,7 @@ public class DistinctAggregationFunctionTest extends AbstractAggregationFunction
             "null",
             "null"
         ).whenQuery("select 'literal', count(distinct myField) from testTable group by 'literal'")
-        .thenResultIs("STRING | INTEGER", "literal | 1");
+        .thenResultIs("STRING | INT", "literal | 1");
   }
 
   @Test(dataProvider = "scenarios")
@@ -94,7 +94,7 @@ public class DistinctAggregationFunctionTest extends AbstractAggregationFunction
             "null",
             "null"
         ).whenQuery("select 'literal', count(distinct myField) from testTable group by 'literal'")
-        .thenResultIs("STRING | INTEGER", "literal | 0");
+        .thenResultIs("STRING | INT", "literal | 0");
   }
 
   @Test(dataProvider = "scenarios")
@@ -110,7 +110,7 @@ public class DistinctAggregationFunctionTest extends AbstractAggregationFunction
             "null",
             "null"
         ).whenQuery("select count(distinct myField) from testTable")
-        .thenResultIs("INTEGER", "3");
+        .thenResultIs("INT", "3");
   }
 
   @Test(dataProvider = "scenarios")
@@ -126,7 +126,7 @@ public class DistinctAggregationFunctionTest extends AbstractAggregationFunction
             "null",
             "null"
         ).whenQuery("select count(distinct myField) from testTable")
-        .thenResultIs("INTEGER", "2");
+        .thenResultIs("INT", "2");
   }
 
   @Test(dataProvider = "scenarios")
@@ -141,7 +141,7 @@ public class DistinctAggregationFunctionTest extends AbstractAggregationFunction
             "3",
             "2"
         ).whenQuery("select 'literal', count(distinct myField) from testTable group by 'literal'")
-        .thenResultIs("STRING | INTEGER", "literal | 3");
+        .thenResultIs("STRING | INT", "literal | 3");
   }
 
   @Test(dataProvider = "scenarios")
@@ -164,14 +164,14 @@ public class DistinctAggregationFunctionTest extends AbstractAggregationFunction
         )
         .whenQuery("select tags, count(distinct value) from testTable group by tags order by tags")
         .thenResultIs(
-            "STRING | INTEGER",
+            "STRING | INT",
             "tag1    | 2",
             "tag2    | 3",
             "tag3    | 1")
         .whenQueryWithNullHandlingEnabled("select tags, count(distinct value) from testTable group by tags "
             + "order by tags")
         .thenResultIs(
-            "STRING | INTEGER",
+            "STRING | INT",
             "tag1    | 2",
             "tag2    | 2",
             "tag3    | 0"
@@ -190,7 +190,7 @@ public class DistinctAggregationFunctionTest extends AbstractAggregationFunction
             "null",
             "null"
         ).whenQuery("select sum(distinct myField) from testTable")
-        .thenResultIs("INTEGER", "null");
+        .thenResultIs("INT", "null");
   }
 
   @Test(dataProvider = "scenarios")

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctAvgAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctAvgAggregationFunctionTest.java
@@ -68,14 +68,14 @@ public class DistinctAvgAggregationFunctionTest extends AbstractAggregationFunct
             "null"
         )
         .whenQuery("select myField, DISTINCT_AVG(myField) from testTable group by myField order by myField")
-        .thenResultIs("INTEGER | DOUBLE",
+        .thenResultIs("INT | DOUBLE",
             "-2147483648 | " + FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_INT,
             "1           | 1",
             "2           | 2"
         )
         .whenQueryWithNullHandlingEnabled(
             "select myField, DISTINCT_AVG(myField) from testTable  group by myField order by myField")
-        .thenResultIs("INTEGER | DOUBLE",
+        .thenResultIs("INT | DOUBLE",
             "1    | 1",
             "2    | 2",
             "null | null"

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountAggregationFunctionTest.java
@@ -43,10 +43,10 @@ public class DistinctCountAggregationFunctionTest extends AbstractAggregationFun
             "null"
         )
         .whenQuery("select DISTINCT_COUNT(myField) from testTable")
-        .thenResultIs("INTEGER",
+        .thenResultIs("INT",
             "3"
         ).whenQueryWithNullHandlingEnabled("select DISTINCT_COUNT(myField) from testTable")
-        .thenResultIs("INTEGER",
+        .thenResultIs("INT",
             "2"
         );
   }
@@ -68,14 +68,14 @@ public class DistinctCountAggregationFunctionTest extends AbstractAggregationFun
             "null"
         )
         .whenQuery("select myField, DISTINCT_COUNT(myField) from testTable group by myField order by myField")
-        .thenResultIs("INTEGER | INTEGER",
+        .thenResultIs("INT | INT",
             "-2147483648 | 1",
             "1           | 1",
             "2           | 1"
         )
         .whenQueryWithNullHandlingEnabled(
             "select myField, DISTINCT_COUNT(myField) from testTable  group by myField order by myField")
-        .thenResultIs("INTEGER | INTEGER",
+        .thenResultIs("INT | INT",
             "1    | 1",
             "2    | 1",
             "null | 0"
@@ -102,7 +102,7 @@ public class DistinctCountAggregationFunctionTest extends AbstractAggregationFun
         )
         .whenQuery("select tags, DISTINCT_COUNT(value) from testTable group by tags order by tags")
         .thenResultIs(
-            "STRING | INTEGER",
+            "STRING | INT",
             "tag1    | 1",
             "tag2    | 2",
             "tag3    | 1"
@@ -110,7 +110,7 @@ public class DistinctCountAggregationFunctionTest extends AbstractAggregationFun
         .whenQueryWithNullHandlingEnabled(
             "select tags, DISTINCT_COUNT(value) from testTable group by tags order by tags")
         .thenResultIs(
-            "STRING | INTEGER",
+            "STRING | INT",
             "tag1    | 1",
             "tag2    | 1",
             "tag3    | 0"
@@ -135,7 +135,7 @@ public class DistinctCountAggregationFunctionTest extends AbstractAggregationFun
             new Object[]{"9;10;11;12"}
         )
         .whenQuery("select DISTINCT_COUNT(mv) from testTable")
-        .thenResultIs("INTEGER", "12");
+        .thenResultIs("INT", "12");
   }
 
   @Test
@@ -156,9 +156,9 @@ public class DistinctCountAggregationFunctionTest extends AbstractAggregationFun
             new Object[]{"1;2"}
         )
         .whenQuery("select DISTINCT_COUNT(mv) from testTable")
-        .thenResultIs("INTEGER", "3")
+        .thenResultIs("INT", "3")
         .whenQueryWithNullHandlingEnabled("select DISTINCT_COUNT(mv) from testTable")
-        .thenResultIs("INTEGER", "2");
+        .thenResultIs("INT", "2");
   }
 
   @Test
@@ -179,9 +179,9 @@ public class DistinctCountAggregationFunctionTest extends AbstractAggregationFun
             new Object[]{"1;2", "k1"}
         )
         .whenQuery("select DISTINCT_COUNT(mv) from testTable group by sv")
-        .thenResultIs("INTEGER", "3")
+        .thenResultIs("INT", "3")
         .whenQueryWithNullHandlingEnabled("select DISTINCT_COUNT(mv) from testTable group by sv")
-        .thenResultIs("INTEGER", "2");
+        .thenResultIs("INT", "2");
   }
 
   @Test
@@ -200,7 +200,7 @@ public class DistinctCountAggregationFunctionTest extends AbstractAggregationFun
             "3.5"
         )
         .whenQuery("select DISTINCT_COUNT(myField) from testTable")
-        .thenResultIs("INTEGER", "3");
+        .thenResultIs("INT", "3");
   }
 
   @Test
@@ -222,7 +222,7 @@ public class DistinctCountAggregationFunctionTest extends AbstractAggregationFun
             new Object[]{"b", "3.5"}
         )
         .whenQuery("select grp, DISTINCT_COUNT(value) from testTable group by grp order by grp")
-        .thenResultIs("STRING | INTEGER",
+        .thenResultIs("STRING | INT",
             "a | 2",
             "b | 1"
         );
@@ -244,7 +244,7 @@ public class DistinctCountAggregationFunctionTest extends AbstractAggregationFun
             new Object[]{"3.5;4.5"}
         )
         .whenQuery("select DISTINCT_COUNT(mv) from testTable")
-        .thenResultIs("INTEGER", "4");
+        .thenResultIs("INT", "4");
   }
 
   @Test
@@ -265,7 +265,7 @@ public class DistinctCountAggregationFunctionTest extends AbstractAggregationFun
             new Object[]{"b", "3.5;4.5"}
         )
         .whenQuery("select grp, DISTINCT_COUNT(mv) from testTable group by grp order by grp")
-        .thenResultIs("STRING | INTEGER",
+        .thenResultIs("STRING | INT",
             "a | 3",
             "b | 2"
         );
@@ -286,7 +286,7 @@ public class DistinctCountAggregationFunctionTest extends AbstractAggregationFun
             new Object[]{"b;c", "2.5;3.5"}
         )
         .whenQuery("select grp, DISTINCT_COUNT(mv) from testTable group by grp order by grp")
-        .thenResultIs("STRING | INTEGER",
+        .thenResultIs("STRING | INT",
             "a | 2",
             "b | 3",
             "c | 2"
@@ -312,8 +312,8 @@ public class DistinctCountAggregationFunctionTest extends AbstractAggregationFun
             new Object[]{"1;2", "k1;k2"}
         )
         .whenQuery("select DISTINCT_COUNT(mv1) from testTable group by mv2")
-        .thenResultIs("INTEGER", "3", "3")
+        .thenResultIs("INT", "3", "3")
         .whenQueryWithNullHandlingEnabled("select DISTINCT_COUNT(mv1) from testTable group by mv2")
-        .thenResultIs("INTEGER", "2", "2");
+        .thenResultIs("INT", "2", "2");
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountBitmapMVAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountBitmapMVAggregationFunctionTest.java
@@ -43,7 +43,7 @@ public class DistinctCountBitmapMVAggregationFunctionTest extends AbstractAggreg
         )
         // Distinct values: 1, 2, 3, 4 = 4 distinct
         .whenQuery("select distinctcountbitmap(mv) from testTable")
-        .thenResultIs("INTEGER", "4");
+        .thenResultIs("INT", "4");
   }
 
   @Test
@@ -65,7 +65,7 @@ public class DistinctCountBitmapMVAggregationFunctionTest extends AbstractAggreg
             new Object[]{"5;6", "k2"}
         )
         .whenQuery("select sv, distinctcountbitmap(mv) from testTable group by sv order by sv")
-        .thenResultIs("STRING | INTEGER",
+        .thenResultIs("STRING | INT",
             "k1 | 3",   // distinct: 1, 2, 3
             "k2 | 3");  // distinct: 4, 5, 6
   }
@@ -88,7 +88,7 @@ public class DistinctCountBitmapMVAggregationFunctionTest extends AbstractAggreg
             new Object[]{"2;3", "tag1;tag2"}
         )
         .whenQuery("select tags, distinctcountbitmap(nums) from testTable group by tags order by tags")
-        .thenResultIs("STRING | INTEGER",
+        .thenResultIs("STRING | INT",
             "tag1 | 3",   // distinct: 1, 2, 3
             "tag2 | 3");  // distinct: 1, 2, 3
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctSumAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctSumAggregationFunctionTest.java
@@ -68,14 +68,14 @@ public class DistinctSumAggregationFunctionTest extends AbstractAggregationFunct
             "null"
         )
         .whenQuery("select myField, DISTINCT_SUM(myField) from testTable group by myField order by myField")
-        .thenResultIs("INTEGER | DOUBLE",
+        .thenResultIs("INT | DOUBLE",
             "-2147483648 | " + FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_INT,
             "1           | 1",
             "2           | 2"
         )
         .whenQueryWithNullHandlingEnabled(
             "select myField, DISTINCT_SUM(myField) from testTable  group by myField order by myField")
-        .thenResultIs("INTEGER | DOUBLE",
+        .thenResultIs("INT | DOUBLE",
             "1    | 1",
             "2    | 2",
             "null | null"

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/FirstWithTimeAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/FirstWithTimeAggregationFunctionTest.java
@@ -54,8 +54,7 @@ public class FirstWithTimeAggregationFunctionTest extends AbstractAggregationFun
       _valAsStr1 = valAsStr1;
       _valAsStr2 = valAsStr2;
       _defaultNullValue = defaultNullValue;
-      _pinotDataType =
-          _dataType == FieldSpec.DataType.INT ? PinotDataType.INTEGER : PinotDataType.valueOf(_dataType.name());
+      _pinotDataType = PinotDataType.valueOf(dataType.name());
     }
 
     public FluentQueryTest.DeclaringTable getDeclaringTable(boolean nullHandlingEnabled) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/LastWithTimeAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/LastWithTimeAggregationFunctionTest.java
@@ -54,8 +54,7 @@ public class LastWithTimeAggregationFunctionTest extends AbstractAggregationFunc
       _valAsStr1 = valAsStr1;
       _valAsStr2 = valAsStr2;
       _defaultNullValue = defaultNullValue;
-      _pinotDataType =
-          _dataType == FieldSpec.DataType.INT ? PinotDataType.INTEGER : PinotDataType.valueOf(_dataType.name());
+      _pinotDataType = PinotDataType.valueOf(dataType.name());
     }
 
     public FluentQueryTest.DeclaringTable getDeclaringTable(boolean nullHandlingEnabled) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunctionTest.java
@@ -137,8 +137,7 @@ public class MinMaxRangeAggregationFunctionTest extends AbstractAggregationFunct
 
   @Test(dataProvider = "scenarios")
   void aggrSvSelfWithoutNull(DataTypeScenario scenario) {
-    PinotDataType pinotDataType = scenario.getDataType() == FieldSpec.DataType.INT
-        ? PinotDataType.INTEGER : PinotDataType.valueOf(scenario.getDataType().name());
+    PinotDataType pinotDataType = PinotDataType.valueOf(scenario.getDataType().name());
 
     Object defaultNullValue;
     switch (scenario.getDataType()) {
@@ -176,8 +175,7 @@ public class MinMaxRangeAggregationFunctionTest extends AbstractAggregationFunct
 
   @Test(dataProvider = "scenarios")
   void aggrSvSelfWithNull(DataTypeScenario scenario) {
-    PinotDataType pinotDataType = scenario.getDataType() == FieldSpec.DataType.INT
-        ? PinotDataType.INTEGER : PinotDataType.valueOf(scenario.getDataType().name());
+    PinotDataType pinotDataType = PinotDataType.valueOf(scenario.getDataType().name());
 
     scenario.getDeclaringTable(true)
         .onFirstInstance("myField",

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/ModeAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/ModeAggregationFunctionTest.java
@@ -174,8 +174,7 @@ public class ModeAggregationFunctionTest extends AbstractAggregationFunctionTest
 
   @Test(dataProvider = "scenarios")
   void aggrSvSelfWithoutNull(Scenario scenario) {
-    PinotDataType pinotDataType = scenario._dataType == FieldSpec.DataType.INT
-        ? PinotDataType.INTEGER : PinotDataType.valueOf(scenario._dataType.name());
+    PinotDataType pinotDataType = PinotDataType.valueOf(scenario._dataType.name());
 
     Object defaultNullValue;
     switch (scenario._dataType) {
@@ -213,8 +212,7 @@ public class ModeAggregationFunctionTest extends AbstractAggregationFunctionTest
 
   @Test(dataProvider = "scenarios")
   void aggrSvSelfWithNull(Scenario scenario) {
-    PinotDataType pinotDataType = scenario._dataType == FieldSpec.DataType.INT
-        ? PinotDataType.INTEGER : PinotDataType.valueOf(scenario._dataType.name());
+    PinotDataType pinotDataType = PinotDataType.valueOf(scenario._dataType.name());
 
     scenario.getDeclaringTable(true)
         .onFirstInstance("myField",

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/selection/SelectionOrderByTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/selection/SelectionOrderByTest.java
@@ -292,7 +292,7 @@ public class SelectionOrderByTest {
             new Object[]{null}
         )
         .whenQuery("select myField from testTable order by myField")
-        .thenResultIs("INTEGER",
+        .thenResultIs("INT",
             "-2147483648",
             "1",
             "2",
@@ -314,7 +314,7 @@ public class SelectionOrderByTest {
             new Object[]{null}
         )
         .whenQuery("select myField from testTable order by myField")
-        .thenResultIs("INTEGER",
+        .thenResultIs("INT",
             "1",
             "2",
             "3",
@@ -336,7 +336,7 @@ public class SelectionOrderByTest {
             new Object[]{null, null}
         )
         .whenQuery("select field1, field2 from testTable2 order by field1")
-        .thenResultIs("INTEGER|INTEGER",
+        .thenResultIs("INT|INT",
             "-2147483648|-2147483648",
             "1|5",
             "2|3",
@@ -358,7 +358,7 @@ public class SelectionOrderByTest {
             new Object[]{null, 2}
         )
         .whenQuery("select field1, field2 from testTable2 order by field1")
-        .thenResultIs("INTEGER|INTEGER",
+        .thenResultIs("INT|INT",
             "1|5",
             "2|3",
             "3|4",
@@ -380,7 +380,7 @@ public class SelectionOrderByTest {
             new Object[]{null, 2}
         )
         .whenQuery("select field1, field2 from testTable2 order by field1 nulls first")
-        .thenResultIs("INTEGER|INTEGER",
+        .thenResultIs("INT|INT",
             "null|2",
             "1|5",
             "2|3",
@@ -402,7 +402,7 @@ public class SelectionOrderByTest {
             new Object[]{null, null}
         )
         .whenQuery("select field1, field2 from testTable2 order by field1 desc")
-        .thenResultIs("INTEGER|INTEGER",
+        .thenResultIs("INT|INT",
             "3|4",
             "2|3",
             "1|5",
@@ -425,7 +425,7 @@ public class SelectionOrderByTest {
             new Object[]{null, 2}
         )
         .whenQuery("select field1, field2 from testTable2 order by field1 desc")
-        .thenResultIs("INTEGER|INTEGER",
+        .thenResultIs("INT|INT",
             "null|2",
             "4|4",
             "3|0",
@@ -449,7 +449,7 @@ public class SelectionOrderByTest {
             new Object[]{null, 2}
         )
         .whenQuery("select field1, field2 from testTable2 order by field1 desc nulls last")
-        .thenResultIs("INTEGER|INTEGER",
+        .thenResultIs("INT|INT",
             "4|4",
             "3|0",
             "2|3",
@@ -473,7 +473,7 @@ public class SelectionOrderByTest {
             new Object[]{null, 2}
         )
         .whenQuery("select field1, field2 from testTable2 order by field1, field2")
-        .thenResultIs("INTEGER|INTEGER",
+        .thenResultIs("INT|INT",
             "-2147483648|2",
             "1|5",
             "2|3",
@@ -498,7 +498,7 @@ public class SelectionOrderByTest {
             new Object[]{null, 2}
         )
         .whenQuery("select field1, field2 from testTable2 order by field1, field2")
-        .thenResultIs("INTEGER|INTEGER",
+        .thenResultIs("INT|INT",
             "1|5",
             "2|3",
             "2|4",
@@ -524,7 +524,7 @@ public class SelectionOrderByTest {
             new Object[]{null, 2}
         )
         .whenQuery("select field1, field2 from testTable2 order by field1 desc, field2")
-        .thenResultIs("INTEGER|INTEGER",
+        .thenResultIs("INT|INT",
             "3|4",
             "2|3",
             "2|4",
@@ -550,7 +550,7 @@ public class SelectionOrderByTest {
             new Object[]{null, 2}
         )
         .whenQuery("select field1, field2 from testTable2 order by field1 desc, field2")
-        .thenResultIs("INTEGER|INTEGER",
+        .thenResultIs("INT|INT",
             "null|2",
             "null|4",
             "3|4",
@@ -574,7 +574,7 @@ public class SelectionOrderByTest {
             new Object[]{null}
         )
         .whenQuery("select myField from testTable order by myField offset 1")
-        .thenResultIs("INTEGER",
+        .thenResultIs("INT",
             "1",
             "2",
             "3"
@@ -595,7 +595,7 @@ public class SelectionOrderByTest {
             new Object[]{null}
         )
         .whenQuery("select myField from testTable order by myField offset 1 limit 2")
-        .thenResultIs("INTEGER",
+        .thenResultIs("INT",
             "1",
             "2"
         );
@@ -614,7 +614,7 @@ public class SelectionOrderByTest {
             new Object[]{2}
         )
         .whenQuery("select myField from testTable order by myField offset 1 limit 3")
-        .thenResultIs("INTEGER",
+        .thenResultIs("INT",
             "2",
             "3"
         );
@@ -634,7 +634,7 @@ public class SelectionOrderByTest {
             new Object[]{null}
         )
         .whenQuery("select myField from testTable order by myField offset 10")
-        .thenResultIs("INTEGER"
+        .thenResultIs("INT"
         );
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/columntransformer/DataTypeColumnTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/columntransformer/DataTypeColumnTransformer.java
@@ -56,7 +56,7 @@ public class DataTypeColumnTransformer implements ColumnTransformer {
     // If source and destination data types are primitive types and the same, no transformation is needed.
     if (_columnReader.isSingleValue()) {
       if (_columnReader.isInt()) {
-        return _destDataType == PinotDataType.INTEGER;
+        return _destDataType == PinotDataType.INT;
       } else if (_columnReader.isLong()) {
         return _destDataType == PinotDataType.LONG;
       } else if (_columnReader.isFloat()) {
@@ -72,7 +72,7 @@ public class DataTypeColumnTransformer implements ColumnTransformer {
       }
     } else {
       if (_columnReader.isInt()) {
-        return _destDataType == PinotDataType.INTEGER_ARRAY;
+        return _destDataType == PinotDataType.INT_ARRAY;
       } else if (_columnReader.isLong()) {
         return _destDataType == PinotDataType.LONG_ARRAY;
       } else if (_columnReader.isFloat()) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/MapColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/MapColumnPreIndexStatsCollector.java
@@ -363,7 +363,7 @@ public class MapColumnPreIndexStatsCollector extends AbstractColumnStatisticsCol
       case BYTE:
       case CHARACTER:
       case SHORT:
-      case INTEGER:
+      case INT:
         return FieldSpec.DataType.INT;
       case LONG:
         return FieldSpec.DataType.LONG;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/OpenStructTypeInference.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/OpenStructTypeInference.java
@@ -37,10 +37,10 @@ public final class OpenStructTypeInference {
   @Nullable
   public static FieldSpec.DataType inferDataType(Object rawValue) {
     switch (PinotDataType.getSingleValueType(rawValue)) {
-      case INTEGER:
       case BYTE:
       case CHARACTER:
       case SHORT:
+      case INT:
         return FieldSpec.DataType.INT;
       case LONG:
         return FieldSpec.DataType.LONG;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/PinotDataType.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/PinotDataType.java
@@ -264,7 +264,7 @@ public enum PinotDataType {
     }
   },
 
-  INTEGER {
+  INT {
     @Override
     public int toInt(Object value) {
       return (Integer) value;
@@ -297,7 +297,7 @@ public enum PinotDataType {
 
     @Override
     public Timestamp toTimestamp(Object value) {
-      throw new UnsupportedOperationException("Cannot convert value from INTEGER to TIMESTAMP");
+      throw new UnsupportedOperationException("Cannot convert value from INT to TIMESTAMP");
     }
 
     @Override
@@ -307,7 +307,7 @@ public enum PinotDataType {
 
     @Override
     public byte[] toBytes(Object value) {
-      throw new UnsupportedOperationException("Cannot convert value from INTEGER to BYTES");
+      throw new UnsupportedOperationException("Cannot convert value from INT to BYTES");
     }
 
     @Override
@@ -545,7 +545,7 @@ public enum PinotDataType {
   TIMESTAMP {
     @Override
     public int toInt(Object value) {
-      throw new UnsupportedOperationException("Cannot convert value from TIMESTAMP to INTEGER");
+      throw new UnsupportedOperationException("Cannot convert value from TIMESTAMP to INT");
     }
 
     @Override
@@ -659,7 +659,7 @@ public enum PinotDataType {
       switch (sourceType) {
         case DATE:
           return (LocalDate) value;
-        case INTEGER:
+        case INT:
         case LONG:
           return LocalDate.ofEpochDay(((Number) value).longValue());
         case TIMESTAMP:
@@ -746,7 +746,7 @@ public enum PinotDataType {
       switch (sourceType) {
         case TIME:
           return (LocalTime) value;
-        case INTEGER:
+        case INT:
         case LONG:
           // Treat the input as millis-since-midnight (matches `toLong`).
           return LocalTime.ofNanoOfDay(((Number) value).longValue() * 1_000_000L);
@@ -893,7 +893,7 @@ public enum PinotDataType {
   BYTES {
     @Override
     public int toInt(Object value) {
-      throw new UnsupportedOperationException("Cannot convert value from BYTES to INTEGER");
+      throw new UnsupportedOperationException("Cannot convert value from BYTES to INT");
     }
 
     @Override
@@ -959,7 +959,7 @@ public enum PinotDataType {
   UUID {
     @Override
     public int toInt(Object value) {
-      throw new UnsupportedOperationException("Cannot convert value from UUID to INTEGER");
+      throw new UnsupportedOperationException("Cannot convert value from UUID to INT");
     }
 
     @Override
@@ -1148,7 +1148,7 @@ public enum PinotDataType {
     }
   },
 
-  INTEGER_ARRAY {
+  INT_ARRAY {
     @Override
     public Integer[] convert(Object value, PinotDataType sourceType) {
       return sourceType.toIntegerArray(value);
@@ -1788,8 +1788,8 @@ public enum PinotDataType {
       case SHORT_ARRAY:
         return SHORT;
       case PRIMITIVE_INT_ARRAY:
-      case INTEGER_ARRAY:
-        return INTEGER;
+      case INT_ARRAY:
+        return INT;
       case PRIMITIVE_LONG_ARRAY:
       case LONG_ARRAY:
         return LONG;
@@ -1829,7 +1829,7 @@ public enum PinotDataType {
   /// (e.g. vendor `Timestamp` subclasses returned by JDBC drivers) are matched by their parent type.
   public static PinotDataType getSingleValueType(Object value) {
     if (value instanceof Integer) {
-      return INTEGER;
+      return INT;
     }
     if (value instanceof Long) {
       return LONG;
@@ -1883,7 +1883,7 @@ public enum PinotDataType {
   /// via `instanceof`. Returns [#OBJECT_ARRAY] for any unrecognized type.
   public static PinotDataType getMultiValueType(Object element) {
     if (element instanceof Integer) {
-      return INTEGER_ARRAY;
+      return INT_ARRAY;
     }
     if (element instanceof Long) {
       return LONG_ARRAY;
@@ -1954,7 +1954,7 @@ public enum PinotDataType {
     DataType dataType = fieldSpec.getDataType();
     switch (dataType) {
       case INT:
-        return fieldSpec.isSingleValueField() ? INTEGER : INTEGER_ARRAY;
+        return fieldSpec.isSingleValueField() ? INT : INT_ARRAY;
       case LONG:
         return fieldSpec.isSingleValueField() ? LONG : LONG_ARRAY;
       case FLOAT:

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/PinotDataTypeTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/PinotDataTypeTest.java
@@ -41,8 +41,8 @@ import static org.testng.Assert.fail;
 
 public class PinotDataTypeTest {
   private static final PinotDataType[] SOURCE_TYPES = {
-      BYTE, CHARACTER, SHORT, INTEGER, LONG, FLOAT, DOUBLE, BIG_DECIMAL, STRING, JSON,
-      BYTE_ARRAY, CHARACTER_ARRAY, SHORT_ARRAY, INTEGER_ARRAY, LONG_ARRAY, FLOAT_ARRAY, DOUBLE_ARRAY, STRING_ARRAY
+      BYTE, CHARACTER, SHORT, INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL, STRING, JSON,
+      BYTE_ARRAY, CHARACTER_ARRAY, SHORT_ARRAY, INT_ARRAY, LONG_ARRAY, FLOAT_ARRAY, DOUBLE_ARRAY, STRING_ARRAY
   };
   private static final Object[] SOURCE_VALUES = {
       (byte) 123, (char) 123, (short) 123, 123, 123L, 123f, 123d, BigDecimal.valueOf(123), " 123", "123 ",
@@ -50,7 +50,7 @@ public class PinotDataTypeTest {
       new Object[]{123L}, new Object[]{123f}, new Object[]{123d}, new Object[]{" 123"}
   };
   private static final PinotDataType[] DEST_TYPES =
-      {INTEGER, LONG, FLOAT, DOUBLE, BIG_DECIMAL, INTEGER_ARRAY, LONG_ARRAY, FLOAT_ARRAY, DOUBLE_ARRAY};
+      {INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL, INT_ARRAY, LONG_ARRAY, FLOAT_ARRAY, DOUBLE_ARRAY};
   private static final Object[] EXPECTED_DEST_VALUES =
       {123, 123L, 123f, 123d, BigDecimal.valueOf(123), new Object[]{123}, new Object[]{123L}, new Object[]{123f},
           new Object[]{123d}};
@@ -64,10 +64,10 @@ public class PinotDataTypeTest {
 
   // Test cases where array for MV column contains values of mixing types.
   private static final PinotDataType[] SOURCE_ARRAY_TYPES =
-      {SHORT_ARRAY, INTEGER_ARRAY, LONG_ARRAY, FLOAT_ARRAY, DOUBLE_ARRAY};
+      {SHORT_ARRAY, INT_ARRAY, LONG_ARRAY, FLOAT_ARRAY, DOUBLE_ARRAY};
   private static final Object[] SOURCE_ARRAY_VALUES = new Object[]{(short) 123, 4, 5L, 6f, 7d, "8"};
 
-  private static final PinotDataType[] DEST_ARRAY_TYPES = {INTEGER_ARRAY, LONG_ARRAY, FLOAT_ARRAY, DOUBLE_ARRAY};
+  private static final PinotDataType[] DEST_ARRAY_TYPES = {INT_ARRAY, LONG_ARRAY, FLOAT_ARRAY, DOUBLE_ARRAY};
   private static final Object[] EXPECTED_DEST_ARRAY_VALUES = {
       new Object[]{123, 4, 5, 6, 7, 8}, new Object[]{123L, 4L, 5L, 6L, 7L, 8L}, new Object[]{123f, 4f, 5f, 6f, 7f, 8f},
       new Object[]{123d, 4d, 5d, 6d, 7d, 8d}
@@ -128,9 +128,9 @@ public class PinotDataTypeTest {
   @DataProvider
   public Object[][] numberFormatConversionErrors() {
     return new Object[][] {
-        {INTEGER_ARRAY, LONG_ARRAY, new Object[]{"abc"}},
-        {INTEGER_ARRAY, INTEGER_ARRAY, new Object[]{"abc"}},
-        {INTEGER_ARRAY, PRIMITIVE_BOOLEAN_ARRAY, new Object[]{"abc"}}
+        {INT_ARRAY, LONG_ARRAY, new Object[]{"abc"}},
+        {INT_ARRAY, INT_ARRAY, new Object[]{"abc"}},
+        {INT_ARRAY, PRIMITIVE_BOOLEAN_ARRAY, new Object[]{"abc"}}
     };
   }
 
@@ -180,8 +180,8 @@ public class PinotDataTypeTest {
 
   @Test
   public void testBoolean() {
-    assertEquals(INTEGER.convert(true, BOOLEAN), 1);
-    assertEquals(INTEGER.convert(false, BOOLEAN), 0);
+    assertEquals(INT.convert(true, BOOLEAN), 1);
+    assertEquals(INT.convert(false, BOOLEAN), 0);
     assertEquals(LONG.convert(true, BOOLEAN), 1L);
     assertEquals(LONG.convert(false, BOOLEAN), 0L);
     assertEquals(FLOAT.convert(true, BOOLEAN), 1f);
@@ -226,7 +226,7 @@ public class PinotDataTypeTest {
     // 2022-04-14 = 19_096 days since epoch. `LocalDate` is TZ-independent — round-trips identically in any
     // JVM timezone.
     LocalDate date = LocalDate.parse("2022-04-14");
-    assertEquals(DATE.convert(19_096, INTEGER), date);
+    assertEquals(DATE.convert(19_096, INT), date);
     assertEquals(DATE.convert(19_096L, LONG), date);
     assertEquals(DATE.convert("2022-04-14", STRING), date);
     // JSON: quoted ISO-8601 string parsed via Jackson.
@@ -245,8 +245,8 @@ public class PinotDataTypeTest {
     assertEquals(DATE_ARRAY.convert(dates, DATE_ARRAY), dates);
     // STRING_ARRAY → DATE_ARRAY: per-element ISO-8601 parsing via DATE.convert.
     assertEquals(DATE_ARRAY.convert(new String[]{"2022-04-14", "2024-01-01"}, STRING_ARRAY), dates);
-    // INTEGER_ARRAY → DATE_ARRAY: per-element epoch-day decoding.
-    assertEquals(DATE_ARRAY.convert(new Integer[]{19_096, 19_723}, INTEGER_ARRAY), dates);
+    // INT_ARRAY → DATE_ARRAY: per-element epoch-day decoding.
+    assertEquals(DATE_ARRAY.convert(new Integer[]{19_096, 19_723}, INT_ARRAY), dates);
     // DATE_ARRAY → STRING_ARRAY: each element via DATE.toString.
     assertEquals(STRING_ARRAY.convert(dates, DATE_ARRAY), new String[]{"2022-04-14", "2024-01-01"});
     // Lookup: Object[] of LocalDate routes to DATE_ARRAY.
@@ -261,7 +261,7 @@ public class PinotDataTypeTest {
     // identically in any JVM timezone.
     LocalTime time = LocalTime.parse("08:51:32");
     assertEquals(TIME.convert(31_892_000L, LONG), time);
-    assertEquals(TIME.convert(31_892_000, INTEGER), time);
+    assertEquals(TIME.convert(31_892_000, INT), time);
     assertEquals(TIME.convert("08:51:32", STRING), time);
     // JSON: quoted ISO-8601 string parsed via Jackson.
     assertEquals(TIME.convert("\"08:51:32\"", JSON), time);
@@ -389,7 +389,7 @@ public class PinotDataTypeTest {
 
   @Test
   public void testGetSingleValueType() {
-    assertEquals(getSingleValueType(1), INTEGER);
+    assertEquals(getSingleValueType(1), INT);
     assertEquals(getSingleValueType(1L), LONG);
     assertEquals(getSingleValueType(1.0f), FLOAT);
     assertEquals(getSingleValueType(1.0d), DOUBLE);
@@ -419,7 +419,7 @@ public class PinotDataTypeTest {
 
   @Test
   public void testGetMultipleValueType() {
-    assertEquals(getMultiValueType(1), INTEGER_ARRAY);
+    assertEquals(getMultiValueType(1), INT_ARRAY);
     assertEquals(getMultiValueType(1L), LONG_ARRAY);
     assertEquals(getMultiValueType(1.0f), FLOAT_ARRAY);
     assertEquals(getMultiValueType(1.0d), DOUBLE_ARRAY);
@@ -465,17 +465,17 @@ public class PinotDataTypeTest {
     // Single-value types that do NOT support BYTES conversion; STRING / JSON / BYTES / BIG_DECIMAL / UUID
     // each have their own valid byte-form encoding and are tested elsewhere.
     PinotDataType[] noBytesConversion = {
-        BOOLEAN, BYTE, CHARACTER, SHORT, INTEGER, LONG, FLOAT, DOUBLE, TIMESTAMP, DATE, TIME, OBJECT
+        BOOLEAN, BYTE, CHARACTER, SHORT, INT, LONG, FLOAT, DOUBLE, TIMESTAMP, DATE, TIME, OBJECT
     };
     for (PinotDataType sourceType : noBytesConversion) {
       assertInvalidConversion(null, sourceType, BYTES, UnsupportedOperationException.class);
     }
 
-    assertInvalidConversion(null, BYTES, INTEGER, UnsupportedOperationException.class);
+    assertInvalidConversion(null, BYTES, INT, UnsupportedOperationException.class);
     assertInvalidConversion(null, BYTES, LONG, UnsupportedOperationException.class);
     assertInvalidConversion(null, BYTES, FLOAT, UnsupportedOperationException.class);
     assertInvalidConversion(null, BYTES, DOUBLE, UnsupportedOperationException.class);
-    assertInvalidConversion(null, BYTES, INTEGER_ARRAY, UnsupportedOperationException.class);
+    assertInvalidConversion(null, BYTES, INT_ARRAY, UnsupportedOperationException.class);
     assertInvalidConversion(null, BYTES, LONG_ARRAY, UnsupportedOperationException.class);
     assertInvalidConversion(null, BYTES, FLOAT_ARRAY, UnsupportedOperationException.class);
     assertInvalidConversion(null, BYTES, DOUBLE_ARRAY, UnsupportedOperationException.class);


### PR DESCRIPTION
## Summary

Renames the enum constants `PinotDataType.INTEGER` → `INT` and `INTEGER_ARRAY` → `INT_ARRAY` so the spelling matches `FieldSpec.DataType.INT`, `DataSchema.ColumnDataType.INT`, and the SQL type name. The mismatch (`INTEGER` vs the `INT` everyone else uses) is a recurring source of confusion.

`PinotDataType` is a transient type-conversion helper — it is never persisted by name into segment metadata, ZooKeeper, table config, or the wire protocol (only `FieldSpec.DataType` is, and it is untouched). So the rename carries no serialization or mixed-version compatibility risk.

### Backward compatibility

The only place that resolves a `PinotDataType` from a user-supplied string by name is the `cast` scalar function. `CAST(x AS INTEGER)` previously resolved via the `PinotDataType.valueOf("INTEGER")` default branch. An explicit `case "INTEGER"` alias is added so that literal keeps working (alongside `INT`), and a regression test pins it.

The rest of the change is a mechanical reference update (`PinotDataType.INTEGER` → `INT`, `case INTEGER:` → `case INT:` for `PinotDataType` switches only — Calcite `SqlTypeName`/`SqlTypeFamily` and `java.sql.Types` `INTEGER` references are left intact) plus test-data updates.
