### PR TITLE
Change segment names to add stable config IDs for multi topic ingestion

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java
@@ -73,7 +73,8 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
   }
 
   /**
-   * Returns whether the given segment name represents an LLC segment.
+   * Returns whether the given segment name represents an LLC segment (either 4-part single-topic
+   * or 5-part multi-topic format).
    */
   public static boolean isLLCSegment(String segmentName) {
     int numSeparators = 0;
@@ -82,7 +83,13 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
       numSeparators++;
       index += 2; // SEPARATOR.length()
     }
-    return numSeparators == 3;
+    if (numSeparators == 3) {
+      return true;
+    }
+    if (numSeparators == 4) {
+      return MultiTopicLLCSegmentName.isMultiTopicLLCSegment(segmentName);
+    }
+    return false;
   }
 
   @Deprecated

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -41,11 +42,21 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
 
   public LLCSegmentName(String segmentName) {
     String[] parts = StringUtils.splitByWholeSeparator(segmentName, SEPARATOR);
-    Preconditions.checkArgument(parts.length == 4, "Invalid LLC segment name: %s", segmentName);
-    _tableName = parts[0];
-    _partitionGroupId = Integer.parseInt(parts[1]);
-    _sequenceNumber = Integer.parseInt(parts[2]);
-    _creationTime = parts[3];
+    if (parts.length == 5) {
+      // Multi-topic format: tableName__configId__streamPartitionId__sequenceNumber__creationTime
+      _tableName = parts[0];
+      int configId = Integer.parseInt(parts[1]);
+      int streamPartitionId = Integer.parseInt(parts[2]);
+      _partitionGroupId = configId * IngestionConfigUtils.PARTITION_PADDING_OFFSET + streamPartitionId;
+      _sequenceNumber = Integer.parseInt(parts[3]);
+      _creationTime = parts[4];
+    } else {
+      Preconditions.checkArgument(parts.length == 4, "Invalid LLC segment name: %s", segmentName);
+      _tableName = parts[0];
+      _partitionGroupId = Integer.parseInt(parts[1]);
+      _sequenceNumber = Integer.parseInt(parts[2]);
+      _creationTime = parts[3];
+    }
     _segmentName = segmentName;
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java
@@ -36,6 +36,7 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
 
   private final String _tableName;
   private final int _partitionGroupId;
+  private final int _streamConfigId;
   private final int _sequenceNumber;
   private final String _creationTime;
   private final String _segmentName;
@@ -47,6 +48,7 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
       _tableName = parts[0];
       int configId = Integer.parseInt(parts[1]);
       int streamPartitionId = Integer.parseInt(parts[2]);
+      _streamConfigId = configId;
       _partitionGroupId = configId * IngestionConfigUtils.PARTITION_PADDING_OFFSET + streamPartitionId;
       _sequenceNumber = Integer.parseInt(parts[3]);
       _creationTime = parts[4];
@@ -54,6 +56,7 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
       Preconditions.checkArgument(parts.length == 4, "Invalid LLC segment name: %s", segmentName);
       _tableName = parts[0];
       _partitionGroupId = Integer.parseInt(parts[1]);
+      _streamConfigId = 0;
       _sequenceNumber = Integer.parseInt(parts[2]);
       _creationTime = parts[3];
     }
@@ -64,6 +67,7 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
     Preconditions.checkArgument(!tableName.contains(SEPARATOR), "Illegal table name: %s", tableName);
     _tableName = tableName;
     _partitionGroupId = partitionGroupId;
+    _streamConfigId = 0;
     _sequenceNumber = sequenceNumber;
     // ISO8601 date: 20160120T1234Z
     _creationTime = DATE_FORMATTER.print(msSinceEpoch);
@@ -121,6 +125,10 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
 
   public int getPartitionGroupId() {
     return _partitionGroupId;
+  }
+
+  public int getStreamConfigId() {
+    return _streamConfigId;
   }
 
   public int getSequenceNumber() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/MultiTopicLLCSegmentName.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/MultiTopicLLCSegmentName.java
