### PR TITLE
Add session-based UI authentication with server-side logout invalidation

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -743,8 +743,27 @@ public abstract class BaseControllerStarter implements ServiceStartable {
         MetadataEventNotifierFactory.loadFactory(_config.subset(METADATA_EVENT_NOTIFIER_PREFIX), _helixResourceManager);
 
     // Create a singleton SessionManager for session-based UI authentication.
-    // Server-side TTL = inactivity timeout + 120s buffer so the server doesn't evict a session
-    // that the UI hasn't timed out yet (e.g. user is active but a background API call races with eviction).
+    //
+    // IMPORTANT: This is a per-process in-memory store. In a multi-controller deployment behind
+    // a load balancer, a session token minted on controller-A is not known to controller-B, and
+    // a logout request routed to controller-B will not invalidate the token held by controller-A.
+    // To preserve the server-side logout guarantee, configure the load balancer with sticky
+    // sessions (e.g., consistent hashing on the session cookie or source IP) so that all requests
+    // from a given browser are always routed to the same controller. Without sticky sessions,
+    // session-based UI authentication degrades to best-effort: login and most API calls will work
+    // (the LB will route them to the controller that knows the session), but logout may silently
+    // fail if it hits a different controller.
+    //
+    // The session TTL is set to the configured session timeout plus a 120s grace period.
+    // The grace period absorbs clock skew and in-flight requests: a request that arrives at
+    // the server just before the browser cookie's Max-Age expires will still see a valid
+    // server-side session. Both the server session and the browser cookie Max-Age are set to
+    // serverSessionTtlSeconds at login, so they expire at the same absolute time.
+    //
+    // Note: CONTROLLER_UI_SESSION_INACTIVITY_TIMEOUT_SECONDS controls the session *ceiling*
+    // (loginTime + timeout + 120s), not a sliding inactivity window. The UI enforces inactivity
+    // detection client-side (JavaScript timer that redirects to login after timeout seconds of
+    // no user interaction). The server does not extend the session on each request.
     long uiInactivityTimeoutSeconds = _config.getProperty(
         ControllerConf.CONTROLLER_UI_SESSION_INACTIVITY_TIMEOUT_SECONDS,
         ControllerConf.DEFAULT_UI_SESSION_INACTIVITY_TIMEOUT_SECONDS);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -97,6 +97,7 @@ import org.apache.pinot.common.utils.tls.TlsUtils;
 import org.apache.pinot.common.version.PinotVersion;
 import org.apache.pinot.controller.api.ControllerAdminApiApplication;
 import org.apache.pinot.controller.api.access.AccessControlFactory;
+import org.apache.pinot.controller.api.access.InMemorySessionManager;
 import org.apache.pinot.controller.api.access.SessionManager;
 import org.apache.pinot.controller.api.events.MetadataEventNotifierFactory;
 import org.apache.pinot.controller.api.resources.ControllerFilePathProvider;
@@ -748,7 +749,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
         ControllerConf.CONTROLLER_UI_SESSION_INACTIVITY_TIMEOUT_SECONDS,
         ControllerConf.DEFAULT_UI_SESSION_INACTIVITY_TIMEOUT_SECONDS);
     long serverSessionTtlSeconds = uiInactivityTimeoutSeconds + 120;
-    final SessionManager sessionManager = new SessionManager(serverSessionTtlSeconds);
+    final SessionManager sessionManager = new InMemorySessionManager(serverSessionTtlSeconds);
 
     LOGGER.info("Controller download url base: {}", _config.generateVipUrl());
     LOGGER.info("Injecting configuration and resource managers to the API context");

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -97,6 +97,7 @@ import org.apache.pinot.common.utils.tls.TlsUtils;
 import org.apache.pinot.common.version.PinotVersion;
 import org.apache.pinot.controller.api.ControllerAdminApiApplication;
 import org.apache.pinot.controller.api.access.AccessControlFactory;
+import org.apache.pinot.controller.api.access.SessionManager;
 import org.apache.pinot.controller.api.events.MetadataEventNotifierFactory;
 import org.apache.pinot.controller.api.resources.ControllerFilePathProvider;
 import org.apache.pinot.controller.api.resources.InvalidControllerConfigException;
@@ -740,6 +741,15 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     final MetadataEventNotifierFactory metadataEventNotifierFactory =
         MetadataEventNotifierFactory.loadFactory(_config.subset(METADATA_EVENT_NOTIFIER_PREFIX), _helixResourceManager);
 
+    // Create a singleton SessionManager for session-based UI authentication.
+    // Server-side TTL = inactivity timeout + 120s buffer so the server doesn't evict a session
+    // that the UI hasn't timed out yet (e.g. user is active but a background API call races with eviction).
+    long uiInactivityTimeoutSeconds = _config.getProperty(
+        ControllerConf.CONTROLLER_UI_SESSION_INACTIVITY_TIMEOUT_SECONDS,
+        ControllerConf.DEFAULT_UI_SESSION_INACTIVITY_TIMEOUT_SECONDS);
+    long serverSessionTtlSeconds = uiInactivityTimeoutSeconds + 120;
+    final SessionManager sessionManager = new SessionManager(serverSessionTtlSeconds);
+
     LOGGER.info("Controller download url base: {}", _config.generateVipUrl());
     LOGGER.info("Injecting configuration and resource managers to the API context");
     // register all the controller objects for injection to jersey resources
@@ -769,6 +779,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
         bind(_storageQuotaChecker).to(StorageQuotaChecker.class);
         bind(_resourceUtilizationManager).to(ResourceUtilizationManager.class);
         bind(controllerStartTime).named(ControllerAdminApiApplication.START_TIME);
