### PR TITLE
Support a per-execution PlanMaker override in QueryExecutor.execute

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/QueryExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/QueryExecutor.java
@@ -25,6 +25,7 @@ import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
+import org.apache.pinot.core.plan.maker.PlanMaker;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.spi.env.PinotConfiguration;
 
@@ -71,4 +72,17 @@ public interface QueryExecutor {
   /// - For non-streaming request, the returned {@link InstanceResponseBlock} contains both data and metadata.
   InstanceResponseBlock execute(ServerQueryRequest queryRequest, ExecutorService executorService,
       @Nullable ResultsBlockStreamer streamer);
+
+  /// Executes the query with a caller-supplied [PlanMaker] override instead of the executor's
+  /// configured one, letting a caller plug in alternate segment-level plan nodes/operators for this
+  /// single execution (e.g. to produce a different result-block representation). Passing `null` uses
+  /// the configured plan maker, i.e. it is equivalent to [#execute(ServerQueryRequest, ExecutorService,
+  /// ResultsBlockStreamer)].
+  ///
+  /// The default implementation ignores the override (preserving behavior for implementations that do
+  /// not support it); [org.apache.pinot.core.query.executor.ServerQueryExecutorV1Impl] honors it.
+  default InstanceResponseBlock execute(ServerQueryRequest queryRequest, ExecutorService executorService,
+      @Nullable ResultsBlockStreamer streamer, @Nullable PlanMaker planMakerOverride) {
+    return execute(queryRequest, executorService, streamer);
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -146,20 +146,26 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
   @Override
   public InstanceResponseBlock execute(ServerQueryRequest queryRequest, ExecutorService executorService,
       @Nullable ResultsBlockStreamer streamer) {
+    return execute(queryRequest, executorService, streamer, null);
+  }
+
+  @Override
+  public InstanceResponseBlock execute(ServerQueryRequest queryRequest, ExecutorService executorService,
+      @Nullable ResultsBlockStreamer streamer, @Nullable PlanMaker planMakerOverride) {
     if (!queryRequest.isEnableTrace()) {
-      return executeInternal(queryRequest, executorService, streamer);
+      return executeInternal(queryRequest, executorService, streamer, planMakerOverride);
     }
     Tracer tracer = Tracing.getTracer();
     tracer.register();
     try {
-      return executeInternal(queryRequest, executorService, streamer);
+      return executeInternal(queryRequest, executorService, streamer, planMakerOverride);
     } finally {
       tracer.unregister();
     }
   }
 
   private InstanceResponseBlock executeInternal(ServerQueryRequest queryRequest, ExecutorService executorService,
-      @Nullable ResultsBlockStreamer streamer) {
+      @Nullable ResultsBlockStreamer streamer, @Nullable PlanMaker planMakerOverride) {
     TimerContext timerContext = queryRequest.getTimerContext();
     TimerContext.Timer schedulerWaitTimer = timerContext.getPhaseTimer(ServerQueryPhase.SCHEDULER_WAIT);
     if (schedulerWaitTimer != null) {
@@ -235,7 +241,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
     InstanceResponseBlock instanceResponse = null;
     try {
       instanceResponse = executeInternal(executionInfo, queryContext, timerContext, executorService, streamer,
-          queryRequest.isEnableStreaming());
+          queryRequest.isEnableStreaming(), planMakerOverride);
     } catch (Exception e) {
       _serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.QUERY_EXECUTION_EXCEPTIONS, 1);
       instanceResponse = new InstanceResponseBlock();
@@ -315,7 +321,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
   // NOTE: This method might change indexSegments. Do not use it after calling this method.
   private InstanceResponseBlock executeInternal(TableExecutionInfo executionInfo, QueryContext queryContext,
       TimerContext timerContext, ExecutorService executorService, @Nullable ResultsBlockStreamer streamer,
-      boolean enableStreaming)
+      boolean enableStreaming, @Nullable PlanMaker planMakerOverride)
       throws Exception {
     handleSubquery(queryContext, executionInfo, timerContext, executorService);
 
@@ -326,7 +332,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
 
     InstanceResponseBlock instanceResponse =
         execute(selectedSegmentsInfo.getIndexSegments(), queryContext, timerContext, executorService, streamer,
-            enableStreaming, selectedSegmentsInfo.getSelectedSegmentContexts());
+            enableStreaming, selectedSegmentsInfo.getSelectedSegmentContexts(), planMakerOverride);
 
     // Update the total docs in the metadata based on the un-pruned segments
     instanceResponse.addMetadata(MetadataKey.TOTAL_DOCS.getName(),
@@ -513,7 +519,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       subquery.setEndTimeMs(endTimeMs);
       // Make a clone of indexSegments because the method might modify the list
       InstanceResponseBlock instanceResponse =
-          executeInternal(executionInfo, subquery, timerContext, executorService, null, false);
+          executeInternal(executionInfo, subquery, timerContext, executorService, null, false, null);
       BaseResultsBlock resultsBlock = instanceResponse.getResultsBlock();
       Preconditions.checkState(resultsBlock instanceof AggregationResultsBlock,
           "Got unexpected results block type: %s, expecting aggregation results",
@@ -585,15 +591,17 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
   }
 
   private Plan planCombineQuery(QueryContext queryContext, TimerContext timerContext, ExecutorService executorService,
-      @Nullable ResultsBlockStreamer streamer, List<SegmentContext> selectedSegmentContexts) {
+      @Nullable ResultsBlockStreamer streamer, List<SegmentContext> selectedSegmentContexts,
+      @Nullable PlanMaker planMakerOverride) {
     TimerContext.Timer planBuildTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.BUILD_QUERY_PLAN);
 
+    PlanMaker planMaker = planMakerOverride != null ? planMakerOverride : _planMaker;
     Plan queryPlan;
     if (streamer != null) {
       queryPlan =
-          _planMaker.makeStreamingInstancePlan(selectedSegmentContexts, queryContext, executorService, streamer);
+          planMaker.makeStreamingInstancePlan(selectedSegmentContexts, queryContext, executorService, streamer);
     } else {
-      queryPlan = _planMaker.makeInstancePlan(selectedSegmentContexts, queryContext, executorService);
+      queryPlan = planMaker.makeInstancePlan(selectedSegmentContexts, queryContext, executorService);
     }
     planBuildTimer.stopAndRecord();
     return queryPlan;
@@ -601,7 +609,8 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
 
   private InstanceResponseBlock execute(List<IndexSegment> indexSegments, QueryContext queryContext,
       TimerContext timerContext, ExecutorService executorService, ResultsBlockStreamer streamer,
-      boolean enableStreaming, List<SegmentContext> selectedSegmentContexts)
+      boolean enableStreaming, List<SegmentContext> selectedSegmentContexts,
+      @Nullable PlanMaker planMakerOverride)
       throws TimeoutException {
     InstanceResponseBlock instanceResponse;
     @Nullable
@@ -617,7 +626,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
         break;
       case NONE:
         instanceResponse = executeQuery(queryContext, timerContext, executorService, actualStreamer,
-            selectedSegmentContexts);
+            selectedSegmentContexts, planMakerOverride);
         break;
       default:
         throw new IllegalStateException("Unsupported explain mode: " + queryContext.getExplain());
@@ -627,13 +636,14 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
 
   private InstanceResponseBlock executeQuery(QueryContext queryContext, TimerContext timerContext,
       ExecutorService executorService, @Nullable ResultsBlockStreamer streamer,
-      List<SegmentContext> selectedSegmentContexts)
+      List<SegmentContext> selectedSegmentContexts, @Nullable PlanMaker planMakerOverride)
       throws TimeoutException {
     if (selectedSegmentContexts.isEmpty()) {
       return new InstanceResponseBlock(ResultsBlockUtils.buildEmptyQueryResults(queryContext));
     }
     InstanceResponseBlock instanceResponse;
-    Plan queryPlan = planCombineQuery(queryContext, timerContext, executorService, streamer, selectedSegmentContexts);
+    Plan queryPlan = planCombineQuery(queryContext, timerContext, executorService, streamer, selectedSegmentContexts,
+        planMakerOverride);
     // Sample to track usage of query planning, since it can be expensive for large segment lists.
     QueryThreadContext.checkTerminationAndSampleUsage("Server query planning");
 
@@ -655,7 +665,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
     }
 
     Plan queryPlan = planCombineQuery(queryContext, timerContext, executorService, streamer,
-        selectedSegmentContexts);
+        selectedSegmentContexts, null);
 
     TimerContext.Timer planExecTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.QUERY_PLAN_EXECUTION);
 
