### PR TITLE
Fix time segment pruning for remote clusters in multi-cluster routing

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentZkMetadataFetcher.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentZkMetadataFetcher.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.helix.AccessOption;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
@@ -84,7 +85,11 @@ public class SegmentZkMetadataFetcher {
           listener.init(idealState, externalView, segments, znRecords);
         }
         for (int i = 0; i < numSegments; i++) {
-          if (!isConsumingInExternalView(externalView, segments.get(i))) {
+          // Only cache segments that are both non-consuming in EV AND have a committed ZNRecord.
+          // If a segment is ONLINE in EV but its ZNRecord still has startTime=-1 (brief window between
+          // server updating EV and writing ZNRecord to ZK), do not cache it so it is re-evaluated on
+          // the next onAssignmentChange once the ZNRecord is consistent.
+          if (!isConsumingInExternalView(externalView, segments.get(i)) && isCommittedZNRecord(znRecords.get(i))) {
             _onlineSegmentsCached.add(segments.get(i));
           }
         }
@@ -117,8 +122,10 @@ public class SegmentZkMetadataFetcher {
       }
       int numSegments = segments.size();
       for (int i = 0; i < numSegments; i++) {
-        // All fetched segments are non-consuming (guaranteed by the EV check above), cache them if metadata exists.
-        if (znRecords.get(i) != null) {
+        // Cache only if ZNRecord is committed (startTime >= 0). Segments that are ONLINE in EV but still
+        // have startTime=-1 in ZK (brief inconsistency between EV and ZNRecord updates) are left uncached
+        // so they are retried on the next onAssignmentChange.
+        if (isCommittedZNRecord(znRecords.get(i))) {
           _onlineSegmentsCached.add(segments.get(i));
         }
       }
@@ -138,6 +145,15 @@ public class SegmentZkMetadataFetcher {
         _onlineSegmentsCached.remove(segment);
       }
     }
+  }
+
+  /**
+   * Returns true if the ZNRecord represents a committed segment with a valid startTime.
+   * A null ZNRecord or one with startTime=-1 (consuming, or briefly inconsistent after commit)
+   * should not be cached — the segment will be re-fetched on the next onAssignmentChange.
+   */
+  private static boolean isCommittedZNRecord(@Nullable ZNRecord znRecord) {
+    return znRecord != null && znRecord.getLongField(CommonConstants.Segment.START_TIME, -1L) >= 0L;
   }
 
   /**

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentZkMetadataFetcher.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentZkMetadataFetcher.java
@@ -21,6 +21,7 @@ package org.apache.pinot.broker.routing.segmentmetadata;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.apache.helix.AccessOption;
 import org.apache.helix.model.ExternalView;
@@ -28,6 +29,7 @@ import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.spi.utils.CommonConstants;
 
 
 /**
@@ -82,7 +84,7 @@ public class SegmentZkMetadataFetcher {
           listener.init(idealState, externalView, segments, znRecords);
         }
         for (int i = 0; i < numSegments; i++) {
-          if (znRecords.get(i) != null) {
+          if (!isConsumingInExternalView(externalView, segments.get(i))) {
             _onlineSegmentsCached.add(segments.get(i));
           }
         }
@@ -98,10 +100,16 @@ public class SegmentZkMetadataFetcher {
       List<String> segments = new ArrayList<>();
       List<String> segmentZKMetadataPaths = new ArrayList<>();
       for (String segment : onlineSegments) {
-        if (!_onlineSegmentsCached.contains(segment)) {
-          segments.add(segment);
-          segmentZKMetadataPaths.add(_segmentZKMetadataPathPrefix + segment);
+        if (_onlineSegmentsCached.contains(segment)) {
+          continue;
         }
+        // Skip segments still in CONSUMING state — they'll be re-evaluated on the next EV change
+        // when they transition to ONLINE (i.e., when they commit).
+        if (isConsumingInExternalView(externalView, segment)) {
+          continue;
+        }
+        segments.add(segment);
+        segmentZKMetadataPaths.add(_segmentZKMetadataPathPrefix + segment);
       }
       List<ZNRecord> znRecords = _propertyStore.get(segmentZKMetadataPaths, null, AccessOption.PERSISTENT, false);
       for (SegmentZkMetadataFetchListener listener : _listeners) {
@@ -109,6 +117,7 @@ public class SegmentZkMetadataFetcher {
       }
       int numSegments = segments.size();
       for (int i = 0; i < numSegments; i++) {
+        // All fetched segments are non-consuming (guaranteed by the EV check above), cache them if metadata exists.
         if (znRecords.get(i) != null) {
           _onlineSegmentsCached.add(segments.get(i));
         }
@@ -130,4 +139,18 @@ public class SegmentZkMetadataFetcher {
       }
     }
   }
+
+  /**
+   * Returns true if the segment is in CONSUMING state on any server in the ExternalView.
+   * Such segments should not be cached in {@code _onlineSegmentsCached} — they will be re-evaluated
+   * on the next ExternalView change, at which point they will have transitioned to ONLINE (committed).
+   */
+  private static boolean isConsumingInExternalView(ExternalView externalView, String segment) {
+    if (externalView == null) {
+      return false;
+    }
+    Map<String, String> stateMap = externalView.getStateMap(segment);
+    return stateMap != null && stateMap.containsValue(CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING);
+  }
+
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentZkMetadataFetcher.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentZkMetadataFetcher.java
@@ -152,5 +152,4 @@ public class SegmentZkMetadataFetcher {
     Map<String, String> stateMap = externalView.getStateMap(segment);
     return stateMap != null && stateMap.containsValue(CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING);
   }
