### PR TITLE
Remove deprecated DEFAULT_SEGMENT_PUSH_TYPE constant

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -55,7 +55,6 @@ import org.apache.pinot.spi.config.table.sampler.TableSamplerConfig;
 
 
 public class TableConfigBuilder {
-  private static final String DEFAULT_SEGMENT_PUSH_TYPE = "APPEND";
   private static final String REFRESH_SEGMENT_PUSH_TYPE = "REFRESH";
   private static final String DEFAULT_DELETED_SEGMENTS_RETENTION_PERIOD = "7d";
   private static final String DEFAULT_NUM_REPLICAS = "1";
@@ -79,9 +78,8 @@ public class TableConfigBuilder {
   @Deprecated
   private String _segmentPushFrequency;
 
-  // TODO: Remove 'DEFAULT_SEGMENT_PUSH_TYPE' in the future major release.
   @Deprecated
-  private String _segmentPushType = DEFAULT_SEGMENT_PUSH_TYPE;
+  private String _segmentPushType = "APPEND";
   private String _peerSegmentDownloadScheme;
   @Deprecated
   private ReplicaGroupStrategyConfig _replicaGroupStrategyConfig;
@@ -224,7 +222,7 @@ public class TableConfigBuilder {
     if (REFRESH_SEGMENT_PUSH_TYPE.equalsIgnoreCase(segmentPushType)) {
       _segmentPushType = REFRESH_SEGMENT_PUSH_TYPE;
     } else {
-      _segmentPushType = DEFAULT_SEGMENT_PUSH_TYPE;
+      _segmentPushType = "APPEND";
     }
     return this;
   }


### PR DESCRIPTION
## Description

Remove the deprecated `DEFAULT_SEGMENT_PUSH_TYPE` constant from `TableConfigBuilder`. The string literal `"APPEND"` is now inlined at the two usage sites (field initializer and fallback branch in `setSegmentPushType()`). The associated TODO comment requesting this removal is also deleted.

The `_segmentPushType` field and `setSegmentPushType()` method remain in place (they are independently marked `@Deprecated`) so all existing callers continue to compile and behave identically.

Note: the similarly-named `DEFAULT_SEGMENT_PUSH_TYPE` in `SegmentGenerationAndPushTaskGenerator` is a separate, non-deprecated constant of type `BatchConfigProperties.SegmentPushType` and is intentionally left untouched.

## Related Issue

Fixes #17072

## Changes Made

- Removed `private static final String DEFAULT_SEGMENT_PUSH_TYPE = "APPEND"` from `TableConfigBuilder`
- Replaced its two usages with the inline literal `"APPEND"`
- Removed the `// TODO: Remove 'DEFAULT_SEGMENT_PUSH_TYPE' in the future major release.` comment

## Testing Done

- [x] `mvn spotless:apply -pl pinot-spi` — passes
- [x] `mvn checkstyle:check -pl pinot-spi` — passes
- [x] `mvn license:format -pl pinot-spi` — passes
- [x] `mvn -pl pinot-spi -am test-compile` — compiles cleanly

## Upgrade Notes

No breaking change. The removed constant was `private` and had no external visibility. All public API behavior is preserved.