### PR TITLE
Use TopicPartitionId as primary partition identity across all internal code

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java
@@ -34,7 +34,7 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
   private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormat.forPattern(DATE_FORMAT).withZoneUTC();
 
   private final String _tableName;
-  private final int _partitionGroupId;
+  private final TopicPartitionId _topicPartitionId;
   private final int _sequenceNumber;
   private final String _creationTime;
   private final String _segmentName;
@@ -43,7 +43,7 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
     String[] parts = StringUtils.splitByWholeSeparator(segmentName, SEPARATOR);
     Preconditions.checkArgument(parts.length == 4, "Invalid LLC segment name: %s", segmentName);
     _tableName = parts[0];
-    _partitionGroupId = Integer.parseInt(parts[1]);
+    _topicPartitionId = new TopicPartitionId(Integer.parseInt(parts[1]));
     _sequenceNumber = Integer.parseInt(parts[2]);
     _creationTime = parts[3];
     _segmentName = segmentName;
@@ -52,7 +52,7 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
   public LLCSegmentName(String tableName, int partitionGroupId, int sequenceNumber, long msSinceEpoch) {
     Preconditions.checkArgument(!tableName.contains(SEPARATOR), "Illegal table name: %s", tableName);
     _tableName = tableName;
-    _partitionGroupId = partitionGroupId;
+    _topicPartitionId = new TopicPartitionId(partitionGroupId);
     _sequenceNumber = sequenceNumber;
     // ISO8601 date: 20160120T1234Z
     _creationTime = DATE_FORMATTER.print(msSinceEpoch);
@@ -101,8 +101,13 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
     return _tableName;
   }
 
