### PR TITLE
Fix ProtoBufRecordExtractor cache invalidation for Protobuf schema evolution

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
@@ -1,4 +1,16 @@
 rules:
+# tableTenantInfo: emitted by SegmentStatusChecker as
+#   pinot.controller.tableTenantInfo.<tableNameWithType>.<serverTenant>
+# MUST appear before the generic tableNameWithType rules — the extra tenant path segment would otherwise be consumed
+# by those patterns and the tenant label would not be extracted.
+- pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.tableTenantInfo\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.([^\"]+)\"><>(\\w+)"
+  name: "pinot_controller_tableTenantInfo_$6"
+  cache: true
+  labels:
+    database: "$2"
+    table: "$1$3"
+    tableType: "$4"
+    tenant: "$5"
 # Gauges that accept tableNameWithType
 - pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.((\\w+)\\.)?(\\w+)_(OFFLINE|REALTIME)\\\"?><>(\\w+)"
   name: "pinot_$1_$2_$7"

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -225,6 +225,16 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
 
   // The progress of a certain table rebalance job of a table
   TABLE_REBALANCE_JOB_PROGRESS_PERCENT("percent", false),
+
+  // Mapping metric for table-to-server-tenant attribution. Always set to 1.
+  // The server tenant name is embedded as an extra key segment in the metric name so that Prometheus can extract it
+  // as a label and join it onto other table-scoped metrics via group_left.
+  // JMX name pattern: pinot.controller.tableTenantInfo.<tableNameWithType>.<serverTenant>
+  // NOTE: this gauge is exempt from the standard ControllerGauge.values() loop in removeMetricsForTable because its
+  // registered name includes the tenant segment. Removal is handled explicitly via _tableTenantMap in
+  // SegmentStatusChecker.
+  TABLE_TENANT_INFO("info", false),
+
   // HTTP thread utilization
   HTTP_THREAD_UTILIZATION("httpThreadUtilization", true),
   // Track the concurrent executions of the API resources that use @ManagedAsync

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -43,6 +43,7 @@ import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.metrics.ControllerTimer;
+import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
@@ -54,6 +55,7 @@ import org.apache.pinot.controller.util.ServerQueryInfoFetcher.ServerQueryInfo;
 import org.apache.pinot.controller.util.TableSizeReader;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.TenantConfig;
 import org.apache.pinot.spi.config.table.TierConfig;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
@@ -81,6 +83,9 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
   private final int _waitForPushTimeSeconds;
   private final TableSizeReader _tableSizeReader;
   private final Set<String> _tierBackendGauges = new HashSet<>();
+  // Maps tableNameWithType -> server tenant name, so stale gauges can be removed when a table changes tenant.
+  // Accessed only from the single-threaded periodic task execution loop (processTable / removeMetricsForTable).
+  private final Map<String, String> _tableTenantMap = new HashMap<>();
 
   private long _lastDisabledTableLogTimestamp = 0;
 
@@ -170,6 +175,10 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
     if (tableConfig == null) {
       LOGGER.warn("Found null table config for table: {}. Resetting table config metrics.", tableNameWithType);
       _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.REPLICATION_FROM_CONFIG, 0);
+      String tenant = _tableTenantMap.remove(tableNameWithType);
+      if (tenant != null) {
+        _controllerMetrics.removeTableGauge(tableNameWithType, tenant, ControllerGauge.TABLE_TENANT_INFO);
+      }
       return;
     }
     if (tableConfig.getTableType() == TableType.OFFLINE) {
@@ -194,6 +203,31 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
     }
     int replication = tableConfig.getReplication();
     _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.REPLICATION_FROM_CONFIG, replication);
+
+    updateTenantInfoGauge(tableNameWithType, tableConfig);
+  }
+
+  /**
+   * Emits a {@code tableTenantInfo} gauge keyed by server tenant name so Prometheus can extract the tenant as a
+   * label and join it onto other table-scoped metrics.  Always set to {@code 1}.
+   * The gauge is registered once per unique (table, tenant) pair and only re-registered when the tenant changes,
+   * avoiding redundant metric writes on each periodic cycle.
+   * When the tenant changes, the new gauge is registered first to avoid a gap window, then the stale gauge is removed.
+   */
+  private void updateTenantInfoGauge(String tableNameWithType, TableConfig tableConfig) {
+    TenantConfig tenantConfig = tableConfig.getTenantConfig();
+    String serverTenant =
+        (tenantConfig != null && tenantConfig.getServer() != null) ? tenantConfig.getServer()
+            : TagNameUtils.DEFAULT_TENANT_NAME;
+
+    String previousTenant = _tableTenantMap.put(tableNameWithType, serverTenant);
+    if (serverTenant.equals(previousTenant)) {
+      return;
+    }
+    _controllerMetrics.setOrUpdateTableGauge(tableNameWithType, serverTenant, ControllerGauge.TABLE_TENANT_INFO, 1L);
+    if (previousTenant != null) {
+      _controllerMetrics.removeTableGauge(tableNameWithType, previousTenant, ControllerGauge.TABLE_TENANT_INFO);
+    }
   }
 
   private void updateTableSizeMetrics(String tableNameWithType)
