### PR TITLE
Add TABLE_TENANT_INFO controller gauge for table-to-tenant mapping

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
@@ -1,16 +1,18 @@
 rules:
 # tableTenantInfo: emitted by SegmentStatusChecker as
-#   pinot.controller.tableTenantInfo.<tableNameWithType>.<serverTenant>
-# MUST appear before the generic tableNameWithType rules — the extra tenant path segment would otherwise be consumed
-# by those patterns and the tenant label would not be extracted.
-- pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.tableTenantInfo\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.([^\"]+)\"><>(\\w+)"
-  name: "pinot_controller_tableTenantInfo_$6"
+#   pinot.controller.tableTenantInfo.<tableNameWithType>.<tenantType>.<tenantName>
+# tenantType is one of: server, broker, tier.
+# MUST appear before the generic tableNameWithType rules — the extra path segments would otherwise be consumed
+# by those patterns and the tenantType/tenant labels would not be extracted.
+- pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.tableTenantInfo\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.([^.]+)\\.([^\"]+)\"><>(\\w+)"
+  name: "pinot_controller_tableTenantInfo_$7"
   cache: true
   labels:
     database: "$2"
     table: "$1$3"
     tableType: "$4"
-    tenant: "$5"
+    tenantType: "$5"
+    tenant: "$6"
 # Gauges that accept tableNameWithType
 - pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.((\\w+)\\.)?(\\w+)_(OFFLINE|REALTIME)\\\"?><>(\\w+)"
   name: "pinot_$1_$2_$7"

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
@@ -1,4 +1,16 @@
 rules:
+# tableTenantInfo: emitted by SegmentStatusChecker as
+#   pinot.controller.tableTenantInfo.<tableNameWithType>.<serverTenant>
+# MUST appear before the generic tableNameWithType rules — the extra tenant path segment would otherwise be consumed
+# by those patterns and the tenant label would not be extracted.
+- pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.tableTenantInfo\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.([^\"]+)\"><>(\\w+)"
+  name: "pinot_controller_tableTenantInfo_$6"
+  cache: true
+  labels:
+    database: "$2"
+    table: "$1$3"
+    tableType: "$4"
+    tenant: "$5"
 # Gauges that accept tableNameWithType
 - pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.((\\w+)\\.)?(\\w+)_(OFFLINE|REALTIME)\\\"?><>(\\w+)"
   name: "pinot_$1_$2_$7"

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -225,6 +225,16 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
 
   // The progress of a certain table rebalance job of a table
   TABLE_REBALANCE_JOB_PROGRESS_PERCENT("percent", false),
+
+  // Mapping metric for table-to-server-tenant attribution. Always set to 1.
+  // The server tenant name is embedded as an extra key segment in the metric name so that Prometheus can extract it
+  // as a label and join it onto other table-scoped metrics via group_left.
+  // JMX name pattern: pinot.controller.tableTenantInfo.<tableNameWithType>.<serverTenant>
+  // NOTE: this gauge is exempt from the standard ControllerGauge.values() loop in removeMetricsForTable because its
+  // registered name includes the tenant segment. Removal is handled explicitly via _tableTenantMap in
+  // SegmentStatusChecker.
+  TABLE_TENANT_INFO("info", false),
+
   // HTTP thread utilization
   HTTP_THREAD_UTILIZATION("httpThreadUtilization", true),
   // Track the concurrent executions of the API resources that use @ManagedAsync

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -226,12 +226,13 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   // The progress of a certain table rebalance job of a table
   TABLE_REBALANCE_JOB_PROGRESS_PERCENT("percent", false),
 
-  // Mapping metric for table-to-server-tenant attribution. Always set to 1.
-  // The server tenant name is embedded as an extra key segment in the metric name so that Prometheus can extract it
-  // as a label and join it onto other table-scoped metrics via group_left.
-  // JMX name pattern: pinot.controller.tableTenantInfo.<tableNameWithType>.<serverTenant>
+  // Mapping metric for table-to-tenant attribution. One gauge per (tenantType, tenantName) pair; always set to 1.
+  // The compound key "<tenantType>.<tenantName>" is embedded as extra segments in the JMX metric name so that
+  // Prometheus can extract both as labels and join them onto other table-scoped metrics via group_left.
+  // tenantType values: "server" (server tenant), "broker" (broker tenant), "tier" (tier server tenant).
+  // JMX name pattern: pinot.controller.tableTenantInfo.<tableNameWithType>.<tenantType>.<tenantName>
   // NOTE: this gauge is exempt from the standard ControllerGauge.values() loop in removeMetricsForTable because its
-  // registered name includes the tenant segment. Removal is handled explicitly via _tableTenantMap in
+  // registered name includes extra key segments. Removal is handled explicitly via _tableTenantMap in
   // SegmentStatusChecker.
   TABLE_TENANT_INFO("info", false),
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -43,6 +43,7 @@ import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.metrics.ControllerTimer;
+import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
@@ -54,6 +55,7 @@ import org.apache.pinot.controller.util.ServerQueryInfoFetcher.ServerQueryInfo;
 import org.apache.pinot.controller.util.TableSizeReader;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.TenantConfig;
 import org.apache.pinot.spi.config.table.TierConfig;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
@@ -81,6 +83,9 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
   private final int _waitForPushTimeSeconds;
   private final TableSizeReader _tableSizeReader;
   private final Set<String> _tierBackendGauges = new HashSet<>();
+  // Maps tableNameWithType -> server tenant name, so stale gauges can be removed when a table changes tenant.
+  // Accessed only from the single-threaded periodic task execution loop (processTable / removeMetricsForTable).
+  private final Map<String, String> _tableTenantMap = new HashMap<>();
 
   private long _lastDisabledTableLogTimestamp = 0;
 
@@ -170,6 +175,10 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
     if (tableConfig == null) {
       LOGGER.warn("Found null table config for table: {}. Resetting table config metrics.", tableNameWithType);
       _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.REPLICATION_FROM_CONFIG, 0);
+      String tenant = _tableTenantMap.remove(tableNameWithType);
+      if (tenant != null) {
+        _controllerMetrics.removeTableGauge(tableNameWithType, tenant, ControllerGauge.TABLE_TENANT_INFO);
+      }
       return;
     }
     if (tableConfig.getTableType() == TableType.OFFLINE) {
@@ -194,6 +203,31 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
     }
     int replication = tableConfig.getReplication();
     _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.REPLICATION_FROM_CONFIG, replication);
+
+    updateTenantInfoGauge(tableNameWithType, tableConfig);
+  }
+
+  /**
+   * Emits a {@code tableTenantInfo} gauge keyed by server tenant name so Prometheus can extract the tenant as a
+   * label and join it onto other table-scoped metrics.  Always set to {@code 1}.
+   * The gauge is registered once per unique (table, tenant) pair and only re-registered when the tenant changes,
+   * avoiding redundant metric writes on each periodic cycle.
+   * When the tenant changes, the new gauge is registered first to avoid a gap window, then the stale gauge is removed.
+   */
+  private void updateTenantInfoGauge(String tableNameWithType, TableConfig tableConfig) {
+    TenantConfig tenantConfig = tableConfig.getTenantConfig();
+    String serverTenant =
+        (tenantConfig != null && tenantConfig.getServer() != null) ? tenantConfig.getServer()
+            : TagNameUtils.DEFAULT_TENANT_NAME;
+
+    String previousTenant = _tableTenantMap.put(tableNameWithType, serverTenant);
+    if (serverTenant.equals(previousTenant)) {
+      return;
+    }
+    _controllerMetrics.setOrUpdateTableGauge(tableNameWithType, serverTenant, ControllerGauge.TABLE_TENANT_INFO, 1L);
+    if (previousTenant != null) {
+      _controllerMetrics.removeTableGauge(tableNameWithType, previousTenant, ControllerGauge.TABLE_TENANT_INFO);
+    }
   }
 
   private void updateTableSizeMetrics(String tableNameWithType)
@@ -500,6 +534,10 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
 
   private void removeMetricsForTable(String tableNameWithType) {
     LOGGER.info("Removing metrics from {} given it is not a table known by Helix", tableNameWithType);
+    String tenant = _tableTenantMap.remove(tableNameWithType);
+    if (tenant != null) {
+      _controllerMetrics.removeTableGauge(tableNameWithType, tenant, ControllerGauge.TABLE_TENANT_INFO);
+    }
     for (ControllerGauge metric : ControllerGauge.values()) {
       if (!metric.isGlobal()) {
         _controllerMetrics.removeTableGauge(tableNameWithType, metric);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -83,9 +83,10 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
   private final int _waitForPushTimeSeconds;
   private final TableSizeReader _tableSizeReader;
   private final Set<String> _tierBackendGauges = new HashSet<>();
-  // Maps tableNameWithType -> server tenant name, so stale gauges can be removed when a table changes tenant.
+  // Maps tableNameWithType -> set of compound tenant keys ("server.tenantName", "broker.tenantName",
+  // "tier.tenantName"), so stale gauges can be removed when a table's tenant assignment changes.
   // Accessed only from the single-threaded periodic task execution loop (processTable / removeMetricsForTable).
-  private final Map<String, String> _tableTenantMap = new HashMap<>();
+  private final Map<String, Set<String>> _tableTenantMap = new HashMap<>();
 
   private long _lastDisabledTableLogTimestamp = 0;
 
@@ -175,9 +176,11 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
     if (tableConfig == null) {
       LOGGER.warn("Found null table config for table: {}. Resetting table config metrics.", tableNameWithType);
       _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.REPLICATION_FROM_CONFIG, 0);
-      String tenant = _tableTenantMap.remove(tableNameWithType);
-      if (tenant != null) {
-        _controllerMetrics.removeTableGauge(tableNameWithType, tenant, ControllerGauge.TABLE_TENANT_INFO);
+      Set<String> tenantKeys = _tableTenantMap.remove(tableNameWithType);
+      if (tenantKeys != null) {
+        for (String key : tenantKeys) {
+          _controllerMetrics.removeTableGauge(tableNameWithType, key, ControllerGauge.TABLE_TENANT_INFO);
+        }
       }
       return;
     }
@@ -208,25 +211,48 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
   }
 
   /**
-   * Emits a {@code tableTenantInfo} gauge keyed by server tenant name so Prometheus can extract the tenant as a
-   * label and join it onto other table-scoped metrics.  Always set to {@code 1}.
-   * The gauge is registered once per unique (table, tenant) pair and only re-registered when the tenant changes,
-   * avoiding redundant metric writes on each periodic cycle.
-   * When the tenant changes, the new gauge is registered first to avoid a gap window, then the stale gauge is removed.
+   * Emits one {@code tableTenantInfo} gauge per (tenantType, tenantName) pair for a table so Prometheus can extract
+   * both as labels and join them onto other table-scoped metrics.  Every gauge is always set to {@code 1}.
+   * TenantType values: {@code "server"} (server tenant), {@code "broker"} (broker tenant), {@code "tier"} (tier
+   * server tenant).  The compound key {@code "<tenantType>.<tenantName>"} is embedded in the JMX metric name.
+   * Gauges are only written on first registration or when the tenant assignment changes, not on every periodic cycle.
+   * When assignments change, new gauges are registered before stale ones are removed to avoid a scrape-window gap.
    */
   private void updateTenantInfoGauge(String tableNameWithType, TableConfig tableConfig) {
     TenantConfig tenantConfig = tableConfig.getTenantConfig();
-    String serverTenant =
-        (tenantConfig != null && tenantConfig.getServer() != null) ? tenantConfig.getServer()
-            : TagNameUtils.DEFAULT_TENANT_NAME;
 
-    String previousTenant = _tableTenantMap.put(tableNameWithType, serverTenant);
-    if (serverTenant.equals(previousTenant)) {
+    Set<String> newKeys = new HashSet<>();
+    String serverTenant = (tenantConfig != null && tenantConfig.getServer() != null)
+        ? tenantConfig.getServer() : TagNameUtils.DEFAULT_TENANT_NAME;
+    newKeys.add("server." + serverTenant);
+
+    String brokerTenant = (tenantConfig != null && tenantConfig.getBroker() != null)
+        ? tenantConfig.getBroker() : TagNameUtils.DEFAULT_TENANT_NAME;
+    newKeys.add("broker." + brokerTenant);
+
+    List<TierConfig> tierConfigs = tableConfig.getTierConfigsList();
+    if (tierConfigs != null) {
+      for (TierConfig tierConfig : tierConfigs) {
+        String serverTag = tierConfig.getServerTag();
+        if (serverTag != null && serverTag.contains("_")) {
+          newKeys.add("tier." + TagNameUtils.getTenantFromTag(serverTag));
+        }
+      }
+    }
+
+    Set<String> previousKeys = _tableTenantMap.put(tableNameWithType, newKeys);
+    if (newKeys.equals(previousKeys)) {
       return;
     }
-    _controllerMetrics.setOrUpdateTableGauge(tableNameWithType, serverTenant, ControllerGauge.TABLE_TENANT_INFO, 1L);
-    if (previousTenant != null) {
-      _controllerMetrics.removeTableGauge(tableNameWithType, previousTenant, ControllerGauge.TABLE_TENANT_INFO);
+    for (String key : newKeys) {
+      _controllerMetrics.setOrUpdateTableGauge(tableNameWithType, key, ControllerGauge.TABLE_TENANT_INFO, 1L);
+    }
+    if (previousKeys != null) {
+      for (String key : previousKeys) {
+        if (!newKeys.contains(key)) {
+          _controllerMetrics.removeTableGauge(tableNameWithType, key, ControllerGauge.TABLE_TENANT_INFO);
+        }
+      }
     }
   }
 
@@ -534,9 +560,11 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
 
   private void removeMetricsForTable(String tableNameWithType) {
     LOGGER.info("Removing metrics from {} given it is not a table known by Helix", tableNameWithType);
-    String tenant = _tableTenantMap.remove(tableNameWithType);
-    if (tenant != null) {
-      _controllerMetrics.removeTableGauge(tableNameWithType, tenant, ControllerGauge.TABLE_TENANT_INFO);
+    Set<String> tenantKeys = _tableTenantMap.remove(tableNameWithType);
+    if (tenantKeys != null) {
+      for (String key : tenantKeys) {
+        _controllerMetrics.removeTableGauge(tableNameWithType, key, ControllerGauge.TABLE_TENANT_INFO);
+      }
     }
     for (ControllerGauge metric : ControllerGauge.values()) {
       if (!metric.isGlobal()) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
@@ -976,4 +976,146 @@ public class SegmentStatusCheckerTest {
     assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, OFFLINE_TABLE_NAME,
         ControllerGauge.SEGMENTS_WITH_INVALID_END_TIME), 1);
   }
+
+  @Test
+  public void tableTenantInfoGaugeNamedTenantTest() {
+    String serverTenant = "myTenant";
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setServerTenant(serverTenant).build();
+
+    IdealState idealState = new IdealState(OFFLINE_TABLE_NAME);
+    idealState.setReplicas("1");
+    idealState.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
+
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    when(resourceManager.getAllTables()).thenReturn(List.of(OFFLINE_TABLE_NAME));
+    when(resourceManager.getTableConfig(OFFLINE_TABLE_NAME)).thenReturn(tableConfig);
+    when(resourceManager.getTableIdealState(OFFLINE_TABLE_NAME)).thenReturn(idealState);
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    when(resourceManager.getPropertyStore()).thenReturn(propertyStore);
+
+    runSegmentStatusChecker(resourceManager, 0);
+
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, OFFLINE_TABLE_NAME, serverTenant,
+        ControllerGauge.TABLE_TENANT_INFO), 1);
+  }
+
+  @Test
+  public void tableTenantInfoGaugeDefaultTenantFallbackTest() {
+    // No server tenant configured — should fall back to "DefaultTenant".
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+
+    IdealState idealState = new IdealState(OFFLINE_TABLE_NAME);
+    idealState.setReplicas("1");
+    idealState.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
+
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    when(resourceManager.getAllTables()).thenReturn(List.of(OFFLINE_TABLE_NAME));
+    when(resourceManager.getTableConfig(OFFLINE_TABLE_NAME)).thenReturn(tableConfig);
+    when(resourceManager.getTableIdealState(OFFLINE_TABLE_NAME)).thenReturn(idealState);
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    when(resourceManager.getPropertyStore()).thenReturn(propertyStore);
+
+    runSegmentStatusChecker(resourceManager, 0);
+
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, OFFLINE_TABLE_NAME,
+        "DefaultTenant", ControllerGauge.TABLE_TENANT_INFO), 1);
+  }
+
+  @Test
+  public void tableTenantInfoGaugeTenantChangeCleansStaleGaugeTest() {
+    String firstTenant = "tenantA";
+    String secondTenant = "tenantB";
+
+    IdealState idealState = new IdealState(OFFLINE_TABLE_NAME);
+    idealState.setReplicas("1");
+    idealState.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
+
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    when(resourceManager.getAllTables()).thenReturn(List.of(OFFLINE_TABLE_NAME));
+    when(resourceManager.getTableIdealState(OFFLINE_TABLE_NAME)).thenReturn(idealState);
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    when(resourceManager.getPropertyStore()).thenReturn(propertyStore);
+
+    // First run: table on firstTenant.
+    when(resourceManager.getTableConfig(OFFLINE_TABLE_NAME)).thenReturn(
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setServerTenant(firstTenant).build());
+    SegmentStatusChecker checker = buildSegmentStatusChecker(resourceManager, 0);
+    checker.start();
+    checker.run();
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, OFFLINE_TABLE_NAME, firstTenant,
+        ControllerGauge.TABLE_TENANT_INFO), 1);
+
+    // Second run: table moves to secondTenant — stale gauge for firstTenant must be removed.
+    when(resourceManager.getTableConfig(OFFLINE_TABLE_NAME)).thenReturn(
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setServerTenant(secondTenant).build());
+    checker.run();
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, OFFLINE_TABLE_NAME, secondTenant,
+        ControllerGauge.TABLE_TENANT_INFO), 1);
+    assertFalse(MetricValueUtils.tableGaugeExists(_controllerMetrics, OFFLINE_TABLE_NAME, firstTenant,
+        ControllerGauge.TABLE_TENANT_INFO), "stale firstTenant gauge must be removed after tenant change");
+  }
+
+  @Test
+  public void tableTenantInfoGaugeTableRemovedCleansUpTest() {
+    String serverTenant = "myTenant";
+
+    IdealState idealState = new IdealState(OFFLINE_TABLE_NAME);
+    idealState.setReplicas("1");
+    idealState.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
+
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    when(resourceManager.getAllTables()).thenReturn(List.of(OFFLINE_TABLE_NAME));
+    when(resourceManager.getTableConfig(OFFLINE_TABLE_NAME)).thenReturn(
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setServerTenant(serverTenant).build());
+    when(resourceManager.getTableIdealState(OFFLINE_TABLE_NAME)).thenReturn(idealState);
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    when(resourceManager.getPropertyStore()).thenReturn(propertyStore);
+
+    SegmentStatusChecker checker = buildSegmentStatusChecker(resourceManager, 0);
+    checker.start();
+    checker.run();
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, OFFLINE_TABLE_NAME, serverTenant,
+        ControllerGauge.TABLE_TENANT_INFO), 1);
+
+    // Table disappears from Helix — nonLeaderCleanup triggers removeMetricsForTable.
+    checker.nonLeaderCleanup(List.of(OFFLINE_TABLE_NAME));
+    assertFalse(MetricValueUtils.tableGaugeExists(_controllerMetrics, OFFLINE_TABLE_NAME, serverTenant,
+        ControllerGauge.TABLE_TENANT_INFO), "tenant gauge must be removed when table is cleaned up");
+  }
+
+  @Test
+  public void tableTenantInfoGaugeRealtimeTableTest() {
+    String serverTenant = "realtimeTenant";
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setServerTenant(serverTenant)
+            .setTimeColumnName("timeColumn").setStreamConfigs(getStreamConfigMap()).build();
+
+    IdealState idealState = new IdealState(REALTIME_TABLE_NAME);
+    idealState.setReplicas("1");
+    idealState.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
+
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    when(resourceManager.getAllTables()).thenReturn(List.of(REALTIME_TABLE_NAME));
+    when(resourceManager.getTableConfig(REALTIME_TABLE_NAME)).thenReturn(tableConfig);
+    when(resourceManager.getTableIdealState(REALTIME_TABLE_NAME)).thenReturn(idealState);
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    when(resourceManager.getPropertyStore()).thenReturn(propertyStore);
+
+    runSegmentStatusChecker(resourceManager, 0);
+
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, REALTIME_TABLE_NAME, serverTenant,
+        ControllerGauge.TABLE_TENANT_INFO), 1);
+  }
+
+  private SegmentStatusChecker buildSegmentStatusChecker(PinotHelixResourceManager resourceManager,
+      int waitForPushTimeInSeconds) {
+    LeadControllerManager leadControllerManager = mock(LeadControllerManager.class);
+    when(leadControllerManager.isLeaderForTable(anyString())).thenReturn(true);
+    ControllerConf controllerConf = mock(ControllerConf.class);
+    when(controllerConf.getStatusCheckerWaitForPushTimeInSeconds()).thenReturn(waitForPushTimeInSeconds);
+    TableSizeReader tableSizeReader = mock(TableSizeReader.class);
+    return new SegmentStatusChecker(resourceManager, leadControllerManager, controllerConf, _controllerMetrics,
+        tableSizeReader);
+  }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
@@ -39,6 +39,7 @@ import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.metrics.MetricValueUtils;
+import org.apache.pinot.common.tier.TierFactory;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.LeadControllerManager;
@@ -48,6 +49,7 @@ import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.util.TableSizeReader;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.TierConfig;
 import org.apache.pinot.spi.metrics.PinotMetricUtils;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Segment.Realtime.Status;
