### PR TITLE
Skip recently committed (COMMITTING) segments in SegmentStatusChecker

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -402,21 +402,26 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
       }
 
       // NOTE: We want to skip segments that are just created/pushed to avoid false alerts because it is expected for
-      //       servers to take some time to load them. For consuming (IN_PROGRESS) segments, we use creation time from
-      //       the ZK metadata; for pushed segments, we use push time from the ZK metadata. Both of them are the time
-      //       when segment is newly created. For committed segments from real-time table, push time doesn't exist, and
-      //       creationTimeMs will be Long.MIN_VALUE, which is fine because we want to include them in the check.
+      //       servers to take some time to load them. For segments that are not yet completed (still consuming
+      //       IN_PROGRESS segments, and COMMITTING segments of pauseless tables that have finished consuming but are
+      //       still being built and uploaded by the server), we use creation time from the ZK metadata; for pushed
+      //       segments, we use push time from the ZK metadata. Both of them are the time when segment is newly created.
+      //       For committed (DONE) segments from real-time table, push time doesn't exist, and creationTimeMs will be
+      //       Long.MIN_VALUE, which is fine because we want to include them in the check.
       //       The comparison uses evSnapshotTimestamp instead of System.currentTimeMillis() because for large tables
       //       with many segments, the status check can take several minutes. A segment updated after
       //       the EV snapshot was taken but before this individual segment check runs could be incorrectly flagged as
       //       OFFLINE when using current time.
-      long creationTimeMs = segmentZKMetadata.getStatus() == Status.IN_PROGRESS ? segmentZKMetadata.getCreationTime()
-          : segmentZKMetadata.getPushTime();
+      Status segmentStatus = segmentZKMetadata.getStatus();
+      long creationTimeMs =
+          segmentStatus.isCompleted() ? segmentZKMetadata.getPushTime() : segmentZKMetadata.getCreationTime();
       if (creationTimeMs > evSnapshotTimestamp - _waitForPushTimeSeconds * 1000L) {
         continue;
       }
 
-      if (segmentZKMetadata.getStatus() != Status.IN_PROGRESS) {
+      // Only completed (DONE/UPLOADED) segments have finalized start/end time in the ZK metadata. Consuming
+      // (IN_PROGRESS) and COMMITTING segments do not, so skip the time range validation for them to avoid false alerts.
+      if (segmentStatus.isCompleted()) {
         if (!TimeUtils.timeValueInValidRange(segmentZKMetadata.getStartTimeMs())) {
           segmentsInvalidStartTime.add(segment);
         }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
@@ -473,6 +473,69 @@ public class SegmentStatusCheckerTest {
         ControllerGauge.MISSING_CONSUMING_SEGMENT_TOTAL_COUNT), 2);
   }
 
