### PR TITLE
Make the server query meter table level

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -26,7 +26,8 @@ import org.apache.pinot.spi.metrics.PinotMeter;
  * Enumeration containing all the meters exposed by the Pinot server.
  */
 public enum ServerMeter implements AbstractMetrics.Meter {
-  QUERIES("queries", false),
+  QUERIES("queries", true),
+  QUERIES_ON_TABLE("queries", false),
   UNCAUGHT_EXCEPTIONS("exceptions", true),
   REQUEST_DESERIALIZATION_EXCEPTIONS("exceptions", true),
   RESPONSE_SERIALIZATION_EXCEPTIONS("exceptions", true),

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -26,7 +26,7 @@ import org.apache.pinot.spi.metrics.PinotMeter;
  * Enumeration containing all the meters exposed by the Pinot server.
  */
 public enum ServerMeter implements AbstractMetrics.Meter {
-  QUERIES("queries", true),
+  QUERIES("queries", false),
   UNCAUGHT_EXCEPTIONS("exceptions", true),
   REQUEST_DESERIALIZATION_EXCEPTIONS("exceptions", true),
   RESPONSE_SERIALIZATION_EXCEPTIONS("exceptions", true),

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/InstanceRequestHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/InstanceRequestHandler.java
@@ -121,6 +121,7 @@ public class InstanceRequestHandler extends SimpleChannelInboundHandler<ByteBuf>
   protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) {
     long queryArrivalTimeMs = System.currentTimeMillis();
     int requestSize = msg.readableBytes();
+    _serverMetrics.addMeteredGlobalValue(ServerMeter.QUERIES, 1);
     _serverMetrics.addMeteredGlobalValue(ServerMeter.NETTY_CONNECTION_BYTES_RECEIVED, requestSize);
     byte[] requestBytes = new byte[requestSize];
     msg.readBytes(requestBytes);
@@ -129,7 +130,7 @@ public class InstanceRequestHandler extends SimpleChannelInboundHandler<ByteBuf>
       InstanceRequest instanceRequest = new InstanceRequest();
       THREAD_LOCAL_T_DESERIALIZER.get().deserialize(instanceRequest, requestBytes);
       queryRequest = new ServerQueryRequest(instanceRequest, _serverMetrics, queryArrivalTimeMs);
-      _serverMetrics.addMeteredTableValue(queryRequest.getTableNameWithType(), ServerMeter.QUERIES, 1);
+      _serverMetrics.addMeteredTableValue(queryRequest.getTableNameWithType(), ServerMeter.QUERIES_ON_TABLE, 1);
       queryRequest.getTimerContext().startNewPhaseTimer(ServerQueryPhase.REQUEST_DESERIALIZATION, queryArrivalTimeMs)
           .stopAndRecord();
     } catch (Exception e) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/InstanceRequestHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/InstanceRequestHandler.java
@@ -121,7 +121,6 @@ public class InstanceRequestHandler extends SimpleChannelInboundHandler<ByteBuf>
   protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) {
     long queryArrivalTimeMs = System.currentTimeMillis();
     int requestSize = msg.readableBytes();
-    _serverMetrics.addMeteredGlobalValue(ServerMeter.QUERIES, 1);
     _serverMetrics.addMeteredGlobalValue(ServerMeter.NETTY_CONNECTION_BYTES_RECEIVED, requestSize);
     byte[] requestBytes = new byte[requestSize];
     msg.readBytes(requestBytes);
@@ -130,6 +129,7 @@ public class InstanceRequestHandler extends SimpleChannelInboundHandler<ByteBuf>
       InstanceRequest instanceRequest = new InstanceRequest();
       THREAD_LOCAL_T_DESERIALIZER.get().deserialize(instanceRequest, requestBytes);
       queryRequest = new ServerQueryRequest(instanceRequest, _serverMetrics, queryArrivalTimeMs);
+      _serverMetrics.addMeteredTableValue(queryRequest.getTableNameWithType(), ServerMeter.QUERIES, 1);
       queryRequest.getTimerContext().startNewPhaseTimer(ServerQueryPhase.REQUEST_DESERIALIZATION, queryArrivalTimeMs)
           .stopAndRecord();
     } catch (Exception e) {


### PR DESCRIPTION
## Description
The query meter didn't carry table information since https://github.com/apache/pinot/pull/9001. Adding it so we can track table level QPS