### PR TITLE
Replace schema registry TODO with explicit redirect in ProtoBufMessageDecoder

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufMessageDecoder.java
@@ -32,9 +32,9 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.stream.StreamMessageDecoder;
 
 
-// This decoder is intentionally file-based and does not support schema registry.
-// For Confluent Schema Registry-backed descriptor resolution, use
-// KafkaConfluentSchemaRegistryProtoBufMessageDecoder instead.
+/// This decoder is intentionally file-based and does not support schema registry.
+/// For Confluent Schema Registry-backed descriptor resolution, use
+/// `KafkaConfluentSchemaRegistryProtoBufMessageDecoder` instead.
 
 public class ProtoBufMessageDecoder implements StreamMessageDecoder<byte[]> {
   public static final String DESCRIPTOR_FILE_PATH = "descriptorFile";
@@ -45,8 +45,7 @@ public class ProtoBufMessageDecoder implements StreamMessageDecoder<byte[]> {
   private Message.Builder _builder;
 
   @Override
-  public void init(Map<String, String> props, Set<String> fieldsToRead, String topicName)
-          throws Exception {
+  public void init(Map<String, String> props, Set<String> fieldsToRead, String topicName) throws Exception {
     Preconditions.checkState(props.containsKey(DESCRIPTOR_FILE_PATH),
             "Property '%s' must be specified for ProtoBufMessageDecoder. "
                     + "If you are using Confluent Schema Registry, use "

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufMessageDecoder.java
@@ -32,7 +32,10 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.stream.StreamMessageDecoder;
 
 
-//TODO: Add support for Schema Registry
+// This decoder is intentionally file-based and does not support schema registry.
+// For Confluent Schema Registry-backed descriptor resolution, use
+// KafkaConfluentSchemaRegistryProtoBufMessageDecoder instead.
+
 public class ProtoBufMessageDecoder implements StreamMessageDecoder<byte[]> {
   public static final String DESCRIPTOR_FILE_PATH = "descriptorFile";
   public static final String PROTO_CLASS_NAME = "protoClassName";
@@ -43,13 +46,16 @@ public class ProtoBufMessageDecoder implements StreamMessageDecoder<byte[]> {
 
   @Override
   public void init(Map<String, String> props, Set<String> fieldsToRead, String topicName)
-      throws Exception {
+          throws Exception {
     Preconditions.checkState(props.containsKey(DESCRIPTOR_FILE_PATH),
-        "Protocol Buffer schema descriptor file must be provided");
+            "Property '%s' must be specified for ProtoBufMessageDecoder. "
+                    + "If you are using Confluent Schema Registry, use "
+                    + "KafkaConfluentSchemaRegistryProtoBufMessageDecoder instead.",
+            DESCRIPTOR_FILE_PATH);
 
     _protoClassName = props.getOrDefault(PROTO_CLASS_NAME, "");
     InputStream descriptorFileInputStream = ProtoBufUtils.getDescriptorFileInputStream(
-        props.get(DESCRIPTOR_FILE_PATH));
+            props.get(DESCRIPTOR_FILE_PATH));
     Descriptors.Descriptor descriptor = buildProtoBufDescriptor(descriptorFileInputStream);
     _recordExtractor = new ProtoBufRecordExtractor();
     _recordExtractor.init(fieldsToRead, null);
@@ -58,7 +64,7 @@ public class ProtoBufMessageDecoder implements StreamMessageDecoder<byte[]> {
   }
 
   private Descriptors.Descriptor buildProtoBufDescriptor(InputStream fin)
-      throws IOException {
+          throws IOException {
     try {
       DynamicSchema dynamicSchema = DynamicSchema.parseFrom(fin);
 

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufMessageDecoder.java
@@ -53,8 +53,7 @@ public class ProtoBufMessageDecoder implements StreamMessageDecoder<byte[]> {
             DESCRIPTOR_FILE_PATH);
 
     _protoClassName = props.getOrDefault(PROTO_CLASS_NAME, "");
-    InputStream descriptorFileInputStream = ProtoBufUtils.getDescriptorFileInputStream(
-            props.get(DESCRIPTOR_FILE_PATH));
+    InputStream descriptorFileInputStream = ProtoBufUtils.getDescriptorFileInputStream(props.get(DESCRIPTOR_FILE_PATH));
     Descriptors.Descriptor descriptor = buildProtoBufDescriptor(descriptorFileInputStream);
     _recordExtractor = new ProtoBufRecordExtractor();
     _recordExtractor.init(fieldsToRead, null);

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufMessageDecoderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufMessageDecoderTest.java
@@ -30,7 +30,6 @@ import org.testng.annotations.Test;
 import static org.apache.pinot.plugin.inputformat.protobuf.ProtoBufTestDataGenerator.*;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
 
 
 public class ProtoBufMessageDecoderTest {
@@ -156,23 +155,4 @@ public class ProtoBufMessageDecoderTest {
     assertEquals(((Map<String, Object>) destination.getValue("sample_record")).get("id"), 18);
   }
 
-  @Test
-  public void testInitThrowsHelpfulMessageWhenDescriptorFileMissing() {
-    ProtoBufMessageDecoder decoder = new ProtoBufMessageDecoder();
-    Map<String, String> props = new HashMap<>();
-    // No descriptorFile provided — should fail with a message pointing
-    // to KafkaConfluentSchemaRegistryProtoBufMessageDecoder
-    try {
-      decoder.init(props, ImmutableSet.of(), "test-topic");
-      throw new AssertionError("Expected IllegalStateException when descriptorFile is missing");
-    } catch (IllegalStateException e) {
-      assertNotNull(e.getMessage());
-      assertTrue(e.getMessage().contains("KafkaConfluentSchemaRegistryProtoBufMessageDecoder"),
-              "Error message should point users to the registry-backed decoder, but was: " + e.getMessage());
-      assertTrue(e.getMessage().contains(ProtoBufMessageDecoder.DESCRIPTOR_FILE_PATH),
-              "Error message should mention the missing property name, but was: " + e.getMessage());
-    } catch (Exception e) {
-      throw new AssertionError("Expected IllegalStateException but got: " + e.getClass().getName(), e);
-    }
-  }
 }

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufMessageDecoderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufMessageDecoderTest.java
@@ -30,6 +30,7 @@ import org.testng.annotations.Test;
 import static org.apache.pinot.plugin.inputformat.protobuf.ProtoBufTestDataGenerator.*;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 
 public class ProtoBufMessageDecoderTest {
@@ -153,5 +154,25 @@ public class ProtoBufMessageDecoderTest {
     assertEquals(((Map<String, Object>) destination.getValue("sample_record")).get("email"), "foobar@hello.com");
     assertEquals(((Map<String, Object>) destination.getValue("sample_record")).get("name"), "Alice");
     assertEquals(((Map<String, Object>) destination.getValue("sample_record")).get("id"), 18);
+  }
+
+  @Test
+  public void testInitThrowsHelpfulMessageWhenDescriptorFileMissing() {
+    ProtoBufMessageDecoder decoder = new ProtoBufMessageDecoder();
+    Map<String, String> props = new HashMap<>();
+    // No descriptorFile provided — should fail with a message pointing
+    // to KafkaConfluentSchemaRegistryProtoBufMessageDecoder
+    try {
+      decoder.init(props, ImmutableSet.of(), "test-topic");
+      throw new AssertionError("Expected IllegalStateException when descriptorFile is missing");
+    } catch (IllegalStateException e) {
+      assertNotNull(e.getMessage());
+      assertTrue(e.getMessage().contains("KafkaConfluentSchemaRegistryProtoBufMessageDecoder"),
+              "Error message should point users to the registry-backed decoder, but was: " + e.getMessage());
+      assertTrue(e.getMessage().contains(ProtoBufMessageDecoder.DESCRIPTOR_FILE_PATH),
+              "Error message should mention the missing property name, but was: " + e.getMessage());
+    } catch (Exception e) {
+      throw new AssertionError("Expected IllegalStateException but got: " + e.getClass().getName(), e);
+    }
   }
 }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Shows init method flow: validates descriptorFile, throws guidance error if missing, otherwise builds decoder\.

```mermaid
flowchart TD
  N0["ProtoBufMessageDecoder#46;init #40;F1#41;"]:::stModified
  N1["Preconditions#46;checkState descriptorFile #40;F1#41;"]:::stModified
  N2["Throw IllegalStateException with guidance #40;F1#41;"]:::stModified
  N3["Get protoClassName from props #40;F1#41;"]:::stModified
  N4["Get descriptor file input stream #40;F1#41;"]:::stModified
  N5["buildProtoBufDescriptor #40;F1#41;"]:::stModified
  N6["Instantiate ProtoBufRecordExtractor #40;F1#41;"]:::stModified
  N7["Init recordExtractor with fields #40;F1#41;"]:::stModified
  N8["Get DynamicMessage default instance #40;F1#41;"]:::stModified
  N9["Create message builder #40;F1#41;"]:::stModified
  N0 -->|"entry"| N1
  N1 -->|"if missing"| N2
  N1 -->|"if present"| N3
  N3 -->|"next"| N4
  N4 -->|"next"| N5
  N5 -->|"next"| N6
  N6 -->|"next"| N7
  N7 -->|"next"| N8
  N8 -->|"next"| N9
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-plugins/pinot\-input\-format/pinot\-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufMessageDecoder\.java — [before](https://github.com/apache/pinot/blob/ff7df4893c898251c42911902aec31953638986b/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufMessageDecoder.java) · [after](https://github.com/apache/pinot/blob/d36ca7b1205dcb03dfe0512e745549b9ae6e92fe/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufMessageDecoder.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImZmN2RmNDg5M2M4OTgyNTFjNDI5MTE5MDJhZWMzMTk1MzYzODk4NmIiLCJjb250ZXh0X2hhc2giOiJmM2VjN2Y2YmM2YTQ2MjhmMTFmMjUxZWRlZWE2NWQzNTkxNjZiNjZmN2UzZjE0MzhiYTBlNTQ1MDhjNmM4YmQ5IiwiZ2VuZXJhdGVkX2F0IjoxNzg4OTA3MjI1LCJoZWFkX3NoYSI6ImQzNmNhN2IxMjA1ZGNiMDNkZmUwNTEyZTc0NTU0OWI5YWU2ZTkyZmUiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJmZjdkZjQ4OTNjODk4MjUxYzQyOTExOTAyYWVjMzE5NTM2Mzg5ODZiIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 2c9a1c11565127509c17741ef5d91e83473e79f3893193558630266fff661c3e -->
<!-- pinot-pr-flow:end -->

## What changed and why

Closes #18221

`ProtoBufMessageDecoder` has carried a class-level `TODO: Add support for Schema Registry`
since it was introduced. After reviewing the existing decoder landscape:

- `KafkaConfluentSchemaRegistryProtoBufMessageDecoder` already fully implements
  Confluent Schema Registry-backed descriptor resolution
- `ProtoBufMessageDecoder` is intentionally file-based and stream-format-agnostic;
  adding registry support here would either duplicate that logic or introduce a
  Confluent dependency where there is none today

This PR takes the explicit redirect path listed in the issue scope:
- Replaces the TODO with a comment explaining the design boundary
- Improves the error message when `descriptorFile` is missing to explicitly
  point users to `KafkaConfluentSchemaRegistryProtoBufMessageDecoder`

## Testing

Added a test to `ProtoBufMessageDecoderTest` verifying that initialising the
decoder without `descriptorFile` throws an `IllegalStateException` whose message
references both the missing property name and the registry-backed decoder class.