-
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentZkMetadataFetcher.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentZkMetadataFetcher.java
@@ -23,7 +23,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 import org.apache.helix.AccessOption;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
@@ -83,11 +82,9 @@ public class SegmentZkMetadataFetcher {
           listener.init(idealState, externalView, segments, znRecords);
         }
         for (int i = 0; i < numSegments; i++) {
-          // Only cache segments that are both non-consuming in EV AND have a committed ZNRecord.
-          // If a segment is ONLINE in EV but its ZNRecord still has startTime=-1 (brief window between
-          // server updating EV and writing ZNRecord to ZK), do not cache it so it is re-evaluated on
-          // the next onAssignmentChange once the ZNRecord is consistent.
-          if (!isConsumingInExternalView(externalView, segments.get(i)) && isCommittedZNRecord(znRecords.get(i))) {
+          // Only cache segments that are both non-consuming in EV and have a non-null ZNRecord. Consuming
+          // segments are left uncached so they are re-evaluated on the next onAssignmentChange once committed.
+          if (!isConsumingInExternalView(externalView, segments.get(i)) && znRecords.get(i) != null) {
             _onlineSegmentsCached.add(segments.get(i));
           }
         }
@@ -120,10 +117,7 @@ public class SegmentZkMetadataFetcher {
       }
       int numSegments = segments.size();
       for (int i = 0; i < numSegments; i++) {
-        // Cache only if ZNRecord is committed (startTime >= 0). Segments that are ONLINE in EV but still
-        // have startTime=-1 in ZK (brief inconsistency between EV and ZNRecord updates) are left uncached
-        // so they are retried on the next onAssignmentChange.
-        if (isCommittedZNRecord(znRecords.get(i))) {
+        if (znRecords.get(i) != null) {
           _onlineSegmentsCached.add(segments.get(i));
         }
       }
@@ -145,24 +139,10 @@ public class SegmentZkMetadataFetcher {
     }
   }
 
-  /**
-   * Returns true if the ZNRecord represents a committed segment with a valid startTime.
-   * A null ZNRecord or one with startTime=-1 (consuming, or briefly inconsistent after commit)
-   * should not be cached — the segment will be re-fetched on the next onAssignmentChange.
-   */
-  private static boolean isCommittedZNRecord(@Nullable ZNRecord znRecord) {
-    return znRecord != null && znRecord.getLongField(CommonConstants.Segment.START_TIME, -1L) >= 0L;
-  }
-
-  /**
-   * Returns true if the segment is in CONSUMING state on any server in the ExternalView.
-   * Such segments should not be cached in {@code _onlineSegmentsCached} — they will be re-evaluated
-   * on the next ExternalView change, at which point they will have transitioned to ONLINE (committed).
-   */
+  /// Returns true if the segment is in CONSUMING state on any server in the ExternalView.
+  /// Such segments should not be cached in {@code _onlineSegmentsCached} — they will be re-evaluated
+  /// on the next ExternalView change, at which point they will have transitioned to ONLINE (committed).
   private static boolean isConsumingInExternalView(ExternalView externalView, String segment) {
-    if (externalView == null) {
-      return false;
-    }
     Map<String, String> stateMap = externalView.getStateMap(segment);
     return stateMap != null && stateMap.containsValue(CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING);
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentZkMetadataFetcher.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentZkMetadataFetcher.java
@@ -21,6 +21,7 @@ package org.apache.pinot.broker.routing.segmentmetadata;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.apache.helix.AccessOption;
 import org.apache.helix.model.ExternalView;
@@ -28,6 +29,7 @@ import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.spi.utils.CommonConstants;
 
 
 /// `SegmentZkMetadataFetcher` is used to cache [ZNRecord] stored in [ZkHelixPropertyStore] for
@@ -80,7 +82,7 @@ public class SegmentZkMetadataFetcher {
           listener.init(idealState, externalView, segments, znRecords);
         }
         for (int i = 0; i < numSegments; i++) {
-          if (znRecords.get(i) != null) {
+          if (!isConsumingInExternalView(externalView, segments.get(i))) {
             _onlineSegmentsCached.add(segments.get(i));
           }
         }
@@ -96,10 +98,16 @@ public class SegmentZkMetadataFetcher {
       List<String> segments = new ArrayList<>();
       List<String> segmentZKMetadataPaths = new ArrayList<>();
       for (String segment : onlineSegments) {
-        if (!_onlineSegmentsCached.contains(segment)) {
-          segments.add(segment);
-          segmentZKMetadataPaths.add(_segmentZKMetadataPathPrefix + segment);
+        if (_onlineSegmentsCached.contains(segment)) {
+          continue;
         }
+        // Skip segments still in CONSUMING state — they'll be re-evaluated on the next EV change
+        // when they transition to ONLINE (i.e., when they commit).
+        if (isConsumingInExternalView(externalView, segment)) {
+          continue;
+        }
+        segments.add(segment);
+        segmentZKMetadataPaths.add(_segmentZKMetadataPathPrefix + segment);
       }
       List<ZNRecord> znRecords = _propertyStore.get(segmentZKMetadataPaths, null, AccessOption.PERSISTENT, false);
       for (SegmentZkMetadataFetchListener listener : _listeners) {
@@ -107,6 +115,7 @@ public class SegmentZkMetadataFetcher {
       }
       int numSegments = segments.size();
       for (int i = 0; i < numSegments; i++) {
+        // All fetched segments are non-consuming (guaranteed by the EV check above), cache them if metadata exists.
         if (znRecords.get(i) != null) {
           _onlineSegmentsCached.add(segments.get(i));
         }
@@ -128,4 +137,18 @@ public class SegmentZkMetadataFetcher {
       }
     }
   }
+
+  /**
+   * Returns true if the segment is in CONSUMING state on any server in the ExternalView.
+   * Such segments should not be cached in {@code _onlineSegmentsCached} — they will be re-evaluated
+   * on the next ExternalView change, at which point they will have transitioned to ONLINE (committed).
+   */
+  private static boolean isConsumingInExternalView(ExternalView externalView, String segment) {
+    if (externalView == null) {
+      return false;
+    }
+    Map<String, String> stateMap = externalView.getStateMap(segment);
+    return stateMap != null && stateMap.containsValue(CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING);
+  }
+
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentZkMetadataFetcher.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentZkMetadataFetcher.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.helix.AccessOption;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
@@ -82,7 +83,11 @@ public class SegmentZkMetadataFetcher {
           listener.init(idealState, externalView, segments, znRecords);
         }
         for (int i = 0; i < numSegments; i++) {
-          if (!isConsumingInExternalView(externalView, segments.get(i))) {
+          // Only cache segments that are both non-consuming in EV AND have a committed ZNRecord.
+          // If a segment is ONLINE in EV but its ZNRecord still has startTime=-1 (brief window between
+          // server updating EV and writing ZNRecord to ZK), do not cache it so it is re-evaluated on
+          // the next onAssignmentChange once the ZNRecord is consistent.
+          if (!isConsumingInExternalView(externalView, segments.get(i)) && isCommittedZNRecord(znRecords.get(i))) {
             _onlineSegmentsCached.add(segments.get(i));
           }
         }
@@ -115,8 +120,10 @@ public class SegmentZkMetadataFetcher {
       }
       int numSegments = segments.size();
       for (int i = 0; i < numSegments; i++) {
-        // All fetched segments are non-consuming (guaranteed by the EV check above), cache them if metadata exists.
-        if (znRecords.get(i) != null) {
+        // Cache only if ZNRecord is committed (startTime >= 0). Segments that are ONLINE in EV but still
+        // have startTime=-1 in ZK (brief inconsistency between EV and ZNRecord updates) are left uncached
+        // so they are retried on the next onAssignmentChange.
+        if (isCommittedZNRecord(znRecords.get(i))) {
           _onlineSegmentsCached.add(segments.get(i));
         }
       }
@@ -136,6 +143,15 @@ public class SegmentZkMetadataFetcher {
         _onlineSegmentsCached.remove(segment);
       }
     }
+  }
+
+  /**
+   * Returns true if the ZNRecord represents a committed segment with a valid startTime.
+   * A null ZNRecord or one with startTime=-1 (consuming, or briefly inconsistent after commit)
+   * should not be cached — the segment will be re-fetched on the next onAssignmentChange.
+   */
+  private static boolean isCommittedZNRecord(@Nullable ZNRecord znRecord) {
+    return znRecord != null && znRecord.getLongField(CommonConstants.Segment.START_TIME, -1L) >= 0L;
   }
 
   /**

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentZkMetadataFetcher.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentZkMetadataFetcher.java
@@ -150,5 +150,4 @@ public class SegmentZkMetadataFetcher {
     Map<String, String> stateMap = externalView.getStateMap(segment);
     return stateMap != null && stateMap.containsValue(CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING);
   }
-
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java
@@ -107,12 +107,16 @@ public class TimeSegmentPruner implements SegmentPruner {
   @Override
   public synchronized void onAssignmentChange(IdealState idealState, ExternalView externalView,
       Set<String> onlineSegments, List<String> pulledSegments, List<ZNRecord> znRecords) {
-    // NOTE: We don't update all the segment ZK metadata for every external view change, but only the new added/removed
-    //       ones. The refreshed segment ZK metadata change won't be picked up.
     for (int idx = 0; idx < pulledSegments.size(); idx++) {
       String segment = pulledSegments.get(idx);
       ZNRecord zNrecord = znRecords.get(idx);
-      _intervalMap.computeIfAbsent(segment, k -> extractIntervalFromSegmentZKMetaZNRecord(k, zNrecord));
+      // Always update segments that have DEFAULT_INTERVAL, which covers two cases:
+      // 1. New segments not yet in the map
+      // 2. Segments that transitioned from CONSUMING (DEFAULT_INTERVAL) to COMMITTED (valid time range)
+      Interval existing = _intervalMap.get(segment);
+      if (existing == null || existing == DEFAULT_INTERVAL) {
+        _intervalMap.put(segment, extractIntervalFromSegmentZKMetaZNRecord(segment, zNrecord));
+      }
     }
     _intervalMap.keySet().retainAll(onlineSegments);
     _intervalTree = new IntervalTree<>(_intervalMap);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java
@@ -105,12 +105,16 @@ public class TimeSegmentPruner implements SegmentPruner {
   @Override
   public synchronized void onAssignmentChange(IdealState idealState, ExternalView externalView,
       Set<String> onlineSegments, List<String> pulledSegments, List<ZNRecord> znRecords) {
-    // NOTE: We don't update all the segment ZK metadata for every external view change, but only the new added/removed
-    //       ones. The refreshed segment ZK metadata change won't be picked up.
     for (int idx = 0; idx < pulledSegments.size(); idx++) {
       String segment = pulledSegments.get(idx);
       ZNRecord zNrecord = znRecords.get(idx);
-      _intervalMap.computeIfAbsent(segment, k -> extractIntervalFromSegmentZKMetaZNRecord(k, zNrecord));
+      // Always update segments that have DEFAULT_INTERVAL, which covers two cases:
+      // 1. New segments not yet in the map
+      // 2. Segments that transitioned from CONSUMING (DEFAULT_INTERVAL) to COMMITTED (valid time range)
+      Interval existing = _intervalMap.get(segment);
+      if (existing == null || existing == DEFAULT_INTERVAL) {
+        _intervalMap.put(segment, extractIntervalFromSegmentZKMetaZNRecord(segment, zNrecord));
+      }
     }
     _intervalMap.keySet().retainAll(onlineSegments);
     _intervalTree = new IntervalTree<>(_intervalMap);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java
@@ -111,10 +111,9 @@ public class TimeSegmentPruner implements SegmentPruner {
       // Always update segments that have DEFAULT_INTERVAL, which covers two cases:
       // 1. New segments not yet in the map
       // 2. Segments that transitioned from CONSUMING (DEFAULT_INTERVAL) to COMMITTED (valid time range)
-      Interval existing = _intervalMap.get(segment);
-      if (existing == null || existing == DEFAULT_INTERVAL) {
-        _intervalMap.put(segment, extractIntervalFromSegmentZKMetaZNRecord(segment, zNrecord));
-      }
+      _intervalMap.compute(segment, (k, existing) ->
+          (existing == null || existing == DEFAULT_INTERVAL) ? extractIntervalFromSegmentZKMetaZNRecord(k, zNrecord)
+              : existing);
     }
     _intervalMap.keySet().retainAll(onlineSegments);
     _intervalTree = new IntervalTree<>(_intervalMap);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentZkMetadataFetcherTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentZkMetadataFetcherTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
@@ -30,6 +31,7 @@ import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.broker.routing.segmentpruner.SegmentPruner;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.controller.helix.ControllerTest;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
@@ -150,6 +152,49 @@ public class SegmentZkMetadataFetcherTest extends ControllerTest {
     verify(mockPropertyStore, times(1)).get(endsWith("foo"), any(), anyInt());
     verify(pruner1, times(1)).refreshSegment(eq("foo"), any());
     verify(pruner2, times(1)).refreshSegment(eq("foo"), any());
+  }
+
+  @Test
+  public void testSegmentZkMetadataFetcherShouldNotCacheConsumingSegmentUntilCommitted() {
+    ZkHelixPropertyStore<ZNRecord> mockPropertyStore = mock(ZkHelixPropertyStore.class);
+    when(mockPropertyStore.get(any(), any(), anyInt(), anyBoolean())).thenAnswer(inv -> {
+      List<String> pathList = inv.getArgument(0);
+      List<ZNRecord> result = new ArrayList<>(pathList.size());
+      for (String path : pathList) {
+        String[] pathParts = path.split("/");
+        String segmentName = pathParts[pathParts.length - 1];
+        result.add(new SegmentZKMetadata(segmentName).toZNRecord());
+      }
+      return result;
+    });
+    SegmentPruner pruner = mock(SegmentPruner.class);
+    SegmentZkMetadataFetcher segmentZkMetadataFetcher =
+        new SegmentZkMetadataFetcher(OFFLINE_TABLE_NAME, mockPropertyStore);
+    segmentZkMetadataFetcher.register(pruner);
+    IdealState idealState = mock(IdealState.class);
+    segmentZkMetadataFetcher.init(idealState, mock(ExternalView.class), Set.of());
+    clearInvocations(mockPropertyStore);
+
+    // Segment is CONSUMING: onAssignmentChange should skip fetching and caching it
+    ExternalView consumingExternalView = mock(ExternalView.class);
+    when(consumingExternalView.getStateMap("segment")).thenReturn(
+        Map.of("server0", CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING));
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, consumingExternalView, Set.of("segment"));
+    verify(mockPropertyStore, times(0)).get(argThat(new ListMatcher("segment")), any(), anyInt(), anyBoolean());
+    verify(pruner, times(0)).onAssignmentChange(any(), any(), any(), argThat(new ListMatcher("segment")), any());
+
+    // Segment commits and transitions to ONLINE: should now be fetched and cached
+    ExternalView onlineExternalView = mock(ExternalView.class);
+    when(onlineExternalView.getStateMap("segment")).thenReturn(
+        Map.of("server0", CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE));
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, onlineExternalView, Set.of("segment"));
+    verify(mockPropertyStore, times(1)).get(argThat(new ListMatcher("segment")), any(), anyInt(), anyBoolean());
+    verify(pruner, times(1)).onAssignmentChange(any(), any(), any(), argThat(new ListMatcher("segment")), any());
+
+    // Already cached: subsequent assignment changes should not re-fetch or re-notify
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, onlineExternalView, Set.of("segment"));
+    verify(mockPropertyStore, times(1)).get(argThat(new ListMatcher("segment")), any(), anyInt(), anyBoolean());
+    verify(pruner, times(1)).onAssignmentChange(any(), any(), any(), argThat(new ListMatcher("segment")), any());
   }
 
   private static class ListMatcher implements ArgumentMatcher<List<String>> {

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerTest.java
@@ -54,6 +54,7 @@ import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
 import org.mockito.Mockito;
@@ -499,6 +500,44 @@ public class SegmentPrunerTest extends ControllerTest {
     assertEquals(segmentPruner.prune(brokerRequest7, input), Set.of(segment0));
     assertEquals(segmentPruner.prune(brokerRequest8, input), input);
     assertEquals(segmentPruner.prune(brokerRequest9, input), Set.of()); // Query with invalid range
+  }
+
+  @Test
+  public void testTimeSegmentPrunerConsumingSegmentCommit() {
+    // Query range [20, 30] does not overlap the segment's post-commit interval [50, 65]
+    BrokerRequest brokerRequest = CalciteSqlCompiler.compileToBrokerRequest(TIME_QUERY_2);
+
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setTimeColumnName(TIME_COLUMN)
+            .build();
+    DateTimeFieldSpec timeFieldSpec = new DateTimeFieldSpec(TIME_COLUMN, DataType.INT, "EPOCH|DAYS", "1:DAYS");
+    TimeSegmentPruner segmentPruner = new TimeSegmentPruner(tableConfig, timeFieldSpec);
+    SegmentZkMetadataFetcher segmentZkMetadataFetcher =
+        new SegmentZkMetadataFetcher(REALTIME_TABLE_NAME, _propertyStore);
+    segmentZkMetadataFetcher.register(segmentPruner);
+
+    String segment = "consumingSegment";
+    Set<String> onlineSegments = Set.of(segment);
+    Set<String> input = Set.of(segment);
+    IdealState idealState = Mockito.mock(IdealState.class);
+
+    // Segment starts CONSUMING with no time-range metadata yet: should not be pruned (matches every query)
+    ZKMetadataProvider.setSegmentZKMetadata(_propertyStore, REALTIME_TABLE_NAME, new SegmentZKMetadata(segment));
+    ExternalView consumingExternalView = Mockito.mock(ExternalView.class);
+    when(consumingExternalView.getStateMap(segment)).thenReturn(
+        Map.of("server0", CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING));
+    segmentZkMetadataFetcher.init(idealState, consumingExternalView, onlineSegments);
+    assertEquals(segmentPruner.prune(brokerRequest, input), input);
+
+    // Segment commits: real time-range metadata is written and the external view moves it to ONLINE
+    setSegmentZKTimeRangeMetadata(REALTIME_TABLE_NAME, segment, 50, 65, TimeUnit.DAYS);
+    ExternalView onlineExternalView = Mockito.mock(ExternalView.class);
+    when(onlineExternalView.getStateMap(segment)).thenReturn(
+        Map.of("server0", CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE));
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, onlineExternalView, onlineSegments);
+
+    // Committed interval no longer overlaps the query range: segment should now be pruned
+    assertEquals(segmentPruner.prune(brokerRequest, input), Set.of());
   }
 
   @Test


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Fixes remote segment time pruning by fetching committed ZNRecords and updating interval maps on assignment change\.

```mermaid
flowchart TD
  N0["SegmentZkMetadataFetcher#46;onAssignmentChange #40;F1#41;"]:::stModified
  N1["Check if segment cached or consuming #40;F1#41;"]:::stModified
  N2["Fetch ZNRecord from ZK #40;F1#41;"]:::stModified
  N3["Notify listeners #40;TimeSegmentPruner#41; #40;F1#41;"]:::stModified
  N4["TimeSegmentPruner#46;onAssignmentChange update interval map #40;F2#41;"]:::stModified
  N5["Rebuild interval tree #40;F2#41;"]:::stModified
  N0 -->|"control flow #40;if#47;else checks cache#47;consuming state via if#47;#38;#38;"| N1
  N1 -->|"segment not cached #38;#38; not still consuming #45;#62; add to fetch"| N2
  N2 -->|"propertyStore#46;get returns ZNRecord#59; listener#46;onAssignmentSeg"| N3
  N3 -->|"TimeSegmentPruner#46;onAssignmentChange called#59; compute map"| N4
  N4 -->|"after loop#58; retain online segments and rebuild IntervalTree"| N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentZkMetadataFetcher\.java — [before](https://github.com/apache/pinot/blob/efe37ec91f9ed508c15c27d731ee6d70a07d4677/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentZkMetadataFetcher.java) · [after](https://github.com/apache/pinot/blob/463f69d899e9c0e3122537119a43f36fff6332c4/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentZkMetadataFetcher.java)
- F2: pinot\-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner\.java — [before](https://github.com/apache/pinot/blob/efe37ec91f9ed508c15c27d731ee6d70a07d4677/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java) · [after](https://github.com/apache/pinot/blob/463f69d899e9c0e3122537119a43f36fff6332c4/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImVmZTM3ZWM5MWY5ZWQ1MDhjMTVjMjdkNzMxZWU2ZDcwYTA3ZDQ2NzciLCJjb250ZXh0X2hhc2giOiI1YzMwNzIxZDJjZGE1ZjZhYzA3Y2RmYWVmNjNiNzY0MzE2Yzk2YWVjZjZmMTA5Y2MzZGFiNWIwOGYwODQ1ZTBhIiwiZ2VuZXJhdGVkX2F0IjoxNzg5NzA1MzM2LCJoZWFkX3NoYSI6IjQ2M2Y2OWQ4OTllOWMwZTMxMjI1MzcxMTlhNDNmMzZmZmY2MzMyYzQiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJlZmUzN2VjOTFmOWVkNTA4YzE1YzI3ZDczMWVlNmQ3MGEwN2Q0Njc3IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 99e343d9791412ddaa998c0385ac230472997379f4918e41a4d1b2ee47361cfb -->
<!-- pinot-pr-flow:end -->

  ---

  ## Motivation

  When `enableMultiClusterRouting=true`, a broker (e.g. in one region) builds a full routing table for each remote cluster, including a `TimeSegmentPruner` per table. The pruner is supposed to skip segments whose time range does not
  overlap the query's time filter — the same pruning that works correctly for local segments.

  In practice, time pruning was silently broken for **all** remote segments. Every remote segment was mapped to
  `DEFAULT_INTERVAL = [0, Long.MAX_VALUE]`, which matches every query, so nothing was pruned. 

On a federated table spanning two clusters in internal testing, `numSegmentsQueried` with `enableMultiClusterRouting=true` was 6× higher than two equivalent local-only queries combined (684 vs ~108).

  ---

  ## Root cause

  Two bugs in the routing update pipeline conspired to produce this outcome.

  ### Bug 1 — `TimeSegmentPruner.onAssignmentChange`: `computeIfAbsent` prevented committed segments from being updated

  `TimeSegmentPruner` maintains a map of `segment → time interval`. REALTIME segments first appear in CONSUMING state with `startTime = -1`, so they are mapped to `DEFAULT_INTERVAL`. When the segment later commits and ZooKeeper is updated with  a valid `startTime`/`endTime`, the pruner should replace `DEFAULT_INTERVAL` with the real interval.

  The old code used `computeIfAbsent`, which only writes if the key is absent. Since the CONSUMING entry already exists,  the update is silently skipped. The segment stays at `DEFAULT_INTERVAL` permanently.

  ```java
  // Before
  _intervalMap.computeIfAbsent(segment, k -> extractInterval(k, znRecord));

  // After — re-evaluate any segment still at DEFAULT_INTERVAL
  Interval existing = _intervalMap.get(segment);
  if (existing == null || existing == DEFAULT_INTERVAL) {
      _intervalMap.put(segment, extractInterval(segment, znRecord));
  }
  ```

  ### Bug 2 — `SegmentZkMetadataFetcher.onAssignmentChange`: consuming segments were cached and never re-fetched

  `SegmentZkMetadataFetcher` maintains `_onlineSegmentsCached` to avoid redundant ZK reads. Once a segment's ZNRecord is  fetched, it is added to the cache and skipped on all subsequent `onAssignmentChange` calls.

  The original caching condition was `znRecord != null`. A CONSUMING segment **does** have a non-null ZNRecord (it just has `startTime = -1`), so it was immediately cached. From that point on it was never re-fetched — even after it committed and ZK was updated with a valid time range. `TimeSegmentPruner` never received the committed ZNRecord, so Bug 1's fix  never had a chance to run.

  For **local** routing this is masked: when a server commits a segment, it sends a Helix user-defined message (UDM)
  directly to the local broker, which calls `refreshSegment()` — bypassing the cache entirely. Remote brokers never receive
  these UDMs (**because remote brokers are spectators, not participants** ), so `onAssignmentChange` is the sole update path for remote segments.

  ---

  ## Fix

  ### `SegmentZkMetadataFetcher` — use ExternalView state instead of caching consuming segments

  Rather than caching a segment as soon as its ZNRecord is non-null, we consult the ExternalView that is already delivered
  with every `onAssignmentChange` call:

  ```java
  for (String segment : onlineSegments) {
      if (_onlineSegmentsCached.contains(segment)) continue;  // committed, already cached
      if (isConsumingInExternalView(externalView, segment)) continue;  // still consuming, skip
      segments.add(segment);  // fetch from ZK
  }

  private static boolean isConsumingInExternalView(ExternalView externalView, String segment) {
      Map<String, String> stateMap = externalView.getStateMap(segment);
      return stateMap != null && stateMap.containsValue(CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING);
  }
  ```

  A segment goes through exactly three states in this logic:

  | State | In cache? | CONSUMING in EV? | Action |
  |---|---|---|---|
  | CONSUMING | No | Yes | Skip — nothing useful to fetch yet |
  | Just committed (CONSUMING → ONLINE) | No | No | **Fetch once** — get committed ZNRecord |
  | Committed, previously seen | Yes | No | Skip — already cached |

  The ExternalView change that fires `onAssignmentChange` is the same event that flips the segment's state from CONSUMING  to ONLINE. We use that state, already in memory, to decide what to fetch — no additional ZK reads required to make the decision.

  ### `TimeSegmentPruner` — re-evaluate segments at `DEFAULT_INTERVAL`

  With the above fix ensuring the committed ZNRecord now flows through on each transition, the `computeIfAbsent` in 
  `TimeSegmentPruner` is replaced with a conditional put that updates any segment still at `DEFAULT_INTERVAL`:

  ```java
  Interval existing = _intervalMap.get(segment);
  if (existing == null || existing == DEFAULT_INTERVAL) {
      _intervalMap.put(segment, extractInterval(segment, znRecord));
  }
  ```
  ---

  ## Why this does not degrade performance

  `onAssignmentChange` is called on a background thread in response to Helix ExternalView changes — it is never on the
  query path.
  
  The original code fetched a segment's ZNRecord once (when first seen as CONSUMING), cached it, and skipped it forever.  
The new code does the same for committed segments. The key difference is what happens to CONSUMING segments: instead of  fetching and caching them eagerly, we skip them entirely using the ExternalView state already in memory. No ZK read is  issued for a CONSUMING segment on any `onAssignmentChange` call.
  
  The number of ZK reads per `onAssignmentChange` is now **O(segments that just committed in this batch)** — typically 1–5  per ExternalView change during active ingestion — compared to O(all currently-consuming segments) that a naive re-fetch  approach would require. In steady state between commits, zero extra ZK reads are performed beyond what the original code  did.
  
  The `IntervalTree` rebuild in `TimeSegmentPruner` at the end of every `onAssignmentChange` is O(N log N) in total
  segments and was already happening before this change — unaffected.
  
  ---
  
  ## Verification

  Tested on a staging cluster:

  ```
  useMultiClusterRouting=false (local only):  queried=54   processed=30   ✓ (baseline, unchanged)
  useMultiClusterRouting=true  (local + remote):   queried=108  processed=60   ✓ (was 684, now = 54+54)
  ```

  `numSegmentsQueried` with multi-cluster routing now equals the sum of both clusters' local-only counts.
  `numSegmentsProcessed` is unchanged — correct results, no data regression.