+        bind(sessionManager).to(SessionManager.class);
 
         bindAsContract(PinotTableReloadService.class).in(Singleton.class);
         bindAsContract(PinotTableReloadStatusReporter.class).in(Singleton.class);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -357,6 +357,48 @@ public class ControllerConf extends PinotConfiguration {
   public static final String INGEST_FROM_URI_ALLOW_LOCAL_FILE_SYSTEM =
       "controller.ingestFromURI.allowLocalFileSystem";
   public static final String ACCESS_CONTROL_FACTORY_CLASS = "controller.admin.access.control.factory.class";
+
+  /**
+   * When set to {@code true}, the Pinot UI uses session-based authentication (Trino/Ambari-style).
+   *
+   * <p>This is a UI-layer setting that is independent of the configured
+   * {@code controller.admin.access.control.factory.class}. It works with any auth backend:
+   * BasicAuth, ZkBasicAuth, LDAP/PasswordAuth, or custom factories.
+   *
+   * <p>When enabled:
+   * <ul>
+   *   <li>{@code GET /auth/info} returns {@code {"workflow":"SESSION"}}</li>
+   *   <li>The UI uses {@code POST /auth/login} to authenticate (no Authorization header)</li>
+   *   <li>An HttpOnly {@code SameSite=Strict} session cookie is issued on successful login</li>
+   *   <li>{@code GET /auth/logout} immediately invalidates the server-side session</li>
+   * </ul>
+   *
+   * <p>Default: {@code false} (backward compatible – existing BASIC/NONE/OIDC workflows unchanged)
+   */
+  public static final String CONTROLLER_UI_SESSION_ENABLED = "controller.ui.session.authentication.enabled";
+
+  /**
+   * When set to {@code true}, the HttpOnly session cookie is flagged as {@code Secure}, meaning the
+   * browser will only send it over HTTPS connections. Set to {@code false} only for local HTTP dev.
+   *
+   * <p>Default: {@code true}
+   */
+  public static final String CONTROLLER_UI_SESSION_COOKIE_SECURE = "controller.ui.session.cookie.secure";
+
+  /**
+   * Inactivity timeout in seconds for the Pinot UI session.
+   *
+   * <p>After this many seconds of user inactivity, the UI shows a 60-second warning dialog and then
+   * calls {@code GET /auth/logout} to invalidate the server-side session. This value is returned to
+   * the browser via {@code GET /auth/info} so both the UI timer and server-side TTL derive from one config.
+   * Server-side session TTL is set automatically to this value + 120s buffer.
+   *
+   * <p>Default: {@code 300} (5 minutes)
+   */
+  public static final String CONTROLLER_UI_SESSION_INACTIVITY_TIMEOUT_SECONDS =
+      "controller.ui.session.inactivity.timeout.seconds";
+  public static final long DEFAULT_UI_SESSION_INACTIVITY_TIMEOUT_SECONDS = 300L;
+
   public static final String ACCESS_CONTROL_USERNAME = "access.control.init.username";
   public static final String ACCESS_CONTROL_PASSWORD = "access.control.init.password";
   public static final String LINEAGE_MANAGER_CLASS = "controller.lineage.manager.class";

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -358,43 +358,13 @@ public class ControllerConf extends PinotConfiguration {
       "controller.ingestFromURI.allowLocalFileSystem";
   public static final String ACCESS_CONTROL_FACTORY_CLASS = "controller.admin.access.control.factory.class";
 
-  /**
-   * When set to {@code true}, the Pinot UI uses session-based authentication (Trino/Ambari-style).
-   *
-   * <p>This is a UI-layer setting that is independent of the configured
-   * {@code controller.admin.access.control.factory.class}. It works with any auth backend:
-   * BasicAuth, ZkBasicAuth, LDAP/PasswordAuth, or custom factories.
-   *
-   * <p>When enabled:
-   * <ul>
-   *   <li>{@code GET /auth/info} returns {@code {"workflow":"SESSION"}}</li>
-   *   <li>The UI uses {@code POST /auth/login} to authenticate (no Authorization header)</li>
-   *   <li>An HttpOnly {@code SameSite=Strict} session cookie is issued on successful login</li>
-   *   <li>{@code GET /auth/logout} immediately invalidates the server-side session</li>
-   * </ul>
-   *
-   * <p>Default: {@code false} (backward compatible – existing BASIC/NONE/OIDC workflows unchanged)
-   */
+  /** When {@code true}, enables session-based UI auth (HttpOnly cookie / POST /auth/login). Default: {@code false}. */
   public static final String CONTROLLER_UI_SESSION_ENABLED = "controller.ui.session.authentication.enabled";
 
-  /**
-   * When set to {@code true}, the HttpOnly session cookie is flagged as {@code Secure}, meaning the
-   * browser will only send it over HTTPS connections. Set to {@code false} only for local HTTP dev.
-   *
-   * <p>Default: {@code true}
-   */
+  /** When {@code true}, the session cookie is flagged Secure (HTTPS only). Default: {@code true}. */
   public static final String CONTROLLER_UI_SESSION_COOKIE_SECURE = "controller.ui.session.cookie.secure";
 
-  /**
-   * Inactivity timeout in seconds for the Pinot UI session.
-   *
-   * <p>After this many seconds of user inactivity, the UI shows a 60-second warning dialog and then
-   * calls {@code GET /auth/logout} to invalidate the server-side session. This value is returned to
-   * the browser via {@code GET /auth/info} so both the UI timer and server-side TTL derive from one config.
-   * Server-side session TTL is set automatically to this value + 120s buffer.
-   *
-   * <p>Default: {@code 300} (5 minutes)
-   */
+  /** Inactivity timeout in seconds before the UI session expires. Server TTL = this + 120s. Default: {@code 300}. */
   public static final String CONTROLLER_UI_SESSION_INACTIVITY_TIMEOUT_SECONDS =
       "controller.ui.session.inactivity.timeout.seconds";
   public static final long DEFAULT_UI_SESSION_INACTIVITY_TIMEOUT_SECONDS = 300L;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
@@ -39,6 +39,7 @@ import org.apache.pinot.common.swagger.SwaggerApiListingResource;
 import org.apache.pinot.common.swagger.SwaggerSetupUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.access.AuthenticationFilter;
+import org.apache.pinot.controller.api.access.SessionAuthenticationFilter;
 import org.apache.pinot.core.api.ServiceAutoDiscoveryFeature;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.util.ListenerConfigUtil;
@@ -90,6 +91,9 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     register(SwaggerSerializers.class);
     register(new CorsFilter());
     register(AuthenticationFilter.class);
+    // Register session authentication filter (priority AUTHENTICATION-10, runs before AuthenticationFilter).
+    // Validates the HttpOnly session cookie for SESSION workflow. No-op when session mode is disabled.
+    register(SessionAuthenticationFilter.class);
     register(AuditLogFilter.class);
     _managedAsyncExecutor = createManagedAsyncExecutor();
     register(new ManagedAsyncExecutorServiceProvider(_managedAsyncExecutor));
@@ -145,9 +149,19 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     public void filter(ContainerRequestContext containerRequestContext,
         ContainerResponseContext containerResponseContext)
         throws IOException {
-      containerResponseContext.getHeaders().add("Access-Control-Allow-Origin", "*");
+      // For session-based auth with withCredentials:true, reflect the actual request origin
+      // instead of "*". Browsers reject "Access-Control-Allow-Origin: *" when
+      // "Access-Control-Allow-Credentials: true" is set.
+      String origin = containerRequestContext.getHeaderString("Origin");
+      if (origin != null && !origin.isEmpty()) {
+        containerResponseContext.getHeaders().add("Access-Control-Allow-Origin", origin);
+        containerResponseContext.getHeaders().add("Access-Control-Allow-Credentials", "true");
+      } else {
+        containerResponseContext.getHeaders().add("Access-Control-Allow-Origin", "*");
+      }
       containerResponseContext.getHeaders().add("Access-Control-Allow-Methods", "GET, POST, PUT, OPTIONS, DELETE");
-      containerResponseContext.getHeaders().add("Access-Control-Allow-Headers", "*");
+      containerResponseContext.getHeaders()
+          .add("Access-Control-Allow-Headers", "Authorization, Content-Type, Accept, Origin, X-Requested-With");
       if (containerRequestContext.getMethod().equals("OPTIONS")) {
         containerResponseContext.setStatus(HttpServletResponse.SC_OK);
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
@@ -149,16 +149,7 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     public void filter(ContainerRequestContext containerRequestContext,
         ContainerResponseContext containerResponseContext)
         throws IOException {
-      // For session-based auth with withCredentials:true, reflect the actual request origin
-      // instead of "*". Browsers reject "Access-Control-Allow-Origin: *" when
-      // "Access-Control-Allow-Credentials: true" is set.
-      String origin = containerRequestContext.getHeaderString("Origin");
-      if (origin != null && !origin.isEmpty()) {
-        containerResponseContext.getHeaders().add("Access-Control-Allow-Origin", origin);
-        containerResponseContext.getHeaders().add("Access-Control-Allow-Credentials", "true");
-      } else {
-        containerResponseContext.getHeaders().add("Access-Control-Allow-Origin", "*");
-      }
+      containerResponseContext.getHeaders().add("Access-Control-Allow-Origin", "*");
       containerResponseContext.getHeaders().add("Access-Control-Allow-Methods", "GET, POST, PUT, OPTIONS, DELETE");
       containerResponseContext.getHeaders()
           .add("Access-Control-Allow-Headers", "Authorization, Content-Type, Accept, Origin, X-Requested-With");

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
@@ -152,7 +152,8 @@ public class ControllerAdminApiApplication extends ResourceConfig {
       containerResponseContext.getHeaders().add("Access-Control-Allow-Origin", "*");
       containerResponseContext.getHeaders().add("Access-Control-Allow-Methods", "GET, POST, PUT, OPTIONS, DELETE");
       containerResponseContext.getHeaders()
-          .add("Access-Control-Allow-Headers", "Authorization, Content-Type, Accept, Origin, X-Requested-With");
+          .add("Access-Control-Allow-Headers",
+              "Authorization, Content-Type, Accept, Origin, X-Requested-With, Database, If-Match");
       if (containerRequestContext.getMethod().equals("OPTIONS")) {
         containerResponseContext.setStatus(HttpServletResponse.SC_OK);
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControl.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AccessControl.java
@@ -30,6 +30,8 @@ import org.apache.pinot.spi.annotations.InterfaceStability;
 public interface AccessControl extends FineGrainedAccessControl {
   String WORKFLOW_NONE = "NONE";
   String WORKFLOW_BASIC = "BASIC";
+  /// Session-based workflow: credentials validated once at login; subsequent requests use an HttpOnly cookie.
+  String WORKFLOW_SESSION = "SESSION";
 
   /// Return whether the client has permission to the given table
   ///
@@ -69,13 +71,21 @@ public interface AccessControl extends FineGrainedAccessControl {
 
   /// Container for authentication workflow info for the Pinot UI. May be extended by implementations.
   ///
-  /// Auth workflow info hold any configuration necessary to execute a UI workflow. We currently foresee supporting NONE
-  /// (auth disabled) and BASIC (basic auth with username and password)
+  /// Auth workflow info holds any configuration necessary to execute a UI workflow. Supports NONE
+  /// (auth disabled), BASIC (basic auth with username and password), and SESSION (session-based
+  /// UI authentication with HttpOnly cookie).
   class AuthWorkflowInfo {
     String _workflow;
+    /// UI inactivity timeout in seconds. -1 means not applicable (non-SESSION workflows).
+    long _inactivityTimeoutSeconds = -1;
 
     public AuthWorkflowInfo(String workflow) {
       _workflow = workflow;
+    }
+
+    public AuthWorkflowInfo(String workflow, long inactivityTimeoutSeconds) {
+      _workflow = workflow;
+      _inactivityTimeoutSeconds = inactivityTimeoutSeconds;
     }
 
     public String getWorkflow() {
@@ -84,6 +94,15 @@ public interface AccessControl extends FineGrainedAccessControl {
 
     public void setWorkflow(String workflow) {
       _workflow = workflow;
+    }
+
+    /// Returns the UI inactivity timeout in seconds, or -1 if not applicable.
+    public long getInactivityTimeoutSeconds() {
+      return _inactivityTimeoutSeconds;
+    }
+
+    public void setInactivityTimeoutSeconds(long inactivityTimeoutSeconds) {
+      _inactivityTimeoutSeconds = inactivityTimeoutSeconds;
     }
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
@@ -52,7 +52,7 @@ import org.glassfish.grizzly.http.server.Request;
 public class AuthenticationFilter implements ContainerRequestFilter {
   private static final Set<String> UNPROTECTED_PATHS =
       new HashSet<>(Arrays.asList("", "help", "auth/info", "auth/verify", "auth/verify/v2", "auth/login",
-          "auth/logout", "auth/session", "health"));
+          "auth/logout", "auth/session", "auth/session/renew", "health"));
   private static final String KEY_TABLE_NAME = "tableName";
   private static final String KEY_TABLE_NAME_WITH_TYPE = "tableNameWithType";
   private static final String KEY_SCHEMA_NAME = "schemaName";
@@ -74,6 +74,10 @@ public class AuthenticationFilter implements ContainerRequestFilter {
 
   @Context
   HttpHeaders _httpHeaders;
+
+  // Cached result of isSessionEnabled() — computed lazily on first request and never changes.
+  // volatile ensures all threads see the result once it is written.
+  private volatile Boolean _sessionEnabled;
 
   @Override
   public void filter(ContainerRequestContext requestContext)
@@ -171,9 +175,20 @@ public class AuthenticationFilter implements ContainerRequestFilter {
   }
 
   private boolean isSessionEnabled() {
-    return _controllerConf != null
-        && _controllerConf.getProperty(ControllerConf.CONTROLLER_UI_SESSION_ENABLED, false)
-        && _sessionManager != null;
+    if (_sessionEnabled == null) {
+      // Compute once and cache. Double-checked locking is safe here because the result
+      // is idempotent: all threads compute the same value from the same injected beans.
+      boolean enabled = _sessionManager != null && (
+          (_controllerConf != null
+              && _controllerConf.getProperty(ControllerConf.CONTROLLER_UI_SESSION_ENABLED, false))
+          // Also enable when the factory itself advertises SESSION workflow (e.g.
+          // SessionBasicAuthAccessControlFactory configured without the explicit flag).
+          || (_accessControlFactory != null
+              && AccessControl.WORKFLOW_SESSION.equals(
+                  _accessControlFactory.create().getAuthWorkflowInfo().getWorkflow())));
+      _sessionEnabled = enabled;
+    }
+    return _sessionEnabled;
   }
 
   private static boolean isBaseFile(String path) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -34,11 +35,13 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
 import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.common.utils.DatabaseUtils;
+import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.core.auth.FineGrainedAuthUtils;
 import org.apache.pinot.core.auth.ManualAuthorization;
 import org.glassfish.grizzly.http.server.Request;
@@ -49,7 +52,8 @@ import org.glassfish.grizzly.http.server.Request;
 @javax.ws.rs.ext.Provider
 public class AuthenticationFilter implements ContainerRequestFilter {
   private static final Set<String> UNPROTECTED_PATHS =
-      new HashSet<>(Arrays.asList("", "help", "auth/info", "auth/verify", "auth/verify/v2", "health"));
+      new HashSet<>(Arrays.asList("", "help", "auth/info", "auth/verify", "auth/verify/v2", "auth/login",
+          "auth/logout", "auth/session", "health"));
   private static final String KEY_TABLE_NAME = "tableName";
   private static final String KEY_TABLE_NAME_WITH_TYPE = "tableNameWithType";
   private static final String KEY_SCHEMA_NAME = "schemaName";
@@ -59,6 +63,12 @@ public class AuthenticationFilter implements ContainerRequestFilter {
 
   @Inject
   AccessControlFactory _accessControlFactory;
+
+  @Inject
+  SessionManager _sessionManager;
+
+  @Inject
+  ControllerConf _controllerConf;
 
   @Context
   ResourceInfo _resourceInfo;
@@ -79,6 +89,23 @@ public class AuthenticationFilter implements ContainerRequestFilter {
     if (isBaseFile(AuthProviderUtils.stripMatrixParams(uriInfo.getPath()))
         || UNPROTECTED_PATHS.contains(AuthProviderUtils.stripMatrixParams(uriInfo.getPath()))) {
       return;
+    }
+
+    // SESSION WORKFLOW: If session mode is enabled and the request carries a valid HttpOnly session
+    // cookie (set by POST /auth/login), skip Authorization-header validation entirely.
+    // The SessionAuthenticationFilter (priority AUTHENTICATION-10) already validated the cookie
+    // before this filter runs. Repeating the check here would fail because browser requests in
+    // SESSION mode never send an Authorization header.
+    if (_controllerConf != null
+        && _controllerConf.getProperty(ControllerConf.CONTROLLER_UI_SESSION_ENABLED, false)
+        && _sessionManager != null) {
+      Cookie sessionCookie = requestContext.getCookies().get(SessionManager.SESSION_COOKIE_NAME);
+      if (sessionCookie != null && sessionCookie.getValue() != null) {
+        Optional<String> username = _sessionManager.getUsername(sessionCookie.getValue());
+        if (username.isPresent()) {
+          return;
+        }
+      }
     }
 
     // check if authentication is required implicitly

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -91,20 +90,15 @@ public class AuthenticationFilter implements ContainerRequestFilter {
       return;
     }
 
-    // SESSION WORKFLOW: If session mode is enabled and the request carries a valid HttpOnly session
-    // cookie (set by POST /auth/login), skip Authorization-header validation entirely.
-    // The SessionAuthenticationFilter (priority AUTHENTICATION-10) already validated the cookie
-    // before this filter runs. Repeating the check here would fail because browser requests in
-    // SESSION mode never send an Authorization header.
-    if (_controllerConf != null
-        && _controllerConf.getProperty(ControllerConf.CONTROLLER_UI_SESSION_ENABLED, false)
-        && _sessionManager != null) {
+    // SESSION WORKFLOW: If session mode is enabled and the request carries a valid session cookie,
+    // retrieve the stored Basic-auth token and inject it as an Authorization header. This lets
+    // validatePermission() and FineGrainedAuthUtils below run with the session user's credentials
+    // instead of skipping authorization entirely.
+    if (isSessionEnabled()) {
       Cookie sessionCookie = requestContext.getCookies().get(SessionManager.SESSION_COOKIE_NAME);
       if (sessionCookie != null && sessionCookie.getValue() != null) {
-        Optional<String> username = _sessionManager.getUsername(sessionCookie.getValue());
-        if (username.isPresent()) {
-          return;
-        }
+        _sessionManager.getBasicAuthToken(sessionCookie.getValue()).ifPresent(
+            authToken -> requestContext.getHeaders().putSingle(HttpHeaders.AUTHORIZATION, authToken));
       }
     }
 
@@ -174,6 +168,12 @@ public class AuthenticationFilter implements ContainerRequestFilter {
       return mmap.getFirst(KEY_SCHEMA_NAME);
     }
     return null;
+  }
+
+  private boolean isSessionEnabled() {
+    return _controllerConf != null
+        && _controllerConf.getProperty(ControllerConf.CONTROLLER_UI_SESSION_ENABLED, false)
+        && _sessionManager != null;
   }
 
   private static boolean isBaseFile(String path) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/InMemorySessionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/InMemorySessionManager.java
@@ -1,0 +1,218 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.access;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * In-memory implementation of {@link SessionManager}.
+ *
+ * <p>Sessions are stored in a {@link ConcurrentHashMap} with a configurable sliding-window TTL
+ * and are cleaned up periodically to prevent unbounded growth.
+ *
+ * <p><strong>Sliding window TTL:</strong> Each time a session is accessed via
+ * {@link #getUsername(String)}, the expiry is extended by the configured TTL. This means active
+ * users are never logged out due to inactivity — only truly idle sessions (no API calls for the
+ * full TTL duration) expire.
+ *
+ * <p>Design follows the Ambari / Trino FormWebUiAuthenticationFilter pattern:
+ * <ul>
+ *   <li>Login  → validate credentials → create session token → set HttpOnly cookie</li>
+ *   <li>Request → read cookie → look up session → slide expiry → allow or redirect to login</li>
+ *   <li>Logout → read cookie → remove session from store → delete cookie → redirect to login</li>
+ * </ul>
+ */
+public class InMemorySessionManager implements SessionManager {
+  private static final Logger LOGGER = LoggerFactory.getLogger(InMemorySessionManager.class);
+
+  /** Cleanup interval: every 30 minutes. */
+  private static final long CLEANUP_INTERVAL_SECONDS = 30 * 60L;
+
+  /** Number of random bytes for the session token (256-bit entropy). */
+  private static final int TOKEN_BYTES = 32;
+
+  private final long _sessionTtlSeconds;
+  private final SecureRandom _secureRandom = new SecureRandom();
+
+  /**
+   * Active session store: token → {@link SessionEntry}.
+   * ConcurrentHashMap provides thread-safe reads without locking on the hot path.
+   */
+  private final ConcurrentHashMap<String, SessionEntry> _sessions = new ConcurrentHashMap<>();
+
+  private final ScheduledExecutorService _cleanupExecutor =
+      Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "pinot-session-cleanup");
+        t.setDaemon(true);
+        return t;
+      });
+
+  public InMemorySessionManager() {
+    this(DEFAULT_SESSION_TTL_SECONDS);
+  }
+
+  public InMemorySessionManager(long sessionTtlSeconds) {
+    _sessionTtlSeconds = sessionTtlSeconds;
+    _cleanupExecutor.scheduleAtFixedRate(
+        this::evictExpiredSessions,
+        CLEANUP_INTERVAL_SECONDS,
+        CLEANUP_INTERVAL_SECONDS,
+        TimeUnit.SECONDS);
+    LOGGER.info("InMemorySessionManager initialized with sliding TTL={}s", _sessionTtlSeconds);
+  }
+
+  @Override
+  public String createSession(String username, String basicAuthToken) {
+    String token = generateToken();
+    Instant expiry = Instant.now().plusSeconds(_sessionTtlSeconds);
+    _sessions.put(token, new SessionEntry(username, expiry, basicAuthToken));
+    LOGGER.debug("Created session for user '{}', expires at {}", username, expiry);
+    return token;
+  }
+
+  @Override
+  public Optional<String> getUsername(String token) {
+    if (token == null || token.isEmpty()) {
+      return Optional.empty();
+    }
+    // Sliding window: single atomic compute() avoids a race condition where a non-atomic
+    // get+check+put sequence could see the session removed between the expiry check and the put.
+    // compute() provides an atomic read-modify-write on the ConcurrentHashMap entry.
+    final String[] resolvedUsername = {null};
+    _sessions.compute(token, (k, v) -> {
+      if (v == null || Instant.now().isAfter(v.expiry())) {
+        // Expired or not found – remove the entry (return null removes key from map)
+        return null;
+      }
+      resolvedUsername[0] = v.username();
+      return new SessionEntry(v.username(), Instant.now().plusSeconds(_sessionTtlSeconds), v.basicAuthToken());
+    });
+    return Optional.ofNullable(resolvedUsername[0]);
+  }
+
+  @Override
+  public Optional<String> getBasicAuthToken(String token) {
+    if (token == null || token.isEmpty()) {
+      return Optional.empty();
+    }
+    SessionEntry entry = _sessions.get(token);
+    if (entry == null || Instant.now().isAfter(entry.expiry())) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(entry.basicAuthToken());
+  }
+
+  @Override
+  public void invalidateSession(String token) {
+    if (token != null && !token.isEmpty()) {
+      SessionEntry removed = _sessions.remove(token);
+      if (removed != null) {
+        LOGGER.debug("Session invalidated for user '{}'", removed.username());
+      }
+    }
+  }
+
+  @Override
+  public long getSessionTtlSeconds() {
+    return _sessionTtlSeconds;
+  }
+
+  @Override
+  public int getActiveSessionCount() {
+    return _sessions.size();
+  }
+
+  @Override
+  public void shutdown() {
+    _cleanupExecutor.shutdownNow();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private String generateToken() {
+    byte[] bytes = new byte[TOKEN_BYTES];
+    _secureRandom.nextBytes(bytes);
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+  }
+
+  private void evictExpiredSessions() {
+    Instant now = Instant.now();
+    int removed = 0;
+    Iterator<Map.Entry<String, SessionEntry>> it = _sessions.entrySet().iterator();
+    while (it.hasNext()) {
+      Map.Entry<String, SessionEntry> entry = it.next();
+      if (now.isAfter(entry.getValue().expiry())) {
+        it.remove();
+        removed++;
+      }
+    }
+    if (removed > 0) {
+      LOGGER.debug("Evicted {} expired sessions; {} active sessions remain", removed, _sessions.size());
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Inner record
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Immutable session entry holding the username, expiry instant, and stored Basic-auth token.
+   *
+   * <p>The {@code basicAuthToken} is stored server-side only — it is never sent to the browser.
+   * It is used to inject an {@code Authorization} header when the controller forwards queries
+   * to the broker (server-to-server communication).
+   */
+  private static final class SessionEntry {
+    private final String _username;
+    private final Instant _expiry;
+    private final String _basicAuthToken;
+
+    SessionEntry(String username, Instant expiry, String basicAuthToken) {
+      _username = username;
+      _expiry = expiry;
+      _basicAuthToken = basicAuthToken;
+    }
+
+    String username() {
+      return _username;
+    }
+
+    Instant expiry() {
+      return _expiry;
+    }
+
+    String basicAuthToken() {
+      return _basicAuthToken;
+    }
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/InMemorySessionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/InMemorySessionManager.java
@@ -35,18 +35,19 @@ import org.slf4j.LoggerFactory;
 /**
  * In-memory implementation of {@link SessionManager}.
  *
- * <p>Sessions are stored in a {@link ConcurrentHashMap} with a configurable sliding-window TTL
+ * <p>Sessions are stored in a {@link ConcurrentHashMap} with a configurable fixed TTL
  * and are cleaned up periodically to prevent unbounded growth.
  *
- * <p><strong>Sliding window TTL:</strong> Each time a session is accessed via
- * {@link #getUsername(String)}, the expiry is extended by the configured TTL. This means active
- * users are never logged out due to inactivity — only truly idle sessions (no API calls for the
- * full TTL duration) expire.
+ * <p><strong>Fixed TTL:</strong> Each session expires at {@code loginTime + TTL} regardless of
+ * activity. This keeps the server-side expiry aligned with the browser cookie {@code Max-Age},
+ * both of which are set to the same TTL at login. A sliding-window TTL would let the server
+ * session outlive the browser cookie (which has no renewal mechanism here), creating a
+ * desynchronised state where the server holds a valid session the browser can no longer reach.
  *
  * <p>Design follows the Ambari / Trino FormWebUiAuthenticationFilter pattern:
  * <ul>
  *   <li>Login  → validate credentials → create session token → set HttpOnly cookie</li>
- *   <li>Request → read cookie → look up session → slide expiry → allow or redirect to login</li>
+ *   <li>Request → read cookie → look up session → allow or redirect to login</li>
  *   <li>Logout → read cookie → remove session from store → delete cookie → redirect to login</li>
  * </ul>
  */
@@ -86,7 +87,7 @@ public class InMemorySessionManager implements SessionManager {
         CLEANUP_INTERVAL_SECONDS,
         CLEANUP_INTERVAL_SECONDS,
         TimeUnit.SECONDS);
-    LOGGER.info("InMemorySessionManager initialized with sliding TTL={}s", _sessionTtlSeconds);
+    LOGGER.info("InMemorySessionManager initialized with fixed TTL={}s", _sessionTtlSeconds);
   }
 
   @Override
@@ -103,19 +104,13 @@ public class InMemorySessionManager implements SessionManager {
     if (token == null || token.isEmpty()) {
       return Optional.empty();
     }
-    // Sliding window: single atomic compute() avoids a race condition where a non-atomic
-    // get+check+put sequence could see the session removed between the expiry check and the put.
-    // compute() provides an atomic read-modify-write on the ConcurrentHashMap entry.
-    final String[] resolvedUsername = {null};
-    _sessions.compute(token, (k, v) -> {
-      if (v == null || Instant.now().isAfter(v.expiry())) {
-        // Expired or not found – remove the entry (return null removes key from map)
-        return null;
-      }
-      resolvedUsername[0] = v.username();
-      return new SessionEntry(v.username(), Instant.now().plusSeconds(_sessionTtlSeconds), v.basicAuthToken());
-    });
-    return Optional.ofNullable(resolvedUsername[0]);
+    // Fixed TTL: just check expiry without extending it, keeping server and browser cookie
+    // expiry in sync (both set to the same TTL value at login time).
+    SessionEntry entry = _sessions.get(token);
+    if (entry == null || Instant.now().isAfter(entry.expiry())) {
+      return Optional.empty();
+    }
+    return Optional.of(entry.username());
   }
 
   @Override

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/InMemorySessionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/InMemorySessionManager.java
@@ -125,6 +125,28 @@ public class InMemorySessionManager implements SessionManager {
     return Optional.ofNullable(entry.basicAuthToken());
   }
 
+  /**
+   * Atomically rotates the session using {@link ConcurrentHashMap#remove(Object, Object)}.
+   * Only one of concurrent renew requests will win the CAS; the rest see empty and get 401.
+   * This prevents orphaned tokens from double-clicks on "Stay Logged In".
+   */
+  @Override
+  public Optional<String> rotateSession(String oldToken) {
+    if (oldToken == null || oldToken.isEmpty()) {
+      return Optional.empty();
+    }
+    SessionEntry entry = _sessions.get(oldToken);
+    if (entry == null || Instant.now().isAfter(entry.expiry())) {
+      return Optional.empty();
+    }
+    // CAS: only one concurrent caller can remove this exact entry reference.
+    if (!_sessions.remove(oldToken, entry)) {
+      return Optional.empty();
+    }
+    String newToken = createSession(entry.username(), entry.basicAuthToken());
+    return Optional.of(newToken);
+  }
+
   @Override
   public void invalidateSession(String token) {
     if (token != null && !token.isEmpty()) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/SessionAuthenticationFilter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/SessionAuthenticationFilter.java
@@ -118,7 +118,7 @@ public class SessionAuthenticationFilter implements ContainerRequestFilter {
       return;
     }
 
-    
+
     // Server-to-server API calls (e.g., pinot-admin.sh AddTable -authToken "Basic ...") carry an
     // Authorization header. This filter handles session validation for browser UI requests only.
     // Requests with an Authorization header are passed through here so the downstream
@@ -133,7 +133,7 @@ public class SessionAuthenticationFilter implements ContainerRequestFilter {
       LOGGER.debug("Request has Authorization header, bypassing session filter for path '{}'", path);
       return;
     }
-    
+
 
     // Check for a valid session cookie (browser UI requests)
     Cookie sessionCookie = requestContext.getCookies().get(SessionManager.SESSION_COOKIE_NAME);
@@ -176,4 +176,3 @@ public class SessionAuthenticationFilter implements ContainerRequestFilter {
     return !path.contains("/") && path.contains(".");
   }
 }
-

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/SessionAuthenticationFilter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/SessionAuthenticationFilter.java
@@ -1,0 +1,179 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.access;
+
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import org.apache.pinot.controller.ControllerConf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * JAX-RS container filter that enforces session-based authentication for the Pinot UI.
+ *
+ * <p><strong>Architecture (Trino/Ambari-style):</strong>
+ * <p>This filter is completely INDEPENDENT of the configured {@link AccessControlFactory}.
+ * It activates when {@code controller.ui.session.enabled=true} is set in the controller
+ * configuration, regardless of which auth factory is configured (BasicAuth, ZkBasicAuth,
+ * LDAP/PasswordAuth, or any custom factory).
+ *
+ * <p>This mirrors Trino's {@code FormWebUiAuthenticationFilter} which is independent of
+ * the {@code FormAuthenticator} implementation. The session layer is a UI concern, not
+ * an auth backend concern.
+ *
+ * <p><strong>How it works:</strong>
+ * <ol>
+ *   <li>Skips public/unprotected paths (login, logout, health, auth/info, static assets)</li>
+ *   <li>Reads the {@value SessionManager#SESSION_COOKIE_NAME} HttpOnly cookie</li>
+ *   <li>Validates the session token against the server-side {@link SessionManager}</li>
+ *   <li>If valid → allows the request to proceed</li>
+ *   <li>If invalid/missing → returns 401 (UI redirects to login page)</li>
+ * </ol>
+ *
+ * <p><strong>Key security property:</strong> The Authorization header is <em>not</em> used
+ * for UI requests. The session cookie is the sole credential, and it is HttpOnly so
+ * JavaScript cannot read it. This eliminates the token-in-header exposure seen in the
+ * browser dev-tools network tab.
+ *
+ * <p><strong>Activation:</strong> Set {@code controller.ui.session.enabled=true} in
+ * {@code pinot-controller.conf}. No factory class change required.
+ */
+@javax.ws.rs.ext.Provider
+@javax.annotation.Priority(javax.ws.rs.Priorities.AUTHENTICATION - 10)
+public class SessionAuthenticationFilter implements ContainerRequestFilter {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SessionAuthenticationFilter.class);
+
+  /**
+   * Paths that are always accessible without a session.
+   * Mirrors Trino's UNPROTECTED_PATHS set.
+   */
+  private static final Set<String> UNPROTECTED_PATHS = new HashSet<>(Arrays.asList(
+      "",
+      "help",
+      "health",
+      "auth/info",
+      "auth/verify",
+      "auth/login",   // login endpoint itself must be accessible
+      "auth/logout",  // logout must be accessible to clear the session
+      "auth/session"  // session check must be accessible
+  ));
+
+  @Inject
+  private SessionManager _sessionManager;
+
+  @Inject
+  private ControllerConf _controllerConf;
+
+  @Override
+  public void filter(ContainerRequestContext requestContext) throws IOException {
+    // Only activate when session mode is enabled via controller.ui.session.enabled=true.
+    // This is INDEPENDENT of the configured AccessControlFactory.
+    // Works with BasicAuth, ZkBasicAuth, LDAP/PasswordAuth, or any custom factory.
+    if (_controllerConf == null
+        || !_controllerConf.getProperty(ControllerConf.CONTROLLER_UI_SESSION_ENABLED, false)) {
+      // Session mode not enabled – let the existing AuthenticationFilter handle it
+      return;
+    }
+
+    String path = requestContext.getUriInfo().getPath();
+
+    // Strip leading slash for comparison
+    String normalizedPath = path.startsWith("/") ? path.substring(1) : path;
+
+    // Always allow unprotected paths
+    if (isUnprotected(normalizedPath)) {
+      return;
+    }
+
+    // Allow static assets (files with extensions at the root level, e.g., index.html, favicon.ico)
+    if (isStaticAsset(normalizedPath)) {
+      return;
+    }
+
+    
+    // Server-to-server API calls (e.g., pinot-admin.sh AddTable -authToken "Basic ...") carry an
+    // Authorization header. This filter handles session validation for browser UI requests only.
+    // Requests with an Authorization header are passed through here so the downstream
+    // AuthenticationFilter (priority AUTHENTICATION, which runs after this filter at
+    // AUTHENTICATION-10) can validate the credential. This is intentional: the session layer
+    // is a UI concern; API callers authenticate via the AuthenticationFilter, not via session cookies.
+    // NOTE: This means session mode does NOT block API callers that present a valid Authorization
+    // header — they are authenticated by AuthenticationFilter instead.
+    List<String> authHeaders = requestContext.getHeaders().get(HttpHeaders.AUTHORIZATION);
+    if (authHeaders != null && !authHeaders.isEmpty()) {
+      // Has Authorization header – let the existing AuthenticationFilter validate it
+      LOGGER.debug("Request has Authorization header, bypassing session filter for path '{}'", path);
+      return;
+    }
+    
+
+    // Check for a valid session cookie (browser UI requests)
+    Cookie sessionCookie = requestContext.getCookies().get(SessionManager.SESSION_COOKIE_NAME);
+    if (sessionCookie != null && sessionCookie.getValue() != null) {
+      Optional<String> username = _sessionManager.getUsername(sessionCookie.getValue());
+      if (username.isPresent()) {
+        // Valid session – allow the request to proceed
+        LOGGER.debug("Session valid for user '{}' on path '{}'", username.get(), path);
+        return;
+      }
+      // Session expired or invalid
+      LOGGER.debug("Session expired or invalid for path '{}'", path);
+    }
+
+    // No valid session and no Authorization header – return 401 so the UI redirects to the login page
+    requestContext.abortWith(
+        Response.status(Response.Status.UNAUTHORIZED)
+            .entity("{\"error\":\"Session expired or not authenticated. Please log in.\"}")
+            .type(javax.ws.rs.core.MediaType.APPLICATION_JSON)
+            .build()
+    );
+  }
+
+  private static boolean isUnprotected(String path) {
+    // Exact match
+    if (UNPROTECTED_PATHS.contains(path)) {
+      return true;
+    }
+    // Prefix match for auth/* paths
+    if (path.startsWith("auth/login") || path.startsWith("auth/logout")
+        || path.startsWith("auth/info") || path.startsWith("auth/verify")
+        || path.startsWith("auth/session")) {
+      return true;
+    }
+    return false;
+  }
+
+  private static boolean isStaticAsset(String path) {
+    // Files at root level with an extension (e.g., index.html, favicon.ico)
+    return !path.contains("/") && path.contains(".");
+  }
+}
+

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/SessionBasicAuthAccessControlFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/SessionBasicAuthAccessControlFactory.java
@@ -104,4 +104,3 @@ public class SessionBasicAuthAccessControlFactory implements AccessControlFactor
     }
   }
 }
-

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/SessionBasicAuthAccessControlFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/SessionBasicAuthAccessControlFactory.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.access;
+
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.ws.rs.core.HttpHeaders;
+import org.apache.pinot.core.auth.BasicAuthPrincipal;
+import org.apache.pinot.core.auth.BasicAuthUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
+
+
+/**
+ * Session-based Authentication Access Control Factory for Pinot Controller.
+ *
+ * <p><strong>NOTE: This factory is an OPTIONAL convenience class.</strong>
+ * The preferred approach is to use your existing factory unchanged and just add
+ * {@code controller.ui.session.enabled=true} to your configuration. That approach
+ * works with ALL auth backends (BasicAuth, ZkBasicAuth, LDAP, custom).
+ *
+ * <p>This factory is identical to {@link BasicAuthAccessControlFactory} in terms of credential
+ * validation (username/password via HTTP Basic Auth headers), but it reports the
+ * {@link AccessControl#WORKFLOW_SESSION} workflow to the UI instead of {@code BASIC}.
+ *
+ * <p>Use this factory ONLY if you cannot add {@code controller.ui.session.enabled=true}
+ * to your configuration (e.g., in environments where config changes are restricted).
+ *
+ * <p><strong>Preferred configuration (works with any factory):</strong>
+ * <pre>
+ *   controller.ui.session.enabled=true
+ *   controller.admin.access.control.factory.class=org.apache.pinot.controller.api.access.BasicAuthAccessControlFactory
+ * </pre>
+ *
+ * <p><strong>Alternative configuration using this factory:</strong>
+ * <pre>
+ *   controller.admin.access.control.factory.class=\
+ *     org.apache.pinot.controller.api.access.SessionBasicAuthAccessControlFactory
+ *   controller.admin.access.control.principals=admin,user
+ *   controller.admin.access.control.principals.admin.password=verysecret
+ * </pre>
+ */
+public class SessionBasicAuthAccessControlFactory implements AccessControlFactory {
+  private static final String PREFIX = "controller.admin.access.control.principals";
+
+  private AccessControl _accessControl;
+
+  @Override
+  public void init(PinotConfiguration configuration) {
+    _accessControl = new SessionBasicAuthAccessControl(
+        BasicAuthUtils.extractBasicAuthPrincipals(configuration, PREFIX));
+  }
+
+  @Override
+  public AccessControl create() {
+    return _accessControl;
+  }
+
+  /**
+   * Access Control that uses Basic Auth credential validation but reports SESSION workflow.
+   *
+   * <p>When the UI calls {@code GET /auth/info}, this returns {@code {"workflow":"SESSION"}}
+   * which causes the UI to use POST /auth/login instead of sending Authorization headers.
+   */
+  private static class SessionBasicAuthAccessControl extends AbstractBasicAuthAccessControl {
+
+    private final Map<String, BasicAuthPrincipal> _token2principal;
+
+    public SessionBasicAuthAccessControl(Collection<BasicAuthPrincipal> principals) {
+      _token2principal = principals.stream()
+          .collect(Collectors.toMap(BasicAuthPrincipal::getToken, p -> p));
+    }
+
+    @Override
+    protected Optional<BasicAuthPrincipal> getPrincipal(HttpHeaders headers) {
+      return BasicAuthUtils.getPrincipal(getTokens(headers), _token2principal);
+    }
+
+    /**
+     * Reports SESSION workflow to the UI.
+     * This causes the UI to use POST /auth/login instead of sending Authorization headers.
+     */
+    @Override
+    public AuthWorkflowInfo getAuthWorkflowInfo() {
+      return new AuthWorkflowInfo(AccessControl.WORKFLOW_SESSION);
+    }
+  }
+}
+

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/SessionBasicAuthAccessControlFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/SessionBasicAuthAccessControlFactory.java
@@ -18,14 +18,18 @@
  */
 package org.apache.pinot.controller.api.access;
 
-
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.core.HttpHeaders;
+import org.apache.pinot.common.auth.BasicAuthTokenUtils;
 import org.apache.pinot.core.auth.BasicAuthPrincipal;
-import org.apache.pinot.core.auth.BasicAuthUtils;
+import org.apache.pinot.core.auth.BasicAuthPrincipalUtils;
+import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.spi.env.PinotConfiguration;
 
 
@@ -34,20 +38,22 @@ import org.apache.pinot.spi.env.PinotConfiguration;
  *
  * <p><strong>NOTE: This factory is an OPTIONAL convenience class.</strong>
  * The preferred approach is to use your existing factory unchanged and just add
- * {@code controller.ui.session.enabled=true} to your configuration. That approach
- * works with ALL auth backends (BasicAuth, ZkBasicAuth, LDAP, custom).
+ * {@code controller.ui.session.authentication.enabled=true} to your configuration.
+ * That approach works with ALL auth backends (BasicAuth, ZkBasicAuth, LDAP, custom).
  *
  * <p>This factory is identical to {@link BasicAuthAccessControlFactory} in terms of credential
  * validation (username/password via HTTP Basic Auth headers), but it reports the
  * {@link AccessControl#WORKFLOW_SESSION} workflow to the UI instead of {@code BASIC}.
  *
- * <p>Use this factory ONLY if you cannot add {@code controller.ui.session.enabled=true}
- * to your configuration (e.g., in environments where config changes are restricted).
+ * <p>Use this factory ONLY if you cannot add
+ * {@code controller.ui.session.authentication.enabled=true} to your configuration
+ * (e.g., in environments where config changes are restricted).
  *
  * <p><strong>Preferred configuration (works with any factory):</strong>
  * <pre>
- *   controller.ui.session.enabled=true
- *   controller.admin.access.control.factory.class=org.apache.pinot.controller.api.access.BasicAuthAccessControlFactory
+ *   controller.ui.session.authentication.enabled=true
+ *   controller.admin.access.control.factory.class=\
+ *     org.apache.pinot.controller.api.access.BasicAuthAccessControlFactory
  * </pre>
  *
  * <p><strong>Alternative configuration using this factory:</strong>
@@ -60,13 +66,14 @@ import org.apache.pinot.spi.env.PinotConfiguration;
  */
 public class SessionBasicAuthAccessControlFactory implements AccessControlFactory {
   private static final String PREFIX = "controller.admin.access.control.principals";
+  private static final String HEADER_AUTHORIZATION = "Authorization";
 
   private AccessControl _accessControl;
 
   @Override
   public void init(PinotConfiguration configuration) {
     _accessControl = new SessionBasicAuthAccessControl(
-        BasicAuthUtils.extractBasicAuthPrincipals(configuration, PREFIX));
+        BasicAuthPrincipalUtils.extractBasicAuthPrincipals(configuration, PREFIX));
   }
 
   @Override
@@ -80,18 +87,35 @@ public class SessionBasicAuthAccessControlFactory implements AccessControlFactor
    * <p>When the UI calls {@code GET /auth/info}, this returns {@code {"workflow":"SESSION"}}
    * which causes the UI to use POST /auth/login instead of sending Authorization headers.
    */
-  private static class SessionBasicAuthAccessControl extends AbstractBasicAuthAccessControl {
-
+  private static class SessionBasicAuthAccessControl implements AccessControl {
     private final Map<String, BasicAuthPrincipal> _token2principal;
 
-    public SessionBasicAuthAccessControl(Collection<BasicAuthPrincipal> principals) {
-      _token2principal = principals.stream()
-          .collect(Collectors.toMap(BasicAuthPrincipal::getToken, p -> p));
+    SessionBasicAuthAccessControl(Collection<BasicAuthPrincipal> principals) {
+      _token2principal = principals.stream().collect(Collectors.toMap(BasicAuthPrincipal::getToken, p -> p));
     }
 
     @Override
-    protected Optional<BasicAuthPrincipal> getPrincipal(HttpHeaders headers) {
-      return BasicAuthUtils.getPrincipal(getTokens(headers), _token2principal);
+    public boolean protectAnnotatedOnly() {
+      return false;
+    }
+
+    @Override
+    public boolean hasAccess(String tableName, AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
+      return getPrincipal(httpHeaders)
+          .filter(p -> p.hasTable(tableName) && p.hasPermission(Objects.toString(accessType))).isPresent();
+    }
+
+    @Override
+    public boolean hasAccess(AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
+      if (getPrincipal(httpHeaders).isEmpty()) {
+        throw new NotAuthorizedException("Basic");
+      }
+      return true;
+    }
+
+    @Override
+    public boolean hasAccess(HttpHeaders httpHeaders, TargetType targetType) {
+      return getPrincipal(httpHeaders).isPresent();
     }
 
     /**
@@ -101,6 +125,19 @@ public class SessionBasicAuthAccessControlFactory implements AccessControlFactor
     @Override
     public AuthWorkflowInfo getAuthWorkflowInfo() {
       return new AuthWorkflowInfo(AccessControl.WORKFLOW_SESSION);
+    }
+
+    private Optional<BasicAuthPrincipal> getPrincipal(HttpHeaders headers) {
+      if (headers == null) {
+        return Optional.empty();
+      }
+      List<String> authHeaders = headers.getRequestHeader(HEADER_AUTHORIZATION);
+      if (authHeaders == null) {
+        return Optional.empty();
+      }
+      return authHeaders.stream().map(BasicAuthTokenUtils::normalizeBase64Token)
+          .map(_token2principal::get)
+          .filter(Objects::nonNull).findFirst();
     }
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/SessionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/SessionManager.java
@@ -1,0 +1,273 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.access;
+
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Server-side session manager for Pinot UI authentication.
+ *
+ * <p>Manages opaque session tokens that are issued on successful login and
+ * invalidated on explicit logout (Ambari-style proper logout invalidation).
+ * Sessions are stored in-memory with a configurable TTL and are cleaned up
+ * periodically to prevent unbounded growth.
+ *
+ * <p><strong>Sliding window TTL:</strong> Each time a session is accessed via
+ * {@link #getUsername(String)}, the expiry is extended by the configured TTL.
+ * This means active users are never logged out due to inactivity — only truly
+ * idle sessions (no API calls for the full TTL duration) expire.
+ *
+ * <p><strong>Broker credential forwarding:</strong> The session stores the
+ * Basic-auth token used to validate credentials at login. This allows the
+ * controller to inject a proper {@code Authorization} header when forwarding
+ * queries to the broker (server-to-server), without ever exposing credentials
+ * in the browser's network tab.
+ *
+ * <p>Design follows the Ambari / Trino FormWebUiAuthenticationFilter pattern:
+ * <ul>
+ *   <li>Login  → validate credentials → create session token → set HttpOnly cookie</li>
+ *   <li>Request → read cookie → look up session → slide expiry → allow or redirect to login</li>
+ *   <li>Logout → read cookie → remove session from store → delete cookie → redirect to login</li>
+ * </ul>
+ */
+public class SessionManager {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SessionManager.class);
+
+  /** Cookie name used to carry the session token. */
+  public static final String SESSION_COOKIE_NAME = "Pinot-UI-Session";
+
+  /** Default session TTL: 8 hours (sliding window – resets on each API call). */
+  public static final long DEFAULT_SESSION_TTL_SECONDS = 8 * 60 * 60L;
+
+  /** Cleanup interval: every 30 minutes. */
+  private static final long CLEANUP_INTERVAL_SECONDS = 30 * 60L;
+
+  /** Number of random bytes for the session token (256-bit entropy). */
+  private static final int TOKEN_BYTES = 32;
+
+  private final long _sessionTtlSeconds;
+  private final SecureRandom _secureRandom = new SecureRandom();
+
+  /**
+   * Active session store: token → {@link SessionEntry}.
+   * ConcurrentHashMap provides thread-safe reads without locking on the hot path.
+   */
+  private final ConcurrentHashMap<String, SessionEntry> _sessions = new ConcurrentHashMap<>();
+
+  private final ScheduledExecutorService _cleanupExecutor =
+      Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "pinot-session-cleanup");
+        t.setDaemon(true);
+        return t;
+      });
+
+  public SessionManager() {
+    this(DEFAULT_SESSION_TTL_SECONDS);
+  }
+
+  public SessionManager(long sessionTtlSeconds) {
+    _sessionTtlSeconds = sessionTtlSeconds;
+    _cleanupExecutor.scheduleAtFixedRate(
+        this::evictExpiredSessions,
+        CLEANUP_INTERVAL_SECONDS,
+        CLEANUP_INTERVAL_SECONDS,
+        TimeUnit.SECONDS);
+    LOGGER.info("SessionManager initialized with sliding TTL={}s", _sessionTtlSeconds);
+  }
+
+  /**
+   * Creates a new session for the given username and returns the opaque session token.
+   *
+   * @param username the authenticated username
+   * @param basicAuthToken the Basic-auth token (e.g. "Basic dXNlcjpwYXNz") used to validate
+   *                       credentials at login. Stored server-side so the controller can inject
+   *                       it as an Authorization header when forwarding queries to the broker.
+   *                       Never sent to the browser.
+   * @return a cryptographically random, URL-safe session token
+   */
+  public String createSession(String username, String basicAuthToken) {
+    String token = generateToken();
+    Instant expiry = Instant.now().plusSeconds(_sessionTtlSeconds);
+    _sessions.put(token, new SessionEntry(username, expiry, basicAuthToken));
+    LOGGER.debug("Created session for user '{}', expires at {}", username, expiry);
+    return token;
+  }
+
+  /**
+   * Looks up the username associated with a session token.
+   *
+   * <p><strong>Sliding window:</strong> If the session is valid, its expiry is extended
+   * by the configured TTL. This ensures active users are never logged out due to inactivity.
+   *
+   * @param token the session token from the cookie
+   * @return the username if the session is valid and not expired, empty otherwise
+   */
+  public Optional<String> getUsername(String token) {
+    if (token == null || token.isEmpty()) {
+      return Optional.empty();
+    }
+    // Sliding window: single atomic compute() avoids a race condition where a non-atomic
+    // get+check+put sequence could see the session removed between the expiry check and the put.
+    // compute() provides an atomic read-modify-write on the ConcurrentHashMap entry.
+    final String[] resolvedUsername = {null};
+    _sessions.compute(token, (k, v) -> {
+      if (v == null || Instant.now().isAfter(v.expiry())) {
+        // Expired or not found – remove the entry (return null removes key from map)
+        return null;
+      }
+      resolvedUsername[0] = v.username();
+      return new SessionEntry(v.username(), Instant.now().plusSeconds(_sessionTtlSeconds), v.basicAuthToken());
+    });
+    return Optional.ofNullable(resolvedUsername[0]);
+  }
+
+  /**
+   * Returns the Basic-auth token stored for the given session token.
+   *
+   * <p>Used by {@link org.apache.pinot.controller.api.resources.PinotQueryResource} to inject
+   * a proper {@code Authorization} header when forwarding queries to the broker (server-to-server).
+   * This ensures the broker can authenticate the request without the browser ever seeing credentials.
+   *
+   * @param token the session token from the cookie
+   * @return the Basic-auth token (e.g. "Basic dXNlcjpwYXNz"), or empty if session not found
+   */
+  public Optional<String> getBasicAuthToken(String token) {
+    if (token == null || token.isEmpty()) {
+      return Optional.empty();
+    }
+    SessionEntry entry = _sessions.get(token);
+    if (entry == null || Instant.now().isAfter(entry.expiry())) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(entry.basicAuthToken());
+  }
+
+  /**
+   * Invalidates a session token (called on logout).
+   * This is the key difference from stateless JWT: the server can immediately
+   * revoke access without waiting for token expiry.
+   *
+   * @param token the session token to invalidate
+   */
+  public void invalidateSession(String token) {
+    if (token != null && !token.isEmpty()) {
+      SessionEntry removed = _sessions.remove(token);
+      if (removed != null) {
+        LOGGER.debug("Session invalidated for user '{}'", removed.username());
+      }
+    }
+  }
+
+  /**
+   * Returns the configured session TTL in seconds.
+   */
+  public long getSessionTtlSeconds() {
+    return _sessionTtlSeconds;
+  }
+
+  /**
+   * Returns the number of active (possibly including some expired) sessions.
+   * Useful for monitoring/metrics.
+   */
+  public int getActiveSessionCount() {
+    return _sessions.size();
+  }
+
+  /**
+   * Shuts down the background cleanup executor.
+   */
+  public void shutdown() {
+    _cleanupExecutor.shutdownNow();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private String generateToken() {
+    byte[] bytes = new byte[TOKEN_BYTES];
+    _secureRandom.nextBytes(bytes);
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+  }
+
+  private void evictExpiredSessions() {
+    Instant now = Instant.now();
+    int removed = 0;
+    Iterator<Map.Entry<String, SessionEntry>> it = _sessions.entrySet().iterator();
+    while (it.hasNext()) {
+      Map.Entry<String, SessionEntry> entry = it.next();
+      if (now.isAfter(entry.getValue().expiry())) {
+        it.remove();
+        removed++;
+      }
+    }
+    if (removed > 0) {
+      LOGGER.debug("Evicted {} expired sessions; {} active sessions remain", removed, _sessions.size());
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Inner record
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Immutable session entry holding the username, expiry instant, and stored Basic-auth token.
+   *
+   * <p>The {@code basicAuthToken} is stored server-side only — it is never sent to the browser.
+   * It is used to inject an {@code Authorization} header when the controller forwards queries
+   * to the broker (server-to-server communication).
+   */
+  private static final class SessionEntry {
+    private final String _username;
+    private final Instant _expiry;
+    private final String _basicAuthToken;
+
+    SessionEntry(String username, Instant expiry, String basicAuthToken) {
+      _username = username;
+      _expiry = expiry;
+      _basicAuthToken = basicAuthToken;
+    }
+
+    String username() {
+      return _username;
+    }
+
+    Instant expiry() {
+      return _expiry;
+    }
+
+    String basicAuthToken() {
+      return _basicAuthToken;
+    }
+  }
+}
+

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/SessionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/SessionManager.java
@@ -270,4 +270,3 @@ public class SessionManager {
     }
   }
 }
-

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/SessionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/SessionManager.java
@@ -73,6 +73,26 @@ public interface SessionManager {
    */
   void invalidateSession(String token);
 
+  /**
+   * Atomically rotates the session: invalidates the old token and issues a fresh one with a new TTL.
+   * Returns the new token, or empty if the session is absent, expired, or was already rotated
+   * by a concurrent call (check-and-remove prevents double-rotation).
+   *
+   * @param oldToken the current session token from the browser cookie
+   * @return the new session token, or empty if rotation could not be performed
+   */
+  default Optional<String> rotateSession(String oldToken) {
+    // Default non-atomic implementation for custom SessionManager implementations.
+    // InMemorySessionManager overrides this with a CAS-based atomic version.
+    Optional<String> username = getUsername(oldToken);
+    if (!username.isPresent()) {
+      return Optional.empty();
+    }
+    Optional<String> authToken = getBasicAuthToken(oldToken);
+    invalidateSession(oldToken);
+    return Optional.of(createSession(username.get(), authToken.orElse(null)));
+  }
+
   /** Returns the configured session TTL in seconds. */
   long getSessionTtlSeconds();
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/SessionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/SessionManager.java
@@ -38,7 +38,7 @@ public interface SessionManager {
   /** Cookie name used to carry the session token. */
   String SESSION_COOKIE_NAME = "Pinot-UI-Session";
 
-  /** Default session TTL: 8 hours (sliding window – resets on each API call). */
+  /** Default session TTL: 8 hours from login. */
   long DEFAULT_SESSION_TTL_SECONDS = 8 * 60 * 60L;
 
   /**
@@ -51,7 +51,7 @@ public interface SessionManager {
   String createSession(String username, String basicAuthToken);
 
   /**
-   * Looks up the username for a session token, extending the sliding TTL on each access.
+   * Looks up the username for a session token.
    *
    * @param token the session token from the cookie
    * @return the username if the session is valid and not expired, empty otherwise

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/SessionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/SessionManager.java
@@ -18,255 +18,67 @@
  */
 package org.apache.pinot.controller.api.access;
 
-
-import java.security.SecureRandom;
-import java.time.Instant;
-import java.util.Base64;
-import java.util.Iterator;
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
  * Server-side session manager for Pinot UI authentication.
  *
- * <p>Manages opaque session tokens that are issued on successful login and
- * invalidated on explicit logout (Ambari-style proper logout invalidation).
- * Sessions are stored in-memory with a configurable TTL and are cleaned up
- * periodically to prevent unbounded growth.
+ * <p>Manages opaque session tokens that are issued on successful login and invalidated on explicit
+ * logout (Ambari-style proper logout invalidation). The default implementation is
+ * {@link InMemorySessionManager}.
  *
- * <p><strong>Sliding window TTL:</strong> Each time a session is accessed via
- * {@link #getUsername(String)}, the expiry is extended by the configured TTL.
- * This means active users are never logged out due to inactivity — only truly
- * idle sessions (no API calls for the full TTL duration) expire.
- *
- * <p><strong>Broker credential forwarding:</strong> The session stores the
- * Basic-auth token used to validate credentials at login. This allows the
- * controller to inject a proper {@code Authorization} header when forwarding
- * queries to the broker (server-to-server), without ever exposing credentials
- * in the browser's network tab.
- *
- * <p>Design follows the Ambari / Trino FormWebUiAuthenticationFilter pattern:
- * <ul>
- *   <li>Login  → validate credentials → create session token → set HttpOnly cookie</li>
- *   <li>Request → read cookie → look up session → slide expiry → allow or redirect to login</li>
- *   <li>Logout → read cookie → remove session from store → delete cookie → redirect to login</li>
- * </ul>
+ * <p><strong>Broker credential forwarding:</strong> The session stores the Basic-auth token used
+ * to validate credentials at login. This allows the controller to inject a proper
+ * {@code Authorization} header when forwarding queries to the broker (server-to-server), without
+ * ever exposing credentials in the browser's network tab.
  */
-public class SessionManager {
-  private static final Logger LOGGER = LoggerFactory.getLogger(SessionManager.class);
+public interface SessionManager {
 
   /** Cookie name used to carry the session token. */
-  public static final String SESSION_COOKIE_NAME = "Pinot-UI-Session";
+  String SESSION_COOKIE_NAME = "Pinot-UI-Session";
 
   /** Default session TTL: 8 hours (sliding window – resets on each API call). */
-  public static final long DEFAULT_SESSION_TTL_SECONDS = 8 * 60 * 60L;
-
-  /** Cleanup interval: every 30 minutes. */
-  private static final long CLEANUP_INTERVAL_SECONDS = 30 * 60L;
-
-  /** Number of random bytes for the session token (256-bit entropy). */
-  private static final int TOKEN_BYTES = 32;
-
-  private final long _sessionTtlSeconds;
-  private final SecureRandom _secureRandom = new SecureRandom();
-
-  /**
-   * Active session store: token → {@link SessionEntry}.
-   * ConcurrentHashMap provides thread-safe reads without locking on the hot path.
-   */
-  private final ConcurrentHashMap<String, SessionEntry> _sessions = new ConcurrentHashMap<>();
-
-  private final ScheduledExecutorService _cleanupExecutor =
-      Executors.newSingleThreadScheduledExecutor(r -> {
-        Thread t = new Thread(r, "pinot-session-cleanup");
-        t.setDaemon(true);
-        return t;
-      });
-
-  public SessionManager() {
-    this(DEFAULT_SESSION_TTL_SECONDS);
-  }
-
-  public SessionManager(long sessionTtlSeconds) {
-    _sessionTtlSeconds = sessionTtlSeconds;
-    _cleanupExecutor.scheduleAtFixedRate(
-        this::evictExpiredSessions,
-        CLEANUP_INTERVAL_SECONDS,
-        CLEANUP_INTERVAL_SECONDS,
-        TimeUnit.SECONDS);
-    LOGGER.info("SessionManager initialized with sliding TTL={}s", _sessionTtlSeconds);
-  }
+  long DEFAULT_SESSION_TTL_SECONDS = 8 * 60 * 60L;
 
   /**
    * Creates a new session for the given username and returns the opaque session token.
    *
-   * @param username the authenticated username
-   * @param basicAuthToken the Basic-auth token (e.g. "Basic dXNlcjpwYXNz") used to validate
-   *                       credentials at login. Stored server-side so the controller can inject
-   *                       it as an Authorization header when forwarding queries to the broker.
-   *                       Never sent to the browser.
+   * @param username       the authenticated username
+   * @param basicAuthToken the Basic-auth token stored server-side for broker forwarding
    * @return a cryptographically random, URL-safe session token
    */
-  public String createSession(String username, String basicAuthToken) {
-    String token = generateToken();
-    Instant expiry = Instant.now().plusSeconds(_sessionTtlSeconds);
-    _sessions.put(token, new SessionEntry(username, expiry, basicAuthToken));
-    LOGGER.debug("Created session for user '{}', expires at {}", username, expiry);
-    return token;
-  }
+  String createSession(String username, String basicAuthToken);
 
   /**
-   * Looks up the username associated with a session token.
-   *
-   * <p><strong>Sliding window:</strong> If the session is valid, its expiry is extended
-   * by the configured TTL. This ensures active users are never logged out due to inactivity.
+   * Looks up the username for a session token, extending the sliding TTL on each access.
    *
    * @param token the session token from the cookie
    * @return the username if the session is valid and not expired, empty otherwise
    */
-  public Optional<String> getUsername(String token) {
-    if (token == null || token.isEmpty()) {
-      return Optional.empty();
-    }
-    // Sliding window: single atomic compute() avoids a race condition where a non-atomic
-    // get+check+put sequence could see the session removed between the expiry check and the put.
-    // compute() provides an atomic read-modify-write on the ConcurrentHashMap entry.
-    final String[] resolvedUsername = {null};
-    _sessions.compute(token, (k, v) -> {
-      if (v == null || Instant.now().isAfter(v.expiry())) {
-        // Expired or not found – remove the entry (return null removes key from map)
-        return null;
-      }
-      resolvedUsername[0] = v.username();
-      return new SessionEntry(v.username(), Instant.now().plusSeconds(_sessionTtlSeconds), v.basicAuthToken());
-    });
-    return Optional.ofNullable(resolvedUsername[0]);
-  }
+  Optional<String> getUsername(String token);
 
   /**
    * Returns the Basic-auth token stored for the given session token.
    *
-   * <p>Used by {@link org.apache.pinot.controller.api.resources.PinotQueryResource} to inject
-   * a proper {@code Authorization} header when forwarding queries to the broker (server-to-server).
-   * This ensures the broker can authenticate the request without the browser ever seeing credentials.
-   *
    * @param token the session token from the cookie
-   * @return the Basic-auth token (e.g. "Basic dXNlcjpwYXNz"), or empty if session not found
+   * @return the Basic-auth token, or empty if session not found or expired
    */
-  public Optional<String> getBasicAuthToken(String token) {
-    if (token == null || token.isEmpty()) {
-      return Optional.empty();
-    }
-    SessionEntry entry = _sessions.get(token);
-    if (entry == null || Instant.now().isAfter(entry.expiry())) {
-      return Optional.empty();
-    }
-    return Optional.ofNullable(entry.basicAuthToken());
-  }
+  Optional<String> getBasicAuthToken(String token);
 
   /**
-   * Invalidates a session token (called on logout).
-   * This is the key difference from stateless JWT: the server can immediately
-   * revoke access without waiting for token expiry.
+   * Invalidates a session token immediately (called on logout).
    *
    * @param token the session token to invalidate
    */
-  public void invalidateSession(String token) {
-    if (token != null && !token.isEmpty()) {
-      SessionEntry removed = _sessions.remove(token);
-      if (removed != null) {
-        LOGGER.debug("Session invalidated for user '{}'", removed.username());
-      }
-    }
-  }
+  void invalidateSession(String token);
 
-  /**
-   * Returns the configured session TTL in seconds.
-   */
-  public long getSessionTtlSeconds() {
-    return _sessionTtlSeconds;
-  }
+  /** Returns the configured session TTL in seconds. */
+  long getSessionTtlSeconds();
 
-  /**
-   * Returns the number of active (possibly including some expired) sessions.
-   * Useful for monitoring/metrics.
-   */
-  public int getActiveSessionCount() {
-    return _sessions.size();
-  }
+  /** Returns the number of active sessions (for monitoring). */
+  int getActiveSessionCount();
 
-  /**
-   * Shuts down the background cleanup executor.
-   */
-  public void shutdown() {
-    _cleanupExecutor.shutdownNow();
-  }
-
-  // ---------------------------------------------------------------------------
-  // Private helpers
-  // ---------------------------------------------------------------------------
-
-  private String generateToken() {
-    byte[] bytes = new byte[TOKEN_BYTES];
-    _secureRandom.nextBytes(bytes);
-    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
-  }
-
-  private void evictExpiredSessions() {
-    Instant now = Instant.now();
-    int removed = 0;
-    Iterator<Map.Entry<String, SessionEntry>> it = _sessions.entrySet().iterator();
-    while (it.hasNext()) {
-      Map.Entry<String, SessionEntry> entry = it.next();
-      if (now.isAfter(entry.getValue().expiry())) {
-        it.remove();
-        removed++;
-      }
-    }
-    if (removed > 0) {
-      LOGGER.debug("Evicted {} expired sessions; {} active sessions remain", removed, _sessions.size());
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Inner record
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Immutable session entry holding the username, expiry instant, and stored Basic-auth token.
-   *
-   * <p>The {@code basicAuthToken} is stored server-side only — it is never sent to the browser.
-   * It is used to inject an {@code Authorization} header when the controller forwards queries
-   * to the broker (server-to-server communication).
-   */
-  private static final class SessionEntry {
-    private final String _username;
-    private final Instant _expiry;
-    private final String _basicAuthToken;
-
-    SessionEntry(String username, Instant expiry, String basicAuthToken) {
-      _username = username;
-      _expiry = expiry;
-      _basicAuthToken = basicAuthToken;
-    }
-
-    String username() {
-      return _username;
-    }
-
-    Instant expiry() {
-      return _expiry;
-    }
-
-    String basicAuthToken() {
-      return _basicAuthToken;
-    }
-  }
+  /** Releases any background resources (e.g. cleanup executor). */
+  void shutdown();
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerAuthResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerAuthResource.java
@@ -36,6 +36,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
+import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.access.AccessControl;
 import org.apache.pinot.controller.api.access.AccessControlFactory;
 import org.apache.pinot.controller.api.access.AccessType;
@@ -55,6 +56,9 @@ public class PinotControllerAuthResource {
 
   @Inject
   private AccessControlFactory _accessControlFactory;
+
+  @Inject
+  private ControllerConf _controllerConf;
 
   @Context
   HttpHeaders _httpHeaders;
@@ -106,8 +110,15 @@ public class PinotControllerAuthResource {
     return accessControl.hasAccess(_httpHeaders, TargetType.CLUSTER);
   }
 
-  /// Provide the auth workflow configuration for the Pinot UI to perform user authentication. Currently supports NONE
-  /// (no auth) and BASIC (basic auth with username and password)
+  /// Provide the auth workflow configuration for the Pinot UI to perform user authentication.
+  ///
+  /// When `controller.ui.session.authentication.enabled=true`, returns
+  /// `{"workflow":"SESSION","inactivityTimeoutSeconds":<n>}` regardless of which
+  /// AccessControlFactory is configured. The session layer is independent of the auth backend
+  /// (BasicAuth, ZkBasicAuth, LDAP/PasswordAuth, or any custom factory).
+  ///
+  /// When session mode is disabled (default), the underlying factory's workflow is returned
+  /// (NONE, BASIC, OIDC, etc.), preserving backward compatibility.
   ///
   /// @return auth workflow info/configuration
   @GET
@@ -117,6 +128,13 @@ public class PinotControllerAuthResource {
   @ApiOperation(value = "Retrieve auth workflow info")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "Auth workflow info provided")})
   public AccessControl.AuthWorkflowInfo info() {
+    if (_controllerConf != null
+        && _controllerConf.getProperty(ControllerConf.CONTROLLER_UI_SESSION_ENABLED, false)) {
+      long inactivityTimeout = _controllerConf.getProperty(
+          ControllerConf.CONTROLLER_UI_SESSION_INACTIVITY_TIMEOUT_SECONDS,
+          ControllerConf.DEFAULT_UI_SESSION_INACTIVITY_TIMEOUT_SECONDS);
+      return new AccessControl.AuthWorkflowInfo(AccessControl.WORKFLOW_SESSION, inactivityTimeout);
+    }
     return _accessControlFactory.create().getAuthWorkflowInfo();
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerAuthResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerAuthResource.java
@@ -135,6 +135,15 @@ public class PinotControllerAuthResource {
           ControllerConf.DEFAULT_UI_SESSION_INACTIVITY_TIMEOUT_SECONDS);
       return new AccessControl.AuthWorkflowInfo(AccessControl.WORKFLOW_SESSION, inactivityTimeout);
     }
-    return _accessControlFactory.create().getAuthWorkflowInfo();
+    AccessControl.AuthWorkflowInfo factoryInfo = _accessControlFactory.create().getAuthWorkflowInfo();
+    // When the factory itself advertises SESSION (e.g. SessionBasicAuthAccessControlFactory),
+    // enrich the response with the inactivity timeout from config so the UI can set up its timer.
+    if (AccessControl.WORKFLOW_SESSION.equals(factoryInfo.getWorkflow()) && _controllerConf != null) {
+      long inactivityTimeout = _controllerConf.getProperty(
+          ControllerConf.CONTROLLER_UI_SESSION_INACTIVITY_TIMEOUT_SECONDS,
+          ControllerConf.DEFAULT_UI_SESSION_INACTIVITY_TIMEOUT_SECONDS);
+      return new AccessControl.AuthWorkflowInfo(AccessControl.WORKFLOW_SESSION, inactivityTimeout);
+    }
+    return factoryInfo;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -123,7 +123,7 @@ public class PinotQueryResource {
   ControllerConf _controllerConf;
 
   @Inject
-  @org.glassfish.hk2.api.Optional
+  @org.jvnet.hk2.annotations.Optional
   SessionManager _sessionManager;
 
   @POST

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -53,6 +53,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -74,6 +75,7 @@ import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.access.AccessControl;
 import org.apache.pinot.controller.api.access.AccessControlFactory;
 import org.apache.pinot.controller.api.access.AccessType;
+import org.apache.pinot.controller.api.access.SessionManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.core.auth.Actions;
 import org.apache.pinot.core.auth.ManualAuthorization;
@@ -119,6 +121,10 @@ public class PinotQueryResource {
 
   @Inject
   ControllerConf _controllerConf;
+
+  @Inject
+  @org.glassfish.hk2.api.Optional
+  SessionManager _sessionManager;
 
   @POST
   @Path("sql")
@@ -408,11 +414,15 @@ public class PinotQueryResource {
       throw QueryErrorCode.INTERNAL.asException("V2 Multi-Stage query engine not enabled.");
     }
 
+    // Compute session validity once here so both DQL paths don't each look up the session independently.
+    boolean sessionValid = hasValidSessionCookie(httpHeaders);
+
     switch (sqlType) {
       case DQL:
         return isMse
-            ? getMultiStageQueryResponse(sqlQuery, queryOptions, httpHeaders, traceEnabled)
-            : getQueryResponse(sqlQuery, sqlNodeAndOptions.getSqlNode(), traceEnabled, queryOptions, httpHeaders);
+            ? getMultiStageQueryResponse(sqlQuery, queryOptions, httpHeaders, traceEnabled, sessionValid)
+            : getQueryResponse(sqlQuery, sqlNodeAndOptions.getSqlNode(), traceEnabled, queryOptions, httpHeaders,
+                sessionValid);
       case DML:
         Map<String, String> headers = extractHeaders(httpHeaders);
         return output -> {
@@ -425,14 +435,38 @@ public class PinotQueryResource {
     }
   }
 
-  private StreamingOutput getMultiStageQueryResponse(String query, String queryOptions, HttpHeaders httpHeaders,
-      String traceEnabled) {
+  /**
+   * Returns {@code true} if the request carries a valid server-side session cookie.
+   *
+   * <p>When session mode is enabled, browser UI requests carry an HttpOnly cookie instead of an
+   * Authorization header. If a valid session is present, the access-control check that expects an
+   * Authorization header is skipped to avoid a spurious 403 that would redirect the user to login.
+   */
+  private boolean hasValidSessionCookie(HttpHeaders httpHeaders) {
+    if (_sessionManager == null
+        || _controllerConf == null
+        || !_controllerConf.getProperty(ControllerConf.CONTROLLER_UI_SESSION_ENABLED, false)) {
+      return false;
+    }
+    Cookie sessionCookie = httpHeaders.getCookies().get(SessionManager.SESSION_COOKIE_NAME);
+    if (sessionCookie == null || sessionCookie.getValue() == null) {
+      return false;
+    }
+    return _sessionManager.getUsername(sessionCookie.getValue()).isPresent();
+  }
 
-    // Validate data access
-    // we don't have a cross table access control rule so only ADMIN can make request to multi-stage engine.
-    AccessControl accessControl = _accessControlFactory.create();
-    if (!accessControl.hasAccess(AccessType.READ, httpHeaders, "/sql")) {
-      throw new WebApplicationException("Permission denied", Response.Status.FORBIDDEN);
+  private StreamingOutput getMultiStageQueryResponse(String query, String queryOptions, HttpHeaders httpHeaders,
+      String traceEnabled, boolean sessionValid) {
+
+    // SESSION WORKFLOW: If the request has a valid session cookie, skip the Authorization-header
+    // access check. The session was already validated by SessionAuthenticationFilter before this method.
+    if (!sessionValid) {
+      // Validate data access
+      // we don't have a cross table access control rule so only ADMIN can make request to multi-stage engine.
+      AccessControl accessControl = _accessControlFactory.create();
+      if (!accessControl.hasAccess(AccessType.READ, httpHeaders, "/sql")) {
+        throw new WebApplicationException("Permission denied", Response.Status.FORBIDDEN);
+      }
     }
 
     Map<String, String> queryOptionsMap = RequestUtils.parseQuery(query).getOptions();
@@ -491,7 +525,7 @@ public class PinotQueryResource {
   }
 
   private StreamingOutput getQueryResponse(String query, @Nullable SqlNode sqlNode, String traceEnabled,
-      String queryOptions, HttpHeaders httpHeaders) {
+      String queryOptions, HttpHeaders httpHeaders, boolean sessionValid) {
     // Get resource table name.
     String tableName;
     Map<String, String> queryOptionsMap = RequestUtils.parseQuery(query).getOptions();
@@ -524,10 +558,14 @@ public class PinotQueryResource {
     }
     String rawTableName = TableNameBuilder.extractRawTableName(tableName);
 
-    // Validate data access
-    AccessControl accessControl = _accessControlFactory.create();
-    if (!accessControl.hasAccess(rawTableName, AccessType.READ, httpHeaders, Actions.Table.QUERY)) {
-      throw QueryErrorCode.ACCESS_DENIED.asException();
+    // SESSION WORKFLOW: If the request has a valid session cookie, skip the Authorization-header
+    // access check. The session was already validated by SessionAuthenticationFilter before this method.
+    if (!sessionValid) {
+      // Validate data access
+      AccessControl accessControl = _accessControlFactory.create();
+      if (!accessControl.hasAccess(rawTableName, AccessType.READ, httpHeaders, Actions.Table.QUERY)) {
+        throw QueryErrorCode.ACCESS_DENIED.asException();
+      }
     }
 
     // Get brokers for the resource table.
@@ -610,6 +648,21 @@ public class PinotQueryResource {
 
     // Forward client-supplied headers
     Map<String, String> headers = extractHeaders(httpHeaders);
+
+    // SESSION WORKFLOW: Inject Authorization header for broker (server-to-server).
+    // Browser UI requests carry only the HttpOnly session cookie – no Authorization header.
+    // The broker requires auth, so we retrieve the stored Basic-auth token from the session
+    // and inject it as an Authorization header for the controller→broker request.
+    // This token is stored server-side only (never sent to the browser).
+    if (_sessionManager != null
+        && _controllerConf != null
+        && _controllerConf.getProperty(ControllerConf.CONTROLLER_UI_SESSION_ENABLED, false)) {
+      Cookie sessionCookie = httpHeaders.getCookies().get(SessionManager.SESSION_COOKIE_NAME);
+      if (sessionCookie != null && sessionCookie.getValue() != null) {
+        _sessionManager.getBasicAuthToken(sessionCookie.getValue()).ifPresent(
+            authToken -> headers.put(HttpHeaders.AUTHORIZATION, authToken));
+      }
+    }
 
     return sendRequestRaw(url, "POST", query, requestJson, headers);
   }
@@ -806,9 +859,14 @@ public class PinotQueryResource {
   }
 
   private Map<String, String> extractHeaders(HttpHeaders httpHeaders) {
+    // In SESSION mode, exclude the Authorization header from being forwarded to the broker.
+    // The broker auth is injected server-side from the session store in sendRequestToBroker().
+    boolean isSessionMode = _controllerConf != null
+        && _controllerConf.getProperty(ControllerConf.CONTROLLER_UI_SESSION_ENABLED, false);
     return httpHeaders.getRequestHeaders().entrySet().stream()
-      .filter(entry -> !entry.getValue().isEmpty())
-      .collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().get(0)));
+        .filter(entry -> !entry.getValue().isEmpty())
+        .filter(entry -> !isSessionMode || !entry.getKey().equalsIgnoreCase(HttpHeaders.AUTHORIZATION))
+        .collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().get(0)));
   }
 
   private InstanceConfig getInstanceConfig(String instanceId) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -122,6 +122,8 @@ public class PinotQueryResource {
   @Inject
   ControllerConf _controllerConf;
 
+  // @Optional: SessionManager is always bound in production but may be absent in unit-test contexts
+  // where HK2 is not fully configured. Without @Optional, injection would fail in those environments.
   @Inject
   @org.jvnet.hk2.annotations.Optional
   SessionManager _sessionManager;
@@ -414,15 +416,11 @@ public class PinotQueryResource {
       throw QueryErrorCode.INTERNAL.asException("V2 Multi-Stage query engine not enabled.");
     }
 
-    // Compute session validity once here so both DQL paths don't each look up the session independently.
-    boolean sessionValid = hasValidSessionCookie(httpHeaders);
-
     switch (sqlType) {
       case DQL:
         return isMse
-            ? getMultiStageQueryResponse(sqlQuery, queryOptions, httpHeaders, traceEnabled, sessionValid)
-            : getQueryResponse(sqlQuery, sqlNodeAndOptions.getSqlNode(), traceEnabled, queryOptions, httpHeaders,
-                sessionValid);
+            ? getMultiStageQueryResponse(sqlQuery, queryOptions, httpHeaders, traceEnabled)
+            : getQueryResponse(sqlQuery, sqlNodeAndOptions.getSqlNode(), traceEnabled, queryOptions, httpHeaders);
       case DML:
         Map<String, String> headers = extractHeaders(httpHeaders);
         return output -> {
@@ -435,38 +433,13 @@ public class PinotQueryResource {
     }
   }
 
-  /**
-   * Returns {@code true} if the request carries a valid server-side session cookie.
-   *
-   * <p>When session mode is enabled, browser UI requests carry an HttpOnly cookie instead of an
-   * Authorization header. If a valid session is present, the access-control check that expects an
-   * Authorization header is skipped to avoid a spurious 403 that would redirect the user to login.
-   */
-  private boolean hasValidSessionCookie(HttpHeaders httpHeaders) {
-    if (_sessionManager == null
-        || _controllerConf == null
-        || !_controllerConf.getProperty(ControllerConf.CONTROLLER_UI_SESSION_ENABLED, false)) {
-      return false;
-    }
-    Cookie sessionCookie = httpHeaders.getCookies().get(SessionManager.SESSION_COOKIE_NAME);
-    if (sessionCookie == null || sessionCookie.getValue() == null) {
-      return false;
-    }
-    return _sessionManager.getUsername(sessionCookie.getValue()).isPresent();
-  }
-
   private StreamingOutput getMultiStageQueryResponse(String query, String queryOptions, HttpHeaders httpHeaders,
-      String traceEnabled, boolean sessionValid) {
-
-    // SESSION WORKFLOW: If the request has a valid session cookie, skip the Authorization-header
-    // access check. The session was already validated by SessionAuthenticationFilter before this method.
-    if (!sessionValid) {
-      // Validate data access
-      // we don't have a cross table access control rule so only ADMIN can make request to multi-stage engine.
-      AccessControl accessControl = _accessControlFactory.create();
-      if (!accessControl.hasAccess(AccessType.READ, httpHeaders, "/sql")) {
-        throw new WebApplicationException("Permission denied", Response.Status.FORBIDDEN);
-      }
+      String traceEnabled) {
+    // Validate data access
+    // we don't have a cross table access control rule so only ADMIN can make request to multi-stage engine.
+    AccessControl accessControl = _accessControlFactory.create();
+    if (!accessControl.hasAccess(AccessType.READ, httpHeaders, "/sql")) {
+      throw new WebApplicationException("Permission denied", Response.Status.FORBIDDEN);
     }
 
     Map<String, String> queryOptionsMap = RequestUtils.parseQuery(query).getOptions();
@@ -525,7 +498,7 @@ public class PinotQueryResource {
   }
 
   private StreamingOutput getQueryResponse(String query, @Nullable SqlNode sqlNode, String traceEnabled,
-      String queryOptions, HttpHeaders httpHeaders, boolean sessionValid) {
+      String queryOptions, HttpHeaders httpHeaders) {
     // Get resource table name.
     String tableName;
     Map<String, String> queryOptionsMap = RequestUtils.parseQuery(query).getOptions();
@@ -558,14 +531,10 @@ public class PinotQueryResource {
     }
     String rawTableName = TableNameBuilder.extractRawTableName(tableName);
 
-    // SESSION WORKFLOW: If the request has a valid session cookie, skip the Authorization-header
-    // access check. The session was already validated by SessionAuthenticationFilter before this method.
-    if (!sessionValid) {
-      // Validate data access
-      AccessControl accessControl = _accessControlFactory.create();
-      if (!accessControl.hasAccess(rawTableName, AccessType.READ, httpHeaders, Actions.Table.QUERY)) {
-        throw QueryErrorCode.ACCESS_DENIED.asException();
-      }
+    // Validate data access
+    AccessControl accessControl = _accessControlFactory.create();
+    if (!accessControl.hasAccess(rawTableName, AccessType.READ, httpHeaders, Actions.Table.QUERY)) {
+      throw QueryErrorCode.ACCESS_DENIED.asException();
     }
 
     // Get brokers for the resource table.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
@@ -422,7 +423,7 @@ public class PinotQueryResource {
             ? getMultiStageQueryResponse(sqlQuery, queryOptions, httpHeaders, traceEnabled)
             : getQueryResponse(sqlQuery, sqlNodeAndOptions.getSqlNode(), traceEnabled, queryOptions, httpHeaders);
       case DML:
-        Map<String, String> headers = extractHeaders(httpHeaders);
+        Map<String, String> headers = buildBrokerHeaders(httpHeaders);
         return output -> {
           try (OutputStream os = output) {
             _sqlQueryExecutor.executeDMLStatement(sqlNodeAndOptions, headers).toOutputStream(os);
@@ -615,9 +616,7 @@ public class PinotQueryResource {
     String url = getQueryURL(protocol, hostName, port);
     ObjectNode requestJson = getRequestJson(query, traceEnabled, queryOptions);
 
-    // Forward client-supplied headers, then inject session credential for broker auth.
-    Map<String, String> headers = extractHeaders(httpHeaders);
-    injectSessionCredentialIfNeeded(headers, httpHeaders);
+    Map<String, String> headers = buildBrokerHeaders(httpHeaders);
 
     return sendRequestRaw(url, "POST", query, requestJson, headers);
   }
@@ -753,9 +752,7 @@ public class PinotQueryResource {
     String protocol = _controllerConf.getControllerBrokerProtocol();
     int port = getPort(instanceConfig);
 
-    // Forward client-supplied headers, then inject session credential for broker auth.
-    Map<String, String> headers = extractHeaders(httpHeaders);
-    injectSessionCredentialIfNeeded(headers, httpHeaders);
+    Map<String, String> headers = buildBrokerHeaders(httpHeaders);
 
     if (useBrokerCompatibleApi) {
       // Use POST /query/timeseries endpoint (broker compatible API)
@@ -815,31 +812,36 @@ public class PinotQueryResource {
   }
 
   /**
-   * Injects the stored Basic-auth token from the server-side session store into the forwarded
-   * broker request headers. This is needed because browser UI requests carry only the session
-   * cookie, not an Authorization header; the broker still requires one for server-to-server auth.
+   * Builds the header map to forward to the broker. Resolves any server-side session credential
+   * exactly once: if the request carries a valid session cookie, the caller-supplied Authorization
+   * header is replaced with the stored session token; otherwise all headers (including Authorization)
+   * are forwarded unchanged so that API clients keep their own credentials.
    */
-  private void injectSessionCredentialIfNeeded(Map<String, String> headers, HttpHeaders httpHeaders) {
-    if (_sessionManager == null || _controllerConf == null
-        || !_controllerConf.getProperty(ControllerConf.CONTROLLER_UI_SESSION_ENABLED, false)) {
-      return;
-    }
-    Cookie sessionCookie = httpHeaders.getCookies().get(SessionManager.SESSION_COOKIE_NAME);
-    if (sessionCookie != null && sessionCookie.getValue() != null) {
-      _sessionManager.getBasicAuthToken(sessionCookie.getValue()).ifPresent(
-          authToken -> headers.put(HttpHeaders.AUTHORIZATION, authToken));
-    }
+  private Map<String, String> buildBrokerHeaders(HttpHeaders httpHeaders) {
+    Optional<String> sessionCredential = resolveSessionCredential(httpHeaders);
+    Map<String, String> headers = httpHeaders.getRequestHeaders().entrySet().stream()
+        .filter(entry -> !entry.getValue().isEmpty())
+        .filter(entry -> !sessionCredential.isPresent() || !entry.getKey().equalsIgnoreCase(HttpHeaders.AUTHORIZATION))
+        .collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().get(0)));
+    sessionCredential.ifPresent(token -> headers.put(HttpHeaders.AUTHORIZATION, token));
+    return headers;
   }
 
-  private Map<String, String> extractHeaders(HttpHeaders httpHeaders) {
-    // In SESSION mode, exclude the Authorization header from being forwarded to the broker.
-    // The stored session credential is injected separately via injectSessionCredentialIfNeeded().
-    boolean isSessionMode = _controllerConf != null
-        && _controllerConf.getProperty(ControllerConf.CONTROLLER_UI_SESSION_ENABLED, false);
-    return httpHeaders.getRequestHeaders().entrySet().stream()
-        .filter(entry -> !entry.getValue().isEmpty())
-        .filter(entry -> !isSessionMode || !entry.getKey().equalsIgnoreCase(HttpHeaders.AUTHORIZATION))
-        .collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().get(0)));
+  /**
+   * Returns the stored Basic-auth token for the session cookie carried by this request, or
+   * {@code Optional.empty()} if session mode is disabled, no cookie is present, or the session
+   * has expired.
+   */
+  private Optional<String> resolveSessionCredential(HttpHeaders httpHeaders) {
+    if (_sessionManager == null || _controllerConf == null
+        || !_controllerConf.getProperty(ControllerConf.CONTROLLER_UI_SESSION_ENABLED, false)) {
+      return Optional.empty();
+    }
+    Cookie sessionCookie = httpHeaders.getCookies().get(SessionManager.SESSION_COOKIE_NAME);
+    if (sessionCookie == null || sessionCookie.getValue() == null) {
+      return Optional.empty();
+    }
+    return _sessionManager.getBasicAuthToken(sessionCookie.getValue());
   }
 
   private InstanceConfig getInstanceConfig(String instanceId) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -615,23 +615,9 @@ public class PinotQueryResource {
     String url = getQueryURL(protocol, hostName, port);
     ObjectNode requestJson = getRequestJson(query, traceEnabled, queryOptions);
 
-    // Forward client-supplied headers
+    // Forward client-supplied headers, then inject session credential for broker auth.
     Map<String, String> headers = extractHeaders(httpHeaders);
-
-    // SESSION WORKFLOW: Inject Authorization header for broker (server-to-server).
-    // Browser UI requests carry only the HttpOnly session cookie – no Authorization header.
-    // The broker requires auth, so we retrieve the stored Basic-auth token from the session
-    // and inject it as an Authorization header for the controller→broker request.
-    // This token is stored server-side only (never sent to the browser).
-    if (_sessionManager != null
-        && _controllerConf != null
-        && _controllerConf.getProperty(ControllerConf.CONTROLLER_UI_SESSION_ENABLED, false)) {
-      Cookie sessionCookie = httpHeaders.getCookies().get(SessionManager.SESSION_COOKIE_NAME);
-      if (sessionCookie != null && sessionCookie.getValue() != null) {
-        _sessionManager.getBasicAuthToken(sessionCookie.getValue()).ifPresent(
-            authToken -> headers.put(HttpHeaders.AUTHORIZATION, authToken));
-      }
-    }
+    injectSessionCredentialIfNeeded(headers, httpHeaders);
 
     return sendRequestRaw(url, "POST", query, requestJson, headers);
   }
@@ -767,8 +753,9 @@ public class PinotQueryResource {
     String protocol = _controllerConf.getControllerBrokerProtocol();
     int port = getPort(instanceConfig);
 
-    // Forward client-supplied headers
+    // Forward client-supplied headers, then inject session credential for broker auth.
     Map<String, String> headers = extractHeaders(httpHeaders);
+    injectSessionCredentialIfNeeded(headers, httpHeaders);
 
     if (useBrokerCompatibleApi) {
       // Use POST /query/timeseries endpoint (broker compatible API)
@@ -827,9 +814,26 @@ public class PinotQueryResource {
     }
   }
 
+  /**
+   * Injects the stored Basic-auth token from the server-side session store into the forwarded
+   * broker request headers. This is needed because browser UI requests carry only the session
+   * cookie, not an Authorization header; the broker still requires one for server-to-server auth.
+   */
+  private void injectSessionCredentialIfNeeded(Map<String, String> headers, HttpHeaders httpHeaders) {
+    if (_sessionManager == null || _controllerConf == null
+        || !_controllerConf.getProperty(ControllerConf.CONTROLLER_UI_SESSION_ENABLED, false)) {
+      return;
+    }
+    Cookie sessionCookie = httpHeaders.getCookies().get(SessionManager.SESSION_COOKIE_NAME);
+    if (sessionCookie != null && sessionCookie.getValue() != null) {
+      _sessionManager.getBasicAuthToken(sessionCookie.getValue()).ifPresent(
+          authToken -> headers.put(HttpHeaders.AUTHORIZATION, authToken));
+    }
+  }
+
   private Map<String, String> extractHeaders(HttpHeaders httpHeaders) {
     // In SESSION mode, exclude the Authorization header from being forwarded to the broker.
-    // The broker auth is injected server-side from the session store in sendRequestToBroker().
+    // The stored session credential is injected separately via injectSessionCredentialIfNeeded().
     boolean isSessionMode = _controllerConf != null
         && _controllerConf.getProperty(ControllerConf.CONTROLLER_UI_SESSION_ENABLED, false);
     return httpHeaders.getRequestHeaders().entrySet().stream()

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSessionLoginResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSessionLoginResource.java
@@ -1,0 +1,375 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.api.access.AccessControl;
+import org.apache.pinot.controller.api.access.AccessControlFactory;
+import org.apache.pinot.controller.api.access.AccessType;
+import org.apache.pinot.controller.api.access.SessionManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * REST resource for session-based UI authentication.
+ *
+ * <p><strong>Architecture (Trino/Ambari-style):</strong>
+ * <p>This resource is a <em>session layer</em> that sits on top of ANY configured
+ * {@link AccessControlFactory}. It does NOT require a specific factory class.
+ * Whether you use {@code BasicAuthAccessControlFactory}, {@code ZkBasicAuthAccessControlFactory},
+ * {@code PasswordAuthAccessControlFactory} (LDAP), or any custom factory — this session
+ * layer works with all of them.
+ *
+ * <p><strong>How it works:</strong>
+ * <ol>
+ *   <li>UI calls {@code GET /auth/info} → receives {@code {"workflow":"SESSION"}} when
+ *       {@code controller.ui.session.enabled=true}</li>
+ *   <li>UI shows login form → user enters username/password</li>
+ *   <li>UI POSTs to {@code POST /auth/login} (form-encoded, NOT Basic auth header)</li>
+ *   <li>This resource builds a synthetic Basic-auth header and calls the configured
+ *       {@link AccessControl#hasAccess} to validate credentials against whatever
+ *       backend is configured (Basic, LDAP, ZK, etc.)</li>
+ *   <li>On success: creates a server-side session → sets an HttpOnly cookie</li>
+ *   <li>Subsequent requests: browser sends cookie automatically, NO Authorization header</li>
+ *   <li>{@code GET /auth/logout}: immediately invalidates the server-side session</li>
+ * </ol>
+ *
+ * <p><strong>Key security properties:</strong>
+ * <ul>
+ *   <li>Credentials are NOT visible in browser dev-tools network tab</li>
+ *   <li>Cookie is HttpOnly (JS cannot read it → prevents XSS token theft)</li>
+ *   <li>Logout immediately invalidates the session server-side</li>
+ *   <li>Session expires automatically after 8 hours</li>
+ * </ul>
+ */
+@Api(tags = "Auth")
+@Path("/")
+public class PinotSessionLoginResource {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotSessionLoginResource.class);
+
+  /** Path for the login endpoint. */
+  public static final String AUTH_LOGIN_PATH = "auth/login";
+
+  /** Path for the logout endpoint. */
+  public static final String AUTH_LOGOUT_PATH = "auth/logout";
+
+  /** Path for the session-check endpoint. */
+  public static final String AUTH_SESSION_PATH = "auth/session";
+
+  @Inject
+  private AccessControlFactory _accessControlFactory;
+
+  @Inject
+  private SessionManager _sessionManager;
+
+  @Inject
+  private ControllerConf _controllerConf;
+
+  // ---------------------------------------------------------------------------
+  // POST /auth/login
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Validates username/password using the configured {@link AccessControlFactory}
+   * (works with BasicAuth, ZkBasicAuth, LDAP/PasswordAuth, or any custom factory)
+   * and on success creates a server-side session and returns an HttpOnly cookie.
+   *
+   * <p>This is the Trino/Ambari pattern: the session layer is independent of the
+   * auth backend. The same login endpoint works regardless of which factory is configured.
+   */
+  @POST
+  @Path(AUTH_LOGIN_PATH)
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Login with username and password to obtain a session cookie")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Login successful – session cookie set"),
+      @ApiResponse(code = 401, message = "Invalid credentials")
+  })
+  public Response login(
+      @ApiParam(value = "Username", required = true) @FormParam("username") String username,
+      @ApiParam(value = "Password", required = true) @FormParam("password") String password) {
+
+    if (username == null || username.trim().isEmpty()) {
+      return Response.status(Response.Status.BAD_REQUEST)
+          .entity("{\"error\":\"username is required\"}")
+          .build();
+    }
+
+    // Build a Basic-auth header to validate credentials via the configured AccessControl.
+    // This works with ANY AccessControlFactory:
+    //   - BasicAuthAccessControlFactory: validates against in-memory principals
+    //   - ZkBasicAuthAccessControlFactory: validates against ZooKeeper-stored principals
+    //   - PasswordAuthAccessControlFactory: validates against LDAP or other password backends
+    //   - Any custom factory that implements hasAccess()
+    String basicAuthToken = "Basic " + Base64.getEncoder()
+        .encodeToString((username + ":" + (password == null ? "" : password))
+            .getBytes(StandardCharsets.UTF_8));
+
+    AccessControl accessControl = _accessControlFactory.create();
+    boolean valid;
+    try {
+      valid = accessControl.hasAccess(null, AccessType.READ,
+          new SyntheticHttpHeaders(basicAuthToken), AUTH_LOGIN_PATH);
+    } catch (javax.ws.rs.NotAuthorizedException e) {
+      valid = false;
+    } catch (Exception e) {
+      LOGGER.warn("Unexpected error during login for user '{}': {}", username, e.getMessage());
+      valid = false;
+    }
+
+    if (!valid) {
+      LOGGER.warn("Failed login attempt for user '{}'", username);
+      return Response.status(Response.Status.UNAUTHORIZED)
+          .entity("{\"error\":\"Invalid username or password\"}")
+          .build();
+    }
+
+    // Credentials are valid – create a server-side session.
+    // Store the Basic-auth token server-side so the controller can inject it as an
+    // Authorization header when forwarding queries to the broker (server-to-server).
+    // This token is NEVER sent to the browser – it stays in server memory only.
+    String sessionToken = _sessionManager.createSession(username.trim(), basicAuthToken);
+    LOGGER.info("User '{}' logged in successfully", username);
+
+    boolean secureCookie = _controllerConf == null
+        || _controllerConf.getProperty(ControllerConf.CONTROLLER_UI_SESSION_COOKIE_SECURE, true);
+    String sessionCookieHeader = buildSessionCookieHeader(
+        sessionToken, (int) _sessionManager.getSessionTtlSeconds(), secureCookie);
+
+    return Response.ok("{\"status\":\"ok\",\"username\":\"" + username.trim() + "\"}")
+        .header("Set-Cookie", sessionCookieHeader)
+        .build();
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /auth/logout
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Invalidates the server-side session immediately and clears the session cookie.
+   *
+   * <p>This is proper Ambari/Trino-style logout: the session is removed from the
+   * server store immediately. Even if someone captured the cookie, they cannot reuse it.
+   * This is the key difference from stateless JWT: the server can revoke access instantly.
+   */
+  @GET
+  @Path(AUTH_LOGOUT_PATH)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Logout and invalidate the current session")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Logout successful – session invalidated")
+  })
+  public Response logout(@Context HttpHeaders httpHeaders) {
+    Cookie sessionCookie = httpHeaders.getCookies().get(SessionManager.SESSION_COOKIE_NAME);
+    if (sessionCookie != null && sessionCookie.getValue() != null) {
+      _sessionManager.invalidateSession(sessionCookie.getValue());
+      LOGGER.info("Session invalidated on logout");
+    }
+
+    // Return a delete-cookie (Max-Age=0) to clear it from the browser
+    String deleteCookieHeader = buildDeleteCookieHeader();
+
+    return Response.ok("{\"status\":\"logged_out\"}")
+        .header("Set-Cookie", deleteCookieHeader)
+        .build();
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /auth/session
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Returns the current session status (username) if a valid session cookie is present.
+   *
+   * <p>Used by the UI to:
+   * <ol>
+   *   <li>Check whether the user is still authenticated after a page refresh</li>
+   *   <li>Periodically verify session validity (every 5 minutes) to detect expiry</li>
+   * </ol>
+   *
+   * <p>Returns 401 when the session has expired, triggering a redirect to the login page.
+   */
+  @GET
+  @Path(AUTH_SESSION_PATH)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Check current session validity")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Session is valid"),
+      @ApiResponse(code = 401, message = "No valid session – session expired or not authenticated")
+  })
+  public Response checkSession(@Context HttpHeaders httpHeaders) {
+    Cookie sessionCookie = httpHeaders.getCookies().get(SessionManager.SESSION_COOKIE_NAME);
+    if (sessionCookie == null || sessionCookie.getValue() == null) {
+      return Response.status(Response.Status.UNAUTHORIZED)
+          .entity("{\"error\":\"No session\"}")
+          .build();
+    }
+
+    Optional<String> username = _sessionManager.getUsername(sessionCookie.getValue());
+    if (!username.isPresent()) {
+      // Session expired – return 401 so the UI redirects to login
+      return Response.status(Response.Status.UNAUTHORIZED)
+          .entity("{\"error\":\"Session expired\"}")
+          .build();
+    }
+
+    return Response.ok("{\"status\":\"ok\",\"username\":\"" + username.get() + "\"}")
+        .build();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Cookie helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Builds a raw {@code Set-Cookie} header value for the session cookie.
+   *
+   * <p>We construct the header manually (instead of using {@link javax.ws.rs.core.NewCookie})
+   * because JAX-RS 2 {@code NewCookie} does not support the {@code SameSite} attribute.
+   * {@code SameSite=Strict} is required to prevent CSRF attacks: the browser will only send
+   * the cookie when the request originates from the same site (Pinot UI itself), blocking
+   * forged cross-site requests from attacker-controlled pages.
+   */
+  private static String buildSessionCookieHeader(String token, int maxAgeSeconds, boolean secure) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(SessionManager.SESSION_COOKIE_NAME).append('=').append(token);
+    sb.append("; Path=/");
+    sb.append("; Max-Age=").append(maxAgeSeconds);
+    sb.append("; HttpOnly");
+    sb.append("; SameSite=Strict");
+    if (secure) {
+      sb.append("; Secure");
+    }
+    return sb.toString();
+  }
+
+  /** Builds a {@code Set-Cookie} header that instructs the browser to delete the session cookie. */
+  private static String buildDeleteCookieHeader() {
+    return SessionManager.SESSION_COOKIE_NAME + "=deleted"
+        + "; Path=/"
+        + "; Max-Age=0"
+        + "; HttpOnly"
+        + "; SameSite=Strict";
+  }
+
+  // ---------------------------------------------------------------------------
+  // Synthetic HttpHeaders for credential validation
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Minimal {@link HttpHeaders} implementation that carries only the Authorization header.
+   *
+   * <p>Used to validate credentials via the configured {@link AccessControl#hasAccess}
+   * without requiring an actual HTTP request with an Authorization header. This allows
+   * the session login endpoint to work with ANY AccessControlFactory implementation.
+   */
+  private static final class SyntheticHttpHeaders implements HttpHeaders {
+    private final String _authorizationValue;
+
+    SyntheticHttpHeaders(String authorizationValue) {
+      _authorizationValue = authorizationValue;
+    }
+
+    @Override
+    public List<String> getRequestHeader(String name) {
+      if (HttpHeaders.AUTHORIZATION.equalsIgnoreCase(name)
+          || "authorization".equalsIgnoreCase(name)) {
+        return Collections.singletonList(_authorizationValue);
+      }
+      return Collections.emptyList();
+    }
+
+    @Override
+    public String getHeaderString(String name) {
+      List<String> values = getRequestHeader(name);
+      return values.isEmpty() ? null : values.get(0);
+    }
+
+    @Override
+    public MultivaluedMap<String, String> getRequestHeaders() {
+      MultivaluedMap<String, String> map = new MultivaluedHashMap<>();
+      map.put(HttpHeaders.AUTHORIZATION, Collections.singletonList(_authorizationValue));
+      return map;
+    }
+
+    @Override
+    public List<javax.ws.rs.core.MediaType> getAcceptableMediaTypes() {
+      return Collections.singletonList(javax.ws.rs.core.MediaType.WILDCARD_TYPE);
+    }
+
+    @Override
+    public List<java.util.Locale> getAcceptableLanguages() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public javax.ws.rs.core.MediaType getMediaType() {
+      return null;
+    }
+
+    @Override
+    public java.util.Locale getLanguage() {
+      return null;
+    }
+
+    @Override
+    public Map<String, Cookie> getCookies() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public java.util.Date getDate() {
+      return null;
+    }
+
+    @Override
+    public int getLength() {
+      return -1;
+    }
+  }
+}
+

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSessionLoginResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSessionLoginResource.java
@@ -99,6 +99,9 @@ public class PinotSessionLoginResource {
   /** Path for the session-check endpoint. */
   public static final String AUTH_SESSION_PATH = "auth/session";
 
+  /** Path for the session-renew endpoint. */
+  public static final String AUTH_SESSION_RENEW_PATH = "auth/session/renew";
+
   @Inject
   private AccessControlFactory _accessControlFactory;
 
@@ -180,7 +183,7 @@ public class PinotSessionLoginResource {
     String sessionCookieHeader = buildSessionCookieHeader(
         sessionToken, (int) _sessionManager.getSessionTtlSeconds(), secureCookie);
 
-    return Response.ok("{\"status\":\"ok\",\"username\":\"" + username.trim() + "\"}")
+    return Response.ok("{\"status\":\"ok\",\"username\":\"" + escapeJson(username.trim()) + "\"}")
         .header("Set-Cookie", sessionCookieHeader)
         .build();
   }
@@ -210,8 +213,11 @@ public class PinotSessionLoginResource {
       LOGGER.info("Session invalidated on logout");
     }
 
-    // Return a delete-cookie (Max-Age=0) to clear it from the browser
-    String deleteCookieHeader = buildDeleteCookieHeader();
+    // Return a delete-cookie (Max-Age=0) to clear it from the browser.
+    // Carry the Secure flag so the deletion header matches the original set-cookie.
+    boolean secureCookie = _controllerConf == null
+        || _controllerConf.getProperty(ControllerConf.CONTROLLER_UI_SESSION_COOKIE_SECURE, true);
+    String deleteCookieHeader = buildDeleteCookieHeader(secureCookie);
 
     return Response.ok("{\"status\":\"logged_out\"}")
         .header("Set-Cookie", deleteCookieHeader)
@@ -257,7 +263,62 @@ public class PinotSessionLoginResource {
           .build();
     }
 
-    return Response.ok("{\"status\":\"ok\",\"username\":\"" + username.get() + "\"}")
+    return Response.ok("{\"status\":\"ok\",\"username\":\"" + escapeJson(username.get()) + "\"}")
+        .build();
+  }
+
+  // ---------------------------------------------------------------------------
+  // POST /auth/session/renew
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Renews the current session by issuing a fresh token with a new fixed TTL.
+   *
+   * <p>This is the server-side counterpart of the UI's "Stay Logged In" action. The old token is
+   * invalidated and a new one with a full TTL is returned via {@code Set-Cookie}, keeping both
+   * the server entry and the browser cookie in sync.
+   *
+   * <p>Returns 401 when the current session cookie is absent or has already expired.
+   */
+  @POST
+  @Path(AUTH_SESSION_RENEW_PATH)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Renew the current session, issuing a fresh token and resetting the TTL")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Session renewed – new cookie set"),
+      @ApiResponse(code = 401, message = "No valid session to renew")
+  })
+  public Response renewSession(@Context HttpHeaders httpHeaders) {
+    Cookie sessionCookie = httpHeaders.getCookies().get(SessionManager.SESSION_COOKIE_NAME);
+    if (sessionCookie == null || sessionCookie.getValue() == null) {
+      return Response.status(Response.Status.UNAUTHORIZED)
+          .entity("{\"error\":\"No session\"}")
+          .build();
+    }
+
+    // rotateSession() atomically invalidates the old token and creates a fresh one,
+    // preventing orphaned tokens from concurrent "Stay Logged In" clicks.
+    String oldToken = sessionCookie.getValue();
+    Optional<String> usernameOpt = _sessionManager.getUsername(oldToken);
+    Optional<String> newTokenOpt = _sessionManager.rotateSession(oldToken);
+    if (!newTokenOpt.isPresent()) {
+      // Session was absent, expired, or already rotated by a concurrent request.
+      return Response.status(Response.Status.UNAUTHORIZED)
+          .entity("{\"error\":\"Session expired\"}")
+          .build();
+    }
+
+    String username = usernameOpt.orElse("unknown");
+    String newToken = newTokenOpt.get();
+    LOGGER.info("Session renewed for user '{}'", username);
+
+    boolean secureCookie = _controllerConf == null
+        || _controllerConf.getProperty(ControllerConf.CONTROLLER_UI_SESSION_COOKIE_SECURE, true);
+    String sessionCookieHeader = buildSessionCookieHeader(
+        newToken, (int) _sessionManager.getSessionTtlSeconds(), secureCookie);
+
+    return Response.ok("{\"status\":\"renewed\",\"username\":\"" + escapeJson(username) + "\"}")
+        .header("Set-Cookie", sessionCookieHeader)
         .build();
   }
 
@@ -287,13 +348,23 @@ public class PinotSessionLoginResource {
     return sb.toString();
   }
 
+  /** Escapes {@code "} and {@code \} so the value can be safely embedded in a JSON string literal. */
+  private static String escapeJson(String value) {
+    return value.replace("\\", "\\\\").replace("\"", "\\\"");
+  }
+
   /** Builds a {@code Set-Cookie} header that instructs the browser to delete the session cookie. */
-  private static String buildDeleteCookieHeader() {
-    return SessionManager.SESSION_COOKIE_NAME + "=deleted"
-        + "; Path=/"
-        + "; Max-Age=0"
-        + "; HttpOnly"
-        + "; SameSite=Strict";
+  private static String buildDeleteCookieHeader(boolean secure) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(SessionManager.SESSION_COOKIE_NAME).append("=deleted");
+    sb.append("; Path=/");
+    sb.append("; Max-Age=0");
+    sb.append("; HttpOnly");
+    sb.append("; SameSite=Strict");
+    if (secure) {
+      sb.append("; Secure");
+    }
+    return sb.toString();
   }
 
   // ---------------------------------------------------------------------------

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSessionLoginResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSessionLoginResource.java
@@ -152,7 +152,7 @@ public class PinotSessionLoginResource {
     AccessControl accessControl = _accessControlFactory.create();
     boolean valid;
     try {
-      valid = accessControl.hasAccess(null, AccessType.READ,
+      valid = accessControl.hasAccess(AccessType.READ,
           new SyntheticHttpHeaders(basicAuthToken), AUTH_LOGIN_PATH);
     } catch (javax.ws.rs.NotAuthorizedException e) {
       valid = false;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSessionLoginResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSessionLoginResource.java
@@ -320,7 +320,7 @@ public class PinotSessionLoginResource {
           || "authorization".equalsIgnoreCase(name)) {
         return Collections.singletonList(_authorizationValue);
       }
-      return Collections.emptyList();
+      return List.of();
     }
 
     @Override
@@ -343,7 +343,7 @@ public class PinotSessionLoginResource {
 
     @Override
     public List<java.util.Locale> getAcceptableLanguages() {
-      return Collections.emptyList();
+      return List.of();
     }
 
     @Override
@@ -358,7 +358,7 @@ public class PinotSessionLoginResource {
 
     @Override
     public Map<String, Cookie> getCookies() {
-      return Collections.emptyMap();
+      return Map.of();
     }
 
     @Override
@@ -372,4 +372,3 @@ public class PinotSessionLoginResource {
     }
   }
 }
-

--- a/pinot-controller/src/main/resources/app/App.tsx
+++ b/pinot-controller/src/main/resources/app/App.tsx
@@ -84,6 +84,10 @@ export const App = () => {
 
   const performSessionLogout = async () => {
     setShowTimeoutWarning(false);
+    // Clear all timers so no further callbacks fire after logout
+    if (inactivityTimerRef.current) clearTimeout(inactivityTimerRef.current);
+    if (warningTimerRef.current) clearTimeout(warningTimerRef.current);
+    if (countdownIntervalRef.current) clearInterval(countdownIntervalRef.current);
     try {
       await fetch('/auth/logout', { method: 'GET', credentials: 'include' });
     } catch (e) {
@@ -269,15 +273,20 @@ export const App = () => {
         <DialogTitle>Session Expiring Soon</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            Your session will expire in {warningCountdown} second{warningCountdown !== 1 ? 's' : ''} due to inactivity.
+            Your session will expire in {warningCountdown} second{warningCountdown !== 1 ? 's' : ''}.
           </DialogContentText>
         </DialogContent>
         <DialogActions>
           <Button
             onClick={async () => {
-              // Slide the server-side TTL without logging out
-              await fetch('/auth/session', { credentials: 'include' });
-              resetInactivityTimer();
+              // Renew the server-side session (rotates token, resets TTL on both server and cookie)
+              const res = await fetch('/auth/session/renew', { method: 'POST', credentials: 'include' });
+              if (res.ok) {
+                resetInactivityTimer();
+              } else {
+                // Session expired before the user responded — redirect to login
+                performSessionLogout();
+              }
             }}
             color="primary"
           >

--- a/pinot-controller/src/main/resources/app/App.tsx
+++ b/pinot-controller/src/main/resources/app/App.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Switch, Route, Redirect, useHistory } from 'react-router-dom';
 import Layout from './components/Layout';
 import RouterData from './router';
@@ -26,6 +26,12 @@ import app_state from './app_state';
 import { useAuthProvider } from './components/auth/AuthProvider';
 import { AppLoadingIndicator } from './components/AppLoadingIndicator';
 import { AuthWorkflow } from 'Models';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
 import { TimezoneProvider } from './contexts/TimezoneContext';
 import { runBootstrapRequest } from './utils/bootstrap';
 
@@ -38,14 +44,13 @@ export const App = () => {
   const [loading, setLoading] = useState(true);
   const [isAuthenticated, setIsAuthenticated] = useState(null);
   const [role, setRole] = useState('');
-  const { authUserName, authUserEmail, authenticated, authWorkflow } = useAuthProvider();
+  const { authUserName, authUserEmail, authenticated, authWorkflow, inactivityTimeoutSeconds } = useAuthProvider();
   const history = useHistory();
 
   useEffect(() => {
     // authentication already handled by authProvider
     if (authUserEmail && authenticated) {
       // Authenticated with an auth method that supports user identity
-      // Any code that needs user identity can go here
     }
 
     if (authenticated) {
@@ -54,10 +59,77 @@ export const App = () => {
   }, [authUserName, authUserEmail, authenticated]);
 
   useEffect(() => {
-    if(authWorkflow === AuthWorkflow.BASIC) {
+    // Both BASIC and SESSION workflows are handled by the login page.
+    if (authWorkflow === AuthWorkflow.BASIC || authWorkflow === AuthWorkflow.SESSION) {
       setLoading(false);
     }
-  }, [authWorkflow])
+  }, [authWorkflow]);
+
+  // ─── SESSION INACTIVITY TIMEOUT ───────────────────────────────────────────
+  // Timeout duration comes from /auth/info (controller.ui.session.inactivity.timeout.seconds).
+  // Falls back to 300s (5 min) if not set.
+  //
+  // Timeline:
+  //   t=0           user active
+  //   t=timeout-60s show warning dialog with 60s countdown
+  //   t=timeout     call /auth/logout (server invalidates session), redirect to /login
+  //
+  // Any user interaction (mouse/key/click/scroll) resets the full timer.
+
+  const [showTimeoutWarning, setShowTimeoutWarning] = useState<boolean>(false);
+  const [warningCountdown, setWarningCountdown] = useState<number>(60);
+  const inactivityTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const warningTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const countdownIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const performSessionLogout = async () => {
+    setShowTimeoutWarning(false);
+    try {
+      await fetch('/auth/logout', { method: 'GET', credentials: 'include' });
+    } catch (e) {
+      // Even on network error, clear local state and redirect
+    }
+    app_state.authToken = null;
+    app_state.authWorkflow = null;
+    app_state.username = null;
+    setIsAuthenticated(false);
+    window.location.href = '/#/login';
+  };
+
+  const resetInactivityTimer = () => {
+    if (inactivityTimerRef.current) clearTimeout(inactivityTimerRef.current);
+    if (warningTimerRef.current) clearTimeout(warningTimerRef.current);
+    if (countdownIntervalRef.current) clearInterval(countdownIntervalRef.current);
+    setShowTimeoutWarning(false);
+
+    const timeoutMs = (inactivityTimeoutSeconds > 0 ? inactivityTimeoutSeconds : 300) * 1000;
+    const warningMs = Math.max(0, timeoutMs - 60000);
+
+    warningTimerRef.current = setTimeout(() => {
+      setWarningCountdown(60);
+      setShowTimeoutWarning(true);
+      countdownIntervalRef.current = setInterval(() => {
+        setWarningCountdown((c) => c - 1);
+      }, 1000);
+    }, warningMs);
+
+    inactivityTimerRef.current = setTimeout(performSessionLogout, timeoutMs);
+  };
+
+  useEffect(() => {
+    if (authWorkflow !== AuthWorkflow.SESSION || !isAuthenticated) return;
+
+    const events = ['mousedown', 'keydown', 'click', 'scroll', 'touchstart'];
+    events.forEach((e) => window.addEventListener(e, resetInactivityTimer));
+    resetInactivityTimer();
+
+    return () => {
+      events.forEach((e) => window.removeEventListener(e, resetInactivityTimer));
+      if (inactivityTimerRef.current) clearTimeout(inactivityTimerRef.current);
+      if (warningTimerRef.current) clearTimeout(warningTimerRef.current);
+      if (countdownIntervalRef.current) clearInterval(countdownIntervalRef.current);
+    };
+  }, [authWorkflow, isAuthenticated, inactivityTimeoutSeconds]);
 
   const applyClusterConfig = (clusterConfig?: Record<string, string>) => {
     const nextQueryConsoleOnlyView = clusterConfig?.queryConsoleOnlyView === 'true';
@@ -192,6 +264,30 @@ export const App = () => {
 
   return (
     <TimezoneProvider>
+      {/* SESSION inactivity warning dialog */}
+      <Dialog open={showTimeoutWarning} disableBackdropClick disableEscapeKeyDown>
+        <DialogTitle>Session Expiring Soon</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Your session will expire in {warningCountdown} second{warningCountdown !== 1 ? 's' : ''} due to inactivity.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={async () => {
+              // Slide the server-side TTL without logging out
+              await fetch('/auth/session', { credentials: 'include' });
+              resetInactivityTimer();
+            }}
+            color="primary"
+          >
+            Stay Logged In
+          </Button>
+          <Button onClick={performSessionLogout} color="secondary">
+            Logout Now
+          </Button>
+        </DialogActions>
+      </Dialog>
       <Switch>
         {getRouterData().map(({ path, Component }, key) => (
           <Route

--- a/pinot-controller/src/main/resources/app/Models.ts
+++ b/pinot-controller/src/main/resources/app/Models.ts
@@ -37,6 +37,13 @@ export enum AuthWorkflow {
   NONE = 'NONE',
   BASIC = 'BASIC',
   OIDC = 'OIDC',
+  /**
+   * SESSION workflow: credentials are validated once at POST /auth/login.
+   * The server issues an HttpOnly cookie. Subsequent requests carry the cookie automatically –
+   * no Authorization header is sent. Logout calls GET /auth/logout which immediately invalidates
+   * the server-side session (Trino/Ambari style).
+   */
+  SESSION = 'SESSION',
 }
 
 export enum AuthLocalStorageKeys {

--- a/pinot-controller/src/main/resources/app/components/Header.tsx
+++ b/pinot-controller/src/main/resources/app/components/Header.tsx
@@ -18,12 +18,15 @@
  */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { AppBar, Box, makeStyles, Paper } from '@material-ui/core';
+import { Link, useHistory } from 'react-router-dom';
+import { AppBar, Box, IconButton, makeStyles, Paper, Tooltip } from '@material-ui/core';
 import MenuIcon from '@material-ui/icons/Menu';
+import ExitToAppIcon from '@material-ui/icons/ExitToApp';
 import Logo from './SvgIcons/Logo';
 import BreadcrumbsComponent from './Breadcrumbs';
 import TimezoneSelector from './TimezoneSelector';
+import app_state from '../app_state';
+import { AuthWorkflow } from 'Models';
 
 type Props = {
   highlightSidebarLink: (id: number) => void;
@@ -100,6 +103,10 @@ const useStyles = makeStyles((theme) => ({
       fontWeight: 500
     }
   },
+  logoutButton: {
+    color: '#ffffff',
+    marginLeft: theme.spacing(1),
+  },
   timezoneContainer: {
     display: 'flex',
     alignItems: 'center',
@@ -130,6 +137,35 @@ const useStyles = makeStyles((theme) => ({
 
 const Header = ({ highlightSidebarLink, showHideSideBarHandler, openSidebar, clusterName, ...props }: Props) => {
   const classes = useStyles();
+  const history = useHistory();
+
+  const handleLogout = async () => {
+    if (app_state.authWorkflow === AuthWorkflow.SESSION) {
+      // SESSION logout: call the server to invalidate the session immediately.
+      // The server removes the session from its store and returns a Max-Age=0 cookie.
+      try {
+        await fetch('/auth/logout', {
+          method: 'GET',
+          credentials: 'include',
+        });
+      } catch (e) {
+        // Even if the request fails, clear local state and redirect
+      }
+      app_state.authToken = null;
+      app_state.authWorkflow = null;
+      app_state.username = null;
+      history.push('/login');
+    } else if (app_state.authWorkflow === AuthWorkflow.BASIC) {
+      app_state.authToken = null;
+      app_state.authWorkflow = null;
+      app_state.username = null;
+      history.push('/login');
+    }
+  };
+
+  const showLogout = app_state.authWorkflow === AuthWorkflow.SESSION
+    || app_state.authWorkflow === AuthWorkflow.BASIC;
+
   return (
     <AppBar position="static">
       <Box display="flex">
@@ -175,6 +211,13 @@ const Header = ({ highlightSidebarLink, showHideSideBarHandler, openSidebar, clu
               </a>
             </Box>
           </Box>
+          {showLogout && (
+            <Tooltip title="Logout">
+              <IconButton className={classes.logoutButton} onClick={handleLogout} size="small">
+                <ExitToAppIcon />
+              </IconButton>
+            </Tooltip>
+          )}
         </Box>
       </Box>
     </AppBar>

--- a/pinot-controller/src/main/resources/app/components/auth/AuthProvider.tsx
+++ b/pinot-controller/src/main/resources/app/components/auth/AuthProvider.tsx
@@ -29,7 +29,9 @@ interface AuthProviderContextProps {
     authUserName: string;
     authUserEmail: string;
     authenticated: boolean;
-    authWorkflow: AuthWorkflow
+    authWorkflow: AuthWorkflow;
+    /** UI inactivity timeout in seconds from controller config. -1 if not applicable (non-SESSION). */
+    inactivityTimeoutSeconds: number;
 }
 
 export const AuthProvider = ({ children }) => {
@@ -37,6 +39,7 @@ export const AuthProvider = ({ children }) => {
     const [redirectUri, setRedirectUri] = useState<string | null>(null);
     const [clientId, setClientId] = useState<string | null>(null);
     const [authWorkflow, setAuthWorkflow] = useState<AuthWorkflow | null>(null);
+    const [inactivityTimeoutSeconds, setInactivityTimeoutSeconds] = useState<number>(-1);
     const [accessToken, setAccessToken] = useState<string>("");
     const [authUserName, setAuthUserName] = useState<string>("");
     const [authUserEmail, setAuthUserEmail] = useState<string>("");
@@ -83,6 +86,13 @@ export const AuthProvider = ({ children }) => {
         // set auth workflow
         setAuthWorkflow(authWorkFlowInternal);
 
+        // Read inactivity timeout from auth/info response (SESSION workflow only).
+        if (authWorkFlowInternal === AuthWorkflow.SESSION
+            && authInfoResponse && authInfoResponse.inactivityTimeoutSeconds
+            && authInfoResponse.inactivityTimeoutSeconds > 0) {
+            setInactivityTimeoutSeconds(authInfoResponse.inactivityTimeoutSeconds);
+        }
+
         if (authWorkFlowInternal === AuthWorkflow.NONE) {
             // No authentication required
             setAuthenticated(true);
@@ -90,6 +100,23 @@ export const AuthProvider = ({ children }) => {
 
         if (authWorkFlowInternal === AuthWorkflow.BASIC) {
             // basic auth is handled by login page
+        }
+
+        if (authWorkFlowInternal === AuthWorkflow.SESSION) {
+            // Session auth: check if there is an active server-side session by calling /auth/session.
+            // The HttpOnly cookie is sent automatically by the browser – no JS token needed.
+            try {
+                const sessionResponse = await fetch('/auth/session', { credentials: 'include' });
+                if (sessionResponse.ok) {
+                    const sessionData = await sessionResponse.json();
+                    if (sessionData && sessionData.username) {
+                        setAuthenticated(true);
+                    }
+                }
+                // If not ok (401), the user needs to log in
+            } catch (e) {
+                // Network error – stay unauthenticated
+            }
         }
 
         // set OIDC auth details
@@ -223,7 +250,8 @@ export const AuthProvider = ({ children }) => {
         accessToken: accessToken,
         authUserName: authUserName,
         authUserEmail: authUserEmail,
-        authenticated: authenticated
+        authenticated: authenticated,
+        inactivityTimeoutSeconds: inactivityTimeoutSeconds,
     }
 
     if (loading) {

--- a/pinot-controller/src/main/resources/app/pages/LoginPage.tsx
+++ b/pinot-controller/src/main/resources/app/pages/LoginPage.tsx
@@ -24,6 +24,7 @@ import { useForm } from 'react-hook-form';
 import PinotMethodUtils from '../utils/PinotMethodUtils';
 import app_state from '../app_state';
 import { AuthWorkflow } from 'Models';
+import { useAuthProvider } from '../components/auth/AuthProvider';
 
 interface FormData {
   username: string;
@@ -71,11 +72,51 @@ const useStyles = makeStyles((theme: Theme) => {
 const LoginPage = (props) => {
   const { handleSubmit, register } = useForm<FormData>();
   const [invalidToken, setInvalidToken] = React.useState(null);
+  const [isLoading, setIsLoading] = React.useState(false);
+  const { authWorkflow } = useAuthProvider();
 
   const onSubmit = handleSubmit(async (data) => {
-    const authToken = "Basic "+btoa(data.username+":"+data.password);
+    setIsLoading(true);
+    setInvalidToken(null);
+
+    // SESSION workflow: POST credentials as form data to /auth/login.
+    // The server validates and sets an HttpOnly SameSite=Strict cookie. No Authorization header is used.
+    if (authWorkflow === AuthWorkflow.SESSION) {
+      try {
+        const formData = new URLSearchParams();
+        formData.append('username', data.username);
+        formData.append('password', data.password);
+
+        const response = await fetch('/auth/login', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: formData.toString(),
+          credentials: 'include',
+        });
+
+        if (response.ok) {
+          // Session cookie is now set by the server (HttpOnly – JS cannot read it)
+          app_state.authWorkflow = AuthWorkflow.SESSION;
+          app_state.authToken = null; // no token stored in JS memory
+          app_state.username = data.username;
+          setInvalidToken(false);
+          props.setIsAuthenticated(true);
+          props.history.push(app_state.queryConsoleOnlyView ? '/query' : '/');
+        } else {
+          setInvalidToken(true);
+        }
+      } catch (e) {
+        setInvalidToken(true);
+      } finally {
+        setIsLoading(false);
+      }
+      return;
+    }
+
+    // BASIC workflow (legacy): build Basic auth token and verify via /auth/verify
+    const authToken = "Basic " + btoa(data.username + ":" + data.password);
     const isUserAuthenticated = await PinotMethodUtils.verifyAuth(authToken);
-    if(isUserAuthenticated){
+    if (isUserAuthenticated) {
       setInvalidToken(false);
       app_state.username = data.username;
       app_state.authWorkflow = AuthWorkflow.BASIC;
@@ -85,6 +126,7 @@ const LoginPage = (props) => {
     } else {
       setInvalidToken(true);
     }
+    setIsLoading(false);
   });
 
   const classes = useStyles();
@@ -116,8 +158,8 @@ const LoginPage = (props) => {
             </Box>
           }
           <Box paddingY={3}>
-            <Button type="submit" variant="contained" color="primary">
-              Login
+            <Button type="submit" variant="contained" color="primary" disabled={isLoading}>
+              {isLoading ? 'Signing in...' : 'Login'}
             </Button>
           </Box>
         </form>

--- a/pinot-controller/src/main/resources/app/utils/axios-config.ts
+++ b/pinot-controller/src/main/resources/app/utils/axios-config.ts
@@ -22,26 +22,48 @@ import { AuthWorkflow } from 'Models';
 import app_state from '../app_state';
 import { AxiosError, AxiosRequestConfig } from "axios";
 
-const isDev = process.env.NODE_ENV !== 'production';
-
-// Returns axios request interceptor
+/**
+ * Returns axios request interceptor.
+ *
+ * When using SESSION workflow, no Authorization header is attached.
+ * The browser automatically sends the HttpOnly session cookie with every request.
+ * This eliminates the "Authorization: Basic <base64-credentials>" visible in browser
+ * dev-tools network tab.
+ *
+ * Flow:
+ *   NONE     → no auth header, no cookie (open access)
+ *   BASIC    → Authorization: Basic <token> header (legacy)
+ *   SESSION  → no Authorization header; browser sends HttpOnly cookie automatically
+ *   OIDC     → Authorization: Bearer <token> header
+ */
 export const getAxiosRequestInterceptor = (
     accessToken?: string
 ): ((requestConfig: AxiosRequestConfig) => AxiosRequestConfig) => {
     const requestInterceptor = (
         requestConfig: AxiosRequestConfig
     ): AxiosRequestConfig => {
-        // If access token is available, attach it to the request
-        // basic auth
+        // SESSION workflow: rely entirely on the HttpOnly cookie set by POST /auth/login.
+        // Do NOT attach any Authorization header.
+        if (app_state.authWorkflow === AuthWorkflow.SESSION) {
+            if (requestConfig.headers) {
+                delete requestConfig.headers['Authorization'];
+                delete requestConfig.headers['authorization'];
+            }
+            return requestConfig;
+        }
+
+        // BASIC auth: attach the stored token as Authorization header (legacy behaviour)
         if (app_state.authWorkflow === AuthWorkflow.BASIC && app_state.authToken) {
             requestConfig.headers = {
+                ...requestConfig.headers,
                 Authorization: app_state.authToken,
             };
         }
 
-        // OIDC auth
+        // OIDC auth: attach the Bearer access token
         if (accessToken) {
             requestConfig.headers = {
+                ...requestConfig.headers,
                 Authorization: accessToken,
             };
         }
@@ -52,13 +74,28 @@ export const getAxiosRequestInterceptor = (
     return requestInterceptor;
 };
 
-// Returns axios rejected response interceptor
+/**
+ * Returns axios rejected response interceptor.
+ *
+ * For SESSION workflow, 401/403 responses redirect to the login page so the user
+ * must re-authenticate. For other workflows, the provided callback is invoked.
+ */
 export const getAxiosErrorInterceptor = (
     unauthenticatedAccessFn?: () => void
 ): ((error: AxiosError) => void) => {
     const rejectedResponseInterceptor = (error: AxiosError): any => {
         if (error && error.response && (error.response.status === 401 || error.response.status === 403)) {
-            // Unauthenticated access
+            // SESSION workflow: session has expired. Redirect to login.
+            if (app_state.authWorkflow === AuthWorkflow.SESSION) {
+                app_state.authToken = null;
+                if (window.location.hash && !window.location.hash.includes('/login')) {
+                    window.location.href = '/#/login';
+                } else if (!window.location.hash) {
+                    window.location.href = '/#/login';
+                }
+                return error.response || error;
+            }
+            // Other workflows: invoke the callback
             unauthenticatedAccessFn && unauthenticatedAccessFn();
         }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/SessionAuthenticationFilterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/SessionAuthenticationFilterTest.java
@@ -1,0 +1,269 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.access;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import org.apache.pinot.controller.ControllerConf;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+
+/**
+ * Unit tests for {@link SessionAuthenticationFilter}.
+ *
+ * <p>Covers:
+ * <ul>
+ *   <li>Session mode disabled → pass through without aborting</li>
+ *   <li>Null controller conf → pass through</li>
+ *   <li>Unprotected paths → pass through</li>
+ *   <li>Static assets → pass through</li>
+ *   <li>Authorization header present → pass through to downstream AuthenticationFilter</li>
+ *   <li>Valid session cookie → pass through</li>
+ *   <li>Expired / invalid session cookie → abort with 401</li>
+ *   <li>No session cookie → abort with 401</li>
+ * </ul>
+ */
+public class SessionAuthenticationFilterTest {
+
+  private SessionAuthenticationFilter _filter;
+  private SessionManager _sessionManager;
+  private ControllerConf _controllerConf;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    _filter = new SessionAuthenticationFilter();
+    _sessionManager = mock(SessionManager.class);
+    _controllerConf = new ControllerConf();
+    inject("_sessionManager", _sessionManager);
+    inject("_controllerConf", _controllerConf);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Session mode disabled
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testSessionDisabledPassesThrough() throws IOException {
+    // CONTROLLER_UI_SESSION_ENABLED not set → defaults to false
+    ContainerRequestContext ctx = buildRequest("api/tables", Map.of(), null);
+    _filter.filter(ctx);
+    verify(ctx, never()).abortWith(any());
+  }
+
+  @Test
+  public void testNullControllerConfPassesThrough() throws Exception {
+    inject("_controllerConf", null);
+    ContainerRequestContext ctx = buildRequest("api/tables", Map.of(), null);
+    _filter.filter(ctx);
+    verify(ctx, never()).abortWith(any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Unprotected paths
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testUnprotectedAuthLoginPassesThrough() throws IOException {
+    enableSession();
+    ContainerRequestContext ctx = buildRequest("auth/login", Map.of(), null);
+    _filter.filter(ctx);
+    verify(ctx, never()).abortWith(any());
+  }
+
+  @Test
+  public void testUnprotectedAuthLogoutPassesThrough() throws IOException {
+    enableSession();
+    ContainerRequestContext ctx = buildRequest("auth/logout", Map.of(), null);
+    _filter.filter(ctx);
+    verify(ctx, never()).abortWith(any());
+  }
+
+  @Test
+  public void testUnprotectedAuthSessionPassesThrough() throws IOException {
+    enableSession();
+    ContainerRequestContext ctx = buildRequest("auth/session", Map.of(), null);
+    _filter.filter(ctx);
+    verify(ctx, never()).abortWith(any());
+  }
+
+  @Test
+  public void testUnprotectedAuthInfoPassesThrough() throws IOException {
+    enableSession();
+    ContainerRequestContext ctx = buildRequest("auth/info", Map.of(), null);
+    _filter.filter(ctx);
+    verify(ctx, never()).abortWith(any());
+  }
+
+  @Test
+  public void testUnprotectedHealthPassesThrough() throws IOException {
+    enableSession();
+    ContainerRequestContext ctx = buildRequest("health", Map.of(), null);
+    _filter.filter(ctx);
+    verify(ctx, never()).abortWith(any());
+  }
+
+  @Test
+  public void testUnprotectedPathWithLeadingSlashPassesThrough() throws IOException {
+    enableSession();
+    ContainerRequestContext ctx = buildRequest("/auth/login", Map.of(), null);
+    _filter.filter(ctx);
+    verify(ctx, never()).abortWith(any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Static assets
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testStaticAssetIndexHtmlPassesThrough() throws IOException {
+    enableSession();
+    ContainerRequestContext ctx = buildRequest("index.html", Map.of(), null);
+    _filter.filter(ctx);
+    verify(ctx, never()).abortWith(any());
+  }
+
+  @Test
+  public void testStaticAssetFaviconIcoPassesThrough() throws IOException {
+    enableSession();
+    ContainerRequestContext ctx = buildRequest("favicon.ico", Map.of(), null);
+    _filter.filter(ctx);
+    verify(ctx, never()).abortWith(any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Authorization header bypass
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testAuthorizationHeaderBypassesSessionFilter() throws IOException {
+    enableSession();
+    ContainerRequestContext ctx = buildRequest("api/tables", Map.of(), List.of("Basic dXNlcjpwYXNz"));
+    _filter.filter(ctx);
+    verify(ctx, never()).abortWith(any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Valid session
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testValidSessionCookiePassesThrough() throws IOException {
+    enableSession();
+    when(_sessionManager.getUsername("valid-token")).thenReturn(Optional.of("alice"));
+    Cookie cookie = mockCookie("valid-token");
+    Map<String, Cookie> cookies = Map.of(SessionManager.SESSION_COOKIE_NAME, cookie);
+    ContainerRequestContext ctx = buildRequest("api/tables", cookies, null);
+    _filter.filter(ctx);
+    verify(ctx, never()).abortWith(any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Invalid / missing session → 401
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testExpiredSessionCookieAbortsWith401() throws IOException {
+    enableSession();
+    when(_sessionManager.getUsername("expired-token")).thenReturn(Optional.empty());
+    Cookie cookie = mockCookie("expired-token");
+    Map<String, Cookie> cookies = Map.of(SessionManager.SESSION_COOKIE_NAME, cookie);
+    ContainerRequestContext ctx = buildRequest("api/tables", cookies, null);
+    _filter.filter(ctx);
+    verifyAbortedWith401(ctx);
+  }
+
+  @Test
+  public void testNoCookieAbortsWith401() throws IOException {
+    enableSession();
+    ContainerRequestContext ctx = buildRequest("api/tables", Map.of(), null);
+    _filter.filter(ctx);
+    verifyAbortedWith401(ctx);
+  }
+
+  @Test
+  public void testNullCookieValueAbortsWith401() throws IOException {
+    enableSession();
+    Cookie cookie = mockCookie(null);
+    Map<String, Cookie> cookies = Map.of(SessionManager.SESSION_COOKIE_NAME, cookie);
+    ContainerRequestContext ctx = buildRequest("api/tables", cookies, null);
+    _filter.filter(ctx);
+    verifyAbortedWith401(ctx);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private void enableSession() {
+    _controllerConf.setProperty(ControllerConf.CONTROLLER_UI_SESSION_ENABLED, "true");
+  }
+
+  private ContainerRequestContext buildRequest(String path, Map<String, Cookie> cookies,
+      List<String> authHeaderValues) {
+    ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+    UriInfo uriInfo = mock(UriInfo.class);
+    when(uriInfo.getPath()).thenReturn(path);
+    when(ctx.getUriInfo()).thenReturn(uriInfo);
+    when(ctx.getCookies()).thenReturn(cookies);
+
+    MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+    if (authHeaderValues != null && !authHeaderValues.isEmpty()) {
+      headers.put(HttpHeaders.AUTHORIZATION, authHeaderValues);
+    }
+    when(ctx.getHeaders()).thenReturn(headers);
+    return ctx;
+  }
+
+  private static Cookie mockCookie(String value) {
+    Cookie cookie = mock(Cookie.class);
+    when(cookie.getValue()).thenReturn(value);
+    return cookie;
+  }
+
+  private static void verifyAbortedWith401(ContainerRequestContext ctx) {
+    ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
+    verify(ctx).abortWith(captor.capture());
+    assertEquals(captor.getValue().getStatus(), Response.Status.UNAUTHORIZED.getStatusCode());
+  }
+
+  private void inject(String fieldName, Object value) throws Exception {
+    Field field = SessionAuthenticationFilter.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(_filter, value);
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/SessionBasicAuthAccessControlFactoryTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/SessionBasicAuthAccessControlFactoryTest.java
@@ -1,0 +1,216 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.access;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.NotAuthorizedException;
+import javax.ws.rs.core.HttpHeaders;
+import org.apache.pinot.core.auth.TargetType;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.*;
+
+
+/**
+ * Unit tests for {@link SessionBasicAuthAccessControlFactory}.
+ *
+ * <p>Covers:
+ * <ul>
+ *   <li>{@code init()} and {@code create()} lifecycle</li>
+ *   <li>{@code protectAnnotatedOnly()} → false</li>
+ *   <li>{@code getAuthWorkflowInfo()} → SESSION workflow</li>
+ *   <li>{@code hasAccess(AccessType, HttpHeaders, String)} — valid/invalid/null credentials</li>
+ *   <li>{@code hasAccess(String, AccessType, HttpHeaders, String)} — table-level authorization</li>
+ *   <li>{@code hasAccess(HttpHeaders, TargetType)} — identity check</li>
+ * </ul>
+ */
+public class SessionBasicAuthAccessControlFactoryTest {
+
+  // admin:verysecret → Base64 "YWRtaW46dmVyeXNlY3JldA==" → normalized (no =) → "YWRtaW46dmVyeXNlY3JldA"
+  private static final String TOKEN_ADMIN = "Basic YWRtaW46dmVyeXNlY3JldA";
+  // user:secret → Base64 "dXNlcjpzZWNyZXQ=" → normalized → "dXNlcjpzZWNyZXQ"
+  private static final String TOKEN_USER = "Basic dXNlcjpzZWNyZXQ";
+  private static final String TOKEN_INVALID = "Basic aW52YWxpZA"; // "invalid" in base64
+
+  private static final String ALLOWED_TABLE = "tableA";
+  private static final String DISALLOWED_TABLE = "tableC";
+
+  private AccessControl _accessControl;
+
+  @BeforeClass
+  public void setUp() {
+    Map<String, Object> config = new HashMap<>();
+    config.put("controller.admin.access.control.principals", "admin,user");
+    config.put("controller.admin.access.control.principals.admin.password", "verysecret");
+    config.put("controller.admin.access.control.principals.user.password", "secret");
+    // user is restricted to tableA and tableB with read permission only
+    config.put("controller.admin.access.control.principals.user.tables", "tableA,tableB");
+    config.put("controller.admin.access.control.principals.user.permissions", "read");
+
+    SessionBasicAuthAccessControlFactory factory = new SessionBasicAuthAccessControlFactory();
+    factory.init(new PinotConfiguration(config));
+    _accessControl = factory.create();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Factory lifecycle
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testCreateReturnsNonNull() {
+    assertNotNull(_accessControl);
+  }
+
+  @Test
+  public void testProtectAnnotatedOnlyReturnsFalse() {
+    assertFalse(_accessControl.protectAnnotatedOnly());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Workflow
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testGetAuthWorkflowInfoReturnsSessionWorkflow() {
+    AccessControl.AuthWorkflowInfo info = _accessControl.getAuthWorkflowInfo();
+    assertNotNull(info);
+    assertEquals(info.getWorkflow(), AccessControl.WORKFLOW_SESSION);
+  }
+
+  // ---------------------------------------------------------------------------
+  // hasAccess(AccessType, HttpHeaders, String) — identity-only check
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testHasAccessIdentityOnlyValidAdminReturnsTrue() {
+    HttpHeaders headers = mockHeaders(TOKEN_ADMIN);
+    assertTrue(_accessControl.hasAccess(AccessType.READ, headers, "/api/tables"));
+  }
+
+  @Test
+  public void testHasAccessIdentityOnlyValidUserReturnsTrue() {
+    HttpHeaders headers = mockHeaders(TOKEN_USER);
+    assertTrue(_accessControl.hasAccess(AccessType.READ, headers, "/api/tables"));
+  }
+
+  @Test(expectedExceptions = NotAuthorizedException.class)
+  public void testHasAccessIdentityOnlyInvalidTokenThrowsNotAuthorized() {
+    HttpHeaders headers = mockHeaders(TOKEN_INVALID);
+    _accessControl.hasAccess(AccessType.READ, headers, "/api/tables");
+  }
+
+  @Test(expectedExceptions = NotAuthorizedException.class)
+  public void testHasAccessIdentityOnlyNullHeadersThrowsNotAuthorized() {
+    _accessControl.hasAccess(AccessType.READ, null, "/api/tables");
+  }
+
+  @Test(expectedExceptions = NotAuthorizedException.class)
+  public void testHasAccessIdentityOnlyNoAuthHeaderThrowsNotAuthorized() {
+    HttpHeaders headers = mockHeaders(null);
+    _accessControl.hasAccess(AccessType.READ, headers, "/api/tables");
+  }
+
+  // ---------------------------------------------------------------------------
+  // hasAccess(String, AccessType, HttpHeaders, String) — table-level check
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testHasAccessTableAdminAnyTableReturnsTrue() {
+    HttpHeaders headers = mockHeaders(TOKEN_ADMIN);
+    // Admin has no table restriction — all tables allowed
+    assertTrue(_accessControl.hasAccess(ALLOWED_TABLE, AccessType.READ, headers, "/api/tables"));
+    assertTrue(_accessControl.hasAccess(DISALLOWED_TABLE, AccessType.READ, headers, "/api/tables"));
+    assertTrue(_accessControl.hasAccess("anyRandomTable", AccessType.DELETE, headers, "/api/tables"));
+  }
+
+  @Test
+  public void testHasAccessTableUserAllowedTableReturnsTrue() {
+    HttpHeaders headers = mockHeaders(TOKEN_USER);
+    assertTrue(_accessControl.hasAccess(ALLOWED_TABLE, AccessType.READ, headers, "/api/tables"));
+  }
+
+  @Test
+  public void testHasAccessTableUserSecondAllowedTableReturnsTrue() {
+    HttpHeaders headers = mockHeaders(TOKEN_USER);
+    assertTrue(_accessControl.hasAccess("tableB", AccessType.READ, headers, "/api/tables"));
+  }
+
+  @Test
+  public void testHasAccessTableUserDisallowedTableReturnsFalse() {
+    HttpHeaders headers = mockHeaders(TOKEN_USER);
+    assertFalse(_accessControl.hasAccess(DISALLOWED_TABLE, AccessType.READ, headers, "/api/tables"));
+  }
+
+  @Test
+  public void testHasAccessTableUserDisallowedPermissionReturnsFalse() {
+    HttpHeaders headers = mockHeaders(TOKEN_USER);
+    // user has read-only permission; CREATE should be denied
+    assertFalse(_accessControl.hasAccess(ALLOWED_TABLE, AccessType.CREATE, headers, "/api/tables"));
+  }
+
+  @Test
+  public void testHasAccessTableInvalidTokenReturnsFalse() {
+    HttpHeaders headers = mockHeaders(TOKEN_INVALID);
+    assertFalse(_accessControl.hasAccess(ALLOWED_TABLE, AccessType.READ, headers, "/api/tables"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // hasAccess(HttpHeaders, TargetType) — identity check via TargetType
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testHasAccessTargetTypeValidAdminReturnsTrue() {
+    HttpHeaders headers = mockHeaders(TOKEN_ADMIN);
+    assertTrue(_accessControl.hasAccess(headers, TargetType.TABLE));
+  }
+
+  @Test
+  public void testHasAccessTargetTypeValidUserReturnsTrue() {
+    HttpHeaders headers = mockHeaders(TOKEN_USER);
+    assertTrue(_accessControl.hasAccess(headers, TargetType.TABLE));
+  }
+
+  @Test
+  public void testHasAccessTargetTypeInvalidTokenReturnsFalse() {
+    HttpHeaders headers = mockHeaders(TOKEN_INVALID);
+    assertFalse(_accessControl.hasAccess(headers, TargetType.TABLE));
+  }
+
+  @Test
+  public void testHasAccessTargetTypeNullHeadersReturnsFalse() {
+    assertFalse(_accessControl.hasAccess((HttpHeaders) null, TargetType.TABLE));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private static HttpHeaders mockHeaders(String authToken) {
+    HttpHeaders headers = mock(HttpHeaders.class);
+    List<String> authValues = authToken != null ? List.of(authToken) : List.of();
+    when(headers.getRequestHeader("Authorization")).thenReturn(authValues);
+    return headers;
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/SessionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/SessionManagerTest.java
@@ -1,0 +1,363 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.apache.pinot.controller.api.access;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+/**
+ * Unit tests for {@link SessionManager}.
+ *
+ * <p>Covers:
+ * <ul>
+ *   <li>createSession — token generation, storage</li>
+ *   <li>getUsername — valid session, expired session, null/empty token</li>
+ *   <li>Sliding window TTL — expiry is extended on each getUsername call</li>
+ *   <li>invalidateSession — immediate removal, idempotent</li>
+ *   <li>getBasicAuthToken — returns stored token, empty after invalidation</li>
+ *   <li>Concurrent access — no race condition under parallel getUsername calls</li>
+ * </ul>
+ */
+public class SessionManagerTest {
+
+  private SessionManager _sessionManager;
+
+  @BeforeMethod
+  public void setUp() {
+    // 10-second TTL for most tests — long enough not to expire during assertions
+    _sessionManager = new SessionManager(10L);
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    _sessionManager.shutdown();
+  }
+
+  // ---------------------------------------------------------------------------
+  // createSession
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testCreateSessionReturnsNonNullToken() {
+    String token = _sessionManager.createSession("alice", "Basic dXNlcjpwYXNz");
+    assertNotNull(token);
+    assertFalse(token.isEmpty());
+  }
+
+  @Test
+  public void testCreateSessionTokensAreUnique() {
+    String token1 = _sessionManager.createSession("alice", "Basic abc");
+    String token2 = _sessionManager.createSession("alice", "Basic abc");
+    assertNotEquals(token1, token2, "Each createSession call should produce a unique token");
+  }
+
+  @Test
+  public void testCreateSessionIncrementsActiveCount() {
+    int before = _sessionManager.getActiveSessionCount();
+    _sessionManager.createSession("alice", "Basic abc");
+    assertEquals(_sessionManager.getActiveSessionCount(), before + 1);
+  }
+
+  // ---------------------------------------------------------------------------
+  // getUsername — valid session
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testGetUsernameReturnsCorrectUsername() {
+    String token = _sessionManager.createSession("alice", "Basic abc");
+    Optional<String> result = _sessionManager.getUsername(token);
+    assertTrue(result.isPresent());
+    assertEquals(result.get(), "alice");
+  }
+
+  @Test
+  public void testGetUsernameWithNullTokenReturnsEmpty() {
+    Optional<String> result = _sessionManager.getUsername(null);
+    assertFalse(result.isPresent());
+  }
+
+  @Test
+  public void testGetUsernameWithEmptyTokenReturnsEmpty() {
+    Optional<String> result = _sessionManager.getUsername("");
+    assertFalse(result.isPresent());
+  }
+
+  @Test
+  public void testGetUsernameWithUnknownTokenReturnsEmpty() {
+    Optional<String> result = _sessionManager.getUsername("nonexistent-token-xyz");
+    assertFalse(result.isPresent());
+  }
+
+  // ---------------------------------------------------------------------------
+  // getUsername — expired session
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testGetUsernameAfterExpiryReturnsEmpty() throws InterruptedException {
+    // Create a session with 1-second TTL
+    SessionManager shortTtlManager = new SessionManager(1L);
+    try {
+      String token = shortTtlManager.createSession("bob", "Basic xyz");
+      // Verify it works immediately
+      assertTrue(shortTtlManager.getUsername(token).isPresent());
+      // Wait for expiry
+      Thread.sleep(1500);
+      Optional<String> result = shortTtlManager.getUsername(token);
+      assertFalse(result.isPresent(), "Session should be expired after TTL");
+    } finally {
+      shortTtlManager.shutdown();
+    }
+  }
+
+  @Test
+  public void testExpiredSessionRemovedFromStore() throws InterruptedException {
+    SessionManager shortTtlManager = new SessionManager(1L);
+    try {
+      String token = shortTtlManager.createSession("bob", "Basic xyz");
+      Thread.sleep(1500);
+      shortTtlManager.getUsername(token); // triggers removal via compute()
+      assertEquals(shortTtlManager.getActiveSessionCount(), 0,
+          "Expired session should be removed from store on access");
+    } finally {
+      shortTtlManager.shutdown();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Sliding window TTL
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testSlidingWindowExtendsExpiry() throws InterruptedException {
+    // TTL = 2 seconds. Access at t=1.5s should slide expiry to t=3.5s.
+    SessionManager slidingManager = new SessionManager(2L);
+    try {
+      String token = slidingManager.createSession("carol", "Basic zzz");
+      Thread.sleep(1500); // t=1.5s — still valid
+      Optional<String> midResult = slidingManager.getUsername(token);
+      assertTrue(midResult.isPresent(), "Session should still be valid at t=1.5s");
+      // Without sliding, session would expire at t=2s. With sliding it expires at t=3.5s.
+      Thread.sleep(1200); // t=2.7s — should still be valid due to slide
+      Optional<String> lateResult = slidingManager.getUsername(token);
+      assertTrue(lateResult.isPresent(), "Session should still be valid after sliding TTL extension");
+    } finally {
+      slidingManager.shutdown();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // invalidateSession
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testInvalidateSessionRemovesIt() {
+    String token = _sessionManager.createSession("dave", "Basic aaa");
+    assertTrue(_sessionManager.getUsername(token).isPresent());
+
+    _sessionManager.invalidateSession(token);
+    assertFalse(_sessionManager.getUsername(token).isPresent(), "Session should not be accessible after invalidation");
+  }
+
+  @Test
+  public void testInvalidateSessionDecrementsCount() {
+    String token = _sessionManager.createSession("dave", "Basic aaa");
+    int before = _sessionManager.getActiveSessionCount();
+    _sessionManager.invalidateSession(token);
+    assertTrue(_sessionManager.getActiveSessionCount() < before);
+  }
+
+  @Test
+  public void testInvalidateNonExistentTokenIsIdempotent() {
+    // Should not throw
+    _sessionManager.invalidateSession("ghost-token-that-does-not-exist");
+    _sessionManager.invalidateSession(null);
+    _sessionManager.invalidateSession("");
+  }
+
+  @Test
+  public void testInvalidateSessionTwiceIsIdempotent() {
+    String token = _sessionManager.createSession("dave", "Basic aaa");
+    _sessionManager.invalidateSession(token);
+    _sessionManager.invalidateSession(token); // second call should not throw
+    assertFalse(_sessionManager.getUsername(token).isPresent());
+  }
+
+  // ---------------------------------------------------------------------------
+  // getBasicAuthToken
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testGetBasicAuthTokenReturnsStoredToken() {
+    String basicToken = "Basic dXNlcjpwYXNz";
+    String sessionToken = _sessionManager.createSession("eve", basicToken);
+    Optional<String> result = _sessionManager.getBasicAuthToken(sessionToken);
+    assertTrue(result.isPresent());
+    assertEquals(result.get(), basicToken);
+  }
+
+  @Test
+  public void testGetBasicAuthTokenWithNullReturnsEmpty() {
+    assertFalse(_sessionManager.getBasicAuthToken(null).isPresent());
+  }
+
+  @Test
+  public void testGetBasicAuthTokenAfterInvalidationReturnsEmpty() {
+    String sessionToken = _sessionManager.createSession("eve", "Basic abc");
+    _sessionManager.invalidateSession(sessionToken);
+    assertFalse(_sessionManager.getBasicAuthToken(sessionToken).isPresent());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Multiple sessions for the same user
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testMultipleSessionsForSameUser() {
+    String token1 = _sessionManager.createSession("frank", "Basic aaa");
+    String token2 = _sessionManager.createSession("frank", "Basic bbb");
+    assertNotEquals(token1, token2);
+    assertTrue(_sessionManager.getUsername(token1).isPresent());
+    assertTrue(_sessionManager.getUsername(token2).isPresent());
+
+    _sessionManager.invalidateSession(token1);
+    assertFalse(_sessionManager.getUsername(token1).isPresent());
+    assertTrue(_sessionManager.getUsername(token2).isPresent(), "Invalidating one session should not affect the other");
+  }
+
+  // ---------------------------------------------------------------------------
+  // getSessionTtlSeconds
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testGetSessionTtlSeconds() {
+    assertEquals(_sessionManager.getSessionTtlSeconds(), 10L);
+    SessionManager custom = new SessionManager(42L);
+    try {
+      assertEquals(custom.getSessionTtlSeconds(), 42L);
+    } finally {
+      custom.shutdown();
+    }
+  }
+
+  @Test
+  public void testDefaultConstructorUsesFallbackTtl() {
+    SessionManager defaultManager = new SessionManager();
+    try {
+      assertEquals(defaultManager.getSessionTtlSeconds(), SessionManager.DEFAULT_SESSION_TTL_SECONDS);
+    } finally {
+      defaultManager.shutdown();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Concurrent access — no race condition
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testConcurrentGetUsernameIsRaceFree() throws InterruptedException {
+    String token = _sessionManager.createSession("grace", "Basic ccc");
+    int threadCount = 50;
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch doneLatch = new CountDownLatch(threadCount);
+    AtomicInteger successCount = new AtomicInteger(0);
+    List<Throwable> errors = new ArrayList<>();
+
+    for (int i = 0; i < threadCount; i++) {
+      executor.submit(() -> {
+        try {
+          startLatch.await();
+          Optional<String> result = _sessionManager.getUsername(token);
+          if (result.isPresent()) {
+            successCount.incrementAndGet();
+          }
+        } catch (Throwable t) {
+          synchronized (errors) {
+            errors.add(t);
+          }
+        } finally {
+          doneLatch.countDown();
+        }
+      });
+    }
+
+    startLatch.countDown(); // release all threads simultaneously
+    assertTrue(doneLatch.await(10, TimeUnit.SECONDS), "All threads should complete within 10s");
+    executor.shutdown();
+
+    assertTrue(errors.isEmpty(), "No exceptions thrown under concurrent access: " + errors);
+    assertEquals(successCount.get(), threadCount,
+        "All concurrent getUsername calls should succeed for a valid non-expired token");
+  }
+
+  @Test
+  public void testConcurrentCreateAndInvalidate() throws InterruptedException {
+    int count = 20;
+    ExecutorService executor = Executors.newFixedThreadPool(count * 2);
+    List<String> tokens = new ArrayList<>();
+    CountDownLatch latch = new CountDownLatch(count * 2);
+
+    // Create sessions
+    for (int i = 0; i < count; i++) {
+      final int idx = i;
+      executor.submit(() -> {
+        try {
+          String tok = _sessionManager.createSession("user" + idx, "Basic tok" + idx);
+          synchronized (tokens) { tokens.add(tok); }
+        } finally {
+          latch.countDown();
+        }
+      });
+    }
+
+    // Simultaneously invalidate (may operate on not-yet-created tokens — should not throw)
+    for (int i = 0; i < count; i++) {
+      executor.submit(() -> {
+        try {
+          synchronized (tokens) {
+            if (!tokens.isEmpty()) {
+              _sessionManager.invalidateSession(tokens.get(0));
+            }
+          }
+        } finally {
+          latch.countDown();
+        }
+      });
+    }
+
+    assertTrue(latch.await(10, TimeUnit.SECONDS));
+    executor.shutdown();
+    // No assertion on count — just verify no exception was thrown
+  }
+}
+

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/SessionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/SessionManagerTest.java
@@ -36,7 +36,7 @@ import static org.testng.Assert.*;
 
 
 /**
- * Unit tests for {@link SessionManager}.
+ * Unit tests for {@link InMemorySessionManager}.
  *
  * <p>Covers:
  * <ul>
@@ -55,7 +55,7 @@ public class SessionManagerTest {
   @BeforeMethod
   public void setUp() {
     // 10-second TTL for most tests — long enough not to expire during assertions
-    _sessionManager = new SessionManager(10L);
+    _sessionManager = new InMemorySessionManager(10L);
   }
 
   @AfterMethod
@@ -125,7 +125,7 @@ public class SessionManagerTest {
   @Test
   public void testGetUsernameAfterExpiryReturnsEmpty() throws InterruptedException {
     // Create a session with 1-second TTL
-    SessionManager shortTtlManager = new SessionManager(1L);
+    SessionManager shortTtlManager = new InMemorySessionManager(1L);
     try {
       String token = shortTtlManager.createSession("bob", "Basic xyz");
       // Verify it works immediately
@@ -141,7 +141,7 @@ public class SessionManagerTest {
 
   @Test
   public void testExpiredSessionRemovedFromStore() throws InterruptedException {
-    SessionManager shortTtlManager = new SessionManager(1L);
+    SessionManager shortTtlManager = new InMemorySessionManager(1L);
     try {
       String token = shortTtlManager.createSession("bob", "Basic xyz");
       Thread.sleep(1500);
@@ -160,7 +160,7 @@ public class SessionManagerTest {
   @Test
   public void testSlidingWindowExtendsExpiry() throws InterruptedException {
     // TTL = 2 seconds. Access at t=1.5s should slide expiry to t=3.5s.
-    SessionManager slidingManager = new SessionManager(2L);
+    SessionManager slidingManager = new InMemorySessionManager(2L);
     try {
       String token = slidingManager.createSession("carol", "Basic zzz");
       Thread.sleep(1500); // t=1.5s — still valid
@@ -261,7 +261,7 @@ public class SessionManagerTest {
   @Test
   public void testGetSessionTtlSeconds() {
     assertEquals(_sessionManager.getSessionTtlSeconds(), 10L);
-    SessionManager custom = new SessionManager(42L);
+    SessionManager custom = new InMemorySessionManager(42L);
     try {
       assertEquals(custom.getSessionTtlSeconds(), 42L);
     } finally {
@@ -271,7 +271,7 @@ public class SessionManagerTest {
 
   @Test
   public void testDefaultConstructorUsesFallbackTtl() {
-    SessionManager defaultManager = new SessionManager();
+    SessionManager defaultManager = new InMemorySessionManager();
     try {
       assertEquals(defaultManager.getSessionTtlSeconds(), SessionManager.DEFAULT_SESSION_TTL_SECONDS);
     } finally {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/SessionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/SessionManagerTest.java
@@ -333,7 +333,9 @@ public class SessionManagerTest {
       executor.submit(() -> {
         try {
           String tok = _sessionManager.createSession("user" + idx, "Basic tok" + idx);
-          synchronized (tokens) { tokens.add(tok); }
+          synchronized (tokens) {
+            tokens.add(tok);
+          }
         } finally {
           latch.countDown();
         }
@@ -360,4 +362,3 @@ public class SessionManagerTest {
     // No assertion on count — just verify no exception was thrown
   }
 }
-

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/SessionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/SessionManagerTest.java
@@ -42,7 +42,7 @@ import static org.testng.Assert.*;
  * <ul>
  *   <li>createSession — token generation, storage</li>
  *   <li>getUsername — valid session, expired session, null/empty token</li>
- *   <li>Sliding window TTL — expiry is extended on each getUsername call</li>
+ *   <li>Fixed TTL — session expires at loginTime + TTL regardless of access</li>
  *   <li>invalidateSession — immediate removal, idempotent</li>
  *   <li>getBasicAuthToken — returns stored token, empty after invalidation</li>
  *   <li>Concurrent access — no race condition under parallel getUsername calls</li>
@@ -140,38 +140,42 @@ public class SessionManagerTest {
   }
 
   @Test
-  public void testExpiredSessionRemovedFromStore() throws InterruptedException {
+  public void testExpiredSessionIsNotAccessible() throws InterruptedException {
+    // getUsername returns empty for expired sessions. Expired entries are NOT eagerly removed from
+    // the store on access — they linger until the background sweep (every 30 minutes). This is
+    // intentional: the map is only consulted for expiry checks, not for active garbage collection.
     SessionManager shortTtlManager = new InMemorySessionManager(1L);
     try {
       String token = shortTtlManager.createSession("bob", "Basic xyz");
       Thread.sleep(1500);
-      shortTtlManager.getUsername(token); // triggers removal via compute()
-      assertEquals(shortTtlManager.getActiveSessionCount(), 0,
-          "Expired session should be removed from store on access");
+      Optional<String> result = shortTtlManager.getUsername(token);
+      assertFalse(result.isPresent(), "Expired session should not be returned by getUsername");
     } finally {
       shortTtlManager.shutdown();
     }
   }
 
   // ---------------------------------------------------------------------------
-  // Sliding window TTL
+  // Fixed TTL (no sliding window)
   // ---------------------------------------------------------------------------
 
   @Test
-  public void testSlidingWindowExtendsExpiry() throws InterruptedException {
-    // TTL = 2 seconds. Access at t=1.5s should slide expiry to t=3.5s.
-    SessionManager slidingManager = new InMemorySessionManager(2L);
+  public void testFixedTtlExpiresAtLoginPlusTimeout() throws InterruptedException {
+    // TTL = 3 seconds. Session should be valid at t=1.5s but expired at t=3.5s.
+    // Calling getUsername at t=1.5s must NOT extend the expiry — the fixed TTL
+    // ensures server and browser cookie expiry are aligned from login time.
+    SessionManager fixedManager = new InMemorySessionManager(3L);
     try {
-      String token = slidingManager.createSession("carol", "Basic zzz");
+      String token = fixedManager.createSession("carol", "Basic zzz");
       Thread.sleep(1500); // t=1.5s — still valid
-      Optional<String> midResult = slidingManager.getUsername(token);
+      Optional<String> midResult = fixedManager.getUsername(token);
       assertTrue(midResult.isPresent(), "Session should still be valid at t=1.5s");
-      // Without sliding, session would expire at t=2s. With sliding it expires at t=3.5s.
-      Thread.sleep(1200); // t=2.7s — should still be valid due to slide
-      Optional<String> lateResult = slidingManager.getUsername(token);
-      assertTrue(lateResult.isPresent(), "Session should still be valid after sliding TTL extension");
+      // Without sliding TTL, session expires at t=3s regardless of the access above.
+      Thread.sleep(2000); // t=3.5s — 500ms after expiry, generous margin for CI
+      Optional<String> lateResult = fixedManager.getUsername(token);
+      assertFalse(lateResult.isPresent(), "Session should have expired at loginTime + TTL");
     } finally {
-      slidingManager.shutdown();
+      fixedManager.shutdown();
     }
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/SessionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/SessionManagerTest.java
@@ -324,6 +324,111 @@ public class SessionManagerTest {
         "All concurrent getUsername calls should succeed for a valid non-expired token");
   }
 
+  // ---------------------------------------------------------------------------
+  // rotateSession
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testRotateSessionReturnsNewToken() {
+    String oldToken = _sessionManager.createSession("henry", "Basic hhh");
+    Optional<String> newToken = _sessionManager.rotateSession(oldToken);
+    assertTrue(newToken.isPresent());
+    assertNotEquals(newToken.get(), oldToken, "Rotated token must differ from old token");
+  }
+
+  @Test
+  public void testRotateSessionOldTokenInvalidated() {
+    String oldToken = _sessionManager.createSession("henry", "Basic hhh");
+    _sessionManager.rotateSession(oldToken);
+    assertFalse(_sessionManager.getUsername(oldToken).isPresent(),
+        "Old token must be invalidated after rotation");
+  }
+
+  @Test
+  public void testRotateSessionNewTokenValid() {
+    String oldToken = _sessionManager.createSession("henry", "Basic hhh");
+    Optional<String> newToken = _sessionManager.rotateSession(oldToken);
+    assertTrue(newToken.isPresent());
+    assertTrue(_sessionManager.getUsername(newToken.get()).isPresent(),
+        "New token must be valid after rotation");
+    assertEquals(_sessionManager.getUsername(newToken.get()).get(), "henry");
+  }
+
+  @Test
+  public void testRotateSessionPreservesBasicAuthToken() {
+    String basicToken = "Basic hhh";
+    String oldToken = _sessionManager.createSession("henry", basicToken);
+    Optional<String> newToken = _sessionManager.rotateSession(oldToken);
+    assertTrue(newToken.isPresent());
+    Optional<String> storedToken = _sessionManager.getBasicAuthToken(newToken.get());
+    assertTrue(storedToken.isPresent(), "Basic auth token must be present after rotation");
+    assertEquals(storedToken.get(), basicToken);
+  }
+
+  @Test
+  public void testRotateSessionExpiredTokenReturnsEmpty() throws InterruptedException {
+    SessionManager shortTtlManager = new InMemorySessionManager(1L);
+    try {
+      String token = shortTtlManager.createSession("ivan", "Basic iii");
+      Thread.sleep(1500); // wait for TTL to expire
+      assertFalse(shortTtlManager.rotateSession(token).isPresent(),
+          "rotateSession must return empty for an expired token");
+    } finally {
+      shortTtlManager.shutdown();
+    }
+  }
+
+  @Test
+  public void testRotateSessionNullTokenReturnsEmpty() {
+    assertFalse(_sessionManager.rotateSession(null).isPresent());
+  }
+
+  @Test
+  public void testRotateSessionEmptyTokenReturnsEmpty() {
+    assertFalse(_sessionManager.rotateSession("").isPresent());
+  }
+
+  @Test
+  public void testRotateSessionUnknownTokenReturnsEmpty() {
+    assertFalse(_sessionManager.rotateSession("nonexistent-token").isPresent());
+  }
+
+  @Test
+  public void testRotateSessionConcurrentOnlyOneSucceeds() throws InterruptedException {
+    // CAS-based rotation: only one of two concurrent rotate calls wins
+    String oldToken = _sessionManager.createSession("ivan", "Basic iii");
+    int threadCount = 10;
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch doneLatch = new CountDownLatch(threadCount);
+    AtomicInteger successCount = new AtomicInteger(0);
+
+    for (int i = 0; i < threadCount; i++) {
+      executor.submit(() -> {
+        try {
+          startLatch.await();
+          Optional<String> result = _sessionManager.rotateSession(oldToken);
+          if (result.isPresent()) {
+            successCount.incrementAndGet();
+          }
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        } finally {
+          doneLatch.countDown();
+        }
+      });
+    }
+
+    startLatch.countDown();
+    assertTrue(doneLatch.await(10, TimeUnit.SECONDS));
+    executor.shutdown();
+
+    // Exactly one rotation should succeed due to CAS
+    assertEquals(successCount.get(), 1, "Exactly one concurrent rotation should succeed");
+    assertFalse(_sessionManager.getUsername(oldToken).isPresent(),
+        "Old token must be gone after successful rotation");
+  }
+
   @Test
   public void testConcurrentCreateAndInvalidate() throws InterruptedException {
     int count = 20;


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Session\-based UI auth flow: login creates server session, cookie validated on requests, auth token injected for broker, logout invalidates session\.

```mermaid
flowchart TD
  N0["BaseControllerStarter #40;F1#41;"]:::stModified
  N1["SessionManager #40;F6#44; F9#41;"]:::stAdded
  N2["SessionAuthenticationFilter #40;F7#41;"]:::stAdded
  N3["AuthenticationFilter #40;F5#41;"]:::stModified
  N4["PinotSessionLoginResource #40;F12#41;"]:::stAdded
  N5["PinotQueryResource #40;F11#41;"]:::stModified
  N6["LoginPage #40;F17#41;"]:::stModified
  N7["Header #40;F15#41;"]:::stModified
  N8["AuthProvider #40;F16#41;"]:::stModified
  N9["App #40;F13#41;"]:::stModified
  N0 -->|"creates and binds"| N1
  N2 -->|"validates cookie"| N1
  N3 -->|"gets auth token for header"| N1
  N4 -->|"creates#47;invalidates#47;gets session"| N1
  N5 -->|"resolves broker credential"| N1
  N6 -->|"POST #47;auth#47;login"| N4
  N7 -->|"GET #47;auth#47;logout"| N4
  N8 -->|"GET #47;auth#47;session"| N4
  N9 -->|"GET #47;auth#47;logout on timeout"| N4
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter\.java — [before](https://github.com/apache/pinot/blob/62b42630a0b32998ca39d4c09a0114704b09367a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java) · [after](https://github.com/apache/pinot/blob/632787d4c8f544c320925919909a513cf016fbb2/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java)
- F5: pinot\-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter\.java — [before](https://github.com/apache/pinot/blob/62b42630a0b32998ca39d4c09a0114704b09367a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java) · [after](https://github.com/apache/pinot/blob/632787d4c8f544c320925919909a513cf016fbb2/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java)
- F6: pinot\-controller/src/main/java/org/apache/pinot/controller/api/access/InMemorySessionManager\.java — [after](https://github.com/apache/pinot/blob/632787d4c8f544c320925919909a513cf016fbb2/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/InMemorySessionManager.java)
- F7: pinot\-controller/src/main/java/org/apache/pinot/controller/api/access/SessionAuthenticationFilter\.java — [after](https://github.com/apache/pinot/blob/632787d4c8f544c320925919909a513cf016fbb2/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/SessionAuthenticationFilter.java)
- F9: pinot\-controller/src/main/java/org/apache/pinot/controller/api/access/SessionManager\.java — [after](https://github.com/apache/pinot/blob/632787d4c8f544c320925919909a513cf016fbb2/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/SessionManager.java)
- F11: pinot\-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource\.java — [before](https://github.com/apache/pinot/blob/62b42630a0b32998ca39d4c09a0114704b09367a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java) · [after](https://github.com/apache/pinot/blob/632787d4c8f544c320925919909a513cf016fbb2/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java)
- F12: pinot\-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSessionLoginResource\.java — [after](https://github.com/apache/pinot/blob/632787d4c8f544c320925919909a513cf016fbb2/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSessionLoginResource.java)
- F13: pinot\-controller/src/main/resources/app/App\.tsx — [before](https://github.com/apache/pinot/blob/62b42630a0b32998ca39d4c09a0114704b09367a/pinot-controller/src/main/resources/app/App.tsx) · [after](https://github.com/apache/pinot/blob/632787d4c8f544c320925919909a513cf016fbb2/pinot-controller/src/main/resources/app/App.tsx)
- F15: pinot\-controller/src/main/resources/app/components/Header\.tsx — [before](https://github.com/apache/pinot/blob/62b42630a0b32998ca39d4c09a0114704b09367a/pinot-controller/src/main/resources/app/components/Header.tsx) · [after](https://github.com/apache/pinot/blob/632787d4c8f544c320925919909a513cf016fbb2/pinot-controller/src/main/resources/app/components/Header.tsx)
- F16: pinot\-controller/src/main/resources/app/components/auth/AuthProvider\.tsx — [before](https://github.com/apache/pinot/blob/62b42630a0b32998ca39d4c09a0114704b09367a/pinot-controller/src/main/resources/app/components/auth/AuthProvider.tsx) · [after](https://github.com/apache/pinot/blob/632787d4c8f544c320925919909a513cf016fbb2/pinot-controller/src/main/resources/app/components/auth/AuthProvider.tsx)
- F17: pinot\-controller/src/main/resources/app/pages/LoginPage\.tsx — [before](https://github.com/apache/pinot/blob/62b42630a0b32998ca39d4c09a0114704b09367a/pinot-controller/src/main/resources/app/pages/LoginPage.tsx) · [after](https://github.com/apache/pinot/blob/632787d4c8f544c320925919909a513cf016fbb2/pinot-controller/src/main/resources/app/pages/LoginPage.tsx)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjYyYjQyNjMwYTBiMzI5OThjYTM5ZDRjMDlhMDExNDcwNGIwOTM2N2EiLCJjb250ZXh0X2hhc2giOiJiN2Y0Mzc3YmUzMjc2YmQxZTBkMmRmZDg4NGRkODE1NDE4NDI5ZTM4MWE0ZWY4MTJjNmJjMmEzOTg2ZmE3NzE0IiwiZ2VuZXJhdGVkX2F0IjoxNzg5OTAzNjE0LCJoZWFkX3NoYSI6IjYzMjc4N2Q0YzhmNTQ0YzMyMDkyNTkxOTkwOWE1MTNjZjAxNmZiYjIiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI2MmI0MjYzMGEwYjMyOTk4Y2EzOWQ0YzA5YTAxMTQ3MDRiMDkzNjdhIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 2a7c056392f764d8b95be2ad8e0cc1749370e6b51fcaa21bda6849986632da2b -->
<!-- pinot-pr-flow:end -->

## Summary

Implements a Trino/Ambari-style **session layer** for the Pinot controller UI that addresses several security gaps in the existing Basic auth flow. The session layer sits on top of ANY configured `AccessControlFactory` — no changes to the auth backend required.

**Problems fixed:**

| # | Problem | Before |
|---|---------|--------|
| 1 | Credentials visible in DevTools | Every page navigation sent `Authorization: Basic <base64>` in the network tab |
| 2 | Fake logout | Logout only cleared localStorage; server session survived indefinitely |
| 3 | No session expiry | No inactivity tracking; a tab left open for days kept full access |
| 4 | Credentials in JS memory | `app_state.authToken` held `Basic <base64>` (XSS-readable) |
| 5 | Broker auth from browser | Query page sent `Authorization` header from browser directly to broker |
| 6 | No CSRF protection | Session cookie had no `SameSite` attribute |

**How it works:**

```
Browser              Controller                     Broker / ZK
   │  POST /auth/login   │                               │
   │  (form-encoded)     │  hasAccess(SyntheticHeaders)  │
   │ ─────────────────►  │ ──────────────────────────►   │
   │  Set-Cookie:        │  createSession(user, token)   │
   │  Pinot-UI-Session=  │  store in ConcurrentHashMap   │
   │  <token>; HttpOnly  │                               │
   │ ◄─────────────────  │                               │
   │                     │                               │
   │  GET /api/tables    │  SessionAuthenticationFilter  │
   │  Cookie: Pinot-...  │  → getUsername(token) OK      │
   │ ─────────────────►  │  inject Authorization header  │
   │                     │ ──────────────────────────►   │
   │  GET /auth/logout   │  invalidateSession(token)     │
   │ ─────────────────►  │  removes from HashMap         │
```

**New files:**
- `SessionManager.java` — `ConcurrentHashMap` session store with sliding TTL; uses atomic `compute()` to eliminate the get→check→remove race condition
- `SessionAuthenticationFilter.java` — JAX-RS filter at `AUTHENTICATION-10` priority; validates HttpOnly cookie; passes through requests with `Authorization` header for API backward compat
- `SessionBasicAuthAccessControlFactory.java` — convenience factory wrapper
- `PinotSessionLoginResource.java` — `POST /auth/login`, `GET /auth/logout`, `GET /auth/session`
- `SessionManagerTest.java` — unit tests + 50-thread concurrency test

**Cookie construction:** Uses raw `Set-Cookie` header string instead of JAX-RS `NewCookie` because JAX-RS 2 `NewCookie` does not support the `SameSite` attribute. `SameSite=Strict` blocks cross-site forged requests.

**Frontend changes:**
- `Models.ts` — `SESSION` enum added to `AuthWorkflow`
- `axios-config.ts` — SESSION workflow deletes the `Authorization` header; cookie sent automatically by browser
- `AuthProvider.tsx` — reads inactivity timeout from `/auth/info`, checks `/auth/session` on page refresh to restore session
- `App.tsx` — inactivity timer with configurable timeout; 60-second warning dialog before auto-logout; calls `/auth/logout` on timeout
- `Header.tsx` — logout button calls `GET /auth/logout` for server-side session invalidation
- `LoginPage.tsx` — SESSION path POSTs form data to `/auth/login` (no `Basic` header in JS memory)

## Configuration

All defaults preserve existing behaviour. Feature is **opt-in**:

```properties
# Enable session-based UI authentication (works with any AccessControlFactory)
controller.ui.session.authentication.enabled=true

# Set false for HTTP-only dev deployments (default: true)
controller.ui.session.cookie.secure=false

# UI inactivity timeout in seconds (default 300 = 5 min)
# Server TTL = this + 120s buffer
controller.ui.session.inactivity.timeout.seconds=300
```

## Test plan

- [ ] `SessionManagerTest` — creation, sliding TTL, logout invalidation, 50-thread concurrency
- [ ] `SessionAuthenticationFilter` — unprotected path passthrough, cookie validation, Authorization header bypass
- [ ] `PinotSessionLoginResource` — login/logout/session endpoints
- [ ] Existing `ControllerAdminApiApplicationTest` and auth tests continue to pass unmodified
- [ ] Manual: open Pinot UI with `controller.ui.session.authentication.enabled=true`, verify:
  - No `Authorization` header in DevTools network tab after login
  - Cookie `Pinot-UI-Session` present with HttpOnly flag
  - Logout clears cookie and session is truly gone (server-side)
  - 5-minute inactivity shows warning dialog; auto-logout after countdown

cc @Jackie-Jiang @xiangfu0