+  /**
+   * COMMITTING segments of pauseless tables have been consumed but are still being built and uploaded by the server,
+   * so they should be treated like consuming (IN_PROGRESS) segments rather than committed ones: a recently created one
+   * is skipped from the checks during the wait-for-push grace period, and none of them is flagged for an invalid time
+   * range since their time range is only finalized once they become DONE.
+   */
+  @Test
+  public void realtimeCommittingSegmentTest() {
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setTimeColumnName("timeColumn")
+            .setNumReplicas(3).setStreamConfigs(getStreamConfigMap()).build();
+
+    long now = System.currentTimeMillis();
+    String recentCommittingSegment = new LLCSegmentName(RAW_TABLE_NAME, 1, 0, now).getSegmentName();
+    String oldCommittingSegment = new LLCSegmentName(RAW_TABLE_NAME, 2, 0, now).getSegmentName();
+
+    // Both segments are ONLINE on all three replicas in the ideal state, but only one replica is ONLINE in the
+    // external view, mimicking replicas that are still building/downloading the freshly committed segment.
+    IdealState idealState = new IdealState(REALTIME_TABLE_NAME);
+    ExternalView externalView = new ExternalView(REALTIME_TABLE_NAME);
+    for (String segment : List.of(recentCommittingSegment, oldCommittingSegment)) {
+      idealState.setPartitionState(segment, "pinot1", "ONLINE");
+      idealState.setPartitionState(segment, "pinot2", "ONLINE");
+      idealState.setPartitionState(segment, "pinot3", "ONLINE");
+      externalView.setState(segment, "pinot1", "ONLINE");
+      externalView.setState(segment, "pinot2", "OFFLINE");
+      externalView.setState(segment, "pinot3", "OFFLINE");
+    }
+    idealState.setReplicas("3");
+    idealState.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
+
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    when(resourceManager.getHelixInstanceConfig(any())).thenReturn(newQuerableInstanceConfig("any"));
+    when(resourceManager.getTableConfig(REALTIME_TABLE_NAME)).thenReturn(tableConfig);
+    when(resourceManager.getAllTables()).thenReturn(List.of(REALTIME_TABLE_NAME));
+    when(resourceManager.getTableIdealState(REALTIME_TABLE_NAME)).thenReturn(idealState);
+    when(resourceManager.getTableExternalView(REALTIME_TABLE_NAME)).thenReturn(externalView);
+    SegmentZKMetadata recentCommittingSegmentZKMetadata = mockCommittingSegmentZKMetadata(now);
+    when(resourceManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, recentCommittingSegment)).thenReturn(
+        recentCommittingSegmentZKMetadata);
+    SegmentZKMetadata oldCommittingSegmentZKMetadata = mockCommittingSegmentZKMetadata(11111L);
+    when(resourceManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, oldCommittingSegment)).thenReturn(
+        oldCommittingSegmentZKMetadata);
+
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    when(resourceManager.getPropertyStore()).thenReturn(propertyStore);
+    ZNRecord znRecord = new ZNRecord("0");
+    znRecord.setSimpleField(CommonConstants.Segment.Realtime.END_OFFSET, "10000");
+    when(propertyStore.get(anyString(), any(), anyInt())).thenReturn(znRecord);
+
+    // Use a large wait-for-push window so the recently created COMMITTING segment is skipped while the old one is not.
+    runSegmentStatusChecker(resourceManager, 3600);
+
+    // Only the old COMMITTING segment is checked for replica availability; the recent one is skipped entirely.
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, REALTIME_TABLE_NAME,
+        ControllerGauge.SEGMENTS_WITH_LESS_REPLICAS), 1);
+    // COMMITTING segments have not finalized their time range yet, so neither should be flagged for invalid time.
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, REALTIME_TABLE_NAME,
+        ControllerGauge.SEGMENTS_WITH_INVALID_START_TIME), 0);
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, REALTIME_TABLE_NAME,
+        ControllerGauge.SEGMENTS_WITH_INVALID_END_TIME), 0);
+  }
+
   private Map<String, String> getStreamConfigMap() {
     return Map.of("streamType", "kafka", "stream.kafka.topic.name", "test", "stream.kafka.decoder.class.name",
         "org.apache.pinot.plugin.stream.kafka.KafkaAvroMessageDecoder", "stream.kafka.consumer.factory.class.name",
@@ -490,6 +553,14 @@ public class SegmentStatusCheckerTest {
   private SegmentZKMetadata mockConsumingSegmentZKMetadata(long creationTimeMs) {
     SegmentZKMetadata segmentZKMetadata = mock(SegmentZKMetadata.class);
     when(segmentZKMetadata.getStatus()).thenReturn(Status.IN_PROGRESS);
+    when(segmentZKMetadata.getSizeInBytes()).thenReturn(-1L);
+    when(segmentZKMetadata.getCreationTime()).thenReturn(creationTimeMs);
+    return segmentZKMetadata;
+  }
+
+  private SegmentZKMetadata mockCommittingSegmentZKMetadata(long creationTimeMs) {
+    SegmentZKMetadata segmentZKMetadata = mock(SegmentZKMetadata.class);
+    when(segmentZKMetadata.getStatus()).thenReturn(Status.COMMITTING);
     when(segmentZKMetadata.getSizeInBytes()).thenReturn(-1L);
     when(segmentZKMetadata.getCreationTime()).thenReturn(creationTimeMs);
     return segmentZKMetadata;


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Updated SegmentStatusChecker skips IN\_PROGRESS and COMMITTING segments during wait\-for\-push grace period and defers time\-range validation to only DONE/UPLOADED segments\.

```mermaid
flowchart TD
  N0["Get segment status #40;F1#41;"]:::stModified
  N1["Check if status#46;isCompleted#40;#41; #40;F1#41;"]:::stModified
  N2["Choose timestamp#58; push time if completed else creation time #40;F1#41;"]:::stModified
  N3["Wait#45;for#45;push grace period#58; skip if timestamp #62; evSnapshot #45; waitForPush #40;F1#41;"]:::stModified
  N4["If not skipped#44; check if status#46;isCompleted#40;#41; for time validation #40;F1#41;"]:::stModified
  N5["If completed#44; validate start#47;end time #40;F1#41;"]:::stModified
  N6["If not completed#44; skip time validation #40;F1#41;"]:::stModified
  N0 --> N1
  N1 --> N2
  N2 --> N3
  N3 -->|"not skipped"| N4
  N4 -->|"completed"| N5
  N4 -->|"not completed"| N6
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker\.java — [before](https://github.com/apache/pinot/blob/b6c3ca686af50988a39e762151dcec3646466744/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java) · [after](https://github.com/apache/pinot/blob/f986a9238da94e6dfe222304ee6d57662397ccbb/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImI2YzNjYTY4NmFmNTA5ODhhMzllNzYyMTUxZGNlYzM2NDY0NjY3NDQiLCJjb250ZXh0X2hhc2giOiI4M2E1ODRjYWExZWU1NTUyYjBiOWIxZWFlZGQ3MTdjOTUzYzA5NmFkNWZmZDcwNTY3NGMyNWM2MWE2ODNlOTJjIiwiZ2VuZXJhdGVkX2F0IjoxNzg5Mjk4NjUxLCJoZWFkX3NoYSI6ImY5ODZhOTIzOGRhOTRlNmRmZTIyMjMwNGVlNmQ1NzY2MjM5N2NjYmIiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJiNmMzY2E2ODZhZjUwOTg4YTM5ZTc2MjE1MWRjZWMzNjQ2NDY2NzQ0IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 9fa8f6ed3b60af99ae3a19cdc55146f4b102617051267847c5d72d02e52e0230 -->
<!-- pinot-pr-flow:end -->

## Summary

`SegmentStatusChecker`'s logic to skip recently created/pushed segments predates the pauseless
`COMMITTING` status and only special-cased `IN_PROGRESS`. As a result, a `COMMITTING` segment — one
that has finished consuming but is still being built and uploaded by the server on a pauseless
table — was mishandled in two places in `updateSegmentMetrics`:

1. **Wait-for-push grace period.** The reference timestamp was
   `getStatus() == IN_PROGRESS ? getCreationTime() : getPushTime()`. A realtime `COMMITTING` segment
   has no push time, so `getPushTime()` returns `Long.MIN_VALUE` and the segment is never skipped.
   While servers are still loading it, it gets counted as under-replicated/offline
   (`SEGMENTS_WITH_LESS_REPLICAS`, `PERCENT_SEGMENTS_AVAILABLE < 100`) and produces WARN log spam.
2. **Time-range validation.** Guarded by `getStatus() != IN_PROGRESS`. A `COMMITTING` segment's
   start/end time is only finalized once it becomes `DONE`, so it was flagged as
   `SEGMENTS_WITH_INVALID_START_TIME` / `SEGMENTS_WITH_INVALID_END_TIME`.

## Fix

Both checks now key off `Status.isCompleted()` (true only for `DONE`/`UPLOADED`), so `IN_PROGRESS`
and `COMMITTING` segments are handled the same way. A recently committed segment gets the
wait-for-push grace period and is not time-validated, while a genuinely stuck old `COMMITTING`
segment is still surfaced as under-replicated (but no longer as invalid-time noise).

## Testing

Added `SegmentStatusCheckerTest#realtimeCommittingSegmentTest`: a recently created `COMMITTING`
segment is skipped entirely, while an older one is still checked for replica availability but never
flagged for an invalid time range. The test fails without the fix (`expected [1] but found [2]`)
and passes with it. The full `SegmentStatusCheckerTest` suite (30 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