@@ -980,8 +982,10 @@ public class SegmentStatusCheckerTest {
   @Test
   public void tableTenantInfoGaugeNamedTenantTest() {
     String serverTenant = "myTenant";
+    String brokerTenant = "myBroker";
     TableConfig tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setServerTenant(serverTenant).build();
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setServerTenant(serverTenant)
+            .setBrokerTenant(brokerTenant).build();
 
     IdealState idealState = new IdealState(OFFLINE_TABLE_NAME);
     idealState.setReplicas("1");
@@ -996,13 +1000,15 @@ public class SegmentStatusCheckerTest {
 
     runSegmentStatusChecker(resourceManager, 0);
 
-    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, OFFLINE_TABLE_NAME, serverTenant,
-        ControllerGauge.TABLE_TENANT_INFO), 1);
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, OFFLINE_TABLE_NAME,
+        "server." + serverTenant, ControllerGauge.TABLE_TENANT_INFO), 1);
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, OFFLINE_TABLE_NAME,
+        "broker." + brokerTenant, ControllerGauge.TABLE_TENANT_INFO), 1);
   }
 
   @Test
   public void tableTenantInfoGaugeDefaultTenantFallbackTest() {
-    // No server tenant configured — should fall back to "DefaultTenant".
+    // No tenant configured — both server and broker should fall back to "DefaultTenant".
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
 
     IdealState idealState = new IdealState(OFFLINE_TABLE_NAME);
@@ -1019,7 +1025,37 @@ public class SegmentStatusCheckerTest {
     runSegmentStatusChecker(resourceManager, 0);
 
     assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, OFFLINE_TABLE_NAME,
-        "DefaultTenant", ControllerGauge.TABLE_TENANT_INFO), 1);
+        "server.DefaultTenant", ControllerGauge.TABLE_TENANT_INFO), 1);
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, OFFLINE_TABLE_NAME,
+        "broker.DefaultTenant", ControllerGauge.TABLE_TENANT_INFO), 1);
+  }
+
+  @Test
+  public void tableTenantInfoGaugeTierTenantTest() {
+    // Table with a tier config — tier server tenant should be extracted from the server tag and emitted.
+    TierConfig tierConfig = new TierConfig("coldTier", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
+        TierFactory.PINOT_SERVER_STORAGE_TYPE, "tierTenant_OFFLINE", null, null);
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setServerTenant("myTenant")
+            .setTierConfigList(List.of(tierConfig)).build();
+
+    IdealState idealState = new IdealState(OFFLINE_TABLE_NAME);
+    idealState.setReplicas("1");
+    idealState.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
+
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    when(resourceManager.getAllTables()).thenReturn(List.of(OFFLINE_TABLE_NAME));
+    when(resourceManager.getTableConfig(OFFLINE_TABLE_NAME)).thenReturn(tableConfig);
+    when(resourceManager.getTableIdealState(OFFLINE_TABLE_NAME)).thenReturn(idealState);
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    when(resourceManager.getPropertyStore()).thenReturn(propertyStore);
+
+    runSegmentStatusChecker(resourceManager, 0);
+
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, OFFLINE_TABLE_NAME,
+        "server.myTenant", ControllerGauge.TABLE_TENANT_INFO), 1);
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, OFFLINE_TABLE_NAME,
+        "tier.tierTenant", ControllerGauge.TABLE_TENANT_INFO), 1);
   }
 
   @Test
