### PR TITLE
Add optional fieldId and aliases to FieldSpec for column identity

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
@@ -160,6 +160,16 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
   @Nullable
   protected List<String> _tags;
 
+  @JsonProperty("fieldId")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @Nullable
+  protected Integer _fieldId;
+
+  @JsonProperty("aliases")
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  @Nullable
+  protected List<String> _aliases;
+
   protected String _name;
   protected DataType _dataType;
   protected boolean _singleValueField = true;
@@ -238,6 +248,24 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
 
   public void setTags(@Nullable List<String> tags) {
     _tags = tags;
+  }
+
+  @Nullable
+  public Integer getFieldId() {
+    return _fieldId;
+  }
+
+  public void setFieldId(@Nullable Integer fieldId) {
+    _fieldId = fieldId;
+  }
+
+  @Nullable
+  public List<String> getAliases() {
+    return _aliases;
+  }
+
+  public void setAliases(@Nullable List<String> aliases) {
+    _aliases = aliases == null || aliases.isEmpty() ? null : aliases;
   }
 
   public DataType getDataType() {
@@ -585,7 +613,25 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
       }
       jsonObject.set("tags", tagsArray);
     }
+    appendFieldIdAndAliases(jsonObject);
     return jsonObject;
+  }
+
+  /// Appends `fieldId` and `aliases` (when set) to the given JSON object.
+  ///
+  /// Subclasses that build JSON without calling [FieldSpec#toJsonObject()], such as [TimeFieldSpec], use this helper
+  /// to preserve these fields during schema round-trip serialization.
+  protected void appendFieldIdAndAliases(ObjectNode jsonObject) {
+    if (_fieldId != null) {
+      jsonObject.put("fieldId", _fieldId);
+    }
+    if (_aliases != null && !_aliases.isEmpty()) {
+      ArrayNode aliasesArray = JsonUtils.newArrayNode();
+      for (String alias : _aliases) {
+        aliasesArray.add(alias);
+      }
+      jsonObject.set("aliases", aliasesArray);
+    }
   }
 
   protected void appendDefaultNullValue(ObjectNode jsonNode) {
@@ -658,14 +704,16 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
         && Objects.equals(_transformFunction, that._transformFunction)
         && Objects.equals(_virtualColumnProvider, that._virtualColumnProvider)
         && Objects.equals(_description, that._description)
-        && Objects.equals(_tags, that._tags);
+        && Objects.equals(_tags, that._tags)
+        && Objects.equals(_fieldId, that._fieldId)
+        && Objects.equals(_aliases, that._aliases);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(_name, _dataType, _singleValueField, _notNull, _maxLength, _maxLengthExceedStrategy,
         _allowTrailingZeros, _dataType.hashCode(_defaultNullValue), _transformFunction, _virtualColumnProvider,
-        _description, _tags);
+        _description, _tags, _fieldId, _aliases);
   }
 
   /**

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/TimeFieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/TimeFieldSpec.java
@@ -114,6 +114,7 @@ public final class TimeFieldSpec extends FieldSpec {
     }
     appendDefaultNullValue(jsonObject);
     appendTransformFunction(jsonObject);
+    appendFieldIdAndAliases(jsonObject);
     return jsonObject;
   }
 

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/FieldSpecTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/FieldSpecTest.java
@@ -592,4 +592,112 @@ public class FieldSpecTest {
 
     assertThat(newSpec.isBackwardCompatibleWith(oldSpec)).isTrue();
   }
+
+  @Test
+  public void testFieldIdAndAliasesSerdeRoundtrip()
+      throws Exception {
+    DimensionFieldSpec fieldSpec = new DimensionFieldSpec("user_id", STRING, true);
+    fieldSpec.setFieldId(42);
+    fieldSpec.setAliases(Arrays.asList("uid", "userId"));
+
+    String json = fieldSpec.toJsonObject().toString();
+    assertThat(json).contains("\"fieldId\":42");
+    assertThat(json).contains("\"aliases\":[\"uid\",\"userId\"]");
+
+    DimensionFieldSpec deserialized = JsonUtils.stringToObject(json, DimensionFieldSpec.class);
+    assertThat(deserialized.getFieldId()).isEqualTo(42);
+    assertThat(deserialized.getAliases()).isEqualTo(Arrays.asList("uid", "userId"));
+
+    String jacksonJson = JsonUtils.objectToString(fieldSpec);
+    DimensionFieldSpec fromJackson = JsonUtils.stringToObject(jacksonJson, DimensionFieldSpec.class);
+    assertThat(fromJackson.getFieldId()).isEqualTo(42);
+    assertThat(fromJackson.getAliases()).isEqualTo(Arrays.asList("uid", "userId"));
+  }
+
+  @Test
+  public void testFieldIdAndAliasesOmittedWhenNotSet()
+      throws Exception {
+    DimensionFieldSpec fieldSpec = new DimensionFieldSpec("col1", INT, true);
+
+    String json = fieldSpec.toJsonObject().toString();
+    assertThat(json).as("fieldId should be absent when null").doesNotContain("fieldId");
+    assertThat(json).as("aliases should be absent when null").doesNotContain("aliases");
+
+    String jacksonJson = JsonUtils.objectToString(fieldSpec);
+    assertThat(jacksonJson).as("fieldId should be absent when null").doesNotContain("fieldId");
+    assertThat(jacksonJson).as("aliases should be absent when null").doesNotContain("aliases");
+  }
+
+  @Test
+  public void testEmptyAliasesOmittedFromJson()
+      throws Exception {
+    DimensionFieldSpec fieldSpec = new DimensionFieldSpec("col1", INT, true);
+    fieldSpec.setAliases(List.of());
+    assertThat(fieldSpec.getAliases()).isNull();
+
+    String json = fieldSpec.toJsonObject().toString();
+    assertThat(json).as("empty aliases should be absent").doesNotContain("aliases");
+    assertThat(JsonUtils.stringToObject(json, DimensionFieldSpec.class)).isEqualTo(fieldSpec);
+
+    String jacksonJson = JsonUtils.objectToString(fieldSpec);
+    assertThat(jacksonJson).as("empty aliases should be absent (Jackson)").doesNotContain("aliases");
+    assertThat(JsonUtils.stringToObject(jacksonJson, DimensionFieldSpec.class)).isEqualTo(fieldSpec);
+  }
+
+  @Test
+  public void testTimeFieldSpecRoundTripsFieldIdAndAliasesThroughSchema()
+      throws Exception {
+    // TimeFieldSpec.toJsonObject() builds its JSON without calling super.toJsonObject(), so ensure the
+    // generic fieldId/aliases still round-trip through schema (de)serialization for legacy TIME columns.
+    TimeFieldSpec timeFieldSpec = new TimeFieldSpec(new TimeGranularitySpec(LONG, TimeUnit.DAYS, "ts"));
+    timeFieldSpec.setFieldId(7);
+    timeFieldSpec.setAliases(Arrays.asList("event_ts", "ingestion_ts"));
+
+    Schema schema = new Schema();
+    schema.setSchemaName("ts_schema");
+    schema.addField(timeFieldSpec);
+
+    String json = schema.toSingleLineJsonString();
+    assertThat(json).contains("\"fieldId\":7");
+    assertThat(json).contains("\"aliases\":[\"event_ts\",\"ingestion_ts\"]");
+
+    FieldSpec deserialized = Schema.fromString(json).getFieldSpecFor("ts");
+    assertThat(deserialized.getFieldId()).isEqualTo(7);
+    assertThat(deserialized.getAliases()).isEqualTo(Arrays.asList("event_ts", "ingestion_ts"));
+  }
+
+  @Test
+  public void testOldJsonWithoutFieldIdAndAliasesDeserializesCleanly()
+      throws Exception {
+    String oldJson = "{\"name\":\"col1\",\"dataType\":\"STRING\"}";
+    DimensionFieldSpec fieldSpec = JsonUtils.stringToObject(oldJson, DimensionFieldSpec.class);
+    assertThat(fieldSpec.getFieldId()).isNull();
+    assertThat(fieldSpec.getAliases()).isNull();
+  }
+
+  @Test
+  public void testFieldIdAndAliasesInEqualsAndHashCode() {
+    DimensionFieldSpec spec1 = new DimensionFieldSpec("col1", STRING, true);
+    DimensionFieldSpec spec2 = new DimensionFieldSpec("col1", STRING, true);
+    spec2.setFieldId(42);
+    spec2.setAliases(Arrays.asList("uid"));
+
+    assertThat(spec1).isNotEqualTo(spec2);
+    assertThat(spec1.hashCode()).isNotEqualTo(spec2.hashCode());
+
+    spec1.setFieldId(42);
+    spec1.setAliases(Arrays.asList("uid"));
+    assertThat(spec1).isEqualTo(spec2);
+    assertThat(spec1.hashCode()).isEqualTo(spec2.hashCode());
+  }
+
+  @Test
+  public void testFieldIdAndAliasesNotInBackwardCompatibility() {
+    DimensionFieldSpec oldSpec = new DimensionFieldSpec("col1", STRING, true);
+    DimensionFieldSpec newSpec = new DimensionFieldSpec("col1", STRING, true);
+    newSpec.setFieldId(42);
+    newSpec.setAliases(Arrays.asList("uid"));
+
+    assertThat(newSpec.isBackwardCompatibleWith(oldSpec)).isTrue();
+  }
 }


### PR DESCRIPTION
## What
Adds two optional, nullable metadata fields to `FieldSpec` (`pinot-spi`):

| Field | Type | Meaning |
|---|---|---|
| `fieldId` | `Integer` | A stable, name-independent identifier for the column. |
| `aliases` | `List<String>` | Alternate / historical names for the column. |

Both follow the existing `description` / `tags` convention on `FieldSpec`:
- `fieldId` is serialized with `@JsonInclude(NON_NULL)`, `aliases` with `@JsonInclude(NON_EMPTY)`.
- Both are mirrored in the manual `toJsonObject()` serialization and included in `equals()` / `hashCode()`.
- They are not part of schema backward-compatibility validation, so adding or changing them doesn't fail a schema update today.

## Why
`fieldId` provides a stable column identity that is decoupled from the column name. Together with `aliases`, it lays the groundwork for advanced schema evolutions like column rename in Pinot — a rename can preserve the column's identity and record the prior name as an alias, instead of looking like a drop-plus-add.

## Compatibility
- **No impact on existing tables.** Both fields default to `null`/empty and are omitted from JSON, so the serialized schema and wire format are unchanged for any column that doesn't set them.
- **Mixed-version safe.** Older components ignore the unknown JSON properties on read; newer components emit nothing for columns without these fields. They are excluded from backward-compatibility checks, so a schema carrying them validates against one that doesn't.
- **No updates to query/ingestion paths or segment metadata today** — this change only adds the fields to the schema model.

## Tests
`FieldSpecTest` adds coverage for the new getters/setters, JSON round-trip (including omission when unset), and `equals`/`hashCode` participation.
