### PR TITLE
Fix SmartHLL ClassCastException in GROUP BY ORDER BY

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctCountSmartSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctCountSmartSketchAggregationFunction.java
@@ -515,11 +515,7 @@ abstract class BaseDistinctCountSmartSketchAggregationFunction
     }
 
     if (result instanceof DictIdsWrapper dictIdsWrapper) {
-      if (dictIdsWrapper._dictIdBitmap.cardinalityExceeds(getThreshold())) {
-        return convertToSketch(dictIdsWrapper);
-      } else {
-        return convertToValueSet(dictIdsWrapper);
-      }
+      return convertToValueSet(dictIdsWrapper);
     } else {
       return result;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctCountSmartSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctCountSmartSketchAggregationFunction.java
@@ -508,16 +508,20 @@ abstract class BaseDistinctCountSmartSketchAggregationFunction
   }
 
   @Override
-  public final Set extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
+  public final Object extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     Object result = groupByResultHolder.getResult(groupKey);
     if (result == null) {
       return EMPTY_PLACEHOLDER;
     }
 
-    if (result instanceof DictIdsWrapper) {
-      return convertToValueSet((DictIdsWrapper) result);
+    if (result instanceof DictIdsWrapper dictIdsWrapper) {
+      if (dictIdsWrapper._dictIdBitmap.cardinalityExceeds(getThreshold())) {
+        return convertToSketch(dictIdsWrapper);
+      } else {
+        return convertToValueSet(dictIdsWrapper);
+      }
     } else {
-      return (Set) result;
+      return result;
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctCountSmartSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctCountSmartSketchAggregationFunction.java
@@ -514,8 +514,8 @@ abstract class BaseDistinctCountSmartSketchAggregationFunction
       return EMPTY_PLACEHOLDER;
     }
 
-    if (result instanceof DictIdsWrapper dictIdsWrapper) {
-      return convertToValueSet(dictIdsWrapper);
+    if (result instanceof DictIdsWrapper) {
+      return convertToValueSet((DictIdsWrapper) result);
     } else {
       return result;
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartHLLAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartHLLAggregationFunctionTest.java
@@ -20,12 +20,15 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import java.util.List;
+import java.util.Set;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -149,6 +152,29 @@ public class DistinctCountSmartHLLAggregationFunctionTest {
     assertNotNull(merged);
     long mergedCardinality = merged.cardinality();
     assertTrue(mergedCardinality >= 700 && mergedCardinality <= 800, "Merged cardinality: " + mergedCardinality);
+  }
+
+  @Test
+  public void itExtractsHLLFromGroupByResultHolderWhenSketchConverted() {
+    DistinctCountSmartHLLAggregationFunction function = new DistinctCountSmartHLLAggregationFunction(
+        List.of(ExpressionContext.forIdentifier("col"),
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "threshold=5;dictThreshold=5")));
+
+    ObjectGroupByResultHolder holder = new ObjectGroupByResultHolder(10, 10);
+
+    HyperLogLog hll = new HyperLogLog(12);
+    for (int i = 0; i < 100; i++) {
+      hll.offer(i);
+    }
+    holder.setValueForKey(0, hll);
+
+    Object extracted = function.extractGroupByResult(holder, 0);
+    assertTrue(extracted instanceof HyperLogLog,
+        "Expected HyperLogLog but got: " + (extracted == null ? "null" : extracted.getClass().getName()));
+    assertFalse(extracted instanceof Set, "HyperLogLog must not be cast to Set");
+
+    int cardinality = function.extractFinalResult(extracted);
+    assertTrue(cardinality >= 90 && cardinality <= 110, "Cardinality out of range: " + cardinality);
   }
 
   @Test


### PR DESCRIPTION
extractGroupByResult() blindly cast to Set but the holder can contain a HyperLogLog once the dict-ID cardinality threshold is exceeded via checkAndConvertToSketchForGroups. Mirror the threshold check already present in extractAggregationResult().

Labels: `bugfix`

