### PR TITLE
Mark numMinionSubtasks* gauges as non-global to match PR #18854 Prometheus rule

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/ControllerPrometheusMetricsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/ControllerPrometheusMetricsTest.java
@@ -38,23 +38,22 @@ public abstract class ControllerPrometheusMetricsTest extends PinotPrometheusMet
 
   //that accept global gauge with suffix
   private static final List<ControllerGauge> GLOBAL_GAUGES_ACCEPTING_TASKTYPE =
-      List.of(ControllerGauge.NUM_MINION_TASKS_IN_PROGRESS, ControllerGauge.NUM_MINION_SUBTASKS_RUNNING,
-          ControllerGauge.NUM_MINION_SUBTASKS_WAITING, ControllerGauge.NUM_MINION_SUBTASKS_ERROR,
-          ControllerGauge.NUM_MINION_SUBTASKS_UNKNOWN,
-          ControllerGauge.NUM_MINION_SUBTASKS_DROPPED,
-          ControllerGauge.NUM_MINION_SUBTASKS_TIMED_OUT,
-          ControllerGauge.NUM_MINION_SUBTASKS_ABORTED,
-          ControllerGauge.PERCENT_MINION_SUBTASKS_IN_QUEUE, ControllerGauge.PERCENT_MINION_SUBTASKS_IN_ERROR);
+      List.of(ControllerGauge.NUM_MINION_TASKS_IN_PROGRESS);
 
   //local gauges that accept partition
   private static final List<ControllerGauge> GAUGES_ACCEPTING_PARTITION =
       List.of(ControllerGauge.MAX_RECORDS_LAG, ControllerGauge.MAX_RECORD_AVAILABILITY_LAG_MS);
 
-  //these accept task type
+  //these accept task type (per-table scoped)
   private static final List<ControllerGauge> GAUGES_ACCEPTING_TASKTYPE =
       List.of(ControllerGauge.TIME_MS_SINCE_LAST_MINION_TASK_METADATA_UPDATE,
           ControllerGauge.TIME_MS_SINCE_LAST_SUCCESSFUL_MINION_TASK_GENERATION,
-          ControllerGauge.LAST_MINION_TASK_GENERATION_ENCOUNTERS_ERROR);
+          ControllerGauge.LAST_MINION_TASK_GENERATION_ENCOUNTERS_ERROR,
+          ControllerGauge.NUM_MINION_SUBTASKS_RUNNING, ControllerGauge.NUM_MINION_SUBTASKS_WAITING,
+          ControllerGauge.NUM_MINION_SUBTASKS_ERROR, ControllerGauge.NUM_MINION_SUBTASKS_UNKNOWN,
+          ControllerGauge.NUM_MINION_SUBTASKS_DROPPED, ControllerGauge.NUM_MINION_SUBTASKS_TIMED_OUT,
+          ControllerGauge.NUM_MINION_SUBTASKS_ABORTED,
+          ControllerGauge.PERCENT_MINION_SUBTASKS_IN_QUEUE, ControllerGauge.PERCENT_MINION_SUBTASKS_IN_ERROR);
 
   private static final List<ControllerGauge> GAUGES_ACCEPTING_RAW_TABLENAME = List.of();
 


### PR DESCRIPTION
## Summary

PR #18854 updated `controller.yml` to emit `numMinionSubtasks*` / `percentMinionSubtasks*` metrics with per-table+taskType labels (removing them from the global taskType-only rule). The Java side was not updated to match:

- `ControllerGauge`: the 9 affected gauges were still marked `isGlobal=true`
- `ControllerPrometheusMetricsTest`: still asserting the old global scoping for those gauges

This PR aligns both to the new per-table scoping introduced by #18854.

## Changes

- **`ControllerGauge.java`**: mark 9 subtask gauges as `isGlobal=false` — `NUM_MINION_SUBTASKS_WAITING`, `NUM_MINION_SUBTASKS_RUNNING`, `NUM_MINION_SUBTASKS_ERROR`, `NUM_MINION_SUBTASKS_UNKNOWN`, `NUM_MINION_SUBTASKS_DROPPED`, `NUM_MINION_SUBTASKS_TIMED_OUT`, `NUM_MINION_SUBTASKS_ABORTED`, `PERCENT_MINION_SUBTASKS_IN_QUEUE`, `PERCENT_MINION_SUBTASKS_IN_ERROR`
- **`ControllerPrometheusMetricsTest.java`**: move the 9 gauges from `GLOBAL_GAUGES_ACCEPTING_TASKTYPE` into `GAUGES_ACCEPTING_TASKTYPE` (per-table scoped)

## Test plan

- [x] `./mvnw -pl pinot-plugins/pinot-metrics/pinot-yammer -am -Dtest=YammerControllerPrometheusMetricsTest test` — passes (163 tests, 0 failures)
- [x] `./mvnw checkstyle:check -pl pinot-common` — clean