+  public TopicPartitionId getTopicPartitionId() {
+    return _topicPartitionId;
+  }
+
+  @Deprecated
   public int getPartitionGroupId() {
-    return _partitionGroupId;
+    return _topicPartitionId.getPartitionId();
   }
 
   public int getSequenceNumber() {
@@ -127,8 +132,9 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
   public int compareTo(LLCSegmentName other) {
     Preconditions.checkArgument(_tableName.equals(other._tableName),
         "Cannot compare segment names from different table: %s, %s", _segmentName, other.getSegmentName());
-    if (_partitionGroupId != other._partitionGroupId) {
-      return Integer.compare(_partitionGroupId, other._partitionGroupId);
+    int cmp = _topicPartitionId.compareTo(other._topicPartitionId);
+    if (cmp != 0) {
+      return cmp;
     }
     return Integer.compare(_sequenceNumber, other._sequenceNumber);
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java
@@ -28,6 +28,10 @@ import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
 
+/**
+ * Represents an LLC (Low-Level Consumer) segment name in the format:
+ * {@code {tableName}__{partitionGroupId}__{sequenceNumber}__{date}}
+ */
 public class LLCSegmentName implements Comparable<LLCSegmentName> {
   private static final String SEPARATOR = "__";
   private static final String DATE_FORMAT = "yyyyMMdd'T'HHmm'Z'";
@@ -39,37 +43,59 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
   private final String _creationTime;
   private final String _segmentName;
 
-  public LLCSegmentName(String segmentName) {
+  /**
+   * Parses a segment name string.
+   *
+   * <p>When {@code hasMultipleStreams} is true, composite partition IDs (>= 10000)
+   * are decomposed into their topic and partition components. This ensures that
+   * segment {@code table__10003__5__date} produces {@code TopicPartitionId(1, 3)}
+   * instead of {@code TopicPartitionId(0, 10003)}.
+   */
+  public LLCSegmentName(String segmentName, boolean hasMultipleStreams) {
     String[] parts = StringUtils.splitByWholeSeparator(segmentName, SEPARATOR);
     Preconditions.checkArgument(parts.length == 4, "Invalid LLC segment name: %s", segmentName);
     _tableName = parts[0];
-    _topicPartitionId = new TopicPartitionId(Integer.parseInt(parts[1]));
+    int rawId = Integer.parseInt(parts[1]);
+    if (hasMultipleStreams && rawId >= TopicPartitionId.PARTITION_PADDING_OFFSET) {
+      _topicPartitionId = TopicPartitionId.fromMultiTopicPinotPartitionId(rawId);
+    } else {
+      _topicPartitionId = new TopicPartitionId(rawId);
+    }
     _sequenceNumber = Integer.parseInt(parts[2]);
     _creationTime = parts[3];
     _segmentName = segmentName;
   }
 
+  /** @deprecated Use {@link #LLCSegmentName(String, boolean)} to provide multi-stream context. */
+  @Deprecated
+  public LLCSegmentName(String segmentName) {
+    this(segmentName, false);
+  }
+
+  @Deprecated
   public LLCSegmentName(String tableName, int partitionGroupId, int sequenceNumber, long msSinceEpoch) {
     Preconditions.checkArgument(!tableName.contains(SEPARATOR), "Illegal table name: %s", tableName);
     _tableName = tableName;
     _topicPartitionId = new TopicPartitionId(partitionGroupId);
     _sequenceNumber = sequenceNumber;
-    // ISO8601 date: 20160120T1234Z
     _creationTime = DATE_FORMATTER.print(msSinceEpoch);
     _segmentName = tableName + SEPARATOR + partitionGroupId + SEPARATOR + sequenceNumber + SEPARATOR + _creationTime;
   }
 
-  /**
-   * Returns the {@link LLCSegmentName} for the given segment name, or {@code null} if the given segment name does not
-   * represent an LLC segment.
-   */
   @Nullable
-  public static LLCSegmentName of(String segmentName) {
+  public static LLCSegmentName of(String segmentName, boolean hasMultipleStreams) {
     try {
-      return new LLCSegmentName(segmentName);
+      return new LLCSegmentName(segmentName, hasMultipleStreams);
     } catch (Exception e) {
       return null;
     }
+  }
+
+  /** @deprecated Use {@link #of(String, boolean)} to provide multi-stream context. */
+  @Deprecated
+  @Nullable
+  public static LLCSegmentName of(String segmentName) {
+    return of(segmentName, false);
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/SegmentUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/SegmentUtils.java
@@ -72,7 +72,7 @@ public class SegmentUtils {
   public static Integer getPartitionIdFromSegmentName(String segmentName) {
     LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentName);
     if (llcSegmentName != null) {
-      return llcSegmentName.getPartitionGroupId();
+      return llcSegmentName.getTopicPartitionId().getPartitionId();
     }
     UploadedRealtimeSegmentName uploadedRealtimeSegmentName = UploadedRealtimeSegmentName.of(segmentName);
     if (uploadedRealtimeSegmentName != null) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/SegmentUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/SegmentUtils.java
@@ -68,15 +68,33 @@ public class SegmentUtils {
 
   /// Returns the partition id of a segment based on segment name.
   /// Can return `null` if the partition id cannot be determined.
+  /// @deprecated Use {@link #getTopicPartitionIdFromSegmentName(String, boolean)} instead.
+  @Deprecated
   @Nullable
   public static Integer getPartitionIdFromSegmentName(String segmentName) {
     LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentName);
     if (llcSegmentName != null) {
-      return llcSegmentName.getTopicPartitionId().getPartitionId();
+      return llcSegmentName.getTopicPartitionId().toMultiTopicPinotPartitionId();
     }
     UploadedRealtimeSegmentName uploadedRealtimeSegmentName = UploadedRealtimeSegmentName.of(segmentName);
     if (uploadedRealtimeSegmentName != null) {
       return uploadedRealtimeSegmentName.getPartitionId();
+    }
+    return null;
+  }
+
+  /// Returns the topic-partition ID of a segment based on segment name.
+  /// Can return {@code null} if the partition ID cannot be determined.
+  @Nullable
+  public static TopicPartitionId getTopicPartitionIdFromSegmentName(
+      String segmentName, boolean hasMultipleStreams) {
+    LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentName, hasMultipleStreams);
+    if (llcSegmentName != null) {
+      return llcSegmentName.getTopicPartitionId();
+    }
+    UploadedRealtimeSegmentName uploadedRealtimeSegmentName = UploadedRealtimeSegmentName.of(segmentName);
+    if (uploadedRealtimeSegmentName != null) {
+      return new TopicPartitionId(uploadedRealtimeSegmentName.getPartitionId());
     }
     return null;
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/TopicPartitionId.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/TopicPartitionId.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.utils;
 
+import com.google.common.base.Preconditions;
 import java.util.Objects;
 
 
@@ -31,6 +32,9 @@ import java.util.Objects;
  * <p>Thread-safe: instances are immutable.
  */
 public final class TopicPartitionId implements Comparable<TopicPartitionId> {
+  // Must match IngestionConfigUtils.PARTITION_PADDING_OFFSET in pinot-spi
+  public static final int PARTITION_PADDING_OFFSET = 10000;
+
   private final int _topicId;
   private final int _partitionId;
 
@@ -72,6 +76,30 @@ public final class TopicPartitionId implements Comparable<TopicPartitionId> {
   @Override
   public int hashCode() {
     return Objects.hash(_topicId, _partitionId);
+  }
+
+  /** Recomposes the composite Pinot partition ID: {@code topicId * 10000 + partitionId}. */
+  public int toMultiTopicPinotPartitionId() {
+    return _topicId * PARTITION_PADDING_OFFSET + _partitionId;
+  }
+
+  /** Decomposes a composite Pinot partition ID into its topic and partition components. */
+  public static TopicPartitionId fromMultiTopicPinotPartitionId(int pinotPartitionId) {
+    Preconditions.checkArgument(pinotPartitionId >= 0, "Negative Pinot partition ID: %s", pinotPartitionId);
+    return new TopicPartitionId(pinotPartitionId / PARTITION_PADDING_OFFSET,
+        pinotPartitionId % PARTITION_PADDING_OFFSET);
+  }
+
+  /**
+   * Wraps a partition group ID from stream metadata into a {@link TopicPartitionId}.
+   * When {@code hasMultipleStreams} is true and the ID is composite-encoded (>= 10000),
+   * decomposes it into topic and partition components.
+   */
+  public static TopicPartitionId fromPartitionGroupMetadata(int partitionGroupId, boolean hasMultipleStreams) {
+    if (hasMultipleStreams && partitionGroupId >= PARTITION_PADDING_OFFSET) {
+      return fromMultiTopicPinotPartitionId(partitionGroupId);
+    }
+    return new TopicPartitionId(partitionGroupId);
   }
 
   @Override

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/TopicPartitionId.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/TopicPartitionId.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils;
+
+import java.util.Objects;
+
+
+/**
+ * Identifies a partition within a (possibly multi-topic) real-time table.
+ *
+ * <p>For single-topic tables, {@code topicId} is 0 and {@code partitionId} is the stream partition number.
+ * For multi-topic tables, {@code topicId} distinguishes the topic and {@code partitionId} is the stream partition
+ * number within that topic.
+ *
+ * <p>Thread-safe: instances are immutable.
+ */
+public final class TopicPartitionId implements Comparable<TopicPartitionId> {
+  private final int _topicId;
+  private final int _partitionId;
+
+  public TopicPartitionId(int topicId, int partitionId) {
+    _topicId = topicId;
+    _partitionId = partitionId;
+  }
+
+  public TopicPartitionId(int partitionId) {
+    this(0, partitionId);
+  }
+
+  public int getTopicId() {
+    return _topicId;
+  }
+
+  public int getPartitionId() {
+    return _partitionId;
+  }
+
+  @Override
+  public int compareTo(TopicPartitionId other) {
+    int cmp = Integer.compare(_topicId, other._topicId);
+    return cmp != 0 ? cmp : Integer.compare(_partitionId, other._partitionId);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof TopicPartitionId)) {
+      return false;
+    }
+    TopicPartitionId that = (TopicPartitionId) o;
+    return _topicId == that._topicId && _partitionId == that._partitionId;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_topicId, _partitionId);
+  }
+
+  @Override
+  public String toString() {
+    return _topicId + ":" + _partitionId;
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/LLCSegmentNameTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/LLCSegmentNameTest.java
@@ -39,7 +39,7 @@ public class LLCSegmentNameTest {
     assertEquals(segmentName, "myTable__0__1__20160609T2142Z");
     assertTrue(LLCSegmentName.isLLCSegment(segmentName));
     assertEquals(llcSegmentName.getTableName(), "myTable");
-    assertEquals(llcSegmentName.getPartitionGroupId(), 0);
+    assertEquals(llcSegmentName.getTopicPartitionId().getPartitionId(), 0);
     assertEquals(llcSegmentName.getSequenceNumber(), 1);
 
     // Invalid segment name
@@ -58,7 +58,7 @@ public class LLCSegmentNameTest {
 
     LLCSegmentName segName1 = new LLCSegmentName(tableName, partitionGroupId, sequenceNumber, msSinceEpoch);
     Assert.assertEquals(segName1.getSegmentName(), segmentName);
-    Assert.assertEquals(segName1.getPartitionGroupId(), partitionGroupId);
+    Assert.assertEquals(segName1.getTopicPartitionId().getPartitionId(), partitionGroupId);
     Assert.assertEquals(segName1.getCreationTime(), creationTime);
     Assert.assertEquals(segName1.getCreationTimeMs(), creationTimeInMs);
     Assert.assertEquals(segName1.getSequenceNumber(), sequenceNumber);
@@ -66,7 +66,7 @@ public class LLCSegmentNameTest {
 
     LLCSegmentName segName2 = new LLCSegmentName(segmentName);
     Assert.assertEquals(segName2.getSegmentName(), segmentName);
-    Assert.assertEquals(segName2.getPartitionGroupId(), partitionGroupId);
+    Assert.assertEquals(segName2.getTopicPartitionId().getPartitionId(), partitionGroupId);
     Assert.assertEquals(segName2.getCreationTime(), creationTime);
     Assert.assertEquals(segName2.getCreationTimeMs(), creationTimeInMs);
     Assert.assertEquals(segName2.getSequenceNumber(), sequenceNumber);

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/LLCSegmentNameTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/LLCSegmentNameTest.java
@@ -95,4 +95,22 @@ public class LLCSegmentNameTest {
     Arrays.sort(testSorted);
     Assert.assertEquals(testSorted, new LLCSegmentName[]{segName5, segName1, segName6, segName3, segName4});
   }
+
+  @Test
+  public void testContextAwareParsing() {
+    // Old format with hasMultipleStreams=true decomposes composite
+    LLCSegmentName withContext = new LLCSegmentName("myTable__10003__5__20250101T0000Z", true);
+    assertEquals(withContext.getTopicPartitionId().getTopicId(), 1);
+    assertEquals(withContext.getTopicPartitionId().getPartitionId(), 3);
+
+    // Old format with hasMultipleStreams=false keeps raw partition
+    LLCSegmentName withoutContext = new LLCSegmentName("myTable__10003__5__20250101T0000Z", false);
+    assertEquals(withoutContext.getTopicPartitionId().getTopicId(), 0);
+    assertEquals(withoutContext.getTopicPartitionId().getPartitionId(), 10003);
+
+    // Small partition ID stays unchanged even with hasMultipleStreams=true
+    LLCSegmentName small = new LLCSegmentName("myTable__5__3__20250101T0000Z", true);
+    assertEquals(small.getTopicPartitionId().getTopicId(), 0);
+    assertEquals(small.getTopicPartitionId().getPartitionId(), 5);
+  }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/TopicPartitionIdTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/TopicPartitionIdTest.java
@@ -97,4 +97,40 @@ public class TopicPartitionIdTest {
     TopicPartitionId id = new TopicPartitionId(2, 7);
     assertEquals(id.toString(), "2:7");
   }
+
+  @Test
+  public void testToMultiTopicPinotPartitionId() {
+    assertEquals(new TopicPartitionId(0, 5).toMultiTopicPinotPartitionId(), 5);
+    assertEquals(new TopicPartitionId(1, 3).toMultiTopicPinotPartitionId(), 10003);
+    assertEquals(new TopicPartitionId(2, 0).toMultiTopicPinotPartitionId(), 20000);
+    assertEquals(new TopicPartitionId(5).toMultiTopicPinotPartitionId(), 5);
+  }
+
+  @Test
+  public void testFromMultiTopicPinotPartitionId() {
+    TopicPartitionId id1 = TopicPartitionId.fromMultiTopicPinotPartitionId(10003);
+    assertEquals(id1.getTopicId(), 1);
+    assertEquals(id1.getPartitionId(), 3);
+
+    TopicPartitionId id2 = TopicPartitionId.fromMultiTopicPinotPartitionId(3);
+    assertEquals(id2.getTopicId(), 0);
+    assertEquals(id2.getPartitionId(), 3);
+
+    TopicPartitionId id3 = TopicPartitionId.fromMultiTopicPinotPartitionId(20000);
+    assertEquals(id3.getTopicId(), 2);
+    assertEquals(id3.getPartitionId(), 0);
+  }
+
+  @Test
+  public void testRoundTrip() {
+    TopicPartitionId original = new TopicPartitionId(1, 3);
+    TopicPartitionId roundTripped =
+        TopicPartitionId.fromMultiTopicPinotPartitionId(original.toMultiTopicPinotPartitionId());
+    assertEquals(roundTripped, original);
+
+    TopicPartitionId singleTopic = new TopicPartitionId(0, 42);
+    TopicPartitionId roundTripped2 =
+        TopicPartitionId.fromMultiTopicPinotPartitionId(singleTopic.toMultiTopicPinotPartitionId());
+    assertEquals(roundTripped2, singleTopic);
+  }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/TopicPartitionIdTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/TopicPartitionIdTest.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+
+
+public class TopicPartitionIdTest {
+
+  @Test
+  public void testSingleArgConstructor() {
+    TopicPartitionId id = new TopicPartitionId(5);
+    assertEquals(id.getTopicId(), 0);
+    assertEquals(id.getPartitionId(), 5);
+  }
+
+  @Test
+  public void testTwoArgConstructor() {
+    TopicPartitionId id = new TopicPartitionId(2, 7);
+    assertEquals(id.getTopicId(), 2);
+    assertEquals(id.getPartitionId(), 7);
+  }
+
+  @Test
+  public void testEquality() {
+    TopicPartitionId id1 = new TopicPartitionId(1, 3);
+    TopicPartitionId id2 = new TopicPartitionId(1, 3);
+    TopicPartitionId id3 = new TopicPartitionId(1, 4);
+    TopicPartitionId id4 = new TopicPartitionId(2, 3);
+
+    assertEquals(id1, id2);
+    assertEquals(id1.hashCode(), id2.hashCode());
+    assertNotEquals(id1, id3);
+    assertNotEquals(id1, id4);
+  }
+
+  @Test
+  public void testSingleArgEqualsZeroTopic() {
+    TopicPartitionId id1 = new TopicPartitionId(5);
+    TopicPartitionId id2 = new TopicPartitionId(0, 5);
+    assertEquals(id1, id2);
+    assertEquals(id1.hashCode(), id2.hashCode());
+  }
+
+  @Test
+  public void testCompareTo() {
+    TopicPartitionId a = new TopicPartitionId(0, 1);
+    TopicPartitionId b = new TopicPartitionId(0, 2);
+    TopicPartitionId c = new TopicPartitionId(1, 0);
+    TopicPartitionId d = new TopicPartitionId(1, 1);
+
+    assertTrue(a.compareTo(b) < 0);
+    assertTrue(b.compareTo(a) > 0);
+    assertTrue(a.compareTo(c) < 0);
+    assertTrue(c.compareTo(d) < 0);
+    assertEquals(a.compareTo(new TopicPartitionId(0, 1)), 0);
+  }
+
+  @Test
+  public void testAsMapKey() {
+    Map<TopicPartitionId, String> map = new HashMap<>();
+    TopicPartitionId id1 = new TopicPartitionId(1, 3);
+    map.put(id1, "value1");
+
+    TopicPartitionId id2 = new TopicPartitionId(1, 3);
+    assertEquals(map.get(id2), "value1");
+
+    assertFalse(map.containsKey(new TopicPartitionId(1, 4)));
+    assertFalse(map.containsKey(new TopicPartitionId(2, 3)));
+  }
+
+  @Test
+  public void testToString() {
+    TopicPartitionId id = new TopicPartitionId(2, 7);
+    assertEquals(id.toString(), "2:7");
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -1124,7 +1124,7 @@ public class PinotSegmentRestletResource {
         LOGGER.info("Skip segment: {} not in low-level consumer format", segmentName);
         continue;
       }
-      int partitionId = llcSegmentName.getPartitionGroupId();
+      int partitionId = llcSegmentName.getTopicPartitionId().getPartitionId();
 
       LLCSegmentName oldestSegment = partitionToOldestSegment.get(partitionId);
       if (oldestSegment == null) {
@@ -1163,7 +1163,7 @@ public class PinotSegmentRestletResource {
         LOGGER.warn("Segment: {} is not present in the ideal state", segment);
         continue;
       }
-      int partitionId = llcSegmentName.getPartitionGroupId();
+      int partitionId = llcSegmentName.getTopicPartitionId().getPartitionId();
 
       LLCSegmentName currentOldest = partitionToOldestSegment.get(partitionId);
       if (currentOldest == null || llcSegmentName.getSequenceNumber() < currentOldest.getSequenceNumber()) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -73,6 +73,7 @@ import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.PauselessConsumptionUtils;
+import org.apache.pinot.common.utils.TopicPartitionId;
 import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.common.utils.UploadedRealtimeSegmentName;
 import org.apache.pinot.controller.ControllerConf;
@@ -1046,17 +1047,17 @@ public class PinotSegmentRestletResource {
     Preconditions.checkState(idealState != null, "Ideal State does not exist for table " + tableNameWithType);
 
     Set<String> idealStateSegmentsSet = idealState.getRecord().getMapFields().keySet();
-    Map<Integer, LLCSegmentName> partitionToOldestSegment =
+    Map<TopicPartitionId, LLCSegmentName> partitionToOldestSegment =
         getPartitionIDToOldestSegment(segments, idealStateSegmentsSet);
-    Map<Integer, LLCSegmentName> partitionIdToLatestSegment = new HashMap<>();
-    Map<Integer, Set<String>> partitionIdToSegmentsToDeleteMap =
-        getPartitionIdToSegmentsToDeleteMap(partitionToOldestSegment, idealStateSegmentsSet,
-            partitionIdToLatestSegment);
+    Map<TopicPartitionId, LLCSegmentName> partitionIdToLatestSegment = new HashMap<>();
+    Map<TopicPartitionId, Set<String>> partitionIdToSegmentsToDeleteMap =
+        getPartitionIdToSegmentsToDeleteMap(partitionToOldestSegment,
+            idealStateSegmentsSet, partitionIdToLatestSegment);
 
     Map<String, Object> response = new HashMap<>();
-    Map<Integer, Object> partitionDetails = new HashMap<>();
+    Map<TopicPartitionId, Object> partitionDetails = new HashMap<>();
 
-    for (Integer partitionID : partitionToOldestSegment.keySet()) {
+    for (TopicPartitionId partitionID : partitionToOldestSegment.keySet()) {
       Set<String> segmentsToDeleteForPartition = partitionIdToSegmentsToDeleteMap.get(partitionID);
       LLCSegmentName oldestSegment = partitionToOldestSegment.get(partitionID);
       LLCSegmentName latestSegment = partitionIdToLatestSegment.get(partitionID);
@@ -1111,12 +1112,13 @@ public class PinotSegmentRestletResource {
    *         for that particular partition.
    */
   @VisibleForTesting
-  Map<Integer, Set<String>> getPartitionIdToSegmentsToDeleteMap(
-      Map<Integer, LLCSegmentName> partitionToOldestSegment,
-      Set<String> idealStateSegmentsSet, Map<Integer, LLCSegmentName> partitionIdToLatestSegment) {
+  Map<TopicPartitionId, Set<String>> getPartitionIdToSegmentsToDeleteMap(
+      Map<TopicPartitionId, LLCSegmentName> partitionToOldestSegment,
+      Set<String> idealStateSegmentsSet,
+      Map<TopicPartitionId, LLCSegmentName> partitionIdToLatestSegment) {
 
     // Find segments to delete (those with higher sequence numbers)
-    Map<Integer, Set<String>> partitionToSegmentsToDelete = new HashMap<>();
+    Map<TopicPartitionId, Set<String>> partitionToSegmentsToDelete = new HashMap<>();
 
     for (String segmentName : idealStateSegmentsSet) {
       LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentName);
@@ -1124,7 +1126,7 @@ public class PinotSegmentRestletResource {
         LOGGER.info("Skip segment: {} not in low-level consumer format", segmentName);
         continue;
       }
-      int partitionId = llcSegmentName.getTopicPartitionId().getPartitionId();
+      TopicPartitionId partitionId = llcSegmentName.getTopicPartitionId();
 
       LLCSegmentName oldestSegment = partitionToOldestSegment.get(partitionId);
       if (oldestSegment == null) {
@@ -1148,8 +1150,9 @@ public class PinotSegmentRestletResource {
   }
 
   @VisibleForTesting
-  Map<Integer, LLCSegmentName> getPartitionIDToOldestSegment(List<String> segments, Set<String> idealStateSegmentsSet) {
-    Map<Integer, LLCSegmentName> partitionToOldestSegment = new HashMap<>();
+  Map<TopicPartitionId, LLCSegmentName> getPartitionIDToOldestSegment(
+      List<String> segments, Set<String> idealStateSegmentsSet) {
+    Map<TopicPartitionId, LLCSegmentName> partitionToOldestSegment = new HashMap<>();
 
     for (String segment : segments) {
       LLCSegmentName llcSegmentName = LLCSegmentName.of(segment);
@@ -1163,7 +1166,7 @@ public class PinotSegmentRestletResource {
         LOGGER.warn("Segment: {} is not present in the ideal state", segment);
         continue;
       }
-      int partitionId = llcSegmentName.getTopicPartitionId().getPartitionId();
+      TopicPartitionId partitionId = llcSegmentName.getTopicPartitionId();
 
       LLCSegmentName currentOldest = partitionToOldestSegment.get(partitionId);
       if (currentOldest == null || llcSegmentName.getSequenceNumber() < currentOldest.getSequenceNumber()) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableViews.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableViews.java
@@ -217,7 +217,8 @@ public class TableViews {
         if (llcSegmentName == null) {
           continue;
         }
-        partitionIdToSegments.computeIfAbsent(llcSegmentName.getPartitionGroupId(), k -> new TreeSet<>())
+        partitionIdToSegments.computeIfAbsent(
+            llcSegmentName.getTopicPartitionId().getPartitionId(), k -> new TreeSet<>())
             .add(llcSegmentName);
       }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableViews.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableViews.java
@@ -57,6 +57,7 @@ import org.apache.pinot.common.lineage.SegmentLineageAccessHelper;
 import org.apache.pinot.common.lineage.SegmentLineageUtils;
 import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.TopicPartitionId;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.core.auth.Actions;
@@ -210,7 +211,7 @@ public class TableViews {
         return JsonUtils.objectToPrettyString(new HashMap<>());
       }
 
-      Map<Integer, SortedSet<LLCSegmentName>> partitionIdToSegments = new HashMap<>();
+      Map<TopicPartitionId, SortedSet<LLCSegmentName>> partitionIdToSegments = new HashMap<>();
       for (SegmentStatusInfo segmentStatusInfo : segmentStatusInfoList) {
         String segmentName = segmentStatusInfo.getSegmentName();
         LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentName);
@@ -218,7 +219,7 @@ public class TableViews {
           continue;
         }
         partitionIdToSegments.computeIfAbsent(
-            llcSegmentName.getTopicPartitionId().getPartitionId(), k -> new TreeSet<>())
+            llcSegmentName.getTopicPartitionId(), k -> new TreeSet<>())
             .add(llcSegmentName);
       }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -131,6 +131,7 @@ import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.common.utils.HashUtil;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.LogicalTableConfigUtils;
+import org.apache.pinot.common.utils.TopicPartitionId;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.common.utils.config.AccessControlUserConfigUtils;
 import org.apache.pinot.common.utils.config.InstanceUtils;
@@ -1156,7 +1157,7 @@ public class PinotHelixResourceManager {
   /// segments of a table and want to derive the last-completed LLC segment per partition without
   /// re-reading the property store).
   public Collection<String> getLastLLCCompletedSegments(List<? extends SegmentZKMetadata> segmentZKMetadataList) {
-    Map<Integer, String> partitionIdToLastLLCCompletedSegmentMap = new HashMap<>();
+    Map<TopicPartitionId, String> partitionIdToLastLLCCompletedSegmentMap = new HashMap<>();
     for (SegmentZKMetadata zkMetadata : segmentZKMetadataList) {
       if (zkMetadata.getStatus() == CommonConstants.Segment.Realtime.Status.DONE) {
         LLCSegmentName llcName = LLCSegmentName.of(zkMetadata.getSegmentName());
@@ -1164,7 +1165,7 @@ public class PinotHelixResourceManager {
           // llcName can be null if the segment is uploaded through offline ingestion
           continue;
         }
-        int partitionGroupId = llcName.getTopicPartitionId().getPartitionId();
+        TopicPartitionId partitionGroupId = llcName.getTopicPartitionId();
         int sequenceNumber = llcName.getSequenceNumber();
         String lastCompletedSegName = partitionIdToLastLLCCompletedSegmentMap.get(partitionGroupId);
         if (lastCompletedSegName == null

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1164,7 +1164,7 @@ public class PinotHelixResourceManager {
           // llcName can be null if the segment is uploaded through offline ingestion
           continue;
         }
-        int partitionGroupId = llcName.getPartitionGroupId();
+        int partitionGroupId = llcName.getTopicPartitionId().getPartitionId();
         int sequenceNumber = llcName.getSequenceNumber();
         String lastCompletedSegName = partitionIdToLastLLCCompletedSegmentMap.get(partitionGroupId);
         if (lastCompletedSegName == null

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/BaseStrictRealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/BaseStrictRealtimeSegmentAssignment.java
@@ -115,7 +115,7 @@ public abstract class BaseStrictRealtimeSegmentAssignment extends RealtimeSegmen
         uploadedSegments.add(entry.getKey());
         continue;
       }
-      if (llcSegmentName.getPartitionGroupId() == partitionId) {
+      if (llcSegmentName.getTopicPartitionId().getPartitionId() == partitionId) {
         return entry.getValue().keySet();
       }
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/BaseStrictRealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/BaseStrictRealtimeSegmentAssignment.java
@@ -19,8 +19,8 @@
 package org.apache.pinot.controller.helix.core.assignment.segment;
 
 import com.google.common.base.Preconditions;
-import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -29,8 +29,10 @@ import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.SegmentUtils;
+import org.apache.pinot.common.utils.TopicPartitionId;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 
 
 /**
@@ -66,7 +68,7 @@ public abstract class BaseStrictRealtimeSegmentAssignment extends RealtimeSegmen
   //    Replacing a segment with a segment from a different partition should not be allowed for upsert/dedup table
   //    because it will cause the segment being served by the wrong servers. If this happens during the table
   //    rebalance, another rebalance might be needed to fix the assignment.
-  private final Object2IntOpenHashMap<String> _segmentPartitionIdMap = new Object2IntOpenHashMap<>();
+  private final Map<String, TopicPartitionId> _segmentPartitionIdMap = new HashMap<>();
 
   @Override
   public List<String> assignSegment(String segmentName, Map<String, Map<String, String>> currentAssignment,
@@ -78,8 +80,9 @@ public abstract class BaseStrictRealtimeSegmentAssignment extends RealtimeSegmen
     _logger.info("Assigning segment: {} with instance partitions: {} for table: {}", segmentName, instancePartitions,
         _tableNameWithType);
 
-    int partitionId = getPartitionId(segmentName);
-    List<String> instancesAssigned = assignConsumingSegment(partitionId, instancePartitions);
+    TopicPartitionId partitionId = getPartitionId(segmentName);
+    List<String> instancesAssigned = assignConsumingSegment(
+        partitionId, instancePartitions);
     Set<String> existingAssignment = getExistingAssignment(partitionId, currentAssignment);
     // Check if the candidate assignment is consistent with existing assignment. Use existing assignment if not.
     if (existingAssignment == null) {
@@ -103,7 +106,8 @@ public abstract class BaseStrictRealtimeSegmentAssignment extends RealtimeSegmen
    * partition. We try to derive the partition id from segment name to avoid ZK reads.
    */
   @Nullable
-  protected Set<String> getExistingAssignment(int partitionId, Map<String, Map<String, String>> currentAssignment) {
+  protected Set<String> getExistingAssignment(TopicPartitionId partitionId,
+      Map<String, Map<String, String>> currentAssignment) {
     List<String> uploadedSegments = new ArrayList<>();
     for (Map.Entry<String, Map<String, String>> entry : currentAssignment.entrySet()) {
       // Skip OFFLINE segments as they are not rebalanced, so their assignment in idealState can be stale.
@@ -115,13 +119,13 @@ public abstract class BaseStrictRealtimeSegmentAssignment extends RealtimeSegmen
         uploadedSegments.add(entry.getKey());
         continue;
       }
-      if (llcSegmentName.getTopicPartitionId().getPartitionId() == partitionId) {
+      if (llcSegmentName.getTopicPartitionId().equals(partitionId)) {
         return entry.getValue().keySet();
       }
     }
     // Check ZK metadata for uploaded segments to look for a segment that's in the same partition
     for (String uploadedSegment : uploadedSegments) {
-      if (getPartitionId(uploadedSegment) == partitionId) {
+      if (getPartitionId(uploadedSegment).equals(partitionId)) {
         return currentAssignment.get(uploadedSegment).keySet();
       }
     }
@@ -139,12 +143,15 @@ public abstract class BaseStrictRealtimeSegmentAssignment extends RealtimeSegmen
   /**
    * Returns the partition id of the given segment.
    */
-  private int getPartitionId(String segmentName) {
+  private TopicPartitionId getPartitionId(String segmentName) {
     Integer partitionId =
         SegmentUtils.getSegmentPartitionId(segmentName, _tableNameWithType, _helixManager, _partitionColumn);
     Preconditions.checkState(partitionId != null, "Failed to find partition id for segment: %s of table: %s",
         segmentName, _tableNameWithType);
-    return partitionId;
+    boolean hasMultipleStreams =
+        IngestionConfigUtils.hasMultipleStreams(_tableConfig);
+    return TopicPartitionId.fromPartitionGroupMetadata(
+        partitionId, hasMultipleStreams);
   }
 
   /**
@@ -157,7 +164,8 @@ public abstract class BaseStrictRealtimeSegmentAssignment extends RealtimeSegmen
   /**
    * Returns the partition id of the given segment, using cached partition id if exists.
    */
-  protected int getPartitionIdUsingCache(String segmentName) {
-    return _segmentPartitionIdMap.computeIntIfAbsent(segmentName, this::getPartitionId);
+  protected TopicPartitionId getPartitionIdUsingCache(String segmentName) {
+    return _segmentPartitionIdMap.computeIfAbsent(segmentName,
+        this::getPartitionId);
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/MultiTierStrictRealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/MultiTierStrictRealtimeSegmentAssignment.java
@@ -107,7 +107,7 @@ public class MultiTierStrictRealtimeSegmentAssignment extends BaseStrictRealtime
       if (llcSegmentName == null) {
         continue;
       }
-      if (llcSegmentName.getPartitionGroupId() == partitionId && (latestLLCSegmentName == null
+      if (llcSegmentName.getTopicPartitionId().getPartitionId() == partitionId && (latestLLCSegmentName == null
           || llcSegmentName.getSequenceNumber() > latestLLCSegmentName.getSequenceNumber())) {
         latestLLCSegmentName = llcSegmentName;
         latestAssignment = entry.getValue().keySet();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/MultiTierStrictRealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/MultiTierStrictRealtimeSegmentAssignment.java
@@ -32,6 +32,7 @@ import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.restlet.resources.RebalanceConfig;
 import org.apache.pinot.common.tier.Tier;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.TopicPartitionId;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.utils.CommonConstants;
 
@@ -72,7 +73,9 @@ public class MultiTierStrictRealtimeSegmentAssignment extends BaseStrictRealtime
       } else {
         // Reassign CONSUMING and COMPLETED segments
         List<String> instancesAssigned =
-            assignConsumingSegment(getPartitionIdUsingCache(segmentName), instancePartitions);
+            assignConsumingSegment(
+                getPartitionIdUsingCache(segmentName),
+                instancePartitions);
         String state = instanceStateMap.containsValue(CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING)
             ? CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING
             : CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE;
@@ -96,7 +99,8 @@ public class MultiTierStrictRealtimeSegmentAssignment extends BaseStrictRealtime
    */
   @Nullable
   @Override
-  protected Set<String> getExistingAssignment(int partitionId, Map<String, Map<String, String>> currentAssignment) {
+  protected Set<String> getExistingAssignment(TopicPartitionId partitionId,
+      Map<String, Map<String, String>> currentAssignment) {
     LLCSegmentName latestLLCSegmentName = null;
     Set<String> latestAssignment = null;
     for (Map.Entry<String, Map<String, String>> entry : currentAssignment.entrySet()) {
@@ -107,7 +111,8 @@ public class MultiTierStrictRealtimeSegmentAssignment extends BaseStrictRealtime
       if (llcSegmentName == null) {
         continue;
       }
-      if (llcSegmentName.getTopicPartitionId().getPartitionId() == partitionId && (latestLLCSegmentName == null
+      if (llcSegmentName.getTopicPartitionId().equals(partitionId)
+          && (latestLLCSegmentName == null
           || llcSegmentName.getSequenceNumber() > latestLLCSegmentName.getSequenceNumber())) {
         latestLLCSegmentName = llcSegmentName;
         latestAssignment = entry.getValue().keySet();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeSegmentAssignment.java
@@ -33,6 +33,7 @@ import org.apache.pinot.common.restlet.resources.RebalanceConfig;
 import org.apache.pinot.common.tier.Tier;
 import org.apache.pinot.common.utils.PauselessConsumptionUtils;
 import org.apache.pinot.common.utils.SegmentUtils;
+import org.apache.pinot.common.utils.TopicPartitionId;
 import org.apache.pinot.controller.helix.core.assignment.segment.strategy.SegmentAssignmentStrategy;
 import org.apache.pinot.controller.helix.core.assignment.segment.strategy.SegmentAssignmentStrategyFactory;
 import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
@@ -112,14 +113,15 @@ public class RealtimeSegmentAssignment extends BaseSegmentAssignment {
   private List<String> assignConsumingSegment(String segmentName, InstancePartitions instancePartitions) {
     int segmentPartitionId =
         SegmentUtils.getSegmentPartitionIdOrDefault(segmentName, _tableNameWithType, _helixManager, _partitionColumn);
-    return assignConsumingSegment(segmentPartitionId, instancePartitions);
+    boolean hasMultipleStreams = IngestionConfigUtils.hasMultipleStreams(_tableConfig);
+    TopicPartitionId topicPartitionId =
+        TopicPartitionId.fromPartitionGroupMetadata(segmentPartitionId, hasMultipleStreams);
+    return assignConsumingSegment(topicPartitionId, instancePartitions);
   }
 
-  protected List<String> assignConsumingSegment(int segmentPartitionId, InstancePartitions instancePartitions) {
-    // For multi-stream tables, Pinot partition IDs are encoded as (streamIndex * 10000 + streamPartitionId).
-    // Extract the stream-level partition id before computing the instance index to avoid incorrect slot mapping.
-    segmentPartitionId =
-        IngestionConfigUtils.getStreamPartitionIdFromPinotPartitionId(_tableConfig, segmentPartitionId);
+  protected List<String> assignConsumingSegment(TopicPartitionId topicPartitionId,
+      InstancePartitions instancePartitions) {
+    int segmentPartitionId = topicPartitionId.getPartitionId();
 
     int numReplicaGroups = instancePartitions.getNumReplicaGroups();
     int numPartitions = instancePartitions.getNumPartitions();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SingleTierStrictRealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SingleTierStrictRealtimeSegmentAssignment.java
@@ -64,7 +64,8 @@ public class SingleTierStrictRealtimeSegmentAssignment extends BaseStrictRealtim
       } else {
         // Reassign CONSUMING and COMPLETED segments
         List<String> instancesAssigned =
-            assignConsumingSegment(getPartitionIdUsingCache(segmentName), instancePartitions);
+            assignConsumingSegment(getPartitionIdUsingCache(segmentName),
+                instancePartitions);
         String state = instanceStateMap.containsValue(SegmentStateModel.CONSUMING) ? SegmentStateModel.CONSUMING
             : SegmentStateModel.ONLINE;
         newAssignment.put(segmentName, SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, state));

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinder.java
@@ -37,6 +37,7 @@ import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.TopicPartitionId;
 import org.apache.pinot.controller.helix.core.PinotTableIdealStateBuilder;
 import org.apache.pinot.spi.config.table.PauseState;
 import org.apache.pinot.spi.stream.OffsetCriteria;
@@ -63,7 +64,7 @@ public class MissingConsumingSegmentFinder {
 
   private final String _realtimeTableName;
   private final SegmentMetadataFetcher _segmentMetadataFetcher;
-  private final Map<Integer, StreamPartitionMsgOffset> _partitionGroupIdToLargestStreamOffsetMap;
+  private final Map<TopicPartitionId, StreamPartitionMsgOffset> _partitionGroupIdToLargestStreamOffsetMap;
   private final StreamPartitionMsgOffsetFactory _streamPartitionMsgOffsetFactory;
 
   private ControllerMetrics _controllerMetrics;
@@ -87,8 +88,12 @@ public class MissingConsumingSegmentFinder {
       PinotTableIdealStateBuilder.getStreamMetadataList(streamConfigs, List.of(),
               pauseState == null ? new ArrayList<>() : pauseState.getIndexOfInactiveTopics(), false)
           .forEach(streamMetadata -> {
+            boolean hasMultipleStreams = streamConfigs.size() > 1;
             for (PartitionGroupMetadata metadata : streamMetadata.getPartitionGroupMetadataList()) {
-              _partitionGroupIdToLargestStreamOffsetMap.put(metadata.getPartitionGroupId(), metadata.getStartOffset());
+              _partitionGroupIdToLargestStreamOffsetMap.put(
+                  TopicPartitionId.fromPartitionGroupMetadata(
+                      metadata.getPartitionGroupId(), hasMultipleStreams),
+                  metadata.getStartOffset());
             }
           });
     } catch (Exception e) {
@@ -101,7 +106,7 @@ public class MissingConsumingSegmentFinder {
 
   @VisibleForTesting
   MissingConsumingSegmentFinder(String realtimeTableName, SegmentMetadataFetcher segmentMetadataFetcher,
-      Map<Integer, StreamPartitionMsgOffset> partitionGroupIdToLargestStreamOffsetMap,
+      Map<TopicPartitionId, StreamPartitionMsgOffset> partitionGroupIdToLargestStreamOffsetMap,
       StreamPartitionMsgOffsetFactory streamPartitionMsgOffsetFactory) {
     _realtimeTableName = realtimeTableName;
     _segmentMetadataFetcher = segmentMetadataFetcher;
@@ -124,8 +129,8 @@ public class MissingConsumingSegmentFinder {
   @VisibleForTesting
   MissingSegmentInfo findMissingSegments(Map<String, Map<String, String>> idealStateMap, Instant now) {
     // create the maps
-    Map<Integer, LLCSegmentName> partitionGroupIdToLatestConsumingSegmentMap = new HashMap<>();
-    Map<Integer, LLCSegmentName> partitionGroupIdToLatestCompletedSegmentMap = new HashMap<>();
+    Map<TopicPartitionId, LLCSegmentName> partitionGroupIdToLatestConsumingSegmentMap = new HashMap<>();
+    Map<TopicPartitionId, LLCSegmentName> partitionGroupIdToLatestCompletedSegmentMap = new HashMap<>();
     idealStateMap.forEach((segmentName, instanceToStatusMap) -> {
       LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentName);
       if (llcSegmentName != null) { // Skip the uploaded realtime segments that don't conform to llc naming
@@ -176,7 +181,7 @@ public class MissingConsumingSegmentFinder {
     return missingSegmentInfo;
   }
 
-  private void updateMaxDurationInfo(MissingSegmentInfo missingSegmentInfo, Integer partitionGroupId,
+  private void updateMaxDurationInfo(MissingSegmentInfo missingSegmentInfo, TopicPartitionId partitionGroupId,
       long segmentCompletionTimeMillis, Instant now) {
     long duration = Duration.between(Instant.ofEpochMilli(segmentCompletionTimeMillis), now).toMinutes();
     if (duration > missingSegmentInfo._maxDurationInMinutes) {
@@ -185,9 +190,9 @@ public class MissingConsumingSegmentFinder {
     LOGGER.warn("PartitionGroupId {} hasn't had a consuming segment for {} minutes!", partitionGroupId, duration);
   }
 
-  private void updateMap(Map<Integer, LLCSegmentName> partitionGroupIdToLatestSegmentMap,
+  private void updateMap(Map<TopicPartitionId, LLCSegmentName> partitionGroupIdToLatestSegmentMap,
       LLCSegmentName llcSegmentName) {
-    int partitionGroupId = llcSegmentName.getTopicPartitionId().getPartitionId();
+    TopicPartitionId partitionGroupId = llcSegmentName.getTopicPartitionId();
     partitionGroupIdToLatestSegmentMap.compute(partitionGroupId, (pid, existingSegment) -> {
       if (existingSegment == null) {
         return llcSegmentName;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinder.java
@@ -187,7 +187,7 @@ public class MissingConsumingSegmentFinder {
 
   private void updateMap(Map<Integer, LLCSegmentName> partitionGroupIdToLatestSegmentMap,
       LLCSegmentName llcSegmentName) {
-    int partitionGroupId = llcSegmentName.getPartitionGroupId();
+    int partitionGroupId = llcSegmentName.getTopicPartitionId().getPartitionId();
     partitionGroupIdToLatestSegmentMap.compute(partitionGroupId, (pid, existingSegment) -> {
       if (existingSegment == null) {
         return llcSegmentName;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -85,6 +85,7 @@ import org.apache.pinot.common.restlet.resources.TableLLCSegmentUploadResponse;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.PauselessConsumptionUtils;
+import org.apache.pinot.common.utils.TopicPartitionId;
 import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.common.utils.helix.IdealStateSingleCommit;
@@ -272,7 +273,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     List<PartitionGroupConsumptionStatus> partitionGroupConsumptionStatusList = new ArrayList<>();
 
     // From all segment names in the ideal state, find unique partition group ids and their latest segment
-    Map<Integer, LLCSegmentName> partitionGroupIdToLatestSegment = new HashMap<>();
+    Map<TopicPartitionId, LLCSegmentName> partitionGroupIdToLatestSegment = new HashMap<>();
     for (String segment : idealState.getRecord().getMapFields().keySet()) {
       // With Pinot upsert table allowing uploads of segments, the segment name of an upsert table segment may not
       // conform to LLCSegment format. We can skip such segments because they are NOT the consuming segments.
@@ -280,7 +281,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
       if (llcSegmentName == null) {
         continue;
       }
-      int partitionGroupId = llcSegmentName.getTopicPartitionId().getPartitionId();
+      TopicPartitionId partitionGroupId = llcSegmentName.getTopicPartitionId();
       partitionGroupIdToLatestSegment.compute(partitionGroupId, (k, latestSegment) -> {
         if (latestSegment == null) {
           return llcSegmentName;
@@ -301,12 +302,13 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
       StreamConfig streamConfig = streamConfigs.get(0);
       StreamPartitionMsgOffsetFactory offsetFactory =
           StreamConsumerFactoryProvider.create(streamConfig).createStreamMsgOffsetFactory();
-      for (Map.Entry<Integer, LLCSegmentName> entry : partitionGroupIdToLatestSegment.entrySet()) {
-        int partitionGroupId = entry.getKey();
+      for (Map.Entry<TopicPartitionId, LLCSegmentName> entry : partitionGroupIdToLatestSegment.entrySet()) {
+        TopicPartitionId partitionGroupId = entry.getKey();
         LLCSegmentName llcSegmentName = entry.getValue();
         SegmentZKMetadata segmentZKMetadata = getSegmentZKMetadata(tableNameWithType, llcSegmentName.getSegmentName());
         PartitionGroupConsumptionStatus partitionGroupConsumptionStatus =
-            new PartitionGroupConsumptionStatus(partitionGroupId, llcSegmentName.getSequenceNumber(),
+            new PartitionGroupConsumptionStatus(partitionGroupId.toMultiTopicPinotPartitionId(),
+                llcSegmentName.getSequenceNumber(),
                 offsetFactory.create(segmentZKMetadata.getStartOffset()),
                 segmentZKMetadata.getEndOffset() != null ? offsetFactory.create(segmentZKMetadata.getEndOffset())
                     : null, segmentZKMetadata.getStatus().toString());
@@ -315,10 +317,10 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     } else {
       // Multiple streams
       StreamPartitionMsgOffsetFactory[] offsetFactories = new StreamPartitionMsgOffsetFactory[numStreams];
-      for (Map.Entry<Integer, LLCSegmentName> entry : partitionGroupIdToLatestSegment.entrySet()) {
-        int partitionGroupId = entry.getKey();
-        int index = IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(partitionGroupId);
-        int streamPartitionId = IngestionConfigUtils.getStreamPartitionIdFromPinotPartitionId(partitionGroupId);
+      for (Map.Entry<TopicPartitionId, LLCSegmentName> entry : partitionGroupIdToLatestSegment.entrySet()) {
+        TopicPartitionId partitionGroupId = entry.getKey();
+        int index = partitionGroupId.getTopicId();
+        int streamPartitionId = partitionGroupId.getPartitionId();
         LLCSegmentName llcSegmentName = entry.getValue();
         SegmentZKMetadata segmentZKMetadata = getSegmentZKMetadata(tableNameWithType, llcSegmentName.getSegmentName());
         StreamPartitionMsgOffsetFactory offsetFactory = offsetFactories[index];
@@ -327,7 +329,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
           offsetFactories[index] = offsetFactory;
         }
         PartitionGroupConsumptionStatus partitionGroupConsumptionStatus =
-            new PartitionGroupConsumptionStatus(partitionGroupId, streamPartitionId, llcSegmentName.getSequenceNumber(),
+            new PartitionGroupConsumptionStatus(partitionGroupId.toMultiTopicPinotPartitionId(), streamPartitionId,
+                llcSegmentName.getSequenceNumber(),
                 offsetFactory.create(segmentZKMetadata.getStartOffset()),
                 segmentZKMetadata.getEndOffset() != null ? offsetFactory.create(segmentZKMetadata.getEndOffset())
                     : null, segmentZKMetadata.getStatus().toString());
@@ -837,12 +840,12 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
 
     String newConsumingSegmentName = null;
     LLCSegmentName committingLLCSegment = new LLCSegmentName(committingSegmentName);
-    int committingSegmentPartitionGroupId = committingLLCSegment.getTopicPartitionId().getPartitionId();
+    TopicPartitionId committingSegmentPartitionGroupId = committingLLCSegment.getTopicPartitionId();
 
     List<StreamConfig> streamConfigs = IngestionConfigUtils.getStreamConfigs(tableConfig);
     PartitionIdsWithIdealState partitionIdsWithIdealState = getPartitionIdsWithIdealState(streamConfigs,
         () -> getIdealState(realtimeTableName));
-    Set<Integer> partitionIds = partitionIdsWithIdealState._partitionIds;
+    Set<TopicPartitionId> partitionIds = partitionIdsWithIdealState._partitionIds;
 
     if (partitionIds.contains(committingSegmentPartitionGroupId)) {
       IdealState idealState = partitionIdsWithIdealState._idealState;
@@ -857,11 +860,11 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
       }
       String rawTableName = TableNameBuilder.extractRawTableName(realtimeTableName);
       long newSegmentCreationTimeMs = getCurrentTimeMs();
-      LLCSegmentName newLLCSegment = new LLCSegmentName(rawTableName, committingSegmentPartitionGroupId,
+      LLCSegmentName newLLCSegment = new LLCSegmentName(rawTableName,
+          committingSegmentPartitionGroupId.toMultiTopicPinotPartitionId(),
           committingLLCSegment.getSequenceNumber() + 1, newSegmentCreationTimeMs);
 
-      StreamConfig streamConfig =
-          IngestionConfigUtils.getStreamConfigFromPinotPartitionId(streamConfigs, committingSegmentPartitionGroupId);
+      StreamConfig streamConfig = streamConfigs.get(committingSegmentPartitionGroupId.getTopicId());
       createNewSegmentZKMetadata(tableConfig, streamConfig, newLLCSegment, newSegmentCreationTimeMs,
           committingSegmentDescriptor, committingSegmentZKMetadata, instancePartitions, partitionIds.size(),
           numReplicas);
@@ -1008,7 +1011,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     // Handle offset auto reset
     String nextOffset = committingSegmentDescriptor.getNextOffset();
     String startOffset = computeStartOffset(nextOffset, streamConfig,
-        newLLCSegmentName.getTopicPartitionId().getPartitionId());
+        newLLCSegmentName.getTopicPartitionId());
     if (!startOffset.equals(nextOffset)) {
       _controllerMetrics.addMeteredTableValue(realtimeTableName, ControllerMeter.OFFSET_AUTO_RESET_SKIPPED_OFFSETS,
           Long.parseLong(startOffset) - Long.parseLong(nextOffset));
@@ -1036,7 +1039,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     // Add the partition metadata if available
     SegmentPartitionMetadata partitionMetadata =
         getPartitionMetadataFromTableConfig(tableConfig,
-            newLLCSegmentName.getTopicPartitionId().getPartitionId(), numPartitions);
+            newLLCSegmentName.getTopicPartitionId(), numPartitions);
     if (partitionMetadata != null) {
       newSegmentZKMetadata.setPartitionMetadata(partitionMetadata);
     }
@@ -1074,7 +1077,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
         ControllerGauge.NUM_ROWS_THRESHOLD_WITH_TOPIC, flushThreshold);
   }
 
-  private String computeStartOffset(String nextOffset, StreamConfig streamConfig, int partitionId) {
+  private String computeStartOffset(String nextOffset, StreamConfig streamConfig, TopicPartitionId topicPartitionId) {
     if (!streamConfig.isEnableOffsetAutoReset() || streamConfig.isBackfillTopic()) {
       return nextOffset;
     }
@@ -1087,7 +1090,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
           timeThreshold, offsetThreshold);
       return nextOffset;
     }
-    int streamPartitionId = IngestionConfigUtils.getStreamPartitionIdFromPinotPartitionId(partitionId);
+    int streamPartitionId = topicPartitionId.getPartitionId();
     String clientId = getTableTopicUniqueClientId(streamConfig);
     StreamConsumerFactory consumerFactory = StreamConsumerFactoryProvider.create(streamConfig);
     StreamPartitionMsgOffsetFactory offsetFactory = consumerFactory.createStreamMsgOffsetFactory();
@@ -1137,8 +1140,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
 
   @Nullable
   @VisibleForTesting
-  SegmentPartitionMetadata getPartitionMetadataFromTableConfig(TableConfig tableConfig, int partitionId,
-      int numPartitionGroups) {
+  SegmentPartitionMetadata getPartitionMetadataFromTableConfig(TableConfig tableConfig,
+      TopicPartitionId topicPartitionId, int numPartitionGroups) {
     SegmentPartitionConfig partitionConfig = tableConfig.getIndexingConfig().getSegmentPartitionConfig();
     if (partitionConfig == null) {
       return null;
@@ -1147,10 +1150,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     if (columnPartitionMap.size() == 1) {
       Map.Entry<String, ColumnPartitionConfig> entry = columnPartitionMap.entrySet().iterator().next();
       ColumnPartitionConfig columnPartitionConfig = entry.getValue();
-      // For multi-stream tables, convert Pinot partition ID (which includes padding offset) to stream partition ID.
-      // This ensures the partition metadata stored in ZK matches what the broker's partition function computes
-      // during query pruning. For example, stream 1 partition 5 has Pinot partition ID 10005, but should store 5.
-      int streamPartitionId = IngestionConfigUtils.getStreamPartitionIdFromPinotPartitionId(tableConfig, partitionId);
+      int streamPartitionId = topicPartitionId.getPartitionId();
       // If there are multiple streams, we assume the partition groups are evenly distributed across the streams, and
       // compute the per-stream partition group count accordingly.
       // This is needed for the partition function to correctly compute the stream partition id for pruning.
@@ -1235,16 +1235,18 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
   }
 
   @VisibleForTesting
-  Set<Integer> getPartitionIds(List<StreamConfig> streamConfigs, IdealState idealState) {
+  Set<TopicPartitionId> getPartitionIds(List<StreamConfig> streamConfigs,
+      IdealState idealState) {
     return getPartitionIdsWithIdealState(streamConfigs, () -> idealState)._partitionIds;
   }
 
   private static class PartitionIdsWithIdealState {
-    private final Set<Integer> _partitionIds;
+    private final Set<TopicPartitionId> _partitionIds;
     @Nullable
     private final IdealState _idealState;
 
-    private PartitionIdsWithIdealState(Set<Integer> partitionIds, @Nullable IdealState idealState) {
+    private PartitionIdsWithIdealState(Set<TopicPartitionId> partitionIds,
+        @Nullable IdealState idealState) {
       _partitionIds = partitionIds;
       _idealState = idealState;
     }
@@ -1252,7 +1254,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
 
   private PartitionIdsWithIdealState getPartitionIdsWithIdealState(List<StreamConfig> streamConfigs,
       Supplier<IdealState> idealStateSupplier) {
-    Set<Integer> partitionIds = new HashSet<>();
+    Set<TopicPartitionId> partitionIds = new HashSet<>();
     boolean allPartitionIdsFetched = true;
     int numStreams = streamConfigs.size();
     if (numStreams == 1) {
@@ -1261,7 +1263,9 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
       // larger than 10000.
       StreamConfig streamConfig = streamConfigs.get(0);
       try {
-        partitionIds = getPartitionIds(streamConfig);
+        partitionIds = getPartitionIds(streamConfig).stream()
+            .map(TopicPartitionId::new)
+            .collect(Collectors.toSet());
       } catch (UnsupportedOperationException ignored) {
         allPartitionIdsFetched = false;
         // Stream does not support fetching partition ids. There is a log in the fallback code which is sufficient
@@ -1276,7 +1280,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
         int index = i;
         try {
           partitionIds.addAll(getPartitionIds(streamConfig).stream()
-              .map(partitionId -> IngestionConfigUtils.getPinotPartitionIdFromStreamPartitionId(partitionId, index))
+              .map(partitionId -> new TopicPartitionId(index, partitionId))
               .collect(Collectors.toSet()));
         } catch (UnsupportedOperationException ignored) {
           allPartitionIdsFetched = false;
@@ -1303,7 +1307,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
           getNewStreamMetadataList(streamConfigs, currentPartitionGroupConsumptionStatusList, idealState);
       for (StreamMetadata streamMetadata : streamMetadataList) {
         for (PartitionGroupMetadata partitionGroupMetadata : streamMetadata.getPartitionGroupMetadataList()) {
-          partitionIds.add(partitionGroupMetadata.getPartitionGroupId());
+          partitionIds.add(TopicPartitionId.fromPartitionGroupMetadata(
+              partitionGroupMetadata.getPartitionGroupId(), numStreams > 1));
         }
       }
       return new PartitionIdsWithIdealState(partitionIds, idealState);
@@ -1425,13 +1430,14 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
    * @param realtimeTableName Realtime table name
    * @return Map from partition group id to the latest LLC realtime segment ZK metadata
    */
-  private Map<Integer, SegmentZKMetadata> getLatestSegmentZKMetadataMap(String realtimeTableName) {
+  private Map<TopicPartitionId, SegmentZKMetadata> getLatestSegmentZKMetadataMap(
+      String realtimeTableName) {
     List<String> segments = getLLCSegments(realtimeTableName);
 
-    Map<Integer, LLCSegmentName> latestLLCSegmentNameMap = new HashMap<>();
+    Map<TopicPartitionId, LLCSegmentName> latestLLCSegmentNameMap = new HashMap<>();
     for (String segmentName : segments) {
       LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
-      latestLLCSegmentNameMap.compute(llcSegmentName.getTopicPartitionId().getPartitionId(),
+      latestLLCSegmentNameMap.compute(llcSegmentName.getTopicPartitionId(),
           (partitionId, latestLLCSegmentName) -> {
             if (latestLLCSegmentName == null) {
               return llcSegmentName;
@@ -1445,8 +1451,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
           });
     }
 
-    Map<Integer, SegmentZKMetadata> latestSegmentZKMetadataMap = new HashMap<>();
-    for (Map.Entry<Integer, LLCSegmentName> entry : latestLLCSegmentNameMap.entrySet()) {
+    Map<TopicPartitionId, SegmentZKMetadata> latestSegmentZKMetadataMap = new HashMap<>();
+    for (Map.Entry<TopicPartitionId, LLCSegmentName> entry : latestLLCSegmentNameMap.entrySet()) {
       SegmentZKMetadata latestSegmentZKMetadata =
           getSegmentZKMetadata(realtimeTableName, entry.getValue().getSegmentName());
       latestSegmentZKMetadataMap.put(entry.getKey(), latestSegmentZKMetadata);
@@ -1584,8 +1590,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentName);
     if (llcSegmentName != null) {
       return isTopicPaused(idealState,
-          IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(
-              llcSegmentName.getTopicPartitionId().getPartitionId()));
+          llcSegmentName.getTopicPartitionId().getTopicId());
     }
     return false;
   }
@@ -1634,7 +1639,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     // of attempting such a zk update).
     if (newSegmentName != null && !isTableOrTopicPaused) {
       LLCSegmentName newLLCSegmentName = new LLCSegmentName(newSegmentName);
-      int partitionId = newLLCSegmentName.getTopicPartitionId().getPartitionId();
+      TopicPartitionId partitionId = newLLCSegmentName.getTopicPartitionId();
       int seqNum = newLLCSegmentName.getSequenceNumber();
       for (String segmentNameStr : instanceStatesMap.keySet()) {
         LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentNameStr);
@@ -1644,7 +1649,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
           LOGGER.debug("Skip segment name {} not in low-level consumer format", segmentNameStr);
           continue;
         }
-        if (llcSegmentName.getTopicPartitionId().getPartitionId() == partitionId
+        if (llcSegmentName.getTopicPartitionId().equals(partitionId)
             && llcSegmentName.getSequenceNumber() == seqNum) {
           String errorMsg =
               String.format("Segment %s is a duplicate of existing segment %s", newSegmentName, segmentNameStr);
@@ -1785,18 +1790,22 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
         StreamConsumerFactoryProvider.create(streamConfigs.get(0)).createStreamMsgOffsetFactory();
 
     // Get the latest segment ZK metadata for each partition
-    Map<Integer, SegmentZKMetadata> latestSegmentZKMetadataMap = getLatestSegmentZKMetadataMap(realtimeTableName);
+    Map<TopicPartitionId, SegmentZKMetadata> latestSegmentZKMetadataMap =
+        getLatestSegmentZKMetadataMap(realtimeTableName);
 
     // Create a map from partition id to start offset
     // TODO: Directly return map from StreamMetadataProvider
-    Map<Integer, StreamPartitionMsgOffset> partitionIdToStartOffset = Maps.newHashMapWithExpectedSize(numPartitions);
+    boolean hasMultipleStreams = streamConfigs.size() > 1;
+    Map<TopicPartitionId, StreamPartitionMsgOffset> partitionIdToStartOffset =
+        Maps.newHashMapWithExpectedSize(numPartitions);
     for (StreamMetadata streamMetadata : streamMetadataList) {
       for (PartitionGroupMetadata metadata : streamMetadata.getPartitionGroupMetadataList()) {
-        partitionIdToStartOffset.put(metadata.getPartitionGroupId(), metadata.getStartOffset());
+        partitionIdToStartOffset.put(TopicPartitionId.fromPartitionGroupMetadata(
+            metadata.getPartitionGroupId(), hasMultipleStreams), metadata.getStartOffset());
       }
     }
     // Create a map from partition id to the smallest stream offset
-    Map<Integer, StreamPartitionMsgOffset> partitionIdToSmallestOffset = null;
+    Map<TopicPartitionId, StreamPartitionMsgOffset> partitionIdToSmallestOffset = null;
     if (offsetCriteria != null && offsetCriteria.equals(OffsetCriteria.SMALLEST_OFFSET_CRITERIA)) {
       partitionIdToSmallestOffset = partitionIdToStartOffset;
     }
@@ -1828,12 +1837,12 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     Status statusPostSegmentMetadataUpdate =
         PauselessConsumptionUtils.isPauselessEnabled(tableConfig) ? Status.COMMITTING : Status.DONE;
 
-    for (Map.Entry<Integer, SegmentZKMetadata> entry : latestSegmentZKMetadataMap.entrySet()) {
-      int partitionId = entry.getKey();
+    for (Map.Entry<TopicPartitionId, SegmentZKMetadata> entry : latestSegmentZKMetadataMap.entrySet()) {
+      TopicPartitionId partitionId = entry.getKey();
       SegmentZKMetadata latestSegmentZKMetadata = entry.getValue();
       String latestSegmentName = latestSegmentZKMetadata.getSegmentName();
       LLCSegmentName latestLLCSegmentName = new LLCSegmentName(latestSegmentName);
-      int streamConfigIdx = IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(partitionId);
+      int streamConfigIdx = partitionId.getTopicId();
 
       Map<String, String> instanceStateMap = instanceStatesMap.get(latestSegmentName);
       if (instanceStateMap != null) {
@@ -1852,7 +1861,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
               LOGGER.info("Repairing segment: {} which is {} in segment ZK metadata, but is CONSUMING in IdealState",
                   latestSegmentName, statusPostSegmentMetadataUpdate);
 
-              LLCSegmentName newLLCSegmentName = getNextLLCSegmentName(latestLLCSegmentName, currentTimeMs);
+              LLCSegmentName newLLCSegmentName =
+                  getNextLLCSegmentName(latestLLCSegmentName, currentTimeMs);
               String newSegmentName = newLLCSegmentName.getSegmentName();
               CommittingSegmentDescriptor committingSegmentDescriptor =
                   new CommittingSegmentDescriptor(latestSegmentName,
@@ -1960,7 +1970,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
           String previousConsumingSegment = null;
           for (Map.Entry<String, Map<String, String>> segmentEntry : instanceStatesMap.entrySet()) {
             if (segmentEntry.getValue().containsValue(SegmentStateModel.CONSUMING)
-                && new LLCSegmentName(segmentEntry.getKey()).getTopicPartitionId().getPartitionId() == partitionId) {
+                && new LLCSegmentName(segmentEntry.getKey()).getTopicPartitionId()
+                .equals(partitionId)) {
               previousConsumingSegment = segmentEntry.getKey();
               break;
             }
@@ -1983,7 +1994,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     // Set up new partitions if not exist
     for (StreamMetadata streamMetadata : streamMetadataList) {
       for (PartitionGroupMetadata partitionGroupMetadata : streamMetadata.getPartitionGroupMetadataList()) {
-        int partitionId = partitionGroupMetadata.getPartitionGroupId();
+        TopicPartitionId partitionId = TopicPartitionId.fromPartitionGroupMetadata(
+            partitionGroupMetadata.getPartitionGroupId(), hasMultipleStreams);
         if (!latestSegmentZKMetadataMap.containsKey(partitionId)) {
           String newSegmentName =
               setupNewPartitionGroup(tableConfig, streamMetadata.getStreamConfig(), partitionGroupMetadata,
@@ -2004,7 +2016,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
       Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap, StreamPartitionMsgOffset startOffset) {
     int numReplicas = getNumReplicas(tableConfig, instancePartitions);
     LLCSegmentName latestLLCSegmentName = new LLCSegmentName(latestSegmentZKMetadata.getSegmentName());
-    LLCSegmentName newLLCSegmentName = getNextLLCSegmentName(latestLLCSegmentName, currentTimeMs);
+    LLCSegmentName newLLCSegmentName =
+        getNextLLCSegmentName(latestLLCSegmentName, currentTimeMs);
     CommittingSegmentDescriptor committingSegmentDescriptor =
         new CommittingSegmentDescriptor(latestSegmentZKMetadata.getSegmentName(), startOffset.toString(), 0);
     createNewSegmentZKMetadata(tableConfig, streamConfig, newLLCSegmentName, currentTimeMs, committingSegmentDescriptor,
@@ -2014,13 +2027,14 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
         instancePartitionsMap);
   }
 
-  private Map<Integer, StreamPartitionMsgOffset> fetchPartitionGroupIdToSmallestOffset(List<StreamConfig> streamConfigs,
-      IdealState idealState, Map<Integer, SegmentZKMetadata> latestSegmentZKMetadataMap) {
+  private Map<TopicPartitionId, StreamPartitionMsgOffset> fetchPartitionGroupIdToSmallestOffset(
+      List<StreamConfig> streamConfigs, IdealState idealState,
+      Map<TopicPartitionId, SegmentZKMetadata> latestSegmentZKMetadataMap) {
     // Build consumption status from pre-computed ZK metadata map instead of rescanning IdealState (O(1) vs O(N))
     List<PartitionGroupConsumptionStatus> currentPartitionGroupConsumptionStatusList =
         buildPartitionGroupConsumptionStatusFromZKMetadata(latestSegmentZKMetadataMap, streamConfigs);
 
-    Map<Integer, StreamPartitionMsgOffset> partitionGroupIdToSmallestOffset = new HashMap<>();
+    Map<TopicPartitionId, StreamPartitionMsgOffset> partitionGroupIdToSmallestOffset = new HashMap<>();
     for (StreamConfig streamConfig : streamConfigs) {
       OffsetCriteria originalOffsetCriteria = streamConfig.getOffsetCriteria();
       streamConfig.setOffsetCriteria(OffsetCriteria.SMALLEST_OFFSET_CRITERIA);
@@ -2034,7 +2048,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
       streamConfig.setOffsetCriteria(originalOffsetCriteria);
       for (StreamMetadata streamMetadata : streamMetadataList) {
         for (PartitionGroupMetadata metadata : streamMetadata.getPartitionGroupMetadataList()) {
-          partitionGroupIdToSmallestOffset.put(metadata.getPartitionGroupId(), metadata.getStartOffset());
+          partitionGroupIdToSmallestOffset.put(TopicPartitionId.fromPartitionGroupMetadata(
+              metadata.getPartitionGroupId(), streamConfigs.size() > 1), metadata.getStartOffset());
         }
       }
     }
@@ -2047,27 +2062,29 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
    */
   @VisibleForTesting
   List<PartitionGroupConsumptionStatus> buildPartitionGroupConsumptionStatusFromZKMetadata(
-      Map<Integer, SegmentZKMetadata> latestSegmentZKMetadataMap, List<StreamConfig> streamConfigs) {
+      Map<TopicPartitionId, SegmentZKMetadata> latestSegmentZKMetadataMap,
+      List<StreamConfig> streamConfigs) {
     List<PartitionGroupConsumptionStatus> result = new ArrayList<>(latestSegmentZKMetadataMap.size());
     int numStreams = streamConfigs.size();
     if (numStreams == 1) {
       StreamPartitionMsgOffsetFactory offsetFactory =
           StreamConsumerFactoryProvider.create(streamConfigs.get(0)).createStreamMsgOffsetFactory();
-      for (Map.Entry<Integer, SegmentZKMetadata> entry : latestSegmentZKMetadataMap.entrySet()) {
-        int partitionGroupId = entry.getKey();
+      for (Map.Entry<TopicPartitionId, SegmentZKMetadata> entry : latestSegmentZKMetadataMap.entrySet()) {
+        TopicPartitionId partitionGroupId = entry.getKey();
         SegmentZKMetadata zkMetadata = entry.getValue();
         LLCSegmentName llcSegmentName = new LLCSegmentName(zkMetadata.getSegmentName());
-        result.add(new PartitionGroupConsumptionStatus(partitionGroupId, llcSegmentName.getSequenceNumber(),
+        result.add(new PartitionGroupConsumptionStatus(partitionGroupId.toMultiTopicPinotPartitionId(),
+            llcSegmentName.getSequenceNumber(),
             offsetFactory.create(zkMetadata.getStartOffset()),
             zkMetadata.getEndOffset() != null ? offsetFactory.create(zkMetadata.getEndOffset()) : null,
             zkMetadata.getStatus().toString()));
       }
     } else {
       StreamPartitionMsgOffsetFactory[] offsetFactories = new StreamPartitionMsgOffsetFactory[numStreams];
-      for (Map.Entry<Integer, SegmentZKMetadata> entry : latestSegmentZKMetadataMap.entrySet()) {
-        int partitionGroupId = entry.getKey();
-        int index = IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(partitionGroupId);
-        int streamPartitionId = IngestionConfigUtils.getStreamPartitionIdFromPinotPartitionId(partitionGroupId);
+      for (Map.Entry<TopicPartitionId, SegmentZKMetadata> entry : latestSegmentZKMetadataMap.entrySet()) {
+        TopicPartitionId partitionGroupId = entry.getKey();
+        int index = partitionGroupId.getTopicId();
+        int streamPartitionId = partitionGroupId.getPartitionId();
         SegmentZKMetadata zkMetadata = entry.getValue();
         LLCSegmentName llcSegmentName = new LLCSegmentName(zkMetadata.getSegmentName());
         StreamPartitionMsgOffsetFactory offsetFactory = offsetFactories[index];
@@ -2076,7 +2093,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
               StreamConsumerFactoryProvider.create(streamConfigs.get(index)).createStreamMsgOffsetFactory();
           offsetFactories[index] = offsetFactory;
         }
-        result.add(new PartitionGroupConsumptionStatus(partitionGroupId, streamPartitionId,
+        result.add(new PartitionGroupConsumptionStatus(
+            partitionGroupId.toMultiTopicPinotPartitionId(), streamPartitionId,
             llcSegmentName.getSequenceNumber(),
             offsetFactory.create(zkMetadata.getStartOffset()),
             zkMetadata.getEndOffset() != null ? offsetFactory.create(zkMetadata.getEndOffset()) : null,
@@ -2086,9 +2104,11 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     return result;
   }
 
-  private StreamPartitionMsgOffset selectStartOffset(OffsetCriteria offsetCriteria, int partitionGroupId,
-      Map<Integer, StreamPartitionMsgOffset> partitionGroupIdToStartOffset,
-      Map<Integer, StreamPartitionMsgOffset> partitionGroupIdToSmallestStreamOffset, String tableName,
+  private StreamPartitionMsgOffset selectStartOffset(OffsetCriteria offsetCriteria,
+      TopicPartitionId partitionGroupId,
+      Map<TopicPartitionId, StreamPartitionMsgOffset> partitionGroupIdToStartOffset,
+      Map<TopicPartitionId, StreamPartitionMsgOffset> partitionGroupIdToSmallestStreamOffset,
+      String tableName,
       StreamPartitionMsgOffsetFactory offsetFactory, String startOffsetInSegmentZkMetadataStr) {
     if (offsetCriteria != null) {
       // use the fetched offset according to offset criteria
@@ -2706,13 +2726,15 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     }
 
     // partitionGroupIdsToCommitStr != null
-    Set<Integer> partitionsToCommit = Arrays.stream(partitionGroupIdsToCommitStr.split(","))
+    Set<TopicPartitionId> partitionsToCommit = Arrays.stream(
+        partitionGroupIdsToCommitStr.split(","))
         .map(String::trim)
-        .map(Integer::parseInt)
+        .map(s -> TopicPartitionId.fromMultiTopicPinotPartitionId(
+            Integer.parseInt(s)))
         .collect(Collectors.toSet());
     Set<String> targetSegments = allConsumingSegments.stream()
         .filter(segmentName -> partitionsToCommit.contains(
-            new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId()))
+            new LLCSegmentName(segmentName).getTopicPartitionId()))
         .collect(Collectors.toSet());
     Preconditions.checkState(!targetSegments.isEmpty(), "Cannot find segments to commit for partitions: %s",
         partitionGroupIdsToCommitStr);
@@ -2900,8 +2922,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     idealState.getRecord().getMapFields().forEach((segmentName, instanceToStateMap) -> {
       LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentName);
       if (llcSegmentName != null && !topicIndices.contains(
-          IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(
-              llcSegmentName.getTopicPartitionId().getPartitionId()))) {
+          llcSegmentName.getTopicPartitionId().getTopicId())) {
         return;
       }
       for (String state : instanceToStateMap.values()) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -280,7 +280,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
       if (llcSegmentName == null) {
         continue;
       }
-      int partitionGroupId = llcSegmentName.getPartitionGroupId();
+      int partitionGroupId = llcSegmentName.getTopicPartitionId().getPartitionId();
       partitionGroupIdToLatestSegment.compute(partitionGroupId, (k, latestSegment) -> {
         if (latestSegment == null) {
           return llcSegmentName;
@@ -837,7 +837,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
 
     String newConsumingSegmentName = null;
     LLCSegmentName committingLLCSegment = new LLCSegmentName(committingSegmentName);
-    int committingSegmentPartitionGroupId = committingLLCSegment.getPartitionGroupId();
+    int committingSegmentPartitionGroupId = committingLLCSegment.getTopicPartitionId().getPartitionId();
 
     List<StreamConfig> streamConfigs = IngestionConfigUtils.getStreamConfigs(tableConfig);
     PartitionIdsWithIdealState partitionIdsWithIdealState = getPartitionIdsWithIdealState(streamConfigs,
@@ -1007,7 +1007,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
 
     // Handle offset auto reset
     String nextOffset = committingSegmentDescriptor.getNextOffset();
-    String startOffset = computeStartOffset(nextOffset, streamConfig, newLLCSegmentName.getPartitionGroupId());
+    String startOffset = computeStartOffset(nextOffset, streamConfig,
+        newLLCSegmentName.getTopicPartitionId().getPartitionId());
     if (!startOffset.equals(nextOffset)) {
       _controllerMetrics.addMeteredTableValue(realtimeTableName, ControllerMeter.OFFSET_AUTO_RESET_SKIPPED_OFFSETS,
           Long.parseLong(startOffset) - Long.parseLong(nextOffset));
@@ -1016,7 +1017,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
       taskProperties.put(Constants.RESET_OFFSET_TO, startOffset);
       taskProperties.put(Constants.RESET_OFFSET_TOPIC_NAME, streamConfig.getTopicName());
       taskProperties.put(Constants.RESET_OFFSET_TOPIC_PARTITION,
-          Integer.toString(newLLCSegmentName.getPartitionGroupId()));
+          Integer.toString(newLLCSegmentName.getTopicPartitionId().getPartitionId()));
       _helixResourceManager.invokeControllerPeriodicTask(streamConfig.getTableNameWithType(),
           Constants.REALTIME_OFFSET_AUTO_RESET_MANAGER, taskProperties);
     }
@@ -1034,7 +1035,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
 
     // Add the partition metadata if available
     SegmentPartitionMetadata partitionMetadata =
-        getPartitionMetadataFromTableConfig(tableConfig, newLLCSegmentName.getPartitionGroupId(), numPartitions);
+        getPartitionMetadataFromTableConfig(tableConfig,
+            newLLCSegmentName.getTopicPartitionId().getPartitionId(), numPartitions);
     if (partitionMetadata != null) {
       newSegmentZKMetadata.setPartitionMetadata(partitionMetadata);
     }
@@ -1429,17 +1431,18 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     Map<Integer, LLCSegmentName> latestLLCSegmentNameMap = new HashMap<>();
     for (String segmentName : segments) {
       LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
-      latestLLCSegmentNameMap.compute(llcSegmentName.getPartitionGroupId(), (partitionId, latestLLCSegmentName) -> {
-        if (latestLLCSegmentName == null) {
-          return llcSegmentName;
-        } else {
-          if (llcSegmentName.getSequenceNumber() > latestLLCSegmentName.getSequenceNumber()) {
-            return llcSegmentName;
-          } else {
-            return latestLLCSegmentName;
-          }
-        }
-      });
+      latestLLCSegmentNameMap.compute(llcSegmentName.getTopicPartitionId().getPartitionId(),
+          (partitionId, latestLLCSegmentName) -> {
+            if (latestLLCSegmentName == null) {
+              return llcSegmentName;
+            } else {
+              if (llcSegmentName.getSequenceNumber() > latestLLCSegmentName.getSequenceNumber()) {
+                return llcSegmentName;
+              } else {
+                return latestLLCSegmentName;
+              }
+            }
+          });
     }
 
     Map<Integer, SegmentZKMetadata> latestSegmentZKMetadataMap = new HashMap<>();
@@ -1581,7 +1584,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentName);
     if (llcSegmentName != null) {
       return isTopicPaused(idealState,
-          IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(llcSegmentName.getPartitionGroupId()));
+          IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(
+              llcSegmentName.getTopicPartitionId().getPartitionId()));
     }
     return false;
   }
@@ -1630,7 +1634,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     // of attempting such a zk update).
     if (newSegmentName != null && !isTableOrTopicPaused) {
       LLCSegmentName newLLCSegmentName = new LLCSegmentName(newSegmentName);
-      int partitionId = newLLCSegmentName.getPartitionGroupId();
+      int partitionId = newLLCSegmentName.getTopicPartitionId().getPartitionId();
       int seqNum = newLLCSegmentName.getSequenceNumber();
       for (String segmentNameStr : instanceStatesMap.keySet()) {
         LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentNameStr);
@@ -1640,7 +1644,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
           LOGGER.debug("Skip segment name {} not in low-level consumer format", segmentNameStr);
           continue;
         }
-        if (llcSegmentName.getPartitionGroupId() == partitionId && llcSegmentName.getSequenceNumber() == seqNum) {
+        if (llcSegmentName.getTopicPartitionId().getPartitionId() == partitionId
+            && llcSegmentName.getSequenceNumber() == seqNum) {
           String errorMsg =
               String.format("Segment %s is a duplicate of existing segment %s", newSegmentName, segmentNameStr);
           LOGGER.error(errorMsg);
@@ -1955,7 +1960,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
           String previousConsumingSegment = null;
           for (Map.Entry<String, Map<String, String>> segmentEntry : instanceStatesMap.entrySet()) {
             if (segmentEntry.getValue().containsValue(SegmentStateModel.CONSUMING)
-                && new LLCSegmentName(segmentEntry.getKey()).getPartitionGroupId() == partitionId) {
+                && new LLCSegmentName(segmentEntry.getKey()).getTopicPartitionId().getPartitionId() == partitionId) {
               previousConsumingSegment = segmentEntry.getKey();
               break;
             }
@@ -2104,7 +2109,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
   }
 
   private LLCSegmentName getNextLLCSegmentName(LLCSegmentName lastLLCSegmentName, long creationTimeMs) {
-    return new LLCSegmentName(lastLLCSegmentName.getTableName(), lastLLCSegmentName.getPartitionGroupId(),
+    return new LLCSegmentName(lastLLCSegmentName.getTableName(),
+        lastLLCSegmentName.getTopicPartitionId().getPartitionId(),
         lastLLCSegmentName.getSequenceNumber() + 1, creationTimeMs);
   }
 
@@ -2705,7 +2711,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
         .map(Integer::parseInt)
         .collect(Collectors.toSet());
     Set<String> targetSegments = allConsumingSegments.stream()
-        .filter(segmentName -> partitionsToCommit.contains(new LLCSegmentName(segmentName).getPartitionGroupId()))
+        .filter(segmentName -> partitionsToCommit.contains(
+            new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId()))
         .collect(Collectors.toSet());
     Preconditions.checkState(!targetSegments.isEmpty(), "Cannot find segments to commit for partitions: %s",
         partitionGroupIdsToCommitStr);
@@ -2893,7 +2900,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     idealState.getRecord().getMapFields().forEach((segmentName, instanceToStateMap) -> {
       LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentName);
       if (llcSegmentName != null && !topicIndices.contains(
-          IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(llcSegmentName.getPartitionGroupId()))) {
+          IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(
+              llcSegmentName.getTopicPartitionId().getPartitionId()))) {
         return;
       }
       for (String state : instanceToStateMap.values()) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResourceTest.java
@@ -30,6 +30,7 @@ import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.exception.TableNotFoundException;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.TopicPartitionId;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.mockito.InjectMocks;
@@ -87,31 +88,31 @@ public class PinotSegmentRestletResourceTest {
     when(znRecord.getMapFields()).thenReturn(segmentsToInstanceState);
 
     // Create the partition to oldest segment map
-    Map<Integer, LLCSegmentName> partitionToOldestSegment = Map.of(
-        0, new LLCSegmentName(tableName, 0, 3, currentTime),
-        1, new LLCSegmentName(tableName, 1, 5, currentTime)
+    Map<TopicPartitionId, LLCSegmentName> partitionToOldestSegment = Map.of(
+        new TopicPartitionId(0), new LLCSegmentName(tableName, 0, 3, currentTime),
+        new TopicPartitionId(1), new LLCSegmentName(tableName, 1, 5, currentTime)
     );
 
     // This map will be populated by the method
-    Map<Integer, LLCSegmentName> partitionIdToLatestSegment = new HashMap<>();
+    Map<TopicPartitionId, LLCSegmentName> partitionIdToLatestSegment = new HashMap<>();
 
     // Create the expected response map
-    Map<Integer, Set<String>> expectedResponse = new HashMap<>();
-    expectedResponse.put(0,
+    Map<TopicPartitionId, Set<String>> expectedResponse = new HashMap<>();
+    expectedResponse.put(new TopicPartitionId(0),
         getSegmentForPartition(tableName, 0, 3, 7, currentTime).stream().collect(Collectors.toSet()));
-    expectedResponse.put(1,
+    expectedResponse.put(new TopicPartitionId(1),
         getSegmentForPartition(tableName, 1, 5, 5, currentTime).stream().collect(Collectors.toSet()));
 
     // Call the method and check the result
-    Map<Integer, Set<String>> result = _pinotSegmentRestletResource.getPartitionIdToSegmentsToDeleteMap(
+    Map<TopicPartitionId, Set<String>> result = _pinotSegmentRestletResource.getPartitionIdToSegmentsToDeleteMap(
         partitionToOldestSegment, segmentsToInstanceState.keySet(), partitionIdToLatestSegment);
 
     assertEquals(expectedResponse, result);
 
     // Verify that partitionIdToLatestSegment has been populated with the latest segment for each partition
     assertEquals(2, partitionIdToLatestSegment.size());
-    assertEquals(9, partitionIdToLatestSegment.get(0).getSequenceNumber());
-    assertEquals(9, partitionIdToLatestSegment.get(1).getSequenceNumber());
+    assertEquals(9, partitionIdToLatestSegment.get(new TopicPartitionId(0)).getSequenceNumber());
+    assertEquals(9, partitionIdToLatestSegment.get(new TopicPartitionId(1)).getSequenceNumber());
   }
 
   @Test
@@ -132,12 +133,12 @@ public class PinotSegmentRestletResourceTest {
         getSegmentForPartition(tableName + "fake", 0, 1, 3, currentTime)); // Segments with seq 1,2,3 for partition 0
 
     // Create expected result map
-    Map<Integer, LLCSegmentName> expectedResult = new HashMap<>();
-    expectedResult.put(0, new LLCSegmentName(tableName, 0, 3, currentTime));
-    expectedResult.put(1, new LLCSegmentName(tableName, 1, 4, currentTime));
+    Map<TopicPartitionId, LLCSegmentName> expectedResult = new HashMap<>();
+    expectedResult.put(new TopicPartitionId(0), new LLCSegmentName(tableName, 0, 3, currentTime));
+    expectedResult.put(new TopicPartitionId(1), new LLCSegmentName(tableName, 1, 4, currentTime));
 
     // Call the method and check the result
-    Map<Integer, LLCSegmentName> result =
+    Map<TopicPartitionId, LLCSegmentName> result =
         _pinotSegmentRestletResource.getPartitionIDToOldestSegment(segments, idealStateSegmentSet);
 
     assertEquals(expectedResult, result);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotResourceManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotResourceManagerTest.java
@@ -215,7 +215,7 @@ public class PinotResourceManagerTest {
       int partitionId;
       LLCSegmentName llcSegmentName = LLCSegmentName.of(segment);
       if (llcSegmentName != null) {
-        partitionId = llcSegmentName.getTopicPartitionId().getPartitionId();
+        partitionId = llcSegmentName.getTopicPartitionId().toMultiTopicPinotPartitionId();
       } else {
         partitionId = Integer.parseInt(segment.substring(1, 2));
       }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotResourceManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotResourceManagerTest.java
@@ -215,7 +215,7 @@ public class PinotResourceManagerTest {
       int partitionId;
       LLCSegmentName llcSegmentName = LLCSegmentName.of(segment);
       if (llcSegmentName != null) {
-        partitionId = llcSegmentName.getPartitionGroupId();
+        partitionId = llcSegmentName.getTopicPartitionId().getPartitionId();
       } else {
         partitionId = Integer.parseInt(segment.substring(1, 2));
       }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -1860,7 +1860,7 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
 
     for (String segmentName : idealState.getPartitionSet()) {
       LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
-      int partitionGroupId = llcSegmentName.getPartitionGroupId();
+      int partitionGroupId = llcSegmentName.getTopicPartitionId().getPartitionId();
       if (partitionGroupId == 0) {
         assertEquals(llcSegmentName.getSequenceNumber(), 5);
       } else if (partitionGroupId == 1) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -1860,7 +1860,7 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
 
     for (String segmentName : idealState.getPartitionSet()) {
       LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
-      int partitionGroupId = llcSegmentName.getTopicPartitionId().getPartitionId();
+      int partitionGroupId = llcSegmentName.getTopicPartitionId().toMultiTopicPinotPartitionId();
       if (partitionGroupId == 0) {
         assertEquals(llcSegmentName.getSequenceNumber(), 5);
       } else if (partitionGroupId == 1) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeReplicaGroupSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeReplicaGroupSegmentAssignmentTest.java
@@ -543,7 +543,7 @@ public class RealtimeReplicaGroupSegmentAssignmentTest {
 
       // Extract partition ID from segment name
       LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
-      int partitionId = llcSegmentName.getTopicPartitionId().getPartitionId();
+      int partitionId = llcSegmentName.getTopicPartitionId().toMultiTopicPinotPartitionId();
 
       // Verify the partition ID is one of our subset partitions
       boolean isSubsetPartition = false;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeReplicaGroupSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeReplicaGroupSegmentAssignmentTest.java
@@ -543,7 +543,7 @@ public class RealtimeReplicaGroupSegmentAssignmentTest {
 
       // Extract partition ID from segment name
       LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
-      int partitionId = llcSegmentName.getPartitionGroupId();
+      int partitionId = llcSegmentName.getTopicPartitionId().getPartitionId();
 
       // Verify the partition ID is one of our subset partitions
       boolean isSubsetPartition = false;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinderTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinderTest.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.utils.TopicPartitionId;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.LongMsgOffsetFactory;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
@@ -90,11 +91,11 @@ public class MissingConsumingSegmentFinderTest {
     idealStateMap.put("tableA__3__1__20220601T1200Z", Map.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
     idealStateMap.put("tableA__3__2__20220601T1500Z", Map.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
 
-    Map<Integer, StreamPartitionMsgOffset> partitionGroupIdToLargestStreamOffsetMap = Map.of(
-        0, new LongMsgOffset(1000),
-        1, new LongMsgOffset(1001),
-        2, new LongMsgOffset(1002),
-        3, new LongMsgOffset(1003)
+    Map<TopicPartitionId, StreamPartitionMsgOffset> partitionGroupIdToLargestStreamOffsetMap = Map.of(
+        new TopicPartitionId(0), new LongMsgOffset(1000),
+        new TopicPartitionId(1), new LongMsgOffset(1001),
+        new TopicPartitionId(2), new LongMsgOffset(1002),
+        new TopicPartitionId(3), new LongMsgOffset(1003)
     );
 
     Instant now = Instant.parse("2022-06-01T18:00:00.00Z");
@@ -127,11 +128,11 @@ public class MissingConsumingSegmentFinderTest {
     idealStateMap.put("tableA__3__0__20220601T0900Z", Map.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
     idealStateMap.put("tableA__3__1__20220601T1200Z", Map.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
 
-    Map<Integer, StreamPartitionMsgOffset> partitionGroupIdToLargestStreamOffsetMap = Map.of(
-        0, new LongMsgOffset(1000),
-        1, new LongMsgOffset(701),
-        2, new LongMsgOffset(1002),
-        3, new LongMsgOffset(703)
+    Map<TopicPartitionId, StreamPartitionMsgOffset> partitionGroupIdToLargestStreamOffsetMap = Map.of(
+        new TopicPartitionId(0), new LongMsgOffset(1000),
+        new TopicPartitionId(1), new LongMsgOffset(701),
+        new TopicPartitionId(2), new LongMsgOffset(1002),
+        new TopicPartitionId(3), new LongMsgOffset(703)
     );
 
     // setup segment metadata fetcher
@@ -228,14 +229,14 @@ public class MissingConsumingSegmentFinderTest {
     idealStateMap.put("tableA__5__2__20220601T1500Z", Map.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
     // partition 6 is a new partition and there's no consuming segment in ideal states for it
 
-    Map<Integer, StreamPartitionMsgOffset> partitionGroupIdToLargestStreamOffsetMap = new HashMap<>();
-    partitionGroupIdToLargestStreamOffsetMap.put(0, new LongMsgOffset(1000));
-    partitionGroupIdToLargestStreamOffsetMap.put(1, new LongMsgOffset(1001));
-    partitionGroupIdToLargestStreamOffsetMap.put(2, new LongMsgOffset(1002));
-    partitionGroupIdToLargestStreamOffsetMap.put(3, new LongMsgOffset(1003));
-    partitionGroupIdToLargestStreamOffsetMap.put(4, new LongMsgOffset(1004));
-    partitionGroupIdToLargestStreamOffsetMap.put(5, new LongMsgOffset(1005));
-    partitionGroupIdToLargestStreamOffsetMap.put(6, new LongMsgOffset(16));
+    Map<TopicPartitionId, StreamPartitionMsgOffset> partitionGroupIdToLargestStreamOffsetMap = new HashMap<>();
+    partitionGroupIdToLargestStreamOffsetMap.put(new TopicPartitionId(0), new LongMsgOffset(1000));
+    partitionGroupIdToLargestStreamOffsetMap.put(new TopicPartitionId(1), new LongMsgOffset(1001));
+    partitionGroupIdToLargestStreamOffsetMap.put(new TopicPartitionId(2), new LongMsgOffset(1002));
+    partitionGroupIdToLargestStreamOffsetMap.put(new TopicPartitionId(3), new LongMsgOffset(1003));
+    partitionGroupIdToLargestStreamOffsetMap.put(new TopicPartitionId(4), new LongMsgOffset(1004));
+    partitionGroupIdToLargestStreamOffsetMap.put(new TopicPartitionId(5), new LongMsgOffset(1005));
+    partitionGroupIdToLargestStreamOffsetMap.put(new TopicPartitionId(6), new LongMsgOffset(16));
 
     // setup segment metadata fetcher
     SegmentZKMetadata m1 = mock(SegmentZKMetadata.class);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -65,6 +65,7 @@ import org.apache.pinot.common.restlet.resources.PauseStatusDetails;
 import org.apache.pinot.common.restlet.resources.TableLLCSegmentUploadResponse;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.TopicPartitionId;
 import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
@@ -259,7 +260,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     // Verify segments are created with the explicit sequence numbers
     for (String segmentName : instanceStatesMap.keySet()) {
       LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
-      int partitionGroupId = llcSegmentName.getTopicPartitionId().getPartitionId();
+      int partitionGroupId = llcSegmentName.getTopicPartitionId().toMultiTopicPinotPartitionId();
       int sequence = llcSegmentName.getSequenceNumber();
       if (partitionGroupId == 0) {
         assertEquals(sequence, 5);
@@ -297,7 +298,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
       LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
       assertEquals(llcSegmentName.getSequenceNumber(), 0,
           "Default sequence number -1 should resolve to 0 for partition "
-              + llcSegmentName.getTopicPartitionId().getPartitionId());
+              + llcSegmentName.getTopicPartitionId().toMultiTopicPinotPartitionId());
     }
   }
 
@@ -779,7 +780,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
       assertTrue(segmentZKMetadataMap.containsKey(segmentName));
       assertEquals(segmentZKMetadataMap.get(segmentName), oldSegmentZKMetadataMap.get(segmentName));
       oldNumPartitions = Math.max(oldNumPartitions,
-          new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId() + 1);
+          new LLCSegmentName(segmentName).getTopicPartitionId().toMultiTopicPinotPartitionId() + 1);
     }
 
     // Check that for new partition groups, each partition group should have exactly 1 new segment in CONSUMING
@@ -788,7 +789,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     Map<Integer, List<String>> partitionGroupIdToSegmentsMap = new HashMap<>();
     for (Map.Entry<String, Map<String, String>> entry : instanceStatesMap.entrySet()) {
       String segmentName = entry.getKey();
-      int partitionGroupId = new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId();
+      int partitionGroupId = new LLCSegmentName(segmentName).getTopicPartitionId().toMultiTopicPinotPartitionId();
       partitionGroupIdToSegmentsMap.computeIfAbsent(partitionGroupId, k -> new ArrayList<>()).add(segmentName);
     }
     for (int partitionGroupId = oldNumPartitions; partitionGroupId < segmentManager._numPartitions;
@@ -1156,7 +1157,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
       if (instanceStateMap.containsValue(SegmentStateModel.ONLINE) || instanceStateMap.containsValue(
           SegmentStateModel.CONSUMING)) {
         LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
-        int partitionsId = llcSegmentName.getTopicPartitionId().getPartitionId();
+        int partitionsId = llcSegmentName.getTopicPartitionId().toMultiTopicPinotPartitionId();
         Map<Integer, String> sequenceNumberToSegmentMap = partitionGroupIdToSegmentsMap.get(partitionsId);
         int sequenceNumber = llcSegmentName.getSequenceNumber();
         assertFalse(sequenceNumberToSegmentMap.containsKey(sequenceNumber));
@@ -1954,7 +1955,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     segmentManager._numPartitions = 2;
 
     // Test empty ideal state
-    Set<Integer> partitionIds = segmentManager.getPartitionIds(streamConfigs, idealState);
+    Set<TopicPartitionId> partitionIds = segmentManager.getPartitionIds(streamConfigs, idealState);
     Assert.assertEquals(partitionIds.size(), 2);
     partitionIds.clear();
 
@@ -1995,10 +1996,10 @@ public class PinotLLCRealtimeSegmentManagerTest {
     }
 
     // Build latestSegmentZKMetadataMap from the fake ZK metadata (same logic as getLatestSegmentZKMetadataMap)
-    Map<Integer, SegmentZKMetadata> latestSegmentZKMetadataMap = new HashMap<>();
+    Map<TopicPartitionId, SegmentZKMetadata> latestSegmentZKMetadataMap = new HashMap<>();
     for (Map.Entry<String, SegmentZKMetadata> entry : segmentManager._segmentZKMetadataMap.entrySet()) {
       LLCSegmentName llcSegmentName = new LLCSegmentName(entry.getKey());
-      int partitionId = llcSegmentName.getTopicPartitionId().getPartitionId();
+      TopicPartitionId partitionId = llcSegmentName.getTopicPartitionId();
       latestSegmentZKMetadataMap.merge(partitionId, entry.getValue(), (existing, candidate) -> {
         int existingSeq = new LLCSegmentName(existing.getSegmentName()).getSequenceNumber();
         int candidateSeq = new LLCSegmentName(candidate.getSegmentName()).getSequenceNumber();
@@ -2374,11 +2375,12 @@ public class PinotLLCRealtimeSegmentManagerTest {
     // No SegmentPartitionConfig → null
     TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME)
         .setStreamConfigs(singleStreamConfigMap).build();
-    assertNull(segmentManager.getPartitionMetadataFromTableConfig(tableConfig, 2, 4));
+    assertNull(segmentManager.getPartitionMetadataFromTableConfig(tableConfig, new TopicPartitionId(2), 4));
 
     // Single-stream: perStreamNumPartitions = numPartitionGroups
     tableConfig.getIndexingConfig().setSegmentPartitionConfig(partitionConfig);
-    SegmentPartitionMetadata metadata = segmentManager.getPartitionMetadataFromTableConfig(tableConfig, 2, 4);
+    SegmentPartitionMetadata metadata =
+        segmentManager.getPartitionMetadataFromTableConfig(tableConfig, new TopicPartitionId(2), 4);
     assertNotNull(metadata);
     ColumnPartitionMetadata colMetadata = metadata.getColumnPartitionMap().get("col");
     assertEquals(colMetadata.getNumPartitions(), 4);
@@ -2394,16 +2396,17 @@ public class PinotLLCRealtimeSegmentManagerTest {
             .build();
     multiStreamTableConfig.getIndexingConfig().setSegmentPartitionConfig(partitionConfig);
 
-    // Stream 0, partition 2: Pinot partition ID = 0 * 10000 + 2 = 2
-    metadata = segmentManager.getPartitionMetadataFromTableConfig(multiStreamTableConfig, 2, 8);
+    // Stream 0, partition 2: TopicPartitionId(topicId=0, partitionId=2)
+    metadata = segmentManager.getPartitionMetadataFromTableConfig(multiStreamTableConfig,
+        new TopicPartitionId(0, 2), 8);
     assertNotNull(metadata);
     colMetadata = metadata.getColumnPartitionMap().get("col");
     assertEquals(colMetadata.getNumPartitions(), 4,
         "Multi-stream partition count must be per-stream (numPartitionGroups / numStreams), not total");
     assertEquals(colMetadata.getPartitions(), Set.of(2));
 
-    // Stream 1, partition 3: Pinot partition ID = 1 * 10000 + 3 = 10003
-    int stream1Partition3 = IngestionConfigUtils.PARTITION_PADDING_OFFSET + 3;
+    // Stream 1, partition 3: TopicPartitionId(topicId=1, partitionId=3)
+    TopicPartitionId stream1Partition3 = new TopicPartitionId(1, 3);
     metadata = segmentManager.getPartitionMetadataFromTableConfig(multiStreamTableConfig, stream1Partition3, 8);
     assertNotNull(metadata);
     colMetadata = metadata.getColumnPartitionMap().get("col");
@@ -2411,7 +2414,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     assertEquals(colMetadata.getPartitions(), Set.of(3));
 
     // Multi-stream, uneven distribution: numPartitionGroups not divisible by numStreams → null
-    assertNull(segmentManager.getPartitionMetadataFromTableConfig(multiStreamTableConfig, 0, 7),
+    assertNull(
+        segmentManager.getPartitionMetadataFromTableConfig(
+            multiStreamTableConfig, new TopicPartitionId(0, 0), 7),
         "Uneven partition distribution across streams must return null");
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -259,7 +259,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     // Verify segments are created with the explicit sequence numbers
     for (String segmentName : instanceStatesMap.keySet()) {
       LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
-      int partitionGroupId = llcSegmentName.getPartitionGroupId();
+      int partitionGroupId = llcSegmentName.getTopicPartitionId().getPartitionId();
       int sequence = llcSegmentName.getSequenceNumber();
       if (partitionGroupId == 0) {
         assertEquals(sequence, 5);
@@ -296,7 +296,8 @@ public class PinotLLCRealtimeSegmentManagerTest {
     for (String segmentName : instanceStatesMap.keySet()) {
       LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
       assertEquals(llcSegmentName.getSequenceNumber(), 0,
-          "Default sequence number -1 should resolve to 0 for partition " + llcSegmentName.getPartitionGroupId());
+          "Default sequence number -1 should resolve to 0 for partition "
+              + llcSegmentName.getTopicPartitionId().getPartitionId());
     }
   }
 
@@ -777,7 +778,8 @@ public class PinotLLCRealtimeSegmentManagerTest {
       assertTrue(oldSegmentZKMetadataMap.containsKey(segmentName));
       assertTrue(segmentZKMetadataMap.containsKey(segmentName));
       assertEquals(segmentZKMetadataMap.get(segmentName), oldSegmentZKMetadataMap.get(segmentName));
-      oldNumPartitions = Math.max(oldNumPartitions, new LLCSegmentName(segmentName).getPartitionGroupId() + 1);
+      oldNumPartitions = Math.max(oldNumPartitions,
+          new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId() + 1);
     }
 
     // Check that for new partition groups, each partition group should have exactly 1 new segment in CONSUMING
@@ -786,7 +788,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     Map<Integer, List<String>> partitionGroupIdToSegmentsMap = new HashMap<>();
     for (Map.Entry<String, Map<String, String>> entry : instanceStatesMap.entrySet()) {
       String segmentName = entry.getKey();
-      int partitionGroupId = new LLCSegmentName(segmentName).getPartitionGroupId();
+      int partitionGroupId = new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId();
       partitionGroupIdToSegmentsMap.computeIfAbsent(partitionGroupId, k -> new ArrayList<>()).add(segmentName);
     }
     for (int partitionGroupId = oldNumPartitions; partitionGroupId < segmentManager._numPartitions;
@@ -1154,7 +1156,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
       if (instanceStateMap.containsValue(SegmentStateModel.ONLINE) || instanceStateMap.containsValue(
           SegmentStateModel.CONSUMING)) {
         LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
-        int partitionsId = llcSegmentName.getPartitionGroupId();
+        int partitionsId = llcSegmentName.getTopicPartitionId().getPartitionId();
         Map<Integer, String> sequenceNumberToSegmentMap = partitionGroupIdToSegmentsMap.get(partitionsId);
         int sequenceNumber = llcSegmentName.getSequenceNumber();
         assertFalse(sequenceNumberToSegmentMap.containsKey(sequenceNumber));
@@ -1996,7 +1998,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     Map<Integer, SegmentZKMetadata> latestSegmentZKMetadataMap = new HashMap<>();
     for (Map.Entry<String, SegmentZKMetadata> entry : segmentManager._segmentZKMetadataMap.entrySet()) {
       LLCSegmentName llcSegmentName = new LLCSegmentName(entry.getKey());
-      int partitionId = llcSegmentName.getPartitionGroupId();
+      int partitionId = llcSegmentName.getTopicPartitionId().getPartitionId();
       latestSegmentZKMetadataMap.merge(partitionId, entry.getValue(), (existing, candidate) -> {
         int existingSeq = new LLCSegmentName(existing.getSegmentName()).getSequenceNumber();
         int candidateSeq = new LLCSegmentName(candidate.getSegmentName()).getSequenceNumber();

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
@@ -48,7 +48,7 @@ public class TableRebalancerTest {
   private static final TableRebalancer.PartitionIdFetcher DUMMY_PARTITION_FETCHER = segmentName -> 0;
   private static final TableRebalancer.PartitionIdFetcher SIMPLE_PARTITION_FETCHER = segmentName -> {
     LLCSegmentName name = LLCSegmentName.of(segmentName);
-    return name == null ? -1 : name.getTopicPartitionId().getPartitionId();
+    return name == null ? -1 : name.getTopicPartitionId().toMultiTopicPinotPartitionId();
   };
 
   private static final TableRebalancer.DataLossRiskAssessor DEFAULT_DATA_LOSS_RISK_ASSESSOR =

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerTest.java
@@ -48,7 +48,7 @@ public class TableRebalancerTest {
   private static final TableRebalancer.PartitionIdFetcher DUMMY_PARTITION_FETCHER = segmentName -> 0;
   private static final TableRebalancer.PartitionIdFetcher SIMPLE_PARTITION_FETCHER = segmentName -> {
     LLCSegmentName name = LLCSegmentName.of(segmentName);
-    return name == null ? -1 : name.getPartitionGroupId();
+    return name == null ? -1 : name.getTopicPartitionId().getPartitionId();
   };
 
   private static final TableRebalancer.DataLossRiskAssessor DEFAULT_DATA_LOSS_RISK_ASSESSOR =

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/ConsumerCoordinator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/ConsumerCoordinator.java
@@ -102,11 +102,11 @@ public class ConsumerCoordinator {
         LOGGER.warn("Failed to acquire consumer semaphore for segment: {} in: {}ms. Retrying.", segmentName,
             waitTimeMs);
         _serverMetrics.setValueOfPartitionGauge(_realtimeTableDataManager.getTableName(),
-            llcSegmentName.getPartitionGroupId(), ServerGauge.CONSUMER_LOCK_WAIT_TIME_MS, waitTimeMs);
+            llcSegmentName.getTopicPartitionId().getPartitionId(), ServerGauge.CONSUMER_LOCK_WAIT_TIME_MS, waitTimeMs);
       }
     } finally {
       _serverMetrics.setValueOfPartitionGauge(_realtimeTableDataManager.getTableName(),
-          llcSegmentName.getPartitionGroupId(), ServerGauge.CONSUMER_LOCK_WAIT_TIME_MS, 0);
+          llcSegmentName.getTopicPartitionId().getPartitionId(), ServerGauge.CONSUMER_LOCK_WAIT_TIME_MS, 0);
     }
   }
 
@@ -197,7 +197,7 @@ public class ConsumerCoordinator {
     // so that it can always pass the check.
     int maxSequenceNumberBelowCurrentSegment = -1;
     String instanceId = _realtimeTableDataManager.getServerInstance();
-    int partitionId = currentSegment.getPartitionGroupId();
+    int partitionId = currentSegment.getTopicPartitionId().getPartitionId();
     int currentSequenceNumber = currentSegment.getSequenceNumber();
 
     for (Map.Entry<String, Map<String, String>> entry : getSegmentAssignment().entrySet()) {
@@ -215,7 +215,7 @@ public class ConsumerCoordinator {
         continue;
       }
 
-      if (llcSegmentName.getPartitionGroupId() != partitionId) {
+      if (llcSegmentName.getTopicPartitionId().getPartitionId() != partitionId) {
         // ignore segments of different partitions.
         continue;
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/ConsumerCoordinator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/ConsumerCoordinator.java
@@ -33,6 +33,7 @@ import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.metrics.ServerTimer;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.TopicPartitionId;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
@@ -102,11 +103,13 @@ public class ConsumerCoordinator {
         LOGGER.warn("Failed to acquire consumer semaphore for segment: {} in: {}ms. Retrying.", segmentName,
             waitTimeMs);
         _serverMetrics.setValueOfPartitionGauge(_realtimeTableDataManager.getTableName(),
-            llcSegmentName.getTopicPartitionId().getPartitionId(), ServerGauge.CONSUMER_LOCK_WAIT_TIME_MS, waitTimeMs);
+            llcSegmentName.getTopicPartitionId().toMultiTopicPinotPartitionId(),
+            ServerGauge.CONSUMER_LOCK_WAIT_TIME_MS, waitTimeMs);
       }
     } finally {
       _serverMetrics.setValueOfPartitionGauge(_realtimeTableDataManager.getTableName(),
-          llcSegmentName.getTopicPartitionId().getPartitionId(), ServerGauge.CONSUMER_LOCK_WAIT_TIME_MS, 0);
+          llcSegmentName.getTopicPartitionId().toMultiTopicPinotPartitionId(),
+          ServerGauge.CONSUMER_LOCK_WAIT_TIME_MS, 0);
     }
   }
 
@@ -197,7 +200,7 @@ public class ConsumerCoordinator {
     // so that it can always pass the check.
     int maxSequenceNumberBelowCurrentSegment = -1;
     String instanceId = _realtimeTableDataManager.getServerInstance();
-    int partitionId = currentSegment.getTopicPartitionId().getPartitionId();
+    TopicPartitionId partitionId = currentSegment.getTopicPartitionId();
     int currentSequenceNumber = currentSegment.getSequenceNumber();
 
     for (Map.Entry<String, Map<String, String>> entry : getSegmentAssignment().entrySet()) {
@@ -215,7 +218,7 @@ public class ConsumerCoordinator {
         continue;
       }
 
-      if (llcSegmentName.getTopicPartitionId().getPartitionId() != partitionId) {
+      if (!llcSegmentName.getTopicPartitionId().equals(partitionId)) {
         // ignore segments of different partitions.
         continue;
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
@@ -485,7 +485,7 @@ public class IngestionDelayTracker {
    */
   public void stopTrackingPartition(String segmentName) {
     _segmentsToIgnore.put(segmentName, true);
-    removePartitionId(new LLCSegmentName(segmentName).getPartitionGroupId());
+    removePartitionId(new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId());
   }
 
   /**
@@ -535,7 +535,8 @@ public class IngestionDelayTracker {
       // Do not update the tracker state during server startup period or if the segment is marked to be ignored
       return;
     }
-    _partitionsMarkedForVerification.put(new LLCSegmentName(segmentName).getPartitionGroupId(), _clock.millis());
+    _partitionsMarkedForVerification.put(new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId(),
+        _clock.millis());
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
@@ -24,6 +24,7 @@ import com.google.common.cache.CacheBuilder;
 import java.io.IOException;
 import java.time.Clock;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +41,7 @@ import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.metrics.ServerTimer;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.TopicPartitionId;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConsumerFactory;
@@ -140,21 +142,22 @@ public class IngestionDelayTracker {
   // This map is accessed by:
   // 1. _ingestionDelayTrackingScheduler thread.
   // 2. All threads which can removes metrics - Consumer thread, Helix Thread, Server API Thread, etc.
-  private final Map<Integer, Boolean> _partitionsTracked = new ConcurrentHashMap<>();
+  private final Map<TopicPartitionId, Boolean> _partitionsTracked = new ConcurrentHashMap<>();
   // Map to hold the ingestion info reported by the consumer.
   // This map is accessed by:
   // 1. _ingestionDelayTrackingScheduler thread.
   // 2. All threads which can removes metrics - Consumer thread, Helix Thread, Server API Thread, etc.
   // 3. Consumer thread when it updates the ingestion info of the partition.
-  private final Map<Integer, IngestionInfo> _ingestionInfoMap = new ConcurrentHashMap<>();
-  private final Map<Integer, Long> _partitionsMarkedForVerification = new ConcurrentHashMap<>();
+  private final Map<TopicPartitionId, IngestionInfo> _ingestionInfoMap = new ConcurrentHashMap<>();
+  private final Map<TopicPartitionId, Long> _partitionsMarkedForVerification = new ConcurrentHashMap<>();
   private final ScheduledExecutorService _metricsRemovalScheduler;
   private final ScheduledExecutorService _ingestionDelayTrackingScheduler;
 
   private Clock _clock = Clock.systemUTC();
 
-  protected volatile Map<Integer, StreamPartitionMsgOffset> _partitionIdToLatestOffset;
-  protected volatile ConcurrentHashMap<Integer, Boolean> _partitionsHostedByThisServer = new ConcurrentHashMap<>();
+  protected volatile Map<TopicPartitionId, StreamPartitionMsgOffset> _partitionIdToLatestOffset;
+  protected volatile ConcurrentHashMap<TopicPartitionId, Boolean> _partitionsHostedByThisServer =
+      new ConcurrentHashMap<>();
   // Map of StreamMetadataProvider to fetch upstream latest stream offset (Table can have multiple upstream topics)
   // This map is accessed by:
   // 1. _ingestionDelayTrackingScheduler thread.
@@ -232,7 +235,8 @@ public class IngestionDelayTracker {
         // or once the table data manager has been shutdown.
         return;
       }
-      Set<Integer> partitionsHosted = new HashSet<>(_partitionsHostedByThisServer.keySet());
+      Set<TopicPartitionId> partitionsHosted =
+          new HashSet<>(_partitionsHostedByThisServer.keySet());
 
       if (_ingestionInfoMap.size() > partitionsHosted.size()) {
         // In-case new partition got assigned to the server before _partitionsHostedByThisServer was updated.
@@ -245,7 +249,7 @@ public class IngestionDelayTracker {
 
       updateLatestStreamOffset(partitionsHosted);
 
-      for (Integer partitionId : partitionsHosted) {
+      for (TopicPartitionId partitionId : partitionsHosted) {
         _partitionsTracked.computeIfAbsent(partitionId, k -> {
           // Check below condition in-case partition was stopped being tracked. Eg: due to manual operations like -
           // calling remove ingestion metrics API
@@ -267,9 +271,12 @@ public class IngestionDelayTracker {
   }
 
   @VisibleForTesting
-  void updateLatestStreamOffset(Set<Integer> partitionsHosted) {
-    Map<Integer, Set<Integer>> streamIndexToStreamPartitionIds =
-        IngestionConfigUtils.getStreamConfigIndexToStreamPartitions(partitionsHosted);
+  void updateLatestStreamOffset(Set<TopicPartitionId> partitionsHosted) {
+    Map<Integer, Set<Integer>> streamIndexToStreamPartitionIds = new HashMap<>();
+    for (TopicPartitionId tpId : partitionsHosted) {
+      streamIndexToStreamPartitionIds.computeIfAbsent(tpId.getTopicId(), k -> new HashSet<>())
+          .add(tpId.getPartitionId());
+    }
 
     if (streamIndexToStreamPartitionIds.size() > _streamConfigIndexToStreamMetadataProvider.size()) {
       // There might be a new stream config added or need to retry creation of streamMetadataProvider for a stream
@@ -293,15 +300,19 @@ public class IngestionDelayTracker {
               streamMetadataProvider.fetchLatestStreamOffset(streamPartitionIds,
                   LATEST_STREAM_OFFSET_FETCH_TIMEOUT_MS);
           if (streamIndex > 0) {
-            // Need to convert stream partition Ids back to pinot partition Ids.
+            // Need to convert stream partition Ids back to TopicPartitionId keys.
             for (Map.Entry<Integer, StreamPartitionMsgOffset> latestOffsetEntry
                 : streamPartitionIdToLatestOffset.entrySet()) {
               _partitionIdToLatestOffset.put(
-                  IngestionConfigUtils.getPinotPartitionIdFromStreamPartitionId(latestOffsetEntry.getKey(),
-                      streamIndex), latestOffsetEntry.getValue());
+                  new TopicPartitionId(streamIndex, latestOffsetEntry.getKey()),
+                  latestOffsetEntry.getValue());
             }
           } else {
-            _partitionIdToLatestOffset.putAll(streamPartitionIdToLatestOffset);
+            for (Map.Entry<Integer, StreamPartitionMsgOffset> e
+                : streamPartitionIdToLatestOffset.entrySet()) {
+              _partitionIdToLatestOffset.put(
+                  new TopicPartitionId(e.getKey()), e.getValue());
+            }
           }
         } catch (Exception e) {
           _serverMetrics.addMeteredTableValue(_realTimeTableDataManager.getTableName(),
@@ -331,7 +342,7 @@ public class IngestionDelayTracker {
    *
    * @param partitionId partition ID which we should stop tracking.
    */
-  private void removePartitionId(int partitionId) {
+  private void removePartitionId(TopicPartitionId partitionId) {
     _partitionsHostedByThisServer.remove(partitionId);
     _ingestionInfoMap.remove(partitionId);
     _partitionsTracked.computeIfPresent(partitionId, (k, v) -> {
@@ -347,9 +358,10 @@ public class IngestionDelayTracker {
    * Helper functions that creates a list of all the partitions that are marked for verification and whose
    * timeouts are expired. This helps us optimize checks of the ideal state.
    */
-  private List<Integer> getPartitionsToBeVerified() {
-    List<Integer> partitionsToVerify = new ArrayList<>();
-    for (Map.Entry<Integer, Long> entry : _partitionsMarkedForVerification.entrySet()) {
+  private List<TopicPartitionId> getPartitionsToBeVerified() {
+    List<TopicPartitionId> partitionsToVerify = new ArrayList<>();
+    for (Map.Entry<TopicPartitionId, Long> entry
+        : _partitionsMarkedForVerification.entrySet()) {
       long timeMarked = _clock.millis() - entry.getValue();
       if (timeMarked > PARTITION_TIMEOUT_MS) {
         // Partition must be verified
@@ -370,45 +382,57 @@ public class IngestionDelayTracker {
   }
 
   @VisibleForTesting
-  void createMetrics(int partitionId) {
-    int streamConfigIndex = IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(partitionId);
-    StreamMetadataProvider streamMetadataProvider = _streamConfigIndexToStreamMetadataProvider.get(streamConfigIndex);
+  void createMetrics(TopicPartitionId partitionId) {
+    int streamConfigIndex = partitionId.getTopicId();
+    StreamMetadataProvider streamMetadataProvider =
+        _streamConfigIndexToStreamMetadataProvider.get(streamConfigIndex);
+    int pinotPartitionId = partitionId.toMultiTopicPinotPartitionId();
 
     if (streamMetadataProvider != null && streamMetadataProvider.supportsOffsetLag()) {
-      _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionId, ServerGauge.REALTIME_INGESTION_OFFSET_LAG,
+      _serverMetrics.setOrUpdatePartitionGauge(_metricName, pinotPartitionId,
+          ServerGauge.REALTIME_INGESTION_OFFSET_LAG,
           () -> getPartitionIngestionOffsetLag(partitionId));
 
-      _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionId,
-          ServerGauge.REALTIME_INGESTION_CONSUMING_OFFSET, () -> getPartitionIngestionConsumingOffset(partitionId));
+      _serverMetrics.setOrUpdatePartitionGauge(_metricName, pinotPartitionId,
+          ServerGauge.REALTIME_INGESTION_CONSUMING_OFFSET,
+          () -> getPartitionIngestionConsumingOffset(partitionId));
 
-      _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionId,
-          ServerGauge.REALTIME_INGESTION_UPSTREAM_OFFSET, () -> getLatestPartitionOffset(partitionId));
+      _serverMetrics.setOrUpdatePartitionGauge(_metricName, pinotPartitionId,
+          ServerGauge.REALTIME_INGESTION_UPSTREAM_OFFSET,
+          () -> getLatestPartitionOffset(partitionId));
     }
-    _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionId, ServerGauge.REALTIME_INGESTION_DELAY_MS,
+    _serverMetrics.setOrUpdatePartitionGauge(_metricName, pinotPartitionId,
+        ServerGauge.REALTIME_INGESTION_DELAY_MS,
         () -> getPartitionIngestionDelayMs(partitionId));
-    _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionId,
-        ServerGauge.END_TO_END_REALTIME_INGESTION_DELAY_MS, () -> getPartitionEndToEndIngestionDelayMs(partitionId));
-    _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionId,
-        ServerGauge.REALTIME_INGESTION_DELAY_REPORTING_STATUS, () -> getPartitionIngestionReportingStatus(partitionId));
+    _serverMetrics.setOrUpdatePartitionGauge(_metricName, pinotPartitionId,
+        ServerGauge.END_TO_END_REALTIME_INGESTION_DELAY_MS,
+        () -> getPartitionEndToEndIngestionDelayMs(partitionId));
+    _serverMetrics.setOrUpdatePartitionGauge(_metricName, pinotPartitionId,
+        ServerGauge.REALTIME_INGESTION_DELAY_REPORTING_STATUS,
+        () -> getPartitionIngestionReportingStatus(partitionId));
 
     LOGGER.info("Successfully created ingestion metrics for partition id: {}", partitionId);
   }
 
-  private void removeMetrics(int partitionId) {
-    int streamConfigIndex = IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(partitionId);
+  private void removeMetrics(TopicPartitionId partitionId) {
+    int streamConfigIndex = partitionId.getTopicId();
+    int pinotPartitionId = partitionId.toMultiTopicPinotPartitionId();
     StreamMetadataProvider streamMetadataProvider =
         _streamConfigIndexToStreamMetadataProvider.get(streamConfigIndex);
     // Remove all metrics associated with this partition
     if (streamMetadataProvider != null && streamMetadataProvider.supportsOffsetLag()) {
-      _serverMetrics.removePartitionGauge(_metricName, partitionId, ServerGauge.REALTIME_INGESTION_OFFSET_LAG);
-      _serverMetrics.removePartitionGauge(_metricName, partitionId, ServerGauge.REALTIME_INGESTION_UPSTREAM_OFFSET);
-      _serverMetrics.removePartitionGauge(_metricName, partitionId,
+      _serverMetrics.removePartitionGauge(_metricName, pinotPartitionId,
+          ServerGauge.REALTIME_INGESTION_OFFSET_LAG);
+      _serverMetrics.removePartitionGauge(_metricName, pinotPartitionId,
+          ServerGauge.REALTIME_INGESTION_UPSTREAM_OFFSET);
+      _serverMetrics.removePartitionGauge(_metricName, pinotPartitionId,
           ServerGauge.REALTIME_INGESTION_CONSUMING_OFFSET);
     }
-    _serverMetrics.removePartitionGauge(_metricName, partitionId, ServerGauge.REALTIME_INGESTION_DELAY_MS);
-    _serverMetrics.removePartitionGauge(_metricName, partitionId,
+    _serverMetrics.removePartitionGauge(_metricName, pinotPartitionId,
+        ServerGauge.REALTIME_INGESTION_DELAY_MS);
+    _serverMetrics.removePartitionGauge(_metricName, pinotPartitionId,
         ServerGauge.END_TO_END_REALTIME_INGESTION_DELAY_MS);
-    _serverMetrics.removePartitionGauge(_metricName, partitionId,
+    _serverMetrics.removePartitionGauge(_metricName, pinotPartitionId,
         ServerGauge.REALTIME_INGESTION_DELAY_REPORTING_STATUS);
 
     LOGGER.info("Successfully removed ingestion metrics for partition id: {}", partitionId);
@@ -425,7 +449,8 @@ public class IngestionDelayTracker {
    * {@link StreamMessageMetadata})
    * @param currentOffset              offset of the last consumed message (from {@link StreamMessageMetadata})
    */
-  public void updateMetrics(String segmentName, int partitionId, long ingestionTimeMs,
+  public void updateMetrics(String segmentName, TopicPartitionId partitionId,
+      long ingestionTimeMs,
       long firstStreamIngestionTimeMs, @Nullable StreamPartitionMsgOffset currentOffset) {
     if (!_isServerReadyToServeQueries.getAsBoolean() || _realTimeTableDataManager.isShutDown()) {
       // Do not update the ingestion delay metrics during server startup period
@@ -460,7 +485,7 @@ public class IngestionDelayTracker {
    *
    * @param partitionId partition id that we should stop tracking.
    */
-  public void stopTrackingPartition(int partitionId) {
+  public void stopTrackingPartition(TopicPartitionId partitionId) {
     removePartitionId(partitionId);
   }
 
@@ -470,9 +495,10 @@ public class IngestionDelayTracker {
    *
    * @return Set of partitionIds for which ingestion metrics were removed.
    */
-  public Set<Integer> stopTrackingAllPartitions() {
-    Set<Integer> removedPartitionIds = new HashSet<>(_ingestionInfoMap.keySet());
-    for (Integer partitionId : _ingestionInfoMap.keySet()) {
+  public Set<TopicPartitionId> stopTrackingAllPartitions() {
+    Set<TopicPartitionId> removedPartitionIds =
+        new HashSet<>(_ingestionInfoMap.keySet());
+    for (TopicPartitionId partitionId : _ingestionInfoMap.keySet()) {
       removePartitionId(partitionId);
     }
     return removedPartitionIds;
@@ -485,7 +511,8 @@ public class IngestionDelayTracker {
    */
   public void stopTrackingPartition(String segmentName) {
     _segmentsToIgnore.put(segmentName, true);
-    removePartitionId(new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId());
+    removePartitionId(
+        new LLCSegmentName(segmentName).getTopicPartitionId());
   }
 
   /**
@@ -501,27 +528,31 @@ public class IngestionDelayTracker {
     }
     // Check if we have any partition to verify, else don't make the call to check ideal state as that
     // involves network traffic and may be inefficient.
-    List<Integer> partitionsToVerify = getPartitionsToBeVerified();
+    List<TopicPartitionId> partitionsToVerify = getPartitionsToBeVerified();
     if (partitionsToVerify.isEmpty()) {
       // Don't make the call to getHostedPartitionsGroupIds() as it involves checking ideal state.
       return;
     }
-    Set<Integer> partitionsHostedByThisServer;
+    Set<TopicPartitionId> partitionsHostedByThisServer;
     try {
-      partitionsHostedByThisServer = _realTimeTableDataManager.getHostedPartitionsGroupIds();
+      partitionsHostedByThisServer =
+          _realTimeTableDataManager.getHostedPartitionsGroupIds();
     } catch (Exception e) {
-      LOGGER.error("Failed to get partitions hosted by this server, table={}, exception={}:{}", _tableNameWithType,
-          e.getClass(), e.getMessage());
+      LOGGER.error(
+          "Failed to get partitions hosted by this server, table={}, "
+              + "exception={}:{}",
+          _tableNameWithType, e.getClass(), e.getMessage());
       return;
     }
-    for (int partitionId : partitionsToVerify) {
+    for (TopicPartitionId partitionId : partitionsToVerify) {
       if (!partitionsHostedByThisServer.contains(partitionId)) {
         // Partition is not hosted in this server anymore, stop tracking it
         removePartitionId(partitionId);
       }
     }
 
-    ConcurrentHashMap<Integer, Boolean> newMap = new ConcurrentHashMap<>();
+    ConcurrentHashMap<TopicPartitionId, Boolean> newMap =
+        new ConcurrentHashMap<>();
     partitionsHostedByThisServer.forEach(p -> newMap.put(p, true));
     _partitionsHostedByThisServer = newMap;
   }
@@ -535,7 +566,8 @@ public class IngestionDelayTracker {
       // Do not update the tracker state during server startup period or if the segment is marked to be ignored
       return;
     }
-    _partitionsMarkedForVerification.put(new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId(),
+    _partitionsMarkedForVerification.put(
+        new LLCSegmentName(segmentName).getTopicPartitionId(),
         _clock.millis());
   }
 
@@ -546,7 +578,7 @@ public class IngestionDelayTracker {
    *
    * @return ingestion delay timestamp in milliseconds for the given partition ID.
    */
-  public long getPartitionIngestionTimeMs(int partitionId) {
+  public long getPartitionIngestionTimeMs(TopicPartitionId partitionId) {
     IngestionInfo ingestionInfo = _ingestionInfoMap.get(partitionId);
     return ingestionInfo != null ? ingestionInfo._ingestionTimeMs : Long.MIN_VALUE;
   }
@@ -560,7 +592,7 @@ public class IngestionDelayTracker {
    * or null if first stream ingestion time is not available for the partition.
    */
   @Nullable
-  public Long getPartitionEndToEndIngestionDelayMs(int partitionId) {
+  public Long getPartitionEndToEndIngestionDelayMs(TopicPartitionId partitionId) {
     IngestionInfo ingestionInfo = _ingestionInfoMap.get(partitionId);
     if (ingestionInfo == null || ingestionInfo._firstStreamIngestionTimeMs < 0) {
       return null;
@@ -580,7 +612,7 @@ public class IngestionDelayTracker {
    * or null if ingestion time is not available for the partition.
    */
   @Nullable
-  public Long getPartitionIngestionDelayMs(int partitionId) {
+  public Long getPartitionIngestionDelayMs(TopicPartitionId partitionId) {
     IngestionInfo ingestionInfo = _ingestionInfoMap.get(partitionId);
     if (ingestionInfo == null || ingestionInfo._ingestionTimeMs < 0) {
       return null;
@@ -592,6 +624,7 @@ public class IngestionDelayTracker {
   }
 
   /**
+  /**
    * Method to get if ingestion delay data is available for the given partition (i.e.
    * ingestion info has been reported)
    *
@@ -599,7 +632,7 @@ public class IngestionDelayTracker {
    *
    * @return 1 if ingestion delay data is available, 0 otherwise
    */
-  public long getPartitionIngestionReportingStatus(int partitionId) {
+  public long getPartitionIngestionReportingStatus(TopicPartitionId partitionId) {
     IngestionInfo ingestionInfo = _ingestionInfoMap.get(partitionId);
     if (ingestionInfo == null) {
       return 0;
@@ -616,7 +649,7 @@ public class IngestionDelayTracker {
    * @param partitionId partition for which the ingestion lag is computed
    * @return offset lag for the given partition
    */
-  public long getPartitionIngestionOffsetLag(int partitionId) {
+  public long getPartitionIngestionOffsetLag(TopicPartitionId partitionId) {
     StreamPartitionMsgOffset latestOffset = _partitionIdToLatestOffset.get(partitionId);
     if (latestOffset == null) {
       return 0;
@@ -645,7 +678,7 @@ public class IngestionDelayTracker {
    * @param partitionId partition for which the consuming offset was retrieved
    * @return consuming offset value for the given partition, or {@code 0} if no ingestion info is available
    */
-  public long getPartitionIngestionConsumingOffset(int partitionId) {
+  public long getPartitionIngestionConsumingOffset(TopicPartitionId partitionId) {
     IngestionInfo ingestionInfo = _ingestionInfoMap.get(partitionId);
     if (ingestionInfo == null) {
       return 0;
@@ -668,7 +701,7 @@ public class IngestionDelayTracker {
    * @param partitionId partition for which the latest upstream offset is retrieved
    * @return latest offset value for the given partition, or {@code 0} if not available
    */
-  public long getLatestPartitionOffset(int partitionId) {
+  public long getLatestPartitionOffset(TopicPartitionId partitionId) {
     StreamPartitionMsgOffset latestOffset = _partitionIdToLatestOffset.get(partitionId);
     if (latestOffset == null) {
       return 0;
@@ -699,7 +732,7 @@ public class IngestionDelayTracker {
       return;
     }
     // Remove partitions so their related metrics get uninstalled.
-    for (Integer partitionId : _ingestionInfoMap.keySet()) {
+    for (TopicPartitionId partitionId : _ingestionInfoMap.keySet()) {
       removePartitionId(partitionId);
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -52,6 +52,7 @@ import org.apache.pinot.common.restlet.resources.SegmentErrorInfo;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.PauselessConsumptionUtils;
 import org.apache.pinot.common.utils.TarCompressionUtils;
+import org.apache.pinot.common.utils.TopicPartitionId;
 import org.apache.pinot.core.data.manager.SegmentOperationsTaskContext;
 import org.apache.pinot.core.data.manager.SegmentOperationsTaskType;
 import org.apache.pinot.core.data.manager.realtime.RealtimeConsumptionRateManager.ConsumptionRateLimiter;
@@ -306,13 +307,13 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   private static final int MAX_TIME_FOR_CONSUMING_TO_ONLINE_IN_SECONDS = 31;
 
   private Thread _consumerThread;
-  // _partitionGroupId represents the Pinot's internal partition number which will eventually be used as part of
-  // segment name.
+  // _partitionGroupId is a TopicPartitionId that encodes both the topic index and stream partition. It is used
+  // to derive the Pinot partition number (for segment names) via toMultiTopicPinotPartitionId().
   // _streamPartitionId represents the partition number in the stream topic, which could be derived from the
   // _partitionGroupId and identify which partition of the stream topic this consumer is consuming from.
   // Note that in traditional single topic ingestion mode, those two concepts were identical which got separated
   // in multi-topic ingestion mode.
-  private final int _partitionGroupId;
+  private final TopicPartitionId _partitionGroupId;
   private final int _streamPartitionId;
   private final PartitionGroupConsumptionStatus _partitionGroupConsumptionStatus;
   final String _clientId;
@@ -1129,7 +1130,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
    * Returns the current offset for the partition group.
    */
   public Map<String, String> getPartitionToCurrentOffset() {
-    return Map.of(String.valueOf(_partitionGroupId), _currentOffset.toString());
+    return Map.of(_partitionGroupId.toString(), _currentOffset.toString());
   }
 
   /**
@@ -1151,7 +1152,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
    */
   public Map<String, ConsumerPartitionState> getConsumerPartitionState(
       @Nullable StreamPartitionMsgOffset latestMsgOffset) {
-    String partitionGroupId = String.valueOf(_partitionGroupId);
+    String partitionGroupId = _partitionGroupId.toString();
     return Map.of(partitionGroupId,
         new ConsumerPartitionState(partitionGroupId, getCurrentOffset(), getLastConsumedTimestamp(), latestMsgOffset,
             _lastRowMetadata));
@@ -1784,21 +1785,17 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     String timeColumnName = tableConfig.getValidationConfig().getTimeColumnName();
     // TODO Validate configs
     IndexingConfig indexingConfig = _tableConfig.getIndexingConfig();
-    _partitionGroupId = llcSegmentName.getTopicPartitionId().getPartitionId();
+    _partitionGroupId = llcSegmentName.getTopicPartitionId();
     List<Map<String, String>> streamConfigMaps = IngestionConfigUtils.getStreamConfigMaps(_tableConfig);
     int numStreams = streamConfigMaps.size();
     if (numStreams == 1) {
-      // Single stream
-      // NOTE: We skip partition id translation logic to handle cases where custom stream might return partition id
-      // larger than 10000.
-      _streamPartitionId = _partitionGroupId;
+      _streamPartitionId = _partitionGroupId.getPartitionId();
       _streamConfig = new StreamConfig(_tableNameWithType, streamConfigMaps.get(0));
     } else {
-      // Multiple streams
-      _streamPartitionId = IngestionConfigUtils.getStreamPartitionIdFromPinotPartitionId(_partitionGroupId);
-      int index = IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(_partitionGroupId);
-      Preconditions.checkState(numStreams > index, "Cannot find stream config of index: %s for table: %s", index,
-          _tableNameWithType);
+      _streamPartitionId = _partitionGroupId.getPartitionId();
+      int index = _partitionGroupId.getTopicId();
+      Preconditions.checkState(numStreams > index,
+          "Cannot find stream config of index: %s for table: %s", index, _tableNameWithType);
       _streamConfig = new StreamConfig(_tableNameWithType, streamConfigMaps.get(index));
     }
     _streamConsumerFactory = StreamConsumerFactoryProvider.create(_streamConfig);
@@ -1806,7 +1803,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     String streamTopic = _streamConfig.getTopicName();
     _segmentNameStr = _segmentZKMetadata.getSegmentName();
     _partitionGroupConsumptionStatus =
-        new PartitionGroupConsumptionStatus(_partitionGroupId, _streamPartitionId, llcSegmentName.getSequenceNumber(),
+        new PartitionGroupConsumptionStatus(_partitionGroupId.toMultiTopicPinotPartitionId(),
+            _streamPartitionId, llcSegmentName.getSequenceNumber(),
             _streamPartitionMsgOffsetFactory.create(_segmentZKMetadata.getStartOffset()),
             _segmentZKMetadata.getEndOffset() == null ? null
                 : _streamPartitionMsgOffsetFactory.create(_segmentZKMetadata.getEndOffset()),
@@ -1875,7 +1873,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         .setTextIndexConfig(consumingIndexLoadingConfig.getMultiColTextIndexConfig())
         .setDropRecordOnPartitionMismatch(ingestionConfig != null
             && ingestionConfig.getStreamIngestionConfig() != null
-            && ingestionConfig.getStreamIngestionConfig().isDropRecordOnPartitionMismatch());
+            && ingestionConfig.getStreamIngestionConfig().isDropRecordOnPartitionMismatch())
+        .setHasMultipleStreams(IngestionConfigUtils.hasMultipleStreams(_tableConfig));
 
     // Create message decoder
     Set<String> fieldsToRead = IngestionUtils.getFieldsForRecordExtractor(_tableConfig, _schema);
@@ -2082,7 +2081,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         realtimeSegmentConfigBuilder.setPartitionFunction(
             PartitionFunctionFactory.getPartitionFunction(partitionFunctionName, numPartitions,
                 columnPartitionConfig.getFunctionConfig()));
-        realtimeSegmentConfigBuilder.setPartitionId(_partitionGroupId);
+        realtimeSegmentConfigBuilder.setPartitionId(_partitionGroupId.toMultiTopicPinotPartitionId());
       } else {
         _segmentLogger.warn("Cannot partition on multiple columns: {}", columnPartitionMap.keySet());
       }
@@ -2157,8 +2156,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
    */
   private void setIngestionDelayToZero() {
     long currentTimeMs = System.currentTimeMillis();
-    _realtimeTableDataManager.updateIngestionMetrics(_segmentNameStr, _partitionGroupId, currentTimeMs, currentTimeMs,
-        null);
+    _realtimeTableDataManager.updateIngestionMetrics(_segmentNameStr, _partitionGroupId,
+        currentTimeMs, currentTimeMs, null);
   }
 
   // This should be done during commit? We may not always commit when we build a segment....

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1784,7 +1784,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     String timeColumnName = tableConfig.getValidationConfig().getTimeColumnName();
     // TODO Validate configs
     IndexingConfig indexingConfig = _tableConfig.getIndexingConfig();
-    _partitionGroupId = llcSegmentName.getPartitionGroupId();
+    _partitionGroupId = llcSegmentName.getTopicPartitionId().getPartitionId();
     List<Map<String, String>> streamConfigMaps = IngestionConfigUtils.getStreamConfigMaps(_tableConfig);
     int numStreams = streamConfigMaps.size();
     if (numStreams == 1) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -53,6 +53,7 @@ import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.restlet.resources.SegmentErrorInfo;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.SegmentUtils;
+import org.apache.pinot.common.utils.TopicPartitionId;
 import org.apache.pinot.core.data.manager.BaseTableDataManager;
 import org.apache.pinot.core.util.PeerServerSegmentFinder;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
@@ -108,7 +109,8 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   // allows releasing the lock from a different thread.
   // The consumer coordinators will stay in the map even if the consuming partitions moved to a different server. We
   // expect a small number of consumer coordinators, so it should be fine to not remove them.
-  private final Map<Integer, ConsumerCoordinator> _partitionIdToConsumerCoordinatorMap = new ConcurrentHashMap<>();
+  private final Map<TopicPartitionId, ConsumerCoordinator> _partitionIdToConsumerCoordinatorMap =
+      new ConcurrentHashMap<>();
   // The old name of the stats file used to be stats.ser which we changed when we moved all packages
   // from com.linkedin to org.apache because of not being able to deserialize the old files using the newer classes
   private static final String STATS_FILE_NAME = "segment-stats.ser";
@@ -332,15 +334,16 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
    * Updates the ingestion metrics for the given partition.
    *
    * @param segmentName                      name of the consuming segment
-   * @param partitionId                      partition id of the consuming segment (directly passed in to avoid parsing
-   *                                         the segment name)
+   * @param partitionId                      partition id of the consuming segment (directly passed
+   *                                         in to avoid parsing the segment name)
    * @param ingestionTimeMs                  ingestion time of the last consumed message (from
    *                                         {@link StreamMessageMetadata})
    * @param firstStreamIngestionTimeMs ingestion time of the last consumed message in the first stream (from
    * {@link StreamMessageMetadata})
    * @param currentOffset                    offset of the last consumed message (from {@link StreamMessageMetadata})
    */
-  public void updateIngestionMetrics(String segmentName, int partitionId, long ingestionTimeMs,
+  public void updateIngestionMetrics(String segmentName, TopicPartitionId partitionId,
+      long ingestionTimeMs,
       long firstStreamIngestionTimeMs, @Nullable StreamPartitionMsgOffset currentOffset) {
     _ingestionDelayTracker.updateMetrics(segmentName, partitionId, ingestionTimeMs, firstStreamIngestionTimeMs,
         currentOffset);
@@ -352,7 +355,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
    */
   public long getPartitionIngestionTimeMs(String segmentName) {
     return _ingestionDelayTracker.getPartitionIngestionTimeMs(
-        new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId());
+        new LLCSegmentName(segmentName).getTopicPartitionId());
   }
 
   /**
@@ -374,7 +377,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   public void onConsumingToDropped(String segmentName) {
     // NOTE: No need to mark segment ignored here because it should have already been dropped.
     _ingestionDelayTracker.stopTrackingPartition(
-        new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId());
+        new LLCSegmentName(segmentName).getTopicPartitionId());
   }
 
   /**
@@ -409,13 +412,13 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
    * Returns all partitionGroupIds for the partitions hosted by this server for current table.
    * @apiNote this involves Zookeeper read and should not be used frequently due to efficiency concerns.
    */
-  public Set<Integer> getHostedPartitionsGroupIds() {
-    Set<Integer> partitionsHostedByThisServer = new HashSet<>();
+  public Set<TopicPartitionId> getHostedPartitionsGroupIds() {
+    Set<TopicPartitionId> partitionsHostedByThisServer = new HashSet<>();
     List<String> segments = TableStateUtils.getSegmentsInGivenStateForThisInstance(_helixManager, _tableNameWithType,
         CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING);
     for (String segmentNameStr : segments) {
-      LLCSegmentName segmentName = new LLCSegmentName(segmentNameStr);
-      partitionsHostedByThisServer.add(segmentName.getTopicPartitionId().getPartitionId());
+      partitionsHostedByThisServer.add(
+          new LLCSegmentName(segmentNameStr).getTopicPartitionId());
     }
     return partitionsHostedByThisServer;
   }
@@ -526,7 +529,8 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     if (_enforceConsumptionInOrder) {
       LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentName);
       if (llcSegmentName != null) {
-        getConsumerCoordinator(llcSegmentName.getTopicPartitionId().getPartitionId()).register(llcSegmentName);
+        getConsumerCoordinator(llcSegmentName.getTopicPartitionId())
+            .register(llcSegmentName);
       }
     }
   }
@@ -551,12 +555,24 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     }
   }
 
-  public Set<Integer> stopTrackingPartitionIngestionDelay(@Nullable Set<Integer> partitionIds) {
+  /**
+   * Stops tracking ingestion delay for the given partition IDs (as raw integers).
+   * Kept for backward compatibility with the REST API which receives partition IDs
+   * as integers from query parameters.
+   */
+  public Set<Integer> stopTrackingPartitionIngestionDelay(
+      @Nullable Set<Integer> partitionIds) {
     if (CollectionUtils.isEmpty(partitionIds)) {
-      return _ingestionDelayTracker.stopTrackingAllPartitions();
+      Set<TopicPartitionId> removed = _ingestionDelayTracker.stopTrackingAllPartitions();
+      Set<Integer> result = new HashSet<>();
+      for (TopicPartitionId tpId : removed) {
+        result.add(tpId.toMultiTopicPinotPartitionId());
+      }
+      return result;
     }
-    for (Integer partitionId: partitionIds) {
-      _ingestionDelayTracker.stopTrackingPartition(partitionId);
+    for (Integer partitionId : partitionIds) {
+      _ingestionDelayTracker.stopTrackingPartition(
+          TopicPartitionId.fromMultiTopicPinotPartitionId(partitionId));
     }
     return partitionIds;
   }
@@ -601,15 +617,19 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
 
     // Generates only one semaphore for every partition
     LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
-    int partitionGroupId = llcSegmentName.getTopicPartitionId().getPartitionId();
+    TopicPartitionId partitionGroupId = llcSegmentName.getTopicPartitionId();
     ConsumerCoordinator consumerCoordinator = getConsumerCoordinator(partitionGroupId);
 
     // Create the segment data manager and register it
     PartitionUpsertMetadataManager partitionUpsertMetadataManager =
-        _tableUpsertMetadataManager != null ? _tableUpsertMetadataManager.getOrCreatePartitionManager(partitionGroupId)
+        _tableUpsertMetadataManager != null
+            ? _tableUpsertMetadataManager.getOrCreatePartitionManager(
+                partitionGroupId.getPartitionId())
             : null;
     PartitionDedupMetadataManager partitionDedupMetadataManager =
-        _tableDedupMetadataManager != null ? _tableDedupMetadataManager.getOrCreatePartitionManager(partitionGroupId)
+        _tableDedupMetadataManager != null
+            ? _tableDedupMetadataManager.getOrCreatePartitionManager(
+                partitionGroupId.getPartitionId())
             : null;
     RealtimeSegmentDataManager realtimeSegmentDataManager =
         createRealtimeSegmentDataManager(zkMetadata, tableConfig, indexLoadingConfig, schema, llcSegmentName,
@@ -853,7 +873,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   }
 
   @VisibleForTesting
-  ConsumerCoordinator getConsumerCoordinator(int partitionId) {
+  ConsumerCoordinator getConsumerCoordinator(TopicPartitionId partitionId) {
     return _partitionIdToConsumerCoordinatorMap.computeIfAbsent(partitionId,
         k -> new ConsumerCoordinator(_enforceConsumptionInOrder, this));
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -351,7 +351,8 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
    * {@code Long.MIN_VALUE} when it is not available.
    */
   public long getPartitionIngestionTimeMs(String segmentName) {
-    return _ingestionDelayTracker.getPartitionIngestionTimeMs(new LLCSegmentName(segmentName).getPartitionGroupId());
+    return _ingestionDelayTracker.getPartitionIngestionTimeMs(
+        new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId());
   }
 
   /**
@@ -372,7 +373,8 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   @Override
   public void onConsumingToDropped(String segmentName) {
     // NOTE: No need to mark segment ignored here because it should have already been dropped.
-    _ingestionDelayTracker.stopTrackingPartition(new LLCSegmentName(segmentName).getPartitionGroupId());
+    _ingestionDelayTracker.stopTrackingPartition(
+        new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId());
   }
 
   /**
@@ -413,7 +415,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
         CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING);
     for (String segmentNameStr : segments) {
       LLCSegmentName segmentName = new LLCSegmentName(segmentNameStr);
-      partitionsHostedByThisServer.add(segmentName.getPartitionGroupId());
+      partitionsHostedByThisServer.add(segmentName.getTopicPartitionId().getPartitionId());
     }
     return partitionsHostedByThisServer;
   }
@@ -524,7 +526,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     if (_enforceConsumptionInOrder) {
       LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentName);
       if (llcSegmentName != null) {
-        getConsumerCoordinator(llcSegmentName.getPartitionGroupId()).register(llcSegmentName);
+        getConsumerCoordinator(llcSegmentName.getTopicPartitionId().getPartitionId()).register(llcSegmentName);
       }
     }
   }
@@ -599,7 +601,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
 
     // Generates only one semaphore for every partition
     LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
-    int partitionGroupId = llcSegmentName.getPartitionGroupId();
+    int partitionGroupId = llcSegmentName.getTopicPartitionId().getPartitionId();
     ConsumerCoordinator consumerCoordinator = getConsumerCoordinator(partitionGroupId);
 
     // Create the segment data manager and register it

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/ConsumerCoordinatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/ConsumerCoordinatorTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.TopicPartitionId;
 import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
 import org.apache.pinot.spi.utils.CommonConstants.Segment.Realtime.Status;
 import org.apache.pinot.util.TestUtils;
@@ -55,7 +56,7 @@ public class ConsumerCoordinatorTest {
     }
 
     @Override
-    ConsumerCoordinator getConsumerCoordinator(int partitionId) {
+    ConsumerCoordinator getConsumerCoordinator(TopicPartitionId partitionId) {
       return _consumerCoordinator;
     }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTrackerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTrackerTest.java
@@ -37,13 +37,13 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.TopicPartitionId;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
-import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
@@ -84,7 +84,7 @@ public class IngestionDelayTrackerTest {
   }
 
   private static class MockIngestionDelayTracker extends IngestionDelayTracker {
-    private volatile Map<Integer, Map<String, List<Long>>> _partitionToMetricToValues;
+    private volatile Map<TopicPartitionId, Map<String, List<Long>>> _partitionToMetricToValues;
     private ScheduledExecutorService _scheduledExecutorService;
 
     public MockIngestionDelayTracker(ServerMetrics serverMetrics, String tableNameWithType,
@@ -101,7 +101,7 @@ public class IngestionDelayTrackerTest {
     }
 
     @Override
-    public void createMetrics(int partitionId) {
+    public void createMetrics(TopicPartitionId partitionId) {
       synchronized (this) {
         if (_partitionToMetricToValues == null) {
           _partitionToMetricToValues = new ConcurrentHashMap<>();
@@ -137,7 +137,8 @@ public class IngestionDelayTrackerTest {
       }), 0, 10, TimeUnit.MILLISECONDS);
     }
 
-    void updatePartitionIdToLatestOffset(Map<Integer, StreamPartitionMsgOffset> partitionIdToLatestOffset) {
+    void updatePartitionIdToLatestOffset(
+        Map<TopicPartitionId, StreamPartitionMsgOffset> partitionIdToLatestOffset) {
       _partitionIdToLatestOffset = partitionIdToLatestOffset;
     }
 
@@ -163,21 +164,22 @@ public class IngestionDelayTrackerTest {
     Clock clock = Clock.systemUTC();
     ingestionDelayTracker.setClock(clock);
 
+    TopicPartitionId tp0 = new TopicPartitionId(0);
     // Untracked partitions should return null (metric not emitted)
-    Assert.assertNull(ingestionDelayTracker.getPartitionIngestionDelayMs(0));
-    Assert.assertNull(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(0));
-    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(0), Long.MIN_VALUE);
-    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionReportingStatus(0), 0);
+    Assert.assertNull(ingestionDelayTracker.getPartitionIngestionDelayMs(tp0));
+    Assert.assertNull(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(tp0));
+    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(tp0), Long.MIN_VALUE);
+    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionReportingStatus(tp0), 0);
     ingestionDelayTracker.shutdown();
     // Test constructor with timer arguments
     ingestionDelayTracker =
         new MockIngestionDelayTracker(_serverMetrics, REALTIME_TABLE_NAME, REALTIME_TABLE_DATA_MANAGER,
             METRICS_CLEANUP_TICK_INTERVAL_MS, METRICS_TRACKING_TICK_INTERVAL_MS, () -> true);
     // Untracked partitions should return null (metric not emitted)
-    Assert.assertNull(ingestionDelayTracker.getPartitionIngestionDelayMs(0));
-    Assert.assertNull(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(0));
-    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(0), Long.MIN_VALUE);
-    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionReportingStatus(0), 0);
+    Assert.assertNull(ingestionDelayTracker.getPartitionIngestionDelayMs(tp0));
+    Assert.assertNull(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(tp0));
+    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(tp0), Long.MIN_VALUE);
+    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionReportingStatus(tp0), 0);
     // Test bad timer args to the constructor
     try {
       new IngestionDelayTracker(_serverMetrics, REALTIME_TABLE_NAME, REALTIME_TABLE_DATA_MANAGER, 0, 0, () -> true);
@@ -192,10 +194,12 @@ public class IngestionDelayTrackerTest {
   @Test
   public void testRecordIngestionDelayWithNoAging() {
     final long maxTestDelay = 100;
-    final int partition0 = 0;
-    final String segment0 = new LLCSegmentName(RAW_TABLE_NAME, partition0, 0, 123).getSegmentName();
-    final int partition1 = 1;
-    final String segment1 = new LLCSegmentName(RAW_TABLE_NAME, partition1, 0, 234).getSegmentName();
+    final TopicPartitionId partition0 = new TopicPartitionId(0);
+    final String segment0 =
+        new LLCSegmentName(RAW_TABLE_NAME, 0, 0, 123).getSegmentName();
+    final TopicPartitionId partition1 = new TopicPartitionId(1);
+    final String segment1 =
+        new LLCSegmentName(RAW_TABLE_NAME, 1, 0, 234).getSegmentName();
 
     IngestionDelayTracker ingestionDelayTracker = createTracker();
     // Use fixed clock so samples dont age
@@ -261,14 +265,16 @@ public class IngestionDelayTrackerTest {
 
   @Test
   public void testRecordIngestionDelayWithAging() {
-    final int partition0 = 0;
-    final String segment0 = new LLCSegmentName(RAW_TABLE_NAME, partition0, 0, 123).getSegmentName();
+    final TopicPartitionId partition0 = new TopicPartitionId(0);
+    final String segment0 =
+        new LLCSegmentName(RAW_TABLE_NAME, 0, 0, 123).getSegmentName();
     final long partition0Delay0 = 1000;
     final long partition0Delay1 = 10; // record lower delay to make sure max gets reduced
     final long partition0Offset0Ms = 300;
     final long partition0Offset1Ms = 1000;
-    final int partition1 = 1;
-    final String segment1 = new LLCSegmentName(RAW_TABLE_NAME, partition1, 0, 234).getSegmentName();
+    final TopicPartitionId partition1 = new TopicPartitionId(1);
+    final String segment1 =
+        new LLCSegmentName(RAW_TABLE_NAME, 1, 0, 234).getSegmentName();
     final long partition1Delay0 = 11;
     final long partition1Offset0Ms = 150;
 
@@ -335,22 +341,34 @@ public class IngestionDelayTrackerTest {
 
     // Record a number of partitions with delay equal to partition id
     for (int partitionId = 0; partitionId <= maxTestDelay; partitionId++) {
-      String segmentName = new LLCSegmentName(RAW_TABLE_NAME, partitionId, 0, 123).getSegmentName();
+      TopicPartitionId tpId = new TopicPartitionId(partitionId);
+      String segmentName =
+          new LLCSegmentName(RAW_TABLE_NAME, partitionId, 0, 123)
+              .getSegmentName();
       long ingestionTimeMs = clock.millis() - partitionId;
-      ingestionDelayTracker.updateMetrics(segmentName, partitionId, ingestionTimeMs, ingestionTimeMs, null);
-      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partitionId), partitionId);
-      Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partitionId), partitionId);
-      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partitionId), ingestionTimeMs);
+      ingestionDelayTracker.updateMetrics(
+          segmentName, tpId, ingestionTimeMs, ingestionTimeMs, null);
+      Assert.assertEquals(
+          ingestionDelayTracker.getPartitionIngestionDelayMs(tpId),
+          partitionId);
+      Assert.assertEquals(
+          ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(tpId),
+          partitionId);
+      Assert.assertEquals(
+          ingestionDelayTracker.getPartitionIngestionTimeMs(tpId),
+          ingestionTimeMs);
     }
     for (int partitionId = maxPartition; partitionId >= 0; partitionId--) {
-      ingestionDelayTracker.stopTrackingPartition(partitionId);
+      ingestionDelayTracker.stopTrackingPartition(
+          new TopicPartitionId(partitionId));
     }
     for (int partitionId = 0; partitionId <= maxTestDelay; partitionId++) {
+      TopicPartitionId tpId = new TopicPartitionId(partitionId);
       // Untracked partitions must return null (metric not emitted)
-      Assert.assertNull(ingestionDelayTracker.getPartitionIngestionDelayMs(partitionId));
-      Assert.assertNull(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partitionId));
-      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(partitionId), Long.MIN_VALUE);
-      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionReportingStatus(partitionId), 0);
+      Assert.assertNull(ingestionDelayTracker.getPartitionIngestionDelayMs(tpId));
+      Assert.assertNull(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(tpId));
+      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(tpId), Long.MIN_VALUE);
+      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionReportingStatus(tpId), 0);
     }
   }
 
@@ -363,23 +381,30 @@ public class IngestionDelayTrackerTest {
     Clock clock = Clock.fixed(now, zoneId);
     ingestionDelayTracker.setClock(clock);
 
-    String segmentName = new LLCSegmentName(RAW_TABLE_NAME, 0, 0, 123).getSegmentName();
+    TopicPartitionId tp0 = new TopicPartitionId(0);
+    String segmentName =
+        new LLCSegmentName(RAW_TABLE_NAME, 0, 0, 123).getSegmentName();
     long ingestionTimeMs = clock.millis() - 10;
-    ingestionDelayTracker.updateMetrics(segmentName, 0, ingestionTimeMs, ingestionTimeMs, null);
-    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(0), 10);
-    Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(0), 10);
-    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(0), ingestionTimeMs);
+    ingestionDelayTracker.updateMetrics(
+        segmentName, tp0, ingestionTimeMs, ingestionTimeMs, null);
+    Assert.assertEquals(
+        ingestionDelayTracker.getPartitionIngestionDelayMs(tp0), 10);
+    Assert.assertEquals(
+        ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(tp0), 10);
+    Assert.assertEquals(
+        ingestionDelayTracker.getPartitionIngestionTimeMs(tp0),
+        ingestionTimeMs);
 
     ingestionDelayTracker.stopTrackingPartition(segmentName);
-    Assert.assertNull(ingestionDelayTracker.getPartitionIngestionDelayMs(0));
-    Assert.assertNull(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(0));
-    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(0), Long.MIN_VALUE);
+    Assert.assertNull(ingestionDelayTracker.getPartitionIngestionDelayMs(tp0));
+    Assert.assertNull(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(tp0));
+    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(tp0), Long.MIN_VALUE);
 
     // Should not update metrics for removed segment
-    ingestionDelayTracker.updateMetrics(segmentName, 0, ingestionTimeMs, ingestionTimeMs, null);
-    Assert.assertNull(ingestionDelayTracker.getPartitionIngestionDelayMs(0));
-    Assert.assertNull(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(0));
-    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(0), Long.MIN_VALUE);
+    ingestionDelayTracker.updateMetrics(segmentName, tp0, ingestionTimeMs, ingestionTimeMs, null);
+    Assert.assertNull(ingestionDelayTracker.getPartitionIngestionDelayMs(tp0));
+    Assert.assertNull(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(tp0));
+    Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionTimeMs(tp0), Long.MIN_VALUE);
   }
 
   @Test
@@ -395,11 +420,19 @@ public class IngestionDelayTrackerTest {
 
     // Test Shutdown with partitions active
     for (int partitionId = 0; partitionId <= maxTestDelay; partitionId++) {
-      String segmentName = new LLCSegmentName(RAW_TABLE_NAME, partitionId, 0, 123).getSegmentName();
+      TopicPartitionId tpId = new TopicPartitionId(partitionId);
+      String segmentName =
+          new LLCSegmentName(RAW_TABLE_NAME, partitionId, 0, 123)
+              .getSegmentName();
       long ingestionTimeMs = clock.millis() - partitionId;
-      ingestionDelayTracker.updateMetrics(segmentName, partitionId, ingestionTimeMs, ingestionTimeMs, null);
-      Assert.assertEquals(ingestionDelayTracker.getPartitionIngestionDelayMs(partitionId), partitionId);
-      Assert.assertEquals(ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(partitionId), partitionId);
+      ingestionDelayTracker.updateMetrics(
+          segmentName, tpId, ingestionTimeMs, ingestionTimeMs, null);
+      Assert.assertEquals(
+          ingestionDelayTracker.getPartitionIngestionDelayMs(tpId),
+          partitionId);
+      Assert.assertEquals(
+          ingestionDelayTracker.getPartitionEndToEndIngestionDelayMs(tpId),
+          partitionId);
     }
     ingestionDelayTracker.shutdown();
 
@@ -410,13 +443,16 @@ public class IngestionDelayTrackerTest {
 
   @Test
   public void testRecordIngestionDelayOffset() {
-    final int partition0 = 0;
-    final String segment0 = new LLCSegmentName(RAW_TABLE_NAME, partition0, 0, 123).getSegmentName();
-    final int partition1 = 1;
-    final String segment1 = new LLCSegmentName(RAW_TABLE_NAME, partition1, 0, 234).getSegmentName();
+    final TopicPartitionId partition0 = new TopicPartitionId(0);
+    final String segment0 =
+        new LLCSegmentName(RAW_TABLE_NAME, 0, 0, 123).getSegmentName();
+    final TopicPartitionId partition1 = new TopicPartitionId(1);
+    final String segment1 =
+        new LLCSegmentName(RAW_TABLE_NAME, 1, 0, 234).getSegmentName();
 
     IngestionDelayTracker ingestionDelayTracker = createTracker();
-    Map<Integer, StreamPartitionMsgOffset> partitionMsgOffsetMap = new HashMap<>();
+    Map<TopicPartitionId, StreamPartitionMsgOffset> partitionMsgOffsetMap =
+        new HashMap<>();
     ((MockIngestionDelayTracker) ingestionDelayTracker).updatePartitionIdToLatestOffset(partitionMsgOffsetMap);
 
     // Test tracking offset lag for a single partition
@@ -455,40 +491,56 @@ public class IngestionDelayTrackerTest {
   @Test
   public void testUpdateLatestStreamOffset() {
     IngestionDelayTracker ingestionDelayTracker = createTracker();
-    Set<Integer> partitionsHosted = new HashSet<>();
-    partitionsHosted.add(0);
-    partitionsHosted.add(1);
+    Set<TopicPartitionId> partitionsHosted = new HashSet<>();
+    partitionsHosted.add(new TopicPartitionId(0));
+    partitionsHosted.add(new TopicPartitionId(1));
 
     ingestionDelayTracker.updateLatestStreamOffset(partitionsHosted);
-    Assert.assertEquals(ingestionDelayTracker._partitionIdToLatestOffset.size(), 2);
-    Assert.assertEquals(((LongMsgOffset) (ingestionDelayTracker._partitionIdToLatestOffset.get(0))).getOffset(),
+    Assert.assertEquals(
+        ingestionDelayTracker._partitionIdToLatestOffset.size(), 2);
+    Assert.assertEquals(
+        ((LongMsgOffset) (ingestionDelayTracker._partitionIdToLatestOffset
+            .get(new TopicPartitionId(0)))).getOffset(),
         Integer.MAX_VALUE);
-    Assert.assertEquals(((LongMsgOffset) (ingestionDelayTracker._partitionIdToLatestOffset.get(1))).getOffset(),
+    Assert.assertEquals(
+        ((LongMsgOffset) (ingestionDelayTracker._partitionIdToLatestOffset
+            .get(new TopicPartitionId(1)))).getOffset(),
         Integer.MAX_VALUE);
 
     IngestionConfig ingestionConfig = new IngestionConfig();
     List<Map<String, String>> streamConfigMaps = new ArrayList<>();
     streamConfigMaps.add(getStreamConfigs());
     streamConfigMaps.add(getStreamConfigs());
-    StreamIngestionConfig streamIngestionConfig = new StreamIngestionConfig(streamConfigMaps);
+    StreamIngestionConfig streamIngestionConfig =
+        new StreamIngestionConfig(streamConfigMaps);
     ingestionConfig.setStreamIngestionConfig(streamIngestionConfig);
-    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME)
-        .setTimeColumnName("ts")
-        .setNullHandlingEnabled(true)
-        .setIngestionConfig(ingestionConfig)
-        .setStreamConfigs(getStreamConfigs())
-        .build();
-    when(REALTIME_TABLE_DATA_MANAGER.getCachedTableConfigAndSchema()).thenReturn(Pair.of(tableConfig, null));
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.REALTIME)
+            .setTableName(RAW_TABLE_NAME)
+            .setTimeColumnName("ts")
+            .setNullHandlingEnabled(true)
+            .setIngestionConfig(ingestionConfig)
+            .setStreamConfigs(getStreamConfigs())
+            .build();
+    when(REALTIME_TABLE_DATA_MANAGER.getCachedTableConfigAndSchema())
+        .thenReturn(Pair.of(tableConfig, null));
     ingestionDelayTracker = createTracker();
-    partitionsHosted.add(IngestionConfigUtils.getPinotPartitionIdFromStreamPartitionId(0, 1));
+    partitionsHosted.add(new TopicPartitionId(1, 0));
     ingestionDelayTracker.updateLatestStreamOffset(partitionsHosted);
-    Assert.assertEquals(ingestionDelayTracker._partitionIdToLatestOffset.size(), 3);
-    Assert.assertEquals(((LongMsgOffset) (ingestionDelayTracker._partitionIdToLatestOffset.get(0))).getOffset(),
+    Assert.assertEquals(
+        ingestionDelayTracker._partitionIdToLatestOffset.size(), 3);
+    Assert.assertEquals(
+        ((LongMsgOffset) (ingestionDelayTracker._partitionIdToLatestOffset
+            .get(new TopicPartitionId(0)))).getOffset(),
         Integer.MAX_VALUE);
-    Assert.assertEquals(((LongMsgOffset) (ingestionDelayTracker._partitionIdToLatestOffset.get(1))).getOffset(),
+    Assert.assertEquals(
+        ((LongMsgOffset) (ingestionDelayTracker._partitionIdToLatestOffset
+            .get(new TopicPartitionId(1)))).getOffset(),
         Integer.MAX_VALUE);
-    Assert.assertEquals(((LongMsgOffset) (ingestionDelayTracker._partitionIdToLatestOffset.get(
-        IngestionConfigUtils.getPinotPartitionIdFromStreamPartitionId(0, 1)))).getOffset(), Integer.MAX_VALUE);
+    Assert.assertEquals(
+        ((LongMsgOffset) (ingestionDelayTracker._partitionIdToLatestOffset
+            .get(new TopicPartitionId(1, 0)))).getOffset(),
+        Integer.MAX_VALUE);
   }
 
   @Test
@@ -497,26 +549,37 @@ public class IngestionDelayTrackerTest {
         new MockIngestionDelayTracker(_serverMetrics, REALTIME_TABLE_NAME, REALTIME_TABLE_DATA_MANAGER,
             METRICS_CLEANUP_TICK_INTERVAL_MS, METRICS_TRACKING_TICK_INTERVAL_MS, () -> true);
 
-    final int partition0 = 0;
-    final String segment0 = new LLCSegmentName(RAW_TABLE_NAME, partition0, 0, 123).getSegmentName();
-    final int partition1 = 1;
+    final TopicPartitionId partition0 = new TopicPartitionId(0);
+    final String segment0 =
+        new LLCSegmentName(RAW_TABLE_NAME, 0, 0, 123).getSegmentName();
+    final TopicPartitionId partition1 = new TopicPartitionId(1);
 
-    ingestionDelayTracker._partitionsHostedByThisServer.put(partition0, true);
-    ingestionDelayTracker._partitionsHostedByThisServer.put(partition1, true);
-    ingestionDelayTracker.updateMetrics(segment0, partition0, System.currentTimeMillis(), System.currentTimeMillis(),
+    ingestionDelayTracker._partitionsHostedByThisServer.put(
+        partition0, true);
+    ingestionDelayTracker._partitionsHostedByThisServer.put(
+        partition1, true);
+    ingestionDelayTracker.updateMetrics(segment0, partition0,
+        System.currentTimeMillis(), System.currentTimeMillis(),
         new LongMsgOffset(50));
 
-    ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
-    Map<Integer, StreamPartitionMsgOffset> partitionIdVsLatestOffset = new HashMap<>();
+    ScheduledExecutorService scheduledExecutorService =
+        Executors.newSingleThreadScheduledExecutor();
+    Map<TopicPartitionId, StreamPartitionMsgOffset>
+        partitionIdVsLatestOffset = new HashMap<>();
     partitionIdVsLatestOffset.put(partition0, new LongMsgOffset(200));
     partitionIdVsLatestOffset.put(partition1, new LongMsgOffset(200));
-    ingestionDelayTracker.updatePartitionIdToLatestOffset(partitionIdVsLatestOffset);
+    ingestionDelayTracker.updatePartitionIdToLatestOffset(
+        partitionIdVsLatestOffset);
 
     scheduledExecutorService.scheduleWithFixedDelay(() -> {
       partitionIdVsLatestOffset.put(partition0,
-          new LongMsgOffset(((LongMsgOffset) (partitionIdVsLatestOffset.get(partition0))).getOffset() + 50));
+          new LongMsgOffset(
+              ((LongMsgOffset) (partitionIdVsLatestOffset.get(partition0)))
+                  .getOffset() + 50));
       partitionIdVsLatestOffset.put(partition1,
-          new LongMsgOffset(((LongMsgOffset) (partitionIdVsLatestOffset.get(partition1))).getOffset() + 50));
+          new LongMsgOffset(
+              ((LongMsgOffset) (partitionIdVsLatestOffset.get(partition1)))
+                  .getOffset() + 50));
     }, 0, 10, TimeUnit.MILLISECONDS);
 
     TestUtils.waitForCondition((aVoid) -> {
@@ -531,10 +594,14 @@ public class IngestionDelayTrackerTest {
     ingestionDelayTracker.shutdown();
   }
 
-  private void verifyMetrics(Map<Integer, Map<String, List<Long>>> partitionToMetricToValues) {
+  private void verifyMetrics(
+      Map<TopicPartitionId, Map<String, List<Long>>>
+          partitionToMetricToValues) {
     Assert.assertEquals(partitionToMetricToValues.size(), 2);
-    verifyPartition0(partitionToMetricToValues.get(0));
-    verifyPartition1(partitionToMetricToValues.get(1));
+    verifyPartition0(
+        partitionToMetricToValues.get(new TopicPartitionId(0)));
+    verifyPartition1(
+        partitionToMetricToValues.get(new TopicPartitionId(1)));
   }
 
   private void verifyPartition0(Map<String, List<Long>> metrics) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
@@ -1200,7 +1200,7 @@ public class RealtimeSegmentDataManagerTest {
         throws Exception {
       super(segmentZKMetadata, tableConfig, realtimeTableDataManager, resourceDataDir,
           new IndexLoadingConfig(makeInstanceDataManagerConfig(), tableConfig), schema, llcSegmentName,
-          consumerCoordinatorMap.get(llcSegmentName.getPartitionGroupId()), serverMetrics, null, null,
+          consumerCoordinatorMap.get(llcSegmentName.getTopicPartitionId().getPartitionId()), serverMetrics, null, null,
           () -> true);
       _state = RealtimeSegmentDataManager.class.getDeclaredField("_state");
       _state.setAccessible(true);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
@@ -1200,7 +1200,8 @@ public class RealtimeSegmentDataManagerTest {
         throws Exception {
       super(segmentZKMetadata, tableConfig, realtimeTableDataManager, resourceDataDir,
           new IndexLoadingConfig(makeInstanceDataManagerConfig(), tableConfig), schema, llcSegmentName,
-          consumerCoordinatorMap.get(llcSegmentName.getTopicPartitionId().getPartitionId()), serverMetrics, null, null,
+          consumerCoordinatorMap.get(llcSegmentName.getTopicPartitionId().toMultiTopicPinotPartitionId()),
+          serverMetrics, null, null,
           () -> true);
       _state = RealtimeSegmentDataManager.class.getDeclaredField("_state");
       _state.setAccessible(true);

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -1098,7 +1098,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
       Map<String, String> stateMap = idealState.getInstanceStateMap(segmentName);
       if (stateMap != null
           && stateMap.containsValue(CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING)) {
-        consumingPartitions.add(new LLCSegmentName(segmentName).getPartitionGroupId());
+        consumingPartitions.add(new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId());
       }
     }
     return consumingPartitions.size();

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -1098,7 +1098,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
       Map<String, String> stateMap = idealState.getInstanceStateMap(segmentName);
       if (stateMap != null
           && stateMap.containsValue(CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING)) {
-        consumingPartitions.add(new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId());
+        consumingPartitions.add(new LLCSegmentName(segmentName).getTopicPartitionId().toMultiTopicPinotPartitionId());
       }
     }
     return consumingPartitions.size();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
@@ -152,7 +152,8 @@ public class LLCRealtimeClusterIntegrationTest extends BaseRealtimeClusterIntegr
     for (String segmentNameStr : ev.getPartitionSet()) {
       if (LLCSegmentName.isLLCSegment(segmentNameStr)) {
         LLCSegmentName segmentName = new LLCSegmentName(segmentNameStr);
-        if (segmentName.getSequenceNumber() == seqNum && segmentName.getTopicPartitionId().getPartitionId() == partition
+        if (segmentName.getSequenceNumber() == seqNum
+            && segmentName.getTopicPartitionId().toMultiTopicPinotPartitionId() == partition
             && ev.getStateMap(segmentNameStr).values().contains(
             CommonConstants.Helix.StateModel.SegmentStateModel.OFFLINE)) {
           isOffline = true;
@@ -563,7 +564,7 @@ public class LLCRealtimeClusterIntegrationTest extends BaseRealtimeClusterIntegr
           if (is.getInstanceStateMap(segmentNameStr).values().contains(
               CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING)) {
             LLCSegmentName segmentName = new LLCSegmentName(segmentNameStr);
-            if (segmentName.getTopicPartitionId().getPartitionId() == partition) {
+            if (segmentName.getTopicPartitionId().toMultiTopicPinotPartitionId() == partition) {
               seqNum.set(segmentName.getSequenceNumber());
             }
           }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
@@ -152,7 +152,7 @@ public class LLCRealtimeClusterIntegrationTest extends BaseRealtimeClusterIntegr
     for (String segmentNameStr : ev.getPartitionSet()) {
       if (LLCSegmentName.isLLCSegment(segmentNameStr)) {
         LLCSegmentName segmentName = new LLCSegmentName(segmentNameStr);
-        if (segmentName.getSequenceNumber() == seqNum && segmentName.getPartitionGroupId() == partition
+        if (segmentName.getSequenceNumber() == seqNum && segmentName.getTopicPartitionId().getPartitionId() == partition
             && ev.getStateMap(segmentNameStr).values().contains(
             CommonConstants.Helix.StateModel.SegmentStateModel.OFFLINE)) {
           isOffline = true;
@@ -563,7 +563,7 @@ public class LLCRealtimeClusterIntegrationTest extends BaseRealtimeClusterIntegr
           if (is.getInstanceStateMap(segmentNameStr).values().contains(
               CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING)) {
             LLCSegmentName segmentName = new LLCSegmentName(segmentNameStr);
-            if (segmentName.getPartitionGroupId() == partition) {
+            if (segmentName.getTopicPartitionId().getPartitionId() == partition) {
               seqNum.set(segmentName.getSequenceNumber());
             }
           }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeKafka3ClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeKafka3ClusterIntegrationTest.java
@@ -111,7 +111,7 @@ public class LLCRealtimeKafka3ClusterIntegrationTest extends LLCRealtimeClusterI
           if (is.getInstanceStateMap(segmentNameStr).values().contains(
               CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING)) {
             LLCSegmentName segmentName = new LLCSegmentName(segmentNameStr);
-            if (segmentName.getTopicPartitionId().getPartitionId() == partition) {
+            if (segmentName.getTopicPartitionId().toMultiTopicPinotPartitionId() == partition) {
               seqNum.set(segmentName.getSequenceNumber());
             }
           }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeKafka3ClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeKafka3ClusterIntegrationTest.java
@@ -111,7 +111,7 @@ public class LLCRealtimeKafka3ClusterIntegrationTest extends LLCRealtimeClusterI
           if (is.getInstanceStateMap(segmentNameStr).values().contains(
               CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING)) {
             LLCSegmentName segmentName = new LLCSegmentName(segmentNameStr);
-            if (segmentName.getPartitionGroupId() == partition) {
+            if (segmentName.getTopicPartitionId().getPartitionId() == partition) {
               seqNum.set(segmentName.getSequenceNumber());
             }
           }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeKafka4ClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeKafka4ClusterIntegrationTest.java
@@ -111,7 +111,7 @@ public class LLCRealtimeKafka4ClusterIntegrationTest extends LLCRealtimeClusterI
           if (is.getInstanceStateMap(segmentNameStr).values().contains(
               CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING)) {
             LLCSegmentName segmentName = new LLCSegmentName(segmentNameStr);
-            if (segmentName.getTopicPartitionId().getPartitionId() == partition) {
+            if (segmentName.getTopicPartitionId().toMultiTopicPinotPartitionId() == partition) {
               seqNum.set(segmentName.getSequenceNumber());
             }
           }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeKafka4ClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeKafka4ClusterIntegrationTest.java
@@ -111,7 +111,7 @@ public class LLCRealtimeKafka4ClusterIntegrationTest extends LLCRealtimeClusterI
           if (is.getInstanceStateMap(segmentNameStr).values().contains(
               CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING)) {
             LLCSegmentName segmentName = new LLCSegmentName(segmentNameStr);
-            if (segmentName.getPartitionGroupId() == partition) {
+            if (segmentName.getTopicPartitionId().getPartitionId() == partition) {
               seqNum.set(segmentName.getSequenceNumber());
             }
           }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PartialUpsertTableRebalanceIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PartialUpsertTableRebalanceIntegrationTest.java
@@ -407,7 +407,7 @@ public class PartialUpsertTableRebalanceIntegrationTest extends BaseClusterInteg
       case UPLOADED_SEGMENT_3:
         return 1;
       default:
-        return new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId();
+        return new LLCSegmentName(segmentName).getTopicPartitionId().toMultiTopicPinotPartitionId();
     }
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PartialUpsertTableRebalanceIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PartialUpsertTableRebalanceIntegrationTest.java
@@ -407,7 +407,7 @@ public class PartialUpsertTableRebalanceIntegrationTest extends BaseClusterInteg
       case UPLOADED_SEGMENT_3:
         return 1;
       default:
-        return new LLCSegmentName(segmentName).getPartitionGroupId();
+        return new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId();
     }
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionSegmentCommitFailureTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionSegmentCommitFailureTest.java
@@ -245,7 +245,8 @@ public class PauselessRealtimeIngestionSegmentCommitFailureTest extends BaseClus
     for (SegmentZKMetadata segmentZKMetadata : segmentsZKMetadata) {
       LLCSegmentName llcSegmentName = new LLCSegmentName(segmentZKMetadata.getSegmentName());
       String segmentKey =
-          llcSegmentName.getTopicPartitionId().getPartitionId() + "_" + llcSegmentName.getSequenceNumber();
+          llcSegmentName.getTopicPartitionId().toMultiTopicPinotPartitionId()
+              + "_" + llcSegmentName.getSequenceNumber();
       segmentZKMetadataMap.put(segmentKey, segmentZKMetadata);
     }
     return segmentZKMetadataMap;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionSegmentCommitFailureTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionSegmentCommitFailureTest.java
@@ -244,7 +244,8 @@ public class PauselessRealtimeIngestionSegmentCommitFailureTest extends BaseClus
     Map<String, SegmentZKMetadata> segmentZKMetadataMap = new HashMap<>();
     for (SegmentZKMetadata segmentZKMetadata : segmentsZKMetadata) {
       LLCSegmentName llcSegmentName = new LLCSegmentName(segmentZKMetadata.getSegmentName());
-      String segmentKey = llcSegmentName.getPartitionGroupId() + "_" + llcSegmentName.getSequenceNumber();
+      String segmentKey =
+          llcSegmentName.getTopicPartitionId().getPartitionId() + "_" + llcSegmentName.getSequenceNumber();
       segmentZKMetadataMap.put(segmentKey, segmentZKMetadata);
     }
     return segmentZKMetadataMap;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentPartitionLLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentPartitionLLCRealtimeClusterIntegrationTest.java
@@ -161,7 +161,8 @@ public class SegmentPartitionLLCRealtimeClusterIntegrationTest extends BaseClust
       assertNotNull(columnPartitionMetadata);
       assertTrue(columnPartitionMetadata.getFunctionName().equalsIgnoreCase("murmur"));
       assertEquals(columnPartitionMetadata.getNumPartitions(), 2);
-      int partitionGroupId = new LLCSegmentName(segmentZKMetadata.getSegmentName()).getPartitionGroupId();
+      int partitionGroupId =
+          new LLCSegmentName(segmentZKMetadata.getSegmentName()).getTopicPartitionId().getPartitionId();
       assertEquals(columnPartitionMetadata.getPartitions(), Set.of(partitionGroupId));
       numSegmentsForPartition[partitionGroupId]++;
     }
@@ -268,7 +269,8 @@ public class SegmentPartitionLLCRealtimeClusterIntegrationTest extends BaseClust
       assertNotNull(columnPartitionMetadata);
       assertTrue(columnPartitionMetadata.getFunctionName().equalsIgnoreCase("murmur"));
       assertEquals(columnPartitionMetadata.getNumPartitions(), 2);
-      int partitionGroupId = new LLCSegmentName(segmentZKMetadata.getSegmentName()).getPartitionGroupId();
+      int partitionGroupId =
+          new LLCSegmentName(segmentZKMetadata.getSegmentName()).getTopicPartitionId().getPartitionId();
       numSegmentsForPartition[partitionGroupId]++;
 
       if (segmentZKMetadata.getStatus() == Status.IN_PROGRESS) {
@@ -345,7 +347,8 @@ public class SegmentPartitionLLCRealtimeClusterIntegrationTest extends BaseClust
       assertNotNull(columnPartitionMetadata);
       assertTrue(columnPartitionMetadata.getFunctionName().equalsIgnoreCase("murmur"));
       assertEquals(columnPartitionMetadata.getNumPartitions(), 2);
-      int partitionGroupId = new LLCSegmentName(segmentZKMetadata.getSegmentName()).getPartitionGroupId();
+      int partitionGroupId =
+          new LLCSegmentName(segmentZKMetadata.getSegmentName()).getTopicPartitionId().getPartitionId();
       numSegmentsForPartition[partitionGroupId]++;
 
       if (segmentZKMetadata.getStatus() == Status.IN_PROGRESS) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentPartitionLLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentPartitionLLCRealtimeClusterIntegrationTest.java
@@ -162,7 +162,7 @@ public class SegmentPartitionLLCRealtimeClusterIntegrationTest extends BaseClust
       assertTrue(columnPartitionMetadata.getFunctionName().equalsIgnoreCase("murmur"));
       assertEquals(columnPartitionMetadata.getNumPartitions(), 2);
       int partitionGroupId =
-          new LLCSegmentName(segmentZKMetadata.getSegmentName()).getTopicPartitionId().getPartitionId();
+          new LLCSegmentName(segmentZKMetadata.getSegmentName()).getTopicPartitionId().toMultiTopicPinotPartitionId();
       assertEquals(columnPartitionMetadata.getPartitions(), Set.of(partitionGroupId));
       numSegmentsForPartition[partitionGroupId]++;
     }
@@ -270,7 +270,7 @@ public class SegmentPartitionLLCRealtimeClusterIntegrationTest extends BaseClust
       assertTrue(columnPartitionMetadata.getFunctionName().equalsIgnoreCase("murmur"));
       assertEquals(columnPartitionMetadata.getNumPartitions(), 2);
       int partitionGroupId =
-          new LLCSegmentName(segmentZKMetadata.getSegmentName()).getTopicPartitionId().getPartitionId();
+          new LLCSegmentName(segmentZKMetadata.getSegmentName()).getTopicPartitionId().toMultiTopicPinotPartitionId();
       numSegmentsForPartition[partitionGroupId]++;
 
       if (segmentZKMetadata.getStatus() == Status.IN_PROGRESS) {
@@ -348,7 +348,7 @@ public class SegmentPartitionLLCRealtimeClusterIntegrationTest extends BaseClust
       assertTrue(columnPartitionMetadata.getFunctionName().equalsIgnoreCase("murmur"));
       assertEquals(columnPartitionMetadata.getNumPartitions(), 2);
       int partitionGroupId =
-          new LLCSegmentName(segmentZKMetadata.getSegmentName()).getTopicPartitionId().getPartitionId();
+          new LLCSegmentName(segmentZKMetadata.getSegmentName()).getTopicPartitionId().toMultiTopicPinotPartitionId();
       numSegmentsForPartition[partitionGroupId]++;
 
       if (segmentZKMetadata.getStatus() == Status.IN_PROGRESS) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentPreloadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentPreloadIntegrationTest.java
@@ -298,7 +298,7 @@ public class UpsertTableSegmentPreloadIntegrationTest extends BaseClusterIntegra
       case UPLOADED_SEGMENT_3:
         return 1;
       default:
-        return new LLCSegmentName(segmentName).getPartitionGroupId();
+        return new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId();
     }
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentPreloadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentPreloadIntegrationTest.java
@@ -298,7 +298,7 @@ public class UpsertTableSegmentPreloadIntegrationTest extends BaseClusterIntegra
       case UPLOADED_SEGMENT_3:
         return 1;
       default:
-        return new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId();
+        return new LLCSegmentName(segmentName).getTopicPartitionId().toMultiTopicPinotPartitionId();
     }
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentUploadIntegrationTest.java
@@ -225,7 +225,7 @@ public class UpsertTableSegmentUploadIntegrationTest extends BaseClusterIntegrat
       case UPLOADED_SEGMENT_3:
         return 1;
       default:
-        return new LLCSegmentName(segmentName).getPartitionGroupId();
+        return new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId();
     }
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentUploadIntegrationTest.java
@@ -225,7 +225,7 @@ public class UpsertTableSegmentUploadIntegrationTest extends BaseClusterIntegrat
       case UPLOADED_SEGMENT_3:
         return 1;
       default:
-        return new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId();
+        return new LLCSegmentName(segmentName).getTopicPartitionId().toMultiTopicPinotPartitionId();
     }
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/MultiTopicRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/MultiTopicRealtimeClusterIntegrationTest.java
@@ -256,7 +256,7 @@ public class MultiTopicRealtimeClusterIntegrationTest extends CustomDataQueryClu
       Map<String, String> stateMap = idealState.getInstanceStateMap(segmentName);
       if (stateMap != null
           && stateMap.containsValue(CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING)) {
-        consumingPartitions.add(new LLCSegmentName(segmentName).getPartitionGroupId());
+        consumingPartitions.add(new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId());
       }
     }
     return consumingPartitions.size();
@@ -383,7 +383,7 @@ public class MultiTopicRealtimeClusterIntegrationTest extends CustomDataQueryClu
     Set<Integer> topicIndicesSeen = new HashSet<>();
     for (String segmentName : idealState.getPartitionSet()) {
       if (LLCSegmentName.isLLCSegment(segmentName)) {
-        int pgId = new LLCSegmentName(segmentName).getPartitionGroupId();
+        int pgId = new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId();
         topicIndicesSeen.add(IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(pgId));
       }
     }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/MultiTopicRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/MultiTopicRealtimeClusterIntegrationTest.java
@@ -256,7 +256,7 @@ public class MultiTopicRealtimeClusterIntegrationTest extends CustomDataQueryClu
       Map<String, String> stateMap = idealState.getInstanceStateMap(segmentName);
       if (stateMap != null
           && stateMap.containsValue(CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING)) {
-        consumingPartitions.add(new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId());
+        consumingPartitions.add(new LLCSegmentName(segmentName).getTopicPartitionId().toMultiTopicPinotPartitionId());
       }
     }
     return consumingPartitions.size();
@@ -383,7 +383,7 @@ public class MultiTopicRealtimeClusterIntegrationTest extends CustomDataQueryClu
     Set<Integer> topicIndicesSeen = new HashSet<>();
     for (String segmentName : idealState.getPartitionSet()) {
       if (LLCSegmentName.isLLCSegment(segmentName)) {
-        int pgId = new LLCSegmentName(segmentName).getTopicPartitionId().getPartitionId();
+        int pgId = new LLCSegmentName(segmentName).getTopicPartitionId().toMultiTopicPinotPartitionId();
         topicIndicesSeen.add(IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(pgId));
       }
     }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/PauselessRealtimeTestUtils.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/PauselessRealtimeTestUtils.java
@@ -71,7 +71,8 @@ public class PauselessRealtimeTestUtils {
     for (SegmentZKMetadata segmentZKMetadata : segmentsZKMetadata) {
       LLCSegmentName llcSegmentName = new LLCSegmentName(segmentZKMetadata.getSegmentName());
       String segmentKey =
-          llcSegmentName.getTopicPartitionId().getPartitionId() + "_" + llcSegmentName.getSequenceNumber();
+          llcSegmentName.getTopicPartitionId().toMultiTopicPinotPartitionId()
+              + "_" + llcSegmentName.getSequenceNumber();
       segmentZKMetadataMap.put(segmentKey, segmentZKMetadata);
     }
     return segmentZKMetadataMap;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/PauselessRealtimeTestUtils.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/PauselessRealtimeTestUtils.java
@@ -70,7 +70,8 @@ public class PauselessRealtimeTestUtils {
     Map<String, SegmentZKMetadata> segmentZKMetadataMap = new HashMap<>();
     for (SegmentZKMetadata segmentZKMetadata : segmentsZKMetadata) {
       LLCSegmentName llcSegmentName = new LLCSegmentName(segmentZKMetadata.getSegmentName());
-      String segmentKey = llcSegmentName.getPartitionGroupId() + "_" + llcSegmentName.getSequenceNumber();
+      String segmentKey =
+          llcSegmentName.getTopicPartitionId().getPartitionId() + "_" + llcSegmentName.getSequenceNumber();
       segmentZKMetadataMap.put(segmentKey, segmentZKMetadata);
     }
     return segmentZKMetadataMap;

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
@@ -43,6 +43,7 @@ import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.minion.MergeRollupTaskMetadata;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.TopicPartitionId;
 import org.apache.pinot.controller.helix.core.minion.generator.BaseTaskGenerator;
 import org.apache.pinot.controller.helix.core.minion.generator.PinotTaskGenerator;
 import org.apache.pinot.controller.helix.core.minion.generator.TaskGeneratorUtils;
@@ -168,7 +169,8 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
               tableConfig.getTableType() == TableType.OFFLINE
                       ? getSegmentsZKMetadataForTable(tableNameWithType)
                       : filterSegmentsforRealtimeTable(
-                              getNonConsumingSegmentsZKMetadataForRealtimeTable(tableNameWithType));
+                              getNonConsumingSegmentsZKMetadataForRealtimeTable(tableNameWithType),
+                              tableConfig);
 
       // Select current segment snapshot based on lineage, filter out empty segments
       SegmentLineage segmentLineage = _clusterInfoAccessor.getSegmentLineage(tableNameWithType);
@@ -577,7 +579,8 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
   }
 
   @VisibleForTesting
-  static List<SegmentZKMetadata> filterSegmentsforRealtimeTable(List<SegmentZKMetadata> allSegments) {
+  static List<SegmentZKMetadata> filterSegmentsforRealtimeTable(List<SegmentZKMetadata> allSegments,
+      TableConfig tableConfig) {
     // For realtime table, don't process
     // 1. in-progress segments (Segment.Realtime.Status.IN_PROGRESS), this has been taken care of in
     //    getNonConsumingSegmentsZKMetadataForRealtimeTable()
@@ -598,12 +601,13 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
     //    if new records are consumed later, the MergeRollupTask may have already moved watermarks forward, and may
     //    not be able to merge those lately-created segments -- we assume that users will have a way to backfill those
     //    records correctly.
-    Map<Integer, LLCSegmentName> partitionIdToLatestCompletedSegment = new HashMap<>();
+    boolean hasMultipleStreams = IngestionConfigUtils.hasMultipleStreams(tableConfig);
+    Map<TopicPartitionId, LLCSegmentName> partitionIdToLatestCompletedSegment = new HashMap<>();
     for (SegmentZKMetadata segmentZKMetadata : allSegments) {
       String segmentName = segmentZKMetadata.getSegmentName();
       if (LLCSegmentName.isLLCSegment(segmentName)) {
-        LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
-        partitionIdToLatestCompletedSegment.compute(llcSegmentName.getTopicPartitionId().getPartitionId(),
+        LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName, hasMultipleStreams);
+        partitionIdToLatestCompletedSegment.compute(llcSegmentName.getTopicPartitionId(),
             (partId, latestSegment) -> {
               if (latestSegment == null) {
                 return llcSegmentName;

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
@@ -603,14 +603,15 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
       String segmentName = segmentZKMetadata.getSegmentName();
       if (LLCSegmentName.isLLCSegment(segmentName)) {
         LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
-        partitionIdToLatestCompletedSegment.compute(llcSegmentName.getPartitionGroupId(), (partId, latestSegment) -> {
-          if (latestSegment == null) {
-            return llcSegmentName;
-          } else {
-            return latestSegment.getSequenceNumber() > llcSegmentName.getSequenceNumber()
+        partitionIdToLatestCompletedSegment.compute(llcSegmentName.getTopicPartitionId().getPartitionId(),
+            (partId, latestSegment) -> {
+              if (latestSegment == null) {
+                return llcSegmentName;
+              } else {
+                return latestSegment.getSequenceNumber() > llcSegmentName.getSequenceNumber()
                     ? latestSegment : llcSegmentName;
-          }
-        });
+              }
+            });
       }
     }
     Set<String> filteredSegmentNames = new HashSet<>();

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskGenerator.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import org.apache.pinot.common.data.Segment;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.TopicPartitionId;
 import org.apache.pinot.controller.helix.core.minion.generator.BaseTaskGenerator;
 import org.apache.pinot.controller.helix.core.minion.generator.TaskGeneratorUtils;
 import org.apache.pinot.core.common.MinionConstants;
@@ -39,6 +40,7 @@ import org.apache.pinot.spi.annotations.minion.TaskGenerator;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.TimeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -108,7 +110,7 @@ public class PurgeTaskGenerator extends BaseTaskGenerator {
       // For realtime tables, build a map of partition to latest segment to avoid deleting last segments
       Set<String> lastLLCSegmentPerPartition = new HashSet<>();
       if (tableConfig.getTableType() == TableType.REALTIME) {
-        lastLLCSegmentPerPartition = getLastLLCSegmentPerPartition(segmentsZKMetadata);
+        lastLLCSegmentPerPartition = getLastLLCSegmentPerPartition(segmentsZKMetadata, tableConfig);
       }
       for (SegmentZKMetadata segmentZKMetadata : notpurgedSegmentsZKMetadata) {
         String segmentName = segmentZKMetadata.getSegmentName();
@@ -163,13 +165,15 @@ public class PurgeTaskGenerator extends BaseTaskGenerator {
     return pinotTaskConfigs;
   }
 
-  private Set<String> getLastLLCSegmentPerPartition(List<SegmentZKMetadata> segmentsZKMetadata) {
-    Map<Integer, LLCSegmentName> latestLLCSegmentNameMap = new HashMap<>();
+  private Set<String> getLastLLCSegmentPerPartition(List<SegmentZKMetadata> segmentsZKMetadata,
+      TableConfig tableConfig) {
+    boolean hasMultipleStreams = IngestionConfigUtils.hasMultipleStreams(tableConfig);
+    Map<TopicPartitionId, LLCSegmentName> latestLLCSegmentNameMap = new HashMap<>();
     for (SegmentZKMetadata segmentZKMetadata : segmentsZKMetadata) {
       // Skip UPLOADED segments that don't conform to the LLC segment name
-      LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentZKMetadata.getSegmentName());
+      LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentZKMetadata.getSegmentName(), hasMultipleStreams);
       if (llcSegmentName != null) {
-        latestLLCSegmentNameMap.compute(llcSegmentName.getTopicPartitionId().getPartitionId(),
+        latestLLCSegmentNameMap.compute(llcSegmentName.getTopicPartitionId(),
             (k, latestLLCSegmentName) -> {
               if (latestLLCSegmentName == null
                   || llcSegmentName.getSequenceNumber() > latestLLCSegmentName.getSequenceNumber()) {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskGenerator.java
@@ -169,14 +169,15 @@ public class PurgeTaskGenerator extends BaseTaskGenerator {
       // Skip UPLOADED segments that don't conform to the LLC segment name
       LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentZKMetadata.getSegmentName());
       if (llcSegmentName != null) {
-        latestLLCSegmentNameMap.compute(llcSegmentName.getPartitionGroupId(), (k, latestLLCSegmentName) -> {
-          if (latestLLCSegmentName == null
-              || llcSegmentName.getSequenceNumber() > latestLLCSegmentName.getSequenceNumber()) {
-            return llcSegmentName;
-          } else {
-            return latestLLCSegmentName;
-          }
-        });
+        latestLLCSegmentNameMap.compute(llcSegmentName.getTopicPartitionId().getPartitionId(),
+            (k, latestLLCSegmentName) -> {
+              if (latestLLCSegmentName == null
+                  || llcSegmentName.getSequenceNumber() > latestLLCSegmentName.getSequenceNumber()) {
+                return llcSegmentName;
+              } else {
+                return latestLLCSegmentName;
+              }
+            });
       }
     }
     Set<String> lastLLCSegmentPerPartition = new HashSet<>();

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
@@ -32,6 +32,7 @@ import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.minion.RealtimeToOfflineSegmentsTaskMetadata;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.TopicPartitionId;
 import org.apache.pinot.controller.helix.core.minion.generator.BaseTaskGenerator;
 import org.apache.pinot.controller.helix.core.minion.generator.PinotTaskGenerator;
 import org.apache.pinot.controller.helix.core.minion.generator.TaskGeneratorUtils;
@@ -48,6 +49,7 @@ import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.TimeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -117,10 +119,10 @@ public class RealtimeToOfflineSegmentsTaskGenerator extends BaseTaskGenerator {
 
       // Get all segment metadata for completed segments (DONE/UPLOADED status).
       List<SegmentZKMetadata> completedSegmentsZKMetadata = new ArrayList<>();
-      Map<Integer, String> partitionToLatestLLCSegmentName = new HashMap<>();
-      Set<Integer> allPartitions = new HashSet<>();
-      getCompletedSegmentsInfo(realtimeTableName, completedSegmentsZKMetadata, partitionToLatestLLCSegmentName,
-          allPartitions);
+      Map<TopicPartitionId, String> partitionToLatestLLCSegmentName = new HashMap<>();
+      Set<TopicPartitionId> allPartitions = new HashSet<>();
+      getCompletedSegmentsInfo(realtimeTableName, tableConfig, completedSegmentsZKMetadata,
+          partitionToLatestLLCSegmentName, allPartitions);
       if (completedSegmentsZKMetadata.isEmpty()) {
         LOGGER.info("No realtime-completed segments found for table: {}, skipping task generation: {}",
             realtimeTableName, taskType);
@@ -245,22 +247,25 @@ public class RealtimeToOfflineSegmentsTaskGenerator extends BaseTaskGenerator {
    * Fetch completed (DONE/UPLOADED) segment and partition information
    *
    * @param realtimeTableName the realtime table name
+   * @param tableConfig the table config for multi-stream context
    * @param completedSegmentsZKMetadata list for collecting the completed (DONE/UPLOADED) segments ZK metadata
    * @param partitionToLatestLLCSegmentName map for collecting the partitionId to the latest LLC segment name
    * @param allPartitions set for collecting all partition ids
    */
-  private void getCompletedSegmentsInfo(String realtimeTableName, List<SegmentZKMetadata> completedSegmentsZKMetadata,
-      Map<Integer, String> partitionToLatestLLCSegmentName, Set<Integer> allPartitions) {
+  private void getCompletedSegmentsInfo(String realtimeTableName, TableConfig tableConfig,
+      List<SegmentZKMetadata> completedSegmentsZKMetadata,
+      Map<TopicPartitionId, String> partitionToLatestLLCSegmentName, Set<TopicPartitionId> allPartitions) {
+    boolean hasMultipleStreams = IngestionConfigUtils.hasMultipleStreams(tableConfig);
     List<SegmentZKMetadata> segmentsZKMetadata = getNonConsumingSegmentsZKMetadataForRealtimeTable(realtimeTableName);
 
-    Map<Integer, LLCSegmentName> latestLLCSegmentNameMap = new HashMap<>();
+    Map<TopicPartitionId, LLCSegmentName> latestLLCSegmentNameMap = new HashMap<>();
     for (SegmentZKMetadata segmentZKMetadata : segmentsZKMetadata) {
       completedSegmentsZKMetadata.add(segmentZKMetadata);
 
       // Skip UPLOADED segments that don't conform to the LLC segment name
-      LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentZKMetadata.getSegmentName());
+      LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentZKMetadata.getSegmentName(), hasMultipleStreams);
       if (llcSegmentName != null) {
-        int partitionId = llcSegmentName.getTopicPartitionId().getPartitionId();
+        TopicPartitionId partitionId = llcSegmentName.getTopicPartitionId();
         allPartitions.add(partitionId);
         latestLLCSegmentNameMap.compute(partitionId, (k, latestLLCSegmentName) -> {
           if (latestLLCSegmentName == null
@@ -273,7 +278,7 @@ public class RealtimeToOfflineSegmentsTaskGenerator extends BaseTaskGenerator {
       }
     }
 
-    for (Map.Entry<Integer, LLCSegmentName> entry : latestLLCSegmentNameMap.entrySet()) {
+    for (Map.Entry<TopicPartitionId, LLCSegmentName> entry : latestLLCSegmentNameMap.entrySet()) {
       partitionToLatestLLCSegmentName.put(entry.getKey(), entry.getValue().getSegmentName());
     }
   }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
@@ -260,7 +260,7 @@ public class RealtimeToOfflineSegmentsTaskGenerator extends BaseTaskGenerator {
       // Skip UPLOADED segments that don't conform to the LLC segment name
       LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentZKMetadata.getSegmentName());
       if (llcSegmentName != null) {
-        int partitionId = llcSegmentName.getPartitionGroupId();
+        int partitionId = llcSegmentName.getTopicPartitionId().getPartitionId();
         allPartitions.add(partitionId);
         latestLLCSegmentNameMap.compute(partitionId, (k, latestLLCSegmentName) -> {
           if (latestLLCSegmentName == null

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGeneratorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGeneratorTest.java
@@ -404,7 +404,8 @@ public class MergeRollupTaskGeneratorTest {
     // Skip task generation, if the table is a realtime table and all segments are skipped
     // We don't test realtime REFRESH table because this combination does not make sense
     assertTrue(MergeRollupTaskGenerator.filterSegmentsforRealtimeTable(
-            Lists.newArrayList(realtimeTableSegmentMetadata1, realtimeTableSegmentMetadata2)
+            Lists.newArrayList(realtimeTableSegmentMetadata1, realtimeTableSegmentMetadata2),
+            getTableConfig(TableType.REALTIME, new HashMap<>())
     ).isEmpty());
     TableConfig realtimeTableConfig = getTableConfig(TableType.REALTIME, new HashMap<>());
     List<PinotTaskConfig> pinotTaskConfigs = generator.generateTasks(Lists.newArrayList(realtimeTableConfig));
@@ -454,7 +455,8 @@ public class MergeRollupTaskGeneratorTest {
 
     List<SegmentZKMetadata> filterResult = MergeRollupTaskGenerator.filterSegmentsforRealtimeTable(
             Lists.newArrayList(realtimeTableSegmentMetadata1, realtimeTableSegmentMetadata2,
-                    realtimeTableSegmentMetadata3));
+                    realtimeTableSegmentMetadata3),
+            getTableConfig(TableType.REALTIME, new HashMap<>()));
     assertEquals(filterResult.size(), 1);
     assertEquals(filterResult.get(0).getSegmentName(), "testTable__0__0__20250224T0900Z");
   }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LeafStageWorkerAssignmentRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LeafStageWorkerAssignmentRule.java
@@ -455,7 +455,7 @@ public class LeafStageWorkerAssignmentRule extends PRelOptRule {
   static int inferPartitionId(String segmentName, int numPartitions) {
     if (LLCSegmentName.isLLCSegment(segmentName)) {
       LLCSegmentName llc = LLCSegmentName.of(segmentName);
-      return llc != null ? (llc.getPartitionGroupId() % numPartitions) : -1;
+      return llc != null ? (llc.getTopicPartitionId().getPartitionId() % numPartitions) : -1;
     } else if (UploadedRealtimeSegmentName.isUploadedRealtimeSegmentName(segmentName)) {
       UploadedRealtimeSegmentName uploaded = UploadedRealtimeSegmentName.of(segmentName);
       return uploaded != null ? (uploaded.getPartitionId() % numPartitions) : -1;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LeafStageWorkerAssignmentRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LeafStageWorkerAssignmentRule.java
@@ -453,6 +453,11 @@ public class LeafStageWorkerAssignmentRule extends PRelOptRule {
 
   @VisibleForTesting
   static int inferPartitionId(String segmentName, int numPartitions) {
+    // TODO: Thread hasMultipleStreams through the call chain from _tableCache so that
+    //  multi-stream composite partition IDs are properly decomposed into raw stream partition IDs.
+    //  Currently uses the deprecated no-arg parse, which treats composite IDs as single-stream
+    //  partition IDs. This is correct for single-stream tables; for multi-stream tables the
+    //  modulo result may differ but worker assignment remains deterministic.
     if (LLCSegmentName.isLLCSegment(segmentName)) {
       LLCSegmentName llc = LLCSegmentName.of(segmentName);
       return llc != null ? (llc.getTopicPartitionId().getPartitionId() % numPartitions) : -1;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -335,6 +335,7 @@ public class MutableSegmentImpl implements MutableSegment {
               .withEstimatedColSize(_statsHistory.getEstimatedAvgColSize(column))
               .withAvgNumMultiValues(_statsHistory.getEstimatedAvgColSize(column))
               .withConsumerDir(_consumerDir)
+              .withHasMultipleStreams(config.hasMultipleStreams())
               .withFixedLengthBytes(fixedByteSize).build();
 
       // Partition info
@@ -481,7 +482,7 @@ public class MutableSegmentImpl implements MutableSegment {
       }
       _multiColumnTextIndex =
           new MultiColumnRealtimeLuceneTextIndex(textColumns, columnsSV, _consumerDir, config.getSegmentName(),
-              textConfig);
+              textConfig, config.hasMultipleStreams());
       _multiColumnPos = _multiColumnTextIndex.getMapping();
       _multiColumnValues = new ArrayList<>(_multiColumnPos.size());
       for (int i = 0; i < _multiColumnPos.size(); i++) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/RealtimeSegmentConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/RealtimeSegmentConfig.java
@@ -72,6 +72,7 @@ public class RealtimeSegmentConfig {
   @Nullable
   private final MultiColumnTextIndexConfig _multiColIndexConfig;
   private final boolean _dropRecordOnPartitionMismatch;
+  private final boolean _hasMultipleStreams;
 
   // TODO: Clean up this constructor. Most of these things can be extracted from tableConfig.
 
@@ -101,7 +102,8 @@ public class RealtimeSegmentConfig {
       @Nullable PartitionDedupMetadataManager partitionDedupMetadataManager,
       String consumerDir,
       @Nullable MultiColumnTextIndexConfig textIndexConfig,
-      boolean dropRecordOnPartitionMismatch) {
+      boolean dropRecordOnPartitionMismatch,
+      boolean hasMultipleStreams) {
     _tableNameWithType = tableNameWithType;
     _segmentName = segmentName;
     _streamName = streamName;
@@ -125,6 +127,7 @@ public class RealtimeSegmentConfig {
     _consumerDir = consumerDir;
     _multiColIndexConfig = textIndexConfig;
     _dropRecordOnPartitionMismatch = dropRecordOnPartitionMismatch;
+    _hasMultipleStreams = hasMultipleStreams;
   }
 
   public String getTableNameWithType() {
@@ -224,6 +227,10 @@ public class RealtimeSegmentConfig {
     return _dropRecordOnPartitionMismatch;
   }
 
+  public boolean hasMultipleStreams() {
+    return _hasMultipleStreams;
+  }
+
   public static class Builder {
     private String _tableNameWithType;
     private String _segmentName;
@@ -252,6 +259,7 @@ public class RealtimeSegmentConfig {
     private String _consumerDir;
     private MultiColumnTextIndexConfig _textIndexConfig;
     private boolean _dropRecordOnPartitionMismatch;
+    private boolean _hasMultipleStreams;
 
     public Builder() {
       _indexConfigByCol = new HashMap<>();
@@ -429,6 +437,11 @@ public class RealtimeSegmentConfig {
       return this;
     }
 
+    public Builder setHasMultipleStreams(boolean hasMultipleStreams) {
+      _hasMultipleStreams = hasMultipleStreams;
+      return this;
+    }
+
     public RealtimeSegmentConfig build() {
       Map<String, FieldIndexConfigs> indexConfigByCol = Maps.newHashMapWithExpectedSize(_indexConfigByCol.size());
       for (Map.Entry<String, FieldIndexConfigs.Builder> entry : _indexConfigByCol.entrySet()) {
@@ -439,7 +452,8 @@ public class RealtimeSegmentConfig {
           _capacity, _avgNumMultiValues, Collections.unmodifiableMap(indexConfigByCol), _segmentZKMetadata, _offHeap,
           _memoryManager, _statsHistory, _partitionColumn, _partitionFunction, _partitionId, _aggregateMetrics,
           _ingestionAggregationConfigs, _defaultNullHandlingEnabled, _partitionUpsertMetadataManager,
-          _partitionDedupMetadataManager, _consumerDir, _textIndexConfig, _dropRecordOnPartitionMismatch);
+          _partitionDedupMetadataManager, _consumerDir, _textIndexConfig, _dropRecordOnPartitionMismatch,
+          _hasMultipleStreams);
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/MultiColumnRealtimeLuceneTextIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/MultiColumnRealtimeLuceneTextIndex.java
@@ -83,13 +83,15 @@ public class MultiColumnRealtimeLuceneTextIndex implements MultiColumnTextIndexR
    * @param segmentIndexDir realtime segment consumer dir
    * @param segmentName realtime segment name
    * @param mcTextConfig the table index config
+   * @param hasMultipleStreams whether the table has multiple stream configs
    */
   public MultiColumnRealtimeLuceneTextIndex(
       List<String> columns,
       BooleanList columnsSV,
       File segmentIndexDir,
       String segmentName,
-      MultiColumnTextIndexConfig mcTextConfig) {
+      MultiColumnTextIndexConfig mcTextConfig,
+      boolean hasMultipleStreams) {
     _columns = columns;
     _segmentName = segmentName;
     try {
@@ -112,7 +114,7 @@ public class MultiColumnRealtimeLuceneTextIndex implements MultiColumnTextIndexR
       IndexWriter indexWriter = _indexCreator.getIndexWriter();
       _searcherManager = new SearcherManager(indexWriter, false, false, null);
 
-      LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
+      LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName, hasMultipleStreams);
       _refreshListener = new RealtimeLuceneRefreshListener(llcSegmentName.getTableName(), segmentName,
           MultiColumnTextIndexConstants.INDEX_DIR_NAME,
           llcSegmentName.getTopicPartitionId().getPartitionId(), _indexCreator::getNumDocs);
@@ -133,6 +135,13 @@ public class MultiColumnRealtimeLuceneTextIndex implements MultiColumnTextIndexR
           e.getMessage());
       throw new RuntimeException(e);
     }
+  }
+
+  /** @deprecated Use the constructor with {@code hasMultipleStreams} parameter. */
+  @Deprecated
+  public MultiColumnRealtimeLuceneTextIndex(List<String> columns, BooleanList columnsSV, File segmentIndexDir,
+      String segmentName, MultiColumnTextIndexConfig mcTextConfig) {
+    this(columns, columnsSV, segmentIndexDir, segmentName, mcTextConfig, false);
   }
 
   public void add(List<Object> values) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/MultiColumnRealtimeLuceneTextIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/MultiColumnRealtimeLuceneTextIndex.java
@@ -115,7 +115,7 @@ public class MultiColumnRealtimeLuceneTextIndex implements MultiColumnTextIndexR
       LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
       _refreshListener = new RealtimeLuceneRefreshListener(llcSegmentName.getTableName(), segmentName,
           MultiColumnTextIndexConstants.INDEX_DIR_NAME,
-          llcSegmentName.getPartitionGroupId(), _indexCreator::getNumDocs);
+          llcSegmentName.getTopicPartitionId().getPartitionId(), _indexCreator::getNumDocs);
       _searcherManager.addListener(_refreshListener);
       _analyzer = _indexCreator.getIndexWriter().getConfig().getAnalyzer();
       _queryParserClassConstructor =

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneTextIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneTextIndex.java
@@ -71,8 +71,10 @@ public class RealtimeLuceneTextIndex implements MutableTextIndex {
    * @param segmentIndexDir realtime segment consumer dir
    * @param segmentName realtime segment name
    * @param config the table index config
+   * @param hasMultipleStreams whether the table has multiple stream configs
    */
-  public RealtimeLuceneTextIndex(String column, File segmentIndexDir, String segmentName, TextIndexConfig config) {
+  public RealtimeLuceneTextIndex(String column, File segmentIndexDir, String segmentName, TextIndexConfig config,
+      boolean hasMultipleStreams) {
     _column = column;
     _segmentName = segmentName;
     try {
@@ -90,7 +92,7 @@ public class RealtimeLuceneTextIndex implements MutableTextIndex {
       IndexWriter indexWriter = _indexCreator.getIndexWriter();
       _searcherManager = new SearcherManager(indexWriter, false, false, null);
 
-      LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
+      LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName, hasMultipleStreams);
       _refreshListener = new RealtimeLuceneRefreshListener(llcSegmentName.getTableName(), segmentName, column,
           llcSegmentName.getTopicPartitionId().getPartitionId(), _indexCreator::getNumDocs);
       _searcherManager.addListener(_refreshListener);
@@ -109,6 +111,12 @@ public class RealtimeLuceneTextIndex implements MutableTextIndex {
           e.getMessage());
       throw new RuntimeException(e);
     }
+  }
+
+  /** @deprecated Use {@link #RealtimeLuceneTextIndex(String, File, String, TextIndexConfig, boolean)}. */
+  @Deprecated
+  public RealtimeLuceneTextIndex(String column, File segmentIndexDir, String segmentName, TextIndexConfig config) {
+    this(column, segmentIndexDir, segmentName, config, false);
   }
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneTextIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneTextIndex.java
@@ -92,7 +92,7 @@ public class RealtimeLuceneTextIndex implements MutableTextIndex {
 
       LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
       _refreshListener = new RealtimeLuceneRefreshListener(llcSegmentName.getTableName(), segmentName, column,
-          llcSegmentName.getPartitionGroupId(), _indexCreator::getNumDocs);
+          llcSegmentName.getTopicPartitionId().getPartitionId(), _indexCreator::getNumDocs);
       _searcherManager.addListener(_refreshListener);
       _analyzer = _indexCreator.getIndexWriter().getConfig().getAnalyzer();
       _queryParserClassConstructor =

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/writer/StatelessRealtimeSegmentWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/writer/StatelessRealtimeSegmentWriter.java
@@ -122,10 +122,12 @@ public class StatelessRealtimeSegmentWriter implements Closeable {
       throws Exception {
     Preconditions.checkNotNull(indexLoadingConfig.getTableConfig(), "Table config must be set in index loading config");
     Preconditions.checkNotNull(indexLoadingConfig.getSchema(), "Schema must be set in index loading config");
-    LLCSegmentName llcSegmentName = new LLCSegmentName(segmentZKMetadata.getSegmentName());
+    LLCSegmentName llcSegmentName =
+        new LLCSegmentName(segmentZKMetadata.getSegmentName(),
+            IngestionConfigUtils.hasMultipleStreams(indexLoadingConfig.getTableConfig()));
 
     _segmentName = segmentZKMetadata.getSegmentName();
-    _partitionGroupId = llcSegmentName.getTopicPartitionId().getPartitionId();
+    _partitionGroupId = llcSegmentName.getTopicPartitionId().toMultiTopicPinotPartitionId();
     _segBuildSemaphore = segBuildSemaphore;
     _tableNameWithType = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(llcSegmentName.getTableName());
     _segmentZKMetadata = segmentZKMetadata;
@@ -196,7 +198,8 @@ public class StatelessRealtimeSegmentWriter implements Closeable {
         .setConsumerDir(_resourceDataDir.getAbsolutePath())
         .setDropRecordOnPartitionMismatch(ingestionConfig != null
             && ingestionConfig.getStreamIngestionConfig() != null
-            && ingestionConfig.getStreamIngestionConfig().isDropRecordOnPartitionMismatch());
+            && ingestionConfig.getStreamIngestionConfig().isDropRecordOnPartitionMismatch())
+        .setHasMultipleStreams(IngestionConfigUtils.hasMultipleStreams(_tableConfig));
 
     setPartitionParameters(realtimeSegmentConfigBuilder, _tableConfig.getIndexingConfig().getSegmentPartitionConfig());
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/writer/StatelessRealtimeSegmentWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/writer/StatelessRealtimeSegmentWriter.java
@@ -125,7 +125,7 @@ public class StatelessRealtimeSegmentWriter implements Closeable {
     LLCSegmentName llcSegmentName = new LLCSegmentName(segmentZKMetadata.getSegmentName());
 
     _segmentName = segmentZKMetadata.getSegmentName();
-    _partitionGroupId = llcSegmentName.getPartitionGroupId();
+    _partitionGroupId = llcSegmentName.getTopicPartitionId().getPartitionId();
     _segBuildSemaphore = segBuildSemaphore;
     _tableNameWithType = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(llcSegmentName.getTableName());
     _segmentZKMetadata = segmentZKMetadata;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexType.java
@@ -174,6 +174,6 @@ public class TextIndexType extends AbstractIndexType<TextIndexConfig, TextIndexR
       return null;
     }
     return new RealtimeLuceneTextIndex(context.getFieldSpec().getName(), context.getConsumerDir(),
-        context.getSegmentName(), config);
+        context.getSegmentName(), config, context.hasMultipleStreams());
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/mutable/provider/MutableIndexContext.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/mutable/provider/MutableIndexContext.java
@@ -36,10 +36,11 @@ public class MutableIndexContext {
   private final String _segmentName;
   private final PinotDataBufferMemoryManager _memoryManager;
   private final File _consumerDir;
+  private final boolean _hasMultipleStreams;
 
   public MutableIndexContext(FieldSpec fieldSpec, int fixedLengthBytes, boolean hasDictionary, String segmentName,
       PinotDataBufferMemoryManager memoryManager, int capacity, boolean offHeap, int estimatedColSize,
-      int estimatedCardinality, int avgNumMultiValues, File consumerDir) {
+      int estimatedCardinality, int avgNumMultiValues, File consumerDir, boolean hasMultipleStreams) {
     _fieldSpec = fieldSpec;
     _fixedLengthBytes = fixedLengthBytes;
     _hasDictionary = hasDictionary;
@@ -51,6 +52,7 @@ public class MutableIndexContext {
     _estimatedCardinality = estimatedCardinality;
     _avgNumMultiValues = avgNumMultiValues;
     _consumerDir = consumerDir;
+    _hasMultipleStreams = hasMultipleStreams;
   }
 
   public PinotDataBufferMemoryManager getMemoryManager() {
@@ -97,6 +99,10 @@ public class MutableIndexContext {
     return _consumerDir;
   }
 
+  public boolean hasMultipleStreams() {
+    return _hasMultipleStreams;
+  }
+
   public static Builder builder() {
     return new Builder();
   }
@@ -113,6 +119,7 @@ public class MutableIndexContext {
     private int _estimatedCardinality;
     private int _avgNumMultiValues;
     private File _consumerDir;
+    private boolean _hasMultipleStreams;
 
     public Builder withMemoryManager(PinotDataBufferMemoryManager memoryManager) {
       _memoryManager = memoryManager;
@@ -164,6 +171,11 @@ public class MutableIndexContext {
       return this;
     }
 
+    public Builder withHasMultipleStreams(boolean hasMultipleStreams) {
+      _hasMultipleStreams = hasMultipleStreams;
+      return this;
+    }
+
     public Builder withFixedLengthBytes(int fixedLengthBytes) {
       _fixedLengthBytes = fixedLengthBytes;
       return this;
@@ -172,7 +184,7 @@ public class MutableIndexContext {
     public MutableIndexContext build() {
       return new MutableIndexContext(Objects.requireNonNull(_fieldSpec), _fixedLengthBytes, _hasDictionary,
           Objects.requireNonNull(_segmentName), Objects.requireNonNull(_memoryManager), _capacity, _offHeap,
-          _estimatedColSize, _estimatedCardinality, _avgNumMultiValues, _consumerDir);
+          _estimatedColSize, _estimatedCardinality, _avgNumMultiValues, _consumerDir, _hasMultipleStreams);
     }
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupConsumptionStatus.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupConsumptionStatus.java
@@ -33,6 +33,9 @@ package org.apache.pinot.spi.stream;
  * 6. status - the consumption status IN_PROGRESS/DONE
  *
  * This information is needed by the stream, when grouping the partitions/shards into new partition groups.
+ *
+ * TODO: Add an overloaded constructor that accepts TopicPartitionId instead of int partitionGroupId,
+ *  to avoid callers needing to decompose/recompose composite partition IDs.
  */
 public class PartitionGroupConsumptionStatus {
   private final int _partitionGroupId;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
@@ -124,7 +124,9 @@ public final class IngestionConfigUtils {
   }
 
   /// Returns the stream partition id from the Pinot segment partition id.
-  /// Returns {@code partitionId} unchanged for tables without multiple streams.
+  /// Safe to call for any table type: returns `partitionId` unchanged for OFFLINE tables or REALTIME tables
+  /// that lack stream configs (treat as single-stream).
+  @Deprecated
   public static int getStreamPartitionIdFromPinotPartitionId(TableConfig tableConfig, int partitionId) {
     return hasMultipleStreams(tableConfig) ? getStreamPartitionIdFromPinotPartitionId(partitionId) : partitionId;
   }
@@ -132,6 +134,7 @@ public final class IngestionConfigUtils {
   /// Returns the stream partition id from the Pinot segment partition id.
   /// NOTE: First verify if there are multiple stream configs before invoking this method. User might plug in a stream
   ///       that generates large partition id.
+  @Deprecated
   public static int getStreamPartitionIdFromPinotPartitionId(int partitionId) {
     return partitionId % PARTITION_PADDING_OFFSET;
   }
@@ -145,6 +148,7 @@ public final class IngestionConfigUtils {
   /// Returns the index of the StreamConfigs from the Pinot segment partition id.
   /// NOTE: First verify if there are multiple stream configs before invoking this method. User might plug in a stream
   ///       that generates large partition id.
+  @Deprecated
   public static int getStreamConfigIndexFromPinotPartitionId(int partitionId) {
     return partitionId / PARTITION_PADDING_OFFSET;
   }
@@ -351,6 +355,7 @@ public final class IngestionConfigUtils {
    * Returns a Map of stream config index to Set of stream partition Ids.
    * @param pinotPartitionIds Set of pinot partition ids.
    */
+  @Deprecated
   public static Map<Integer, Set<Integer>> getStreamConfigIndexToStreamPartitions(Set<Integer> pinotPartitionIds) {
     Map<Integer, Set<Integer>> streamIndexToPartitions = new HashMap<>();
     for (Integer partition : pinotPartitionIds) {


### PR DESCRIPTION
## Summary

Stacked on #18913 (`TopicPartitionId` introduction) — please review/merge that one first. This PR migrates internal partition-identity handling from raw `int`/`Integer` partition IDs to the `TopicPartitionId` composite key introduced in the prior PR, in preparation for supporting multiple Kafka topics per Pinot table.

- Add context-aware `LLCSegmentName(String, boolean hasMultipleStreams)` that decomposes old-format composite partition IDs (e.g. `10003` -> topic 1, partition 3) at parse time when the table has multiple streams, so `TopicPartitionId` is always canonical regardless of segment format.
- Migrate internal maps from `Map<Integer, ...>` to `Map<TopicPartitionId, ...>` across controller, server, query planner, segment-local, and minion tasks.
- Change `assignConsumingSegment`, `computeStartOffset`, and other internal methods to accept `TopicPartitionId` directly instead of raw partition ints.
- Thread `hasMultipleStreams` through `RealtimeSegmentConfig`, `MutableIndexContext`, and Lucene index constructors.
- Add `TopicPartitionId.fromPartitionGroupMetadata()` for SPI boundary wrapping and `SegmentUtils.getTopicPartitionIdFromSegmentName()` as the new API.
- Deprecate the now-superseded `IngestionConfigUtils` encode/decode helpers (kept for external/legacy call sites not covered by this migration).

## Test plan

- [x] `test-compile` across `pinot-spi, pinot-common, pinot-controller, pinot-core, pinot-segment-local, pinot-query-planner` passes cleanly
- [x] `PinotLLCRealtimeSegmentManagerTest` — 42/42 pass
- [x] `IngestionDelayTrackerTest` — 9/9 pass
- [x] `PinotSegmentRestletResourceTest` — 8/8 pass