### PR TITLE
Fix SchemaUtils to surface actual validation failure reason

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
@@ -477,7 +477,7 @@ public class PinotSchemaRestletResource {
     } catch (SchemaBackwardIncompatibleException e) {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_SCHEMA_UPLOAD_ERROR, 1L);
       throw new ControllerApplicationException(LOGGER,
-          String.format("Backward incompatible schema %s. Only allow adding new columns", schemaName),
+          String.format("Backward incompatible schema %s. Reason: %s", schemaName, e.getMessage()),
           Response.Status.BAD_REQUEST, e);
     } catch (TableNotFoundException e) {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_SCHEMA_UPLOAD_ERROR, 1L);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSchemaRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSchemaRestletResourceTest.java
@@ -107,9 +107,10 @@ public class PinotSchemaRestletResourceTest {
     // Update the schema with addSchema api and override on
     expectValidationException(() -> adminClient.getSchemaClient().createSchema(schema.toSingleLineJsonString()));
 
-    // Update the schema with updateSchema api
-    expectValidationException(
-        () -> adminClient.getSchemaClient().updateSchema(schemaName, schema.toSingleLineJsonString()));
+    // Update the schema with updateSchema api - verify the error message includes the actual reason
+    expectValidationExceptionWithMessage(
+        () -> adminClient.getSchemaClient().updateSchema(schemaName, schema.toSingleLineJsonString()),
+        "Incompatible field specifications");
 
     // Change the column data type from STRING to BOOLEAN
     newColumnFieldSpec.setDataType(DataType.BOOLEAN);
@@ -274,6 +275,15 @@ public class PinotSchemaRestletResourceTest {
         expectThrows(RuntimeException.class, () -> runUnchecked(runnable));
     Throwable cause = unwrap(runtimeException);
     assertTrue(cause instanceof PinotAdminValidationException, "Unexpected exception: " + cause);
+  }
+
+  private void expectValidationExceptionWithMessage(ThrowingRunnable runnable, String expectedMessageSubstring) {
+    RuntimeException runtimeException =
+        expectThrows(RuntimeException.class, () -> runUnchecked(runnable));
+    Throwable cause = unwrap(runtimeException);
+    assertTrue(cause instanceof PinotAdminValidationException, "Unexpected exception: " + cause);
+    assertTrue(cause.getMessage().contains(expectedMessageSubstring),
+        "Expected message to contain '" + expectedMessageSubstring + "' but was: " + cause.getMessage());
   }
 
   private void expectNotFoundException(ThrowingRunnable runnable) {


### PR DESCRIPTION
## Description

The `updateSchema` endpoint in `PinotSchemaRestletResource` was catching `SchemaBackwardIncompatibleException` but discarding the actual error details, returning only a generic message: `"Backward incompatible schema <name>. Only allow adding new columns"`.

This made it very difficult for users to understand **why** their schema update was rejected. The exception itself already contains detailed information about incompatible field specifications, missing columns, primary key changes, and suggestions for fixing the issue — but this information was never surfaced to the user.

After this fix, the error response includes the actual reason from `e.getMessage()`, giving users actionable information about what is incompatible and how to fix it.

## Related Issue

Fixes #14787

## Changes Made

- Modified `PinotSchemaRestletResource.updateSchema()` to include `e.getMessage()` in the error response for `SchemaBackwardIncompatibleException`, replacing the generic "Only allow adding new columns" message.
- Added a test assertion in `PinotSchemaRestletResourceTest` to verify that backward-incompatible schema update errors include the actual incompatibility details.

## Testing Done

- [x] Unit test updated to verify error message includes incompatibility details
- [x] Spotless formatting passes
- [x] Checkstyle passes
- [x] Compilation verified

## Upgrade Notes

None. This is a user-facing error message improvement only — no API or configuration changes.