### PR TITLE
Remove redundant UUID special-casing in FieldSpec.DataType

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
@@ -37,7 +37,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.UUID;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.ByteArray;
@@ -887,17 +886,14 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
     }
 
     public boolean equals(Object value1, Object value2) {
-      if (this == UUID) {
-        return UuidUtils.equals(toBytesValue(value1), toBytesValue(value2));
-      }
-      return this == BYTES ? Arrays.equals(toBytesValue(value1), toBytesValue(value2)) : value1.equals(value2);
+      // UUID is stored as fixed 16-byte BYTES with byte-identity equality, so Arrays.equals matches UuidUtils.equals.
+      return (this == BYTES || this == UUID) ? Arrays.equals(toBytesValue(value1), toBytesValue(value2))
+          : value1.equals(value2);
     }
 
     public int hashCode(Object value) {
-      if (this == UUID) {
-        return UuidUtils.hashCode(toBytesValue(value));
-      }
-      return this == BYTES ? Arrays.hashCode(toBytesValue(value)) : value.hashCode();
+      // Arrays.hashCode over the 16 stored bytes is identical to UuidUtils.hashCode, so UUID shares the BYTES path.
+      return (this == BYTES || this == UUID) ? Arrays.hashCode(toBytesValue(value)) : value.hashCode();
     }
 
     /**
@@ -927,9 +923,10 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
         case JSON:
           return ((String) value1).compareTo((String) value2);
         case BYTES:
-          return ByteArray.compare(toBytesValue(value1), toBytesValue(value2));
         case UUID:
-          return UuidUtils.compare(toBytesValue(value1), toBytesValue(value2));
+          // UUID is stored as fixed 16-byte BYTES; ByteArray.compare is unsigned lexicographic, matching
+          // UuidUtils.compare on those bytes.
+          return ByteArray.compare(toBytesValue(value1), toBytesValue(value2));
         case MAP:
         case OPEN_STRUCT:
         case LIST:
@@ -947,9 +944,8 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
         return ((BigDecimal) value).toPlainString();
       }
       if (this == UUID) {
-        if (value instanceof UUID) {
-          return UuidUtils.toString((UUID) value);
-        }
+        // Canonical 8-4-4-4-12 form (not raw hex like BYTES) so it round-trips through convert(...). The stored
+        // value is always byte[], so no separate UUID-instance branch is needed.
         return UuidUtils.toString(toBytesValue(value));
       }
       if (this == BYTES) {
@@ -1006,17 +1002,12 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
     }
 
     private byte[] toBytesValue(Object value) {
+      // BYTES and UUID stored values are always byte[] (or a ByteArray wrapper); UUID is never a java.util.UUID here.
       if (value instanceof byte[]) {
         return (byte[]) value;
       }
       if (value instanceof ByteArray) {
         return ((ByteArray) value).getBytes();
-      }
-      if (value instanceof UUID) {
-        return UuidUtils.toBytes((UUID) value);
-      }
-      if (value instanceof String && this == UUID) {
-        return UuidUtils.toBytes((String) value);
       }
       throw new IllegalArgumentException("Unsupported value for " + this + ": " + value);
     }


### PR DESCRIPTION
## Description

Follow-up cleanup to the UUID logical type introduced in #18869.

`UUID` is a logical type stored as fixed-width 16-byte `BYTES`, so a UUID-typed value's stored representation is always `byte[]` (a `java.util.UUID` is only a transient compute-time type) — exactly like `TIMESTAMP` values are always `long`. The `DataType` value-semantics methods therefore don't need UUID-specific branches:

- **`equals` / `hashCode` / `compare`** now share the `BYTES` path. `Arrays.equals`, `Arrays.hashCode`, and `ByteArray.compare` (unsigned lexicographic) are byte-for-byte equivalent to `UuidUtils.equals`/`hashCode`/`compare` on the fixed 16-byte values, so results are unchanged.
- **`toString`** drops the dead `instanceof UUID` sub-check but keeps the canonical `8-4-4-4-12` form (raw hex would break round-tripping through `convert()`).
- **`toBytesValue`** is narrowed to `byte[]`/`ByteArray` only; UUID-object and canonical-`String` inputs are no longer accepted, matching its Javadoc (*"input value should be byte[]"*). No stored-value caller passes those.
- Removed the now-unused `java.util.UUID` import.

Dispatch stays uniform across the four methods (each enumerates `BYTES` and `UUID` explicitly) so a future `BYTES`-stored logical type is not silently folded into the byte path.

## Testing

- `FieldSpecTest` + `UuidUtilsTest` pass (57 tests). The equality/hash/compare equivalence is pinned by existing assertions (`FieldSpecTest#testUUIDConversions`, `UuidUtilsTest#testComparePreservesUnsignedByteOrdering`).
- `spotless:check`, `checkstyle:check`, `license:check` clean on `pinot-spi`.

## Backward-compatibility

Behavior-preserving for all valid UUID values. UUID is unreleased (introduced in #18869, not in any release tag), so there is no cross-version wire/serialization surface affected.