### PR TITLE
Fix Thrift checksum URL in base Docker images

### DIFF
--- a/docker/images/pinot-base/pinot-base-build/amazoncorretto.dockerfile
+++ b/docker/images/pinot-base/pinot-base-build/amazoncorretto.dockerfile
@@ -87,10 +87,11 @@ ENV MAVEN_CONFIG=/opt/.m2
 # install thrift — version matches libthrift in Pinot's pom.xml
 RUN echo "Building Thrift for $(uname -m) architecture..." && \
   wget https://archive.apache.org/dist/thrift/0.22.0/thrift-0.22.0.tar.gz -O /tmp/thrift-0.22.0.tar.gz && \
-  wget https://archive.apache.org/dist/thrift/0.22.0/thrift-0.22.0.tar.gz.sha512 -O /tmp/thrift-0.22.0.tar.gz.sha512 && \
-  echo "$(cat /tmp/thrift-0.22.0.tar.gz.sha512)  /tmp/thrift-0.22.0.tar.gz" | sha512sum -c - && \
-  tar xfz /tmp/thrift-0.22.0.tar.gz --directory /tmp && \
-  cd /tmp/thrift-0.22.0 && \
+  wget https://archive.apache.org/dist/thrift/0.22.0/thrift-0.22.0.tar.gz.sha256 -O /tmp/thrift-0.22.0.tar.gz.sha256 && \
+  cd /tmp && \
+  sha256sum -c thrift-0.22.0.tar.gz.sha256 && \
+  tar xfz thrift-0.22.0.tar.gz && \
+  cd thrift-0.22.0 && \
   echo "Configuring Thrift..." && \
   ./configure --with-cpp=no --with-c_glib=no --with-java=yes --with-python=no --with-ruby=no --with-erlang=no --with-go=no --with-nodejs=no --with-php=no && \
   echo "Building Thrift..." && \

--- a/docker/images/pinot-base/pinot-base-build/ms-openjdk.dockerfile
+++ b/docker/images/pinot-base/pinot-base-build/ms-openjdk.dockerfile
@@ -60,10 +60,11 @@ ENV MAVEN_CONFIG=/opt/.m2
 # install thrift — version matches libthrift in Pinot's pom.xml
 RUN echo "Building Thrift for $(uname -m) architecture..." && \
   wget https://archive.apache.org/dist/thrift/0.22.0/thrift-0.22.0.tar.gz -O /tmp/thrift-0.22.0.tar.gz && \
-  wget https://archive.apache.org/dist/thrift/0.22.0/thrift-0.22.0.tar.gz.sha512 -O /tmp/thrift-0.22.0.tar.gz.sha512 && \
-  echo "$(cat /tmp/thrift-0.22.0.tar.gz.sha512)  /tmp/thrift-0.22.0.tar.gz" | sha512sum -c - && \
-  tar xfz /tmp/thrift-0.22.0.tar.gz --directory /tmp && \
-  cd /tmp/thrift-0.22.0 && \
+  wget https://archive.apache.org/dist/thrift/0.22.0/thrift-0.22.0.tar.gz.sha256 -O /tmp/thrift-0.22.0.tar.gz.sha256 && \
+  cd /tmp && \
+  sha256sum -c thrift-0.22.0.tar.gz.sha256 && \
+  tar xfz thrift-0.22.0.tar.gz && \
+  cd thrift-0.22.0 && \
   echo "Configuring Thrift..." && \
   ./configure --with-cpp=no --with-c_glib=no --with-java=yes --with-python=no --with-ruby=no --with-erlang=no --with-go=no --with-nodejs=no --with-php=no && \
   echo "Building Thrift..." && \


### PR DESCRIPTION
## Summary
- switch Thrift 0.22.0 source verification from the missing `.sha512` file to the published `.sha256` file
- apply the same fix to both `amazoncorretto` and `ms-openjdk` Pinot base build images

## Root cause
The Apache Thrift 0.22.0 archive publishes `thrift-0.22.0.tar.gz.sha256`, but not `thrift-0.22.0.tar.gz.sha512`. The Pinot base image workflow was downloading the non-existent `.sha512` file, causing the build matrix to fail with HTTP 404 during the Thrift install step.

Failing job: https://github.com/apache/pinot/actions/runs/28479837682/job/84413400317

## User manual / sample configs
Not applicable. This change only fixes CI Docker base image checksum verification and does not change Pinot user-facing behavior, table config, or query syntax.

## Validation
- `gh run view 28479837682 --job 84413400317 --log` to confirm the failing `.sha512` download
- downloaded `thrift-0.22.0.tar.gz` and `thrift-0.22.0.tar.gz.sha256`, then ran `sha256sum -c thrift-0.22.0.tar.gz.sha256` successfully
- `git diff --cached --check`

Full local Docker build was not run because the Docker daemon is not running in this environment.
