### PR TITLE
Enforce validDocIds consensus in upsert task generators and add includeBitmaps to validDocIdsMetadata API

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsBitmapResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsBitmapResponse.java
@@ -51,11 +51,11 @@ public class ValidDocIdsBitmapResponse {
       @JsonProperty("segmentDataCrc") @Nullable String segmentDataCrc) {
     _segmentName = segmentName;
     _segmentCrc = crc;
+    _segmentDataCrc = segmentDataCrc;
     _validDocIdsType = validDocIdsType;
     _bitmap = bitmap;
     _instanceId = instanceId;
     _serverStatus = serverStatus;
-    _segmentDataCrc = segmentDataCrc;
   }
 
   public String getSegmentName() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsBitmapResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsBitmapResponse.java
@@ -38,17 +38,12 @@ public class ValidDocIdsBitmapResponse {
   private final String _instanceId;
   private final ServiceStatus.Status _serverStatus;
 
-  public ValidDocIdsBitmapResponse(String segmentName, String crc, ValidDocIdsType validDocIdsType, byte[] bitmap,
-      String instanceId, ServiceStatus.Status serverStatus) {
-    this(segmentName, crc, validDocIdsType, bitmap, instanceId, serverStatus, null);
-  }
-
   @JsonCreator
   public ValidDocIdsBitmapResponse(@JsonProperty("segmentName") String segmentName,
-      @JsonProperty("segmentCrc") String crc, @JsonProperty("validDocIdsType") ValidDocIdsType validDocIdsType,
-      @JsonProperty("bitmap") byte[] bitmap, @JsonProperty("instanceId") String instanceId,
-      @JsonProperty("serverStatus") ServiceStatus.Status serverStatus,
-      @JsonProperty("segmentDataCrc") @Nullable String segmentDataCrc) {
+      @JsonProperty("segmentCrc") String crc, @JsonProperty("segmentDataCrc") @Nullable String segmentDataCrc,
+      @JsonProperty("validDocIdsType") ValidDocIdsType validDocIdsType, @JsonProperty("bitmap") byte[] bitmap,
+      @JsonProperty("instanceId") String instanceId,
+      @JsonProperty("serverStatus") ServiceStatus.Status serverStatus) {
     _segmentName = segmentName;
     _segmentCrc = crc;
     _segmentDataCrc = segmentDataCrc;
@@ -66,6 +61,13 @@ public class ValidDocIdsBitmapResponse {
     return _segmentCrc;
   }
 
+  /// Server's data CRC, or null if not reported. Omitted from the payload when null.
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @Nullable
+  public String getSegmentDataCrc() {
+    return _segmentDataCrc;
+  }
+
   public ValidDocIdsType getValidDocIdsType() {
     return _validDocIdsType;
   }
@@ -80,12 +82,5 @@ public class ValidDocIdsBitmapResponse {
 
   public ServiceStatus.Status getServerStatus() {
     return _serverStatus;
-  }
-
-  /// Server's data CRC, or null if not reported. Omitted from the payload when null.
-  @JsonInclude(JsonInclude.Include.NON_NULL)
-  @Nullable
-  public String getSegmentDataCrc() {
-    return _segmentDataCrc;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsBitmapResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsBitmapResponse.java
@@ -82,7 +82,7 @@ public class ValidDocIdsBitmapResponse {
     return _serverStatus;
   }
 
-  /** Server's data CRC, or null if not reported. Omitted from the payload when null. */
+  /// Server's data CRC, or null if not reported. Omitted from the payload when null.
   @JsonInclude(JsonInclude.Include.NON_NULL)
   @Nullable
   public String getSegmentDataCrc() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsBitmapResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsBitmapResponse.java
@@ -18,10 +18,15 @@
  */
 package org.apache.pinot.common.restlet.resources;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.ServiceStatus;
 
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ValidDocIdsBitmapResponse {
   private final String _segmentName;
   private final String _segmentCrc;
@@ -29,17 +34,28 @@ public class ValidDocIdsBitmapResponse {
   private final byte[] _bitmap;
   private final String _instanceId;
   private final ServiceStatus.Status _serverStatus;
+  // Server's data CRC (forward index + dictionary checksum); null when the server doesn't report it.
+  @Nullable
+  private final String _segmentDataCrc;
 
+  public ValidDocIdsBitmapResponse(String segmentName, String crc, ValidDocIdsType validDocIdsType, byte[] bitmap,
+      String instanceId, ServiceStatus.Status serverStatus) {
+    this(segmentName, crc, validDocIdsType, bitmap, instanceId, serverStatus, null);
+  }
+
+  @JsonCreator
   public ValidDocIdsBitmapResponse(@JsonProperty("segmentName") String segmentName,
       @JsonProperty("segmentCrc") String crc, @JsonProperty("validDocIdsType") ValidDocIdsType validDocIdsType,
       @JsonProperty("bitmap") byte[] bitmap, @JsonProperty("instanceId") String instanceId,
-      @JsonProperty("serverStatus") ServiceStatus.Status serverStatus) {
+      @JsonProperty("serverStatus") ServiceStatus.Status serverStatus,
+      @JsonProperty("segmentDataCrc") @Nullable String segmentDataCrc) {
     _segmentName = segmentName;
     _segmentCrc = crc;
     _validDocIdsType = validDocIdsType;
     _bitmap = bitmap;
     _instanceId = instanceId;
     _serverStatus = serverStatus;
+    _segmentDataCrc = segmentDataCrc;
   }
 
   public String getSegmentName() {
@@ -64,5 +80,12 @@ public class ValidDocIdsBitmapResponse {
 
   public ServiceStatus.Status getServerStatus() {
     return _serverStatus;
+  }
+
+  /** Server's data CRC, or null if not reported. Omitted from the payload when null. */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @Nullable
+  public String getSegmentDataCrc() {
+    return _segmentDataCrc;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsBitmapResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsBitmapResponse.java
@@ -30,13 +30,13 @@ import org.apache.pinot.common.utils.ServiceStatus;
 public class ValidDocIdsBitmapResponse {
   private final String _segmentName;
   private final String _segmentCrc;
+  // Server's data CRC (forward index + dictionary checksum); null when the server doesn't report it.
+  @Nullable
+  private final String _segmentDataCrc;
   private final ValidDocIdsType _validDocIdsType;
   private final byte[] _bitmap;
   private final String _instanceId;
   private final ServiceStatus.Status _serverStatus;
-  // Server's data CRC (forward index + dictionary checksum); null when the server doesn't report it.
-  @Nullable
-  private final String _segmentDataCrc;
 
   public ValidDocIdsBitmapResponse(String segmentName, String crc, ValidDocIdsType validDocIdsType, byte[] bitmap,
       String instanceId, ServiceStatus.Status serverStatus) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsMetadataInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsMetadataInfo.java
@@ -63,12 +63,12 @@ public class ValidDocIdsMetadataInfo {
     _totalInvalidDocs = totalInvalidDocs;
     _totalDocs = totalDocs;
     _segmentCrc = segmentCrc;
+    _segmentDataCrc = segmentDataCrc;
     _validDocIdsType = validDocIdsType;
     _segmentSizeInBytes = segmentSizeInBytes;
     _segmentCreationTimeMillis = segmentCreationTimeMillis;
     _instanceId = instanceId;
     _serverStatus = serverStatus;
-    _segmentDataCrc = segmentDataCrc;
   }
 
   public String getSegmentName() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsMetadataInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsMetadataInfo.java
@@ -18,8 +18,11 @@
  */
 package org.apache.pinot.common.restlet.resources;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.ServiceStatus;
 
 
@@ -35,14 +38,26 @@ public class ValidDocIdsMetadataInfo {
   private final long _segmentCreationTimeMillis;
   private final String _instanceId;
   private final ServiceStatus.Status _serverStatus;
+  // Server's data CRC (forward index + dictionary checksum); null when the server doesn't report it.
+  @Nullable
+  private final String _segmentDataCrc;
 
+  public ValidDocIdsMetadataInfo(String segmentName, long totalValidDocs, long totalInvalidDocs, long totalDocs,
+      String segmentCrc, ValidDocIdsType validDocIdsType, long segmentSizeInBytes, long segmentCreationTimeMillis,
+      String instanceId, ServiceStatus.Status serverStatus) {
+    this(segmentName, totalValidDocs, totalInvalidDocs, totalDocs, segmentCrc, validDocIdsType, segmentSizeInBytes,
+        segmentCreationTimeMillis, instanceId, serverStatus, null);
+  }
+
+  @JsonCreator
   public ValidDocIdsMetadataInfo(@JsonProperty("segmentName") String segmentName,
       @JsonProperty("totalValidDocs") long totalValidDocs, @JsonProperty("totalInvalidDocs") long totalInvalidDocs,
       @JsonProperty("totalDocs") long totalDocs, @JsonProperty("segmentCrc") String segmentCrc,
       @JsonProperty("validDocIdsType") ValidDocIdsType validDocIdsType,
       @JsonProperty("segmentSizeInBytes") long segmentSizeInBytes,
       @JsonProperty("segmentCreationTimeMillis") long segmentCreationTimeMillis,
-      @JsonProperty("instanceId") String instanceId, @JsonProperty("serverStatus") ServiceStatus.Status serverStatus) {
+      @JsonProperty("instanceId") String instanceId, @JsonProperty("serverStatus") ServiceStatus.Status serverStatus,
+      @JsonProperty("segmentDataCrc") @Nullable String segmentDataCrc) {
     _segmentName = segmentName;
     _totalValidDocs = totalValidDocs;
     _totalInvalidDocs = totalInvalidDocs;
@@ -53,6 +68,7 @@ public class ValidDocIdsMetadataInfo {
     _segmentCreationTimeMillis = segmentCreationTimeMillis;
     _instanceId = instanceId;
     _serverStatus = serverStatus;
+    _segmentDataCrc = segmentDataCrc;
   }
 
   public String getSegmentName() {
@@ -93,5 +109,12 @@ public class ValidDocIdsMetadataInfo {
 
   public ServiceStatus.Status getServerStatus() {
     return _serverStatus;
+  }
+
+  /** Server's data CRC, or null if not reported. Omitted from the payload when null. */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @Nullable
+  public String getSegmentDataCrc() {
+    return _segmentDataCrc;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsMetadataInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsMetadataInfo.java
@@ -42,22 +42,16 @@ public class ValidDocIdsMetadataInfo {
   private final String _instanceId;
   private final ServiceStatus.Status _serverStatus;
 
-  public ValidDocIdsMetadataInfo(String segmentName, long totalValidDocs, long totalInvalidDocs, long totalDocs,
-      String segmentCrc, ValidDocIdsType validDocIdsType, long segmentSizeInBytes, long segmentCreationTimeMillis,
-      String instanceId, ServiceStatus.Status serverStatus) {
-    this(segmentName, totalValidDocs, totalInvalidDocs, totalDocs, segmentCrc, validDocIdsType, segmentSizeInBytes,
-        segmentCreationTimeMillis, instanceId, serverStatus, null);
-  }
-
   @JsonCreator
   public ValidDocIdsMetadataInfo(@JsonProperty("segmentName") String segmentName,
       @JsonProperty("totalValidDocs") long totalValidDocs, @JsonProperty("totalInvalidDocs") long totalInvalidDocs,
       @JsonProperty("totalDocs") long totalDocs, @JsonProperty("segmentCrc") String segmentCrc,
+      @JsonProperty("segmentDataCrc") @Nullable String segmentDataCrc,
       @JsonProperty("validDocIdsType") ValidDocIdsType validDocIdsType,
       @JsonProperty("segmentSizeInBytes") long segmentSizeInBytes,
       @JsonProperty("segmentCreationTimeMillis") long segmentCreationTimeMillis,
-      @JsonProperty("instanceId") String instanceId, @JsonProperty("serverStatus") ServiceStatus.Status serverStatus,
-      @JsonProperty("segmentDataCrc") @Nullable String segmentDataCrc) {
+      @JsonProperty("instanceId") String instanceId,
+      @JsonProperty("serverStatus") ServiceStatus.Status serverStatus) {
     _segmentName = segmentName;
     _totalValidDocs = totalValidDocs;
     _totalInvalidDocs = totalInvalidDocs;
@@ -91,6 +85,13 @@ public class ValidDocIdsMetadataInfo {
     return _segmentCrc;
   }
 
+  /// Server's data CRC, or null if not reported. Omitted from the payload when null.
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @Nullable
+  public String getSegmentDataCrc() {
+    return _segmentDataCrc;
+  }
+
   public ValidDocIdsType getValidDocIdsType() {
     return _validDocIdsType;
   }
@@ -109,12 +110,5 @@ public class ValidDocIdsMetadataInfo {
 
   public ServiceStatus.Status getServerStatus() {
     return _serverStatus;
-  }
-
-  /// Server's data CRC, or null if not reported. Omitted from the payload when null.
-  @JsonInclude(JsonInclude.Include.NON_NULL)
-  @Nullable
-  public String getSegmentDataCrc() {
-    return _segmentDataCrc;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsMetadataInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsMetadataInfo.java
@@ -111,7 +111,7 @@ public class ValidDocIdsMetadataInfo {
     return _serverStatus;
   }
 
-  /** Server's data CRC, or null if not reported. Omitted from the payload when null. */
+  /// Server's data CRC, or null if not reported. Omitted from the payload when null.
   @JsonInclude(JsonInclude.Include.NON_NULL)
   @Nullable
   public String getSegmentDataCrc() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsMetadataInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsMetadataInfo.java
@@ -18,8 +18,11 @@
  */
 package org.apache.pinot.common.restlet.resources;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.ServiceStatus;
 
 
@@ -35,14 +38,29 @@ public class ValidDocIdsMetadataInfo {
   private final long _segmentCreationTimeMillis;
   private final String _instanceId;
   private final ServiceStatus.Status _serverStatus;
+  // Optional serialized RoaringBitmap of the validDocIds for the segment. Populated only when the caller of the
+  // batched validDocIdsMetadata endpoint passes includeBitmaps=true. Null when omitted or when the responding
+  // server is older and doesn't recognise the flag. Field is JsonInclude.NON_NULL on the getter so payloads stay
+  // small when bitmaps are not requested.
+  @Nullable
+  private final byte[] _bitmap;
 
+  public ValidDocIdsMetadataInfo(String segmentName, long totalValidDocs, long totalInvalidDocs, long totalDocs,
+      String segmentCrc, ValidDocIdsType validDocIdsType, long segmentSizeInBytes, long segmentCreationTimeMillis,
+      String instanceId, ServiceStatus.Status serverStatus) {
+    this(segmentName, totalValidDocs, totalInvalidDocs, totalDocs, segmentCrc, validDocIdsType, segmentSizeInBytes,
+        segmentCreationTimeMillis, instanceId, serverStatus, null);
+  }
+
+  @JsonCreator
   public ValidDocIdsMetadataInfo(@JsonProperty("segmentName") String segmentName,
       @JsonProperty("totalValidDocs") long totalValidDocs, @JsonProperty("totalInvalidDocs") long totalInvalidDocs,
       @JsonProperty("totalDocs") long totalDocs, @JsonProperty("segmentCrc") String segmentCrc,
       @JsonProperty("validDocIdsType") ValidDocIdsType validDocIdsType,
       @JsonProperty("segmentSizeInBytes") long segmentSizeInBytes,
       @JsonProperty("segmentCreationTimeMillis") long segmentCreationTimeMillis,
-      @JsonProperty("instanceId") String instanceId, @JsonProperty("serverStatus") ServiceStatus.Status serverStatus) {
+      @JsonProperty("instanceId") String instanceId, @JsonProperty("serverStatus") ServiceStatus.Status serverStatus,
+      @JsonProperty("bitmap") @Nullable byte[] bitmap) {
     _segmentName = segmentName;
     _totalValidDocs = totalValidDocs;
     _totalInvalidDocs = totalInvalidDocs;
@@ -53,6 +71,7 @@ public class ValidDocIdsMetadataInfo {
     _segmentCreationTimeMillis = segmentCreationTimeMillis;
     _instanceId = instanceId;
     _serverStatus = serverStatus;
+    _bitmap = bitmap;
   }
 
   public String getSegmentName() {
@@ -93,5 +112,16 @@ public class ValidDocIdsMetadataInfo {
 
   public ServiceStatus.Status getServerStatus() {
     return _serverStatus;
+  }
+
+  /**
+   * Returns the serialized RoaringBitmap of validDocIds for the segment, or null when not requested by the caller
+   * (or the responding server is older and doesn't emit it). Callers can deserialize via
+   * {@code RoaringBitmapUtils.deserialize}.
+   */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @Nullable
+  public byte[] getBitmap() {
+    return _bitmap;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsMetadataInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsMetadataInfo.java
@@ -33,14 +33,14 @@ public class ValidDocIdsMetadataInfo {
   private final long _totalInvalidDocs;
   private final long _totalDocs;
   private final String _segmentCrc;
+  // Server's data CRC (forward index + dictionary checksum); null when the server doesn't report it.
+  @Nullable
+  private final String _segmentDataCrc;
   private final ValidDocIdsType _validDocIdsType;
   private final long _segmentSizeInBytes;
   private final long _segmentCreationTimeMillis;
   private final String _instanceId;
   private final ServiceStatus.Status _serverStatus;
-  // Server's data CRC (forward index + dictionary checksum); null when the server doesn't report it.
-  @Nullable
-  private final String _segmentDataCrc;
 
   public ValidDocIdsMetadataInfo(String segmentName, long totalValidDocs, long totalInvalidDocs, long totalDocs,
       String segmentCrc, ValidDocIdsType validDocIdsType, long segmentSizeInBytes, long segmentCreationTimeMillis,

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsMetadataInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsMetadataInfo.java
@@ -18,11 +18,8 @@
  */
 package org.apache.pinot.common.restlet.resources;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.ServiceStatus;
 
 
@@ -38,29 +35,14 @@ public class ValidDocIdsMetadataInfo {
   private final long _segmentCreationTimeMillis;
   private final String _instanceId;
   private final ServiceStatus.Status _serverStatus;
-  // Optional serialized RoaringBitmap of the validDocIds for the segment. Populated only when the caller of the
-  // batched validDocIdsMetadata endpoint passes includeBitmaps=true. Null when omitted or when the responding
-  // server is older and doesn't recognise the flag. Field is JsonInclude.NON_NULL on the getter so payloads stay
-  // small when bitmaps are not requested.
-  @Nullable
-  private final byte[] _bitmap;
 
-  public ValidDocIdsMetadataInfo(String segmentName, long totalValidDocs, long totalInvalidDocs, long totalDocs,
-      String segmentCrc, ValidDocIdsType validDocIdsType, long segmentSizeInBytes, long segmentCreationTimeMillis,
-      String instanceId, ServiceStatus.Status serverStatus) {
-    this(segmentName, totalValidDocs, totalInvalidDocs, totalDocs, segmentCrc, validDocIdsType, segmentSizeInBytes,
-        segmentCreationTimeMillis, instanceId, serverStatus, null);
-  }
-
-  @JsonCreator
   public ValidDocIdsMetadataInfo(@JsonProperty("segmentName") String segmentName,
       @JsonProperty("totalValidDocs") long totalValidDocs, @JsonProperty("totalInvalidDocs") long totalInvalidDocs,
       @JsonProperty("totalDocs") long totalDocs, @JsonProperty("segmentCrc") String segmentCrc,
       @JsonProperty("validDocIdsType") ValidDocIdsType validDocIdsType,
       @JsonProperty("segmentSizeInBytes") long segmentSizeInBytes,
       @JsonProperty("segmentCreationTimeMillis") long segmentCreationTimeMillis,
-      @JsonProperty("instanceId") String instanceId, @JsonProperty("serverStatus") ServiceStatus.Status serverStatus,
-      @JsonProperty("bitmap") @Nullable byte[] bitmap) {
+      @JsonProperty("instanceId") String instanceId, @JsonProperty("serverStatus") ServiceStatus.Status serverStatus) {
     _segmentName = segmentName;
     _totalValidDocs = totalValidDocs;
     _totalInvalidDocs = totalInvalidDocs;
@@ -71,7 +53,6 @@ public class ValidDocIdsMetadataInfo {
     _segmentCreationTimeMillis = segmentCreationTimeMillis;
     _instanceId = instanceId;
     _serverStatus = serverStatus;
-    _bitmap = bitmap;
   }
 
   public String getSegmentName() {
@@ -112,16 +93,5 @@ public class ValidDocIdsMetadataInfo {
 
   public ServiceStatus.Status getServerStatus() {
     return _serverStatus;
-  }
-
-  /**
-   * Returns the serialized RoaringBitmap of validDocIds for the segment, or null when not requested by the caller
-   * (or the responding server is older and doesn't emit it). Callers can deserialize via
-   * {@code RoaringBitmapUtils.deserialize}.
-   */
-  @JsonInclude(JsonInclude.Include.NON_NULL)
-  @Nullable
-  public byte[] getBitmap() {
-    return _bitmap;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
@@ -284,10 +284,6 @@ public class ServerSegmentMetadataReader {
       @Nullable List<String> segmentNames, int timeoutMs, String validDocIdsType,
       int numSegmentsBatchPerServerRequest) {
     List<Pair<String, String>> serverURLsAndBodies = new ArrayList<>();
-    // Expected replica count per segment, tallied from the server-to-segments assignment as we build the requests. A
-    // replica that fails to respond is simply absent from the metadata below, so callers compare the responder count
-    // against this to tell when not all replicas replied. Only segments passing the segmentNames filter are tallied,
-    // but every server hosting such a segment is counted, so each tallied count is exact.
     Map<String, Integer> segmentToExpectedReplicaCount = new HashMap<>();
     for (Map.Entry<String, List<String>> serverToSegments : serverToSegmentsMap.entrySet()) {
       List<String> segmentsForServer = serverToSegments.getValue();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
@@ -267,8 +267,9 @@ public class ServerSegmentMetadataReader {
       @Nullable List<String> segmentNames, int timeoutMs, String validDocIdsType,
       int numSegmentsBatchPerServerRequest) {
     return getSegmentToValidDocIdsMetadataFromServer(tableNameWithType, serverToSegmentsMap, serverToEndpoints,
-        segmentNames, timeoutMs, validDocIdsType, numSegmentsBatchPerServerRequest).values().stream()
-        .filter(list -> list != null && !list.isEmpty()).map(list -> list.get(0)).collect(Collectors.toList());
+        segmentNames, timeoutMs, validDocIdsType, numSegmentsBatchPerServerRequest).getSegmentToMetadata().values()
+        .stream().filter(list -> list != null && !list.isEmpty()).map(list -> list.get(0))
+        .collect(Collectors.toList());
   }
 
   /**
@@ -276,13 +277,17 @@ public class ServerSegmentMetadataReader {
    * This method will pick all servers that hosts the target segment and fetch the segment metadata result and
    * return as a list.
    *
-   * @return map of segment name to list of valid doc id metadata where each element is every server's metadata.
+   * @return the per-segment metadata from every responding server, plus the expected replica count per segment.
    */
-  public Map<String, List<ValidDocIdsMetadataInfo>> getSegmentToValidDocIdsMetadataFromServer(String tableNameWithType,
+  public ValidDocIdsMetadataResult getSegmentToValidDocIdsMetadataFromServer(String tableNameWithType,
       Map<String, List<String>> serverToSegmentsMap, BiMap<String, String> serverToEndpoints,
       @Nullable List<String> segmentNames, int timeoutMs, String validDocIdsType,
       int numSegmentsBatchPerServerRequest) {
     List<Pair<String, String>> serverURLsAndBodies = new ArrayList<>();
+    // Expected replica count per segment, tallied from the server-to-segments assignment as we build the requests. A
+    // replica that fails to respond is simply absent from the metadata below, so callers compare the responder count
+    // against this to tell when not all replicas replied.
+    Map<String, Integer> segmentToExpectedReplicaCount = new HashMap<>();
     for (Map.Entry<String, List<String>> serverToSegments : serverToSegmentsMap.entrySet()) {
       List<String> segmentsForServer = serverToSegments.getValue();
       List<String> segmentsToQuery = new ArrayList<>();
@@ -295,6 +300,9 @@ public class ServerSegmentMetadataReader {
             segmentsToQuery.add(segment);
           }
         }
+      }
+      for (String segment : segmentsToQuery) {
+        segmentToExpectedReplicaCount.merge(segment, 1, Integer::sum);
       }
 
       // Number of segments to query per server request. If a table has a lot of segments, then we might send a
@@ -352,7 +360,29 @@ public class ServerSegmentMetadataReader {
 
     LOGGER.info("Retrieved validDocIds metadata for {} segments from {} server requests.",
         validDocIdsMetadataInfos.size(), returnedServerRequestsCount);
-    return validDocIdsMetadataInfos;
+    return new ValidDocIdsMetadataResult(validDocIdsMetadataInfos, segmentToExpectedReplicaCount);
+  }
+
+  /// Result of [#getSegmentToValidDocIdsMetadataFromServer]: the per-segment metadata from every responding server,
+  /// plus the expected replica count per segment (how many servers host it). The count lets callers detect a replica
+  /// that did not respond, since a missing replica is simply absent from the metadata.
+  public static class ValidDocIdsMetadataResult {
+    private final Map<String, List<ValidDocIdsMetadataInfo>> _segmentToMetadata;
+    private final Map<String, Integer> _segmentToExpectedReplicaCount;
+
+    public ValidDocIdsMetadataResult(Map<String, List<ValidDocIdsMetadataInfo>> segmentToMetadata,
+        Map<String, Integer> segmentToExpectedReplicaCount) {
+      _segmentToMetadata = segmentToMetadata;
+      _segmentToExpectedReplicaCount = segmentToExpectedReplicaCount;
+    }
+
+    public Map<String, List<ValidDocIdsMetadataInfo>> getSegmentToMetadata() {
+      return _segmentToMetadata;
+    }
+
+    public Map<String, Integer> getSegmentToExpectedReplicaCount() {
+      return _segmentToExpectedReplicaCount;
+    }
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
@@ -282,6 +282,20 @@ public class ServerSegmentMetadataReader {
       Map<String, List<String>> serverToSegmentsMap, BiMap<String, String> serverToEndpoints,
       @Nullable List<String> segmentNames, int timeoutMs, String validDocIdsType,
       int numSegmentsBatchPerServerRequest) {
+    return getSegmentToValidDocIdsMetadataFromServer(tableNameWithType, serverToSegmentsMap, serverToEndpoints,
+        segmentNames, timeoutMs, validDocIdsType, numSegmentsBatchPerServerRequest, false);
+  }
+
+  /**
+   * Overload that also lets the caller request the serialized validDocIds bitmap in each per-segment response entry.
+   * When {@code includeBitmaps} is true, every {@link ValidDocIdsMetadataInfo} returned by the server includes its
+   * bitmap bytes (see {@link ValidDocIdsMetadataInfo#getBitmap()}). Use sparingly — the response payload grows with
+   * the total bitmap size across the requested segments.
+   */
+  public Map<String, List<ValidDocIdsMetadataInfo>> getSegmentToValidDocIdsMetadataFromServer(String tableNameWithType,
+      Map<String, List<String>> serverToSegmentsMap, BiMap<String, String> serverToEndpoints,
+      @Nullable List<String> segmentNames, int timeoutMs, String validDocIdsType,
+      int numSegmentsBatchPerServerRequest, boolean includeBitmaps) {
     List<Pair<String, String>> serverURLsAndBodies = new ArrayList<>();
     for (Map.Entry<String, List<String>> serverToSegments : serverToSegmentsMap.entrySet()) {
       List<String> segmentsForServer = serverToSegments.getValue();
@@ -301,7 +315,7 @@ public class ServerSegmentMetadataReader {
       // huge payload to pinot-server in request. Batching the requests will help in reducing the payload size.
       Lists.partition(segmentsToQuery, numSegmentsBatchPerServerRequest).forEach(segmentsToQueryBatch ->
           serverURLsAndBodies.add(generateValidDocIdsMetadataURL(tableNameWithType, segmentsToQueryBatch,
-              validDocIdsType, serverToEndpoints.get(serverToSegments.getKey()))));
+              validDocIdsType, serverToEndpoints.get(serverToSegments.getKey()), includeBitmaps)));
     }
 
     BiMap<String, String> endpointsToServers = serverToEndpoints.inverse();
@@ -482,6 +496,11 @@ public class ServerSegmentMetadataReader {
 
   private Pair<String, String> generateValidDocIdsMetadataURL(String tableNameWithType, List<String> segmentNames,
       String validDocIdsType, String endpoint) {
+    return generateValidDocIdsMetadataURL(tableNameWithType, segmentNames, validDocIdsType, endpoint, false);
+  }
+
+  private Pair<String, String> generateValidDocIdsMetadataURL(String tableNameWithType, List<String> segmentNames,
+      String validDocIdsType, String endpoint, boolean includeBitmaps) {
     tableNameWithType = encode(tableNameWithType);
     TableSegments tableSegments = new TableSegments(segmentNames);
     String jsonTableSegments;
@@ -491,11 +510,17 @@ public class ServerSegmentMetadataReader {
       LOGGER.error("Failed to convert segment names to json request body: segmentNames={}", segmentNames);
       throw new RuntimeException(e);
     }
-    String url = String.format("%s/tables/%s/validDocIdsMetadata", endpoint, tableNameWithType);
+    StringBuilder url = new StringBuilder(
+        String.format("%s/tables/%s/validDocIdsMetadata", endpoint, tableNameWithType));
+    String separator = "?";
     if (validDocIdsType != null) {
-      url = url + "?validDocIdsType=" + validDocIdsType;
+      url.append(separator).append("validDocIdsType=").append(validDocIdsType);
+      separator = "&";
     }
-    return Pair.of(url, jsonTableSegments);
+    if (includeBitmaps) {
+      url.append(separator).append("includeBitmaps=true");
+    }
+    return Pair.of(url.toString(), jsonTableSegments);
   }
 
   private String generateStaleSegmentsServerURL(String tableNameWithType, String endpoint) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
@@ -286,7 +286,8 @@ public class ServerSegmentMetadataReader {
     List<Pair<String, String>> serverURLsAndBodies = new ArrayList<>();
     // Expected replica count per segment, tallied from the server-to-segments assignment as we build the requests. A
     // replica that fails to respond is simply absent from the metadata below, so callers compare the responder count
-    // against this to tell when not all replicas replied.
+    // against this to tell when not all replicas replied. Only segments passing the segmentNames filter are tallied,
+    // but every server hosting such a segment is counted, so each tallied count is exact.
     Map<String, Integer> segmentToExpectedReplicaCount = new HashMap<>();
     for (Map.Entry<String, List<String>> serverToSegments : serverToSegmentsMap.entrySet()) {
       List<String> segmentsForServer = serverToSegments.getValue();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
@@ -282,20 +282,6 @@ public class ServerSegmentMetadataReader {
       Map<String, List<String>> serverToSegmentsMap, BiMap<String, String> serverToEndpoints,
       @Nullable List<String> segmentNames, int timeoutMs, String validDocIdsType,
       int numSegmentsBatchPerServerRequest) {
-    return getSegmentToValidDocIdsMetadataFromServer(tableNameWithType, serverToSegmentsMap, serverToEndpoints,
-        segmentNames, timeoutMs, validDocIdsType, numSegmentsBatchPerServerRequest, false);
-  }
-
-  /**
-   * Overload that also lets the caller request the serialized validDocIds bitmap in each per-segment response entry.
-   * When {@code includeBitmaps} is true, every {@link ValidDocIdsMetadataInfo} returned by the server includes its
-   * bitmap bytes (see {@link ValidDocIdsMetadataInfo#getBitmap()}). Use sparingly — the response payload grows with
-   * the total bitmap size across the requested segments.
-   */
-  public Map<String, List<ValidDocIdsMetadataInfo>> getSegmentToValidDocIdsMetadataFromServer(String tableNameWithType,
-      Map<String, List<String>> serverToSegmentsMap, BiMap<String, String> serverToEndpoints,
-      @Nullable List<String> segmentNames, int timeoutMs, String validDocIdsType,
-      int numSegmentsBatchPerServerRequest, boolean includeBitmaps) {
     List<Pair<String, String>> serverURLsAndBodies = new ArrayList<>();
     for (Map.Entry<String, List<String>> serverToSegments : serverToSegmentsMap.entrySet()) {
       List<String> segmentsForServer = serverToSegments.getValue();
@@ -315,7 +301,7 @@ public class ServerSegmentMetadataReader {
       // huge payload to pinot-server in request. Batching the requests will help in reducing the payload size.
       Lists.partition(segmentsToQuery, numSegmentsBatchPerServerRequest).forEach(segmentsToQueryBatch ->
           serverURLsAndBodies.add(generateValidDocIdsMetadataURL(tableNameWithType, segmentsToQueryBatch,
-              validDocIdsType, serverToEndpoints.get(serverToSegments.getKey()), includeBitmaps)));
+              validDocIdsType, serverToEndpoints.get(serverToSegments.getKey()))));
     }
 
     BiMap<String, String> endpointsToServers = serverToEndpoints.inverse();
@@ -496,11 +482,6 @@ public class ServerSegmentMetadataReader {
 
   private Pair<String, String> generateValidDocIdsMetadataURL(String tableNameWithType, List<String> segmentNames,
       String validDocIdsType, String endpoint) {
-    return generateValidDocIdsMetadataURL(tableNameWithType, segmentNames, validDocIdsType, endpoint, false);
-  }
-
-  private Pair<String, String> generateValidDocIdsMetadataURL(String tableNameWithType, List<String> segmentNames,
-      String validDocIdsType, String endpoint, boolean includeBitmaps) {
     tableNameWithType = encode(tableNameWithType);
     TableSegments tableSegments = new TableSegments(segmentNames);
     String jsonTableSegments;
@@ -510,17 +491,11 @@ public class ServerSegmentMetadataReader {
       LOGGER.error("Failed to convert segment names to json request body: segmentNames={}", segmentNames);
       throw new RuntimeException(e);
     }
-    StringBuilder url = new StringBuilder(
-        String.format("%s/tables/%s/validDocIdsMetadata", endpoint, tableNameWithType));
-    String separator = "?";
+    String url = String.format("%s/tables/%s/validDocIdsMetadata", endpoint, tableNameWithType);
     if (validDocIdsType != null) {
-      url.append(separator).append("validDocIdsType=").append(validDocIdsType);
-      separator = "&";
+      url = url + "?validDocIdsType=" + validDocIdsType;
     }
-    if (includeBitmaps) {
-      url.append(separator).append("includeBitmaps=true");
-    }
-    return Pair.of(url.toString(), jsonTableSegments);
+    return Pair.of(url, jsonTableSegments);
   }
 
   private String generateStaleSegmentsServerURL(String tableNameWithType, String endpoint) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -92,16 +92,14 @@ public class MinionConstants {
    */
   public static final String SEGMENT_DOWNLOAD_PARALLELISM = "segmentDownloadParallelism";
 
-  /** Valid doc ids consensus mode enforced by both the task generators (pre-scheduling) and the executors. */
+  /// Valid doc ids consensus mode enforced by both the task generators (pre-scheduling) and the executors.
   public enum ValidDocIdsConsensusMode {
     UNSAFE, EQUAL, MOST_VALID_DOCS
   }
 
-  /**
-   * Where validDocIds consensus is enforced. STRICT (default) runs the checks in both the task generator
-   * (pre-scheduling) and the executor; EXECUTOR_ONLY skips the generator-side checks and leaves the executor as the
-   * sole gate.
-   */
+  /// Where validDocIds consensus is enforced. STRICT (default) runs the checks in both the task generator
+  /// (pre-scheduling) and the executor; EXECUTOR_ONLY skips the generator-side checks and leaves the executor as the
+  /// sole gate.
   public enum ValidDocIdsValidationMode {
     STRICT, EXECUTOR_ONLY
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -92,9 +92,18 @@ public class MinionConstants {
    */
   public static final String SEGMENT_DOWNLOAD_PARALLELISM = "segmentDownloadParallelism";
 
-  /** Valid doc ids consensus mode (executor-only). Kept internal; executors pass config string. */
+  /** Valid doc ids consensus mode enforced by both the task generators (pre-scheduling) and the executors. */
   public enum ValidDocIdsConsensusMode {
     UNSAFE, EQUAL, MOST_VALID_DOCS
+  }
+
+  /**
+   * Where validDocIds consensus is enforced. STRICT (default) runs the checks in both the task generator
+   * (pre-scheduling) and the executor; EXECUTOR_ONLY skips the generator-side checks and leaves the executor as the
+   * sole gate.
+   */
+  public enum ValidDocIdsValidationMode {
+    STRICT, EXECUTOR_ONLY
   }
 
   // Purges rows inside segment that match chosen criteria
@@ -269,14 +278,25 @@ public class MinionConstants {
     public static final String NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST = "numSegmentsBatchPerServerRequest";
 
     /**
-     * Valid doc ids consensus mode used by the executor only (generator unchanged). Values: UNSAFE, EQUAL,
-     * MOST_VALID_DOCS. UNSAFE = use first server with matching CRC and READY; EQUAL = require all replicas
-     * to have the same valid doc set (default); MOST_VALID_DOCS = use replica with most valid docs.
+     * Valid doc ids consensus mode enforced by both the task generators (pre-scheduling) and the executors. Values:
+     * UNSAFE, EQUAL, MOST_VALID_DOCS. UNSAFE = use the first server with matching CRC and GOOD status; EQUAL =
+     * require all replicas to have the same valid doc set (default); MOST_VALID_DOCS = use the replica with the most
+     * valid docs. Shared by UpsertCompactionTask and UpsertCompactMergeTask.
      */
     public static final String VALID_DOC_IDS_CONSENSUS_MODE_KEY = "validDocIdsConsensusMode";
 
     /** Default: equal valid doc set consensus across replicas. */
     public static final String DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE = "EQUAL";
+
+    /**
+     * Whether the consensus checks run in the generator too. STRICT (default) = generator + executor; EXECUTOR_ONLY =
+     * executor only (generator skips the checks and the bitmap fetch). Shared by UpsertCompactionTask,
+     * UpsertCompactMergeTask, and SegmentRefreshTask.
+     */
+    public static final String VALID_DOC_IDS_VALIDATION_MODE_KEY = "validDocIdsValidationMode";
+
+    /** Default: enforce in both generator and executor. */
+    public static final String DEFAULT_VALID_DOC_IDS_VALIDATION_MODE = "STRICT";
   }
 
   public static class UpsertCompactMergeTask {

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -279,13 +279,12 @@ public class MinionConstants {
 
     /// Valid doc ids consensus mode used by both the task generators (pre-scheduling) and the executors. UNSAFE =
     /// first server with matching CRC and GOOD status; EQUAL (default) = all replicas must agree; MOST_VALID_DOCS =
-    /// the replica with the most valid docs. Shared by UpsertCompactionTask, UpsertCompactMergeTask, and
-    /// SegmentRefreshTask.
+    /// the replica with the most valid docs. Shared by UpsertCompactionTask and UpsertCompactMergeTask.
     public static final String VALID_DOC_IDS_CONSENSUS_MODE_KEY = "validDocIdsConsensusMode";
     public static final String DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE = "EQUAL";
 
     /// Whether the consensus checks also run in the generator. STRICT (default) = generator + executor;
-    /// EXECUTOR_ONLY = executor only. Shared by UpsertCompactionTask, UpsertCompactMergeTask, and SegmentRefreshTask.
+    /// EXECUTOR_ONLY = executor only. Shared by UpsertCompactionTask and UpsertCompactMergeTask.
     public static final String VALID_DOC_IDS_VALIDATION_MODE_KEY = "validDocIdsValidationMode";
     public static final String DEFAULT_VALID_DOC_IDS_VALIDATION_MODE = "STRICT";
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -297,6 +297,16 @@ public class MinionConstants {
 
     /** Default: enforce in both generator and executor. */
     public static final String DEFAULT_VALID_DOC_IDS_VALIDATION_MODE = "STRICT";
+
+    /**
+     * Per-server batch size for the validDocIds fetch when generator consensus runs (EQUAL/MOST_VALID_DOCS). Kept
+     * small because consensus fetches from every replica and EQUAL also carries the serialized bitmap in each entry.
+     * Shared by UpsertCompactionTask and UpsertCompactMergeTask.
+     */
+    public static final String VALID_DOC_IDS_CONSENSUS_FETCH_BATCH_SIZE_KEY = "validDocIdsConsensusFetchBatchSize";
+
+    /** Default consensus fetch batch size, small since all replicas respond and EQUAL includes the bitmap. */
+    public static final int DEFAULT_VALID_DOC_IDS_CONSENSUS_FETCH_BATCH_SIZE = 10;
   }
 
   public static class UpsertCompactMergeTask {

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -106,6 +106,28 @@ public class MinionConstants {
     STRICT, EXECUTOR_ONLY
   }
 
+  /**
+   * Valid doc ids consensus mode used by both the task generators (pre-scheduling) and the executors. UNSAFE = first
+   * server with matching CRC and GOOD status; EQUAL (default) = all replicas must have the same valid doc set;
+   * MOST_VALID_DOCS = the replica with the most valid docs.
+   */
+  public static final String VALID_DOC_IDS_CONSENSUS_MODE_KEY = "validDocIdsConsensusMode";
+  public static final String DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE = "EQUAL";
+
+  /**
+   * Whether the consensus checks run in the generator too. STRICT (default) = generator + executor; EXECUTOR_ONLY =
+   * executor only (generator skips the checks and the bitmap fetch).
+   */
+  public static final String VALID_DOC_IDS_VALIDATION_MODE_KEY = "validDocIdsValidationMode";
+  public static final String DEFAULT_VALID_DOC_IDS_VALIDATION_MODE = "STRICT";
+
+  /**
+   * Per-server batch size for the validDocIds fetch when generator consensus runs (EQUAL/MOST_VALID_DOCS). Kept small
+   * because consensus fetches from every replica and EQUAL also carries the serialized bitmap in each entry.
+   */
+  public static final String VALID_DOC_IDS_CONSENSUS_FETCH_BATCH_SIZE_KEY = "validDocIdsConsensusFetchBatchSize";
+  public static final int DEFAULT_VALID_DOC_IDS_CONSENSUS_FETCH_BATCH_SIZE = 10;
+
   // Purges rows inside segment that match chosen criteria
   public static class PurgeTask {
     public static final String TASK_TYPE = "PurgeTask";
@@ -277,36 +299,14 @@ public class MinionConstants {
      */
     public static final String NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST = "numSegmentsBatchPerServerRequest";
 
-    /**
-     * Valid doc ids consensus mode enforced by both the task generators (pre-scheduling) and the executors. Values:
-     * UNSAFE, EQUAL, MOST_VALID_DOCS. UNSAFE = use the first server with matching CRC and GOOD status; EQUAL =
-     * require all replicas to have the same valid doc set (default); MOST_VALID_DOCS = use the replica with the most
-     * valid docs. Shared by UpsertCompactionTask and UpsertCompactMergeTask.
-     */
-    public static final String VALID_DOC_IDS_CONSENSUS_MODE_KEY = "validDocIdsConsensusMode";
+    /** @deprecated moved to {@link MinionConstants#VALID_DOC_IDS_CONSENSUS_MODE_KEY}. */
+    @Deprecated
+    public static final String VALID_DOC_IDS_CONSENSUS_MODE_KEY = MinionConstants.VALID_DOC_IDS_CONSENSUS_MODE_KEY;
 
-    /** Default: equal valid doc set consensus across replicas. */
-    public static final String DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE = "EQUAL";
-
-    /**
-     * Whether the consensus checks run in the generator too. STRICT (default) = generator + executor; EXECUTOR_ONLY =
-     * executor only (generator skips the checks and the bitmap fetch). Shared by UpsertCompactionTask,
-     * UpsertCompactMergeTask, and SegmentRefreshTask.
-     */
-    public static final String VALID_DOC_IDS_VALIDATION_MODE_KEY = "validDocIdsValidationMode";
-
-    /** Default: enforce in both generator and executor. */
-    public static final String DEFAULT_VALID_DOC_IDS_VALIDATION_MODE = "STRICT";
-
-    /**
-     * Per-server batch size for the validDocIds fetch when generator consensus runs (EQUAL/MOST_VALID_DOCS). Kept
-     * small because consensus fetches from every replica and EQUAL also carries the serialized bitmap in each entry.
-     * Shared by UpsertCompactionTask and UpsertCompactMergeTask.
-     */
-    public static final String VALID_DOC_IDS_CONSENSUS_FETCH_BATCH_SIZE_KEY = "validDocIdsConsensusFetchBatchSize";
-
-    /** Default consensus fetch batch size, small since all replicas respond and EQUAL includes the bitmap. */
-    public static final int DEFAULT_VALID_DOC_IDS_CONSENSUS_FETCH_BATCH_SIZE = 10;
+    /** @deprecated moved to {@link MinionConstants#DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE}. */
+    @Deprecated
+    public static final String DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE =
+        MinionConstants.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE;
   }
 
   public static class UpsertCompactMergeTask {

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -277,19 +277,15 @@ public class MinionConstants {
      */
     public static final String NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST = "numSegmentsBatchPerServerRequest";
 
-    /**
-     * Valid doc ids consensus mode used by both the task generators (pre-scheduling) and the executors. UNSAFE =
-     * first server with matching CRC and GOOD status; EQUAL (default) = all replicas must agree; MOST_VALID_DOCS =
-     * the replica with the most valid docs. Shared by UpsertCompactionTask, UpsertCompactMergeTask, and
-     * SegmentRefreshTask.
-     */
+    /// Valid doc ids consensus mode used by both the task generators (pre-scheduling) and the executors. UNSAFE =
+    /// first server with matching CRC and GOOD status; EQUAL (default) = all replicas must agree; MOST_VALID_DOCS =
+    /// the replica with the most valid docs. Shared by UpsertCompactionTask, UpsertCompactMergeTask, and
+    /// SegmentRefreshTask.
     public static final String VALID_DOC_IDS_CONSENSUS_MODE_KEY = "validDocIdsConsensusMode";
     public static final String DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE = "EQUAL";
 
-    /**
-     * Whether the consensus checks also run in the generator. STRICT (default) = generator + executor;
-     * EXECUTOR_ONLY = executor only. Shared by UpsertCompactionTask, UpsertCompactMergeTask, and SegmentRefreshTask.
-     */
+    /// Whether the consensus checks also run in the generator. STRICT (default) = generator + executor;
+    /// EXECUTOR_ONLY = executor only. Shared by UpsertCompactionTask, UpsertCompactMergeTask, and SegmentRefreshTask.
     public static final String VALID_DOC_IDS_VALIDATION_MODE_KEY = "validDocIdsValidationMode";
     public static final String DEFAULT_VALID_DOC_IDS_VALIDATION_MODE = "STRICT";
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -106,21 +106,6 @@ public class MinionConstants {
     STRICT, EXECUTOR_ONLY
   }
 
-  /**
-   * Valid doc ids consensus mode used by both the task generators (pre-scheduling) and the executors. UNSAFE = first
-   * server with matching CRC and GOOD status; EQUAL (default) = all replicas must have the same valid doc set;
-   * MOST_VALID_DOCS = the replica with the most valid docs.
-   */
-  public static final String VALID_DOC_IDS_CONSENSUS_MODE_KEY = "validDocIdsConsensusMode";
-  public static final String DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE = "EQUAL";
-
-  /**
-   * Whether the consensus checks run in the generator too. STRICT (default) = generator + executor; EXECUTOR_ONLY =
-   * executor only (generator skips the checks and the bitmap fetch).
-   */
-  public static final String VALID_DOC_IDS_VALIDATION_MODE_KEY = "validDocIdsValidationMode";
-  public static final String DEFAULT_VALID_DOC_IDS_VALIDATION_MODE = "STRICT";
-
   // Purges rows inside segment that match chosen criteria
   public static class PurgeTask {
     public static final String TASK_TYPE = "PurgeTask";
@@ -292,14 +277,21 @@ public class MinionConstants {
      */
     public static final String NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST = "numSegmentsBatchPerServerRequest";
 
-    /** @deprecated moved to {@link MinionConstants#VALID_DOC_IDS_CONSENSUS_MODE_KEY}. */
-    @Deprecated
-    public static final String VALID_DOC_IDS_CONSENSUS_MODE_KEY = MinionConstants.VALID_DOC_IDS_CONSENSUS_MODE_KEY;
+    /**
+     * Valid doc ids consensus mode used by both the task generators (pre-scheduling) and the executors. UNSAFE =
+     * first server with matching CRC and GOOD status; EQUAL (default) = all replicas must agree; MOST_VALID_DOCS =
+     * the replica with the most valid docs. Shared by UpsertCompactionTask, UpsertCompactMergeTask, and
+     * SegmentRefreshTask.
+     */
+    public static final String VALID_DOC_IDS_CONSENSUS_MODE_KEY = "validDocIdsConsensusMode";
+    public static final String DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE = "EQUAL";
 
-    /** @deprecated moved to {@link MinionConstants#DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE}. */
-    @Deprecated
-    public static final String DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE =
-        MinionConstants.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE;
+    /**
+     * Whether the consensus checks also run in the generator. STRICT (default) = generator + executor;
+     * EXECUTOR_ONLY = executor only. Shared by UpsertCompactionTask, UpsertCompactMergeTask, and SegmentRefreshTask.
+     */
+    public static final String VALID_DOC_IDS_VALIDATION_MODE_KEY = "validDocIdsValidationMode";
+    public static final String DEFAULT_VALID_DOC_IDS_VALIDATION_MODE = "STRICT";
   }
 
   public static class UpsertCompactMergeTask {

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -121,13 +121,6 @@ public class MinionConstants {
   public static final String VALID_DOC_IDS_VALIDATION_MODE_KEY = "validDocIdsValidationMode";
   public static final String DEFAULT_VALID_DOC_IDS_VALIDATION_MODE = "STRICT";
 
-  /**
-   * Per-server batch size for the validDocIds fetch when generator consensus runs (EQUAL/MOST_VALID_DOCS). Kept small
-   * because consensus fetches from every replica and EQUAL also carries the serialized bitmap in each entry.
-   */
-  public static final String VALID_DOC_IDS_CONSENSUS_FETCH_BATCH_SIZE_KEY = "validDocIdsConsensusFetchBatchSize";
-  public static final int DEFAULT_VALID_DOC_IDS_CONSENSUS_FETCH_BATCH_SIZE = 10;
-
   // Purges rows inside segment that match chosen criteria
   public static class PurgeTask {
     public static final String TASK_TYPE = "PurgeTask";

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
@@ -464,17 +464,20 @@ public class MinionTaskUtils {
   }
 
   /**
-   * Picks the replica whose validDocIds the generator should use for the segment, or returns {@code null} to skip it.
-   * Runs the executor's checks (CRC, server health, consensus) on the already-fetched replica metadata, so
-   * inconsistent segments are dropped before a task is scheduled rather than failed later. By mode:
+   * Picks the replica whose validDocIds the generator should use for a segment, or returns {@code null} to skip the
+   * segment. Applies the same checks the executor would (CRC match, healthy server, replica consensus) so bad
+   * segments are dropped before a task is scheduled.
+   *
+   * <p>How the replica is chosen depends on {@code consensusMode}:
    * <ul>
-   *   <li>{@code UNSAFE}: first replica with a matching CRC and a healthy server.</li>
-   *   <li>{@code EQUAL}: every replica must respond, match CRC, be healthy, and share an identical bitmap (needs
-   *       {@code includeBitmaps=true}).</li>
-   *   <li>{@code MOST_VALID_DOCS}: every replica must respond, match CRC, and be healthy; pick the one with the most
-   *       valid docs.</li>
+   *   <li>{@code UNSAFE}: the first replica with a matching CRC and a healthy server.</li>
+   *   <li>{@code EQUAL}: all replicas must match CRC, be healthy, and have an identical bitmap.</li>
+   *   <li>{@code MOST_VALID_DOCS}: all replicas must match CRC and be healthy; the one with the most valid docs
+   *       wins.</li>
    * </ul>
-   * {@code expectedReplicaCount} is how many replicas must respond for the strict modes (ignored for {@code UNSAFE}).
+   *
+   * <p>For {@code EQUAL} and {@code MOST_VALID_DOCS}, {@code expectedReplicaCount} replicas must respond, otherwise the
+   * segment is skipped; {@code UNSAFE} ignores it.
    */
   @Nullable
   public static ValidDocIdsMetadataInfo selectValidDocIdsMetadataForConsensus(String taskType, String segmentName,

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
@@ -76,7 +76,7 @@ public class MinionTaskUtils {
 
   /// Parses the validDocIdsConsensusMode config string. Blank/null defaults to `EQUAL`.
   public static MinionConstants.ValidDocIdsConsensusMode parseValidDocIdsConsensusMode(String value) {
-    if (value == null || value.isBlank()) {
+    if (StringUtils.isBlank(value)) {
       return MinionConstants.ValidDocIdsConsensusMode.EQUAL;
     }
     return MinionConstants.ValidDocIdsConsensusMode.valueOf(value.toUpperCase().trim());
@@ -84,7 +84,7 @@ public class MinionTaskUtils {
 
   /// Parses the validDocIdsValidationMode config string. Blank/null defaults to `STRICT`.
   public static MinionConstants.ValidDocIdsValidationMode parseValidDocIdsValidationMode(String value) {
-    if (value == null || value.isBlank()) {
+    if (StringUtils.isBlank(value)) {
       return MinionConstants.ValidDocIdsValidationMode.STRICT;
     }
     return MinionConstants.ValidDocIdsValidationMode.valueOf(value.toUpperCase().trim());
@@ -456,18 +456,6 @@ public class MinionTaskUtils {
           maxCard, segmentName, servers.size());
     }
     return maxCardinalityMap;
-  }
-
-  /// Counts how many servers host each segment (its online replica count) from a server-to-segments map, so callers
-  /// can tell whether every assigned replica responded.
-  public static Map<String, Integer> getSegmentToReplicaCount(Map<String, List<String>> serverToSegments) {
-    Map<String, Integer> segmentToReplicaCount = new HashMap<>();
-    for (List<String> segments : serverToSegments.values()) {
-      for (String segment : segments) {
-        segmentToReplicaCount.merge(segment, 1, Integer::sum);
-      }
-    }
-    return segmentToReplicaCount;
   }
 
   /// Picks the replica whose validDocIds the generator should use, or null to skip the segment, applying the same

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
@@ -475,19 +475,10 @@ public class MinionTaskUtils {
   }
 
   /**
-   * Picks the replica whose validDocIds the generator should use for a segment, or returns {@code null} to skip the
-   * segment. Applies the same checks the executor would (CRC match, healthy server, replica consensus) so bad
-   * segments are dropped before a task is scheduled.
-   *
-   * CRC is matched by {@link #crcMatches} (segment CRC, with the data CRC as a fallback when segment CRCs differ).
-   * The executor uses the same check, so a segment accepted here isn't later rejected on CRC.
-   *
-   * How the replica is chosen depends on {@code consensusMode}:
-   *   - UNSAFE: the first replica with a matching CRC and a healthy server.
-   *   - EQUAL: all replicas must match CRC, be healthy, and report the same valid doc count. Counts (rather than
-   *     full bitmaps) are compared here to keep the generator cheap; the executor still verifies byte-identical
-   *     bitmaps before compacting.
-   *   - MOST_VALID_DOCS: all replicas must match CRC and be healthy; the one with the most valid docs wins.
+   * Picks the replica whose validDocIds the generator should use, or null to skip the segment, applying the same
+   * checks the executor would so bad segments aren't scheduled: the replica must match CRC (via {@link #crcMatches})
+   * and be on a healthy server. UNSAFE uses the first such replica, EQUAL requires all to report the same valid doc
+   * count, and MOST_VALID_DOCS picks the highest.
    */
   @Nullable
   public static ValidDocIdsMetadataInfo selectValidDocIdsMetadataForConsensus(String taskType,

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
@@ -101,6 +101,21 @@ public class MinionTaskUtils {
         ? MinionConstants.ValidDocIdsConsensusMode.UNSAFE : consensusMode;
   }
 
+  /**
+   * Resolves the per-server batch size for the generator's validDocIds fetch. UNSAFE keeps {@code regularBatchSize}
+   * (the no-bitmap fetch). The consensus modes fetch from every replica (and EQUAL also carries a bitmap per entry),
+   * so they use the smaller {@code validDocIdsConsensusFetchBatchSize} to keep the payload bounded.
+   */
+  public static int resolveValidDocIdsFetchBatchSize(Map<String, String> taskConfigs,
+      MinionConstants.ValidDocIdsConsensusMode consensusMode, int regularBatchSize) {
+    if (consensusMode == MinionConstants.ValidDocIdsConsensusMode.UNSAFE) {
+      return regularBatchSize;
+    }
+    return Integer.parseInt(taskConfigs.getOrDefault(
+        MinionConstants.UpsertCompactionTask.VALID_DOC_IDS_CONSENSUS_FETCH_BATCH_SIZE_KEY,
+        String.valueOf(MinionConstants.UpsertCompactionTask.DEFAULT_VALID_DOC_IDS_CONSENSUS_FETCH_BATCH_SIZE)));
+  }
+
   private static final String DEFAULT_DIR_PATH_TERMINATOR = "/";
 
   public static final String DATETIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
@@ -112,8 +112,8 @@ public class MinionTaskUtils {
       return regularBatchSize;
     }
     return Integer.parseInt(taskConfigs.getOrDefault(
-        MinionConstants.UpsertCompactionTask.VALID_DOC_IDS_CONSENSUS_FETCH_BATCH_SIZE_KEY,
-        String.valueOf(MinionConstants.UpsertCompactionTask.DEFAULT_VALID_DOC_IDS_CONSENSUS_FETCH_BATCH_SIZE)));
+        MinionConstants.VALID_DOC_IDS_CONSENSUS_FETCH_BATCH_SIZE_KEY,
+        String.valueOf(MinionConstants.DEFAULT_VALID_DOC_IDS_CONSENSUS_FETCH_BATCH_SIZE)));
   }
 
   private static final String DEFAULT_DIR_PATH_TERMINATOR = "/";

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
@@ -38,6 +38,7 @@ import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.common.auth.NullAuthProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.restlet.resources.ValidDocIdsBitmapResponse;
+import org.apache.pinot.common.restlet.resources.ValidDocIdsMetadataInfo;
 import org.apache.pinot.common.restlet.resources.ValidDocIdsType;
 import org.apache.pinot.common.utils.RetentionUtils;
 import org.apache.pinot.common.utils.RoaringBitmapUtils;
@@ -72,12 +73,32 @@ import org.slf4j.LoggerFactory;
 public class MinionTaskUtils {
   private static final Logger LOGGER = LoggerFactory.getLogger(MinionTaskUtils.class);
 
-  /** Package-private for testing: parses validDocIdsComparisonMode config string. */
-  static MinionConstants.ValidDocIdsConsensusMode parseValidDocIdsConsensusMode(String value) {
+  /** Parses the validDocIdsConsensusMode config string. Blank/null defaults to {@code EQUAL}. */
+  public static MinionConstants.ValidDocIdsConsensusMode parseValidDocIdsConsensusMode(String value) {
     if (value == null || value.isBlank()) {
       return MinionConstants.ValidDocIdsConsensusMode.EQUAL;
     }
     return MinionConstants.ValidDocIdsConsensusMode.valueOf(value.toUpperCase().trim());
+  }
+
+  /** Parses the validDocIdsValidationMode config string. Blank/null defaults to {@code STRICT}. */
+  public static MinionConstants.ValidDocIdsValidationMode parseValidDocIdsValidationMode(String value) {
+    if (value == null || value.isBlank()) {
+      return MinionConstants.ValidDocIdsValidationMode.STRICT;
+    }
+    return MinionConstants.ValidDocIdsValidationMode.valueOf(value.toUpperCase().trim());
+  }
+
+  /**
+   * Resolves the consensus mode the generator should apply, given the configured consensus mode and validation mode.
+   * EXECUTOR_ONLY downgrades the generator to UNSAFE (lenient pick, no bitmaps, no cross-replica enforcement) so the
+   * executor stays the sole gate; STRICT keeps the configured mode.
+   */
+  public static MinionConstants.ValidDocIdsConsensusMode resolveGeneratorConsensusMode(
+      MinionConstants.ValidDocIdsConsensusMode consensusMode,
+      MinionConstants.ValidDocIdsValidationMode validationMode) {
+    return validationMode == MinionConstants.ValidDocIdsValidationMode.EXECUTOR_ONLY
+        ? MinionConstants.ValidDocIdsConsensusMode.UNSAFE : consensusMode;
   }
 
   private static final String DEFAULT_DIR_PATH_TERMINATOR = "/";
@@ -426,6 +447,134 @@ public class MinionTaskUtils {
           maxCard, segmentName, servers.size());
     }
     return maxCardinalityMap;
+  }
+
+  /**
+   * Counts how many servers host each segment (its online replica count) from a server-to-segments map, so callers
+   * can tell whether every assigned replica responded.
+   */
+  public static Map<String, Integer> getSegmentToReplicaCount(Map<String, List<String>> serverToSegments) {
+    Map<String, Integer> segmentToReplicaCount = new HashMap<>();
+    for (List<String> segments : serverToSegments.values()) {
+      for (String segment : segments) {
+        segmentToReplicaCount.merge(segment, 1, Integer::sum);
+      }
+    }
+    return segmentToReplicaCount;
+  }
+
+  /**
+   * Picks the replica whose validDocIds the generator should use for the segment, or returns {@code null} to skip it.
+   * Runs the executor's checks (CRC, server health, consensus) on the already-fetched replica metadata, so
+   * inconsistent segments are dropped before a task is scheduled rather than failed later. By mode:
+   * <ul>
+   *   <li>{@code UNSAFE}: first replica with a matching CRC and a healthy server.</li>
+   *   <li>{@code EQUAL}: every replica must respond, match CRC, be healthy, and share an identical bitmap (needs
+   *       {@code includeBitmaps=true}).</li>
+   *   <li>{@code MOST_VALID_DOCS}: every replica must respond, match CRC, and be healthy; pick the one with the most
+   *       valid docs.</li>
+   * </ul>
+   * {@code expectedReplicaCount} is how many replicas must respond for the strict modes (ignored for {@code UNSAFE}).
+   */
+  @Nullable
+  public static ValidDocIdsMetadataInfo selectValidDocIdsMetadataForConsensus(String taskType, String segmentName,
+      long expectedCrc, @Nullable List<ValidDocIdsMetadataInfo> replicas, int expectedReplicaCount,
+      MinionConstants.ValidDocIdsConsensusMode consensusMode) {
+    if (replicas == null || replicas.isEmpty()) {
+      return null;
+    }
+    boolean unsafe = consensusMode == MinionConstants.ValidDocIdsConsensusMode.UNSAFE;
+    List<ValidDocIdsMetadataInfo> usableReplicas = new ArrayList<>();
+    for (ValidDocIdsMetadataInfo replica : replicas) {
+      // A CRC mismatch usually means the server is still reloading the segment, so its valid doc set can't be
+      // trusted. UNSAFE skips just this replica; stricter modes skip the whole segment.
+      long replicaCrc;
+      try {
+        replicaCrc = Long.parseLong(replica.getSegmentCrc());
+      } catch (NumberFormatException e) {
+        LOGGER.warn("Unparseable CRC '{}' for segment: {} from server: {}, skipping {} (mode={}) for {}",
+            replica.getSegmentCrc(), segmentName, replica.getInstanceId(), unsafe ? "replica" : "segment",
+            consensusMode, taskType);
+        if (unsafe) {
+          continue;
+        }
+        return null;
+      }
+      if (expectedCrc != replicaCrc) {
+        LOGGER.warn("CRC mismatch for segment: {} (expected={}, server={} reported={}), skipping {} (mode={}) for {}",
+            segmentName, expectedCrc, replica.getInstanceId(), replicaCrc, unsafe ? "replica" : "segment",
+            consensusMode, taskType);
+        if (unsafe) {
+          continue;
+        }
+        return null;
+      }
+      // A non-GOOD server may still be mutating the segment, so its valid doc set is unreliable.
+      if (replica.getServerStatus() != null && replica.getServerStatus() != ServiceStatus.Status.GOOD) {
+        LOGGER.warn("Server {} is in {} state for segment: {}, skipping {} (mode={}) for {}", replica.getInstanceId(),
+            replica.getServerStatus(), segmentName, unsafe ? "replica" : "segment", consensusMode, taskType);
+        if (unsafe) {
+          continue;
+        }
+        return null;
+      }
+      if (unsafe) {
+        return replica;
+      }
+      usableReplicas.add(replica);
+    }
+
+    if (usableReplicas.isEmpty()) {
+      return null;
+    }
+
+    // Strict modes need every assigned replica to have responded; a short responder list means a server dropped out
+    // (network error, parse failure, or it no longer has the segment), so we can't confirm consensus across the full
+    // replica set and skip the segment.
+    if (usableReplicas.size() < expectedReplicaCount) {
+      LOGGER.warn("Only {} of {} replicas responded for segment: {}, cannot confirm consensus, skipping for {}",
+          usableReplicas.size(), expectedReplicaCount, segmentName, taskType);
+      return null;
+    }
+
+    if (consensusMode == MinionConstants.ValidDocIdsConsensusMode.EQUAL) {
+      ValidDocIdsMetadataInfo first = usableReplicas.get(0);
+      RoaringBitmap consensusBitmap = deserializeBitmapOrNull(first);
+      if (consensusBitmap == null) {
+        // No bitmap means EQUAL can't be verified - skip rather than risk an inconsistent task. Make sure the
+        // metadata was fetched with includeBitmaps=true.
+        LOGGER.warn("Missing validDocIds bitmap for segment: {} from server: {}, cannot verify EQUAL consensus, "
+            + "skipping segment for {}", segmentName, first.getInstanceId(), taskType);
+        return null;
+      }
+      for (int i = 1; i < usableReplicas.size(); i++) {
+        RoaringBitmap bitmap = deserializeBitmapOrNull(usableReplicas.get(i));
+        if (bitmap == null || !bitmap.equals(consensusBitmap)) {
+          LOGGER.warn("Replicas disagree on validDocIds for segment: {}, skipping segment for {}", segmentName,
+              taskType);
+          return null;
+        }
+      }
+      return first;
+    }
+
+    // MOST_VALID_DOCS: pick the replica reporting the most valid docs.
+    ValidDocIdsMetadataInfo chosen = usableReplicas.get(0);
+    for (ValidDocIdsMetadataInfo replica : usableReplicas) {
+      if (replica.getTotalValidDocs() > chosen.getTotalValidDocs()) {
+        chosen = replica;
+      }
+    }
+    return chosen;
+  }
+
+  @Nullable
+  private static RoaringBitmap deserializeBitmapOrNull(ValidDocIdsMetadataInfo info) {
+    byte[] bitmap = info.getBitmap();
+    if (bitmap == null || bitmap.length == 0) {
+      return null;
+    }
+    return RoaringBitmapUtils.deserialize(bitmap);
   }
 
   public static String toUTCString(long epochMillis) {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
@@ -472,9 +472,6 @@ public class MinionTaskUtils {
    *   - UNSAFE: the first replica with a matching CRC and a healthy server.
    *   - EQUAL: all replicas must match CRC, be healthy, and have an identical bitmap.
    *   - MOST_VALID_DOCS: all replicas must match CRC and be healthy; the one with the most valid docs wins.
-   *
-   * For EQUAL and MOST_VALID_DOCS, {@code expectedReplicaCount} replicas must respond, otherwise the segment is
-   * skipped; UNSAFE ignores it.
    */
   @Nullable
   public static ValidDocIdsMetadataInfo selectValidDocIdsMetadataForConsensus(String taskType, String segmentName,

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
@@ -101,21 +101,6 @@ public class MinionTaskUtils {
         ? MinionConstants.ValidDocIdsConsensusMode.UNSAFE : consensusMode;
   }
 
-  /**
-   * Resolves the per-server batch size for the generator's validDocIds fetch. UNSAFE keeps {@code regularBatchSize}
-   * (the no-bitmap fetch). The consensus modes fetch from every replica (and EQUAL also carries a bitmap per entry),
-   * so they use the smaller {@code validDocIdsConsensusFetchBatchSize} to keep the payload bounded.
-   */
-  public static int resolveValidDocIdsFetchBatchSize(Map<String, String> taskConfigs,
-      MinionConstants.ValidDocIdsConsensusMode consensusMode, int regularBatchSize) {
-    if (consensusMode == MinionConstants.ValidDocIdsConsensusMode.UNSAFE) {
-      return regularBatchSize;
-    }
-    return Integer.parseInt(taskConfigs.getOrDefault(
-        MinionConstants.VALID_DOC_IDS_CONSENSUS_FETCH_BATCH_SIZE_KEY,
-        String.valueOf(MinionConstants.DEFAULT_VALID_DOC_IDS_CONSENSUS_FETCH_BATCH_SIZE)));
-  }
-
   private static final String DEFAULT_DIR_PATH_TERMINATOR = "/";
 
   public static final String DATETIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
@@ -485,7 +470,9 @@ public class MinionTaskUtils {
    *
    * How the replica is chosen depends on {@code consensusMode}:
    *   - UNSAFE: the first replica with a matching CRC and a healthy server.
-   *   - EQUAL: all replicas must match CRC, be healthy, and have an identical bitmap.
+   *   - EQUAL: all replicas must match CRC, be healthy, and report the same valid doc count. Counts (rather than
+   *     full bitmaps) are compared here to keep the generator cheap; the executor still verifies byte-identical
+   *     bitmaps before compacting.
    *   - MOST_VALID_DOCS: all replicas must match CRC and be healthy; the one with the most valid docs wins.
    */
   @Nullable
@@ -550,19 +537,12 @@ public class MinionTaskUtils {
     }
 
     if (consensusMode == MinionConstants.ValidDocIdsConsensusMode.EQUAL) {
+      // Require every replica to report the same valid doc count. Comparing counts (rather than the full bitmaps)
+      // keeps the generator cheap - it avoids serializing a bitmap per replica back to the controller.
       ValidDocIdsMetadataInfo first = usableReplicas.get(0);
-      RoaringBitmap consensusBitmap = deserializeBitmapOrNull(first);
-      if (consensusBitmap == null) {
-        // No bitmap means EQUAL can't be verified - skip rather than risk an inconsistent task. Make sure the
-        // metadata was fetched with includeBitmaps=true.
-        LOGGER.warn("Missing validDocIds bitmap for segment: {} from server: {}, cannot verify EQUAL consensus, "
-            + "skipping segment for {}", segmentName, first.getInstanceId(), taskType);
-        return null;
-      }
       for (int i = 1; i < usableReplicas.size(); i++) {
-        RoaringBitmap bitmap = deserializeBitmapOrNull(usableReplicas.get(i));
-        if (bitmap == null || !bitmap.equals(consensusBitmap)) {
-          LOGGER.warn("Replicas disagree on validDocIds for segment: {}, skipping segment for {}", segmentName,
+        if (usableReplicas.get(i).getTotalValidDocs() != first.getTotalValidDocs()) {
+          LOGGER.warn("Replicas disagree on valid doc count for segment: {}, skipping segment for {}", segmentName,
               taskType);
           return null;
         }
@@ -578,15 +558,6 @@ public class MinionTaskUtils {
       }
     }
     return chosen;
-  }
-
-  @Nullable
-  private static RoaringBitmap deserializeBitmapOrNull(ValidDocIdsMetadataInfo info) {
-    byte[] bitmap = info.getBitmap();
-    if (bitmap == null || bitmap.length == 0) {
-      return null;
-    }
-    return RoaringBitmapUtils.deserialize(bitmap);
   }
 
   public static String toUTCString(long epochMillis) {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
@@ -74,7 +74,7 @@ import org.slf4j.LoggerFactory;
 public class MinionTaskUtils {
   private static final Logger LOGGER = LoggerFactory.getLogger(MinionTaskUtils.class);
 
-  /** Parses the validDocIdsConsensusMode config string. Blank/null defaults to {@code EQUAL}. */
+  /// Parses the validDocIdsConsensusMode config string. Blank/null defaults to `EQUAL`.
   public static MinionConstants.ValidDocIdsConsensusMode parseValidDocIdsConsensusMode(String value) {
     if (value == null || value.isBlank()) {
       return MinionConstants.ValidDocIdsConsensusMode.EQUAL;
@@ -82,7 +82,7 @@ public class MinionTaskUtils {
     return MinionConstants.ValidDocIdsConsensusMode.valueOf(value.toUpperCase().trim());
   }
 
-  /** Parses the validDocIdsValidationMode config string. Blank/null defaults to {@code STRICT}. */
+  /// Parses the validDocIdsValidationMode config string. Blank/null defaults to `STRICT`.
   public static MinionConstants.ValidDocIdsValidationMode parseValidDocIdsValidationMode(String value) {
     if (value == null || value.isBlank()) {
       return MinionConstants.ValidDocIdsValidationMode.STRICT;
@@ -90,11 +90,9 @@ public class MinionTaskUtils {
     return MinionConstants.ValidDocIdsValidationMode.valueOf(value.toUpperCase().trim());
   }
 
-  /**
-   * Resolves the consensus mode the generator should apply, given the configured consensus mode and validation mode.
-   * EXECUTOR_ONLY downgrades the generator to UNSAFE (lenient pick, no bitmaps, no cross-replica enforcement) so the
-   * executor stays the sole gate; STRICT keeps the configured mode.
-   */
+  /// Resolves the consensus mode the generator should apply, given the configured consensus mode and validation
+  /// mode. EXECUTOR_ONLY downgrades the generator to UNSAFE (lenient pick, no bitmaps, no cross-replica enforcement)
+  /// so the executor stays the sole gate; STRICT keeps the configured mode.
   public static MinionConstants.ValidDocIdsConsensusMode resolveGeneratorConsensusMode(
       MinionConstants.ValidDocIdsConsensusMode consensusMode,
       MinionConstants.ValidDocIdsValidationMode validationMode) {
@@ -350,7 +348,7 @@ public class MinionTaskUtils {
         expectedCrc, null, comparisonModeStr);
   }
 
-  /** Variant that also matches on the expected data CRC; see {@link #crcMatches}. */
+  /// Variant that also matches on the expected data CRC; see [#crcMatches].
   public static RoaringBitmap getValidDocIdFromServerMatchingCrc(String tableNameWithType, String segmentName,
       String validDocIdsType, MinionContext minionContext, String expectedCrc, @Nullable String expectedDataCrc,
       String comparisonModeStr) {
@@ -460,10 +458,8 @@ public class MinionTaskUtils {
     return maxCardinalityMap;
   }
 
-  /**
-   * Counts how many servers host each segment (its online replica count) from a server-to-segments map, so callers
-   * can tell whether every assigned replica responded.
-   */
+  /// Counts how many servers host each segment (its online replica count) from a server-to-segments map, so callers
+  /// can tell whether every assigned replica responded.
   public static Map<String, Integer> getSegmentToReplicaCount(Map<String, List<String>> serverToSegments) {
     Map<String, Integer> segmentToReplicaCount = new HashMap<>();
     for (List<String> segments : serverToSegments.values()) {
@@ -474,12 +470,10 @@ public class MinionTaskUtils {
     return segmentToReplicaCount;
   }
 
-  /**
-   * Picks the replica whose validDocIds the generator should use, or null to skip the segment, applying the same
-   * checks the executor would so bad segments aren't scheduled: the replica must match CRC (via {@link #crcMatches})
-   * and be on a healthy server. UNSAFE uses the first such replica, EQUAL requires all to report the same valid doc
-   * count, and MOST_VALID_DOCS picks the highest.
-   */
+  /// Picks the replica whose validDocIds the generator should use, or null to skip the segment, applying the same
+  /// checks the executor would so bad segments aren't scheduled: the replica must match CRC (via [#crcMatches]) and
+  /// be on a healthy server. UNSAFE uses the first such replica, EQUAL requires all to report the same valid doc
+  /// count, and MOST_VALID_DOCS picks the highest.
   @Nullable
   public static ValidDocIdsMetadataInfo selectValidDocIdsMetadataForConsensus(String taskType,
       SegmentZKMetadata segmentZKMetadata, @Nullable List<ValidDocIdsMetadataInfo> replicas, int expectedReplicaCount,
@@ -567,13 +561,11 @@ public class MinionTaskUtils {
     return chosen;
   }
 
-  /**
-   * Whether two segment copies hold the same data. Matches on the full segment CRC, or - when those differ - on the
-   * data CRC (a checksum over only the forward index and dictionary, so index/metadata-only changes don't affect it)
-   * when both copies report one ({@code >= 0}). A negative data CRC means "not reported". Mirrors the logic of
-   * {@code BaseTableDataManager.hasSameCRC} and is used by both the generator's pre-scheduling check and the
-   * executor's per-server check.
-   */
+  /// Whether two segment copies hold the same data. Matches on the full segment CRC, or - when those differ - on the
+  /// data CRC (a checksum over only the forward index and dictionary, so index/metadata-only changes don't affect
+  /// it) when both copies report one (`>= 0`). A negative data CRC means "not reported". Mirrors the logic of
+  /// `BaseTableDataManager.hasSameCRC` and is used by both the generator's pre-scheduling check and the executor's
+  /// per-server check.
   @VisibleForTesting
   static boolean crcMatches(long segmentCrc, long dataCrc, long otherSegmentCrc, long otherDataCrc) {
     if (segmentCrc == otherSegmentCrc) {
@@ -582,7 +574,7 @@ public class MinionTaskUtils {
     return dataCrc >= 0 && otherDataCrc >= 0 && dataCrc == otherDataCrc;
   }
 
-  /** Parses a CRC string, returning {@code -1} ("unavailable") when it is null or unparseable. */
+  /// Parses a CRC string, returning `-1` ("unavailable") when it is null or unparseable.
   private static long parseCrc(@Nullable String crc) {
     if (crc == null) {
       return -1;

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
@@ -468,16 +468,13 @@ public class MinionTaskUtils {
    * segment. Applies the same checks the executor would (CRC match, healthy server, replica consensus) so bad
    * segments are dropped before a task is scheduled.
    *
-   * <p>How the replica is chosen depends on {@code consensusMode}:
-   * <ul>
-   *   <li>{@code UNSAFE}: the first replica with a matching CRC and a healthy server.</li>
-   *   <li>{@code EQUAL}: all replicas must match CRC, be healthy, and have an identical bitmap.</li>
-   *   <li>{@code MOST_VALID_DOCS}: all replicas must match CRC and be healthy; the one with the most valid docs
-   *       wins.</li>
-   * </ul>
+   * How the replica is chosen depends on {@code consensusMode}:
+   *   - UNSAFE: the first replica with a matching CRC and a healthy server.
+   *   - EQUAL: all replicas must match CRC, be healthy, and have an identical bitmap.
+   *   - MOST_VALID_DOCS: all replicas must match CRC and be healthy; the one with the most valid docs wins.
    *
-   * <p>For {@code EQUAL} and {@code MOST_VALID_DOCS}, {@code expectedReplicaCount} replicas must respond, otherwise the
-   * segment is skipped; {@code UNSAFE} ignores it.
+   * For EQUAL and MOST_VALID_DOCS, {@code expectedReplicaCount} replicas must respond, otherwise the segment is
+   * skipped; UNSAFE ignores it.
    */
   @Nullable
   public static ValidDocIdsMetadataInfo selectValidDocIdsMetadataForConsensus(String taskType, String segmentName,

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.model.ExternalView;
@@ -467,7 +468,7 @@ public class MinionTaskUtils {
       SegmentZKMetadata segmentZKMetadata, @Nullable List<ValidDocIdsMetadataInfo> replicas, int expectedReplicaCount,
       MinionConstants.ValidDocIdsConsensusMode consensusMode) {
     String segmentName = segmentZKMetadata.getSegmentName();
-    if (replicas == null || replicas.isEmpty()) {
+    if (CollectionUtils.isEmpty(replicas)) {
       return null;
     }
     boolean unsafe = consensusMode == MinionConstants.ValidDocIdsConsensusMode.UNSAFE;

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.plugin.minion.tasks;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.net.URI;
 import java.text.SimpleDateFormat;
@@ -345,6 +346,14 @@ public class MinionTaskUtils {
   @Nullable
   public static RoaringBitmap getValidDocIdFromServerMatchingCrc(String tableNameWithType, String segmentName,
       String validDocIdsType, MinionContext minionContext, String expectedCrc, String comparisonModeStr) {
+    return getValidDocIdFromServerMatchingCrc(tableNameWithType, segmentName, validDocIdsType, minionContext,
+        expectedCrc, null, comparisonModeStr);
+  }
+
+  /** Variant that also matches on the expected data CRC; see {@link #crcMatches}. */
+  public static RoaringBitmap getValidDocIdFromServerMatchingCrc(String tableNameWithType, String segmentName,
+      String validDocIdsType, MinionContext minionContext, String expectedCrc, @Nullable String expectedDataCrc,
+      String comparisonModeStr) {
     MinionConstants.ValidDocIdsConsensusMode consensusMode = parseValidDocIdsConsensusMode(comparisonModeStr);
     String clusterName = minionContext.getHelixManager().getClusterName();
     HelixAdmin helixAdmin = minionContext.getHelixManager().getClusterManagmentTool();
@@ -373,13 +382,15 @@ public class MinionTaskUtils {
       }
 
       String crcFromValidDocIdsBitmap = validDocIdsBitmapResponse.getSegmentCrc();
+      long serverDataCrc = parseCrc(validDocIdsBitmapResponse.getSegmentDataCrc());
       // Check crc from the downloaded segment against the crc returned from the server along with the valid doc id
       // bitmap. If this doesn't match, this means that we are hitting the race condition where the segment has been
       // uploaded successfully while the server is still reloading the segment. Reloading can take a while when the
       // offheap upsert is used because we will need to delete & add all primary keys.
       // `BaseSingleSegmentConversionExecutor.executeTask()` already checks for the crc from the task generator
       // against the crc from the current segment zk metadata, so we don't need to check that here.
-      if (!expectedCrc.equals(crcFromValidDocIdsBitmap)) {
+      if (!crcMatches(parseCrc(expectedCrc), parseCrc(expectedDataCrc), parseCrc(crcFromValidDocIdsBitmap),
+          serverDataCrc)) {
         if (consensusMode == MinionConstants.ValidDocIdsConsensusMode.UNSAFE) {
           LOGGER.warn("CRC mismatch for segment: {} from endpoint {}, skipping", segmentName, endpoint);
           continue;
@@ -468,6 +479,9 @@ public class MinionTaskUtils {
    * segment. Applies the same checks the executor would (CRC match, healthy server, replica consensus) so bad
    * segments are dropped before a task is scheduled.
    *
+   * CRC is matched by {@link #crcMatches} (segment CRC, with the data CRC as a fallback when segment CRCs differ).
+   * The executor uses the same check, so a segment accepted here isn't later rejected on CRC.
+   *
    * How the replica is chosen depends on {@code consensusMode}:
    *   - UNSAFE: the first replica with a matching CRC and a healthy server.
    *   - EQUAL: all replicas must match CRC, be healthy, and report the same valid doc count. Counts (rather than
@@ -476,9 +490,10 @@ public class MinionTaskUtils {
    *   - MOST_VALID_DOCS: all replicas must match CRC and be healthy; the one with the most valid docs wins.
    */
   @Nullable
-  public static ValidDocIdsMetadataInfo selectValidDocIdsMetadataForConsensus(String taskType, String segmentName,
-      long expectedCrc, @Nullable List<ValidDocIdsMetadataInfo> replicas, int expectedReplicaCount,
+  public static ValidDocIdsMetadataInfo selectValidDocIdsMetadataForConsensus(String taskType,
+      SegmentZKMetadata segmentZKMetadata, @Nullable List<ValidDocIdsMetadataInfo> replicas, int expectedReplicaCount,
       MinionConstants.ValidDocIdsConsensusMode consensusMode) {
+    String segmentName = segmentZKMetadata.getSegmentName();
     if (replicas == null || replicas.isEmpty()) {
       return null;
     }
@@ -487,10 +502,8 @@ public class MinionTaskUtils {
     for (ValidDocIdsMetadataInfo replica : replicas) {
       // A CRC mismatch usually means the server is still reloading the segment, so its valid doc set can't be
       // trusted. UNSAFE skips just this replica; stricter modes skip the whole segment.
-      long replicaCrc;
-      try {
-        replicaCrc = Long.parseLong(replica.getSegmentCrc());
-      } catch (NumberFormatException e) {
+      long replicaCrc = parseCrc(replica.getSegmentCrc());
+      if (replicaCrc < 0) {
         LOGGER.warn("Unparseable CRC '{}' for segment: {} from server: {}, skipping {} (mode={}) for {}",
             replica.getSegmentCrc(), segmentName, replica.getInstanceId(), unsafe ? "replica" : "segment",
             consensusMode, taskType);
@@ -499,10 +512,13 @@ public class MinionTaskUtils {
         }
         return null;
       }
-      if (expectedCrc != replicaCrc) {
-        LOGGER.warn("CRC mismatch for segment: {} (expected={}, server={} reported={}), skipping {} (mode={}) for {}",
-            segmentName, expectedCrc, replica.getInstanceId(), replicaCrc, unsafe ? "replica" : "segment",
-            consensusMode, taskType);
+      // -1 when this table doesn't use data CRC, so crcMatches falls back to the segment CRC.
+      long zkDataCrc = segmentZKMetadata.isUseDataCrc() ? segmentZKMetadata.getDataCrc() : -1;
+      if (!crcMatches(segmentZKMetadata.getCrc(), zkDataCrc, replicaCrc, parseCrc(replica.getSegmentDataCrc()))) {
+        LOGGER.warn("CRC mismatch for segment: {} (zkCrc={}, zkDataCrc={}, server={} reported crc={} dataCrc={}), "
+                + "skipping {} (mode={}) for {}", segmentName, segmentZKMetadata.getCrc(),
+            segmentZKMetadata.getDataCrc(), replica.getInstanceId(), replicaCrc, replica.getSegmentDataCrc(),
+            unsafe ? "replica" : "segment", consensusMode, taskType);
         if (unsafe) {
           continue;
         }
@@ -558,6 +574,33 @@ public class MinionTaskUtils {
       }
     }
     return chosen;
+  }
+
+  /**
+   * Whether two segment copies hold the same data. Matches on the full segment CRC, or - when those differ - on the
+   * data CRC (a checksum over only the forward index and dictionary, so index/metadata-only changes don't affect it)
+   * when both copies report one ({@code >= 0}). A negative data CRC means "not reported". Mirrors the logic of
+   * {@code BaseTableDataManager.hasSameCRC} and is used by both the generator's pre-scheduling check and the
+   * executor's per-server check.
+   */
+  @VisibleForTesting
+  static boolean crcMatches(long segmentCrc, long dataCrc, long otherSegmentCrc, long otherDataCrc) {
+    if (segmentCrc == otherSegmentCrc) {
+      return true;
+    }
+    return dataCrc >= 0 && otherDataCrc >= 0 && dataCrc == otherDataCrc;
+  }
+
+  /** Parses a CRC string, returning {@code -1} ("unavailable") when it is null or unparseable. */
+  private static long parseCrc(@Nullable String crc) {
+    if (crc == null) {
+      return -1;
+    }
+    try {
+      return Long.parseLong(crc);
+    } catch (NumberFormatException e) {
+      return -1;
+    }
   }
 
   public static String toUTCString(long epochMillis) {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
@@ -78,10 +78,10 @@ public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExe
     // Executor-only: read comparison mode string from task config (no auth resolution or URL hits).
     Map<String, String> taskConfigs =
         tableConfig.getTaskConfig() != null ? tableConfig.getTaskConfig().getConfigsForTaskType(taskType) : null;
-    String consensusMode =
-        taskConfigs != null ? taskConfigs.getOrDefault(MinionConstants.VALID_DOC_IDS_CONSENSUS_MODE_KEY,
-            MinionConstants.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE)
-            : MinionConstants.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE;
+    String consensusMode = taskConfigs != null
+        ? taskConfigs.getOrDefault(MinionConstants.UpsertCompactionTask.VALID_DOC_IDS_CONSENSUS_MODE_KEY,
+            MinionConstants.UpsertCompactionTask.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE)
+        : MinionConstants.UpsertCompactionTask.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE;
     RoaringBitmap validDocIds =
         MinionTaskUtils.getValidDocIdFromServerMatchingCrc(tableNameWithType, segmentName, validDocIdsTypeStr,
             MINION_CONTEXT, originalSegmentCrcFromTaskGenerator, segmentMetadata.getDataCrc(), consensusMode);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
@@ -79,9 +79,9 @@ public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExe
     Map<String, String> taskConfigs =
         tableConfig.getTaskConfig() != null ? tableConfig.getTaskConfig().getConfigsForTaskType(taskType) : null;
     String consensusMode =
-        taskConfigs != null ? taskConfigs.getOrDefault(UpsertCompactionTask.VALID_DOC_IDS_CONSENSUS_MODE_KEY,
-            UpsertCompactionTask.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE)
-            : UpsertCompactionTask.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE;
+        taskConfigs != null ? taskConfigs.getOrDefault(MinionConstants.VALID_DOC_IDS_CONSENSUS_MODE_KEY,
+            MinionConstants.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE)
+            : MinionConstants.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE;
     RoaringBitmap validDocIds =
         MinionTaskUtils.getValidDocIdFromServerMatchingCrc(tableNameWithType, segmentName, validDocIdsTypeStr,
             MINION_CONTEXT, originalSegmentCrcFromTaskGenerator, consensusMode);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
@@ -84,7 +84,7 @@ public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExe
             : MinionConstants.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE;
     RoaringBitmap validDocIds =
         MinionTaskUtils.getValidDocIdFromServerMatchingCrc(tableNameWithType, segmentName, validDocIdsTypeStr,
-            MINION_CONTEXT, originalSegmentCrcFromTaskGenerator, consensusMode);
+            MINION_CONTEXT, originalSegmentCrcFromTaskGenerator, segmentMetadata.getDataCrc(), consensusMode);
     if (validDocIds == null) {
       // no valid crc match found or no validDocIds obtained from all servers
       // error out the task instead of silently failing so that we can track it via task-error metrics

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
@@ -149,11 +149,11 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
       // scheduled. With EXECUTOR_ONLY the generator skips these checks (the executor stays the gate).
       MinionConstants.ValidDocIdsConsensusMode consensusMode = MinionTaskUtils.resolveGeneratorConsensusMode(
           MinionTaskUtils.parseValidDocIdsConsensusMode(
-              taskConfigs.getOrDefault(MinionConstants.VALID_DOC_IDS_CONSENSUS_MODE_KEY,
-                  MinionConstants.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE)),
+              taskConfigs.getOrDefault(MinionConstants.UpsertCompactionTask.VALID_DOC_IDS_CONSENSUS_MODE_KEY,
+                  MinionConstants.UpsertCompactionTask.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE)),
           MinionTaskUtils.parseValidDocIdsValidationMode(
-              taskConfigs.getOrDefault(MinionConstants.VALID_DOC_IDS_VALIDATION_MODE_KEY,
-                  MinionConstants.DEFAULT_VALID_DOC_IDS_VALIDATION_MODE)));
+              taskConfigs.getOrDefault(MinionConstants.UpsertCompactionTask.VALID_DOC_IDS_VALIDATION_MODE_KEY,
+                  MinionConstants.UpsertCompactionTask.DEFAULT_VALID_DOC_IDS_VALIDATION_MODE)));
 
       // Number of segments to query per server request. If a table has a lot of segments, then we might send a
       // huge payload to pinot-server in request. Batching the requests will help in reducing the payload size.

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
@@ -150,11 +150,11 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
       // only needed for EQUAL consensus, so fetch them only then to keep the payload small.
       MinionConstants.ValidDocIdsConsensusMode consensusMode = MinionTaskUtils.resolveGeneratorConsensusMode(
           MinionTaskUtils.parseValidDocIdsConsensusMode(
-              taskConfigs.getOrDefault(UpsertCompactionTask.VALID_DOC_IDS_CONSENSUS_MODE_KEY,
-                  UpsertCompactionTask.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE)),
+              taskConfigs.getOrDefault(MinionConstants.VALID_DOC_IDS_CONSENSUS_MODE_KEY,
+                  MinionConstants.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE)),
           MinionTaskUtils.parseValidDocIdsValidationMode(
-              taskConfigs.getOrDefault(UpsertCompactionTask.VALID_DOC_IDS_VALIDATION_MODE_KEY,
-                  UpsertCompactionTask.DEFAULT_VALID_DOC_IDS_VALIDATION_MODE)));
+              taskConfigs.getOrDefault(MinionConstants.VALID_DOC_IDS_VALIDATION_MODE_KEY,
+                  MinionConstants.DEFAULT_VALID_DOC_IDS_VALIDATION_MODE)));
       boolean includeBitmaps = consensusMode == MinionConstants.ValidDocIdsConsensusMode.EQUAL;
 
       // Number of segments to query per server request. If a table has a lot of segments, then we might send a

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
@@ -161,22 +161,18 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
           taskConfigs.getOrDefault(UpsertCompactionTask.NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST,
               String.valueOf(DEFAULT_NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST)));
 
-      Map<String, List<ValidDocIdsMetadataInfo>> validDocIdsMetadataList =
+      ServerSegmentMetadataReader.ValidDocIdsMetadataResult validDocIdsMetadataResult =
           serverSegmentMetadataReader.getSegmentToValidDocIdsMetadataFromServer(tableNameWithType, serverToSegments,
               serverToEndpoints, null, 60_000, validDocIdsType.toString(), numSegmentsBatchPerServerRequest);
+      Map<String, List<ValidDocIdsMetadataInfo>> validDocIdsMetadataList =
+          validDocIdsMetadataResult.getSegmentToMetadata();
 
       Map<String, SegmentZKMetadata> completedSegmentsMap =
           completedSegments.stream().collect(Collectors.toMap(SegmentZKMetadata::getSegmentName, Function.identity()));
 
-      // Expected replica count per segment (from the External View), so consensus can skip a segment when not all
-      // of its replicas responded. Only the strict modes use it; UNSAFE never checks it.
-      Map<String, Integer> segmentToReplicaCount =
-          consensusMode == MinionConstants.ValidDocIdsConsensusMode.UNSAFE ? Map.of()
-              : MinionTaskUtils.getSegmentToReplicaCount(serverToSegments);
-
       SegmentSelectionResult segmentSelectionResult =
-          processValidDocIdsMetadata(taskConfigs, completedSegmentsMap, validDocIdsMetadataList, segmentToReplicaCount,
-              consensusMode);
+          processValidDocIdsMetadata(taskConfigs, completedSegmentsMap, validDocIdsMetadataList,
+              validDocIdsMetadataResult.getSegmentToExpectedReplicaCount(), consensusMode);
       int skippedSegmentsCount = validDocIdsMetadataList.size()
               - segmentSelectionResult.getSegmentsForCompaction().size()
               - segmentSelectionResult.getSegmentsForDeletion().size();

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
@@ -245,7 +245,7 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
       // segment should be skipped so we never schedule a task the executor would later reject.
       List<ValidDocIdsMetadataInfo> replicas = validDocIdsMetadataInfoMap.get(segmentName);
       ValidDocIdsMetadataInfo validDocIdsMetadata = MinionTaskUtils.selectValidDocIdsMetadataForConsensus(
-          MinionConstants.UpsertCompactionTask.TASK_TYPE, segmentName, segment.getCrc(), replicas,
+          MinionConstants.UpsertCompactionTask.TASK_TYPE, segment, replicas,
           segmentToReplicaCount.getOrDefault(segmentName, replicas.size()), consensusMode);
       if (validDocIdsMetadata == null) {
         continue;

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
@@ -158,10 +158,14 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
       boolean includeBitmaps = consensusMode == MinionConstants.ValidDocIdsConsensusMode.EQUAL;
 
       // Number of segments to query per server request. If a table has a lot of segments, then we might send a
-      // huge payload to pinot-server in request. Batching the requests will help in reducing the payload size.
-      int numSegmentsBatchPerServerRequest = Integer.parseInt(
+      // huge payload to pinot-server in request. Batching the requests will help in reducing the payload size. The
+      // consensus modes use a smaller batch (validDocIdsConsensusFetchBatchSize) since they fetch from every replica
+      // and EQUAL also carries a bitmap per entry; UNSAFE keeps the regular batch.
+      int regularBatchPerServerRequest = Integer.parseInt(
           taskConfigs.getOrDefault(UpsertCompactionTask.NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST,
               String.valueOf(DEFAULT_NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST)));
+      int numSegmentsBatchPerServerRequest =
+          MinionTaskUtils.resolveValidDocIdsFetchBatchSize(taskConfigs, consensusMode, regularBatchPerServerRequest);
 
       Map<String, List<ValidDocIdsMetadataInfo>> validDocIdsMetadataList =
           serverSegmentMetadataReader.getSegmentToValidDocIdsMetadataFromServer(tableNameWithType, serverToSegments,

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
@@ -34,7 +34,6 @@ import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.restlet.resources.ValidDocIdsMetadataInfo;
 import org.apache.pinot.common.restlet.resources.ValidDocIdsType;
-import org.apache.pinot.common.utils.ServiceStatus;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.minion.generator.BaseTaskGenerator;
 import org.apache.pinot.controller.helix.core.minion.generator.TaskGeneratorUtils;
@@ -146,6 +145,18 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
       ValidDocIdsType validDocIdsType = MinionTaskUtils.getValidDocIdsType(tableConfig.getUpsertConfig(), taskConfigs,
           UpsertCompactionTask.VALID_DOC_IDS_TYPE);
 
+      // Validate replicas before scheduling, matching the executor's checks, so inconsistent segments are never
+      // scheduled. With EXECUTOR_ONLY the generator skips these checks (the executor stays the gate). Bitmaps are
+      // only needed for EQUAL consensus, so fetch them only then to keep the payload small.
+      MinionConstants.ValidDocIdsConsensusMode consensusMode = MinionTaskUtils.resolveGeneratorConsensusMode(
+          MinionTaskUtils.parseValidDocIdsConsensusMode(
+              taskConfigs.getOrDefault(UpsertCompactionTask.VALID_DOC_IDS_CONSENSUS_MODE_KEY,
+                  UpsertCompactionTask.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE)),
+          MinionTaskUtils.parseValidDocIdsValidationMode(
+              taskConfigs.getOrDefault(UpsertCompactionTask.VALID_DOC_IDS_VALIDATION_MODE_KEY,
+                  UpsertCompactionTask.DEFAULT_VALID_DOC_IDS_VALIDATION_MODE)));
+      boolean includeBitmaps = consensusMode == MinionConstants.ValidDocIdsConsensusMode.EQUAL;
+
       // Number of segments to query per server request. If a table has a lot of segments, then we might send a
       // huge payload to pinot-server in request. Batching the requests will help in reducing the payload size.
       int numSegmentsBatchPerServerRequest = Integer.parseInt(
@@ -154,13 +165,21 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
 
       Map<String, List<ValidDocIdsMetadataInfo>> validDocIdsMetadataList =
           serverSegmentMetadataReader.getSegmentToValidDocIdsMetadataFromServer(tableNameWithType, serverToSegments,
-              serverToEndpoints, null, 60_000, validDocIdsType.toString(), numSegmentsBatchPerServerRequest);
+              serverToEndpoints, null, 60_000, validDocIdsType.toString(), numSegmentsBatchPerServerRequest,
+              includeBitmaps);
 
       Map<String, SegmentZKMetadata> completedSegmentsMap =
           completedSegments.stream().collect(Collectors.toMap(SegmentZKMetadata::getSegmentName, Function.identity()));
 
+      // Expected replica count per segment (from the External View), so consensus can skip a segment when not all
+      // of its replicas responded. Only the strict modes use it; UNSAFE never checks it.
+      Map<String, Integer> segmentToReplicaCount =
+          consensusMode == MinionConstants.ValidDocIdsConsensusMode.UNSAFE ? Map.of()
+              : MinionTaskUtils.getSegmentToReplicaCount(serverToSegments);
+
       SegmentSelectionResult segmentSelectionResult =
-          processValidDocIdsMetadata(taskConfigs, completedSegmentsMap, validDocIdsMetadataList);
+          processValidDocIdsMetadata(taskConfigs, completedSegmentsMap, validDocIdsMetadataList, segmentToReplicaCount,
+              consensusMode);
       int skippedSegmentsCount = validDocIdsMetadataList.size()
               - segmentSelectionResult.getSegmentsForCompaction().size()
               - segmentSelectionResult.getSegmentsForDeletion().size();
@@ -207,7 +226,8 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
   @VisibleForTesting
   public static SegmentSelectionResult processValidDocIdsMetadata(Map<String, String> taskConfigs,
       Map<String, SegmentZKMetadata> completedSegmentsMap,
-      Map<String, List<ValidDocIdsMetadataInfo>> validDocIdsMetadataInfoMap) {
+      Map<String, List<ValidDocIdsMetadataInfo>> validDocIdsMetadataInfoMap,
+      Map<String, Integer> segmentToReplicaCount, MinionConstants.ValidDocIdsConsensusMode consensusMode) {
     double invalidRecordsThresholdPercent = Double.parseDouble(
         taskConfigs.getOrDefault(UpsertCompactionTask.INVALID_RECORDS_THRESHOLD_PERCENT,
             String.valueOf(DEFAULT_INVALID_RECORDS_THRESHOLD_PERCENT)));
@@ -223,43 +243,33 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
         continue;
       }
       SegmentZKMetadata segment = completedSegmentsMap.get(segmentName);
-      for (ValidDocIdsMetadataInfo validDocIdsMetadata : validDocIdsMetadataInfoMap.get(segmentName)) {
-        long totalInvalidDocs = validDocIdsMetadata.getTotalInvalidDocs();
 
-        // Skip segments if the crc from zk metadata and server does not match. They may be being reloaded.
-        if (segment.getCrc() != Long.parseLong(validDocIdsMetadata.getSegmentCrc())) {
-          LOGGER.warn("CRC mismatch for segment: {}, (segmentZKMetadata={}, validDocIdsMetadata={})", segmentName,
-              segment.getCrc(), validDocIdsMetadata.getSegmentCrc());
-          continue;
-        }
+      // Validate replicas (CRC match, server health, validDocIds consensus) before scheduling. Returns null when the
+      // segment should be skipped so we never schedule a task the executor would later reject.
+      List<ValidDocIdsMetadataInfo> replicas = validDocIdsMetadataInfoMap.get(segmentName);
+      ValidDocIdsMetadataInfo validDocIdsMetadata = MinionTaskUtils.selectValidDocIdsMetadataForConsensus(
+          MinionConstants.UpsertCompactionTask.TASK_TYPE, segmentName, segment.getCrc(), replicas,
+          segmentToReplicaCount.getOrDefault(segmentName, replicas.size()), consensusMode);
+      if (validDocIdsMetadata == null) {
+        continue;
+      }
 
-        // skipping segments for which their servers are not in READY state. The bitmaps would be inconsistent when
-        // server is NOT READY as UPDATING segments might be updating the ONLINE segments
-        if (validDocIdsMetadata.getServerStatus() != null && !validDocIdsMetadata.getServerStatus()
-            .equals(ServiceStatus.Status.GOOD)) {
-          LOGGER.warn("Server {} is in {} state, skipping {} generation for segment: {}",
-              validDocIdsMetadata.getInstanceId(), validDocIdsMetadata.getServerStatus(),
-              MinionConstants.UpsertCompactionTask.TASK_TYPE, segmentName);
-          continue;
-        }
-
-        long totalDocs = validDocIdsMetadata.getTotalDocs();
-        double invalidRecordPercent = ((double) totalInvalidDocs / totalDocs) * 100;
-        if (totalInvalidDocs == totalDocs) {
-          LOGGER.debug("Segment {} contains only invalid records, adding it to the deletion list", segmentName);
-          segmentsForDeletion.add(segment.getSegmentName());
-        } else if (invalidRecordPercent >= invalidRecordsThresholdPercent
-            && totalInvalidDocs >= invalidRecordsThresholdCount) {
-          LOGGER.debug("Segment {} contains {} invalid records out of {} total records "
-                  + "(count threshold: {}, percent threshold: {}), adding it to the compaction list", segmentName,
-              totalInvalidDocs, totalDocs, invalidRecordsThresholdCount, invalidRecordsThresholdPercent);
-          segmentsForCompaction.add(Pair.of(segment, totalInvalidDocs));
-        } else {
-          LOGGER.debug("Segment {} contains {} invalid records out of {} total records "
-                  + "(count threshold: {}, percent threshold: {}), skipping it for compaction", segmentName,
-              totalInvalidDocs, totalDocs, invalidRecordsThresholdCount, invalidRecordsThresholdPercent);
-        }
-        break;
+      long totalInvalidDocs = validDocIdsMetadata.getTotalInvalidDocs();
+      long totalDocs = validDocIdsMetadata.getTotalDocs();
+      double invalidRecordPercent = ((double) totalInvalidDocs / totalDocs) * 100;
+      if (totalInvalidDocs == totalDocs) {
+        LOGGER.debug("Segment {} contains only invalid records, adding it to the deletion list", segmentName);
+        segmentsForDeletion.add(segment.getSegmentName());
+      } else if (invalidRecordPercent >= invalidRecordsThresholdPercent
+          && totalInvalidDocs >= invalidRecordsThresholdCount) {
+        LOGGER.debug("Segment {} contains {} invalid records out of {} total records "
+                + "(count threshold: {}, percent threshold: {}), adding it to the compaction list", segmentName,
+            totalInvalidDocs, totalDocs, invalidRecordsThresholdCount, invalidRecordsThresholdPercent);
+        segmentsForCompaction.add(Pair.of(segment, totalInvalidDocs));
+      } else {
+        LOGGER.debug("Segment {} contains {} invalid records out of {} total records "
+                + "(count threshold: {}, percent threshold: {}), skipping it for compaction", segmentName,
+            totalInvalidDocs, totalDocs, invalidRecordsThresholdCount, invalidRecordsThresholdPercent);
       }
     }
     segmentsForCompaction.sort((o1, o2) -> {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
@@ -146,8 +146,7 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
           UpsertCompactionTask.VALID_DOC_IDS_TYPE);
 
       // Validate replicas before scheduling, matching the executor's checks, so inconsistent segments are never
-      // scheduled. With EXECUTOR_ONLY the generator skips these checks (the executor stays the gate). Bitmaps are
-      // only needed for EQUAL consensus, so fetch them only then to keep the payload small.
+      // scheduled. With EXECUTOR_ONLY the generator skips these checks (the executor stays the gate).
       MinionConstants.ValidDocIdsConsensusMode consensusMode = MinionTaskUtils.resolveGeneratorConsensusMode(
           MinionTaskUtils.parseValidDocIdsConsensusMode(
               taskConfigs.getOrDefault(MinionConstants.VALID_DOC_IDS_CONSENSUS_MODE_KEY,
@@ -155,22 +154,16 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
           MinionTaskUtils.parseValidDocIdsValidationMode(
               taskConfigs.getOrDefault(MinionConstants.VALID_DOC_IDS_VALIDATION_MODE_KEY,
                   MinionConstants.DEFAULT_VALID_DOC_IDS_VALIDATION_MODE)));
-      boolean includeBitmaps = consensusMode == MinionConstants.ValidDocIdsConsensusMode.EQUAL;
 
       // Number of segments to query per server request. If a table has a lot of segments, then we might send a
-      // huge payload to pinot-server in request. Batching the requests will help in reducing the payload size. The
-      // consensus modes use a smaller batch (validDocIdsConsensusFetchBatchSize) since they fetch from every replica
-      // and EQUAL also carries a bitmap per entry; UNSAFE keeps the regular batch.
-      int regularBatchPerServerRequest = Integer.parseInt(
+      // huge payload to pinot-server in request. Batching the requests will help in reducing the payload size.
+      int numSegmentsBatchPerServerRequest = Integer.parseInt(
           taskConfigs.getOrDefault(UpsertCompactionTask.NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST,
               String.valueOf(DEFAULT_NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST)));
-      int numSegmentsBatchPerServerRequest =
-          MinionTaskUtils.resolveValidDocIdsFetchBatchSize(taskConfigs, consensusMode, regularBatchPerServerRequest);
 
       Map<String, List<ValidDocIdsMetadataInfo>> validDocIdsMetadataList =
           serverSegmentMetadataReader.getSegmentToValidDocIdsMetadataFromServer(tableNameWithType, serverToSegments,
-              serverToEndpoints, null, 60_000, validDocIdsType.toString(), numSegmentsBatchPerServerRequest,
-              includeBitmaps);
+              serverToEndpoints, null, 60_000, validDocIdsType.toString(), numSegmentsBatchPerServerRequest);
 
       Map<String, SegmentZKMetadata> completedSegmentsMap =
           completedSegments.stream().collect(Collectors.toMap(SegmentZKMetadata::getSegmentName, Function.identity()));

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskExecutor.java
@@ -112,9 +112,9 @@ public class UpsertCompactMergeTaskExecutor extends BaseMultipleSegmentsConversi
     Map<String, String> taskConfigs =
         tableConfig.getTaskConfig() != null ? tableConfig.getTaskConfig().getConfigsForTaskType(taskType) : null;
     String consensusMode = taskConfigs != null ? taskConfigs.getOrDefault(
-        MinionConstants.UpsertCompactionTask.VALID_DOC_IDS_CONSENSUS_MODE_KEY,
-        MinionConstants.UpsertCompactionTask.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE)
-        : MinionConstants.UpsertCompactionTask.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE;
+        MinionConstants.VALID_DOC_IDS_CONSENSUS_MODE_KEY,
+        MinionConstants.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE)
+        : MinionConstants.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE;
 
     List<RecordReader> recordReaders = segmentMetadataList.stream().map(x -> {
       RoaringBitmap validDocIds = MinionTaskUtils.getValidDocIdFromServerMatchingCrc(tableNameWithType, x.getName(),

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskExecutor.java
@@ -118,7 +118,7 @@ public class UpsertCompactMergeTaskExecutor extends BaseMultipleSegmentsConversi
 
     List<RecordReader> recordReaders = segmentMetadataList.stream().map(x -> {
       RoaringBitmap validDocIds = MinionTaskUtils.getValidDocIdFromServerMatchingCrc(tableNameWithType, x.getName(),
-          ValidDocIdsType.SNAPSHOT.name(), MINION_CONTEXT, x.getCrc(), consensusMode);
+          ValidDocIdsType.SNAPSHOT.name(), MINION_CONTEXT, x.getCrc(), x.getDataCrc(), consensusMode);
       if (validDocIds == null) {
         // no valid crc match found or no validDocIds obtained from all servers
         // error out the task instead of silently failing so that we can track it via task-error metrics

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskExecutor.java
@@ -112,9 +112,9 @@ public class UpsertCompactMergeTaskExecutor extends BaseMultipleSegmentsConversi
     Map<String, String> taskConfigs =
         tableConfig.getTaskConfig() != null ? tableConfig.getTaskConfig().getConfigsForTaskType(taskType) : null;
     String consensusMode = taskConfigs != null ? taskConfigs.getOrDefault(
-        MinionConstants.VALID_DOC_IDS_CONSENSUS_MODE_KEY,
-        MinionConstants.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE)
-        : MinionConstants.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE;
+        MinionConstants.UpsertCompactionTask.VALID_DOC_IDS_CONSENSUS_MODE_KEY,
+        MinionConstants.UpsertCompactionTask.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE)
+        : MinionConstants.UpsertCompactionTask.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE;
 
     List<RecordReader> recordReaders = segmentMetadataList.stream().map(x -> {
       RoaringBitmap validDocIds = MinionTaskUtils.getValidDocIdFromServerMatchingCrc(tableNameWithType, x.getName(),

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGenerator.java
@@ -194,24 +194,21 @@ public class UpsertCompactMergeTaskGenerator extends BaseTaskGenerator {
           taskConfigs.getOrDefault(MinionConstants.UpsertCompactMergeTask.NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST,
               String.valueOf(DEFAULT_NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST)));
 
-      Map<String, List<ValidDocIdsMetadataInfo>> validDocIdsMetadataList =
+      ServerSegmentMetadataReader.ValidDocIdsMetadataResult validDocIdsMetadataResult =
           serverSegmentMetadataReader.getSegmentToValidDocIdsMetadataFromServer(tableNameWithType, serverToSegments,
               serverToEndpoints, null, 60_000, ValidDocIdsType.SNAPSHOT.toString(), numSegmentsBatchPerServerRequest);
+      Map<String, List<ValidDocIdsMetadataInfo>> validDocIdsMetadataList =
+          validDocIdsMetadataResult.getSegmentToMetadata();
 
       Map<String, SegmentZKMetadata> candidateSegmentsMap =
           candidateSegments.stream().collect(Collectors.toMap(SegmentZKMetadata::getSegmentName, Function.identity()));
 
       Set<String> alreadyMergedSegments = getAlreadyMergedSegments(allSegments);
 
-      // Expected replica count per segment (from the External View), so consensus can skip a segment when not all
-      // of its replicas responded. Only the strict modes use it; UNSAFE never checks it.
-      Map<String, Integer> segmentToReplicaCount =
-          consensusMode == MinionConstants.ValidDocIdsConsensusMode.UNSAFE ? Map.of()
-              : MinionTaskUtils.getSegmentToReplicaCount(serverToSegments);
-
       SegmentSelectionResult segmentSelectionResult =
           processValidDocIdsMetadata(tableNameWithType, taskConfigs, candidateSegmentsMap, validDocIdsMetadataList,
-              alreadyMergedSegments, segmentToReplicaCount, consensusMode, _clusterInfoAccessor.getControllerMetrics());
+              alreadyMergedSegments, validDocIdsMetadataResult.getSegmentToExpectedReplicaCount(), consensusMode,
+              _clusterInfoAccessor.getControllerMetrics());
 
       if (!segmentSelectionResult.getSegmentsForDeletion().isEmpty()) {
         pinotHelixResourceManager.deleteSegments(tableNameWithType, segmentSelectionResult.getSegmentsForDeletion(),

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGenerator.java
@@ -178,6 +178,18 @@ public class UpsertCompactMergeTaskGenerator extends BaseTaskGenerator {
           new ServerSegmentMetadataReader(_clusterInfoAccessor.getExecutor(),
               _clusterInfoAccessor.getConnectionManager());
 
+      // Reuse the compaction task's consensus-mode and validation-mode config so both tasks behave the same. With
+      // EXECUTOR_ONLY the generator skips these checks (the executor stays the gate). Bitmaps are only needed for
+      // EQUAL consensus, so fetch them only then to keep the payload small.
+      MinionConstants.ValidDocIdsConsensusMode consensusMode = MinionTaskUtils.resolveGeneratorConsensusMode(
+          MinionTaskUtils.parseValidDocIdsConsensusMode(
+              taskConfigs.getOrDefault(MinionConstants.UpsertCompactionTask.VALID_DOC_IDS_CONSENSUS_MODE_KEY,
+                  MinionConstants.UpsertCompactionTask.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE)),
+          MinionTaskUtils.parseValidDocIdsValidationMode(
+              taskConfigs.getOrDefault(MinionConstants.UpsertCompactionTask.VALID_DOC_IDS_VALIDATION_MODE_KEY,
+                  MinionConstants.UpsertCompactionTask.DEFAULT_VALID_DOC_IDS_VALIDATION_MODE)));
+      boolean includeBitmaps = consensusMode == MinionConstants.ValidDocIdsConsensusMode.EQUAL;
+
       // Number of segments to query per server request. If a table has a lot of segments, then we might send a
       // huge payload to pinot-server in request. Batching the requests will help in reducing the payload size.
       int numSegmentsBatchPerServerRequest = Integer.parseInt(
@@ -186,16 +198,23 @@ public class UpsertCompactMergeTaskGenerator extends BaseTaskGenerator {
 
       Map<String, List<ValidDocIdsMetadataInfo>> validDocIdsMetadataList =
           serverSegmentMetadataReader.getSegmentToValidDocIdsMetadataFromServer(tableNameWithType, serverToSegments,
-              serverToEndpoints, null, 60_000, ValidDocIdsType.SNAPSHOT.toString(), numSegmentsBatchPerServerRequest);
+              serverToEndpoints, null, 60_000, ValidDocIdsType.SNAPSHOT.toString(), numSegmentsBatchPerServerRequest,
+              includeBitmaps);
 
       Map<String, SegmentZKMetadata> candidateSegmentsMap =
           candidateSegments.stream().collect(Collectors.toMap(SegmentZKMetadata::getSegmentName, Function.identity()));
 
       Set<String> alreadyMergedSegments = getAlreadyMergedSegments(allSegments);
 
+      // Expected replica count per segment (from the External View), so consensus can skip a segment when not all
+      // of its replicas responded. Only the strict modes use it; UNSAFE never checks it.
+      Map<String, Integer> segmentToReplicaCount =
+          consensusMode == MinionConstants.ValidDocIdsConsensusMode.UNSAFE ? Map.of()
+              : MinionTaskUtils.getSegmentToReplicaCount(serverToSegments);
+
       SegmentSelectionResult segmentSelectionResult =
           processValidDocIdsMetadata(tableNameWithType, taskConfigs, candidateSegmentsMap, validDocIdsMetadataList,
-              alreadyMergedSegments, _clusterInfoAccessor.getControllerMetrics());
+              alreadyMergedSegments, segmentToReplicaCount, consensusMode, _clusterInfoAccessor.getControllerMetrics());
 
       if (!segmentSelectionResult.getSegmentsForDeletion().isEmpty()) {
         pinotHelixResourceManager.deleteSegments(tableNameWithType, segmentSelectionResult.getSegmentsForDeletion(),
@@ -249,15 +268,15 @@ public class UpsertCompactMergeTaskGenerator extends BaseTaskGenerator {
   }
 
   /**
-   * Processes validDocIds metadata to determine segments eligible for deletion or compaction.
-   * Evaluates segments based on valid/invalid document counts, server readiness, and CRC consistency.
-   * Requires consensus across all replicas on validDoc counts before proceeding with any operations.
-   * Marks segments with zero valid documents for deletion and groups others by partition for compaction.
+   * Determines which segments are eligible for deletion or compact-merge. For each segment, replicas are validated
+   * via {@code consensusMode} (CRC match, server health, validDocIds agreement); segments that fail are skipped.
+   * Segments with zero valid docs are marked for deletion, the rest are grouped by partition for compaction.
    */
   @VisibleForTesting
   public static SegmentSelectionResult processValidDocIdsMetadata(String tableNameWithType,
       Map<String, String> taskConfigs, Map<String, SegmentZKMetadata> candidateSegmentsMap,
       Map<String, List<ValidDocIdsMetadataInfo>> validDocIdsMetadataInfoMap, Set<String> alreadyMergedSegments,
+      Map<String, Integer> segmentToReplicaCount, MinionConstants.ValidDocIdsConsensusMode consensusMode,
       ControllerMetrics controllerMetrics) {
     Map<Integer, List<SegmentMergerMetadata>> segmentsEligibleForCompactMerge = new HashMap<>();
     Set<String> segmentsForDeletion = new HashSet<>();
@@ -302,40 +321,38 @@ public class UpsertCompactMergeTaskGenerator extends BaseTaskGenerator {
       }
       SegmentZKMetadata segment = candidateSegmentsMap.get(segmentName);
 
-      // Process with existing logic using the first replica with matching CRC (since all have consensus)
-      for (ValidDocIdsMetadataInfo validDocIdsMetadata : validDocIdsMetadataInfoMap.get(segmentName)) {
-        long totalInvalidDocs = validDocIdsMetadata.getTotalInvalidDocs();
-        long totalValidDocs = validDocIdsMetadata.getTotalValidDocs();
-        long segmentSizeInBytes = validDocIdsMetadata.getSegmentSizeInBytes();
+      // Validate replicas (CRC match, server health, validDocIds consensus) before scheduling. Returns null when the
+      // segment should be skipped so we never schedule a task the executor would later reject.
+      List<ValidDocIdsMetadataInfo> replicas = validDocIdsMetadataInfoMap.get(segmentName);
+      ValidDocIdsMetadataInfo validDocIdsMetadata = MinionTaskUtils.selectValidDocIdsMetadataForConsensus(
+          MinionConstants.UpsertCompactMergeTask.TASK_TYPE, segmentName, segment.getCrc(), replicas,
+          segmentToReplicaCount.getOrDefault(segmentName, replicas.size()), consensusMode);
+      if (validDocIdsMetadata == null) {
+        continue;
+      }
 
-        // Skip segments if the crc from zk metadata and server does not match. They may be getting reloaded.
-        if (segment.getCrc() != Long.parseLong(validDocIdsMetadata.getSegmentCrc())) {
-          LOGGER.warn("CRC mismatch for segment: {}, (segmentZKMetadata={}, validDocIdsMetadata={})", segmentName,
-              segment.getCrc(), validDocIdsMetadata.getSegmentCrc());
+      long totalInvalidDocs = validDocIdsMetadata.getTotalInvalidDocs();
+      long totalValidDocs = validDocIdsMetadata.getTotalValidDocs();
+      long segmentSizeInBytes = validDocIdsMetadata.getSegmentSizeInBytes();
+      long totalDocs = validDocIdsMetadata.getTotalDocs();
+
+      // Segments with no valid records can be deleted outright.
+      if (totalInvalidDocs == totalDocs) {
+        segmentsForDeletion.add(segmentName);
+      } else if (alreadyMergedSegments.contains(segmentName)) {
+        LOGGER.debug("Segment {} already merged. Skipping it for {}", segmentName,
+            MinionConstants.UpsertCompactMergeTask.TASK_TYPE);
+      } else {
+        Integer partitionID = SegmentUtils.getPartitionIdFromSegmentName(segmentName);
+        if (partitionID == null) {
+          LOGGER.warn("Partition ID not found for segment: {}, skipping it for {}", segmentName,
+              MinionConstants.UpsertCompactMergeTask.TASK_TYPE);
           continue;
         }
-
-        // segments eligible for deletion with no valid records
-        long totalDocs = validDocIdsMetadata.getTotalDocs();
-        if (totalInvalidDocs == totalDocs) {
-          segmentsForDeletion.add(segmentName);
-        } else if (alreadyMergedSegments.contains(segmentName)) {
-          LOGGER.debug("Segment {} already merged. Skipping it for {}", segmentName,
-              MinionConstants.UpsertCompactMergeTask.TASK_TYPE);
-          break;
-        } else {
-          Integer partitionID = SegmentUtils.getPartitionIdFromSegmentName(segmentName);
-          if (partitionID == null) {
-            LOGGER.warn("Partition ID not found for segment: {}, skipping it for {}", segmentName,
-                MinionConstants.UpsertCompactMergeTask.TASK_TYPE);
-            continue;
-          }
-          double expectedSegmentSizeAfterCompaction = (segmentSizeInBytes * totalValidDocs * 1.0) / totalDocs;
-          segmentsEligibleForCompactMerge.computeIfAbsent(partitionID, k -> new ArrayList<>())
-              .add(new SegmentMergerMetadata(segment, totalValidDocs, totalInvalidDocs,
-                  expectedSegmentSizeAfterCompaction));
-        }
-        break;
+        double expectedSegmentSizeAfterCompaction = (segmentSizeInBytes * totalValidDocs * 1.0) / totalDocs;
+        segmentsEligibleForCompactMerge.computeIfAbsent(partitionID, k -> new ArrayList<>())
+            .add(new SegmentMergerMetadata(segment, totalValidDocs, totalInvalidDocs,
+                expectedSegmentSizeAfterCompaction));
       }
     }
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGenerator.java
@@ -179,8 +179,7 @@ public class UpsertCompactMergeTaskGenerator extends BaseTaskGenerator {
               _clusterInfoAccessor.getConnectionManager());
 
       // Reuse the compaction task's consensus-mode and validation-mode config so both tasks behave the same. With
-      // EXECUTOR_ONLY the generator skips these checks (the executor stays the gate). Bitmaps are only needed for
-      // EQUAL consensus, so fetch them only then to keep the payload small.
+      // EXECUTOR_ONLY the generator skips these checks (the executor stays the gate).
       MinionConstants.ValidDocIdsConsensusMode consensusMode = MinionTaskUtils.resolveGeneratorConsensusMode(
           MinionTaskUtils.parseValidDocIdsConsensusMode(
               taskConfigs.getOrDefault(MinionConstants.VALID_DOC_IDS_CONSENSUS_MODE_KEY,
@@ -188,22 +187,16 @@ public class UpsertCompactMergeTaskGenerator extends BaseTaskGenerator {
           MinionTaskUtils.parseValidDocIdsValidationMode(
               taskConfigs.getOrDefault(MinionConstants.VALID_DOC_IDS_VALIDATION_MODE_KEY,
                   MinionConstants.DEFAULT_VALID_DOC_IDS_VALIDATION_MODE)));
-      boolean includeBitmaps = consensusMode == MinionConstants.ValidDocIdsConsensusMode.EQUAL;
 
       // Number of segments to query per server request. If a table has a lot of segments, then we might send a
-      // huge payload to pinot-server in request. Batching the requests will help in reducing the payload size. The
-      // consensus modes use a smaller batch (validDocIdsConsensusFetchBatchSize) since they fetch from every replica
-      // and EQUAL also carries a bitmap per entry; UNSAFE keeps the regular batch.
-      int regularBatchPerServerRequest = Integer.parseInt(
+      // huge payload to pinot-server in request. Batching the requests will help in reducing the payload size.
+      int numSegmentsBatchPerServerRequest = Integer.parseInt(
           taskConfigs.getOrDefault(MinionConstants.UpsertCompactMergeTask.NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST,
               String.valueOf(DEFAULT_NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST)));
-      int numSegmentsBatchPerServerRequest =
-          MinionTaskUtils.resolveValidDocIdsFetchBatchSize(taskConfigs, consensusMode, regularBatchPerServerRequest);
 
       Map<String, List<ValidDocIdsMetadataInfo>> validDocIdsMetadataList =
           serverSegmentMetadataReader.getSegmentToValidDocIdsMetadataFromServer(tableNameWithType, serverToSegments,
-              serverToEndpoints, null, 60_000, ValidDocIdsType.SNAPSHOT.toString(), numSegmentsBatchPerServerRequest,
-              includeBitmaps);
+              serverToEndpoints, null, 60_000, ValidDocIdsType.SNAPSHOT.toString(), numSegmentsBatchPerServerRequest);
 
       Map<String, SegmentZKMetadata> candidateSegmentsMap =
           candidateSegments.stream().collect(Collectors.toMap(SegmentZKMetadata::getSegmentName, Function.identity()));

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGenerator.java
@@ -191,10 +191,14 @@ public class UpsertCompactMergeTaskGenerator extends BaseTaskGenerator {
       boolean includeBitmaps = consensusMode == MinionConstants.ValidDocIdsConsensusMode.EQUAL;
 
       // Number of segments to query per server request. If a table has a lot of segments, then we might send a
-      // huge payload to pinot-server in request. Batching the requests will help in reducing the payload size.
-      int numSegmentsBatchPerServerRequest = Integer.parseInt(
+      // huge payload to pinot-server in request. Batching the requests will help in reducing the payload size. The
+      // consensus modes use a smaller batch (validDocIdsConsensusFetchBatchSize) since they fetch from every replica
+      // and EQUAL also carries a bitmap per entry; UNSAFE keeps the regular batch.
+      int regularBatchPerServerRequest = Integer.parseInt(
           taskConfigs.getOrDefault(MinionConstants.UpsertCompactMergeTask.NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST,
               String.valueOf(DEFAULT_NUM_SEGMENTS_BATCH_PER_SERVER_REQUEST)));
+      int numSegmentsBatchPerServerRequest =
+          MinionTaskUtils.resolveValidDocIdsFetchBatchSize(taskConfigs, consensusMode, regularBatchPerServerRequest);
 
       Map<String, List<ValidDocIdsMetadataInfo>> validDocIdsMetadataList =
           serverSegmentMetadataReader.getSegmentToValidDocIdsMetadataFromServer(tableNameWithType, serverToSegments,

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGenerator.java
@@ -183,11 +183,11 @@ public class UpsertCompactMergeTaskGenerator extends BaseTaskGenerator {
       // EQUAL consensus, so fetch them only then to keep the payload small.
       MinionConstants.ValidDocIdsConsensusMode consensusMode = MinionTaskUtils.resolveGeneratorConsensusMode(
           MinionTaskUtils.parseValidDocIdsConsensusMode(
-              taskConfigs.getOrDefault(MinionConstants.UpsertCompactionTask.VALID_DOC_IDS_CONSENSUS_MODE_KEY,
-                  MinionConstants.UpsertCompactionTask.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE)),
+              taskConfigs.getOrDefault(MinionConstants.VALID_DOC_IDS_CONSENSUS_MODE_KEY,
+                  MinionConstants.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE)),
           MinionTaskUtils.parseValidDocIdsValidationMode(
-              taskConfigs.getOrDefault(MinionConstants.UpsertCompactionTask.VALID_DOC_IDS_VALIDATION_MODE_KEY,
-                  MinionConstants.UpsertCompactionTask.DEFAULT_VALID_DOC_IDS_VALIDATION_MODE)));
+              taskConfigs.getOrDefault(MinionConstants.VALID_DOC_IDS_VALIDATION_MODE_KEY,
+                  MinionConstants.DEFAULT_VALID_DOC_IDS_VALIDATION_MODE)));
       boolean includeBitmaps = consensusMode == MinionConstants.ValidDocIdsConsensusMode.EQUAL;
 
       // Number of segments to query per server request. If a table has a lot of segments, then we might send a

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGenerator.java
@@ -322,7 +322,7 @@ public class UpsertCompactMergeTaskGenerator extends BaseTaskGenerator {
       // segment should be skipped so we never schedule a task the executor would later reject.
       List<ValidDocIdsMetadataInfo> replicas = validDocIdsMetadataInfoMap.get(segmentName);
       ValidDocIdsMetadataInfo validDocIdsMetadata = MinionTaskUtils.selectValidDocIdsMetadataForConsensus(
-          MinionConstants.UpsertCompactMergeTask.TASK_TYPE, segmentName, segment.getCrc(), replicas,
+          MinionConstants.UpsertCompactMergeTask.TASK_TYPE, segment, replicas,
           segmentToReplicaCount.getOrDefault(segmentName, replicas.size()), consensusMode);
       if (validDocIdsMetadata == null) {
         continue;

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGenerator.java
@@ -182,11 +182,11 @@ public class UpsertCompactMergeTaskGenerator extends BaseTaskGenerator {
       // EXECUTOR_ONLY the generator skips these checks (the executor stays the gate).
       MinionConstants.ValidDocIdsConsensusMode consensusMode = MinionTaskUtils.resolveGeneratorConsensusMode(
           MinionTaskUtils.parseValidDocIdsConsensusMode(
-              taskConfigs.getOrDefault(MinionConstants.VALID_DOC_IDS_CONSENSUS_MODE_KEY,
-                  MinionConstants.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE)),
+              taskConfigs.getOrDefault(MinionConstants.UpsertCompactionTask.VALID_DOC_IDS_CONSENSUS_MODE_KEY,
+                  MinionConstants.UpsertCompactionTask.DEFAULT_VALID_DOC_IDS_CONSENSUS_MODE)),
           MinionTaskUtils.parseValidDocIdsValidationMode(
-              taskConfigs.getOrDefault(MinionConstants.VALID_DOC_IDS_VALIDATION_MODE_KEY,
-                  MinionConstants.DEFAULT_VALID_DOC_IDS_VALIDATION_MODE)));
+              taskConfigs.getOrDefault(MinionConstants.UpsertCompactionTask.VALID_DOC_IDS_VALIDATION_MODE_KEY,
+                  MinionConstants.UpsertCompactionTask.DEFAULT_VALID_DOC_IDS_VALIDATION_MODE)));
 
       // Number of segments to query per server request. If a table has a lot of segments, then we might send a
       // huge payload to pinot-server in request. Batching the requests will help in reducing the payload size.

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtilsTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtilsTest.java
@@ -370,7 +370,7 @@ public class MinionTaskUtilsTest {
   public void testResolveValidDocIdsFetchBatchSize() {
     // UNSAFE keeps the regular (no-bitmap) batch and ignores the consensus key.
     Map<String, String> withConsensusKey = Map.of(
-        MinionConstants.UpsertCompactionTask.VALID_DOC_IDS_CONSENSUS_FETCH_BATCH_SIZE_KEY, "7");
+        MinionConstants.VALID_DOC_IDS_CONSENSUS_FETCH_BATCH_SIZE_KEY, "7");
     assertEquals(MinionTaskUtils.resolveValidDocIdsFetchBatchSize(withConsensusKey,
         MinionConstants.ValidDocIdsConsensusMode.UNSAFE, 500), 500);
 
@@ -380,7 +380,7 @@ public class MinionTaskUtilsTest {
       assertEquals(MinionTaskUtils.resolveValidDocIdsFetchBatchSize(withConsensusKey, mode, 500), 7);
       // Falls back to the small default when the consensus key is absent (does not inherit the regular batch).
       assertEquals(MinionTaskUtils.resolveValidDocIdsFetchBatchSize(Map.of(), mode, 500),
-          MinionConstants.UpsertCompactionTask.DEFAULT_VALID_DOC_IDS_CONSENSUS_FETCH_BATCH_SIZE);
+          MinionConstants.DEFAULT_VALID_DOC_IDS_CONSENSUS_FETCH_BATCH_SIZE);
     }
   }
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtilsTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtilsTest.java
@@ -65,6 +65,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
 
@@ -369,6 +370,40 @@ public class MinionTaskUtilsTest {
   /**
    * Builds a RoaringBitmap with {@code numDocs} valid doc ids (0..numDocs-1).
    */
+  @Test
+  public void testCrcMatches() {
+    // Segment CRC equal -> match (data CRC not consulted).
+    assertTrue(MinionTaskUtils.crcMatches(1000, 5000, 1000, 9999));
+    // Segment CRC differs but data CRC present on both sides and equal -> match (data-CRC fallback).
+    assertTrue(MinionTaskUtils.crcMatches(1000, 5000, 2000, 5000));
+    // Segment CRC differs, data CRC present but differs -> no match.
+    assertFalse(MinionTaskUtils.crcMatches(1000, 5000, 2000, 9999));
+    // Segment CRC differs, data CRC missing on one side -> fall back to segment CRC -> no match.
+    assertFalse(MinionTaskUtils.crcMatches(1000, 5000, 2000, -1));
+    assertFalse(MinionTaskUtils.crcMatches(1000, -1, 2000, 5000));
+    // Segment CRC differs, no data CRC anywhere -> no match.
+    assertFalse(MinionTaskUtils.crcMatches(1000, -1, 2000, -1));
+  }
+
+  @Test
+  public void testExecutorDataCrcFallbackMatch() {
+    // Server's segment CRC differs from expected, but the data CRC matches -> the bitmap is used.
+    List<Object> responses = List.of(makeResponse("seg1", "2000", "5000", "server1", makeBitmap(4)));
+    RoaringBitmap result = getValidDocIdFromServerMatchingCrcWithMockedReader("myTable_REALTIME", "seg1", "1000",
+        "5000", "UNSAFE", responses, new String[]{"server1"}, this);
+    assertNotNull(result);
+    assertEquals(result.getCardinality(), 4);
+  }
+
+  @Test
+  public void testExecutorDataCrcMismatchSkips() {
+    // Both segment CRC and data CRC differ -> the server is skipped, no matching bitmap found.
+    List<Object> responses = List.of(makeResponse("seg1", "2000", "9999", "server1", makeBitmap(4)));
+    RoaringBitmap result = getValidDocIdFromServerMatchingCrcWithMockedReader("myTable_REALTIME", "seg1", "1000",
+        "5000", "UNSAFE", responses, new String[]{"server1"}, this);
+    assertNull(result);
+  }
+
   private static RoaringBitmap makeBitmap(int numDocs) {
     RoaringBitmap b = new RoaringBitmap();
     for (int i = 0; i < numDocs; i++) {
@@ -384,6 +419,12 @@ public class MinionTaskUtilsTest {
       RoaringBitmap bitmap) {
     return new ValidDocIdsBitmapResponse(segmentName, crc, ValidDocIdsType.SNAPSHOT,
         RoaringBitmapUtils.serialize(bitmap), instanceId, ServiceStatus.Status.GOOD);
+  }
+
+  private static ValidDocIdsBitmapResponse makeResponse(String segmentName, String crc, String dataCrc,
+      String instanceId, RoaringBitmap bitmap) {
+    return new ValidDocIdsBitmapResponse(segmentName, crc, ValidDocIdsType.SNAPSHOT,
+        RoaringBitmapUtils.serialize(bitmap), instanceId, ServiceStatus.Status.GOOD, dataCrc);
   }
 
   /**
@@ -428,6 +469,13 @@ public class MinionTaskUtilsTest {
   private static RoaringBitmap getValidDocIdFromServerMatchingCrcWithMockedReader(String tableName,
       String segmentName, String expectedCrc, String consensusMode, List<Object> responseOrThrowByCallOrder,
       String[] servers, MinionTaskUtilsTest testInstance) {
+    return getValidDocIdFromServerMatchingCrcWithMockedReader(tableName, segmentName, expectedCrc, null, consensusMode,
+        responseOrThrowByCallOrder, servers, testInstance);
+  }
+
+  private static RoaringBitmap getValidDocIdFromServerMatchingCrcWithMockedReader(String tableName,
+      String segmentName, String expectedCrc, String expectedDataCrc, String consensusMode,
+      List<Object> responseOrThrowByCallOrder, String[] servers, MinionTaskUtilsTest testInstance) {
     testInstance.setupMinionContextWithServers(tableName, segmentName, servers);
     // Shared across all mock instances (production creates one reader per server).
     AtomicInteger callIndex = new AtomicInteger(0);
@@ -447,7 +495,7 @@ public class MinionTaskUtilsTest {
               });
         })) {
       return MinionTaskUtils.getValidDocIdFromServerMatchingCrc(tableName, segmentName,
-          ValidDocIdsType.SNAPSHOT.name(), MinionContext.getInstance(), expectedCrc, consensusMode);
+          ValidDocIdsType.SNAPSHOT.name(), MinionContext.getInstance(), expectedCrc, expectedDataCrc, consensusMode);
     }
   }
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtilsTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtilsTest.java
@@ -366,24 +366,6 @@ public class MinionTaskUtilsTest {
     }
   }
 
-  @Test
-  public void testResolveValidDocIdsFetchBatchSize() {
-    // UNSAFE keeps the regular (no-bitmap) batch and ignores the consensus key.
-    Map<String, String> withConsensusKey = Map.of(
-        MinionConstants.VALID_DOC_IDS_CONSENSUS_FETCH_BATCH_SIZE_KEY, "7");
-    assertEquals(MinionTaskUtils.resolveValidDocIdsFetchBatchSize(withConsensusKey,
-        MinionConstants.ValidDocIdsConsensusMode.UNSAFE, 500), 500);
-
-    // The consensus modes use the configured consensus batch size.
-    for (MinionConstants.ValidDocIdsConsensusMode mode : List.of(
-        MinionConstants.ValidDocIdsConsensusMode.EQUAL, MinionConstants.ValidDocIdsConsensusMode.MOST_VALID_DOCS)) {
-      assertEquals(MinionTaskUtils.resolveValidDocIdsFetchBatchSize(withConsensusKey, mode, 500), 7);
-      // Falls back to the small default when the consensus key is absent (does not inherit the regular batch).
-      assertEquals(MinionTaskUtils.resolveValidDocIdsFetchBatchSize(Map.of(), mode, 500),
-          MinionConstants.DEFAULT_VALID_DOC_IDS_CONSENSUS_FETCH_BATCH_SIZE);
-    }
-  }
-
   /**
    * Builds a RoaringBitmap with {@code numDocs} valid doc ids (0..numDocs-1).
    */

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtilsTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtilsTest.java
@@ -366,6 +366,24 @@ public class MinionTaskUtilsTest {
     }
   }
 
+  @Test
+  public void testResolveValidDocIdsFetchBatchSize() {
+    // UNSAFE keeps the regular (no-bitmap) batch and ignores the consensus key.
+    Map<String, String> withConsensusKey = Map.of(
+        MinionConstants.UpsertCompactionTask.VALID_DOC_IDS_CONSENSUS_FETCH_BATCH_SIZE_KEY, "7");
+    assertEquals(MinionTaskUtils.resolveValidDocIdsFetchBatchSize(withConsensusKey,
+        MinionConstants.ValidDocIdsConsensusMode.UNSAFE, 500), 500);
+
+    // The consensus modes use the configured consensus batch size.
+    for (MinionConstants.ValidDocIdsConsensusMode mode : List.of(
+        MinionConstants.ValidDocIdsConsensusMode.EQUAL, MinionConstants.ValidDocIdsConsensusMode.MOST_VALID_DOCS)) {
+      assertEquals(MinionTaskUtils.resolveValidDocIdsFetchBatchSize(withConsensusKey, mode, 500), 7);
+      // Falls back to the small default when the consensus key is absent (does not inherit the regular batch).
+      assertEquals(MinionTaskUtils.resolveValidDocIdsFetchBatchSize(Map.of(), mode, 500),
+          MinionConstants.UpsertCompactionTask.DEFAULT_VALID_DOC_IDS_CONSENSUS_FETCH_BATCH_SIZE);
+    }
+  }
+
   /**
    * Builds a RoaringBitmap with {@code numDocs} valid doc ids (0..numDocs-1).
    */

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtilsTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtilsTest.java
@@ -407,14 +407,14 @@ public class MinionTaskUtilsTest {
    */
   private static ValidDocIdsBitmapResponse makeResponse(String segmentName, String crc, String instanceId,
       RoaringBitmap bitmap) {
-    return new ValidDocIdsBitmapResponse(segmentName, crc, ValidDocIdsType.SNAPSHOT,
+    return new ValidDocIdsBitmapResponse(segmentName, crc, null, ValidDocIdsType.SNAPSHOT,
         RoaringBitmapUtils.serialize(bitmap), instanceId, ServiceStatus.Status.GOOD);
   }
 
   private static ValidDocIdsBitmapResponse makeResponse(String segmentName, String crc, String dataCrc,
       String instanceId, RoaringBitmap bitmap) {
-    return new ValidDocIdsBitmapResponse(segmentName, crc, ValidDocIdsType.SNAPSHOT,
-        RoaringBitmapUtils.serialize(bitmap), instanceId, ServiceStatus.Status.GOOD, dataCrc);
+    return new ValidDocIdsBitmapResponse(segmentName, crc, dataCrc, ValidDocIdsType.SNAPSHOT,
+        RoaringBitmapUtils.serialize(bitmap), instanceId, ServiceStatus.Status.GOOD);
   }
 
   /**

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtilsTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtilsTest.java
@@ -331,6 +331,41 @@ public class MinionTaskUtilsTest {
         () -> MinionTaskUtils.parseValidDocIdsConsensusMode("INVALID_MODE"));
   }
 
+  @Test
+  public void testParseValidDocIdsValidationMode() {
+    // Blank/null defaults to STRICT
+    assertEquals(MinionTaskUtils.parseValidDocIdsValidationMode(null),
+        MinionConstants.ValidDocIdsValidationMode.STRICT);
+    assertEquals(MinionTaskUtils.parseValidDocIdsValidationMode(""),
+        MinionConstants.ValidDocIdsValidationMode.STRICT);
+    assertEquals(MinionTaskUtils.parseValidDocIdsValidationMode("  "),
+        MinionConstants.ValidDocIdsValidationMode.STRICT);
+
+    // Case-insensitive parsing
+    assertEquals(MinionTaskUtils.parseValidDocIdsValidationMode("STRICT"),
+        MinionConstants.ValidDocIdsValidationMode.STRICT);
+    assertEquals(MinionTaskUtils.parseValidDocIdsValidationMode("executor_only"),
+        MinionConstants.ValidDocIdsValidationMode.EXECUTOR_ONLY);
+    assertEquals(MinionTaskUtils.parseValidDocIdsValidationMode("  EXECUTOR_ONLY  "),
+        MinionConstants.ValidDocIdsValidationMode.EXECUTOR_ONLY);
+
+    expectThrows(IllegalArgumentException.class,
+        () -> MinionTaskUtils.parseValidDocIdsValidationMode("INVALID_MODE"));
+  }
+
+  @Test
+  public void testResolveGeneratorConsensusMode() {
+    // EXECUTOR_ONLY downgrades the generator to UNSAFE regardless of the configured consensus mode.
+    for (MinionConstants.ValidDocIdsConsensusMode mode : MinionConstants.ValidDocIdsConsensusMode.values()) {
+      assertEquals(
+          MinionTaskUtils.resolveGeneratorConsensusMode(mode, MinionConstants.ValidDocIdsValidationMode.EXECUTOR_ONLY),
+          MinionConstants.ValidDocIdsConsensusMode.UNSAFE);
+      // STRICT keeps the configured mode.
+      assertEquals(
+          MinionTaskUtils.resolveGeneratorConsensusMode(mode, MinionConstants.ValidDocIdsValidationMode.STRICT), mode);
+    }
+  }
+
   /**
    * Builds a RoaringBitmap with {@code numDocs} valid doc ids (0..numDocs-1).
    */

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtilsTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtilsTest.java
@@ -367,27 +367,18 @@ public class MinionTaskUtilsTest {
     }
   }
 
-  /**
-   * Builds a RoaringBitmap with {@code numDocs} valid doc ids (0..numDocs-1).
-   */
   @Test
   public void testCrcMatches() {
-    // Segment CRC equal -> match (data CRC not consulted).
     assertTrue(MinionTaskUtils.crcMatches(1000, 5000, 1000, 9999));
-    // Segment CRC differs but data CRC present on both sides and equal -> match (data-CRC fallback).
     assertTrue(MinionTaskUtils.crcMatches(1000, 5000, 2000, 5000));
-    // Segment CRC differs, data CRC present but differs -> no match.
     assertFalse(MinionTaskUtils.crcMatches(1000, 5000, 2000, 9999));
-    // Segment CRC differs, data CRC missing on one side -> fall back to segment CRC -> no match.
     assertFalse(MinionTaskUtils.crcMatches(1000, 5000, 2000, -1));
     assertFalse(MinionTaskUtils.crcMatches(1000, -1, 2000, 5000));
-    // Segment CRC differs, no data CRC anywhere -> no match.
     assertFalse(MinionTaskUtils.crcMatches(1000, -1, 2000, -1));
   }
 
   @Test
   public void testExecutorDataCrcFallbackMatch() {
-    // Server's segment CRC differs from expected, but the data CRC matches -> the bitmap is used.
     List<Object> responses = List.of(makeResponse("seg1", "2000", "5000", "server1", makeBitmap(4)));
     RoaringBitmap result = getValidDocIdFromServerMatchingCrcWithMockedReader("myTable_REALTIME", "seg1", "1000",
         "5000", "UNSAFE", responses, new String[]{"server1"}, this);
@@ -397,7 +388,6 @@ public class MinionTaskUtilsTest {
 
   @Test
   public void testExecutorDataCrcMismatchSkips() {
-    // Both segment CRC and data CRC differ -> the server is skipped, no matching bitmap found.
     List<Object> responses = List.of(makeResponse("seg1", "2000", "9999", "server1", makeBitmap(4)));
     RoaringBitmap result = getValidDocIdFromServerMatchingCrcWithMockedReader("myTable_REALTIME", "seg1", "1000",
         "5000", "UNSAFE", responses, new String[]{"server1"}, this);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGeneratorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGeneratorTest.java
@@ -28,6 +28,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.restlet.resources.ValidDocIdsMetadataInfo;
+import org.apache.pinot.common.restlet.resources.ValidDocIdsType;
+import org.apache.pinot.common.utils.RoaringBitmapUtils;
+import org.apache.pinot.common.utils.ServiceStatus;
 import org.apache.pinot.controller.helix.core.minion.ClusterInfoAccessor;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.common.MinionConstants.UpsertCompactionTask;
@@ -42,6 +45,7 @@ import org.apache.pinot.spi.utils.Enablement;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.TimeUtils;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.roaringbitmap.RoaringBitmap;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -232,13 +236,13 @@ public class UpsertCompactionTaskGeneratorTest {
     // no completed segments scenario, there shouldn't be any segment selected for compaction
     UpsertCompactionTaskGenerator.SegmentSelectionResult segmentSelectionResult =
         UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, new HashMap<>(),
-            validDocIdsMetadataInfo);
+            validDocIdsMetadataInfo, Map.of(), MinionConstants.ValidDocIdsConsensusMode.UNSAFE);
     assertEquals(segmentSelectionResult.getSegmentsForCompaction().size(), 0);
 
     // test with valid crc and thresholds
     segmentSelectionResult =
         UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
-            validDocIdsMetadataInfo);
+            validDocIdsMetadataInfo, Map.of(), MinionConstants.ValidDocIdsConsensusMode.UNSAFE);
     assertEquals(segmentSelectionResult.getSegmentsForCompaction().size(), 1);
     assertEquals(segmentSelectionResult.getSegmentsForDeletion().size(), 1);
     assertEquals(segmentSelectionResult.getSegmentsForCompaction().get(0).getSegmentName(),
@@ -249,7 +253,7 @@ public class UpsertCompactionTaskGeneratorTest {
     compactionConfigs = getCompactionConfigs("60", "10");
     segmentSelectionResult =
         UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
-            validDocIdsMetadataInfo);
+            validDocIdsMetadataInfo, Map.of(), MinionConstants.ValidDocIdsConsensusMode.UNSAFE);
     assertTrue(segmentSelectionResult.getSegmentsForCompaction().isEmpty());
     assertEquals(segmentSelectionResult.getSegmentsForDeletion().size(), 1);
     assertEquals(segmentSelectionResult.getSegmentsForDeletion().get(0), _completedSegment2.getSegmentName());
@@ -258,7 +262,7 @@ public class UpsertCompactionTaskGeneratorTest {
     compactionConfigs = getCompactionConfigs("0", "10");
     segmentSelectionResult =
         UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
-            validDocIdsMetadataInfo);
+            validDocIdsMetadataInfo, Map.of(), MinionConstants.ValidDocIdsConsensusMode.UNSAFE);
     assertEquals(segmentSelectionResult.getSegmentsForDeletion().size(), 1);
     assertEquals(segmentSelectionResult.getSegmentsForCompaction().size(), 1);
     assertEquals(segmentSelectionResult.getSegmentsForCompaction().get(0).getSegmentName(),
@@ -269,7 +273,7 @@ public class UpsertCompactionTaskGeneratorTest {
     compactionConfigs = getCompactionConfigs("30", "0");
     segmentSelectionResult =
         UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
-            validDocIdsMetadataInfo);
+            validDocIdsMetadataInfo, Map.of(), MinionConstants.ValidDocIdsConsensusMode.UNSAFE);
     assertEquals(segmentSelectionResult.getSegmentsForDeletion().size(), 1);
     assertEquals(segmentSelectionResult.getSegmentsForCompaction().size(), 1);
     assertEquals(segmentSelectionResult.getSegmentsForCompaction().get(0).getSegmentName(),
@@ -288,7 +292,7 @@ public class UpsertCompactionTaskGeneratorTest {
     });
     segmentSelectionResult =
         UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
-            validDocIdsMetadataInfo);
+            validDocIdsMetadataInfo, Map.of(), MinionConstants.ValidDocIdsConsensusMode.UNSAFE);
 
     // completedSegment is supposed to be filtered out
     Assert.assertEquals(segmentSelectionResult.getSegmentsForCompaction().size(), 0);
@@ -313,7 +317,7 @@ public class UpsertCompactionTaskGeneratorTest {
     compactionConfigs = getCompactionConfigs("30", "0");
     segmentSelectionResult =
         UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
-            validDocIdsMetadataInfo);
+            validDocIdsMetadataInfo, Map.of(), MinionConstants.ValidDocIdsConsensusMode.UNSAFE);
     Assert.assertEquals(segmentSelectionResult.getSegmentsForCompaction().size(), 2);
     Assert.assertEquals(segmentSelectionResult.getSegmentsForDeletion().size(), 0);
     assertEquals(segmentSelectionResult.getSegmentsForCompaction().get(0).getSegmentName(),
@@ -324,6 +328,101 @@ public class UpsertCompactionTaskGeneratorTest {
     // Check segmentCreationTimeMillis is deserialized correctly
     assertEquals(validDocIdsMetadataInfo.get("testTable__0").get(0).getSegmentCreationTimeMillis(), 1234567890L);
     assertEquals(validDocIdsMetadataInfo.get("testTable__1").get(0).getSegmentCreationTimeMillis(), 9876543210L);
+  }
+
+  @Test
+  public void testProcessValidDocIdsMetadataConsensus() {
+    Map<String, String> compactionConfigs = getCompactionConfigs("1", "10");
+    String segmentName = _completedSegment.getSegmentName();
+    long crc = _completedSegment.getCrc();
+    // Both replicas are expected to respond.
+    Map<String, Integer> twoReplicas = Map.of(segmentName, 2);
+
+    // EQUAL: replicas agree (identical bitmaps), so the segment is compacted.
+    Map<String, List<ValidDocIdsMetadataInfo>> equalReplicas = Map.of(segmentName, List.of(
+        metaWithBitmap(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1", range(0, 50)),
+        metaWithBitmap(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server2", range(0, 50))));
+    UpsertCompactionTaskGenerator.SegmentSelectionResult result =
+        UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
+            equalReplicas, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL);
+    assertEquals(result.getSegmentsForCompaction().size(), 1);
+
+    // EQUAL: replicas disagree (different bitmaps), so the segment is skipped entirely.
+    Map<String, List<ValidDocIdsMetadataInfo>> unequalReplicas = Map.of(segmentName, List.of(
+        metaWithBitmap(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1", range(0, 50)),
+        metaWithBitmap(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server2", range(1, 51))));
+    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
+        unequalReplicas, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL);
+    assertTrue(result.getSegmentsForCompaction().isEmpty());
+    assertTrue(result.getSegmentsForDeletion().isEmpty());
+
+    // EQUAL: only one of the two assigned replicas responded, so consensus can't be confirmed and the segment is
+    // skipped.
+    Map<String, List<ValidDocIdsMetadataInfo>> oneResponded = Map.of(segmentName, List.of(
+        metaWithBitmap(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1", range(0, 50))));
+    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
+        oneResponded, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL);
+    assertTrue(result.getSegmentsForCompaction().isEmpty());
+
+    // EQUAL: a CRC mismatch on any replica skips the segment.
+    Map<String, List<ValidDocIdsMetadataInfo>> crcMismatch = Map.of(segmentName, List.of(
+        metaWithBitmap(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1", range(0, 50)),
+        metaWithBitmap(segmentName, 50, 50, 100, crc + 1, ServiceStatus.Status.GOOD, "server2", range(0, 50))));
+    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
+        crcMismatch, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL);
+    assertTrue(result.getSegmentsForCompaction().isEmpty());
+
+    // EQUAL: an unhealthy server skips the segment.
+    Map<String, List<ValidDocIdsMetadataInfo>> unhealthy = Map.of(segmentName, List.of(
+        metaWithBitmap(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1", range(0, 50)),
+        metaWithBitmap(segmentName, 50, 50, 100, crc, ServiceStatus.Status.STARTING, "server2", range(0, 50))));
+    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
+        unhealthy, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL);
+    assertTrue(result.getSegmentsForCompaction().isEmpty());
+
+    // UNSAFE: skip the CRC-mismatched replica and use the healthy one. A missing replica is tolerated.
+    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
+        crcMismatch, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.UNSAFE);
+    assertEquals(result.getSegmentsForCompaction().size(), 1);
+
+    // MOST_VALID_DOCS is strict: a CRC-mismatched replica skips the whole segment (unlike UNSAFE).
+    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
+        crcMismatch, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.MOST_VALID_DOCS);
+    assertTrue(result.getSegmentsForCompaction().isEmpty());
+
+    // EQUAL: a replica without a bitmap can't be verified, so the segment is skipped.
+    Map<String, List<ValidDocIdsMetadataInfo>> missingBitmap = Map.of(segmentName, List.of(
+        new ValidDocIdsMetadataInfo(segmentName, 50, 50, 100, String.valueOf(crc), ValidDocIdsType.SNAPSHOT, 1000,
+            System.currentTimeMillis(), "server1", ServiceStatus.Status.GOOD)));
+    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
+        missingBitmap, Map.of(segmentName, 1), MinionConstants.ValidDocIdsConsensusMode.EQUAL);
+    assertTrue(result.getSegmentsForCompaction().isEmpty());
+
+    // MOST_VALID_DOCS: the replica with the most valid docs wins. Here that replica has zero invalid docs, so the
+    // segment is neither compacted nor deleted - proving the other (all-invalid) replica was not chosen.
+    Map<String, List<ValidDocIdsMetadataInfo>> mostValidDocs = Map.of(segmentName, List.of(
+        metaWithBitmap(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1"),
+        metaWithBitmap(segmentName, 100, 0, 100, crc, ServiceStatus.Status.GOOD, "server2", range(0, 100))));
+    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
+        mostValidDocs, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.MOST_VALID_DOCS);
+    assertTrue(result.getSegmentsForCompaction().isEmpty());
+    assertTrue(result.getSegmentsForDeletion().isEmpty());
+  }
+
+  private static ValidDocIdsMetadataInfo metaWithBitmap(String segmentName, long validDocs, long invalidDocs,
+      long totalDocs, long crc, ServiceStatus.Status serverStatus, String instanceId, int... validIds) {
+    RoaringBitmap bitmap = RoaringBitmap.bitmapOf(validIds);
+    return new ValidDocIdsMetadataInfo(segmentName, validDocs, invalidDocs, totalDocs, String.valueOf(crc),
+        ValidDocIdsType.SNAPSHOT, 1000, System.currentTimeMillis(), instanceId, serverStatus,
+        RoaringBitmapUtils.serialize(bitmap));
+  }
+
+  private static int[] range(int fromInclusive, int toExclusive) {
+    int[] ids = new int[toExclusive - fromInclusive];
+    for (int i = 0; i < ids.length; i++) {
+      ids[i] = fromInclusive + i;
+    }
+    return ids;
   }
 
   @Test

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGeneratorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGeneratorTest.java
@@ -333,10 +333,8 @@ public class UpsertCompactionTaskGeneratorTest {
     Map<String, String> compactionConfigs = getCompactionConfigs("1", "10");
     String segmentName = _completedSegment.getSegmentName();
     long crc = _completedSegment.getCrc();
-    // Both replicas are expected to respond.
     Map<String, Integer> twoReplicas = Map.of(segmentName, 2);
 
-    // EQUAL: replicas agree on the valid doc count, so the segment is compacted.
     Map<String, List<ValidDocIdsMetadataInfo>> equalReplicas = Map.of(segmentName, List.of(
         meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1"),
         meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server2")));
@@ -345,7 +343,6 @@ public class UpsertCompactionTaskGeneratorTest {
             equalReplicas, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL);
     assertEquals(result.getSegmentsForCompaction().size(), 1);
 
-    // EQUAL: replicas disagree on the valid doc count, so the segment is skipped entirely.
     Map<String, List<ValidDocIdsMetadataInfo>> unequalReplicas = Map.of(segmentName, List.of(
         meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1"),
         meta(segmentName, 60, 40, 100, crc, ServiceStatus.Status.GOOD, "server2")));
@@ -354,15 +351,12 @@ public class UpsertCompactionTaskGeneratorTest {
     assertTrue(result.getSegmentsForCompaction().isEmpty());
     assertTrue(result.getSegmentsForDeletion().isEmpty());
 
-    // EQUAL: only one of the two assigned replicas responded, so consensus can't be confirmed and the segment is
-    // skipped.
     Map<String, List<ValidDocIdsMetadataInfo>> oneResponded = Map.of(segmentName, List.of(
         meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1")));
     result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
         oneResponded, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL);
     assertTrue(result.getSegmentsForCompaction().isEmpty());
 
-    // EQUAL: a CRC mismatch on any replica skips the segment.
     Map<String, List<ValidDocIdsMetadataInfo>> crcMismatch = Map.of(segmentName, List.of(
         meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1"),
         meta(segmentName, 50, 50, 100, crc + 1, ServiceStatus.Status.GOOD, "server2")));
@@ -370,7 +364,6 @@ public class UpsertCompactionTaskGeneratorTest {
         crcMismatch, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL);
     assertTrue(result.getSegmentsForCompaction().isEmpty());
 
-    // EQUAL: an unhealthy server skips the segment.
     Map<String, List<ValidDocIdsMetadataInfo>> unhealthy = Map.of(segmentName, List.of(
         meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1"),
         meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.STARTING, "server2")));
@@ -378,18 +371,14 @@ public class UpsertCompactionTaskGeneratorTest {
         unhealthy, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL);
     assertTrue(result.getSegmentsForCompaction().isEmpty());
 
-    // UNSAFE: skip the CRC-mismatched replica and use the healthy one. A missing replica is tolerated.
     result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
         crcMismatch, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.UNSAFE);
     assertEquals(result.getSegmentsForCompaction().size(), 1);
 
-    // MOST_VALID_DOCS is strict: a CRC-mismatched replica skips the whole segment (unlike UNSAFE).
     result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
         crcMismatch, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.MOST_VALID_DOCS);
     assertTrue(result.getSegmentsForCompaction().isEmpty());
 
-    // MOST_VALID_DOCS: the replica with the most valid docs wins. Here that replica has zero invalid docs, so the
-    // segment is neither compacted nor deleted - proving the other (all-invalid) replica was not chosen.
     Map<String, List<ValidDocIdsMetadataInfo>> mostValidDocs = Map.of(segmentName, List.of(
         meta(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1"),
         meta(segmentName, 100, 0, 100, crc, ServiceStatus.Status.GOOD, "server2")));
@@ -398,8 +387,6 @@ public class UpsertCompactionTaskGeneratorTest {
     assertTrue(result.getSegmentsForCompaction().isEmpty());
     assertTrue(result.getSegmentsForDeletion().isEmpty());
 
-    // Data CRC: when the segment CRC differs (e.g. an index/metadata-only change) the data CRC is compared as a
-    // fallback, so a segment whose data CRC still matches is accepted.
     SegmentZKMetadata dataCrcSegment = new SegmentZKMetadata(segmentName);
     dataCrcSegment.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
     dataCrcSegment.setTotalDocs(100L);
@@ -414,7 +401,6 @@ public class UpsertCompactionTaskGeneratorTest {
         twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL);
     assertEquals(result.getSegmentsForCompaction().size(), 1);
 
-    // Both segment CRC and data CRC differ from ZK -> skipped (the data-CRC fallback doesn't match either).
     Map<String, List<ValidDocIdsMetadataInfo>> dataCrcMismatch = Map.of(segmentName, List.of(
         metaWithDataCrc(segmentName, 50, 50, 100, 2000, "9999", ServiceStatus.Status.GOOD, "server1"),
         metaWithDataCrc(segmentName, 50, 50, 100, 2000, "9999", ServiceStatus.Status.GOOD, "server2")));

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGeneratorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGeneratorTest.java
@@ -411,14 +411,14 @@ public class UpsertCompactionTaskGeneratorTest {
 
   private static ValidDocIdsMetadataInfo meta(String segmentName, long validDocs, long invalidDocs, long totalDocs,
       long crc, ServiceStatus.Status serverStatus, String instanceId) {
-    return new ValidDocIdsMetadataInfo(segmentName, validDocs, invalidDocs, totalDocs, String.valueOf(crc),
+    return new ValidDocIdsMetadataInfo(segmentName, validDocs, invalidDocs, totalDocs, String.valueOf(crc), null,
         ValidDocIdsType.SNAPSHOT, 1000, System.currentTimeMillis(), instanceId, serverStatus);
   }
 
   private static ValidDocIdsMetadataInfo metaWithDataCrc(String segmentName, long validDocs, long invalidDocs,
       long totalDocs, long crc, String dataCrc, ServiceStatus.Status serverStatus, String instanceId) {
-    return new ValidDocIdsMetadataInfo(segmentName, validDocs, invalidDocs, totalDocs, String.valueOf(crc),
-        ValidDocIdsType.SNAPSHOT, 1000, System.currentTimeMillis(), instanceId, serverStatus, dataCrc);
+    return new ValidDocIdsMetadataInfo(segmentName, validDocs, invalidDocs, totalDocs, String.valueOf(crc), dataCrc,
+        ValidDocIdsType.SNAPSHOT, 1000, System.currentTimeMillis(), instanceId, serverStatus);
   }
 
   @Test

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGeneratorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGeneratorTest.java
@@ -397,12 +397,42 @@ public class UpsertCompactionTaskGeneratorTest {
         mostValidDocs, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.MOST_VALID_DOCS);
     assertTrue(result.getSegmentsForCompaction().isEmpty());
     assertTrue(result.getSegmentsForDeletion().isEmpty());
+
+    // Data CRC: when the segment CRC differs (e.g. an index/metadata-only change) the data CRC is compared as a
+    // fallback, so a segment whose data CRC still matches is accepted.
+    SegmentZKMetadata dataCrcSegment = new SegmentZKMetadata(segmentName);
+    dataCrcSegment.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
+    dataCrcSegment.setTotalDocs(100L);
+    dataCrcSegment.setCrc(1000);
+    dataCrcSegment.setUseDataCrc(true);
+    dataCrcSegment.setDataCrc(5000);
+    Map<String, SegmentZKMetadata> dataCrcMap = Map.of(segmentName, dataCrcSegment);
+    Map<String, List<ValidDocIdsMetadataInfo>> dataCrcMatch = Map.of(segmentName, List.of(
+        metaWithDataCrc(segmentName, 50, 50, 100, 2000, "5000", ServiceStatus.Status.GOOD, "server1"),
+        metaWithDataCrc(segmentName, 50, 50, 100, 2000, "5000", ServiceStatus.Status.GOOD, "server2")));
+    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, dataCrcMap, dataCrcMatch,
+        twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL);
+    assertEquals(result.getSegmentsForCompaction().size(), 1);
+
+    // Both segment CRC and data CRC differ from ZK -> skipped (the data-CRC fallback doesn't match either).
+    Map<String, List<ValidDocIdsMetadataInfo>> dataCrcMismatch = Map.of(segmentName, List.of(
+        metaWithDataCrc(segmentName, 50, 50, 100, 2000, "9999", ServiceStatus.Status.GOOD, "server1"),
+        metaWithDataCrc(segmentName, 50, 50, 100, 2000, "9999", ServiceStatus.Status.GOOD, "server2")));
+    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, dataCrcMap, dataCrcMismatch,
+        twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL);
+    assertTrue(result.getSegmentsForCompaction().isEmpty());
   }
 
   private static ValidDocIdsMetadataInfo meta(String segmentName, long validDocs, long invalidDocs, long totalDocs,
       long crc, ServiceStatus.Status serverStatus, String instanceId) {
     return new ValidDocIdsMetadataInfo(segmentName, validDocs, invalidDocs, totalDocs, String.valueOf(crc),
         ValidDocIdsType.SNAPSHOT, 1000, System.currentTimeMillis(), instanceId, serverStatus);
+  }
+
+  private static ValidDocIdsMetadataInfo metaWithDataCrc(String segmentName, long validDocs, long invalidDocs,
+      long totalDocs, long crc, String dataCrc, ServiceStatus.Status serverStatus, String instanceId) {
+    return new ValidDocIdsMetadataInfo(segmentName, validDocs, invalidDocs, totalDocs, String.valueOf(crc),
+        ValidDocIdsType.SNAPSHOT, 1000, System.currentTimeMillis(), instanceId, serverStatus, dataCrc);
   }
 
   @Test

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGeneratorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGeneratorTest.java
@@ -29,7 +29,6 @@ import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.restlet.resources.ValidDocIdsMetadataInfo;
 import org.apache.pinot.common.restlet.resources.ValidDocIdsType;
-import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.common.utils.ServiceStatus;
 import org.apache.pinot.controller.helix.core.minion.ClusterInfoAccessor;
 import org.apache.pinot.core.common.MinionConstants;
@@ -45,7 +44,6 @@ import org.apache.pinot.spi.utils.Enablement;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.TimeUtils;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
-import org.roaringbitmap.RoaringBitmap;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -338,19 +336,19 @@ public class UpsertCompactionTaskGeneratorTest {
     // Both replicas are expected to respond.
     Map<String, Integer> twoReplicas = Map.of(segmentName, 2);
 
-    // EQUAL: replicas agree (identical bitmaps), so the segment is compacted.
+    // EQUAL: replicas agree on the valid doc count, so the segment is compacted.
     Map<String, List<ValidDocIdsMetadataInfo>> equalReplicas = Map.of(segmentName, List.of(
-        metaWithBitmap(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1", range(0, 50)),
-        metaWithBitmap(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server2", range(0, 50))));
+        meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1"),
+        meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server2")));
     UpsertCompactionTaskGenerator.SegmentSelectionResult result =
         UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
             equalReplicas, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL);
     assertEquals(result.getSegmentsForCompaction().size(), 1);
 
-    // EQUAL: replicas disagree (different bitmaps), so the segment is skipped entirely.
+    // EQUAL: replicas disagree on the valid doc count, so the segment is skipped entirely.
     Map<String, List<ValidDocIdsMetadataInfo>> unequalReplicas = Map.of(segmentName, List.of(
-        metaWithBitmap(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1", range(0, 50)),
-        metaWithBitmap(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server2", range(1, 51))));
+        meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1"),
+        meta(segmentName, 60, 40, 100, crc, ServiceStatus.Status.GOOD, "server2")));
     result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
         unequalReplicas, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL);
     assertTrue(result.getSegmentsForCompaction().isEmpty());
@@ -359,23 +357,23 @@ public class UpsertCompactionTaskGeneratorTest {
     // EQUAL: only one of the two assigned replicas responded, so consensus can't be confirmed and the segment is
     // skipped.
     Map<String, List<ValidDocIdsMetadataInfo>> oneResponded = Map.of(segmentName, List.of(
-        metaWithBitmap(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1", range(0, 50))));
+        meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1")));
     result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
         oneResponded, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL);
     assertTrue(result.getSegmentsForCompaction().isEmpty());
 
     // EQUAL: a CRC mismatch on any replica skips the segment.
     Map<String, List<ValidDocIdsMetadataInfo>> crcMismatch = Map.of(segmentName, List.of(
-        metaWithBitmap(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1", range(0, 50)),
-        metaWithBitmap(segmentName, 50, 50, 100, crc + 1, ServiceStatus.Status.GOOD, "server2", range(0, 50))));
+        meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1"),
+        meta(segmentName, 50, 50, 100, crc + 1, ServiceStatus.Status.GOOD, "server2")));
     result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
         crcMismatch, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL);
     assertTrue(result.getSegmentsForCompaction().isEmpty());
 
     // EQUAL: an unhealthy server skips the segment.
     Map<String, List<ValidDocIdsMetadataInfo>> unhealthy = Map.of(segmentName, List.of(
-        metaWithBitmap(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1", range(0, 50)),
-        metaWithBitmap(segmentName, 50, 50, 100, crc, ServiceStatus.Status.STARTING, "server2", range(0, 50))));
+        meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.GOOD, "server1"),
+        meta(segmentName, 50, 50, 100, crc, ServiceStatus.Status.STARTING, "server2")));
     result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
         unhealthy, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL);
     assertTrue(result.getSegmentsForCompaction().isEmpty());
@@ -390,39 +388,21 @@ public class UpsertCompactionTaskGeneratorTest {
         crcMismatch, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.MOST_VALID_DOCS);
     assertTrue(result.getSegmentsForCompaction().isEmpty());
 
-    // EQUAL: a replica without a bitmap can't be verified, so the segment is skipped.
-    Map<String, List<ValidDocIdsMetadataInfo>> missingBitmap = Map.of(segmentName, List.of(
-        new ValidDocIdsMetadataInfo(segmentName, 50, 50, 100, String.valueOf(crc), ValidDocIdsType.SNAPSHOT, 1000,
-            System.currentTimeMillis(), "server1", ServiceStatus.Status.GOOD)));
-    result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
-        missingBitmap, Map.of(segmentName, 1), MinionConstants.ValidDocIdsConsensusMode.EQUAL);
-    assertTrue(result.getSegmentsForCompaction().isEmpty());
-
     // MOST_VALID_DOCS: the replica with the most valid docs wins. Here that replica has zero invalid docs, so the
     // segment is neither compacted nor deleted - proving the other (all-invalid) replica was not chosen.
     Map<String, List<ValidDocIdsMetadataInfo>> mostValidDocs = Map.of(segmentName, List.of(
-        metaWithBitmap(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1"),
-        metaWithBitmap(segmentName, 100, 0, 100, crc, ServiceStatus.Status.GOOD, "server2", range(0, 100))));
+        meta(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1"),
+        meta(segmentName, 100, 0, 100, crc, ServiceStatus.Status.GOOD, "server2")));
     result = UpsertCompactionTaskGenerator.processValidDocIdsMetadata(compactionConfigs, _completedSegmentsMap,
         mostValidDocs, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.MOST_VALID_DOCS);
     assertTrue(result.getSegmentsForCompaction().isEmpty());
     assertTrue(result.getSegmentsForDeletion().isEmpty());
   }
 
-  private static ValidDocIdsMetadataInfo metaWithBitmap(String segmentName, long validDocs, long invalidDocs,
-      long totalDocs, long crc, ServiceStatus.Status serverStatus, String instanceId, int... validIds) {
-    RoaringBitmap bitmap = RoaringBitmap.bitmapOf(validIds);
+  private static ValidDocIdsMetadataInfo meta(String segmentName, long validDocs, long invalidDocs, long totalDocs,
+      long crc, ServiceStatus.Status serverStatus, String instanceId) {
     return new ValidDocIdsMetadataInfo(segmentName, validDocs, invalidDocs, totalDocs, String.valueOf(crc),
-        ValidDocIdsType.SNAPSHOT, 1000, System.currentTimeMillis(), instanceId, serverStatus,
-        RoaringBitmapUtils.serialize(bitmap));
-  }
-
-  private static int[] range(int fromInclusive, int toExclusive) {
-    int[] ids = new int[toExclusive - fromInclusive];
-    for (int i = 0; i < ids.length; i++) {
-      ids[i] = fromInclusive + i;
-    }
-    return ids;
+        ValidDocIdsType.SNAPSHOT, 1000, System.currentTimeMillis(), instanceId, serverStatus);
   }
 
   @Test

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGeneratorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGeneratorTest.java
@@ -363,11 +363,11 @@ public class UpsertCompactMergeTaskGeneratorTest {
 
     Map<String, List<ValidDocIdsMetadataInfo>> validDocIdsMetadata = new HashMap<>();
     validDocIdsMetadata.put("testTable__0__0__12345", Arrays.asList(
-        new ValidDocIdsMetadataInfo("testTable__0__0__12345", 90, 10, 100, "1000",
+        new ValidDocIdsMetadataInfo("testTable__0__0__12345", 90, 10, 100, "1000", null,
             ValidDocIdsType.SNAPSHOT, 100000, System.currentTimeMillis(), "server1",
             ServiceStatus.Status.GOOD)));
     validDocIdsMetadata.put("testTable__0__1__12346", Arrays.asList(
-        new ValidDocIdsMetadataInfo("testTable__0__1__12346", 8, 2, 10, "2000",
+        new ValidDocIdsMetadataInfo("testTable__0__1__12346", 8, 2, 10, "2000", null,
             ValidDocIdsType.SNAPSHOT, 10000, System.currentTimeMillis(), "server1",
             ServiceStatus.Status.GOOD)));
 
@@ -401,11 +401,11 @@ public class UpsertCompactMergeTaskGeneratorTest {
     Map<String, List<ValidDocIdsMetadataInfo>> validDocIdsMetadata = new HashMap<>();
     // Segment with 0 valid docs - should be marked for deletion
     validDocIdsMetadata.put("testTable__0__0__12345", Arrays.asList(
-        new ValidDocIdsMetadataInfo("testTable__0__0__12345", 0, 100, 100, "1000",
+        new ValidDocIdsMetadataInfo("testTable__0__0__12345", 0, 100, 100, "1000", null,
             ValidDocIdsType.SNAPSHOT, 100000, System.currentTimeMillis(), "server1",
             ServiceStatus.Status.GOOD)));
     validDocIdsMetadata.put("testTable__0__1__12346", Arrays.asList(
-        new ValidDocIdsMetadataInfo("testTable__0__1__12346", 8, 2, 10, "2000",
+        new ValidDocIdsMetadataInfo("testTable__0__1__12346", 8, 2, 10, "2000", null,
             ValidDocIdsType.SNAPSHOT, 10000, System.currentTimeMillis(), "server1",
             ServiceStatus.Status.GOOD)));
 
@@ -486,7 +486,7 @@ public class UpsertCompactMergeTaskGeneratorTest {
 
   private static ValidDocIdsMetadataInfo meta(String segmentName, long validDocs, long invalidDocs, long totalDocs,
       long crc, ServiceStatus.Status serverStatus, String instanceId) {
-    return new ValidDocIdsMetadataInfo(segmentName, validDocs, invalidDocs, totalDocs, String.valueOf(crc),
+    return new ValidDocIdsMetadataInfo(segmentName, validDocs, invalidDocs, totalDocs, String.valueOf(crc), null,
         ValidDocIdsType.SNAPSHOT, 1000, System.currentTimeMillis(), instanceId, serverStatus);
   }
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGeneratorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGeneratorTest.java
@@ -29,7 +29,6 @@ import org.apache.helix.task.TaskState;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.restlet.resources.ValidDocIdsMetadataInfo;
 import org.apache.pinot.common.restlet.resources.ValidDocIdsType;
-import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.common.utils.ServiceStatus;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.minion.ClusterInfoAccessor;
@@ -53,7 +52,6 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.roaringbitmap.RoaringBitmap;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
@@ -438,25 +436,25 @@ public class UpsertCompactMergeTaskGeneratorTest {
 
     // EQUAL: replicas agree (both fully invalid, identical empty bitmaps), so the segment is processed and deleted.
     Map<String, List<ValidDocIdsMetadataInfo>> agree = Map.of(segmentName, List.of(
-        metaWithBitmap(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1"),
-        metaWithBitmap(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server2")));
+        meta(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1"),
+        meta(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server2")));
     SegmentSelectionResult result = UpsertCompactMergeTaskGenerator.processValidDocIdsMetadata(RAW_TABLE_NAME,
         taskConfigs, candidateSegmentsMap, agree, noMerged, twoReplicas,
         MinionConstants.ValidDocIdsConsensusMode.EQUAL, null);
     Assert.assertTrue(result.getSegmentsForDeletion().contains(segmentName));
 
-    // EQUAL: replicas disagree (different valid doc sets), so the segment is skipped.
+    // EQUAL: replicas disagree on the valid doc count, so the segment is skipped.
     Map<String, List<ValidDocIdsMetadataInfo>> disagree = Map.of(segmentName, List.of(
-        metaWithBitmap(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1"),
-        metaWithBitmap(segmentName, 1, 99, 100, crc, ServiceStatus.Status.GOOD, "server2", 0)));
+        meta(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1"),
+        meta(segmentName, 1, 99, 100, crc, ServiceStatus.Status.GOOD, "server2")));
     result = UpsertCompactMergeTaskGenerator.processValidDocIdsMetadata(RAW_TABLE_NAME, taskConfigs,
         candidateSegmentsMap, disagree, noMerged, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL, null);
     Assert.assertTrue(result.getSegmentsForDeletion().isEmpty());
 
     // EQUAL: a CRC mismatch on any replica skips the segment.
     Map<String, List<ValidDocIdsMetadataInfo>> crcMismatch = Map.of(segmentName, List.of(
-        metaWithBitmap(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1"),
-        metaWithBitmap(segmentName, 0, 100, 100, crc + 1, ServiceStatus.Status.GOOD, "server2")));
+        meta(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1"),
+        meta(segmentName, 0, 100, 100, crc + 1, ServiceStatus.Status.GOOD, "server2")));
     result = UpsertCompactMergeTaskGenerator.processValidDocIdsMetadata(RAW_TABLE_NAME, taskConfigs,
         candidateSegmentsMap, crcMismatch, noMerged, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL,
         null);
@@ -464,8 +462,8 @@ public class UpsertCompactMergeTaskGeneratorTest {
 
     // EQUAL: an unhealthy server skips the segment.
     Map<String, List<ValidDocIdsMetadataInfo>> unhealthy = Map.of(segmentName, List.of(
-        metaWithBitmap(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1"),
-        metaWithBitmap(segmentName, 0, 100, 100, crc, ServiceStatus.Status.STARTING, "server2")));
+        meta(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1"),
+        meta(segmentName, 0, 100, 100, crc, ServiceStatus.Status.STARTING, "server2")));
     result = UpsertCompactMergeTaskGenerator.processValidDocIdsMetadata(RAW_TABLE_NAME, taskConfigs,
         candidateSegmentsMap, unhealthy, noMerged, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL, null);
     Assert.assertTrue(result.getSegmentsForDeletion().isEmpty());
@@ -479,8 +477,8 @@ public class UpsertCompactMergeTaskGeneratorTest {
     // MOST_VALID_DOCS: the replica with the most valid docs wins, so the fully-valid replica is chosen and the
     // segment is not deleted (proving the all-invalid replica was not picked).
     Map<String, List<ValidDocIdsMetadataInfo>> mostValidDocs = Map.of(segmentName, List.of(
-        metaWithBitmap(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1"),
-        metaWithBitmap(segmentName, 100, 0, 100, crc, ServiceStatus.Status.GOOD, "server2", range(0, 100))));
+        meta(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1"),
+        meta(segmentName, 100, 0, 100, crc, ServiceStatus.Status.GOOD, "server2")));
     result = UpsertCompactMergeTaskGenerator.processValidDocIdsMetadata(RAW_TABLE_NAME, taskConfigs,
         candidateSegmentsMap, mostValidDocs, noMerged, twoReplicas,
         MinionConstants.ValidDocIdsConsensusMode.MOST_VALID_DOCS, null);
@@ -489,27 +487,17 @@ public class UpsertCompactMergeTaskGeneratorTest {
     // EQUAL: only one of the two assigned replicas responded, so consensus can't be confirmed and the segment is
     // skipped.
     Map<String, List<ValidDocIdsMetadataInfo>> oneResponded = Map.of(segmentName, List.of(
-        metaWithBitmap(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1")));
+        meta(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1")));
     result = UpsertCompactMergeTaskGenerator.processValidDocIdsMetadata(RAW_TABLE_NAME, taskConfigs,
         candidateSegmentsMap, oneResponded, noMerged, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL,
         null);
     Assert.assertTrue(result.getSegmentsForDeletion().isEmpty());
   }
 
-  private static ValidDocIdsMetadataInfo metaWithBitmap(String segmentName, long validDocs, long invalidDocs,
-      long totalDocs, long crc, ServiceStatus.Status serverStatus, String instanceId, int... validIds) {
-    RoaringBitmap bitmap = RoaringBitmap.bitmapOf(validIds);
+  private static ValidDocIdsMetadataInfo meta(String segmentName, long validDocs, long invalidDocs, long totalDocs,
+      long crc, ServiceStatus.Status serverStatus, String instanceId) {
     return new ValidDocIdsMetadataInfo(segmentName, validDocs, invalidDocs, totalDocs, String.valueOf(crc),
-        ValidDocIdsType.SNAPSHOT, 1000, System.currentTimeMillis(), instanceId, serverStatus,
-        RoaringBitmapUtils.serialize(bitmap));
-  }
-
-  private static int[] range(int fromInclusive, int toExclusive) {
-    int[] ids = new int[toExclusive - fromInclusive];
-    for (int i = 0; i < ids.length; i++) {
-      ids[i] = fromInclusive + i;
-    }
-    return ids;
+        ValidDocIdsType.SNAPSHOT, 1000, System.currentTimeMillis(), instanceId, serverStatus);
   }
 
   /**

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGeneratorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGeneratorTest.java
@@ -29,6 +29,7 @@ import org.apache.helix.task.TaskState;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.restlet.resources.ValidDocIdsMetadataInfo;
 import org.apache.pinot.common.restlet.resources.ValidDocIdsType;
+import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.common.utils.ServiceStatus;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.minion.ClusterInfoAccessor;
@@ -52,6 +53,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.roaringbitmap.RoaringBitmap;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
@@ -375,7 +377,7 @@ public class UpsertCompactMergeTaskGeneratorTest {
 
     SegmentSelectionResult result = UpsertCompactMergeTaskGenerator.processValidDocIdsMetadata(
         RAW_TABLE_NAME + "_REALTIME", taskConfigs, candidateSegmentsMap,
-        validDocIdsMetadata, alreadyMergedSegments, null);
+        validDocIdsMetadata, alreadyMergedSegments, Map.of(), MinionConstants.ValidDocIdsConsensusMode.UNSAFE, null);
 
     Assert.assertNotNull(result);
     Assert.assertNotNull(result.getSegmentsForCompactMergeByPartition());
@@ -413,11 +415,101 @@ public class UpsertCompactMergeTaskGeneratorTest {
 
     SegmentSelectionResult result = UpsertCompactMergeTaskGenerator.processValidDocIdsMetadata(
         RAW_TABLE_NAME + "_REALTIME", taskConfigs, candidateSegmentsMap,
-        validDocIdsMetadata, alreadyMergedSegments, null);
+        validDocIdsMetadata, alreadyMergedSegments, Map.of(), MinionConstants.ValidDocIdsConsensusMode.UNSAFE, null);
 
     Assert.assertNotNull(result);
     Assert.assertEquals(result.getSegmentsForDeletion().size(), 1, "Should have one segment for deletion");
     Assert.assertTrue(result.getSegmentsForDeletion().contains("testTable__0__0__12345"));
+  }
+
+  /**
+   * Tests that replica consensus is enforced before a segment is selected. Uses the deletion path (a fully-invalid
+   * segment) as a clean signal: the segment is processed only when its replicas pass the consensus check.
+   */
+  @Test
+  public void testProcessValidDocIdsMetadataConsensus() {
+    Map<String, String> taskConfigs = new HashMap<>();
+    String segmentName = _completedSegment.getSegmentName();
+    long crc = _completedSegment.getCrc();
+    Map<String, SegmentZKMetadata> candidateSegmentsMap = Map.of(segmentName, _completedSegment);
+    Set<String> noMerged = Set.of();
+    // Both replicas are expected to respond.
+    Map<String, Integer> twoReplicas = Map.of(segmentName, 2);
+
+    // EQUAL: replicas agree (both fully invalid, identical empty bitmaps), so the segment is processed and deleted.
+    Map<String, List<ValidDocIdsMetadataInfo>> agree = Map.of(segmentName, List.of(
+        metaWithBitmap(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1"),
+        metaWithBitmap(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server2")));
+    SegmentSelectionResult result = UpsertCompactMergeTaskGenerator.processValidDocIdsMetadata(RAW_TABLE_NAME,
+        taskConfigs, candidateSegmentsMap, agree, noMerged, twoReplicas,
+        MinionConstants.ValidDocIdsConsensusMode.EQUAL, null);
+    Assert.assertTrue(result.getSegmentsForDeletion().contains(segmentName));
+
+    // EQUAL: replicas disagree (different valid doc sets), so the segment is skipped.
+    Map<String, List<ValidDocIdsMetadataInfo>> disagree = Map.of(segmentName, List.of(
+        metaWithBitmap(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1"),
+        metaWithBitmap(segmentName, 1, 99, 100, crc, ServiceStatus.Status.GOOD, "server2", 0)));
+    result = UpsertCompactMergeTaskGenerator.processValidDocIdsMetadata(RAW_TABLE_NAME, taskConfigs,
+        candidateSegmentsMap, disagree, noMerged, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL, null);
+    Assert.assertTrue(result.getSegmentsForDeletion().isEmpty());
+
+    // EQUAL: a CRC mismatch on any replica skips the segment.
+    Map<String, List<ValidDocIdsMetadataInfo>> crcMismatch = Map.of(segmentName, List.of(
+        metaWithBitmap(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1"),
+        metaWithBitmap(segmentName, 0, 100, 100, crc + 1, ServiceStatus.Status.GOOD, "server2")));
+    result = UpsertCompactMergeTaskGenerator.processValidDocIdsMetadata(RAW_TABLE_NAME, taskConfigs,
+        candidateSegmentsMap, crcMismatch, noMerged, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL,
+        null);
+    Assert.assertTrue(result.getSegmentsForDeletion().isEmpty());
+
+    // EQUAL: an unhealthy server skips the segment.
+    Map<String, List<ValidDocIdsMetadataInfo>> unhealthy = Map.of(segmentName, List.of(
+        metaWithBitmap(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1"),
+        metaWithBitmap(segmentName, 0, 100, 100, crc, ServiceStatus.Status.STARTING, "server2")));
+    result = UpsertCompactMergeTaskGenerator.processValidDocIdsMetadata(RAW_TABLE_NAME, taskConfigs,
+        candidateSegmentsMap, unhealthy, noMerged, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL, null);
+    Assert.assertTrue(result.getSegmentsForDeletion().isEmpty());
+
+    // UNSAFE: skip the CRC-mismatched replica and use the healthy one, so the segment is still processed.
+    result = UpsertCompactMergeTaskGenerator.processValidDocIdsMetadata(RAW_TABLE_NAME, taskConfigs,
+        candidateSegmentsMap, crcMismatch, noMerged, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.UNSAFE,
+        null);
+    Assert.assertTrue(result.getSegmentsForDeletion().contains(segmentName));
+
+    // MOST_VALID_DOCS: the replica with the most valid docs wins, so the fully-valid replica is chosen and the
+    // segment is not deleted (proving the all-invalid replica was not picked).
+    Map<String, List<ValidDocIdsMetadataInfo>> mostValidDocs = Map.of(segmentName, List.of(
+        metaWithBitmap(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1"),
+        metaWithBitmap(segmentName, 100, 0, 100, crc, ServiceStatus.Status.GOOD, "server2", range(0, 100))));
+    result = UpsertCompactMergeTaskGenerator.processValidDocIdsMetadata(RAW_TABLE_NAME, taskConfigs,
+        candidateSegmentsMap, mostValidDocs, noMerged, twoReplicas,
+        MinionConstants.ValidDocIdsConsensusMode.MOST_VALID_DOCS, null);
+    Assert.assertTrue(result.getSegmentsForDeletion().isEmpty());
+
+    // EQUAL: only one of the two assigned replicas responded, so consensus can't be confirmed and the segment is
+    // skipped.
+    Map<String, List<ValidDocIdsMetadataInfo>> oneResponded = Map.of(segmentName, List.of(
+        metaWithBitmap(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1")));
+    result = UpsertCompactMergeTaskGenerator.processValidDocIdsMetadata(RAW_TABLE_NAME, taskConfigs,
+        candidateSegmentsMap, oneResponded, noMerged, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL,
+        null);
+    Assert.assertTrue(result.getSegmentsForDeletion().isEmpty());
+  }
+
+  private static ValidDocIdsMetadataInfo metaWithBitmap(String segmentName, long validDocs, long invalidDocs,
+      long totalDocs, long crc, ServiceStatus.Status serverStatus, String instanceId, int... validIds) {
+    RoaringBitmap bitmap = RoaringBitmap.bitmapOf(validIds);
+    return new ValidDocIdsMetadataInfo(segmentName, validDocs, invalidDocs, totalDocs, String.valueOf(crc),
+        ValidDocIdsType.SNAPSHOT, 1000, System.currentTimeMillis(), instanceId, serverStatus,
+        RoaringBitmapUtils.serialize(bitmap));
+  }
+
+  private static int[] range(int fromInclusive, int toExclusive) {
+    int[] ids = new int[toExclusive - fromInclusive];
+    for (int i = 0; i < ids.length; i++) {
+      ids[i] = fromInclusive + i;
+    }
+    return ids;
   }
 
   /**

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGeneratorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGeneratorTest.java
@@ -431,10 +431,8 @@ public class UpsertCompactMergeTaskGeneratorTest {
     long crc = _completedSegment.getCrc();
     Map<String, SegmentZKMetadata> candidateSegmentsMap = Map.of(segmentName, _completedSegment);
     Set<String> noMerged = Set.of();
-    // Both replicas are expected to respond.
     Map<String, Integer> twoReplicas = Map.of(segmentName, 2);
 
-    // EQUAL: replicas agree (both fully invalid, identical empty bitmaps), so the segment is processed and deleted.
     Map<String, List<ValidDocIdsMetadataInfo>> agree = Map.of(segmentName, List.of(
         meta(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1"),
         meta(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server2")));
@@ -443,7 +441,6 @@ public class UpsertCompactMergeTaskGeneratorTest {
         MinionConstants.ValidDocIdsConsensusMode.EQUAL, null);
     Assert.assertTrue(result.getSegmentsForDeletion().contains(segmentName));
 
-    // EQUAL: replicas disagree on the valid doc count, so the segment is skipped.
     Map<String, List<ValidDocIdsMetadataInfo>> disagree = Map.of(segmentName, List.of(
         meta(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1"),
         meta(segmentName, 1, 99, 100, crc, ServiceStatus.Status.GOOD, "server2")));
@@ -451,7 +448,6 @@ public class UpsertCompactMergeTaskGeneratorTest {
         candidateSegmentsMap, disagree, noMerged, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL, null);
     Assert.assertTrue(result.getSegmentsForDeletion().isEmpty());
 
-    // EQUAL: a CRC mismatch on any replica skips the segment.
     Map<String, List<ValidDocIdsMetadataInfo>> crcMismatch = Map.of(segmentName, List.of(
         meta(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1"),
         meta(segmentName, 0, 100, 100, crc + 1, ServiceStatus.Status.GOOD, "server2")));
@@ -460,7 +456,6 @@ public class UpsertCompactMergeTaskGeneratorTest {
         null);
     Assert.assertTrue(result.getSegmentsForDeletion().isEmpty());
 
-    // EQUAL: an unhealthy server skips the segment.
     Map<String, List<ValidDocIdsMetadataInfo>> unhealthy = Map.of(segmentName, List.of(
         meta(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1"),
         meta(segmentName, 0, 100, 100, crc, ServiceStatus.Status.STARTING, "server2")));
@@ -468,14 +463,11 @@ public class UpsertCompactMergeTaskGeneratorTest {
         candidateSegmentsMap, unhealthy, noMerged, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.EQUAL, null);
     Assert.assertTrue(result.getSegmentsForDeletion().isEmpty());
 
-    // UNSAFE: skip the CRC-mismatched replica and use the healthy one, so the segment is still processed.
     result = UpsertCompactMergeTaskGenerator.processValidDocIdsMetadata(RAW_TABLE_NAME, taskConfigs,
         candidateSegmentsMap, crcMismatch, noMerged, twoReplicas, MinionConstants.ValidDocIdsConsensusMode.UNSAFE,
         null);
     Assert.assertTrue(result.getSegmentsForDeletion().contains(segmentName));
 
-    // MOST_VALID_DOCS: the replica with the most valid docs wins, so the fully-valid replica is chosen and the
-    // segment is not deleted (proving the all-invalid replica was not picked).
     Map<String, List<ValidDocIdsMetadataInfo>> mostValidDocs = Map.of(segmentName, List.of(
         meta(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1"),
         meta(segmentName, 100, 0, 100, crc, ServiceStatus.Status.GOOD, "server2")));
@@ -484,8 +476,6 @@ public class UpsertCompactMergeTaskGeneratorTest {
         MinionConstants.ValidDocIdsConsensusMode.MOST_VALID_DOCS, null);
     Assert.assertTrue(result.getSegmentsForDeletion().isEmpty());
 
-    // EQUAL: only one of the two assigned replicas responded, so consensus can't be confirmed and the segment is
-    // skipped.
     Map<String, List<ValidDocIdsMetadataInfo>> oneResponded = Map.of(segmentName, List.of(
         meta(segmentName, 0, 100, 100, crc, ServiceStatus.Status.GOOD, "server1")));
     result = UpsertCompactMergeTaskGenerator.processValidDocIdsMetadata(RAW_TABLE_NAME, taskConfigs,

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -674,24 +674,15 @@ public class TablesResource {
       @ApiParam(value = "Table name including type", required = true, example = "myTable_REALTIME")
       @PathParam("tableNameWithType") String tableNameWithType,
       @ApiParam(value = "Valid doc ids type") @QueryParam("validDocIdsType") String validDocIdsType,
-      @ApiParam(value = "Whether to include the serialized validDocIds bitmap in each per-segment response entry. "
-          + "When true the response payload grows linearly with the number of valid doc bitmaps, so callers should "
-          + "request bitmaps only for the set of segments they actually need cross-replica consensus for.")
-      @QueryParam("includeBitmaps") @DefaultValue("false") boolean includeBitmaps,
       TableSegments tableSegments, @Context HttpHeaders headers) {
     tableNameWithType = DatabaseUtils.translateTableName(tableNameWithType, headers);
     List<String> segmentNames = tableSegments.getSegments();
     return ResourceUtils.convertToJsonString(
-        processValidDocIdsMetadata(tableNameWithType, segmentNames, validDocIdsType, includeBitmaps));
+        processValidDocIdsMetadata(tableNameWithType, segmentNames, validDocIdsType));
   }
 
   private List<Map<String, Object>> processValidDocIdsMetadata(String tableNameWithType, List<String> segments,
       String validDocIdsType) {
-    return processValidDocIdsMetadata(tableNameWithType, segments, validDocIdsType, false);
-  }
-
-  private List<Map<String, Object>> processValidDocIdsMetadata(String tableNameWithType, List<String> segments,
-      String validDocIdsType, boolean includeBitmaps) {
     TableDataManager tableDataManager =
         ServerResourceUtils.checkGetTableDataManager(_serverInstance, tableNameWithType);
     List<String> missingSegments = new ArrayList<>();
@@ -764,9 +755,6 @@ public class TablesResource {
               ((ImmutableSegment) segmentDataManager.getSegment()).getSegmentSizeBytes());
         }
         validDocIdsMetadata.put("segmentCreationTimeMillis", indexSegment.getSegmentMetadata().getIndexCreationTime());
-        if (includeBitmaps) {
-          validDocIdsMetadata.put("bitmap", RoaringBitmapUtils.serialize(validDocIdsSnapshot));
-        }
         allValidDocIdsMetadata.add(validDocIdsMetadata);
       }
       if (nonImmutableSegmentCount > 0) {

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -674,15 +674,24 @@ public class TablesResource {
       @ApiParam(value = "Table name including type", required = true, example = "myTable_REALTIME")
       @PathParam("tableNameWithType") String tableNameWithType,
       @ApiParam(value = "Valid doc ids type") @QueryParam("validDocIdsType") String validDocIdsType,
+      @ApiParam(value = "Whether to include the serialized validDocIds bitmap in each per-segment response entry. "
+          + "When true the response payload grows linearly with the number of valid doc bitmaps, so callers should "
+          + "request bitmaps only for the set of segments they actually need cross-replica consensus for.")
+      @QueryParam("includeBitmaps") @DefaultValue("false") boolean includeBitmaps,
       TableSegments tableSegments, @Context HttpHeaders headers) {
     tableNameWithType = DatabaseUtils.translateTableName(tableNameWithType, headers);
     List<String> segmentNames = tableSegments.getSegments();
     return ResourceUtils.convertToJsonString(
-        processValidDocIdsMetadata(tableNameWithType, segmentNames, validDocIdsType));
+        processValidDocIdsMetadata(tableNameWithType, segmentNames, validDocIdsType, includeBitmaps));
   }
 
   private List<Map<String, Object>> processValidDocIdsMetadata(String tableNameWithType, List<String> segments,
       String validDocIdsType) {
+    return processValidDocIdsMetadata(tableNameWithType, segments, validDocIdsType, false);
+  }
+
+  private List<Map<String, Object>> processValidDocIdsMetadata(String tableNameWithType, List<String> segments,
+      String validDocIdsType, boolean includeBitmaps) {
     TableDataManager tableDataManager =
         ServerResourceUtils.checkGetTableDataManager(_serverInstance, tableNameWithType);
     List<String> missingSegments = new ArrayList<>();
@@ -755,6 +764,9 @@ public class TablesResource {
               ((ImmutableSegment) segmentDataManager.getSegment()).getSegmentSizeBytes());
         }
         validDocIdsMetadata.put("segmentCreationTimeMillis", indexSegment.getSegmentMetadata().getIndexCreationTime());
+        if (includeBitmaps) {
+          validDocIdsMetadata.put("bitmap", RoaringBitmapUtils.serialize(validDocIdsSnapshot));
+        }
         allValidDocIdsMetadata.add(validDocIdsMetadata);
       }
       if (nonImmutableSegmentCount > 0) {

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -64,6 +64,8 @@ import javax.ws.rs.core.StreamingOutput;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.model.IdealState;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadataUtils;
@@ -574,7 +576,8 @@ public class TablesResource {
       byte[] validDocIdsBytes = RoaringBitmapUtils.serialize(validDocIdSnapshot);
       return new ValidDocIdsBitmapResponse(segmentName, indexSegment.getSegmentMetadata().getCrc(),
           finalValidDocIdsType, validDocIdsBytes, _serverInstance.getInstanceDataManager().getInstanceId(),
-          status, getReportableDataCrc(tableNameWithType, segmentName, indexSegment.getSegmentMetadata().getDataCrc()));
+          status, getReportableDataCrc(getSegmentZKMetadataOrNull(tableNameWithType, segmentName),
+              indexSegment.getSegmentMetadata().getDataCrc()));
     } finally {
       tableDataManager.releaseSegment(segmentDataManager);
     }
@@ -705,6 +708,7 @@ public class TablesResource {
       ServiceStatus.Status status = ServiceStatus.getServiceStatus(_instanceId);
 
       List<Map<String, Object>> allValidDocIdsMetadata = new ArrayList<>(segmentDataManagers.size());
+      Map<String, SegmentZKMetadata> segmentZKMetadataMap = getSegmentZKMetadataMap(tableNameWithType);
       for (SegmentDataManager segmentDataManager : segmentDataManagers) {
         IndexSegment indexSegment = segmentDataManager.getSegment();
         if (indexSegment == null) {
@@ -747,7 +751,8 @@ public class TablesResource {
         validDocIdsMetadata.put("totalValidDocs", totalValidDocs);
         validDocIdsMetadata.put("totalInvalidDocs", totalInvalidDocs);
         validDocIdsMetadata.put("segmentCrc", indexSegment.getSegmentMetadata().getCrc());
-        String reportableDataCrc = getReportableDataCrc(tableNameWithType, segmentDataManager.getSegmentName(),
+        String reportableDataCrc = getReportableDataCrc(
+            segmentZKMetadataMap.get(segmentDataManager.getSegmentName()),
             indexSegment.getSegmentMetadata().getDataCrc());
         if (reportableDataCrc != null) {
           validDocIdsMetadata.put("segmentDataCrc", reportableDataCrc);
@@ -786,13 +791,31 @@ public class TablesResource {
    * CRC, since neither has the ZK useDataCrc flag.
    */
   @Nullable
-  private String getReportableDataCrc(String tableNameWithType, String segmentName, String dataCrc) {
-    SegmentZKMetadata zkMetadata = ZKMetadataProvider.getSegmentZKMetadata(
-        _serverInstance.getHelixManager().getHelixPropertyStore(), tableNameWithType, segmentName);
+  private static String getReportableDataCrc(@Nullable SegmentZKMetadata zkMetadata, String dataCrc) {
     if (zkMetadata == null || !zkMetadata.isUseDataCrc() || dataCrc == null || Long.parseLong(dataCrc) < 0) {
       return null;
     }
     return dataCrc;
+  }
+
+  /** All segment ZK metadata for the table, keyed by segment name. Empty when the property store isn't available. */
+  private Map<String, SegmentZKMetadata> getSegmentZKMetadataMap(String tableNameWithType) {
+    ZkHelixPropertyStore<ZNRecord> propertyStore = _serverInstance.getHelixManager().getHelixPropertyStore();
+    if (propertyStore == null) {
+      return Map.of();
+    }
+    Map<String, SegmentZKMetadata> zkMetadataMap = new HashMap<>();
+    for (SegmentZKMetadata zkMetadata : ZKMetadataProvider.getSegmentsZKMetadata(propertyStore, tableNameWithType)) {
+      zkMetadataMap.put(zkMetadata.getSegmentName(), zkMetadata);
+    }
+    return zkMetadataMap;
+  }
+
+  @Nullable
+  private SegmentZKMetadata getSegmentZKMetadataOrNull(String tableNameWithType, String segmentName) {
+    ZkHelixPropertyStore<ZNRecord> propertyStore = _serverInstance.getHelixManager().getHelixPropertyStore();
+    return propertyStore == null ? null
+        : ZKMetadataProvider.getSegmentZKMetadata(propertyStore, tableNameWithType, segmentName);
   }
 
   private Pair<ValidDocIdsType, MutableRoaringBitmap> getValidDocIds(IndexSegment indexSegment,

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -574,7 +574,7 @@ public class TablesResource {
       byte[] validDocIdsBytes = RoaringBitmapUtils.serialize(validDocIdSnapshot);
       return new ValidDocIdsBitmapResponse(segmentName, indexSegment.getSegmentMetadata().getCrc(),
           finalValidDocIdsType, validDocIdsBytes, _serverInstance.getInstanceDataManager().getInstanceId(),
-          status);
+          status, getReportableDataCrc(tableNameWithType, segmentName, indexSegment.getSegmentMetadata().getDataCrc()));
     } finally {
       tableDataManager.releaseSegment(segmentDataManager);
     }
@@ -747,6 +747,11 @@ public class TablesResource {
         validDocIdsMetadata.put("totalValidDocs", totalValidDocs);
         validDocIdsMetadata.put("totalInvalidDocs", totalInvalidDocs);
         validDocIdsMetadata.put("segmentCrc", indexSegment.getSegmentMetadata().getCrc());
+        String reportableDataCrc = getReportableDataCrc(tableNameWithType, segmentDataManager.getSegmentName(),
+            indexSegment.getSegmentMetadata().getDataCrc());
+        if (reportableDataCrc != null) {
+          validDocIdsMetadata.put("segmentDataCrc", reportableDataCrc);
+        }
         validDocIdsMetadata.put("validDocIdsType", finalValidDocIdsType);
         validDocIdsMetadata.put("serverStatus", status);
         validDocIdsMetadata.put("instanceId", _serverInstance.getInstanceDataManager().getInstanceId());
@@ -772,6 +777,22 @@ public class TablesResource {
         tableDataManager.releaseSegment(segmentDataManager);
       }
     }
+  }
+
+  /**
+   * Returns the segment's data CRC to report, or null when it shouldn't be matched on data CRC. Only segments
+   * committed from a consuming segment carry a trusted data CRC (isUseDataCrc), so callers fall back to the full
+   * segment CRC otherwise. Reporting null keeps the generator and executor consistent on which segments use data
+   * CRC, since neither has the ZK useDataCrc flag.
+   */
+  @Nullable
+  private String getReportableDataCrc(String tableNameWithType, String segmentName, String dataCrc) {
+    SegmentZKMetadata zkMetadata = ZKMetadataProvider.getSegmentZKMetadata(
+        _serverInstance.getHelixManager().getHelixPropertyStore(), tableNameWithType, segmentName);
+    if (zkMetadata == null || !zkMetadata.isUseDataCrc() || dataCrc == null || Long.parseLong(dataCrc) < 0) {
+      return null;
+    }
+    return dataCrc;
   }
 
   private Pair<ValidDocIdsType, MutableRoaringBitmap> getValidDocIds(IndexSegment indexSegment,

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -64,8 +64,6 @@ import javax.ws.rs.core.StreamingOutput;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.model.IdealState;
-import org.apache.helix.store.zk.ZkHelixPropertyStore;
-import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadataUtils;
@@ -575,9 +573,8 @@ public class TablesResource {
       }
       byte[] validDocIdsBytes = RoaringBitmapUtils.serialize(validDocIdSnapshot);
       return new ValidDocIdsBitmapResponse(segmentName, indexSegment.getSegmentMetadata().getCrc(),
-          finalValidDocIdsType, validDocIdsBytes, _serverInstance.getInstanceDataManager().getInstanceId(),
-          status, getReportableDataCrc(getSegmentZKMetadataOrNull(tableNameWithType, segmentName),
-              indexSegment.getSegmentMetadata().getDataCrc()));
+          toReportableDataCrc(indexSegment.getSegmentMetadata().getDataCrc()), finalValidDocIdsType, validDocIdsBytes,
+          _serverInstance.getInstanceDataManager().getInstanceId(), status);
     } finally {
       tableDataManager.releaseSegment(segmentDataManager);
     }
@@ -708,7 +705,6 @@ public class TablesResource {
       ServiceStatus.Status status = ServiceStatus.getServiceStatus(_instanceId);
 
       List<Map<String, Object>> allValidDocIdsMetadata = new ArrayList<>(segmentDataManagers.size());
-      Map<String, SegmentZKMetadata> segmentZKMetadataMap = getSegmentZKMetadataMap(tableNameWithType);
       for (SegmentDataManager segmentDataManager : segmentDataManagers) {
         IndexSegment indexSegment = segmentDataManager.getSegment();
         if (indexSegment == null) {
@@ -751,9 +747,7 @@ public class TablesResource {
         validDocIdsMetadata.put("totalValidDocs", totalValidDocs);
         validDocIdsMetadata.put("totalInvalidDocs", totalInvalidDocs);
         validDocIdsMetadata.put("segmentCrc", indexSegment.getSegmentMetadata().getCrc());
-        String reportableDataCrc = getReportableDataCrc(
-            segmentZKMetadataMap.get(segmentDataManager.getSegmentName()),
-            indexSegment.getSegmentMetadata().getDataCrc());
+        String reportableDataCrc = toReportableDataCrc(indexSegment.getSegmentMetadata().getDataCrc());
         if (reportableDataCrc != null) {
           validDocIdsMetadata.put("segmentDataCrc", reportableDataCrc);
         }
@@ -784,36 +778,10 @@ public class TablesResource {
     }
   }
 
-  /// Returns the segment's data CRC to report, or null when it shouldn't be matched on data CRC. Only segments
-  /// committed from a consuming segment carry a trusted data CRC (isUseDataCrc), so callers fall back to the full
-  /// segment CRC otherwise. Reporting null keeps the generator and executor consistent on which segments use data
-  /// CRC, since neither has the ZK useDataCrc flag.
+  /// The segment's data CRC to report, or null when unavailable (negative).
   @Nullable
-  private static String getReportableDataCrc(@Nullable SegmentZKMetadata zkMetadata, String dataCrc) {
-    if (zkMetadata == null || !zkMetadata.isUseDataCrc() || dataCrc == null || Long.parseLong(dataCrc) < 0) {
-      return null;
-    }
-    return dataCrc;
-  }
-
-  /// All segment ZK metadata for the table, keyed by segment name. Empty when the property store isn't available.
-  private Map<String, SegmentZKMetadata> getSegmentZKMetadataMap(String tableNameWithType) {
-    ZkHelixPropertyStore<ZNRecord> propertyStore = _serverInstance.getHelixManager().getHelixPropertyStore();
-    if (propertyStore == null) {
-      return Map.of();
-    }
-    Map<String, SegmentZKMetadata> zkMetadataMap = new HashMap<>();
-    for (SegmentZKMetadata zkMetadata : ZKMetadataProvider.getSegmentsZKMetadata(propertyStore, tableNameWithType)) {
-      zkMetadataMap.put(zkMetadata.getSegmentName(), zkMetadata);
-    }
-    return zkMetadataMap;
-  }
-
-  @Nullable
-  private SegmentZKMetadata getSegmentZKMetadataOrNull(String tableNameWithType, String segmentName) {
-    ZkHelixPropertyStore<ZNRecord> propertyStore = _serverInstance.getHelixManager().getHelixPropertyStore();
-    return propertyStore == null ? null
-        : ZKMetadataProvider.getSegmentZKMetadata(propertyStore, tableNameWithType, segmentName);
+  private static String toReportableDataCrc(String dataCrc) {
+    return dataCrc != null && Long.parseLong(dataCrc) >= 0 ? dataCrc : null;
   }
 
   private Pair<ValidDocIdsType, MutableRoaringBitmap> getValidDocIds(IndexSegment indexSegment,

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -784,12 +784,10 @@ public class TablesResource {
     }
   }
 
-  /**
-   * Returns the segment's data CRC to report, or null when it shouldn't be matched on data CRC. Only segments
-   * committed from a consuming segment carry a trusted data CRC (isUseDataCrc), so callers fall back to the full
-   * segment CRC otherwise. Reporting null keeps the generator and executor consistent on which segments use data
-   * CRC, since neither has the ZK useDataCrc flag.
-   */
+  /// Returns the segment's data CRC to report, or null when it shouldn't be matched on data CRC. Only segments
+  /// committed from a consuming segment carry a trusted data CRC (isUseDataCrc), so callers fall back to the full
+  /// segment CRC otherwise. Reporting null keeps the generator and executor consistent on which segments use data
+  /// CRC, since neither has the ZK useDataCrc flag.
   @Nullable
   private static String getReportableDataCrc(@Nullable SegmentZKMetadata zkMetadata, String dataCrc) {
     if (zkMetadata == null || !zkMetadata.isUseDataCrc() || dataCrc == null || Long.parseLong(dataCrc) < 0) {
@@ -798,7 +796,7 @@ public class TablesResource {
     return dataCrc;
   }
 
-  /** All segment ZK metadata for the table, keyed by segment name. Empty when the property store isn't available. */
+  /// All segment ZK metadata for the table, keyed by segment name. Empty when the property store isn't available.
   private Map<String, SegmentZKMetadata> getSegmentZKMetadataMap(String tableNameWithType) {
     ZkHelixPropertyStore<ZNRecord> propertyStore = _serverInstance.getHelixManager().getHelixPropertyStore();
     if (propertyStore == null) {

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
@@ -399,44 +399,12 @@ public class TablesResourceTest extends BaseResourceTest {
         ((ImmutableSegmentImpl) segment).getSegmentSizeBytes());
     Assert.assertTrue(validDocIdsMetadata.has("segmentCreationTimeMillis"));
     Assert.assertTrue(validDocIdsMetadata.get("segmentCreationTimeMillis").asLong() > 0);
-    // bitmap field is omitted by default (includeBitmaps was not requested).
-    Assert.assertFalse(validDocIdsMetadata.has("bitmap"),
-        "Bitmap should not be included by default to keep response payloads small");
 
     // Verify server status information
     Assert.assertTrue(validDocIdsMetadata.has("serverStatus"), "Server status should be included in response");
     String serverStatus = validDocIdsMetadata.get("serverStatus").asText();
     Assert.assertNotNull(serverStatus, "Server status should not be null");
     Assert.assertEquals(serverStatus, "NOT_STARTED", serverStatus);
-  }
-
-  @Test
-  public void testValidDocIdsMetadataPostWithIncludeBitmaps()
-      throws IOException {
-    IndexSegment segment = _realtimeIndexSegments.get(0);
-
-    List<String> segments = List.of(segment.getSegmentName());
-    TableSegments tableSegments = new TableSegments(segments);
-    String validDocIdsMetadataPath = "/tables/" + REALTIME_TABLE_NAME + "/validDocIdsMetadata";
-    String response = _webTarget.path(validDocIdsMetadataPath)
-        .queryParam("includeBitmaps", "true")
-        .request()
-        .post(Entity.json(tableSegments), String.class);
-    JsonNode validDocIdsMetadata = JsonUtils.stringToJsonNode(response).get(0);
-
-    // The metadata counts are still emitted alongside the bitmap.
-    Assert.assertEquals(validDocIdsMetadata.get("totalValidDocs").asInt(), 8);
-    Assert.assertEquals(validDocIdsMetadata.get("totalDocs").asInt(), 200000);
-
-    // The bitmap should now be present and its cardinality must match totalValidDocs.
-    Assert.assertTrue(validDocIdsMetadata.has("bitmap"),
-        "Bitmap field should be included when includeBitmaps=true");
-    byte[] bitmapBytes = validDocIdsMetadata.get("bitmap").binaryValue();
-    Assert.assertNotNull(bitmapBytes);
-    org.roaringbitmap.RoaringBitmap bitmap = new org.roaringbitmap.RoaringBitmap();
-    bitmap.deserialize(java.nio.ByteBuffer.wrap(bitmapBytes));
-    Assert.assertEquals(bitmap.getCardinality(), 8,
-        "Deserialized bitmap cardinality must equal totalValidDocs");
   }
 
   @Test

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
@@ -399,12 +399,44 @@ public class TablesResourceTest extends BaseResourceTest {
         ((ImmutableSegmentImpl) segment).getSegmentSizeBytes());
     Assert.assertTrue(validDocIdsMetadata.has("segmentCreationTimeMillis"));
     Assert.assertTrue(validDocIdsMetadata.get("segmentCreationTimeMillis").asLong() > 0);
+    // bitmap field is omitted by default (includeBitmaps was not requested).
+    Assert.assertFalse(validDocIdsMetadata.has("bitmap"),
+        "Bitmap should not be included by default to keep response payloads small");
 
     // Verify server status information
     Assert.assertTrue(validDocIdsMetadata.has("serverStatus"), "Server status should be included in response");
     String serverStatus = validDocIdsMetadata.get("serverStatus").asText();
     Assert.assertNotNull(serverStatus, "Server status should not be null");
     Assert.assertEquals(serverStatus, "NOT_STARTED", serverStatus);
+  }
+
+  @Test
+  public void testValidDocIdsMetadataPostWithIncludeBitmaps()
+      throws IOException {
+    IndexSegment segment = _realtimeIndexSegments.get(0);
+
+    List<String> segments = List.of(segment.getSegmentName());
+    TableSegments tableSegments = new TableSegments(segments);
+    String validDocIdsMetadataPath = "/tables/" + REALTIME_TABLE_NAME + "/validDocIdsMetadata";
+    String response = _webTarget.path(validDocIdsMetadataPath)
+        .queryParam("includeBitmaps", "true")
+        .request()
+        .post(Entity.json(tableSegments), String.class);
+    JsonNode validDocIdsMetadata = JsonUtils.stringToJsonNode(response).get(0);
+
+    // The metadata counts are still emitted alongside the bitmap.
+    Assert.assertEquals(validDocIdsMetadata.get("totalValidDocs").asInt(), 8);
+    Assert.assertEquals(validDocIdsMetadata.get("totalDocs").asInt(), 200000);
+
+    // The bitmap should now be present and its cardinality must match totalValidDocs.
+    Assert.assertTrue(validDocIdsMetadata.has("bitmap"),
+        "Bitmap field should be included when includeBitmaps=true");
+    byte[] bitmapBytes = validDocIdsMetadata.get("bitmap").binaryValue();
+    Assert.assertNotNull(bitmapBytes);
+    org.roaringbitmap.RoaringBitmap bitmap = new org.roaringbitmap.RoaringBitmap();
+    bitmap.deserialize(java.nio.ByteBuffer.wrap(bitmapBytes));
+    Assert.assertEquals(bitmap.getCardinality(), 8,
+        "Deserialized bitmap cardinality must equal totalValidDocs");
   }
 
   @Test


### PR DESCRIPTION
## Summary

Make the upsert task generators reject segments with inconsistent replicas before scheduling, instead of relying on the executor to fail those tasks after the fact. Concretely, this PR:

1. Applies the executor's validDocIds consensus checks (CRC match, server health, and EQUAL / UNSAFE / MOST_VALID_DOCS) in UpsertCompactionTaskGenerator and UpsertCompactMergeTaskGenerator, skipping any segment whose replicas disagree.
2. In EQUAL mode the generator compares the valid-doc count across replicas, not the full bitmaps. Comparing counts keeps the generator cheap — it avoids serializing a RoaringBitmap per replica back to the controller — while the executor still verifies byte-identical bitmaps before compacting, so a count match that hides a set difference is caught there.
3. CRC matching prefers the segment data CRC (a checksum over just the forward index + dictionary) over the full segment CRC: when both sides report one, a segment that was only re-indexed or had metadata rewritten (data unchanged) still matches. The server reports segmentDataCrc only for useDataCrc=true segments, and the same crcMatches logic runs in both the generator and the executor.
4. Adds a validDocIdsValidationMode config (STRICT default / EXECUTOR_ONLY) to toggle the generator-side checks.

Follow-up to #17696 (which added the executor-side consensus), per this review comment.

## Background

#17696 made the upsert compaction **executor** reconcile validDocIds across replicas before compacting — it checks CRC, server health, and a configurable `validDocIdsConsensusMode` (`UNSAFE` / `EQUAL` / `MOST_VALID_DOCS`), failing the task rather than letting a less-complete replica overwrite a more-complete one.

The **generator**, however, still scheduled a task for every eligible segment, even when its replicas were inconsistent (a CRC mismatch mid-reload, an unhealthy server, or divergent validDocIds). The executor then has to fail those tasks to stay safe — which wastes a segment download and a task slot every cycle, and the same segment keeps getting re-picked and re-failed.

Default Setting:
```
{
  "tableName": "myTable_REALTIME",
  "task": {
    "taskTypeConfigsMap": {
      "UpsertCompactionTask": {
        "schedule": "0 0 */6 * * ?",
        "validDocIdsConsensusMode": "EQUAL",
        "validDocIdsValidationMode": "STRICT"
      }
    }
  }
}
```

## Backward compatibility

`validDocIdsValidationMode` defaults to `STRICT`, so generators now enforce consensus by default; set `EXECUTOR_ONLY` to restore the old behavior. 

**Rolling upgrade**

This PR adds an optional segmentDataCrc field to the validDocIdsMetadata and validDocIdsBitmap server responses (emitted only for useDataCrc=true segments). The field is backward-compatible: both DTOs carry @JsonIgnoreProperties(ignoreUnknown=true), so upgraded minions/controllers ignore it when absent and tolerate it when present.

The validDocIdsBitmap response is deserialized by the minion via a strict Jackson client, and pre-this-release minions did not ignore unknown fields. So if servers are upgraded before minions/controllers, an old minion reading the new field will fail that fetch and the upsert compaction / segment-refresh task will error for that iteration.

**Recommendation:** these errors are transient — once the upgrade is complete, the task recovers on its next iteration. No data loss or correctness impact.

## Testing

Unit tests cover each mode through the generators — `EQUAL` (agree / disagree / replica missing / CRC mismatch / unhealthy / missing bitmap), `UNSAFE`, `MOST_VALID_DOCS` — plus the config parsing/resolution helpers.