@@ -687,7 +697,8 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       return new InstanceResponseBlock(explainResults);
     }
 
-    Plan queryPlan = planCombineQuery(queryContext, timerContext, executorService, streamer, selectedSegmentContexts);
+    Plan queryPlan = planCombineQuery(queryContext, timerContext, executorService, streamer, selectedSegmentContexts,
+        null);
 
     TimerContext.Timer planExecTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.QUERY_PLAN_EXECUTION);
     InstanceResponseBlock result = executeDescribeExplain(queryPlan, queryContext);


### PR DESCRIPTION
## What

Adds an optional overload to `QueryExecutor.execute(...)` that accepts a caller-supplied `PlanMaker`, used for that single execution instead of the executor's configured plan maker:

```java
default InstanceResponseBlock execute(ServerQueryRequest queryRequest, ExecutorService executorService,
    @Nullable ResultsBlockStreamer streamer, @Nullable PlanMaker planMakerOverride);
```

- The default implementation ignores the override, so it is backward compatible for any existing `QueryExecutor` implementation.
- `ServerQueryExecutorV1Impl` honors it, threading the override down to plan building (`planCombineQuery`). Passing `null` is equivalent to the existing 3-argument `execute(...)`.

## Why

This lets a caller plug in alternate segment-level plan nodes/operators for a single execution without reconfiguring the executor (for example, to produce a different result-block representation). It is a small, opt-in extensibility hook.

All existing call sites pass `null`, so behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
