### PR TITLE
Fix ClassCastException for single-server colocated aggregations in the multi-stage engine

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/AggregationResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/AggregationResultsBlock.java
@@ -97,7 +97,20 @@ public class AggregationResultsBlock extends BaseResultsBlock {
 
   @Override
   public List<Object[]> getRows() {
-    return Collections.singletonList(_results.toArray());
+    if (!_queryContext.isServerReturnFinalResult()) {
+      return Collections.singletonList(_results.toArray());
+    }
+    // When the server is requested to return the final result (e.g. a single-server colocated DIRECT aggregate in the
+    // multi-stage engine), getDataSchema() reports the final column types. Finalize the intermediate results here so
+    // that the rows are consistent with the schema; otherwise an intermediate object (e.g. a HyperLogLogPlus) would be
+    // left in a column typed as its final type (e.g. LONG) and fail when the block is serialized. This mirrors the
+    // finalization done in getDataTable() and in GroupByCombineOperator for the group-by case.
+    int numColumns = _results.size();
+    Object[] row = new Object[numColumns];
+    for (int i = 0; i < numColumns; i++) {
+      row[i] = _aggregationFunctions[i].extractFinalResult(_results.get(i));
+    }
+    return Collections.singletonList(row);
   }
 
   @Override

--- a/pinot-query-runtime/src/test/resources/queries/DirectAggregateObjectIntermediate.json
+++ b/pinot-query-runtime/src/test/resources/queries/DirectAggregateObjectIntermediate.json
@@ -1,0 +1,69 @@
+{
+  "direct_aggregate_object_intermediate": {
+    "comments": "Regression test for the HLL->Long ClassCastException. When a no-group-by aggregate is colocated on a single server, the v2 physical optimizer produces an AGGREGATE_DIRECT leaf that returns final results (SERVER_RETURN_FINAL_RESULT). Aggregations whose intermediate type differs from their final type (e.g. DISTINCTCOUNTHLLPLUS -> HyperLogLogPlus/LONG, DISTINCTCOUNT -> Set/INT) must be finalized before the leaf serializes its output. A 'replicated' table forces single-server colocation -> AGGREGATE_DIRECT. NOTE: the DISTINCTCOUNT* assertions use exact equality, which is only safe because the distinct cardinality here is tiny (2-3 values) where HLL is exact; do not raise the cardinality.",
+    "tables": {
+      "tbl": {
+        "replicated": true,
+        "schema": [
+          {"name": "amount", "type": "INT"},
+          {"name": "user_id", "type": "STRING"}
+        ],
+        "inputs": [
+          [10, "u1"],
+          [20, "u2"],
+          [30, "u1"],
+          [40, ""]
+        ]
+      }
+    },
+    "queries": [
+      {
+        "description": "SUM + DISTINCTCOUNTHLLPLUS FILTER (the reported failing shape)",
+        "sql": "SELECT SUM(amount) AS s, DISTINCTCOUNTHLLPLUS(user_id) FILTER (WHERE user_id <> '') AS dc FROM {tbl}",
+        "h2Sql": "SELECT SUM(amount) AS s, COUNT(DISTINCT CASE WHEN user_id <> '' THEN user_id END) AS dc FROM {tbl}"
+      },
+      {
+        "description": "Plain DISTINCTCOUNTHLLPLUS (no filter) still hits the same DIRECT path",
+        "sql": "SELECT DISTINCTCOUNTHLLPLUS(user_id) AS dc FROM {tbl}",
+        "h2Sql": "SELECT COUNT(DISTINCT user_id) AS dc FROM {tbl}"
+      },
+      {
+        "description": "DISTINCTCOUNT (Set intermediate, INT final) - same finalize requirement",
+        "sql": "SELECT DISTINCTCOUNT(user_id) AS dc FROM {tbl}",
+        "h2Sql": "SELECT COUNT(DISTINCT user_id) AS dc FROM {tbl}"
+      },
+      {
+        "description": "Primitive-only DIRECT aggregate (intermediate type == final type) - finalize loop must be a correct no-op",
+        "sql": "SELECT SUM(amount) AS s, COUNT(*) AS c FROM {tbl}",
+        "h2Sql": "SELECT SUM(amount) AS s, COUNT(*) AS c FROM {tbl}"
+      }
+    ]
+  },
+  "direct_aggregate_object_intermediate_null_handling": {
+    "comments": "Same DIRECT path with column-based null handling enabled and FILTERs that match zero rows, so the finalized value is NULL (SUM) / 0 (COUNT-family). Exercises the null finalization path of getRows() in SERVER_RETURN_FINAL_RESULT mode.",
+    "extraProps": {
+      "enableColumnBasedNullHandling": true
+    },
+    "tables": {
+      "tbl": {
+        "replicated": true,
+        "schema": [
+          {"name": "amount", "type": "INT"},
+          {"name": "user_id", "type": "STRING"}
+        ],
+        "inputs": [
+          [10, "u1"],
+          [20, "u2"],
+          [30, "u1"]
+        ]
+      }
+    },
+    "queries": [
+      {
+        "description": "Zero-match FILTERs: SUM finalizes to NULL, DISTINCTCOUNTHLLPLUS/COUNT finalize to 0",
+        "sql": "SELECT SUM(amount) FILTER (WHERE amount > 1000) AS s, COUNT(*) FILTER (WHERE amount > 1000) AS c, DISTINCTCOUNTHLLPLUS(user_id) FILTER (WHERE amount > 1000) AS dc FROM {tbl}",
+        "h2Sql": "SELECT SUM(CASE WHEN amount > 1000 THEN amount END) AS s, COUNT(CASE WHEN amount > 1000 THEN 1 END) AS c, COUNT(DISTINCT CASE WHEN amount > 1000 THEN user_id END) AS dc FROM {tbl}"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Problem

With the multi-stage engine and `usePhysicalOptimizer=true`, a no-GROUP-BY aggregate whose data is colocated on a single server is planned as a single-stage `AGGREGATE_DIRECT` leaf that returns **final** results (`SERVER_RETURN_FINAL_RESULT`). This happens, for example, when a query filters on a single partition value of a partitioned, `strictReplicaGroup` table so routing prunes to one server.

For aggregation functions whose intermediate type differs from their final type — e.g. `DISTINCTCOUNTHLLPLUS` (`HyperLogLogPlus` → `LONG`), `DISTINCTCOUNT` (`Set` → `INT`) — the leaf crashes while serializing its output:

```
SET useMultistageEngine=true; SET usePhysicalOptimizer=true;
SELECT SUM(a), DISTINCTCOUNTHLLPLUS(user_id) FILTER (WHERE user_id <> '') FROM tbl WHERE part_col = 'x'

Received 1 error from stage 1 on Server_...:
class com.clearspring.analytics.stream.cardinality.HyperLogLogPlus cannot be cast to class java.lang.Long
```

## Root cause

`AggregationResultsBlock` is inconsistent between the two methods the multi-stage leaf relies on:

- `getDataSchema()` reports the **final** column types (e.g. `LONG`) when `isServerReturnFinalResult()` is true.
- `getRows()` returned the **raw intermediate** `_results` (the `HyperLogLogPlus` object) without finalizing. Only `getDataTable()` finalized via `extractFinalResult()`.

`LeafOperator.composeDirectMseBlock` consumes `getRows()` + `getDataSchema()`. Because the schema already claims the final type, no type conversion is applied, and the intermediate object is left in a column typed as its final type. It then fails on `MAILBOX_SEND` when the block is serialized.

## Fix

`AggregationResultsBlock.getRows()` now finalizes via `extractFinalResult()` when `isServerReturnFinalResult()` is true, so the rows are consistent with the schema it already advertises. This mirrors `getDataTable()` and the group-by path, where `GroupByCombineOperator` already finalizes the indexed table for server-return-final.

## Scope

- Only the **v2 physical optimizer** produces a no-GROUP-BY single-server `DIRECT` aggregate. The default (v1) multi-stage planner always splits no-GROUP-BY aggregates into LEAF + FINAL (intermediate `OBJECT` on the leaf, finalized in the FINAL stage), so it is **not** affected.
- GROUP-BY `DIRECT` aggregates were already safe because `GroupByCombineOperator` finalizes the table.
- This is a crash fix on an existing, option-gated path; prior behavior was a hard `ClassCastException`, so there is no behavior change for any query that previously succeeded.

## Testing

Added `DirectAggregateObjectIntermediate.json` (a `replicated` table forces single-server colocation → `AGGREGATE_DIRECT`), covering:
- `SUM` + `DISTINCTCOUNTHLLPLUS ... FILTER` (the reported shape),
- plain `DISTINCTCOUNTHLLPLUS` and `DISTINCTCOUNT`,
- a primitive-only case (intermediate type == final type) to confirm the finalize loop is a correct no-op,
- a column-based-null-handling case with zero-match filters so a value finalizes to `NULL`.

The legacy planner passes and the physical optimizer fails before / passes after the fix. The full `ResourceBasedQueriesTest` (3589 cases) and the relevant `pinot-core` aggregation tests are green.
