### PR TITLE
Simplify ColumnReader SPI: drop iterator API, replace type checks with getValueType()

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReader.java
@@ -24,7 +24,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.BitSet;
 import javax.annotation.Nullable;
 import org.apache.arrow.vector.BigIntVector;
-import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.Float4Vector;
@@ -35,59 +34,36 @@ import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.pinot.spi.data.readers.ColumnReader;
 import org.apache.pinot.spi.data.readers.MultiValueResult;
+import org.apache.pinot.spi.utils.PinotDataType;
 
 
-/**
- * Column reader for Apache Arrow {@link FieldVector}.
- *
- * <p>Wraps a single Arrow {@link FieldVector} and exposes sequential and random-access
- * read patterns conforming to the {@link ColumnReader} contract. The vector is owned by
- * the enclosing {@link ArrowColumnReaderFactory} which is responsible for its lifecycle;
- * closing this reader is a no-op for the underlying vector.
- *
- * <p>Supported Arrow types map to Pinot's stored types as follows:
- * <ul>
- *   <li>{@code IntVector} / {@code BitVector} → {@code INT} (BitVector promoted to 0/1)</li>
- *   <li>{@code BigIntVector} → {@code LONG}</li>
- *   <li>{@code Float4Vector} → {@code FLOAT}</li>
- *   <li>{@code Float8Vector} → {@code DOUBLE}</li>
- *   <li>{@code DecimalVector} → {@code BIG_DECIMAL}</li>
- *   <li>{@code VarCharVector} → {@code STRING}</li>
- *   <li>{@code VarBinaryVector} → {@code BYTES}</li>
- *   <li>{@code ListVector} of the above → multi-value variant</li>
- * </ul>
- *
- * <p>The list above applies to the typed primitive accessors only ({@link #getInt},
- * {@link #getString}, {@link #getIntMV}, ...). Complex types (Map, Struct, Union, ...)
- * and temporal types are still readable via the generic {@link #getValue(int)} /
- * {@link #next()} accessors, which delegate to {@link ArrowToPinotTypeConverter} and
- * return the same canonical JDK types as the row-major path ({@link
- * ArrowRecordExtractor}) — e.g. {@code Map<String, Object>} for Struct / Map,
- * {@code Object[]} for List variants, {@code LocalDate} / {@code LocalTime} /
- * {@code Timestamp} for temporal types.
- *
- * <p><b>BitVector caveat:</b> Arrow's {@link FieldVector#getObject} returns a {@code Boolean}
- * for a {@link BitVector}, but Pinot stores booleans as {@code INT} (0/1). The generic
- * {@link #getValue(int)} therefore special-cases {@code BitVector} to return an {@code Integer}
- * 0/1, keeping it consistent with {@link #getInt(int)} and the advertised INT mapping above
- * rather than surfacing the shared converter's {@code Boolean}.
- *
- * <p>{@code @SuppressWarnings("serial")}: {@link ColumnReader} is {@link java.io.Serializable} by SPI
- * contract, but this reader holds non-serializable Arrow state and is never serialized — it lives
- * only for the duration of a columnar segment build.
- *
- * <p>This class is not thread-safe.
- */
-@SuppressWarnings("serial")
+/// Column reader for an Apache Arrow [FieldVector].
+///
+/// Wraps a single Arrow [FieldVector] and exposes random-access reads conforming to the [ColumnReader] contract. The
+/// vector is owned by the enclosing [ArrowColumnReaderFactory], which is responsible for its lifecycle; closing this
+/// reader is a no-op for the underlying vector.
+///
+/// [#getValueType()] maps the backing vector's `MinorType` to the value type, naming a type only when a type-specific
+/// accessor reads that vector directly:
+/// - `INT` → `INT`, `BIGINT` → `LONG`, `FLOAT4` → `FLOAT`, `FLOAT8` → `DOUBLE`
+/// - `DECIMAL` (128-bit) → `BIG_DECIMAL`, `VARCHAR` → `STRING`, `VARBINARY` → `BYTES`
+/// - `List` of any of the above → the matching `_ARRAY` variant
+/// - every other vector — `BIT` (boolean), all `TIMESTAMP` / date / time, unsigned or narrow ints, half floats,
+///   `DECIMAL256`, `LARGEVARCHAR` / `LARGEVARBINARY` / fixed-size binary, and complex types (Map, Struct, Union) —
+///   reports `null` and is read through the generic [#getValue(int)] accessor
+///
+/// [#getValue(int)] delegates to [ArrowToPinotTypeConverter] and returns the same canonical JDK types as the row-major
+/// path ([ArrowRecordExtractor]) — e.g. `Boolean` for `Bool`, `Map<String, Object>` for Struct / Map, `Object[]` for
+/// List variants, and `LocalDate` / `LocalTime` / `Timestamp` (or the raw epoch value under `extractRawTimeValues`)
+/// for temporal types.
+///
+/// This class is not thread-safe.
 public class ArrowColumnReader implements ColumnReader {
-
   private final String _columnName;
   private final FieldVector _vector;
   private final int _totalDocs;
   private final boolean _isSingleValue;
   private final boolean _extractRawTimeValues;
-
-  private int _nextDocId;
 
   /**
    * Construct an ArrowColumnReader for the given vector, surfacing converted (non-raw) temporal
@@ -116,214 +92,19 @@ public class ArrowColumnReader implements ColumnReader {
     _totalDocs = vector.getValueCount();
     _isSingleValue = !(vector instanceof ListVector);
     _extractRawTimeValues = extractRawTimeValues;
-    _nextDocId = 0;
-  }
-
-  @Override
-  public boolean hasNext() {
-    return _nextDocId < _totalDocs;
-  }
-
-  @Override
-  @Nullable
-  public Object next()
-      throws IOException {
-    requireHasNext();
-    Object value = getValue(_nextDocId);
-    _nextDocId++;
-    return value;
-  }
-
-  @Override
-  public boolean isNextNull()
-      throws IOException {
-    requireHasNext();
-    return _vector.isNull(_nextDocId);
-  }
-
-  @Override
-  public void skipNext()
-      throws IOException {
-    requireHasNext();
-    _nextDocId++;
-  }
-
-  @Override
-  public boolean isSingleValue() {
-    return _isSingleValue;
-  }
-
-  @Override
-  public boolean isInt() {
-    FieldVector elementVector = elementVector();
-    return elementVector instanceof IntVector || elementVector instanceof BitVector;
-  }
-
-  @Override
-  public boolean isLong() {
-    return elementVector() instanceof BigIntVector;
-  }
-
-  @Override
-  public boolean isFloat() {
-    return elementVector() instanceof Float4Vector;
-  }
-
-  @Override
-  public boolean isDouble() {
-    return elementVector() instanceof Float8Vector;
-  }
-
-  @Override
-  public boolean isBigDecimal() {
-    return elementVector() instanceof DecimalVector;
-  }
-
-  @Override
-  public boolean isString() {
-    return elementVector() instanceof VarCharVector;
-  }
-
-  @Override
-  public boolean isBytes() {
-    return elementVector() instanceof VarBinaryVector;
-  }
-
-  @Override
-  public int nextInt()
-      throws IOException {
-    requireHasNext();
-    int value = getInt(_nextDocId);
-    _nextDocId++;
-    return value;
-  }
-
-  @Override
-  public long nextLong()
-      throws IOException {
-    requireHasNext();
-    long value = getLong(_nextDocId);
-    _nextDocId++;
-    return value;
-  }
-
-  @Override
-  public float nextFloat()
-      throws IOException {
-    requireHasNext();
-    float value = getFloat(_nextDocId);
-    _nextDocId++;
-    return value;
-  }
-
-  @Override
-  public double nextDouble()
-      throws IOException {
-    requireHasNext();
-    double value = getDouble(_nextDocId);
-    _nextDocId++;
-    return value;
-  }
-
-  @Override
-  public BigDecimal nextBigDecimal()
-      throws IOException {
-    requireHasNext();
-    BigDecimal value = getBigDecimal(_nextDocId);
-    _nextDocId++;
-    return value;
-  }
-
-  @Override
-  public String nextString()
-      throws IOException {
-    requireHasNext();
-    String value = getString(_nextDocId);
-    _nextDocId++;
-    return value;
-  }
-
-  @Override
-  public byte[] nextBytes()
-      throws IOException {
-    requireHasNext();
-    byte[] value = getBytes(_nextDocId);
-    _nextDocId++;
-    return value;
-  }
-
-  @Override
-  public MultiValueResult<int[]> nextIntMV()
-      throws IOException {
-    requireHasNext();
-    MultiValueResult<int[]> result = getIntMV(_nextDocId);
-    _nextDocId++;
-    return result;
-  }
-
-  @Override
-  public MultiValueResult<long[]> nextLongMV()
-      throws IOException {
-    requireHasNext();
-    MultiValueResult<long[]> result = getLongMV(_nextDocId);
-    _nextDocId++;
-    return result;
-  }
-
-  @Override
-  public MultiValueResult<float[]> nextFloatMV()
-      throws IOException {
-    requireHasNext();
-    MultiValueResult<float[]> result = getFloatMV(_nextDocId);
-    _nextDocId++;
-    return result;
-  }
-
-  @Override
-  public MultiValueResult<double[]> nextDoubleMV()
-      throws IOException {
-    requireHasNext();
-    MultiValueResult<double[]> result = getDoubleMV(_nextDocId);
-    _nextDocId++;
-    return result;
-  }
-
-  @Override
-  public BigDecimal[] nextBigDecimalMV()
-      throws IOException {
-    requireHasNext();
-    BigDecimal[] result = getBigDecimalMV(_nextDocId);
-    _nextDocId++;
-    return result;
-  }
-
-  @Override
-  public String[] nextStringMV()
-      throws IOException {
-    requireHasNext();
-    String[] result = getStringMV(_nextDocId);
-    _nextDocId++;
-    return result;
-  }
-
-  @Override
-  public byte[][] nextBytesMV()
-      throws IOException {
-    requireHasNext();
-    byte[][] result = getBytesMV(_nextDocId);
-    _nextDocId++;
-    return result;
-  }
-
-  @Override
-  public void rewind()
-      throws IOException {
-    _nextDocId = 0;
   }
 
   @Override
   public String getColumnName() {
     return _columnName;
+  }
+
+  @Override
+  @Nullable
+  public PinotDataType getValueType() {
+    // The element vector's type maps directly to the value type; _isSingleValue selects scalar vs the _ARRAY variant.
+    FieldVector elementVector = _isSingleValue ? _vector : ((ListVector) _vector).getDataVector();
+    return ArrowToPinotTypeConverter.toValueType(elementVector.getMinorType(), _isSingleValue);
   }
 
   @Override
@@ -338,14 +119,27 @@ public class ArrowColumnReader implements ColumnReader {
   }
 
   @Override
+  @Nullable
+  public Object getValue(int docId)
+      throws IOException {
+    checkBounds(docId);
+    Object value = _vector.getObject(docId);
+    if (value == null) {
+      return null;
+    }
+    // Delegate Arrow → Pinot type conversion to the shared utility extracted from
+    // ArrowRecordExtractor. Returns canonical JDK types: Boolean for Bool, String for Utf8 / LargeUtf8 (unwrapped
+    // from Arrow's Text), Object[] for List variants (with recursive element conversion),
+    // LocalDate / LocalTime / Timestamp for temporal types, etc.
+    return ArrowToPinotTypeConverter.toPinotValue(_vector.getField(), value, _extractRawTimeValues);
+  }
+
+  @Override
   public int getInt(int docId)
       throws IOException {
     checkBounds(docId);
     if (_vector instanceof IntVector) {
       return ((IntVector) _vector).get(docId);
-    }
-    if (_vector instanceof BitVector) {
-      return ((BitVector) _vector).get(docId);
     }
     throw typeMismatch("INT");
   }
@@ -412,26 +206,6 @@ public class ArrowColumnReader implements ColumnReader {
   }
 
   @Override
-  @Nullable
-  public Object getValue(int docId)
-      throws IOException {
-    checkBounds(docId);
-    // BitVector -> INT (0/1); see the BitVector caveat in the class Javadoc.
-    if (_vector instanceof BitVector) {
-      return _vector.isNull(docId) ? null : ((BitVector) _vector).get(docId);
-    }
-    Object value = _vector.getObject(docId);
-    if (value == null) {
-      return null;
-    }
-    // Delegate Arrow → Pinot type conversion to the shared utility extracted from
-    // ArrowRecordExtractor. Returns canonical JDK types: String for Utf8 / LargeUtf8 (unwrapped
-    // from Arrow's Text), Object[] for List variants (with recursive element conversion),
-    // LocalDate / LocalTime / Timestamp for temporal types, etc.
-    return ArrowToPinotTypeConverter.toPinotValue(_vector.getField(), value, _extractRawTimeValues);
-  }
-
-  @Override
   public MultiValueResult<int[]> getIntMV(int docId)
       throws IOException {
     checkBounds(docId);
@@ -447,13 +221,6 @@ public class ArrowColumnReader implements ColumnReader {
       for (int i = 0; i < length; i++) {
         if (notNull(nulls, i)) {
           values[i] = iv.get(start + i);
-        }
-      }
-    } else if (elements instanceof BitVector) {
-      BitVector bv = (BitVector) elements;
-      for (int i = 0; i < length; i++) {
-        if (notNull(nulls, i)) {
-          values[i] = bv.get(start + i);
         }
       }
     } else {
@@ -624,28 +391,10 @@ public class ArrowColumnReader implements ColumnReader {
     return nulls == null || !nulls.get(i);
   }
 
-  /**
-   * The vector whose Arrow type determines the {@code isXxx()} predicates: the backing vector
-   * itself for single-value columns, or the {@link ListVector} element (data) vector for
-   * multi-value columns. Per the {@link ColumnReader} contract, {@code isInt()} / {@code isLong()} /
-   * ... report the element type regardless of single- vs multi-value, so a caller that also checks
-   * {@link #isSingleValue()} knows whether to use {@code nextInt()} or {@code nextIntMV()}.
-   */
-  private FieldVector elementVector() {
-    return _isSingleValue ? _vector : ((ListVector) _vector).getDataVector();
-  }
-
-  private void requireHasNext() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-  }
-
   private void requireListVector()
       throws IOException {
     if (!(_vector instanceof ListVector)) {
-      throw new IOException(
-          "Column " + _columnName + " is not a ListVector; cannot read multi-value");
+      throw new IOException("Column " + _columnName + " is not a ListVector; cannot read multi-value");
     }
   }
 