@@ -1,0 +1,183 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.base.Preconditions;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+
+/**
+ * Segment name for multi-topic LLC realtime segments with 5-part format:
+ * {@code tableName__configId__streamPartitionId__sequenceNumber__creationTime}
+ *
+ * <p>This format stores the stream config ID and stream partition ID as separate fields
+ * rather than encoding them into a single partition group ID ({@code configId * 10000 + partitionId}).
+ * This eliminates collision and overflow risks from the encoding scheme.
+ *
+ * <p>Existing 4-part segments ({@link LLCSegmentName}) are not affected. Both formats can
+ * coexist in the same table. Use {@link #of(String)} to parse a segment name that may be
+ * in either format.
+ */
+public class MultiTopicLLCSegmentName implements Comparable<MultiTopicLLCSegmentName> {
+  private static final String SEPARATOR = "__";
+  private static final String DATE_FORMAT = "yyyyMMdd'T'HHmm'Z'";
+  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormat.forPattern(DATE_FORMAT).withZoneUTC();
+
+  private final String _tableName;
+  private final int _configId;
+  private final int _streamPartitionId;
+  private final int _sequenceNumber;
+  private final String _creationTime;
+  private final String _segmentName;
+
+  public MultiTopicLLCSegmentName(String segmentName) {
+    String[] parts = StringUtils.splitByWholeSeparator(segmentName, SEPARATOR);
+    Preconditions.checkArgument(parts.length == 5, "Invalid multi-topic LLC segment name: %s", segmentName);
+    _tableName = parts[0];
+    _configId = Integer.parseInt(parts[1]);
+    _streamPartitionId = Integer.parseInt(parts[2]);
+    _sequenceNumber = Integer.parseInt(parts[3]);
+    _creationTime = parts[4];
+    _segmentName = segmentName;
+  }
+
+  public MultiTopicLLCSegmentName(String tableName, int configId, int streamPartitionId, int sequenceNumber,
+      long msSinceEpoch) {
+    Preconditions.checkArgument(!tableName.contains(SEPARATOR), "Illegal table name: %s", tableName);
+    _tableName = tableName;
+    _configId = configId;
+    _streamPartitionId = streamPartitionId;
+    _sequenceNumber = sequenceNumber;
+    _creationTime = DATE_FORMATTER.print(msSinceEpoch);
+    _segmentName = tableName + SEPARATOR + configId + SEPARATOR + streamPartitionId + SEPARATOR + sequenceNumber
+        + SEPARATOR + _creationTime;
+  }
+
+  @Nullable
+  public static MultiTopicLLCSegmentName of(String segmentName) {
+    try {
+      return new MultiTopicLLCSegmentName(segmentName);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  /**
+   * Returns whether the given segment name is a multi-topic LLC segment (5-part format where
+   * parts[1] and parts[3] are integers, distinguishing it from UploadedRealtimeSegmentName).
+   */
+  public static boolean isMultiTopicLLCSegment(String segmentName) {
+    String[] parts = StringUtils.splitByWholeSeparator(segmentName, SEPARATOR);
+    if (parts.length != 5) {
+      return false;
+    }
+    try {
+      Integer.parseInt(parts[1]); // configId
+      Integer.parseInt(parts[2]); // streamPartitionId
+      Integer.parseInt(parts[3]); // sequenceNumber
+      return true;
+    } catch (NumberFormatException e) {
+      return false;
+    }
+  }
+
+  public String getTableName() {
+    return _tableName;
+  }
+
+  public int getConfigId() {
+    return _configId;
+  }
+
+  public int getStreamPartitionId() {
+    return _streamPartitionId;
+  }
+
+  /// Returns the encoded partition group ID for backward compatibility with code
+  /// that expects the single-integer encoding ({@code configId * 10000 + streamPartitionId}).
+  public int getPartitionGroupId() {
+    return IngestionConfigUtils.getPinotPartitionIdFromConfigId(_streamPartitionId, _configId);
+  }
+
+  public int getSequenceNumber() {
+    return _sequenceNumber;
+  }
+
+  public String getCreationTime() {
+    return _creationTime;
+  }
+
+  public long getCreationTimeMs() {
+    DateTime dateTime = DATE_FORMATTER.parseDateTime(_creationTime);
+    return dateTime.getMillis();
+  }
+
+  @JsonValue
+  public String getSegmentName() {
+    return _segmentName;
+  }
+
+  /// Converts this multi-topic segment name to an equivalent {@link LLCSegmentName} using the
+  /// encoded partition group ID. Useful for interacting with code that only understands the 4-part format.
+  public LLCSegmentName toLLCSegmentName() {
+    return new LLCSegmentName(_tableName, getPartitionGroupId(), _sequenceNumber, getCreationTimeMs());
+  }
+
+  @Override
+  public int compareTo(MultiTopicLLCSegmentName other) {
+    Preconditions.checkArgument(_tableName.equals(other._tableName),
+        "Cannot compare segment names from different table: %s, %s", _segmentName, other.getSegmentName());
+    if (_configId != other._configId) {
+      return Integer.compare(_configId, other._configId);
+    }
+    if (_streamPartitionId != other._streamPartitionId) {
+      return Integer.compare(_streamPartitionId, other._streamPartitionId);
+    }
+    return Integer.compare(_sequenceNumber, other._sequenceNumber);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof MultiTopicLLCSegmentName)) {
+      return false;
+    }
+    MultiTopicLLCSegmentName that = (MultiTopicLLCSegmentName) o;
+    return _segmentName.equals(that._segmentName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_segmentName);
+  }
+
+  @Override
+  public String toString() {
+    return _segmentName;
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/SegmentUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/SegmentUtils.java
@@ -74,6 +74,10 @@ public class SegmentUtils {
     if (llcSegmentName != null) {
       return llcSegmentName.getPartitionGroupId();
     }
+    MultiTopicLLCSegmentName multiTopicLLCSegmentName = MultiTopicLLCSegmentName.of(segmentName);
+    if (multiTopicLLCSegmentName != null) {
+      return multiTopicLLCSegmentName.getPartitionGroupId();
+    }
     UploadedRealtimeSegmentName uploadedRealtimeSegmentName = UploadedRealtimeSegmentName.of(segmentName);
     if (uploadedRealtimeSegmentName != null) {
       return uploadedRealtimeSegmentName.getPartitionId();

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/MultiTopicLLCSegmentNameTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/MultiTopicLLCSegmentNameTest.java
@@ -1,0 +1,146 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class MultiTopicLLCSegmentNameTest {
+
+  @Test
+  public void testConstructFromComponents() {
+    MultiTopicLLCSegmentName name = new MultiTopicLLCSegmentName("myTable", 2, 5, 3, 1700000000000L);
+    assertEquals(name.getTableName(), "myTable");
+    assertEquals(name.getConfigId(), 2);
+    assertEquals(name.getStreamPartitionId(), 5);
+    assertEquals(name.getSequenceNumber(), 3);
+    assertEquals(name.getPartitionGroupId(), 20005);
+    assertEquals(name.getSegmentName(), "myTable__2__5__3__20231114T2213Z");
+  }
+
+  @Test
+  public void testConstructFromString() {
+    MultiTopicLLCSegmentName name = new MultiTopicLLCSegmentName("myTable__2__5__3__20231114T2213Z");
+    assertEquals(name.getTableName(), "myTable");
+    assertEquals(name.getConfigId(), 2);
+    assertEquals(name.getStreamPartitionId(), 5);
+    assertEquals(name.getSequenceNumber(), 3);
+    assertEquals(name.getPartitionGroupId(), 20005);
+  }
+
+  @Test
+  public void testOfValidName() {
+    MultiTopicLLCSegmentName name = MultiTopicLLCSegmentName.of("myTable__0__63__10__20231215T0000Z");
+    assertNotNull(name);
+    assertEquals(name.getConfigId(), 0);
+    assertEquals(name.getStreamPartitionId(), 63);
+    assertEquals(name.getSequenceNumber(), 10);
+    assertEquals(name.getPartitionGroupId(), 63);
+  }
+
+  @Test
+  public void testOfInvalidName() {
+    // 4-part LLC format — should return null
+    assertNull(MultiTopicLLCSegmentName.of("myTable__10005__3__20231215T0000Z"));
+    // Uploaded realtime format — should return null (parts[3] is a date, not integer)
+    assertNull(MultiTopicLLCSegmentName.of("uploaded__myTable__5__20231215T0000Z__suffix"));
+    // Garbage
+    assertNull(MultiTopicLLCSegmentName.of("not_a_segment"));
+  }
+
+  @Test
+  public void testIsMultiTopicLLCSegment() {
+    assertTrue(MultiTopicLLCSegmentName.isMultiTopicLLCSegment("myTable__2__5__3__20231215T0000Z"));
+    assertTrue(MultiTopicLLCSegmentName.isMultiTopicLLCSegment("myTable__0__0__0__20231215T0000Z"));
+    // 4-part LLC
+    assertFalse(MultiTopicLLCSegmentName.isMultiTopicLLCSegment("myTable__10005__3__20231215T0000Z"));
+    // Uploaded realtime — parts[3] is a date string, not parseable as integer
+    assertFalse(MultiTopicLLCSegmentName.isMultiTopicLLCSegment("uploaded__myTable__5__20231215T0000Z__suffix"));
+    // 3 parts
+    assertFalse(MultiTopicLLCSegmentName.isMultiTopicLLCSegment("a__b__c"));
+  }
+
+  @Test
+  public void testPartitionGroupIdEncoding() {
+    // configId=0, partition=5 -> 5
+    MultiTopicLLCSegmentName name0 = new MultiTopicLLCSegmentName("myTable", 0, 5, 0, 1700000000000L);
+    assertEquals(name0.getPartitionGroupId(), 5);
+
+    // configId=1, partition=3 -> 10003
+    MultiTopicLLCSegmentName name1 = new MultiTopicLLCSegmentName("myTable", 1, 3, 0, 1700000000000L);
+    assertEquals(name1.getPartitionGroupId(), 10003);
+
+    // configId=5, partition=99 -> 50099
+    MultiTopicLLCSegmentName name5 = new MultiTopicLLCSegmentName("myTable", 5, 99, 0, 1700000000000L);
+    assertEquals(name5.getPartitionGroupId(), 50099);
+  }
+
+  @Test
+  public void testToLLCSegmentName() {
+    MultiTopicLLCSegmentName multiTopic = new MultiTopicLLCSegmentName("myTable", 1, 5, 3, 1700000000000L);
+    LLCSegmentName llc = multiTopic.toLLCSegmentName();
+    assertEquals(llc.getTableName(), "myTable");
+    assertEquals(llc.getPartitionGroupId(), 10005);
+    assertEquals(llc.getSequenceNumber(), 3);
+  }
+
+  @Test
+  public void testCompareTo() {
+    MultiTopicLLCSegmentName a = new MultiTopicLLCSegmentName("myTable", 0, 5, 1, 1700000000000L);
+    MultiTopicLLCSegmentName b = new MultiTopicLLCSegmentName("myTable", 0, 5, 2, 1700000000000L);
+    MultiTopicLLCSegmentName c = new MultiTopicLLCSegmentName("myTable", 1, 0, 0, 1700000000000L);
+
+    assertTrue(a.compareTo(b) < 0);
+    assertTrue(b.compareTo(a) > 0);
+    assertTrue(a.compareTo(c) < 0); // configId 0 < configId 1
+  }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    MultiTopicLLCSegmentName a = new MultiTopicLLCSegmentName("myTable", 1, 5, 3, 1700000000000L);
+    MultiTopicLLCSegmentName b = new MultiTopicLLCSegmentName(a.getSegmentName());
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+
+    MultiTopicLLCSegmentName c = new MultiTopicLLCSegmentName("myTable", 1, 5, 4, 1700000000000L);
+    assertNotEquals(a, c);
+  }
+
+  @Test
+  public void testLLCSegmentNameIsLLCSegmentIncludesMultiTopic() {
+    // 4-part format
+    assertTrue(LLCSegmentName.isLLCSegment("myTable__10005__3__20231215T0000Z"));
+    // 5-part multi-topic format
+    assertTrue(LLCSegmentName.isLLCSegment("myTable__1__5__3__20231215T0000Z"));
+    // Uploaded realtime — should NOT be detected as LLC
+    assertFalse(LLCSegmentName.isLLCSegment("uploaded__myTable__5__20231215T0000Z__suffix"));
+  }
+
+  @Test
+  public void testSegmentUtilsPartitionId() {
+    // Multi-topic segment returns encoded partition group ID
+    assertEquals(SegmentUtils.getPartitionIdFromSegmentName("myTable__1__5__3__20231215T0000Z"),
+        Integer.valueOf(10005));
+    // Standard LLC segment
+    assertEquals(SegmentUtils.getPartitionIdFromSegmentName("myTable__10005__3__20231215T0000Z"),
+        Integer.valueOf(10005));
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -392,31 +392,28 @@ public class PinotTableRestletResource {
       throws Exception {
     Map<Integer, Integer> streamPartitionCountMap =
         _pinotHelixResourceManager.getRealtimeSegmentManager().getPartitionCountMap(streamConfigs);
-    Map<Integer, List<PartitionGroupMetadata>> partitionGroupMetadataByStreamConfigIndex = new HashMap<>();
+    Map<Integer, List<PartitionGroupMetadata>> partitionGroupMetadataByConfigId = new HashMap<>();
     for (WatermarkInductionResult.Watermark watermark : watermarkInductionResult.getWatermarks()) {
-      int streamConfigIndex =
-          IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(watermark.getPartitionGroupId());
-      Preconditions.checkArgument(streamConfigIndex >= 0 && streamConfigIndex < streamConfigs.size(),
-          "Invalid stream config index %s from watermark partition ID %s. Expected index in range [0, %s)",
-          streamConfigIndex, watermark.getPartitionGroupId(), streamConfigs.size());
-      partitionGroupMetadataByStreamConfigIndex.computeIfAbsent(streamConfigIndex, ignored -> new ArrayList<>()).add(
+      int configId = IngestionConfigUtils.getConfigIdFromPinotPartitionId(watermark.getPartitionGroupId());
+      partitionGroupMetadataByConfigId.computeIfAbsent(configId, ignored -> new ArrayList<>()).add(
           new PartitionGroupMetadata(watermark.getPartitionGroupId(), new LongMsgOffset(watermark.getOffset()),
               watermark.getSequenceNumber()));
     }
 
-    // Iterate in order by streamConfigIndex to ensure deterministic ordering
-    List<StreamMetadata> streamMetadataList = new ArrayList<>(partitionGroupMetadataByStreamConfigIndex.size());
-    for (int streamConfigIndex = 0; streamConfigIndex < streamConfigs.size(); streamConfigIndex++) {
+    // Iterate over stream configs in order to ensure deterministic ordering
+    List<StreamMetadata> streamMetadataList = new ArrayList<>(partitionGroupMetadataByConfigId.size());
+    for (int i = 0; i < streamConfigs.size(); i++) {
+      int configId = IngestionConfigUtils.getConfigIdFromStreamConfig(streamConfigs.get(i));
       List<PartitionGroupMetadata> partitionGroupMetadataList =
-          partitionGroupMetadataByStreamConfigIndex.get(streamConfigIndex);
+          partitionGroupMetadataByConfigId.get(configId);
       if (partitionGroupMetadataList == null) {
-        // No watermarks for this stream config index, skip it
+        // No watermarks for this stream config, skip it
         continue;
       }
-      Integer partitionCount = streamPartitionCountMap.get(streamConfigIndex);
+      Integer partitionCount = streamPartitionCountMap.get(configId);
       Preconditions.checkState(partitionCount != null,
-          "Cannot find partition count for stream config index: %s", streamConfigIndex);
-      streamMetadataList.add(new StreamMetadata(streamConfigs.get(streamConfigIndex),
+          "Cannot find partition count for stream config ID: %s", configId);
+      streamMetadataList.add(new StreamMetadata(streamConfigs.get(i),
           partitionCount, partitionGroupMetadataList));
     }
     return streamMetadataList;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -316,18 +316,17 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
       }
     } else {
       // Multiple streams
-      StreamPartitionMsgOffsetFactory[] offsetFactories = new StreamPartitionMsgOffsetFactory[numStreams];
+      Map<Integer, StreamPartitionMsgOffsetFactory> offsetFactoriesByConfigId = new HashMap<>();
       for (Map.Entry<Integer, LLCSegmentName> entry : partitionGroupIdToLatestSegment.entrySet()) {
         int partitionGroupId = entry.getKey();
-        int index = IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(partitionGroupId);
-        int streamPartitionId = IngestionConfigUtils.getStreamPartitionIdFromPinotPartitionId(partitionGroupId);
         LLCSegmentName llcSegmentName = entry.getValue();
+        int configId = llcSegmentName.getStreamConfigId();
+        int streamPartitionId = IngestionConfigUtils.getStreamPartitionIdFromPinotPartitionId(partitionGroupId);
         SegmentZKMetadata segmentZKMetadata = getSegmentZKMetadata(tableNameWithType, llcSegmentName.getSegmentName());
-        StreamPartitionMsgOffsetFactory offsetFactory = offsetFactories[index];
-        if (offsetFactory == null) {
-          offsetFactory = StreamConsumerFactoryProvider.create(streamConfigs.get(index)).createStreamMsgOffsetFactory();
-          offsetFactories[index] = offsetFactory;
-        }
+        StreamPartitionMsgOffsetFactory offsetFactory =
+            offsetFactoriesByConfigId.computeIfAbsent(configId, k -> StreamConsumerFactoryProvider.create(
+                IngestionConfigUtils.getStreamConfigFromPinotPartitionId(streamConfigs, partitionGroupId))
+                .createStreamMsgOffsetFactory());
         PartitionGroupConsumptionStatus partitionGroupConsumptionStatus =
             new PartitionGroupConsumptionStatus(partitionGroupId, streamPartitionId, llcSegmentName.getSequenceNumber(),
                 offsetFactory.create(segmentZKMetadata.getStartOffset()),
@@ -1273,10 +1272,10 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
       // Multiple streams
       for (int i = 0; i < numStreams; i++) {
         StreamConfig streamConfig = streamConfigs.get(i);
-        int index = i;
+        int configId = IngestionConfigUtils.getConfigIdFromStreamConfig(streamConfig);
         try {
           partitionIds.addAll(getPartitionIds(streamConfig).stream()
-              .map(partitionId -> IngestionConfigUtils.getPinotPartitionIdFromStreamPartitionId(partitionId, index))
+              .map(partitionId -> IngestionConfigUtils.getPinotPartitionIdFromConfigId(partitionId, configId))
               .collect(Collectors.toSet()));
         } catch (UnsupportedOperationException ignored) {
           allPartitionIdsFetched = false;
@@ -1582,8 +1581,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
   public static boolean isTopicPaused(IdealState idealState, String segmentName) {
     LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentName);
     if (llcSegmentName != null) {
-      return isTopicPaused(idealState,
-          IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(llcSegmentName.getPartitionGroupId()));
+      return isTopicPaused(idealState, llcSegmentName.getStreamConfigId());
     }
     return false;
   }
@@ -1830,7 +1828,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
       SegmentZKMetadata latestSegmentZKMetadata = entry.getValue();
       String latestSegmentName = latestSegmentZKMetadata.getSegmentName();
       LLCSegmentName latestLLCSegmentName = new LLCSegmentName(latestSegmentName);
-      int streamConfigIdx = IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(partitionId);
+      StreamConfig streamConfig =
+          IngestionConfigUtils.getStreamConfigFromPinotPartitionId(streamConfigs, partitionId);
 
       Map<String, String> instanceStateMap = instanceStatesMap.get(latestSegmentName);
       if (instanceStateMap != null) {
@@ -1855,7 +1854,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
               CommittingSegmentDescriptor committingSegmentDescriptor =
                   new CommittingSegmentDescriptor(latestSegmentName,
                       (offsetFactory.create(latestSegmentZKMetadata.getEndOffset()).toString()), 0);
-              createNewSegmentZKMetadata(tableConfig, streamConfigs.get(streamConfigIdx), newLLCSegmentName,
+              createNewSegmentZKMetadata(tableConfig, streamConfig, newLLCSegmentName,
                   currentTimeMs,
                   committingSegmentDescriptor, latestSegmentZKMetadata, instancePartitions, numPartitions, numReplicas);
               updateInstanceStatesForNewConsumingSegment(instanceStatesMap, latestSegmentName, newSegmentName,
@@ -1928,7 +1927,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
                 selectStartOffset(offsetCriteria, partitionId, partitionIdToStartOffset, partitionIdToSmallestOffset,
                     tableConfig.getTableName(), offsetFactory,
                     latestSegmentZKMetadata.getStartOffset()); // segments are OFFLINE; start from beginning
-            createNewConsumingSegment(tableConfig, streamConfigs.get(streamConfigIdx), latestSegmentZKMetadata,
+            createNewConsumingSegment(tableConfig, streamConfig, latestSegmentZKMetadata,
                 currentTimeMs, numPartitions, instancePartitions, instanceStatesMap, segmentAssignment,
                 instancePartitionsMap, startOffset);
           } else {
@@ -1936,7 +1935,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
             StreamPartitionMsgOffset startOffset =
                 selectStartOffset(offsetCriteria, partitionId, partitionIdToStartOffset, partitionIdToSmallestOffset,
                     tableConfig.getTableName(), offsetFactory, latestSegmentZKMetadata.getEndOffset());
-            createNewConsumingSegment(tableConfig, streamConfigs.get(streamConfigIdx), latestSegmentZKMetadata,
+            createNewConsumingSegment(tableConfig, streamConfig, latestSegmentZKMetadata,
                 currentTimeMs, numPartitions, instancePartitions, instanceStatesMap, segmentAssignment,
                 instancePartitionsMap, startOffset);
           }
@@ -2062,19 +2061,17 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
             zkMetadata.getStatus().toString()));
       }
     } else {
-      StreamPartitionMsgOffsetFactory[] offsetFactories = new StreamPartitionMsgOffsetFactory[numStreams];
+      Map<Integer, StreamPartitionMsgOffsetFactory> offsetFactoriesByConfigId = new HashMap<>();
       for (Map.Entry<Integer, SegmentZKMetadata> entry : latestSegmentZKMetadataMap.entrySet()) {
         int partitionGroupId = entry.getKey();
-        int index = IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(partitionGroupId);
         int streamPartitionId = IngestionConfigUtils.getStreamPartitionIdFromPinotPartitionId(partitionGroupId);
         SegmentZKMetadata zkMetadata = entry.getValue();
         LLCSegmentName llcSegmentName = new LLCSegmentName(zkMetadata.getSegmentName());
-        StreamPartitionMsgOffsetFactory offsetFactory = offsetFactories[index];
-        if (offsetFactory == null) {
-          offsetFactory =
-              StreamConsumerFactoryProvider.create(streamConfigs.get(index)).createStreamMsgOffsetFactory();
-          offsetFactories[index] = offsetFactory;
-        }
+        int configId = llcSegmentName.getStreamConfigId();
+        StreamPartitionMsgOffsetFactory offsetFactory =
+            offsetFactoriesByConfigId.computeIfAbsent(configId, k -> StreamConsumerFactoryProvider.create(
+                IngestionConfigUtils.getStreamConfigFromPinotPartitionId(streamConfigs, partitionGroupId))
+                .createStreamMsgOffsetFactory());
         result.add(new PartitionGroupConsumptionStatus(partitionGroupId, streamPartitionId,
             llcSegmentName.getSequenceNumber(),
             offsetFactory.create(zkMetadata.getStartOffset()),
@@ -2914,8 +2911,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     Set<String> consumingSegments = new TreeSet<>();
     idealState.getRecord().getMapFields().forEach((segmentName, instanceToStateMap) -> {
       LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentName);
-      if (llcSegmentName != null && !topicIndices.contains(
-          IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(llcSegmentName.getPartitionGroupId()))) {
+      if (llcSegmentName != null && !topicIndices.contains(llcSegmentName.getStreamConfigId())) {
         return;
       }
       for (String state : instanceToStateMap.values()) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -316,6 +316,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
       }
     } else {
       // Multiple streams
+      Map<Integer, StreamConfig> configIdToStreamConfig =
+          IngestionConfigUtils.buildConfigIdToStreamConfigMap(streamConfigs);
       Map<Integer, StreamPartitionMsgOffsetFactory> offsetFactoriesByConfigId = new HashMap<>();
       for (Map.Entry<Integer, LLCSegmentName> entry : partitionGroupIdToLatestSegment.entrySet()) {
         int partitionGroupId = entry.getKey();
@@ -325,7 +327,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
         SegmentZKMetadata segmentZKMetadata = getSegmentZKMetadata(tableNameWithType, llcSegmentName.getSegmentName());
         StreamPartitionMsgOffsetFactory offsetFactory =
             offsetFactoriesByConfigId.computeIfAbsent(configId, k -> StreamConsumerFactoryProvider.create(
-                IngestionConfigUtils.getStreamConfigFromPinotPartitionId(streamConfigs, partitionGroupId))
+                configIdToStreamConfig.get(k))
                 .createStreamMsgOffsetFactory());
         PartitionGroupConsumptionStatus partitionGroupConsumptionStatus =
             new PartitionGroupConsumptionStatus(partitionGroupId, streamPartitionId, llcSegmentName.getSequenceNumber(),
@@ -861,8 +863,9 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
       LLCSegmentName newLLCSegment = getNextLLCSegmentName(committingLLCSegment, newSegmentCreationTimeMs,
           streamConfigs.size() > 1);
 
-      StreamConfig streamConfig =
-          IngestionConfigUtils.getStreamConfigFromPinotPartitionId(streamConfigs, committingSegmentPartitionGroupId);
+      Map<Integer, StreamConfig> configIdToStreamConfig =
+          IngestionConfigUtils.buildConfigIdToStreamConfigMap(streamConfigs);
+      StreamConfig streamConfig = configIdToStreamConfig.get(committingLLCSegment.getStreamConfigId());
       createNewSegmentZKMetadata(tableConfig, streamConfig, newLLCSegment, newSegmentCreationTimeMs,
           committingSegmentDescriptor, committingSegmentZKMetadata, instancePartitions, partitionIds.size(),
           numReplicas);
@@ -1778,6 +1781,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     Map<String, Map<String, String>> instanceStatesMap = idealState.getRecord().getMapFields();
     StreamPartitionMsgOffsetFactory offsetFactory =
         StreamConsumerFactoryProvider.create(streamConfigs.get(0)).createStreamMsgOffsetFactory();
+    Map<Integer, StreamConfig> configIdToStreamConfig =
+        IngestionConfigUtils.buildConfigIdToStreamConfigMap(streamConfigs);
 
     // Get the latest segment ZK metadata for each partition
     Map<Integer, SegmentZKMetadata> latestSegmentZKMetadataMap = getLatestSegmentZKMetadataMap(realtimeTableName);
@@ -1828,8 +1833,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
       SegmentZKMetadata latestSegmentZKMetadata = entry.getValue();
       String latestSegmentName = latestSegmentZKMetadata.getSegmentName();
       LLCSegmentName latestLLCSegmentName = new LLCSegmentName(latestSegmentName);
-      StreamConfig streamConfig =
-          IngestionConfigUtils.getStreamConfigFromPinotPartitionId(streamConfigs, partitionId);
+      StreamConfig streamConfig = configIdToStreamConfig.get(latestLLCSegmentName.getStreamConfigId());
 
       Map<String, String> instanceStateMap = instanceStatesMap.get(latestSegmentName);
       if (instanceStateMap != null) {
@@ -2061,6 +2065,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
             zkMetadata.getStatus().toString()));
       }
     } else {
+      Map<Integer, StreamConfig> configIdToStreamConfig =
+          IngestionConfigUtils.buildConfigIdToStreamConfigMap(streamConfigs);
       Map<Integer, StreamPartitionMsgOffsetFactory> offsetFactoriesByConfigId = new HashMap<>();
       for (Map.Entry<Integer, SegmentZKMetadata> entry : latestSegmentZKMetadataMap.entrySet()) {
         int partitionGroupId = entry.getKey();
@@ -2070,7 +2076,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
         int configId = llcSegmentName.getStreamConfigId();
         StreamPartitionMsgOffsetFactory offsetFactory =
             offsetFactoriesByConfigId.computeIfAbsent(configId, k -> StreamConsumerFactoryProvider.create(
-                IngestionConfigUtils.getStreamConfigFromPinotPartitionId(streamConfigs, partitionGroupId))
+                configIdToStreamConfig.get(k))
                 .createStreamMsgOffsetFactory());
         result.add(new PartitionGroupConsumptionStatus(partitionGroupId, streamPartitionId,
             llcSegmentName.getSequenceNumber(),

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -85,6 +85,7 @@ import org.apache.pinot.common.restlet.resources.PauseStatusDetails;
 import org.apache.pinot.common.restlet.resources.TableLLCSegmentUploadResponse;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.MultiTopicLLCSegmentName;
 import org.apache.pinot.common.utils.PauselessConsumptionUtils;
 import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.common.utils.helix.HelixHelper;
@@ -858,8 +859,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
       }
       String rawTableName = TableNameBuilder.extractRawTableName(realtimeTableName);
       long newSegmentCreationTimeMs = getCurrentTimeMs();
-      LLCSegmentName newLLCSegment = new LLCSegmentName(rawTableName, committingSegmentPartitionGroupId,
-          committingLLCSegment.getSequenceNumber() + 1, newSegmentCreationTimeMs);
+      LLCSegmentName newLLCSegment = getNextLLCSegmentName(committingLLCSegment, newSegmentCreationTimeMs,
+          streamConfigs.size() > 1);
 
       StreamConfig streamConfig =
           IngestionConfigUtils.getStreamConfigFromPinotPartitionId(streamConfigs, committingSegmentPartitionGroupId);
@@ -1848,7 +1849,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
               LOGGER.info("Repairing segment: {} which is {} in segment ZK metadata, but is CONSUMING in IdealState",
                   latestSegmentName, statusPostSegmentMetadataUpdate);
 
-              LLCSegmentName newLLCSegmentName = getNextLLCSegmentName(latestLLCSegmentName, currentTimeMs);
+              LLCSegmentName newLLCSegmentName = getNextLLCSegmentName(latestLLCSegmentName, currentTimeMs,
+                  IngestionConfigUtils.hasMultipleStreams(tableConfig));
               String newSegmentName = newLLCSegmentName.getSegmentName();
               CommittingSegmentDescriptor committingSegmentDescriptor =
                   new CommittingSegmentDescriptor(latestSegmentName,
@@ -2000,7 +2002,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
       Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap, StreamPartitionMsgOffset startOffset) {
     int numReplicas = getNumReplicas(tableConfig, instancePartitions);
     LLCSegmentName latestLLCSegmentName = new LLCSegmentName(latestSegmentZKMetadata.getSegmentName());
-    LLCSegmentName newLLCSegmentName = getNextLLCSegmentName(latestLLCSegmentName, currentTimeMs);
+    LLCSegmentName newLLCSegmentName = getNextLLCSegmentName(latestLLCSegmentName, currentTimeMs,
+        IngestionConfigUtils.hasMultipleStreams(tableConfig));
     CommittingSegmentDescriptor committingSegmentDescriptor =
         new CommittingSegmentDescriptor(latestSegmentZKMetadata.getSegmentName(), startOffset.toString(), 0);
     createNewSegmentZKMetadata(tableConfig, streamConfig, newLLCSegmentName, currentTimeMs, committingSegmentDescriptor,
@@ -2104,9 +2107,19 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     }
   }
 
-  private LLCSegmentName getNextLLCSegmentName(LLCSegmentName lastLLCSegmentName, long creationTimeMs) {
-    return new LLCSegmentName(lastLLCSegmentName.getTableName(), lastLLCSegmentName.getPartitionGroupId(),
-        lastLLCSegmentName.getSequenceNumber() + 1, creationTimeMs);
+  private LLCSegmentName getNextLLCSegmentName(LLCSegmentName lastLLCSegmentName, long creationTimeMs,
+      boolean isMultiTopic) {
+    String tableName = lastLLCSegmentName.getTableName();
+    int nextSeq = lastLLCSegmentName.getSequenceNumber() + 1;
+    if (isMultiTopic) {
+      int partitionGroupId = lastLLCSegmentName.getPartitionGroupId();
+      int configId = IngestionConfigUtils.getConfigIdFromPinotPartitionId(partitionGroupId);
+      int streamPartitionId = IngestionConfigUtils.getStreamPartitionIdFromPinotPartitionId(partitionGroupId);
+      String segmentName = new MultiTopicLLCSegmentName(tableName, configId, streamPartitionId,
+          nextSeq, creationTimeMs).getSegmentName();
+      return new LLCSegmentName(segmentName);
+    }
+    return new LLCSegmentName(tableName, lastLLCSegmentName.getPartitionGroupId(), nextSeq, creationTimeMs);
   }
 
   /**
@@ -2131,8 +2144,16 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
         partitionGroupId, realtimeTableName, sequence, startOffset);
 
     String rawTableName = TableNameBuilder.extractRawTableName(realtimeTableName);
-    LLCSegmentName newLLCSegmentName =
-        new LLCSegmentName(rawTableName, partitionGroupId, sequence, creationTimeMs);
+    LLCSegmentName newLLCSegmentName;
+    if (IngestionConfigUtils.hasMultipleStreams(tableConfig)) {
+      int configId = IngestionConfigUtils.getConfigIdFromPinotPartitionId(partitionGroupId);
+      int streamPartitionId = IngestionConfigUtils.getStreamPartitionIdFromPinotPartitionId(partitionGroupId);
+      String segmentName = new MultiTopicLLCSegmentName(rawTableName, configId, streamPartitionId,
+          sequence, creationTimeMs).getSegmentName();
+      newLLCSegmentName = new LLCSegmentName(segmentName);
+    } else {
+      newLLCSegmentName = new LLCSegmentName(rawTableName, partitionGroupId, sequence, creationTimeMs);
+    }
     String newSegmentName = newLLCSegmentName.getSegmentName();
 
     CommittingSegmentDescriptor committingSegmentDescriptor = new CommittingSegmentDescriptor(null,

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
@@ -154,7 +154,8 @@ public class IngestionDelayTracker {
   private Clock _clock = Clock.systemUTC();
 
   protected volatile Map<Integer, StreamPartitionMsgOffset> _partitionIdToLatestOffset;
-  protected volatile ConcurrentHashMap<Integer, Boolean> _partitionsHostedByThisServer = new ConcurrentHashMap<>();
+  // Maps partitionGroupId -> streamConfigId, populated from LLCSegmentName so no arithmetic needed.
+  protected volatile ConcurrentHashMap<Integer, Integer> _partitionsHostedByThisServer = new ConcurrentHashMap<>();
   // Map of StreamMetadataProvider to fetch upstream latest stream offset (Table can have multiple upstream topics)
   // This map is accessed by:
   // 1. _ingestionDelayTrackingScheduler thread.
@@ -370,7 +371,8 @@ public class IngestionDelayTracker {
 
   @VisibleForTesting
   void createMetrics(int partitionId) {
-    int configId = IngestionConfigUtils.getConfigIdFromPinotPartitionId(partitionId);
+    int configId = _partitionsHostedByThisServer.getOrDefault(partitionId,
+        IngestionConfigUtils.getConfigIdFromPinotPartitionId(partitionId));
     StreamMetadataProvider streamMetadataProvider = _streamConfigIndexToStreamMetadataProvider.get(configId);
 
     if (streamMetadataProvider != null && streamMetadataProvider.supportsOffsetLag()) {
@@ -394,7 +396,8 @@ public class IngestionDelayTracker {
   }
 
   private void removeMetrics(int partitionId) {
-    int configId = IngestionConfigUtils.getConfigIdFromPinotPartitionId(partitionId);
+    int configId = _partitionsHostedByThisServer.getOrDefault(partitionId,
+        IngestionConfigUtils.getConfigIdFromPinotPartitionId(partitionId));
     StreamMetadataProvider streamMetadataProvider =
         _streamConfigIndexToStreamMetadataProvider.get(configId);
     // Remove all metrics associated with this partition
@@ -507,7 +510,11 @@ public class IngestionDelayTracker {
     }
     Set<Integer> partitionsHostedByThisServer;
     try {
-      partitionsHostedByThisServer = _realTimeTableDataManager.getHostedPartitionsGroupIds();
+      Map<Integer, Integer> partitionGroupIdToConfigId =
+          _realTimeTableDataManager.getHostedPartitionsGroupIds();
+      partitionsHostedByThisServer = partitionGroupIdToConfigId.keySet();
+      ConcurrentHashMap<Integer, Integer> newMap = new ConcurrentHashMap<>(partitionGroupIdToConfigId);
+      _partitionsHostedByThisServer = newMap;
     } catch (Exception e) {
       LOGGER.error("Failed to get partitions hosted by this server, table={}, exception={}:{}", _tableNameWithType,
           e.getClass(), e.getMessage());
@@ -519,10 +526,6 @@ public class IngestionDelayTracker {
         removePartitionId(partitionId);
       }
     }
-
-    ConcurrentHashMap<Integer, Boolean> newMap = new ConcurrentHashMap<>();
-    partitionsHostedByThisServer.forEach(p -> newMap.put(p, true));
-    _partitionsHostedByThisServer = newMap;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
@@ -198,14 +198,13 @@ public class IngestionDelayTracker {
     List<StreamConfig> streamConfigs =
         IngestionConfigUtils.getStreamConfigs(_realTimeTableDataManager.getCachedTableConfigAndSchema().getLeft());
 
-    for (int streamConfigIndex = 0; streamConfigIndex < streamConfigs.size(); streamConfigIndex++) {
-      if (_streamConfigIndexToStreamMetadataProvider.containsKey(streamConfigIndex)) {
+    for (StreamConfig streamConfig : streamConfigs) {
+      int configId = IngestionConfigUtils.getConfigIdFromStreamConfig(streamConfig);
+      if (_streamConfigIndexToStreamMetadataProvider.containsKey(configId)) {
         continue;
       }
-      StreamConfig streamConfig = null;
       StreamMetadataProvider streamMetadataProvider;
       try {
-        streamConfig = streamConfigs.get(streamConfigIndex);
         StreamConsumerFactory streamConsumerFactory = StreamConsumerFactoryProvider.create(streamConfig);
         String clientId =
             IngestionConfigUtils.getTableTopicUniqueClientId(IngestionDelayTracker.class.getSimpleName(), streamConfig);
@@ -216,7 +215,7 @@ public class IngestionDelayTracker {
       }
 
       assert streamMetadataProvider != null;
-      _streamConfigIndexToStreamMetadataProvider.put(streamConfigIndex, streamMetadataProvider);
+      _streamConfigIndexToStreamMetadataProvider.put(configId, streamMetadataProvider);
 
       if ((streamMetadataProvider.supportsOffsetLag()) && (_partitionIdToLatestOffset == null)) {
         _partitionIdToLatestOffset = new ConcurrentHashMap<>();
@@ -268,37 +267,37 @@ public class IngestionDelayTracker {
 
   @VisibleForTesting
   void updateLatestStreamOffset(Set<Integer> partitionsHosted) {
-    Map<Integer, Set<Integer>> streamIndexToStreamPartitionIds =
+    Map<Integer, Set<Integer>> configIdToStreamPartitionIds =
         IngestionConfigUtils.getStreamConfigIndexToStreamPartitions(partitionsHosted);
 
-    if (streamIndexToStreamPartitionIds.size() > _streamConfigIndexToStreamMetadataProvider.size()) {
+    if (configIdToStreamPartitionIds.size() > _streamConfigIndexToStreamMetadataProvider.size()) {
       // There might be a new stream config added or need to retry creation of streamMetadataProvider for a stream
       // which might have failed before.
       createOrUpdateStreamMetadataProvider();
     }
 
     for (Map.Entry<Integer, StreamMetadataProvider> entry : _streamConfigIndexToStreamMetadataProvider.entrySet()) {
-      int streamIndex = entry.getKey();
+      int configId = entry.getKey();
       StreamMetadataProvider streamMetadataProvider = entry.getValue();
 
-      if (!streamIndexToStreamPartitionIds.containsKey(streamIndex)) {
+      if (!configIdToStreamPartitionIds.containsKey(configId)) {
         // Server is not hosting any partitions of this stream.
         continue;
       }
 
       if (streamMetadataProvider.supportsOffsetLag()) {
-        Set<Integer> streamPartitionIds = streamIndexToStreamPartitionIds.get(streamIndex);
+        Set<Integer> streamPartitionIds = configIdToStreamPartitionIds.get(configId);
         try {
           Map<Integer, StreamPartitionMsgOffset> streamPartitionIdToLatestOffset =
               streamMetadataProvider.fetchLatestStreamOffset(streamPartitionIds,
                   LATEST_STREAM_OFFSET_FETCH_TIMEOUT_MS);
-          if (streamIndex > 0) {
+          if (configId > 0) {
             // Need to convert stream partition Ids back to pinot partition Ids.
             for (Map.Entry<Integer, StreamPartitionMsgOffset> latestOffsetEntry
                 : streamPartitionIdToLatestOffset.entrySet()) {
               _partitionIdToLatestOffset.put(
-                  IngestionConfigUtils.getPinotPartitionIdFromStreamPartitionId(latestOffsetEntry.getKey(),
-                      streamIndex), latestOffsetEntry.getValue());
+                  IngestionConfigUtils.getPinotPartitionIdFromConfigId(latestOffsetEntry.getKey(), configId),
+                  latestOffsetEntry.getValue());
             }
           } else {
             _partitionIdToLatestOffset.putAll(streamPartitionIdToLatestOffset);
@@ -371,8 +370,8 @@ public class IngestionDelayTracker {
 
   @VisibleForTesting
   void createMetrics(int partitionId) {
-    int streamConfigIndex = IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(partitionId);
-    StreamMetadataProvider streamMetadataProvider = _streamConfigIndexToStreamMetadataProvider.get(streamConfigIndex);
+    int configId = IngestionConfigUtils.getConfigIdFromPinotPartitionId(partitionId);
+    StreamMetadataProvider streamMetadataProvider = _streamConfigIndexToStreamMetadataProvider.get(configId);
 
     if (streamMetadataProvider != null && streamMetadataProvider.supportsOffsetLag()) {
       _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionId, ServerGauge.REALTIME_INGESTION_OFFSET_LAG,
@@ -395,9 +394,9 @@ public class IngestionDelayTracker {
   }
 
   private void removeMetrics(int partitionId) {
-    int streamConfigIndex = IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(partitionId);
+    int configId = IngestionConfigUtils.getConfigIdFromPinotPartitionId(partitionId);
     StreamMetadataProvider streamMetadataProvider =
-        _streamConfigIndexToStreamMetadataProvider.get(streamConfigIndex);
+        _streamConfigIndexToStreamMetadataProvider.get(configId);
     // Remove all metrics associated with this partition
     if (streamMetadataProvider != null && streamMetadataProvider.supportsOffsetLag()) {
       _serverMetrics.removePartitionGauge(_metricName, partitionId, ServerGauge.REALTIME_INGESTION_OFFSET_LAG);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1797,10 +1797,10 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     } else {
       // Multiple streams
       _streamPartitionId = IngestionConfigUtils.getStreamPartitionIdFromPinotPartitionId(_partitionGroupId);
-      int index = IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(_partitionGroupId);
-      Preconditions.checkState(numStreams > index, "Cannot find stream config of index: %s for table: %s", index,
-          _tableNameWithType);
-      _streamConfig = new StreamConfig(_tableNameWithType, streamConfigMaps.get(index));
+      int configId = llcSegmentName.getStreamConfigId();
+      Map<String, String> streamConfigMap = tableConfig.getIngestionConfig().getStreamIngestionConfig()
+          .getStreamConfigMapByConfigId(configId);
+      _streamConfig = new StreamConfig(_tableNameWithType, streamConfigMap);
     }
     _streamConsumerFactory = StreamConsumerFactoryProvider.create(_streamConfig);
     _streamPartitionMsgOffsetFactory = _streamConsumerFactory.createStreamMsgOffsetFactory();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -29,7 +29,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -408,15 +408,15 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
    * Returns all partitionGroupIds for the partitions hosted by this server for current table.
    * @apiNote this involves Zookeeper read and should not be used frequently due to efficiency concerns.
    */
-  public Set<Integer> getHostedPartitionsGroupIds() {
-    Set<Integer> partitionsHostedByThisServer = new HashSet<>();
+  public Map<Integer, Integer> getHostedPartitionsGroupIds() {
+    Map<Integer, Integer> partitionGroupIdToConfigId = new HashMap<>();
     List<String> segments = TableStateUtils.getSegmentsInGivenStateForThisInstance(_helixManager, _tableNameWithType,
         CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING);
     for (String segmentNameStr : segments) {
       LLCSegmentName segmentName = new LLCSegmentName(segmentNameStr);
-      partitionsHostedByThisServer.add(segmentName.getPartitionGroupId());
+      partitionGroupIdToConfigId.put(segmentName.getPartitionGroupId(), segmentName.getStreamConfigId());
     }
-    return partitionsHostedByThisServer;
+    return partitionGroupIdToConfigId;
   }
 
   public RealtimeSegmentStatsHistory getStatsHistory() {

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTrackerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTrackerTest.java
@@ -42,6 +42,7 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
 import org.apache.pinot.spi.stream.LongMsgOffset;
+import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
@@ -468,8 +469,12 @@ public class IngestionDelayTrackerTest {
 
     IngestionConfig ingestionConfig = new IngestionConfig();
     List<Map<String, String>> streamConfigMaps = new ArrayList<>();
-    streamConfigMaps.add(getStreamConfigs());
-    streamConfigMaps.add(getStreamConfigs());
+    Map<String, String> streamConfig0 = getStreamConfigs();
+    streamConfig0.put(StreamConfigProperties.STREAM_CONFIG_ID, "0");
+    Map<String, String> streamConfig1 = getStreamConfigs();
+    streamConfig1.put(StreamConfigProperties.STREAM_CONFIG_ID, "1");
+    streamConfigMaps.add(streamConfig0);
+    streamConfigMaps.add(streamConfig1);
     StreamIngestionConfig streamIngestionConfig = new StreamIngestionConfig(streamConfigMaps);
     ingestionConfig.setStreamIngestionConfig(streamIngestionConfig);
     TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME)

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTrackerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTrackerTest.java
@@ -501,8 +501,8 @@ public class IngestionDelayTrackerTest {
     final String segment0 = new LLCSegmentName(RAW_TABLE_NAME, partition0, 0, 123).getSegmentName();
     final int partition1 = 1;
 
-    ingestionDelayTracker._partitionsHostedByThisServer.put(partition0, true);
-    ingestionDelayTracker._partitionsHostedByThisServer.put(partition1, true);
+    ingestionDelayTracker._partitionsHostedByThisServer.put(partition0, 0);
+    ingestionDelayTracker._partitionsHostedByThisServer.put(partition1, 0);
     ingestionDelayTracker.updateMetrics(segment0, partition0, System.currentTimeMillis(), System.currentTimeMillis(),
         new LongMsgOffset(50));
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/MultiTopicRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/MultiTopicRealtimeClusterIntegrationTest.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.MultiTopicLLCSegmentName;
 import org.apache.pinot.integration.tests.ClusterIntegrationTestUtils;
 import org.apache.pinot.plugin.inputformat.csv.CSVMessageDecoder;
 import org.apache.pinot.plugin.stream.kafka.KafkaStreamConfigProperties;
@@ -404,6 +405,138 @@ public class MultiTopicRealtimeClusterIntegrationTest extends CustomDataQueryClu
 
     for (int i = 0; i < numTopics; i++) {
       assertEquals(rows.get(i).get(0).asText(), sourceName(i));
+    }
+  }
+
+  @Test
+  public void testStreamConfigIdsAssigned() {
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(TABLE_NAME);
+    TableConfig tableConfig = getSharedHelixResourceManager().getTableConfig(realtimeTableName);
+    assertNotNull(tableConfig, "Table config should exist");
+
+    StreamIngestionConfig streamIngestionConfig =
+        tableConfig.getIngestionConfig().getStreamIngestionConfig();
+    assertNotNull(streamIngestionConfig, "Stream ingestion config should exist");
+
+    List<Map<String, String>> streamConfigMaps = streamIngestionConfig.getStreamConfigMaps();
+    int numTopics = getNumTopics();
+    assertEquals(streamConfigMaps.size(), numTopics, "Should have " + numTopics + " stream configs");
+
+    Set<Integer> configIds = new HashSet<>();
+    for (int i = 0; i < numTopics; i++) {
+      Map<String, String> configMap = streamConfigMaps.get(i);
+      String configIdStr = configMap.get(StreamConfigProperties.STREAM_CONFIG_ID);
+      assertNotNull(configIdStr, "stream.config.id should be set for stream config at index " + i);
+
+      int configId = Integer.parseInt(configIdStr);
+      assertTrue(configId >= 0, "Config ID should be non-negative, got: " + configId);
+      assertTrue(configIds.add(configId), "Config IDs should be unique, duplicate: " + configId);
+    }
+
+    assertEquals(streamIngestionConfig.getNextStreamConfigId(), numTopics,
+        "nextStreamConfigId should equal the number of topics");
+  }
+
+  @Test
+  public void testMultiTopicSegmentNameFormat() {
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(TABLE_NAME);
+    IdealState idealState = getSharedHelixResourceManager().getTableIdealState(realtimeTableName);
+    assertNotNull(idealState);
+
+    int numTopics = getNumTopics();
+    if (numTopics <= 1) {
+      return;
+    }
+
+    int multiTopicSegmentCount = 0;
+    Set<Integer> configIdsSeen = new HashSet<>();
+
+    for (String segmentName : idealState.getPartitionSet()) {
+      MultiTopicLLCSegmentName multiTopicName = MultiTopicLLCSegmentName.of(segmentName);
+      if (multiTopicName != null) {
+        multiTopicSegmentCount++;
+        configIdsSeen.add(multiTopicName.getConfigId());
+
+        assertTrue(multiTopicName.getConfigId() >= 0,
+            "Config ID should be non-negative: " + segmentName);
+        assertTrue(multiTopicName.getStreamPartitionId() >= 0,
+            "Stream partition ID should be non-negative: " + segmentName);
+        assertTrue(multiTopicName.getStreamPartitionId() < NUM_PARTITIONS_PER_TOPIC,
+            "Stream partition ID should be < " + NUM_PARTITIONS_PER_TOPIC + ": " + segmentName);
+
+        int expectedPartitionGroupId =
+            IngestionConfigUtils.getPinotPartitionIdFromConfigId(
+                multiTopicName.getStreamPartitionId(), multiTopicName.getConfigId());
+        assertEquals(multiTopicName.getPartitionGroupId(), expectedPartitionGroupId,
+            "Partition group ID encoding mismatch for segment: " + segmentName);
+
+        LLCSegmentName llcParsed = new LLCSegmentName(segmentName);
+        assertEquals(llcParsed.getPartitionGroupId(), expectedPartitionGroupId,
+            "LLCSegmentName should parse 5-part format and produce same partition group ID");
+      }
+    }
+
+    assertTrue(multiTopicSegmentCount > 0,
+        "Should have at least one segment in 5-part multi-topic format");
+
+    for (int i = 0; i < numTopics; i++) {
+      assertTrue(configIdsSeen.contains(i),
+          "Should have segments with config ID " + i);
+    }
+  }
+
+  @Test
+  public void testConfigIdLookupMethods() {
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(TABLE_NAME);
+    TableConfig tableConfig = getSharedHelixResourceManager().getTableConfig(realtimeTableName);
+    assertNotNull(tableConfig);
+
+    StreamIngestionConfig streamIngestionConfig =
+        tableConfig.getIngestionConfig().getStreamIngestionConfig();
+    int numTopics = getNumTopics();
+
+    for (int i = 0; i < numTopics; i++) {
+      int configId = streamIngestionConfig.getConfigId(i);
+      assertEquals(configId, i, "Config ID at index " + i + " should be " + i);
+
+      Map<String, String> configMap = streamIngestionConfig.getStreamConfigMapByConfigId(configId);
+      assertNotNull(configMap, "Should find stream config for config ID " + configId);
+
+      String topicName = configMap.get(
+          StreamConfigProperties.constructStreamProperty("kafka", StreamConfigProperties.STREAM_TOPIC_NAME));
+      assertEquals(topicName, topicName(i),
+          "Topic name for config ID " + configId + " should match");
+    }
+
+    Map<Integer, Map<String, String>> configIdMap = streamIngestionConfig.getConfigIdToStreamConfigMap();
+    assertEquals(configIdMap.size(), numTopics, "Config ID map should have " + numTopics + " entries");
+    for (int i = 0; i < numTopics; i++) {
+      assertTrue(configIdMap.containsKey(i), "Config ID map should contain key " + i);
+    }
+  }
+
+  @Test
+  public void testSegmentNameBackwardCompatibility() {
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(TABLE_NAME);
+    IdealState idealState = getSharedHelixResourceManager().getTableIdealState(realtimeTableName);
+    assertNotNull(idealState);
+
+    for (String segmentName : idealState.getPartitionSet()) {
+      if (!LLCSegmentName.isLLCSegment(segmentName)) {
+        continue;
+      }
+
+      LLCSegmentName llcName = LLCSegmentName.of(segmentName);
+      assertNotNull(llcName, "LLCSegmentName.of() should parse segment: " + segmentName);
+
+      MultiTopicLLCSegmentName multiTopicName = MultiTopicLLCSegmentName.of(segmentName);
+      if (multiTopicName != null) {
+        assertEquals(llcName.getPartitionGroupId(), multiTopicName.getPartitionGroupId(),
+            "Partition group ID should match between LLCSegmentName and MultiTopicLLCSegmentName "
+                + "for segment: " + segmentName);
+        assertEquals(llcName.getTableName(), multiTopicName.getTableName());
+        assertEquals(llcName.getSequenceNumber(), multiTopicName.getSequenceNumber());
+      }
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -200,7 +201,7 @@ public final class TableConfigUtils {
     validateSegmentAssignmentConfig(tableConfig);
     validateIngestionConfig(tableConfig, schema);
     if (tableConfig.getTableType() == TableType.REALTIME) {
-      validateStreamConfigMaps(tableConfig);
+      validateStreamConfigMaps(tableConfig, skipTypes);
     }
     validateTierConfigList(tableConfig.getTierConfigsList());
     validateIndexingConfigAndFieldConfigList(tableConfig, schema);
@@ -764,7 +765,92 @@ public final class TableConfigUtils {
     }
   }
 
-  private static void validateStreamConfigMaps(TableConfig tableConfig) {
+  /**
+   * Ensures every stream config map has a stable {@code stream.config.id} assigned.
+   * <p>Edge cases handled:
+   * <ul>
+   *   <li>No entries have stream.config.id (legacy/new table) → auto-assign starting from 0</li>
+   *   <li>Some entries have stream.config.id, some don't → assign only missing ones, skipping used IDs</li>
+   *   <li>nextStreamConfigId is stale (less than max existing ID + 1) → corrected automatically</li>
+   *   <li>Duplicate config IDs → rejected</li>
+   *   <li>Negative config IDs → rejected</li>
+   * </ul>
+   */
+  @VisibleForTesting
+  static void ensureStreamConfigIds(TableConfig tableConfig) {
+    ensureStreamConfigIds(tableConfig, Collections.emptySet());
+  }
+
+  @VisibleForTesting
+  static void ensureStreamConfigIds(TableConfig tableConfig, Set<ValidationType> skipTypes) {
+    IngestionConfig ingestionConfig = tableConfig.getIngestionConfig();
+    if (ingestionConfig == null || ingestionConfig.getStreamIngestionConfig() == null) {
+      return;
+    }
+    StreamIngestionConfig streamIngestionConfig = ingestionConfig.getStreamIngestionConfig();
+    List<Map<String, String>> streamConfigMaps = streamIngestionConfig.getStreamConfigMaps();
+    if (streamConfigMaps == null || streamConfigMaps.isEmpty()) {
+      return;
+    }
+
+    // First pass: collect existing IDs and validate them
+    Set<Integer> usedIds = new HashSet<>();
+    int maxExistingId = -1;
+    for (Map<String, String> configMap : streamConfigMaps) {
+      String idStr = configMap.get(StreamConfigProperties.STREAM_CONFIG_ID);
+      if (idStr != null) {
+        int configId;
+        try {
+          configId = Integer.parseInt(idStr);
+        } catch (NumberFormatException e) {
+          throw new IllegalStateException("Invalid stream.config.id value: " + idStr);
+        }
+        Preconditions.checkState(configId >= 0,
+            "stream.config.id must be non-negative, got: %s", configId);
+        Preconditions.checkState(usedIds.add(configId),
+            "Duplicate stream.config.id found: %s", configId);
+        maxExistingId = Math.max(maxExistingId, configId);
+      }
+    }
+
+    // Determine the starting point for new IDs
+    int nextId = streamIngestionConfig.getNextStreamConfigId();
+    if (maxExistingId >= 0 && nextId > 0 && nextId <= maxExistingId) {
+      if (!skipTypes.contains(ValidationType.STREAM_CONFIG_ID)) {
+        throw new IllegalStateException(String.format(
+            "nextStreamConfigId (%d) must be greater than the max existing stream.config.id (%d). "
+                + "Update nextStreamConfigId to at least %d, or skip validation type STREAM_CONFIG_ID.",
+            nextId, maxExistingId, maxExistingId + 1));
+      }
+      LOGGER.warn("nextStreamConfigId ({}) is not greater than max existing stream.config.id ({}). "
+          + "Overriding to {} because STREAM_CONFIG_ID validation is skipped.", nextId, maxExistingId,
+          maxExistingId + 1);
+      nextId = maxExistingId + 1;
+    }
+
+    // Second pass: assign IDs to entries that don't have one
+    int numAssigned = 0;
+    for (Map<String, String> configMap : streamConfigMaps) {
+      if (!configMap.containsKey(StreamConfigProperties.STREAM_CONFIG_ID)) {
+        while (usedIds.contains(nextId)) {
+          nextId++;
+        }
+        configMap.put(StreamConfigProperties.STREAM_CONFIG_ID, String.valueOf(nextId));
+        usedIds.add(nextId);
+        nextId++;
+        numAssigned++;
+      }
+    }
+
+    streamIngestionConfig.setNextStreamConfigId(nextId);
+    if (numAssigned > 0) {
+      LOGGER.info("Auto-assigned stream.config.id to {} stream config(s). nextStreamConfigId is now {}.",
+          numAssigned, nextId);
+    }
+  }
+
+  private static void validateStreamConfigMaps(TableConfig tableConfig, Set<ValidationType> skipTypes) {
+    ensureStreamConfigIds(tableConfig, skipTypes);
     List<Map<String, String>> streamConfigMaps = IngestionConfigUtils.getStreamConfigMaps(tableConfig);
     int numStreamConfigs = streamConfigMaps.size();
     List<StreamConfig> streamConfigs = new ArrayList<>(numStreamConfigs);
@@ -2039,7 +2125,7 @@ public final class TableConfigUtils {
 
   // enum of all the skip-able validation types.
   public enum ValidationType {
-    ALL, TASK, UPSERT, TENANT, MINION_INSTANCES, ACTIVE_TASKS
+    ALL, TASK, UPSERT, TENANT, MINION_INSTANCES, ACTIVE_TASKS, STREAM_CONFIG_ID
   }
 
   /**

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -929,8 +929,12 @@ public class TableConfigUtilsTest {
     TableConfigUtils.validateStreamConfig(new StreamConfig("test", streamConfigs));
 
     // Test for multiple stream configs with pauseless consumption enabled - should fail
+    Map<String, String> pauselessStreamConfigs1 = new HashMap<>(streamConfigs);
+    pauselessStreamConfigs1.remove(StreamConfigProperties.STREAM_CONFIG_ID);
+    Map<String, String> pauselessStreamConfigs2 = new HashMap<>(streamConfigs);
+    pauselessStreamConfigs2.remove(StreamConfigProperties.STREAM_CONFIG_ID);
     StreamIngestionConfig streamIngestionConfigWithPauseless =
-        new StreamIngestionConfig(Arrays.asList(streamConfigs, streamConfigs));
+        new StreamIngestionConfig(Arrays.asList(pauselessStreamConfigs1, pauselessStreamConfigs2));
     streamIngestionConfigWithPauseless.setPauselessConsumptionEnabled(true);
 
     IngestionConfig ingestionConfigWithPauseless = new IngestionConfig();
@@ -951,8 +955,13 @@ public class TableConfigUtilsTest {
     }
 
     // Test for multiple stream configs with pauseless consumption disabled - should pass
+    // Use fresh copies because ensureStreamConfigIds mutates the map (adds stream.config.id)
+    Map<String, String> dupStreamConfigs1 = new HashMap<>(streamConfigs);
+    dupStreamConfigs1.remove(StreamConfigProperties.STREAM_CONFIG_ID);
+    Map<String, String> dupStreamConfigs2 = new HashMap<>(streamConfigs);
+    dupStreamConfigs2.remove(StreamConfigProperties.STREAM_CONFIG_ID);
     StreamIngestionConfig streamIngestionConfigWithoutPauseless =
-        new StreamIngestionConfig(Arrays.asList(streamConfigs, streamConfigs));
+        new StreamIngestionConfig(Arrays.asList(dupStreamConfigs1, dupStreamConfigs2));
     streamIngestionConfigWithoutPauseless.setPauselessConsumptionEnabled(false);
 
     IngestionConfig ingestionConfigWithoutPauseless = new IngestionConfig();
@@ -973,10 +982,13 @@ public class TableConfigUtilsTest {
     }
 
     // Test for multiple stream configs with pauseless consumption disabled and unique topic names - should pass
-    Map<String, String> anotherStreamConfig = new HashMap<>(streamConfigs);
-    anotherStreamConfig.put("stream.kafka.topic.name", "myTopic2");
+    Map<String, String> uniqueStreamConfig1 = new HashMap<>(streamConfigs);
+    uniqueStreamConfig1.remove(StreamConfigProperties.STREAM_CONFIG_ID);
+    Map<String, String> uniqueStreamConfig2 = new HashMap<>(streamConfigs);
+    uniqueStreamConfig2.remove(StreamConfigProperties.STREAM_CONFIG_ID);
+    uniqueStreamConfig2.put("stream.kafka.topic.name", "myTopic2");
     StreamIngestionConfig streamIngestionConfigWithoutPauselessUniqueTopics =
-        new StreamIngestionConfig(Arrays.asList(streamConfigs, anotherStreamConfig));
+        new StreamIngestionConfig(Arrays.asList(uniqueStreamConfig1, uniqueStreamConfig2));
     streamIngestionConfigWithoutPauselessUniqueTopics.setPauselessConsumptionEnabled(false);
 
     IngestionConfig ingestionConfigWithoutPauselessUniqueTopics = new IngestionConfig();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -1020,6 +1020,285 @@ public class TableConfigUtilsTest {
   }
 
   @Test
+  public void testEnsureStreamConfigIdsNewTableNoIds() {
+    Map<String, String> config0 = new HashMap<>();
+    config0.put("streamType", "kafka");
+    config0.put("stream.kafka.topic.name", "topic-A");
+    Map<String, String> config1 = new HashMap<>();
+    config1.put("streamType", "kafka");
+    config1.put("stream.kafka.topic.name", "topic-B");
+
+    StreamIngestionConfig sic = new StreamIngestionConfig(Arrays.asList(config0, config1));
+    assertEquals(sic.getNextStreamConfigId(), 0);
+
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setStreamIngestionConfig(sic);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName("timeColumn").setIngestionConfig(ingestionConfig).build();
+
+    TableConfigUtils.ensureStreamConfigIds(tableConfig);
+
+    assertEquals(config0.get("stream.config.id"), "0");
+    assertEquals(config1.get("stream.config.id"), "1");
+    assertEquals(sic.getNextStreamConfigId(), 2);
+  }
+
+  @Test
+  public void testEnsureStreamConfigIdsSingleStream() {
+    Map<String, String> config0 = new HashMap<>();
+    config0.put("streamType", "kafka");
+    config0.put("stream.kafka.topic.name", "topic-A");
+
+    StreamIngestionConfig sic = new StreamIngestionConfig(Collections.singletonList(config0));
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setStreamIngestionConfig(sic);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName("timeColumn").setIngestionConfig(ingestionConfig).build();
+
+    TableConfigUtils.ensureStreamConfigIds(tableConfig);
+
+    assertEquals(config0.get("stream.config.id"), "0");
+    assertEquals(sic.getNextStreamConfigId(), 1);
+  }
+
+  @Test
+  public void testEnsureStreamConfigIdsPartialIds() {
+    Map<String, String> config0 = new HashMap<>();
+    config0.put("streamType", "kafka");
+    config0.put("stream.kafka.topic.name", "topic-A");
+    config0.put("stream.config.id", "0");
+
+    Map<String, String> configNew = new HashMap<>();
+    configNew.put("streamType", "kafka");
+    configNew.put("stream.kafka.topic.name", "topic-C");
+
+    StreamIngestionConfig sic = new StreamIngestionConfig(Arrays.asList(config0, configNew));
+    sic.setNextStreamConfigId(1);
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setStreamIngestionConfig(sic);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName("timeColumn").setIngestionConfig(ingestionConfig).build();
+
+    TableConfigUtils.ensureStreamConfigIds(tableConfig);
+
+    assertEquals(config0.get("stream.config.id"), "0");
+    assertEquals(configNew.get("stream.config.id"), "1");
+    assertEquals(sic.getNextStreamConfigId(), 2);
+  }
+
+  @Test
+  public void testEnsureStreamConfigIdsPartialIdsWithGap() {
+    Map<String, String> config0 = new HashMap<>();
+    config0.put("streamType", "kafka");
+    config0.put("stream.kafka.topic.name", "topic-A");
+    config0.put("stream.config.id", "0");
+
+    Map<String, String> config3 = new HashMap<>();
+    config3.put("streamType", "kafka");
+    config3.put("stream.kafka.topic.name", "topic-D");
+    config3.put("stream.config.id", "3");
+
+    Map<String, String> configNew = new HashMap<>();
+    configNew.put("streamType", "kafka");
+    configNew.put("stream.kafka.topic.name", "topic-E");
+
+    StreamIngestionConfig sic = new StreamIngestionConfig(Arrays.asList(config0, config3, configNew));
+    sic.setNextStreamConfigId(4);
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setStreamIngestionConfig(sic);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName("timeColumn").setIngestionConfig(ingestionConfig).build();
+
+    TableConfigUtils.ensureStreamConfigIds(tableConfig);
+
+    assertEquals(config0.get("stream.config.id"), "0");
+    assertEquals(config3.get("stream.config.id"), "3");
+    assertEquals(configNew.get("stream.config.id"), "4");
+    assertEquals(sic.getNextStreamConfigId(), 5);
+  }
+
+  @Test
+  public void testEnsureStreamConfigIdsStaleNextId() {
+    // nextStreamConfigId explicitly set but below max existing ID — should fail
+    Map<String, String> config0 = new HashMap<>();
+    config0.put("streamType", "kafka");
+    config0.put("stream.kafka.topic.name", "topic-A");
+    config0.put("stream.config.id", "0");
+
+    Map<String, String> config5 = new HashMap<>();
+    config5.put("streamType", "kafka");
+    config5.put("stream.kafka.topic.name", "topic-F");
+    config5.put("stream.config.id", "5");
+
+    StreamIngestionConfig sic = new StreamIngestionConfig(Arrays.asList(config0, config5));
+    sic.setNextStreamConfigId(2);  // Stale — max existing is 5
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setStreamIngestionConfig(sic);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName("timeColumn").setIngestionConfig(ingestionConfig).build();
+
+    try {
+      TableConfigUtils.ensureStreamConfigIds(tableConfig);
+      fail("Should fail when nextStreamConfigId is below max existing stream.config.id");
+    } catch (IllegalStateException e) {
+      assertTrue(e.getMessage().contains("nextStreamConfigId"));
+      assertTrue(e.getMessage().contains("must be greater than"));
+    }
+  }
+
+  @Test
+  public void testEnsureStreamConfigIdsStaleNextIdWithNewEntry() {
+    Map<String, String> config5 = new HashMap<>();
+    config5.put("streamType", "kafka");
+    config5.put("stream.kafka.topic.name", "topic-F");
+    config5.put("stream.config.id", "5");
+
+    Map<String, String> configNew = new HashMap<>();
+    configNew.put("streamType", "kafka");
+    configNew.put("stream.kafka.topic.name", "topic-G");
+
+    StreamIngestionConfig sic = new StreamIngestionConfig(Arrays.asList(config5, configNew));
+    sic.setNextStreamConfigId(1);
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setStreamIngestionConfig(sic);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName("timeColumn").setIngestionConfig(ingestionConfig).build();
+
+    try {
+      TableConfigUtils.ensureStreamConfigIds(tableConfig);
+      fail("Should fail when nextStreamConfigId is below max existing stream.config.id");
+    } catch (IllegalStateException e) {
+      assertTrue(e.getMessage().contains("nextStreamConfigId"));
+    }
+  }
+
+  @Test
+  public void testEnsureStreamConfigIdsStaleNextIdSkipValidation() {
+    // Same stale nextId scenario, but with STREAM_CONFIG_ID validation skipped — should correct silently
+    Map<String, String> config5 = new HashMap<>();
+    config5.put("streamType", "kafka");
+    config5.put("stream.kafka.topic.name", "topic-F");
+    config5.put("stream.config.id", "5");
+
+    Map<String, String> configNew = new HashMap<>();
+    configNew.put("streamType", "kafka");
+    configNew.put("stream.kafka.topic.name", "topic-G");
+
+    StreamIngestionConfig sic = new StreamIngestionConfig(Arrays.asList(config5, configNew));
+    sic.setNextStreamConfigId(1);
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setStreamIngestionConfig(sic);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName("timeColumn").setIngestionConfig(ingestionConfig).build();
+
+    TableConfigUtils.ensureStreamConfigIds(tableConfig,
+        Set.of(TableConfigUtils.ValidationType.STREAM_CONFIG_ID));
+
+    assertEquals(config5.get("stream.config.id"), "5");
+    assertEquals(configNew.get("stream.config.id"), "6");
+    assertEquals(sic.getNextStreamConfigId(), 7);
+  }
+
+  @Test
+  public void testEnsureStreamConfigIdsDuplicateIds() {
+    Map<String, String> config0 = new HashMap<>();
+    config0.put("streamType", "kafka");
+    config0.put("stream.kafka.topic.name", "topic-A");
+    config0.put("stream.config.id", "1");
+
+    Map<String, String> config1 = new HashMap<>();
+    config1.put("streamType", "kafka");
+    config1.put("stream.kafka.topic.name", "topic-B");
+    config1.put("stream.config.id", "1");
+
+    StreamIngestionConfig sic = new StreamIngestionConfig(Arrays.asList(config0, config1));
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setStreamIngestionConfig(sic);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName("timeColumn").setIngestionConfig(ingestionConfig).build();
+
+    try {
+      TableConfigUtils.ensureStreamConfigIds(tableConfig);
+      fail("Should fail for duplicate stream.config.id");
+    } catch (IllegalStateException e) {
+      assertTrue(e.getMessage().contains("Duplicate stream.config.id"));
+    }
+  }
+
+  @Test
+  public void testEnsureStreamConfigIdsNegativeId() {
+    Map<String, String> config0 = new HashMap<>();
+    config0.put("streamType", "kafka");
+    config0.put("stream.kafka.topic.name", "topic-A");
+    config0.put("stream.config.id", "-1");
+
+    StreamIngestionConfig sic = new StreamIngestionConfig(Collections.singletonList(config0));
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setStreamIngestionConfig(sic);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName("timeColumn").setIngestionConfig(ingestionConfig).build();
+
+    try {
+      TableConfigUtils.ensureStreamConfigIds(tableConfig);
+      fail("Should fail for negative stream.config.id");
+    } catch (IllegalStateException e) {
+      assertTrue(e.getMessage().contains("non-negative"));
+    }
+  }
+
+  @Test
+  public void testEnsureStreamConfigIdsAllIdsPresent() {
+    Map<String, String> config0 = new HashMap<>();
+    config0.put("streamType", "kafka");
+    config0.put("stream.kafka.topic.name", "topic-A");
+    config0.put("stream.config.id", "0");
+
+    Map<String, String> config1 = new HashMap<>();
+    config1.put("streamType", "kafka");
+    config1.put("stream.kafka.topic.name", "topic-B");
+    config1.put("stream.config.id", "1");
+
+    StreamIngestionConfig sic = new StreamIngestionConfig(Arrays.asList(config0, config1));
+    sic.setNextStreamConfigId(2);
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setStreamIngestionConfig(sic);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName("timeColumn").setIngestionConfig(ingestionConfig).build();
+
+    TableConfigUtils.ensureStreamConfigIds(tableConfig);
+
+    assertEquals(config0.get("stream.config.id"), "0");
+    assertEquals(config1.get("stream.config.id"), "1");
+    assertEquals(sic.getNextStreamConfigId(), 2);
+  }
+
+  @Test
+  public void testEnsureStreamConfigIdsIdempotent() {
+    Map<String, String> config0 = new HashMap<>();
+    config0.put("streamType", "kafka");
+    config0.put("stream.kafka.topic.name", "topic-A");
+    Map<String, String> config1 = new HashMap<>();
+    config1.put("streamType", "kafka");
+    config1.put("stream.kafka.topic.name", "topic-B");
+
+    StreamIngestionConfig sic = new StreamIngestionConfig(Arrays.asList(config0, config1));
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setStreamIngestionConfig(sic);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName("timeColumn").setIngestionConfig(ingestionConfig).build();
+
+    TableConfigUtils.ensureStreamConfigIds(tableConfig);
+    assertEquals(config0.get("stream.config.id"), "0");
+    assertEquals(config1.get("stream.config.id"), "1");
+    assertEquals(sic.getNextStreamConfigId(), 2);
+
+    TableConfigUtils.ensureStreamConfigIds(tableConfig);
+    assertEquals(config0.get("stream.config.id"), "0");
+    assertEquals(config1.get("stream.config.id"), "1");
+    assertEquals(sic.getNextStreamConfigId(), 2);
+  }
+
+  @Test
   public void ingestionBatchConfigsTest() {
     Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).build();
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/StreamIngestionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/StreamIngestionConfig.java
@@ -19,13 +19,16 @@
 package org.apache.pinot.spi.config.table.ingestion;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.BaseJsonConfig;
 import org.apache.pinot.spi.config.table.DisasterRecoveryMode;
+import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.utils.Enablement;
 
 
@@ -59,6 +62,10 @@ public class StreamIngestionConfig extends BaseJsonConfig {
   @JsonPropertyDescription("Recovery mode which is used to decide how to recover a segment online in IS but having no"
       + " completed (immutable) replica on any server in pause-less ingestion")
   private DisasterRecoveryMode _disasterRecoveryMode = DisasterRecoveryMode.DEFAULT;
+
+  @JsonPropertyDescription("Next stream config ID to assign when a new stream config is added. "
+      + "Each stream config map gets a stable, immutable ID stored as 'stream.config.id' in the map.")
+  private int _nextStreamConfigId;
 
   @JsonPropertyDescription("Class to handle realtime offset auto reset")
   private String _realtimeOffsetAutoResetHandlerClass;
@@ -161,5 +168,43 @@ public class StreamIngestionConfig extends BaseJsonConfig {
 
   public void setOomProtection(@Nullable Enablement oomProtection) {
     _oomProtection = oomProtection == null ? Enablement.DEFAULT : oomProtection;
+  }
+
+  public int getNextStreamConfigId() {
+    return _nextStreamConfigId;
+  }
+
+  public void setNextStreamConfigId(int nextStreamConfigId) {
+    _nextStreamConfigId = nextStreamConfigId;
+  }
+
+  /// Returns the config ID for the stream config at the given list position.
+  /// If the entry has a stream.config.id key, returns that; otherwise returns the positional index.
+  public int getConfigId(int listIndex) {
+    Map<String, String> configMap = _streamConfigMaps.get(listIndex);
+    String idStr = configMap.get(StreamConfigProperties.STREAM_CONFIG_ID);
+    return idStr != null ? Integer.parseInt(idStr) : listIndex;
+  }
+
+  /// Returns the stream config map for the given config ID.
+  /// Falls back to positional index when stream.config.id is not set (legacy tables).
+  /// Throws IllegalStateException if no matching config is found.
+  public Map<String, String> getStreamConfigMapByConfigId(int configId) {
+    Map<String, String> result = getConfigIdToStreamConfigMap().get(configId);
+    if (result == null) {
+      throw new IllegalStateException("Cannot find stream config with config ID: " + configId);
+    }
+    return result;
+  }
+
+  /// Returns a map from config ID to stream config map.
+  /// For legacy tables without stream.config.id, uses positional index as the key.
+  @JsonIgnore
+  public Map<Integer, Map<String, String>> getConfigIdToStreamConfigMap() {
+    Map<Integer, Map<String, String>> result = new HashMap<>();
+    for (int i = 0; i < _streamConfigMaps.size(); i++) {
+      result.put(getConfigId(i), _streamConfigMaps.get(i));
+    }
+    return result;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupMetadataFetcher.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupMetadataFetcher.java
@@ -127,11 +127,10 @@ public class PartitionGroupMetadataFetcher implements Callable<Boolean> {
           PartitionGroupMetadataFetcher.class.getSimpleName() + "-" + streamConfig.getTableNameWithType() + "-"
               + topicName;
       StreamConsumerFactory streamConsumerFactory = StreamConsumerFactoryProvider.create(streamConfig);
-      int index = i;
+      int configId = IngestionConfigUtils.getConfigIdFromStreamConfig(streamConfig);
       List<PartitionGroupConsumptionStatus> topicPartitionGroupConsumptionStatusList =
           _partitionGroupConsumptionStatusList.stream()
-              .filter(partitionGroupConsumptionStatus -> IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(
-                  partitionGroupConsumptionStatus.getPartitionGroupId()) == index)
+              .filter(s -> IngestionConfigUtils.getConfigIdFromPinotPartitionId(s.getPartitionGroupId()) == configId)
               .collect(Collectors.toList());
       try (StreamMetadataProvider streamMetadataProvider = streamConsumerFactory.createStreamMetadataProvider(
           StreamConsumerFactory.getUniqueClientId(clientId))) {
@@ -142,8 +141,8 @@ public class PartitionGroupMetadataFetcher implements Callable<Boolean> {
                     _forceGetOffsetFromStream)
                 .stream()
                 .map(metadata -> new PartitionGroupMetadata(
-                    IngestionConfigUtils.getPinotPartitionIdFromStreamPartitionId(metadata.getPartitionGroupId(),
-                        index), metadata.getStartOffset(), metadata.getSequenceNumber()))
+                    IngestionConfigUtils.getPinotPartitionIdFromConfigId(metadata.getPartitionGroupId(), configId),
+                    metadata.getStartOffset(), metadata.getSequenceNumber()))
                 .collect(Collectors.toList());
         _streamMetadataList.add(
             new StreamMetadata(streamConfig, partitionGroupMetadataList.size(), partitionGroupMetadataList));

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
@@ -37,6 +37,7 @@ public class StreamConfigProperties {
    * Generic properties
    */
   public static final String STREAM_TYPE = "streamType";
+  public static final String STREAM_CONFIG_ID = "stream.config.id";
   public static final String STREAM_TOPIC_NAME = "topic.name";
   public static final String STREAM_CONSUMER_FACTORY_CLASS = "consumer.factory.class.name";
   public static final String STREAM_CONSUMER_OFFSET_CRITERIA = "consumer.prop.auto.offset.reset";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
@@ -33,9 +33,11 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.ingestion.AggregationConfig;
 import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.stream.StreamConsumerFactory;
 
 
@@ -137,9 +139,23 @@ public final class IngestionConfigUtils {
   }
 
   /// Returns the StreamConfig for the given Pinot segment partition id.
+  /// For multi-topic tables, uses the stable config ID stored in the stream config rather than positional index.
   public static StreamConfig getStreamConfigFromPinotPartitionId(List<StreamConfig> streamConfigs, int partitionId) {
-    return streamConfigs.size() > 1 ? streamConfigs.get(getStreamConfigIndexFromPinotPartitionId(partitionId))
-        : streamConfigs.get(0);
+    if (streamConfigs.size() == 1) {
+      return streamConfigs.get(0);
+    }
+    int configId = getConfigIdFromPinotPartitionId(partitionId);
+    return streamConfigs.stream()
+        .filter(sc -> configId == getConfigIdFromStreamConfig(sc))
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException(
+            "Cannot find stream config with config ID: " + configId + " for partition: " + partitionId));
+  }
+
+  /// Returns the config ID stored in a StreamConfig, or 0 if not set (single-topic backward compat).
+  public static int getConfigIdFromStreamConfig(StreamConfig streamConfig) {
+    String idStr = streamConfig.getStreamConfigsMap().get(StreamConfigProperties.STREAM_CONFIG_ID);
+    return idStr != null ? Integer.parseInt(idStr) : 0;
   }
 
   /// Returns the index of the StreamConfigs from the Pinot segment partition id.
@@ -150,23 +166,21 @@ public final class IngestionConfigUtils {
   }
 
   /**
-   * Fetches the streamConfig from the list of streamConfigs according to the partition id.
+   * Fetches the streamConfig map from the table config for the given Pinot partition id.
+   * For multi-topic tables, uses the stable config ID to look up the correct stream config.
    */
   public static Map<String, String> getStreamConfigMap(TableConfig tableConfig, int partitionId) {
     List<Map<String, String>> streamConfigMaps = getStreamConfigMaps(tableConfig);
     int numStreams = streamConfigMaps.size();
     if (numStreams == 1) {
-      // Single stream
-      // NOTE: We skip partition id translation logic to handle cases where custom stream might return partition id
-      // larger than 10000.
+      // Single stream — skip partition id translation to handle custom streams with large partition ids.
       return streamConfigMaps.get(0);
-    } else {
-      // Multiple streams
-      int index = getStreamConfigIndexFromPinotPartitionId(partitionId);
-      Preconditions.checkState(numStreams > index, "Cannot find stream config of index: %s for table: %s", index,
-          tableConfig.getTableName());
-      return streamConfigMaps.get(index);
     }
+    // Multi-stream: look up by stable config ID rather than positional index.
+    int configId = getConfigIdFromPinotPartitionId(partitionId);
+    StreamIngestionConfig streamIngestionConfig =
+        tableConfig.getIngestionConfig().getStreamIngestionConfig();
+    return streamIngestionConfig.getStreamConfigMapByConfigId(configId);
   }
 
   public static List<AggregationConfig> getAggregationConfigs(TableConfig tableConfig) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
@@ -385,4 +385,14 @@ public final class IngestionConfigUtils {
   public static int getConfigIdFromPinotPartitionId(int partitionId) {
     return partitionId / PARTITION_PADDING_OFFSET;
   }
+
+  /// Builds a map from stable config ID to StreamConfig for O(1) lookup by config ID.
+  /// For single-topic tables, returns a singleton map with key 0.
+  public static Map<Integer, StreamConfig> buildConfigIdToStreamConfigMap(List<StreamConfig> streamConfigs) {
+    Map<Integer, StreamConfig> result = new HashMap<>(streamConfigs.size());
+    for (StreamConfig streamConfig : streamConfigs) {
+      result.put(getConfigIdFromStreamConfig(streamConfig), streamConfig);
+    }
+    return result;
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
@@ -359,4 +359,16 @@ public final class IngestionConfigUtils {
     }
     return streamIndexToPartitions;
   }
+
+  // --- Stable config ID methods (Phase 1: multi-topic safe deletion) ---
+
+  /// Returns the Pinot segment partition id encoded from a stream partition id and a stable config ID.
+  public static int getPinotPartitionIdFromConfigId(int streamPartitionId, int configId) {
+    return configId * PARTITION_PADDING_OFFSET + streamPartitionId;
+  }
+
+  /// Extracts the stable config ID from an encoded Pinot segment partition id.
+  public static int getConfigIdFromPinotPartitionId(int partitionId) {
+    return partitionId / PARTITION_PADDING_OFFSET;
+  }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/stream/PartitionGroupMetadataFetcherTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/stream/PartitionGroupMetadataFetcherTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.spi.stream;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -38,7 +39,7 @@ public class PartitionGroupMetadataFetcherTest {
   public void testFetchSingleStreamSuccess()
       throws Exception {
     // Setup
-    StreamConfig streamConfig = createMockStreamConfig("test-topic", "test-table", false);
+    StreamConfig streamConfig = createMockStreamConfig("test-topic", "test-table", 0);
     List<StreamConfig> streamConfigs = Collections.singletonList(streamConfig);
 
     PartitionGroupConsumptionStatus status = mock(PartitionGroupConsumptionStatus.class);
@@ -79,7 +80,7 @@ public class PartitionGroupMetadataFetcherTest {
   public void testFetchSingleStreamTransientException()
       throws Exception {
     // Setup
-    StreamConfig streamConfig = createMockStreamConfig("test-topic", "test-table", false);
+    StreamConfig streamConfig = createMockStreamConfig("test-topic", "test-table", 0);
     List<StreamConfig> streamConfigs = Collections.singletonList(streamConfig);
 
     List<PartitionGroupConsumptionStatus> statusList = Collections.emptyList();
@@ -113,8 +114,8 @@ public class PartitionGroupMetadataFetcherTest {
   public void testFetchMultipleStreams()
       throws Exception {
     // Setup
-    StreamConfig streamConfig1 = createMockStreamConfig("topic1", "test-table", false);
-    StreamConfig streamConfig2 = createMockStreamConfig("topic2", "test-table", false);
+    StreamConfig streamConfig1 = createMockStreamConfig("topic1", "test-table", 0);
+    StreamConfig streamConfig2 = createMockStreamConfig("topic2", "test-table", 1);
     List<StreamConfig> streamConfigs = Arrays.asList(streamConfig1, streamConfig2);
 
     PartitionGroupConsumptionStatus status1 = new PartitionGroupConsumptionStatus(0, 0, null, null, "IN_PROGRESS");
@@ -168,9 +169,9 @@ public class PartitionGroupMetadataFetcherTest {
   public void testFetchMultipleStreamsWithPause()
       throws Exception {
     // Setup
-    StreamConfig streamConfig1 = createMockStreamConfig("topic1", "test-table", false);
-    StreamConfig streamConfig2 = createMockStreamConfig("topic2", "test-table", false);
-    StreamConfig streamConfig3 = createMockStreamConfig("topic3", "test-table", false);
+    StreamConfig streamConfig1 = createMockStreamConfig("topic1", "test-table", 0);
+    StreamConfig streamConfig2 = createMockStreamConfig("topic2", "test-table", 1);
+    StreamConfig streamConfig3 = createMockStreamConfig("topic3", "test-table", 2);
     List<StreamConfig> streamConfigs = Arrays.asList(streamConfig1, streamConfig2, streamConfig3);
 
     PartitionGroupConsumptionStatus status1 = new PartitionGroupConsumptionStatus(0, 0, null, null, "IN_PROGRESS");
@@ -219,8 +220,8 @@ public class PartitionGroupMetadataFetcherTest {
   @Test
   public void testDeprecatedGetPartitionGroupMetadataListFlatMaps()
       throws Exception {
-    StreamConfig streamConfig1 = createMockStreamConfig("topic1", "test-table", false);
-    StreamConfig streamConfig2 = createMockStreamConfig("topic2", "test-table", false);
+    StreamConfig streamConfig1 = createMockStreamConfig("topic1", "test-table", 0);
+    StreamConfig streamConfig2 = createMockStreamConfig("topic2", "test-table", 1);
     List<StreamConfig> streamConfigs = Arrays.asList(streamConfig1, streamConfig2);
 
     PartitionGroupConsumptionStatus status1 = new PartitionGroupConsumptionStatus(0, 0, null, null, "IN_PROGRESS");
@@ -255,7 +256,7 @@ public class PartitionGroupMetadataFetcherTest {
   @Test
   public void testExceptionResetOnRetry()
       throws Exception {
-    StreamConfig streamConfig = createMockStreamConfig("test-topic", "test-table", false);
+    StreamConfig streamConfig = createMockStreamConfig("test-topic", "test-table", 0);
     List<StreamConfig> streamConfigs = Collections.singletonList(streamConfig);
 
     StreamPartitionMsgOffset offset = mock(StreamPartitionMsgOffset.class);
@@ -295,8 +296,8 @@ public class PartitionGroupMetadataFetcherTest {
   @Test
   public void testSequenceNumberPreservedInMultiStreamRemap()
       throws Exception {
-    StreamConfig streamConfig1 = createMockStreamConfig("topic1", "test-table", false);
-    StreamConfig streamConfig2 = createMockStreamConfig("topic2", "test-table", false);
+    StreamConfig streamConfig1 = createMockStreamConfig("topic1", "test-table", 0);
+    StreamConfig streamConfig2 = createMockStreamConfig("topic2", "test-table", 1);
     List<StreamConfig> streamConfigs = Arrays.asList(streamConfig1, streamConfig2);
 
     List<PartitionGroupConsumptionStatus> statusList = Collections.emptyList();
@@ -336,7 +337,7 @@ public class PartitionGroupMetadataFetcherTest {
   @Test
   public void testGetStreamMetadataListReturnsUnmodifiable()
       throws Exception {
-    StreamConfig streamConfig = createMockStreamConfig("test-topic", "test-table", false);
+    StreamConfig streamConfig = createMockStreamConfig("test-topic", "test-table", 0);
     List<StreamConfig> streamConfigs = Collections.singletonList(streamConfig);
 
     PartitionGroupMetadata metadata = new PartitionGroupMetadata(0, mock(StreamPartitionMsgOffset.class));
@@ -374,8 +375,8 @@ public class PartitionGroupMetadataFetcherTest {
   @Test
   public void testFetchMultipleStreamsOneTopicPermanentFailure()
       throws Exception {
-    StreamConfig streamConfig1 = createMockStreamConfig("topic1", "test-table_REALTIME", false);
-    StreamConfig streamConfig2 = createMockStreamConfig("topic2-deleted", "test-table_REALTIME", false);
+    StreamConfig streamConfig1 = createMockStreamConfig("topic1", "test-table_REALTIME", 0);
+    StreamConfig streamConfig2 = createMockStreamConfig("topic2-deleted", "test-table_REALTIME", 1);
     List<StreamConfig> streamConfigs = Arrays.asList(streamConfig1, streamConfig2);
 
     StreamPartitionMsgOffset offset = mock(StreamPartitionMsgOffset.class);
@@ -416,8 +417,8 @@ public class PartitionGroupMetadataFetcherTest {
   @Test
   public void testFetchMultipleStreamsFailedTopicDoesNotBlockOthersOnRetry()
       throws Exception {
-    StreamConfig streamConfig1 = createMockStreamConfig("topic1", "test-table_REALTIME", false);
-    StreamConfig streamConfig2 = createMockStreamConfig("topic2", "test-table_REALTIME", false);
+    StreamConfig streamConfig1 = createMockStreamConfig("topic1", "test-table_REALTIME", 0);
+    StreamConfig streamConfig2 = createMockStreamConfig("topic2", "test-table_REALTIME", 1);
     List<StreamConfig> streamConfigs = Arrays.asList(streamConfig1, streamConfig2);
 
     StreamPartitionMsgOffset offset = mock(StreamPartitionMsgOffset.class);
@@ -458,8 +459,8 @@ public class PartitionGroupMetadataFetcherTest {
   @Test
   public void testFetchMultipleStreamsNonPermanentExceptionStillPropagates()
       throws Exception {
-    StreamConfig streamConfig1 = createMockStreamConfig("topic1", "test-table_REALTIME", false);
-    StreamConfig streamConfig2 = createMockStreamConfig("topic2", "test-table_REALTIME", false);
+    StreamConfig streamConfig1 = createMockStreamConfig("topic1", "test-table_REALTIME", 0);
+    StreamConfig streamConfig2 = createMockStreamConfig("topic2", "test-table_REALTIME", 1);
     List<StreamConfig> streamConfigs = Arrays.asList(streamConfig1, streamConfig2);
 
     StreamMetadataProvider goodProvider = mock(StreamMetadataProvider.class);
@@ -494,10 +495,12 @@ public class PartitionGroupMetadataFetcherTest {
     }
   }
 
-  private StreamConfig createMockStreamConfig(String topicName, String tableName, boolean isEphemeral) {
+  private StreamConfig createMockStreamConfig(String topicName, String tableName, int configId) {
     StreamConfig streamConfig = mock(StreamConfig.class);
     when(streamConfig.getTopicName()).thenReturn(topicName);
     when(streamConfig.getTableNameWithType()).thenReturn(tableName);
+    when(streamConfig.getStreamConfigsMap()).thenReturn(
+        Map.of(StreamConfigProperties.STREAM_CONFIG_ID, String.valueOf(configId)));
     return streamConfig;
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/IngestionConfigUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/IngestionConfigUtilsTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.spi.utils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -32,6 +33,7 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
+import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -229,5 +231,135 @@ public class IngestionConfigUtilsTest {
     Assert.assertEquals(streamConfigIndexToStreamPartitions.get(0), new HashSet<>(Arrays.asList(2)));
     Assert.assertEquals(streamConfigIndexToStreamPartitions.get(1), new HashSet<>(Arrays.asList(100, 1)));
     Assert.assertEquals(streamConfigIndexToStreamPartitions.get(3), new HashSet<>(Arrays.asList(400)));
+  }
+
+  @Test
+  public void testGetPinotPartitionIdFromConfigId() {
+    Assert.assertEquals(IngestionConfigUtils.getPinotPartitionIdFromConfigId(5, 0), 5);
+    Assert.assertEquals(IngestionConfigUtils.getPinotPartitionIdFromConfigId(3, 1), 10003);
+    Assert.assertEquals(IngestionConfigUtils.getPinotPartitionIdFromConfigId(0, 2), 20000);
+    Assert.assertEquals(IngestionConfigUtils.getPinotPartitionIdFromConfigId(99, 5), 50099);
+  }
+
+  @Test
+  public void testGetConfigIdFromPinotPartitionId() {
+    Assert.assertEquals(IngestionConfigUtils.getConfigIdFromPinotPartitionId(5), 0);
+    Assert.assertEquals(IngestionConfigUtils.getConfigIdFromPinotPartitionId(10003), 1);
+    Assert.assertEquals(IngestionConfigUtils.getConfigIdFromPinotPartitionId(20000), 2);
+    Assert.assertEquals(IngestionConfigUtils.getConfigIdFromPinotPartitionId(50099), 5);
+  }
+
+  @Test
+  public void testGetStreamConfigMapByConfigId() {
+    Map<String, String> config0 = new HashMap<>();
+    config0.put(StreamConfigProperties.STREAM_CONFIG_ID, "0");
+    config0.put("stream.kafka.topic.name", "topic-A");
+
+    Map<String, String> config2 = new HashMap<>();
+    config2.put(StreamConfigProperties.STREAM_CONFIG_ID, "2");
+    config2.put("stream.kafka.topic.name", "topic-B");
+
+    StreamIngestionConfig sic = new StreamIngestionConfig(Arrays.asList(config0, config2));
+
+    Assert.assertEquals(sic.getStreamConfigMapByConfigId(0).get("stream.kafka.topic.name"), "topic-A");
+    Assert.assertEquals(sic.getStreamConfigMapByConfigId(2).get("stream.kafka.topic.name"), "topic-B");
+
+    // Config ID 1 was deleted — should throw
+    try {
+      sic.getStreamConfigMapByConfigId(1);
+      Assert.fail("Should fail for missing config ID");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testGetStreamConfigMapByConfigIdFallback() {
+    Map<String, String> config0 = new HashMap<>();
+    config0.put("stream.kafka.topic.name", "topic-A");
+    Map<String, String> config1 = new HashMap<>();
+    config1.put("stream.kafka.topic.name", "topic-B");
+
+    StreamIngestionConfig sic = new StreamIngestionConfig(Arrays.asList(config0, config1));
+
+    Assert.assertEquals(sic.getStreamConfigMapByConfigId(0).get("stream.kafka.topic.name"), "topic-A");
+    Assert.assertEquals(sic.getStreamConfigMapByConfigId(1).get("stream.kafka.topic.name"), "topic-B");
+  }
+
+  @Test
+  public void testGetConfigIdToStreamConfigMap() {
+    Map<String, String> config0 = new HashMap<>();
+    config0.put(StreamConfigProperties.STREAM_CONFIG_ID, "0");
+    config0.put("stream.kafka.topic.name", "topic-A");
+
+    Map<String, String> config3 = new HashMap<>();
+    config3.put(StreamConfigProperties.STREAM_CONFIG_ID, "3");
+    config3.put("stream.kafka.topic.name", "topic-B");
+
+    StreamIngestionConfig sic = new StreamIngestionConfig(Arrays.asList(config0, config3));
+    Map<Integer, Map<String, String>> idMap = sic.getConfigIdToStreamConfigMap();
+
+    Assert.assertEquals(idMap.size(), 2);
+    Assert.assertEquals(idMap.get(0).get("stream.kafka.topic.name"), "topic-A");
+    Assert.assertEquals(idMap.get(3).get("stream.kafka.topic.name"), "topic-B");
+    Assert.assertNull(idMap.get(1));
+  }
+
+  @Test
+  public void testGetConfigIdToStreamConfigMapFallback() {
+    Map<String, String> config0 = new HashMap<>();
+    config0.put("stream.kafka.topic.name", "topic-A");
+    Map<String, String> config1 = new HashMap<>();
+    config1.put("stream.kafka.topic.name", "topic-B");
+
+    StreamIngestionConfig sic = new StreamIngestionConfig(Arrays.asList(config0, config1));
+    Map<Integer, Map<String, String>> idMap = sic.getConfigIdToStreamConfigMap();
+
+    Assert.assertEquals(idMap.size(), 2);
+    Assert.assertEquals(idMap.get(0).get("stream.kafka.topic.name"), "topic-A");
+    Assert.assertEquals(idMap.get(1).get("stream.kafka.topic.name"), "topic-B");
+  }
+
+  @Test
+  public void testGetConfigId() {
+    Map<String, String> config0 = new HashMap<>();
+    config0.put(StreamConfigProperties.STREAM_CONFIG_ID, "5");
+    config0.put("stream.kafka.topic.name", "topic-A");
+    Map<String, String> config1 = new HashMap<>();
+    config1.put("stream.kafka.topic.name", "topic-B");
+
+    StreamIngestionConfig sic = new StreamIngestionConfig(Arrays.asList(config0, config1));
+    Assert.assertEquals(sic.getConfigId(0), 5);
+    Assert.assertEquals(sic.getConfigId(1), 1);
+  }
+
+  @Test
+  public void testStreamIngestionConfigSerDe()
+      throws Exception {
+    Map<String, String> config0 = new HashMap<>();
+    config0.put(StreamConfigProperties.STREAM_CONFIG_ID, "0");
+    config0.put("streamType", "kafka");
+    config0.put("stream.kafka.topic.name", "topic-A");
+
+    Map<String, String> config1 = new HashMap<>();
+    config1.put(StreamConfigProperties.STREAM_CONFIG_ID, "1");
+    config1.put("streamType", "kafka");
+    config1.put("stream.kafka.topic.name", "topic-B");
+
+    StreamIngestionConfig original = new StreamIngestionConfig(Arrays.asList(config0, config1));
+    original.setNextStreamConfigId(2);
+
+    ObjectMapper mapper = new ObjectMapper();
+    String json = mapper.writeValueAsString(original);
+    StreamIngestionConfig deserialized = mapper.readValue(json, StreamIngestionConfig.class);
+
+    Assert.assertEquals(deserialized.getNextStreamConfigId(), 2);
+    Assert.assertEquals(deserialized.getStreamConfigMaps().size(), 2);
+    Assert.assertEquals(
+        deserialized.getStreamConfigMaps().get(0).get(StreamConfigProperties.STREAM_CONFIG_ID), "0");
+    Assert.assertEquals(
+        deserialized.getStreamConfigMaps().get(1).get(StreamConfigProperties.STREAM_CONFIG_ID), "1");
+    Assert.assertEquals(
+        deserialized.getStreamConfigMaps().get(0).get("stream.kafka.topic.name"), "topic-A");
   }
 }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Shows flow of creating multi\-topic segment name and using its configId to lookup stream config for consumption status\.

```mermaid
flowchart TD
  N0["getNextLLCSegmentName #40;multi#45;topic#41; #40;F4#41;"]:::stModified
  N1["LLCSegmentName #40;getStreamConfigId#41; #40;F1#41;"]:::stModified
  N2["getPartitionGroupConsumptionStatusL #40;use configId#41; #40;F4#41;"]:::stModified
  N3["lookup StreamConfig by configId #40;F4#41;"]:::stModified
  N0 -->|"returns LLCSegmentName"| N1
  N1 -->|"getStreamConfigId#40;#41;"| N2
  N2 -->|"get StreamConfig from map"| N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName\.java — [before](https://github.com/apache/pinot/blob/54f29a9d0f11960827b93ec7f5abbd12229a36d1/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java) · [after](https://github.com/apache/pinot/blob/c9c7c58ad1d52455e813562a1c34ad4644c9eee6/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java)
- F4: pinot\-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager\.java — [before](https://github.com/apache/pinot/blob/54f29a9d0f11960827b93ec7f5abbd12229a36d1/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java) · [after](https://github.com/apache/pinot/blob/c9c7c58ad1d52455e813562a1c34ad4644c9eee6/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjU0ZjI5YTlkMGYxMTk2MDgyN2I5M2VjN2Y1YWJiZDEyMjI5YTM2ZDEiLCJjb250ZXh0X2hhc2giOiJkNzgxODAwN2Y1YzljY2I5MTFkMDM3NDEzMmY1ZTYxYjQ1ZGVhMTgxMjk3MGEzYzMxOGEwMDU1Y2M2OThjNjU0IiwiZ2VuZXJhdGVkX2F0IjoxNzg5MjgyMTE2LCJoZWFkX3NoYSI6ImM5YzdjNThhZDFkNTI0NTVlODEzNTYyYTFjMzRhZDQ2NDRjOWVlZTYiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI1NGYyOWE5ZDBmMTE5NjA4MjdiOTNlYzdmNWFiYmQxMjIyOWEzNmQxIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 7d65e7125fe17cb7646e1b4dc2d35fe7a090cd09a80ff6cddfc6edb7895cd0db -->
<!-- pinot-pr-flow:end -->

Resolves #18739.

Multi-topic realtime ingestion encodes partition group IDs as topicIndex * 10000 + streamPartitionId, where topicIndex is the positional index in the config list. Deleting any topic except the last one shifts subsequent indices, breaking existing segment decoding.
This PR introduces stable, immutable config IDs (stream.config.id) that replace positional indices, and a 5-part segment name format that stores the config ID and stream partition ID as separate fields.

Key changes:
- stream.config.id auto-assigned on table create/update, with validation (no duplicates, no negatives, stale-nextId detection)
- MultiTopicLLCSegmentName: tableName__configId__streamPartitionId__sequenceNumber__creationTime
- LLCSegmentName parses both 4-part and 5-part formats transparently
- New segments created in 5-part format for multi-topic tables
- All getStreamConfigIndexFromPinotPartitionId() call sites migrated to segment-name-based config ID lookup