### PR TITLE
Close op chain when scheduling fails to release operator resources

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -324,8 +324,8 @@ public class QueryRunner {
     OpChainExecutionContext executionContext =
         OpChainExecutionContext.fromQueryContext(_mailboxService, opChainMetadata, stageMetadata, workerMetadata,
             pipelineBreakerResult, sendStats, _keepPipelineBreakerStats.getAsBoolean());
+    OpChain opChain = null;
     try {
-      OpChain opChain;
       if (workerMetadata.isLeafStageWorker()) {
         Map<String, String> rlsFilters = RlsUtils.extractRlsFilters(requestMetadata);
         opChain =
@@ -337,6 +337,18 @@ public class QueryRunner {
       // This can fail if the executor rejects the task.
       _opChainScheduler.register(opChain);
     } catch (RuntimeException e) {
+      // register() can fail after the op chain was built — the query was cancelled/terminated before scheduling
+      // (checkTermination / cancelled-query cache), or the executor rejected the task (e.g. under load shedding). In
+      // those cases the op chain is never scheduled, so the scheduler's FutureCallback, which normally close()s the
+      // chain on completion, never fires — leaking any operator resources that are released only in close(). Close the
+      // built chain here (idempotent; guarded so a close failure cannot mask the original error).
+      if (opChain != null) {
+        try {
+          opChain.close();
+        } catch (RuntimeException closeError) {
+          LOGGER.warn("Failed to close op chain after scheduling failure", closeError);
+        }
+      }
       ErrorMseBlock errorBlock = ErrorMseBlock.fromException(e);
       tryPropagateErrorViaOpChainConverter(workerMetadata, stagePlan, opChainMetadata, pipelineBreakerResult,
           errorBlock);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
@@ -254,12 +254,15 @@ public class OpChainSchedulerService {
       _executorService.submit(listenableFutureTask);
     } catch (RuntimeException e) {
       // The MSE executor is wrapped in HardLimitExecutor + heap throttling, so submit() can throw
-      // RejectedExecutionException. When it does, the task never runs and the directExecutor FutureCallback above
-      // (which decrements the active-opchain counter and removes the per-request context entry) never fires. Back
-      // out that bookkeeping here so the entry — and the QueryExecutionContext it pins — does not leak until a later
-      // cancel. Then rethrow so the caller propagates the failure as a stage error. (The caller,
-      // QueryRunner#processQueryBlocking, close()s the op chain on this rethrow, releasing operator resources that
-      // the never-fired FutureCallback would otherwise have closed.)
+      // RejectedExecutionException. When it does, the task never runs, so neither the directExecutor FutureCallback
+      // above (which decrements the active-opchain counter and removes the per-request context entry) nor runJob's
+      // _opChainCache.invalidate() ever fires. Back out both here: invalidate the cache entry this method put()
+      // above so it does not pin the rootOperator tree and QueryExecutionContext until TTL/weight eviction (the same
+      // prompt release cancel() performs for cancelled entries), and back out the active-opchain bookkeeping so the
+      // per-request context entry does not leak until a later cancel. Then rethrow so the caller propagates the
+      // failure as a stage error. The caller, QueryRunner#processQueryBlocking, close()s the op chain on this
+      // rethrow, releasing operator resources that the never-fired FutureCallback would otherwise have closed.
+      _opChainCache.invalidate(opChainId);
       decrementActiveOpChains(requestId);
       throw e;
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
@@ -257,7 +257,9 @@ public class OpChainSchedulerService {
       // RejectedExecutionException. When it does, the task never runs and the directExecutor FutureCallback above
       // (which decrements the active-opchain counter and removes the per-request context entry) never fires. Back
       // out that bookkeeping here so the entry — and the QueryExecutionContext it pins — does not leak until a later
-      // cancel. Then rethrow so the caller propagates the failure as a stage error.
+      // cancel. Then rethrow so the caller propagates the failure as a stage error. (The caller,
+      // QueryRunner#processQueryBlocking, close()s the op chain on this rethrow, releasing operator resources that
+      // the never-fired FutureCallback would otherwise have closed.)
       decrementActiveOpChains(requestId);
       throw e;
     }


### PR DESCRIPTION
## Problem

`OpChainSchedulerService.register()` can throw *after* the op chain has been built, on paths where the op chain is never scheduled to run:

- the query was cancelled or terminated before scheduling (`checkTermination`, or the cancelled-query cache), or
- the executor rejected the task (e.g. under load shedding / when the work queue is full → `RejectedExecutionException`).

On these paths the `ListenableFutureTask` never runs, so the `FutureCallback` that normally calls `operatorChain.close()` on completion (success or failure) never fires, and the op chain's operators are never closed. Any operator that releases resources only in `close()` is then leaked for the lifetime of the process.

## Fix

`QueryRunner#processQueryBlocking` now closes the built op chain in its `catch` when scheduling fails, before propagating the error as a stage error:

- `opChain` is hoisted out of the `try` and closed only when non-null, so a failure during `convert` / `compileLeafStage` (before it is assigned) is unaffected.
- `close()` is idempotent and is wrapped in its own guard, so a failure while closing cannot mask the original exception that must be propagated.
- `OpChainSchedulerService`'s submit-rejection path continues to back out its active-op-chain bookkeeping and rethrow; the added `close()` at the caller does not affect that bookkeeping (a scheduler-registered chain's finish callback is a no-op).

This mirrors the normal completion path, where the `FutureCallback` both decrements the active-op-chain counter and calls `operatorChain.close()`.

## Testing

The affected paths are scheduling-failure races (executor rejection under load shedding; cancellation between build and scheduling), which are awkward to drive deterministically at the `QueryRunner` level. The change is a small, guarded, idempotent `close()` that mirrors the existing `FutureCallback` completion path and is a no-op on the success path. Happy to add a targeted test if reviewers prefer a particular harness.