@@ -657,8 +406,9 @@ public class ArrowColumnReader implements ColumnReader {
   }
 
   private IOException typeMismatch(String expectedType) {
-    return new IOException("Column " + _columnName + " (Arrow type " + _vector.getField().getType()
-        + ") cannot be read as " + expectedType);
+    return new IOException(
+        "Column " + _columnName + " (Arrow type " + _vector.getField().getType() + ") cannot be read as "
+            + expectedType);
   }
 
   /**

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowToPinotTypeConverter.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowToPinotTypeConverter.java
@@ -29,9 +29,11 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.arrow.vector.complex.MapVector;
+import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.pinot.spi.data.readers.BaseRecordExtractor;
+import org.apache.pinot.spi.utils.PinotDataType;
 import org.apache.pinot.spi.utils.TimestampUtils;
 
 
@@ -57,6 +59,40 @@ import org.apache.pinot.spi.utils.TimestampUtils;
 public final class ArrowToPinotTypeConverter {
 
   private ArrowToPinotTypeConverter() {
+  }
+
+  /// Returns the [PinotDataType] that a column with the given Arrow element [Types.MinorType] can be read as through a
+  /// type-specific `ColumnReader` accessor, or `null` when it has no dedicated accessor and must be read through
+  /// `ColumnReader.getValue(int)`. `singleValue` selects the scalar vs `_ARRAY` variant.
+  ///
+  /// The `MinorType` already encodes every distinction the accessors care about, so a plain switch suffices: only
+  /// signed 32/64-bit ints (`INT` / `BIGINT`), single/double floats, 128-bit `DECIMAL`, `VARCHAR`, and `VARBINARY`
+  /// have accessors. Everything else — unsigned/narrow ints, half floats, `DECIMAL256`, `LARGEVARCHAR` /
+  /// `LARGEVARBINARY` / fixed-size binary, `BIT` (boolean), temporal, and complex types — is a distinct `MinorType`
+  /// that falls through to `null` and is read via `getValue(int)`.
+  ///
+  /// @param minorType the element vector's Arrow minor type (for a list column, its element type)
+  /// @param singleValue `true` for a single-value column, `false` for the `_ARRAY` variant
+  @Nullable
+  public static PinotDataType toValueType(Types.MinorType minorType, boolean singleValue) {
+    switch (minorType) {
+      case INT:
+        return singleValue ? PinotDataType.INT : PinotDataType.INT_ARRAY;
+      case BIGINT:
+        return singleValue ? PinotDataType.LONG : PinotDataType.LONG_ARRAY;
+      case FLOAT4:
+        return singleValue ? PinotDataType.FLOAT : PinotDataType.FLOAT_ARRAY;
+      case FLOAT8:
+        return singleValue ? PinotDataType.DOUBLE : PinotDataType.DOUBLE_ARRAY;
+      case DECIMAL:
+        return singleValue ? PinotDataType.BIG_DECIMAL : PinotDataType.BIG_DECIMAL_ARRAY;
+      case VARCHAR:
+        return singleValue ? PinotDataType.STRING : PinotDataType.STRING_ARRAY;
+      case VARBINARY:
+        return singleValue ? PinotDataType.BYTES : PinotDataType.BYTES_ARRAY;
+      default:
+        return null;
+    }
   }
 
   /**
@@ -104,6 +140,10 @@ public final class ArrowToPinotTypeConverter {
         if (value instanceof Character) {
           return (int) (Character) value;
         }
+        // TODO: Widen large unsigned 32/64-bit ints to preserve their value.
+        //   UInt4Vector / UInt8Vector surface the raw bits here (Integer / Long), so values above
+        //   Integer.MAX_VALUE / Long.MAX_VALUE wrap negative. Return a widening long / BigInteger for those instead
+        //   of passing the raw signed box through.
         return value;
       // Null — NullVector.getObject always returns null; callers should short-circuit on null,
       // so this branch is unreachable in practice. Defensive return.

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/BatchedArrowColumnReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/BatchedArrowColumnReader.java
@@ -22,43 +22,34 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import javax.annotation.Nullable;
 import org.apache.arrow.vector.FieldVector;
-import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.pinot.spi.data.readers.ColumnReader;
 import org.apache.pinot.spi.data.readers.MultiValueResult;
+import org.apache.pinot.spi.utils.PinotDataType;
 
 
-/**
- * A {@link ColumnReader} over one column of a {@link BatchedArrowFileSource}. Reads are served by
- * delegating to a per-batch {@link ArrowColumnReader} over the current record batch's column vector;
- * the source loads at most one batch at a time, so peak resident memory is one batch (see
- * {@link BatchedArrowFileSource}).
- *
- * <p>Random access ({@code getXxx(docId)}) seeks to the owning batch and reads it; sequential access
- * ({@code next} / typed {@code nextXxx}) is built on it. Type predicates are derived from the column's
- * (decoded) Arrow {@link Field}, so they need no batch load. The column-major segment build consumes
- * each column to completion sequentially (rewind + next), one column at a time.
- *
- * <p>The per-batch delegate is invalidated when the shared source moves to another batch (whether
- * this reader advanced it or a different one did); {@link #delegate(int)} documents why and rebuilds
- * it. Interleaving readers therefore stays correct (it just re-loads batches); the build never
- * interleaves.
- *
- * <p>This class is not thread-safe. {@code @SuppressWarnings("serial")}: {@link ColumnReader} is
- * {@link java.io.Serializable} by SPI contract, but this reader holds non-serializable Arrow state
- * and is never serialized.
- */
-@SuppressWarnings("serial")
+/// A [ColumnReader] over one column of a [BatchedArrowFileSource]. Reads are served by delegating to a per-batch
+/// [ArrowColumnReader] over the current record batch's column vector; the source loads at most one batch at a time, so
+/// peak resident memory is one batch (see [BatchedArrowFileSource]).
+///
+/// Random access (`getXxx(docId)`) seeks to the owning batch and reads it. The value type is derived from the column's
+/// (decoded) Arrow [Field], so it needs no batch load. The column-major segment build consumes each column to
+/// completion (by ascending docId), one column at a time.
+///
+/// The per-batch delegate is invalidated when the shared source moves to another batch (whether this reader advanced
+/// it or a different one did); [#delegate(int)] documents why and rebuilds it. Interleaving readers therefore stays
+/// correct (it just re-loads batches); the build never interleaves.
+///
+/// This class is not thread-safe.
 public class BatchedArrowColumnReader implements ColumnReader {
-
   private final BatchedArrowFileSource _source;
   private final String _columnName;
   private final boolean _extractRawTimeValues;
   private final int _totalDocs;
   private final Field _effectiveField;
 
-  private int _nextDocId;
   private int _delegateBatchIdx = -1;
   private ArrowColumnReader _delegate;
 
@@ -70,173 +61,25 @@ public class BatchedArrowColumnReader implements ColumnReader {
     _effectiveField = source.effectiveField(columnName);
   }
 
-  // ---- sequential iteration (advance _nextDocId only after a successful read) ----
-
   @Override
-  public boolean hasNext() {
-    return _nextDocId < _totalDocs;
+  public String getColumnName() {
+    return _columnName;
   }
 
   @Override
   @Nullable
-  public Object next()
-      throws IOException {
-    requireHasNext();
-    Object value = getValue(_nextDocId);
-    _nextDocId++;
-    return value;
+  public PinotDataType getValueType() {
+    // Map the element type to the value type, mirroring ArrowColumnReader; the per-batch delegate serves the reads.
+    return ArrowToPinotTypeConverter.toValueType(Types.getMinorTypeForArrowType(elementType()),
+        !isList(_effectiveField.getType()));
   }
 
   @Override
-  public boolean isNextNull()
-      throws IOException {
-    requireHasNext();
-    // Peek; does not advance.
-    return isNull(_nextDocId);
+  public int getTotalDocs() {
+    return _totalDocs;
   }
 
-  @Override
-  public void skipNext()
-      throws IOException {
-    requireHasNext();
-    _nextDocId++;
-  }
-
-  @Override
-  public int nextInt()
-      throws IOException {
-    requireHasNext();
-    int value = getInt(_nextDocId);
-    _nextDocId++;
-    return value;
-  }
-
-  @Override
-  public long nextLong()
-      throws IOException {
-    requireHasNext();
-    long value = getLong(_nextDocId);
-    _nextDocId++;
-    return value;
-  }
-
-  @Override
-  public float nextFloat()
-      throws IOException {
-    requireHasNext();
-    float value = getFloat(_nextDocId);
-    _nextDocId++;
-    return value;
-  }
-
-  @Override
-  public double nextDouble()
-      throws IOException {
-    requireHasNext();
-    double value = getDouble(_nextDocId);
-    _nextDocId++;
-    return value;
-  }
-
-  @Override
-  public BigDecimal nextBigDecimal()
-      throws IOException {
-    requireHasNext();
-    BigDecimal value = getBigDecimal(_nextDocId);
-    _nextDocId++;
-    return value;
-  }
-
-  @Override
-  public String nextString()
-      throws IOException {
-    requireHasNext();
-    String value = getString(_nextDocId);
-    _nextDocId++;
-    return value;
-  }
-
-  @Override
-  public byte[] nextBytes()
-      throws IOException {
-    requireHasNext();
-    byte[] value = getBytes(_nextDocId);
-    _nextDocId++;
-    return value;
-  }
-
-  @Override
-  public MultiValueResult<int[]> nextIntMV()
-      throws IOException {
-    requireHasNext();
-    MultiValueResult<int[]> value = getIntMV(_nextDocId);
-    _nextDocId++;
-    return value;
-  }
-
-  @Override
-  public MultiValueResult<long[]> nextLongMV()
-      throws IOException {
-    requireHasNext();
-    MultiValueResult<long[]> value = getLongMV(_nextDocId);
-    _nextDocId++;
-    return value;
-  }
-
-  @Override
-  public MultiValueResult<float[]> nextFloatMV()
-      throws IOException {
-    requireHasNext();
-    MultiValueResult<float[]> value = getFloatMV(_nextDocId);
-    _nextDocId++;
-    return value;
-  }
-
-  @Override
-  public MultiValueResult<double[]> nextDoubleMV()
-      throws IOException {
-    requireHasNext();
-    MultiValueResult<double[]> value = getDoubleMV(_nextDocId);
-    _nextDocId++;
-    return value;
-  }
-
-  @Override
-  public BigDecimal[] nextBigDecimalMV()
-      throws IOException {
-    requireHasNext();
-    BigDecimal[] value = getBigDecimalMV(_nextDocId);
-    _nextDocId++;
-    return value;
-  }
-
-  @Override
-  public String[] nextStringMV()
-      throws IOException {
-    requireHasNext();
-    String[] value = getStringMV(_nextDocId);
-    _nextDocId++;
-    return value;
-  }
-
-  @Override
-  public byte[][] nextBytesMV()
-      throws IOException {
-    requireHasNext();
-    byte[][] value = getBytesMV(_nextDocId);
-    _nextDocId++;
-    return value;
-  }
-
-  @Override
-  public void rewind() {
-    _nextDocId = 0;
-    _delegateBatchIdx = -1;
-    _delegate = null;
-  }
-
-  // ---- random access (seeks to the owning batch) ----
-
+  // Random access seeks to the owning batch and reads it.
   @Override
   public boolean isNull(int docId) {
     checkBounds(docId);
@@ -247,6 +90,17 @@ public class BatchedArrowColumnReader implements ColumnReader {
       throw new RuntimeException("Failed reading column " + _columnName + " at doc " + docId, e);
     }
   }
+
+  @Override
+  @Nullable
+  public Object getValue(int docId)
+      throws IOException {
+    checkBounds(docId);
+    int batchIdx = _source.batchIndexForDoc(docId);
+    return delegate(batchIdx).getValue(localRow(docId, batchIdx));
+  }
+
+  // Single-value accessors
 
   @Override
   public int getInt(int docId)
@@ -304,14 +158,7 @@ public class BatchedArrowColumnReader implements ColumnReader {
     return delegate(batchIdx).getBytes(localRow(docId, batchIdx));
   }
 
-  @Override
-  @Nullable
-  public Object getValue(int docId)
-      throws IOException {
-    checkBounds(docId);
-    int batchIdx = _source.batchIndexForDoc(docId);
-    return delegate(batchIdx).getValue(localRow(docId, batchIdx));
-  }
+  // Multi-value accessors
 
   @Override
   public MultiValueResult<int[]> getIntMV(int docId)
@@ -369,73 +216,6 @@ public class BatchedArrowColumnReader implements ColumnReader {
     return delegate(batchIdx).getBytesMV(localRow(docId, batchIdx));
   }
 
-  // ---- metadata / type predicates (derived from the schema field, no batch load) ----
-
-  @Override
-  public String getColumnName() {
-    return _columnName;
-  }
-
-  @Override
-  public int getTotalDocs() {
-    return _totalDocs;
-  }
-
-  @Override
-  public boolean isSingleValue() {
-    return !isList(_effectiveField.getType());
-  }
-
-  @Override
-  public boolean isInt() {
-    ArrowType type = elementType();
-    return (type instanceof ArrowType.Int && ((ArrowType.Int) type).getBitWidth() == 32)
-        || type instanceof ArrowType.Bool;
-  }
-
-  @Override
-  public boolean isLong() {
-    ArrowType type = elementType();
-    return type instanceof ArrowType.Int && ((ArrowType.Int) type).getBitWidth() == 64;
-  }
-
-  @Override
-  public boolean isFloat() {
-    ArrowType type = elementType();
-    return type instanceof ArrowType.FloatingPoint
-        && ((ArrowType.FloatingPoint) type).getPrecision() == FloatingPointPrecision.SINGLE;
-  }
-
-  @Override
-  public boolean isDouble() {
-    ArrowType type = elementType();
-    return type instanceof ArrowType.FloatingPoint
-        && ((ArrowType.FloatingPoint) type).getPrecision() == FloatingPointPrecision.DOUBLE;
-  }
-
-  @Override
-  public boolean isBigDecimal() {
-    return elementType() instanceof ArrowType.Decimal;
-  }
-
-  @Override
-  public boolean isString() {
-    return elementType() instanceof ArrowType.Utf8;
-  }
-
-  @Override
-  public boolean isBytes() {
-    return elementType() instanceof ArrowType.Binary;
-  }
-
-  @Override
-  public void close() {
-    // The shared BatchedArrowFileSource owns the file, reader, and allocator; the owning factory
-    // closes it. Closing one column reader must not tear down the source the others still use.
-  }
-
-  // ---- helpers ----
-
   private ArrowColumnReader delegate(int batchIdx)
       throws IOException {
     // Rebuild the per-batch delegate when this reader advances to a new batch, OR when the shared
@@ -461,12 +241,6 @@ public class BatchedArrowColumnReader implements ColumnReader {
     }
   }
 
-  private void requireHasNext() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-  }
-
   private ArrowType elementType() {
     Field field = _effectiveField;
     if (isList(field.getType())) {
@@ -478,5 +252,11 @@ public class BatchedArrowColumnReader implements ColumnReader {
   private static boolean isList(ArrowType type) {
     return type instanceof ArrowType.List || type instanceof ArrowType.LargeList
         || type instanceof ArrowType.FixedSizeList;
+  }
+
+  @Override
+  public void close() {
+    // The shared BatchedArrowFileSource owns the file, reader, and allocator; the owning factory
+    // closes it. Closing one column reader must not tear down the source the others still use.
   }
 }

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReaderFactoryTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReaderFactoryTest.java
@@ -45,12 +45,12 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.readers.ColumnReader;
+import org.apache.pinot.spi.utils.PinotDataType;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 
@@ -72,8 +72,7 @@ public class ArrowColumnReaderFactoryTest {
 
       try (ArrowStreamReader streamReader = new ArrowStreamReader(
           Channels.newChannel(new ByteArrayInputStream(ipcBytes)), callerAllocator);
-          ArrowColumnReaderFactory factory =
-              new ArrowColumnReaderFactory(streamReader, callerAllocator)) {
+          ArrowColumnReaderFactory factory = new ArrowColumnReaderFactory(streamReader, callerAllocator)) {
 
         factory.init(newSchema());
 
@@ -115,8 +114,7 @@ public class ArrowColumnReaderFactoryTest {
 
       try (ArrowStreamReader streamReader = new ArrowStreamReader(
           Channels.newChannel(new ByteArrayInputStream(ipcBytes)), callerAllocator);
-          ArrowColumnReaderFactory factory =
-              new ArrowColumnReaderFactory(streamReader, callerAllocator)) {
+          ArrowColumnReaderFactory factory = new ArrowColumnReaderFactory(streamReader, callerAllocator)) {
 
         factory.init(newSchema());
 
@@ -137,8 +135,7 @@ public class ArrowColumnReaderFactoryTest {
 
       try (ArrowStreamReader streamReader = new ArrowStreamReader(
           Channels.newChannel(new ByteArrayInputStream(ipcBytes)), callerAllocator);
-          ArrowColumnReaderFactory factory =
-              new ArrowColumnReaderFactory(streamReader, callerAllocator)) {
+          ArrowColumnReaderFactory factory = new ArrowColumnReaderFactory(streamReader, callerAllocator)) {
 
         factory.init(newSchema(), Set.of("intCol"));
 
@@ -166,8 +163,7 @@ public class ArrowColumnReaderFactoryTest {
 
       try (ArrowStreamReader streamReader = new ArrowStreamReader(
           Channels.newChannel(new ByteArrayInputStream(ipcBytes)), callerAllocator);
-          ArrowColumnReaderFactory factory =
-              new ArrowColumnReaderFactory(streamReader, callerAllocator)) {
+          ArrowColumnReaderFactory factory = new ArrowColumnReaderFactory(streamReader, callerAllocator)) {
 
         factory.init(newSchema());
         // Second init() over the same (now-drained) reader: it allocates a fresh accumulator set and
@@ -183,39 +179,6 @@ public class ArrowColumnReaderFactoryTest {
         probe.set(0, 1);
         probe.setValueCount(1);
         assertEquals(probe.get(0), 1);
-      }
-    }
-  }
-
-  /**
-   * After the reader is drained, the sequential accessors ({@code next}, the typed {@code nextXxx},
-   * {@code isNextNull}, {@code skipNext}) must throw {@link IllegalStateException} rather than read out
-   * of bounds — matching the {@code DefaultValueColumnReader} / {@code PinotSegmentColumnReaderImpl}
-   * SPI contract ("No more values available").
-   */
-  @Test
-  public void testSequentialAccessorsThrowPastEnd()
-      throws Exception {
-    try (RootAllocator callerAllocator = new RootAllocator(Long.MAX_VALUE)) {
-      byte[] ipcBytes = writeArrowStreamFixture(callerAllocator);
-
-      try (ArrowStreamReader streamReader = new ArrowStreamReader(
-          Channels.newChannel(new ByteArrayInputStream(ipcBytes)), callerAllocator);
-          ArrowColumnReaderFactory factory =
-              new ArrowColumnReaderFactory(streamReader, callerAllocator)) {
-
-        factory.init(newSchema());
-
-        try (ColumnReader intCol = factory.getColumnReader("intCol")) {
-          while (intCol.hasNext()) {
-            intCol.next();
-          }
-          assertFalse(intCol.hasNext());
-          assertThrows(IllegalStateException.class, intCol::next);
-          assertThrows(IllegalStateException.class, intCol::nextInt);
-          assertThrows(IllegalStateException.class, intCol::isNextNull);
-          assertThrows(IllegalStateException.class, intCol::skipNext);
-        }
       }
     }
   }
@@ -240,16 +203,14 @@ public class ArrowColumnReaderFactoryTest {
 
       try (ArrowStreamReader streamReader = new ArrowStreamReader(
           Channels.newChannel(new ByteArrayInputStream(ipcBytes)), callerAllocator);
-          ArrowColumnReaderFactory factory =
-              new ArrowColumnReaderFactory(streamReader, callerAllocator)) {
-
+          ArrowColumnReaderFactory factory = new ArrowColumnReaderFactory(streamReader, callerAllocator)) {
         factory.init(dictColumnSchema());
 
         try (ColumnReader colorCol = factory.getColumnReader("color")) {
           assertNotNull(colorCol);
           assertEquals(colorCol.getTotalDocs(), rows.length);
           // Must report the DECODED logical type (STRING), not the Int32 index type.
-          assertTrue(colorCol.isString());
+          assertEquals(colorCol.getValueType(), PinotDataType.STRING);
           for (int i = 0; i < rows.length; i++) {
             assertEquals(colorCol.getString(i), rows[i], "decoded getString mismatch at doc " + i);
             assertEquals(colorCol.getValue(i), rows[i], "decoded getValue mismatch at doc " + i);

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowColumnReaderTest.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.arrow;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.TimeStampMilliVector;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+
+/// Unit tests for [ArrowColumnReader]'s `Bool` / `Timestamp` handling. Neither has a dedicated accessor, so
+/// [ArrowColumnReader#getValueType()] returns `null` and both are read through [ArrowColumnReader#getValue(int)] —
+/// a `Boolean` for `Bool`; a `Timestamp`, or a raw epoch `Long` under `extractRawTimeValues`, for `Timestamp`.
+public class ArrowColumnReaderTest {
+
+  @Test
+  public void testBooleanReadsAsBooleanThroughGetValue()
+      throws Exception {
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        BitVector vector = new BitVector("boolCol", allocator)) {
+      vector.allocateNew(2);
+      vector.set(0, 1);
+      vector.set(1, 0);
+      vector.setValueCount(2);
+
+      ArrowColumnReader reader = new ArrowColumnReader("boolCol", vector);
+      assertNull(reader.getValueType());
+      assertEquals(reader.getValue(0), Boolean.TRUE);
+      assertEquals(reader.getValue(1), Boolean.FALSE);
+    }
+  }
+
+  @Test
+  public void testTimestampReadsAsTimestampThroughGetValue()
+      throws Exception {
+    long epochMillis = LocalDateTime.of(2026, 7, 3, 12, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        TimeStampMilliVector vector = new TimeStampMilliVector("tsCol", allocator)) {
+      vector.allocateNew(1);
+      vector.set(0, epochMillis);
+      vector.setValueCount(1);
+
+      ArrowColumnReader reader = new ArrowColumnReader("tsCol", vector);
+      assertNull(reader.getValueType());
+      assertEquals(reader.getValue(0), new Timestamp(epochMillis));
+    }
+  }
+
+  @Test
+  public void testTimestampWithRawTimeValuesReadsRawLongThroughGetValue()
+      throws Exception {
+    long epochMillis = LocalDateTime.of(2026, 7, 3, 12, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        TimeStampMilliVector vector = new TimeStampMilliVector("tsCol", allocator)) {
+      vector.allocateNew(1);
+      vector.set(0, epochMillis);
+      vector.setValueCount(1);
+
+      // Timestamp has no dedicated accessor even with raw extraction; getValue() yields the raw epoch Long.
+      ArrowColumnReader reader = new ArrowColumnReader("tsCol", vector, true);
+      assertNull(reader.getValueType());
+      assertEquals(reader.getValue(0), epochMillis);
+    }
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowFileColumnReaderFactoryTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowFileColumnReaderFactoryTest.java
@@ -51,6 +51,7 @@ import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.readers.ColumnReader;
 import org.apache.pinot.spi.data.readers.MultiValueResult;
+import org.apache.pinot.spi.utils.PinotDataType;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -63,14 +64,11 @@ import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 
-/**
- * Unit tests for {@link ArrowFileColumnReaderFactory} and {@link ArrowColumnReader}.
- *
- * <p>Each test materialises a small Arrow IPC file on disk with a known fixture and verifies
- * that the factory can read it back column-by-column using all three documented patterns:
- * generic sequential {@code next()}, typed sequential {@code nextInt() / nextLong() / ...},
- * and random-access {@code getInt(docId) / getLong(docId) / ...}.
- */
+/// Unit tests for [ArrowFileColumnReaderFactory] and [ArrowColumnReader].
+///
+/// Each test materialises a small Arrow IPC file on disk with a known fixture and verifies that the factory can read
+/// it back column-by-column via random access by document id (`getInt(docId) / getLong(docId) / getValue(docId) /
+/// ...`).
 public class ArrowFileColumnReaderFactoryTest {
 
   private static final int ROWS = 8;
@@ -99,7 +97,7 @@ public class ArrowFileColumnReaderFactoryTest {
   }
 
   @Test
-  public void testSequentialReadAllPrimitiveTypes()
+  public void testReadAllPrimitiveTypes()
       throws IOException {
     File arrowFile = writePrimitiveFixture("primitive.arrow");
     org.apache.pinot.spi.data.Schema schema = primitiveSchema();
@@ -111,7 +109,7 @@ public class ArrowFileColumnReaderFactoryTest {
       assertEquals(readers.size(), 6);
       for (ColumnReader r : readers.values()) {
         assertEquals(r.getTotalDocs(), ROWS);
-        assertTrue(r.isSingleValue());
+        assertNotNull(r.getValueType());
       }
 
       ColumnReader intReader = readers.get("intCol");
@@ -121,42 +119,30 @@ public class ArrowFileColumnReaderFactoryTest {
       ColumnReader stringReader = readers.get("stringCol");
       ColumnReader bytesReader = readers.get("bytesCol");
 
-      assertTrue(intReader.isInt());
-      assertTrue(longReader.isLong());
-      assertTrue(floatReader.isFloat());
-      assertTrue(doubleReader.isDouble());
-      assertTrue(stringReader.isString());
-      assertTrue(bytesReader.isBytes());
+      assertEquals(intReader.getValueType(), PinotDataType.INT);
+      assertEquals(longReader.getValueType(), PinotDataType.LONG);
+      assertEquals(floatReader.getValueType(), PinotDataType.FLOAT);
+      assertEquals(doubleReader.getValueType(), PinotDataType.DOUBLE);
+      assertEquals(stringReader.getValueType(), PinotDataType.STRING);
+      assertEquals(bytesReader.getValueType(), PinotDataType.BYTES);
 
-      // Pattern 2: typed sequential read with null handling
       for (int i = 0; i < ROWS; i++) {
         if (i == 3) {
-          assertTrue(intReader.isNextNull(), "Row 3 INT should be null");
-          intReader.skipNext();
-          assertTrue(longReader.isNextNull(), "Row 3 LONG should be null");
-          longReader.skipNext();
-          assertTrue(stringReader.isNextNull(), "Row 3 STRING should be null");
-          stringReader.skipNext();
-          floatReader.nextFloat();
-          doubleReader.nextDouble();
-          bytesReader.nextBytes();
+          assertTrue(intReader.isNull(i));
+          assertTrue(longReader.isNull(i));
+          assertTrue(stringReader.isNull(i));
         } else {
-          assertFalse(intReader.isNextNull());
-          assertEquals(intReader.nextInt(), i * 10);
-          assertEquals(longReader.nextLong(), (long) i * 100);
-          assertEquals(floatReader.nextFloat(), i + 0.5f, 0.0001f);
-          assertEquals(doubleReader.nextDouble(), i + 0.25, 0.0001);
-          assertEquals(stringReader.nextString(), "s_" + i);
-          assertEquals(new String(bytesReader.nextBytes()), "b_" + i);
+          assertFalse(intReader.isNull(i));
+          assertEquals(intReader.getInt(i), i * 10);
+          assertEquals(longReader.getLong(i), (long) i * 100);
         }
+        assertEquals(floatReader.getFloat(i), i + 0.5f, 0.0001f);
+        assertEquals(doubleReader.getDouble(i), i + 0.25, 0.0001);
+        if (i != 3) {
+          assertEquals(stringReader.getString(i), "s_" + i);
+        }
+        assertEquals(new String(bytesReader.getBytes(i)), "b_" + i);
       }
-
-      // Verify rewind enables a second pass.
-      intReader.rewind();
-      stringReader.rewind();
-      assertTrue(intReader.hasNext());
-      assertEquals(intReader.nextInt(), 0);
-      assertEquals(stringReader.nextString(), "s_0");
     }
   }
 
@@ -171,22 +157,18 @@ public class ArrowFileColumnReaderFactoryTest {
       ColumnReader intReader = factory.getColumnReader("intCol");
       ColumnReader longReader = factory.getColumnReader("longCol");
 
-      // Pattern 3: read out of order.
+      // Read out of order.
       assertEquals(intReader.getInt(5), 50);
       assertEquals(intReader.getInt(0), 0);
       assertEquals(intReader.getInt(7), 70);
       assertTrue(intReader.isNull(3));
       assertEquals(longReader.getLong(2), 200L);
       assertEquals(longReader.getValue(3), null);
-
-      // Sequential read is unaffected by prior random-access reads on the same reader.
-      assertTrue(intReader.hasNext());
-      assertEquals(intReader.nextInt(), 0);
     }
   }
 
   @Test
-  public void testGenericNextHandlesNulls()
+  public void testGetValueHandlesNulls()
       throws IOException {
     File arrowFile = writePrimitiveFixture("generic.arrow");
     org.apache.pinot.spi.data.Schema schema = primitiveSchema();
@@ -197,9 +179,8 @@ public class ArrowFileColumnReaderFactoryTest {
 
       int nullCount = 0;
       int nonNullCount = 0;
-      while (stringReader.hasNext()) {
-        Object value = stringReader.next();
-        if (value == null) {
+      for (int docId = 0; docId < stringReader.getTotalDocs(); docId++) {
+        if (stringReader.getValue(docId) == null) {
           nullCount++;
         } else {
           nonNullCount++;
@@ -223,7 +204,7 @@ public class ArrowFileColumnReaderFactoryTest {
       factory.init(schema);
       ColumnReader reader = factory.getColumnReader("intArr");
       assertNotNull(reader);
-      assertFalse(reader.isSingleValue());
+      assertEquals(reader.getValueType(), PinotDataType.INT_ARRAY);
       assertEquals(reader.getTotalDocs(), 3);
 
       MultiValueResult<int[]> doc0 = reader.getIntMV(0);
@@ -242,11 +223,8 @@ public class ArrowFileColumnReaderFactoryTest {
     }
   }
 
-  /**
-   * Type predicates on a multi-value reader reflect the list's <i>element</i> type, not the
-   * {@code ListVector} itself — so an INT multi-value column reports {@code isInt()} (and is not
-   * single-value), letting the build pick the right typed {@code getXxxMV} accessor.
-   */
+  /// The value type on a multi-value reader reflects the list's *element* type combined with its cardinality — so an
+  /// INT multi-value column reports `INT_ARRAY`, letting the build pick the right typed `getXxxMV` accessor.
   @Test
   public void testMultiValueColumnTypePredicates()
       throws IOException {
@@ -260,11 +238,7 @@ public class ArrowFileColumnReaderFactoryTest {
       factory.init(schema);
       ColumnReader reader = factory.getColumnReader("intArr");
       assertNotNull(reader);
-      assertFalse(reader.isSingleValue());
-      assertTrue(reader.isInt(), "INT element type should report isInt()");
-      assertFalse(reader.isLong());
-      assertFalse(reader.isString());
-      assertFalse(reader.isBytes());
+      assertEquals(reader.getValueType(), PinotDataType.INT_ARRAY);
     }
   }
 
@@ -366,14 +340,10 @@ public class ArrowFileColumnReaderFactoryTest {
       assertNotNull(reader);
       assertEquals(reader.getTotalDocs(), 12, "Expected 3 batches of 4 rows = 12 docs total");
 
-      // Sequential traversal yields the global doc order.
-      for (int i = 0; i < 12; i++) {
-        assertEquals(reader.nextInt(), i);
-      }
-      assertFalse(reader.hasNext());
-
       // Random access across batch boundaries.
-      reader.rewind();
+      for (int i = 0; i < 12; i++) {
+        assertEquals(reader.getInt(i), i);
+      }
       assertEquals(reader.getInt(0), 0);
       assertEquals(reader.getInt(3), 3);   // last row of batch 0
       assertEquals(reader.getInt(4), 4);   // first row of batch 1
@@ -429,7 +399,6 @@ public class ArrowFileColumnReaderFactoryTest {
       ColumnReader reader = factory.getColumnReader("seqCol");
       assertNotNull(reader);
       assertEquals(reader.getTotalDocs(), 0);
-      assertFalse(reader.hasNext());
       // SPI contract: an out-of-range docId yields IndexOutOfBoundsException, not an opaque internal
       // error from seeking a non-existent batch.
       assertThrows(IndexOutOfBoundsException.class, () -> reader.getValue(0));
@@ -458,10 +427,9 @@ public class ArrowFileColumnReaderFactoryTest {
       assertNotNull(reader);
       assertEquals(reader.getTotalDocs(), total);
       for (int pass = 0; pass < 2; pass++) {
-        reader.rewind();
         int count = 0;
-        while (reader.hasNext()) {
-          assertEquals(reader.nextInt(), count);
+        for (int docId = 0; docId < total; docId++) {
+          assertEquals(reader.getInt(docId), docId);
           count++;
         }
         assertEquals(count, total, "pass " + pass + " did not read every doc");

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/columntransformer/DataTypeColumnTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/columntransformer/DataTypeColumnTransformer.java
@@ -53,40 +53,9 @@ public class DataTypeColumnTransformer implements ColumnTransformer {
 
   @Override
   public boolean isNoOp() {
-    // If source and destination data types are primitive types and the same, no transformation is needed.
-    if (_columnReader.isSingleValue()) {
-      if (_columnReader.isInt()) {
-        return _destDataType == PinotDataType.INT;
-      } else if (_columnReader.isLong()) {
-        return _destDataType == PinotDataType.LONG;
-      } else if (_columnReader.isFloat()) {
-        return _destDataType == PinotDataType.FLOAT;
-      } else if (_columnReader.isDouble()) {
-        return _destDataType == PinotDataType.DOUBLE;
-      } else if (_columnReader.isBigDecimal()) {
-        return _destDataType == PinotDataType.BIG_DECIMAL;
-      } else if (_columnReader.isString()) {
-        return _destDataType == PinotDataType.STRING;
-      } else if (_columnReader.isBytes()) {
-        return _destDataType == PinotDataType.BYTES;
-      }
-    } else {
-      if (_columnReader.isInt()) {
-        return _destDataType == PinotDataType.INT_ARRAY;
-      } else if (_columnReader.isLong()) {
-        return _destDataType == PinotDataType.LONG_ARRAY;
-      } else if (_columnReader.isFloat()) {
-        return _destDataType == PinotDataType.FLOAT_ARRAY;
-      } else if (_columnReader.isDouble()) {
-        return _destDataType == PinotDataType.DOUBLE_ARRAY;
-      } else if (_columnReader.isString()) {
-        return _destDataType == PinotDataType.STRING_ARRAY;
-      } else if (_columnReader.isBytes()) {
-        return _destDataType == PinotDataType.BYTES_ARRAY;
-      }
-    }
-    // For other types, because there is no overhead to cast to Object, always call transform() which handles all cases
-    return false;
+    // No transformation is needed when the source can be read directly as the destination type. For source types that
+    // cannot be read directly (getValueType() returns null), always transform().
+    return _columnReader.getValueType() == _destDataType;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -147,7 +147,7 @@ public class SegmentColumnarIndexCreator extends BaseSegmentCreator {
 
   /**
    * Index a column using a ColumnReader (column-major approach).
-   * This method processes the column values using the iterator pattern from ColumnReader.
+   * This method processes the column values by document ID using random access from ColumnReader.
    *
    * @param columnName Name of the column to index
    * @param columnReader ColumnReader for the column data
@@ -156,6 +156,8 @@ public class SegmentColumnarIndexCreator extends BaseSegmentCreator {
   @Override
   public void indexColumn(String columnName, ColumnReader columnReader)
       throws IOException {
+    // The statistics pass already traversed this reader; reset it to document 0 for this index-writing pass.
+    columnReader.rewind();
     List<IndexCreator> creatorsByIndex = _colIndexes.get(columnName).getIndexCreators();
     NullValueVectorCreator nullVec = _colIndexes.get(columnName).getNullValueVectorCreator();
     FieldSpec fieldSpec = _schema.getFieldSpecFor(columnName);
@@ -163,20 +165,19 @@ public class SegmentColumnarIndexCreator extends BaseSegmentCreator {
 
     PinotDataType destDataType = PinotDataType.getPinotDataTypeForIngestion(fieldSpec);
 
-    // Reset column reader to start from beginning
-    columnReader.rewind();
+    int numDocs = columnReader.getTotalDocs();
 
     // Typed fast path: for a single-value INT/LONG/FLOAT/DOUBLE column the reader can serve a primitive
-    // directly (ColumnReader.isInt()/...), the dictionary offers indexOfSV(primitive), and every index
+    // directly (ColumnReader.getValueType()), the dictionary offers indexOfSV(primitive), and every index
     // creator offers addInt/addLong/... (ForwardIndexCreator, CombinedInvertedIndexCreator and
     // DictionaryBasedInvertedIndexCreator de-box; any other creator falls back to the boxing default).
     // Driving the column through those eliminates the per-value Integer/Long/Float/Double box that
-    // next() -> indexOfSV(Object) -> add(Object, ...) incurs. Null docs (rare) and everything else
+    // getValue(docId) -> indexOfSV(Object) -> add(Object, ...) incurs. Null docs (rare) and everything else
     // (multi-value, BIG_DECIMAL/STRING/BYTES, BOOLEAN/TIMESTAMP coercion) fall through to the Object
     // path below, which stays the single source of truth for null and type handling.
     if (fieldSpec.isSingleValueField()
         && indexSingleValuePrimitive(columnName, fieldSpec, destDataType, columnReader, dictionaryCreator,
-            creatorsByIndex, nullVec)) {
+            creatorsByIndex, nullVec, numDocs)) {
       _columnMajorTypedFastPathColumns++;
       return;
     }
@@ -186,9 +187,8 @@ public class SegmentColumnarIndexCreator extends BaseSegmentCreator {
     _columnMajorObjectPathColumns++;
 
     Object reuseColumnValueToIndex;
-    int docId = 0;
-    while (columnReader.hasNext()) {
-      Object rawValue = columnReader.next();
+    for (int docId = 0; docId < numDocs; docId++) {
+      Object rawValue = columnReader.getValue(docId);
 
       // Record whole-value-null docs in the null-value vector BEFORE substituting the default (matching
       // the row-major path, which marks null only for whole-value nulls). The column-major driver runs
@@ -209,100 +209,94 @@ public class SegmentColumnarIndexCreator extends BaseSegmentCreator {
       } catch (JsonParseException jpe) {
         throw new ColumnJsonParserException(columnName, jpe);
       }
-
-      docId++;
     }
   }
 
   /**
    * Typed, allocation-free index write for a single-value primitive column. Returns {@code true} if it consumed
    * the column (the reader served it as INT / LONG / FLOAT / DOUBLE directly). Otherwise it returns {@code false}
-   * — without advancing the reader — either because the column is not a fast-path primitive, or because it is
+   * — without reading any value — either because the column is not a fast-path primitive, or because it is
    * one but the reader serves a different physical type, so the caller falls back to the Object path. Drives each
-   * value through {@code ColumnReader.nextInt()}/... -> {@code indexOfSV(primitive)} -> {@code
-   * IndexCreator.addInt(primitive, dictId)}, avoiding the box that {@code next() -> indexOfSV(Object) ->
+   * value through {@code ColumnReader.getInt(docId)}/... -> {@code indexOfSV(primitive)} -> {@code
+   * IndexCreator.addInt(primitive, dictId)}, avoiding the box that {@code getValue(docId) -> indexOfSV(Object) ->
    * add(Object, ...)} incurs. Null docs (rare) are routed through the shared Object handling for exact parity,
    * including whole-value-null marking in the null-value vector.
    */
   private boolean indexSingleValuePrimitive(String columnName, FieldSpec fieldSpec, PinotDataType destDataType,
       ColumnReader columnReader, SegmentDictionaryCreator dictionaryCreator, List<IndexCreator> creatorsByIndex,
-      NullValueVectorCreator nullVec)
+      NullValueVectorCreator nullVec, int numDocs)
       throws IOException {
-    int docId = 0;
+    PinotDataType valueType = columnReader.getValueType();
     switch (fieldSpec.getDataType()) {
       case INT: {
-        if (!columnReader.isInt()) {
+        if (valueType != PinotDataType.INT) {
           return false;
         }
-        while (columnReader.hasNext()) {
-          if (columnReader.isNextNull()) {
+        for (int docId = 0; docId < numDocs; docId++) {
+          if (columnReader.isNull(docId)) {
             indexSingleValueRow(dictionaryCreator,
                 normalizeNullRow(columnName, fieldSpec, destDataType, columnReader, nullVec, docId), creatorsByIndex);
           } else {
-            int value = columnReader.nextInt();
+            int value = columnReader.getInt(docId);
             int dictId = dictionaryCreator != null ? dictionaryCreator.indexOfSV(value) : -1;
             for (IndexCreator creator : creatorsByIndex) {
               creator.addInt(value, dictId);
             }
           }
-          docId++;
         }
         return true;
       }
       case LONG: {
-        if (!columnReader.isLong()) {
+        if (valueType != PinotDataType.LONG) {
           return false;
         }
-        while (columnReader.hasNext()) {
-          if (columnReader.isNextNull()) {
+        for (int docId = 0; docId < numDocs; docId++) {
+          if (columnReader.isNull(docId)) {
             indexSingleValueRow(dictionaryCreator,
                 normalizeNullRow(columnName, fieldSpec, destDataType, columnReader, nullVec, docId), creatorsByIndex);
           } else {
-            long value = columnReader.nextLong();
+            long value = columnReader.getLong(docId);
             int dictId = dictionaryCreator != null ? dictionaryCreator.indexOfSV(value) : -1;
             for (IndexCreator creator : creatorsByIndex) {
               creator.addLong(value, dictId);
             }
           }
-          docId++;
         }
         return true;
       }
       case FLOAT: {
-        if (!columnReader.isFloat()) {
+        if (valueType != PinotDataType.FLOAT) {
           return false;
         }
-        while (columnReader.hasNext()) {
-          if (columnReader.isNextNull()) {
+        for (int docId = 0; docId < numDocs; docId++) {
+          if (columnReader.isNull(docId)) {
             indexSingleValueRow(dictionaryCreator,
                 normalizeNullRow(columnName, fieldSpec, destDataType, columnReader, nullVec, docId), creatorsByIndex);
           } else {
-            float value = columnReader.nextFloat();
+            float value = columnReader.getFloat(docId);
             int dictId = dictionaryCreator != null ? dictionaryCreator.indexOfSV(value) : -1;
             for (IndexCreator creator : creatorsByIndex) {
               creator.addFloat(value, dictId);
             }
           }
-          docId++;
         }
         return true;
       }
       case DOUBLE: {
-        if (!columnReader.isDouble()) {
+        if (valueType != PinotDataType.DOUBLE) {
           return false;
         }
-        while (columnReader.hasNext()) {
-          if (columnReader.isNextNull()) {
+        for (int docId = 0; docId < numDocs; docId++) {
+          if (columnReader.isNull(docId)) {
             indexSingleValueRow(dictionaryCreator,
                 normalizeNullRow(columnName, fieldSpec, destDataType, columnReader, nullVec, docId), creatorsByIndex);
           } else {
-            double value = columnReader.nextDouble();
+            double value = columnReader.getDouble(docId);
             int dictId = dictionaryCreator != null ? dictionaryCreator.indexOfSV(value) : -1;
             for (IndexCreator creator : creatorsByIndex) {
               creator.addDouble(value, dictId);
             }
           }
-          docId++;
         }
         return true;
       }
@@ -320,7 +314,7 @@ public class SegmentColumnarIndexCreator extends BaseSegmentCreator {
   private Object normalizeNullRow(String columnName, FieldSpec fieldSpec, PinotDataType destDataType,
       ColumnReader columnReader, NullValueVectorCreator nullVec, int docId)
       throws IOException {
-    Object rawValue = columnReader.next();
+    Object rawValue = columnReader.getValue(docId);
     if (rawValue == null && nullVec != null) {
       nullVec.setNull(docId);
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/ColumnarSegmentPreIndexStatsContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/ColumnarSegmentPreIndexStatsContainer.java
@@ -115,7 +115,7 @@ public class ColumnarSegmentPreIndexStatsContainer implements SegmentPreIndexSta
   }
 
   /**
-   * Consume one column sequentially (rewind + next) and feed each normalized value to its collector.
+   * Consume one column by document ID and feed each normalized value to its collector.
    *
    * <p>The column-major driver runs with no transform pipeline, so each value must be normalized here
    * the way the row-major {@code NullValueTransformer} + {@code DataTypeTransformer} would: substitute
@@ -124,29 +124,28 @@ public class ColumnarSegmentPreIndexStatsContainer implements SegmentPreIndexSta
    * (e.g. Arrow) feeds nulls / source-typed values into the typed collectors' {@code collect(Object)}
    * cast convention and NPEs / ClassCastExceptions. Shared with the index-write path via {@link
    * ColumnarValueNormalizer}; closes the null/type-handling gap in {@code buildColumnar()}
-   * (apache/pinot#18629). Sequential (rewindable) consumption is the contract every columnar source
-   * can satisfy cheaply, including lazy / streaming readers that cannot serve random docId access.
+   * (apache/pinot#18629).
    */
   private static void collectColumn(String columnName, FieldSpec fieldSpec, ColumnReader columnReader,
       AbstractColumnStatisticsCollector statsCollector) {
     PinotDataType destDataType = PinotDataType.getPinotDataTypeForIngestion(fieldSpec);
     try {
-      columnReader.rewind();
+      int numDocs = columnReader.getTotalDocs();
       // Typed fast path: when the reader can serve a single-value column as a primitive directly
-      // (ColumnReader.isInt()/isLong()/...), read it with the type-specific accessor and feed the
-      // matching AbstractColumnStatisticsCollector.collect(primitive) overload. This avoids the
-      // Integer/Long/Float/Double box that next() -> collect(Object) incurs on every value, plus the
+      // (ColumnReader.getValueType()), read it with the type-specific accessor and feed the matching
+      // AbstractColumnStatisticsCollector.collect(primitive) overload. This avoids the
+      // Integer/Long/Float/Double box that getValue(docId) -> collect(Object) incurs on every value, plus the
       // per-value normalize() allocation. Anything the reader cannot type directly — multi-value,
       // BIG_DECIMAL/STRING/BYTES, or a column needing coercion (BOOLEAN/TIMESTAMP) — falls through to
       // the shared, normalize()-based Object path below, which stays the single source of truth for
       // null and type handling.
       if (fieldSpec.isSingleValueField()
-          && collectSingleValuePrimitive(columnName, fieldSpec, destDataType, columnReader, statsCollector)) {
+          && collectSingleValuePrimitive(columnName, fieldSpec, destDataType, columnReader, statsCollector, numDocs)) {
         return;
       }
-      while (columnReader.hasNext()) {
+      for (int docId = 0; docId < numDocs; docId++) {
         statsCollector.collect(
-            ColumnarValueNormalizer.normalize(columnName, fieldSpec, destDataType, columnReader.next()));
+            ColumnarValueNormalizer.normalize(columnName, fieldSpec, destDataType, columnReader.getValue(docId)));
       }
     } catch (IOException e) {
       throw new RuntimeException("Caught exception collecting stats for column: " + columnName, e);
@@ -160,63 +159,64 @@ public class ColumnarSegmentPreIndexStatsContainer implements SegmentPreIndexSta
    *
    * <p>A {@code null} value is collected as the column's default, pre-normalized once via {@link
    * ColumnarValueNormalizer} so it matches the value the Object path would collect (segment metadata
-   * stays identical between the two paths). The reader's {@code isInt()} / {@code isLong()} / ...
-   * capability check guards each typed accessor, so a column the reader cannot type natively (e.g.
-   * BOOLEAN or TIMESTAMP read from a non-native vector) returns {@code false} here rather than risking
-   * a wrong typed read.
+   * stays identical between the two paths). The reader's {@code getValueType()} check guards each typed
+   * accessor, so a column the reader cannot type natively (e.g. BOOLEAN or TIMESTAMP read from a
+   * non-native vector) returns {@code false} here rather than risking a wrong typed read.
    */
   private static boolean collectSingleValuePrimitive(String columnName, FieldSpec fieldSpec,
-      PinotDataType destDataType, ColumnReader columnReader, AbstractColumnStatisticsCollector statsCollector)
+      PinotDataType destDataType, ColumnReader columnReader, AbstractColumnStatisticsCollector statsCollector,
+      int numDocs)
       throws IOException {
+    PinotDataType valueType = columnReader.getValueType();
     switch (fieldSpec.getDataType()) {
       case INT: {
-        if (!columnReader.isInt()) {
+        if (valueType != PinotDataType.INT) {
           return false;
         }
-        while (columnReader.hasNext()) {
-          if (columnReader.isNextNull()) {
-            collectNull(columnName, fieldSpec, destDataType, columnReader, statsCollector);
+        for (int docId = 0; docId < numDocs; docId++) {
+          if (columnReader.isNull(docId)) {
+            collectNull(columnName, fieldSpec, destDataType, columnReader, statsCollector, docId);
           } else {
-            statsCollector.collect(columnReader.nextInt());
+            statsCollector.collect(columnReader.getInt(docId));
           }
         }
         return true;
       }
       case LONG: {
-        if (!columnReader.isLong()) {
+        if (valueType != PinotDataType.LONG) {
           return false;
         }
-        while (columnReader.hasNext()) {
-          if (columnReader.isNextNull()) {
-            collectNull(columnName, fieldSpec, destDataType, columnReader, statsCollector);
+        for (int docId = 0; docId < numDocs; docId++) {
+          if (columnReader.isNull(docId)) {
+            collectNull(columnName, fieldSpec, destDataType, columnReader, statsCollector, docId);
           } else {
-            statsCollector.collect(columnReader.nextLong());
+            statsCollector.collect(columnReader.getLong(docId));
           }
         }
         return true;
       }
       case FLOAT: {
-        if (!columnReader.isFloat()) {
+        if (valueType != PinotDataType.FLOAT) {
           return false;
         }
-        while (columnReader.hasNext()) {
-          if (columnReader.isNextNull()) {
-            collectNull(columnName, fieldSpec, destDataType, columnReader, statsCollector);
+        for (int docId = 0; docId < numDocs; docId++) {
+          if (columnReader.isNull(docId)) {
+            collectNull(columnName, fieldSpec, destDataType, columnReader, statsCollector, docId);
           } else {
-            statsCollector.collect(columnReader.nextFloat());
+            statsCollector.collect(columnReader.getFloat(docId));
           }
         }
         return true;
       }
       case DOUBLE: {
-        if (!columnReader.isDouble()) {
+        if (valueType != PinotDataType.DOUBLE) {
           return false;
         }
-        while (columnReader.hasNext()) {
-          if (columnReader.isNextNull()) {
-            collectNull(columnName, fieldSpec, destDataType, columnReader, statsCollector);
+        for (int docId = 0; docId < numDocs; docId++) {
+          if (columnReader.isNull(docId)) {
+            collectNull(columnName, fieldSpec, destDataType, columnReader, statsCollector, docId);
           } else {
-            statsCollector.collect(columnReader.nextDouble());
+            statsCollector.collect(columnReader.getDouble(docId));
           }
         }
         return true;
@@ -235,10 +235,10 @@ public class ColumnarSegmentPreIndexStatsContainer implements SegmentPreIndexSta
    * immaterial; the non-null hot path stays primitive.
    */
   private static void collectNull(String columnName, FieldSpec fieldSpec, PinotDataType destDataType,
-      ColumnReader columnReader, AbstractColumnStatisticsCollector statsCollector)
+      ColumnReader columnReader, AbstractColumnStatisticsCollector statsCollector, int docId)
       throws IOException {
     statsCollector.collect(
-        ColumnarValueNormalizer.normalize(columnName, fieldSpec, destDataType, columnReader.next()));
+        ColumnarValueNormalizer.normalize(columnName, fieldSpec, destDataType, columnReader.getValue(docId)));
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/DefaultValueColumnReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/DefaultValueColumnReader.java
@@ -24,6 +24,7 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.readers.ColumnReader;
 import org.apache.pinot.spi.data.readers.MultiValueResult;
+import org.apache.pinot.spi.utils.PinotDataType;
 
 
 /**
@@ -37,6 +38,7 @@ public class DefaultValueColumnReader implements ColumnReader {
   private final String _columnName;
   private final int _numDocs;
   private final Object _defaultValue;
+  private final Object _logicalValue;
   private final FieldSpec _fieldSpec;
   private final DataType _dataType;
 
@@ -49,8 +51,6 @@ public class DefaultValueColumnReader implements ColumnReader {
   private String[] _defaultStringMV;
   private byte[][] _defaultBytesMV;
 
-  private int _currentIndex;
-
   /**
    * Create a DefaultValueColumnReader for a new column.
    *
@@ -61,7 +61,6 @@ public class DefaultValueColumnReader implements ColumnReader {
   public DefaultValueColumnReader(String columnName, int numDocs, FieldSpec fieldSpec) {
     _columnName = columnName;
     _numDocs = numDocs;
-    _currentIndex = 0;
     _fieldSpec = fieldSpec;
     _dataType = fieldSpec.getDataType();
 
@@ -120,213 +119,20 @@ public class DefaultValueColumnReader implements ColumnReader {
           break;
       }
     }
-  }
-
-  @Override
-  public boolean hasNext() {
-    return _currentIndex < _numDocs;
-  }
-
-  @Override
-  @Nullable
-  public Object next() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    _currentIndex++;
-    return _defaultValue;
-  }
-
-  @Override
-  public void rewind() {
-    _currentIndex = 0;
-  }
-
-  @Override
-  public boolean isNextNull() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    return _defaultValue == null;
-  }
-
-  @Override
-  public void skipNext() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    _currentIndex++;
-  }
-
-  @Override
-  public boolean isSingleValue() {
-    return _fieldSpec.isSingleValueField();
-  }
-
-  @Override
-  public boolean isInt() {
-    return _dataType == DataType.INT;
-  }
-
-  @Override
-  public boolean isLong() {
-    return _dataType == DataType.LONG;
-  }
-
-  @Override
-  public boolean isFloat() {
-    return _dataType == DataType.FLOAT;
-  }
-
-  @Override
-  public boolean isDouble() {
-    return _dataType == DataType.DOUBLE;
-  }
-
-  @Override
-  public boolean isBigDecimal() {
-    return _dataType == DataType.BIG_DECIMAL;
-  }
-
-  @Override
-  public boolean isString() {
-    return _dataType == DataType.STRING;
-  }
-
-  @Override
-  public boolean isBytes() {
-    return _dataType == DataType.BYTES;
-  }
-
-  @Override
-  public int nextInt() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    _currentIndex++;
-    return ((Number) _defaultValue).intValue();
-  }
-
-  @Override
-  public long nextLong() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    _currentIndex++;
-    return ((Number) _defaultValue).longValue();
-  }
-
-  @Override
-  public float nextFloat() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    _currentIndex++;
-    return ((Number) _defaultValue).floatValue();
-  }
-
-  @Override
-  public double nextDouble() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    _currentIndex++;
-    return ((Number) _defaultValue).doubleValue();
-  }
-
-  @Override
-  public BigDecimal nextBigDecimal() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    _currentIndex++;
-    return (BigDecimal) _defaultValue;
-  }
-
-  @Override
-  public String nextString() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    _currentIndex++;
-    return (String) _defaultValue;
-  }
-
-  @Override
-  public byte[] nextBytes() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    _currentIndex++;
-    return (byte[]) _defaultValue;
-  }
-
-  @Override
-  public MultiValueResult<int[]> nextIntMV() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    _currentIndex++;
-    return MultiValueResult.of(_defaultIntMV, null);
-  }
-
-  @Override
-  public MultiValueResult<long[]> nextLongMV() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    _currentIndex++;
-    return MultiValueResult.of(_defaultLongMV, null);
-  }
-
-  @Override
-  public MultiValueResult<float[]> nextFloatMV() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    _currentIndex++;
-    return MultiValueResult.of(_defaultFloatMV, null);
-  }
-
-  @Override
-  public MultiValueResult<double[]> nextDoubleMV() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    _currentIndex++;
-    return MultiValueResult.of(_defaultDoubleMV, null);
-  }
-
-  @Override
-  public BigDecimal[] nextBigDecimalMV() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    _currentIndex++;
-    return _defaultBigDecimalMV;
-  }
-
-  @Override
-  public String[] nextStringMV() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    _currentIndex++;
-    return _defaultStringMV;
-  }
-
-  @Override
-  public byte[][] nextBytesMV() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    _currentIndex++;
-    return _defaultBytesMV;
+    // getValue() surfaces the logical object; the segment stores BOOLEAN as int and TIMESTAMP as long, so the
+    // physical default is converted once here. Typed accessors keep using the physical _defaultValue.
+    _logicalValue = ColumnReader.toLogicalValue(_defaultValue, _dataType);
   }
 
   @Override
   public String getColumnName() {
     return _columnName;
+  }
+
+  @Nullable
+  @Override
+  public PinotDataType getValueType() {
+    return ColumnReader.toValueType(_dataType, _fieldSpec.isSingleValueField());
   }
 
   @Override
@@ -338,6 +144,12 @@ public class DefaultValueColumnReader implements ColumnReader {
   public boolean isNull(int docId) {
     validateDocId(docId);
     return _defaultValue == null;
+  }
+
+  @Override
+  public Object getValue(int docId) {
+    validateDocId(docId);
+    return _logicalValue;
   }
 
   // Single-value accessors
@@ -382,12 +194,6 @@ public class DefaultValueColumnReader implements ColumnReader {
   public byte[] getBytes(int docId) {
     validateDocId(docId);
     return (byte[]) _defaultValue;
-  }
-
-  @Override
-  public Object getValue(int docId) {
-    validateDocId(docId);
-    return _defaultValue;
   }
 
   // Multi-value accessors

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentColumnReaderImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentColumnReaderImpl.java
@@ -25,6 +25,7 @@ import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.readers.ColumnReader;
 import org.apache.pinot.spi.data.readers.MultiValueResult;
+import org.apache.pinot.spi.utils.PinotDataType;
 
 
 /**
@@ -43,8 +44,6 @@ public class PinotSegmentColumnReaderImpl implements ColumnReader {
   private final int _numDocs;
   private final DataType _dataType;
   private final boolean _skipDefaultNullValues;
-
-  private int _nextDocId;
 
   /**
    * Create a PinotSegmentColumnReaderImpl for an existing column in the segment.
@@ -94,207 +93,14 @@ public class PinotSegmentColumnReaderImpl implements ColumnReader {
   }
 
   @Override
-  public boolean hasNext() {
-    return _nextDocId < _numDocs;
-  }
-
-  @Override
-  @Nullable
-  public Object next()
-      throws IOException {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-
-    // Return null if the value is null and skipDefaultNullValues is true
-    if (_skipDefaultNullValues && _segmentColumnReader.isNull(_nextDocId)) {
-      _nextDocId++;
-      return null;
-    }
-
-    return _segmentColumnReader.getValue(_nextDocId++);
-  }
-
-  @Override
-  public boolean isNextNull() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    return _segmentColumnReader.isNull(_nextDocId);
-  }
-
-  @Override
-  public void skipNext() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    _nextDocId++;
-  }
-
-  @Override
-  public boolean isSingleValue() {
-    return _segmentColumnReader.isSingleValue();
-  }
-
-  @Override
-  public boolean isInt() {
-    return _dataType == DataType.INT;
-  }
-
-  @Override
-  public boolean isLong() {
-    return _dataType == DataType.LONG;
-  }
-
-  @Override
-  public boolean isFloat() {
-    return _dataType == DataType.FLOAT;
-  }
-
-  @Override
-  public boolean isDouble() {
-    return _dataType == DataType.DOUBLE;
-  }
-
-  @Override
-  public boolean isBigDecimal() {
-    return _dataType == DataType.BIG_DECIMAL;
-  }
-
-  @Override
-  public boolean isString() {
-    return _dataType == DataType.STRING;
-  }
-
-  @Override
-  public boolean isBytes() {
-    return _dataType == DataType.BYTES;
-  }
-
-  @Override
-  public int nextInt() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    return _segmentColumnReader.getInt(_nextDocId++);
-  }
-
-  @Override
-  public long nextLong() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    return _segmentColumnReader.getLong(_nextDocId++);
-  }
-
-  @Override
-  public float nextFloat() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    return _segmentColumnReader.getFloat(_nextDocId++);
-  }
-
-  @Override
-  public double nextDouble() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    return _segmentColumnReader.getDouble(_nextDocId++);
-  }
-
-  @Override
-  public BigDecimal nextBigDecimal() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    return _segmentColumnReader.getBigDecimal(_nextDocId++);
-  }
-
-  @Override
-  public String nextString() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    return _segmentColumnReader.getString(_nextDocId++);
-  }
-
-  @Override
-  public byte[] nextBytes() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    return _segmentColumnReader.getBytes(_nextDocId++);
-  }
-
-  // For all multi-value primitive type methods (nextIntMV, nextLongMV, nextFloatMV, nextDoubleMV,
-  // getIntMV, getLongMV, getFloatMV, getDoubleMV), we pass null for the validity bitset since
-  // multi-value primitive types cannot have null elements. Nulls are removed by NullValueTransformer
-  @Override
-  public MultiValueResult<int[]> nextIntMV() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    return MultiValueResult.of(_segmentColumnReader.getIntMV(_nextDocId++), null);
-  }
-
-  @Override
-  public MultiValueResult<long[]> nextLongMV() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    return MultiValueResult.of(_segmentColumnReader.getLongMV(_nextDocId++), null);
-  }
-
-  @Override
-  public MultiValueResult<float[]> nextFloatMV() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    return MultiValueResult.of(_segmentColumnReader.getFloatMV(_nextDocId++), null);
-  }
-
-  @Override
-  public MultiValueResult<double[]> nextDoubleMV() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    return MultiValueResult.of(_segmentColumnReader.getDoubleMV(_nextDocId++), null);
-  }
-
-  @Override
-  public BigDecimal[] nextBigDecimalMV() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    return _segmentColumnReader.getBigDecimalMV(_nextDocId++);
-  }
-
-  @Override
-  public String[] nextStringMV() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    return _segmentColumnReader.getStringMV(_nextDocId++);
-  }
-
-  @Override
-  public byte[][] nextBytesMV() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values available");
-    }
-    return _segmentColumnReader.getBytesMV(_nextDocId++);
-  }
-
-  @Override
-  public void rewind()
-      throws IOException {
-    _nextDocId = 0;
-  }
-
-  @Override
   public String getColumnName() {
     return _columnName;
+  }
+
+  @Nullable
+  @Override
+  public PinotDataType getValueType() {
+    return ColumnReader.toValueType(_dataType, _segmentColumnReader.isSingleValue());
   }
 
   @Override
@@ -306,6 +112,18 @@ public class PinotSegmentColumnReaderImpl implements ColumnReader {
   public boolean isNull(int docId) {
     validateDocId(docId);
     return _segmentColumnReader.isNull(docId);
+  }
+
+  @Override
+  public Object getValue(int docId)
+      throws IOException {
+    // Return null if the value is null and skipDefaultNullValues is true
+    if (_skipDefaultNullValues && _segmentColumnReader.isNull(docId)) {
+      return null;
+    }
+    // The segment stores physical values (e.g. int for BOOLEAN, long for TIMESTAMP); surface the logical object per
+    // the getValue() contract. Null entries return the segment's stored default, also converted to the logical type.
+    return ColumnReader.toLogicalValue(_segmentColumnReader.getValue(docId), _dataType);
   }
 
   // Single-value accessors
@@ -345,19 +163,11 @@ public class PinotSegmentColumnReaderImpl implements ColumnReader {
     return _segmentColumnReader.getBytes(docId);
   }
 
-  @Override
-  public Object getValue(int docId)
-      throws IOException {
-    // Return null if the value is null and skipDefaultNullValues is true
-    if (_skipDefaultNullValues && _segmentColumnReader.isNull(docId)) {
-      return null;
-    }
-    // Return the segment value (which contains the default for null entries)
-    return _segmentColumnReader.getValue(docId);
-  }
-
   // Multi-value accessors
 
+  // For all multi-value primitive type methods (getIntMV, getLongMV, getFloatMV, getDoubleMV), we pass null for
+  // the validity bitset since multi-value primitive types cannot have null elements. Nulls are removed by
+  // NullValueTransformer
   @Override
   public MultiValueResult<int[]> getIntMV(int docId) {
     return MultiValueResult.of(_segmentColumnReader.getIntMV(docId), null);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/columntransformer/DataTypeColumnTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/columntransformer/DataTypeColumnTransformerTest.java
@@ -19,12 +19,14 @@
 package org.apache.pinot.segment.local.columntransformer;
 
 import java.math.BigDecimal;
+import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.ColumnReader;
+import org.apache.pinot.spi.utils.PinotDataType;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
@@ -40,73 +42,13 @@ import static org.testng.Assert.*;
 public class DataTypeColumnTransformerTest {
   private static final String COLUMN_NAME = "testColumn";
 
-  private static class MockColumnReaderBuilder {
-    private boolean _isSingleValue = true;
-    private boolean _isInt;
-    private boolean _isLong;
-    private boolean _isFloat;
-    private boolean _isDouble;
-    private boolean _isBigDecimal;
-    private boolean _isString;
-    private boolean _isBytes;
-
-    MockColumnReaderBuilder multiValue() {
-      _isSingleValue = false;
-      return this;
-    }
-
-    MockColumnReaderBuilder asInt() {
-      _isInt = true;
-      return this;
-    }
-
-    MockColumnReaderBuilder asLong() {
-      _isLong = true;
-      return this;
-    }
-
-    MockColumnReaderBuilder asFloat() {
-      _isFloat = true;
-      return this;
-    }
-
-    MockColumnReaderBuilder asDouble() {
-      _isDouble = true;
-      return this;
-    }
-
-    MockColumnReaderBuilder asBigDecimal() {
-      _isBigDecimal = true;
-      return this;
-    }
-
-    MockColumnReaderBuilder asString() {
-      _isString = true;
-      return this;
-    }
-
-    MockColumnReaderBuilder asBytes() {
-      _isBytes = true;
-      return this;
-    }
-
-    ColumnReader build() {
-      ColumnReader reader = Mockito.mock(ColumnReader.class);
-      when(reader.getColumnName()).thenReturn(COLUMN_NAME);
-      when(reader.isSingleValue()).thenReturn(_isSingleValue);
-      when(reader.isInt()).thenReturn(_isInt);
-      when(reader.isLong()).thenReturn(_isLong);
-      when(reader.isFloat()).thenReturn(_isFloat);
-      when(reader.isDouble()).thenReturn(_isDouble);
-      when(reader.isBigDecimal()).thenReturn(_isBigDecimal);
-      when(reader.isString()).thenReturn(_isString);
-      when(reader.isBytes()).thenReturn(_isBytes);
-      return reader;
-    }
-  }
-
-  private static MockColumnReaderBuilder mockColumnReader() {
-    return new MockColumnReaderBuilder();
+  /// Mocks a [ColumnReader] whose [ColumnReader#getValueType()] returns the given type (`null` for a
+  /// column with no directly-readable type, e.g. JSON / BOOLEAN).
+  private static ColumnReader mockReader(@Nullable PinotDataType valueType) {
+    ColumnReader reader = Mockito.mock(ColumnReader.class);
+    when(reader.getColumnName()).thenReturn(COLUMN_NAME);
+    when(reader.getValueType()).thenReturn(valueType);
+    return reader;
   }
 
   // isNoOp - SV matching types (in order: INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL, STRING, BYTES)
@@ -118,7 +60,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asInt().build();
+    ColumnReader reader = mockReader(PinotDataType.INT);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     assertTrue(transformer.isNoOp(), "Should be no-op when source and dest are both INT");
@@ -131,7 +73,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asLong().build();
+    ColumnReader reader = mockReader(PinotDataType.LONG);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     assertTrue(transformer.isNoOp(), "Should be no-op when source and dest are both LONG");
@@ -144,7 +86,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asFloat().build();
+    ColumnReader reader = mockReader(PinotDataType.FLOAT);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     assertTrue(transformer.isNoOp(), "Should be no-op when source and dest are both FLOAT");
@@ -157,7 +99,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asDouble().build();
+    ColumnReader reader = mockReader(PinotDataType.DOUBLE);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     assertTrue(transformer.isNoOp(), "Should be no-op when source and dest are both DOUBLE");
@@ -170,7 +112,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asBigDecimal().build();
+    ColumnReader reader = mockReader(PinotDataType.BIG_DECIMAL);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     assertTrue(transformer.isNoOp(), "Should be no-op when source and dest are both BIG_DECIMAL");
@@ -183,7 +125,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asString().build();
+    ColumnReader reader = mockReader(PinotDataType.STRING);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     assertTrue(transformer.isNoOp(), "Should be no-op when source and dest are both STRING");
@@ -196,7 +138,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asBytes().build();
+    ColumnReader reader = mockReader(PinotDataType.BYTES);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     assertTrue(transformer.isNoOp(), "Should be no-op when source and dest are both BYTES");
@@ -211,7 +153,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().multiValue().asInt().build();
+    ColumnReader reader = mockReader(PinotDataType.INT_ARRAY);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     assertTrue(transformer.isNoOp(), "Should be no-op when source and dest are both INT[]");
@@ -224,10 +166,36 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().multiValue().asLong().build();
+    ColumnReader reader = mockReader(PinotDataType.LONG_ARRAY);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     assertTrue(transformer.isNoOp(), "Should be no-op when source and dest are both LONG[]");
+  }
+
+  @Test
+  public void testIsNoOpForMatchingFloatMVTypes() {
+    Schema schema = new Schema.SchemaBuilder()
+        .addMultiValueDimension(COLUMN_NAME, FieldSpec.DataType.FLOAT)
+        .build();
+    FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
+    ColumnReader reader = mockReader(PinotDataType.FLOAT_ARRAY);
+    DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
+
+    assertTrue(transformer.isNoOp(), "Should be no-op when source and dest are both FLOAT[]");
+  }
+
+  @Test
+  public void testIsNoOpForMatchingDoubleMVTypes() {
+    Schema schema = new Schema.SchemaBuilder()
+        .addMultiValueDimension(COLUMN_NAME, FieldSpec.DataType.DOUBLE)
+        .build();
+    FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
+    ColumnReader reader = mockReader(PinotDataType.DOUBLE_ARRAY);
+    DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
+
+    assertTrue(transformer.isNoOp(), "Should be no-op when source and dest are both DOUBLE[]");
   }
 
   @Test
@@ -237,7 +205,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().multiValue().asString().build();
+    ColumnReader reader = mockReader(PinotDataType.STRING_ARRAY);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     assertTrue(transformer.isNoOp(), "Should be no-op when source and dest are both STRING[]");
@@ -250,7 +218,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().multiValue().asBytes().build();
+    ColumnReader reader = mockReader(PinotDataType.BYTES_ARRAY);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     assertTrue(transformer.isNoOp(), "Should be no-op when source and dest are both BYTES[]");
@@ -265,7 +233,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asInt().build();
+    ColumnReader reader = mockReader(PinotDataType.INT);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     assertFalse(transformer.isNoOp(), "Should not be no-op when converting INT to LONG");
@@ -278,7 +246,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asBytes().build();
+    ColumnReader reader = mockReader(PinotDataType.BYTES);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     assertFalse(transformer.isNoOp(), "Should not be no-op when source is BYTES but dest is STRING");
@@ -291,7 +259,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().multiValue().asBytes().build();
+    ColumnReader reader = mockReader(PinotDataType.BYTES_ARRAY);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     assertFalse(transformer.isNoOp(), "Should not be no-op when source is BYTES[] but dest is STRING[]");
@@ -305,7 +273,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().build();
+    ColumnReader reader = mockReader(null);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     assertFalse(transformer.isNoOp());
@@ -320,7 +288,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asInt().build();
+    ColumnReader reader = mockReader(PinotDataType.INT);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     Object result = transformer.transform(null);
@@ -334,7 +302,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asString().build();
+    ColumnReader reader = mockReader(PinotDataType.STRING);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     Object result = transformer.transform("42");
@@ -348,7 +316,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asString().build();
+    ColumnReader reader = mockReader(PinotDataType.STRING);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     Object result = transformer.transform("1234567890");
@@ -362,7 +330,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asString().build();
+    ColumnReader reader = mockReader(PinotDataType.STRING);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     Object result = transformer.transform("3.14");
@@ -376,7 +344,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asString().build();
+    ColumnReader reader = mockReader(PinotDataType.STRING);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     Object result = transformer.transform("3.14159");
@@ -390,7 +358,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asString().build();
+    ColumnReader reader = mockReader(PinotDataType.STRING);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     Object result = transformer.transform("123.456");
@@ -405,7 +373,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asString().build();
+    ColumnReader reader = mockReader(PinotDataType.STRING);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     Object result = transformer.transform("true");
@@ -422,7 +390,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asInt().build();
+    ColumnReader reader = mockReader(PinotDataType.INT);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     Object result = transformer.transform(42);
@@ -436,7 +404,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asInt().build();
+    ColumnReader reader = mockReader(PinotDataType.INT);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     Object result = transformer.transform(42);
@@ -450,7 +418,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asLong().build();
+    ColumnReader reader = mockReader(PinotDataType.LONG);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     long timestampValue = 1609459200000L; // 2021-01-01 00:00:00 UTC
@@ -465,7 +433,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asFloat().build();
+    ColumnReader reader = mockReader(PinotDataType.FLOAT);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     Object result = transformer.transform(3.14f);
@@ -480,7 +448,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asDouble().build();
+    ColumnReader reader = mockReader(PinotDataType.DOUBLE);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     Object result = transformer.transform(3.14159);
@@ -495,7 +463,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().build();
+    ColumnReader reader = mockReader(null);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     Object result = transformer.transform(true);
@@ -509,7 +477,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asBytes().build();
+    ColumnReader reader = mockReader(PinotDataType.BYTES);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     byte[] bytes = "test".getBytes();
@@ -524,7 +492,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().multiValue().asString().build();
+    ColumnReader reader = mockReader(PinotDataType.STRING_ARRAY);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     Object result = transformer.transform(new Object[]{"1", "2", "3"});
@@ -542,7 +510,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asString().build();
+    ColumnReader reader = mockReader(PinotDataType.STRING);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     // Empty arrays should be standardized to null
@@ -557,7 +525,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asString().build();
+    ColumnReader reader = mockReader(PinotDataType.STRING);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     // Single element arrays should be unwrapped
@@ -574,7 +542,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asInt().build();
+    ColumnReader reader = mockReader(PinotDataType.INT);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     Object result = transformer.transform(42);
@@ -588,7 +556,7 @@ public class DataTypeColumnTransformerTest {
         .build();
     FieldSpec fieldSpec = schema.getFieldSpecFor(COLUMN_NAME);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().build();
+    ColumnReader reader = mockReader(null);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     // Try to convert multi-value array to single-value
@@ -604,7 +572,7 @@ public class DataTypeColumnTransformerTest {
 
     // Default table config has continueOnError = false
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
-    ColumnReader reader = mockColumnReader().asString().build();
+    ColumnReader reader = mockReader(PinotDataType.STRING);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     // Try to convert invalid string to int
@@ -625,7 +593,7 @@ public class DataTypeColumnTransformerTest {
         .setTableName("testTable")
         .setIngestionConfig(ingestionConfig)
         .build();
-    ColumnReader reader = mockColumnReader().asString().build();
+    ColumnReader reader = mockReader(PinotDataType.STRING);
     DataTypeColumnTransformer transformer = new DataTypeColumnTransformer(tableConfig, fieldSpec, reader);
 
     // Try to convert invalid string to int - should return null

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/ColumnReaderInterfaceTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/ColumnReaderInterfaceTest.java
@@ -26,8 +26,10 @@ import org.apache.pinot.segment.local.segment.readers.PinotSegmentColumnReaderFa
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.spi.data.readers.ColumnReader;
 import org.apache.pinot.spi.utils.ReadMode;
-import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 
 /**
@@ -56,36 +58,24 @@ public class ColumnReaderInterfaceTest extends ColumnarSegmentBuildingTestBase {
 
         // Test that all expected columns are available
         Set<String> availableColumns = factory.getAvailableColumns();
-        Assert.assertTrue(availableColumns.contains(STRING_COL_1));
-        Assert.assertTrue(availableColumns.contains(INT_COL_1));
-        Assert.assertTrue(availableColumns.contains(MV_INT_COL));
+        assertTrue(availableColumns.contains(STRING_COL_1));
+        assertTrue(availableColumns.contains(INT_COL_1));
+        assertTrue(availableColumns.contains(MV_INT_COL));
 
         // Test getting individual column readers
         ColumnReader stringReader = factory.getColumnReader(STRING_COL_1);
-        Assert.assertEquals(stringReader.getColumnName(), STRING_COL_1);
+        assertEquals(stringReader.getColumnName(), STRING_COL_1);
 
         ColumnReader mvReader = factory.getColumnReader(MV_INT_COL);
-        Assert.assertEquals(mvReader.getColumnName(), MV_INT_COL);
+        assertEquals(mvReader.getColumnName(), MV_INT_COL);
 
-        // Test reading values using iterator pattern
-        Assert.assertTrue(stringReader.hasNext());
-        Object firstStringValue = stringReader.next();
-        Assert.assertEquals(firstStringValue, "string1_0");
-
-        // Test that we can continue reading
-        Assert.assertTrue(stringReader.hasNext());
-        Object secondStringValue = stringReader.next();
-        Assert.assertEquals(secondStringValue, "string1_1");
-
-        // Reset and test again
-        stringReader.rewind();
-        Assert.assertTrue(stringReader.hasNext());
-        firstStringValue = stringReader.next();
-        Assert.assertEquals(firstStringValue, "string1_0");
+        // Test reading values by document ID
+        assertEquals(stringReader.getValue(0), "string1_0");
+        assertEquals(stringReader.getValue(1), "string1_1");
 
         // Test getting all column readers
         Map<String, ColumnReader> allReaders = factory.getAllColumnReaders();
-        Assert.assertEquals(allReaders.size(), _originalSchema.getPhysicalColumnNames().size());
+        assertEquals(allReaders.size(), _originalSchema.getPhysicalColumnNames().size());
       }
     } finally {
       segment.destroy();
@@ -106,21 +96,15 @@ public class ColumnReaderInterfaceTest extends ColumnarSegmentBuildingTestBase {
 
         // Test getting reader for new column
         ColumnReader newStringReader = factory.getColumnReader(NEW_STRING_COL);
-        Assert.assertEquals(newStringReader.getColumnName(), NEW_STRING_COL);
+        assertEquals(newStringReader.getColumnName(), NEW_STRING_COL);
 
-        // Verify it returns default values using iterator pattern
-        Assert.assertTrue(newStringReader.hasNext());
-        Object defaultValue = newStringReader.next();
-        Assert.assertEquals(defaultValue, _extendedSchema.getFieldSpecFor(NEW_STRING_COL).getDefaultNullValue());
-
-        // Test that all values are the same (default)
-        int valueCount = 1; // We already read one value
-        while (newStringReader.hasNext()) {
-          Object value = newStringReader.next();
-          Assert.assertEquals(value, defaultValue);
-          valueCount++;
+        // Verify it returns default values by document ID
+        Object defaultValue = _extendedSchema.getFieldSpecFor(NEW_STRING_COL).getDefaultNullValue();
+        int numDocs = newStringReader.getTotalDocs();
+        assertEquals(numDocs, _testData.size());
+        for (int docId = 0; docId < numDocs; docId++) {
+          assertEquals(newStringReader.getValue(docId), defaultValue);
         }
-        Assert.assertEquals(valueCount, _testData.size());
       }
     } finally {
       segment.destroy();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/readers/DefaultValueColumnReaderTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/readers/DefaultValueColumnReaderTest.java
@@ -19,13 +19,17 @@
 package org.apache.pinot.segment.local.segment.readers;
 
 import java.math.BigDecimal;
-import java.util.Arrays;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.readers.MultiValueResult;
-import org.testng.Assert;
+import org.apache.pinot.spi.utils.PinotDataType;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
 
 
 /// Comprehensive tests for [DefaultValueColumnReader].
@@ -33,10 +37,8 @@ import org.testng.annotations.Test;
 /// This test validates:
 /// - Single-value fields for all data types (INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL, STRING, BYTES)
 /// - Multi-value fields for all data types
-/// - Sequential access methods (next*, hasNext, skipNext, isNextNull)
 /// - Random access methods (get*, isNull)
-/// - Type indicator methods (isInt, isLong, isBigDecimal, etc.)
-/// - Rewind functionality
+/// - Value type reporting (getValueType)
 /// - Boundary conditions and exception handling
 /// - Array reuse optimization for multi-value fields
 public class DefaultValueColumnReaderTest {
@@ -52,32 +54,16 @@ public class DefaultValueColumnReaderTest {
     DefaultValueColumnReader reader = new DefaultValueColumnReader(COLUMN_NAME, NUM_DOCS, fieldSpec);
 
     // Test metadata
-    Assert.assertEquals(reader.getColumnName(), COLUMN_NAME);
-    Assert.assertEquals(reader.getTotalDocs(), NUM_DOCS);
-    Assert.assertTrue(reader.isInt());
-    Assert.assertFalse(reader.isLong());
-    Assert.assertFalse(reader.isString());
-
-    // Test sequential access with nextInt
-    int expectedValue = ((Number) fieldSpec.getDefaultNullValue()).intValue();
-    for (int i = 0; i < NUM_DOCS; i++) {
-      Assert.assertTrue(reader.hasNext());
-      Assert.assertFalse(reader.isNextNull());
-      Assert.assertEquals(reader.nextInt(), expectedValue);
-    }
-    Assert.assertFalse(reader.hasNext());
-
-    // Test rewind and next()
-    reader.rewind();
-    for (int i = 0; i < NUM_DOCS; i++) {
-      Assert.assertEquals(reader.next(), expectedValue);
-    }
+    assertEquals(reader.getColumnName(), COLUMN_NAME);
+    assertEquals(reader.getTotalDocs(), NUM_DOCS);
+    assertEquals(reader.getValueType(), PinotDataType.INT);
 
     // Test random access
-    reader.rewind();
-    for (int i = 0; i < NUM_DOCS; i++) {
-      Assert.assertFalse(reader.isNull(i));
-      Assert.assertEquals(reader.getInt(i), expectedValue);
+    int expectedValue = ((Number) fieldSpec.getDefaultNullValue()).intValue();
+    for (int docId = 0; docId < reader.getTotalDocs(); docId++) {
+      assertFalse(reader.isNull(docId));
+      assertEquals(reader.getInt(docId), expectedValue);
+      assertEquals(reader.getValue(docId), expectedValue);
     }
 
     reader.close();
@@ -89,20 +75,12 @@ public class DefaultValueColumnReaderTest {
     DefaultValueColumnReader reader = new DefaultValueColumnReader(COLUMN_NAME, NUM_DOCS, fieldSpec);
 
     // Test type indicators
-    Assert.assertFalse(reader.isInt());
-    Assert.assertTrue(reader.isLong());
-    Assert.assertFalse(reader.isString());
-
-    // Test sequential access with nextLong
-    long expectedValue = ((Number) fieldSpec.getDefaultNullValue()).longValue();
-    for (int i = 0; i < NUM_DOCS; i++) {
-      Assert.assertTrue(reader.hasNext());
-      Assert.assertEquals(reader.nextLong(), expectedValue);
-    }
+    assertEquals(reader.getValueType(), PinotDataType.LONG);
 
     // Test random access
-    for (int i = 0; i < NUM_DOCS; i++) {
-      Assert.assertEquals(reader.getLong(i), expectedValue);
+    long expectedValue = ((Number) fieldSpec.getDefaultNullValue()).longValue();
+    for (int docId = 0; docId < reader.getTotalDocs(); docId++) {
+      assertEquals(reader.getLong(docId), expectedValue);
     }
 
     reader.close();
@@ -114,19 +92,12 @@ public class DefaultValueColumnReaderTest {
     DefaultValueColumnReader reader = new DefaultValueColumnReader(COLUMN_NAME, NUM_DOCS, fieldSpec);
 
     // Test type indicators
-    Assert.assertTrue(reader.isFloat());
-    Assert.assertFalse(reader.isDouble());
-
-    // Test sequential access with nextFloat
-    float expectedValue = ((Number) fieldSpec.getDefaultNullValue()).floatValue();
-    for (int i = 0; i < NUM_DOCS; i++) {
-      Assert.assertEquals(reader.nextFloat(), expectedValue);
-    }
+    assertEquals(reader.getValueType(), PinotDataType.FLOAT);
 
     // Test random access
-    reader.rewind();
-    for (int i = 0; i < NUM_DOCS; i++) {
-      Assert.assertEquals(reader.getFloat(i), expectedValue);
+    float expectedValue = ((Number) fieldSpec.getDefaultNullValue()).floatValue();
+    for (int docId = 0; docId < reader.getTotalDocs(); docId++) {
+      assertEquals(reader.getFloat(docId), expectedValue);
     }
 
     reader.close();
@@ -138,19 +109,12 @@ public class DefaultValueColumnReaderTest {
     DefaultValueColumnReader reader = new DefaultValueColumnReader(COLUMN_NAME, NUM_DOCS, fieldSpec);
 
     // Test type indicators
-    Assert.assertFalse(reader.isFloat());
-    Assert.assertTrue(reader.isDouble());
-
-    // Test sequential access with nextDouble
-    double expectedValue = ((Number) fieldSpec.getDefaultNullValue()).doubleValue();
-    for (int i = 0; i < NUM_DOCS; i++) {
-      Assert.assertEquals(reader.nextDouble(), expectedValue);
-    }
+    assertEquals(reader.getValueType(), PinotDataType.DOUBLE);
 
     // Test random access
-    reader.rewind();
-    for (int i = 0; i < NUM_DOCS; i++) {
-      Assert.assertEquals(reader.getDouble(i), expectedValue);
+    double expectedValue = ((Number) fieldSpec.getDefaultNullValue()).doubleValue();
+    for (int docId = 0; docId < reader.getTotalDocs(); docId++) {
+      assertEquals(reader.getDouble(docId), expectedValue);
     }
 
     reader.close();
@@ -162,30 +126,14 @@ public class DefaultValueColumnReaderTest {
     DefaultValueColumnReader reader = new DefaultValueColumnReader(COLUMN_NAME, NUM_DOCS, fieldSpec);
 
     // Test type indicators
-    Assert.assertFalse(reader.isDouble());
-    Assert.assertTrue(reader.isBigDecimal());
-    Assert.assertFalse(reader.isString());
-
-    // Test sequential access with nextBigDecimal
-    BigDecimal expectedValue = (BigDecimal) fieldSpec.getDefaultNullValue();
-    for (int i = 0; i < NUM_DOCS; i++) {
-      Assert.assertTrue(reader.hasNext());
-      Assert.assertFalse(reader.isNextNull());
-      Assert.assertEquals(reader.nextBigDecimal().compareTo(expectedValue), 0);
-    }
-    Assert.assertFalse(reader.hasNext());
-
-    // Test rewind and next()
-    reader.rewind();
-    for (int i = 0; i < NUM_DOCS; i++) {
-      Assert.assertEquals(((BigDecimal) reader.next()).compareTo(expectedValue), 0);
-    }
+    assertEquals(reader.getValueType(), PinotDataType.BIG_DECIMAL);
 
     // Test random access
-    reader.rewind();
-    for (int i = 0; i < NUM_DOCS; i++) {
-      Assert.assertFalse(reader.isNull(i));
-      Assert.assertEquals(reader.getBigDecimal(i).compareTo(expectedValue), 0);
+    BigDecimal expectedValue = (BigDecimal) fieldSpec.getDefaultNullValue();
+    for (int docId = 0; docId < reader.getTotalDocs(); docId++) {
+      assertFalse(reader.isNull(docId));
+      assertEquals(reader.getBigDecimal(docId).compareTo(expectedValue), 0);
+      assertEquals(((BigDecimal) reader.getValue(docId)).compareTo(expectedValue), 0);
     }
 
     reader.close();
@@ -197,19 +145,12 @@ public class DefaultValueColumnReaderTest {
     DefaultValueColumnReader reader = new DefaultValueColumnReader(COLUMN_NAME, NUM_DOCS, fieldSpec);
 
     // Test type indicators
-    Assert.assertTrue(reader.isString());
-    Assert.assertFalse(reader.isBytes());
-
-    // Test sequential access with nextString
-    String expectedValue = (String) fieldSpec.getDefaultNullValue();
-    for (int i = 0; i < NUM_DOCS; i++) {
-      Assert.assertEquals(reader.nextString(), expectedValue);
-    }
+    assertEquals(reader.getValueType(), PinotDataType.STRING);
 
     // Test random access
-    reader.rewind();
-    for (int i = 0; i < NUM_DOCS; i++) {
-      Assert.assertEquals(reader.getString(i), expectedValue);
+    String expectedValue = (String) fieldSpec.getDefaultNullValue();
+    for (int docId = 0; docId < reader.getTotalDocs(); docId++) {
+      assertEquals(reader.getString(docId), expectedValue);
     }
 
     reader.close();
@@ -221,19 +162,12 @@ public class DefaultValueColumnReaderTest {
     DefaultValueColumnReader reader = new DefaultValueColumnReader(COLUMN_NAME, NUM_DOCS, fieldSpec);
 
     // Test type indicators
-    Assert.assertFalse(reader.isString());
-    Assert.assertTrue(reader.isBytes());
-
-    // Test sequential access with nextBytes
-    byte[] expectedValue = (byte[]) fieldSpec.getDefaultNullValue();
-    for (int i = 0; i < NUM_DOCS; i++) {
-      Assert.assertTrue(Arrays.equals(reader.nextBytes(), expectedValue));
-    }
+    assertEquals(reader.getValueType(), PinotDataType.BYTES);
 
     // Test random access
-    reader.rewind();
-    for (int i = 0; i < NUM_DOCS; i++) {
-      Assert.assertTrue(Arrays.equals(reader.getBytes(i), expectedValue));
+    byte[] expectedValue = (byte[]) fieldSpec.getDefaultNullValue();
+    for (int docId = 0; docId < reader.getTotalDocs(); docId++) {
+      assertEquals(reader.getBytes(docId), expectedValue);
     }
 
     reader.close();
@@ -247,31 +181,21 @@ public class DefaultValueColumnReaderTest {
     DefaultValueColumnReader reader = new DefaultValueColumnReader(COLUMN_NAME, NUM_DOCS, fieldSpec);
 
     // Test type indicators
-    Assert.assertTrue(reader.isInt());
-
-    // Test sequential access with nextIntMV
-    int expectedValue = ((Number) fieldSpec.getDefaultNullValue()).intValue();
-    int[] expectedArray = new int[]{expectedValue};
-    for (int i = 0; i < NUM_DOCS; i++) {
-      Assert.assertTrue(reader.hasNext());
-      MultiValueResult<int[]> mvResult = reader.nextIntMV();
-      Assert.assertFalse(mvResult.hasNulls());
-      Assert.assertTrue(Arrays.equals(mvResult.getValues(), expectedArray));
-    }
+    assertEquals(reader.getValueType(), PinotDataType.INT_ARRAY);
 
     // Test random access
-    reader.rewind();
-    for (int i = 0; i < NUM_DOCS; i++) {
-      MultiValueResult<int[]> mvResult = reader.getIntMV(i);
-      Assert.assertFalse(mvResult.hasNulls());
-      Assert.assertTrue(Arrays.equals(mvResult.getValues(), expectedArray));
+    int expectedValue = ((Number) fieldSpec.getDefaultNullValue()).intValue();
+    int[] expectedArray = new int[]{expectedValue};
+    for (int docId = 0; docId < reader.getTotalDocs(); docId++) {
+      MultiValueResult<int[]> mvResult = reader.getIntMV(docId);
+      assertFalse(mvResult.hasNulls());
+      assertEquals(mvResult.getValues(), expectedArray);
     }
 
     // Test that the same array instance is returned (optimization)
-    reader.rewind();
     int[] firstCall = reader.getIntMV(0).getValues();
     int[] secondCall = reader.getIntMV(1).getValues();
-    Assert.assertSame(firstCall, secondCall, "Multi-value arrays should be reused");
+    assertSame(firstCall, secondCall, "Multi-value arrays should be reused");
 
     reader.close();
   }
@@ -282,23 +206,22 @@ public class DefaultValueColumnReaderTest {
     DefaultValueColumnReader reader = new DefaultValueColumnReader(COLUMN_NAME, NUM_DOCS, fieldSpec);
 
     // Test type indicators
-    Assert.assertTrue(reader.isLong());
+    assertEquals(reader.getValueType(), PinotDataType.LONG_ARRAY);
 
-    // Test sequential access with nextLongMV
+    // Test random access
     long expectedValue = ((Number) fieldSpec.getDefaultNullValue()).longValue();
     long[] expectedArray = new long[]{expectedValue};
-    for (int i = 0; i < NUM_DOCS; i++) {
-      MultiValueResult<long[]> mvResult = reader.nextLongMV();
-      Assert.assertFalse(mvResult.hasNulls());
-      Assert.assertTrue(Arrays.equals(mvResult.getValues(), expectedArray));
+    for (int docId = 0; docId < reader.getTotalDocs(); docId++) {
+      MultiValueResult<long[]> mvResult = reader.getLongMV(docId);
+      assertFalse(mvResult.hasNulls());
+      assertEquals(mvResult.getValues(), expectedArray);
     }
 
-    // Test random access and array reuse
-    reader.rewind();
+    // Test array reuse
     long[] firstCall = reader.getLongMV(0).getValues();
     long[] secondCall = reader.getLongMV(1).getValues();
-    Assert.assertTrue(Arrays.equals(firstCall, expectedArray));
-    Assert.assertSame(firstCall, secondCall, "Multi-value arrays should be reused");
+    assertEquals(firstCall, expectedArray);
+    assertSame(firstCall, secondCall, "Multi-value arrays should be reused");
 
     reader.close();
   }
@@ -308,20 +231,19 @@ public class DefaultValueColumnReaderTest {
     FieldSpec fieldSpec = new DimensionFieldSpec(COLUMN_NAME, FieldSpec.DataType.FLOAT, false);
     DefaultValueColumnReader reader = new DefaultValueColumnReader(COLUMN_NAME, NUM_DOCS, fieldSpec);
 
-    // Test sequential access with nextFloatMV
+    // Test random access
     float expectedValue = ((Number) fieldSpec.getDefaultNullValue()).floatValue();
     float[] expectedArray = new float[]{expectedValue};
-    for (int i = 0; i < NUM_DOCS; i++) {
-      MultiValueResult<float[]> mvResult = reader.nextFloatMV();
-      Assert.assertFalse(mvResult.hasNulls());
-      Assert.assertTrue(Arrays.equals(mvResult.getValues(), expectedArray));
+    for (int docId = 0; docId < reader.getTotalDocs(); docId++) {
+      MultiValueResult<float[]> mvResult = reader.getFloatMV(docId);
+      assertFalse(mvResult.hasNulls());
+      assertEquals(mvResult.getValues(), expectedArray);
     }
 
-    // Test random access and array reuse
-    reader.rewind();
+    // Test array reuse
     float[] firstCall = reader.getFloatMV(0).getValues();
     float[] secondCall = reader.getFloatMV(1).getValues();
-    Assert.assertSame(firstCall, secondCall, "Multi-value arrays should be reused");
+    assertSame(firstCall, secondCall, "Multi-value arrays should be reused");
 
     reader.close();
   }
@@ -331,20 +253,19 @@ public class DefaultValueColumnReaderTest {
     FieldSpec fieldSpec = new DimensionFieldSpec(COLUMN_NAME, FieldSpec.DataType.DOUBLE, false);
     DefaultValueColumnReader reader = new DefaultValueColumnReader(COLUMN_NAME, NUM_DOCS, fieldSpec);
 
-    // Test sequential access with nextDoubleMV
+    // Test random access
     double expectedValue = ((Number) fieldSpec.getDefaultNullValue()).doubleValue();
     double[] expectedArray = new double[]{expectedValue};
-    for (int i = 0; i < NUM_DOCS; i++) {
-      MultiValueResult<double[]> mvResult = reader.nextDoubleMV();
-      Assert.assertFalse(mvResult.hasNulls());
-      Assert.assertTrue(Arrays.equals(mvResult.getValues(), expectedArray));
+    for (int docId = 0; docId < reader.getTotalDocs(); docId++) {
+      MultiValueResult<double[]> mvResult = reader.getDoubleMV(docId);
+      assertFalse(mvResult.hasNulls());
+      assertEquals(mvResult.getValues(), expectedArray);
     }
 
-    // Test random access and array reuse
-    reader.rewind();
+    // Test array reuse
     double[] firstCall = reader.getDoubleMV(0).getValues();
     double[] secondCall = reader.getDoubleMV(1).getValues();
-    Assert.assertSame(firstCall, secondCall, "Multi-value arrays should be reused");
+    assertSame(firstCall, secondCall, "Multi-value arrays should be reused");
 
     reader.close();
   }
@@ -354,19 +275,18 @@ public class DefaultValueColumnReaderTest {
     FieldSpec fieldSpec = new DimensionFieldSpec(COLUMN_NAME, FieldSpec.DataType.STRING, false);
     DefaultValueColumnReader reader = new DefaultValueColumnReader(COLUMN_NAME, NUM_DOCS, fieldSpec);
 
-    // Test sequential access with nextStringMV
+    // Test random access
     String expectedValue = (String) fieldSpec.getDefaultNullValue();
     String[] expectedArray = new String[]{expectedValue};
-    for (int i = 0; i < NUM_DOCS; i++) {
-      String[] result = reader.nextStringMV();
-      Assert.assertTrue(Arrays.equals(result, expectedArray));
+    for (int docId = 0; docId < reader.getTotalDocs(); docId++) {
+      String[] result = reader.getStringMV(docId);
+      assertEquals(result, expectedArray);
     }
 
-    // Test random access and array reuse
-    reader.rewind();
+    // Test array reuse
     String[] firstCall = reader.getStringMV(0);
     String[] secondCall = reader.getStringMV(1);
-    Assert.assertSame(firstCall, secondCall, "Multi-value arrays should be reused");
+    assertSame(firstCall, secondCall, "Multi-value arrays should be reused");
 
     reader.close();
   }
@@ -376,70 +296,24 @@ public class DefaultValueColumnReaderTest {
     FieldSpec fieldSpec = new DimensionFieldSpec(COLUMN_NAME, FieldSpec.DataType.BYTES, false);
     DefaultValueColumnReader reader = new DefaultValueColumnReader(COLUMN_NAME, NUM_DOCS, fieldSpec);
 
-    // Test sequential access with nextBytesMV
+    // Test random access
     byte[] expectedValue = (byte[]) fieldSpec.getDefaultNullValue();
     byte[][] expectedArray = new byte[][]{expectedValue};
-    for (int i = 0; i < NUM_DOCS; i++) {
-      byte[][] result = reader.nextBytesMV();
-      Assert.assertEquals(result.length, expectedArray.length);
-      Assert.assertTrue(Arrays.equals(result[0], expectedArray[0]));
+    for (int docId = 0; docId < reader.getTotalDocs(); docId++) {
+      byte[][] result = reader.getBytesMV(docId);
+      assertEquals(result.length, expectedArray.length);
+      assertEquals(result[0], expectedArray[0]);
     }
 
-    // Test random access and array reuse
-    reader.rewind();
+    // Test array reuse
     byte[][] firstCall = reader.getBytesMV(0);
     byte[][] secondCall = reader.getBytesMV(1);
-    Assert.assertSame(firstCall, secondCall, "Multi-value arrays should be reused");
+    assertSame(firstCall, secondCall, "Multi-value arrays should be reused");
 
     reader.close();
   }
 
   // ========== Edge Cases and Error Handling ==========
-
-  @Test(expectedExceptions = IllegalStateException.class)
-  public void testNextPastEnd() {
-    FieldSpec fieldSpec = new DimensionFieldSpec(COLUMN_NAME, FieldSpec.DataType.INT, true);
-    DefaultValueColumnReader reader = new DefaultValueColumnReader(COLUMN_NAME, 5, fieldSpec);
-
-    // Read all values
-    for (int i = 0; i < 5; i++) {
-      reader.nextInt();
-    }
-
-    // This should throw IllegalStateException
-    reader.nextInt();
-    reader.close();
-  }
-
-  @Test(expectedExceptions = IllegalStateException.class)
-  public void testIsNextNullPastEnd() {
-    FieldSpec fieldSpec = new DimensionFieldSpec(COLUMN_NAME, FieldSpec.DataType.INT, true);
-    DefaultValueColumnReader reader = new DefaultValueColumnReader(COLUMN_NAME, 5, fieldSpec);
-
-    // Read all values
-    for (int i = 0; i < 5; i++) {
-      reader.nextInt();
-    }
-
-    // This should throw IllegalStateException
-    reader.isNextNull();
-    reader.close();
-  }
-
-  @Test(expectedExceptions = IllegalStateException.class)
-  public void testSkipNextPastEnd() {
-    FieldSpec fieldSpec = new DimensionFieldSpec(COLUMN_NAME, FieldSpec.DataType.INT, true);
-    DefaultValueColumnReader reader = new DefaultValueColumnReader(COLUMN_NAME, 5, fieldSpec);
-
-    // Read all values
-    for (int i = 0; i < 5; i++) {
-      reader.skipNext();
-    }
-
-    // This should throw IllegalStateException
-    reader.skipNext();
-    reader.close();
-  }
 
   @Test(expectedExceptions = IndexOutOfBoundsException.class)
   public void testRandomAccessOutOfBounds() {
@@ -467,66 +341,23 @@ public class DefaultValueColumnReaderTest {
     DefaultValueColumnReader reader = new DefaultValueColumnReader(COLUMN_NAME, NUM_DOCS, fieldSpec);
 
     // Default values are never null
-    for (int i = 0; i < NUM_DOCS; i++) {
-      Assert.assertFalse(reader.isNull(i));
-      Assert.assertFalse(reader.isNextNull());
-      reader.skipNext();
+    for (int docId = 0; docId < NUM_DOCS; docId++) {
+      assertFalse(reader.isNull(docId));
     }
 
     reader.close();
   }
 
   @Test
-  public void testSkipNext() {
-    FieldSpec fieldSpec = new DimensionFieldSpec(COLUMN_NAME, FieldSpec.DataType.INT, true);
-    DefaultValueColumnReader reader = new DefaultValueColumnReader(COLUMN_NAME, 10, fieldSpec);
-
-    int expectedValue = ((Number) fieldSpec.getDefaultNullValue()).intValue();
-
-    // Skip every other value
-    for (int i = 0; i < 5; i++) {
-      Assert.assertEquals(reader.nextInt(), expectedValue);
-      reader.skipNext();
-    }
-
-    Assert.assertFalse(reader.hasNext());
-    reader.close();
-  }
-
-  @Test
-  public void testRewind() {
-    FieldSpec fieldSpec = new DimensionFieldSpec(COLUMN_NAME, FieldSpec.DataType.INT, true);
-    DefaultValueColumnReader reader = new DefaultValueColumnReader(COLUMN_NAME, 10, fieldSpec);
-
-    int expectedValue = ((Number) fieldSpec.getDefaultNullValue()).intValue();
-
-    // Read all values
-    for (int i = 0; i < 10; i++) {
-      Assert.assertEquals(reader.nextInt(), expectedValue);
-    }
-    Assert.assertFalse(reader.hasNext());
-
-    // Rewind and read again
-    reader.rewind();
-    Assert.assertTrue(reader.hasNext());
-    for (int i = 0; i < 10; i++) {
-      Assert.assertEquals(reader.nextInt(), expectedValue);
-    }
-    Assert.assertFalse(reader.hasNext());
-
-    reader.close();
-  }
-
-  @Test
-  public void testNextObjectMethod() {
+  public void testGetValueMethod() {
     // Test single-value field
     FieldSpec svFieldSpec = new DimensionFieldSpec(COLUMN_NAME, FieldSpec.DataType.INT, true);
     DefaultValueColumnReader svReader = new DefaultValueColumnReader(COLUMN_NAME, 5, svFieldSpec);
 
     int expectedSvValue = ((Number) svFieldSpec.getDefaultNullValue()).intValue();
-    for (int i = 0; i < 5; i++) {
-      Object value = svReader.next();
-      Assert.assertEquals(value, expectedSvValue);
+    for (int docId = 0; docId < svReader.getTotalDocs(); docId++) {
+      Object value = svReader.getValue(docId);
+      assertEquals(value, expectedSvValue);
     }
     svReader.close();
 
@@ -536,10 +367,10 @@ public class DefaultValueColumnReaderTest {
 
     int expectedMvValue = ((Number) mvFieldSpec.getDefaultNullValue()).intValue();
     Object[] expectedArray = new Object[]{expectedMvValue};
-    for (int i = 0; i < 5; i++) {
-      Object value = mvReader.next();
-      Assert.assertTrue(value instanceof Object[]);
-      Assert.assertTrue(Arrays.equals((Object[]) value, expectedArray));
+    for (int docId = 0; docId < mvReader.getTotalDocs(); docId++) {
+      Object value = mvReader.getValue(docId);
+      assertTrue(value instanceof Object[]);
+      assertEquals((Object[]) value, expectedArray);
     }
     mvReader.close();
   }
@@ -549,7 +380,7 @@ public class DefaultValueColumnReaderTest {
     for (int numDocs : new int[]{0, 1, 10, 100, 1000}) {
       FieldSpec fieldSpec = new DimensionFieldSpec(COLUMN_NAME, FieldSpec.DataType.INT, true);
       DefaultValueColumnReader reader = new DefaultValueColumnReader(COLUMN_NAME, numDocs, fieldSpec);
-      Assert.assertEquals(reader.getTotalDocs(), numDocs);
+      assertEquals(reader.getTotalDocs(), numDocs);
       reader.close();
     }
   }
@@ -559,8 +390,7 @@ public class DefaultValueColumnReaderTest {
     FieldSpec fieldSpec = new DimensionFieldSpec(COLUMN_NAME, FieldSpec.DataType.INT, true);
     DefaultValueColumnReader reader = new DefaultValueColumnReader(COLUMN_NAME, 0, fieldSpec);
 
-    Assert.assertEquals(reader.getTotalDocs(), 0);
-    Assert.assertFalse(reader.hasNext());
+    assertEquals(reader.getTotalDocs(), 0);
 
     reader.close();
   }
@@ -572,12 +402,8 @@ public class DefaultValueColumnReaderTest {
 
     int expectedValue = ((Number) fieldSpec.getDefaultNullValue()).intValue();
 
-    Assert.assertTrue(reader.hasNext());
-    Assert.assertEquals(reader.nextInt(), expectedValue);
-    Assert.assertFalse(reader.hasNext());
-
-    reader.rewind();
-    Assert.assertEquals(reader.getInt(0), expectedValue);
+    assertEquals(reader.getTotalDocs(), 1);
+    assertEquals(reader.getInt(0), expectedValue);
 
     reader.close();
   }
@@ -587,74 +413,43 @@ public class DefaultValueColumnReaderTest {
     // Test INT
     FieldSpec intSpec = new DimensionFieldSpec("int_col", FieldSpec.DataType.INT, true);
     DefaultValueColumnReader intReader = new DefaultValueColumnReader("int_col", 1, intSpec);
-    Assert.assertTrue(intReader.isInt());
-    Assert.assertFalse(intReader.isLong());
-    Assert.assertFalse(intReader.isFloat());
-    Assert.assertFalse(intReader.isDouble());
-    Assert.assertFalse(intReader.isBigDecimal());
-    Assert.assertFalse(intReader.isString());
-    Assert.assertFalse(intReader.isBytes());
+    assertEquals(intReader.getValueType(), PinotDataType.INT);
     intReader.close();
 
     // Test LONG
     FieldSpec longSpec = new DimensionFieldSpec("long_col", FieldSpec.DataType.LONG, true);
     DefaultValueColumnReader longReader = new DefaultValueColumnReader("long_col", 1, longSpec);
-    Assert.assertFalse(longReader.isInt());
-    Assert.assertTrue(longReader.isLong());
+    assertEquals(longReader.getValueType(), PinotDataType.LONG);
     longReader.close();
 
     // Test FLOAT
     FieldSpec floatSpec = new DimensionFieldSpec("float_col", FieldSpec.DataType.FLOAT, true);
     DefaultValueColumnReader floatReader = new DefaultValueColumnReader("float_col", 1, floatSpec);
-    Assert.assertTrue(floatReader.isFloat());
-    Assert.assertFalse(floatReader.isDouble());
+    assertEquals(floatReader.getValueType(), PinotDataType.FLOAT);
     floatReader.close();
 
     // Test DOUBLE
     FieldSpec doubleSpec = new DimensionFieldSpec("double_col", FieldSpec.DataType.DOUBLE, true);
     DefaultValueColumnReader doubleReader = new DefaultValueColumnReader("double_col", 1, doubleSpec);
-    Assert.assertFalse(doubleReader.isFloat());
-    Assert.assertTrue(doubleReader.isDouble());
+    assertEquals(doubleReader.getValueType(), PinotDataType.DOUBLE);
     doubleReader.close();
 
     // Test BIG_DECIMAL
     FieldSpec bigDecimalSpec = new DimensionFieldSpec("big_decimal_col", FieldSpec.DataType.BIG_DECIMAL, true);
     DefaultValueColumnReader bigDecimalReader = new DefaultValueColumnReader("big_decimal_col", 1, bigDecimalSpec);
-    Assert.assertFalse(bigDecimalReader.isDouble());
-    Assert.assertTrue(bigDecimalReader.isBigDecimal());
-    Assert.assertFalse(bigDecimalReader.isString());
+    assertEquals(bigDecimalReader.getValueType(), PinotDataType.BIG_DECIMAL);
     bigDecimalReader.close();
 
     // Test STRING
     FieldSpec stringSpec = new DimensionFieldSpec("string_col", FieldSpec.DataType.STRING, true);
     DefaultValueColumnReader stringReader = new DefaultValueColumnReader("string_col", 1, stringSpec);
-    Assert.assertTrue(stringReader.isString());
-    Assert.assertFalse(stringReader.isBytes());
+    assertEquals(stringReader.getValueType(), PinotDataType.STRING);
     stringReader.close();
 
     // Test BYTES
     FieldSpec bytesSpec = new DimensionFieldSpec("bytes_col", FieldSpec.DataType.BYTES, true);
     DefaultValueColumnReader bytesReader = new DefaultValueColumnReader("bytes_col", 1, bytesSpec);
-    Assert.assertFalse(bytesReader.isString());
-    Assert.assertTrue(bytesReader.isBytes());
-    Assert.assertFalse(bytesReader.isBigDecimal());
+    assertEquals(bytesReader.getValueType(), PinotDataType.BYTES);
     bytesReader.close();
-  }
-
-  @Test
-  public void testMultipleReadsFromSamePosition() {
-    FieldSpec fieldSpec = new DimensionFieldSpec(COLUMN_NAME, FieldSpec.DataType.INT, true);
-    DefaultValueColumnReader reader = new DefaultValueColumnReader(COLUMN_NAME, 10, fieldSpec);
-
-    int expectedValue = ((Number) fieldSpec.getDefaultNullValue()).intValue();
-
-    // Read from the same random access position multiple times
-    for (int i = 0; i < 5; i++) {
-      Assert.assertEquals(reader.getInt(0), expectedValue);
-      Assert.assertEquals(reader.getInt(5), expectedValue);
-      Assert.assertEquals(reader.getInt(9), expectedValue);
-    }
-
-    reader.close();
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/readers/InMemoryColumnReader.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/readers/InMemoryColumnReader.java
@@ -18,10 +18,13 @@
  */
 package org.apache.pinot.segment.local.segment.readers;
 
+import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import javax.annotation.Nullable;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.readers.ColumnReader;
 import org.apache.pinot.spi.data.readers.MultiValueResult;
+import org.apache.pinot.spi.utils.PinotDataType;
 
 
 /**
@@ -33,7 +36,6 @@ public class InMemoryColumnReader implements ColumnReader {
   private final boolean[] _isNull;
   private final boolean _isSingleValue;
   private final Class<?> _dataType;
-  private int _currentIndex = 0;
 
   public InMemoryColumnReader(String columnName, Object[] values, boolean[] isNull, boolean isSingleValue,
       Class<?> dataType) {
@@ -45,151 +47,32 @@ public class InMemoryColumnReader implements ColumnReader {
   }
 
   @Override
-  public boolean hasNext() {
-    return _currentIndex < _values.length;
+  public String getColumnName() {
+    return _columnName;
   }
 
   @Nullable
   @Override
-  public Object next() {
-    if (!hasNext()) {
-      throw new IllegalStateException("No more values");
+  public PinotDataType getValueType() {
+    DataType dataType;
+    if (_dataType == Integer.class) {
+      dataType = DataType.INT;
+    } else if (_dataType == Long.class) {
+      dataType = DataType.LONG;
+    } else if (_dataType == Float.class) {
+      dataType = DataType.FLOAT;
+    } else if (_dataType == Double.class) {
+      dataType = DataType.DOUBLE;
+    } else if (_dataType == BigDecimal.class) {
+      dataType = DataType.BIG_DECIMAL;
+    } else if (_dataType == String.class) {
+      dataType = DataType.STRING;
+    } else if (_dataType == byte[].class) {
+      dataType = DataType.BYTES;
+    } else {
+      return null;
     }
-    Object value = _values[_currentIndex];
-    _currentIndex++;
-    return value;
-  }
-
-  @Override
-  public boolean isNextNull() {
-    return hasNext() && _isNull[_currentIndex];
-  }
-
-  @Override
-  public void skipNext() {
-    if (hasNext()) {
-      _currentIndex++;
-    }
-  }
-
-  @Override
-  public boolean isSingleValue() {
-    return _isSingleValue;
-  }
-
-  @Override
-  public boolean isInt() {
-    return _dataType == Integer.class;
-  }
-
-  @Override
-  public boolean isLong() {
-    return _dataType == Long.class;
-  }
-
-  @Override
-  public boolean isFloat() {
-    return _dataType == Float.class;
-  }
-
-  @Override
-  public boolean isDouble() {
-    return _dataType == Double.class;
-  }
-
-  @Override
-  public boolean isBigDecimal() {
-    return _dataType == BigDecimal.class;
-  }
-
-  @Override
-  public boolean isString() {
-    return _dataType == String.class;
-  }
-
-  @Override
-  public boolean isBytes() {
-    return _dataType == byte[].class;
-  }
-
-  @Override
-  public int nextInt() {
-    return (Integer) next();
-  }
-
-  @Override
-  public long nextLong() {
-    return (Long) next();
-  }
-
-  @Override
-  public float nextFloat() {
-    return (Float) next();
-  }
-
-  @Override
-  public double nextDouble() {
-    return (Double) next();
-  }
-
-  @Override
-  public BigDecimal nextBigDecimal() {
-    return (BigDecimal) next();
-  }
-
-  @Override
-  public String nextString() {
-    return (String) next();
-  }
-
-  @Override
-  public byte[] nextBytes() {
-    return (byte[]) next();
-  }
-
-  @Override
-  public MultiValueResult<int[]> nextIntMV() {
-    return MultiValueResult.of((int[]) next(), null);
-  }
-
-  @Override
-  public MultiValueResult<long[]> nextLongMV() {
-    return MultiValueResult.of((long[]) next(), null);
-  }
-
-  @Override
-  public MultiValueResult<float[]> nextFloatMV() {
-    return MultiValueResult.of((float[]) next(), null);
-  }
-
-  @Override
-  public MultiValueResult<double[]> nextDoubleMV() {
-    return MultiValueResult.of((double[]) next(), null);
-  }
-
-  @Override
-  public BigDecimal[] nextBigDecimalMV() {
-    return (BigDecimal[]) next();
-  }
-
-  @Override
-  public String[] nextStringMV() {
-    return (String[]) next();
-  }
-
-  @Override
-  public byte[][] nextBytesMV() {
-    return (byte[][]) next();
-  }
-
-  @Override
-  public void rewind() {
-    _currentIndex = 0;
-  }
-
-  @Override
-  public String getColumnName() {
-    return _columnName;
+    return ColumnReader.toValueType(dataType, _isSingleValue);
   }
 
   @Override
@@ -200,6 +83,22 @@ public class InMemoryColumnReader implements ColumnReader {
   @Override
   public boolean isNull(int docId) {
     return _isNull[docId];
+  }
+
+  @Override
+  public Object getValue(int docId) {
+    Object value = _values[docId];
+    if (_isSingleValue || value == null || value instanceof Object[]) {
+      return value;
+    }
+    // A multi-value column returns an Object[] per the ColumnReader contract; box primitive MV arrays (int[], long[],
+    // ...) so getValue() matches the interface instead of leaking the raw primitive array.
+    int length = Array.getLength(value);
+    Object[] boxed = new Object[length];
+    for (int i = 0; i < length; i++) {
+      boxed[i] = Array.get(value, i);
+    }
+    return boxed;
   }
 
   @Override
@@ -235,11 +134,6 @@ public class InMemoryColumnReader implements ColumnReader {
   @Override
   public byte[] getBytes(int docId) {
     return (byte[]) _values[docId];
-  }
-
-  @Override
-  public Object getValue(int docId) {
-    return _values[docId];
   }
 
   @Override

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentColumnReaderImplTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentColumnReaderImplTest.java
@@ -29,27 +29,29 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.ColumnReader;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.MultiValueResult;
 import org.apache.pinot.spi.utils.ReadMode;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
-/// Comprehensive tests for {@link PinotSegmentColumnReaderImpl}.
+
+/// Comprehensive tests for [PinotSegmentColumnReaderImpl].
 ///
 /// This test validates:
 /// - Single-value accessor methods (getInt, getLong, getFloat, getDouble, getBigDecimal, getString, getBytes)
 /// - Multi-value accessor methods (getIntMV, getLongMV, getFloatMV, getDoubleMV, getStringMV, getBytesMV)
-/// - Sequential accessor methods (nextInt, nextLong, nextFloat, nextDouble, nextBigDecimal, nextString, nextBytes,
-///   and MV variants)
-/// - Type indicator methods (isInt, isLong, isFloat, isDouble, isBigDecimal, isString, isBytes)
+/// - Value type reporting (getValueType)
 /// - Metadata methods (getTotalDocs, isNull)
 /// - Boundary conditions and exception handling
-/// - Consistency between iterator and random access patterns
 /// - Multiple readers for the same column
 /// - Dictionary-encoded, raw forward index, and nullable columns
 public class PinotSegmentColumnReaderImplTest extends ColumnarSegmentBuildingTestBase {
@@ -58,9 +60,7 @@ public class PinotSegmentColumnReaderImplTest extends ColumnarSegmentBuildingTes
    * Enum representing different segment index configurations for testing.
    */
   enum IndexType {
-    DICT_ENCODED,
-    RAW_INDEX,
-    NULLABLE
+    DICT_ENCODED, RAW_INDEX, NULLABLE
   }
 
   /**
@@ -73,29 +73,11 @@ public class PinotSegmentColumnReaderImplTest extends ColumnarSegmentBuildingTes
   }
 
   /**
-   * Functional interface for single-value sequential getters that can throw IOException.
-   */
-  @FunctionalInterface
-  interface SingleValueSequentialGetter {
-    Object get(PinotSegmentColumnReaderImpl reader)
-        throws IOException;
-  }
-
-  /**
    * Functional interface for multi-value getters that can throw IOException.
    */
   @FunctionalInterface
   interface MultiValueGetter {
     Object get(PinotSegmentColumnReaderImpl reader, int docId)
-        throws IOException;
-  }
-
-  /**
-   * Functional interface for multi-value sequential getters that can throw IOException.
-   */
-  @FunctionalInterface
-  interface MultiValueSequentialGetter {
-    Object get(PinotSegmentColumnReaderImpl reader)
         throws IOException;
   }
 
@@ -148,8 +130,8 @@ public class PinotSegmentColumnReaderImplTest extends ColumnarSegmentBuildingTes
       throws Exception {
     PinotSegmentColumnReaderImpl reader = new PinotSegmentColumnReaderImpl(_dictEncodedSegment, INT_COL_1);
 
-    Assert.assertEquals(reader.getTotalDocs(), _testData.size());
-    Assert.assertEquals(reader.getTotalDocs(), _dictEncodedSegment.getSegmentMetadata().getTotalDocs());
+    assertEquals(reader.getTotalDocs(), _testData.size());
+    assertEquals(reader.getTotalDocs(), _dictEncodedSegment.getSegmentMetadata().getTotalDocs());
 
     reader.close();
   }
@@ -185,30 +167,24 @@ public class PinotSegmentColumnReaderImplTest extends ColumnarSegmentBuildingTes
     }
   }
 
-  /**
-   * Data provider for single-value accessor methods.
-   * @return test parameters: column name, random access getter, sequential getter,
-   * value converter function (required for float), index type
-   */
+  /// Data provider for single-value accessor methods.
+  ///
+  /// @return test parameters: column name, random access getter, value converter function (required for float), index
+  ///     type
   @DataProvider(name = "singleValueAccessorProvider")
   public Object[][] singleValueAccessorProvider() {
     // Base column configurations
-    Object[][] baseConfigs = new Object[][] {
-        {INT_COL_1, (SingleValueGetter) PinotSegmentColumnReaderImpl::getInt,
-            (SingleValueSequentialGetter) PinotSegmentColumnReaderImpl::nextInt, null},
-        {LONG_COL, (SingleValueGetter) PinotSegmentColumnReaderImpl::getLong,
-            (SingleValueSequentialGetter) PinotSegmentColumnReaderImpl::nextLong, null},
-        {FLOAT_COL, (SingleValueGetter) PinotSegmentColumnReaderImpl::getFloat,
-            (SingleValueSequentialGetter) PinotSegmentColumnReaderImpl::nextFloat,
-            (Function<Object, Object>) val -> val instanceof Double ? ((Double) val).floatValue() : val},
-        {DOUBLE_COL, (SingleValueGetter) PinotSegmentColumnReaderImpl::getDouble,
-            (SingleValueSequentialGetter) PinotSegmentColumnReaderImpl::nextDouble, null},
-        {BIG_DECIMAL_COL, (SingleValueGetter) PinotSegmentColumnReaderImpl::getBigDecimal,
-            (SingleValueSequentialGetter) PinotSegmentColumnReaderImpl::nextBigDecimal, null},
-        {STRING_COL_1, (SingleValueGetter) PinotSegmentColumnReaderImpl::getString,
-            (SingleValueSequentialGetter) PinotSegmentColumnReaderImpl::nextString, null},
-        {BYTES_COL, (SingleValueGetter) PinotSegmentColumnReaderImpl::getBytes,
-            (SingleValueSequentialGetter) PinotSegmentColumnReaderImpl::nextBytes, null},
+    Object[][] baseConfigs = new Object[][]{
+        {INT_COL_1, (SingleValueGetter) PinotSegmentColumnReaderImpl::getInt, null},
+        {LONG_COL, (SingleValueGetter) PinotSegmentColumnReaderImpl::getLong, null},
+        {
+            FLOAT_COL, (SingleValueGetter) PinotSegmentColumnReaderImpl::getFloat,
+            (Function<Object, Object>) val -> val instanceof Double ? ((Double) val).floatValue() : val
+        },
+        {DOUBLE_COL, (SingleValueGetter) PinotSegmentColumnReaderImpl::getDouble, null},
+        {BIG_DECIMAL_COL, (SingleValueGetter) PinotSegmentColumnReaderImpl::getBigDecimal, null},
+        {STRING_COL_1, (SingleValueGetter) PinotSegmentColumnReaderImpl::getString, null},
+        {BYTES_COL, (SingleValueGetter) PinotSegmentColumnReaderImpl::getBytes, null}
     };
 
     // Create test cases for all index types
@@ -217,7 +193,7 @@ public class PinotSegmentColumnReaderImplTest extends ColumnarSegmentBuildingTes
     int idx = 0;
     for (Object[] baseConfig : baseConfigs) {
       for (IndexType indexType : indexTypes) {
-        result[idx++] = new Object[]{baseConfig[0], baseConfig[1], baseConfig[2], baseConfig[3], indexType};
+        result[idx++] = new Object[]{baseConfig[0], baseConfig[1], baseConfig[2], indexType};
       }
     }
     return result;
@@ -225,7 +201,7 @@ public class PinotSegmentColumnReaderImplTest extends ColumnarSegmentBuildingTes
 
   @Test(dataProvider = "singleValueAccessorProvider")
   public void testSingleValueAccessors(String columnName, SingleValueGetter randomAccessGetter,
-      SingleValueSequentialGetter sequentialGetter, Function<Object, Object> valueConverter, IndexType indexType)
+      Function<Object, Object> valueConverter, IndexType indexType)
       throws Exception {
     ImmutableSegment segment = getSegment(indexType);
     Schema schema = getSchema(indexType);
@@ -233,38 +209,25 @@ public class PinotSegmentColumnReaderImplTest extends ColumnarSegmentBuildingTes
 
     try {
       int totalDocs = reader.getTotalDocs();
-      Assert.assertEquals(totalDocs, _testData.size());
+      assertEquals(totalDocs, _testData.size());
 
       // Get field spec and data type for the column
       FieldSpec fieldSpec = schema.getFieldSpecFor(columnName);
       Object defaultValue = fieldSpec.getDefaultNullValue();
       DataType dataType = fieldSpec.getDataType();
 
-      // Test type indicator methods
-      Assert.assertEquals(reader.isInt(), dataType == DataType.INT,
-          "isInt() should return " + (dataType == DataType.INT) + " for " + columnName);
-      Assert.assertEquals(reader.isLong(), dataType == DataType.LONG,
-          "isLong() should return " + (dataType == DataType.LONG) + " for " + columnName);
-      Assert.assertEquals(reader.isFloat(), dataType == DataType.FLOAT,
-          "isFloat() should return " + (dataType == DataType.FLOAT) + " for " + columnName);
-      Assert.assertEquals(reader.isDouble(), dataType == DataType.DOUBLE,
-          "isDouble() should return " + (dataType == DataType.DOUBLE) + " for " + columnName);
-      Assert.assertEquals(reader.isBigDecimal(), dataType == DataType.BIG_DECIMAL,
-          "isBigDecimal() should return " + (dataType == DataType.BIG_DECIMAL) + " for " + columnName);
-      Assert.assertEquals(reader.isString(), dataType == DataType.STRING,
-          "isString() should return " + (dataType == DataType.STRING) + " for " + columnName);
-      Assert.assertEquals(reader.isBytes(), dataType == DataType.BYTES,
-          "isBytes() should return " + (dataType == DataType.BYTES) + " for " + columnName);
+      // Test the reported value type
+      assertEquals(reader.getValueType(), ColumnReader.toValueType(dataType, true),
+          "getValueType() should be the single-value type for " + columnName);
 
-      // Test reading all documents using random access (Pattern 3)
+      // Test reading all documents using random access
       for (int docId = 0; docId < totalDocs; docId++) {
         GenericRow expectedRow = _testData.get(docId);
         Object expectedValue = expectedRow.getValue(columnName);
 
         // For nullable segments, check if the value is actually null
         if (indexType == IndexType.NULLABLE && expectedValue == null) {
-          Assert.assertTrue(reader.isNull(docId),
-              "isNull() should return true for null value at docId " + docId);
+          assertTrue(reader.isNull(docId), "isNull() should return true for null value at docId " + docId);
           continue;
         }
 
@@ -273,141 +236,73 @@ public class PinotSegmentColumnReaderImplTest extends ColumnarSegmentBuildingTes
         if (expectedValue == null) {
           // Null values are replaced with default during segment creation (non-nullable)
           if (actualValue instanceof byte[]) {
-            Assert.assertEquals(actualValue, defaultValue, "Null should be replaced with default at docId " + docId);
+            assertEquals(actualValue, defaultValue, "Null should be replaced with default at docId " + docId);
           } else if (actualValue instanceof Double) {
-            Assert.assertEquals((Double) actualValue, (Double) defaultValue, 0.0001,
+            assertEquals((Double) actualValue, (Double) defaultValue, 0.0001,
                 "Null should be replaced with default at docId " + docId);
           } else if (actualValue instanceof Float) {
-            Assert.assertEquals((Float) actualValue, (Float) defaultValue, 0.0001f,
+            assertEquals((Float) actualValue, (Float) defaultValue, 0.0001f,
                 "Null should be replaced with default at docId " + docId);
           } else if (actualValue instanceof BigDecimal) {
-            Assert.assertEquals(((BigDecimal) actualValue).compareTo((BigDecimal) defaultValue), 0,
+            assertEquals(((BigDecimal) actualValue).compareTo((BigDecimal) defaultValue), 0,
                 "Null should be replaced with default at docId " + docId);
           } else {
-            Assert.assertEquals(actualValue, defaultValue, "Null should be replaced with default at docId " + docId);
+            assertEquals(actualValue, defaultValue, "Null should be replaced with default at docId " + docId);
           }
         } else {
           // Convert expected value if converter is provided
           Object convertedExpectedValue = valueConverter != null ? valueConverter.apply(expectedValue) : expectedValue;
           if (actualValue instanceof Double) {
-            Assert.assertEquals((Double) actualValue, (Double) convertedExpectedValue, 0.0001,
+            assertEquals((Double) actualValue, (Double) convertedExpectedValue, 0.0001,
                 "Value mismatch at docId " + docId);
           } else if (actualValue instanceof Float) {
-            Assert.assertEquals((Float) actualValue, (Float) convertedExpectedValue, 0.0001f,
+            assertEquals((Float) actualValue, (Float) convertedExpectedValue, 0.0001f,
                 "Value mismatch at docId " + docId);
           } else if (actualValue instanceof BigDecimal) {
-            Assert.assertEquals(((BigDecimal) actualValue).compareTo((BigDecimal) convertedExpectedValue), 0,
+            assertEquals(((BigDecimal) actualValue).compareTo((BigDecimal) convertedExpectedValue), 0,
                 "Value mismatch at docId " + docId);
           } else {
-            Assert.assertEquals(actualValue, convertedExpectedValue, "Value mismatch at docId " + docId);
+            assertEquals(actualValue, convertedExpectedValue, "Value mismatch at docId " + docId);
           }
         }
-      }
-
-      // Test sequential iteration with type-specific methods (Pattern 2) - only for columns with sequential getters
-      if (sequentialGetter != null) {
-        reader.rewind();
-        int docId = 0;
-        while (reader.hasNext()) {
-          GenericRow expectedRow = _testData.get(docId);
-          Object expectedValue = expectedRow.getValue(columnName);
-
-          if (indexType == IndexType.NULLABLE && expectedValue == null) {
-            Assert.assertTrue(reader.isNextNull(),
-                "isNextNull() should return true for null value at docId " + docId);
-            reader.skipNext();
-          } else if (reader.isNextNull()) {
-            reader.skipNext();
-            // For non-nullable segments, null is replaced with default
-            Assert.assertNull(expectedValue, "Expected null value at docId " + docId);
-          } else {
-            Object actualValue = sequentialGetter.get(reader);
-
-            if (expectedValue == null) {
-              // Null values are replaced with default during segment creation (non-nullable)
-              if (actualValue instanceof byte[]) {
-                Assert.assertEquals(actualValue, defaultValue,
-                    "Null should be replaced with default at docId " + docId + " (sequential)");
-              } else if (actualValue instanceof Double) {
-                Assert.assertEquals((Double) actualValue, (Double) defaultValue, 0.0001,
-                    "Null should be replaced with default at docId " + docId + " (sequential)");
-              } else if (actualValue instanceof Float) {
-                Assert.assertEquals((Float) actualValue, (Float) defaultValue, 0.0001f,
-                    "Null should be replaced with default at docId " + docId + " (sequential)");
-              } else if (actualValue instanceof BigDecimal) {
-                Assert.assertEquals(((BigDecimal) actualValue).compareTo((BigDecimal) defaultValue), 0,
-                    "Null should be replaced with default at docId " + docId + " (sequential)");
-              } else {
-                Assert.assertEquals(actualValue, defaultValue,
-                    "Null should be replaced with default at docId " + docId + " (sequential)");
-              }
-            } else {
-              // Convert expected value if converter is provided
-              Object convertedValue = valueConverter != null ? valueConverter.apply(expectedValue) : expectedValue;
-              if (actualValue instanceof Double) {
-                Assert.assertEquals((Double) actualValue, (Double) convertedValue, 0.0001,
-                    "Value mismatch at docId " + docId + " (sequential)");
-              } else if (actualValue instanceof Float) {
-                Assert.assertEquals((Float) actualValue, (Float) convertedValue, 0.0001f,
-                    "Value mismatch at docId " + docId + " (sequential)");
-              } else if (actualValue instanceof BigDecimal) {
-                Assert.assertEquals(((BigDecimal) actualValue).compareTo((BigDecimal) convertedValue), 0,
-                    "Value mismatch at docId " + docId + " (sequential)");
-              } else {
-                Assert.assertEquals(actualValue, convertedValue,
-                    "Value mismatch at docId " + docId + " (sequential)");
-              }
-            }
-          }
-          docId++;
-        }
-        Assert.assertEquals(docId, totalDocs, "Should have iterated through all documents");
       }
     } finally {
       reader.close();
     }
   }
 
-
-  /**
-   * Data provider for multi-value accessor methods.
-   * @return test parameters: column name, random access getter function,
-   * sequential getter function, array converter function, index type
-   */
+  /// Data provider for multi-value accessor methods.
+  ///
+  /// @return test parameters: column name, random access getter function, array converter function, index type
   @DataProvider(name = "multiValueAccessorProvider")
   public Object[][] multiValueAccessorProvider() {
     // Base column configurations
     // For primitive MV types, we need to extract .getValues() from MultiValueResult
     // and verify that hasNulls() is false (nulls are removed by NullValueTransformer for MV primitive types)
-    Object[][] baseConfigs = new Object[][] {
-        {MV_INT_COL, (MultiValueGetter) (reader, docId) -> {
-          MultiValueResult<int[]> result = reader.getIntMV(docId);
-          Assert.assertFalse(result.hasNulls(), "Multi-value primitive types should not have nulls");
-          return result.getValues();
-        },
-            (MultiValueSequentialGetter) reader -> {
-              MultiValueResult<int[]> result = reader.nextIntMV();
-              Assert.assertFalse(result.hasNulls(), "Multi-value primitive types should not have nulls");
+    Object[][] baseConfigs = new Object[][]{
+        {
+            MV_INT_COL,
+            (MultiValueGetter) (reader, docId) -> {
+              MultiValueResult<int[]> result = reader.getIntMV(docId);
+              assertFalse(result.hasNulls(), "Multi-value primitive types should not have nulls");
               return result.getValues();
-            }, null},
-        {MV_LONG_COL, (MultiValueGetter) (reader, docId) -> {
-          MultiValueResult<long[]> result = reader.getLongMV(docId);
-          Assert.assertFalse(result.hasNulls(), "Multi-value primitive types should not have nulls");
-          return result.getValues();
+            },
+            null
         },
-            (MultiValueSequentialGetter) reader -> {
-              MultiValueResult<long[]> result = reader.nextLongMV();
-              Assert.assertFalse(result.hasNulls(), "Multi-value primitive types should not have nulls");
+        {
+            MV_LONG_COL,
+            (MultiValueGetter) (reader, docId) -> {
+              MultiValueResult<long[]> result = reader.getLongMV(docId);
+              assertFalse(result.hasNulls(), "Multi-value primitive types should not have nulls");
               return result.getValues();
-            }, null},
-        {MV_FLOAT_COL, (MultiValueGetter) (reader, docId) -> {
-          MultiValueResult<float[]> result = reader.getFloatMV(docId);
-          Assert.assertFalse(result.hasNulls(), "Multi-value primitive types should not have nulls");
-          return result.getValues();
+            },
+            null
         },
-            (MultiValueSequentialGetter) reader -> {
-              MultiValueResult<float[]> result = reader.nextFloatMV();
-              Assert.assertFalse(result.hasNulls(), "Multi-value primitive types should not have nulls");
+        {
+            MV_FLOAT_COL,
+            (MultiValueGetter) (reader, docId) -> {
+              MultiValueResult<float[]> result = reader.getFloatMV(docId);
+              assertFalse(result.hasNulls(), "Multi-value primitive types should not have nulls");
               return result.getValues();
             },
             (Function<Object[], Object>) expectedArray -> {
@@ -416,23 +311,20 @@ public class PinotSegmentColumnReaderImplTest extends ColumnarSegmentBuildingTes
                 expectedFloatArray[i] = (Float) expectedArray[i];
               }
               return expectedFloatArray;
-            } },
-        {MV_DOUBLE_COL, (MultiValueGetter) (reader, docId) -> {
-          MultiValueResult<double[]> result = reader.getDoubleMV(docId);
-          Assert.assertFalse(result.hasNulls(), "Multi-value primitive types should not have nulls");
-          return result.getValues();
+            }
         },
-            (MultiValueSequentialGetter) reader -> {
-              MultiValueResult<double[]> result = reader.nextDoubleMV();
-              Assert.assertFalse(result.hasNulls(), "Multi-value primitive types should not have nulls");
+        {
+            MV_DOUBLE_COL,
+            (MultiValueGetter) (reader, docId) -> {
+              MultiValueResult<double[]> result = reader.getDoubleMV(docId);
+              assertFalse(result.hasNulls(), "Multi-value primitive types should not have nulls");
               return result.getValues();
-            }, null},
-        {MV_BIG_DECIMAL_COL, (MultiValueGetter) PinotSegmentColumnReaderImpl::getBigDecimalMV,
-            (MultiValueSequentialGetter) PinotSegmentColumnReaderImpl::nextBigDecimalMV, null},
-        {MV_STRING_COL, (MultiValueGetter) PinotSegmentColumnReaderImpl::getStringMV,
-            (MultiValueSequentialGetter) PinotSegmentColumnReaderImpl::nextStringMV, null},
-        {MV_BYTES_COL, (MultiValueGetter) PinotSegmentColumnReaderImpl::getBytesMV,
-            (MultiValueSequentialGetter) PinotSegmentColumnReaderImpl::nextBytesMV, null},
+            },
+            null
+        },
+        {MV_BIG_DECIMAL_COL, (MultiValueGetter) PinotSegmentColumnReaderImpl::getBigDecimalMV, null},
+        {MV_STRING_COL, (MultiValueGetter) PinotSegmentColumnReaderImpl::getStringMV, null},
+        {MV_BYTES_COL, (MultiValueGetter) PinotSegmentColumnReaderImpl::getBytesMV, null},
     };
 
     // Create test cases for all index types
@@ -441,7 +333,7 @@ public class PinotSegmentColumnReaderImplTest extends ColumnarSegmentBuildingTes
     int idx = 0;
     for (Object[] baseConfig : baseConfigs) {
       for (IndexType indexType : indexTypes) {
-        result[idx++] = new Object[]{baseConfig[0], baseConfig[1], baseConfig[2], baseConfig[3], indexType};
+        result[idx++] = new Object[]{baseConfig[0], baseConfig[1], baseConfig[2], indexType};
       }
     }
     return result;
@@ -449,7 +341,7 @@ public class PinotSegmentColumnReaderImplTest extends ColumnarSegmentBuildingTes
 
   @Test(dataProvider = "multiValueAccessorProvider")
   public void testMultiValueAccessors(String columnName, MultiValueGetter randomAccessGetter,
-      MultiValueSequentialGetter sequentialGetter, Function<Object[], Object> arrayConverter, IndexType indexType)
+      Function<Object[], Object> arrayConverter, IndexType indexType)
       throws Exception {
     ImmutableSegment segment = getSegment(indexType);
     Schema schema = getSchema(indexType);
@@ -464,21 +356,9 @@ public class PinotSegmentColumnReaderImplTest extends ColumnarSegmentBuildingTes
       DataType dataType = fieldSpec.getDataType();
       Object defaultValue;
 
-      // Test type indicator methods
-      Assert.assertEquals(reader.isInt(), dataType == DataType.INT,
-          "isInt() should return " + (dataType == DataType.INT) + " for " + columnName);
-      Assert.assertEquals(reader.isLong(), dataType == DataType.LONG,
-          "isLong() should return " + (dataType == DataType.LONG) + " for " + columnName);
-      Assert.assertEquals(reader.isFloat(), dataType == DataType.FLOAT,
-          "isFloat() should return " + (dataType == DataType.FLOAT) + " for " + columnName);
-      Assert.assertEquals(reader.isDouble(), dataType == DataType.DOUBLE,
-          "isDouble() should return " + (dataType == DataType.DOUBLE) + " for " + columnName);
-      Assert.assertEquals(reader.isBigDecimal(), dataType == DataType.BIG_DECIMAL,
-          "isBigDecimal() should return " + (dataType == DataType.BIG_DECIMAL) + " for " + columnName);
-      Assert.assertEquals(reader.isString(), dataType == DataType.STRING,
-          "isString() should return " + (dataType == DataType.STRING) + " for " + columnName);
-      Assert.assertEquals(reader.isBytes(), dataType == DataType.BYTES,
-          "isBytes() should return " + (dataType == DataType.BYTES) + " for " + columnName);
+      // Test the reported value type
+      assertEquals(reader.getValueType(), ColumnReader.toValueType(dataType, false),
+          "getValueType() should be the multi-value type for " + columnName);
 
       // Create default array based on type
       switch (fieldSpec.getDataType()) {
@@ -514,8 +394,7 @@ public class PinotSegmentColumnReaderImplTest extends ColumnarSegmentBuildingTes
 
         // For nullable segments, check if the value is actually null
         if (indexType == IndexType.NULLABLE && expectedValue == null) {
-          Assert.assertTrue(reader.isNull(docId),
-              "isNull() should return true for null value at docId " + docId);
+          assertTrue(reader.isNull(docId), "isNull() should return true for null value at docId " + docId);
           continue;
         }
 
@@ -523,53 +402,15 @@ public class PinotSegmentColumnReaderImplTest extends ColumnarSegmentBuildingTes
 
         if (expectedValue == null) {
           // Null values are replaced with default array during segment creation (non-nullable)
-          Assert.assertEquals(actualValue, defaultValue,
-              "Null should be replaced with default array at docId " + docId);
+          assertEquals(actualValue, defaultValue, "Null should be replaced with default array at docId " + docId);
         } else {
           // Convert expected Object[] to appropriate type array for comparison
           Object[] expectedArray = (Object[]) expectedValue;
           Object expectedConvertedArray = arrayConverter != null ? arrayConverter.apply(expectedArray) : expectedArray;
 
-          Assert.assertEquals(actualValue, expectedConvertedArray,
-              "MV array mismatch at docId " + docId);
+          assertEquals(actualValue, expectedConvertedArray, "MV array mismatch at docId " + docId);
         }
       }
-
-      // Test sequential iteration with type-specific MV methods
-      reader.rewind();
-      int docId = 0;
-      while (reader.hasNext()) {
-        GenericRow expectedRow = _testData.get(docId);
-        Object expectedValue = expectedRow.getValue(columnName);
-
-        if (indexType == IndexType.NULLABLE && expectedValue == null) {
-          Assert.assertTrue(reader.isNextNull(),
-              "isNextNull() should return true for null value at docId " + docId);
-          reader.skipNext();
-        } else if (reader.isNextNull()) {
-          reader.skipNext();
-          // For non-nullable segments, null is replaced with default
-          Assert.assertNull(expectedValue, "Expected null value at docId " + docId);
-        } else {
-          Object actualValue = sequentialGetter.get(reader);
-
-          if (expectedValue == null) {
-            // Null values are replaced with default array during segment creation (non-nullable)
-            Assert.assertEquals(actualValue, defaultValue,
-                "Null should be replaced with default array at docId " + docId + " (sequential)");
-          } else {
-            // Convert expected Object[] to appropriate type array for comparison
-            Object[] expectedArray = (Object[]) expectedValue;
-            Object convertedArray = arrayConverter != null ? arrayConverter.apply(expectedArray) : expectedArray;
-
-            Assert.assertEquals(actualValue, convertedArray,
-                "MV array mismatch at docId " + docId + " (sequential)");
-          }
-        }
-        docId++;
-      }
-
-      Assert.assertEquals(docId, totalDocs, "Should have iterated through all documents");
     } finally {
       reader.close();
     }
@@ -586,7 +427,7 @@ public class PinotSegmentColumnReaderImplTest extends ColumnarSegmentBuildingTes
       // In Pinot segments, nulls are replaced with defaults, so isNull should always return false
       for (int docId = 0; docId < totalDocs; docId++) {
         boolean actualNull = reader.isNull(docId);
-        Assert.assertFalse(actualNull, "isNull() should return false (nulls replaced with defaults) at docId " + docId);
+        assertFalse(actualNull, "isNull() should return false (nulls replaced with defaults) at docId " + docId);
       }
     } finally {
       reader.close();
@@ -600,13 +441,13 @@ public class PinotSegmentColumnReaderImplTest extends ColumnarSegmentBuildingTes
 
     try {
       int totalDocs = reader.getTotalDocs();
-      Assert.assertTrue(totalDocs > 0, "Expected non-empty segment");
+      assertTrue(totalDocs > 0, "Expected non-empty segment");
 
       // Test first document (docId = 0)
       int firstValue = reader.getInt(0);
       Object expectedFirst = _testData.get(0).getValue(INT_COL_1);
       if (expectedFirst != null) {
-        Assert.assertEquals(firstValue, expectedFirst, "First document value mismatch");
+        assertEquals(firstValue, expectedFirst, "First document value mismatch");
       }
 
       // Test last document (docId = totalDocs - 1)
@@ -614,13 +455,13 @@ public class PinotSegmentColumnReaderImplTest extends ColumnarSegmentBuildingTes
       int lastValue = reader.getInt(lastDocId);
       Object expectedLast = _testData.get(lastDocId).getValue(INT_COL_1);
       if (expectedLast != null) {
-        Assert.assertEquals(lastValue, expectedLast, "Last document value mismatch");
+        assertEquals(lastValue, expectedLast, "Last document value mismatch");
       }
 
       // Test docId = -1 (should throw IndexOutOfBoundsException)
       try {
         reader.getInt(-1);
-        Assert.fail("Expected IndexOutOfBoundsException for docId = -1");
+        fail("Expected IndexOutOfBoundsException for docId = -1");
       } catch (IndexOutOfBoundsException e) {
         // Expected
       }
@@ -628,7 +469,7 @@ public class PinotSegmentColumnReaderImplTest extends ColumnarSegmentBuildingTes
       // Test docId = totalDocs (should throw IndexOutOfBoundsException)
       try {
         reader.getInt(totalDocs);
-        Assert.fail("Expected IndexOutOfBoundsException for docId = totalDocs");
+        fail("Expected IndexOutOfBoundsException for docId = totalDocs");
       } catch (IndexOutOfBoundsException e) {
         // Expected
       }
@@ -636,7 +477,7 @@ public class PinotSegmentColumnReaderImplTest extends ColumnarSegmentBuildingTes
       // Test docId = totalDocs + 100 (should throw IndexOutOfBoundsException)
       try {
         reader.getInt(totalDocs + 100);
-        Assert.fail("Expected IndexOutOfBoundsException for docId > totalDocs");
+        fail("Expected IndexOutOfBoundsException for docId > totalDocs");
       } catch (IndexOutOfBoundsException e) {
         // Expected
       }
@@ -644,14 +485,14 @@ public class PinotSegmentColumnReaderImplTest extends ColumnarSegmentBuildingTes
       // Test isNull with out of bounds docId
       try {
         reader.isNull(-1);
-        Assert.fail("Expected IndexOutOfBoundsException for isNull(-1)");
+        fail("Expected IndexOutOfBoundsException for isNull(-1)");
       } catch (IndexOutOfBoundsException e) {
         // Expected
       }
 
       try {
         reader.isNull(totalDocs);
-        Assert.fail("Expected IndexOutOfBoundsException for isNull(totalDocs)");
+        fail("Expected IndexOutOfBoundsException for isNull(totalDocs)");
       } catch (IndexOutOfBoundsException e) {
         // Expected
       }
@@ -661,34 +502,16 @@ public class PinotSegmentColumnReaderImplTest extends ColumnarSegmentBuildingTes
   }
 
   @Test
-  public void testIteratorAndRandomAccessConsistency()
+  public void testGetValueAndTypedAccessorConsistency()
       throws Exception {
     PinotSegmentColumnReaderImpl reader = new PinotSegmentColumnReaderImpl(_dictEncodedSegment, INT_COL_1);
 
     try {
       int totalDocs = reader.getTotalDocs();
 
-      // First, read all values using random access
-      Integer[] randomAccessValues = new Integer[totalDocs];
       for (int docId = 0; docId < totalDocs; docId++) {
-        randomAccessValues[docId] = reader.getInt(docId);
-      }
-
-      // Now read using iterator pattern
-      reader.rewind();
-      Integer[] iteratorValues = new Integer[totalDocs];
-      int index = 0;
-      while (reader.hasNext()) {
-        Object value = reader.next();
-        iteratorValues[index++] = (Integer) value;
-      }
-
-      Assert.assertEquals(index, totalDocs, "Iterator should read all documents");
-
-      // Compare values
-      for (int i = 0; i < totalDocs; i++) {
-        Assert.assertEquals(iteratorValues[i], randomAccessValues[i],
-            "Iterator and random access values differ at index " + i);
+        Object value = reader.getValue(docId);
+        assertEquals(value, reader.getInt(docId), "getValue() and getInt() differ at docId " + docId);
       }
     } finally {
       reader.close();
@@ -696,42 +519,24 @@ public class PinotSegmentColumnReaderImplTest extends ColumnarSegmentBuildingTes
   }
 
   @Test
-  public void testIteratorAndRandomAccessConsistencyMV()
+  public void testGetValueAndTypedAccessorConsistencyMV()
       throws Exception {
     PinotSegmentColumnReaderImpl reader = new PinotSegmentColumnReaderImpl(_dictEncodedSegment, MV_INT_COL);
 
     try {
       int totalDocs = reader.getTotalDocs();
 
-      // First, read all values using random access
-      int[][] randomAccessValues = new int[totalDocs][];
       for (int docId = 0; docId < totalDocs; docId++) {
-        MultiValueResult<int[]> result = reader.getIntMV(docId);
-        randomAccessValues[docId] = result.getValues();
-      }
+        int[] typedValues = reader.getIntMV(docId).getValues();
 
-      // Now read using iterator pattern
-      reader.rewind();
-      Object[] iteratorValues = new Object[totalDocs];
-      int index = 0;
-      while (reader.hasNext()) {
-        Object value = reader.next();
-        iteratorValues[index++] = value;
-      }
-
-      Assert.assertEquals(index, totalDocs, "Iterator should read all documents");
-
-      // Compare values
-      for (int i = 0; i < totalDocs; i++) {
-        // Convert iterator value (Integer[]) to int[]
-        Integer[] iteratorArray = (Integer[]) iteratorValues[i];
-        int[] iteratorIntArray = new int[iteratorArray.length];
-        for (int j = 0; j < iteratorArray.length; j++) {
-          iteratorIntArray[j] = iteratorArray[j];
+        // getValue() returns the boxed Integer[] representation
+        Integer[] boxedValues = (Integer[]) reader.getValue(docId);
+        int[] unboxedValues = new int[boxedValues.length];
+        for (int j = 0; j < boxedValues.length; j++) {
+          unboxedValues[j] = boxedValues[j];
         }
 
-        Assert.assertEquals(iteratorIntArray, randomAccessValues[i],
-            "Iterator and random access MV values differ at index " + i);
+        assertEquals(unboxedValues, typedValues, "getValue() and getIntMV() differ at docId " + docId);
       }
     } finally {
       reader.close();
@@ -747,13 +552,13 @@ public class PinotSegmentColumnReaderImplTest extends ColumnarSegmentBuildingTes
 
     try {
       int totalDocs = reader1.getTotalDocs();
-      Assert.assertEquals(reader2.getTotalDocs(), totalDocs);
+      assertEquals(reader2.getTotalDocs(), totalDocs);
 
       // Read from both readers at different positions
       for (int docId = 0; docId < Math.min(10, totalDocs); docId++) {
         int value1 = reader1.getInt(docId);
         int value2 = reader2.getInt(docId);
-        Assert.assertEquals(value1, value2, "Values should match at docId " + docId);
+        assertEquals(value1, value2, "Values should match at docId " + docId);
       }
     } finally {
       reader1.close();
@@ -767,219 +572,7 @@ public class PinotSegmentColumnReaderImplTest extends ColumnarSegmentBuildingTes
     PinotSegmentColumnReaderImpl reader = new PinotSegmentColumnReaderImpl(_dictEncodedSegment, STRING_COL_1);
 
     try {
-      Assert.assertEquals(reader.getColumnName(), STRING_COL_1);
-    } finally {
-      reader.close();
-    }
-  }
-
-  /**
-   * Test isNextNull() method behavior.
-   */
-  @Test
-  public void testIsNextNull()
-      throws Exception {
-    PinotSegmentColumnReaderImpl reader = new PinotSegmentColumnReaderImpl(_dictEncodedSegment, INT_COL_1);
-
-    try {
-      int totalDocs = reader.getTotalDocs();
-      int docId = 0;
-
-      // For non-nullable segments, isNextNull should always return false
-      while (reader.hasNext()) {
-        boolean isNull = reader.isNextNull();
-        boolean expectedNull = reader.isNull(docId);
-        Assert.assertEquals(isNull, expectedNull, "isNextNull() mismatch at docId " + docId);
-        // Verify isNextNull doesn't advance the iterator
-        if (!isNull) {
-          int value = reader.nextInt();
-          Assert.assertEquals(value, reader.getInt(docId));
-        } else {
-          reader.skipNext();
-        }
-        docId++;
-      }
-
-      Assert.assertEquals(docId, totalDocs);
-    } finally {
-      reader.close();
-    }
-  }
-
-  /**
-   * Test skipNext() method behavior.
-   */
-  @Test
-  public void testSkipNext()
-      throws Exception {
-    PinotSegmentColumnReaderImpl reader = new PinotSegmentColumnReaderImpl(_dictEncodedSegment, INT_COL_1);
-
-    try {
-      int totalDocs = reader.getTotalDocs();
-      // Skip every other value
-      int docId = 0;
-      int valuesRead = 0;
-      while (reader.hasNext()) {
-        if (docId % 2 == 0) {
-          // Read even-indexed documents
-          int value = reader.nextInt();
-          Assert.assertEquals(value, reader.getInt(docId));
-          valuesRead++;
-        } else {
-          // Skip odd-indexed documents
-          reader.skipNext();
-        }
-        docId++;
-      }
-
-      Assert.assertEquals(docId, totalDocs);
-      Assert.assertEquals(valuesRead, (totalDocs + 1) / 2, "Should have read half the documents");
-    } finally {
-      reader.close();
-    }
-  }
-
-  /**
-   * Test that calling next methods after hasNext returns false throws exception.
-   */
-  @Test
-  public void testNextMethodsAfterEnd()
-      throws Exception {
-    PinotSegmentColumnReaderImpl reader = new PinotSegmentColumnReaderImpl(_dictEncodedSegment, INT_COL_1);
-
-    try {
-      // Read all values
-      while (reader.hasNext()) {
-        reader.nextInt();
-      }
-
-      // Now try to read more - should throw IllegalStateException
-      Assert.assertFalse(reader.hasNext());
-
-      try {
-        reader.nextInt();
-        Assert.fail("nextInt() should throw IllegalStateException when hasNext is false");
-      } catch (IllegalStateException e) {
-        // Expected
-      }
-
-      try {
-        reader.isNextNull();
-        Assert.fail("isNextNull() should throw IllegalStateException when hasNext is false");
-      } catch (IllegalStateException e) {
-        // Expected
-      }
-
-      try {
-        reader.skipNext();
-        Assert.fail("skipNext() should throw IllegalStateException when hasNext is false");
-      } catch (IllegalStateException e) {
-        // Expected
-      }
-    } finally {
-      reader.close();
-    }
-  }
-
-  /**
-   * Test rewind with type-specific iteration methods.
-   */
-  @Test
-  public void testRewindWithTypeSpecificMethods()
-      throws Exception {
-    PinotSegmentColumnReaderImpl reader = new PinotSegmentColumnReaderImpl(_dictEncodedSegment, LONG_COL);
-
-    try {
-      int totalDocs = reader.getTotalDocs();
-
-      // First pass: read all values
-      long[] firstPassValues = new long[totalDocs];
-      int idx = 0;
-      while (reader.hasNext()) {
-        if (!reader.isNextNull()) {
-          firstPassValues[idx++] = reader.nextLong();
-        } else {
-          reader.skipNext();
-          idx++;
-        }
-      }
-
-      Assert.assertFalse(reader.hasNext(), "Should be at end after first pass");
-
-      // Rewind
-      reader.rewind();
-      Assert.assertTrue(reader.hasNext(), "Should have values after rewind");
-
-      // Second pass: verify values match
-      idx = 0;
-      while (reader.hasNext()) {
-        if (!reader.isNextNull()) {
-          long value = reader.nextLong();
-          Assert.assertEquals(value, firstPassValues[idx++], "Value mismatch on second pass at index " + idx);
-        } else {
-          reader.skipNext();
-          idx++;
-        }
-      }
-
-      Assert.assertEquals(idx, totalDocs, "Should read same number of documents on second pass");
-    } finally {
-      reader.close();
-    }
-  }
-
-  /**
-   * Test consistency between all three iteration patterns.
-   */
-  @Test
-  public void testAllIterationPatternsConsistency()
-      throws Exception {
-    PinotSegmentColumnReaderImpl reader = new PinotSegmentColumnReaderImpl(_dictEncodedSegment, INT_COL_1);
-
-    try {
-      int totalDocs = reader.getTotalDocs();
-
-      // Pattern 1: Read using next() and null checks
-      reader.rewind();
-      Integer[] pattern1Values = new Integer[totalDocs];
-      int idx = 0;
-      while (reader.hasNext()) {
-        Object value = reader.next();
-        pattern1Values[idx++] = (Integer) value;
-      }
-
-      // Pattern 2: Read using isNextNull() + nextInt()
-      reader.rewind();
-      Integer[] pattern2Values = new Integer[totalDocs];
-      idx = 0;
-      while (reader.hasNext()) {
-        if (!reader.isNextNull()) {
-          pattern2Values[idx++] = reader.nextInt();
-        } else {
-          reader.skipNext();
-          pattern2Values[idx++] = null;
-        }
-      }
-
-      // Pattern 3: Read using getTotalDocs() + getInt(docId)
-      Integer[] pattern3Values = new Integer[totalDocs];
-      for (int docId = 0; docId < totalDocs; docId++) {
-        if (!reader.isNull(docId)) {
-          pattern3Values[docId] = reader.getInt(docId);
-        } else {
-          pattern3Values[docId] = null;
-        }
-      }
-
-      // Compare all patterns
-      for (int i = 0; i < totalDocs; i++) {
-        Assert.assertEquals(pattern1Values[i], pattern2Values[i],
-            "Pattern 1 and Pattern 2 differ at index " + i);
-        Assert.assertEquals(pattern1Values[i], pattern3Values[i],
-            "Pattern 1 and Pattern 3 differ at index " + i);
-        Assert.assertEquals(pattern2Values[i], pattern3Values[i],
-            "Pattern 2 and Pattern 3 differ at index " + i);
-      }
+      assertEquals(reader.getColumnName(), STRING_COL_1);
     } finally {
       reader.close();
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/ColumnReader.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/ColumnReader.java
@@ -22,301 +22,180 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import javax.annotation.Nullable;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.BooleanUtils;
+import org.apache.pinot.spi.utils.PinotDataType;
 
 
-/**
- * The <code>ColumnReader</code> interface is used to read column data from various data sources
- * for columnar segment building. Unlike RecordReader which reads row-by-row, ColumnReader provides
- * column-wise access to data, enabling efficient columnar segment creation.
- *
- * <p>This interface provides 3 patterns optimised for different use cases
- * (Some implementations may not support all patterns):
- * <ul>
- *   <li>Sequential iteration over all values in a column using hasNext(), next() and rewind()</li>
- *   <li>Sequential iteration with type-specific methods (isInt(), isLong(), nextInt(), nextLong(), etc.)
- *        and null handling (isNextNull(), skipNext()) and supports hasNext() and rewind()</li>
- *   <li>Random access by document ID using getInt(docId), getLong(docId), etc. and isNull(docId) for null checks</li>
- * </ul>
- *
- * <p>Implementations should handle data type conversions and efficient column-wise data access patterns.
- *
- * <h2>Usage Patterns</h2>
- *
- * <p>There are three primary patterns for reading data from a ColumnReader:
- *
- * <h3>Pattern 1: Sequential Iteration with Generic next() and Null Checks</h3>
- * <p>This pattern uses the generic {@link #next()} method which returns Object and may return null.
- * Suitable when you need to handle arbitrary data types or when null handling is done on the return value.
- *
- * <pre>{@code
- * // Read all values in the column
- * while (columnReader.hasNext()) {
- *   Object value;
- *   try {
- *    value = columnReader.next();
- *   } catch (Exception e) {
- *    // Handle exception / log
- *    continue;
- *    }
- *   if (value != null) {
- *     // Process non-null value
- *     processValue(value);
- *   } else {
- *     // Handle null value
- *     handleNullValue();
- *   }
- * }
- *
- * // Rewind to read the column again
- * columnReader.rewind();
- *
- * // Second pass through the data
- * while (columnReader.hasNext()) {
- *   Object value = columnReader.next();
- *   if (value != null) {
- *     processValueAgain(value);
- *   }
- * }
- * }</pre>
- *
- * <h3>Pattern 2: Sequential Iteration with Type-Specific Methods and Explicit Null Checks</h3>
- * <p>This pattern uses {@link #isNextNull()} to check for nulls before calling type-specific methods
- * like {@link #nextInt()}, {@link #nextLong()}, etc. Use {@link #skipNext()} to advance past null values.
- * This is the preferred pattern when you know the column data type and want to avoid boxing overhead.
- * Before using this pattern, check the column data type using methods like {@link #isInt()}, {@link #isLong()}, etc.
- * If the data type does not match, fall back to Pattern 1 with {@link #next()}.
- * <pre>{@code
- * // Read all int values in the column, handling nulls
- * if (columnReader.isInt()) {
- *  while (columnReader.hasNext()) {
- *     if (columnReader.isNextNull()) {
- *       // Skip the null value
- *      columnReader.skipNext();
- *      handleNullValue();
- *     } else {
- *      // Read the primitive int value (no boxing)
- *      int value = columnReader.nextInt();
- *      processIntValue(value);
- *    }
- *  }
- * } else {
- *  // Fallback to Pattern 1 if not INT type
- * }
- *
- * }</pre>
- *
- * <h3>Pattern 3: Random Access by Document ID</h3>
- * <p>This pattern uses {@link #getTotalDocs()} to get the total number of documents, then uses
- * document ID-based accessors like {@link #getInt(int)}, {@link #getLong(int)}, etc. to read
- * specific values. Use {@link #isNull(int)} to check if a value is null before reading.
- * This pattern is useful when you need random access or want to process documents in a specific order.
- *
- * <pre>{@code
- *
- * // Random access example - read specific document IDs
- * int[] docIdsToRead = {5, 10, 15, 20};
- * for (int docId : docIdsToRead) {
- *   if (!columnReader.isNull(docId)) {
- *     int value = columnReader.getInt(docId);
- *     processSpecificDoc(docId, value);
- *   }
- * }
- *
- * // Read in reverse order
- * // Get the total number of documents
- * int totalDocs = columnReader.getTotalDocs();
- * for (int docId = totalDocs - 1; docId >= 0; docId--) {
- *   if (!columnReader.isNull(docId)) {
- *     int value = columnReader.getInt(docId);
- *     processReverseOrder(docId, value);
- *   }
- * }
- * }</pre>
- *
- * <h3>Choosing the Right Pattern</h3>
- * <ul>
- *   <li><b>Pattern 1</b>: Use when dealing with generic Object types or when you don't know
- *       the column type at compile time. Less efficient due to boxing.</li>
- *   <li><b>Pattern 2</b>: Use when you know the column type and want efficient sequential iteration
- *       with primitive types. Preferred for most columnar segment building scenarios.</li>
- *   <li><b>Pattern 3</b>: Use when you need random access, want to process documents in a specific
- *       order, or need to access the same document multiple times.</li>
- * </ul>
- *
- */
+/// Reads the values of a single column by document ID, for columnar segment building. Where a `RecordReader` exposes a
+/// data source row-by-row, a `ColumnReader` exposes one column at a time: a caller reads every value of a column before
+/// moving to the next one. Building a segment one fully-materialized column at a time is cheaper than transposing row
+/// records when the source is already columnar (e.g. Arrow, Parquet).
+///
+/// Documents are addressed by a 0-based id, from 0 (inclusive) to [#getTotalDocs()] (exclusive). Two access patterns
+/// are supported:
+/// - **Random access** — [#getValue(int)] and the typed accessors may be called for any document id, in any order.
+/// - **Repeated sequential traversal** — the full range may be traversed by ascending document id more than once. The
+///   reader starts positioned at document 0; call [#rewind()] to reset it before each subsequent traversal. The
+///   segment build uses this: a statistics pass, then an index-writing pass over the same reader.
+///
+/// To read a column:
+/// 1. Call [#getValueType()] once. A non-`null` result names the type that can be read directly through the matching
+///    type-specific accessor; `null` means the column must be read through the boxed [#getValue(int)].
+/// 2. For each document id, call [#isNull(int)] first — type-specific accessors cannot represent null and must not be
+///    called for a null value.
+/// 3. Read each non-null value with the accessor chosen in step 1, e.g. [#getInt(int)] / [#getIntMV(int)] when
+///    [#getValueType()] is [PinotDataType#INT] / [PinotDataType#INT_ARRAY], or [#getValue(int)] otherwise.
+///
+/// Implementations perform any conversion between the source encoding and the returned Pinot type, are not required to
+/// be thread-safe, and must be released with [#close()] when no longer needed.
+///
+/// ```
+/// PinotDataType valueType = columnReader.getValueType();
+/// for (int docId = 0; docId < columnReader.getTotalDocs(); docId++) {
+///   if (columnReader.isNull(docId)) {
+///     continue;
+///   }
+///   if (valueType == PinotDataType.INT) {
+///     consumeInt(columnReader.getInt(docId));
+///   } else {
+///     consumeObject(columnReader.getValue(docId));
+///   }
+/// }
+/// ```
 public interface ColumnReader extends Closeable, Serializable {
 
-  /**
-   * Return <code>true</code> if more values remain to be read in this column.
-   * <p>This method should not throw exception. Caller is not responsible for handling exceptions from this method.
-   */
-  boolean hasNext();
-
-  /**
-   * Get the next value in the column.
-   * <p>This method should be called only if {@link #hasNext()} returns <code>true</code>. Caller is responsible for
-   * handling exceptions from this method and skip the value if user wants to continue reading the remaining values.
-   *
-   * @return Next column value, or null if the value is null
-   * @throws IOException If an I/O error occurs while reading
-   */
-  @Nullable
-  Object next()
-      throws IOException;
-
-  /**
-   * Check if the next value to be read is null.
-   */
-  boolean isNextNull()
-      throws IOException;
-
-  /**
-   * Move the reader to skip the next value in the column and advance to the following value.
-   * This method is typically used because type specific methods like {@link #nextInt()}, {@link #nextLong()}, etc.
-   * cannot return null values
-   * Thus, if {@link #isNextNull()} returns true, clients should call this method to skip the null value.
-   *
-   * <p><b>Example</b>
-   * <pre>{@code
-   * if (columnReader.isNextNull()) {
-   *   columnReader.skipNext();  // Skip null and move to next value
-   * } else {
-   *   int value = columnReader.nextInt();
-   * }
-   * }</pre>
-   *
-   * @throws IOException If an I/O error occurs while skipping
-   */
-  void skipNext()
-      throws IOException;
-
-  /**
-   * Check if the column data is single-value or multi-value.
-   */
-  boolean isSingleValue();
-
-  /**
-   * Check if the column data type from the actual reader can be returned as the expected type directly.
-   * For multi-value columns, this indicates if the multi-value type specific methods can be called directly.
-   * If true, the type specific methods like nextInt() can be called directly.
-   * Otherwise, clients should use next() and cast the result.
-   */
-  boolean isInt();
-
-  boolean isLong();
-
-  boolean isFloat();
-
-  boolean isDouble();
-
-  boolean isBigDecimal();
-
-  boolean isString();
-
-  boolean isBytes();
-
-  /**
-   * Get the next int / long / float / double / BigDecimal / string / byte[] value for single-value columns.
-   * Should be called only if isNextNull() returns false.
-   * @throws IOException If an I/O error occurs while reading
-   */
-  int nextInt()
-      throws IOException;
-
-  long nextLong()
-      throws IOException;
-
-  float nextFloat()
-      throws IOException;
-
-  double nextDouble()
-      throws IOException;
-
-  BigDecimal nextBigDecimal()
-      throws IOException;
-
-  String nextString()
-      throws IOException;
-
-  byte[] nextBytes()
-      throws IOException;
-
-  /**
-   * Get the next int[] / long[] / float[] / double[] / string[] / bytes[][] values for multi-value columns.
-   * Should be called only if isNextNull() returns false.
-   *
-   * <p>For primitive types (int, long, float, double), returns a {@link MultiValueResult} that includes
-   * element-level null validity tracking. Use {@link MultiValueResult#hasNulls()} and
-   * {@link MultiValueResult#isNull(int)} to check for null elements within the array.
-   *
-   * @throws IOException If an I/O error occurs while reading
-   */
-  MultiValueResult<int[]> nextIntMV()
-      throws IOException;
-
-  MultiValueResult<long[]> nextLongMV()
-      throws IOException;
-
-  MultiValueResult<float[]> nextFloatMV()
-      throws IOException;
-
-  MultiValueResult<double[]> nextDoubleMV()
-      throws IOException;
-
-  BigDecimal[] nextBigDecimalMV()
-      throws IOException;
-
-  String[] nextStringMV()
-      throws IOException;
-
-  byte[][] nextBytesMV()
-      throws IOException;
-
-  /**
-   * Rewind the reader to start reading from the first value again.
-   *
-   * @throws IOException If an I/O error occurs while rewinding
-   */
-  void rewind()
-      throws IOException;
-
-  /**
-   * Get the name of the column.
-   *
-   * @return Column name
-   */
+  /// Returns the name of the column read by this reader.
   String getColumnName();
 
-  /**
-   * Get the total number of documents in this column.
-   *
-   * @return Total number of documents
-   */
+  /// Returns the [PinotDataType] that [#getValue(int)] produces for this column, when that type has a matching typed
+  /// accessor; otherwise `null`.
+  ///
+  /// A non-`null` result `T` therefore names an accessor that returns exactly what [#getValue(int)] returns, only
+  /// unboxed: for every document id where [#isNull(int)] is `false`, the accessor matching `T` — e.g. [#getInt(int)]
+  /// for [PinotDataType#INT], [#getIntMV(int)] for [PinotDataType#INT_ARRAY] — returns the same value as
+  /// [#getValue(int)]. `null` means [#getValue(int)]'s type has no typed accessor; read the column through
+  /// [#getValue(int)].
+  ///
+  /// The result is a constant property of the column (independent of the document id) and, when non-`null`, is one of
+  /// the accessor-backed types — [PinotDataType#INT], [PinotDataType#LONG], [PinotDataType#FLOAT],
+  /// [PinotDataType#DOUBLE], [PinotDataType#BIG_DECIMAL], [PinotDataType#STRING], [PinotDataType#BYTES] — or their
+  /// `_ARRAY` variants for a multi-value column.
+  ///
+  /// Because [#getValue(int)] returns the column's logical type, a logical type whose object is not itself an
+  /// accessor-backed type returns `null`: `BOOLEAN` (a `Boolean`), `TIMESTAMP` (a `Timestamp`), and the complex types.
+  /// A `JSON` column reports [PinotDataType#STRING], since it is stored and read as its text `String`. Implementations
+  /// keyed on the stored [DataType] can use [#toValueType(DataType, boolean)].
+  @Nullable
+  PinotDataType getValueType();
+
+  /// Maps a stored [DataType] and cardinality to the [PinotDataType] a [#getValueType()] implementation should report,
+  /// or `null` when the type has no dedicated accessor (e.g. BOOLEAN, TIMESTAMP, or a complex type). A convenience for
+  /// implementations that already hold the column's [DataType]. `JSON` maps to [PinotDataType#STRING], since it is
+  /// stored and read as its text `String`.
+  @Nullable
+  static PinotDataType toValueType(DataType dataType, boolean singleValue) {
+    switch (dataType) {
+      case INT:
+        return singleValue ? PinotDataType.INT : PinotDataType.INT_ARRAY;
+      case LONG:
+        return singleValue ? PinotDataType.LONG : PinotDataType.LONG_ARRAY;
+      case FLOAT:
+        return singleValue ? PinotDataType.FLOAT : PinotDataType.FLOAT_ARRAY;
+      case DOUBLE:
+        return singleValue ? PinotDataType.DOUBLE : PinotDataType.DOUBLE_ARRAY;
+      case BIG_DECIMAL:
+        return singleValue ? PinotDataType.BIG_DECIMAL : PinotDataType.BIG_DECIMAL_ARRAY;
+      case STRING:
+        return singleValue ? PinotDataType.STRING : PinotDataType.STRING_ARRAY;
+      case JSON:
+        return PinotDataType.STRING;
+      case BYTES:
+        return singleValue ? PinotDataType.BYTES : PinotDataType.BYTES_ARRAY;
+      default:
+        return null;
+    }
+  }
+
+  /// Converts a value read from physical storage into the logical object [#getValue(int)] must return. Pinot stores
+  /// `BOOLEAN` as an `int` (`0`/`1`) and `TIMESTAMP` as a `long` (epoch millis), so those surface as `Boolean` /
+  /// `Timestamp`; every other type is stored as its logical type already. Handles the single-value form and the
+  /// multi-value `Object[]` form, and returns `null` unchanged. A convenience for segment-backed implementations that
+  /// read stored values keyed on the stored [DataType].
+  @Nullable
+  static Object toLogicalValue(@Nullable Object storedValue, DataType dataType) {
+    if (storedValue == null) {
+      return null;
+    }
+    switch (dataType) {
+      case BOOLEAN:
+        if (storedValue instanceof Object[]) {
+          Object[] stored = (Object[]) storedValue;
+          Boolean[] logical = new Boolean[stored.length];
+          for (int i = 0; i < stored.length; i++) {
+            logical[i] = BooleanUtils.fromNonNullInternalValue(stored[i]);
+          }
+          return logical;
+        }
+        return BooleanUtils.fromNonNullInternalValue(storedValue);
+      case TIMESTAMP:
+        if (storedValue instanceof Object[]) {
+          Object[] stored = (Object[]) storedValue;
+          Timestamp[] logical = new Timestamp[stored.length];
+          for (int i = 0; i < stored.length; i++) {
+            logical[i] = new Timestamp(((Number) stored[i]).longValue());
+          }
+          return logical;
+        }
+        return new Timestamp(((Number) storedValue).longValue());
+      default:
+        return storedValue;
+    }
+  }
+
+  /// Returns the number of documents in this column. Document ids run from 0 (inclusive) to this value (exclusive).
   int getTotalDocs();
 
-  /**
-   * Check if the value at the given document ID is null.
-   * <p>Document ID is 0-based. Valid values are 0 to {@link #getTotalDocs()} - 1.
-   *
-   * @param docId Document ID (0-based)
-   * @return true if the value is null, false otherwise
-   * @throws IndexOutOfBoundsException If docId is out of range
-   */
+  /// Resets this reader to the beginning so the column can be traversed again from document 0. The segment build
+  /// traverses each column twice — a statistics pass, then an index-writing pass — and calls this before the second
+  /// traversal. A random-access reader may keep the default no-op; a streaming or batched reader overrides it to reset
+  /// its position (e.g. rewind the source or drop the current batch).
+  ///
+  /// @throws IOException if an I/O error occurs while resetting
+  default void rewind()
+      throws IOException {
+  }
+
+  /// Returns whether the value at the given document id is null. Call this before any type-specific accessor, which
+  /// cannot represent null.
+  ///
+  /// @param docId 0-based document id, from 0 (inclusive) to [#getTotalDocs()] (exclusive)
+  /// @throws IndexOutOfBoundsException if `docId` is out of range
   boolean isNull(int docId)
+      throws IOException;
+
+  /// Returns the value at the given document id as a boxed `Object`, for both single-value and multi-value columns (a
+  /// multi-value column returns an `Object[]`). This is the general-purpose path, used when [#getValueType()] returns
+  /// `null`, or when the caller does not need the primitive form — e.g. it would box the value anyway, or it converts
+  /// the value itself.
+  ///
+  /// @param docId 0-based document id, from 0 (inclusive) to [#getTotalDocs()] (exclusive)
+  /// @throws IndexOutOfBoundsException if `docId` is out of range
+  /// @throws IOException if an I/O error occurs while reading
+  @Nullable
+  Object getValue(int docId)
       throws IOException;
 
   // Single-value accessors
 
-  /**
-   * Get int / long / float / double / BigDecimal / string / byte[] value at the given document ID for single-value
-   * columns. Should be called only if isNull(docId) returns false.
-   * Document ID is 0-based. Valid values are 0 to {@link #getTotalDocs()} - 1.
-   *
-   * @param docId Document ID (0-based)
-   * @throws IndexOutOfBoundsException If docId is out of range
-   * @throws IOException If an I/O error occurs while reading
-   */
+  /// Returns the single-value int / long / float / double / BigDecimal / String / byte[] value at the given document
+  /// id. Call the accessor matching [#getValueType()], and only for a non-null value (see [#isNull(int)]).
+  ///
+  /// @param docId 0-based document id, from 0 (inclusive) to [#getTotalDocs()] (exclusive)
+  /// @throws IndexOutOfBoundsException if `docId` is out of range
+  /// @throws IOException if an I/O error occurs while reading
   int getInt(int docId)
       throws IOException;
 
@@ -338,37 +217,19 @@ public interface ColumnReader extends Closeable, Serializable {
   byte[] getBytes(int docId)
       throws IOException;
 
-  /**
-   * Get the value at the given document ID as a Java Object.
-   * Can be used for both single-value and multi-value columns.
-   * This should be used if
-   * 1. Certain API's don't yet support primitive type specific methods (eg: TimeHandler, Partitioner, etc.) and
-   *    thus will be boxed anyway.
-   * 2. The required data type does not match the actual type and the client will handle the conversion
-   * Document ID is 0-based. Valid values are 0 to {@link #getTotalDocs()} - 1.
-   *
-   * @param docId Document ID (0-based)
-   * @throws IndexOutOfBoundsException If docId is out of range
-   * @throws IOException If an I/O error occurs while reading
-   */
-  Object getValue(int docId)
-      throws IOException;
-
   // Multi-value accessors
 
-  /**
-   * Get int[] / long[] / float[] / double[] / string[] / bytes[][] values at the given doc ID for multi-value columns.
-   * Should be called only if isNull(docId) returns false.
-   * <p>Document ID is 0-based. Valid values are 0 to {@link #getTotalDocs()} - 1.
-   *
-   * <p>For primitive types (int, long, float, double), returns a {@link MultiValueResult} that includes
-   * element-level null validity tracking. Use {@link MultiValueResult#hasNulls()} and
-   * {@link MultiValueResult#isNull(int)} to check for null elements within the array.
-   *
-   * @param docId Document ID (0-based)
-   * @throws IndexOutOfBoundsException If docId is out of range
-   * @throws IOException If an I/O error occurs while reading
-   */
+  /// Returns the multi-value int[] / long[] / float[] / double[] / BigDecimal[] / String[] / byte[][] values at the
+  /// given document id. Call the accessor matching [#getValueType()], and only for a non-null value (see
+  /// [#isNull(int)]).
+  ///
+  /// The primitive-array accessors ([#getIntMV(int)], [#getLongMV(int)], [#getFloatMV(int)], [#getDoubleMV(int)])
+  /// return a [MultiValueResult] that also tracks element-level nullity; use [MultiValueResult#hasNulls()] and
+  /// [MultiValueResult#isNull(int)] to detect null elements within the array.
+  ///
+  /// @param docId 0-based document id, from 0 (inclusive) to [#getTotalDocs()] (exclusive)
+  /// @throws IndexOutOfBoundsException if `docId` is out of range
+  /// @throws IOException if an I/O error occurs while reading
   MultiValueResult<int[]> getIntMV(int docId)
       throws IOException;
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/MultiValueResult.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/MultiValueResult.java
@@ -22,40 +22,36 @@ import java.util.BitSet;
 import javax.annotation.Nullable;
 
 
-/**
- * Result wrapper for multi-value column reads that tracks element-level nulls.
- *
- * <p>This class addresses a limitation where bulk reads from columnar formats (like Arrow)
- * don't check the validity bitmap for null elements. By returning both the values array
- * and a nulls BitSet, callers can properly handle null elements within multi-value columns.
- *
- * <p><b>BitSet Semantics:</b>
- * <ul>
- *   <li>Set bit (1) = null element</li>
- *   <li>Unset bit (0) = valid/non-null element</li>
- *   <li>Null nulls BitSet = no nulls in the range (fast path)</li>
- * </ul>
- *
- * <p><b>Usage Example:</b>
- * <pre>{@code
- * MultiValueResult<int[]> result = columnReader.nextIntMV();
- * int[] values = result.getValues();
- *
- * if (result.hasNulls()) {
- *   for (int i = 0; i < values.length; i++) {
- *     if (result.isNull(i)) {
- *       // Handle null element - values[i] contains default value (0 for int)
- *     } else {
- *       // Use values[i]
- *     }
- *   }
- * } else {
- *   // Fast path: no nulls, use values array directly
- * }
- * }</pre>
- *
- * @param <T> The array type (int[], long[], float[], double[])
- */
+/// Result wrapper for multi-value column reads that tracks element-level nulls.
+///
+/// This class addresses a limitation where bulk reads from columnar formats (like Arrow) don't check the validity
+/// bitmap for null elements. By returning both the values array and a nulls BitSet, callers can properly handle null
+/// elements within multi-value columns.
+///
+/// **BitSet semantics:**
+/// - Set bit (1) = null element
+/// - Unset bit (0) = valid / non-null element
+/// - Null nulls BitSet = no nulls in the range (fast path)
+///
+/// **Usage example:**
+/// ```
+/// MultiValueResult<int[]> result = columnReader.getIntMV(docId);
+/// int[] values = result.getValues();
+///
+/// if (result.hasNulls()) {
+///   for (int i = 0; i < values.length; i++) {
+///     if (result.isNull(i)) {
+///       // Handle null element - values[i] contains default value (0 for int)
+///     } else {
+///       // Use values[i]
+///     }
+///   }
+/// } else {
+///   // Fast path: no nulls, use values array directly
+/// }
+/// ```
+///
+/// @param <T> The array type (int[], long[], float[], double[])
 public class MultiValueResult<T> {
   private final T _values;
   @Nullable

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/ColumnReaderTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/ColumnReaderTest.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.data.readers;
+
+import java.sql.Timestamp;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.PinotDataType;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+
+/// Tests for the [ColumnReader] static helpers: [ColumnReader#toValueType(DataType, boolean)] maps a logical
+/// [DataType] to the value type a reader reports, and [ColumnReader#toLogicalValue(Object, DataType)] converts a
+/// physically-stored value to the logical object [ColumnReader#getValue(int)] returns.
+public class ColumnReaderTest {
+
+  @Test
+  public void testToValueType() {
+    assertEquals(ColumnReader.toValueType(DataType.INT, true), PinotDataType.INT);
+    assertEquals(ColumnReader.toValueType(DataType.INT, false), PinotDataType.INT_ARRAY);
+    assertEquals(ColumnReader.toValueType(DataType.LONG, true), PinotDataType.LONG);
+    assertEquals(ColumnReader.toValueType(DataType.FLOAT, true), PinotDataType.FLOAT);
+    assertEquals(ColumnReader.toValueType(DataType.DOUBLE, true), PinotDataType.DOUBLE);
+    assertEquals(ColumnReader.toValueType(DataType.BIG_DECIMAL, true), PinotDataType.BIG_DECIMAL);
+    assertEquals(ColumnReader.toValueType(DataType.STRING, true), PinotDataType.STRING);
+    assertEquals(ColumnReader.toValueType(DataType.BYTES, true), PinotDataType.BYTES);
+    assertEquals(ColumnReader.toValueType(DataType.BYTES, false), PinotDataType.BYTES_ARRAY);
+    // Logical types with no dedicated accessor are read through getValue().
+    assertNull(ColumnReader.toValueType(DataType.BOOLEAN, true));
+    assertNull(ColumnReader.toValueType(DataType.TIMESTAMP, true));
+    assertNull(ColumnReader.toValueType(DataType.MAP, true));
+    // JSON is stored and read as its text String.
+    assertEquals(ColumnReader.toValueType(DataType.JSON, true), PinotDataType.STRING);
+  }
+
+  @Test
+  public void testToLogicalValueScalar() {
+    // BOOLEAN is stored as int 0/1 but surfaces as Boolean, so it stringifies as "true"/"false", not "1"/"0".
+    assertEquals(ColumnReader.toLogicalValue(1, DataType.BOOLEAN), Boolean.TRUE);
+    assertEquals(ColumnReader.toLogicalValue(0, DataType.BOOLEAN), Boolean.FALSE);
+    // TIMESTAMP is stored as an epoch-millis long but surfaces as Timestamp.
+    Object timestamp = ColumnReader.toLogicalValue(1000L, DataType.TIMESTAMP);
+    assertEquals(timestamp, new Timestamp(1000L));
+    assertEquals(String.valueOf(timestamp), new Timestamp(1000L).toString());
+    // Types stored as their logical type pass through unchanged (JSON is read as its text String).
+    assertEquals(ColumnReader.toLogicalValue(42, DataType.INT), 42);
+    assertEquals(ColumnReader.toLogicalValue("foo", DataType.STRING), "foo");
+    assertEquals(ColumnReader.toLogicalValue("{\"a\":1}", DataType.JSON), "{\"a\":1}");
+    assertNull(ColumnReader.toLogicalValue(null, DataType.BOOLEAN));
+  }
+
+  @Test
+  public void testToLogicalValueMultiValue() {
+    assertEquals((Boolean[]) ColumnReader.toLogicalValue(new Object[]{1, 0, 1}, DataType.BOOLEAN),
+        new Boolean[]{true, false, true});
+    assertEquals((Timestamp[]) ColumnReader.toLogicalValue(new Object[]{1000L, 2000L}, DataType.TIMESTAMP),
+        new Timestamp[]{new Timestamp(1000L), new Timestamp(2000L)});
+  }
+}


### PR DESCRIPTION
## Summary

Cleans up the `ColumnReader` SPI (`pinot-spi`), used for column-major segment building, by removing a
redundant second read API and simplifying type introspection.

`ColumnReader` previously exposed two overlapping ways to read a column:
- an iterator-style API — `hasNext()`, `next()`, `isNextNull()`, `skipNext()`, and the
  `nextXxx()` / `nextXxxMV()` type-specific methods, and
- random access by document id — `getXxx(docId)` / `getValue(docId)`.

Every production consumer can be expressed with random access alone, so this removes the iterator API
entirely. Both column-major consumers — `SegmentColumnarIndexCreator.indexColumn(String, ColumnReader)`
and `ColumnarSegmentPreIndexStatsContainer.collectColumn(...)` — now read via a
`for (docId = 0; docId < getTotalDocs(); docId++)` loop over `getValue(docId)`, preserving the previous
null semantics.

The build traverses each column twice over the same cached reader — a statistics pass, then an
index-writing pass — so `rewind()` is retained (as `default void rewind()`), but with a narrower contract:
reset the reader to document 0 before a repeated forward traversal (it is no longer an iterator cursor
op). `indexColumn(...)` calls it before its pass; a random-access reader keeps the default no-op, while a
streaming/batched reader overrides it to reset its position.

It also replaces the boolean type-check methods (`isSingleValue()` + `isInt()`…`isBytes()`) with a single
`@Nullable PinotDataType getValueType()` that encodes both value type and cardinality (e.g. `INT` vs
`INT_ARRAY`). It returns `null` when `getValue(docId)`'s logical type has no matching typed accessor —
`BOOLEAN` (a `Boolean`), `TIMESTAMP` (a `Timestamp`), and the complex types — which are read through
`getValue(docId)`; a `JSON` column reports `STRING`, since it is stored and read as its text `String`. A
static `ColumnReader.toValueType(DataType, boolean)` helper centralizes the mapping for implementations
backed by a `DataType`, and `DataTypeColumnTransformer.isNoOp()` collapses to `getValueType() == destType`.

All implementations (`PinotSegmentColumnReaderImpl`, `DefaultValueColumnReader`, `ArrowColumnReader`,
`BatchedArrowColumnReader`) and their tests are migrated; the interface members are reordered and the
Javadoc rewritten for clarity.

## Backward incompatibility

`ColumnReader` is a `pinot-spi` interface first shipped in 1.5.0. Removing methods from it is
binary-incompatible for any external plugin that implements or calls `ColumnReader`. It is a
recently-added, internal-facing SPI for the still-evolving column-major segment build, so the expected
blast radius is nil, but the PR is labeled `backward-incompat` accordingly.

Release note: the `ColumnReader` SPI no longer exposes the sequential/iterator read API
(`hasNext`/`next`/`nextXxx`/`nextXxxMV`/`skipNext`/`isNextNull`) or the boolean type-check methods
(`isSingleValue`/`isInt`/…/`isBytes`). Read column values by document id via `getValue(docId)` /
`getXxx(docId)`, and use `getValueType()` to obtain the directly-readable value type and cardinality.
`rewind()` is retained as a default method that resets the reader to document 0 for a repeated forward
traversal.
