### PR TITLE
[Bug fix] Skip flushing empty chunk in OffHeapH3IndexCreator

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/OffHeapH3IndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/OffHeapH3IndexCreator.java
@@ -83,6 +83,11 @@ public class OffHeapH3IndexCreator extends BaseH3IndexCreator {
    */
   private void flush()
       throws IOException {
+    // Skip flushing an empty posting list map. This could happen when add() didn't add any entry due to invalid
+    // Geometry and _continueOnError is set
+    if (_postingListMap.isEmpty()) {
+      return;
+    }
     long length = 0;
     for (Map.Entry<Long, RoaringBitmapWriter<RoaringBitmap>> entry : _postingListMap.entrySet()) {
       _postingListOutputStream.writeLong(entry.getKey());
@@ -135,7 +140,10 @@ public class OffHeapH3IndexCreator extends BaseH3IndexCreator {
       // Merge posting lists from the chunk iterators
       PriorityQueue<PostingListEntry> priorityQueue = new PriorityQueue<>(numChunks);
       for (ChunkIterator chunkIterator : chunkIterators) {
-        priorityQueue.offer(chunkIterator.next());
+        // Defensive: skip empty chunks instead of blindly reading the first entry (flush() should never produce one)
+        if (chunkIterator.hasNext()) {
+          priorityQueue.offer(chunkIterator.next());
+        }
       }
       long currentH3Id = Long.MIN_VALUE;
       MutableRoaringBitmap currentDocIds = null;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/OffHeapH3IndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/OffHeapH3IndexCreator.java
@@ -73,7 +73,9 @@ public class OffHeapH3IndexCreator extends BaseH3IndexCreator {
   public void add(@Nullable Geometry geometry)
       throws IOException {
     super.add(geometry);
-    if (_postingListMap.size() % FLUSH_THRESHOLD == 0) {
+    // Skip flushing an empty posting list map. This could happen when add() didn't add any entry due to invalid
+    // Geometry and _continueOnError is set
+    if (!_postingListMap.isEmpty() && _postingListMap.size() % FLUSH_THRESHOLD == 0) {
       flush();
     }
   }
@@ -83,11 +85,6 @@ public class OffHeapH3IndexCreator extends BaseH3IndexCreator {
    */
   private void flush()
       throws IOException {
-    // Skip flushing an empty posting list map. This could happen when add() didn't add any entry due to invalid
-    // Geometry and _continueOnError is set
-    if (_postingListMap.isEmpty()) {
-      return;
-    }
     long length = 0;
     for (Map.Entry<Long, RoaringBitmapWriter<RoaringBitmap>> entry : _postingListMap.entrySet()) {
       _postingListOutputStream.writeLong(entry.getKey());
@@ -118,7 +115,7 @@ public class OffHeapH3IndexCreator extends BaseH3IndexCreator {
     }
 
     // Flush the last chunk
-    if (_postingListMap.size() % FLUSH_THRESHOLD != 0) {
+    if (!_postingListMap.isEmpty() && _postingListMap.size() % FLUSH_THRESHOLD != 0) {
       flush();
     }
     _postingListOutputStream.close();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/OffHeapH3IndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/OffHeapH3IndexCreator.java
@@ -73,9 +73,7 @@ public class OffHeapH3IndexCreator extends BaseH3IndexCreator {
   public void add(@Nullable Geometry geometry)
       throws IOException {
     super.add(geometry);
-    // Skip flushing an empty posting list map. This could happen when add() didn't add any entry due to invalid
-    // Geometry and _continueOnError is set
-    if (!_postingListMap.isEmpty() && _postingListMap.size() % FLUSH_THRESHOLD == 0) {
+    if (_postingListMap.size() == FLUSH_THRESHOLD) {
       flush();
     }
   }
@@ -115,7 +113,7 @@ public class OffHeapH3IndexCreator extends BaseH3IndexCreator {
     }
 
     // Flush the last chunk
-    if (!_postingListMap.isEmpty() && _postingListMap.size() % FLUSH_THRESHOLD != 0) {
+    if (!_postingListMap.isEmpty()) {
       flush();
     }
     _postingListOutputStream.close();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/H3IndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/H3IndexTest.java
@@ -263,6 +263,41 @@ public class H3IndexTest implements PinotBuffersAfterMethodCheckRule {
   }
 
   @Test
+  public void testOffHeapSkipAtEmptyBufferDoesNotCreateEmptyChunk()
+      throws Exception {
+    // Regression test for an IndexOutOfBoundsException in OffHeapH3IndexCreator.seal(). When a record is skipped
+    // (e.g. a null/invalid geometry tolerated via continueOnError) while the in-memory posting list buffer is empty
+    // -- which is the case for the very first record and immediately after each flush -- the flush trigger (buffer
+    // size being a multiple of FLUSH_THRESHOLD, which includes 0) used to append a zero-length chunk. That empty
+    // chunk produced an empty ChunkIterator that was read unconditionally during the merge in seal(), throwing.
+    String columnName = "offHeapSkipAtEmptyBuffer";
+    int res = 5;
+    H3IndexResolution resolution = new H3IndexResolution(Collections.singletonList(res));
+
+    try (GeoSpatialIndexCreator creator = new OffHeapH3IndexCreator(TEMP_DIR, columnName, "myTable_OFFLINE", true,
+        resolution)) {
+      // Skip the very first record while the buffer is empty. This used to create a zero-length leading chunk, which
+      // also pushed seal() into the multi-chunk merge path where the empty chunk was read and threw.
+      creator.add(null);
+      creator.add(GeometryUtils.GEOMETRY_FACTORY.createPoint(new Coordinate(10, 20)));
+      creator.add(GeometryUtils.GEOMETRY_FACTORY.createPoint(new Coordinate(30, 40)));
+
+      // seal() must not throw and must produce a valid, readable index.
+      creator.seal();
+    }
+
+    File indexFile = new File(TEMP_DIR, columnName + V1Constants.Indexes.H3_INDEX_FILE_EXTENSION);
+    try (PinotDataBuffer buffer = PinotDataBuffer.mapReadOnlyBigEndianFile(indexFile);
+        H3IndexReader reader = new ImmutableH3IndexReader(buffer)) {
+      // docId 0 was the skipped record; the two valid points are docIds 1 and 2.
+      Assert.assertEquals(reader.getDocIds(H3Utils.H3_CORE.latLngToCell(20, 10, res)),
+          ImmutableRoaringBitmap.bitmapOf(1));
+      Assert.assertEquals(reader.getDocIds(H3Utils.H3_CORE.latLngToCell(40, 30, res)),
+          ImmutableRoaringBitmap.bitmapOf(2));
+    }
+  }
+
+  @Test
   public void testSkipInvalidGeometryContinueOnErrorFalse()
       throws Exception {
     String columnName = "skipInvalid";


### PR DESCRIPTION
## Desciption
H3 index could run into `java.lang.IndexOutOfBoundsException`
```
java.lang.IndexOutOfBoundsException
      at java.base/java.nio.Buffer$1.apply(Buffer.java:757)
      at java.base/java.nio.Buffer$1.apply(Buffer.java:754)
      at java.base/jdk.internal.util.Preconditions$4.apply(Preconditions.java:213)
      at java.base/jdk.internal.util.Preconditions$4.apply(Preconditions.java:210)
      at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:98)
      at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106)
      at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302)
      at java.base/java.nio.Buffer.checkIndex(Buffer.java:779)
      at java.base/java.nio.DirectByteBuffer.getLong(DirectByteBuffer.java:861)
      at org.apache.pinot.segment.spi.memory.PinotByteBuffer.getLong(PinotByteBuffer.java:181)
      at org.apache.pinot.segment.local.segment.creator.impl.inv.geospatial.OffHeapH3IndexCreator$ChunkIt
  erator.next(OffHeapH3IndexCreator.java:193)
      at org.apache.pinot.segment.local.segment.creator.impl.inv.geospatial.OffHeapH3IndexCreator.seal(Of
  fHeapH3IndexCreator.java:138)
      at org.apache.pinot.segment.local.segment.creator.impl.ColumnIndexCreators.seal(ColumnIndexCreators
  .java:98)
      at org.apache.pinot.segment.local.segment.creator.impl.BaseSegmentCreator.flushColIndexes(BaseSegme
  ntCreator.java:818)
      at org.apache.pinot.segment.local.segment.creator.impl.BaseSegmentCreator.seal(BaseSegmentCreator.j
  ava:753)
```
because empty chunk could be added into the chunk list. An empty chunk would cause out of bound read in `ChunkIterator`

## Change
* Don't add when posting list is empty while flush
* Check and skip empty chunk while iterating

## Test
Added an unit test and verified it would fail without the patch