@@ -1043,17 +1079,17 @@ public class SegmentStatusCheckerTest {
     SegmentStatusChecker checker = buildSegmentStatusChecker(resourceManager, 0);
     checker.start();
     checker.run();
-    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, OFFLINE_TABLE_NAME, firstTenant,
-        ControllerGauge.TABLE_TENANT_INFO), 1);
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, OFFLINE_TABLE_NAME,
+        "server." + firstTenant, ControllerGauge.TABLE_TENANT_INFO), 1);
 
     // Second run: table moves to secondTenant — stale gauge for firstTenant must be removed.
     when(resourceManager.getTableConfig(OFFLINE_TABLE_NAME)).thenReturn(
         new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setServerTenant(secondTenant).build());
     checker.run();
-    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, OFFLINE_TABLE_NAME, secondTenant,
-        ControllerGauge.TABLE_TENANT_INFO), 1);
-    assertFalse(MetricValueUtils.tableGaugeExists(_controllerMetrics, OFFLINE_TABLE_NAME, firstTenant,
-        ControllerGauge.TABLE_TENANT_INFO), "stale firstTenant gauge must be removed after tenant change");
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, OFFLINE_TABLE_NAME,
+        "server." + secondTenant, ControllerGauge.TABLE_TENANT_INFO), 1);
+    assertFalse(MetricValueUtils.tableGaugeExists(_controllerMetrics, OFFLINE_TABLE_NAME, "server." + firstTenant,
+        ControllerGauge.TABLE_TENANT_INFO), "stale server firstTenant gauge must be removed after tenant change");
   }
 
   @Test
