### PR TITLE
Expose the query executor init config via QueryExecutor#getQueryExecutorConfig

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/QueryExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/QueryExecutor.java
@@ -43,6 +43,15 @@ public interface QueryExecutor {
 
   InstanceDataManager getInstanceDataManager();
 
+  /// Returns the configuration this executor was initialized with (the subset of server config with
+  /// prefix `pinot.server.query.executor`). Callers that build a per-execution [PlanMaker] override
+  /// can initialize it with the same settings the executor's own plan maker uses, so the override
+  /// honors limits such as `max.execution.threads` and the group-by trim sizes. The default returns
+  /// an empty configuration for implementations that do not track their init config.
+  default PinotConfiguration getQueryExecutorConfig() {
+    return new PinotConfiguration();
+  }
+
   /**
    * Starts the query executor.
    * <p>Should be called only once after query executor gets initialized but before calling any other method.

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -103,6 +103,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
   private ServerMetrics _serverMetrics;
   private SegmentPrunerService _segmentPrunerService;
   private PlanMaker _planMaker;
+  private PinotConfiguration _config;
   private long _defaultTimeoutMs;
   private boolean _enablePrefetch;
 
@@ -110,6 +111,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
   public synchronized void init(PinotConfiguration config, InstanceDataManager instanceDataManager,
       ServerMetrics serverMetrics)
       throws ConfigurationException {
+    _config = config;
     _instanceDataManager = instanceDataManager;
     _serverMetrics = serverMetrics;
     LOGGER.info("Trying to build SegmentPrunerService");
@@ -131,6 +133,11 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
   @Override
   public InstanceDataManager getInstanceDataManager() {
     return _instanceDataManager;
+  }
+
+  @Override
+  public PinotConfiguration getQueryExecutorConfig() {
+    return _config;
   }
 
   @Override


### PR DESCRIPTION
## Summary

Adds `QueryExecutor#getQueryExecutorConfig()` so callers can read the `PinotConfiguration` the executor was initialized with (the `pinot.server.query.executor` subset).

- New interface method with a default that returns an empty `PinotConfiguration` (back-compatible for any implementation that does not track its init config).
- `ServerQueryExecutorV1Impl` retains the config passed to `init(...)` and returns it.

## Motivation

A caller that supplies a per-execution `PlanMaker` override (the `execute(..., PlanMaker)` overload) currently has no way to obtain the executor's configuration, so it cannot initialize that `PlanMaker` with the same settings the executor's own plan maker uses. As a result the override silently falls back to `InstancePlanMakerImplV2` defaults and ignores server limits such as `max.execution.threads` and the group-by trim sizes. This accessor lets such an override be initialized from the executor's real config.

## Compatibility

Purely additive: a new default interface method plus a stored field and getter. No existing signatures change and no behavior changes for current callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)