### PR TITLE
Add getUnavailableSegments broker hook for route-level unavailable filtering

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -732,7 +732,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
 
     Set<ServerInstance> offlineExecutionServers = routeInfo.getOfflineExecutionServers();
     Set<ServerInstance> realtimeExecutionServers = routeInfo.getRealtimeExecutionServers();
-    List<String> unavailableSegments = routeInfo.getUnavailableSegments();
+    List<String> unavailableSegments = getUnavailableSegments(serverBrokerRequest, routeInfo);
     int numPrunedSegmentsTotal = routeInfo.getNumPrunedSegmentsTotal();
 
     // Rewrite the broker requests as the rest of the code expects them to be null or not based on whether the routing
@@ -913,7 +913,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       /// as-is — its metric was already recorded at pre-split time.
       offlineExecutionServers = routeInfo.getOfflineExecutionServers();
       realtimeExecutionServers = routeInfo.getRealtimeExecutionServers();
-      unavailableSegments = routeInfo.getUnavailableSegments();
+      unavailableSegments = getUnavailableSegments(serverBrokerRequest, routeInfo);
       numPrunedSegmentsTotal = routeInfo.getNumPrunedSegmentsTotal();
     }
 
@@ -2628,6 +2628,15 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       BrokerRequest serverBrokerRequest, TableRouteInfo route, long timeoutMs,
       ServerStats serverStats, RequestContext requestContext)
       throws Exception;
+
+  /**
+   * Returns the segments to report as unavailable for this query. The default returns the route's unavailable
+   * segments unchanged. A subclass may narrow the set, e.g. to the segments the query will actually read after
+   * routing-level pruning, so the "segments unavailable" warning does not include segments the query never touches.
+   */
+  protected List<String> getUnavailableSegments(BrokerRequest serverBrokerRequest, TableRouteInfo routeInfo) {
+    return routeInfo.getUnavailableSegments();
+  }
 
   /// Processes an MV-split query by issuing two independent scatter-gather requests - one to the
   /// base table (for recent data beyond the MV boundary) and one to the materialized view table (for historical


### PR DESCRIPTION
## What

Adds a `protected List<String> getUnavailableSegments(BrokerRequest serverBrokerRequest, TableRouteInfo routeInfo)` hook to `BaseSingleStageBrokerRequestHandler`.

- The default returns `routeInfo.getUnavailableSegments()` unchanged.
- Both read sites in `handleRequest` (the main routing path and the materialized-view-split fallback) now call the hook instead of reading the route directly.

## Why

The single-stage handler builds the "segments unavailable" warning from `routeInfo.getUnavailableSegments()` before any subclass gets to post-process the route in `processBrokerRequest`. A subclass that prunes routing (e.g. narrowing a query to a single snapshot/version) has no way to keep that warning in sync, so it can report segments the query will never actually read.

This hook is the extension point: a subclass can narrow the reported unavailable segments to the set the query will actually read after routing-level pruning.

## Behavior change

None for OSS or existing tables — the default hook returns the same list the code read before.

## Testing

Existing `pinot-broker` tests pass. The hook has no standalone behavior to test beyond the passthrough default, which existing routing/handler tests already exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