@@ -1075,12 +1111,12 @@ public class SegmentStatusCheckerTest {
     SegmentStatusChecker checker = buildSegmentStatusChecker(resourceManager, 0);
     checker.start();
     checker.run();
-    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, OFFLINE_TABLE_NAME, serverTenant,
-        ControllerGauge.TABLE_TENANT_INFO), 1);
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, OFFLINE_TABLE_NAME,
+        "server." + serverTenant, ControllerGauge.TABLE_TENANT_INFO), 1);
 
     // Table disappears from Helix — nonLeaderCleanup triggers removeMetricsForTable.
     checker.nonLeaderCleanup(List.of(OFFLINE_TABLE_NAME));
-    assertFalse(MetricValueUtils.tableGaugeExists(_controllerMetrics, OFFLINE_TABLE_NAME, serverTenant,
+    assertFalse(MetricValueUtils.tableGaugeExists(_controllerMetrics, OFFLINE_TABLE_NAME, "server." + serverTenant,
         ControllerGauge.TABLE_TENANT_INFO), "tenant gauge must be removed when table is cleaned up");
   }
 
@@ -1104,8 +1140,8 @@ public class SegmentStatusCheckerTest {
 
     runSegmentStatusChecker(resourceManager, 0);
 
-    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, REALTIME_TABLE_NAME, serverTenant,
-        ControllerGauge.TABLE_TENANT_INFO), 1);
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, REALTIME_TABLE_NAME,
+        "server." + serverTenant, ControllerGauge.TABLE_TENANT_INFO), 1);
   }
 
   private SegmentStatusChecker buildSegmentStatusChecker(PinotHelixResourceManager resourceManager,


### PR DESCRIPTION
## Summary

- Adds a new `TABLE_TENANT_INFO` controller gauge emitted by `SegmentStatusChecker` that encodes both the tenant type and tenant name as key segments in the JMX metric name: `pinot.controller.tableTenantInfo.<tableNameWithType>.<tenantType>.<tenantName> = 1`
- Covers all three tenant types per table: `server` (server tenant), `broker` (broker tenant), and `tier` (tier server tenant, when tier configs exist)
- Adds a dedicated JMX exporter rule in `controller.yml` that extracts `table`, `tableType`, `tenantType`, `tenant`, and `database` as Prometheus labels
- Enables tenant-scoped aggregation of any existing table-level metric in Prometheus via a `group_left(tenant)` join — no changes to broker/server metric pipelines required

## Motivation

Previously there was no way to aggregate table-scoped metrics (e.g. `numDocsScanned`, segment counts) by tenant in Prometheus/Grafana without scattered, disruptive changes to add a `tenant` tag throughout the metrics pipeline. This approach exposes the table→tenant mapping as a standalone info metric that Prometheus can join against.

**Aggregate across all tenants:**
```promql
sum by (tenant) (
  sum by (table) (pinot_server_numDocsScanned_OneMinuteRate{...})
  * on(table) group_left(tenant)
  pinot_controller_tableTenantInfo
)
```

**Filter to a specific tenant (e.g. `DefaultTenant`):**
```promql
sum by (tenant) (
  sum by (table) (pinot_server_numDocsScanned_OneMinuteRate{...})
  * on(table) group_left(tenant)
  pinot_controller_tableTenantInfo{tenant="DefaultTenant"}
)
```

**Filter by tenant type (e.g. only server tenants):**
```promql
sum by (tenant) (
  sum by (table) (pinot_server_numDocsScanned_OneMinuteRate{...})
  * on(table) group_left(tenant)
  pinot_controller_tableTenantInfo{tenantType="server"}
)
```

The `tenant` and `tenantType` labels can be used in any label matcher (`=`, `!=`, `=~`, `!~`) wherever PromQL label selectors are supported — in dashboards, alerts, and recording rules.

## Implementation

**JMX metric name pattern:**
```
pinot.controller.tableTenantInfo.<tableNameWithType>.<tenantType>.<tenantName>
```

**Prometheus output (via JMX exporter):**
```
pinot_controller_tableTenantInfo_Value{table="airlineStats", tableType="OFFLINE", tenantType="server", tenant="DefaultTenant"} 1
pinot_controller_tableTenantInfo_Value{table="airlineStats", tableType="OFFLINE", tenantType="broker", tenant="DefaultTenant"} 1
pinot_controller_tableTenantInfo_Value{table="airlineStats", tableType="OFFLINE", tenantType="tier",   tenant="tierTenant"}    1
```

**Emission strategy:**
- Gauges are written only once per `(table, tenantType, tenantName)` tuple — on first registration or when the tenant assignment changes. Not re-emitted on every 5-minute `SegmentStatusChecker` cycle (early-return when the key set is unchanged).
- `_tableTenantMap` tracks the current set of compound keys per table so stale gauges are removed on: tenant change, null table config, and table removal (`nonLeaderCleanup`).
- New gauges are registered **before** removing stale ones on an assignment change, to avoid a scrape-window gap.

## Test plan

- [ ] `tableTenantInfoGaugeNamedTenantTest` — named server and broker tenants are both registered
- [ ] `tableTenantInfoGaugeDefaultTenantFallbackTest` — server and broker fall back to `DefaultTenant` when unconfigured
- [ ] `tableTenantInfoGaugeTierTenantTest` — tier server tenant is extracted from the tier's server tag
- [ ] `tableTenantInfoGaugeTenantChangeCleansStaleGaugeTest` — stale gauge removed when server tenant changes
- [ ] `tableTenantInfoGaugeTableRemovedCleansUpTest` — all gauges cleaned up via `nonLeaderCleanup`
- [ ] `tableTenantInfoGaugeRealtimeTableTest` — REALTIME table type covered
- [ ] Verified locally via batch quickstart: 7 MBeans registered across 3 tables (server + broker + tier where applicable), all value=1