### PR TITLE
Add ranged-read support to PinotFS

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
@@ -22,6 +22,7 @@ import com.google.api.gax.paging.Page;
 import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.ReadChannel;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
@@ -388,6 +389,31 @@ public class GcsPinotFS extends BasePinotFS {
     } catch (StorageException e) {
       throw new IOException(e);
     }
+  }
+
+  @Override
+  public InputStream openForRead(URI uri, long offset, long length)
+      throws IOException {
+    if (offset < 0 || length < 0) {
+      throw new IllegalArgumentException(
+          "offset and length must be non-negative, got offset=" + offset + ", length=" + length);
+    }
+    try {
+      Blob blob = getBlob(new GcsUri(uri));
+      // ReadChannel.limit is the absolute, exclusive end position; seek positions the start. This issues a
+      // ranged GET so only [offset, offset + length) is transferred (truncated at end-of-file).
+      ReadChannel reader = blob.reader();
+      reader.seek(offset);
+      reader.limit(offset + length);
+      return Channels.newInputStream(reader);
+    } catch (StorageException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public boolean supportsRangedRead() {
+    return true;
   }
 
   private Bucket getBucket(GcsUri gcsUri) {

--- a/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
@@ -400,6 +400,9 @@ public class GcsPinotFS extends BasePinotFS {
     }
     try {
       Blob blob = getBlob(new GcsUri(uri));
+      if (blob == null) {
+        throw new FileNotFoundException("File '" + uri + "' does not exist");
+      }
       // ReadChannel.limit is the absolute, exclusive end position; seek positions the start. This issues a
       // ranged GET so only [offset, offset + length) is transferred (truncated at end-of-file).
       ReadChannel reader = blob.reader();

--- a/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
@@ -403,11 +403,21 @@ public class GcsPinotFS extends BasePinotFS {
       if (blob == null) {
         throw new FileNotFoundException("File '" + uri + "' does not exist");
       }
+      // A zero-length range would make limit == offset, which formats as an invalid HTTP range header; match
+      // LocalPinotFS and return an empty stream. Checked after the existence check so a missing file still throws.
+      if (length == 0) {
+        return InputStream.nullInputStream();
+      }
       // ReadChannel.limit is the absolute, exclusive end position; seek positions the start. This issues a
       // ranged GET so only [offset, offset + length) is transferred (truncated at end-of-file).
+      long endExclusive = offset + length;
+      if (endExclusive < 0) {
+        // Saturate rather than wrap, so a deliberately huge length still means "read to end of file".
+        endExclusive = Long.MAX_VALUE;
+      }
       ReadChannel reader = blob.reader();
       reader.seek(offset);
-      reader.limit(offset + length);
+      reader.limit(endExclusive);
       return Channels.newInputStream(reader);
     } catch (StorageException e) {
       throw new IOException(e);

--- a/pinot-plugins/pinot-file-system/pinot-gcs/src/test/java/org/apache/pinot/plugin/filesystem/GcsPinotFSNullSafetyTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/src/test/java/org/apache/pinot/plugin/filesystem/GcsPinotFSNullSafetyTest.java
@@ -42,6 +42,7 @@ import static org.testng.Assert.fail;
 /**
  * Unit tests verifying null-safety fixes in GcsPinotFS:
  * - open() throws FileNotFoundException (not NPE) when the blob does not exist
+ * - openForRead() throws FileNotFoundException (not NPE) when the blob does not exist
  * - copy() throws FileNotFoundException (not NPE) when the source blob does not exist
  */
 public class GcsPinotFSNullSafetyTest {
@@ -81,6 +82,30 @@ public class GcsPinotFSNullSafetyTest {
 
     // Must throw FileNotFoundException, not NullPointerException
     assertThrows(FileNotFoundException.class, () -> _gcsPinotFS.open(uri));
+  }
+
+  @Test
+  public void testOpenForReadThrowsFileNotFoundExceptionWhenBlobDoesNotExist()
+      throws IOException {
+    URI uri = URI.create("gs://test-bucket/missing-file");
+    when(_mockStorage.get(any(BlobId.class))).thenReturn(null);
+
+    try {
+      _gcsPinotFS.openForRead(uri, 0, 128);
+      fail("Expected FileNotFoundException");
+    } catch (FileNotFoundException ex) {
+      assertEquals(ex.getMessage(), "File '" + uri + "' does not exist");
+    }
+  }
+
+  @Test
+  public void testOpenForReadDoesNotThrowNullPointerException()
+      throws IOException {
+    URI uri = URI.create("gs://test-bucket/missing-file");
+    when(_mockStorage.get(any(BlobId.class))).thenReturn(null);
+
+    // A ranged read against a missing object must throw FileNotFoundException, not NullPointerException
+    assertThrows(FileNotFoundException.class, () -> _gcsPinotFS.openForRead(uri, 0, 128));
   }
 
   @SuppressWarnings("unchecked")

--- a/pinot-plugins/pinot-file-system/pinot-gcs/src/test/java/org/apache/pinot/plugin/filesystem/GcsPinotFSNullSafetyTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/src/test/java/org/apache/pinot/plugin/filesystem/GcsPinotFSNullSafetyTest.java
@@ -19,11 +19,13 @@
 package org.apache.pinot.plugin.filesystem;
 
 import com.google.api.gax.paging.Page;
+import com.google.cloud.ReadChannel;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.net.URI;
 import java.util.List;
@@ -33,8 +35,11 @@ import org.testng.annotations.Test;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.fail;
 
@@ -157,5 +162,50 @@ public class GcsPinotFSNullSafetyTest {
 
     // Must throw FileNotFoundException, not NullPointerException
     assertThrows(FileNotFoundException.class, () -> _gcsPinotFS.copyDir(srcUri, dstUri));
+  }
+
+  @Test
+  public void testOpenForReadZeroLengthReturnsEmptyStreamWithoutRangedGet()
+      throws IOException {
+    URI uri = URI.create("gs://test-bucket/file");
+    Blob blob = mock(Blob.class);
+    when(_mockStorage.get(any(BlobId.class))).thenReturn(blob);
+
+    try (InputStream in = _gcsPinotFS.openForRead(uri, 30, 0)) {
+      assertNotNull(in);
+      assertEquals(in.readAllBytes().length, 0);
+    }
+    // A zero-length range must not open a channel; limit == offset formats as an invalid HTTP range header
+    verifyNoInteractions(blob);
+  }
+
+  @Test
+  public void testOpenForReadLimitIsAbsoluteExclusiveEnd()
+      throws IOException {
+    URI uri = URI.create("gs://test-bucket/file");
+    Blob blob = mock(Blob.class);
+    ReadChannel channel = mock(ReadChannel.class);
+    when(_mockStorage.get(any(BlobId.class))).thenReturn(blob);
+    when(blob.reader()).thenReturn(channel);
+
+    _gcsPinotFS.openForRead(uri, 10, 20);
+
+    verify(channel).seek(10L);
+    verify(channel).limit(30L);
+  }
+
+  @Test
+  public void testOpenForReadSaturatesInsteadOfOverflowing()
+      throws IOException {
+    URI uri = URI.create("gs://test-bucket/file");
+    Blob blob = mock(Blob.class);
+    ReadChannel channel = mock(ReadChannel.class);
+    when(_mockStorage.get(any(BlobId.class))).thenReturn(blob);
+    when(blob.reader()).thenReturn(channel);
+
+    _gcsPinotFS.openForRead(uri, 1, Long.MAX_VALUE);
+
+    // offset + length would wrap negative and trip ReadChannel.limit's own precondition
+    verify(channel).limit(Long.MAX_VALUE);
   }
 }

--- a/pinot-plugins/pinot-file-system/pinot-gcs/src/test/java/org/apache/pinot/plugin/filesystem/GcsPinotFSNullSafetyTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/src/test/java/org/apache/pinot/plugin/filesystem/GcsPinotFSNullSafetyTest.java
@@ -41,6 +41,7 @@ import static org.testng.Assert.fail;
 
 /// Unit tests verifying null-safety fixes in GcsPinotFS:
 /// - open() throws FileNotFoundException (not NPE) when the blob does not exist
+/// - openForRead() throws FileNotFoundException (not NPE) when the blob does not exist
 /// - copy() throws FileNotFoundException (not NPE) when the source blob does not exist
 public class GcsPinotFSNullSafetyTest {
 
@@ -79,6 +80,30 @@ public class GcsPinotFSNullSafetyTest {
 
     // Must throw FileNotFoundException, not NullPointerException
     assertThrows(FileNotFoundException.class, () -> _gcsPinotFS.open(uri));
+  }
+
+  @Test
+  public void testOpenForReadThrowsFileNotFoundExceptionWhenBlobDoesNotExist()
+      throws IOException {
+    URI uri = URI.create("gs://test-bucket/missing-file");
+    when(_mockStorage.get(any(BlobId.class))).thenReturn(null);
+
+    try {
+      _gcsPinotFS.openForRead(uri, 0, 128);
+      fail("Expected FileNotFoundException");
+    } catch (FileNotFoundException ex) {
+      assertEquals(ex.getMessage(), "File '" + uri + "' does not exist");
+    }
+  }
+
+  @Test
+  public void testOpenForReadDoesNotThrowNullPointerException()
+      throws IOException {
+    URI uri = URI.create("gs://test-bucket/missing-file");
+    when(_mockStorage.get(any(BlobId.class))).thenReturn(null);
+
+    // A ranged read against a missing object must throw FileNotFoundException, not NullPointerException
+    assertThrows(FileNotFoundException.class, () -> _gcsPinotFS.openForRead(uri, 0, 128));
   }
 
   @SuppressWarnings("unchecked")

--- a/pinot-plugins/pinot-file-system/pinot-gcs/src/test/java/org/apache/pinot/plugin/filesystem/GcsPinotFSTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/src/test/java/org/apache/pinot/plugin/filesystem/GcsPinotFSTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.plugin.filesystem;
 import com.google.common.io.Closer;
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.file.Files;
@@ -168,6 +169,36 @@ public class GcsPinotFSTest {
   private Stream<GcsUri> listFilesToStream(GcsUri gcsUri)
       throws IOException {
     return Arrays.asList(_pinotFS.listFiles(gcsUri.getUri(), true)).stream().map(URI::create).map(GcsUri::new);
+  }
+
+  @Test
+  public void testOpenForRead()
+      throws Exception {
+    skipIfNotConfigured();
+    assertTrue(_pinotFS.supportsRangedRead());
+
+    byte[] data = new byte[256];
+    for (int i = 0; i < data.length; i++) {
+      data[i] = (byte) i;
+    }
+    Path localFile = _localTmpDir.resolve("rangeFile");
+    Files.write(localFile, data);
+    GcsUri gcsUri = _dataDir.resolve("rangeFile");
+    _pinotFS.copyFromLocalFile(localFile.toFile(), gcsUri.getUri());
+    URI uri = gcsUri.getUri();
+
+    // Mid-file range [10, 30)
+    try (InputStream in = _pinotFS.openForRead(uri, 10, 20)) {
+      assertEquals(in.readAllBytes(), Arrays.copyOfRange(data, 10, 30));
+    }
+    // Length beyond EOF is truncated at end-of-file
+    try (InputStream in = _pinotFS.openForRead(uri, 250, 100)) {
+      assertEquals(in.readAllBytes(), Arrays.copyOfRange(data, 250, 256));
+    }
+    // Whole file
+    try (InputStream in = _pinotFS.openForRead(uri, 0, 256)) {
+      assertEquals(in.readAllBytes(), data);
+    }
   }
 
   @Test

--- a/pinot-plugins/pinot-file-system/pinot-gcs/src/test/java/org/apache/pinot/plugin/filesystem/GcsPinotFSTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/src/test/java/org/apache/pinot/plugin/filesystem/GcsPinotFSTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.plugin.filesystem;
 import com.google.common.io.Closer;
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.file.Files;
@@ -164,6 +165,36 @@ public class GcsPinotFSTest {
   private Stream<GcsUri> listFilesToStream(GcsUri gcsUri)
       throws IOException {
     return Arrays.asList(_pinotFS.listFiles(gcsUri.getUri(), true)).stream().map(URI::create).map(GcsUri::new);
+  }
+
+  @Test
+  public void testOpenForRead()
+      throws Exception {
+    skipIfNotConfigured();
+    assertTrue(_pinotFS.supportsRangedRead());
+
+    byte[] data = new byte[256];
+    for (int i = 0; i < data.length; i++) {
+      data[i] = (byte) i;
+    }
+    Path localFile = _localTmpDir.resolve("rangeFile");
+    Files.write(localFile, data);
+    GcsUri gcsUri = _dataDir.resolve("rangeFile");
+    _pinotFS.copyFromLocalFile(localFile.toFile(), gcsUri.getUri());
+    URI uri = gcsUri.getUri();
+
+    // Mid-file range [10, 30)
+    try (InputStream in = _pinotFS.openForRead(uri, 10, 20)) {
+      assertEquals(in.readAllBytes(), Arrays.copyOfRange(data, 10, 30));
+    }
+    // Length beyond EOF is truncated at end-of-file
+    try (InputStream in = _pinotFS.openForRead(uri, 250, 100)) {
+      assertEquals(in.readAllBytes(), Arrays.copyOfRange(data, 250, 256));
+    }
+    // Whole file
+    try (InputStream in = _pinotFS.openForRead(uri, 0, 256)) {
+      assertEquals(in.readAllBytes(), data);
+    }
   }
 
   @Test

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
@@ -21,10 +21,13 @@ package org.apache.pinot.spi.filesystem;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.RandomAccessFile;
 import java.net.URI;
 import java.net.URLDecoder;
+import java.nio.channels.Channels;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -195,6 +198,30 @@ public class LocalPinotFS extends BasePinotFS {
     return new BufferedInputStream(new FileInputStream(toFile(uri)));
   }
 
+  @Override
+  public InputStream openForRead(URI uri, long offset, long length)
+      throws IOException {
+    if (offset < 0 || length < 0) {
+      throw new IllegalArgumentException(
+          "offset and length must be non-negative, got offset=" + offset + ", length=" + length);
+    }
+    RandomAccessFile randomAccessFile = new RandomAccessFile(toFile(uri), "r");
+    try {
+      randomAccessFile.seek(offset);
+      // Closing the stream returned by Channels.newInputStream closes the channel, which closes the
+      // RandomAccessFile, so the caller closing the returned stream releases the file handle.
+      return new RangeInputStream(Channels.newInputStream(randomAccessFile.getChannel()), length);
+    } catch (IOException | RuntimeException e) {
+      randomAccessFile.close();
+      throw e;
+    }
+  }
+
+  @Override
+  public boolean supportsRangedRead() {
+    return true;
+  }
+
   private static File toFile(URI uri) {
     // NOTE: Do not use new File(uri) because scheme might not exist and it does not decode '+' to ' '
     //       Do not use uri.getPath() because it does not decode '+' to ' '
@@ -246,6 +273,51 @@ public class LocalPinotFS extends BasePinotFS {
   public static class LocalPinotFSException extends IOException {
     LocalPinotFSException(Throwable e) {
       super(e);
+    }
+  }
+
+  /**
+   * Wraps an InputStream to expose at most {@code limit} bytes. Closing this stream propagates to the
+   * delegate (which releases the underlying file handle).
+   */
+  private static class RangeInputStream extends FilterInputStream {
+    private long _remaining;
+
+    RangeInputStream(InputStream in, long limit) {
+      super(in);
+      _remaining = limit;
+    }
+
+    @Override
+    public int read()
+        throws IOException {
+      if (_remaining <= 0) {
+        return -1;
+      }
+      int b = in.read();
+      if (b >= 0) {
+        _remaining--;
+      }
+      return b;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len)
+        throws IOException {
+      if (_remaining <= 0) {
+        return -1;
+      }
+      int read = in.read(b, off, (int) Math.min(len, _remaining));
+      if (read > 0) {
+        _remaining -= read;
+      }
+      return read;
+    }
+
+    @Override
+    public int available()
+        throws IOException {
+      return (int) Math.min(in.available(), _remaining);
     }
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
@@ -21,10 +21,13 @@ package org.apache.pinot.spi.filesystem;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.RandomAccessFile;
 import java.net.URI;
 import java.net.URLDecoder;
+import java.nio.channels.Channels;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -209,6 +212,30 @@ public class LocalPinotFS extends BasePinotFS {
     return new BufferedInputStream(new FileInputStream(toFile(uri)));
   }
 
+  @Override
+  public InputStream openForRead(URI uri, long offset, long length)
+      throws IOException {
+    if (offset < 0 || length < 0) {
+      throw new IllegalArgumentException(
+          "offset and length must be non-negative, got offset=" + offset + ", length=" + length);
+    }
+    RandomAccessFile randomAccessFile = new RandomAccessFile(toFile(uri), "r");
+    try {
+      randomAccessFile.seek(offset);
+      // Closing the stream returned by Channels.newInputStream closes the channel, which closes the
+      // RandomAccessFile, so the caller closing the returned stream releases the file handle.
+      return new RangeInputStream(Channels.newInputStream(randomAccessFile.getChannel()), length);
+    } catch (IOException | RuntimeException e) {
+      randomAccessFile.close();
+      throw e;
+    }
+  }
+
+  @Override
+  public boolean supportsRangedRead() {
+    return true;
+  }
+
   private static File toFile(URI uri) {
     // NOTE: Do not use new File(uri) because scheme might not exist and it does not decode '+' to ' '
     //       Do not use uri.getPath() because it does not decode '+' to ' '
@@ -260,6 +287,51 @@ public class LocalPinotFS extends BasePinotFS {
   public static class LocalPinotFSException extends IOException {
     LocalPinotFSException(Throwable e) {
       super(e);
+    }
+  }
+
+  /**
+   * Wraps an InputStream to expose at most {@code limit} bytes. Closing this stream propagates to the
+   * delegate (which releases the underlying file handle).
+   */
+  private static class RangeInputStream extends FilterInputStream {
+    private long _remaining;
+
+    RangeInputStream(InputStream in, long limit) {
+      super(in);
+      _remaining = limit;
+    }
+
+    @Override
+    public int read()
+        throws IOException {
+      if (_remaining <= 0) {
+        return -1;
+      }
+      int b = in.read();
+      if (b >= 0) {
+        _remaining--;
+      }
+      return b;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len)
+        throws IOException {
+      if (_remaining <= 0) {
+        return -1;
+      }
+      int read = in.read(b, off, (int) Math.min(len, _remaining));
+      if (read > 0) {
+        _remaining -= read;
+      }
+      return read;
+    }
+
+    @Override
+    public int available()
+        throws IOException {
+      return (int) Math.min(in.available(), _remaining);
     }
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
@@ -291,7 +291,7 @@ public class LocalPinotFS extends BasePinotFS {
   }
 
   /// Wraps an InputStream to expose at most {@code limit} bytes. Closing this stream propagates to the
-  /// delegate (which releases the underlying file handle).
+  /// delegate (which releases the underlying file handle). Not thread-safe: confine an instance to one thread.
   private static class RangeInputStream extends FilterInputStream {
     private long _remaining;
 
@@ -327,9 +327,29 @@ public class LocalPinotFS extends BasePinotFS {
     }
 
     @Override
+    public long skip(long n)
+        throws IOException {
+      if (n <= 0 || _remaining <= 0) {
+        return 0;
+      }
+      long skipped = in.skip(Math.min(n, _remaining));
+      if (skipped > 0) {
+        _remaining -= skipped;
+      }
+      return skipped;
+    }
+
+    @Override
     public int available()
         throws IOException {
       return (int) Math.min(in.available(), _remaining);
+    }
+
+    /// Not supported: mark/reset would let a caller re-read bytes without {@code _remaining} accounting for them,
+    /// which would expose more than {@code limit} bytes.
+    @Override
+    public boolean markSupported() {
+      return false;
     }
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
@@ -290,10 +290,8 @@ public class LocalPinotFS extends BasePinotFS {
     }
   }
 
-  /**
-   * Wraps an InputStream to expose at most {@code limit} bytes. Closing this stream propagates to the
-   * delegate (which releases the underlying file handle).
-   */
+  /// Wraps an InputStream to expose at most {@code limit} bytes. Closing this stream propagates to the
+  /// delegate (which releases the underlying file handle).
   private static class RangeInputStream extends FilterInputStream {
     private long _remaining;
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/NoClosePinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/NoClosePinotFS.java
@@ -147,4 +147,15 @@ public class NoClosePinotFS implements PinotFS {
       throws IOException {
     return _delegate.open(uri);
   }
+
+  @Override
+  public InputStream openForRead(URI uri, long offset, long length)
+      throws IOException {
+    return _delegate.openForRead(uri, offset, length);
+  }
+
+  @Override
+  public boolean supportsRangedRead() {
+    return _delegate.supportsRangedRead();
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java
@@ -286,6 +286,32 @@ public interface PinotFS extends Closeable, Serializable {
       throws IOException;
 
   /**
+   * Opens a byte range {@code [offset, offset + length)} of a file and returns an InputStream over just that range,
+   * without reading (or downloading) the whole file. This is intended for filesystems backed by remote object stores
+   * that support range requests (e.g. S3/GCS), enabling targeted reads of file regions (such as Parquet footers and
+   * column chunks) instead of fetching entire objects.
+   * <p>The default implementation throws {@link UnsupportedOperationException}; implementations that support ranged
+   * reads must override both this method and {@link #supportsRangedRead()}. Callers should gate usage on
+   * {@link #supportsRangedRead()} rather than catching the exception.
+   * @param uri location of the file to open
+   * @param offset starting byte offset (inclusive, {@code >= 0})
+   * @param length number of bytes to read ({@code >= 0}); reads are truncated at end-of-file
+   * @return a new InputStream over the requested byte range; the caller is responsible for closing it
+   * @throws IOException on any IO error - missing file, not a file etc
+   */
+  default InputStream openForRead(URI uri, long offset, long length)
+      throws IOException {
+    throw new UnsupportedOperationException(getClass().getSimpleName() + " does not support ranged reads");
+  }
+
+  /**
+   * @return true if this filesystem supports {@link #openForRead(URI, long, long)}. Default is false.
+   */
+  default boolean supportsRangedRead() {
+    return false;
+  }
+
+  /**
    * For certain filesystems, we may need to close the filesystem and do relevant operations to prevent leaks.
    * By default, this method does nothing.
    * @throws IOException on IO failure

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java
@@ -246,6 +246,28 @@ public interface PinotFS extends Closeable, Serializable {
   InputStream open(URI uri)
       throws IOException;
 
+  /// Opens a byte range {@code [offset, offset + length)} of a file and returns an InputStream over just that range,
+  /// without reading (or downloading) the whole file. This is intended for filesystems backed by remote object stores
+  /// that support range requests (e.g. S3/GCS), enabling targeted reads of file regions (such as Parquet footers and
+  /// column chunks) instead of fetching entire objects.
+  /// <p>The default implementation throws {@link UnsupportedOperationException}; implementations that support ranged
+  /// reads must override both this method and {@link #supportsRangedRead()}. Callers should gate usage on
+  /// {@link #supportsRangedRead()} rather than catching the exception.
+  /// @param uri location of the file to open
+  /// @param offset starting byte offset (inclusive, {@code >= 0})
+  /// @param length number of bytes to read ({@code >= 0}); reads are truncated at end-of-file
+  /// @return a new InputStream over the requested byte range; the caller is responsible for closing it
+  /// @throws IOException on any IO error - missing file, not a file etc
+  default InputStream openForRead(URI uri, long offset, long length)
+      throws IOException {
+    throw new UnsupportedOperationException(getClass().getSimpleName() + " does not support ranged reads");
+  }
+
+  /// @return true if this filesystem supports {@link #openForRead(URI, long, long)}. Default is false.
+  default boolean supportsRangedRead() {
+    return false;
+  }
+
   /// For certain filesystems, we may need to close the filesystem and do relevant operations to prevent leaks.
   /// Implementations must only close resources owned by this instance, not clients shared with other PinotFS
   /// instances. By default, this method does nothing.

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/LocalPinotFSTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/LocalPinotFSTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.spi.filesystem;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -309,5 +310,46 @@ public class LocalPinotFSTest {
     Assert.assertTrue(
         expectedRecursive.containsAll(fileMetadata.stream().map(FileMetadata::getFilePath).collect(Collectors.toSet())),
         fileMetadata.toString());
+  }
+
+  @Test
+  public void testOpenForRead()
+      throws IOException {
+    LocalPinotFS localPinotFS = new LocalPinotFS();
+    Assert.assertTrue(localPinotFS.supportsRangedRead());
+
+    File rangeFile = new File(_absoluteTmpDirPath, "rangeFile");
+    byte[] data = new byte[256];
+    for (int i = 0; i < data.length; i++) {
+      data[i] = (byte) i;
+    }
+    FileUtils.writeByteArrayToFile(rangeFile, data);
+    URI uri = rangeFile.toURI();
+
+    // Mid-file range [10, 30)
+    try (InputStream in = localPinotFS.openForRead(uri, 10, 20)) {
+      Assert.assertEquals(in.readAllBytes(), Arrays.copyOfRange(data, 10, 30));
+    }
+    // From the start
+    try (InputStream in = localPinotFS.openForRead(uri, 0, 5)) {
+      Assert.assertEquals(in.readAllBytes(), Arrays.copyOfRange(data, 0, 5));
+    }
+    // Length beyond EOF is truncated at end-of-file
+    try (InputStream in = localPinotFS.openForRead(uri, 250, 100)) {
+      Assert.assertEquals(in.readAllBytes(), Arrays.copyOfRange(data, 250, 256));
+    }
+    // Zero length yields an empty stream
+    try (InputStream in = localPinotFS.openForRead(uri, 30, 0)) {
+      Assert.assertEquals(in.readAllBytes().length, 0);
+    }
+    // Whole file
+    try (InputStream in = localPinotFS.openForRead(uri, 0, 256)) {
+      Assert.assertEquals(in.readAllBytes(), data);
+    }
+    // Negative arguments are rejected
+    Assert.assertThrows(IllegalArgumentException.class, () -> localPinotFS.openForRead(uri, -1, 10));
+    Assert.assertThrows(IllegalArgumentException.class, () -> localPinotFS.openForRead(uri, 0, -1));
+
+    Assert.assertTrue(rangeFile.delete());
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/LocalPinotFSTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/LocalPinotFSTest.java
@@ -373,4 +373,35 @@ public class LocalPinotFSTest {
 
     Assert.assertTrue(rangeFile.delete());
   }
+
+  @Test
+  public void testOpenForReadSkipStaysWithinRange()
+      throws IOException {
+    LocalPinotFS localPinotFS = new LocalPinotFS();
+
+    File rangeFile = new File(_absoluteTmpDirPath, "skipRangeFile");
+    byte[] data = new byte[256];
+    for (int i = 0; i < data.length; i++) {
+      data[i] = (byte) i;
+    }
+    FileUtils.writeByteArrayToFile(rangeFile, data);
+    URI uri = rangeFile.toURI();
+
+    // Skipping must consume the range, not extend it: 5 skipped of [0, 10) leaves 5 readable
+    try (InputStream in = localPinotFS.openForRead(uri, 0, 10)) {
+      Assert.assertEquals(in.skip(5), 5);
+      Assert.assertEquals(in.readAllBytes(), Arrays.copyOfRange(data, 5, 10));
+    }
+    // Skipping beyond the range is capped at the range end
+    try (InputStream in = localPinotFS.openForRead(uri, 10, 20)) {
+      Assert.assertEquals(in.skip(100), 20);
+      Assert.assertEquals(in.readAllBytes().length, 0);
+    }
+    // mark/reset must not be advertised, or a caller could re-read past the bound
+    try (InputStream in = localPinotFS.openForRead(uri, 0, 10)) {
+      Assert.assertFalse(in.markSupported());
+    }
+
+    Assert.assertTrue(rangeFile.delete());
+  }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/LocalPinotFSTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/LocalPinotFSTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.spi.filesystem;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -330,5 +331,46 @@ public class LocalPinotFSTest {
     URI fileUri = testFile.toURI();
     Assert.assertThrows(IOException.class, () -> localPinotFS.listFiles(fileUri, false));
     Assert.assertThrows(IOException.class, () -> localPinotFS.listFilesWithMetadata(fileUri, false));
+  }
+
+  @Test
+  public void testOpenForRead()
+      throws IOException {
+    LocalPinotFS localPinotFS = new LocalPinotFS();
+    Assert.assertTrue(localPinotFS.supportsRangedRead());
+
+    File rangeFile = new File(_absoluteTmpDirPath, "rangeFile");
+    byte[] data = new byte[256];
+    for (int i = 0; i < data.length; i++) {
+      data[i] = (byte) i;
+    }
+    FileUtils.writeByteArrayToFile(rangeFile, data);
+    URI uri = rangeFile.toURI();
+
+    // Mid-file range [10, 30)
+    try (InputStream in = localPinotFS.openForRead(uri, 10, 20)) {
+      Assert.assertEquals(in.readAllBytes(), Arrays.copyOfRange(data, 10, 30));
+    }
+    // From the start
+    try (InputStream in = localPinotFS.openForRead(uri, 0, 5)) {
+      Assert.assertEquals(in.readAllBytes(), Arrays.copyOfRange(data, 0, 5));
+    }
+    // Length beyond EOF is truncated at end-of-file
+    try (InputStream in = localPinotFS.openForRead(uri, 250, 100)) {
+      Assert.assertEquals(in.readAllBytes(), Arrays.copyOfRange(data, 250, 256));
+    }
+    // Zero length yields an empty stream
+    try (InputStream in = localPinotFS.openForRead(uri, 30, 0)) {
+      Assert.assertEquals(in.readAllBytes().length, 0);
+    }
+    // Whole file
+    try (InputStream in = localPinotFS.openForRead(uri, 0, 256)) {
+      Assert.assertEquals(in.readAllBytes(), data);
+    }
+    // Negative arguments are rejected
+    Assert.assertThrows(IllegalArgumentException.class, () -> localPinotFS.openForRead(uri, -1, 10));
+    Assert.assertThrows(IllegalArgumentException.class, () -> localPinotFS.openForRead(uri, 0, -1));
+
+    Assert.assertTrue(rangeFile.delete());
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/NoClosePinotFSTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/NoClosePinotFSTest.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.filesystem;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.Arrays;
+import org.apache.commons.io.FileUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class NoClosePinotFSTest {
+
+  /**
+   * {@link NoClosePinotFS} must delegate the ranged-read methods to its delegate; otherwise anything obtained
+   * via {@link PinotFSFactory} (which wraps every registered FS in a NoClosePinotFS) would report no ranged-read
+   * support and throw on {@link PinotFS#openForRead}.
+   */
+  @Test
+  public void testDelegatesRangedRead()
+      throws Exception {
+    File file = Files.createTempFile("noclose-ranged", ".bin").toFile();
+    try {
+      byte[] data = new byte[256];
+      for (int i = 0; i < data.length; i++) {
+        data[i] = (byte) i;
+      }
+      FileUtils.writeByteArrayToFile(file, data);
+
+      NoClosePinotFS fs = new NoClosePinotFS(new LocalPinotFS());
+      Assert.assertTrue(fs.supportsRangedRead(), "must delegate supportsRangedRead() to the wrapped FS");
+      try (InputStream in = fs.openForRead(file.toURI(), 10, 20)) {
+        Assert.assertEquals(in.readAllBytes(), Arrays.copyOfRange(data, 10, 30));
+      }
+    } finally {
+      Assert.assertTrue(file.delete());
+    }
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/NoClosePinotFSTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/NoClosePinotFSTest.java
@@ -29,11 +29,9 @@ import org.testng.annotations.Test;
 
 public class NoClosePinotFSTest {
 
-  /**
-   * {@link NoClosePinotFS} must delegate the ranged-read methods to its delegate; otherwise anything obtained
-   * via {@link PinotFSFactory} (which wraps every registered FS in a NoClosePinotFS) would report no ranged-read
-   * support and throw on {@link PinotFS#openForRead}.
-   */
+  /// {@link NoClosePinotFS} must delegate the ranged-read methods to its delegate; otherwise anything obtained
+  /// via {@link PinotFSFactory} (which wraps every registered FS in a NoClosePinotFS) would report no ranged-read
+  /// support and throw on {@link PinotFS#openForRead}.
   @Test
   public void testDelegatesRangedRead()
       throws Exception {


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Caller checks ranged\-read support, then opens a byte range stream validated and bounded by the filesystem implementation\.

```mermaid
flowchart TD
  N0["Caller#58; check supportsRangedRead#40;#41; #40;F7#41;"]:::stAdded
  N1["Caller#58; call openForRead#40;#41; #40;F7#41;"]:::stAdded
  N2["Validate offset and length #40;F2#41;"]:::stAdded
  N3["Open RandomAccessFile #40;F2#41;"]:::stAdded
  N4["Seek to offset #40;F2#41;"]:::stAdded
  N5["Return RangeInputStream #40;F2#41;"]:::stAdded
  N6["RangeInputStream#58; enforce limit #40;F2#41;"]:::stAdded
  N0 --> N1
  N1 --> N2
  N2 --> N3
  N3 --> N4
  N4 --> N5
  N5 --> N6
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F2: pinot\-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS\.java — [before](https://github.com/apache/pinot/blob/f5fee8e7023af2af57e249493da1c8649a33ecb5/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java) · [after](https://github.com/apache/pinot/blob/f91ddd178a38e510f697c5e48340324fd9bb75c1/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java)
- F7: pinot\-spi/src/test/java/org/apache/pinot/spi/filesystem/LocalPinotFSTest\.java — [before](https://github.com/apache/pinot/blob/f5fee8e7023af2af57e249493da1c8649a33ecb5/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/LocalPinotFSTest.java) · [after](https://github.com/apache/pinot/blob/f91ddd178a38e510f697c5e48340324fd9bb75c1/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/LocalPinotFSTest.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImY1ZmVlOGU3MDIzYWYyYWY1N2UyNDk0OTNkYTFjODY0OWEzM2VjYjUiLCJjb250ZXh0X2hhc2giOiJhNGFlYzIwYzQ0OGQ3ZmMyMzVjZTVjYjQyY2Q4ZTc5Y2UwM2Q3YjlhMjFkNTkwYTA4MGFkYWYxMjgyMDYyZTM0IiwiZ2VuZXJhdGVkX2F0IjoxNzkwMDAzNDgxLCJoZWFkX3NoYSI6ImY5MWRkZDE3OGEzOGU1MTBmNjk3YzVlNDgzNDAzMjRmZDliYjc1YzEiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIyYWU3MTk1ZWE0MzI5MTU2MDBmNTY0ZThmNjdiYmRlYjJlYjA0MzYwIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 13dbef6874cf56b74e0999b190cfd2a32d28da8c3f3503e7972219ccda9bf2a0 -->
<!-- pinot-pr-flow:end -->

**Description**

Adds an additive ranged-read capability to the PinotFS SPI so callers can read a specific byte range of a file without downloading the whole object.

- New default methods openForRead(URI uri, long offset, long length) and supportsRangedRead() on PinotFS. Defaults throw UnsupportedOperationException / return false, so all existing
  implementations remain source- and binary-compatible — no behavior change unless an implementation opts in.
- LocalPinotFS: implemented via RandomAccessFile + a bounded stream that releases the file handle on close.
- GcsPinotFS: implemented via ReadChannel.seek/limit (a single ranged GET, truncated at EOF).

**Motivation**

Enables targeted reads of file regions (e.g. Parquet footers and column chunks) for engines/plugins that query columnar data in place, avoiding full-object transfers.

**Testing**

LocalPinotFSTest covers mid-range, from-start, EOF truncation, zero-length, whole-file, and invalid-argument cases (runs in CI). GcsPinotFSTest adds a ranged-read case (credentials-gated, consistent with the existing GCS integration test).

**PR Tags**

   1. `feature`
   2. `performance`

**release-notes**:

- Signature changes to public methods/interfaces
