### PR TITLE
Forward SegmentDirectoryLoaderContext in DefaultSegmentDirectoryLoader

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/loader/DefaultSegmentDirectoryLoader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/loader/DefaultSegmentDirectoryLoader.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.net.URI;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.segment.store.SegmentLocalFSDirectory;
+import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoader;
 import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderContext;
 import org.apache.pinot.segment.spi.loader.SegmentLoader;
@@ -39,7 +40,12 @@ public class DefaultSegmentDirectoryLoader implements SegmentDirectoryLoader {
 
   /**
    * Creates and loads the {@link SegmentLocalFSDirectory} which is the default implementation of
-   * {@link SegmentDirectory}
+   * {@link SegmentDirectory}.
+   *
+   * <p>The {@link SegmentDirectoryLoaderContext} is forwarded into the {@link SegmentLocalFSDirectory}
+   * so downstream consumers (e.g. {@code SingleFileIndexDirectory#createRemoteBuffers}) can use it to
+   * propagate the table's task configuration into remote/empty index buffers.
+   *
    * @param indexDir segment index directory
    * @param segmentLoaderContext context for instantiation of the SegmentDirectory
    * @return instance of {@link SegmentLocalFSDirectory}
@@ -51,7 +57,9 @@ public class DefaultSegmentDirectoryLoader implements SegmentDirectoryLoader {
     if (!directory.exists()) {
       return new SegmentLocalFSDirectory(directory);
     }
-    return new SegmentLocalFSDirectory(directory, segmentLoaderContext.getReadMode());
+    SegmentMetadataImpl metadata = new SegmentMetadataImpl(directory);
+    return new SegmentLocalFSDirectory(directory, metadata, segmentLoaderContext.getReadMode(),
+        segmentLoaderContext);
   }
 
   @Override


### PR DESCRIPTION
## What

[#18806](https://github.com/apache/pinot/pull/18806) ("Replace `segmentDirectoryConfigs` map with `ReadMode` in `SegmentDirectoryLoaderContext`") refactored `DefaultSegmentDirectoryLoader.load` and inadvertently dropped the `segmentLoaderContext` argument when constructing `SegmentLocalFSDirectory`:

```java
// Before #18806
return new SegmentLocalFSDirectory(directory, segmentLoaderContext,
    ReadMode.valueOf(segmentDirectoryConfigs.getProperty(IndexLoadingConfig.READ_MODE_KEY)));

// After #18806 (current master)
return new SegmentLocalFSDirectory(directory, segmentLoaderContext.getReadMode());
```

The 2-arg `SegmentLocalFSDirectory(File, ReadMode)` constructor sets the underlying `SingleFileIndexDirectory#_segmentDirectoryLoaderContext` to `null`. This silently breaks the task-config propagation introduced in [#18264](https://github.com/apache/pinot/pull/18264) — `SingleFileIndexDirectory#serializeTaskConfigToJsonFromContext()` short-circuits at its first guard:

```java
private String serializeTaskConfigToJsonFromContext() {
  if (_segmentDirectoryLoaderContext == null) {
    return null;     // ← #18806 makes this always true on the default loader path
  }
  ...
}
```

As a result, `task.config.json` is never injected into `EmptyIndexBuffer.properties`, and downstream consumers that depend on the table's task configuration to resolve their own configuration silently fall back to ambient defaults 
