### PR TITLE
Inspect segments under the per-segment lock in needReloadSegments()

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -1638,26 +1638,50 @@ public abstract class BaseTableDataManager implements TableDataManager {
   public boolean needReloadSegments()
       throws Exception {
     IndexLoadingConfig indexLoadingConfig = fetchIndexLoadingConfig();
+    // Snapshot the current segment names, then release the references right away. The per-segment reload
+    // lock acquired below is not taken while holding segment references (avoiding lock/refcount ordering
+    // surprises), and each segment is re-acquired fresh under its lock anyway.
+    List<String> segmentNames = new ArrayList<>();
     List<SegmentDataManager> segmentDataManagers = acquireAllSegments();
-    boolean needReload = false;
     try {
       for (SegmentDataManager segmentDataManager : segmentDataManagers) {
-        IndexSegment segment = segmentDataManager.getSegment();
-        if (segment instanceof ImmutableSegmentImpl) {
-          ImmutableSegmentImpl immutableSegment = (ImmutableSegmentImpl) segment;
-          indexLoadingConfig.setSegmentTier(immutableSegment.getTier());
-          if (immutableSegment.isReloadNeeded(indexLoadingConfig)) {
-            needReload = true;
-            break;
-          }
-        }
+        segmentNames.add(segmentDataManager.getSegmentName());
       }
     } finally {
       for (SegmentDataManager segmentDataManager : segmentDataManagers) {
         releaseSegment(segmentDataManager);
       }
     }
-    return needReload;
+    for (String segmentName : segmentNames) {
+      // Hold the per-segment reload lock while inspecting the segment. isReloadNeeded() reads the segment
+      // directory (via SegmentPreProcessor), which a concurrent reload/replace/offload of the same segment
+      // can mutate or release under this same lock. Inspecting without the lock can therefore race with a
+      // reload freeing the segment's backing resources. Re-acquiring the segment fresh under the lock also
+      // avoids inspecting a segment that a reload has already replaced.
+      Lock segmentLock = getSegmentLock(segmentName);
+      segmentLock.lock();
+      try {
+        SegmentDataManager segmentDataManager = acquireSegment(segmentName);
+        if (segmentDataManager == null) {
+          continue;
+        }
+        try {
+          IndexSegment segment = segmentDataManager.getSegment();
+          if (segment instanceof ImmutableSegmentImpl) {
+            ImmutableSegmentImpl immutableSegment = (ImmutableSegmentImpl) segment;
+            indexLoadingConfig.setSegmentTier(immutableSegment.getTier());
+            if (immutableSegment.isReloadNeeded(indexLoadingConfig)) {
+              return true;
+            }
+          }
+        } finally {
+          releaseSegment(segmentDataManager);
+        }
+      } finally {
+        segmentLock.unlock();
+      }
+    }
+    return false;
   }
 
   @Override


### PR DESCRIPTION
## Description

`BaseTableDataManager.needReloadSegments()` inspects each segment via
`ImmutableSegment.isReloadNeeded()` → `SegmentPreProcessor.needProcess()`, which reads the
segment directory. It did so while holding only a reference count (from `acquireAllSegments()`),
not the per-segment lock (`getSegmentLock`) that `reloadSegment` / `replaceSegment` /
`offloadSegment` acquire. As a result, the reload-need check can run concurrently with a reload
of the same segment that is mutating or releasing that segment's backing resources.

This change inspects each segment under `getSegmentLock(segmentName)`, and re-acquires the
segment fresh under the lock so a segment that a reload has already replaced is not inspected.
Segment names are snapshotted first, so the lock is never taken while holding segment references
(avoiding lock/refcount ordering surprises).

## Notes

- Behavior is unchanged in the common case (no concurrent reload); the check simply no longer
  races with a reload / replace / offload of the same segment.
- The per-segment lock is the same striped lock already used by the reload path, so the check now
  serializes with an in-progress reload of that segment.

## Testing

- Existing table-data-manager tests pass.
