### PR TITLE
[#12507] Implement adaptive pool selection for StrictReplicaGroupInstanceSelector

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BalancedInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BalancedInstanceSelector.java
@@ -21,7 +21,6 @@ package org.apache.pinot.broker.routing.instanceselector;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.broker.routing.adaptiveserverselector.ServerSelectionContext;
 import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
@@ -45,7 +44,7 @@ import org.apache.pinot.common.utils.HashUtil;
 public class BalancedInstanceSelector extends BaseInstanceSelector {
 
   @Override
-  public Pair<Map<String, String>, Map<String, String>> select(List<String> segments, int requestId,
+  public InstanceMapping select(List<String> segments, int requestId,
       SegmentStates segmentStates, Map<String, String> queryOptions) {
     Map<String, String> segmentToSelectedInstanceMap = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
     // No need to adjust this map per total segment numbers, as optional segments should be empty most of the time.
@@ -88,6 +87,6 @@ public class BalancedInstanceSelector extends BaseInstanceSelector {
       _brokerMetrics.addMeteredValue(BrokerMeter.POOL_SEG_QUERIES, entry.getValue(),
           BrokerMetrics.getTagForPreferredPool(queryOptions), String.valueOf(entry.getKey()));
     }
-    return Pair.of(segmentToSelectedInstanceMap, optionalSegmentToInstanceMap);
+    return new InstanceMapping(segmentToSelectedInstanceMap, optionalSegmentToInstanceMap);
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BalancedInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BalancedInstanceSelector.java
@@ -21,7 +21,6 @@ package org.apache.pinot.broker.routing.instanceselector;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.broker.routing.adaptiveserverselector.ServerSelectionContext;
 import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
@@ -44,7 +43,7 @@ import org.apache.pinot.common.utils.HashUtil;
 public class BalancedInstanceSelector extends BaseInstanceSelector {
 
   @Override
-  public Pair<Map<String, String>, Map<String, String>> select(List<String> segments, int requestId,
+  public InstanceMapping select(List<String> segments, int requestId,
       SegmentStates segmentStates, Map<String, String> queryOptions) {
     Map<String, String> segmentToSelectedInstanceMap = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
     // No need to adjust this map per total segment numbers, as optional segments should be empty most of the time.
@@ -87,6 +86,6 @@ public class BalancedInstanceSelector extends BaseInstanceSelector {
       _brokerMetrics.addMeteredValue(BrokerMeter.POOL_SEG_QUERIES, entry.getValue(),
           BrokerMetrics.getTagForPreferredPool(queryOptions), String.valueOf(entry.getKey()));
     }
-    return Pair.of(segmentToSelectedInstanceMap, optionalSegmentToInstanceMap);
+    return new InstanceMapping(segmentToSelectedInstanceMap, optionalSegmentToInstanceMap);
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
@@ -466,11 +466,12 @@ public abstract class BaseInstanceSelector implements InstanceSelector {
     SegmentStates segmentStates = _segmentStates;
     InstanceMapping mapping = select(segments, requestIdInt, segmentStates, queryOptions);
     Set<String> unavailableSegments = segmentStates.getUnavailableSegments();
+    List<String> mappingUnavailable = mapping.unavailableSegments();
 
-    if (unavailableSegments.isEmpty()) {
+    if (unavailableSegments.isEmpty() && mappingUnavailable.isEmpty()) {
       return new SelectionResult(mapping, Collections.emptyList(), 0);
     } else {
-      List<String> unavailableSegmentsForRequest = new ArrayList<>();
+      List<String> unavailableSegmentsForRequest = new ArrayList<>(mappingUnavailable);
       for (String segment : segments) {
         if (unavailableSegments.contains(segment)) {
           unavailableSegmentsForRequest.add(segment);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
@@ -469,7 +469,7 @@ public abstract class BaseInstanceSelector implements InstanceSelector {
     List<String> mappingUnavailable = mapping.unavailableSegments();
 
     if (unavailableSegments.isEmpty() && mappingUnavailable.isEmpty()) {
-      return new SelectionResult(mapping, Collections.emptyList(), 0);
+      return new SelectionResult(mapping, List.of(), 0);
     } else {
       List<String> unavailableSegmentsForRequest = new ArrayList<>(mappingUnavailable);
       for (String segment : segments) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
@@ -30,7 +30,6 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import javax.annotation.Nullable;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.AccessOption;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
@@ -465,12 +464,11 @@ public abstract class BaseInstanceSelector implements InstanceSelector {
     // Copy the volatile reference so that segmentToInstanceMap and unavailableSegments can have a consistent view of
     // the state.
     SegmentStates segmentStates = _segmentStates;
-    Pair<Map<String, String>, Map<String, String>> segmentToInstanceMap =
-        select(segments, requestIdInt, segmentStates, queryOptions);
+    InstanceMapping mapping = select(segments, requestIdInt, segmentStates, queryOptions);
     Set<String> unavailableSegments = segmentStates.getUnavailableSegments();
 
     if (unavailableSegments.isEmpty()) {
-      return new SelectionResult(segmentToInstanceMap, List.of(), 0);
+      return new SelectionResult(mapping, Collections.emptyList(), 0);
     } else {
       List<String> unavailableSegmentsForRequest = new ArrayList<>();
       for (String segment : segments) {
@@ -478,7 +476,7 @@ public abstract class BaseInstanceSelector implements InstanceSelector {
           unavailableSegmentsForRequest.add(segment);
         }
       }
-      return new SelectionResult(segmentToInstanceMap, unavailableSegmentsForRequest, 0);
+      return new SelectionResult(mapping, unavailableSegmentsForRequest, 0);
     }
   }
 
@@ -501,11 +499,11 @@ public abstract class BaseInstanceSelector implements InstanceSelector {
   }
 
   /**
-   * Selects the server instances for the given segments based on the request id and segment states. Returns two maps
-   * from segment to selected server instance hosting the segment. The 2nd map is for optional segments. The optional
-   * segments are used to get the new segments that are not online yet. Instead of simply skipping them by broker at
-   * routing time, we can send them to servers and let servers decide how to handle them.
+   * Selects the server instances for the given segments based on the request id and segment states. Returns an
+   * {@link InstanceSelector.InstanceMapping} containing two maps from segment to selected server instance. The optional
+   * map covers new segments that are not online yet; instead of simply skipping them at the broker, we can send them to
+   * servers and let servers decide how to handle them.
    */
-  protected abstract Pair<Map<String, String>, Map<String, String>/*optional segments*/> select(List<String> segments,
-      int requestId, SegmentStates segmentStates, Map<String, String> queryOptions);
+  protected abstract InstanceMapping select(List<String> segments, int requestId, SegmentStates segmentStates,
+      Map<String, String> queryOptions);
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
@@ -23,6 +23,7 @@ import java.time.Clock;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -526,13 +527,13 @@ public abstract class BaseInstanceSelector implements InstanceSelector {
     if (unavailableSegments.isEmpty() && mappingUnavailable.isEmpty()) {
       return new SelectionResult(mapping, List.of(), 0);
     } else {
-      List<String> unavailableSegmentsForRequest = new ArrayList<>(mappingUnavailable);
+      Set<String> unavailableSegmentsForRequest = new LinkedHashSet<>(mappingUnavailable);
       for (String segment : segments) {
         if (unavailableSegments.contains(segment)) {
           unavailableSegmentsForRequest.add(segment);
         }
       }
-      return new SelectionResult(mapping, unavailableSegmentsForRequest, 0);
+      return new SelectionResult(mapping, new ArrayList<>(unavailableSegmentsForRequest), 0);
     }
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
@@ -23,7 +23,6 @@ import java.time.Clock;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -517,23 +516,22 @@ public abstract class BaseInstanceSelector implements InstanceSelector {
         (brokerRequest.getPinotQuery() != null && brokerRequest.getPinotQuery().getQueryOptions() != null)
             ? brokerRequest.getPinotQuery().getQueryOptions() : Map.of();
     int requestIdInt = (int) (requestId % MAX_REQUEST_ID);
-    // Copy the volatile reference so that segmentToInstanceMap and unavailableSegments can have a consistent view of
-    // the state.
+    // Copy the volatile reference so that the segment-to-instance map and unavailable segments have a consistent view
+    // of the state.
     SegmentStates segmentStates = _segmentStates;
     InstanceMapping mapping = select(segments, requestIdInt, segmentStates, queryOptions);
     Set<String> unavailableSegments = segmentStates.getUnavailableSegments();
-    List<String> mappingUnavailable = mapping.unavailableSegments();
 
-    if (unavailableSegments.isEmpty() && mappingUnavailable.isEmpty()) {
+    if (unavailableSegments.isEmpty()) {
       return new SelectionResult(mapping, List.of(), 0);
     } else {
-      Set<String> unavailableSegmentsForRequest = new LinkedHashSet<>(mappingUnavailable);
+      List<String> unavailableSegmentsForRequest = new ArrayList<>();
       for (String segment : segments) {
         if (unavailableSegments.contains(segment)) {
           unavailableSegmentsForRequest.add(segment);
         }
       }
-      return new SelectionResult(mapping, new ArrayList<>(unavailableSegmentsForRequest), 0);
+      return new SelectionResult(mapping, unavailableSegmentsForRequest, 0);
     }
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
@@ -521,11 +521,12 @@ public abstract class BaseInstanceSelector implements InstanceSelector {
     SegmentStates segmentStates = _segmentStates;
     InstanceMapping mapping = select(segments, requestIdInt, segmentStates, queryOptions);
     Set<String> unavailableSegments = segmentStates.getUnavailableSegments();
+    List<String> mappingUnavailable = mapping.unavailableSegments();
 
-    if (unavailableSegments.isEmpty()) {
+    if (unavailableSegments.isEmpty() && mappingUnavailable.isEmpty()) {
       return new SelectionResult(mapping, List.of(), 0);
     } else {
-      List<String> unavailableSegmentsForRequest = new ArrayList<>();
+      List<String> unavailableSegmentsForRequest = new ArrayList<>(mappingUnavailable);
       for (String segment : segments) {
         if (unavailableSegments.contains(segment)) {
           unavailableSegmentsForRequest.add(segment);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
@@ -30,7 +30,6 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import javax.annotation.Nullable;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.AccessOption;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
@@ -520,12 +519,11 @@ public abstract class BaseInstanceSelector implements InstanceSelector {
     // Copy the volatile reference so that segmentToInstanceMap and unavailableSegments can have a consistent view of
     // the state.
     SegmentStates segmentStates = _segmentStates;
-    Pair<Map<String, String>, Map<String, String>> segmentToInstanceMap =
-        select(segments, requestIdInt, segmentStates, queryOptions);
+    InstanceMapping mapping = select(segments, requestIdInt, segmentStates, queryOptions);
     Set<String> unavailableSegments = segmentStates.getUnavailableSegments();
 
     if (unavailableSegments.isEmpty()) {
-      return new SelectionResult(segmentToInstanceMap, List.of(), 0);
+      return new SelectionResult(mapping, List.of(), 0);
     } else {
       List<String> unavailableSegmentsForRequest = new ArrayList<>();
       for (String segment : segments) {
@@ -533,7 +531,7 @@ public abstract class BaseInstanceSelector implements InstanceSelector {
           unavailableSegmentsForRequest.add(segment);
         }
       }
-      return new SelectionResult(segmentToInstanceMap, unavailableSegmentsForRequest, 0);
+      return new SelectionResult(mapping, unavailableSegmentsForRequest, 0);
     }
   }
 
@@ -555,10 +553,10 @@ public abstract class BaseInstanceSelector implements InstanceSelector {
     return pool;
   }
 
-  /// Selects the server instances for the given segments based on the request id and segment states. Returns two maps
-  /// from segment to selected server instance hosting the segment. The 2nd map is for optional segments. The optional
-  /// segments are used to get the new segments that are not online yet. Instead of simply skipping them by broker at
-  /// routing time, we can send them to servers and let servers decide how to handle them.
-  protected abstract Pair<Map<String, String>, Map<String, String>/*optional segments*/> select(List<String> segments,
-      int requestId, SegmentStates segmentStates, Map<String, String> queryOptions);
+  /// Selects the server instances for the given segments based on the request id and segment states. Returns an
+  /// [InstanceSelector.InstanceMapping] containing two maps from segment to selected server instance. The optional map
+  /// covers new segments that are not online yet; instead of simply skipping them at the broker, we can send them to
+  /// servers and let servers decide how to handle them.
+  protected abstract InstanceMapping select(List<String> segments, int requestId, SegmentStates segmentStates,
+      Map<String, String> queryOptions);
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.broker.routing.instanceselector;
 
 import java.time.Clock;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -92,10 +91,10 @@ public interface InstanceSelector {
       Map<String, String> optionalSegmentToInstanceMap,
       List<String> unavailableSegments) {
     static final InstanceMapping EMPTY =
-        new InstanceMapping(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyList());
+        new InstanceMapping(Map.of(), Map.of(), List.of());
 
     InstanceMapping(Map<String, String> segmentToInstanceMap, Map<String, String> optionalSegmentToInstanceMap) {
-      this(segmentToInstanceMap, optionalSegmentToInstanceMap, Collections.emptyList());
+      this(segmentToInstanceMap, optionalSegmentToInstanceMap, List.of());
     }
   }
 
@@ -112,7 +111,7 @@ public interface InstanceSelector {
     }
 
     public static SelectionResult empty(int numPrunedSegments) {
-      return new SelectionResult(InstanceMapping.EMPTY, Collections.emptyList(), numPrunedSegments);
+      return new SelectionResult(InstanceMapping.EMPTY, List.of(), numPrunedSegments);
     }
 
     /**

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
@@ -19,11 +19,11 @@
 package org.apache.pinot.broker.routing.instanceselector;
 
 import java.time.Clock;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -83,23 +83,36 @@ public interface InstanceSelector {
    */
   Set<String> getServingInstances();
 
+  /**
+   * Holds the result of an instance selection: {@code segmentToInstanceMap} maps each segment to its selected server
+   * instance, and {@code optionalSegmentToInstanceMap} maps segments not yet fully online that the server may skip.
+   */
+  record InstanceMapping(Map<String, String> segmentToInstanceMap,
+      Map<String, String> optionalSegmentToInstanceMap) {
+    static final InstanceMapping EMPTY = new InstanceMapping(Collections.emptyMap(), Collections.emptyMap());
+  }
+
   class SelectionResult {
-    private final Pair<Map<String, String>, Map<String, String>/*optional segments*/> _segmentToInstanceMap;
+    private final InstanceMapping _instanceMapping;
     private final List<String> _unavailableSegments;
     private int _numPrunedSegments;
 
-    public SelectionResult(Pair<Map<String, String>, Map<String, String>> segmentToInstanceMap,
+    public SelectionResult(InstanceMapping instanceMapping,
         List<String> unavailableSegments, int numPrunedSegments) {
-      _segmentToInstanceMap = segmentToInstanceMap;
+      _instanceMapping = instanceMapping;
       _unavailableSegments = unavailableSegments;
       _numPrunedSegments = numPrunedSegments;
+    }
+
+    public static SelectionResult empty(int numPrunedSegments) {
+      return new SelectionResult(InstanceMapping.EMPTY, Collections.emptyList(), numPrunedSegments);
     }
 
     /**
      * Returns the map from segment to selected server instance hosting the segment.
      */
     public Map<String, String> getSegmentToInstanceMap() {
-      return _segmentToInstanceMap.getLeft();
+      return _instanceMapping.segmentToInstanceMap();
     }
 
     /**
@@ -107,7 +120,7 @@ public interface InstanceSelector {
      * Optional segments can be skipped by broker or server upon any issue w/o failing the query.
      */
     public Map<String, String> getOptionalSegmentToInstanceMap() {
-      return _segmentToInstanceMap.getRight();
+      return _instanceMapping.optionalSegmentToInstanceMap();
     }
 
     /**

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
@@ -85,11 +85,18 @@ public interface InstanceSelector {
 
   /**
    * Holds the result of an instance selection: {@code segmentToInstanceMap} maps each segment to its selected server
-   * instance, and {@code optionalSegmentToInstanceMap} maps segments not yet fully online that the server may skip.
+   * instance, {@code optionalSegmentToInstanceMap} maps segments not yet fully online that the server may skip, and
+   * {@code unavailableSegments} lists segments that have candidates but could not be routed.
    */
   record InstanceMapping(Map<String, String> segmentToInstanceMap,
-      Map<String, String> optionalSegmentToInstanceMap) {
-    static final InstanceMapping EMPTY = new InstanceMapping(Collections.emptyMap(), Collections.emptyMap());
+      Map<String, String> optionalSegmentToInstanceMap,
+      List<String> unavailableSegments) {
+    static final InstanceMapping EMPTY =
+        new InstanceMapping(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyList());
+
+    InstanceMapping(Map<String, String> segmentToInstanceMap, Map<String, String> optionalSegmentToInstanceMap) {
+      this(segmentToInstanceMap, optionalSegmentToInstanceMap, Collections.emptyList());
+    }
   }
 
   class SelectionResult {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
@@ -89,13 +89,14 @@ public interface InstanceSelector {
 
   /// Holds the result of an instance selection: `segmentToInstanceMap` maps each segment to its selected server
   /// instance, `optionalSegmentToInstanceMap` maps segments not yet fully online that the server may skip, and
-  /// `unavailableSegments` lists segments that have candidates but could not be routed.
+  /// `unavailableSegments` lists segments that have candidates but could not be routed. These unavailable segments are
+  /// merged into the query's unavailable-segment list and surfaced as a `BROKER_SEGMENT_UNAVAILABLE` error.
   record InstanceMapping(Map<String, String> segmentToInstanceMap,
       Map<String, String> optionalSegmentToInstanceMap,
       List<String> unavailableSegments) {
     static final InstanceMapping EMPTY = new InstanceMapping(Map.of(), Map.of(), List.of());
 
-    InstanceMapping(Map<String, String> segmentToInstanceMap, Map<String, String> optionalSegmentToInstanceMap) {
+    public InstanceMapping(Map<String, String> segmentToInstanceMap, Map<String, String> optionalSegmentToInstanceMap) {
       this(segmentToInstanceMap, optionalSegmentToInstanceMap, List.of());
     }
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -88,27 +87,38 @@ public interface InstanceSelector {
     return null;
   }
 
+  /// Holds the result of an instance selection: `segmentToInstanceMap` maps each segment to its selected server
+  /// instance, and `optionalSegmentToInstanceMap` maps segments not yet fully online that the server may skip.
+  record InstanceMapping(Map<String, String> segmentToInstanceMap,
+      Map<String, String> optionalSegmentToInstanceMap) {
+    static final InstanceMapping EMPTY = new InstanceMapping(Map.of(), Map.of());
+  }
+
   class SelectionResult {
-    private final Pair<Map<String, String>, Map<String, String>/*optional segments*/> _segmentToInstanceMap;
+    private final InstanceMapping _instanceMapping;
     private final List<String> _unavailableSegments;
     private int _numPrunedSegments;
 
-    public SelectionResult(Pair<Map<String, String>, Map<String, String>> segmentToInstanceMap,
+    public SelectionResult(InstanceMapping instanceMapping,
         List<String> unavailableSegments, int numPrunedSegments) {
-      _segmentToInstanceMap = segmentToInstanceMap;
+      _instanceMapping = instanceMapping;
       _unavailableSegments = unavailableSegments;
       _numPrunedSegments = numPrunedSegments;
     }
 
+    public static SelectionResult empty(int numPrunedSegments) {
+      return new SelectionResult(InstanceMapping.EMPTY, List.of(), numPrunedSegments);
+    }
+
     /// Returns the map from segment to selected server instance hosting the segment.
     public Map<String, String> getSegmentToInstanceMap() {
-      return _segmentToInstanceMap.getLeft();
+      return _instanceMapping.segmentToInstanceMap();
     }
 
     /// Returns the map from optional segment to selected server instance hosting the optional segment.
     /// Optional segments can be skipped by broker or server upon any issue w/o failing the query.
     public Map<String, String> getOptionalSegmentToInstanceMap() {
-      return _segmentToInstanceMap.getRight();
+      return _instanceMapping.optionalSegmentToInstanceMap();
     }
 
     /// Returns the unavailable segments (no enabled instance or all enabled instances are in ERROR state).

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
@@ -88,10 +88,16 @@ public interface InstanceSelector {
   }
 
   /// Holds the result of an instance selection: `segmentToInstanceMap` maps each segment to its selected server
-  /// instance, and `optionalSegmentToInstanceMap` maps segments not yet fully online that the server may skip.
+  /// instance, `optionalSegmentToInstanceMap` maps segments not yet fully online that the server may skip, and
+  /// `unavailableSegments` lists segments that have candidates but could not be routed.
   record InstanceMapping(Map<String, String> segmentToInstanceMap,
-      Map<String, String> optionalSegmentToInstanceMap) {
-    static final InstanceMapping EMPTY = new InstanceMapping(Map.of(), Map.of());
+      Map<String, String> optionalSegmentToInstanceMap,
+      List<String> unavailableSegments) {
+    static final InstanceMapping EMPTY = new InstanceMapping(Map.of(), Map.of(), List.of());
+
+    InstanceMapping(Map<String, String> segmentToInstanceMap, Map<String, String> optionalSegmentToInstanceMap) {
+      this(segmentToInstanceMap, optionalSegmentToInstanceMap, List.of());
+    }
   }
 
   class SelectionResult {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
@@ -88,17 +88,10 @@ public interface InstanceSelector {
   }
 
   /// Holds the result of an instance selection: `segmentToInstanceMap` maps each segment to its selected server
-  /// instance, `optionalSegmentToInstanceMap` maps segments not yet fully online that the server may skip, and
-  /// `unavailableSegments` lists segments that have candidates but could not be routed. These unavailable segments are
-  /// merged into the query's unavailable-segment list and surfaced as a `BROKER_SEGMENT_UNAVAILABLE` error.
+  /// instance, and `optionalSegmentToInstanceMap` maps segments not yet fully online that the server may skip.
   record InstanceMapping(Map<String, String> segmentToInstanceMap,
-      Map<String, String> optionalSegmentToInstanceMap,
-      List<String> unavailableSegments) {
-    static final InstanceMapping EMPTY = new InstanceMapping(Map.of(), Map.of(), List.of());
-
-    public InstanceMapping(Map<String, String> segmentToInstanceMap, Map<String, String> optionalSegmentToInstanceMap) {
-      this(segmentToInstanceMap, optionalSegmentToInstanceMap, List.of());
-    }
+      Map<String, String> optionalSegmentToInstanceMap) {
+    static final InstanceMapping EMPTY = new InstanceMapping(Map.of(), Map.of());
   }
 
   class SelectionResult {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorFactory.java
@@ -107,6 +107,17 @@ public class InstanceSelectorFactory {
           case RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE: {
             LOGGER.info("Using StrictReplicaGroupInstanceSelector for table: {}", tableNameWithType);
             instanceSelector = new StrictReplicaGroupInstanceSelector();
+
+            // Adaptive Routing is incompatible with Strict Replica Group routing, because Adaptive Routing routes
+            // each segment independently to the lowest-latency server, violating the same-replica-group guarantee.
+            // TODO: rework StrictReplicaGroupInstanceSelector::select to do pool-based adaptive routing.
+            // See https://github.com/apache/pinot/issues/12507
+            if (adaptiveServerSelector != null) {
+              LOGGER.info(
+                  "Disabling adaptive routing for StrictReplicaGroupInstanceSelector table: {}",
+                  tableNameWithType);
+              adaptiveServerSelector = null;
+            }
             break;
           }
           case RoutingConfig.MULTI_STAGE_REPLICA_GROUP_SELECTOR_TYPE: {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorFactory.java
@@ -106,18 +106,15 @@ public class InstanceSelectorFactory {
           }
           case RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE: {
             LOGGER.info("Using StrictReplicaGroupInstanceSelector for table: {}", tableNameWithType);
-            instanceSelector = new StrictReplicaGroupInstanceSelector();
-
-            // Adaptive Routing is incompatible with Strict Replica Group routing, because Adaptive Routing routes
-            // each segment independently to the lowest-latency server, violating the same-replica-group guarantee.
-            // TODO: rework StrictReplicaGroupInstanceSelector::select to do pool-based adaptive routing.
-            // See https://github.com/apache/pinot/issues/12507
-            if (adaptiveServerSelector != null) {
-              LOGGER.info(
-                  "Disabling adaptive routing for StrictReplicaGroupInstanceSelector table: {}",
+            boolean enableStrictReplicaGroupAdaptiveRouting = brokerConfig.getProperty(
+                CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STRICT_REPLICA_GROUP,
+                CommonConstants.Broker.AdaptiveServerSelector.DEFAULT_ENABLE_STRICT_REPLICA_GROUP);
+            if (!enableStrictReplicaGroupAdaptiveRouting && adaptiveServerSelector != null) {
+              LOGGER.info("Adaptive routing disabled for StrictReplicaGroupInstanceSelector table: {}",
                   tableNameWithType);
               adaptiveServerSelector = null;
             }
+            instanceSelector = new StrictReplicaGroupInstanceSelector();
             break;
           }
           case RoutingConfig.MULTI_STAGE_REPLICA_GROUP_SELECTOR_TYPE: {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorFactory.java
@@ -74,6 +74,7 @@ public class InstanceSelectorFactory {
       ExternalView externalView, Set<String> onlineSegments) {
     String tableNameWithType = tableConfig.getTableName();
     RoutingConfig routingConfig = tableConfig.getRoutingConfig();
+    AdaptiveServerSelector effectiveAdaptiveServerSelector = adaptiveServerSelector;
     boolean useFixedReplica = brokerConfig.getProperty(CommonConstants.Broker.CONFIG_OF_USE_FIXED_REPLICA,
         CommonConstants.Broker.DEFAULT_USE_FIXED_REPLICA);
     if (routingConfig != null && routingConfig.getUseFixedReplica() != null) {
@@ -107,12 +108,12 @@ public class InstanceSelectorFactory {
           case RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE: {
             LOGGER.info("Using StrictReplicaGroupInstanceSelector for table: {}", tableNameWithType);
             boolean enableStrictReplicaGroupAdaptiveRouting = brokerConfig.getProperty(
-                CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STRICT_REPLICA_GROUP,
-                CommonConstants.Broker.AdaptiveServerSelector.DEFAULT_ENABLE_STRICT_REPLICA_GROUP);
-            if (!enableStrictReplicaGroupAdaptiveRouting && adaptiveServerSelector != null) {
+                CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_STRICT_REPLICA_GROUP_ENABLED,
+                CommonConstants.Broker.AdaptiveServerSelector.DEFAULT_STRICT_REPLICA_GROUP_ENABLED);
+            if (!enableStrictReplicaGroupAdaptiveRouting && effectiveAdaptiveServerSelector != null) {
               LOGGER.info("Adaptive routing disabled for StrictReplicaGroupInstanceSelector table: {}",
                   tableNameWithType);
-              adaptiveServerSelector = null;
+              effectiveAdaptiveServerSelector = null;
             }
             instanceSelector = new StrictReplicaGroupInstanceSelector();
             break;
@@ -144,8 +145,15 @@ public class InstanceSelectorFactory {
     if (instanceSelector == null) {
       instanceSelector = new BalancedInstanceSelector();
     }
+    if (instanceSelector.getClass() == ReplicaGroupInstanceSelector.class
+        && (tableConfig.isUpsertEnabled() || tableConfig.isDedupEnabled())
+        && effectiveAdaptiveServerSelector != null) {
+      LOGGER.warn("Disabling adaptive routing for legacy upsert/dedup table {} using ReplicaGroupInstanceSelector",
+          tableNameWithType);
+      effectiveAdaptiveServerSelector = null;
+    }
 
-    instanceSelector.init(tableConfig, propertyStore, brokerMetrics, adaptiveServerSelector, clock,
+    instanceSelector.init(tableConfig, propertyStore, brokerMetrics, effectiveAdaptiveServerSelector, clock,
         config, enabledInstances, enabledServerMap, idealState, externalView, onlineSegments);
     return instanceSelector;
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorFactory.java
@@ -115,6 +115,11 @@ public class InstanceSelectorFactory {
                   tableNameWithType);
               effectiveAdaptiveServerSelector = null;
             }
+            if (useFixedReplica && effectiveAdaptiveServerSelector != null) {
+              LOGGER.warn("Disabling adaptive routing for StrictReplicaGroupInstanceSelector table {} using fixed "
+                  + "replica routing", tableNameWithType);
+              effectiveAdaptiveServerSelector = null;
+            }
             instanceSelector = new StrictReplicaGroupInstanceSelector();
             break;
           }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/MultiStageReplicaGroupSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/MultiStageReplicaGroupSelector.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -86,7 +85,7 @@ public class MultiStageReplicaGroupSelector extends BaseInstanceSelector {
   }
 
   @Override
-  public Pair<Map<String, String>, Map<String, String>> select(List<String> segments, int requestId,
+  public InstanceMapping select(List<String> segments, int requestId,
       SegmentStates segmentStates, Map<String, String> queryOptions) {
     // Create a copy of InstancePartitions to avoid race-condition with event-listeners above.
     InstancePartitions instancePartitions = _instancePartitions;
@@ -110,8 +109,9 @@ public class MultiStageReplicaGroupSelector extends BaseInstanceSelector {
    * Returns a map from the segmentName to the corresponding server. It tries to select all servers from the
    * preferredReplicaGroup, but if it fails, it will try to select the relevant server from other instance partitions.
    *
-   * @return A pair of maps, where the first map contains the segments that are assigned to a server and the second
-   * map contains the segments that are optional (i.e., the server is not online to serve that segment).
+   * @return An {@link InstanceMapping} whose {@code segmentToInstanceMap} contains the segments assigned to a server
+   * and whose {@code optionalSegmentToInstanceMap} contains segments that are optional (i.e., the server is not
+   * online to serve that segment).
    * Example:
    * {
    *   "required_segments": {
@@ -124,7 +124,7 @@ public class MultiStageReplicaGroupSelector extends BaseInstanceSelector {
    *   }
    * }
    */
-  private Pair<Map<String, String>, Map<String, String>> assign(Set<String> segments,
+  private InstanceMapping assign(Set<String> segments,
       SegmentStates segmentStates, InstancePartitions instancePartitions, int preferredReplicaId) {
     Map<String, Integer> instanceToPartitionMap = instancePartitions.getInstanceToPartitionIdMap();
     Map<String, Set<String>> instanceToSegmentsMap = new HashMap<>();
@@ -229,7 +229,7 @@ public class MultiStageReplicaGroupSelector extends BaseInstanceSelector {
    * Based on whether the selected instance for the segment is online to serve that segment or not,
    * this method computes the segments that are optional and the segments that are not.
    */
-  private Pair<Map<String, String>, Map<String, String>> computeOptionalSegments(
+  private InstanceMapping computeOptionalSegments(
       Map<String, String> segmentToSelectedInstanceMap, SegmentStates segmentStates) {
 
     Map<String, String> segmentsToInstanceMap = new HashMap<>();
@@ -258,7 +258,7 @@ public class MultiStageReplicaGroupSelector extends BaseInstanceSelector {
       }
     }
 
-    return Pair.of(segmentsToInstanceMap, optionalSegmentToInstanceMap);
+    return new InstanceMapping(segmentsToInstanceMap, optionalSegmentToInstanceMap);
   }
 
   @VisibleForTesting

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/MultiStageReplicaGroupSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/MultiStageReplicaGroupSelector.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -84,7 +83,7 @@ public class MultiStageReplicaGroupSelector extends BaseInstanceSelector {
   }
 
   @Override
-  public Pair<Map<String, String>, Map<String, String>> select(List<String> segments, int requestId,
+  public InstanceMapping select(List<String> segments, int requestId,
       SegmentStates segmentStates, Map<String, String> queryOptions) {
     // Create a copy of InstancePartitions to avoid race-condition with event-listeners above.
     InstancePartitions instancePartitions = _instancePartitions;
@@ -107,8 +106,9 @@ public class MultiStageReplicaGroupSelector extends BaseInstanceSelector {
   /// Returns a map from the segmentName to the corresponding server. It tries to select all servers from the
   /// preferredReplicaGroup, but if it fails, it will try to select the relevant server from other instance partitions.
   ///
-  /// @return A pair of maps, where the first map contains the segments that are assigned to a server and the second
-  /// map contains the segments that are optional (i.e., the server is not online to serve that segment).
+  /// @return An [InstanceMapping] whose `segmentToInstanceMap` contains the segments assigned to a server and whose
+  /// `optionalSegmentToInstanceMap` contains segments that are optional (i.e., the server is not online to serve that
+  /// segment).
   /// Example:
   /// {
   ///   "required_segments": {
@@ -120,7 +120,7 @@ public class MultiStageReplicaGroupSelector extends BaseInstanceSelector {
   ///     "segment4": "server4"
   ///   }
   /// }
-  private Pair<Map<String, String>, Map<String, String>> assign(Set<String> segments,
+  private InstanceMapping assign(Set<String> segments,
       SegmentStates segmentStates, InstancePartitions instancePartitions, int preferredReplicaId) {
     Map<String, Integer> instanceToPartitionMap = instancePartitions.getInstanceToPartitionIdMap();
     Map<String, Set<String>> instanceToSegmentsMap = new HashMap<>();
@@ -221,7 +221,7 @@ public class MultiStageReplicaGroupSelector extends BaseInstanceSelector {
 
   /// Based on whether the selected instance for the segment is online to serve that segment or not,
   /// this method computes the segments that are optional and the segments that are not.
-  private Pair<Map<String, String>, Map<String, String>> computeOptionalSegments(
+  private InstanceMapping computeOptionalSegments(
       Map<String, String> segmentToSelectedInstanceMap, SegmentStates segmentStates) {
 
     Map<String, String> segmentsToInstanceMap = new HashMap<>();
@@ -250,7 +250,7 @@ public class MultiStageReplicaGroupSelector extends BaseInstanceSelector {
       }
     }
 
-    return Pair.of(segmentsToInstanceMap, optionalSegmentToInstanceMap);
+    return new InstanceMapping(segmentsToInstanceMap, optionalSegmentToInstanceMap);
   }
 
   @VisibleForTesting

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
@@ -90,7 +90,7 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
     }
   }
 
-  private InstanceMapping selectServers(List<String> segments, int requestId,
+  protected InstanceMapping selectServers(List<String> segments, int requestId,
       SegmentStates segmentStates, @Nullable Map<String, Integer> serverRankMap, ServerSelectionContext ctx) {
 
     Map<String, String> segmentToSelectedInstanceMap = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
@@ -120,7 +120,7 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
       } else if (MapUtils.isNotEmpty(serverRankMap)) {
         // Adaptive Server Selection is enabled.
         // Use the instance with the best rank if all servers have stats populated, else use the round-robin selected
-        // instance
+        // instance. As of 8 July 2026, this fallback is unreachable, but new implementations could require it.
         selectedInstance = candidates.stream()
             .anyMatch(candidate -> !serverRankMap.containsKey(candidate.getInstance()))
             ? selectedInstance

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.commons.collections.MapUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.pinot.broker.routing.adaptiveserverselector.ServerSelectionContext;
@@ -70,7 +69,7 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
   private static final Logger LOGGER = LoggerFactory.getLogger(ReplicaGroupInstanceSelector.class);
 
   @Override
-  public Pair<Map<String, String>, Map<String, String>> select(List<String> segments, int requestId,
+  public InstanceMapping select(List<String> segments, int requestId,
       SegmentStates segmentStates, Map<String, String> queryOptions) {
     ServerSelectionContext ctx = new ServerSelectionContext(queryOptions, _config);
     if (_adaptiveServerSelector != null) {
@@ -91,7 +90,7 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
     }
   }
 
-  private Pair<Map<String, String>, Map<String, String>> selectServers(List<String> segments, int requestId,
+  private InstanceMapping selectServers(List<String> segments, int requestId,
       SegmentStates segmentStates, @Nullable Map<String, Integer> serverRankMap, ServerSelectionContext ctx) {
 
     Map<String, String> segmentToSelectedInstanceMap = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
@@ -147,7 +146,7 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
       _brokerMetrics.addMeteredValue(BrokerMeter.POOL_SEG_QUERIES, entry.getValue(),
           BrokerMetrics.getTagForPreferredPool(ctx.getQueryOptions()), String.valueOf(entry.getKey()));
     }
-    return Pair.of(segmentToSelectedInstanceMap, optionalSegmentToInstanceMap);
+    return new InstanceMapping(segmentToSelectedInstanceMap, optionalSegmentToInstanceMap);
   }
 
   private List<SegmentInstanceCandidate> fetchCandidateServersForQuery(List<String> segments,

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
@@ -93,7 +93,7 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
     }
   }
 
-  private InstanceMapping selectServers(List<String> segments, int requestId,
+  protected InstanceMapping selectServers(List<String> segments, int requestId,
       SegmentStates segmentStates, @Nullable Map<String, Integer> serverRankMap, ServerSelectionContext ctx) {
 
     Map<String, String> segmentToSelectedInstanceMap = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
@@ -123,7 +123,7 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
       } else if (MapUtils.isNotEmpty(serverRankMap)) {
         // Adaptive Server Selection is enabled.
         // Use the instance with the best rank if all servers have stats populated, else use the round-robin selected
-        // instance
+        // instance. As of 8 July 2026, this fallback is unreachable, but new implementations could require it.
         selectedInstance = candidates.stream()
             .anyMatch(candidate -> !serverRankMap.containsKey(candidate.getInstance()))
             ? selectedInstance

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.broker.routing.instanceselector;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -74,7 +73,11 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
   @Override
   public InstanceMapping select(List<String> segments, int requestId,
       SegmentStates segmentStates, Map<String, String> queryOptions) {
-    ServerSelectionContext ctx = new ServerSelectionContext(queryOptions, _config);
+    return selectWithContext(segments, requestId, segmentStates, new ServerSelectionContext(queryOptions, _config));
+  }
+
+  protected InstanceMapping selectWithContext(List<String> segments, int requestId,
+      SegmentStates segmentStates, ServerSelectionContext ctx) {
     if (_adaptiveServerSelector != null) {
       // Adaptive Server Selection is enabled.
       List<SegmentInstanceCandidate> candidateServers = fetchCandidateServersForQuery(segments, segmentStates);
@@ -114,7 +117,7 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
 
       // Round-robin selection (default behavior)
       int numCandidates = candidates.size();
-      int instanceIdx = (requestId + replicaOffset) % numCandidates;
+      int instanceIdx = Math.floorMod(requestId + replicaOffset, numCandidates);
       SegmentInstanceCandidate selectedInstance = candidates.get(instanceIdx);
       if (useFixedReplica) {
         // Adaptive Server Selection cannot be used with fixed replica routing.
@@ -124,12 +127,18 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
         // Adaptive Server Selection is enabled.
         // Use the instance with the best rank if all servers have stats populated, else use the round-robin selected
         // instance. As of 8 July 2026, this fallback is unreachable, but new implementations could require it.
-        selectedInstance = candidates.stream()
-            .anyMatch(candidate -> !serverRankMap.containsKey(candidate.getInstance()))
-            ? selectedInstance
-            : candidates.stream()
-                .min(Comparator.comparingInt(candidate -> serverRankMap.get(candidate.getInstance())))
-                .orElse(selectedInstance);
+        int bestRank = Integer.MAX_VALUE;
+        for (SegmentInstanceCandidate candidate : candidates) {
+          Integer rank = serverRankMap.get(candidate.getInstance());
+          if (rank == null) {
+            selectedInstance = candidates.get(instanceIdx);
+            break;
+          }
+          if (rank < bestRank) {
+            bestRank = rank;
+            selectedInstance = candidate;
+          }
+        }
       }
 
       poolToSegmentCount.merge(selectedInstance.getPool(), 1, Integer::sum);
@@ -193,7 +202,6 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
     _oldSegmentExpectedReplicasMap.clear();
     int newSegmentMapCapacity = HashUtil.getHashMapCapacity(newSegmentCreationTimeMap.size());
     _newSegmentStateMap = new HashMap<>(newSegmentMapCapacity);
-
     Map<String, Map<String, String>> idealStateAssignment = idealState.getRecord().getMapFields();
     Map<String, Map<String, String>> externalViewAssignment = externalView.getRecord().getMapFields();
 
@@ -246,7 +254,6 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
       // NOTE: onlineInstances is either a TreeSet or an EmptySet (sorted)
       Set<String> onlineInstances = entry.getValue();
       Map<String, String> idealStateInstanceStateMap = idealStateAssignment.get(segment);
-
       Set<String> unavailableInstances = unavailableInstancesMap.get(idealStateInstanceStateMap.keySet());
       List<SegmentInstanceCandidate> candidates = new ArrayList<>(onlineInstances.size());
       int idealStateReplicaId = 0;
@@ -266,7 +273,6 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
       Set<String> onlineInstances = entry.getValue();
       Map<String, String> idealStateInstanceStateMap = idealStateAssignment.get(segment);
       Map<String, String> sortedIdealStateInstanceStateMap = convertToSortedMap(idealStateInstanceStateMap);
-
       Set<String> unavailableInstances =
           unavailableInstancesMap.getOrDefault(idealStateInstanceStateMap.keySet(), Set.of());
       List<SegmentInstanceCandidate> candidates = new ArrayList<>(idealStateInstanceStateMap.size());

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.commons.collections.MapUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.pinot.broker.routing.adaptiveserverselector.ServerSelectionContext;
@@ -73,7 +72,7 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
   private static final Logger LOGGER = LoggerFactory.getLogger(ReplicaGroupInstanceSelector.class);
 
   @Override
-  public Pair<Map<String, String>, Map<String, String>> select(List<String> segments, int requestId,
+  public InstanceMapping select(List<String> segments, int requestId,
       SegmentStates segmentStates, Map<String, String> queryOptions) {
     ServerSelectionContext ctx = new ServerSelectionContext(queryOptions, _config);
     if (_adaptiveServerSelector != null) {
@@ -94,7 +93,7 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
     }
   }
 
-  private Pair<Map<String, String>, Map<String, String>> selectServers(List<String> segments, int requestId,
+  private InstanceMapping selectServers(List<String> segments, int requestId,
       SegmentStates segmentStates, @Nullable Map<String, Integer> serverRankMap, ServerSelectionContext ctx) {
 
     Map<String, String> segmentToSelectedInstanceMap = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
@@ -150,7 +149,7 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
       _brokerMetrics.addMeteredValue(BrokerMeter.POOL_SEG_QUERIES, entry.getValue(),
           BrokerMetrics.getTagForPreferredPool(ctx.getQueryOptions()), String.valueOf(entry.getKey()));
     }
-    return Pair.of(segmentToSelectedInstanceMap, optionalSegmentToInstanceMap);
+    return new InstanceMapping(segmentToSelectedInstanceMap, optionalSegmentToInstanceMap);
   }
 
   private List<SegmentInstanceCandidate> fetchCandidateServersForQuery(List<String> segments,

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/SegmentInstanceCandidate.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/SegmentInstanceCandidate.java
@@ -70,6 +70,6 @@ public class SegmentInstanceCandidate {
   @Override
   public String toString() {
     return "SegmentInstanceCandidate{" + "_instance='" + _instance + '\'' + ", _online=" + _online + ", _pool=" + _pool
-        + '}';
+        + ", _idealStateReplicaId=" + _idealStateReplicaId + '}';
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
@@ -64,7 +64,7 @@ import org.slf4j.LoggerFactory;
  * segments with the same assignment ([S1, S2, S3]) down on S1 to ensure that we always route the segments to the same
  * replica-group.
  *
- * When adaptive server selection is enabled, this selector uses pool-level adaptive routing: it picks the best
+ * When adaptive server selection is enabled, this selector uses replica-group-level adaptive routing: it picks the best
  * replica group for the entire query (using worst-case server rank within each group) and routes all segments to
  * that group. This preserves the same-replica-group guarantee while benefiting from adaptive routing intelligence.
  *
@@ -89,31 +89,31 @@ public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSele
       return selectServers(segments, requestId, segmentStates, null, ctx);
     }
 
-    // Build a map: pool (replica group) -> distinct servers in that group that are candidates for this query.
-    // Keyed by instance name to deduplicate (a server hosting multiple segments appears once per group).
-    // Also track how many query segments each pool can serve (segment coverage) in a single pass.
-    // The guard defends against multiple candidates per pool per segment (e.g., during rebalancing).
+    // Build a map: idealStateReplicaId (replica group) -> distinct servers in that group that are candidates for this
+    // query. Keyed by instance name to deduplicate (a server hosting multiple segments appears once per group).
+    // Also track how many query segments each replica group can serve (segment coverage) in a single pass.
+    // The guard defends against multiple candidates per replica group per segment (e.g., during rebalancing).
     Map<Integer, Map<String, SegmentInstanceCandidate>> replicaGroupToQueryServers = new LinkedHashMap<>();
     Map<Integer, Integer> replicaGroupSegmentCount = new HashMap<>();
     int totalSegmentsWithCandidates = 0;
 
-    Set<Integer> seenPools = new HashSet<>(); // allocate once and clear per segment to avoid O(n) allocations
+    Set<Integer> seenReplicaIds = new HashSet<>(); // allocate once and clear per segment to avoid O(n) allocations
     for (String segment : segments) {
       List<SegmentInstanceCandidate> candidates = segmentStates.getCandidates(segment);
       if (candidates == null) {
         continue;
       }
 
-      seenPools.clear();
+      seenReplicaIds.clear();
 
       totalSegmentsWithCandidates++;
       for (SegmentInstanceCandidate candidate : candidates) {
-        int pool = candidate.getPool();
+        int replicaId = candidate.getIdealStateReplicaId();
         replicaGroupToQueryServers
-            .computeIfAbsent(pool, k -> new LinkedHashMap<>())
+            .computeIfAbsent(replicaId, k -> new LinkedHashMap<>())
             .putIfAbsent(candidate.getInstance(), candidate);
-        if (seenPools.add(pool)) {
-          replicaGroupSegmentCount.merge(pool, 1, Integer::sum);
+        if (seenReplicaIds.add(replicaId)) {
+          replicaGroupSegmentCount.merge(replicaId, 1, Integer::sum);
         }
       }
     }
@@ -187,7 +187,7 @@ public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSele
 
   /**
    * Routes all segments to the chosen replica group. For each segment, picks the candidate whose
-   * pool matches the selected replica group ID. If no candidate matches (transitional state during
+   * idealStateReplicaId matches the selected replica group ID. If no candidate matches (transitional state during
    * rebalancing), the segment is reported as unavailable.
    */
   private InstanceMapping selectServersForReplicaGroup(
@@ -196,6 +196,7 @@ public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSele
     Map<String, String> segmentToInstance = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
     Map<String, String> optionalSegmentToInstance = new HashMap<>();
     List<String> unavailableSegments = new ArrayList<>();
+    Map<Integer, Integer> poolToSegmentCount = new HashMap<>();
 
     for (String segment : segments) {
       List<SegmentInstanceCandidate> candidates = segmentStates.getCandidates(segment);
@@ -204,7 +205,7 @@ public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSele
       }
 
       SegmentInstanceCandidate selected = candidates.stream()
-          .filter(c -> c.getPool() == replicaGroupId)
+          .filter(c -> c.getIdealStateReplicaId() == replicaGroupId)
           .findFirst()
           .orElse(null);
 
@@ -223,12 +224,14 @@ public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSele
       } else {
         optionalSegmentToInstance.put(segment, selected.getInstance());
       }
+      poolToSegmentCount.merge(selected.getPool(), 1, Integer::sum);
     }
 
-    // Emit POOL_SEG_QUERIES metric for observability.
-    _brokerMetrics.addMeteredValue(BrokerMeter.POOL_SEG_QUERIES,
-        segmentToInstance.size() + optionalSegmentToInstance.size(),
-        BrokerMetrics.getTagForPreferredPool(queryOptions), String.valueOf(replicaGroupId));
+    // Emit per-pool POOL_SEG_QUERIES metric for observability, matching the parent's pattern.
+    for (Map.Entry<Integer, Integer> entry : poolToSegmentCount.entrySet()) {
+      _brokerMetrics.addMeteredValue(BrokerMeter.POOL_SEG_QUERIES, entry.getValue(),
+          BrokerMetrics.getTagForPreferredPool(queryOptions), String.valueOf(entry.getKey()));
+    }
 
     return new InstanceMapping(segmentToInstance, optionalSegmentToInstance, unavailableSegments);
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.broker.routing.instanceselector;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -120,7 +119,7 @@ public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSele
     }
 
     if (replicaGroupToQueryServers.isEmpty()) {
-      return new InstanceMapping(Collections.emptyMap(), Collections.emptyMap());
+      return new InstanceMapping(Map.of(), Map.of());
     }
 
     // Collect all distinct query-relevant candidates from replicaGroupToQueryServers, which already

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
@@ -18,10 +18,25 @@
  */
 package org.apache.pinot.broker.routing.instanceselector;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
+import org.apache.pinot.broker.routing.adaptiveserverselector.ServerSelectionContext;
+import org.apache.pinot.common.metrics.BrokerMeter;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.utils.HashUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * Instance selector for strict replica-group routing strategy.
@@ -50,14 +65,172 @@ import org.apache.helix.model.IdealState;
  * segments with the same assignment ([S1, S2, S3]) down on S1 to ensure that we always route the segments to the same
  * replica-group.
  *
+ * When adaptive server selection is enabled, this selector uses pool-level adaptive routing: it picks the best
+ * replica group for the entire query (using worst-case server rank within each group) and routes all segments to
+ * that group. This preserves the same-replica-group guarantee while benefiting from adaptive routing intelligence.
+ *
  * Note that new segments won't be used to exclude instances from serving when the segment is unavailable.
  * </pre>
  */
 public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSelector {
+  private static final Logger LOGGER = LoggerFactory.getLogger(StrictReplicaGroupInstanceSelector.class);
 
   @Override
   void updateSegmentMaps(IdealState idealState, ExternalView externalView, Set<String> onlineSegments,
       Map<String, Long> newSegmentCreationTimeMap) {
     super.updateSegmentMapsForUpsertTable(idealState, externalView, onlineSegments, newSegmentCreationTimeMap);
+  }
+
+  @Override
+  public InstanceMapping select(List<String> segments, int requestId,
+      SegmentStates segmentStates, Map<String, String> queryOptions) {
+
+    if (_adaptiveServerSelector == null || _priorityPoolInstanceSelector == null) {
+      ServerSelectionContext ctx = new ServerSelectionContext(queryOptions, _config);
+      return selectServers(segments, requestId, segmentStates, null, ctx);
+    }
+
+    // Build a map: pool (replica group) -> distinct servers in that group that are candidates for this query.
+    // Keyed by instance name to deduplicate (a server hosting multiple segments appears once per group).
+    // Also track how many query segments each pool can serve (segment coverage) in a single pass.
+    // The guard defends against multiple candidates per pool per segment (e.g., during rebalancing).
+    Map<Integer, Map<String, SegmentInstanceCandidate>> replicaGroupToQueryServers = new LinkedHashMap<>();
+    Map<Integer, Integer> replicaGroupSegmentCount = new HashMap<>();
+    int totalSegmentsWithCandidates = 0;
+
+    Set<Integer> seenPools = new HashSet<>(); // allocate once and clear per segment to avoid O(n) allocations
+    for (String segment : segments) {
+      List<SegmentInstanceCandidate> candidates = segmentStates.getCandidates(segment);
+      if (candidates == null) {
+        continue;
+      }
+
+      seenPools.clear();
+
+      totalSegmentsWithCandidates++;
+      for (SegmentInstanceCandidate candidate : candidates) {
+        int pool = candidate.getPool();
+        replicaGroupToQueryServers
+            .computeIfAbsent(pool, k -> new LinkedHashMap<>())
+            .putIfAbsent(candidate.getInstance(), candidate);
+        if (seenPools.add(pool)) {
+          replicaGroupSegmentCount.merge(pool, 1, Integer::sum);
+        }
+      }
+    }
+
+    if (replicaGroupToQueryServers.isEmpty()) {
+      return new InstanceMapping(Collections.emptyMap(), Collections.emptyMap());
+    }
+
+    // Collect all distinct query-relevant candidates from replicaGroupToQueryServers, which already
+    // deduplicates by instance name. This avoids a second traversal of segments.
+    List<SegmentInstanceCandidate> allQueryCandidates = replicaGroupToQueryServers.values().stream()
+        .flatMap(m -> m.values().stream())
+        .collect(Collectors.toList());
+    ServerSelectionContext ctx = new ServerSelectionContext(queryOptions, _config);
+    int bestReplicaGroupId = chooseBestReplicaGroup(
+        replicaGroupToQueryServers, replicaGroupSegmentCount, totalSegmentsWithCandidates,
+        allQueryCandidates, ctx, requestId);
+    return selectServersForReplicaGroup(segments, bestReplicaGroupId, segmentStates, queryOptions);
+  }
+
+  /**
+   * Scores and ranks replica groups using adaptive server selection stats.
+   *
+   * Each replica group is scored by the worst (maximum) rank among its query-relevant servers.
+   * Since scatter-gather query latency is bounded by the slowest server, we pick the group
+   * whose bottleneck server is the best (lowest worst-case rank).
+   *
+   * Groups that can serve ALL query segments (full coverage) are preferred over groups that
+   * would drop segments. Among full-coverage groups, the one with the best worst-case rank wins.
+   * If no group has full coverage, the best-ranked group is chosen regardless of coverage.
+   */
+  private int chooseBestReplicaGroup(
+      Map<Integer, Map<String, SegmentInstanceCandidate>> replicaGroupToQueryServers,
+      Map<Integer, Integer> replicaGroupSegmentCount,
+      int totalSegmentsWithCandidates,
+      List<SegmentInstanceCandidate> allQueryCandidates,
+      ServerSelectionContext ctx,
+      int requestId) {
+
+    List<String> rankedServers = _priorityPoolInstanceSelector.rank(ctx, allQueryCandidates);
+
+    // If no stats are available yet (empty ranking), fall back to pool based round-robin.
+    if (rankedServers.isEmpty()) {
+      List<Integer> groupIds = new ArrayList<>(replicaGroupToQueryServers.keySet());
+      return groupIds.get(Math.abs(requestId) % groupIds.size());
+    }
+
+    Map<String, Integer> serverRankMap = new HashMap<>(HashUtil.getHashMapCapacity(rankedServers.size()));
+    for (int i = 0; i < rankedServers.size(); i++) {
+      serverRankMap.put(rankedServers.get(i), i);
+    }
+
+    // Pick the group with full coverage first, then best worst-case rank.
+    // getOrDefault guards against AdaptiveServerSelector implementations that may not return every
+    // submitted server — unranked servers get rank -1 (best), matching HybridSelector's convention.
+    // As of 8 July 2026, this fallback is unreachable, but new implementations could require it.
+    return replicaGroupToQueryServers.entrySet().stream()
+        .min(Comparator.<Map.Entry<Integer, Map<String, SegmentInstanceCandidate>>>comparingInt(
+                e -> hasFullCoverage(e.getKey(), replicaGroupSegmentCount, totalSegmentsWithCandidates) ? 0 : 1)
+            .thenComparingInt(e -> e.getValue().values().stream()
+                .mapToInt(c -> serverRankMap.getOrDefault(c.getInstance(), -1))
+                .max().orElse(Integer.MAX_VALUE)))
+        .map(Map.Entry::getKey)
+        .orElse(-1);
+  }
+
+  private boolean hasFullCoverage(int pool, Map<Integer, Integer> replicaGroupSegmentCount,
+      int totalSegmentsWithCandidates) {
+    return replicaGroupSegmentCount.getOrDefault(pool, 0) >= totalSegmentsWithCandidates;
+  }
+
+  /**
+   * Routes all segments to the chosen replica group. For each segment, picks the candidate whose
+   * pool matches the selected replica group ID. If no candidate matches (transitional state during
+   * rebalancing), the segment is reported as unavailable.
+   */
+  private InstanceMapping selectServersForReplicaGroup(
+      List<String> segments, int replicaGroupId, SegmentStates segmentStates, Map<String, String> queryOptions) {
+
+    Map<String, String> segmentToInstance = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
+    Map<String, String> optionalSegmentToInstance = new HashMap<>();
+    List<String> unavailableSegments = new ArrayList<>();
+
+    for (String segment : segments) {
+      List<SegmentInstanceCandidate> candidates = segmentStates.getCandidates(segment);
+      if (candidates == null) {
+        continue;
+      }
+
+      SegmentInstanceCandidate selected = candidates.stream()
+          .filter(c -> c.getPool() == replicaGroupId)
+          .findFirst()
+          .orElse(null);
+
+      // Skip segments with no candidate in the chosen replica group to preserve the strict same-replica-group
+      // invariant. We prefer to use groups that cover all queried segments, so this warning only occurs when we've
+      // selected a partial group.
+      if (selected == null) {
+        LOGGER.debug("No candidate found in replica group {} for segment {}; reporting as unavailable",
+            replicaGroupId, segment);
+        unavailableSegments.add(segment);
+        continue;
+      }
+
+      if (selected.isOnline()) {
+        segmentToInstance.put(segment, selected.getInstance());
+      } else {
+        optionalSegmentToInstance.put(segment, selected.getInstance());
+      }
+    }
+
+    // Emit POOL_SEG_QUERIES metric for observability.
+    _brokerMetrics.addMeteredValue(BrokerMeter.POOL_SEG_QUERIES,
+        segmentToInstance.size() + optionalSegmentToInstance.size(),
+        BrokerMetrics.getTagForPreferredPool(queryOptions), String.valueOf(replicaGroupId));
+
+    return new InstanceMapping(segmentToInstance, optionalSegmentToInstance, unavailableSegments);
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
@@ -61,9 +61,9 @@ import org.slf4j.LoggerFactory;
 /// segments with the same assignment ([S1, S2, S3]) down on S1 to ensure that we always route the segments to the same
 /// replica-group.
 ///
-/// When adaptive server selection is enabled, this selector uses pool-level adaptive routing: it picks the best
-/// replica group for the entire query (using worst-case server rank within each group) and routes all segments to that
-/// group. This preserves the same-replica-group guarantee while benefiting from adaptive routing intelligence.
+/// When adaptive server selection is enabled, this selector uses replica-group-level adaptive routing: it picks the
+/// best replica group for the entire query (using worst-case server rank within each group) and routes all segments to
+/// that group. This preserves the same-replica-group guarantee while benefiting from adaptive routing intelligence.
 ///
 /// Note that new segments won't be used to exclude instances from serving when the segment is unavailable.
 /// ```
@@ -85,31 +85,31 @@ public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSele
       return selectServers(segments, requestId, segmentStates, null, ctx);
     }
 
-    // Build a map: pool (replica group) -> distinct servers in that group that are candidates for this query.
-    // Keyed by instance name to deduplicate (a server hosting multiple segments appears once per group).
-    // Also track how many query segments each pool can serve (segment coverage) in a single pass.
-    // The guard defends against multiple candidates per pool per segment (e.g., during rebalancing).
+    // Build a map: idealStateReplicaId (replica group) -> distinct servers in that group that are candidates for this
+    // query. Keyed by instance name to deduplicate (a server hosting multiple segments appears once per group).
+    // Also track how many query segments each replica group can serve (segment coverage) in a single pass.
+    // The guard defends against multiple candidates per replica group per segment (e.g., during rebalancing).
     Map<Integer, Map<String, SegmentInstanceCandidate>> replicaGroupToQueryServers = new LinkedHashMap<>();
     Map<Integer, Integer> replicaGroupSegmentCount = new HashMap<>();
     int totalSegmentsWithCandidates = 0;
 
-    Set<Integer> seenPools = new HashSet<>(); // allocate once and clear per segment to avoid O(n) allocations
+    Set<Integer> seenReplicaIds = new HashSet<>(); // allocate once and clear per segment to avoid O(n) allocations
     for (String segment : segments) {
       List<SegmentInstanceCandidate> candidates = segmentStates.getCandidates(segment);
       if (candidates == null) {
         continue;
       }
 
-      seenPools.clear();
+      seenReplicaIds.clear();
 
       totalSegmentsWithCandidates++;
       for (SegmentInstanceCandidate candidate : candidates) {
-        int pool = candidate.getPool();
+        int replicaId = candidate.getIdealStateReplicaId();
         replicaGroupToQueryServers
-            .computeIfAbsent(pool, k -> new LinkedHashMap<>())
+            .computeIfAbsent(replicaId, k -> new LinkedHashMap<>())
             .putIfAbsent(candidate.getInstance(), candidate);
-        if (seenPools.add(pool)) {
-          replicaGroupSegmentCount.merge(pool, 1, Integer::sum);
+        if (seenReplicaIds.add(replicaId)) {
+          replicaGroupSegmentCount.merge(replicaId, 1, Integer::sum);
         }
       }
     }
@@ -183,7 +183,7 @@ public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSele
 
   /**
    * Routes all segments to the chosen replica group. For each segment, picks the candidate whose
-   * pool matches the selected replica group ID. If no candidate matches (transitional state during
+   * idealStateReplicaId matches the selected replica group ID. If no candidate matches (transitional state during
    * rebalancing), the segment is reported as unavailable.
    */
   private InstanceMapping selectServersForReplicaGroup(
@@ -192,6 +192,7 @@ public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSele
     Map<String, String> segmentToInstance = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
     Map<String, String> optionalSegmentToInstance = new HashMap<>();
     List<String> unavailableSegments = new ArrayList<>();
+    Map<Integer, Integer> poolToSegmentCount = new HashMap<>();
 
     for (String segment : segments) {
       List<SegmentInstanceCandidate> candidates = segmentStates.getCandidates(segment);
@@ -200,7 +201,7 @@ public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSele
       }
 
       SegmentInstanceCandidate selected = candidates.stream()
-          .filter(c -> c.getPool() == replicaGroupId)
+          .filter(c -> c.getIdealStateReplicaId() == replicaGroupId)
           .findFirst()
           .orElse(null);
 
@@ -219,12 +220,14 @@ public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSele
       } else {
         optionalSegmentToInstance.put(segment, selected.getInstance());
       }
+      poolToSegmentCount.merge(selected.getPool(), 1, Integer::sum);
     }
 
-    // Emit POOL_SEG_QUERIES metric for observability.
-    _brokerMetrics.addMeteredValue(BrokerMeter.POOL_SEG_QUERIES,
-        segmentToInstance.size() + optionalSegmentToInstance.size(),
-        BrokerMetrics.getTagForPreferredPool(queryOptions), String.valueOf(replicaGroupId));
+    // Emit per-pool POOL_SEG_QUERIES metric for observability, matching the parent's pattern.
+    for (Map.Entry<Integer, Integer> entry : poolToSegmentCount.entrySet()) {
+      _brokerMetrics.addMeteredValue(BrokerMeter.POOL_SEG_QUERIES, entry.getValue(),
+          BrokerMetrics.getTagForPreferredPool(queryOptions), String.valueOf(entry.getKey()));
+    }
 
     return new InstanceMapping(segmentToInstance, optionalSegmentToInstance, unavailableSegments);
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
@@ -18,58 +18,31 @@
  */
 package org.apache.pinot.broker.routing.instanceselector;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.pinot.broker.routing.adaptiveserverselector.ServerSelectionContext;
-import org.apache.pinot.common.metrics.BrokerMeter;
-import org.apache.pinot.common.metrics.BrokerMetrics;
-import org.apache.pinot.common.utils.HashUtil;
 import org.apache.pinot.common.utils.config.QueryOptionsUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+
 /// Instance selector for strict replica-group routing strategy.
 ///
-/// ```
-/// The strict replica-group routing strategy always routes the query to the instances within the same replica-group.
-/// (Note that the replica-group information is derived from the ideal state of the table, where the instances are
-/// sorted alphabetically in the instance state map, so the replica-groups in the instance selector might not match the
-/// replica-groups in the instance partitions). The goal of this algorithm is to ensure that segments from the same
-/// partition are never served from multiple different instances. The instances in a replica-group should have all the
-/// online segments (segments with ONLINE/CONSUMING instances in the ideal state and selected by the pre-selector)
-/// available (ONLINE/CONSUMING in the external view) in order to serve queries. If any segment is unavailable in the
-/// replica-group, we mark the whole replica-group down and not serve queries with this replica-group.
+/// The strict replica-group routing strategy always routes same-partition segments to the same instance. During routing
+/// state construction, [#updateSegmentMapsForUpsertTable(IdealState, ExternalView, Set, Map)] removes from every segment
+/// in a partition any replica that is unavailable for any old segment in that partition. Consequently, all
+/// same-partition segments have identical, ordered candidate identities.
 ///
-/// The selection algorithm is the same as {@link ReplicaGroupInstanceSelector}, and will always evenly distribute the
-/// traffic to all replica-groups that have all online segments available.
+/// Adaptive routing preserves that guarantee without explicit partition or mirror-set metadata. The inherited selector
+/// takes one ranking snapshot for the query and deterministically chooses the best candidate from each segment's ordered
+/// list. Identical filtered candidate lists, the same ranking snapshot, and deterministic list-order tie-breaking
+/// therefore produce identical selections for every segment in a partition. Different partitions may independently
+/// choose different replicas.
 ///
-/// The algorithm relies on the mirror segment assignment from replica-group segment assignment strategy. With mirror
-/// segment assignment, any server in one replica-group will always have a corresponding server in other replica-groups
-/// that have the same segments assigned. For example, if S1 is a server in replica-group 1, and it has mirror server S2
-/// in replica-group 2 and S3 in replica-group 3. All segments assigned to S1 will also be assigned to S2 and S3. In
-/// stable scenario (external view matches ideal state), all segments assigned to S1 will have the same enabled
-/// instances of [S1, S2, S3] sorted (in alphabetical order). If we always pick the same index of enabled instances for
-/// all segments, only one of S1, S2, S3 will be picked, and all the segments are processed by the same server. In
-/// transitioning/error scenario (external view does not match ideal state), if a segment is down on S1, we mark all
-/// segments with the same assignment ([S1, S2, S3]) down on S1 to ensure that we always route the segments to the same
-/// replica-group.
-///
-/// When adaptive server selection is enabled, this selector uses replica-group-level adaptive routing: it picks the
-/// best replica group for the entire query (using worst-case server rank within each group) and routes all segments to
-/// that group. This preserves the same-replica-group guarantee while benefiting from adaptive routing intelligence.
-///
-/// Note that new segments won't be used to exclude instances from serving when the segment is unavailable.
-/// ```
+/// New segments do not exclude a candidate when that segment is unavailable; they remain optional so that the broker or
+/// server can skip them if necessary.
 public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSelector {
-  private static final Logger LOGGER = LoggerFactory.getLogger(StrictReplicaGroupInstanceSelector.class);
 
   @Override
   void updateSegmentMaps(IdealState idealState, ExternalView externalView, Set<String> onlineSegments,
@@ -81,164 +54,16 @@ public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSele
   public InstanceMapping select(List<String> segments, int requestId,
       SegmentStates segmentStates, Map<String, String> queryOptions) {
     ServerSelectionContext ctx = new ServerSelectionContext(queryOptions, _config);
-
-    if (_adaptiveServerSelector == null || _priorityPoolInstanceSelector == null) {
-      return selectServers(segments, requestId, segmentStates, null, ctx);
-    }
-    if (ctx.isUseFixedReplica()) {
-      throw new IllegalArgumentException(
-          "useFixedReplica cannot be used when adaptive routing is enabled for StrictReplicaGroupInstanceSelector");
-    }
-    if (QueryOptionsUtils.getNumReplicaGroupsToQuery(ctx.getQueryOptions()) != null) {
-      // The existing option intentionally fans segments across multiple replica groups. Preserve that behavior and do
-      // not apply adaptive single-replica-group selection to this query.
-      return selectServers(segments, requestId, segmentStates, null, ctx);
-    }
-
-    // Build a map: idealStateReplicaId (replica group) -> distinct servers in that group that are candidates for this
-    // query. Keyed by instance name to deduplicate (a server hosting multiple segments appears once per group).
-    // Also track how many query segments each replica group can serve (segment coverage) in a single pass.
-    // The guard defends against multiple candidates per replica group per segment (e.g., during rebalancing).
-    Map<Integer, Map<String, SegmentInstanceCandidate>> replicaGroupToQueryServers = new LinkedHashMap<>();
-    Map<Integer, Integer> replicaGroupSegmentCount = new HashMap<>();
-    int totalSegmentsWithCandidates = 0;
-
-    Set<Integer> seenReplicaIds = new HashSet<>(); // allocate once and clear per segment to avoid O(n) allocations
-    for (String segment : segments) {
-      List<SegmentInstanceCandidate> candidates = segmentStates.getCandidates(segment);
-      if (candidates == null) {
-        continue;
+    if (_adaptiveServerSelector != null && _priorityPoolInstanceSelector != null) {
+      if (ctx.isUseFixedReplica()) {
+        throw new IllegalArgumentException(
+            "useFixedReplica cannot be used when adaptive routing is enabled for StrictReplicaGroupInstanceSelector");
       }
-
-      seenReplicaIds.clear();
-
-      totalSegmentsWithCandidates++;
-      for (SegmentInstanceCandidate candidate : candidates) {
-        int replicaId = candidate.getIdealStateReplicaId();
-        replicaGroupToQueryServers
-            .computeIfAbsent(replicaId, k -> new LinkedHashMap<>())
-            .putIfAbsent(candidate.getInstance(), candidate);
-        if (seenReplicaIds.add(replicaId)) {
-          replicaGroupSegmentCount.merge(replicaId, 1, Integer::sum);
-        }
+      if (QueryOptionsUtils.getNumReplicaGroupsToQuery(ctx.getQueryOptions()) != null) {
+        // This option intentionally fans segments across replica groups, so preserve the non-adaptive behavior.
+        return selectServers(segments, requestId, segmentStates, null, ctx);
       }
     }
-
-    if (replicaGroupToQueryServers.isEmpty()) {
-      return new InstanceMapping(Map.of(), Map.of());
-    }
-
-    // Collect all distinct query-relevant candidates from replicaGroupToQueryServers, which already
-    // deduplicates by instance name. This avoids a second traversal of segments.
-    List<SegmentInstanceCandidate> allQueryCandidates = replicaGroupToQueryServers.values().stream()
-        .flatMap(m -> m.values().stream())
-        .collect(Collectors.toList());
-    ServerSelectionContext ctx = new ServerSelectionContext(queryOptions, _config);
-    int bestReplicaGroupId = chooseBestReplicaGroup(
-        replicaGroupToQueryServers, replicaGroupSegmentCount, totalSegmentsWithCandidates,
-        allQueryCandidates, ctx, requestId);
-    return selectServersForReplicaGroup(segments, bestReplicaGroupId, segmentStates, queryOptions);
-  }
-
-  /**
-   * Scores and ranks replica groups using adaptive server selection stats.
-   *
-   * Each replica group is scored by the worst (maximum) rank among its query-relevant servers.
-   * Since scatter-gather query latency is bounded by the slowest server, we pick the group
-   * whose bottleneck server is the best (lowest worst-case rank).
-   *
-   * Groups that can serve ALL query segments (full coverage) are preferred over groups that
-   * would drop segments. Among full-coverage groups, the one with the best worst-case rank wins.
-   * If no group has full coverage, the best-ranked group is chosen regardless of coverage.
-   */
-  private int chooseBestReplicaGroup(
-      Map<Integer, Map<String, SegmentInstanceCandidate>> replicaGroupToQueryServers,
-      Map<Integer, Integer> replicaGroupSegmentCount,
-      int totalSegmentsWithCandidates,
-      List<SegmentInstanceCandidate> allQueryCandidates,
-      ServerSelectionContext ctx,
-      int requestId) {
-
-    List<String> rankedServers = _priorityPoolInstanceSelector.rank(ctx, allQueryCandidates);
-
-    // If no stats are available yet (empty ranking), fall back to pool based round-robin.
-    if (rankedServers.isEmpty()) {
-      List<Integer> groupIds = new ArrayList<>(replicaGroupToQueryServers.keySet());
-      return groupIds.get(Math.abs(requestId) % groupIds.size());
-    }
-
-    Map<String, Integer> serverRankMap = new HashMap<>(HashUtil.getHashMapCapacity(rankedServers.size()));
-    for (int i = 0; i < rankedServers.size(); i++) {
-      serverRankMap.put(rankedServers.get(i), i);
-    }
-
-    // Pick the group with full coverage first, then best worst-case rank.
-    // getOrDefault guards against AdaptiveServerSelector implementations that may not return every
-    // submitted server — unranked servers get rank -1 (best), matching HybridSelector's convention.
-    // As of 8 July 2026, this fallback is unreachable, but new implementations could require it.
-    return replicaGroupToQueryServers.entrySet().stream()
-        .min(Comparator.<Map.Entry<Integer, Map<String, SegmentInstanceCandidate>>>comparingInt(
-                e -> hasFullCoverage(e.getKey(), replicaGroupSegmentCount, totalSegmentsWithCandidates) ? 0 : 1)
-            .thenComparingInt(e -> e.getValue().values().stream()
-                .mapToInt(c -> serverRankMap.getOrDefault(c.getInstance(), -1))
-                .max().orElse(Integer.MAX_VALUE)))
-        .map(Map.Entry::getKey)
-        .orElse(-1);
-  }
-
-  private boolean hasFullCoverage(int pool, Map<Integer, Integer> replicaGroupSegmentCount,
-      int totalSegmentsWithCandidates) {
-    return replicaGroupSegmentCount.getOrDefault(pool, 0) >= totalSegmentsWithCandidates;
-  }
-
-  /**
-   * Routes all segments to the chosen replica group. For each segment, picks the candidate whose
-   * idealStateReplicaId matches the selected replica group ID. If no candidate matches (transitional state during
-   * rebalancing), the segment is reported as unavailable.
-   */
-  private InstanceMapping selectServersForReplicaGroup(
-      List<String> segments, int replicaGroupId, SegmentStates segmentStates, Map<String, String> queryOptions) {
-
-    Map<String, String> segmentToInstance = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
-    Map<String, String> optionalSegmentToInstance = new HashMap<>();
-    List<String> unavailableSegments = new ArrayList<>();
-    Map<Integer, Integer> poolToSegmentCount = new HashMap<>();
-
-    for (String segment : segments) {
-      List<SegmentInstanceCandidate> candidates = segmentStates.getCandidates(segment);
-      if (candidates == null) {
-        continue;
-      }
-
-      SegmentInstanceCandidate selected = candidates.stream()
-          .filter(c -> c.getIdealStateReplicaId() == replicaGroupId)
-          .findFirst()
-          .orElse(null);
-
-      // Skip segments with no candidate in the chosen replica group to preserve the strict same-replica-group
-      // invariant. We prefer to use groups that cover all queried segments, so this warning only occurs when we've
-      // selected a partial group.
-      if (selected == null) {
-        LOGGER.debug("No candidate found in replica group {} for segment {}; reporting as unavailable",
-            replicaGroupId, segment);
-        unavailableSegments.add(segment);
-        continue;
-      }
-
-      if (selected.isOnline()) {
-        segmentToInstance.put(segment, selected.getInstance());
-      } else {
-        optionalSegmentToInstance.put(segment, selected.getInstance());
-      }
-      poolToSegmentCount.merge(selected.getPool(), 1, Integer::sum);
-    }
-
-    // Emit per-pool POOL_SEG_QUERIES metric for observability, matching the parent's pattern.
-    for (Map.Entry<Integer, Integer> entry : poolToSegmentCount.entrySet()) {
-      _brokerMetrics.addMeteredValue(BrokerMeter.POOL_SEG_QUERIES, entry.getValue(),
-          BrokerMetrics.getTagForPreferredPool(queryOptions), String.valueOf(entry.getKey()));
-    }
-
-    return new InstanceMapping(segmentToInstance, optionalSegmentToInstance, unavailableSegments);
+    return selectWithContext(segments, requestId, segmentStates, ctx);
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
@@ -18,11 +18,23 @@
  */
 package org.apache.pinot.broker.routing.instanceselector;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
-
+import org.apache.pinot.broker.routing.adaptiveserverselector.ServerSelectionContext;
+import org.apache.pinot.common.metrics.BrokerMeter;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.utils.HashUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 /// Instance selector for strict replica-group routing strategy.
 ///
 /// ```
@@ -49,13 +61,171 @@ import org.apache.helix.model.IdealState;
 /// segments with the same assignment ([S1, S2, S3]) down on S1 to ensure that we always route the segments to the same
 /// replica-group.
 ///
+/// When adaptive server selection is enabled, this selector uses pool-level adaptive routing: it picks the best
+/// replica group for the entire query (using worst-case server rank within each group) and routes all segments to that
+/// group. This preserves the same-replica-group guarantee while benefiting from adaptive routing intelligence.
+///
 /// Note that new segments won't be used to exclude instances from serving when the segment is unavailable.
 /// ```
 public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSelector {
+  private static final Logger LOGGER = LoggerFactory.getLogger(StrictReplicaGroupInstanceSelector.class);
 
   @Override
   void updateSegmentMaps(IdealState idealState, ExternalView externalView, Set<String> onlineSegments,
       Map<String, Long> newSegmentCreationTimeMap) {
     super.updateSegmentMapsForUpsertTable(idealState, externalView, onlineSegments, newSegmentCreationTimeMap);
+  }
+
+  @Override
+  public InstanceMapping select(List<String> segments, int requestId,
+      SegmentStates segmentStates, Map<String, String> queryOptions) {
+
+    if (_adaptiveServerSelector == null || _priorityPoolInstanceSelector == null) {
+      ServerSelectionContext ctx = new ServerSelectionContext(queryOptions, _config);
+      return selectServers(segments, requestId, segmentStates, null, ctx);
+    }
+
+    // Build a map: pool (replica group) -> distinct servers in that group that are candidates for this query.
+    // Keyed by instance name to deduplicate (a server hosting multiple segments appears once per group).
+    // Also track how many query segments each pool can serve (segment coverage) in a single pass.
+    // The guard defends against multiple candidates per pool per segment (e.g., during rebalancing).
+    Map<Integer, Map<String, SegmentInstanceCandidate>> replicaGroupToQueryServers = new LinkedHashMap<>();
+    Map<Integer, Integer> replicaGroupSegmentCount = new HashMap<>();
+    int totalSegmentsWithCandidates = 0;
+
+    Set<Integer> seenPools = new HashSet<>(); // allocate once and clear per segment to avoid O(n) allocations
+    for (String segment : segments) {
+      List<SegmentInstanceCandidate> candidates = segmentStates.getCandidates(segment);
+      if (candidates == null) {
+        continue;
+      }
+
+      seenPools.clear();
+
+      totalSegmentsWithCandidates++;
+      for (SegmentInstanceCandidate candidate : candidates) {
+        int pool = candidate.getPool();
+        replicaGroupToQueryServers
+            .computeIfAbsent(pool, k -> new LinkedHashMap<>())
+            .putIfAbsent(candidate.getInstance(), candidate);
+        if (seenPools.add(pool)) {
+          replicaGroupSegmentCount.merge(pool, 1, Integer::sum);
+        }
+      }
+    }
+
+    if (replicaGroupToQueryServers.isEmpty()) {
+      return new InstanceMapping(Map.of(), Map.of());
+    }
+
+    // Collect all distinct query-relevant candidates from replicaGroupToQueryServers, which already
+    // deduplicates by instance name. This avoids a second traversal of segments.
+    List<SegmentInstanceCandidate> allQueryCandidates = replicaGroupToQueryServers.values().stream()
+        .flatMap(m -> m.values().stream())
+        .collect(Collectors.toList());
+    ServerSelectionContext ctx = new ServerSelectionContext(queryOptions, _config);
+    int bestReplicaGroupId = chooseBestReplicaGroup(
+        replicaGroupToQueryServers, replicaGroupSegmentCount, totalSegmentsWithCandidates,
+        allQueryCandidates, ctx, requestId);
+    return selectServersForReplicaGroup(segments, bestReplicaGroupId, segmentStates, queryOptions);
+  }
+
+  /**
+   * Scores and ranks replica groups using adaptive server selection stats.
+   *
+   * Each replica group is scored by the worst (maximum) rank among its query-relevant servers.
+   * Since scatter-gather query latency is bounded by the slowest server, we pick the group
+   * whose bottleneck server is the best (lowest worst-case rank).
+   *
+   * Groups that can serve ALL query segments (full coverage) are preferred over groups that
+   * would drop segments. Among full-coverage groups, the one with the best worst-case rank wins.
+   * If no group has full coverage, the best-ranked group is chosen regardless of coverage.
+   */
+  private int chooseBestReplicaGroup(
+      Map<Integer, Map<String, SegmentInstanceCandidate>> replicaGroupToQueryServers,
+      Map<Integer, Integer> replicaGroupSegmentCount,
+      int totalSegmentsWithCandidates,
+      List<SegmentInstanceCandidate> allQueryCandidates,
+      ServerSelectionContext ctx,
+      int requestId) {
+
+    List<String> rankedServers = _priorityPoolInstanceSelector.rank(ctx, allQueryCandidates);
+
+    // If no stats are available yet (empty ranking), fall back to pool based round-robin.
+    if (rankedServers.isEmpty()) {
+      List<Integer> groupIds = new ArrayList<>(replicaGroupToQueryServers.keySet());
+      return groupIds.get(Math.abs(requestId) % groupIds.size());
+    }
+
+    Map<String, Integer> serverRankMap = new HashMap<>(HashUtil.getHashMapCapacity(rankedServers.size()));
+    for (int i = 0; i < rankedServers.size(); i++) {
+      serverRankMap.put(rankedServers.get(i), i);
+    }
+
+    // Pick the group with full coverage first, then best worst-case rank.
+    // getOrDefault guards against AdaptiveServerSelector implementations that may not return every
+    // submitted server — unranked servers get rank -1 (best), matching HybridSelector's convention.
+    // As of 8 July 2026, this fallback is unreachable, but new implementations could require it.
+    return replicaGroupToQueryServers.entrySet().stream()
+        .min(Comparator.<Map.Entry<Integer, Map<String, SegmentInstanceCandidate>>>comparingInt(
+                e -> hasFullCoverage(e.getKey(), replicaGroupSegmentCount, totalSegmentsWithCandidates) ? 0 : 1)
+            .thenComparingInt(e -> e.getValue().values().stream()
+                .mapToInt(c -> serverRankMap.getOrDefault(c.getInstance(), -1))
+                .max().orElse(Integer.MAX_VALUE)))
+        .map(Map.Entry::getKey)
+        .orElse(-1);
+  }
+
+  private boolean hasFullCoverage(int pool, Map<Integer, Integer> replicaGroupSegmentCount,
+      int totalSegmentsWithCandidates) {
+    return replicaGroupSegmentCount.getOrDefault(pool, 0) >= totalSegmentsWithCandidates;
+  }
+
+  /**
+   * Routes all segments to the chosen replica group. For each segment, picks the candidate whose
+   * pool matches the selected replica group ID. If no candidate matches (transitional state during
+   * rebalancing), the segment is reported as unavailable.
+   */
+  private InstanceMapping selectServersForReplicaGroup(
+      List<String> segments, int replicaGroupId, SegmentStates segmentStates, Map<String, String> queryOptions) {
+
+    Map<String, String> segmentToInstance = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
+    Map<String, String> optionalSegmentToInstance = new HashMap<>();
+    List<String> unavailableSegments = new ArrayList<>();
+
+    for (String segment : segments) {
+      List<SegmentInstanceCandidate> candidates = segmentStates.getCandidates(segment);
+      if (candidates == null) {
+        continue;
+      }
+
+      SegmentInstanceCandidate selected = candidates.stream()
+          .filter(c -> c.getPool() == replicaGroupId)
+          .findFirst()
+          .orElse(null);
+
+      // Skip segments with no candidate in the chosen replica group to preserve the strict same-replica-group
+      // invariant. We prefer to use groups that cover all queried segments, so this warning only occurs when we've
+      // selected a partial group.
+      if (selected == null) {
+        LOGGER.debug("No candidate found in replica group {} for segment {}; reporting as unavailable",
+            replicaGroupId, segment);
+        unavailableSegments.add(segment);
+        continue;
+      }
+
+      if (selected.isOnline()) {
+        segmentToInstance.put(segment, selected.getInstance());
+      } else {
+        optionalSegmentToInstance.put(segment, selected.getInstance());
+      }
+    }
+
+    // Emit POOL_SEG_QUERIES metric for observability.
+    _brokerMetrics.addMeteredValue(BrokerMeter.POOL_SEG_QUERIES,
+        segmentToInstance.size() + optionalSegmentToInstance.size(),
+        BrokerMetrics.getTagForPreferredPool(queryOptions), String.valueOf(replicaGroupId));
+
+    return new InstanceMapping(segmentToInstance, optionalSegmentToInstance, unavailableSegments);
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
@@ -33,6 +33,7 @@ import org.apache.pinot.broker.routing.adaptiveserverselector.ServerSelectionCon
 import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.utils.HashUtil;
+import org.apache.pinot.common.utils.config.QueryOptionsUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 /// Instance selector for strict replica-group routing strategy.
@@ -79,9 +80,18 @@ public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSele
   @Override
   public InstanceMapping select(List<String> segments, int requestId,
       SegmentStates segmentStates, Map<String, String> queryOptions) {
+    ServerSelectionContext ctx = new ServerSelectionContext(queryOptions, _config);
 
     if (_adaptiveServerSelector == null || _priorityPoolInstanceSelector == null) {
-      ServerSelectionContext ctx = new ServerSelectionContext(queryOptions, _config);
+      return selectServers(segments, requestId, segmentStates, null, ctx);
+    }
+    if (ctx.isUseFixedReplica()) {
+      throw new IllegalArgumentException(
+          "useFixedReplica cannot be used when adaptive routing is enabled for StrictReplicaGroupInstanceSelector");
+    }
+    if (QueryOptionsUtils.getNumReplicaGroupsToQuery(ctx.getQueryOptions()) != null) {
+      // The existing option intentionally fans segments across multiple replica groups. Preserve that behavior and do
+      // not apply adaptive single-replica-group selection to this query.
       return selectServers(segments, requestId, segmentStates, null, ctx);
     }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
@@ -34,10 +34,15 @@ import org.apache.pinot.common.utils.config.QueryOptionsUtils;
 /// every segment in a partition any replica that is unavailable for any old segment in that partition. Consequently,
 /// all same-partition segments have identical, ordered candidate identities.
 ///
-/// Adaptive routing preserves that guarantee without explicit partition or mirror-set metadata. The inherited
-/// selector takes one ranking snapshot for the query and deterministically chooses the best candidate from each
-/// segment's ordered list. Identical filtered candidate lists, the same ranking snapshot, and deterministic list-order
-/// tie-breaking therefore produce identical selections for every segment in a partition. Different partitions may
+/// Adaptive routing relies on two parent-selector contracts:
+/// - [#selectWithContext(List, int, SegmentStates, ServerSelectionContext)] obtains one ranking snapshot before
+///   iterating the query's segments; it must not re-rank per segment.
+/// - [#selectServers(List, int, SegmentStates, Map, ServerSelectionContext)] resolves equal-ranked candidates using
+///   its strictly-less-than (`rank < bestRank`) comparison. It consequently retains the first candidate in the shared
+///   ordered candidate list.
+///
+/// Since same-partition old segments have identical ordered candidates, these contracts ensure they select the same
+/// instance. Changing either contract requires revisiting strict replica-group routing. Different partitions may
 /// independently choose different replicas.
 ///
 /// New segments do not exclude a candidate when that segment is unavailable; they remain optional so that the broker or
@@ -61,6 +66,8 @@ public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSele
       }
       if (QueryOptionsUtils.getNumReplicaGroupsToQuery(ctx.getQueryOptions()) != null) {
         // This option intentionally fans segments across replica groups, so preserve the non-adaptive behavior.
+        // This contradicts the behaviour specified by StrictReplicaGroup, so we should eventually reject / ignore
+        // this combination.
         return selectServers(segments, requestId, segmentStates, null, ctx);
       }
     }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
@@ -61,8 +61,9 @@ public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSele
     ServerSelectionContext ctx = new ServerSelectionContext(queryOptions, _config);
     if (_adaptiveServerSelector != null && _priorityPoolInstanceSelector != null) {
       if (ctx.isUseFixedReplica()) {
-        throw new IllegalArgumentException(
-            "useFixedReplica cannot be used when adaptive routing is enabled for StrictReplicaGroupInstanceSelector");
+        // Fixed-replica routing configured on the broker or table disables adaptive routing in InstanceSelectorFactory.
+        // This fixed replica config can still be set per query, in which case we'll prefer that over adaptive routing.
+        return selectServers(segments, requestId, segmentStates, null, ctx);
       }
       if (QueryOptionsUtils.getNumReplicaGroupsToQuery(ctx.getQueryOptions()) != null) {
         // This option intentionally fans segments across replica groups, so preserve the non-adaptive behavior.

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
@@ -29,16 +29,16 @@ import org.apache.pinot.common.utils.config.QueryOptionsUtils;
 
 /// Instance selector for strict replica-group routing strategy.
 ///
-/// The strict replica-group routing strategy always routes same-partition segments to the same instance. During routing
-/// state construction, [#updateSegmentMapsForUpsertTable(IdealState, ExternalView, Set, Map)] removes from every segment
-/// in a partition any replica that is unavailable for any old segment in that partition. Consequently, all
-/// same-partition segments have identical, ordered candidate identities.
+/// The strict replica-group routing strategy always routes same-partition segments to the same instance. During
+/// routing state construction, [#updateSegmentMapsForUpsertTable(IdealState, ExternalView, Set, Map)] removes from
+/// every segment in a partition any replica that is unavailable for any old segment in that partition. Consequently,
+/// all same-partition segments have identical, ordered candidate identities.
 ///
-/// Adaptive routing preserves that guarantee without explicit partition or mirror-set metadata. The inherited selector
-/// takes one ranking snapshot for the query and deterministically chooses the best candidate from each segment's ordered
-/// list. Identical filtered candidate lists, the same ranking snapshot, and deterministic list-order tie-breaking
-/// therefore produce identical selections for every segment in a partition. Different partitions may independently
-/// choose different replicas.
+/// Adaptive routing preserves that guarantee without explicit partition or mirror-set metadata. The inherited
+/// selector takes one ranking snapshot for the query and deterministically chooses the best candidate from each
+/// segment's ordered list. Identical filtered candidate lists, the same ranking snapshot, and deterministic list-order
+/// tie-breaking therefore produce identical selections for every segment in a partition. Different partitions may
+/// independently choose different replicas.
 ///
 /// New segments do not exclude a candidate when that segment is unavailable; they remain optional so that the broker or
 /// server can skip them if necessary.

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
@@ -1490,8 +1490,7 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
         selectionResult.setNumPrunedSegments(numPrunedSegments);
         return selectionResult;
       } else {
-        return new InstanceSelector.SelectionResult(Pair.of(Map.of(), Map.of()),
-            List.of(), numPrunedSegments);
+        return InstanceSelector.SelectionResult.empty(numPrunedSegments);
       }
     }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
@@ -44,7 +44,6 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.AccessOption;
 import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.HelixConstants.ChangeType;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
@@ -768,8 +768,8 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
 
       AdaptiveServerSelector adaptiveServerSelector =
           AdaptiveServerSelectorFactory.getAdaptiveServerSelector(_serverRoutingStatsManager, _pinotConfig);
-      // StrictReplicaGroupInstanceSelector is incompatible with adaptive routing;
-      // InstanceSelectorFactory will nullify the selector for such tables automatically.
+      // For StrictReplicaGroupInstanceSelector tables, pool-level adaptive routing is used,
+      // preserving the same-replica-group guarantee while benefiting from adaptive server selection.
       InstanceSelector instanceSelector =
           InstanceSelectorFactory.getInstanceSelector(tableConfig, _propertyStore, _brokerMetrics,
               adaptiveServerSelector, _pinotConfig, _routableServerInstanceMap.keySet(), _enabledServerInstanceMap,

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
@@ -768,6 +768,8 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
 
       AdaptiveServerSelector adaptiveServerSelector =
           AdaptiveServerSelectorFactory.getAdaptiveServerSelector(_serverRoutingStatsManager, _pinotConfig);
+      // StrictReplicaGroupInstanceSelector is incompatible with adaptive routing;
+      // InstanceSelectorFactory will nullify the selector for such tables automatically.
       InstanceSelector instanceSelector =
           InstanceSelectorFactory.getInstanceSelector(tableConfig, _propertyStore, _brokerMetrics,
               adaptiveServerSelector, _pinotConfig, _routableServerInstanceMap.keySet(), _enabledServerInstanceMap,

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
@@ -815,8 +815,8 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
 
       AdaptiveServerSelector adaptiveServerSelector =
           AdaptiveServerSelectorFactory.getAdaptiveServerSelector(_serverRoutingStatsManager, _pinotConfig);
-      // StrictReplicaGroupInstanceSelector is incompatible with adaptive routing;
-      // InstanceSelectorFactory will nullify the selector for such tables automatically.
+      // For StrictReplicaGroupInstanceSelector tables, pool-level adaptive routing is used,
+      // preserving the same-replica-group guarantee while benefiting from adaptive server selection.
       InstanceSelector instanceSelector =
           InstanceSelectorFactory.getInstanceSelector(tableConfig, _propertyStore, _brokerMetrics,
               adaptiveServerSelector, _pinotConfig, _routableServerInstanceMap.keySet(), _enabledServerInstanceMap,

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
@@ -815,6 +815,8 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
 
       AdaptiveServerSelector adaptiveServerSelector =
           AdaptiveServerSelectorFactory.getAdaptiveServerSelector(_serverRoutingStatsManager, _pinotConfig);
+      // StrictReplicaGroupInstanceSelector is incompatible with adaptive routing;
+      // InstanceSelectorFactory will nullify the selector for such tables automatically.
       InstanceSelector instanceSelector =
           InstanceSelectorFactory.getInstanceSelector(tableConfig, _propertyStore, _brokerMetrics,
               adaptiveServerSelector, _pinotConfig, _routableServerInstanceMap.keySet(), _enabledServerInstanceMap,

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
@@ -45,7 +45,6 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.AccessOption;
 import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.HelixConstants.ChangeType;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
@@ -1553,8 +1553,7 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
         selectionResult.setNumPrunedSegments(numPrunedSegments);
         return selectionResult;
       } else {
-        return new InstanceSelector.SelectionResult(Pair.of(Map.of(), Map.of()),
-            List.of(), numPrunedSegments);
+        return InstanceSelector.SelectionResult.empty(numPrunedSegments);
       }
     }
 

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
@@ -34,13 +34,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
-import org.apache.pinot.broker.routing.adaptiveserverselector.HybridSelector;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.BrokerMetrics;
@@ -52,7 +50,6 @@ import org.apache.pinot.spi.config.table.RoutingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.AfterMethod;
@@ -74,9 +71,6 @@ import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -107,13 +101,6 @@ public class InstanceSelectorTest {
 
   private static final String BALANCED_INSTANCE_SELECTOR = "balanced";
 
-  private static List<String> getSegments() {
-    return SEGMENTS;
-  }
-
-  private final static List<String> SEGMENTS =
-      Arrays.asList("segment0", "segment1", "segment2", "segment3", "segment4", "segment5", "segment6", "segment7",
-          "segment8", "segment9", "segment10", "segment11");
   private static final long NEW_SEGMENT_EXPIRATION_SECONDS = 300;
   private static final long NEW_SEGMENT_EXPIRATION_MILLIS = TimeUnit.SECONDS.toMillis(NEW_SEGMENT_EXPIRATION_SECONDS);
   private final static InstanceSelectorConfig INSTANCE_SELECTOR_CONFIG =
@@ -765,238 +752,6 @@ public class InstanceSelectorTest {
     selectionResult = strictReplicaGroupInstanceSelector.select(brokerRequest, segments, requestId);
     assertEquals(selectionResult.getSegmentToInstanceMap(), expectedReplicaGroupInstanceSelectorResult);
     assertTrue(selectionResult.getUnavailableSegments().isEmpty());
-  }
-
-  @Test
-  public void testReplicaGroupInstanceSelectorNumReplicaGroupsToQuery() {
-    String offlineTableName = "testTable_OFFLINE";
-    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
-    BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
-    BrokerRequest brokerRequest = mock(BrokerRequest.class);
-    PinotQuery pinotQuery = mock(PinotQuery.class);
-    Map<String, String> queryOptions = new HashMap<>();
-    // numReplicas = 3, fanning the query to 2 replica groups
-    queryOptions.put("numReplicaGroupsToQuery", "2");
-    when(brokerRequest.getPinotQuery()).thenReturn(pinotQuery);
-    when(pinotQuery.getQueryOptions()).thenReturn(queryOptions);
-
-    ReplicaGroupInstanceSelector replicaGroupInstanceSelector = new ReplicaGroupInstanceSelector();
-
-    Set<String> enabledInstances = new HashSet<>();
-    IdealState idealState = new IdealState(offlineTableName);
-    Map<String, Map<String, String>> idealStateSegmentAssignment = idealState.getRecord().getMapFields();
-    ExternalView externalView = new ExternalView(offlineTableName);
-    Map<String, Map<String, String>> externalViewSegmentAssignment = externalView.getRecord().getMapFields();
-    Set<String> onlineSegments = new HashSet<>();
-
-    // 12 online segments with each segment having all 3 instances as online
-    // replicas are 3
-    String instance0 = "instance0";
-    String instance1 = "instance1";
-    String instance2 = "instance2";
-    enabledInstances.add(instance0);
-    enabledInstances.add(instance1);
-    enabledInstances.add(instance2);
-
-    Map<String, String> idealStateInstanceStateMap0 = new TreeMap<>();
-    Map<String, String> externalViewInstanceStateMap0 = new TreeMap<>();
-
-    for (String instance : enabledInstances) {
-      idealStateInstanceStateMap0.put(instance, ONLINE);
-      externalViewInstanceStateMap0.put(instance, ONLINE);
-    }
-
-    List<String> segments = getSegments();
-    // add all segments to both idealStateSegmentAssignment and externalViewSegmentAssignment maps and also to online
-    // segments
-    for (String segment : segments) {
-      idealStateSegmentAssignment.put(segment, idealStateInstanceStateMap0);
-      externalViewSegmentAssignment.put(segment, externalViewInstanceStateMap0);
-      onlineSegments.add(segment);
-    }
-
-    replicaGroupInstanceSelector.init(_tableConfig, propertyStore, brokerMetrics, null, Clock.systemUTC(),
-        INSTANCE_SELECTOR_CONFIG, enabledInstances, EMPTY_SERVER_MAP, idealState, externalView, onlineSegments);
-    //   ReplicaGroupInstanceSelector
-    //     segment0 -> instance0
-    //     segment2 -> instance0
-    //     segment4 -> instance0
-    //     segment6 -> instance0
-    //     segment8 -> instance0
-    //     segment10 -> instance0
-    //     segment1 -> instance1
-    //     segment3 -> instance1
-    //     segment5 -> instance1
-    //     segment7 -> instance1
-    //     segment9 -> instance1
-    //     segment11 -> instance1
-
-    Map<String, String> expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
-    expectedReplicaGroupInstanceSelectorResult.put(segments.get(0), instance0);
-    expectedReplicaGroupInstanceSelectorResult.put(segments.get(1), instance1);
-    expectedReplicaGroupInstanceSelectorResult.put(segments.get(2), instance0);
-    expectedReplicaGroupInstanceSelectorResult.put(segments.get(3), instance1);
-    expectedReplicaGroupInstanceSelectorResult.put(segments.get(4), instance0);
-    expectedReplicaGroupInstanceSelectorResult.put(segments.get(5), instance1);
-    expectedReplicaGroupInstanceSelectorResult.put(segments.get(6), instance0);
-    expectedReplicaGroupInstanceSelectorResult.put(segments.get(7), instance1);
-    expectedReplicaGroupInstanceSelectorResult.put(segments.get(8), instance0);
-    expectedReplicaGroupInstanceSelectorResult.put(segments.get(9), instance1);
-    expectedReplicaGroupInstanceSelectorResult.put(segments.get(10), instance0);
-    expectedReplicaGroupInstanceSelectorResult.put(segments.get(11), instance1);
-    InstanceSelector.SelectionResult selectionResult = replicaGroupInstanceSelector.select(brokerRequest, segments, 0);
-    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedReplicaGroupInstanceSelectorResult);
-    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
-  }
-
-  @Test
-  public void testReplicaGroupInstanceSelectorNumReplicaGroupsToQueryGreaterThanReplicas() {
-    String offlineTableName = "testTable_OFFLINE";
-    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
-    BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
-    BrokerRequest brokerRequest = mock(BrokerRequest.class);
-    PinotQuery pinotQuery = mock(PinotQuery.class);
-    Map<String, String> queryOptions = new HashMap<>();
-    queryOptions.put("numReplicaGroupsToQuery", "4");
-
-    when(brokerRequest.getPinotQuery()).thenReturn(pinotQuery);
-    when(pinotQuery.getQueryOptions()).thenReturn(queryOptions);
-
-    ReplicaGroupInstanceSelector replicaGroupInstanceSelector = new ReplicaGroupInstanceSelector();
-
-    Set<String> enabledInstances = new HashSet<>();
-    IdealState idealState = new IdealState(offlineTableName);
-    Map<String, Map<String, String>> idealStateSegmentAssignment = idealState.getRecord().getMapFields();
-    ExternalView externalView = new ExternalView(offlineTableName);
-    Map<String, Map<String, String>> externalViewSegmentAssignment = externalView.getRecord().getMapFields();
-    Set<String> onlineSegments = new HashSet<>();
-
-    // 12 online segments with each segment having all 3 instances as online
-    // replicas are 3
-    String instance0 = "instance0";
-    String instance1 = "instance1";
-    String instance2 = "instance2";
-    enabledInstances.add(instance0);
-    enabledInstances.add(instance1);
-    enabledInstances.add(instance2);
-
-    List<String> segments = getSegments();
-
-    Map<String, String> idealStateInstanceStateMap0 = new TreeMap<>();
-    Map<String, String> externalViewInstanceStateMap0 = new TreeMap<>();
-
-    for (String instance : enabledInstances) {
-      idealStateInstanceStateMap0.put(instance, ONLINE);
-      externalViewInstanceStateMap0.put(instance, ONLINE);
-    }
-
-    // add all segments to both idealStateSegmentAssignment and externalViewSegmentAssignment maps and also to online
-    // segments
-    for (String segment : segments) {
-      idealStateSegmentAssignment.put(segment, idealStateInstanceStateMap0);
-      externalViewSegmentAssignment.put(segment, externalViewInstanceStateMap0);
-      onlineSegments.add(segment);
-    }
-
-    replicaGroupInstanceSelector.init(_tableConfig, propertyStore, brokerMetrics, null, Clock.systemUTC(),
-        INSTANCE_SELECTOR_CONFIG, enabledInstances, EMPTY_SERVER_MAP, idealState, externalView, onlineSegments);
-    //   ReplicaGroupInstanceSelector
-    //     segment0 -> instance0
-    //     segment3 -> instance0
-    //     segment6 -> instance0
-    //     segment9 -> instance0
-    //     segment1 -> instance1
-    //     segment4 -> instance1
-    //     segment7 -> instance1
-    //     segment10 -> instance1
-    //     segment2 -> instance2
-    //     segment5 -> instance2
-    //     segment8 -> instance2
-    //     segment11 -> instance2
-
-    Map<String, String> expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
-    expectedReplicaGroupInstanceSelectorResult.put(segments.get(0), instance0);
-    expectedReplicaGroupInstanceSelectorResult.put(segments.get(1), instance1);
-    expectedReplicaGroupInstanceSelectorResult.put(segments.get(2), instance2);
-    expectedReplicaGroupInstanceSelectorResult.put(segments.get(3), instance0);
-    expectedReplicaGroupInstanceSelectorResult.put(segments.get(4), instance1);
-    expectedReplicaGroupInstanceSelectorResult.put(segments.get(5), instance2);
-    expectedReplicaGroupInstanceSelectorResult.put(segments.get(6), instance0);
-    expectedReplicaGroupInstanceSelectorResult.put(segments.get(7), instance1);
-    expectedReplicaGroupInstanceSelectorResult.put(segments.get(8), instance2);
-    expectedReplicaGroupInstanceSelectorResult.put(segments.get(9), instance0);
-    expectedReplicaGroupInstanceSelectorResult.put(segments.get(10), instance1);
-    expectedReplicaGroupInstanceSelectorResult.put(segments.get(11), instance2);
-    InstanceSelector.SelectionResult selectionResult = replicaGroupInstanceSelector.select(brokerRequest, segments, 0);
-    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedReplicaGroupInstanceSelectorResult);
-    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
-  }
-
-  @Test
-  public void testReplicaGroupInstanceSelectorNumReplicaGroupsNotSet() {
-    String offlineTableName = "testTable_OFFLINE";
-    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
-    BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
-    BrokerRequest brokerRequest = mock(BrokerRequest.class);
-    PinotQuery pinotQuery = mock(PinotQuery.class);
-    Map<String, String> queryOptions = new HashMap<>();
-
-    when(brokerRequest.getPinotQuery()).thenReturn(pinotQuery);
-    when(pinotQuery.getQueryOptions()).thenReturn(queryOptions);
-
-    ReplicaGroupInstanceSelector replicaGroupInstanceSelector = new ReplicaGroupInstanceSelector();
-
-    Set<String> enabledInstances = new HashSet<>();
-    IdealState idealState = new IdealState(offlineTableName);
-    Map<String, Map<String, String>> idealStateSegmentAssignment = idealState.getRecord().getMapFields();
-    ExternalView externalView = new ExternalView(offlineTableName);
-    Map<String, Map<String, String>> externalViewSegmentAssignment = externalView.getRecord().getMapFields();
-    Set<String> onlineSegments = new HashSet<>();
-
-    // 12 online segments with each segment having all 3 instances as online
-    // replicas are 3
-    String instance0 = "instance0";
-    String instance1 = "instance1";
-    String instance2 = "instance2";
-    enabledInstances.add(instance0);
-    enabledInstances.add(instance1);
-    enabledInstances.add(instance2);
-
-    List<String> segments = getSegments();
-
-    Map<String, String> idealStateInstanceStateMap0 = new TreeMap<>();
-    Map<String, String> externalViewInstanceStateMap0 = new TreeMap<>();
-
-    for (String instance : enabledInstances) {
-      idealStateInstanceStateMap0.put(instance, ONLINE);
-      externalViewInstanceStateMap0.put(instance, ONLINE);
-    }
-
-    // add all segments to both idealStateSegmentAssignment and externalViewSegmentAssignment maps and also to online
-    // segments
-    for (String segment : segments) {
-      idealStateSegmentAssignment.put(segment, idealStateInstanceStateMap0);
-      externalViewSegmentAssignment.put(segment, externalViewInstanceStateMap0);
-      onlineSegments.add(segment);
-    }
-
-    replicaGroupInstanceSelector.init(_tableConfig, propertyStore, brokerMetrics, null, Clock.systemUTC(),
-        INSTANCE_SELECTOR_CONFIG, enabledInstances, EMPTY_SERVER_MAP, idealState, externalView, onlineSegments);
-    // since numReplicaGroupsToQuery is not set, first query should go to first replica group,
-    // 2nd query should go to next replica group
-
-    Map<String, String> expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
-    for (String segment : segments) {
-      expectedReplicaGroupInstanceSelectorResult.put(segment, instance0);
-    }
-    InstanceSelector.SelectionResult selectionResult = replicaGroupInstanceSelector.select(brokerRequest, segments, 0);
-    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedReplicaGroupInstanceSelectorResult);
-
-    for (String segment : segments) {
-      expectedReplicaGroupInstanceSelectorResult.put(segment, instance1);
-    }
-    selectionResult = replicaGroupInstanceSelector.select(brokerRequest, segments, 1);
-    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedReplicaGroupInstanceSelectorResult);
   }
 
   @Test
@@ -1860,110 +1615,5 @@ public class InstanceSelectorTest {
         selector.select(_brokerRequest, Lists.newArrayList(onlineSegments), requestId);
     assertEquals(selectionResult.getSegmentToInstanceMap(), expectedBalancedInstanceSelectorResult);
     assertTrue(selectionResult.getUnavailableSegments().isEmpty());
-  }
-
-  // Shared topology for AR tests: 3 segments across 5 instances in two replica groups.
-  // segment2 intentionally has instance4 (unranked) so AR falls back to round-robin for that segment.
-  private static final String AR_INSTANCE0 = "instance0";
-  private static final String AR_INSTANCE1 = "instance1";
-  private static final String AR_INSTANCE2 = "instance2";
-  private static final String AR_INSTANCE3 = "instance3";
-  private static final String AR_INSTANCE4 = "instance4";
-  private static final String AR_SEGMENT0 = "segment0";
-  private static final String AR_SEGMENT1 = "segment1";
-  private static final String AR_SEGMENT2 = "segment2";
-  private static final List<String> AR_SEGMENTS =
-      Arrays.asList(AR_SEGMENT0, AR_SEGMENT1, AR_SEGMENT2);
-  // Rankings: instance3 best → instance2 → instance1 → instance0 worst; instance4 absent (triggers AR fallback)
-  private static final List<Pair<String, Double>> AR_SERVER_RANKS = Arrays.asList(
-      new ImmutablePair<>(AR_INSTANCE3, 1.0),
-      new ImmutablePair<>(AR_INSTANCE2, 2.0),
-      new ImmutablePair<>(AR_INSTANCE1, 3.0),
-      new ImmutablePair<>(AR_INSTANCE0, 4.0)
-  );
-
-  private SegmentStates buildArSegmentStates() {
-    Map<String, List<SegmentInstanceCandidate>> candidatesMap = new HashMap<>();
-    // segment0 → instance0, instance1
-    candidatesMap.put(AR_SEGMENT0, Arrays.asList(
-        new SegmentInstanceCandidate(AR_INSTANCE0, true),
-        new SegmentInstanceCandidate(AR_INSTANCE1, true)));
-    // segment1 → instance2, instance3
-    candidatesMap.put(AR_SEGMENT1, Arrays.asList(
-        new SegmentInstanceCandidate(AR_INSTANCE2, true),
-        new SegmentInstanceCandidate(AR_INSTANCE3, true)));
-    // segment2 → instance4 (unranked), instance3
-    candidatesMap.put(AR_SEGMENT2, Arrays.asList(
-        new SegmentInstanceCandidate(AR_INSTANCE4, true),
-        new SegmentInstanceCandidate(AR_INSTANCE3, true)));
-    return new SegmentStates(candidatesMap, new HashSet<>(AR_SEGMENTS), null);
-  }
-
-  private ReplicaGroupInstanceSelector buildArSelector(String selectorType, HybridSelector hybridSelector) {
-    RoutingConfig routingConfig = new RoutingConfig(null, null, selectorType, false);
-    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName("testTable")
-        .setRoutingConfig(routingConfig).build();
-    IdealState idealState = createIdealState(Map.of(
-        AR_SEGMENT0, List.of(Pair.of(AR_INSTANCE0, ONLINE), Pair.of(AR_INSTANCE1, ONLINE)),
-        AR_SEGMENT1, List.of(Pair.of(AR_INSTANCE2, ONLINE), Pair.of(AR_INSTANCE3, ONLINE)),
-        AR_SEGMENT2, List.of(Pair.of(AR_INSTANCE3, ONLINE), Pair.of(AR_INSTANCE4, ONLINE))));
-    ExternalView externalView = createExternalView(Map.of(
-        AR_SEGMENT0, List.of(Pair.of(AR_INSTANCE0, ONLINE), Pair.of(AR_INSTANCE1, ONLINE)),
-        AR_SEGMENT1, List.of(Pair.of(AR_INSTANCE2, ONLINE), Pair.of(AR_INSTANCE3, ONLINE)),
-        AR_SEGMENT2, List.of(Pair.of(AR_INSTANCE3, ONLINE), Pair.of(AR_INSTANCE4, ONLINE))));
-    return (ReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
-        mock(ZkHelixPropertyStore.class), mock(BrokerMetrics.class), hybridSelector,
-        mock(PinotConfiguration.class),
-        Set.of(AR_INSTANCE0, AR_INSTANCE1, AR_INSTANCE2, AR_INSTANCE3, AR_INSTANCE4),
-        Map.of(), idealState, externalView, new HashSet<>(AR_SEGMENTS));
-  }
-
-  @Test
-  public void testReplicaGroupAdaptiveServerSelector() {
-    HybridSelector hybridSelector = mock(HybridSelector.class);
-    ReplicaGroupInstanceSelector instanceSelector =
-        buildArSelector(REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, hybridSelector);
-
-    assertTrue(instanceSelector instanceof ReplicaGroupInstanceSelector);
-    assertFalse(instanceSelector instanceof StrictReplicaGroupInstanceSelector);
-    assertNotNull(instanceSelector._adaptiveServerSelector);
-    assertNotNull(instanceSelector._priorityPoolInstanceSelector);
-
-    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(AR_SERVER_RANKS);
-    Pair<Map<String, String>, Map<String, String>> result =
-        instanceSelector.select(AR_SEGMENTS, 0, buildArSegmentStates(), null);
-
-    // AR prefers the better-ranked server when all candidates are ranked:
-    // segment0: instance1 (rank 3) over instance0 (rank 4)
-    // segment1: instance3 (rank 1) over instance2 (rank 2)
-    // segment2: instance4 unranked → AR falls back to round-robin → index 0 = instance4
-    assertEquals(result.getLeft(), Map.of(
-        AR_SEGMENT0, AR_INSTANCE1,
-        AR_SEGMENT1, AR_INSTANCE3,
-        AR_SEGMENT2, AR_INSTANCE4));
-  }
-
-  @Test
-  public void testStrictReplicaGroupDoesNotUseAdaptiveServerSelector() {
-    HybridSelector hybridSelector = mock(HybridSelector.class);
-    ReplicaGroupInstanceSelector instanceSelector =
-        buildArSelector(STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, hybridSelector);
-
-    assertTrue(instanceSelector instanceof StrictReplicaGroupInstanceSelector);
-    assertNull(instanceSelector._adaptiveServerSelector);
-    assertNull(instanceSelector._priorityPoolInstanceSelector);
-
-    Pair<Map<String, String>, Map<String, String>> result =
-        instanceSelector.select(AR_SEGMENTS, 0, buildArSegmentStates(), null);
-
-    // hybridSelector never consulted during routing despite being passed to the factory
-    verify(hybridSelector, never()).fetchServerRankingsWithScores(any());
-
-    // Round-robin with requestId=0 picks candidate index 0 per segment — opposite of AR result above,
-    // which returns {segment0→instance1, segment1→instance3} for the same rankings.
-    assertEquals(result.getLeft(), Map.of(
-        AR_SEGMENT0, AR_INSTANCE0,
-        AR_SEGMENT1, AR_INSTANCE2,
-        AR_SEGMENT2, AR_INSTANCE4));
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
@@ -52,6 +52,7 @@ import org.apache.pinot.spi.config.table.RoutingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.AfterMethod;
@@ -73,6 +74,9 @@ import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -1858,73 +1862,108 @@ public class InstanceSelectorTest {
     assertTrue(selectionResult.getUnavailableSegments().isEmpty());
   }
 
+  // Shared topology for AR tests: 3 segments across 5 instances in two replica groups.
+  // segment2 intentionally has instance4 (unranked) so AR falls back to round-robin for that segment.
+  private static final String AR_INSTANCE0 = "instance0";
+  private static final String AR_INSTANCE1 = "instance1";
+  private static final String AR_INSTANCE2 = "instance2";
+  private static final String AR_INSTANCE3 = "instance3";
+  private static final String AR_INSTANCE4 = "instance4";
+  private static final String AR_SEGMENT0 = "segment0";
+  private static final String AR_SEGMENT1 = "segment1";
+  private static final String AR_SEGMENT2 = "segment2";
+  private static final List<String> AR_SEGMENTS =
+      Arrays.asList(AR_SEGMENT0, AR_SEGMENT1, AR_SEGMENT2);
+  // Rankings: instance3 best → instance2 → instance1 → instance0 worst; instance4 absent (triggers AR fallback)
+  private static final List<Pair<String, Double>> AR_SERVER_RANKS = Arrays.asList(
+      new ImmutablePair<>(AR_INSTANCE3, 1.0),
+      new ImmutablePair<>(AR_INSTANCE2, 2.0),
+      new ImmutablePair<>(AR_INSTANCE1, 3.0),
+      new ImmutablePair<>(AR_INSTANCE0, 4.0)
+  );
+
+  private SegmentStates buildArSegmentStates() {
+    Map<String, List<SegmentInstanceCandidate>> candidatesMap = new HashMap<>();
+    // segment0 → instance0, instance1
+    candidatesMap.put(AR_SEGMENT0, Arrays.asList(
+        new SegmentInstanceCandidate(AR_INSTANCE0, true),
+        new SegmentInstanceCandidate(AR_INSTANCE1, true)));
+    // segment1 → instance2, instance3
+    candidatesMap.put(AR_SEGMENT1, Arrays.asList(
+        new SegmentInstanceCandidate(AR_INSTANCE2, true),
+        new SegmentInstanceCandidate(AR_INSTANCE3, true)));
+    // segment2 → instance4 (unranked), instance3
+    candidatesMap.put(AR_SEGMENT2, Arrays.asList(
+        new SegmentInstanceCandidate(AR_INSTANCE4, true),
+        new SegmentInstanceCandidate(AR_INSTANCE3, true)));
+    return new SegmentStates(candidatesMap, new HashSet<>(AR_SEGMENTS), null);
+  }
+
+  private ReplicaGroupInstanceSelector buildArSelector(String selectorType, HybridSelector hybridSelector) {
+    RoutingConfig routingConfig = new RoutingConfig(null, null, selectorType, false);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName("testTable")
+        .setRoutingConfig(routingConfig).build();
+    IdealState idealState = createIdealState(Map.of(
+        AR_SEGMENT0, List.of(Pair.of(AR_INSTANCE0, ONLINE), Pair.of(AR_INSTANCE1, ONLINE)),
+        AR_SEGMENT1, List.of(Pair.of(AR_INSTANCE2, ONLINE), Pair.of(AR_INSTANCE3, ONLINE)),
+        AR_SEGMENT2, List.of(Pair.of(AR_INSTANCE3, ONLINE), Pair.of(AR_INSTANCE4, ONLINE))));
+    ExternalView externalView = createExternalView(Map.of(
+        AR_SEGMENT0, List.of(Pair.of(AR_INSTANCE0, ONLINE), Pair.of(AR_INSTANCE1, ONLINE)),
+        AR_SEGMENT1, List.of(Pair.of(AR_INSTANCE2, ONLINE), Pair.of(AR_INSTANCE3, ONLINE)),
+        AR_SEGMENT2, List.of(Pair.of(AR_INSTANCE3, ONLINE), Pair.of(AR_INSTANCE4, ONLINE))));
+    return (ReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
+        mock(ZkHelixPropertyStore.class), mock(BrokerMetrics.class), hybridSelector,
+        mock(PinotConfiguration.class),
+        Set.of(AR_INSTANCE0, AR_INSTANCE1, AR_INSTANCE2, AR_INSTANCE3, AR_INSTANCE4),
+        Map.of(), idealState, externalView, new HashSet<>(AR_SEGMENTS));
+  }
+
   @Test
   public void testReplicaGroupAdaptiveServerSelector() {
-    // Arrange
-    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
-    BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
     HybridSelector hybridSelector = mock(HybridSelector.class);
-    ReplicaGroupInstanceSelector instanceSelector = new ReplicaGroupInstanceSelector();
+    ReplicaGroupInstanceSelector instanceSelector =
+        buildArSelector(REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, hybridSelector);
 
-    // Define instances and segments
-    String instance0 = "instance0";
-    String instance1 = "instance1";
-    String instance2 = "instance2";
-    String instance3 = "instance3";
-    String instance4 = "instance4";
-    String segment0 = "segment0";
-    String segment1 = "segment1";
-    String segment2 = "segment2";
-    List<String> segments = Arrays.asList(segment0, segment1, segment2);
+    assertTrue(instanceSelector instanceof ReplicaGroupInstanceSelector);
+    assertFalse(instanceSelector instanceof StrictReplicaGroupInstanceSelector);
+    assertNotNull(instanceSelector._adaptiveServerSelector);
+    assertNotNull(instanceSelector._priorityPoolInstanceSelector);
 
-    // Define candidates for each segment
-    Map<String, List<SegmentInstanceCandidate>> instanceCandidatesMap = new HashMap<>();
-    // segment0 -> instance0, instance1
-    instanceCandidatesMap.put(segment0,
-        Arrays.asList(new SegmentInstanceCandidate(instance0, true), new SegmentInstanceCandidate(instance1, true)));
-    // segment1 -> instance2, instance3
-    instanceCandidatesMap.put(segment1,
-        Arrays.asList(new SegmentInstanceCandidate(instance2, true), new SegmentInstanceCandidate(instance3, true)));
-    // segment2 -> instance3, instance4 // instance4 is not in the hybrid selector's server ranking
-    instanceCandidatesMap.put(segment2,
-        Arrays.asList(new SegmentInstanceCandidate(instance4, true), new SegmentInstanceCandidate(instance3, true)));
+    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(AR_SERVER_RANKS);
+    Pair<Map<String, String>, Map<String, String>> result =
+        instanceSelector.select(AR_SEGMENTS, 0, buildArSegmentStates(), null);
 
-    IdealState idealState = createIdealState(
-        Map.of(segment0, List.of(Pair.of(instance0, ONLINE), Pair.of(instance1, ONLINE)), segment1,
-            List.of(Pair.of(instance2, ONLINE), Pair.of(instance3, ONLINE)), segment2,
-            List.of(Pair.of(instance3, ONLINE), Pair.of(instance4, ONLINE))));
+    // AR prefers the better-ranked server when all candidates are ranked:
+    // segment0: instance1 (rank 3) over instance0 (rank 4)
+    // segment1: instance3 (rank 1) over instance2 (rank 2)
+    // segment2: instance4 unranked → AR falls back to round-robin → index 0 = instance4
+    assertEquals(result.getLeft(), Map.of(
+        AR_SEGMENT0, AR_INSTANCE1,
+        AR_SEGMENT1, AR_INSTANCE3,
+        AR_SEGMENT2, AR_INSTANCE4));
+  }
 
-    ExternalView externalView = createExternalView(
-        Map.of(segment0, List.of(Pair.of(instance0, ONLINE), Pair.of(instance1, ONLINE)), segment1,
-            List.of(Pair.of(instance2, ONLINE), Pair.of(instance3, ONLINE)), segment2,
-            List.of(Pair.of(instance3, ONLINE), Pair.of(instance4, ONLINE))));
+  @Test
+  public void testStrictReplicaGroupDoesNotUseAdaptiveServerSelector() {
+    HybridSelector hybridSelector = mock(HybridSelector.class);
+    ReplicaGroupInstanceSelector instanceSelector =
+        buildArSelector(STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, hybridSelector);
 
-    instanceSelector.init(_tableConfig, propertyStore, brokerMetrics, hybridSelector, Clock.systemUTC(),
-        INSTANCE_SELECTOR_CONFIG, Set.of(instance0, instance1, instance2, instance3, instance4), EMPTY_SERVER_MAP,
-        idealState, externalView, new HashSet<>(segments));
+    assertTrue(instanceSelector instanceof StrictReplicaGroupInstanceSelector);
+    assertNull(instanceSelector._adaptiveServerSelector);
+    assertNull(instanceSelector._priorityPoolInstanceSelector);
 
-    // Define the segment states
-    SegmentStates segmentStates = new SegmentStates(instanceCandidatesMap, new HashSet<>(segments), null);
+    Pair<Map<String, String>, Map<String, String>> result =
+        instanceSelector.select(AR_SEGMENTS, 0, buildArSegmentStates(), null);
 
-    // Define server rankings
-    List<Pair<String, Double>> serverRanks = Arrays.asList(
-        new ImmutablePair<>(instance3, 1.0),
-        new ImmutablePair<>(instance2, 2.0),
-        new ImmutablePair<>(instance1, 3.0),
-        new ImmutablePair<>(instance0, 4.0)
-    );
-    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(serverRanks);
+    // hybridSelector never consulted during routing despite being passed to the factory
+    verify(hybridSelector, never()).fetchServerRankingsWithScores(any());
 
-    // Act
-    Pair<Map<String, String>, Map<String, String>> selectedResult =
-        instanceSelector.select(segments, 0, segmentStates, null);
-
-    // Assert
-    Map<String, String> expectedSelection = new HashMap<>();
-    expectedSelection.put(segment0, instance1);
-    expectedSelection.put(segment1, instance3);
-    expectedSelection.put(segment2, instance4);
-
-    assertEquals(selectedResult.getLeft(), expectedSelection);
+    // Round-robin with requestId=0 picks candidate index 0 per segment — opposite of AR result above,
+    // which returns {segment0→instance1, segment1→instance3} for the same rankings.
+    assertEquals(result.getLeft(), Map.of(
+        AR_SEGMENT0, AR_INSTANCE0,
+        AR_SEGMENT1, AR_INSTANCE2,
+        AR_SEGMENT2, AR_INSTANCE4));
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
@@ -1000,6 +1000,29 @@ public class InstanceSelectorTest {
   }
 
   @Test
+  public void testUnavailableSegmentsAreDeduplicated() {
+    String segment = "unavailableSegment";
+    BaseInstanceSelector instanceSelector = new BaseInstanceSelector() {
+      @Override
+      void updateSegmentMaps(IdealState idealState, ExternalView externalView, Set<String> onlineSegments,
+          Map<String, Long> newSegmentCreationTimeMap) {
+      }
+
+      @Override
+      protected InstanceSelector.InstanceMapping select(List<String> segments, int requestId,
+          SegmentStates segmentStates,
+          Map<String, String> queryOptions) {
+        return new InstanceSelector.InstanceMapping(Map.of(), Map.of(), List.of(segment));
+      }
+    };
+    instanceSelector._segmentStates = new SegmentStates(Map.of(), Set.of(), Set.of(segment));
+
+    InstanceSelector.SelectionResult result = instanceSelector.select(_brokerRequest, List.of(segment), 0);
+
+    assertEquals(result.getUnavailableSegments(), List.of(segment));
+  }
+
+  @Test
   public void testUnavailableSegments() {
     String offlineTableName = "testTable_OFFLINE";
     ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
@@ -1021,29 +1021,6 @@ public class InstanceSelectorTest {
   }
 
   @Test
-  public void testUnavailableSegmentsAreDeduplicated() {
-    String segment = "unavailableSegment";
-    BaseInstanceSelector instanceSelector = new BaseInstanceSelector() {
-      @Override
-      void updateSegmentMaps(IdealState idealState, ExternalView externalView, Set<String> onlineSegments,
-          Map<String, Long> newSegmentCreationTimeMap) {
-      }
-
-      @Override
-      protected InstanceSelector.InstanceMapping select(List<String> segments, int requestId,
-          SegmentStates segmentStates,
-          Map<String, String> queryOptions) {
-        return new InstanceSelector.InstanceMapping(Map.of(), Map.of(), List.of(segment));
-      }
-    };
-    instanceSelector._segmentStates = new SegmentStates(Map.of(), Set.of(), Set.of(segment));
-
-    InstanceSelector.SelectionResult result = instanceSelector.select(_brokerRequest, List.of(segment), 0);
-
-    assertEquals(result.getUnavailableSegments(), List.of(segment));
-  }
-
-  @Test
   public void testUnavailableSegments() {
     String offlineTableName = "testTable_OFFLINE";
     ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
@@ -41,6 +41,7 @@ import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.broker.routing.adaptiveserverselector.HybridSelector;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.BrokerGauge;
@@ -77,6 +78,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -249,6 +251,25 @@ public class InstanceSelectorTest {
         InstanceSelectorFactory.getInstanceSelector(tableConfig, propertyStore, brokerMetrics, new PinotConfiguration(),
             Set.of(), Map.of(), new IdealState("testTable_OFFLINE"), new ExternalView("testTable_OFFLINE"),
             Set.of()) instanceof ReplicaGroupInstanceSelector);
+  }
+
+  @Test
+  public void testFactoryDisablesAdaptiveRoutingForLegacyUpsertReplicaGroupSelector() {
+    TableConfig tableConfig = mock(TableConfig.class);
+    RoutingConfig routingConfig = mock(RoutingConfig.class);
+    HybridSelector hybridSelector = mock(HybridSelector.class);
+    when(tableConfig.getTableName()).thenReturn("legacyUpsert_REALTIME");
+    when(tableConfig.getRoutingConfig()).thenReturn(routingConfig);
+    when(tableConfig.isUpsertEnabled()).thenReturn(true);
+    when(routingConfig.getInstanceSelectorType()).thenReturn(REPLICA_GROUP_INSTANCE_SELECTOR_TYPE);
+
+    ReplicaGroupInstanceSelector instanceSelector =
+        (ReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig, _propertyStore,
+            _brokerMetrics, hybridSelector, new PinotConfiguration(), Set.of(), Map.of(),
+            new IdealState("legacyUpsert_REALTIME"), new ExternalView("legacyUpsert_REALTIME"), Set.of());
+
+    assertNull(instanceSelector._adaptiveServerSelector);
+    assertNull(instanceSelector._priorityPoolInstanceSelector);
   }
 
   @Test

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
@@ -54,6 +54,7 @@ import org.apache.pinot.spi.config.table.RoutingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.AfterMethod;
@@ -78,6 +79,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -1863,74 +1867,109 @@ public class InstanceSelectorTest {
     assertTrue(selectionResult.getUnavailableSegments().isEmpty());
   }
 
+  // Shared topology for AR tests: 3 segments across 5 instances in two replica groups.
+  // segment2 intentionally has instance4 (unranked) so AR falls back to round-robin for that segment.
+  private static final String AR_INSTANCE0 = "instance0";
+  private static final String AR_INSTANCE1 = "instance1";
+  private static final String AR_INSTANCE2 = "instance2";
+  private static final String AR_INSTANCE3 = "instance3";
+  private static final String AR_INSTANCE4 = "instance4";
+  private static final String AR_SEGMENT0 = "segment0";
+  private static final String AR_SEGMENT1 = "segment1";
+  private static final String AR_SEGMENT2 = "segment2";
+  private static final List<String> AR_SEGMENTS =
+      Arrays.asList(AR_SEGMENT0, AR_SEGMENT1, AR_SEGMENT2);
+  // Rankings: instance3 best → instance2 → instance1 → instance0 worst; instance4 absent (triggers AR fallback)
+  private static final List<Pair<String, Double>> AR_SERVER_RANKS = Arrays.asList(
+      new ImmutablePair<>(AR_INSTANCE3, 1.0),
+      new ImmutablePair<>(AR_INSTANCE2, 2.0),
+      new ImmutablePair<>(AR_INSTANCE1, 3.0),
+      new ImmutablePair<>(AR_INSTANCE0, 4.0)
+  );
+
+  private SegmentStates buildArSegmentStates() {
+    Map<String, List<SegmentInstanceCandidate>> candidatesMap = new HashMap<>();
+    // segment0 → instance0, instance1
+    candidatesMap.put(AR_SEGMENT0, Arrays.asList(
+        new SegmentInstanceCandidate(AR_INSTANCE0, true),
+        new SegmentInstanceCandidate(AR_INSTANCE1, true)));
+    // segment1 → instance2, instance3
+    candidatesMap.put(AR_SEGMENT1, Arrays.asList(
+        new SegmentInstanceCandidate(AR_INSTANCE2, true),
+        new SegmentInstanceCandidate(AR_INSTANCE3, true)));
+    // segment2 → instance4 (unranked), instance3
+    candidatesMap.put(AR_SEGMENT2, Arrays.asList(
+        new SegmentInstanceCandidate(AR_INSTANCE4, true),
+        new SegmentInstanceCandidate(AR_INSTANCE3, true)));
+    return new SegmentStates(candidatesMap, new HashSet<>(AR_SEGMENTS), null);
+  }
+
+  private ReplicaGroupInstanceSelector buildArSelector(String selectorType, HybridSelector hybridSelector) {
+    RoutingConfig routingConfig = new RoutingConfig(null, null, selectorType, false);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName("testTable")
+        .setRoutingConfig(routingConfig).build();
+    IdealState idealState = createIdealState(Map.of(
+        AR_SEGMENT0, List.of(Pair.of(AR_INSTANCE0, ONLINE), Pair.of(AR_INSTANCE1, ONLINE)),
+        AR_SEGMENT1, List.of(Pair.of(AR_INSTANCE2, ONLINE), Pair.of(AR_INSTANCE3, ONLINE)),
+        AR_SEGMENT2, List.of(Pair.of(AR_INSTANCE3, ONLINE), Pair.of(AR_INSTANCE4, ONLINE))));
+    ExternalView externalView = createExternalView(Map.of(
+        AR_SEGMENT0, List.of(Pair.of(AR_INSTANCE0, ONLINE), Pair.of(AR_INSTANCE1, ONLINE)),
+        AR_SEGMENT1, List.of(Pair.of(AR_INSTANCE2, ONLINE), Pair.of(AR_INSTANCE3, ONLINE)),
+        AR_SEGMENT2, List.of(Pair.of(AR_INSTANCE3, ONLINE), Pair.of(AR_INSTANCE4, ONLINE))));
+    return (ReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
+        mock(ZkHelixPropertyStore.class), mock(BrokerMetrics.class), hybridSelector,
+        mock(PinotConfiguration.class),
+        Set.of(AR_INSTANCE0, AR_INSTANCE1, AR_INSTANCE2, AR_INSTANCE3, AR_INSTANCE4),
+        Map.of(), idealState, externalView, new HashSet<>(AR_SEGMENTS));
+  }
+
   @Test
   public void testReplicaGroupAdaptiveServerSelector() {
-    // Arrange
-    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
-    BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
     HybridSelector hybridSelector = mock(HybridSelector.class);
-    ReplicaGroupInstanceSelector instanceSelector = new ReplicaGroupInstanceSelector();
+    ReplicaGroupInstanceSelector instanceSelector =
+        buildArSelector(REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, hybridSelector);
 
-    // Define instances and segments
-    String instance0 = "instance0";
-    String instance1 = "instance1";
-    String instance2 = "instance2";
-    String instance3 = "instance3";
-    String instance4 = "instance4";
-    String segment0 = "segment0";
-    String segment1 = "segment1";
-    String segment2 = "segment2";
-    List<String> segments = Arrays.asList(segment0, segment1, segment2);
+    assertTrue(instanceSelector instanceof ReplicaGroupInstanceSelector);
+    assertFalse(instanceSelector instanceof StrictReplicaGroupInstanceSelector);
+    assertNotNull(instanceSelector._adaptiveServerSelector);
+    assertNotNull(instanceSelector._priorityPoolInstanceSelector);
 
-    // Define candidates for each segment
-    Map<String, List<SegmentInstanceCandidate>> instanceCandidatesMap = new HashMap<>();
-    // segment0 -> instance0, instance1
-    instanceCandidatesMap.put(segment0,
-        Arrays.asList(new SegmentInstanceCandidate(instance0, true), new SegmentInstanceCandidate(instance1, true)));
-    // segment1 -> instance2, instance3
-    instanceCandidatesMap.put(segment1,
-        Arrays.asList(new SegmentInstanceCandidate(instance2, true), new SegmentInstanceCandidate(instance3, true)));
-    // segment2 -> instance3, instance4 // instance4 is not in the hybrid selector's server ranking
-    instanceCandidatesMap.put(segment2,
-        Arrays.asList(new SegmentInstanceCandidate(instance4, true), new SegmentInstanceCandidate(instance3, true)));
+    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(AR_SERVER_RANKS);
+    Pair<Map<String, String>, Map<String, String>> result =
+        instanceSelector.select(AR_SEGMENTS, 0, buildArSegmentStates(), null);
 
-    IdealState idealState = createIdealState(
-        Map.of(segment0, List.of(Pair.of(instance0, ONLINE), Pair.of(instance1, ONLINE)), segment1,
-            List.of(Pair.of(instance2, ONLINE), Pair.of(instance3, ONLINE)), segment2,
-            List.of(Pair.of(instance3, ONLINE), Pair.of(instance4, ONLINE))));
+    // AR prefers the better-ranked server when all candidates are ranked:
+    // segment0: instance1 (rank 3) over instance0 (rank 4)
+    // segment1: instance3 (rank 1) over instance2 (rank 2)
+    // segment2: instance4 unranked → AR falls back to round-robin → index 0 = instance4
+    assertEquals(result.getLeft(), Map.of(
+        AR_SEGMENT0, AR_INSTANCE1,
+        AR_SEGMENT1, AR_INSTANCE3,
+        AR_SEGMENT2, AR_INSTANCE4));
+  }
 
-    ExternalView externalView = createExternalView(
-        Map.of(segment0, List.of(Pair.of(instance0, ONLINE), Pair.of(instance1, ONLINE)), segment1,
-            List.of(Pair.of(instance2, ONLINE), Pair.of(instance3, ONLINE)), segment2,
-            List.of(Pair.of(instance3, ONLINE), Pair.of(instance4, ONLINE))));
+  @Test
+  public void testStrictReplicaGroupDoesNotUseAdaptiveServerSelector() {
+    HybridSelector hybridSelector = mock(HybridSelector.class);
+    ReplicaGroupInstanceSelector instanceSelector =
+        buildArSelector(STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, hybridSelector);
 
-    instanceSelector.init(_tableConfig, propertyStore, brokerMetrics, hybridSelector, Clock.systemUTC(),
-        INSTANCE_SELECTOR_CONFIG, Set.of(instance0, instance1, instance2, instance3, instance4), EMPTY_SERVER_MAP,
-        idealState, externalView, new HashSet<>(segments));
+    assertTrue(instanceSelector instanceof StrictReplicaGroupInstanceSelector);
+    assertNull(instanceSelector._adaptiveServerSelector);
+    assertNull(instanceSelector._priorityPoolInstanceSelector);
 
-    // Define the segment states
-    SegmentStates segmentStates = new SegmentStates(instanceCandidatesMap, new HashSet<>(segments), null);
+    Pair<Map<String, String>, Map<String, String>> result =
+        instanceSelector.select(AR_SEGMENTS, 0, buildArSegmentStates(), null);
 
-    // Define server rankings
-    List<Pair<String, Double>> serverRanks = Arrays.asList(
-        new ImmutablePair<>(instance3, 1.0),
-        new ImmutablePair<>(instance2, 2.0),
-        new ImmutablePair<>(instance1, 3.0),
-        new ImmutablePair<>(instance0, 4.0)
-    );
-    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(serverRanks);
+    // hybridSelector never consulted during routing despite being passed to the factory
+    verify(hybridSelector, never()).fetchServerRankingsWithScores(any());
 
-    // Act
-    Pair<Map<String, String>, Map<String, String>> selectedResult =
-        instanceSelector.select(segments, 0, segmentStates, null);
-
-    // Assert
-    Map<String, String> expectedSelection = new HashMap<>();
-    expectedSelection.put(segment0, instance1);
-    expectedSelection.put(segment1, instance3);
-    expectedSelection.put(segment2, instance4);
-
-    assertEquals(selectedResult.getLeft(), expectedSelection);
+    // Round-robin with requestId=0 picks candidate index 0 per segment — opposite of AR result above,
+    // which returns {segment0→instance1, segment1→instance3} for the same rankings.
+    assertEquals(result.getLeft(), Map.of(
+        AR_SEGMENT0, AR_INSTANCE0,
+        AR_SEGMENT1, AR_INSTANCE2,
+        AR_SEGMENT2, AR_INSTANCE4));
   }
 
   // Replica health metrics

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
@@ -41,7 +41,6 @@ import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
-import org.apache.pinot.broker.routing.adaptiveserverselector.HybridSelector;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.BrokerGauge;
@@ -54,7 +53,6 @@ import org.apache.pinot.spi.config.table.RoutingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.AfterMethod;
@@ -79,9 +77,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -1865,111 +1860,6 @@ public class InstanceSelectorTest {
         selector.select(_brokerRequest, Lists.newArrayList(onlineSegments), requestId);
     assertEquals(selectionResult.getSegmentToInstanceMap(), expectedBalancedInstanceSelectorResult);
     assertTrue(selectionResult.getUnavailableSegments().isEmpty());
-  }
-
-  // Shared topology for AR tests: 3 segments across 5 instances in two replica groups.
-  // segment2 intentionally has instance4 (unranked) so AR falls back to round-robin for that segment.
-  private static final String AR_INSTANCE0 = "instance0";
-  private static final String AR_INSTANCE1 = "instance1";
-  private static final String AR_INSTANCE2 = "instance2";
-  private static final String AR_INSTANCE3 = "instance3";
-  private static final String AR_INSTANCE4 = "instance4";
-  private static final String AR_SEGMENT0 = "segment0";
-  private static final String AR_SEGMENT1 = "segment1";
-  private static final String AR_SEGMENT2 = "segment2";
-  private static final List<String> AR_SEGMENTS =
-      Arrays.asList(AR_SEGMENT0, AR_SEGMENT1, AR_SEGMENT2);
-  // Rankings: instance3 best → instance2 → instance1 → instance0 worst; instance4 absent (triggers AR fallback)
-  private static final List<Pair<String, Double>> AR_SERVER_RANKS = Arrays.asList(
-      new ImmutablePair<>(AR_INSTANCE3, 1.0),
-      new ImmutablePair<>(AR_INSTANCE2, 2.0),
-      new ImmutablePair<>(AR_INSTANCE1, 3.0),
-      new ImmutablePair<>(AR_INSTANCE0, 4.0)
-  );
-
-  private SegmentStates buildArSegmentStates() {
-    Map<String, List<SegmentInstanceCandidate>> candidatesMap = new HashMap<>();
-    // segment0 → instance0, instance1
-    candidatesMap.put(AR_SEGMENT0, Arrays.asList(
-        new SegmentInstanceCandidate(AR_INSTANCE0, true),
-        new SegmentInstanceCandidate(AR_INSTANCE1, true)));
-    // segment1 → instance2, instance3
-    candidatesMap.put(AR_SEGMENT1, Arrays.asList(
-        new SegmentInstanceCandidate(AR_INSTANCE2, true),
-        new SegmentInstanceCandidate(AR_INSTANCE3, true)));
-    // segment2 → instance4 (unranked), instance3
-    candidatesMap.put(AR_SEGMENT2, Arrays.asList(
-        new SegmentInstanceCandidate(AR_INSTANCE4, true),
-        new SegmentInstanceCandidate(AR_INSTANCE3, true)));
-    return new SegmentStates(candidatesMap, new HashSet<>(AR_SEGMENTS), null);
-  }
-
-  private ReplicaGroupInstanceSelector buildArSelector(String selectorType, HybridSelector hybridSelector) {
-    RoutingConfig routingConfig = new RoutingConfig(null, null, selectorType, false);
-    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName("testTable")
-        .setRoutingConfig(routingConfig).build();
-    IdealState idealState = createIdealState(Map.of(
-        AR_SEGMENT0, List.of(Pair.of(AR_INSTANCE0, ONLINE), Pair.of(AR_INSTANCE1, ONLINE)),
-        AR_SEGMENT1, List.of(Pair.of(AR_INSTANCE2, ONLINE), Pair.of(AR_INSTANCE3, ONLINE)),
-        AR_SEGMENT2, List.of(Pair.of(AR_INSTANCE3, ONLINE), Pair.of(AR_INSTANCE4, ONLINE))));
-    ExternalView externalView = createExternalView(Map.of(
-        AR_SEGMENT0, List.of(Pair.of(AR_INSTANCE0, ONLINE), Pair.of(AR_INSTANCE1, ONLINE)),
-        AR_SEGMENT1, List.of(Pair.of(AR_INSTANCE2, ONLINE), Pair.of(AR_INSTANCE3, ONLINE)),
-        AR_SEGMENT2, List.of(Pair.of(AR_INSTANCE3, ONLINE), Pair.of(AR_INSTANCE4, ONLINE))));
-    return (ReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
-        mock(ZkHelixPropertyStore.class), mock(BrokerMetrics.class), hybridSelector,
-        mock(PinotConfiguration.class),
-        Set.of(AR_INSTANCE0, AR_INSTANCE1, AR_INSTANCE2, AR_INSTANCE3, AR_INSTANCE4),
-        Map.of(), idealState, externalView, new HashSet<>(AR_SEGMENTS));
-  }
-
-  @Test
-  public void testReplicaGroupAdaptiveServerSelector() {
-    HybridSelector hybridSelector = mock(HybridSelector.class);
-    ReplicaGroupInstanceSelector instanceSelector =
-        buildArSelector(REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, hybridSelector);
-
-    assertTrue(instanceSelector instanceof ReplicaGroupInstanceSelector);
-    assertFalse(instanceSelector instanceof StrictReplicaGroupInstanceSelector);
-    assertNotNull(instanceSelector._adaptiveServerSelector);
-    assertNotNull(instanceSelector._priorityPoolInstanceSelector);
-
-    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(AR_SERVER_RANKS);
-    Pair<Map<String, String>, Map<String, String>> result =
-        instanceSelector.select(AR_SEGMENTS, 0, buildArSegmentStates(), null);
-
-    // AR prefers the better-ranked server when all candidates are ranked:
-    // segment0: instance1 (rank 3) over instance0 (rank 4)
-    // segment1: instance3 (rank 1) over instance2 (rank 2)
-    // segment2: instance4 unranked → AR falls back to round-robin → index 0 = instance4
-    assertEquals(result.getLeft(), Map.of(
-        AR_SEGMENT0, AR_INSTANCE1,
-        AR_SEGMENT1, AR_INSTANCE3,
-        AR_SEGMENT2, AR_INSTANCE4));
-  }
-
-  @Test
-  public void testStrictReplicaGroupDoesNotUseAdaptiveServerSelector() {
-    HybridSelector hybridSelector = mock(HybridSelector.class);
-    ReplicaGroupInstanceSelector instanceSelector =
-        buildArSelector(STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, hybridSelector);
-
-    assertTrue(instanceSelector instanceof StrictReplicaGroupInstanceSelector);
-    assertNull(instanceSelector._adaptiveServerSelector);
-    assertNull(instanceSelector._priorityPoolInstanceSelector);
-
-    Pair<Map<String, String>, Map<String, String>> result =
-        instanceSelector.select(AR_SEGMENTS, 0, buildArSegmentStates(), null);
-
-    // hybridSelector never consulted during routing despite being passed to the factory
-    verify(hybridSelector, never()).fetchServerRankingsWithScores(any());
-
-    // Round-robin with requestId=0 picks candidate index 0 per segment — opposite of AR result above,
-    // which returns {segment0→instance1, segment1→instance3} for the same rankings.
-    assertEquals(result.getLeft(), Map.of(
-        AR_SEGMENT0, AR_INSTANCE0,
-        AR_SEGMENT1, AR_INSTANCE2,
-        AR_SEGMENT2, AR_INSTANCE4));
   }
 
   // Replica health metrics

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
@@ -34,6 +34,7 @@ import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.broker.routing.adaptiveserverselector.HybridSelector;
+import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.PinotQuery;
@@ -42,7 +43,9 @@ import org.apache.pinot.spi.config.table.RoutingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.AfterMethod;
@@ -53,6 +56,7 @@ import static org.apache.pinot.spi.config.table.RoutingConfig.REPLICA_GROUP_INST
 import static org.apache.pinot.spi.config.table.RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE;
 import static org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -370,6 +374,11 @@ public class ReplicaGroupSelectorTest {
   }
 
   private ReplicaGroupInstanceSelector buildArSelector(String selectorType, HybridSelector hybridSelector) {
+    return buildArSelector(selectorType, hybridSelector, new PinotConfiguration(Collections.emptyMap()));
+  }
+
+  private ReplicaGroupInstanceSelector buildArSelector(String selectorType, HybridSelector hybridSelector,
+      PinotConfiguration brokerConfig) {
     RoutingConfig routingConfig = new RoutingConfig(null, null, selectorType, false);
     TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName("testTable")
         .setRoutingConfig(routingConfig).build();
@@ -383,7 +392,7 @@ public class ReplicaGroupSelectorTest {
         AR_SEGMENT2, List.of(Pair.of(AR_INSTANCE3, ONLINE), Pair.of(AR_INSTANCE4, ONLINE))));
     return (ReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
         mock(ZkHelixPropertyStore.class), mock(BrokerMetrics.class), hybridSelector,
-        mock(PinotConfiguration.class),
+        brokerConfig,
         Set.of(AR_INSTANCE0, AR_INSTANCE1, AR_INSTANCE2, AR_INSTANCE3, AR_INSTANCE4),
         Map.of(), idealState, externalView, new HashSet<>(AR_SEGMENTS));
   }
@@ -414,26 +423,470 @@ public class ReplicaGroupSelectorTest {
   }
 
   @Test
-  public void testStrictReplicaGroupDoesNotUseAdaptiveServerSelector() {
+  public void testStrictReplicaGroupAdaptiveDisabledByFeatureFlag() {
+    // when the feature flag is disabled, the factory nulls out the adaptive selector so the
+    // selector falls back to round-robin.
     HybridSelector hybridSelector = mock(HybridSelector.class);
+    PinotConfiguration brokerConfig = new PinotConfiguration(Map.of(
+        CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STRICT_REPLICA_GROUP, "false"));
     ReplicaGroupInstanceSelector instanceSelector =
-        buildArSelector(STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, hybridSelector);
+        buildArSelector(STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, hybridSelector, brokerConfig);
 
     assertTrue(instanceSelector instanceof StrictReplicaGroupInstanceSelector);
     assertNull(instanceSelector._adaptiveServerSelector);
     assertNull(instanceSelector._priorityPoolInstanceSelector);
 
-    InstanceSelector.InstanceMapping result =
+    BaseInstanceSelector.InstanceMapping result =
         instanceSelector.select(AR_SEGMENTS, 0, buildArSegmentStates(), null);
 
     // hybridSelector never consulted during routing despite being passed to the factory
     verify(hybridSelector, never()).fetchServerRankingsWithScores(any());
 
-    // Round-robin with requestId=0 picks candidate index 0 per segment — opposite of AR result above,
-    // which returns {segment0→instance1, segment1→instance3} for the same rankings.
+    // Round-robin with requestId=0 picks candidate index 0 per segment
     assertEquals(result.segmentToInstanceMap(), Map.of(
         AR_SEGMENT0, AR_INSTANCE0,
         AR_SEGMENT1, AR_INSTANCE2,
         AR_SEGMENT2, AR_INSTANCE4));
+  }
+
+  @Test
+  public void testStrictReplicaGroupUsesAdaptiveServerSelector() {
+    HybridSelector hybridSelector = mock(HybridSelector.class);
+    ReplicaGroupInstanceSelector instanceSelector =
+        buildArSelector(STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, hybridSelector);
+
+    assertTrue(instanceSelector instanceof StrictReplicaGroupInstanceSelector);
+    assertNotNull(instanceSelector._adaptiveServerSelector);
+    assertNotNull(instanceSelector._priorityPoolInstanceSelector);
+  }
+
+  // --- Strict replica group pool-level adaptive routing tests ---
+
+  // Topology: 2 replica groups (pool 0 and pool 1), 3 segments
+  // Pool 0: server_a (segment0, segment1), server_b (segment2)
+  // Pool 1: server_c (segment0, segment1), server_d (segment2)
+  private static final String SRG_SERVER_A = "server_a";
+  private static final String SRG_SERVER_B = "server_b";
+  private static final String SRG_SERVER_C = "server_c";
+  private static final String SRG_SERVER_D = "server_d";
+  private static final String SRG_SEGMENT0 = "seg0";
+  private static final String SRG_SEGMENT1 = "seg1";
+  private static final String SRG_SEGMENT2 = "seg2";
+  private static final List<String> SRG_SEGMENTS = Arrays.asList(SRG_SEGMENT0, SRG_SEGMENT1, SRG_SEGMENT2);
+
+  private SegmentStates buildStrictReplicaGroupSegmentStates() {
+    Map<String, List<SegmentInstanceCandidate>> candidatesMap = new HashMap<>();
+    // segment0 → server_a (pool 0), server_c (pool 1).
+    // Pool 0 is inserted into the LinkedHashMap before pool 1 because server_a (pool 0) appears
+    // first here. The round-robin fallback test depends on this insertion order.
+    candidatesMap.put(SRG_SEGMENT0, Arrays.asList(
+        new SegmentInstanceCandidate(SRG_SERVER_A, true, 0, 0),
+        new SegmentInstanceCandidate(SRG_SERVER_C, true, 1, 0)));
+    // segment1 → server_a (pool 0), server_c (pool 1)
+    candidatesMap.put(SRG_SEGMENT1, Arrays.asList(
+        new SegmentInstanceCandidate(SRG_SERVER_A, true, 0, 0),
+        new SegmentInstanceCandidate(SRG_SERVER_C, true, 1, 0)));
+    // segment2 → server_b (pool 0), server_d (pool 1)
+    candidatesMap.put(SRG_SEGMENT2, Arrays.asList(
+        new SegmentInstanceCandidate(SRG_SERVER_B, true, 0, 0),
+        new SegmentInstanceCandidate(SRG_SERVER_D, true, 1, 0)));
+    return new SegmentStates(candidatesMap, new HashSet<>(SRG_SEGMENTS), null);
+  }
+
+  private StrictReplicaGroupInstanceSelector buildStrictReplicaGroupArSelector(HybridSelector hybridSelector) {
+    return buildStrictReplicaGroupArSelector(hybridSelector, mock(BrokerMetrics.class));
+  }
+
+  private StrictReplicaGroupInstanceSelector buildStrictReplicaGroupArSelector(HybridSelector hybridSelector,
+      BrokerMetrics brokerMetrics) {
+    return buildStrictReplicaGroupArSelector(hybridSelector, brokerMetrics,
+        new PinotConfiguration(Collections.emptyMap()));
+  }
+
+  private StrictReplicaGroupInstanceSelector buildStrictReplicaGroupArSelector(HybridSelector hybridSelector,
+      BrokerMetrics brokerMetrics, PinotConfiguration brokerConfig) {
+    RoutingConfig routingConfig = new RoutingConfig(null, null, STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, false);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName("testUpsertTable")
+        .setRoutingConfig(routingConfig).build();
+    // Ideal state: mirrors the topology above
+    IdealState idealState = createIdealState(Map.of(
+        SRG_SEGMENT0, List.of(Pair.of(SRG_SERVER_A, ONLINE), Pair.of(SRG_SERVER_C, ONLINE)),
+        SRG_SEGMENT1, List.of(Pair.of(SRG_SERVER_A, ONLINE), Pair.of(SRG_SERVER_C, ONLINE)),
+        SRG_SEGMENT2, List.of(Pair.of(SRG_SERVER_B, ONLINE), Pair.of(SRG_SERVER_D, ONLINE))));
+    ExternalView externalView = createExternalView(Map.of(
+        SRG_SEGMENT0, List.of(Pair.of(SRG_SERVER_A, ONLINE), Pair.of(SRG_SERVER_C, ONLINE)),
+        SRG_SEGMENT1, List.of(Pair.of(SRG_SERVER_A, ONLINE), Pair.of(SRG_SERVER_C, ONLINE)),
+        SRG_SEGMENT2, List.of(Pair.of(SRG_SERVER_B, ONLINE), Pair.of(SRG_SERVER_D, ONLINE))));
+    // Provide server instances with pool assignments
+    ServerInstance serverA = mock(ServerInstance.class);
+    when(serverA.getPool()).thenReturn(0);
+    ServerInstance serverB = mock(ServerInstance.class);
+    when(serverB.getPool()).thenReturn(0);
+    ServerInstance serverC = mock(ServerInstance.class);
+    when(serverC.getPool()).thenReturn(1);
+    ServerInstance serverD = mock(ServerInstance.class);
+    when(serverD.getPool()).thenReturn(1);
+    Map<String, ServerInstance> serverMap = Map.of(
+        SRG_SERVER_A, serverA, SRG_SERVER_B, serverB,
+        SRG_SERVER_C, serverC, SRG_SERVER_D, serverD);
+    return (StrictReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
+        mock(ZkHelixPropertyStore.class), brokerMetrics, hybridSelector,
+        brokerConfig,
+        Set.of(SRG_SERVER_A, SRG_SERVER_B, SRG_SERVER_C, SRG_SERVER_D),
+        serverMap, idealState, externalView, new HashSet<>(SRG_SEGMENTS));
+  }
+
+  @Test
+  public void testStrictReplicaGroupAdaptivePicksBestReplicaGroupByWorstCaseServer() {
+    // Pool 0 servers: server_a (rank 2), server_b (rank 3) → worst = 3
+    // Pool 1 servers: server_c (rank 0), server_d (rank 1) → worst = 1
+    // Pool 1 is better (lower worst-case rank), so all segments should route to pool 1
+    HybridSelector hybridSelector = mock(HybridSelector.class);
+    BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
+    StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector,
+        brokerMetrics);
+
+    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(Arrays.asList(
+        new ImmutablePair<>(SRG_SERVER_C, 1.0),  // rank 0 (best)
+        new ImmutablePair<>(SRG_SERVER_D, 2.0),  // rank 1
+        new ImmutablePair<>(SRG_SERVER_A, 3.0),  // rank 2
+        new ImmutablePair<>(SRG_SERVER_B, 4.0)   // rank 3 (worst)
+    ));
+
+    InstanceSelector.InstanceMapping result =
+        instanceSelector.select(SRG_SEGMENTS, 0, buildStrictReplicaGroupSegmentStates(), null);
+
+    // All segments routed to pool 1
+    assertEquals(result.segmentToInstanceMap(), Map.of(
+        SRG_SEGMENT0, SRG_SERVER_C,
+        SRG_SEGMENT1, SRG_SERVER_C,
+        SRG_SEGMENT2, SRG_SERVER_D));
+    verify(brokerMetrics).addMeteredValue(eq(BrokerMeter.POOL_SEG_QUERIES), eq(3L),
+        eq(BrokerMetrics.getTagForPreferredPool(null)), eq("1"));
+  }
+
+  @Test
+  public void testStrictReplicaGroupAdaptivePicksPool0WhenItHasBetterWorstCase() {
+    // Pool 0 servers: server_a (rank 0), server_b (rank 1) → worst = 1
+    // Pool 1 servers: server_c (rank 2), server_d (rank 3) → worst = 3
+    // Pool 0 is better
+    HybridSelector hybridSelector = mock(HybridSelector.class);
+    StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector);
+
+    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(Arrays.asList(
+        new ImmutablePair<>(SRG_SERVER_A, 1.0),
+        new ImmutablePair<>(SRG_SERVER_B, 2.0),
+        new ImmutablePair<>(SRG_SERVER_C, 3.0),
+        new ImmutablePair<>(SRG_SERVER_D, 4.0)
+    ));
+
+    InstanceSelector.InstanceMapping result =
+        instanceSelector.select(SRG_SEGMENTS, 0, buildStrictReplicaGroupSegmentStates(), null);
+
+    // All segments routed to pool 0
+    assertEquals(result.segmentToInstanceMap(), Map.of(
+        SRG_SEGMENT0, SRG_SERVER_A,
+        SRG_SEGMENT1, SRG_SERVER_A,
+        SRG_SEGMENT2, SRG_SERVER_B));
+  }
+
+  @Test
+  public void testStrictReplicaGroupAdaptiveNoStatsFallsBackToRoundRobin() {
+    // When fetchServerRankingsWithScores returns empty, fall back to round-robin
+    HybridSelector hybridSelector = mock(HybridSelector.class);
+    StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector);
+
+    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(Collections.emptyList());
+
+    // requestId=0 → picks group at index 0 (pool 0)
+    InstanceSelector.InstanceMapping result =
+        instanceSelector.select(SRG_SEGMENTS, 0, buildStrictReplicaGroupSegmentStates(), null);
+    assertEquals(result.segmentToInstanceMap(), Map.of(
+        SRG_SEGMENT0, SRG_SERVER_A,
+        SRG_SEGMENT1, SRG_SERVER_A,
+        SRG_SEGMENT2, SRG_SERVER_B));
+
+    // requestId=1 → picks group at index 1 (pool 1)
+    result = instanceSelector.select(SRG_SEGMENTS, 1, buildStrictReplicaGroupSegmentStates(), null);
+    assertEquals(result.segmentToInstanceMap(), Map.of(
+        SRG_SEGMENT0, SRG_SERVER_C,
+        SRG_SEGMENT1, SRG_SERVER_C,
+        SRG_SEGMENT2, SRG_SERVER_D));
+  }
+
+  @Test
+  public void testStrictReplicaGroupAdaptiveConsistencyAllSegmentsSameReplicaGroup() {
+    // For any set of adaptive scores, all segments must route to the same replica group
+    HybridSelector hybridSelector = mock(HybridSelector.class);
+    StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector);
+
+    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(Arrays.asList(
+        new ImmutablePair<>(SRG_SERVER_C, 1.0),
+        new ImmutablePair<>(SRG_SERVER_D, 2.0),
+        new ImmutablePair<>(SRG_SERVER_A, 3.0),
+        new ImmutablePair<>(SRG_SERVER_B, 4.0)
+    ));
+
+    InstanceSelector.InstanceMapping result =
+        instanceSelector.select(SRG_SEGMENTS, 42, buildStrictReplicaGroupSegmentStates(), null);
+
+    // Collect all pool IDs from selected instances
+    Map<String, String> selections = result.segmentToInstanceMap();
+    Set<Integer> poolsUsed = new HashSet<>();
+    SegmentStates states = buildStrictReplicaGroupSegmentStates();
+    for (Map.Entry<String, String> entry : selections.entrySet()) {
+      String segment = entry.getKey();
+      String selectedInstance = entry.getValue();
+      for (SegmentInstanceCandidate candidate : states.getCandidates(segment)) {
+        if (candidate.getInstance().equals(selectedInstance)) {
+          poolsUsed.add(candidate.getPool());
+          break;
+        }
+      }
+    }
+    // All segments must be from the same pool
+    assertEquals(poolsUsed.size(), 1, "All segments should be routed to the same replica group");
+  }
+
+  @Test
+  public void testStrictReplicaGroupAdaptivePrefersFullCoverageGroup() {
+    // Topology: pool 0 has all 3 segments, pool 1 only has segment0 and segment1 (missing segment2).
+    // Even though pool 1 has better adaptive ranks, pool 0 should be chosen because it has full coverage.
+    // Pool 0: server_a (seg0, seg1), server_b (seg2) — full coverage
+    // Pool 1: server_c (seg0, seg1) — missing seg2, partial coverage
+    String serverC = "server_c";
+    HybridSelector hybridSelector = mock(HybridSelector.class);
+
+    RoutingConfig routingConfig = new RoutingConfig(null, null, STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, false);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName("testUpsertTable")
+        .setRoutingConfig(routingConfig).build();
+    // Pool 1 only has seg0 and seg1 (no seg2)
+    IdealState idealState = createIdealState(Map.of(
+        SRG_SEGMENT0, List.of(Pair.of(SRG_SERVER_A, ONLINE), Pair.of(serverC, ONLINE)),
+        SRG_SEGMENT1, List.of(Pair.of(SRG_SERVER_A, ONLINE), Pair.of(serverC, ONLINE)),
+        SRG_SEGMENT2, List.of(Pair.of(SRG_SERVER_B, ONLINE))));
+    ExternalView externalView = createExternalView(Map.of(
+        SRG_SEGMENT0, List.of(Pair.of(SRG_SERVER_A, ONLINE), Pair.of(serverC, ONLINE)),
+        SRG_SEGMENT1, List.of(Pair.of(SRG_SERVER_A, ONLINE), Pair.of(serverC, ONLINE)),
+        SRG_SEGMENT2, List.of(Pair.of(SRG_SERVER_B, ONLINE))));
+    ServerInstance serverA = mock(ServerInstance.class);
+    when(serverA.getPool()).thenReturn(0);
+    ServerInstance serverB = mock(ServerInstance.class);
+    when(serverB.getPool()).thenReturn(0);
+    ServerInstance serverCInstance = mock(ServerInstance.class);
+    when(serverCInstance.getPool()).thenReturn(1);
+    Map<String, ServerInstance> serverMap = Map.of(
+        SRG_SERVER_A, serverA, SRG_SERVER_B, serverB, serverC, serverCInstance);
+    StrictReplicaGroupInstanceSelector instanceSelector =
+        (StrictReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
+            mock(ZkHelixPropertyStore.class), mock(BrokerMetrics.class), hybridSelector,
+            new PinotConfiguration(Collections.emptyMap()),
+            Set.of(SRG_SERVER_A, SRG_SERVER_B, serverC),
+            serverMap, idealState, externalView, new HashSet<>(SRG_SEGMENTS));
+
+    // Pool 1 (server_c) has rank 0 — best rank, but only covers 2 of 3 segments
+    // Pool 0 (server_a rank 2, server_b rank 3) — worse ranks, but full coverage
+    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(Arrays.asList(
+        new ImmutablePair<>(serverC, 1.0),        // rank 0 (best)
+        new ImmutablePair<>(SRG_SERVER_A, 3.0),   // rank 1
+        new ImmutablePair<>(SRG_SERVER_B, 4.0)    // rank 2
+    ));
+
+    // Build segment states where pool 1 is missing seg2
+    Map<String, List<SegmentInstanceCandidate>> candidatesMap = new HashMap<>();
+    candidatesMap.put(SRG_SEGMENT0, Arrays.asList(
+        new SegmentInstanceCandidate(SRG_SERVER_A, true, 0, 0),
+        new SegmentInstanceCandidate(serverC, true, 1, 0)));
+    candidatesMap.put(SRG_SEGMENT1, Arrays.asList(
+        new SegmentInstanceCandidate(SRG_SERVER_A, true, 0, 0),
+        new SegmentInstanceCandidate(serverC, true, 1, 0)));
+    candidatesMap.put(SRG_SEGMENT2, List.of(
+        new SegmentInstanceCandidate(SRG_SERVER_B, true, 0, 0)));
+    SegmentStates segmentStates = new SegmentStates(candidatesMap, new HashSet<>(SRG_SEGMENTS), null);
+
+    InstanceSelector.InstanceMapping result =
+        instanceSelector.select(SRG_SEGMENTS, 0, segmentStates, null);
+
+    // Pool 0 should be chosen (full coverage) even though pool 1 has better ranks
+    assertEquals(result.segmentToInstanceMap(), Map.of(
+        SRG_SEGMENT0, SRG_SERVER_A,
+        SRG_SEGMENT1, SRG_SERVER_A,
+        SRG_SEGMENT2, SRG_SERVER_B));
+  }
+
+  @Test
+  public void testStrictReplicaGroupAdaptiveNewSegmentNotFalselyUnavailable() {
+    // Topology: server_a (pool 0) hosts seg0 only. seg1 has no online instance (simulating a
+    // new/unassigned segment with null candidates in segmentStates). Pool 0 is chosen (only pool).
+    // seg1 should NOT appear in unavailable — it is a new segment, not a dropped one.
+    String serverA = "new_server_a";
+    String seg0 = "new_seg0";
+    String seg1 = "new_seg1";
+    List<String> segments = Arrays.asList(seg0, seg1);
+    HybridSelector hybridSelector = mock(HybridSelector.class);
+
+    RoutingConfig routingConfig = new RoutingConfig(null, null, STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, false);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName("testNewSegTable")
+        .setRoutingConfig(routingConfig).build();
+    // seg1 intentionally absent from idealState/externalView → null candidates (new segment)
+    IdealState idealState = createIdealState(Map.of(
+        seg0, List.of(Pair.of(serverA, ONLINE))));
+    ExternalView externalView = createExternalView(Map.of(
+        seg0, List.of(Pair.of(serverA, ONLINE))));
+    ServerInstance serverAInstance = mock(ServerInstance.class);
+    when(serverAInstance.getPool()).thenReturn(0);
+    StrictReplicaGroupInstanceSelector instanceSelector =
+        (StrictReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
+            mock(ZkHelixPropertyStore.class), mock(BrokerMetrics.class), hybridSelector,
+            new PinotConfiguration(Collections.emptyMap()),
+            Set.of(serverA),
+            Map.of(serverA, serverAInstance),
+            idealState, externalView, new HashSet<>(List.of(seg0)));
+
+    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(Arrays.asList(
+        new ImmutablePair<>(serverA, 1.0)));
+
+    BrokerRequest brokerRequest = mock(BrokerRequest.class);
+    PinotQuery pinotQuery = mock(PinotQuery.class);
+    when(brokerRequest.getPinotQuery()).thenReturn(pinotQuery);
+    when(pinotQuery.getQueryOptions()).thenReturn(null);
+
+    InstanceSelector.SelectionResult result = instanceSelector.select(brokerRequest, segments, 0);
+    assertEquals(result.getSegmentToInstanceMap(), Map.of(seg0, serverA));
+    // seg1 has null candidates (not yet in the selector's state) → must NOT appear as unavailable
+    assertTrue(result.getUnavailableSegments().isEmpty());
+  }
+
+  @Test
+  public void testStrictReplicaGroupAdaptiveDroppedSegmentReportedAsUnavailable() {
+    // Topology: no replica group has full coverage.
+    // Pool 0: server_a hosts seg0, seg1 (missing seg2)
+    // Pool 1: server_c hosts seg1, seg2 (missing seg0)
+    // Pool 1 has better ranks -> chosen. seg0 has no candidate in pool 1 -> reported unavailable.
+    String serverA = "partial_server_a";
+    String serverC = "partial_server_c";
+    String seg0 = "partial_seg0";
+    String seg1 = "partial_seg1";
+    String seg2 = "partial_seg2";
+    List<String> segments = Arrays.asList(seg0, seg1, seg2);
+    HybridSelector hybridSelector = mock(HybridSelector.class);
+
+    RoutingConfig routingConfig = new RoutingConfig(null, null, STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, false);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName("testPartialCoverage")
+            .setRoutingConfig(routingConfig).build();
+    IdealState idealState = createIdealState(Map.of(
+            seg0, List.of(Pair.of(serverA, ONLINE)),
+            seg1, List.of(Pair.of(serverA, ONLINE), Pair.of(serverC, ONLINE)),
+            seg2, List.of(Pair.of(serverC, ONLINE))));
+    ExternalView externalView = createExternalView(Map.of(
+            seg0, List.of(Pair.of(serverA, ONLINE)),
+            seg1, List.of(Pair.of(serverA, ONLINE), Pair.of(serverC, ONLINE)),
+            seg2, List.of(Pair.of(serverC, ONLINE))));
+    ServerInstance serverAInstance = mock(ServerInstance.class);
+    when(serverAInstance.getPool()).thenReturn(0);
+    ServerInstance serverCInstance = mock(ServerInstance.class);
+    when(serverCInstance.getPool()).thenReturn(1);
+    Map<String, ServerInstance> serverMap = Map.of(serverA, serverAInstance, serverC, serverCInstance);
+    BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
+    StrictReplicaGroupInstanceSelector instanceSelector =
+            (StrictReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
+                    mock(ZkHelixPropertyStore.class), brokerMetrics, hybridSelector,
+                    new PinotConfiguration(Collections.emptyMap()),
+                    Set.of(serverA, serverC),
+                    serverMap, idealState, externalView, new HashSet<>(segments));
+
+    // Pool 1 (server_c) ranked better -> pool 1 chosen
+    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(Arrays.asList(
+            new ImmutablePair<>(serverC, 1.0),
+            new ImmutablePair<>(serverA, 3.0)
+    ));
+
+    BrokerRequest brokerRequest = mock(BrokerRequest.class);
+    PinotQuery pinotQuery = mock(PinotQuery.class);
+    when(brokerRequest.getPinotQuery()).thenReturn(pinotQuery);
+    when(pinotQuery.getQueryOptions()).thenReturn(null);
+
+    InstanceSelector.SelectionResult result = instanceSelector.select(brokerRequest, segments, 0);
+
+    // seg1 and seg2 routed to pool 1
+    assertEquals(result.getSegmentToInstanceMap(), Map.of(seg1, serverC, seg2, serverC));
+    // seg0 has candidates (pool 0 only) but no match in chosen pool 1 -> reported unavailable
+    assertEquals(result.getUnavailableSegments(), List.of(seg0));
+  }
+
+  @Test
+  public void testStrictReplicaGroupAdaptiveOnlyQueryRelevantServersScored() {
+    // Topology: pool 1 has an extra server (server_e) that hosts a segment NOT in the query.
+    // server_e has a very high rank but should not affect pool 1's score since it hosts no query segments.
+    // Pool 0: server_a (rank 2), server_b (rank 3) → worst = 3
+    // Pool 1: server_c (rank 0), server_d (rank 1) → worst = 1
+    //   (server_e at rank 99 hosts segment "seg_extra" which is not in the query)
+    // Pool 1 should win because only query-relevant servers matter (server_e is ignored).
+    String serverE = "server_e";
+    String segExtra = "seg_extra";
+    HybridSelector hybridSelector = mock(HybridSelector.class);
+
+    // Build selector with server_e in pool 1, hosting seg_extra
+    RoutingConfig routingConfig = new RoutingConfig(null, null, STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, false);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName("testUpsertTable")
+        .setRoutingConfig(routingConfig).build();
+    IdealState idealState = createIdealState(Map.of(
+        SRG_SEGMENT0, List.of(Pair.of(SRG_SERVER_A, ONLINE), Pair.of(SRG_SERVER_C, ONLINE)),
+        SRG_SEGMENT1, List.of(Pair.of(SRG_SERVER_A, ONLINE), Pair.of(SRG_SERVER_C, ONLINE)),
+        SRG_SEGMENT2, List.of(Pair.of(SRG_SERVER_B, ONLINE), Pair.of(SRG_SERVER_D, ONLINE)),
+        segExtra, List.of(Pair.of(serverE, ONLINE))));
+    ExternalView externalView = createExternalView(Map.of(
+        SRG_SEGMENT0, List.of(Pair.of(SRG_SERVER_A, ONLINE), Pair.of(SRG_SERVER_C, ONLINE)),
+        SRG_SEGMENT1, List.of(Pair.of(SRG_SERVER_A, ONLINE), Pair.of(SRG_SERVER_C, ONLINE)),
+        SRG_SEGMENT2, List.of(Pair.of(SRG_SERVER_B, ONLINE), Pair.of(SRG_SERVER_D, ONLINE)),
+        segExtra, List.of(Pair.of(serverE, ONLINE))));
+    ServerInstance serverA = mock(ServerInstance.class);
+    when(serverA.getPool()).thenReturn(0);
+    ServerInstance serverB = mock(ServerInstance.class);
+    when(serverB.getPool()).thenReturn(0);
+    ServerInstance serverC = mock(ServerInstance.class);
+    when(serverC.getPool()).thenReturn(1);
+    ServerInstance serverD = mock(ServerInstance.class);
+    when(serverD.getPool()).thenReturn(1);
+    ServerInstance serverEInstance = mock(ServerInstance.class);
+    when(serverEInstance.getPool()).thenReturn(1);
+    Map<String, ServerInstance> serverMap = Map.of(
+        SRG_SERVER_A, serverA, SRG_SERVER_B, serverB,
+        SRG_SERVER_C, serverC, SRG_SERVER_D, serverD,
+        serverE, serverEInstance);
+    Set<String> allSegments = new HashSet<>(SRG_SEGMENTS);
+    allSegments.add(segExtra);
+    StrictReplicaGroupInstanceSelector instanceSelector =
+        (StrictReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
+            mock(ZkHelixPropertyStore.class), mock(BrokerMetrics.class), hybridSelector,
+            new PinotConfiguration(Collections.emptyMap()),
+            Set.of(SRG_SERVER_A, SRG_SERVER_B, SRG_SERVER_C, SRG_SERVER_D, serverE),
+            serverMap, idealState, externalView, allSegments);
+
+    // server_e has rank 99 but hosts no query segments — should be irrelevant
+    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(Arrays.asList(
+        new ImmutablePair<>(SRG_SERVER_C, 1.0),   // rank 0
+        new ImmutablePair<>(SRG_SERVER_D, 2.0),   // rank 1
+        new ImmutablePair<>(SRG_SERVER_A, 3.0),   // rank 2
+        new ImmutablePair<>(SRG_SERVER_B, 4.0),   // rank 3
+        new ImmutablePair<>(serverE, 99.0)        // rank 4 (high score, not query-relevant)
+    ));
+
+    // Query only SRG_SEGMENTS (not seg_extra), so server_e is not query-relevant
+    InstanceSelector.InstanceMapping result =
+        instanceSelector.select(SRG_SEGMENTS, 0, buildStrictReplicaGroupSegmentStates(), null);
+
+    // Pool 1 wins (worst rank among query-relevant servers = 1) over pool 0 (worst = 3)
+    // server_e's rank 4 is not considered because it hosts no query segments
+    assertEquals(result.segmentToInstanceMap(), Map.of(
+        SRG_SEGMENT0, SRG_SERVER_C,
+        SRG_SEGMENT1, SRG_SERVER_C,
+        SRG_SEGMENT2, SRG_SERVER_D));
+
+    ArgumentCaptor<List<String>> rankedCandidatesCaptor = ArgumentCaptor.forClass(List.class);
+    verify(hybridSelector).fetchServerRankingsWithScores(rankedCandidatesCaptor.capture());
+    assertEquals(new HashSet<>(rankedCandidatesCaptor.getValue()),
+        Set.of(SRG_SERVER_A, SRG_SERVER_B, SRG_SERVER_C, SRG_SERVER_D));
+    assertEquals(rankedCandidatesCaptor.getValue().size(), 4);
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
@@ -54,6 +54,7 @@ import org.testng.annotations.Test;
 
 import static org.apache.pinot.spi.config.table.RoutingConfig.REPLICA_GROUP_INSTANCE_SELECTOR_TYPE;
 import static org.apache.pinot.spi.config.table.RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE;
+import static org.apache.pinot.spi.utils.CommonConstants.Broker.FALLBACK_POOL_ID;
 import static org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -70,7 +71,7 @@ import static org.testng.Assert.assertTrue;
 
 /**
  * Tests for {@link ReplicaGroupInstanceSelector} and {@link StrictReplicaGroupInstanceSelector},
- * including adaptive server selection (pool-level routing for strict replica groups).
+ * including adaptive server selection (replica-group-level routing for strict replica groups).
  */
 @SuppressWarnings("unchecked")
 public class ReplicaGroupSelectorTest {
@@ -336,40 +337,40 @@ public class ReplicaGroupSelectorTest {
 
   // --- Adaptive server selection tests ---
 
-  // Shared topology for AR tests: 3 segments across 5 instances in two replica groups.
-  // segment2 intentionally has instance4 (unranked) so AR falls back to round-robin for that segment.
-  private static final String AR_INSTANCE0 = "instance0";
-  private static final String AR_INSTANCE1 = "instance1";
-  private static final String AR_INSTANCE2 = "instance2";
-  private static final String AR_INSTANCE3 = "instance3";
-  private static final String AR_INSTANCE4 = "instance4";
+  // Shared topology for AR tests: 3 segments across 5 instances in two pools / replica groups.
+  // segment2 intentionally has AR_P0_RG0_SERVER_E (unranked) so AR falls back to round-robin for that segment.
+  private static final String AR_P0_RG0_SERVER_A = "ar_p0_rg0_server_a";
+  private static final String AR_P1_RG1_SERVER_B = "ar_p1_rg1_server_b";
+  private static final String AR_P0_RG0_SERVER_C = "ar_p0_rg0_server_c";
+  private static final String AR_P1_RG1_SERVER_D = "ar_p1_rg1_server_d";
+  private static final String AR_P0_RG0_SERVER_E = "ar_p0_rg0_server_e";
   private static final String AR_SEGMENT0 = "segment0";
   private static final String AR_SEGMENT1 = "segment1";
   private static final String AR_SEGMENT2 = "segment2";
   private static final List<String> AR_SEGMENTS =
       Arrays.asList(AR_SEGMENT0, AR_SEGMENT1, AR_SEGMENT2);
-  // Rankings: instance3 best → instance2 → instance1 → instance0 worst; instance4 absent (triggers AR fallback)
+  // Rankings: D best → C → B → A worst; E absent (triggers AR fallback)
   private static final List<Pair<String, Double>> AR_SERVER_RANKS = Arrays.asList(
-      new ImmutablePair<>(AR_INSTANCE3, 1.0),
-      new ImmutablePair<>(AR_INSTANCE2, 2.0),
-      new ImmutablePair<>(AR_INSTANCE1, 3.0),
-      new ImmutablePair<>(AR_INSTANCE0, 4.0)
+      new ImmutablePair<>(AR_P1_RG1_SERVER_D, 1.0),
+      new ImmutablePair<>(AR_P0_RG0_SERVER_C, 2.0),
+      new ImmutablePair<>(AR_P1_RG1_SERVER_B, 3.0),
+      new ImmutablePair<>(AR_P0_RG0_SERVER_A, 4.0)
   );
 
   private SegmentStates buildArSegmentStates() {
     Map<String, List<SegmentInstanceCandidate>> candidatesMap = new HashMap<>();
-    // segment0 → instance0, instance1
+    // segment0 → pool 0 / replica group 0 server A, pool 1 / replica group 1 server B
     candidatesMap.put(AR_SEGMENT0, Arrays.asList(
-        new SegmentInstanceCandidate(AR_INSTANCE0, true),
-        new SegmentInstanceCandidate(AR_INSTANCE1, true)));
-    // segment1 → instance2, instance3
+        new SegmentInstanceCandidate(AR_P0_RG0_SERVER_A, true, 0, 0),
+        new SegmentInstanceCandidate(AR_P1_RG1_SERVER_B, true, 1, 1)));
+    // segment1 → pool 0 / replica group 0 server C, pool 1 / replica group 1 server D
     candidatesMap.put(AR_SEGMENT1, Arrays.asList(
-        new SegmentInstanceCandidate(AR_INSTANCE2, true),
-        new SegmentInstanceCandidate(AR_INSTANCE3, true)));
-    // segment2 → instance4 (unranked), instance3
+        new SegmentInstanceCandidate(AR_P0_RG0_SERVER_C, true, 0, 0),
+        new SegmentInstanceCandidate(AR_P1_RG1_SERVER_D, true, 1, 1)));
+    // segment2 → pool 0 / replica group 0 server E (unranked), pool 1 / replica group 1 server D
     candidatesMap.put(AR_SEGMENT2, Arrays.asList(
-        new SegmentInstanceCandidate(AR_INSTANCE4, true),
-        new SegmentInstanceCandidate(AR_INSTANCE3, true)));
+        new SegmentInstanceCandidate(AR_P0_RG0_SERVER_E, true, 0, 0),
+        new SegmentInstanceCandidate(AR_P1_RG1_SERVER_D, true, 1, 1)));
     return new SegmentStates(candidatesMap, new HashSet<>(AR_SEGMENTS), null);
   }
 
@@ -383,18 +384,34 @@ public class ReplicaGroupSelectorTest {
     TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName("testTable")
         .setRoutingConfig(routingConfig).build();
     IdealState idealState = createIdealState(Map.of(
-        AR_SEGMENT0, List.of(Pair.of(AR_INSTANCE0, ONLINE), Pair.of(AR_INSTANCE1, ONLINE)),
-        AR_SEGMENT1, List.of(Pair.of(AR_INSTANCE2, ONLINE), Pair.of(AR_INSTANCE3, ONLINE)),
-        AR_SEGMENT2, List.of(Pair.of(AR_INSTANCE3, ONLINE), Pair.of(AR_INSTANCE4, ONLINE))));
+        AR_SEGMENT0, List.of(Pair.of(AR_P0_RG0_SERVER_A, ONLINE), Pair.of(AR_P1_RG1_SERVER_B, ONLINE)),
+        AR_SEGMENT1, List.of(Pair.of(AR_P0_RG0_SERVER_C, ONLINE), Pair.of(AR_P1_RG1_SERVER_D, ONLINE)),
+        AR_SEGMENT2, List.of(Pair.of(AR_P1_RG1_SERVER_D, ONLINE), Pair.of(AR_P0_RG0_SERVER_E, ONLINE))));
     ExternalView externalView = createExternalView(Map.of(
-        AR_SEGMENT0, List.of(Pair.of(AR_INSTANCE0, ONLINE), Pair.of(AR_INSTANCE1, ONLINE)),
-        AR_SEGMENT1, List.of(Pair.of(AR_INSTANCE2, ONLINE), Pair.of(AR_INSTANCE3, ONLINE)),
-        AR_SEGMENT2, List.of(Pair.of(AR_INSTANCE3, ONLINE), Pair.of(AR_INSTANCE4, ONLINE))));
+        AR_SEGMENT0, List.of(Pair.of(AR_P0_RG0_SERVER_A, ONLINE), Pair.of(AR_P1_RG1_SERVER_B, ONLINE)),
+        AR_SEGMENT1, List.of(Pair.of(AR_P0_RG0_SERVER_C, ONLINE), Pair.of(AR_P1_RG1_SERVER_D, ONLINE)),
+        AR_SEGMENT2, List.of(Pair.of(AR_P1_RG1_SERVER_D, ONLINE), Pair.of(AR_P0_RG0_SERVER_E, ONLINE))));
+    ServerInstance serverA = mock(ServerInstance.class);
+    when(serverA.getPool()).thenReturn(0);
+    ServerInstance serverB = mock(ServerInstance.class);
+    when(serverB.getPool()).thenReturn(1);
+    ServerInstance serverC = mock(ServerInstance.class);
+    when(serverC.getPool()).thenReturn(0);
+    ServerInstance serverD = mock(ServerInstance.class);
+    when(serverD.getPool()).thenReturn(1);
+    ServerInstance serverE = mock(ServerInstance.class);
+    when(serverE.getPool()).thenReturn(0);
+    Map<String, ServerInstance> serverMap = Map.of(
+        AR_P0_RG0_SERVER_A, serverA,
+        AR_P1_RG1_SERVER_B, serverB,
+        AR_P0_RG0_SERVER_C, serverC,
+        AR_P1_RG1_SERVER_D, serverD,
+        AR_P0_RG0_SERVER_E, serverE);
     return (ReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
         mock(ZkHelixPropertyStore.class), mock(BrokerMetrics.class), hybridSelector,
         brokerConfig,
-        Set.of(AR_INSTANCE0, AR_INSTANCE1, AR_INSTANCE2, AR_INSTANCE3, AR_INSTANCE4),
-        Map.of(), idealState, externalView, new HashSet<>(AR_SEGMENTS));
+        Set.of(AR_P0_RG0_SERVER_A, AR_P1_RG1_SERVER_B, AR_P0_RG0_SERVER_C, AR_P1_RG1_SERVER_D, AR_P0_RG0_SERVER_E),
+        serverMap, idealState, externalView, new HashSet<>(AR_SEGMENTS));
   }
 
   @Test
@@ -413,44 +430,47 @@ public class ReplicaGroupSelectorTest {
         instanceSelector.select(AR_SEGMENTS, 0, buildArSegmentStates(), null);
 
     // AR prefers the better-ranked server when all candidates are ranked:
-    // segment0: instance1 (rank 3) over instance0 (rank 4)
-    // segment1: instance3 (rank 1) over instance2 (rank 2)
-    // segment2: instance4 unranked → AR falls back to round-robin → index 0 = instance4
+    // segment0: B (rank 3) over A (rank 4)
+    // segment1: D (rank 1) over C (rank 2)
+    // segment2: E unranked → AR falls back to round-robin → index 0 = E
     assertEquals(result.segmentToInstanceMap(), Map.of(
-        AR_SEGMENT0, AR_INSTANCE1,
-        AR_SEGMENT1, AR_INSTANCE3,
-        AR_SEGMENT2, AR_INSTANCE4));
+        AR_SEGMENT0, AR_P1_RG1_SERVER_B,
+        AR_SEGMENT1, AR_P1_RG1_SERVER_D,
+        AR_SEGMENT2, AR_P0_RG0_SERVER_E));
   }
 
   @Test
   public void testStrictReplicaGroupAdaptiveDisabledByFeatureFlag() {
-    // when the feature flag is disabled, the factory nulls out the adaptive selector so the
-    // selector falls back to round-robin.
+    // When the feature flag is disabled, the factory nulls out the adaptive selector so the selector falls back to the
+    // strict selector's non-adaptive, round-robin-by-replica-index path.
     HybridSelector hybridSelector = mock(HybridSelector.class);
+    BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
     PinotConfiguration brokerConfig = new PinotConfiguration(Map.of(
         CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STRICT_REPLICA_GROUP, "false"));
-    ReplicaGroupInstanceSelector instanceSelector =
-        buildArSelector(STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, hybridSelector, brokerConfig);
+    StrictReplicaGroupInstanceSelector instanceSelector =
+        buildStrictReplicaGroupArSelector(hybridSelector, brokerMetrics, brokerConfig);
 
-    assertTrue(instanceSelector instanceof StrictReplicaGroupInstanceSelector);
     assertNull(instanceSelector._adaptiveServerSelector);
     assertNull(instanceSelector._priorityPoolInstanceSelector);
 
     BaseInstanceSelector.InstanceMapping result =
-        instanceSelector.select(AR_SEGMENTS, 0, buildArSegmentStates(), null);
+        instanceSelector.select(STRICT_SEGMENTS, 0, buildStrictReplicaGroupSegmentStates(), null);
 
-    // hybridSelector never consulted during routing despite being passed to the factory
     verify(hybridSelector, never()).fetchServerRankingsWithScores(any());
-
-    // Round-robin with requestId=0 picks candidate index 0 per segment
     assertEquals(result.segmentToInstanceMap(), Map.of(
-        AR_SEGMENT0, AR_INSTANCE0,
-        AR_SEGMENT1, AR_INSTANCE2,
-        AR_SEGMENT2, AR_INSTANCE4));
+        STRICT_SEGMENT0, STRICT_RG0_SERVER_A,
+        STRICT_SEGMENT1, STRICT_RG0_SERVER_A,
+        STRICT_SEGMENT2, STRICT_RG0_SERVER_B));
+
+    result = instanceSelector.select(STRICT_SEGMENTS, 1, buildStrictReplicaGroupSegmentStates(), null);
+    assertEquals(result.segmentToInstanceMap(), Map.of(
+        STRICT_SEGMENT0, STRICT_RG1_SERVER_C,
+        STRICT_SEGMENT1, STRICT_RG1_SERVER_C,
+        STRICT_SEGMENT2, STRICT_RG1_SERVER_D));
   }
 
   @Test
-  public void testStrictReplicaGroupUsesAdaptiveServerSelector() {
+  public void testStrictReplicaGroupFactoryEnablesAdaptiveRouting() {
     HybridSelector hybridSelector = mock(HybridSelector.class);
     ReplicaGroupInstanceSelector instanceSelector =
         buildArSelector(STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, hybridSelector);
@@ -460,37 +480,39 @@ public class ReplicaGroupSelectorTest {
     assertNotNull(instanceSelector._priorityPoolInstanceSelector);
   }
 
-  // --- Strict replica group pool-level adaptive routing tests ---
+  // --- Strict replica group adaptive routing tests ---
 
-  // Topology: 2 replica groups (pool 0 and pool 1), 3 segments
-  // Pool 0: server_a (segment0, segment1), server_b (segment2)
-  // Pool 1: server_c (segment0, segment1), server_d (segment2)
-  private static final String SRG_SERVER_A = "server_a";
-  private static final String SRG_SERVER_B = "server_b";
-  private static final String SRG_SERVER_C = "server_c";
-  private static final String SRG_SERVER_D = "server_d";
-  private static final String SRG_SEGMENT0 = "seg0";
-  private static final String SRG_SEGMENT1 = "seg1";
-  private static final String SRG_SEGMENT2 = "seg2";
-  private static final List<String> SRG_SEGMENTS = Arrays.asList(SRG_SEGMENT0, SRG_SEGMENT1, SRG_SEGMENT2);
+  // Topology: 2 replica groups, 3 segments
+  // Replica group 0: server_a (segment0, segment1), server_b (segment2)
+  // Replica group 1: server_c (segment0, segment1), server_d (segment2)
+  // If a strict-fixture server name omits `P#`, its pool is FALLBACK_POOL_ID.
+  private static final String STRICT_RG0_SERVER_A = "strict_rg0_server_a";
+  private static final String STRICT_RG0_SERVER_B = "strict_rg0_server_b";
+  private static final String STRICT_RG1_SERVER_C = "strict_rg1_server_c";
+  private static final String STRICT_RG1_SERVER_D = "strict_rg1_server_d";
+  private static final String STRICT_SEGMENT0 = "seg0";
+  private static final String STRICT_SEGMENT1 = "seg1";
+  private static final String STRICT_SEGMENT2 = "seg2";
+  private static final List<String> STRICT_SEGMENTS = Arrays.asList(STRICT_SEGMENT0, STRICT_SEGMENT1, STRICT_SEGMENT2);
+
+  private List<SegmentInstanceCandidate> buildStrictReplicaGroupCandidates(String replicaGroup0Instance,
+      String replicaGroup1Instance) {
+    return Arrays.asList(
+        new SegmentInstanceCandidate(replicaGroup0Instance, true, FALLBACK_POOL_ID, 0),
+        new SegmentInstanceCandidate(replicaGroup1Instance, true, FALLBACK_POOL_ID, 1));
+  }
 
   private SegmentStates buildStrictReplicaGroupSegmentStates() {
     Map<String, List<SegmentInstanceCandidate>> candidatesMap = new HashMap<>();
-    // segment0 → server_a (pool 0), server_c (pool 1).
-    // Pool 0 is inserted into the LinkedHashMap before pool 1 because server_a (pool 0) appears
-    // first here. The round-robin fallback test depends on this insertion order.
-    candidatesMap.put(SRG_SEGMENT0, Arrays.asList(
-        new SegmentInstanceCandidate(SRG_SERVER_A, true, 0, 0),
-        new SegmentInstanceCandidate(SRG_SERVER_C, true, 1, 0)));
-    // segment1 → server_a (pool 0), server_c (pool 1)
-    candidatesMap.put(SRG_SEGMENT1, Arrays.asList(
-        new SegmentInstanceCandidate(SRG_SERVER_A, true, 0, 0),
-        new SegmentInstanceCandidate(SRG_SERVER_C, true, 1, 0)));
-    // segment2 → server_b (pool 0), server_d (pool 1)
-    candidatesMap.put(SRG_SEGMENT2, Arrays.asList(
-        new SegmentInstanceCandidate(SRG_SERVER_B, true, 0, 0),
-        new SegmentInstanceCandidate(SRG_SERVER_D, true, 1, 0)));
-    return new SegmentStates(candidatesMap, new HashSet<>(SRG_SEGMENTS), null);
+    // All strict-fixture servers intentionally share FALLBACK_POOL_ID so these tests fail if strict routing regresses
+    // back to grouping or filtering by pool instead of idealStateReplicaId.
+    candidatesMap.put(STRICT_SEGMENT0,
+        buildStrictReplicaGroupCandidates(STRICT_RG0_SERVER_A, STRICT_RG1_SERVER_C));
+    candidatesMap.put(STRICT_SEGMENT1,
+        buildStrictReplicaGroupCandidates(STRICT_RG0_SERVER_A, STRICT_RG1_SERVER_C));
+    candidatesMap.put(STRICT_SEGMENT2,
+        buildStrictReplicaGroupCandidates(STRICT_RG0_SERVER_B, STRICT_RG1_SERVER_D));
+    return new SegmentStates(candidatesMap, new HashSet<>(STRICT_SEGMENTS), null);
   }
 
   private StrictReplicaGroupInstanceSelector buildStrictReplicaGroupArSelector(HybridSelector hybridSelector) {
@@ -510,214 +532,217 @@ public class ReplicaGroupSelectorTest {
         .setRoutingConfig(routingConfig).build();
     // Ideal state: mirrors the topology above
     IdealState idealState = createIdealState(Map.of(
-        SRG_SEGMENT0, List.of(Pair.of(SRG_SERVER_A, ONLINE), Pair.of(SRG_SERVER_C, ONLINE)),
-        SRG_SEGMENT1, List.of(Pair.of(SRG_SERVER_A, ONLINE), Pair.of(SRG_SERVER_C, ONLINE)),
-        SRG_SEGMENT2, List.of(Pair.of(SRG_SERVER_B, ONLINE), Pair.of(SRG_SERVER_D, ONLINE))));
+        STRICT_SEGMENT0, List.of(
+            Pair.of(STRICT_RG0_SERVER_A, ONLINE),
+            Pair.of(STRICT_RG1_SERVER_C, ONLINE)),
+        STRICT_SEGMENT1, List.of(
+            Pair.of(STRICT_RG0_SERVER_A, ONLINE),
+            Pair.of(STRICT_RG1_SERVER_C, ONLINE)),
+        STRICT_SEGMENT2, List.of(
+            Pair.of(STRICT_RG0_SERVER_B, ONLINE),
+            Pair.of(STRICT_RG1_SERVER_D, ONLINE))));
     ExternalView externalView = createExternalView(Map.of(
-        SRG_SEGMENT0, List.of(Pair.of(SRG_SERVER_A, ONLINE), Pair.of(SRG_SERVER_C, ONLINE)),
-        SRG_SEGMENT1, List.of(Pair.of(SRG_SERVER_A, ONLINE), Pair.of(SRG_SERVER_C, ONLINE)),
-        SRG_SEGMENT2, List.of(Pair.of(SRG_SERVER_B, ONLINE), Pair.of(SRG_SERVER_D, ONLINE))));
-    // Provide server instances with pool assignments
+        STRICT_SEGMENT0, List.of(
+            Pair.of(STRICT_RG0_SERVER_A, ONLINE),
+            Pair.of(STRICT_RG1_SERVER_C, ONLINE)),
+        STRICT_SEGMENT1, List.of(
+            Pair.of(STRICT_RG0_SERVER_A, ONLINE),
+            Pair.of(STRICT_RG1_SERVER_C, ONLINE)),
+        STRICT_SEGMENT2, List.of(
+            Pair.of(STRICT_RG0_SERVER_B, ONLINE),
+            Pair.of(STRICT_RG1_SERVER_D, ONLINE))));
+    // All servers use the fallback pool to prove strict routing keys off idealStateReplicaId rather than pool.
     ServerInstance serverA = mock(ServerInstance.class);
-    when(serverA.getPool()).thenReturn(0);
+    when(serverA.getPool()).thenReturn(FALLBACK_POOL_ID);
     ServerInstance serverB = mock(ServerInstance.class);
-    when(serverB.getPool()).thenReturn(0);
+    when(serverB.getPool()).thenReturn(FALLBACK_POOL_ID);
     ServerInstance serverC = mock(ServerInstance.class);
-    when(serverC.getPool()).thenReturn(1);
+    when(serverC.getPool()).thenReturn(FALLBACK_POOL_ID);
     ServerInstance serverD = mock(ServerInstance.class);
-    when(serverD.getPool()).thenReturn(1);
+    when(serverD.getPool()).thenReturn(FALLBACK_POOL_ID);
     Map<String, ServerInstance> serverMap = Map.of(
-        SRG_SERVER_A, serverA, SRG_SERVER_B, serverB,
-        SRG_SERVER_C, serverC, SRG_SERVER_D, serverD);
+        STRICT_RG0_SERVER_A, serverA, STRICT_RG0_SERVER_B, serverB,
+        STRICT_RG1_SERVER_C, serverC, STRICT_RG1_SERVER_D, serverD);
     return (StrictReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
         mock(ZkHelixPropertyStore.class), brokerMetrics, hybridSelector,
         brokerConfig,
-        Set.of(SRG_SERVER_A, SRG_SERVER_B, SRG_SERVER_C, SRG_SERVER_D),
-        serverMap, idealState, externalView, new HashSet<>(SRG_SEGMENTS));
+        Set.of(STRICT_RG0_SERVER_A, STRICT_RG0_SERVER_B,
+            STRICT_RG1_SERVER_C, STRICT_RG1_SERVER_D),
+        serverMap, idealState, externalView, new HashSet<>(STRICT_SEGMENTS));
   }
 
   @Test
   public void testStrictReplicaGroupAdaptivePicksBestReplicaGroupByWorstCaseServer() {
-    // Pool 0 servers: server_a (rank 2), server_b (rank 3) → worst = 3
-    // Pool 1 servers: server_c (rank 0), server_d (rank 1) → worst = 1
-    // Pool 1 is better (lower worst-case rank), so all segments should route to pool 1
+    // Replica group 0 servers: server_a (rank 2), server_b (rank 3) → worst = 3
+    // Replica group 1 servers: server_c (rank 0), server_d (rank 1) → worst = 1
+    // Replica group 1 is better (lower worst-case rank), so all segments should route there
     HybridSelector hybridSelector = mock(HybridSelector.class);
     BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
     StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector,
         brokerMetrics);
 
     when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(Arrays.asList(
-        new ImmutablePair<>(SRG_SERVER_C, 1.0),  // rank 0 (best)
-        new ImmutablePair<>(SRG_SERVER_D, 2.0),  // rank 1
-        new ImmutablePair<>(SRG_SERVER_A, 3.0),  // rank 2
-        new ImmutablePair<>(SRG_SERVER_B, 4.0)   // rank 3 (worst)
+        new ImmutablePair<>(STRICT_RG1_SERVER_C, 1.0),  // rank 0 (best)
+        new ImmutablePair<>(STRICT_RG1_SERVER_D, 2.0),  // rank 1
+        new ImmutablePair<>(STRICT_RG0_SERVER_A, 3.0),  // rank 2
+        new ImmutablePair<>(STRICT_RG0_SERVER_B, 4.0)   // rank 3 (worst)
     ));
 
     InstanceSelector.InstanceMapping result =
-        instanceSelector.select(SRG_SEGMENTS, 0, buildStrictReplicaGroupSegmentStates(), null);
+        instanceSelector.select(STRICT_SEGMENTS, 0, buildStrictReplicaGroupSegmentStates(), null);
 
-    // All segments routed to pool 1
+    // All segments routed to replica group 1
     assertEquals(result.segmentToInstanceMap(), Map.of(
-        SRG_SEGMENT0, SRG_SERVER_C,
-        SRG_SEGMENT1, SRG_SERVER_C,
-        SRG_SEGMENT2, SRG_SERVER_D));
+        STRICT_SEGMENT0, STRICT_RG1_SERVER_C,
+        STRICT_SEGMENT1, STRICT_RG1_SERVER_C,
+        STRICT_SEGMENT2, STRICT_RG1_SERVER_D));
+    // Metrics are still reported per actual pool, even though routing is chosen by replica group.
     verify(brokerMetrics).addMeteredValue(eq(BrokerMeter.POOL_SEG_QUERIES), eq(3L),
-        eq(BrokerMetrics.getTagForPreferredPool(null)), eq("1"));
+        eq(BrokerMetrics.getTagForPreferredPool(null)), eq(String.valueOf(FALLBACK_POOL_ID)));
   }
 
   @Test
-  public void testStrictReplicaGroupAdaptivePicksPool0WhenItHasBetterWorstCase() {
-    // Pool 0 servers: server_a (rank 0), server_b (rank 1) → worst = 1
-    // Pool 1 servers: server_c (rank 2), server_d (rank 3) → worst = 3
-    // Pool 0 is better
+  public void testStrictReplicaGroupAdaptivePicksGroup0WhenItHasBetterWorstCase() {
+    // Replica group 0 servers: server_a (rank 0), server_b (rank 1) → worst = 1
+    // Replica group 1 servers: server_c (rank 2), server_d (rank 3) → worst = 3
+    // Replica group 0 is better
     HybridSelector hybridSelector = mock(HybridSelector.class);
     StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector);
 
     when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(Arrays.asList(
-        new ImmutablePair<>(SRG_SERVER_A, 1.0),
-        new ImmutablePair<>(SRG_SERVER_B, 2.0),
-        new ImmutablePair<>(SRG_SERVER_C, 3.0),
-        new ImmutablePair<>(SRG_SERVER_D, 4.0)
+        new ImmutablePair<>(STRICT_RG0_SERVER_A, 1.0),
+        new ImmutablePair<>(STRICT_RG0_SERVER_B, 2.0),
+        new ImmutablePair<>(STRICT_RG1_SERVER_C, 3.0),
+        new ImmutablePair<>(STRICT_RG1_SERVER_D, 4.0)
     ));
 
     InstanceSelector.InstanceMapping result =
-        instanceSelector.select(SRG_SEGMENTS, 0, buildStrictReplicaGroupSegmentStates(), null);
+        instanceSelector.select(STRICT_SEGMENTS, 0, buildStrictReplicaGroupSegmentStates(), null);
 
-    // All segments routed to pool 0
+    // All segments routed to replica group 0
     assertEquals(result.segmentToInstanceMap(), Map.of(
-        SRG_SEGMENT0, SRG_SERVER_A,
-        SRG_SEGMENT1, SRG_SERVER_A,
-        SRG_SEGMENT2, SRG_SERVER_B));
+        STRICT_SEGMENT0, STRICT_RG0_SERVER_A,
+        STRICT_SEGMENT1, STRICT_RG0_SERVER_A,
+        STRICT_SEGMENT2, STRICT_RG0_SERVER_B));
   }
 
   @Test
-  public void testStrictReplicaGroupAdaptiveNoStatsFallsBackToRoundRobin() {
-    // When fetchServerRankingsWithScores returns empty, fall back to round-robin
+  public void testStrictReplicaGroupAdaptiveEmptyRankingsFallBackToRoundRobin() {
+    // When adaptive ranking returns no servers, fall back to round-robin by replica-group index.
     HybridSelector hybridSelector = mock(HybridSelector.class);
     StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector);
 
     when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(List.of());
 
-    // requestId=0 → picks group at index 0 (pool 0)
+    // requestId=0 → picks group at index 0 (replica group 0)
     InstanceSelector.InstanceMapping result =
-        instanceSelector.select(SRG_SEGMENTS, 0, buildStrictReplicaGroupSegmentStates(), null);
+        instanceSelector.select(STRICT_SEGMENTS, 0, buildStrictReplicaGroupSegmentStates(), null);
     assertEquals(result.segmentToInstanceMap(), Map.of(
-        SRG_SEGMENT0, SRG_SERVER_A,
-        SRG_SEGMENT1, SRG_SERVER_A,
-        SRG_SEGMENT2, SRG_SERVER_B));
+        STRICT_SEGMENT0, STRICT_RG0_SERVER_A,
+        STRICT_SEGMENT1, STRICT_RG0_SERVER_A,
+        STRICT_SEGMENT2, STRICT_RG0_SERVER_B));
 
-    // requestId=1 → picks group at index 1 (pool 1)
-    result = instanceSelector.select(SRG_SEGMENTS, 1, buildStrictReplicaGroupSegmentStates(), null);
+    // requestId=1 → picks group at index 1 (replica group 1)
+    result = instanceSelector.select(STRICT_SEGMENTS, 1, buildStrictReplicaGroupSegmentStates(), null);
     assertEquals(result.segmentToInstanceMap(), Map.of(
-        SRG_SEGMENT0, SRG_SERVER_C,
-        SRG_SEGMENT1, SRG_SERVER_C,
-        SRG_SEGMENT2, SRG_SERVER_D));
+        STRICT_SEGMENT0, STRICT_RG1_SERVER_C,
+        STRICT_SEGMENT1, STRICT_RG1_SERVER_C,
+        STRICT_SEGMENT2, STRICT_RG1_SERVER_D));
   }
 
   @Test
   public void testStrictReplicaGroupAdaptiveConsistencyAllSegmentsSameReplicaGroup() {
-    // For any set of adaptive scores, all segments must route to the same replica group
+    // When adaptive scores favor replica group 1, all segments must route to that same replica group.
     HybridSelector hybridSelector = mock(HybridSelector.class);
     StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector);
 
     when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(Arrays.asList(
-        new ImmutablePair<>(SRG_SERVER_C, 1.0),
-        new ImmutablePair<>(SRG_SERVER_D, 2.0),
-        new ImmutablePair<>(SRG_SERVER_A, 3.0),
-        new ImmutablePair<>(SRG_SERVER_B, 4.0)
+        new ImmutablePair<>(STRICT_RG1_SERVER_C, 1.0),
+        new ImmutablePair<>(STRICT_RG1_SERVER_D, 2.0),
+        new ImmutablePair<>(STRICT_RG0_SERVER_A, 3.0),
+        new ImmutablePair<>(STRICT_RG0_SERVER_B, 4.0)
     ));
 
     InstanceSelector.InstanceMapping result =
-        instanceSelector.select(SRG_SEGMENTS, 42, buildStrictReplicaGroupSegmentStates(), null);
+        instanceSelector.select(STRICT_SEGMENTS, 42, buildStrictReplicaGroupSegmentStates(), null);
 
-    // Collect all pool IDs from selected instances
-    Map<String, String> selections = result.segmentToInstanceMap();
-    Set<Integer> poolsUsed = new HashSet<>();
-    SegmentStates states = buildStrictReplicaGroupSegmentStates();
-    for (Map.Entry<String, String> entry : selections.entrySet()) {
-      String segment = entry.getKey();
-      String selectedInstance = entry.getValue();
-      for (SegmentInstanceCandidate candidate : states.getCandidates(segment)) {
-        if (candidate.getInstance().equals(selectedInstance)) {
-          poolsUsed.add(candidate.getPool());
-          break;
-        }
-      }
-    }
-    // All segments must be from the same pool
-    assertEquals(poolsUsed.size(), 1, "All segments should be routed to the same replica group");
+    assertEquals(result.segmentToInstanceMap(), Map.of(
+        STRICT_SEGMENT0, STRICT_RG1_SERVER_C,
+        STRICT_SEGMENT1, STRICT_RG1_SERVER_C,
+        STRICT_SEGMENT2, STRICT_RG1_SERVER_D));
   }
 
   @Test
   public void testStrictReplicaGroupAdaptivePrefersFullCoverageGroup() {
-    // Topology: pool 0 has all 3 segments, pool 1 only has segment0 and segment1 (missing segment2).
-    // Even though pool 1 has better adaptive ranks, pool 0 should be chosen because it has full coverage.
-    // Pool 0: server_a (seg0, seg1), server_b (seg2) — full coverage
-    // Pool 1: server_c (seg0, seg1) — missing seg2, partial coverage
+    // Topology: replica group 0 has all 3 segments, replica group 1 only has segment0 and segment1.
+    // Even though replica group 1 has better adaptive ranks, replica group 0 should be chosen (full coverage).
+    // Replica group 0: server_a (seg0, seg1), server_b (seg2) — full coverage
+    // Replica group 1: server_c (seg0, seg1) — missing seg2, partial coverage
+    // Pools intentionally do not match replica groups: server_a and server_c share pool 0, while server_b is pool 1.
     String serverC = "server_c";
     HybridSelector hybridSelector = mock(HybridSelector.class);
 
     RoutingConfig routingConfig = new RoutingConfig(null, null, STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, false);
     TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName("testUpsertTable")
         .setRoutingConfig(routingConfig).build();
-    // Pool 1 only has seg0 and seg1 (no seg2)
+    // Replica group 1 only has seg0 and seg1 (no seg2)
     IdealState idealState = createIdealState(Map.of(
-        SRG_SEGMENT0, List.of(Pair.of(SRG_SERVER_A, ONLINE), Pair.of(serverC, ONLINE)),
-        SRG_SEGMENT1, List.of(Pair.of(SRG_SERVER_A, ONLINE), Pair.of(serverC, ONLINE)),
-        SRG_SEGMENT2, List.of(Pair.of(SRG_SERVER_B, ONLINE))));
+        STRICT_SEGMENT0, List.of(Pair.of(STRICT_RG0_SERVER_A, ONLINE), Pair.of(serverC, ONLINE)),
+        STRICT_SEGMENT1, List.of(Pair.of(STRICT_RG0_SERVER_A, ONLINE), Pair.of(serverC, ONLINE)),
+        STRICT_SEGMENT2, List.of(Pair.of(STRICT_RG0_SERVER_B, ONLINE))));
     ExternalView externalView = createExternalView(Map.of(
-        SRG_SEGMENT0, List.of(Pair.of(SRG_SERVER_A, ONLINE), Pair.of(serverC, ONLINE)),
-        SRG_SEGMENT1, List.of(Pair.of(SRG_SERVER_A, ONLINE), Pair.of(serverC, ONLINE)),
-        SRG_SEGMENT2, List.of(Pair.of(SRG_SERVER_B, ONLINE))));
+        STRICT_SEGMENT0, List.of(Pair.of(STRICT_RG0_SERVER_A, ONLINE), Pair.of(serverC, ONLINE)),
+        STRICT_SEGMENT1, List.of(Pair.of(STRICT_RG0_SERVER_A, ONLINE), Pair.of(serverC, ONLINE)),
+        STRICT_SEGMENT2, List.of(Pair.of(STRICT_RG0_SERVER_B, ONLINE))));
     ServerInstance serverA = mock(ServerInstance.class);
     when(serverA.getPool()).thenReturn(0);
     ServerInstance serverB = mock(ServerInstance.class);
-    when(serverB.getPool()).thenReturn(0);
+    when(serverB.getPool()).thenReturn(1);
     ServerInstance serverCInstance = mock(ServerInstance.class);
-    when(serverCInstance.getPool()).thenReturn(1);
+    when(serverCInstance.getPool()).thenReturn(0);
     Map<String, ServerInstance> serverMap = Map.of(
-        SRG_SERVER_A, serverA, SRG_SERVER_B, serverB, serverC, serverCInstance);
+        STRICT_RG0_SERVER_A, serverA, STRICT_RG0_SERVER_B, serverB, serverC, serverCInstance);
     StrictReplicaGroupInstanceSelector instanceSelector =
         (StrictReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
             mock(ZkHelixPropertyStore.class), mock(BrokerMetrics.class), hybridSelector,
             new PinotConfiguration(Map.of()),
-            Set.of(SRG_SERVER_A, SRG_SERVER_B, serverC),
-            serverMap, idealState, externalView, new HashSet<>(SRG_SEGMENTS));
+            Set.of(STRICT_RG0_SERVER_A, STRICT_RG0_SERVER_B, serverC),
+            serverMap, idealState, externalView, new HashSet<>(STRICT_SEGMENTS));
 
-    // Pool 1 (server_c) has rank 0 — best rank, but only covers 2 of 3 segments
-    // Pool 0 (server_a rank 2, server_b rank 3) — worse ranks, but full coverage
+    // Replica group 1 (server_c) has rank 0 — best rank, but only covers 2 of 3 segments
+    // Replica group 0 (server_a rank 1, server_b rank 2) — worse ranks, but full coverage
     when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(Arrays.asList(
         new ImmutablePair<>(serverC, 1.0),        // rank 0 (best)
-        new ImmutablePair<>(SRG_SERVER_A, 3.0),   // rank 1
-        new ImmutablePair<>(SRG_SERVER_B, 4.0)    // rank 2
+        new ImmutablePair<>(STRICT_RG0_SERVER_A, 3.0),   // rank 1
+        new ImmutablePair<>(STRICT_RG0_SERVER_B, 4.0)    // rank 2
     ));
 
-    // Build segment states where pool 1 is missing seg2
+    // Build segment states where replica group 1 is missing seg2
     Map<String, List<SegmentInstanceCandidate>> candidatesMap = new HashMap<>();
-    candidatesMap.put(SRG_SEGMENT0, Arrays.asList(
-        new SegmentInstanceCandidate(SRG_SERVER_A, true, 0, 0),
-        new SegmentInstanceCandidate(serverC, true, 1, 0)));
-    candidatesMap.put(SRG_SEGMENT1, Arrays.asList(
-        new SegmentInstanceCandidate(SRG_SERVER_A, true, 0, 0),
-        new SegmentInstanceCandidate(serverC, true, 1, 0)));
-    candidatesMap.put(SRG_SEGMENT2, List.of(
-        new SegmentInstanceCandidate(SRG_SERVER_B, true, 0, 0)));
-    SegmentStates segmentStates = new SegmentStates(candidatesMap, new HashSet<>(SRG_SEGMENTS), null);
+    candidatesMap.put(STRICT_SEGMENT0, Arrays.asList(
+        new SegmentInstanceCandidate(STRICT_RG0_SERVER_A, true, 0, 0),
+        new SegmentInstanceCandidate(serverC, true, 0, 1)));
+    candidatesMap.put(STRICT_SEGMENT1, Arrays.asList(
+        new SegmentInstanceCandidate(STRICT_RG0_SERVER_A, true, 0, 0),
+        new SegmentInstanceCandidate(serverC, true, 0, 1)));
+    candidatesMap.put(STRICT_SEGMENT2, List.of(
+        new SegmentInstanceCandidate(STRICT_RG0_SERVER_B, true, 1, 0)));
+    SegmentStates segmentStates = new SegmentStates(candidatesMap, new HashSet<>(STRICT_SEGMENTS), null);
 
     InstanceSelector.InstanceMapping result =
-        instanceSelector.select(SRG_SEGMENTS, 0, segmentStates, null);
+        instanceSelector.select(STRICT_SEGMENTS, 0, segmentStates, null);
 
-    // Pool 0 should be chosen (full coverage) even though pool 1 has better ranks
+    // Replica group 0 should be chosen (full coverage) even though replica group 1 has better ranks
     assertEquals(result.segmentToInstanceMap(), Map.of(
-        SRG_SEGMENT0, SRG_SERVER_A,
-        SRG_SEGMENT1, SRG_SERVER_A,
-        SRG_SEGMENT2, SRG_SERVER_B));
+        STRICT_SEGMENT0, STRICT_RG0_SERVER_A,
+        STRICT_SEGMENT1, STRICT_RG0_SERVER_A,
+        STRICT_SEGMENT2, STRICT_RG0_SERVER_B));
   }
 
   @Test
   public void testStrictReplicaGroupAdaptiveNewSegmentNotFalselyUnavailable() {
-    // Topology: server_a (pool 0) hosts seg0 only. seg1 has no online instance (simulating a
-    // new/unassigned segment with null candidates in segmentStates). Pool 0 is chosen (only pool).
+    // Topology: server_a (replica group 0) hosts seg0 only. seg1 has no online instance (simulating a
+    // new/unassigned segment with null candidates in segmentStates). Replica group 0 is chosen (only group).
     // seg1 should NOT appear in unavailable — it is a new segment, not a dropped one.
     String serverA = "new_server_a";
     String seg0 = "new_seg0";
@@ -734,7 +759,7 @@ public class ReplicaGroupSelectorTest {
     ExternalView externalView = createExternalView(Map.of(
         seg0, List.of(Pair.of(serverA, ONLINE))));
     ServerInstance serverAInstance = mock(ServerInstance.class);
-    when(serverAInstance.getPool()).thenReturn(0);
+    when(serverAInstance.getPool()).thenReturn(FALLBACK_POOL_ID);
     StrictReplicaGroupInstanceSelector instanceSelector =
         (StrictReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
             mock(ZkHelixPropertyStore.class), mock(BrokerMetrics.class), hybridSelector,
@@ -759,134 +784,130 @@ public class ReplicaGroupSelectorTest {
 
   @Test
   public void testStrictReplicaGroupAdaptiveDroppedSegmentReportedAsUnavailable() {
-    // Topology: no replica group has full coverage.
-    // Pool 0: server_a hosts seg0, seg1 (missing seg2)
-    // Pool 1: server_c hosts seg1, seg2 (missing seg0)
-    // Pool 1 has better ranks -> chosen. seg0 has no candidate in pool 1 -> reported unavailable.
-    String serverA = "partial_server_a";
-    String serverC = "partial_server_c";
-    String seg0 = "partial_seg0";
-    String seg1 = "partial_seg1";
-    String seg2 = "partial_seg2";
-    List<String> segments = Arrays.asList(seg0, seg1, seg2);
+    // Topology: no replica group (idealStateReplicaId) has full coverage.
+    // ReplicaId 0 (server_a): covers seg0, seg1 (missing seg2)
+    // ReplicaId 1 (server_c, server_d): covers seg1, seg2 (missing seg0)
+    // ReplicaId 1 has better rank -> chosen. seg0 has no replicaId-1 candidate -> reported unavailable.
     HybridSelector hybridSelector = mock(HybridSelector.class);
+    StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector);
 
-    RoutingConfig routingConfig = new RoutingConfig(null, null, STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, false);
-    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName("testPartialCoverage")
-            .setRoutingConfig(routingConfig).build();
-    IdealState idealState = createIdealState(Map.of(
-            seg0, List.of(Pair.of(serverA, ONLINE)),
-            seg1, List.of(Pair.of(serverA, ONLINE), Pair.of(serverC, ONLINE)),
-            seg2, List.of(Pair.of(serverC, ONLINE))));
-    ExternalView externalView = createExternalView(Map.of(
-            seg0, List.of(Pair.of(serverA, ONLINE)),
-            seg1, List.of(Pair.of(serverA, ONLINE), Pair.of(serverC, ONLINE)),
-            seg2, List.of(Pair.of(serverC, ONLINE))));
-    ServerInstance serverAInstance = mock(ServerInstance.class);
-    when(serverAInstance.getPool()).thenReturn(0);
-    ServerInstance serverCInstance = mock(ServerInstance.class);
-    when(serverCInstance.getPool()).thenReturn(1);
-    Map<String, ServerInstance> serverMap = Map.of(serverA, serverAInstance, serverC, serverCInstance);
-    BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
-    StrictReplicaGroupInstanceSelector instanceSelector =
-            (StrictReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
-                    mock(ZkHelixPropertyStore.class), brokerMetrics, hybridSelector,
-                    new PinotConfiguration(Map.of()),
-                    Set.of(serverA, serverC),
-                    serverMap, idealState, externalView, new HashSet<>(segments));
-
-    // Pool 1 (server_c) ranked better -> pool 1 chosen
     when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(Arrays.asList(
-            new ImmutablePair<>(serverC, 1.0),
-            new ImmutablePair<>(serverA, 3.0)
+            new ImmutablePair<>(STRICT_RG1_SERVER_C, 1.0),
+            new ImmutablePair<>(STRICT_RG0_SERVER_A, 3.0)
     ));
 
-    BrokerRequest brokerRequest = mock(BrokerRequest.class);
-    PinotQuery pinotQuery = mock(PinotQuery.class);
-    when(brokerRequest.getPinotQuery()).thenReturn(pinotQuery);
-    when(pinotQuery.getQueryOptions()).thenReturn(null);
+    // Craft segment states with partial coverage per replica group:
+    //   seg0: only in replicaId 0 (server_a)
+    //   seg1: in both replicaId 0 (server_a) and replicaId 1 (server_c)
+    //   seg2: only in replicaId 1 (server_d)
+    Map<String, List<SegmentInstanceCandidate>> candidatesMap = new HashMap<>();
+    candidatesMap.put(STRICT_SEGMENT0, List.of(
+        new SegmentInstanceCandidate(STRICT_RG0_SERVER_A, true, FALLBACK_POOL_ID, 0)));
+    candidatesMap.put(STRICT_SEGMENT1, Arrays.asList(
+        new SegmentInstanceCandidate(STRICT_RG0_SERVER_A, true, FALLBACK_POOL_ID, 0),
+        new SegmentInstanceCandidate(STRICT_RG1_SERVER_C, true, FALLBACK_POOL_ID, 1)));
+    candidatesMap.put(STRICT_SEGMENT2, List.of(
+        new SegmentInstanceCandidate(STRICT_RG1_SERVER_D, true, FALLBACK_POOL_ID, 1)));
+    SegmentStates segmentStates = new SegmentStates(candidatesMap, new HashSet<>(STRICT_SEGMENTS), null);
 
-    InstanceSelector.SelectionResult result = instanceSelector.select(brokerRequest, segments, 0);
+    InstanceSelector.InstanceMapping result =
+        instanceSelector.select(STRICT_SEGMENTS, 0, segmentStates, null);
 
-    // seg1 and seg2 routed to pool 1
-    assertEquals(result.getSegmentToInstanceMap(), Map.of(seg1, serverC, seg2, serverC));
-    // seg0 has candidates (pool 0 only) but no match in chosen pool 1 -> reported unavailable
-    assertEquals(result.getUnavailableSegments(), List.of(seg0));
+    // seg1 and seg2 routed to replicaId 1
+    assertEquals(result.segmentToInstanceMap(), Map.of(
+        STRICT_SEGMENT1, STRICT_RG1_SERVER_C,
+        STRICT_SEGMENT2, STRICT_RG1_SERVER_D));
+    // seg0 has candidates (replicaId 0 only) but no match in chosen replicaId 1 -> reported unavailable
+    assertEquals(result.unavailableSegments(), List.of(STRICT_SEGMENT0));
   }
 
   @Test
   public void testStrictReplicaGroupAdaptiveOnlyQueryRelevantServersScored() {
-    // Topology: pool 1 has an extra server (server_e) that hosts a segment NOT in the query.
-    // server_e has a very high rank but should not affect pool 1's score since it hosts no query segments.
-    // Pool 0: server_a (rank 2), server_b (rank 3) → worst = 3
-    // Pool 1: server_c (rank 0), server_d (rank 1) → worst = 1
-    //   (server_e at rank 99 hosts segment "seg_extra" which is not in the query)
-    // Pool 1 should win because only query-relevant servers matter (server_e is ignored).
-    String serverE = "server_e";
+    // Replica group 1 has an extra server (server_e) that only hosts seg_extra, which is not in the query.
+    // server_e should never be scored for a query over STRICT_SEGMENTS.
+    // Replica group 0: server_a (rank 2), server_b (rank 3) → worst = 3
+    // Replica group 1: server_c (rank 0), server_d (rank 1) → worst = 1
+    // Replica group 1 should win because only query-relevant servers matter.
+    String rg1ServerE = "server_e";
     String segExtra = "seg_extra";
     HybridSelector hybridSelector = mock(HybridSelector.class);
 
-    // Build selector with server_e in pool 1, hosting seg_extra
+    // Build selector with server_e in replica group 1, hosting seg_extra.
     RoutingConfig routingConfig = new RoutingConfig(null, null, STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, false);
     TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName("testUpsertTable")
         .setRoutingConfig(routingConfig).build();
+    // server_e's pool intentionally differs from the queried servers to show pool is irrelevant.
+    // segExtra places server_d at position 0 and server_e at position 1 (idealStateReplicaId=1).
     IdealState idealState = createIdealState(Map.of(
-        SRG_SEGMENT0, List.of(Pair.of(SRG_SERVER_A, ONLINE), Pair.of(SRG_SERVER_C, ONLINE)),
-        SRG_SEGMENT1, List.of(Pair.of(SRG_SERVER_A, ONLINE), Pair.of(SRG_SERVER_C, ONLINE)),
-        SRG_SEGMENT2, List.of(Pair.of(SRG_SERVER_B, ONLINE), Pair.of(SRG_SERVER_D, ONLINE)),
-        segExtra, List.of(Pair.of(serverE, ONLINE))));
+        STRICT_SEGMENT0, List.of(Pair.of(STRICT_RG0_SERVER_A, ONLINE), Pair.of(STRICT_RG1_SERVER_C, ONLINE)),
+        STRICT_SEGMENT1, List.of(Pair.of(STRICT_RG0_SERVER_A, ONLINE), Pair.of(STRICT_RG1_SERVER_C, ONLINE)),
+        STRICT_SEGMENT2, List.of(Pair.of(STRICT_RG0_SERVER_B, ONLINE), Pair.of(STRICT_RG1_SERVER_D, ONLINE)),
+        segExtra, List.of(Pair.of(STRICT_RG1_SERVER_D, ONLINE), Pair.of(rg1ServerE, ONLINE))));
     ExternalView externalView = createExternalView(Map.of(
-        SRG_SEGMENT0, List.of(Pair.of(SRG_SERVER_A, ONLINE), Pair.of(SRG_SERVER_C, ONLINE)),
-        SRG_SEGMENT1, List.of(Pair.of(SRG_SERVER_A, ONLINE), Pair.of(SRG_SERVER_C, ONLINE)),
-        SRG_SEGMENT2, List.of(Pair.of(SRG_SERVER_B, ONLINE), Pair.of(SRG_SERVER_D, ONLINE)),
-        segExtra, List.of(Pair.of(serverE, ONLINE))));
+        STRICT_SEGMENT0, List.of(Pair.of(STRICT_RG0_SERVER_A, ONLINE), Pair.of(STRICT_RG1_SERVER_C, ONLINE)),
+        STRICT_SEGMENT1, List.of(Pair.of(STRICT_RG0_SERVER_A, ONLINE), Pair.of(STRICT_RG1_SERVER_C, ONLINE)),
+        STRICT_SEGMENT2, List.of(Pair.of(STRICT_RG0_SERVER_B, ONLINE), Pair.of(STRICT_RG1_SERVER_D, ONLINE)),
+        segExtra, List.of(Pair.of(STRICT_RG1_SERVER_D, ONLINE), Pair.of(rg1ServerE, ONLINE))));
     ServerInstance serverA = mock(ServerInstance.class);
-    when(serverA.getPool()).thenReturn(0);
+    when(serverA.getPool()).thenReturn(FALLBACK_POOL_ID);
     ServerInstance serverB = mock(ServerInstance.class);
-    when(serverB.getPool()).thenReturn(0);
+    when(serverB.getPool()).thenReturn(FALLBACK_POOL_ID);
     ServerInstance serverC = mock(ServerInstance.class);
-    when(serverC.getPool()).thenReturn(1);
+    when(serverC.getPool()).thenReturn(FALLBACK_POOL_ID);
     ServerInstance serverD = mock(ServerInstance.class);
-    when(serverD.getPool()).thenReturn(1);
+    when(serverD.getPool()).thenReturn(FALLBACK_POOL_ID);
     ServerInstance serverEInstance = mock(ServerInstance.class);
-    when(serverEInstance.getPool()).thenReturn(1);
+    when(serverEInstance.getPool()).thenReturn(99);
     Map<String, ServerInstance> serverMap = Map.of(
-        SRG_SERVER_A, serverA, SRG_SERVER_B, serverB,
-        SRG_SERVER_C, serverC, SRG_SERVER_D, serverD,
-        serverE, serverEInstance);
-    Set<String> allSegments = new HashSet<>(SRG_SEGMENTS);
+        STRICT_RG0_SERVER_A, serverA, STRICT_RG0_SERVER_B, serverB,
+        STRICT_RG1_SERVER_C, serverC, STRICT_RG1_SERVER_D, serverD,
+        rg1ServerE, serverEInstance);
+    Set<String> allSegments = new HashSet<>(STRICT_SEGMENTS);
     allSegments.add(segExtra);
     StrictReplicaGroupInstanceSelector instanceSelector =
         (StrictReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
             mock(ZkHelixPropertyStore.class), mock(BrokerMetrics.class), hybridSelector,
             new PinotConfiguration(Map.of()),
-            Set.of(SRG_SERVER_A, SRG_SERVER_B, SRG_SERVER_C, SRG_SERVER_D, serverE),
+            Set.of(STRICT_RG0_SERVER_A, STRICT_RG0_SERVER_B,
+                STRICT_RG1_SERVER_C, STRICT_RG1_SERVER_D, rg1ServerE),
             serverMap, idealState, externalView, allSegments);
 
-    // server_e has rank 99 but hosts no query segments — should be irrelevant
+    // server_e has a much worse mocked score but hosts no query segments, so it should never be ranked.
     when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(Arrays.asList(
-        new ImmutablePair<>(SRG_SERVER_C, 1.0),   // rank 0
-        new ImmutablePair<>(SRG_SERVER_D, 2.0),   // rank 1
-        new ImmutablePair<>(SRG_SERVER_A, 3.0),   // rank 2
-        new ImmutablePair<>(SRG_SERVER_B, 4.0),   // rank 3
-        new ImmutablePair<>(serverE, 99.0)        // rank 4 (high score, not query-relevant)
+        new ImmutablePair<>(STRICT_RG1_SERVER_C, 1.0),   // rank 0
+        new ImmutablePair<>(STRICT_RG1_SERVER_D, 2.0),   // rank 1
+        new ImmutablePair<>(STRICT_RG0_SERVER_A, 3.0),   // rank 2
+        new ImmutablePair<>(STRICT_RG0_SERVER_B, 4.0),   // rank 3
+        new ImmutablePair<>(rg1ServerE, 99.0)        // rank 4 (not query-relevant)
     ));
 
-    // Query only SRG_SEGMENTS (not seg_extra), so server_e is not query-relevant
-    InstanceSelector.InstanceMapping result =
-        instanceSelector.select(SRG_SEGMENTS, 0, buildStrictReplicaGroupSegmentStates(), null);
+    Map<String, List<SegmentInstanceCandidate>> candidatesMap = new HashMap<>();
+    candidatesMap.put(STRICT_SEGMENT0,
+        buildStrictReplicaGroupCandidates(STRICT_RG0_SERVER_A, STRICT_RG1_SERVER_C));
+    candidatesMap.put(STRICT_SEGMENT1,
+        buildStrictReplicaGroupCandidates(STRICT_RG0_SERVER_A, STRICT_RG1_SERVER_C));
+    candidatesMap.put(STRICT_SEGMENT2,
+        buildStrictReplicaGroupCandidates(STRICT_RG0_SERVER_B, STRICT_RG1_SERVER_D));
+    candidatesMap.put(segExtra, Arrays.asList(
+        new SegmentInstanceCandidate(STRICT_RG1_SERVER_D, true, FALLBACK_POOL_ID, 0),
+        new SegmentInstanceCandidate(rg1ServerE, true, 99, 1)));
+    SegmentStates segmentStates = new SegmentStates(candidatesMap, allSegments, null);
 
-    // Pool 1 wins (worst rank among query-relevant servers = 1) over pool 0 (worst = 3)
-    // server_e's rank 4 is not considered because it hosts no query segments
+    InstanceSelector.InstanceMapping result =
+        instanceSelector.select(STRICT_SEGMENTS, 0, segmentStates, null);
+
+    // Replica group 1 wins (worst rank among query-relevant servers = 1) over replica group 0 (worst = 3)
+    // server_e is not considered because it hosts no query segments
     assertEquals(result.segmentToInstanceMap(), Map.of(
-        SRG_SEGMENT0, SRG_SERVER_C,
-        SRG_SEGMENT1, SRG_SERVER_C,
-        SRG_SEGMENT2, SRG_SERVER_D));
+        STRICT_SEGMENT0, STRICT_RG1_SERVER_C,
+        STRICT_SEGMENT1, STRICT_RG1_SERVER_C,
+        STRICT_SEGMENT2, STRICT_RG1_SERVER_D));
 
     ArgumentCaptor<List<String>> rankedCandidatesCaptor = ArgumentCaptor.forClass(List.class);
     verify(hybridSelector).fetchServerRankingsWithScores(rankedCandidatesCaptor.capture());
     assertEquals(new HashSet<>(rankedCandidatesCaptor.getValue()),
-        Set.of(SRG_SERVER_A, SRG_SERVER_B, SRG_SERVER_C, SRG_SERVER_D));
+        Set.of(STRICT_RG0_SERVER_A, STRICT_RG0_SERVER_B,
+            STRICT_RG1_SERVER_C, STRICT_RG1_SERVER_D));
     assertEquals(rankedCandidatesCaptor.getValue().size(), 4);
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
@@ -374,7 +374,7 @@ public class ReplicaGroupSelectorTest {
   }
 
   private ReplicaGroupInstanceSelector buildArSelector(String selectorType, HybridSelector hybridSelector) {
-    return buildArSelector(selectorType, hybridSelector, new PinotConfiguration(Collections.emptyMap()));
+    return buildArSelector(selectorType, hybridSelector, new PinotConfiguration(Map.of()));
   }
 
   private ReplicaGroupInstanceSelector buildArSelector(String selectorType, HybridSelector hybridSelector,
@@ -500,7 +500,7 @@ public class ReplicaGroupSelectorTest {
   private StrictReplicaGroupInstanceSelector buildStrictReplicaGroupArSelector(HybridSelector hybridSelector,
       BrokerMetrics brokerMetrics) {
     return buildStrictReplicaGroupArSelector(hybridSelector, brokerMetrics,
-        new PinotConfiguration(Collections.emptyMap()));
+        new PinotConfiguration(Map.of()));
   }
 
   private StrictReplicaGroupInstanceSelector buildStrictReplicaGroupArSelector(HybridSelector hybridSelector,
@@ -596,7 +596,7 @@ public class ReplicaGroupSelectorTest {
     HybridSelector hybridSelector = mock(HybridSelector.class);
     StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector);
 
-    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(Collections.emptyList());
+    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(List.of());
 
     // requestId=0 → picks group at index 0 (pool 0)
     InstanceSelector.InstanceMapping result =
@@ -680,7 +680,7 @@ public class ReplicaGroupSelectorTest {
     StrictReplicaGroupInstanceSelector instanceSelector =
         (StrictReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
             mock(ZkHelixPropertyStore.class), mock(BrokerMetrics.class), hybridSelector,
-            new PinotConfiguration(Collections.emptyMap()),
+            new PinotConfiguration(Map.of()),
             Set.of(SRG_SERVER_A, SRG_SERVER_B, serverC),
             serverMap, idealState, externalView, new HashSet<>(SRG_SEGMENTS));
 
@@ -738,7 +738,7 @@ public class ReplicaGroupSelectorTest {
     StrictReplicaGroupInstanceSelector instanceSelector =
         (StrictReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
             mock(ZkHelixPropertyStore.class), mock(BrokerMetrics.class), hybridSelector,
-            new PinotConfiguration(Collections.emptyMap()),
+            new PinotConfiguration(Map.of()),
             Set.of(serverA),
             Map.of(serverA, serverAInstance),
             idealState, externalView, new HashSet<>(List.of(seg0)));
@@ -791,7 +791,7 @@ public class ReplicaGroupSelectorTest {
     StrictReplicaGroupInstanceSelector instanceSelector =
             (StrictReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
                     mock(ZkHelixPropertyStore.class), brokerMetrics, hybridSelector,
-                    new PinotConfiguration(Collections.emptyMap()),
+                    new PinotConfiguration(Map.of()),
                     Set.of(serverA, serverC),
                     serverMap, idealState, externalView, new HashSet<>(segments));
 
@@ -859,7 +859,7 @@ public class ReplicaGroupSelectorTest {
     StrictReplicaGroupInstanceSelector instanceSelector =
         (StrictReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
             mock(ZkHelixPropertyStore.class), mock(BrokerMetrics.class), hybridSelector,
-            new PinotConfiguration(Collections.emptyMap()),
+            new PinotConfiguration(Map.of()),
             Set.of(SRG_SERVER_A, SRG_SERVER_B, SRG_SERVER_C, SRG_SERVER_D, serverE),
             serverMap, idealState, externalView, allSegments);
 

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
@@ -1,0 +1,439 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.instanceselector;
+
+import java.time.Clock;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.broker.routing.adaptiveserverselector.HybridSelector;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.core.transport.ServerInstance;
+import org.apache.pinot.spi.config.table.RoutingConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.spi.config.table.RoutingConfig.REPLICA_GROUP_INSTANCE_SELECTOR_TYPE;
+import static org.apache.pinot.spi.config.table.RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE;
+import static org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Tests for {@link ReplicaGroupInstanceSelector} and {@link StrictReplicaGroupInstanceSelector},
+ * including adaptive server selection (pool-level routing for strict replica groups).
+ */
+@SuppressWarnings("unchecked")
+public class ReplicaGroupSelectorTest {
+  private AutoCloseable _mocks;
+
+  @Mock
+  private TableConfig _tableConfig;
+
+  private static final String TABLE_NAME = "testTable_OFFLINE";
+  private static final Map<String, ServerInstance> EMPTY_SERVER_MAP = Collections.EMPTY_MAP;
+  private static final InstanceSelectorConfig INSTANCE_SELECTOR_CONFIG = new InstanceSelectorConfig(false, 300, false);
+  private static final List<String> SEGMENTS =
+      Arrays.asList("segment0", "segment1", "segment2", "segment3", "segment4", "segment5", "segment6", "segment7",
+          "segment8", "segment9", "segment10", "segment11");
+
+  @BeforeMethod
+  public void setUp() {
+    _mocks = MockitoAnnotations.openMocks(this);
+    when(_tableConfig.getTableName()).thenReturn(TABLE_NAME);
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    _mocks.close();
+  }
+
+  // --- Shared helpers ---
+
+  static IdealState createIdealState(Map<String, List<Pair<String, String>>> segmentState) {
+    IdealState idealState = new IdealState(TABLE_NAME);
+    Map<String, Map<String, String>> idealStateSegmentAssignment = idealState.getRecord().getMapFields();
+    for (Map.Entry<String, List<Pair<String, String>>> entry : segmentState.entrySet()) {
+      Map<String, String> instanceStateMap = new TreeMap<>();
+      for (Pair<String, String> instanceState : entry.getValue()) {
+        instanceStateMap.put(instanceState.getLeft(), instanceState.getRight());
+      }
+      idealStateSegmentAssignment.put(entry.getKey(), instanceStateMap);
+    }
+    return idealState;
+  }
+
+  static ExternalView createExternalView(Map<String, List<Pair<String, String>>> segmentState) {
+    ExternalView externalView = new ExternalView(TABLE_NAME);
+    Map<String, Map<String, String>> externalViewSegmentAssignment = externalView.getRecord().getMapFields();
+    for (Map.Entry<String, List<Pair<String, String>>> entry : segmentState.entrySet()) {
+      Map<String, String> instanceStateMap = new TreeMap<>();
+      for (Pair<String, String> instanceState : entry.getValue()) {
+        instanceStateMap.put(instanceState.getLeft(), instanceState.getRight());
+      }
+      externalViewSegmentAssignment.put(entry.getKey(), instanceStateMap);
+    }
+    return externalView;
+  }
+
+  // --- ReplicaGroupInstanceSelector: numReplicaGroupsToQuery tests ---
+
+  @Test
+  public void testReplicaGroupInstanceSelectorNumReplicaGroupsToQuery() {
+    String offlineTableName = "testTable_OFFLINE";
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
+    BrokerRequest brokerRequest = mock(BrokerRequest.class);
+    PinotQuery pinotQuery = mock(PinotQuery.class);
+    Map<String, String> queryOptions = new HashMap<>();
+    // numReplicas = 3, fanning the query to 2 replica groups
+    queryOptions.put("numReplicaGroupsToQuery", "2");
+    when(brokerRequest.getPinotQuery()).thenReturn(pinotQuery);
+    when(pinotQuery.getQueryOptions()).thenReturn(queryOptions);
+
+    ReplicaGroupInstanceSelector replicaGroupInstanceSelector = new ReplicaGroupInstanceSelector();
+
+    Set<String> enabledInstances = new HashSet<>();
+    IdealState idealState = new IdealState(offlineTableName);
+    Map<String, Map<String, String>> idealStateSegmentAssignment = idealState.getRecord().getMapFields();
+    ExternalView externalView = new ExternalView(offlineTableName);
+    Map<String, Map<String, String>> externalViewSegmentAssignment = externalView.getRecord().getMapFields();
+    Set<String> onlineSegments = new HashSet<>();
+
+    // 12 online segments with each segment having all 3 instances as online
+    // replicas are 3
+    String instance0 = "instance0";
+    String instance1 = "instance1";
+    String instance2 = "instance2";
+    enabledInstances.add(instance0);
+    enabledInstances.add(instance1);
+    enabledInstances.add(instance2);
+
+    Map<String, String> idealStateInstanceStateMap0 = new TreeMap<>();
+    Map<String, String> externalViewInstanceStateMap0 = new TreeMap<>();
+
+    for (String instance : enabledInstances) {
+      idealStateInstanceStateMap0.put(instance, ONLINE);
+      externalViewInstanceStateMap0.put(instance, ONLINE);
+    }
+
+    List<String> segments = SEGMENTS;
+    // add all segments to both idealStateSegmentAssignment and externalViewSegmentAssignment maps and also to online
+    // segments
+    for (String segment : segments) {
+      idealStateSegmentAssignment.put(segment, idealStateInstanceStateMap0);
+      externalViewSegmentAssignment.put(segment, externalViewInstanceStateMap0);
+      onlineSegments.add(segment);
+    }
+
+    replicaGroupInstanceSelector.init(_tableConfig, propertyStore, brokerMetrics, null, Clock.systemUTC(),
+        INSTANCE_SELECTOR_CONFIG, enabledInstances, EMPTY_SERVER_MAP, idealState, externalView, onlineSegments);
+
+    Map<String, String> expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
+    expectedReplicaGroupInstanceSelectorResult.put(segments.get(0), instance0);
+    expectedReplicaGroupInstanceSelectorResult.put(segments.get(1), instance1);
+    expectedReplicaGroupInstanceSelectorResult.put(segments.get(2), instance0);
+    expectedReplicaGroupInstanceSelectorResult.put(segments.get(3), instance1);
+    expectedReplicaGroupInstanceSelectorResult.put(segments.get(4), instance0);
+    expectedReplicaGroupInstanceSelectorResult.put(segments.get(5), instance1);
+    expectedReplicaGroupInstanceSelectorResult.put(segments.get(6), instance0);
+    expectedReplicaGroupInstanceSelectorResult.put(segments.get(7), instance1);
+    expectedReplicaGroupInstanceSelectorResult.put(segments.get(8), instance0);
+    expectedReplicaGroupInstanceSelectorResult.put(segments.get(9), instance1);
+    expectedReplicaGroupInstanceSelectorResult.put(segments.get(10), instance0);
+    expectedReplicaGroupInstanceSelectorResult.put(segments.get(11), instance1);
+    InstanceSelector.SelectionResult selectionResult = replicaGroupInstanceSelector.select(brokerRequest, segments, 0);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedReplicaGroupInstanceSelectorResult);
+    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
+  }
+
+  @Test
+  public void testReplicaGroupInstanceSelectorNumReplicaGroupsToQueryGreaterThanReplicas() {
+    String offlineTableName = "testTable_OFFLINE";
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
+    BrokerRequest brokerRequest = mock(BrokerRequest.class);
+    PinotQuery pinotQuery = mock(PinotQuery.class);
+    Map<String, String> queryOptions = new HashMap<>();
+    queryOptions.put("numReplicaGroupsToQuery", "4");
+
+    when(brokerRequest.getPinotQuery()).thenReturn(pinotQuery);
+    when(pinotQuery.getQueryOptions()).thenReturn(queryOptions);
+
+    ReplicaGroupInstanceSelector replicaGroupInstanceSelector = new ReplicaGroupInstanceSelector();
+
+    Set<String> enabledInstances = new HashSet<>();
+    IdealState idealState = new IdealState(offlineTableName);
+    Map<String, Map<String, String>> idealStateSegmentAssignment = idealState.getRecord().getMapFields();
+    ExternalView externalView = new ExternalView(offlineTableName);
+    Map<String, Map<String, String>> externalViewSegmentAssignment = externalView.getRecord().getMapFields();
+    Set<String> onlineSegments = new HashSet<>();
+
+    // 12 online segments with each segment having all 3 instances as online
+    // replicas are 3
+    String instance0 = "instance0";
+    String instance1 = "instance1";
+    String instance2 = "instance2";
+    enabledInstances.add(instance0);
+    enabledInstances.add(instance1);
+    enabledInstances.add(instance2);
+
+    List<String> segments = SEGMENTS;
+
+    Map<String, String> idealStateInstanceStateMap0 = new TreeMap<>();
+    Map<String, String> externalViewInstanceStateMap0 = new TreeMap<>();
+
+    for (String instance : enabledInstances) {
+      idealStateInstanceStateMap0.put(instance, ONLINE);
+      externalViewInstanceStateMap0.put(instance, ONLINE);
+    }
+
+    // add all segments to both idealStateSegmentAssignment and externalViewSegmentAssignment maps and also to online
+    // segments
+    for (String segment : segments) {
+      idealStateSegmentAssignment.put(segment, idealStateInstanceStateMap0);
+      externalViewSegmentAssignment.put(segment, externalViewInstanceStateMap0);
+      onlineSegments.add(segment);
+    }
+
+    replicaGroupInstanceSelector.init(_tableConfig, propertyStore, brokerMetrics, null, Clock.systemUTC(),
+        INSTANCE_SELECTOR_CONFIG, enabledInstances, EMPTY_SERVER_MAP, idealState, externalView, onlineSegments);
+
+    Map<String, String> expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
+    expectedReplicaGroupInstanceSelectorResult.put(segments.get(0), instance0);
+    expectedReplicaGroupInstanceSelectorResult.put(segments.get(1), instance1);
+    expectedReplicaGroupInstanceSelectorResult.put(segments.get(2), instance2);
+    expectedReplicaGroupInstanceSelectorResult.put(segments.get(3), instance0);
+    expectedReplicaGroupInstanceSelectorResult.put(segments.get(4), instance1);
+    expectedReplicaGroupInstanceSelectorResult.put(segments.get(5), instance2);
+    expectedReplicaGroupInstanceSelectorResult.put(segments.get(6), instance0);
+    expectedReplicaGroupInstanceSelectorResult.put(segments.get(7), instance1);
+    expectedReplicaGroupInstanceSelectorResult.put(segments.get(8), instance2);
+    expectedReplicaGroupInstanceSelectorResult.put(segments.get(9), instance0);
+    expectedReplicaGroupInstanceSelectorResult.put(segments.get(10), instance1);
+    expectedReplicaGroupInstanceSelectorResult.put(segments.get(11), instance2);
+    InstanceSelector.SelectionResult selectionResult = replicaGroupInstanceSelector.select(brokerRequest, segments, 0);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedReplicaGroupInstanceSelectorResult);
+    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
+  }
+
+  @Test
+  public void testReplicaGroupInstanceSelectorNumReplicaGroupsNotSet() {
+    String offlineTableName = "testTable_OFFLINE";
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
+    BrokerRequest brokerRequest = mock(BrokerRequest.class);
+    PinotQuery pinotQuery = mock(PinotQuery.class);
+    Map<String, String> queryOptions = new HashMap<>();
+
+    when(brokerRequest.getPinotQuery()).thenReturn(pinotQuery);
+    when(pinotQuery.getQueryOptions()).thenReturn(queryOptions);
+
+    ReplicaGroupInstanceSelector replicaGroupInstanceSelector = new ReplicaGroupInstanceSelector();
+
+    Set<String> enabledInstances = new HashSet<>();
+    IdealState idealState = new IdealState(offlineTableName);
+    Map<String, Map<String, String>> idealStateSegmentAssignment = idealState.getRecord().getMapFields();
+    ExternalView externalView = new ExternalView(offlineTableName);
+    Map<String, Map<String, String>> externalViewSegmentAssignment = externalView.getRecord().getMapFields();
+    Set<String> onlineSegments = new HashSet<>();
+
+    // 12 online segments with each segment having all 3 instances as online
+    // replicas are 3
+    String instance0 = "instance0";
+    String instance1 = "instance1";
+    String instance2 = "instance2";
+    enabledInstances.add(instance0);
+    enabledInstances.add(instance1);
+    enabledInstances.add(instance2);
+
+    List<String> segments = SEGMENTS;
+
+    Map<String, String> idealStateInstanceStateMap0 = new TreeMap<>();
+    Map<String, String> externalViewInstanceStateMap0 = new TreeMap<>();
+
+    for (String instance : enabledInstances) {
+      idealStateInstanceStateMap0.put(instance, ONLINE);
+      externalViewInstanceStateMap0.put(instance, ONLINE);
+    }
+
+    // add all segments to both idealStateSegmentAssignment and externalViewSegmentAssignment maps and also to online
+    // segments
+    for (String segment : segments) {
+      idealStateSegmentAssignment.put(segment, idealStateInstanceStateMap0);
+      externalViewSegmentAssignment.put(segment, externalViewInstanceStateMap0);
+      onlineSegments.add(segment);
+    }
+
+    replicaGroupInstanceSelector.init(_tableConfig, propertyStore, brokerMetrics, null, Clock.systemUTC(),
+        INSTANCE_SELECTOR_CONFIG, enabledInstances, EMPTY_SERVER_MAP, idealState, externalView, onlineSegments);
+    // since numReplicaGroupsToQuery is not set, first query should go to first replica group,
+    // 2nd query should go to next replica group
+
+    Map<String, String> expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
+    for (String segment : segments) {
+      expectedReplicaGroupInstanceSelectorResult.put(segment, instance0);
+    }
+    InstanceSelector.SelectionResult selectionResult = replicaGroupInstanceSelector.select(brokerRequest, segments, 0);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedReplicaGroupInstanceSelectorResult);
+
+    for (String segment : segments) {
+      expectedReplicaGroupInstanceSelectorResult.put(segment, instance1);
+    }
+    selectionResult = replicaGroupInstanceSelector.select(brokerRequest, segments, 1);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedReplicaGroupInstanceSelectorResult);
+  }
+
+  // --- Adaptive server selection tests ---
+
+  // Shared topology for AR tests: 3 segments across 5 instances in two replica groups.
+  // segment2 intentionally has instance4 (unranked) so AR falls back to round-robin for that segment.
+  private static final String AR_INSTANCE0 = "instance0";
+  private static final String AR_INSTANCE1 = "instance1";
+  private static final String AR_INSTANCE2 = "instance2";
+  private static final String AR_INSTANCE3 = "instance3";
+  private static final String AR_INSTANCE4 = "instance4";
+  private static final String AR_SEGMENT0 = "segment0";
+  private static final String AR_SEGMENT1 = "segment1";
+  private static final String AR_SEGMENT2 = "segment2";
+  private static final List<String> AR_SEGMENTS =
+      Arrays.asList(AR_SEGMENT0, AR_SEGMENT1, AR_SEGMENT2);
+  // Rankings: instance3 best → instance2 → instance1 → instance0 worst; instance4 absent (triggers AR fallback)
+  private static final List<Pair<String, Double>> AR_SERVER_RANKS = Arrays.asList(
+      new ImmutablePair<>(AR_INSTANCE3, 1.0),
+      new ImmutablePair<>(AR_INSTANCE2, 2.0),
+      new ImmutablePair<>(AR_INSTANCE1, 3.0),
+      new ImmutablePair<>(AR_INSTANCE0, 4.0)
+  );
+
+  private SegmentStates buildArSegmentStates() {
+    Map<String, List<SegmentInstanceCandidate>> candidatesMap = new HashMap<>();
+    // segment0 → instance0, instance1
+    candidatesMap.put(AR_SEGMENT0, Arrays.asList(
+        new SegmentInstanceCandidate(AR_INSTANCE0, true),
+        new SegmentInstanceCandidate(AR_INSTANCE1, true)));
+    // segment1 → instance2, instance3
+    candidatesMap.put(AR_SEGMENT1, Arrays.asList(
+        new SegmentInstanceCandidate(AR_INSTANCE2, true),
+        new SegmentInstanceCandidate(AR_INSTANCE3, true)));
+    // segment2 → instance4 (unranked), instance3
+    candidatesMap.put(AR_SEGMENT2, Arrays.asList(
+        new SegmentInstanceCandidate(AR_INSTANCE4, true),
+        new SegmentInstanceCandidate(AR_INSTANCE3, true)));
+    return new SegmentStates(candidatesMap, new HashSet<>(AR_SEGMENTS), null);
+  }
+
+  private ReplicaGroupInstanceSelector buildArSelector(String selectorType, HybridSelector hybridSelector) {
+    RoutingConfig routingConfig = new RoutingConfig(null, null, selectorType, false);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName("testTable")
+        .setRoutingConfig(routingConfig).build();
+    IdealState idealState = createIdealState(Map.of(
+        AR_SEGMENT0, List.of(Pair.of(AR_INSTANCE0, ONLINE), Pair.of(AR_INSTANCE1, ONLINE)),
+        AR_SEGMENT1, List.of(Pair.of(AR_INSTANCE2, ONLINE), Pair.of(AR_INSTANCE3, ONLINE)),
+        AR_SEGMENT2, List.of(Pair.of(AR_INSTANCE3, ONLINE), Pair.of(AR_INSTANCE4, ONLINE))));
+    ExternalView externalView = createExternalView(Map.of(
+        AR_SEGMENT0, List.of(Pair.of(AR_INSTANCE0, ONLINE), Pair.of(AR_INSTANCE1, ONLINE)),
+        AR_SEGMENT1, List.of(Pair.of(AR_INSTANCE2, ONLINE), Pair.of(AR_INSTANCE3, ONLINE)),
+        AR_SEGMENT2, List.of(Pair.of(AR_INSTANCE3, ONLINE), Pair.of(AR_INSTANCE4, ONLINE))));
+    return (ReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
+        mock(ZkHelixPropertyStore.class), mock(BrokerMetrics.class), hybridSelector,
+        mock(PinotConfiguration.class),
+        Set.of(AR_INSTANCE0, AR_INSTANCE1, AR_INSTANCE2, AR_INSTANCE3, AR_INSTANCE4),
+        Map.of(), idealState, externalView, new HashSet<>(AR_SEGMENTS));
+  }
+
+  @Test
+  public void testReplicaGroupAdaptiveServerSelector() {
+    HybridSelector hybridSelector = mock(HybridSelector.class);
+    ReplicaGroupInstanceSelector instanceSelector =
+        buildArSelector(REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, hybridSelector);
+
+    assertTrue(instanceSelector instanceof ReplicaGroupInstanceSelector);
+    assertFalse(instanceSelector instanceof StrictReplicaGroupInstanceSelector);
+    assertNotNull(instanceSelector._adaptiveServerSelector);
+    assertNotNull(instanceSelector._priorityPoolInstanceSelector);
+
+    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(AR_SERVER_RANKS);
+    Pair<Map<String, String>, Map<String, String>> result =
+        instanceSelector.select(AR_SEGMENTS, 0, buildArSegmentStates(), null);
+
+    // AR prefers the better-ranked server when all candidates are ranked:
+    // segment0: instance1 (rank 3) over instance0 (rank 4)
+    // segment1: instance3 (rank 1) over instance2 (rank 2)
+    // segment2: instance4 unranked → AR falls back to round-robin → index 0 = instance4
+    assertEquals(result.getLeft(), Map.of(
+        AR_SEGMENT0, AR_INSTANCE1,
+        AR_SEGMENT1, AR_INSTANCE3,
+        AR_SEGMENT2, AR_INSTANCE4));
+  }
+
+  @Test
+  public void testStrictReplicaGroupDoesNotUseAdaptiveServerSelector() {
+    HybridSelector hybridSelector = mock(HybridSelector.class);
+    ReplicaGroupInstanceSelector instanceSelector =
+        buildArSelector(STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, hybridSelector);
+
+    assertTrue(instanceSelector instanceof StrictReplicaGroupInstanceSelector);
+    assertNull(instanceSelector._adaptiveServerSelector);
+    assertNull(instanceSelector._priorityPoolInstanceSelector);
+
+    Pair<Map<String, String>, Map<String, String>> result =
+        instanceSelector.select(AR_SEGMENTS, 0, buildArSegmentStates(), null);
+
+    // hybridSelector never consulted during routing despite being passed to the factory
+    verify(hybridSelector, never()).fetchServerRankingsWithScores(any());
+
+    // Round-robin with requestId=0 picks candidate index 0 per segment — opposite of AR result above,
+    // which returns {segment0→instance1, segment1→instance3} for the same rankings.
+    assertEquals(result.getLeft(), Map.of(
+        AR_SEGMENT0, AR_INSTANCE0,
+        AR_SEGMENT1, AR_INSTANCE2,
+        AR_SEGMENT2, AR_INSTANCE4));
+  }
+}

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
@@ -500,7 +500,7 @@ public class ReplicaGroupSelectorTest {
   private StrictReplicaGroupInstanceSelector buildStrictReplicaGroupArSelector(HybridSelector hybridSelector,
       BrokerMetrics brokerMetrics) {
     return buildStrictReplicaGroupArSelector(hybridSelector, brokerMetrics,
-        new PinotConfiguration(Map.of()));
+        new PinotConfiguration(Collections.emptyMap()));
   }
 
   private StrictReplicaGroupInstanceSelector buildStrictReplicaGroupArSelector(HybridSelector hybridSelector,
@@ -596,7 +596,7 @@ public class ReplicaGroupSelectorTest {
     HybridSelector hybridSelector = mock(HybridSelector.class);
     StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector);
 
-    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(List.of());
+    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(Collections.emptyList());
 
     // requestId=0 → picks group at index 0 (pool 0)
     InstanceSelector.InstanceMapping result =
@@ -680,7 +680,7 @@ public class ReplicaGroupSelectorTest {
     StrictReplicaGroupInstanceSelector instanceSelector =
         (StrictReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
             mock(ZkHelixPropertyStore.class), mock(BrokerMetrics.class), hybridSelector,
-            new PinotConfiguration(Map.of()),
+            new PinotConfiguration(Collections.emptyMap()),
             Set.of(SRG_SERVER_A, SRG_SERVER_B, serverC),
             serverMap, idealState, externalView, new HashSet<>(SRG_SEGMENTS));
 
@@ -738,7 +738,7 @@ public class ReplicaGroupSelectorTest {
     StrictReplicaGroupInstanceSelector instanceSelector =
         (StrictReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
             mock(ZkHelixPropertyStore.class), mock(BrokerMetrics.class), hybridSelector,
-            new PinotConfiguration(Map.of()),
+            new PinotConfiguration(Collections.emptyMap()),
             Set.of(serverA),
             Map.of(serverA, serverAInstance),
             idealState, externalView, new HashSet<>(List.of(seg0)));
@@ -791,7 +791,7 @@ public class ReplicaGroupSelectorTest {
     StrictReplicaGroupInstanceSelector instanceSelector =
             (StrictReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
                     mock(ZkHelixPropertyStore.class), brokerMetrics, hybridSelector,
-                    new PinotConfiguration(Map.of()),
+                    new PinotConfiguration(Collections.emptyMap()),
                     Set.of(serverA, serverC),
                     serverMap, idealState, externalView, new HashSet<>(segments));
 
@@ -859,7 +859,7 @@ public class ReplicaGroupSelectorTest {
     StrictReplicaGroupInstanceSelector instanceSelector =
         (StrictReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
             mock(ZkHelixPropertyStore.class), mock(BrokerMetrics.class), hybridSelector,
-            new PinotConfiguration(Map.of()),
+            new PinotConfiguration(Collections.emptyMap()),
             Set.of(SRG_SERVER_A, SRG_SERVER_B, SRG_SERVER_C, SRG_SERVER_D, serverE),
             serverMap, idealState, externalView, allSegments);
 

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
@@ -500,7 +500,7 @@ public class ReplicaGroupSelectorTest {
   private StrictReplicaGroupInstanceSelector buildStrictReplicaGroupArSelector(HybridSelector hybridSelector,
       BrokerMetrics brokerMetrics) {
     return buildStrictReplicaGroupArSelector(hybridSelector, brokerMetrics,
-        new PinotConfiguration(Collections.emptyMap()));
+        new PinotConfiguration(Map.of()));
   }
 
   private StrictReplicaGroupInstanceSelector buildStrictReplicaGroupArSelector(HybridSelector hybridSelector,
@@ -596,7 +596,7 @@ public class ReplicaGroupSelectorTest {
     HybridSelector hybridSelector = mock(HybridSelector.class);
     StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector);
 
-    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(Collections.emptyList());
+    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(List.of());
 
     // requestId=0 → picks group at index 0 (pool 0)
     InstanceSelector.InstanceMapping result =
@@ -680,7 +680,7 @@ public class ReplicaGroupSelectorTest {
     StrictReplicaGroupInstanceSelector instanceSelector =
         (StrictReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
             mock(ZkHelixPropertyStore.class), mock(BrokerMetrics.class), hybridSelector,
-            new PinotConfiguration(Collections.emptyMap()),
+            new PinotConfiguration(Map.of()),
             Set.of(SRG_SERVER_A, SRG_SERVER_B, serverC),
             serverMap, idealState, externalView, new HashSet<>(SRG_SEGMENTS));
 
@@ -738,7 +738,7 @@ public class ReplicaGroupSelectorTest {
     StrictReplicaGroupInstanceSelector instanceSelector =
         (StrictReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
             mock(ZkHelixPropertyStore.class), mock(BrokerMetrics.class), hybridSelector,
-            new PinotConfiguration(Collections.emptyMap()),
+            new PinotConfiguration(Map.of()),
             Set.of(serverA),
             Map.of(serverA, serverAInstance),
             idealState, externalView, new HashSet<>(List.of(seg0)));
@@ -791,7 +791,7 @@ public class ReplicaGroupSelectorTest {
     StrictReplicaGroupInstanceSelector instanceSelector =
             (StrictReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
                     mock(ZkHelixPropertyStore.class), brokerMetrics, hybridSelector,
-                    new PinotConfiguration(Collections.emptyMap()),
+                    new PinotConfiguration(Map.of()),
                     Set.of(serverA, serverC),
                     serverMap, idealState, externalView, new HashSet<>(segments));
 
@@ -859,7 +859,7 @@ public class ReplicaGroupSelectorTest {
     StrictReplicaGroupInstanceSelector instanceSelector =
         (StrictReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
             mock(ZkHelixPropertyStore.class), mock(BrokerMetrics.class), hybridSelector,
-            new PinotConfiguration(Collections.emptyMap()),
+            new PinotConfiguration(Map.of()),
             Set.of(SRG_SERVER_A, SRG_SERVER_B, SRG_SERVER_C, SRG_SERVER_D, serverE),
             serverMap, idealState, externalView, allSegments);
 

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
@@ -400,14 +400,14 @@ public class ReplicaGroupSelectorTest {
     assertNotNull(instanceSelector._priorityPoolInstanceSelector);
 
     when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(AR_SERVER_RANKS);
-    Pair<Map<String, String>, Map<String, String>> result =
+    InstanceSelector.InstanceMapping result =
         instanceSelector.select(AR_SEGMENTS, 0, buildArSegmentStates(), null);
 
     // AR prefers the better-ranked server when all candidates are ranked:
     // segment0: instance1 (rank 3) over instance0 (rank 4)
     // segment1: instance3 (rank 1) over instance2 (rank 2)
     // segment2: instance4 unranked → AR falls back to round-robin → index 0 = instance4
-    assertEquals(result.getLeft(), Map.of(
+    assertEquals(result.segmentToInstanceMap(), Map.of(
         AR_SEGMENT0, AR_INSTANCE1,
         AR_SEGMENT1, AR_INSTANCE3,
         AR_SEGMENT2, AR_INSTANCE4));
@@ -423,7 +423,7 @@ public class ReplicaGroupSelectorTest {
     assertNull(instanceSelector._adaptiveServerSelector);
     assertNull(instanceSelector._priorityPoolInstanceSelector);
 
-    Pair<Map<String, String>, Map<String, String>> result =
+    InstanceSelector.InstanceMapping result =
         instanceSelector.select(AR_SEGMENTS, 0, buildArSegmentStates(), null);
 
     // hybridSelector never consulted during routing despite being passed to the factory
@@ -431,7 +431,7 @@ public class ReplicaGroupSelectorTest {
 
     // Round-robin with requestId=0 picks candidate index 0 per segment — opposite of AR result above,
     // which returns {segment0→instance1, segment1→instance3} for the same rankings.
-    assertEquals(result.getLeft(), Map.of(
+    assertEquals(result.segmentToInstanceMap(), Map.of(
         AR_SEGMENT0, AR_INSTANCE0,
         AR_SEGMENT1, AR_INSTANCE2,
         AR_SEGMENT2, AR_INSTANCE4));

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
@@ -987,4 +987,19 @@ public class ReplicaGroupSelectorTest {
             STRICT_RG1_SERVER_C, STRICT_RG1_SERVER_D));
     assertEquals(rankedCandidatesCaptor.getValue().size(), 4);
   }
+
+  @Test
+  public void testStrictReplicaGroupAdaptiveHandlesMinimumRequestId() {
+    HybridSelector hybridSelector = mock(HybridSelector.class);
+    StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector);
+    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(List.of());
+
+    InstanceSelector.InstanceMapping result = instanceSelector.select(STRICT_SEGMENTS, Integer.MIN_VALUE,
+        buildStrictReplicaGroupSegmentStates(), null);
+
+    assertEquals(result.segmentToInstanceMap(), Map.of(
+        STRICT_SEGMENT0, STRICT_RG0_SERVER_A,
+        STRICT_SEGMENT1, STRICT_RG0_SERVER_A,
+        STRICT_SEGMENT2, STRICT_RG0_SERVER_B));
+  }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
@@ -67,7 +67,6 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.expectThrows;
 
 
 /// Tests for [ReplicaGroupInstanceSelector] and [StrictReplicaGroupInstanceSelector], including adaptive server
@@ -479,6 +478,38 @@ public class ReplicaGroupSelectorTest {
     assertNotNull(instanceSelector._priorityPoolInstanceSelector);
   }
 
+  @Test
+  public void testStrictReplicaGroupAdaptiveDisabledByFixedReplicaBrokerConfig() {
+    HybridSelector hybridSelector = mock(HybridSelector.class);
+    PinotConfiguration brokerConfig = new PinotConfiguration(Map.of(
+        CommonConstants.Broker.CONFIG_OF_USE_FIXED_REPLICA, "true"));
+    StrictReplicaGroupInstanceSelector instanceSelector =
+        buildStrictReplicaGroupArSelector(hybridSelector, mock(BrokerMetrics.class), brokerConfig);
+
+    assertNull(instanceSelector._adaptiveServerSelector);
+    assertNull(instanceSelector._priorityPoolInstanceSelector);
+    InstanceSelector.InstanceMapping result =
+        instanceSelector.select(STRICT_SEGMENTS, 0, buildStrictReplicaGroupSegmentStates(), null);
+    verify(hybridSelector, never()).fetchServerRankingsWithScores(any());
+    assertEquals(result.segmentToInstanceMap().get(STRICT_SEGMENT0),
+        result.segmentToInstanceMap().get(STRICT_SEGMENT1));
+  }
+
+  @Test
+  public void testStrictReplicaGroupAdaptiveDisabledByFixedReplicaTableConfig() {
+    HybridSelector hybridSelector = mock(HybridSelector.class);
+    StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector,
+        mock(BrokerMetrics.class), new PinotConfiguration(Map.of()), true);
+
+    assertNull(instanceSelector._adaptiveServerSelector);
+    assertNull(instanceSelector._priorityPoolInstanceSelector);
+    InstanceSelector.InstanceMapping result =
+        instanceSelector.select(STRICT_SEGMENTS, 0, buildStrictReplicaGroupSegmentStates(), null);
+    verify(hybridSelector, never()).fetchServerRankingsWithScores(any());
+    assertEquals(result.segmentToInstanceMap().get(STRICT_SEGMENT0),
+        result.segmentToInstanceMap().get(STRICT_SEGMENT1));
+  }
+
   // --- Strict replica group adaptive routing tests ---
 
   // Topology: 2 replica groups, 3 segments
@@ -539,7 +570,13 @@ public class ReplicaGroupSelectorTest {
 
   private StrictReplicaGroupInstanceSelector buildStrictReplicaGroupArSelector(HybridSelector hybridSelector,
       BrokerMetrics brokerMetrics, PinotConfiguration brokerConfig) {
-    RoutingConfig routingConfig = new RoutingConfig(null, null, STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, false);
+    return buildStrictReplicaGroupArSelector(hybridSelector, brokerMetrics, brokerConfig, null);
+  }
+
+  private StrictReplicaGroupInstanceSelector buildStrictReplicaGroupArSelector(HybridSelector hybridSelector,
+      BrokerMetrics brokerMetrics, PinotConfiguration brokerConfig, Boolean useFixedReplica) {
+    RoutingConfig routingConfig = new RoutingConfig(null, null, STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE,
+        useFixedReplica);
     TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName("testUpsertTable")
         .setRoutingConfig(routingConfig).build();
     // Ideal state: mirrors the topology above
@@ -722,16 +759,17 @@ public class ReplicaGroupSelectorTest {
   }
 
   @Test
-  public void testStrictReplicaGroupAdaptiveRejectsFixedReplicaQueryOption() {
+  public void testStrictReplicaGroupAdaptiveSupportsFixedReplicaQueryOption() {
     HybridSelector hybridSelector = mock(HybridSelector.class);
     StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector);
 
     Map<String, String> queryOptions = Map.of(
         CommonConstants.Broker.Request.QueryOptionKey.USE_FIXED_REPLICA, "true");
-    IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
-        () -> instanceSelector.select(STRICT_SEGMENTS, 0, buildStrictReplicaGroupSegmentStates(), queryOptions));
-    assertTrue(exception.getMessage().contains("useFixedReplica cannot be used"));
+    InstanceSelector.InstanceMapping result =
+        instanceSelector.select(STRICT_SEGMENTS, 0, buildStrictReplicaGroupSegmentStates(), queryOptions);
     verify(hybridSelector, never()).fetchServerRankingsWithScores(any());
+    assertEquals(result.segmentToInstanceMap().get(STRICT_SEGMENT0),
+        result.segmentToInstanceMap().get(STRICT_SEGMENT1));
   }
 
   @Test

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
@@ -20,7 +20,6 @@ package org.apache.pinot.broker.routing.instanceselector;
 
 import java.time.Clock;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -81,7 +80,7 @@ public class ReplicaGroupSelectorTest {
   private TableConfig _tableConfig;
 
   private static final String TABLE_NAME = "testTable_OFFLINE";
-  private static final Map<String, ServerInstance> EMPTY_SERVER_MAP = Collections.EMPTY_MAP;
+  private static final Map<String, ServerInstance> EMPTY_SERVER_MAP = Map.of();
   private static final InstanceSelectorConfig INSTANCE_SELECTOR_CONFIG = new InstanceSelectorConfig(false, 300, false);
   private static final List<String> SEGMENTS =
       Arrays.asList("segment0", "segment1", "segment2", "segment3", "segment4", "segment5", "segment6", "segment7",

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
@@ -904,7 +904,6 @@ public class ReplicaGroupSelectorTest {
 
     assertEquals(result.segmentToInstanceMap(), Map.of(STRICT_SEGMENT0, STRICT_RG0_SERVER_A));
     assertEquals(result.optionalSegmentToInstanceMap(), Map.of(newSegment, STRICT_RG1_SERVER_D));
-    assertTrue(result.unavailableSegments().isEmpty());
   }
 
   @Test

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
@@ -70,10 +70,8 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
 
 
-/**
- * Tests for {@link ReplicaGroupInstanceSelector} and {@link StrictReplicaGroupInstanceSelector},
- * including adaptive server selection for strict replica groups.
- */
+/// Tests for [ReplicaGroupInstanceSelector] and [StrictReplicaGroupInstanceSelector], including adaptive server
+/// selection for strict replica groups.
 @SuppressWarnings("unchecked")
 public class ReplicaGroupSelectorTest {
   private AutoCloseable _mocks;

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
@@ -445,7 +445,7 @@ public class ReplicaGroupSelectorTest {
     HybridSelector hybridSelector = mock(HybridSelector.class);
     BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
     PinotConfiguration brokerConfig = new PinotConfiguration(Map.of(
-        CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STRICT_REPLICA_GROUP, "false"));
+        CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_STRICT_REPLICA_GROUP_ENABLED, "false"));
     StrictReplicaGroupInstanceSelector instanceSelector =
         buildStrictReplicaGroupArSelector(hybridSelector, brokerMetrics, brokerConfig);
 

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
@@ -66,6 +66,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 
 /**
@@ -647,6 +648,36 @@ public class ReplicaGroupSelectorTest {
         STRICT_SEGMENT0, STRICT_RG1_SERVER_C,
         STRICT_SEGMENT1, STRICT_RG1_SERVER_C,
         STRICT_SEGMENT2, STRICT_RG1_SERVER_D));
+  }
+
+  @Test
+  public void testStrictReplicaGroupAdaptiveRejectsFixedReplicaQueryOption() {
+    HybridSelector hybridSelector = mock(HybridSelector.class);
+    StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector);
+
+    Map<String, String> queryOptions = Map.of(
+        CommonConstants.Broker.Request.QueryOptionKey.USE_FIXED_REPLICA, "true");
+    IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
+        () -> instanceSelector.select(STRICT_SEGMENTS, 0, buildStrictReplicaGroupSegmentStates(), queryOptions));
+    assertTrue(exception.getMessage().contains("useFixedReplica cannot be used"));
+    verify(hybridSelector, never()).fetchServerRankingsWithScores(any());
+  }
+
+  @Test
+  public void testStrictReplicaGroupAdaptivePreservesNumReplicaGroupsToQuery() {
+    HybridSelector hybridSelector = mock(HybridSelector.class);
+    StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector);
+
+    Map<String, String> queryOptions = Map.of(
+        CommonConstants.Broker.Request.QueryOptionKey.NUM_REPLICA_GROUPS_TO_QUERY, "2");
+    InstanceSelector.InstanceMapping result =
+        instanceSelector.select(STRICT_SEGMENTS, 0, buildStrictReplicaGroupSegmentStates(), queryOptions);
+
+    verify(hybridSelector, never()).fetchServerRankingsWithScores(any());
+    assertEquals(result.segmentToInstanceMap(), Map.of(
+        STRICT_SEGMENT0, STRICT_RG0_SERVER_A,
+        STRICT_SEGMENT1, STRICT_RG1_SERVER_C,
+        STRICT_SEGMENT2, STRICT_RG0_SERVER_B));
   }
 
   @Test

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
@@ -627,6 +627,53 @@ public class ReplicaGroupSelectorTest {
   }
 
   @Test
+  public void testStrictReplicaGroupAdaptiveRoutesAroundDegradedPreferredPool() {
+    HybridSelector hybridSelector = mock(HybridSelector.class);
+    StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector);
+
+    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(Arrays.asList(
+        new ImmutablePair<>(STRICT_RG1_SERVER_C, 1.0),
+        new ImmutablePair<>(STRICT_RG1_SERVER_D, 2.0),
+        new ImmutablePair<>(STRICT_RG0_SERVER_A, 90.0),
+        new ImmutablePair<>(STRICT_RG0_SERVER_B, 100.0)
+    ));
+
+    Map<String, String> queryOptions = Map.of(
+        CommonConstants.Broker.Request.QueryOptionKey.ORDERED_PREFERRED_POOLS, "0");
+    InstanceSelector.InstanceMapping result = instanceSelector.select(STRICT_SEGMENTS, 0,
+        buildStrictReplicaGroupSegmentStates(0, 1), queryOptions);
+
+    // Pool 0 is preferred, but adaptive health is the primary selection criterion.
+    assertEquals(result.segmentToInstanceMap(), Map.of(
+        STRICT_SEGMENT0, STRICT_RG1_SERVER_C,
+        STRICT_SEGMENT1, STRICT_RG1_SERVER_C,
+        STRICT_SEGMENT2, STRICT_RG1_SERVER_D));
+  }
+
+  @Test
+  public void testStrictReplicaGroupAdaptiveUsesPreferredPoolToBreakScoreTie() {
+    HybridSelector hybridSelector = mock(HybridSelector.class);
+    StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector);
+
+    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(Arrays.asList(
+        new ImmutablePair<>(STRICT_RG0_SERVER_A, 1.0),
+        new ImmutablePair<>(STRICT_RG0_SERVER_B, 2.0),
+        new ImmutablePair<>(STRICT_RG1_SERVER_C, 1.0),
+        new ImmutablePair<>(STRICT_RG1_SERVER_D, 2.0)
+    ));
+
+    Map<String, String> queryOptions = Map.of(
+        CommonConstants.Broker.Request.QueryOptionKey.ORDERED_PREFERRED_POOLS, "0");
+    InstanceSelector.InstanceMapping result = instanceSelector.select(STRICT_SEGMENTS, 1,
+        buildStrictReplicaGroupSegmentStates(0, 1), queryOptions);
+
+    assertEquals(result.segmentToInstanceMap(), Map.of(
+        STRICT_SEGMENT0, STRICT_RG0_SERVER_A,
+        STRICT_SEGMENT1, STRICT_RG0_SERVER_A,
+        STRICT_SEGMENT2, STRICT_RG0_SERVER_B));
+  }
+
+  @Test
   public void testStrictReplicaGroupAdaptiveEmptyRankingsFallBackToRoundRobin() {
     // When adaptive ranking returns no servers, fall back to round-robin by replica-group index.
     HybridSelector hybridSelector = mock(HybridSelector.class);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupSelectorTest.java
@@ -54,6 +54,7 @@ import org.testng.annotations.Test;
 import static org.apache.pinot.spi.config.table.RoutingConfig.REPLICA_GROUP_INSTANCE_SELECTOR_TYPE;
 import static org.apache.pinot.spi.config.table.RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE;
 import static org.apache.pinot.spi.utils.CommonConstants.Broker.FALLBACK_POOL_ID;
+import static org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel.OFFLINE;
 import static org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -71,7 +72,7 @@ import static org.testng.Assert.expectThrows;
 
 /**
  * Tests for {@link ReplicaGroupInstanceSelector} and {@link StrictReplicaGroupInstanceSelector},
- * including adaptive server selection (replica-group-level routing for strict replica groups).
+ * including adaptive server selection for strict replica groups.
  */
 @SuppressWarnings("unchecked")
 public class ReplicaGroupSelectorTest {
@@ -497,21 +498,34 @@ public class ReplicaGroupSelectorTest {
 
   private List<SegmentInstanceCandidate> buildStrictReplicaGroupCandidates(String replicaGroup0Instance,
       String replicaGroup1Instance) {
+    return buildStrictReplicaGroupCandidates(replicaGroup0Instance, replicaGroup1Instance, FALLBACK_POOL_ID,
+        FALLBACK_POOL_ID);
+  }
+
+  private List<SegmentInstanceCandidate> buildStrictReplicaGroupCandidates(String replicaGroup0Instance,
+      String replicaGroup1Instance, int replicaGroup0Pool, int replicaGroup1Pool) {
     return Arrays.asList(
-        new SegmentInstanceCandidate(replicaGroup0Instance, true, FALLBACK_POOL_ID, 0),
-        new SegmentInstanceCandidate(replicaGroup1Instance, true, FALLBACK_POOL_ID, 1));
+        new SegmentInstanceCandidate(replicaGroup0Instance, true, replicaGroup0Pool, 0),
+        new SegmentInstanceCandidate(replicaGroup1Instance, true, replicaGroup1Pool, 1));
   }
 
   private SegmentStates buildStrictReplicaGroupSegmentStates() {
+    return buildStrictReplicaGroupSegmentStates(FALLBACK_POOL_ID, FALLBACK_POOL_ID);
+  }
+
+  private SegmentStates buildStrictReplicaGroupSegmentStates(int replicaGroup0Pool, int replicaGroup1Pool) {
     Map<String, List<SegmentInstanceCandidate>> candidatesMap = new HashMap<>();
     // All strict-fixture servers intentionally share FALLBACK_POOL_ID so these tests fail if strict routing regresses
     // back to grouping or filtering by pool instead of idealStateReplicaId.
     candidatesMap.put(STRICT_SEGMENT0,
-        buildStrictReplicaGroupCandidates(STRICT_RG0_SERVER_A, STRICT_RG1_SERVER_C));
+        buildStrictReplicaGroupCandidates(STRICT_RG0_SERVER_A, STRICT_RG1_SERVER_C, replicaGroup0Pool,
+            replicaGroup1Pool));
     candidatesMap.put(STRICT_SEGMENT1,
-        buildStrictReplicaGroupCandidates(STRICT_RG0_SERVER_A, STRICT_RG1_SERVER_C));
+        buildStrictReplicaGroupCandidates(STRICT_RG0_SERVER_A, STRICT_RG1_SERVER_C, replicaGroup0Pool,
+            replicaGroup1Pool));
     candidatesMap.put(STRICT_SEGMENT2,
-        buildStrictReplicaGroupCandidates(STRICT_RG0_SERVER_B, STRICT_RG1_SERVER_D));
+        buildStrictReplicaGroupCandidates(STRICT_RG0_SERVER_B, STRICT_RG1_SERVER_D, replicaGroup0Pool,
+            replicaGroup1Pool));
     return new SegmentStates(candidatesMap, new HashSet<>(STRICT_SEGMENTS), null);
   }
 
@@ -572,10 +586,7 @@ public class ReplicaGroupSelectorTest {
   }
 
   @Test
-  public void testStrictReplicaGroupAdaptivePicksBestReplicaGroupByWorstCaseServer() {
-    // Replica group 0 servers: server_a (rank 2), server_b (rank 3) → worst = 3
-    // Replica group 1 servers: server_c (rank 0), server_d (rank 1) → worst = 1
-    // Replica group 1 is better (lower worst-case rank), so all segments should route there
+  public void testStrictReplicaGroupAdaptivePicksHealthiestCandidatePerPartition() {
     HybridSelector hybridSelector = mock(HybridSelector.class);
     BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
     StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector,
@@ -591,21 +602,19 @@ public class ReplicaGroupSelectorTest {
     InstanceSelector.InstanceMapping result =
         instanceSelector.select(STRICT_SEGMENTS, 0, buildStrictReplicaGroupSegmentStates(), null);
 
-    // All segments routed to replica group 1
+    // Each partition independently prefers its healthier replica. Segments 0 and 1 share a candidate list, so they
+    // make the same choice.
     assertEquals(result.segmentToInstanceMap(), Map.of(
         STRICT_SEGMENT0, STRICT_RG1_SERVER_C,
         STRICT_SEGMENT1, STRICT_RG1_SERVER_C,
         STRICT_SEGMENT2, STRICT_RG1_SERVER_D));
-    // Metrics are still reported per actual pool, even though routing is chosen by replica group.
+    // Metrics are reported per selected pool.
     verify(brokerMetrics).addMeteredValue(eq(BrokerMeter.POOL_SEG_QUERIES), eq(3L),
         eq(BrokerMetrics.getTagForPreferredPool(null)), eq(String.valueOf(FALLBACK_POOL_ID)));
   }
 
   @Test
-  public void testStrictReplicaGroupAdaptivePicksGroup0WhenItHasBetterWorstCase() {
-    // Replica group 0 servers: server_a (rank 0), server_b (rank 1) → worst = 1
-    // Replica group 1 servers: server_c (rank 2), server_d (rank 3) → worst = 3
-    // Replica group 0 is better
+  public void testStrictReplicaGroupAdaptivePicksOtherHealthyCandidates() {
     HybridSelector hybridSelector = mock(HybridSelector.class);
     StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector);
 
@@ -619,7 +628,6 @@ public class ReplicaGroupSelectorTest {
     InstanceSelector.InstanceMapping result =
         instanceSelector.select(STRICT_SEGMENTS, 0, buildStrictReplicaGroupSegmentStates(), null);
 
-    // All segments routed to replica group 0
     assertEquals(result.segmentToInstanceMap(), Map.of(
         STRICT_SEGMENT0, STRICT_RG0_SERVER_A,
         STRICT_SEGMENT1, STRICT_RG0_SERVER_A,
@@ -627,7 +635,7 @@ public class ReplicaGroupSelectorTest {
   }
 
   @Test
-  public void testStrictReplicaGroupAdaptiveRoutesAroundDegradedPreferredPool() {
+  public void testStrictReplicaGroupAdaptivePrefersPoolBeforeAdaptiveHealth() {
     HybridSelector hybridSelector = mock(HybridSelector.class);
     StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector);
 
@@ -643,7 +651,48 @@ public class ReplicaGroupSelectorTest {
     InstanceSelector.InstanceMapping result = instanceSelector.select(STRICT_SEGMENTS, 0,
         buildStrictReplicaGroupSegmentStates(0, 1), queryOptions);
 
-    // Pool 0 is preferred, but adaptive health is the primary selection criterion.
+    // Preferred pools are the primary selection criterion, even when another pool is healthier.
+    assertEquals(result.segmentToInstanceMap(), Map.of(
+        STRICT_SEGMENT0, STRICT_RG0_SERVER_A,
+        STRICT_SEGMENT1, STRICT_RG0_SERVER_A,
+        STRICT_SEGMENT2, STRICT_RG0_SERVER_B));
+  }
+
+  @Test
+  public void testStrictReplicaGroupAdaptiveUsesHealthWithinPreferredPool() {
+    String nonPreferredServerE = "strict_rg2_server_e";
+    String nonPreferredServerF = "strict_rg2_server_f";
+    HybridSelector hybridSelector = mock(HybridSelector.class);
+    StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector);
+
+    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(Arrays.asList(
+        new ImmutablePair<>(nonPreferredServerE, 0.0),
+        new ImmutablePair<>(nonPreferredServerF, 0.0),
+        new ImmutablePair<>(STRICT_RG1_SERVER_C, 1.0),
+        new ImmutablePair<>(STRICT_RG1_SERVER_D, 2.0),
+        new ImmutablePair<>(STRICT_RG0_SERVER_A, 20.0),
+        new ImmutablePair<>(STRICT_RG0_SERVER_B, 30.0)
+    ));
+
+    Map<String, List<SegmentInstanceCandidate>> candidatesMap = new HashMap<>();
+    List<SegmentInstanceCandidate> partition0Candidates = Arrays.asList(
+        new SegmentInstanceCandidate(STRICT_RG0_SERVER_A, true, 0, 0),
+        new SegmentInstanceCandidate(STRICT_RG1_SERVER_C, true, 0, 1),
+        new SegmentInstanceCandidate(nonPreferredServerE, true, 1, 2));
+    candidatesMap.put(STRICT_SEGMENT0, partition0Candidates);
+    candidatesMap.put(STRICT_SEGMENT1, partition0Candidates);
+    candidatesMap.put(STRICT_SEGMENT2, Arrays.asList(
+        new SegmentInstanceCandidate(STRICT_RG0_SERVER_B, true, 0, 0),
+        new SegmentInstanceCandidate(STRICT_RG1_SERVER_D, true, 0, 1),
+        new SegmentInstanceCandidate(nonPreferredServerF, true, 1, 2)));
+    SegmentStates segmentStates = new SegmentStates(candidatesMap, new HashSet<>(STRICT_SEGMENTS), null);
+
+    Map<String, String> queryOptions = Map.of(
+        CommonConstants.Broker.Request.QueryOptionKey.ORDERED_PREFERRED_POOLS, "0");
+    InstanceSelector.InstanceMapping result = instanceSelector.select(STRICT_SEGMENTS, 1, segmentStates,
+        queryOptions);
+
+    // The healthiest candidate within pool 0 wins, while the healthier candidates in pool 1 are ignored.
     assertEquals(result.segmentToInstanceMap(), Map.of(
         STRICT_SEGMENT0, STRICT_RG1_SERVER_C,
         STRICT_SEGMENT1, STRICT_RG1_SERVER_C,
@@ -651,37 +700,14 @@ public class ReplicaGroupSelectorTest {
   }
 
   @Test
-  public void testStrictReplicaGroupAdaptiveUsesPreferredPoolToBreakScoreTie() {
-    HybridSelector hybridSelector = mock(HybridSelector.class);
-    StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector);
-
-    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(Arrays.asList(
-        new ImmutablePair<>(STRICT_RG0_SERVER_A, 1.0),
-        new ImmutablePair<>(STRICT_RG0_SERVER_B, 2.0),
-        new ImmutablePair<>(STRICT_RG1_SERVER_C, 1.0),
-        new ImmutablePair<>(STRICT_RG1_SERVER_D, 2.0)
-    ));
-
-    Map<String, String> queryOptions = Map.of(
-        CommonConstants.Broker.Request.QueryOptionKey.ORDERED_PREFERRED_POOLS, "0");
-    InstanceSelector.InstanceMapping result = instanceSelector.select(STRICT_SEGMENTS, 1,
-        buildStrictReplicaGroupSegmentStates(0, 1), queryOptions);
-
-    assertEquals(result.segmentToInstanceMap(), Map.of(
-        STRICT_SEGMENT0, STRICT_RG0_SERVER_A,
-        STRICT_SEGMENT1, STRICT_RG0_SERVER_A,
-        STRICT_SEGMENT2, STRICT_RG0_SERVER_B));
-  }
-
-  @Test
   public void testStrictReplicaGroupAdaptiveEmptyRankingsFallBackToRoundRobin() {
-    // When adaptive ranking returns no servers, fall back to round-robin by replica-group index.
+    // When adaptive ranking returns no servers, fall back to round-robin by candidate index.
     HybridSelector hybridSelector = mock(HybridSelector.class);
     StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector);
 
     when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(List.of());
 
-    // requestId=0 → picks group at index 0 (replica group 0)
+    // requestId=0 picks candidate index 0.
     InstanceSelector.InstanceMapping result =
         instanceSelector.select(STRICT_SEGMENTS, 0, buildStrictReplicaGroupSegmentStates(), null);
     assertEquals(result.segmentToInstanceMap(), Map.of(
@@ -689,7 +715,7 @@ public class ReplicaGroupSelectorTest {
         STRICT_SEGMENT1, STRICT_RG0_SERVER_A,
         STRICT_SEGMENT2, STRICT_RG0_SERVER_B));
 
-    // requestId=1 → picks group at index 1 (replica group 1)
+    // requestId=1 picks candidate index 1.
     result = instanceSelector.select(STRICT_SEGMENTS, 1, buildStrictReplicaGroupSegmentStates(), null);
     assertEquals(result.segmentToInstanceMap(), Map.of(
         STRICT_SEGMENT0, STRICT_RG1_SERVER_C,
@@ -728,16 +754,15 @@ public class ReplicaGroupSelectorTest {
   }
 
   @Test
-  public void testStrictReplicaGroupAdaptiveConsistencyAllSegmentsSameReplicaGroup() {
-    // When adaptive scores favor replica group 1, all segments must route to that same replica group.
+  public void testStrictReplicaGroupAdaptiveIsConsistentWithinEachPartition() {
     HybridSelector hybridSelector = mock(HybridSelector.class);
     StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector);
 
     when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(Arrays.asList(
         new ImmutablePair<>(STRICT_RG1_SERVER_C, 1.0),
-        new ImmutablePair<>(STRICT_RG1_SERVER_D, 2.0),
+        new ImmutablePair<>(STRICT_RG0_SERVER_B, 2.0),
         new ImmutablePair<>(STRICT_RG0_SERVER_A, 3.0),
-        new ImmutablePair<>(STRICT_RG0_SERVER_B, 4.0)
+        new ImmutablePair<>(STRICT_RG1_SERVER_D, 4.0)
     ));
 
     InstanceSelector.InstanceMapping result =
@@ -746,74 +771,72 @@ public class ReplicaGroupSelectorTest {
     assertEquals(result.segmentToInstanceMap(), Map.of(
         STRICT_SEGMENT0, STRICT_RG1_SERVER_C,
         STRICT_SEGMENT1, STRICT_RG1_SERVER_C,
-        STRICT_SEGMENT2, STRICT_RG1_SERVER_D));
+        STRICT_SEGMENT2, STRICT_RG0_SERVER_B));
   }
 
   @Test
-  public void testStrictReplicaGroupAdaptivePrefersFullCoverageGroup() {
-    // Topology: replica group 0 has all 3 segments, replica group 1 only has segment0 and segment1.
-    // Even though replica group 1 has better adaptive ranks, replica group 0 should be chosen (full coverage).
-    // Replica group 0: server_a (seg0, seg1), server_b (seg2) — full coverage
-    // Replica group 1: server_c (seg0, seg1) — missing seg2, partial coverage
-    // Pools intentionally do not match replica groups: server_a and server_c share pool 0, while server_b is pool 1.
-    String serverC = "server_c";
+  public void testStrictReplicaGroupAdaptiveUsesFilteredCandidatesPerPartition() {
+    String partition0Segment0 = "partition0_segment0";
+    String partition0Segment1 = "partition0_segment1";
+    String partition1Segment0 = "partition1_segment0";
+    String partition1Segment1 = "partition1_segment1";
+    List<String> segments = List.of(partition0Segment0, partition0Segment1, partition1Segment0,
+        partition1Segment1);
+    String partition0Replica0 = "partition0_replica0";
+    String partition0Replica1 = "partition0_replica1";
+    String partition1Replica0 = "partition1_replica0";
+    String partition1Replica1 = "partition1_replica1";
     HybridSelector hybridSelector = mock(HybridSelector.class);
 
     RoutingConfig routingConfig = new RoutingConfig(null, null, STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, false);
-    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName("testUpsertTable")
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName("partitionedTable")
         .setRoutingConfig(routingConfig).build();
-    // Replica group 1 only has seg0 and seg1 (no seg2)
     IdealState idealState = createIdealState(Map.of(
-        STRICT_SEGMENT0, List.of(Pair.of(STRICT_RG0_SERVER_A, ONLINE), Pair.of(serverC, ONLINE)),
-        STRICT_SEGMENT1, List.of(Pair.of(STRICT_RG0_SERVER_A, ONLINE), Pair.of(serverC, ONLINE)),
-        STRICT_SEGMENT2, List.of(Pair.of(STRICT_RG0_SERVER_B, ONLINE))));
+        partition0Segment0, List.of(Pair.of(partition0Replica0, ONLINE), Pair.of(partition0Replica1, ONLINE)),
+        partition0Segment1, List.of(Pair.of(partition0Replica0, ONLINE), Pair.of(partition0Replica1, ONLINE)),
+        partition1Segment0, List.of(Pair.of(partition1Replica0, ONLINE), Pair.of(partition1Replica1, ONLINE)),
+        partition1Segment1, List.of(Pair.of(partition1Replica0, ONLINE), Pair.of(partition1Replica1, ONLINE))));
+    // Degrade opposite replica positions in the two partitions. Strict state construction must remove each degraded
+    // replica from every old segment with the same IdealState assignment.
     ExternalView externalView = createExternalView(Map.of(
-        STRICT_SEGMENT0, List.of(Pair.of(STRICT_RG0_SERVER_A, ONLINE), Pair.of(serverC, ONLINE)),
-        STRICT_SEGMENT1, List.of(Pair.of(STRICT_RG0_SERVER_A, ONLINE), Pair.of(serverC, ONLINE)),
-        STRICT_SEGMENT2, List.of(Pair.of(STRICT_RG0_SERVER_B, ONLINE))));
-    ServerInstance serverA = mock(ServerInstance.class);
-    when(serverA.getPool()).thenReturn(0);
-    ServerInstance serverB = mock(ServerInstance.class);
-    when(serverB.getPool()).thenReturn(1);
-    ServerInstance serverCInstance = mock(ServerInstance.class);
-    when(serverCInstance.getPool()).thenReturn(0);
-    Map<String, ServerInstance> serverMap = Map.of(
-        STRICT_RG0_SERVER_A, serverA, STRICT_RG0_SERVER_B, serverB, serverC, serverCInstance);
+        partition0Segment0, List.of(Pair.of(partition0Replica0, ONLINE), Pair.of(partition0Replica1, ONLINE)),
+        partition0Segment1, List.of(Pair.of(partition0Replica0, OFFLINE), Pair.of(partition0Replica1, ONLINE)),
+        partition1Segment0, List.of(Pair.of(partition1Replica0, ONLINE), Pair.of(partition1Replica1, ONLINE)),
+        partition1Segment1, List.of(Pair.of(partition1Replica0, ONLINE), Pair.of(partition1Replica1, OFFLINE))));
+
+    ServerInstance server0 = mock(ServerInstance.class);
+    when(server0.getPool()).thenReturn(FALLBACK_POOL_ID);
+    ServerInstance server1 = mock(ServerInstance.class);
+    when(server1.getPool()).thenReturn(FALLBACK_POOL_ID);
+    ServerInstance server2 = mock(ServerInstance.class);
+    when(server2.getPool()).thenReturn(FALLBACK_POOL_ID);
+    ServerInstance server3 = mock(ServerInstance.class);
+    when(server3.getPool()).thenReturn(FALLBACK_POOL_ID);
+    Map<String, ServerInstance> serverMap = Map.of(partition0Replica0, server0, partition0Replica1, server1,
+        partition1Replica0, server2, partition1Replica1, server3);
     StrictReplicaGroupInstanceSelector instanceSelector =
         (StrictReplicaGroupInstanceSelector) InstanceSelectorFactory.getInstanceSelector(tableConfig,
             mock(ZkHelixPropertyStore.class), mock(BrokerMetrics.class), hybridSelector,
             new PinotConfiguration(Map.of()),
-            Set.of(STRICT_RG0_SERVER_A, STRICT_RG0_SERVER_B, serverC),
-            serverMap, idealState, externalView, new HashSet<>(STRICT_SEGMENTS));
+            Set.of(partition0Replica0, partition0Replica1, partition1Replica0, partition1Replica1), serverMap,
+            idealState, externalView, new HashSet<>(segments));
 
-    // Replica group 1 (server_c) has rank 0 — best rank, but only covers 2 of 3 segments
-    // Replica group 0 (server_a rank 1, server_b rank 2) — worse ranks, but full coverage
-    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(Arrays.asList(
-        new ImmutablePair<>(serverC, 1.0),        // rank 0 (best)
-        new ImmutablePair<>(STRICT_RG0_SERVER_A, 3.0),   // rank 1
-        new ImmutablePair<>(STRICT_RG0_SERVER_B, 4.0)    // rank 2
-    ));
+    when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(List.of(
+        new ImmutablePair<>(partition1Replica0, 1.0), new ImmutablePair<>(partition0Replica1, 2.0)));
 
-    // Build segment states where replica group 1 is missing seg2
-    Map<String, List<SegmentInstanceCandidate>> candidatesMap = new HashMap<>();
-    candidatesMap.put(STRICT_SEGMENT0, Arrays.asList(
-        new SegmentInstanceCandidate(STRICT_RG0_SERVER_A, true, 0, 0),
-        new SegmentInstanceCandidate(serverC, true, 0, 1)));
-    candidatesMap.put(STRICT_SEGMENT1, Arrays.asList(
-        new SegmentInstanceCandidate(STRICT_RG0_SERVER_A, true, 0, 0),
-        new SegmentInstanceCandidate(serverC, true, 0, 1)));
-    candidatesMap.put(STRICT_SEGMENT2, List.of(
-        new SegmentInstanceCandidate(STRICT_RG0_SERVER_B, true, 1, 0)));
-    SegmentStates segmentStates = new SegmentStates(candidatesMap, new HashSet<>(STRICT_SEGMENTS), null);
+    BrokerRequest brokerRequest = mock(BrokerRequest.class);
+    PinotQuery pinotQuery = mock(PinotQuery.class);
+    when(brokerRequest.getPinotQuery()).thenReturn(pinotQuery);
+    when(pinotQuery.getQueryOptions()).thenReturn(null);
 
-    InstanceSelector.InstanceMapping result =
-        instanceSelector.select(STRICT_SEGMENTS, 0, segmentStates, null);
+    InstanceSelector.SelectionResult result = instanceSelector.select(brokerRequest, segments, 0);
 
-    // Replica group 0 should be chosen (full coverage) even though replica group 1 has better ranks
-    assertEquals(result.segmentToInstanceMap(), Map.of(
-        STRICT_SEGMENT0, STRICT_RG0_SERVER_A,
-        STRICT_SEGMENT1, STRICT_RG0_SERVER_A,
-        STRICT_SEGMENT2, STRICT_RG0_SERVER_B));
+    assertEquals(result.getSegmentToInstanceMap(), Map.of(
+        partition0Segment0, partition0Replica1,
+        partition0Segment1, partition0Replica1,
+        partition1Segment0, partition1Replica0,
+        partition1Segment1, partition1Replica0));
+    assertTrue(result.getUnavailableSegments().isEmpty());
   }
 
   @Test
@@ -860,56 +883,40 @@ public class ReplicaGroupSelectorTest {
   }
 
   @Test
-  public void testStrictReplicaGroupAdaptiveDroppedSegmentReportedAsUnavailable() {
-    // Topology: no replica group (idealStateReplicaId) has full coverage.
-    // ReplicaId 0 (server_a): covers seg0, seg1 (missing seg2)
-    // ReplicaId 1 (server_c, server_d): covers seg1, seg2 (missing seg0)
-    // ReplicaId 1 has better rank -> chosen. seg0 has no replicaId-1 candidate -> reported unavailable.
+  public void testStrictReplicaGroupAdaptiveNewSegmentWithCandidateRemainsOptional() {
+    String newSegment = "new_seg_with_candidate";
     HybridSelector hybridSelector = mock(HybridSelector.class);
     StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector);
 
     when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(Arrays.asList(
-            new ImmutablePair<>(STRICT_RG1_SERVER_C, 1.0),
-            new ImmutablePair<>(STRICT_RG0_SERVER_A, 3.0)
+        new ImmutablePair<>(STRICT_RG0_SERVER_A, 1.0),
+        new ImmutablePair<>(STRICT_RG1_SERVER_D, 2.0)
     ));
 
-    // Craft segment states with partial coverage per replica group:
-    //   seg0: only in replicaId 0 (server_a)
-    //   seg1: in both replicaId 0 (server_a) and replicaId 1 (server_c)
-    //   seg2: only in replicaId 1 (server_d)
     Map<String, List<SegmentInstanceCandidate>> candidatesMap = new HashMap<>();
     candidatesMap.put(STRICT_SEGMENT0, List.of(
         new SegmentInstanceCandidate(STRICT_RG0_SERVER_A, true, FALLBACK_POOL_ID, 0)));
-    candidatesMap.put(STRICT_SEGMENT1, Arrays.asList(
-        new SegmentInstanceCandidate(STRICT_RG0_SERVER_A, true, FALLBACK_POOL_ID, 0),
-        new SegmentInstanceCandidate(STRICT_RG1_SERVER_C, true, FALLBACK_POOL_ID, 1)));
-    candidatesMap.put(STRICT_SEGMENT2, List.of(
-        new SegmentInstanceCandidate(STRICT_RG1_SERVER_D, true, FALLBACK_POOL_ID, 1)));
-    SegmentStates segmentStates = new SegmentStates(candidatesMap, new HashSet<>(STRICT_SEGMENTS), null);
+    candidatesMap.put(newSegment, List.of(
+        new SegmentInstanceCandidate(STRICT_RG1_SERVER_D, false, FALLBACK_POOL_ID, 1)));
+    SegmentStates segmentStates = new SegmentStates(candidatesMap,
+        Set.of(STRICT_RG0_SERVER_A, STRICT_RG1_SERVER_D), Set.of());
 
     InstanceSelector.InstanceMapping result =
-        instanceSelector.select(STRICT_SEGMENTS, 0, segmentStates, null);
+        instanceSelector.select(List.of(STRICT_SEGMENT0, newSegment), 0, segmentStates, Map.of());
 
-    // seg1 and seg2 routed to replicaId 1
-    assertEquals(result.segmentToInstanceMap(), Map.of(
-        STRICT_SEGMENT1, STRICT_RG1_SERVER_C,
-        STRICT_SEGMENT2, STRICT_RG1_SERVER_D));
-    // seg0 has candidates (replicaId 0 only) but no match in chosen replicaId 1 -> reported unavailable
-    assertEquals(result.unavailableSegments(), List.of(STRICT_SEGMENT0));
+    assertEquals(result.segmentToInstanceMap(), Map.of(STRICT_SEGMENT0, STRICT_RG0_SERVER_A));
+    assertEquals(result.optionalSegmentToInstanceMap(), Map.of(newSegment, STRICT_RG1_SERVER_D));
+    assertTrue(result.unavailableSegments().isEmpty());
   }
 
   @Test
   public void testStrictReplicaGroupAdaptiveOnlyQueryRelevantServersScored() {
-    // Replica group 1 has an extra server (server_e) that only hosts seg_extra, which is not in the query.
+    // The selector has an extra server (server_e) that only hosts seg_extra, which is not in the query.
     // server_e should never be scored for a query over STRICT_SEGMENTS.
-    // Replica group 0: server_a (rank 2), server_b (rank 3) → worst = 3
-    // Replica group 1: server_c (rank 0), server_d (rank 1) → worst = 1
-    // Replica group 1 should win because only query-relevant servers matter.
     String rg1ServerE = "server_e";
     String segExtra = "seg_extra";
     HybridSelector hybridSelector = mock(HybridSelector.class);
 
-    // Build selector with server_e in replica group 1, hosting seg_extra.
     RoutingConfig routingConfig = new RoutingConfig(null, null, STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, false);
     TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName("testUpsertTable")
         .setRoutingConfig(routingConfig).build();
@@ -973,8 +980,8 @@ public class ReplicaGroupSelectorTest {
     InstanceSelector.InstanceMapping result =
         instanceSelector.select(STRICT_SEGMENTS, 0, segmentStates, null);
 
-    // Replica group 1 wins (worst rank among query-relevant servers = 1) over replica group 0 (worst = 3)
-    // server_e is not considered because it hosts no query segments
+    // Each query partition picks its healthiest candidate; server_e is not considered because it hosts no query
+    // segments.
     assertEquals(result.segmentToInstanceMap(), Map.of(
         STRICT_SEGMENT0, STRICT_RG1_SERVER_C,
         STRICT_SEGMENT1, STRICT_RG1_SERVER_C,
@@ -990,16 +997,32 @@ public class ReplicaGroupSelectorTest {
 
   @Test
   public void testStrictReplicaGroupAdaptiveHandlesMinimumRequestId() {
+    String replicaGroup2ServerE = "strict_rg2_server_e";
+    String replicaGroup2ServerF = "strict_rg2_server_f";
     HybridSelector hybridSelector = mock(HybridSelector.class);
     StrictReplicaGroupInstanceSelector instanceSelector = buildStrictReplicaGroupArSelector(hybridSelector);
     when(hybridSelector.fetchServerRankingsWithScores(any())).thenReturn(List.of());
 
-    InstanceSelector.InstanceMapping result = instanceSelector.select(STRICT_SEGMENTS, Integer.MIN_VALUE,
-        buildStrictReplicaGroupSegmentStates(), null);
+    Map<String, List<SegmentInstanceCandidate>> candidatesMap = new HashMap<>();
+    List<SegmentInstanceCandidate> partition0Candidates = Arrays.asList(
+        new SegmentInstanceCandidate(STRICT_RG0_SERVER_A, true, FALLBACK_POOL_ID, 0),
+        new SegmentInstanceCandidate(STRICT_RG1_SERVER_C, true, FALLBACK_POOL_ID, 1),
+        new SegmentInstanceCandidate(replicaGroup2ServerE, true, FALLBACK_POOL_ID, 2));
+    candidatesMap.put(STRICT_SEGMENT0, partition0Candidates);
+    candidatesMap.put(STRICT_SEGMENT1, partition0Candidates);
+    candidatesMap.put(STRICT_SEGMENT2, Arrays.asList(
+        new SegmentInstanceCandidate(STRICT_RG0_SERVER_B, true, FALLBACK_POOL_ID, 0),
+        new SegmentInstanceCandidate(STRICT_RG1_SERVER_D, true, FALLBACK_POOL_ID, 1),
+        new SegmentInstanceCandidate(replicaGroup2ServerF, true, FALLBACK_POOL_ID, 2)));
+    SegmentStates segmentStates = new SegmentStates(candidatesMap, new HashSet<>(STRICT_SEGMENTS), null);
 
+    InstanceSelector.InstanceMapping result =
+        instanceSelector.select(STRICT_SEGMENTS, Integer.MIN_VALUE, segmentStates, null);
+
+    // floorMod(Integer.MIN_VALUE, 3) is 1; the previous '%' indexing returned -2 and threw.
     assertEquals(result.segmentToInstanceMap(), Map.of(
-        STRICT_SEGMENT0, STRICT_RG0_SERVER_A,
-        STRICT_SEGMENT1, STRICT_RG0_SERVER_A,
-        STRICT_SEGMENT2, STRICT_RG0_SERVER_B));
+        STRICT_SEGMENT0, STRICT_RG1_SERVER_C,
+        STRICT_SEGMENT1, STRICT_RG1_SERVER_C,
+        STRICT_SEGMENT2, STRICT_RG1_SERVER_D));
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1271,6 +1271,13 @@ public class CommonConstants {
       public static final String CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS =
           CONFIG_PREFIX + ".stats.metric.export.interval.ms";
       public static final long DEFAULT_STATS_METRIC_EXPORT_INTERVAL_MS = 10 * 1000;
+
+      // Controls whether pool-level adaptive routing is enabled for StrictReplicaGroupInstanceSelector.
+      // When false, StrictReplicaGroupInstanceSelector falls back to round-robin even if adaptive server
+      // selection is configured.
+      public static final String CONFIG_OF_ENABLE_STRICT_REPLICA_GROUP =
+          CONFIG_PREFIX + ".enable.strict.replica.group";
+      public static final boolean DEFAULT_ENABLE_STRICT_REPLICA_GROUP = true;
     }
 
     public static class Grpc {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1255,12 +1255,12 @@ public class CommonConstants {
           CONFIG_PREFIX + ".stats.metric.export.interval.ms";
       public static final long DEFAULT_STATS_METRIC_EXPORT_INTERVAL_MS = 10 * 1000;
 
-      // Controls whether pool-level adaptive routing is enabled for StrictReplicaGroupInstanceSelector.
+      // Controls whether replica-group-level adaptive routing is enabled for StrictReplicaGroupInstanceSelector.
       // When false, StrictReplicaGroupInstanceSelector falls back to round-robin even if adaptive server
       // selection is configured.
-      public static final String CONFIG_OF_ENABLE_STRICT_REPLICA_GROUP =
-          CONFIG_PREFIX + ".enable.strict.replica.group";
-      public static final boolean DEFAULT_ENABLE_STRICT_REPLICA_GROUP = true;
+      public static final String CONFIG_OF_STRICT_REPLICA_GROUP_ENABLED =
+          CONFIG_PREFIX + ".strict.replica.group.enabled";
+      public static final boolean DEFAULT_STRICT_REPLICA_GROUP_ENABLED = true;
     }
 
     public static class Grpc {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1254,6 +1254,13 @@ public class CommonConstants {
       public static final String CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS =
           CONFIG_PREFIX + ".stats.metric.export.interval.ms";
       public static final long DEFAULT_STATS_METRIC_EXPORT_INTERVAL_MS = 10 * 1000;
+
+      // Controls whether pool-level adaptive routing is enabled for StrictReplicaGroupInstanceSelector.
+      // When false, StrictReplicaGroupInstanceSelector falls back to round-robin even if adaptive server
+      // selection is configured.
+      public static final String CONFIG_OF_ENABLE_STRICT_REPLICA_GROUP =
+          CONFIG_PREFIX + ".enable.strict.replica.group";
+      public static final boolean DEFAULT_ENABLE_STRICT_REPLICA_GROUP = true;
     }
 
     public static class Grpc {

--- a/pom.xml
+++ b/pom.xml
@@ -2071,7 +2071,9 @@
               <importOrder>
                 <order>,\#</order>
               </importOrder>
-              <removeUnusedImports />
+              <removeUnusedImports>
+                <engine>cleanthat-javaparser-unnecessaryimport</engine>
+              </removeUnusedImports>
             </java>
           </configuration>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -2103,7 +2103,7 @@
         <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
-          <version>2.46.1</version>
+          <version>3.0.0</version>
           <executions>
             <execution>
               <goals>
@@ -2120,9 +2120,7 @@
               <importOrder>
                 <order>,\#</order>
               </importOrder>
-              <removeUnusedImports>
-                <engine>cleanthat-javaparser-unnecessaryimport</engine>
-              </removeUnusedImports>
+              <removeUnusedImports />
             </java>
           </configuration>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -2120,7 +2120,9 @@
               <importOrder>
                 <order>,\#</order>
               </importOrder>
-              <removeUnusedImports />
+              <removeUnusedImports>
+                <engine>cleanthat-javaparser-unnecessaryimport</engine>
+              </removeUnusedImports>
             </java>
           </configuration>
         </plugin>


### PR DESCRIPTION
This PR is split into multiple logical commits for easier review. The bulk of the logic is in "Implement adaptive pool selection for StrictReplicaGroupInstanceSelector" commit. 

### Summary

Adaptive routing violates the same-replica-group invariant required for correctness on upsert tables. This PR restores the latency benefits of adaptive routing while preserving correctness, by making the routing decision at the replica-group level rather than the server level.

Instead of the parent class's per-segment independent adaptive routing (which violates the same-replica-group guarantee), this implementation:
1. Groups all query-relevant candidates by pool (replica group)
2. Scores each replica group by its **worst-case server rank** — since scatter-gather query latency is bounded by the slowest server, we want the group whose bottleneck is least bad
3. Picks the group with the lowest worst-case rank
4. Routes **all** segments to that single replica group

Replica groups with no stats are preferred. 

Also adds a flag `pinot.broker.adaptive.server.selector.enable.strict.replica.group` (default true) to control this behaviour, in case we discover any bugs with the implementation - we can switch to a simple "disable adaptive routing for Strict Replica Groups"

Fixes https://github.com/apache/pinot/issues/12507

## Docs changes:
* https://github.com/pinot-contrib/pinot-docs/pull/910 warns about the existing behaviour
* A follow up PR will describe the fix + version of the fix.

## Commit breakdown

### 1. Disable adaptive routing for Pinot tables using StrictReplicaGroup

Automatically disables adaptive server selection for StrictReplicaGroup tables in `InstanceSelectorFactory`. When the broker has adaptive routing enabled globally (e.g. `pinot.broker.adaptive.server.selector.type = HYBRID`), upsert and dedup tables will now automatically fall back to non-adaptive routing without requiring any table config changes.

### 2. Move ReplicaGroup selector tests to dedicated ReplicaGroupSelectorTest.java

Because there's a lot of Adaptive Routing specific logic that will be added to the ReplicaGroupSelector tests, move it to a new file to isolate the behaviour better. Moving this before changing any logic allows the diff in the follow-up commits to be cleaner.

### 3. Replace Pair return type on BaseInstanceSelector::select with a record

The protected abstract `BaseInstanceSelector::select` method previously returned `Pair<Map<String, String>, Map<String, String>>`, where the positional meaning of left vs. right was only conveyed by a comment. This replaces that with a self-documenting `record`. `record`s aren't used yet in the code base, so we needed a small change to pom.xml because the linter would incorrectly error with `com.google.googlejavaformat.java.FormatterException: 99:5: error: illegal start of expression`. 

### 4. Implement adaptive pool selection for StrictReplicaGroupInstanceSelector

The main feature commit (described in Summary above).

## Test Plan
On a broker, with adaptive routing enabled and an upsert table, we used the script [`pinot-pool-distribution-grapher.sh`](https://gist.github.com/timothy-e/9768ec0dad525e64d42e4289a5a60fa1) to show:

<img width="940" height="332" alt="image" src="https://github.com/user-attachments/assets/6c88c896-be97-4965-9483-2da68583649a" />


Correctness issues were always unlikely, because we'd need an upsert to span a segment boundary, and then the old and new segments would need to be returned by two different servers. Say:

> * Servers p1-1, p2-1 (each different pools) contain the same segments A, B.  
> * key abc123 was in segment A, but we sealed A so now it's stored in segment B.  
> * There was an upsert across segment boundaries - so we want to disregard the value for abc123 from A, and use the value of it from B. 
> * But server p2-1's segment B is slightly out of date and doesn't have the new value of abc123 yet.
> 
> Then, if I ask for segments A, B and I'm willing to go cross replicas, I could get:
> 
> * segment A from p1-1 (won't give me abc123 because it's stale)
> * segment B from p2-1 (won't give me abc123 because it doesn't have it yet)
> 
> so we don't return abc123.
> 
> or
> * segment A from p2-1 (will give me abc123 because it doesn't know it's stale yet)
> * segment B from p1-1 (will give me abc123 because it knows this is the new value)
> 
> so we double-return abc123.


**Steady State with this PR**: we hit p1 and p2 roughly equally
<img width="3327" height="287" alt="60486140-2e52-41fc-890e-88b97e5591b0" src="https://github.com/user-attachments/assets/df13b78b-f18f-4cad-9660-b92a2786a693" />


**Steady state with this PR and `pinot.broker.adaptive.server.selector.enable.strict.replica.group` disabled**: we perform the same as above. 

**When a server in pool p2 is degraded with this PR**: we stop routing immediately to p2 and start routing to p1. When the server is healthy again, we can resume routing to p2.
<img width="3339" height="971" alt="d4b30271-6d3a-442b-b3f4-cd641b6e0c3f" src="https://github.com/user-attachments/assets/ddbab7b1-f1c4-4ebc-9ccd-52263bf08d1d" />

**After switching to one replica group per mirror set**, we tested using [`check_partition_local_routing_from_file.sh`](https://gist.github.com/timothy-e/007988fc3b9f11eb6b0b9e7b99a86bbe) and got `PASS: all 100 calls kept one replica ordinal within every mirror set`. Inducing latency on a host still causes adaptive routing to route around the bad replica group. 