@@ -500,6 +534,10 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
 
   private void removeMetricsForTable(String tableNameWithType) {
     LOGGER.info("Removing metrics from {} given it is not a table known by Helix", tableNameWithType);
+    String tenant = _tableTenantMap.remove(tableNameWithType);
+    if (tenant != null) {
+      _controllerMetrics.removeTableGauge(tableNameWithType, tenant, ControllerGauge.TABLE_TENANT_INFO);
+    }
     for (ControllerGauge metric : ControllerGauge.values()) {
       if (!metric.isGlobal()) {
         _controllerMetrics.removeTableGauge(tableNameWithType, metric);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
@@ -976,4 +976,146 @@ public class SegmentStatusCheckerTest {
     assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, OFFLINE_TABLE_NAME,
         ControllerGauge.SEGMENTS_WITH_INVALID_END_TIME), 1);
   }
+
+  @Test
+  public void tableTenantInfoGaugeNamedTenantTest() {
+    String serverTenant = "myTenant";
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setServerTenant(serverTenant).build();
+
+    IdealState idealState = new IdealState(OFFLINE_TABLE_NAME);
+    idealState.setReplicas("1");
+    idealState.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
+
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    when(resourceManager.getAllTables()).thenReturn(List.of(OFFLINE_TABLE_NAME));
+    when(resourceManager.getTableConfig(OFFLINE_TABLE_NAME)).thenReturn(tableConfig);
+    when(resourceManager.getTableIdealState(OFFLINE_TABLE_NAME)).thenReturn(idealState);
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    when(resourceManager.getPropertyStore()).thenReturn(propertyStore);
+
+    runSegmentStatusChecker(resourceManager, 0);
+
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, OFFLINE_TABLE_NAME, serverTenant,
+        ControllerGauge.TABLE_TENANT_INFO), 1);
+  }
+
+  @Test
+  public void tableTenantInfoGaugeDefaultTenantFallbackTest() {
+    // No server tenant configured — should fall back to "DefaultTenant".
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+
+    IdealState idealState = new IdealState(OFFLINE_TABLE_NAME);
+    idealState.setReplicas("1");
+    idealState.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
+
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    when(resourceManager.getAllTables()).thenReturn(List.of(OFFLINE_TABLE_NAME));
+    when(resourceManager.getTableConfig(OFFLINE_TABLE_NAME)).thenReturn(tableConfig);
+    when(resourceManager.getTableIdealState(OFFLINE_TABLE_NAME)).thenReturn(idealState);
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    when(resourceManager.getPropertyStore()).thenReturn(propertyStore);
+
+    runSegmentStatusChecker(resourceManager, 0);
+
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, OFFLINE_TABLE_NAME,
+        "DefaultTenant", ControllerGauge.TABLE_TENANT_INFO), 1);
+  }
+
+  @Test
+  public void tableTenantInfoGaugeTenantChangeCleansStaleGaugeTest() {
+    String firstTenant = "tenantA";
+    String secondTenant = "tenantB";
+
+    IdealState idealState = new IdealState(OFFLINE_TABLE_NAME);
+    idealState.setReplicas("1");
+    idealState.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
+
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    when(resourceManager.getAllTables()).thenReturn(List.of(OFFLINE_TABLE_NAME));
+    when(resourceManager.getTableIdealState(OFFLINE_TABLE_NAME)).thenReturn(idealState);
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    when(resourceManager.getPropertyStore()).thenReturn(propertyStore);
+
+    // First run: table on firstTenant.
+    when(resourceManager.getTableConfig(OFFLINE_TABLE_NAME)).thenReturn(
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setServerTenant(firstTenant).build());
+    SegmentStatusChecker checker = buildSegmentStatusChecker(resourceManager, 0);
+    checker.start();
+    checker.run();
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, OFFLINE_TABLE_NAME, firstTenant,
+        ControllerGauge.TABLE_TENANT_INFO), 1);
+
+    // Second run: table moves to secondTenant — stale gauge for firstTenant must be removed.
+    when(resourceManager.getTableConfig(OFFLINE_TABLE_NAME)).thenReturn(
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setServerTenant(secondTenant).build());
+    checker.run();
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, OFFLINE_TABLE_NAME, secondTenant,
+        ControllerGauge.TABLE_TENANT_INFO), 1);
+    assertFalse(MetricValueUtils.tableGaugeExists(_controllerMetrics, OFFLINE_TABLE_NAME, firstTenant,
+        ControllerGauge.TABLE_TENANT_INFO), "stale firstTenant gauge must be removed after tenant change");
+  }
+
+  @Test
+  public void tableTenantInfoGaugeTableRemovedCleansUpTest() {
+    String serverTenant = "myTenant";
+
+    IdealState idealState = new IdealState(OFFLINE_TABLE_NAME);
+    idealState.setReplicas("1");
+    idealState.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
+
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    when(resourceManager.getAllTables()).thenReturn(List.of(OFFLINE_TABLE_NAME));
+    when(resourceManager.getTableConfig(OFFLINE_TABLE_NAME)).thenReturn(
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setServerTenant(serverTenant).build());
+    when(resourceManager.getTableIdealState(OFFLINE_TABLE_NAME)).thenReturn(idealState);
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    when(resourceManager.getPropertyStore()).thenReturn(propertyStore);
+
+    SegmentStatusChecker checker = buildSegmentStatusChecker(resourceManager, 0);
+    checker.start();
+    checker.run();
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, OFFLINE_TABLE_NAME, serverTenant,
+        ControllerGauge.TABLE_TENANT_INFO), 1);
+
+    // Table disappears from Helix — nonLeaderCleanup triggers removeMetricsForTable.
+    checker.nonLeaderCleanup(List.of(OFFLINE_TABLE_NAME));
+    assertFalse(MetricValueUtils.tableGaugeExists(_controllerMetrics, OFFLINE_TABLE_NAME, serverTenant,
+        ControllerGauge.TABLE_TENANT_INFO), "tenant gauge must be removed when table is cleaned up");
+  }
+
+  @Test
+  public void tableTenantInfoGaugeRealtimeTableTest() {
+    String serverTenant = "realtimeTenant";
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setServerTenant(serverTenant)
+            .setTimeColumnName("timeColumn").setStreamConfigs(getStreamConfigMap()).build();
+
+    IdealState idealState = new IdealState(REALTIME_TABLE_NAME);
+    idealState.setReplicas("1");
+    idealState.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
+
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    when(resourceManager.getAllTables()).thenReturn(List.of(REALTIME_TABLE_NAME));
+    when(resourceManager.getTableConfig(REALTIME_TABLE_NAME)).thenReturn(tableConfig);
+    when(resourceManager.getTableIdealState(REALTIME_TABLE_NAME)).thenReturn(idealState);
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    when(resourceManager.getPropertyStore()).thenReturn(propertyStore);
+
+    runSegmentStatusChecker(resourceManager, 0);
+
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, REALTIME_TABLE_NAME, serverTenant,
+        ControllerGauge.TABLE_TENANT_INFO), 1);
+  }
+
+  private SegmentStatusChecker buildSegmentStatusChecker(PinotHelixResourceManager resourceManager,
+      int waitForPushTimeInSeconds) {
+    LeadControllerManager leadControllerManager = mock(LeadControllerManager.class);
+    when(leadControllerManager.isLeaderForTable(anyString())).thenReturn(true);
+    ControllerConf controllerConf = mock(ControllerConf.class);
+    when(controllerConf.getStatusCheckerWaitForPushTimeInSeconds()).thenReturn(waitForPushTimeInSeconds);
+    TableSizeReader tableSizeReader = mock(TableSizeReader.class);
+    return new SegmentStatusChecker(resourceManager, leadControllerManager, controllerConf, _controllerMetrics,
+        tableSizeReader);
+  }
 }

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractor.java
@@ -50,9 +50,10 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 public class ProtoBufRecordExtractor extends BaseRecordExtractor<Message> {
 
   // Cached field descriptors initialized lazily on first message extraction to avoid repeated lookups
-  // via findFieldByName. The cache is invalidated when the descriptor's full name changes (handles schema
-  // evolution within a single reader).
-  private String _descriptorFullName;
+  // via findFieldByName. The cache is invalidated by identity comparison on the Descriptor object:
+  // schema evolution (e.g. a new column added in the registry) produces a new Descriptor instance with
+  // the same full name but a different schema ID, so full-name equality is insufficient.
+  private Descriptors.Descriptor _cachedDescriptor;
   private Descriptors.FieldDescriptor[] _fieldDescriptors;
   private String[] _fieldNames;
 
@@ -87,14 +88,15 @@ public class ProtoBufRecordExtractor extends BaseRecordExtractor<Message> {
       _fieldDescriptors = i < numFields ? Arrays.copyOf(fieldDescriptors, i) : fieldDescriptors;
       _fieldNames = i < numFields ? Arrays.copyOf(fieldNames, i) : fieldNames;
     }
-    _descriptorFullName = descriptor.getFullName();
+    _cachedDescriptor = descriptor;
   }
 
   @Override
   public GenericRow extract(Message from, GenericRow to) {
     Descriptors.Descriptor descriptor = from.getDescriptorForType();
-    // Initialize or reinitialize cache if descriptor changed (handles schema evolution).
-    if (_descriptorFullName == null || !_descriptorFullName.equals(descriptor.getFullName())) {
+    // Identity check: a schema evolution in the registry produces a new Descriptor instance even when the
+    // full name is unchanged. Using != catches that case; full-name equality does not.
+    if (_cachedDescriptor != descriptor) {
       initFieldDescriptors(descriptor);
     }
     // The cache only contains live descriptors — fields requested but not in the source schema were filtered

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractorCachingTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractorCachingTest.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.plugin.inputformat.protobuf;
 
+import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.Message;
 import java.io.IOException;
 import java.util.Arrays;
@@ -315,6 +318,90 @@ public class ProtoBufRecordExtractorCachingTest {
     assertEquals(row1.getValue(INT_FIELD), row2.getValue(INT_FIELD));
     assertEquals(row1.getValue(LONG_FIELD), row2.getValue(LONG_FIELD));
     assertEquals(row1.getFieldToValueMap().size(), row2.getFieldToValueMap().size());
+  }
+
+  // ==================== SCHEMA EVOLUTION (SAME FULL NAME, DIFFERENT DESCRIPTOR INSTANCE) ====================
+
+  /**
+   * Regression test for the bug introduced in PR #17593: when a Confluent Schema Registry schema evolves
+   * (e.g. a new column is added), KafkaProtobufDeserializer returns DynamicMessage instances built from a
+   * new Descriptor object even though the message's full name is unchanged. The old cache invalidation
+   * keyed on {@code descriptor.getFullName()} never detected this, so stale FieldDescriptors from the V1
+   * Descriptor were used against V2 DynamicMessages. Protobuf enforces strict identity between a
+   * FieldDescriptor and the Descriptor of the message it is applied to, so this threw
+   * {@code IllegalArgumentException: FieldDescriptor does not match message type}.
+   *
+   * <p>The fix uses object identity ({@code !=}) to detect descriptor changes, which correctly fires
+   * whenever the schema registry serves a new schema version.
+   */
+  @Test
+  public void testSchemaEvolutionSameFullNameDifferentDescriptorInstance()
+      throws Descriptors.DescriptorValidationException {
+    _extractor.init(null, null);
+
+    // Build V1 descriptor: Order { string id = 1; int32 amount = 2; }
+    Descriptors.Descriptor v1Descriptor = buildOrderDescriptor(false);
+    DynamicMessage v1Message = DynamicMessage.newBuilder(v1Descriptor)
+        .setField(v1Descriptor.findFieldByName("id"), "order-1")
+        .setField(v1Descriptor.findFieldByName("amount"), 100)
+        .build();
+
+    GenericRow row1 = _extractor.extract(v1Message, new GenericRow());
+    assertEquals(row1.getValue("id"), "order-1");
+    assertEquals(row1.getValue("amount"), 100);
+
+    // Simulate schema evolution: new column "status" added. Registry returns a fresh Descriptor
+    // object with the same full name "Order" but a different instance — same as what
+    // KafkaProtobufDeserializer does when it fetches a new schema ID.
+    Descriptors.Descriptor v2Descriptor = buildOrderDescriptor(true);
+    // Sanity: same full name, different object — this is the exact condition the old code missed.
+    assertEquals(v1Descriptor.getFullName(), v2Descriptor.getFullName());
+    assertNotSame(v1Descriptor, v2Descriptor);
+
+    DynamicMessage v2Message = DynamicMessage.newBuilder(v2Descriptor)
+        .setField(v2Descriptor.findFieldByName("id"), "order-2")
+        .setField(v2Descriptor.findFieldByName("amount"), 200)
+        .setField(v2Descriptor.findFieldByName("status"), "SHIPPED")
+        .build();
+
+    // Before the fix this threw: IllegalArgumentException: FieldDescriptor does not match message type
+    GenericRow row2 = _extractor.extract(v2Message, new GenericRow());
+    assertEquals(row2.getValue("id"), "order-2");
+    assertEquals(row2.getValue("amount"), 200);
+    assertEquals(row2.getValue("status"), "SHIPPED");
+  }
+
+  /**
+   * Builds a simple "Order" DynamicMessage descriptor with fields id (string) and amount (int32).
+   * When {@code withStatus} is true, a third field "status" (string) is added, simulating a schema
+   * evolution where a new column was appended to the registry schema.
+   *
+   * <p>Each invocation produces a distinct {@link Descriptors.Descriptor} instance even though the
+   * full name is the same — exactly what Confluent Schema Registry does across schema versions.
+   */
+  private static Descriptors.Descriptor buildOrderDescriptor(boolean withStatus)
+      throws Descriptors.DescriptorValidationException {
+    DescriptorProtos.DescriptorProto.Builder msgBuilder = DescriptorProtos.DescriptorProto.newBuilder()
+        .setName("Order")
+        .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+            .setName("id").setNumber(1).setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
+            .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING))
+        .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+            .setName("amount").setNumber(2).setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
+            .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT32));
+    if (withStatus) {
+      msgBuilder.addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+          .setName("status").setNumber(3).setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL)
+          .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING));
+    }
+    DescriptorProtos.FileDescriptorProto fileProto = DescriptorProtos.FileDescriptorProto.newBuilder()
+        .setName(withStatus ? "order_v2.proto" : "order_v1.proto")
+        .setSyntax("proto3")
+        .addMessageType(msgBuilder)
+        .build();
+    Descriptors.FileDescriptor fileDescriptor =
+        Descriptors.FileDescriptor.buildFrom(fileProto, new Descriptors.FileDescriptor[0]);
+    return fileDescriptor.findMessageTypeByName("Order");
   }
 
   // ==================== HELPER METHODS ====================


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #17593 where `ProtoBufRecordExtractor` throws `IllegalArgumentException: FieldDescriptor does not match message type` after a Confluent Schema Registry Protobuf schema evolves (e.g. a new column is added to the schema).

