### PR TITLE
Sort lineage entries by timestamp then id for deterministic list output

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/lineage/SegmentLineage.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/lineage/SegmentLineage.java
@@ -191,14 +191,17 @@ public class SegmentLineage {
 
   /**
    * Returns a json representation of the segment lineage.
-   * Segment lineage entries are sorted in chronological order by default.
+   * Segment lineage entries are sorted by timestamp, with the entry id as a tiebreaker so that entries
+   * sharing the same millisecond are still ordered deterministically (instead of by HashMap iteration).
    */
   public ObjectNode toJsonObject() {
     ObjectNode jsonObject = JsonUtils.newObjectNode();
     jsonObject.put("tableNameWithType", _tableNameWithType);
     LinkedHashMap<String, LineageEntry> sortedLineageEntries = new LinkedHashMap<>();
     _lineageEntries.entrySet().stream()
-        .sorted(Map.Entry.comparingByValue(Comparator.comparingLong(LineageEntry::getTimestamp)))
+        .sorted(Map.Entry.<String, LineageEntry>comparingByValue(
+                Comparator.comparingLong(LineageEntry::getTimestamp))
+            .thenComparing(Map.Entry.comparingByKey()))
         .forEachOrdered(x -> sortedLineageEntries.put(x.getKey(), x.getValue()));
     jsonObject.set("lineageEntries", JsonUtils.objectToJsonNode(sortedLineageEntries));
     if (_customMap != null) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSegmentRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSegmentRestletResourceTest.java
@@ -19,11 +19,15 @@
 package org.apache.pinot.controller.api;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.apache.pinot.client.admin.PinotAdminClient;
+import org.apache.pinot.common.lineage.SegmentLineage;
+import org.apache.pinot.common.lineage.SegmentLineageAccessHelper;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.utils.SegmentMetadataMockUtils;
@@ -99,8 +103,15 @@ public class PinotSegmentRestletResourceTest {
     assertTrue(segmentLineageResponse.contains("\"segmentsTo\":[\"some_segment\"]"));
     assertTrue(segmentLineageResponse.contains("\"segmentsFrom\":[\"s2\",\"s3\"]"));
     assertTrue(segmentLineageResponse.contains("\"segmentsTo\":[\"another_segment\"]"));
+    SegmentLineage lineage =
+        SegmentLineageAccessHelper.getSegmentLineage(resourceManager.getPropertyStore(), offlineTableName);
+    // Sort the two entry ids the same way toJsonObject does -- by timestamp, then by id.
+    List<String> orderedIds = Stream.of(segmentLineageId, nextSegmentLineageId)
+        .sorted(Comparator.comparingLong((String id) -> lineage.getLineageEntry(id).getTimestamp())
+            .thenComparing(Comparator.naturalOrder()))
+        .toList();
     // Ensures the two entries are sorted in chronological order by timestamp.
-    assertTrue(segmentLineageResponse.indexOf(segmentLineageId) < segmentLineageResponse.indexOf(nextSegmentLineageId));
+    assertTrue(segmentLineageResponse.indexOf(orderedIds.get(0)) < segmentLineageResponse.indexOf(orderedIds.get(1)));
 
     // List segment lineage should fail for non-existing table
     assertThrows(Exception.class,


### PR DESCRIPTION
## Problem
`SegmentLineage.toJsonObject()` sorted entries by **millisecond** timestamp only, over a `HashMap`. Entries sharing a millisecond fell back to arbitrary UUID-hash iteration order, so the list API output was non-deterministic. `testListSegmentLineage` asserts two back-to-back `startReplaceSegments` entries appear in a fixed order; on a fast machine the two share a millisecond ~57% of the time, and the assertion failed ~29% of runs (measured over 1000 runs).

## Fix
Add the entry id as a sort tiebreaker: entries are ordered by `(timestamp, then id)`. This makes the list output **deterministic** for a given set of entries. Entries remain identified by UUID. The code generally doesn't make any use of the ordering, but segmentLineage prints a summary where segments at the same millisecond may appear out of order.

The test derives the expected order with the same `(timestamp, id)` sort and asserts the response lists the two entries in that order — deterministic regardless of whether the timestamps tie.