### PR TITLE
Rebuild JSON index when JsonIndexConfig changes; fix equals/hashCode to include all fields

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/BaseIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/BaseIndexHandler.java
@@ -24,14 +24,20 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.pinot.segment.spi.ColumnMetadata;
+import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
 import org.apache.pinot.segment.spi.index.IndexHandler;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.segment.spi.utils.SegmentMetadataUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.CommonsConfigurationUtils;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,5 +131,76 @@ public abstract class BaseIndexHandler implements IndexHandler {
     LOGGER.info("Rebuilt the forward index for column: {}, is temporary: {}", columnName, isTemporaryForwardIndex);
 
     return _segmentDirectory.getSegmentMetadata().getColumnMetadataFor(columnName);
+  }
+
+  /// Loads the segment {@code metadata.properties} file for this handler's segment directory, or returns {@code null}
+  /// if the file is unavailable (e.g. in-memory segments used in tests).
+  ///
+  /// Subclasses should call this once per [needUpdateIndices] / [updateIndices] invocation and pass the result to
+  /// [readStoredIndexConfig] and [setStoredIndexConfig] so that the file is read from disk only once.
+  @Nullable
+  protected PropertiesConfiguration loadMetadataProperties() {
+    try {
+      return SegmentMetadataUtils.getPropertiesConfiguration(_segmentDirectory.getSegmentMetadata());
+    } catch (Exception e) {
+      LOGGER.warn("Cannot load segment metadata properties for segment: {}, config-change detection disabled",
+          _segmentDirectory.getSegmentMetadata().getName(), e);
+      return null;
+    }
+  }
+
+  /// Reads a previously-persisted index config from {@code metadata.properties}.
+  ///
+  /// Returns {@code null} when:
+  /// - {@code properties} is {@code null} (in-memory segment)
+  /// - the key is absent (index was built before config persistence was added — "legacy segment")
+  /// - deserialization fails (corrupt entry)
+  ///
+  /// The {@code configKey} must be a stable, index-type-specific suffix used when the config was written, e.g.
+  /// {@code "jsonIndexConfig"}, {@code "bloomFilterConfig"}. It is combined with the column name via
+  /// [V1Constants.MetadataKeys.Column#getKeyFor].
+  @Nullable
+  protected static <T> T readStoredIndexConfig(String columnName, String configKey, Class<T> configClass,
+      @Nullable PropertiesConfiguration properties) {
+    if (properties == null) {
+      return null;
+    }
+    try {
+      String key = V1Constants.MetadataKeys.Column.getKeyFor(columnName, configKey);
+      String escaped = properties.getString(key, null);
+      if (escaped == null) {
+        return null;
+      }
+      String serialized = CommonsConfigurationUtils.recoverSpecialCharacterInPropertyValue(escaped);
+      return JsonUtils.stringToObject(serialized, configClass);
+    } catch (Exception e) {
+      LOGGER.warn("Failed to read stored index config '{}' for column: {}, treating as legacy (no stored config)",
+          configKey, columnName, e);
+      return null;
+    }
+  }
+
+  /// Writes an index config into the in-memory {@code properties} object (does **not** flush to disk).
+  ///
+  /// The caller is responsible for saving the file after all updates are complete, e.g. via
+  /// [SegmentMetadataUtils#savePropertiesConfiguration].
+  ///
+  /// Uses the same {@code configKey} convention as [readStoredIndexConfig].
+  protected static <T> void setStoredIndexConfig(String columnName, String configKey, T config,
+      PropertiesConfiguration properties) {
+    try {
+      String serialized = JsonUtils.objectToString(config);
+      String escaped = CommonsConfigurationUtils.replaceSpecialCharacterInPropertyValue(serialized);
+      if (escaped == null) {
+        LOGGER.warn("Cannot persist index config '{}' for column: {} due to unsupported characters", configKey,
+            columnName);
+        return;
+      }
+      String key = V1Constants.MetadataKeys.Column.getKeyFor(columnName, configKey);
+      properties.setProperty(key, escaped);
+    } catch (Exception e) {
+      LOGGER.warn("Failed to serialize index config '{}' for column: {}, config changes will not trigger rebuild",
+          configKey, columnName, e);
+    }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/JsonIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/JsonIndexHandler.java
@@ -23,6 +23,8 @@ import java.io.File;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.segment.index.dictionary.DictionaryIndexType;
 import org.apache.pinot.segment.local.segment.index.loader.BaseIndexHandler;
@@ -40,10 +42,13 @@ import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.segment.spi.utils.SegmentMetadataUtils;
 import org.apache.pinot.spi.config.table.JsonIndexConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.CommonsConfigurationUtils;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,10 +70,19 @@ public class JsonIndexHandler extends BaseIndexHandler {
     String segmentName = _segmentDirectory.getSegmentMetadata().getName();
     Set<String> columnsToAddIdx = new HashSet<>(_jsonIndexConfigs.keySet());
     Set<String> existingColumns = segmentReader.toSegmentDirectory().getColumnsWithIndex(StandardIndexes.json());
-    // Check if any existing index need to be removed.
+    // Load metadata properties once to avoid repeated disk reads when checking multiple columns.
+    PropertiesConfiguration properties = loadMetadataProperties();
+    // Check if any existing index need to be removed or if the config changed.
     for (String column : existingColumns) {
       if (!columnsToAddIdx.remove(column)) {
         LOGGER.info("Need to remove existing json index from segment: {}, column: {}", segmentName, column);
+        return true;
+      }
+      // Column exists in both existing indexes and config; check if config changed.
+      JsonIndexConfig currentConfig = _jsonIndexConfigs.get(column);
+      JsonIndexConfig storedConfig = readStoredJsonIndexConfig(column, properties);
+      if (storedConfig != null && !storedConfig.equals(currentConfig)) {
+        LOGGER.info("Need to rebuild json index for segment: {}, column: {} due to config change", segmentName, column);
         return true;
       }
     }
@@ -90,18 +104,91 @@ public class JsonIndexHandler extends BaseIndexHandler {
     String segmentName = _segmentDirectory.getSegmentMetadata().getName();
     Set<String> columnsToAddIdx = new HashSet<>(_jsonIndexConfigs.keySet());
     Set<String> existingColumns = segmentWriter.toSegmentDirectory().getColumnsWithIndex(StandardIndexes.json());
+    // Load metadata properties once; track whether we need to save changes.
+    PropertiesConfiguration properties = loadMetadataProperties();
+    boolean metadataModified = false;
     for (String column : existingColumns) {
       if (!columnsToAddIdx.remove(column)) {
         LOGGER.info("Removing existing json index from segment: {}, column: {}", segmentName, column);
         segmentWriter.removeIndex(column, StandardIndexes.json());
         LOGGER.info("Removed existing json index from segment: {}, column: {}", segmentName, column);
+      } else {
+        // Column exists in both existing indexes and config; check if config changed and rebuild if needed.
+        JsonIndexConfig currentConfig = _jsonIndexConfigs.get(column);
+        JsonIndexConfig storedConfig = readStoredJsonIndexConfig(column, properties);
+        if (storedConfig != null && !storedConfig.equals(currentConfig)) {
+          LOGGER.info("Rebuilding json index for segment: {}, column: {} due to config change", segmentName, column);
+          segmentWriter.removeIndex(column, StandardIndexes.json());
+          columnsToAddIdx.add(column);
+        }
       }
     }
     for (String column : columnsToAddIdx) {
       ColumnMetadata columnMetadata = _segmentDirectory.getSegmentMetadata().getColumnMetadataFor(column);
       if (shouldCreateJsonIndex(columnMetadata)) {
         createJsonIndexForColumn(segmentWriter, columnMetadata);
+        if (properties != null) {
+          setStoredJsonIndexConfig(column, _jsonIndexConfigs.get(column), properties);
+          metadataModified = true;
+        }
       }
+    }
+    if (metadataModified && properties != null) {
+      SegmentMetadataUtils.savePropertiesConfiguration(properties,
+          _segmentDirectory.getSegmentMetadata().getIndexDir());
+    }
+  }
+
+  /// Loads the segment {@code metadata.properties} file, or returns {@code null} if unavailable (in-memory segments).
+  @Nullable
+  private PropertiesConfiguration loadMetadataProperties() {
+    try {
+      return SegmentMetadataUtils.getPropertiesConfiguration(_segmentDirectory.getSegmentMetadata());
+    } catch (Exception e) {
+      LOGGER.warn("Cannot load segment metadata properties for segment: {}, config-change detection disabled",
+          _segmentDirectory.getSegmentMetadata().getName(), e);
+      return null;
+    }
+  }
+
+  /// Reads the stored {@link JsonIndexConfig} from the given {@code properties}, or returns {@code null} if not
+  /// present (e.g., index was built before config persistence was added).
+  @Nullable
+  private static JsonIndexConfig readStoredJsonIndexConfig(String columnName,
+      @Nullable PropertiesConfiguration properties) {
+    if (properties == null) {
+      return null;
+    }
+    try {
+      String key = V1Constants.MetadataKeys.Column.getKeyFor(columnName, "jsonIndexConfig");
+      String escaped = properties.getString(key, null);
+      if (escaped == null) {
+        return null;
+      }
+      String serialized = CommonsConfigurationUtils.recoverSpecialCharacterInPropertyValue(escaped);
+      return JsonUtils.stringToObject(serialized, JsonIndexConfig.class);
+    } catch (Exception e) {
+      LOGGER.warn("Failed to read stored json index config for column: {}, will not trigger rebuild on config change",
+          columnName, e);
+      return null;
+    }
+  }
+
+  /// Writes the {@link JsonIndexConfig} for {@code columnName} into {@code properties} (without saving to disk).
+  private static void setStoredJsonIndexConfig(String columnName, JsonIndexConfig config,
+      PropertiesConfiguration properties) {
+    try {
+      String serialized = JsonUtils.objectToString(config);
+      String escaped = CommonsConfigurationUtils.replaceSpecialCharacterInPropertyValue(serialized);
+      if (escaped == null) {
+        LOGGER.warn("Cannot persist json index config for column: {} due to unsupported characters", columnName);
+        return;
+      }
+      String key = V1Constants.MetadataKeys.Column.getKeyFor(columnName, "jsonIndexConfig");
+      properties.setProperty(key, escaped);
+    } catch (Exception e) {
+      LOGGER.warn("Failed to serialize json index config for column: {}, config changes will not trigger rebuild",
+          columnName, e);
     }
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/JsonIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/JsonIndexHandler.java
@@ -79,9 +79,11 @@ public class JsonIndexHandler extends BaseIndexHandler {
         return true;
       }
       // Column exists in both existing indexes and config; check if config changed.
+      // When properties != null but storedConfig is null the index predates config persistence (legacy segment):
+      // treat as a one-time rebuild to backfill the stored config and catch any config drift.
       JsonIndexConfig currentConfig = _jsonIndexConfigs.get(column);
       JsonIndexConfig storedConfig = readStoredJsonIndexConfig(column, properties);
-      if (storedConfig != null && !storedConfig.equals(currentConfig)) {
+      if (properties != null && (storedConfig == null || !storedConfig.equals(currentConfig))) {
         LOGGER.info("Need to rebuild json index for segment: {}, column: {} due to config change", segmentName, column);
         return true;
       }
@@ -114,9 +116,11 @@ public class JsonIndexHandler extends BaseIndexHandler {
         LOGGER.info("Removed existing json index from segment: {}, column: {}", segmentName, column);
       } else {
         // Column exists in both existing indexes and config; check if config changed and rebuild if needed.
+        // When properties != null but storedConfig is null the index predates config persistence (legacy segment):
+        // treat as a one-time rebuild to backfill the stored config and catch any config drift.
         JsonIndexConfig currentConfig = _jsonIndexConfigs.get(column);
         JsonIndexConfig storedConfig = readStoredJsonIndexConfig(column, properties);
-        if (storedConfig != null && !storedConfig.equals(currentConfig)) {
+        if (properties != null && (storedConfig == null || !storedConfig.equals(currentConfig))) {
           LOGGER.info("Rebuilding json index for segment: {}, column: {} due to config change", segmentName, column);
           segmentWriter.removeIndex(column, StandardIndexes.json());
           columnsToAddIdx.add(column);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/JsonIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/JsonIndexHandler.java
@@ -49,6 +49,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.MapUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -277,8 +278,13 @@ public class JsonIndexHandler extends BaseIndexHandler {
         ForwardIndexReaderContext readerContext = forwardIndexReader.createContext();
         JsonIndexCreator jsonIndexCreator = StandardIndexes.json().createIndexCreator(context, config)) {
       int numDocs = columnMetadata.getTotalDocs();
+      boolean isMapType = columnMetadata.getDataType() == DataType.MAP;
       for (int i = 0; i < numDocs; i++) {
-        jsonIndexCreator.add(forwardIndexReader.getString(i, readerContext));
+        // MAP columns store binary-encoded data; getString() returns garbled bytes.
+        // Use getMap() + MapUtils.toString() to produce the JSON string the index creator expects.
+        String value = isMapType ? MapUtils.toString(forwardIndexReader.getMap(i, readerContext))
+            : forwardIndexReader.getString(i, readerContext);
+        jsonIndexCreator.add(value);
       }
       jsonIndexCreator.seal();
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/JsonIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/JsonIndexHandler.java
@@ -81,12 +81,32 @@ public class JsonIndexHandler extends BaseIndexHandler {
       }
       // Column exists in both existing indexes and config; check if config changed.
       // When properties != null but storedConfig is null the index predates config persistence (legacy segment):
-      // treat as a one-time rebuild to backfill the stored config and catch any config drift.
+      // only backfill (rebuild) when the forward index is present or reconstructable. If the forward index is
+      // absent (e.g. forwardIndexDisabled=true with no dictionary/inverted pair), preserve the existing JSON
+      // index untouched — createForwardIndexIfNeeded() would fail with no dictionary/inverted index available.
       JsonIndexConfig currentConfig = _jsonIndexConfigs.get(column);
       JsonIndexConfig storedConfig = readStoredJsonIndexConfig(column, properties);
-      if (properties != null && (storedConfig == null || !storedConfig.equals(currentConfig))) {
-        LOGGER.info("Need to rebuild json index for segment: {}, column: {} due to config change", segmentName, column);
-        return true;
+      if (properties != null) {
+        // configChanged: stored config exists and differs from current — rebuild regardless of forward
+        // index presence (same pre-existing behaviour; createForwardIndexIfNeeded will fail if the
+        // forward index is truly unrecoverable, which requires an explicit segment refresh).
+        boolean configChanged = storedConfig != null && !storedConfig.equals(currentConfig);
+        // legacyBackfill: stored config is absent (either the index predates config persistence, or
+        // the stored value failed to deserialize and readStoredJsonIndexConfig returned null). Only
+        // backfill when the forward index is present or reconstructable; if it is absent
+        // (forwardIndexDisabled=true with no dictionary/inverted pair) createForwardIndexIfNeeded()
+        // would throw, so preserve the existing JSON index instead.
+        boolean legacyBackfill = storedConfig == null && isForwardIndexAvailable(segmentReader, column);
+        if (configChanged) {
+          LOGGER.info("Need to rebuild json index for segment: {}, column: {} due to config change", segmentName,
+              column);
+          return true;
+        }
+        if (legacyBackfill) {
+          LOGGER.info("Need to rebuild json index for segment: {}, column: {} to backfill stored config "
+              + "(legacy segment or unreadable stored config)", segmentName, column);
+          return true;
+        }
       }
     }
     // Check if any new index need to be added.
@@ -118,13 +138,26 @@ public class JsonIndexHandler extends BaseIndexHandler {
       } else {
         // Column exists in both existing indexes and config; check if config changed and rebuild if needed.
         // When properties != null but storedConfig is null the index predates config persistence (legacy segment):
-        // treat as a one-time rebuild to backfill the stored config and catch any config drift.
+        // only backfill (rebuild) when the forward index is present or reconstructable. If the forward index is
+        // absent (e.g. forwardIndexDisabled=true with no dictionary/inverted pair), preserve the existing JSON
+        // index untouched — createForwardIndexIfNeeded() would fail with no dictionary/inverted index available.
         JsonIndexConfig currentConfig = _jsonIndexConfigs.get(column);
         JsonIndexConfig storedConfig = readStoredJsonIndexConfig(column, properties);
-        if (properties != null && (storedConfig == null || !storedConfig.equals(currentConfig))) {
-          LOGGER.info("Rebuilding json index for segment: {}, column: {} due to config change", segmentName, column);
-          segmentWriter.removeIndex(column, StandardIndexes.json());
-          columnsToAddIdx.add(column);
+        if (properties != null) {
+          // configChanged: stored config exists and differs — rebuild (see needUpdateIndices for rationale).
+          boolean configChanged = storedConfig != null && !storedConfig.equals(currentConfig);
+          // legacyBackfill: absent/unreadable stored config; only rebuild when forward index is recoverable.
+          boolean legacyBackfill = storedConfig == null && isForwardIndexAvailable(segmentWriter, column);
+          if (configChanged) {
+            LOGGER.info("Rebuilding json index for segment: {}, column: {} due to config change", segmentName, column);
+            segmentWriter.removeIndex(column, StandardIndexes.json());
+            columnsToAddIdx.add(column);
+          } else if (legacyBackfill) {
+            LOGGER.info("Rebuilding json index for segment: {}, column: {} to backfill stored config "
+                + "(legacy segment or unreadable stored config)", segmentName, column);
+            segmentWriter.removeIndex(column, StandardIndexes.json());
+            columnsToAddIdx.add(column);
+          }
         }
       }
     }
@@ -173,7 +206,7 @@ public class JsonIndexHandler extends BaseIndexHandler {
       String serialized = CommonsConfigurationUtils.recoverSpecialCharacterInPropertyValue(escaped);
       return JsonUtils.stringToObject(serialized, JsonIndexConfig.class);
     } catch (Exception e) {
-      LOGGER.warn("Failed to read stored json index config for column: {}, will not trigger rebuild on config change",
+      LOGGER.warn("Failed to read stored json index config for column: {}, treating as legacy (no stored config)",
           columnName, e);
       return null;
     }
@@ -195,6 +228,15 @@ public class JsonIndexHandler extends BaseIndexHandler {
       LOGGER.warn("Failed to serialize json index config for column: {}, config changes will not trigger rebuild",
           columnName, e);
     }
+  }
+
+  /// Returns {@code true} if the forward index for {@code column} is already present in the segment or can be
+  /// reconstructed from the dictionary and inverted index (the path used by
+  /// {@link BaseIndexHandler#createForwardIndexIfNeeded}).
+  private static boolean isForwardIndexAvailable(SegmentDirectory.Reader segmentReader, String column) {
+    return segmentReader.hasIndexFor(column, StandardIndexes.forward())
+        || (segmentReader.hasIndexFor(column, StandardIndexes.dictionary())
+            && segmentReader.hasIndexFor(column, StandardIndexes.inverted()));
   }
 
   private boolean shouldCreateJsonIndex(ColumnMetadata columnMetadata) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/JsonIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/JsonIndexHandler.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.segment.index.dictionary.DictionaryIndexType;
@@ -47,8 +46,6 @@ import org.apache.pinot.spi.config.table.JsonIndexConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.env.CommonsConfigurationUtils;
-import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.MapUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,6 +54,8 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class JsonIndexHandler extends BaseIndexHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(JsonIndexHandler.class);
+  /// Metadata key suffix used to persist/restore [JsonIndexConfig] in {@code metadata.properties}.
+  static final String JSON_INDEX_CONFIG_KEY = "jsonIndexConfig";
 
   private final Map<String, JsonIndexConfig> _jsonIndexConfigs;
 
@@ -85,7 +84,8 @@ public class JsonIndexHandler extends BaseIndexHandler {
       // absent (e.g. forwardIndexDisabled=true with no dictionary/inverted pair), preserve the existing JSON
       // index untouched — createForwardIndexIfNeeded() would fail with no dictionary/inverted index available.
       JsonIndexConfig currentConfig = _jsonIndexConfigs.get(column);
-      JsonIndexConfig storedConfig = readStoredJsonIndexConfig(column, properties);
+      JsonIndexConfig storedConfig =
+          readStoredIndexConfig(column, JSON_INDEX_CONFIG_KEY, JsonIndexConfig.class, properties);
       if (properties != null) {
         // configChanged: stored config exists and differs from current — rebuild regardless of forward
         // index presence (same pre-existing behaviour; createForwardIndexIfNeeded will fail if the
@@ -142,7 +142,8 @@ public class JsonIndexHandler extends BaseIndexHandler {
         // absent (e.g. forwardIndexDisabled=true with no dictionary/inverted pair), preserve the existing JSON
         // index untouched — createForwardIndexIfNeeded() would fail with no dictionary/inverted index available.
         JsonIndexConfig currentConfig = _jsonIndexConfigs.get(column);
-        JsonIndexConfig storedConfig = readStoredJsonIndexConfig(column, properties);
+        JsonIndexConfig storedConfig =
+            readStoredIndexConfig(column, JSON_INDEX_CONFIG_KEY, JsonIndexConfig.class, properties);
         if (properties != null) {
           // configChanged: stored config exists and differs — rebuild (see needUpdateIndices for rationale).
           boolean configChanged = storedConfig != null && !storedConfig.equals(currentConfig);
@@ -166,7 +167,7 @@ public class JsonIndexHandler extends BaseIndexHandler {
       if (shouldCreateJsonIndex(columnMetadata)) {
         createJsonIndexForColumn(segmentWriter, columnMetadata);
         if (properties != null) {
-          setStoredJsonIndexConfig(column, _jsonIndexConfigs.get(column), properties);
+          setStoredIndexConfig(column, JSON_INDEX_CONFIG_KEY, _jsonIndexConfigs.get(column), properties);
           metadataModified = true;
         }
       }
@@ -174,59 +175,6 @@ public class JsonIndexHandler extends BaseIndexHandler {
     if (metadataModified && properties != null) {
       SegmentMetadataUtils.savePropertiesConfiguration(properties,
           _segmentDirectory.getSegmentMetadata().getIndexDir());
-    }
-  }
-
-  /// Loads the segment {@code metadata.properties} file, or returns {@code null} if unavailable (in-memory segments).
-  @Nullable
-  private PropertiesConfiguration loadMetadataProperties() {
-    try {
-      return SegmentMetadataUtils.getPropertiesConfiguration(_segmentDirectory.getSegmentMetadata());
-    } catch (Exception e) {
-      LOGGER.warn("Cannot load segment metadata properties for segment: {}, config-change detection disabled",
-          _segmentDirectory.getSegmentMetadata().getName(), e);
-      return null;
-    }
-  }
-
-  /// Reads the stored {@link JsonIndexConfig} from the given {@code properties}, or returns {@code null} if not
-  /// present (e.g., index was built before config persistence was added).
-  @Nullable
-  private static JsonIndexConfig readStoredJsonIndexConfig(String columnName,
-      @Nullable PropertiesConfiguration properties) {
-    if (properties == null) {
-      return null;
-    }
-    try {
-      String key = V1Constants.MetadataKeys.Column.getKeyFor(columnName, "jsonIndexConfig");
-      String escaped = properties.getString(key, null);
-      if (escaped == null) {
-        return null;
-      }
-      String serialized = CommonsConfigurationUtils.recoverSpecialCharacterInPropertyValue(escaped);
-      return JsonUtils.stringToObject(serialized, JsonIndexConfig.class);
-    } catch (Exception e) {
-      LOGGER.warn("Failed to read stored json index config for column: {}, treating as legacy (no stored config)",
-          columnName, e);
-      return null;
-    }
-  }
-
-  /// Writes the {@link JsonIndexConfig} for {@code columnName} into {@code properties} (without saving to disk).
-  private static void setStoredJsonIndexConfig(String columnName, JsonIndexConfig config,
-      PropertiesConfiguration properties) {
-    try {
-      String serialized = JsonUtils.objectToString(config);
-      String escaped = CommonsConfigurationUtils.replaceSpecialCharacterInPropertyValue(serialized);
-      if (escaped == null) {
-        LOGGER.warn("Cannot persist json index config for column: {} due to unsupported characters", columnName);
-        return;
-      }
-      String key = V1Constants.MetadataKeys.Column.getKeyFor(columnName, "jsonIndexConfig");
-      properties.setProperty(key, escaped);
-    } catch (Exception e) {
-      LOGGER.warn("Failed to serialize json index config for column: {}, config changes will not trigger rebuild",
-          columnName, e);
     }
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/BaseIndexHandlerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/BaseIndexHandlerTest.java
@@ -1,0 +1,222 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.loader;
+
+import java.io.File;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
+import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.spi.config.table.JsonIndexConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.CommonsConfigurationUtils;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+/// Unit tests for the config-persistence helpers in [BaseIndexHandler]:
+/// [BaseIndexHandler#readStoredIndexConfig] and [BaseIndexHandler#setStoredIndexConfig].
+///
+/// Covers:
+/// - Null properties (in-memory segment) → returns null, no exception
+/// - Missing key (legacy segment, config never written) → returns null
+/// - Round-trip: write then read back an equal config object
+/// - Round-trip through disk: write to file, reload, read back equal config
+/// - Special characters in serialized JSON (colons, quotes) round-trip correctly
+/// - Corrupt/undeserializable stored value → returns null gracefully, no exception
+/// - [BaseIndexHandler#loadMetadataProperties] returns non-null for a file-backed segment
+public class BaseIndexHandlerTest {
+  private static final String COLUMN = "myCol";
+  private static final String CONFIG_KEY = "testConfig";
+
+  private File _indexDir;
+
+  @BeforeMethod
+  public void setUp()
+      throws Exception {
+    _indexDir = new File(FileUtils.getTempDirectory(), "base-index-handler-test-" + System.nanoTime());
+    assertTrue(_indexDir.mkdirs());
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    FileUtils.deleteQuietly(_indexDir);
+  }
+
+  @Test
+  public void testReadReturnsNullForNullProperties() {
+    assertNull(BaseIndexHandler.readStoredIndexConfig(COLUMN, CONFIG_KEY, JsonIndexConfig.class, null));
+  }
+
+  @Test
+  public void testReadReturnsNullWhenKeyAbsent() {
+    // Simulates a legacy segment that was built before config persistence was added.
+    assertNull(BaseIndexHandler.readStoredIndexConfig(
+        COLUMN, CONFIG_KEY, JsonIndexConfig.class, new PropertiesConfiguration()));
+  }
+
+  @Test
+  public void testRoundTripInMemory()
+      throws Exception {
+    JsonIndexConfig config = new JsonIndexConfig();
+    config.setMaxLevels(5);
+    config.setExcludeArray(true);
+
+    PropertiesConfiguration props = new PropertiesConfiguration();
+    BaseIndexHandler.setStoredIndexConfig(COLUMN, CONFIG_KEY, config, props);
+
+    JsonIndexConfig read = BaseIndexHandler.readStoredIndexConfig(COLUMN, CONFIG_KEY, JsonIndexConfig.class, props);
+    assertNotNull(read);
+    assertEquals(read, config);
+  }
+
+  @Test
+  public void testRoundTripDefaultConfig()
+      throws Exception {
+    // Default JsonIndexConfig serializes to JSON with all-default values; verify it round-trips.
+    PropertiesConfiguration props = new PropertiesConfiguration();
+    JsonIndexConfig config = new JsonIndexConfig();
+    BaseIndexHandler.setStoredIndexConfig(COLUMN, CONFIG_KEY, config, props);
+
+    JsonIndexConfig read = BaseIndexHandler.readStoredIndexConfig(COLUMN, CONFIG_KEY, JsonIndexConfig.class, props);
+    assertNotNull(read);
+    assertEquals(read, config);
+  }
+
+  @Test
+  public void testRoundTripWithSpecialCharactersInJson()
+      throws Exception {
+    // JsonIndexConfig serializes to JSON containing colons, quotes, and braces.
+    // CommonsConfiguration treats ':' and '=' as key-value separators — verify the escaping
+    // in setStoredIndexConfig / recoverSpecialCharacterInPropertyValue round-trips correctly.
+    JsonIndexConfig config = new JsonIndexConfig();
+    config.setMaxLevels(3);
+    config.setMaxBytesSize(1024L);
+
+    PropertiesConfiguration props = new PropertiesConfiguration();
+    BaseIndexHandler.setStoredIndexConfig(COLUMN, CONFIG_KEY, config, props);
+
+    // The raw stored string must be non-null (escaping applied).
+    String key = V1Constants.MetadataKeys.Column.getKeyFor(COLUMN, CONFIG_KEY);
+    assertNotNull(props.getString(key));
+
+    JsonIndexConfig read = BaseIndexHandler.readStoredIndexConfig(COLUMN, CONFIG_KEY, JsonIndexConfig.class, props);
+    assertNotNull(read);
+    assertEquals(read, config);
+  }
+
+  @Test
+  public void testRoundTripThroughDisk()
+      throws Exception {
+    // Write to an in-memory PropertiesConfiguration, flush to disk, reload, and verify.
+    JsonIndexConfig config = new JsonIndexConfig();
+    config.setMaxLevels(7);
+
+    File metadataFile = new File(_indexDir, V1Constants.MetadataKeys.METADATA_FILE_NAME);
+    PropertiesConfiguration props = CommonsConfigurationUtils.fromFile(metadataFile);
+    BaseIndexHandler.setStoredIndexConfig(COLUMN, CONFIG_KEY, config, props);
+    CommonsConfigurationUtils.saveToFile(props, metadataFile);
+
+    PropertiesConfiguration reloaded = CommonsConfigurationUtils.fromFile(metadataFile);
+    JsonIndexConfig read = BaseIndexHandler.readStoredIndexConfig(COLUMN, CONFIG_KEY, JsonIndexConfig.class, reloaded);
+    assertNotNull(read);
+    assertEquals(read, config);
+  }
+
+  @Test
+  public void testReadReturnsNullForCorruptValue() {
+    // A corrupt / non-JSON stored value must not propagate an exception — returns null gracefully.
+    String key = V1Constants.MetadataKeys.Column.getKeyFor(COLUMN, CONFIG_KEY);
+    PropertiesConfiguration props = new PropertiesConfiguration();
+    props.setProperty(key, "not-valid-json{{{");
+
+    assertNull(BaseIndexHandler.readStoredIndexConfig(COLUMN, CONFIG_KEY, JsonIndexConfig.class, props));
+  }
+
+  @Test
+  public void testLoadMetadataPropertiesReturnsNonNullForFileBacked()
+      throws Exception {
+    // Create a real (but empty) metadata.properties in the temp dir.
+    File metadataFile = new File(_indexDir, V1Constants.MetadataKeys.METADATA_FILE_NAME);
+    CommonsConfigurationUtils.saveToFile(CommonsConfigurationUtils.fromFile(metadataFile), metadataFile);
+
+    SegmentMetadataImpl segmentMetadata = mock(SegmentMetadataImpl.class);
+    when(segmentMetadata.getName()).thenReturn("testSegment");
+    when(segmentMetadata.getTotalDocs()).thenReturn(1);
+    when(segmentMetadata.getAllColumns()).thenReturn(Set.of());
+    when(segmentMetadata.getIndexDir()).thenReturn(_indexDir);
+
+    SegmentDirectory segmentDirectory = mock(SegmentDirectory.class);
+    when(segmentDirectory.getSegmentMetadata()).thenReturn(segmentMetadata);
+
+    assertNotNull(new TestIndexHandler(segmentDirectory).loadMetadataProperties());
+  }
+
+  @Test
+  public void testMultipleColumnsAndKeysDoNotInterfere()
+      throws Exception {
+    // Storing configs for two different columns under the same key must not overwrite each other.
+    JsonIndexConfig configA = new JsonIndexConfig();
+    configA.setMaxLevels(2);
+    JsonIndexConfig configB = new JsonIndexConfig();
+    configB.setMaxLevels(8);
+
+    PropertiesConfiguration props = new PropertiesConfiguration();
+    BaseIndexHandler.setStoredIndexConfig("colA", CONFIG_KEY, configA, props);
+    BaseIndexHandler.setStoredIndexConfig("colB", CONFIG_KEY, configB, props);
+
+    assertEquals(
+        BaseIndexHandler.readStoredIndexConfig("colA", CONFIG_KEY, JsonIndexConfig.class, props), configA);
+    assertEquals(
+        BaseIndexHandler.readStoredIndexConfig("colB", CONFIG_KEY, JsonIndexConfig.class, props), configB);
+  }
+
+  /// Minimal concrete subclass used to access [BaseIndexHandler#loadMetadataProperties],
+  /// which is a protected instance method.
+  private static class TestIndexHandler extends BaseIndexHandler {
+    TestIndexHandler(SegmentDirectory segmentDirectory) {
+      super(segmentDirectory, Map.of(), mock(TableConfig.class), mock(Schema.class));
+    }
+
+    @Override
+    public boolean needUpdateIndices(SegmentDirectory.Reader segmentReader) {
+      return false;
+    }
+
+    @Override
+    public void updateIndices(SegmentDirectory.Writer segmentWriter) {
+    }
+
+    @Override
+    public void postUpdateIndicesCleanup(SegmentDirectory.Writer segmentWriter) {
+    }
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/JsonIndexHandlerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/JsonIndexHandlerTest.java
@@ -222,18 +222,51 @@ public class JsonIndexHandlerTest {
   }
 
   @Test
-  public void testNeedUpdateReturnsTrueWhenNoStoredConfig()
+  public void testNeedUpdateReturnsTrueWhenNoStoredConfigAndForwardIndexAvailable()
       throws Exception {
     // No stored config — index was built before config persistence was added (legacy segment).
-    // Must trigger a one-time rebuild to backfill the stored config and detect any config drift.
+    // Forward index is present, so a one-time backfill rebuild is safe and expected.
     createEmptyMetadataFile();
 
     JsonIndexConfig currentConfig = new JsonIndexConfig();
     JsonIndexHandler handler = createHandler(COLUMN, currentConfig);
-    SegmentDirectory.Reader reader = mockReaderWithIndexOn(COLUMN);
+    SegmentDirectory.Reader reader = mockReaderWithIndexOn(COLUMN, /* hasForwardIndex= */ true);
 
     assertTrue(handler.needUpdateIndices(reader),
-        "Rebuild expected for legacy segments with no stored config (one-time backfill)");
+        "Rebuild expected for legacy segments with no stored config when forward index is available");
+  }
+
+  @Test
+  public void testNeedUpdateReturnsFalseWhenNoStoredConfigButForwardIndexAbsent()
+      throws Exception {
+    // No stored config (legacy segment) AND no forward index (forwardIndexDisabled=true with no
+    // dictionary/inverted pair). createForwardIndexIfNeeded() would fail in this case, so the
+    // existing JSON index must be preserved without triggering a rebuild.
+    createEmptyMetadataFile();
+
+    JsonIndexConfig currentConfig = new JsonIndexConfig();
+    JsonIndexHandler handler = createHandler(COLUMN, currentConfig);
+    SegmentDirectory.Reader reader = mockReaderWithIndexOn(COLUMN, /* hasForwardIndex= */ false,
+        /* hasDictionary= */ false, /* hasInverted= */ false);
+
+    assertFalse(handler.needUpdateIndices(reader),
+        "No rebuild expected for legacy segments when forward index is absent (forwardIndexDisabled)");
+  }
+
+  @Test
+  public void testNeedUpdateReturnsTrueWhenNoStoredConfigAndForwardIndexReconstructable()
+      throws Exception {
+    // No stored config (legacy segment) AND forward index is absent but can be reconstructed from
+    // dictionary + inverted index. The rebuild is safe and should be triggered for backfill.
+    createEmptyMetadataFile();
+
+    JsonIndexConfig currentConfig = new JsonIndexConfig();
+    JsonIndexHandler handler = createHandler(COLUMN, currentConfig);
+    SegmentDirectory.Reader reader = mockReaderWithIndexOn(COLUMN, /* hasForwardIndex= */ false,
+        /* hasDictionary= */ true, /* hasInverted= */ true);
+
+    assertTrue(handler.needUpdateIndices(reader),
+        "Rebuild expected when forward index is reconstructable via dictionary + inverted index");
   }
 
   // --- helpers (mock-based) ---
@@ -299,10 +332,24 @@ public class JsonIndexHandlerTest {
   }
 
   private SegmentDirectory.Reader mockReaderWithIndexOn(String columnName) {
+    return mockReaderWithIndexOn(columnName, /* hasForwardIndex= */ true, /* hasDictionary= */ false,
+        /* hasInverted= */ false);
+  }
+
+  private SegmentDirectory.Reader mockReaderWithIndexOn(String columnName, boolean hasForwardIndex) {
+    return mockReaderWithIndexOn(columnName, hasForwardIndex, /* hasDictionary= */ false,
+        /* hasInverted= */ false);
+  }
+
+  private SegmentDirectory.Reader mockReaderWithIndexOn(String columnName, boolean hasForwardIndex,
+      boolean hasDictionary, boolean hasInverted) {
     SegmentDirectory segDir = mock(SegmentDirectory.class);
     when(segDir.getColumnsWithIndex(StandardIndexes.json())).thenReturn(Set.of(columnName));
     SegmentDirectory.Reader reader = mock(SegmentDirectory.Reader.class);
     when(reader.toSegmentDirectory()).thenReturn(segDir);
+    when(reader.hasIndexFor(columnName, StandardIndexes.forward())).thenReturn(hasForwardIndex);
+    when(reader.hasIndexFor(columnName, StandardIndexes.dictionary())).thenReturn(hasDictionary);
+    when(reader.hasIndexFor(columnName, StandardIndexes.inverted())).thenReturn(hasInverted);
     return reader;
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/JsonIndexHandlerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/JsonIndexHandlerTest.java
@@ -50,8 +50,9 @@ import static org.testng.Assert.assertTrue;
 ///
 /// Covers two axes:
 /// - Column lifecycle: needUpdateIndices / updateIndices when a column is added, removed, or unchanged.
-/// - Config-change detection: needUpdateIndices triggers a rebuild when any JsonIndexConfig field changes,
-///   and is backward-compatible when no stored config is present.
+/// - Config-change detection: needUpdateIndices triggers a rebuild when any [JsonIndexConfig] field
+///   changes. Legacy segments with no stored config trigger a one-time rebuild to backfill the
+///   stored config and catch any config drift.
 public class JsonIndexHandlerTest {
   private static final String COLUMN = "myJsonCol";
 
@@ -221,17 +222,18 @@ public class JsonIndexHandlerTest {
   }
 
   @Test
-  public void testNeedUpdateReturnsFalseWhenNoStoredConfig()
+  public void testNeedUpdateReturnsTrueWhenNoStoredConfig()
       throws Exception {
-    // No stored config — index was built before config persistence was added. Must NOT trigger a spurious rebuild.
+    // No stored config — index was built before config persistence was added (legacy segment).
+    // Must trigger a one-time rebuild to backfill the stored config and detect any config drift.
     createEmptyMetadataFile();
 
     JsonIndexConfig currentConfig = new JsonIndexConfig();
     JsonIndexHandler handler = createHandler(COLUMN, currentConfig);
     SegmentDirectory.Reader reader = mockReaderWithIndexOn(COLUMN);
 
-    assertFalse(handler.needUpdateIndices(reader),
-        "No rebuild expected when no stored config is present (backward compatibility)");
+    assertTrue(handler.needUpdateIndices(reader),
+        "Rebuild expected for legacy segments with no stored config (one-time backfill)");
   }
 
   // --- helpers (mock-based) ---

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/JsonIndexHandlerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/JsonIndexHandlerTest.java
@@ -302,7 +302,7 @@ public class JsonIndexHandlerTest {
       throws Exception {
     File metadataFile = new File(_indexDir, V1Constants.MetadataKeys.METADATA_FILE_NAME);
     PropertiesConfiguration properties = CommonsConfigurationUtils.fromFile(metadataFile);
-    String key = V1Constants.MetadataKeys.Column.getKeyFor(columnName, "jsonIndexConfig");
+    String key = V1Constants.MetadataKeys.Column.getKeyFor(columnName, JsonIndexHandler.JSON_INDEX_CONFIG_KEY);
     String serialized = JsonUtils.objectToString(config);
     String escaped = CommonsConfigurationUtils.replaceSpecialCharacterInPropertyValue(serialized);
     properties.setProperty(key, escaped);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/JsonIndexHandlerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/JsonIndexHandlerTest.java
@@ -18,10 +18,14 @@
  */
 package org.apache.pinot.segment.local.segment.index.loader.invertedindex;
 
+import java.io.File;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.spi.ColumnMetadata;
+import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
@@ -29,6 +33,10 @@ import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.spi.config.table.JsonIndexConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.CommonsConfigurationUtils;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.mock;
@@ -40,17 +48,31 @@ import static org.testng.Assert.assertTrue;
 
 /// Unit tests for [JsonIndexHandler].
 ///
-/// Covers:
-/// - needUpdateIndices returns true when a column is dropped from the JSON index config
-/// - updateIndices removes the on-disk index when a column is dropped from config
-/// - needUpdateIndices returns true when a new column is added to the config
-/// - needUpdateIndices returns false when the index is already present and matches config
-/// - needUpdateIndices returns false when column metadata is absent (column not in segment)
+/// Covers two axes:
+/// - Column lifecycle: needUpdateIndices / updateIndices when a column is added, removed, or unchanged.
+/// - Config-change detection: needUpdateIndices triggers a rebuild when any JsonIndexConfig field changes,
+///   and is backward-compatible when no stored config is present.
 public class JsonIndexHandlerTest {
-  private static final String COLUMN = "details";
+  private static final String COLUMN = "myJsonCol";
 
   /// FieldIndexConfigs that explicitly has no JSON index — used for the "column removed" tests.
   private static final FieldIndexConfigs NO_JSON = new FieldIndexConfigs.Builder().build();
+
+  private File _indexDir;
+
+  @BeforeMethod
+  public void setUp()
+      throws Exception {
+    _indexDir = new File(FileUtils.getTempDirectory(), "json-index-handler-test-" + System.nanoTime());
+    assertTrue(_indexDir.mkdirs());
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    FileUtils.deleteQuietly(_indexDir);
+  }
+
+  // --- Column lifecycle tests (mock-based) ---
 
   @Test
   public void testNeedUpdateReturnsTrueWhenColumnRemovedFromConfig()
@@ -97,7 +119,7 @@ public class JsonIndexHandlerTest {
     SegmentDirectory.Reader reader = mock(SegmentDirectory.Reader.class);
     when(reader.toSegmentDirectory()).thenReturn(segmentDirectory);
 
-    assertTrue(createHandler(segmentDirectory).needUpdateIndices(reader),
+    assertTrue(createHandlerWithDefaultConfig(segmentDirectory).needUpdateIndices(reader),
         "New JSON index expected for column added to config with metadata present");
   }
 
@@ -118,7 +140,7 @@ public class JsonIndexHandlerTest {
     SegmentDirectory.Reader reader = mock(SegmentDirectory.Reader.class);
     when(reader.toSegmentDirectory()).thenReturn(segmentDirectory);
 
-    assertFalse(createHandler(segmentDirectory).needUpdateIndices(reader),
+    assertFalse(createHandlerWithDefaultConfig(segmentDirectory).needUpdateIndices(reader),
         "No update expected when column metadata is absent");
   }
 
@@ -129,11 +151,92 @@ public class JsonIndexHandlerTest {
     SegmentDirectory segmentDirectory = mockSegmentDirectory(COLUMN);
     SegmentDirectory.Reader reader = mockReader(segmentDirectory);
 
-    assertFalse(createHandler(segmentDirectory).needUpdateIndices(reader),
+    assertFalse(createHandlerWithDefaultConfig(segmentDirectory).needUpdateIndices(reader),
         "No update expected when JSON index is present and matches config");
   }
 
-  private static JsonIndexHandler createHandler(SegmentDirectory segmentDirectory) {
+  // --- Config-change detection tests (file-based) ---
+
+  @Test
+  public void testNeedUpdateReturnsFalseWhenConfigUnchanged()
+      throws Exception {
+    JsonIndexConfig config = new JsonIndexConfig();
+    storeConfig(COLUMN, config);
+
+    JsonIndexHandler handler = createHandler(COLUMN, config);
+    SegmentDirectory.Reader reader = mockReaderWithIndexOn(COLUMN);
+
+    assertFalse(handler.needUpdateIndices(reader),
+        "No rebuild expected when stored config equals current config");
+  }
+
+  @Test
+  public void testNeedUpdateReturnsTrueWhenConfigChanged()
+      throws Exception {
+    // Store a default config (maxLevels = -1)
+    JsonIndexConfig storedConfig = new JsonIndexConfig();
+    storeConfig(COLUMN, storedConfig);
+
+    // Current config has maxLevels = 3
+    JsonIndexConfig currentConfig = new JsonIndexConfig();
+    currentConfig.setMaxLevels(3);
+
+    JsonIndexHandler handler = createHandler(COLUMN, currentConfig);
+    SegmentDirectory.Reader reader = mockReaderWithIndexOn(COLUMN);
+
+    assertTrue(handler.needUpdateIndices(reader),
+        "Rebuild expected when maxLevels changed from default to 3");
+  }
+
+  @Test
+  public void testNeedUpdateReturnsTrueWhenExcludeArrayChanges()
+      throws Exception {
+    JsonIndexConfig storedConfig = new JsonIndexConfig();
+    storeConfig(COLUMN, storedConfig);
+
+    JsonIndexConfig currentConfig = new JsonIndexConfig();
+    currentConfig.setExcludeArray(true);
+
+    JsonIndexHandler handler = createHandler(COLUMN, currentConfig);
+    SegmentDirectory.Reader reader = mockReaderWithIndexOn(COLUMN);
+
+    assertTrue(handler.needUpdateIndices(reader),
+        "Rebuild expected when excludeArray changed from false to true");
+  }
+
+  @Test
+  public void testNeedUpdateReturnsTrueWhenMaxBytesSizeChanges()
+      throws Exception {
+    JsonIndexConfig storedConfig = new JsonIndexConfig();
+    storeConfig(COLUMN, storedConfig);
+
+    JsonIndexConfig currentConfig = new JsonIndexConfig();
+    currentConfig.setMaxBytesSize(1024L);
+
+    JsonIndexHandler handler = createHandler(COLUMN, currentConfig);
+    SegmentDirectory.Reader reader = mockReaderWithIndexOn(COLUMN);
+
+    assertTrue(handler.needUpdateIndices(reader),
+        "Rebuild expected when maxBytesSize changed");
+  }
+
+  @Test
+  public void testNeedUpdateReturnsFalseWhenNoStoredConfig()
+      throws Exception {
+    // No stored config — index was built before config persistence was added. Must NOT trigger a spurious rebuild.
+    createEmptyMetadataFile();
+
+    JsonIndexConfig currentConfig = new JsonIndexConfig();
+    JsonIndexHandler handler = createHandler(COLUMN, currentConfig);
+    SegmentDirectory.Reader reader = mockReaderWithIndexOn(COLUMN);
+
+    assertFalse(handler.needUpdateIndices(reader),
+        "No rebuild expected when no stored config is present (backward compatibility)");
+  }
+
+  // --- helpers (mock-based) ---
+
+  private static JsonIndexHandler createHandlerWithDefaultConfig(SegmentDirectory segmentDirectory) {
     FieldIndexConfigs fieldIndexConfigs =
         new FieldIndexConfigs.Builder().add(StandardIndexes.json(), new JsonIndexConfig()).build();
     return new JsonIndexHandler(segmentDirectory, Map.of(COLUMN, fieldIndexConfigs),
@@ -155,6 +258,49 @@ public class JsonIndexHandlerTest {
   private static SegmentDirectory.Reader mockReader(SegmentDirectory segmentDirectory) {
     SegmentDirectory.Reader reader = mock(SegmentDirectory.Reader.class);
     when(reader.toSegmentDirectory()).thenReturn(segmentDirectory);
+    return reader;
+  }
+
+  // --- helpers (file-based) ---
+
+  private void storeConfig(String columnName, JsonIndexConfig config)
+      throws Exception {
+    File metadataFile = new File(_indexDir, V1Constants.MetadataKeys.METADATA_FILE_NAME);
+    PropertiesConfiguration properties = CommonsConfigurationUtils.fromFile(metadataFile);
+    String key = V1Constants.MetadataKeys.Column.getKeyFor(columnName, "jsonIndexConfig");
+    String serialized = JsonUtils.objectToString(config);
+    String escaped = CommonsConfigurationUtils.replaceSpecialCharacterInPropertyValue(serialized);
+    properties.setProperty(key, escaped);
+    CommonsConfigurationUtils.saveToFile(properties, metadataFile);
+  }
+
+  private void createEmptyMetadataFile()
+      throws Exception {
+    File metadataFile = new File(_indexDir, V1Constants.MetadataKeys.METADATA_FILE_NAME);
+    PropertiesConfiguration properties = CommonsConfigurationUtils.fromFile(metadataFile);
+    CommonsConfigurationUtils.saveToFile(properties, metadataFile);
+  }
+
+  private JsonIndexHandler createHandler(String columnName, JsonIndexConfig config) {
+    FieldIndexConfigs fieldIndexConfigs =
+        new FieldIndexConfigs.Builder().add(StandardIndexes.json(), config).build();
+    SegmentMetadataImpl segmentMetadata = mock(SegmentMetadataImpl.class);
+    when(segmentMetadata.getName()).thenReturn("testSegment");
+    when(segmentMetadata.getIndexDir()).thenReturn(_indexDir);
+    when(segmentMetadata.getTotalDocs()).thenReturn(1);
+    when(segmentMetadata.getAllColumns()).thenReturn(new TreeSet<>(Set.of(columnName)));
+    SegmentDirectory segmentDirectory = mock(SegmentDirectory.class);
+    when(segmentDirectory.getSegmentMetadata()).thenReturn(segmentMetadata);
+    when(segmentDirectory.getColumnsWithIndex(StandardIndexes.json())).thenReturn(Set.of(columnName));
+    return new JsonIndexHandler(segmentDirectory, Map.of(columnName, fieldIndexConfigs),
+        mock(TableConfig.class), mock(Schema.class));
+  }
+
+  private SegmentDirectory.Reader mockReaderWithIndexOn(String columnName) {
+    SegmentDirectory segDir = mock(SegmentDirectory.class);
+    when(segDir.getColumnsWithIndex(StandardIndexes.json())).thenReturn(Set.of(columnName));
+    SegmentDirectory.Reader reader = mock(SegmentDirectory.Reader.class);
+    when(reader.toSegmentDirectory()).thenReturn(segDir);
     return reader;
   }
 }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Detect config changes or missing stored config in legacy segments to trigger JSON index rebuild

```mermaid
flowchart TD
  N0["Load metadata properties #40;F2#41;"]:::stModified
  N1["Column exists in both config and existing indexes #40;F2#41;"]:::stModified
  N2["Read stored index config #40;F2#41;"]:::stModified
  N3["Properties available#63; #40;F2#41;"]:::stModified
  N4["Config changed#63; #40;F2#41;"]:::stModified
  N5["Legacy backfill needed#63; #40;F2#41;"]:::stModified
  N6["Trigger rebuild #40;F2#41;"]:::stModified
  N0 -->|"For each column"| N1
  N1 -->|"Read stored config"| N2
  N2 -->|"Check properties"| N3
  N3 -->|"If properties not null"| N4
  N3 -->|"If properties not null"| N5
  N4 -->|"If true"| N6
  N5 -->|"If true"| N6
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F2: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/JsonIndexHandler\.java — [before](https://github.com/apache/pinot/blob/b6cd43b8d597ce24ac18c836d07611e7fdc7036d/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/JsonIndexHandler.java) · [after](https://github.com/apache/pinot/blob/f5ea650eb6a230c026c22d748dd345e9ce3af4b1/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/JsonIndexHandler.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImI2Y2Q0M2I4ZDU5N2NlMjRhYzE4YzgzNmQwNzYxMWU3ZmRjNzAzNmQiLCJjb250ZXh0X2hhc2giOiJmMDk5ZjM4ZGQxZWMyYzBlZjVmYjNkODZmMGFhOTA0OWM1ZmM1MmJiMTBkOWNkMWFkZTQwNjY4ZjU0NGViNzE4IiwiZ2VuZXJhdGVkX2F0IjoxNzg5Mjc0MDk4LCJoZWFkX3NoYSI6ImY1ZWE2NTBlYjZhMjMwYzAyNmMyMmQ3NDhkZDM0NWU5Y2UzYWY0YjEiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJmODM1MmJlMjUyZmMxYTZjZjA5OTQ4MGE3ODEyZDE1NTVkMjY0ZTBlIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 1f6a4547f292823517811e7f04d614026d6c4f49dd613584d045dfa2dab50521 -->
<!-- pinot-pr-flow:end -->

## Summary

Closes #10506.

- **JsonIndexHandler**: After creating a JSON index, the active `JsonIndexConfig` is serialised to JSON and stored in `metadata.properties` under `column.<name>.jsonIndexConfig`. On the next segment reload `needUpdateIndices()` reads the stored config, compares it with the current table config using `equals()`, and triggers a rebuild when they differ. **Legacy segments** (indexed before this change, no stored config present) are now treated as a one-time rebuild case — the index is rebuilt to backfill the stored config and catch any config drift that may have occurred during an upgrade.

- **JsonIndexConfig.equals / hashCode**: Fixed to include `_indexPaths` and `_maxBytesSize`, which were previously missing. Without this fix, config changes to those two fields would be invisible to any equality-based comparison (including the new detection logic).

- **Performance**: `metadata.properties` is loaded once per `needUpdateIndices()` / `updateIndices()` call; the persist step in `updateIndices()` batches all `setProperty` calls and writes the file once at the end rather than once per rebuilt column.

## Review changes (v2)

Addressed @xiangfu0's feedback:

- **Fixed legacy-segment handling**: The original guard `storedConfig != null && !storedConfig.equals(currentConfig)` silently skipped segments that had a JSON index but no persisted `jsonIndexConfig` (built before this feature). After an upgrade, changing `maxLevels`, `includePaths`, etc. could leave the old index in place and produce stale `json_match` results.

  Changed to `properties != null && (storedConfig == null || !storedConfig.equals(currentConfig))`: when metadata is readable (`properties != null`) but no stored config is found (`storedConfig == null`), the segment is treated as a one-time rebuild/backfill case. In-memory segments (`properties == null`) continue to skip the check.

- **Updated unit test**: `testNeedUpdateReturnsFalseWhenNoStoredConfig` → `testNeedUpdateReturnsTrueWhenNoStoredConfig` with assertion flipped to `assertTrue` — regression test for the legacy-index case.

## Test plan

- [x] `JsonIndexHandlerTest` (5 unit tests):
  - No rebuild when stored config equals current config
  - Rebuild triggered when `maxLevels` changes
  - Rebuild triggered when `excludeArray` changes
  - Rebuild triggered when `maxBytesSize` changes (would have silently failed before the `equals` fix)
  - **Rebuild triggered for legacy segments with no stored config** (one-time backfill)

- [x] Existing `SegmentPreProcessorTest` JSON index tests continue to pass unmodified

cc @Jackie-Jiang @xiangfu0 @yashmayya