### PR TITLE
Fix dateTimeConvert regression parsing decimal/scientific-notation epoch strings

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeConvert.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeConvert.java
@@ -86,11 +86,14 @@ public class DateTimeConvert {
   }
 
   /// Converts the input time value to millis since epoch:
-  /// - `EPOCH` / `TIMESTAMP` input is treated as a `LONG`.
-  /// - `SIMPLE_DATE_FORMAT` input is treated as a `STRING`.
+  /// - `SIMPLE_DATE_FORMAT` input, and any value that arrives as a `String`, are parsed via
+  ///   [DateTimeFormatSpec#fromFormatToMillis(String)], which tolerates decimal and scientific-notation numeric
+  ///   epoch strings (e.g. `"1.4988924E12"`) rather than requiring a strict integer literal.
+  /// - Other `EPOCH` / `TIMESTAMP` input types (numeric and date/time logical types) are read as a `LONG`.
   private long fromInputFormatToMillis(Object timeValue) {
     PinotDataType argumentType = FunctionUtils.getArgumentType(timeValue);
-    if (_inputFormatSpec.getTimeFormat() == DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT) {
+    if (argumentType == PinotDataType.STRING
+        || _inputFormatSpec.getTimeFormat() == DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT) {
       return _inputFormatSpec.fromFormatToMillis((String) PinotDataType.STRING.convert(timeValue, argumentType));
     }
     return _inputFormatSpec.fromFormatToMillis((Long) PinotDataType.LONG.convert(timeValue, argumentType));

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
@@ -776,6 +776,19 @@ public class DateTimeFunctionsTest {
   }
 
   @Test
+  public void testDateTimeConvertNumericStringEpoch() {
+    // EPOCH input arriving as a numeric string is read as LONG via PinotDataType. Decimal and scientific-notation
+    // forms (e.g. a numeric column stringified upstream) must parse rather than throw; the fractional part is
+    // truncated toward zero.
+    testDateTimeConvert("1505898960000", "1:MILLISECONDS:EPOCH", "1:MILLISECONDS:EPOCH", "1:MILLISECONDS",
+        1505898960000L);
+    testDateTimeConvert("1505898960000.0", "1:MILLISECONDS:EPOCH", "1:MILLISECONDS:EPOCH", "1:MILLISECONDS",
+        1505898960000L);
+    testDateTimeConvert("1.50589896E12", "1:MILLISECONDS:EPOCH", "1:MILLISECONDS:EPOCH", "1:MILLISECONDS",
+        1505898960000L);
+  }
+
+  @Test
   private void testTimestampAdd() {
     long currentTimestamp = System.currentTimeMillis();
     long timestampHalfHourBack = currentTimestamp - (30 * 60 * 1000);

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/DateTimeFormatSpecTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/DateTimeFormatSpecTest.java
@@ -51,6 +51,11 @@ public class DateTimeFormatSpecTest {
     entries.add(new Object[]{"1:MILLISECONDS:EPOCH", "1498892400000", 1498892400000L});
     entries.add(new Object[]{"1:HOURS:EPOCH", "0", 0L});
     entries.add(new Object[]{"5:MINUTES:EPOCH", "4996308", 1498892400000L});
+    // Numeric EPOCH values may arrive as decimal or scientific-notation strings (e.g. from a numeric column
+    // stringified upstream); the fractional part is truncated toward zero.
+    entries.add(new Object[]{"1:HOURS:EPOCH", "416359.0", 1498892400000L});
+    entries.add(new Object[]{"1:MILLISECONDS:EPOCH", "1.4988924E12", 1498892400000L});
+    entries.add(new Object[]{"5:MINUTES:EPOCH", "4996308.9", 1498892400000L});
     entries.add(new Object[]{
         "1:MILLISECONDS:TIMESTAMP", "2017-07-01 00:00:00", Timestamp.valueOf("2017-07-01 00:00:00").getTime()
     });


### PR DESCRIPTION
## Summary

#18814 widened `dateTimeConvert`'s time-value parameter to `Object` and dispatched on the input format: `EPOCH` / `TIMESTAMP` input is read as a `LONG` via `PinotDataType.LONG.convert(value, STRING)`. For values that arrive as a `String`, that routes through `STRING.toLong` (strict `Long.parseLong`), which throws `NumberFormatException` on decimal or scientific-notation numeric strings (e.g. `"1.4988924E12"`, `"416359.0"`).

Before #18814, string time values were parsed by `DateTimeFormatSpec.fromFormatToMillis(String)`, which uses `new BigDecimal(...).longValue()` and tolerates those forms. Epoch values that arrive as stringified doubles therefore regressed from working to throwing.

### Fix

Route any `String`-typed input in `DateTimeConvert.fromInputFormatToMillis` through `fromFormatToMillis(String)` (the `BigDecimal`-tolerant path, i.e. the pre-#18814 behavior for strings) instead of coercing to `LONG` first. Numeric, `Timestamp`, `LocalDate`, and `LocalTime` inputs still read as `LONG`, so #18814's typed-input handling is preserved.

`PinotDataType.STRING`/`JSON` `toInt`/`toLong` are intentionally left **strict**: casting a non-integer string to an integral type should throw, consistent with SQL engines (Postgres, Trino, BigQuery, DuckDB) and the existing `DOUBLE`-vs-`STRING` split in `PinotDataType`. The decimal/scientific tolerance is specific to epoch time-value parsing, not a general string→integral cast.

### Tests

- `DateTimeFunctionsTest#testDateTimeConvertNumericStringEpoch` — end-to-end `dateTimeConvert` regression with decimal/scientific-notation epoch string input.
- `DateTimeFormatSpecTest` — decimal/scientific `EPOCH` entries through `fromFormatToMillis(String)`.