**Root cause:** The field-descriptor cache added in #17593 used `descriptor.getFullName()` equality to detect schema changes. When a new schema version is registered, `KafkaProtobufDeserializer` returns `DynamicMessage` instances built from a *new* `Descriptors.Descriptor` object — same full name, different instance. The stale cache was never invalidated, so `FieldDescriptor` objects from the old `Descriptor` were passed to `DynamicMessage.hasField()` / `getField()` on the new message. Protobuf enforces strict object identity (`fd.getContainingType() != descriptor`), causing the crash.

**Fix:** Replace the full-name string comparison with object identity (`!=`). This is cheaper (no string allocation) and correctly detects any descriptor change, including same-name schema evolutions.

```java
// Before (insufficient — same full name across schema versions)
if (_descriptorFullName == null || !_descriptorFullName.equals(descriptor.getFullName()))

// After (correct — new registry version → new Descriptor instance)
if (_cachedDescriptor != descriptor)
```

## Test plan

- Added `testSchemaEvolutionSameFullNameDifferentDescriptorInstance` to `ProtoBufRecordExtractorCachingTest` — builds two `Descriptor` instances programmatically with the same full name (`Order`) but different fields (V1: `id`, `amount`; V2: `id`, `amount`, `status`), exactly replicating what Confluent Schema Registry does on schema evolution. Without the fix this test throws `IllegalArgumentException`; with the fix all 13 caching tests pass.
- `./mvnw -pl pinot-plugins/pinot-input-format/pinot-protobuf -Dtest=ProtoBufRecordExtractorCachingTest test` → 13/13 pass
- `./mvnw spotless:apply checkstyle:check license:check -pl pinot-plugins/pinot-input-format/pinot-protobuf` → clean