### PR TITLE
Add BSON (MongoDB) input format support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ repo. It is intentionally short and focused on day-to-day work.
   - pinot-arrow: Apache Arrow input format support.
   - pinot-avro: Avro input format support.
   - pinot-avro-base: shared Avro utilities and base classes.
+  - pinot-bson: MongoDB BSON input format support.
   - pinot-clp-log: CLP log input format support.
   - pinot-confluent-avro: Confluent Schema Registry Avro input support.
   - pinot-confluent-json: Confluent Schema Registry JSON input support.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ Apache Pinot is a real-time distributed OLAP datastore for low-latency analytics
   - `pinot-arrow`: Apache Arrow input format support.
   - `pinot-avro`: Avro input format support.
   - `pinot-avro-base`: shared Avro utilities and base classes.
+  - `pinot-bson`: MongoDB BSON input format support.
   - `pinot-clp-log`: CLP log input format support.
   - `pinot-confluent-avro`: Confluent Schema Registry Avro input support.
   - `pinot-confluent-json`: Confluent Schema Registry JSON input support.

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -531,6 +531,7 @@ org.jooq:joou-java-6:0.9.5
 org.jspecify:jspecify:1.0.0
 org.locationtech.proj4j:proj4j:1.2.2
 org.lz4:lz4-java:1.8.0
+org.mongodb:bson:5.6.1
 org.quartz-scheduler:quartz:2.5.2
 org.roaringbitmap:RoaringBitmap:1.6.12
 org.scala-lang.modules:scala-collection-compat_2.13:2.10.0

--- a/pinot-bom/pom.xml
+++ b/pinot-bom/pom.xml
@@ -326,6 +326,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.pinot</groupId>
+        <artifactId>pinot-bson</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.pinot</groupId>
         <artifactId>pinot-csv</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/pinot-distribution/pinot-assembly.xml
+++ b/pinot-distribution/pinot-assembly.xml
@@ -153,6 +153,12 @@
       <destName>plugins/pinot-input-format/pinot-json/pinot-json-${project.version}-shaded.jar</destName>
     </file>
     <file>
+      <source>
+        ${pinot.root}/pinot-plugins/pinot-input-format/pinot-bson/target/pinot-bson-${project.version}-shaded.jar
+      </source>
+      <destName>plugins/pinot-input-format/pinot-bson/pinot-bson-${project.version}-shaded.jar</destName>
+    </file>
+    <file>
       <source>${pinot.root}/pinot-plugins/pinot-input-format/pinot-orc/target/pinot-orc-${project.version}-shaded.jar
       </source>
       <destName>plugins/pinot-input-format/pinot-orc/pinot-orc-${project.version}-shaded.jar</destName>

--- a/pinot-plugins/pinot-input-format/pinot-bson/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-bson/pom.xml
@@ -22,43 +22,32 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>pinot-plugins</artifactId>
+    <artifactId>pinot-input-format</artifactId>
     <groupId>org.apache.pinot</groupId>
     <version>1.6.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>pinot-input-format</artifactId>
-  <packaging>pom</packaging>
-  <name>Pinot Input Format</name>
+  <artifactId>pinot-bson</artifactId>
+  <name>Pinot BSON</name>
   <url>https://pinot.apache.org/</url>
   <properties>
-    <pinot.root>${basedir}/../..</pinot.root>
-    <plugin.type>pinot-input-format</plugin.type>
+    <pinot.root>${basedir}/../../..</pinot.root>
+    <shade.phase.prop>package</shade.phase.prop>
   </properties>
-
-  <modules>
-    <module>pinot-arrow</module>
-    <module>pinot-avro</module>
-    <module>pinot-avro-base</module>
-    <module>pinot-bson</module>
-    <module>pinot-clp-log</module>
-    <module>pinot-confluent-avro</module>
-    <module>pinot-confluent-json</module>
-    <module>pinot-confluent-protobuf</module>
-    <module>pinot-orc</module>
-    <module>pinot-json</module>
-    <module>pinot-parquet</module>
-    <module>pinot-csv</module>
-    <module>pinot-thrift</module>
-    <module>pinot-protobuf</module>
-  </modules>
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.pinot</groupId>
-      <artifactId>pinot-spi</artifactId>
-      <type>test-jar</type>
-      <scope>test</scope>
+      <groupId>org.mongodb</groupId>
+      <artifactId>bson</artifactId>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>pinot-fastdev</id>
+      <properties>
+        <shade.phase.prop>none</shade.phase.prop>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONMessageDecoder.java
@@ -27,11 +27,9 @@ import org.apache.pinot.spi.stream.StreamMessageDecoder;
 import org.bson.Document;
 
 
-/**
- * An implementation of StreamMessageDecoder to read BSON records from a stream. Each message payload is expected
- * to be a single binary-encoded BSON document. The document is decoded into an {@link Document} (a
- * {@code Map<String, Object>}) and handed to a {@link BSONRecordExtractor}.
- */
+/// An implementation of [StreamMessageDecoder] to read BSON records from a stream. Each message payload is
+/// expected to be a single binary-encoded BSON document. The document is decoded into a [Document] (a
+/// `Map<String, Object>`) and handed to a [BSONRecordExtractor].
 public class BSONMessageDecoder implements StreamMessageDecoder<byte[]> {
   private static final String BSON_RECORD_EXTRACTOR_CLASS =
       "org.apache.pinot.plugin.inputformat.bson.BSONRecordExtractor";

--- a/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONMessageDecoder.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.bson;
+
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordExtractor;
+import org.apache.pinot.spi.plugin.PluginManager;
+import org.apache.pinot.spi.stream.StreamMessageDecoder;
+import org.bson.Document;
+
+
+/**
+ * An implementation of StreamMessageDecoder to read BSON records from a stream. Each message payload is expected
+ * to be a single binary-encoded BSON document. The document is decoded into an {@link Document} (a
+ * {@code Map<String, Object>}) and handed to a {@link BSONRecordExtractor}.
+ */
+public class BSONMessageDecoder implements StreamMessageDecoder<byte[]> {
+  private static final String BSON_RECORD_EXTRACTOR_CLASS =
+      "org.apache.pinot.plugin.inputformat.bson.BSONRecordExtractor";
+
+  private RecordExtractor<Map<String, Object>> _bsonRecordExtractor;
+
+  @Override
+  public void init(Map<String, String> props, Set<String> fieldsToRead, String topicName)
+      throws Exception {
+    String recordExtractorClass = null;
+    if (props != null) {
+      recordExtractorClass = props.get(RECORD_EXTRACTOR_CONFIG_KEY);
+    }
+    if (recordExtractorClass == null) {
+      recordExtractorClass = BSON_RECORD_EXTRACTOR_CLASS;
+    }
+    _bsonRecordExtractor = PluginManager.get().createInstance(recordExtractorClass);
+    _bsonRecordExtractor.init(fieldsToRead, null);
+  }
+
+  @Override
+  public GenericRow decode(byte[] payload, GenericRow destination) {
+    return decode(payload, 0, payload.length, destination);
+  }
+
+  @Override
+  public GenericRow decode(byte[] payload, int offset, int length, GenericRow destination) {
+    try {
+      Document document = BSONUtils.decodeDocument(payload, offset, length);
+      return _bsonRecordExtractor.extract(document, destination);
+    } catch (Exception e) {
+      throw new RuntimeException("Caught exception while decoding BSON record", e);
+    }
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordExtractor.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.pinot.spi.data.readers.BaseRecordExtractor;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.bson.BsonTimestamp;
 import org.bson.types.Binary;
 import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
@@ -43,13 +44,21 @@ import org.bson.types.ObjectId;
 /// - `DateTime` → `java.sql.Timestamp`
 /// - `Decimal128` → `BigDecimal` (`NaN` / `Infinity` → `null`, as `BigDecimal` cannot represent them; negative
 ///   zero → `BigDecimal.ZERO`)
-/// - `Binary` → `byte[]`
+/// - `Timestamp` (the internal replication type, e.g. the oplog / change-stream `ts` and `clusterTime` fields)
+///   → `java.sql.Timestamp` at second granularity, matching MongoDB's own `$toDate`. The ordinal counter that
+///   disambiguates operations within the same second is not representable in a `Timestamp` and is dropped, so
+///   this value orders operations only to the second.
+/// - `Binary` → `byte[]`. This includes the UUID subtypes (`0x03` legacy, `0x04` standard): the standard codec
+///   is constructed with `UuidRepresentation.UNSPECIFIED`, so it hands back the raw 16 bytes rather than a
+///   `java.util.UUID`.
 /// - `null` → `null`
 ///
-/// Every other BSON type falls back to `value.toString()` — this covers the internal `Timestamp` type, the
-/// deprecated `Symbol` / `Undefined` / `DBPointer` types, JavaScript `Code`, regular expressions,
-/// `MinKey` / `MaxKey`, and the binary vector types (`Float32BinaryVector` and friends), which the standard
-/// codec decodes to their own classes rather than to `Binary`.
+/// Every other BSON type falls back to `value.toString()` — the deprecated `Symbol` / `Undefined` / `DBPointer`
+/// types, JavaScript `Code`, regular expressions, `MinKey` / `MaxKey`, and the binary vector types
+/// (`Float32BinaryVector` and friends), which the standard codec decodes to their own classes rather than to
+/// `Binary`. These renderings are not a documented contract of `org.mongodb:bson`, so `BSONRecordExtractorTest`
+/// pins the exact strings: a driver upgrade that changes them must fail the build rather than silently change
+/// the contents of every segment built from such a document.
 ///
 /// The converted values follow the shared `RecordExtractor` contract, so the downstream data-type transformer
 /// coerces them to the declared column type.
@@ -85,6 +94,11 @@ public class BSONRecordExtractor extends BaseRecordExtractor<Map<String, Object>
     if (value instanceof Date) {
       return new Timestamp(((Date) value).getTime());
     }
+    if (value instanceof BsonTimestamp) {
+      // getTime() is the seconds component; the ordinal counter in the low 32 bits is dropped.
+      return new Timestamp(((BsonTimestamp) value).getTime() * 1000L);
+    }
+    // NOTE: Decimal128 extends Number, so this must stay above the Number pass-through below.
     if (value instanceof Decimal128) {
       Decimal128 decimal128 = (Decimal128) value;
       // NaN / Infinity are legal Decimal128 values with no BigDecimal representation; surface them as null.

--- a/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordExtractor.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.plugin.inputformat.bson;
 
 import com.google.common.collect.Maps;
+import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.Date;
 import java.util.List;
@@ -40,13 +41,18 @@ import org.bson.types.ObjectId;
 /// - `Array` → `Object[]` (elements recursively converted)
 /// - `ObjectId` → `String` (24-char hex)
 /// - `DateTime` → `java.sql.Timestamp`
-/// - `Decimal128` → `BigDecimal` (`NaN` / `Infinity` → `null`, as `BigDecimal` cannot represent them)
+/// - `Decimal128` → `BigDecimal` (`NaN` / `Infinity` → `null`, as `BigDecimal` cannot represent them; negative
+///   zero → `BigDecimal.ZERO`)
 /// - `Binary` → `byte[]`
 /// - `null` → `null`
 ///
-/// Any other (rare, deprecated, or internal) BSON type falls back to `value.toString()`. The converted values
-/// follow the shared `RecordExtractor` contract, so the downstream data-type transformer coerces them to the
-/// declared column type.
+/// Every other BSON type falls back to `value.toString()` — this covers the internal `Timestamp` type, the
+/// deprecated `Symbol` / `Undefined` / `DBPointer` types, JavaScript `Code`, regular expressions,
+/// `MinKey` / `MaxKey`, and the binary vector types (`Float32BinaryVector` and friends), which the standard
+/// codec decodes to their own classes rather than to `Binary`.
+///
+/// The converted values follow the shared `RecordExtractor` contract, so the downstream data-type transformer
+/// coerces them to the declared column type.
 public class BSONRecordExtractor extends BaseRecordExtractor<Map<String, Object>> {
 
   @Override
@@ -81,9 +87,17 @@ public class BSONRecordExtractor extends BaseRecordExtractor<Map<String, Object>
     }
     if (value instanceof Decimal128) {
       Decimal128 decimal128 = (Decimal128) value;
-      // NaN / Infinity are legal Decimal128 values with no BigDecimal representation; surface them as null
-      // instead of letting bigDecimalValue() throw.
-      return decimal128.isNaN() || decimal128.isInfinite() ? null : decimal128.bigDecimalValue();
+      // NaN / Infinity are legal Decimal128 values with no BigDecimal representation; surface them as null.
+      if (decimal128.isNaN() || decimal128.isInfinite()) {
+        return null;
+      }
+      try {
+        return decimal128.bigDecimalValue();
+      } catch (ArithmeticException e) {
+        // The only remaining value bigDecimalValue() rejects is negative zero (legal in BSON, at any exponent,
+        // and not detectable via a public predicate). It is numerically zero.
+        return BigDecimal.ZERO;
+      }
     }
     if (value instanceof Binary) {
       return ((Binary) value).getData();

--- a/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordExtractor.java
@@ -1,0 +1,116 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.bson;
+
+import com.google.common.collect.Maps;
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.spi.data.readers.BaseRecordExtractor;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.bson.types.Binary;
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
+
+
+/// Extracts a Pinot [GenericRow] from a decoded BSON document (`org.bson.Document`, which is a
+/// `Map<String, Object>`). Values are the Java objects produced by the standard MongoDB
+/// [org.bson.codecs.DocumentCodec].
+///
+/// **BSON type → Java output type:**
+/// - `Double` / `Int32` / `Int64` / `Boolean` / `String` → same boxed type (pass-through)
+/// - `Document` (embedded) → `Map<String, Object>` (values recursively converted)
+/// - `Array` → `Object[]` (elements recursively converted)
+/// - `ObjectId` → `String` (24-char hex)
+/// - `DateTime` → `java.sql.Timestamp`
+/// - `Decimal128` → `BigDecimal` (`NaN` / `Infinity` → `null`, as `BigDecimal` cannot represent them)
+/// - `Binary` → `byte[]`
+/// - `null` → `null`
+///
+/// Any other (rare, deprecated, or internal) BSON type falls back to `value.toString()`. The converted values
+/// follow the shared `RecordExtractor` contract, so the downstream data-type transformer coerces them to the
+/// declared column type.
+public class BSONRecordExtractor extends BaseRecordExtractor<Map<String, Object>> {
+
+  @Override
+  public GenericRow extract(Map<String, Object> from, GenericRow to) {
+    if (_extractAll) {
+      for (Map.Entry<String, Object> entry : from.entrySet()) {
+        Object value = entry.getValue();
+        to.putValue(entry.getKey(), value != null ? convert(value) : null);
+      }
+    } else {
+      for (String fieldName : _fields) {
+        Object value = from.get(fieldName);
+        to.putValue(fieldName, value != null ? convert(value) : null);
+      }
+    }
+    return to;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Object convert(Object value) {
+    if (value instanceof Map) {
+      return convertMap((Map<String, Object>) value);
+    }
+    if (value instanceof List) {
+      return convertList((List<Object>) value);
+    }
+    if (value instanceof ObjectId) {
+      return ((ObjectId) value).toHexString();
+    }
+    if (value instanceof Date) {
+      return new Timestamp(((Date) value).getTime());
+    }
+    if (value instanceof Decimal128) {
+      Decimal128 decimal128 = (Decimal128) value;
+      // NaN / Infinity are legal Decimal128 values with no BigDecimal representation; surface them as null
+      // instead of letting bigDecimalValue() throw.
+      return decimal128.isNaN() || decimal128.isInfinite() ? null : decimal128.bigDecimalValue();
+    }
+    if (value instanceof Binary) {
+      return ((Binary) value).getData();
+    }
+    // Double / Integer / Long / String / Boolean pass through; any other BSON type uses its string form.
+    if (value instanceof Number || value instanceof String || value instanceof Boolean) {
+      return value;
+    }
+    return value.toString();
+  }
+
+  private static Object[] convertList(List<Object> list) {
+    int numValues = list.size();
+    Object[] result = new Object[numValues];
+    for (int i = 0; i < numValues; i++) {
+      Object value = list.get(i);
+      result[i] = value != null ? convert(value) : null;
+    }
+    return result;
+  }
+
+  private static Map<String, Object> convertMap(Map<String, Object> map) {
+    Map<String, Object> result = Maps.newHashMapWithExpectedSize(map.size());
+    for (Map.Entry<String, Object> entry : map.entrySet()) {
+      Object value = entry.getValue();
+      result.put(entry.getKey(), value != null ? convert(value) : null);
+    }
+    return result;
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordExtractor.java
@@ -45,9 +45,10 @@ import org.bson.types.ObjectId;
 /// - `Decimal128` → `BigDecimal` (`NaN` / `Infinity` → `null`, as `BigDecimal` cannot represent them; negative
 ///   zero → `BigDecimal.ZERO`)
 /// - `Timestamp` (the internal replication type, e.g. the oplog / change-stream `ts` and `clusterTime` fields)
-///   → `java.sql.Timestamp` at second granularity, matching MongoDB's own `$toDate`. The ordinal counter that
-///   disambiguates operations within the same second is not representable in a `Timestamp` and is dropped, so
-///   this value orders operations only to the second.
+///   → `java.sql.Timestamp` at second granularity, matching MongoDB's own `$toDate`. The seconds field is
+///   unsigned, so it is read as such and remains correct past 2038. The ordinal counter that disambiguates
+///   operations within the same second is not representable in a `Timestamp` and is dropped, so this value
+///   orders operations only to the second.
 /// - `Binary` → `byte[]`. This includes the UUID subtypes (`0x03` legacy, `0x04` standard): the standard codec
 ///   is constructed with `UuidRepresentation.UNSPECIFIED`, so it hands back the raw 16 bytes rather than a
 ///   `java.util.UUID`.
@@ -95,8 +96,10 @@ public class BSONRecordExtractor extends BaseRecordExtractor<Map<String, Object>
       return new Timestamp(((Date) value).getTime());
     }
     if (value instanceof BsonTimestamp) {
-      // getTime() is the seconds component; the ordinal counter in the low 32 bits is dropped.
-      return new Timestamp(((BsonTimestamp) value).getTime() * 1000L);
+      // getTime() is the seconds component; the ordinal counter in the low 32 bits is dropped. BSON stores
+      // those seconds unsigned but getTime() returns a signed int, so mask before widening -- otherwise every
+      // timestamp from 2038-01-19 onward wraps to a pre-1970 date.
+      return new Timestamp((((BsonTimestamp) value).getTime() & 0xFFFFFFFFL) * 1000L);
     }
     // NOTE: Decimal128 extends Number, so this must stay above the Number pass-through below.
     if (value instanceof Decimal128) {

--- a/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordReader.java
@@ -45,6 +45,9 @@ public class BSONRecordReader implements RecordReader {
   private InputStream _inputStream;
   // Bytes of the next framed document, or null once the stream is exhausted.
   private byte[] _nextDocument;
+  // A read error hit while fetching the next document. Deferred so the current record is still emitted; it
+  // surfaces on the following next() call rather than discarding an already-read valid record.
+  private IOException _fetchError;
 
   public BSONRecordReader() {
   }
@@ -61,34 +64,46 @@ public class BSONRecordReader implements RecordReader {
   private void open()
       throws IOException {
     _inputStream = RecordReaderUtils.getBufferedInputStream(_dataFile);
+    _fetchError = null;
     _nextDocument = readNextDocument();
   }
 
   @Override
   public boolean hasNext() {
-    return _nextDocument != null;
+    return _nextDocument != null || _fetchError != null;
   }
 
   @Override
   public GenericRow next(GenericRow reuse)
       throws IOException {
-    byte[] documentBytes = _nextDocument;
-    // Advance the look-ahead first so that, even if the current record is corrupt, the reader has already moved
-    // past it and the caller can skip the failure and continue.
-    try {
-      _nextDocument = readNextDocument();
-    } catch (IOException e) {
-      _nextDocument = null;
-      throw new RecordFetchException("Failed to read next BSON record", e);
+    if (_fetchError != null) {
+      IOException error = _fetchError;
+      _fetchError = null;
+      throw new RecordFetchException("Failed to read next BSON record", error);
     }
+    byte[] documentBytes = _nextDocument;
     Document document;
     try {
       document = BSONUtils.decodeDocument(documentBytes);
     } catch (RuntimeException e) {
+      // Corrupt frame: advance past it (bytes already consumed) so we don't retry, then report a parse error.
+      advance();
       throw new IOException("Failed to decode BSON record", e);
     }
     _recordExtractor.extract(document, reuse);
+    advance();
     return reuse;
+  }
+
+  /// Advances the look-ahead to the next framed document. A read error is stashed rather than thrown so the
+  /// record just returned by next() is still emitted; the error surfaces on the following next() call.
+  private void advance() {
+    try {
+      _nextDocument = readNextDocument();
+    } catch (IOException e) {
+      _nextDocument = null;
+      _fetchError = e;
+    }
   }
 
   /// Reads the next framed BSON document in full, or returns `null` at a clean end-of-stream. Throws when the

--- a/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordReader.java
@@ -39,6 +39,10 @@ import org.bson.Document;
 public class BSONRecordReader implements RecordReader {
   // Minimum size of a BSON document: 4-byte length prefix + 1-byte terminating NUL of an empty document.
   private static final int MIN_DOCUMENT_LENGTH = 5;
+  // MongoDB caps BSON documents at 16MB. Without an upper bound, a corrupt length prefix (up to ~2GB) would
+  // reach `new byte[length]` and raise OutOfMemoryError -- an Error, so it would escape the recoverable
+  // exception handling in next()/advance() and abort the whole segment build.
+  private static final int MAX_DOCUMENT_LENGTH = 16 * 1024 * 1024;
 
   private File _dataFile;
   private BSONRecordExtractor _recordExtractor;
@@ -65,7 +69,12 @@ public class BSONRecordReader implements RecordReader {
       throws IOException {
     _inputStream = RecordReaderUtils.getBufferedInputStream(_dataFile);
     _fetchError = null;
-    _nextDocument = readNextDocument();
+    try {
+      _nextDocument = readNextDocument();
+    } catch (IOException e) {
+      _inputStream.close();
+      throw e;
+    }
   }
 
   @Override
@@ -123,8 +132,10 @@ public class BSONRecordReader implements RecordReader {
     }
     // BSON length prefix is a little-endian int32 inclusive of these 4 bytes.
     int length = (b0 & 0xFF) | ((b1 & 0xFF) << 8) | ((b2 & 0xFF) << 16) | ((b3 & 0xFF) << 24);
-    if (length < MIN_DOCUMENT_LENGTH) {
-      throw new IOException("Invalid BSON document length: " + length);
+    if (length < MIN_DOCUMENT_LENGTH || length > MAX_DOCUMENT_LENGTH) {
+      throw new IOException(
+          "Invalid BSON document length: " + length + " (expected " + MIN_DOCUMENT_LENGTH + ".."
+              + MAX_DOCUMENT_LENGTH + " bytes)");
     }
     byte[] document = new byte[length];
     document[0] = (byte) b0;

--- a/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordReader.java
@@ -31,11 +31,11 @@ import org.apache.pinot.spi.data.readers.RecordReaderUtils;
 import org.bson.Document;
 
 
-/**
- * Record reader for a BSON file: a concatenation of framed BSON documents (the {@code mongodump} layout), each
- * self-delimited by a leading little-endian int32 byte length. Documents are read sequentially, with the next
- * document's bytes fetched ahead so {@link #hasNext} does not perform I/O. GZIP-compressed files are supported.
- */
+/// Record reader for a BSON file: a concatenation of framed BSON documents (the `mongodump` layout), each
+/// self-delimited by a leading little-endian int32 byte length. Documents are read sequentially, with the next
+/// document's bytes fetched ahead so [#hasNext] does not perform I/O. GZIP-compressed files are supported.
+///
+/// Not thread-safe: a reader instance is single-threaded, like every other [RecordReader].
 public class BSONRecordReader implements RecordReader {
   // Minimum size of a BSON document: 4-byte length prefix + 1-byte terminating NUL of an empty document.
   private static final int MIN_DOCUMENT_LENGTH = 5;

--- a/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordReader.java
@@ -1,0 +1,142 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.bson;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordFetchException;
+import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.data.readers.RecordReaderConfig;
+import org.apache.pinot.spi.data.readers.RecordReaderUtils;
+import org.bson.Document;
+
+
+/**
+ * Record reader for a BSON file: a concatenation of framed BSON documents (the {@code mongodump} layout), each
+ * self-delimited by a leading little-endian int32 byte length. Documents are read sequentially, with the next
+ * document's bytes fetched ahead so {@link #hasNext} does not perform I/O. GZIP-compressed files are supported.
+ */
+public class BSONRecordReader implements RecordReader {
+  // Minimum size of a BSON document: 4-byte length prefix + 1-byte terminating NUL of an empty document.
+  private static final int MIN_DOCUMENT_LENGTH = 5;
+
+  private File _dataFile;
+  private BSONRecordExtractor _recordExtractor;
+  private InputStream _inputStream;
+  // Bytes of the next framed document, or null once the stream is exhausted.
+  private byte[] _nextDocument;
+
+  public BSONRecordReader() {
+  }
+
+  @Override
+  public void init(File dataFile, @Nullable Set<String> fieldsToRead, @Nullable RecordReaderConfig recordReaderConfig)
+      throws IOException {
+    _dataFile = dataFile;
+    _recordExtractor = new BSONRecordExtractor();
+    _recordExtractor.init(fieldsToRead, null);
+    open();
+  }
+
+  private void open()
+      throws IOException {
+    _inputStream = RecordReaderUtils.getBufferedInputStream(_dataFile);
+    _nextDocument = readNextDocument();
+  }
+
+  @Override
+  public boolean hasNext() {
+    return _nextDocument != null;
+  }
+
+  @Override
+  public GenericRow next(GenericRow reuse)
+      throws IOException {
+    byte[] documentBytes = _nextDocument;
+    // Advance the look-ahead first so that, even if the current record is corrupt, the reader has already moved
+    // past it and the caller can skip the failure and continue.
+    try {
+      _nextDocument = readNextDocument();
+    } catch (IOException e) {
+      _nextDocument = null;
+      throw new RecordFetchException("Failed to read next BSON record", e);
+    }
+    Document document;
+    try {
+      document = BSONUtils.decodeDocument(documentBytes);
+    } catch (RuntimeException e) {
+      throw new IOException("Failed to decode BSON record", e);
+    }
+    _recordExtractor.extract(document, reuse);
+    return reuse;
+  }
+
+  /// Reads the next framed BSON document in full, or returns `null` at a clean end-of-stream. Throws when the
+  /// stream ends partway through a document, or the length prefix is invalid.
+  @Nullable
+  private byte[] readNextDocument()
+      throws IOException {
+    int b0 = _inputStream.read();
+    if (b0 == -1) {
+      return null;
+    }
+    int b1 = _inputStream.read();
+    int b2 = _inputStream.read();
+    int b3 = _inputStream.read();
+    if ((b1 | b2 | b3) < 0) {
+      throw new IOException("Truncated BSON document: incomplete length prefix");
+    }
+    // BSON length prefix is a little-endian int32 inclusive of these 4 bytes.
+    int length = (b0 & 0xFF) | ((b1 & 0xFF) << 8) | ((b2 & 0xFF) << 16) | ((b3 & 0xFF) << 24);
+    if (length < MIN_DOCUMENT_LENGTH) {
+      throw new IOException("Invalid BSON document length: " + length);
+    }
+    byte[] document = new byte[length];
+    document[0] = (byte) b0;
+    document[1] = (byte) b1;
+    document[2] = (byte) b2;
+    document[3] = (byte) b3;
+    int bytesRead = 4;
+    while (bytesRead < length) {
+      int count = _inputStream.read(document, bytesRead, length - bytesRead);
+      if (count == -1) {
+        throw new IOException("Truncated BSON document: expected " + length + " bytes");
+      }
+      bytesRead += count;
+    }
+    return document;
+  }
+
+  @Override
+  public void rewind()
+      throws IOException {
+    _inputStream.close();
+    open();
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    _inputStream.close();
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONUtils.java
+++ b/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONUtils.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.bson;
+
+import java.nio.ByteBuffer;
+import org.bson.BsonBinaryReader;
+import org.bson.Document;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.DocumentCodec;
+
+
+/// Decodes a single BSON binary document into an `org.bson.Document` (a `Map<String, Object>`). Shared by
+/// [BSONRecordReader] (batch) and [BSONMessageDecoder] (streaming).
+public final class BSONUtils {
+  private BSONUtils() {
+  }
+
+  private static final DocumentCodec DOCUMENT_CODEC = new DocumentCodec();
+
+  /// Decodes a whole BSON document from the given byte array.
+  public static Document decodeDocument(byte[] bytes) {
+    return decodeDocument(bytes, 0, bytes.length);
+  }
+
+  /// Decodes a single BSON document from the `[offset, offset + length)` sub-range of the given byte array.
+  public static Document decodeDocument(byte[] bytes, int offset, int length) {
+    ByteBuffer buffer = ByteBuffer.wrap(bytes, offset, length).slice();
+    try (BsonBinaryReader reader = new BsonBinaryReader(buffer)) {
+      return DOCUMENT_CODEC.decode(reader, DecoderContext.builder().build());
+    }
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONUtils.java
+++ b/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONUtils.java
@@ -32,6 +32,7 @@ public final class BSONUtils {
   }
 
   private static final DocumentCodec DOCUMENT_CODEC = new DocumentCodec();
+  private static final DecoderContext DECODER_CONTEXT = DecoderContext.builder().build();
 
   /// Decodes a whole BSON document from the given byte array.
   public static Document decodeDocument(byte[] bytes) {
@@ -42,7 +43,7 @@ public final class BSONUtils {
   public static Document decodeDocument(byte[] bytes, int offset, int length) {
     ByteBuffer buffer = ByteBuffer.wrap(bytes, offset, length).slice();
     try (BsonBinaryReader reader = new BsonBinaryReader(buffer)) {
-      return DOCUMENT_CODEC.decode(reader, DecoderContext.builder().build());
+      return DOCUMENT_CODEC.decode(reader, DECODER_CONTEXT);
     }
   }
 }

--- a/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONUtils.java
+++ b/pinot-plugins/pinot-input-format/pinot-bson/src/main/java/org/apache/pinot/plugin/inputformat/bson/BSONUtils.java
@@ -27,12 +27,20 @@ import org.bson.codecs.DocumentCodec;
 
 /// Decodes a single BSON binary document into an `org.bson.Document` (a `Map<String, Object>`). Shared by
 /// [BSONRecordReader] (batch) and [BSONMessageDecoder] (streaming).
+///
+/// Thread-safe: the shared [DocumentCodec] and [DecoderContext] are immutable after construction, and each
+/// [#decodeDocument] call reads through a reader over its own buffer. Callers on different ingestion threads
+/// may decode concurrently.
+///
+/// A malformed document raises `org.bson.BsonSerializationException` (a `RuntimeException`). Bogus internal
+/// length prefixes cannot over-allocate: the reader is bounded by the supplied `[offset, offset + length)`
+/// slice.
 public final class BSONUtils {
-  private BSONUtils() {
-  }
-
   private static final DocumentCodec DOCUMENT_CODEC = new DocumentCodec();
   private static final DecoderContext DECODER_CONTEXT = DecoderContext.builder().build();
+
+  private BSONUtils() {
+  }
 
   /// Decodes a whole BSON document from the given byte array.
   public static Document decodeDocument(byte[] bytes) {

--- a/pinot-plugins/pinot-input-format/pinot-bson/src/test/java/org/apache/pinot/plugin/inputformat/bson/BSONMessageDecoderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-bson/src/test/java/org/apache/pinot/plugin/inputformat/bson/BSONMessageDecoderTest.java
@@ -1,0 +1,148 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.bson;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.bson.BsonBinaryWriter;
+import org.bson.Document;
+import org.bson.codecs.DocumentCodec;
+import org.bson.codecs.EncoderContext;
+import org.bson.io.BasicOutputBuffer;
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+public class BSONMessageDecoderTest {
+
+  @Test
+  public void testDecodeScalarsAndLogicalTypes()
+      throws Exception {
+    ObjectId objectId = new ObjectId("5f2b1c0e1c9d440000a1b2c3");
+    long epochMillis = 1_588_469_340_000L;
+    Document document = new Document()
+        .append("id", objectId)
+        .append("name", "widget")
+        .append("count", 7)
+        .append("views", 1_588_469_340_000L)
+        .append("price", 9.5d)
+        .append("active", true)
+        .append("amount", Decimal128.parse("123.456"))
+        .append("createdAt", new Date(epochMillis));
+
+    Set<String> fields = document.keySet();
+    BSONMessageDecoder decoder = new BSONMessageDecoder();
+    decoder.init(Map.of(), fields, "testTopic");
+
+    GenericRow row = new GenericRow();
+    decoder.decode(encode(document), row);
+
+    assertEquals(row.getValue("id"), objectId.toHexString());
+    assertEquals(row.getValue("name"), "widget");
+    assertEquals(row.getValue("count"), 7);
+    assertEquals(row.getValue("views"), 1_588_469_340_000L);
+    assertEquals(row.getValue("price"), 9.5d);
+    assertEquals(row.getValue("active"), true);
+    assertEquals(row.getValue("amount"), new BigDecimal("123.456"));
+    assertEquals(row.getValue("createdAt"), new Timestamp(epochMillis));
+  }
+
+  @Test
+  public void testDecodeNestedDocumentAndArray()
+      throws Exception {
+    Document document = new Document()
+        .append("tags", List.of("a", "b", "c"))
+        .append("meta", new Document("region", "us-east").append("shard", 3));
+
+    Set<String> fields = document.keySet();
+    BSONMessageDecoder decoder = new BSONMessageDecoder();
+    decoder.init(Map.of(), fields, "testTopic");
+
+    GenericRow row = new GenericRow();
+    decoder.decode(encode(document), row);
+
+    assertEquals((Object[]) row.getValue("tags"), new Object[]{"a", "b", "c"});
+    Map<?, ?> meta = (Map<?, ?>) row.getValue("meta");
+    assertEquals(meta.get("region"), "us-east");
+    assertEquals(meta.get("shard"), 3);
+  }
+
+  @Test
+  public void testDecodeWithFieldProjection()
+      throws Exception {
+    Document document = new Document().append("keep", 1).append("drop", 2);
+
+    BSONMessageDecoder decoder = new BSONMessageDecoder();
+    decoder.init(Map.of(), Set.of("keep"), "testTopic");
+
+    GenericRow row = new GenericRow();
+    decoder.decode(encode(document), row);
+
+    assertEquals(row.getValue("keep"), 1);
+    assertNull(row.getValue("drop"));
+  }
+
+  @Test
+  public void testDecodeWithOffsetAndLength()
+      throws Exception {
+    Document document = new Document().append("k", "v");
+    byte[] encoded = encode(document);
+
+    // Embed the payload inside a larger buffer to exercise the offset/length decode path.
+    byte[] padded = new byte[encoded.length + 8];
+    int offset = 5;
+    System.arraycopy(encoded, 0, padded, offset, encoded.length);
+
+    BSONMessageDecoder decoder = new BSONMessageDecoder();
+    decoder.init(Map.of(), Set.of("k"), "testTopic");
+
+    GenericRow row = new GenericRow();
+    GenericRow result = decoder.decode(padded, offset, encoded.length, row);
+    assertTrue(result == row);
+    assertEquals(row.getValue("k"), "v");
+  }
+
+  @Test(expectedExceptions = RuntimeException.class)
+  public void testDecodeCorruptPayloadThrows()
+      throws Exception {
+    BSONMessageDecoder decoder = new BSONMessageDecoder();
+    decoder.init(Map.of(), Set.of("k"), "testTopic");
+    // Not a valid framed BSON document: the decode failure is wrapped in a RuntimeException.
+    decoder.decode(new byte[]{1, 2, 3}, new GenericRow());
+  }
+
+  private static byte[] encode(Document document) {
+    DocumentCodec codec = new DocumentCodec();
+    BasicOutputBuffer buffer = new BasicOutputBuffer();
+    try (BsonBinaryWriter writer = new BsonBinaryWriter(buffer)) {
+      codec.encode(writer, document, EncoderContext.builder().build());
+    }
+    return buffer.toByteArray();
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-bson/src/test/java/org/apache/pinot/plugin/inputformat/bson/BSONMessageDecoderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-bson/src/test/java/org/apache/pinot/plugin/inputformat/bson/BSONMessageDecoderTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.bson.BsonBinaryWriter;
+import org.bson.BsonTimestamp;
 import org.bson.Document;
 import org.bson.codecs.DocumentCodec;
 import org.bson.codecs.EncoderContext;
@@ -54,7 +55,10 @@ public class BSONMessageDecoderTest {
         .append("price", 9.5d)
         .append("active", true)
         .append("amount", Decimal128.parse("123.456"))
-        .append("createdAt", new Date(epochMillis));
+        .append("createdAt", new Date(epochMillis))
+        // The oplog / change-stream replication timestamp, the field a Kafka-forwarded change stream is most
+        // likely to use as the Pinot time column.
+        .append("ts", new BsonTimestamp((int) (epochMillis / 1000), 3));
 
     Set<String> fields = document.keySet();
     BSONMessageDecoder decoder = new BSONMessageDecoder();
@@ -71,6 +75,7 @@ public class BSONMessageDecoderTest {
     assertEquals(row.getValue("active"), true);
     assertEquals(row.getValue("amount"), new BigDecimal("123.456"));
     assertEquals(row.getValue("createdAt"), new Timestamp(epochMillis));
+    assertEquals(row.getValue("ts"), new Timestamp(epochMillis));
   }
 
   @Test

--- a/pinot-plugins/pinot-input-format/pinot-bson/src/test/java/org/apache/pinot/plugin/inputformat/bson/BSONMessageDecoderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-bson/src/test/java/org/apache/pinot/plugin/inputformat/bson/BSONMessageDecoderTest.java
@@ -36,7 +36,7 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertSame;
 
 
 public class BSONMessageDecoderTest {
@@ -124,7 +124,7 @@ public class BSONMessageDecoderTest {
 
     GenericRow row = new GenericRow();
     GenericRow result = decoder.decode(padded, offset, encoded.length, row);
-    assertTrue(result == row);
+    assertSame(result, row);
     assertEquals(row.getValue("k"), "v");
   }
 

--- a/pinot-plugins/pinot-input-format/pinot-bson/src/test/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-bson/src/test/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordExtractorTest.java
@@ -1,0 +1,201 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.bson;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.bson.Document;
+import org.bson.types.Binary;
+import org.bson.types.Decimal128;
+import org.bson.types.MaxKey;
+import org.bson.types.ObjectId;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+/// Tests [BSONRecordExtractor] — see its class Javadoc for the BSON type → Java output type matrix.
+public class BSONRecordExtractorTest {
+
+  private static final String COLUMN = "col";
+
+  // === Scalars — pass through ===
+
+  @Test
+  public void testBooleanPreserved() {
+    assertEquals(extract(true), true);
+    assertEquals(extract(false), false);
+  }
+
+  @Test
+  public void testIntegerPreserved() {
+    assertEquals(extract(42), 42);
+  }
+
+  @Test
+  public void testLongPreserved() {
+    assertEquals(extract(1_588_469_340_000L), 1_588_469_340_000L);
+  }
+
+  @Test
+  public void testDoublePreserved() {
+    assertEquals(extract(1.5d), 1.5d);
+  }
+
+  @Test
+  public void testStringPreserved() {
+    assertEquals(extract("hello"), "hello");
+  }
+
+  @Test
+  public void testNullPassedThrough() {
+    assertNull(extract(null));
+  }
+
+  // === Extended BSON types found in normal documents ===
+
+  @Test
+  public void testObjectIdConvertedToHexString() {
+    ObjectId objectId = new ObjectId("5f2b1c0e1c9d440000a1b2c3");
+    assertEquals(extract(objectId), "5f2b1c0e1c9d440000a1b2c3");
+  }
+
+  @Test
+  public void testDateConvertedToTimestamp() {
+    long epochMillis = 1_588_469_340_000L;
+    Object result = extract(new Date(epochMillis));
+    assertTrue(result instanceof Timestamp);
+    assertEquals(result, new Timestamp(epochMillis));
+  }
+
+  @Test
+  public void testDecimal128ConvertedToBigDecimal() {
+    assertEquals(extract(Decimal128.parse("123.456")), new BigDecimal("123.456"));
+  }
+
+  @Test
+  public void testDecimal128NaNConvertedToNull() {
+    // NaN / Infinity are legal Decimal128 values with no BigDecimal representation, so they surface as null.
+    assertNull(extract(Decimal128.parse("NaN")));
+    assertNull(extract(Decimal128.parse("Infinity")));
+    assertNull(extract(Decimal128.parse("-Infinity")));
+  }
+
+  @Test
+  public void testBinaryConvertedToByteArray() {
+    byte[] data = {1, 2, 3, 4};
+    Object result = extract(new Binary(data));
+    assertTrue(result instanceof byte[]);
+    assertEquals((byte[]) result, data);
+  }
+
+  @Test
+  public void testExoticTypeFallsBackToToString() {
+    // Rare / deprecated / internal types (MinKey, MaxKey, ...) have no Pinot-native representation.
+    MaxKey maxKey = new MaxKey();
+    assertEquals(extract(maxKey), maxKey.toString());
+  }
+
+  // === Array (BSON array) → Object[] ===
+
+  @Test
+  public void testIntegerListExtractedAsArray() {
+    Object[] result = (Object[]) extract(List.of(10, 20, 30));
+    assertEquals(result, new Object[]{10, 20, 30});
+  }
+
+  @Test
+  public void testStringListExtractedAsArray() {
+    Object[] result = (Object[]) extract(List.of("foo", "bar"));
+    assertEquals(result, new Object[]{"foo", "bar"});
+  }
+
+  @Test
+  public void testListWithNullElement() {
+    Object[] result = (Object[]) extract(Arrays.asList(1, null, 3));
+    assertEquals(result, new Object[]{1, null, 3});
+  }
+
+  @Test
+  public void testEmptyListExtractedAsEmptyArray() {
+    Object[] result = (Object[]) extract(List.of());
+    assertEquals(result, new Object[]{});
+  }
+
+  @Test
+  public void testListOfObjectIdsConvertedElementwise() {
+    ObjectId id1 = new ObjectId("5f2b1c0e1c9d440000a1b2c3");
+    ObjectId id2 = new ObjectId("5f2b1c0e1c9d440000a1b2c4");
+    Object[] result = (Object[]) extract(List.of(id1, id2));
+    assertEquals(result, new Object[]{id1.toHexString(), id2.toHexString()});
+  }
+
+  // === Embedded document (BSON object) → Map<String, Object> ===
+
+  @Test
+  public void testEmbeddedDocumentConvertedToMap() {
+    Document embedded = new Document("k1", 1).append("k2", "foo").append("k3", true);
+    Map<?, ?> result = (Map<?, ?>) extract(embedded);
+    assertEquals(result.size(), 3);
+    assertEquals(result.get("k1"), 1);
+    assertEquals(result.get("k2"), "foo");
+    assertEquals(result.get("k3"), true);
+  }
+
+  @Test
+  public void testEmbeddedDocumentWithNullValue() {
+    Document embedded = new Document("present", 1);
+    embedded.put("absent", null);
+    Map<?, ?> result = (Map<?, ?>) extract(embedded);
+    assertEquals(result.get("present"), 1);
+    assertTrue(result.containsKey("absent"));
+    assertNull(result.get("absent"));
+  }
+
+  @Test
+  public void testNestedDocumentAndArray() {
+    Document embedded =
+        new Document("scalar", 1).append("nested", new Document("sub", 1.1)).append("list", List.of("a", "b"));
+    Map<?, ?> result = (Map<?, ?>) extract(embedded);
+    assertEquals(result.get("scalar"), 1);
+    assertEquals(((Map<?, ?>) result.get("nested")).get("sub"), 1.1);
+    assertEquals((Object[]) result.get("list"), new Object[]{"a", "b"});
+  }
+
+  // === Helpers ===
+
+  /// Run the extractor against a single-column input document and return the extracted value.
+  private static Object extract(@Nullable Object input) {
+    BSONRecordExtractor extractor = new BSONRecordExtractor();
+    extractor.init(null, null);
+    Document record = new Document();
+    record.put(COLUMN, input);
+    GenericRow row = new GenericRow();
+    extractor.extract(record, row);
+    return row.getValue(COLUMN);
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-bson/src/test/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-bson/src/test/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordExtractorTest.java
@@ -19,18 +19,29 @@
 package org.apache.pinot.plugin.inputformat.bson;
 
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.bson.BsonBinaryWriter;
+import org.bson.BsonTimestamp;
 import org.bson.Document;
+import org.bson.codecs.DocumentCodec;
+import org.bson.codecs.EncoderContext;
+import org.bson.io.BasicOutputBuffer;
 import org.bson.types.Binary;
+import org.bson.types.Code;
 import org.bson.types.Decimal128;
 import org.bson.types.MaxKey;
+import org.bson.types.MinKey;
 import org.bson.types.ObjectId;
+import org.bson.types.Symbol;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -122,10 +133,53 @@ public class BSONRecordExtractorTest {
   }
 
   @Test
-  public void testExoticTypeFallsBackToToString() {
-    // Rare / deprecated / internal types (MinKey, MaxKey, ...) have no Pinot-native representation.
-    MaxKey maxKey = new MaxKey();
-    assertEquals(extract(maxKey), maxKey.toString());
+  public void testBsonTimestampConvertedToTimestamp() {
+    // The internal replication timestamp: the oplog `ts` field and the change-stream `clusterTime` field. Its
+    // seconds component becomes a java.sql.Timestamp; the intra-second ordinal counter is dropped.
+    Object result = extract(new BsonTimestamp(1_588_469_340, 7));
+    assertTrue(result instanceof Timestamp);
+    assertEquals(result, new Timestamp(1_588_469_340_000L));
+  }
+
+  @Test
+  public void testUuidBinarySubtypesConvertedToRawBytes() {
+    // Subtypes 0x03 (legacy) and 0x04 (standard) are how MongoDB stores UUIDs. The standard DocumentCodec is
+    // built with UuidRepresentation.UNSPECIFIED, so it decodes them to Binary -- not java.util.UUID -- and they
+    // land as raw 16-byte BYTES. Round-trip through a real encode/decode so this pins the codec's behavior
+    // rather than our own hand-built Binary: if a driver upgrade flips the default representation, these
+    // columns would silently change from BYTES to a 36-char STRING.
+    UUID uuid = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+    byte[] raw = new byte[16];
+    ByteBuffer.wrap(raw).putLong(uuid.getMostSignificantBits()).putLong(uuid.getLeastSignificantBits());
+
+    Document decoded = roundTrip(new Document()
+        .append("standard", new Binary((byte) 0x04, raw))
+        .append("legacy", new Binary((byte) 0x03, raw)));
+
+    GenericRow row = new GenericRow();
+    newExtractor().extract(decoded, row);
+    assertEquals((byte[]) row.getValue("standard"), raw);
+    assertEquals((byte[]) row.getValue("legacy"), raw);
+  }
+
+  @Test
+  public void testExoticTypesFallBackToPinnedToStringForms() {
+    // Rare / deprecated types with no Pinot-native representation fall back to value.toString(). Those strings
+    // are not a documented contract of org.mongodb:bson, and they get baked into segment data -- so pin them
+    // literally. A driver upgrade that reformats them must fail here rather than silently rewrite segments.
+    assertEquals(extract(new MaxKey()), "MaxKey");
+    assertEquals(extract(new MinKey()), "MinKey");
+    assertEquals(extract(new Symbol("sym")), "sym");
+    assertEquals(extract(new Code("function(){}")), "Code{code='function(){}'}");
+
+    // Regex and JS code survive an encode/decode round trip as BsonRegularExpression / Code.
+    Document decoded = roundTrip(new Document()
+        .append("regex", Pattern.compile("^a.*z$"))
+        .append("code", new Code("function(){}")));
+    GenericRow row = new GenericRow();
+    newExtractor().extract(decoded, row);
+    assertEquals(row.getValue("regex"), "BsonRegularExpression{pattern='^a.*z$', options=''}");
+    assertEquals(row.getValue("code"), "Code{code='function(){}'}");
   }
 
   // === Array (BSON array) → Object[] ===
@@ -198,12 +252,26 @@ public class BSONRecordExtractorTest {
 
   /// Run the extractor against a single-column input document and return the extracted value.
   private static Object extract(@Nullable Object input) {
-    BSONRecordExtractor extractor = new BSONRecordExtractor();
-    extractor.init(null, null);
     Document record = new Document();
     record.put(COLUMN, input);
     GenericRow row = new GenericRow();
-    extractor.extract(record, row);
+    newExtractor().extract(record, row);
     return row.getValue(COLUMN);
+  }
+
+  private static BSONRecordExtractor newExtractor() {
+    BSONRecordExtractor extractor = new BSONRecordExtractor();
+    extractor.init(null, null);
+    return extractor;
+  }
+
+  /// Encodes and re-decodes a document so the test sees the Java types the standard `DocumentCodec` actually
+  /// produces, rather than the ones the test handed in.
+  private static Document roundTrip(Document document) {
+    BasicOutputBuffer buffer = new BasicOutputBuffer();
+    try (BsonBinaryWriter writer = new BsonBinaryWriter(buffer)) {
+      new DocumentCodec().encode(writer, document, EncoderContext.builder().build());
+    }
+    return BSONUtils.decodeDocument(buffer.toByteArray());
   }
 }

--- a/pinot-plugins/pinot-input-format/pinot-bson/src/test/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-bson/src/test/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordExtractorTest.java
@@ -142,6 +142,19 @@ public class BSONRecordExtractorTest {
   }
 
   @Test
+  public void testBsonTimestampAfter2038IsNotSignWrapped() {
+    // BSON stores the seconds component as an UNSIGNED 32-bit field, but BsonTimestamp#getTime() returns it as
+    // a signed int. From 2038-01-19T03:14:08Z onward the high bit is set, so a naive read wraps to a pre-1970
+    // date. 2039-01-01T00:00:00Z = 2_177_452_800 seconds, which does not fit a positive signed int.
+    long seconds = 2_177_452_800L;
+    BsonTimestamp afterY2038 = new BsonTimestamp((int) seconds, 1);
+    assertTrue(afterY2038.getTime() < 0, "precondition: the driver reports these seconds as a negative int");
+
+    Object result = extract(afterY2038);
+    assertEquals(result, new Timestamp(seconds * 1000L));
+  }
+
+  @Test
   public void testUuidBinarySubtypesConvertedToRawBytes() {
     // Subtypes 0x03 (legacy) and 0x04 (standard) are how MongoDB stores UUIDs. The standard DocumentCodec is
     // built with UuidRepresentation.UNSPECIFIED, so it decodes them to Binary -- not java.util.UUID -- and they

--- a/pinot-plugins/pinot-input-format/pinot-bson/src/test/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-bson/src/test/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordExtractorTest.java
@@ -106,6 +106,14 @@ public class BSONRecordExtractorTest {
   }
 
   @Test
+  public void testDecimal128NegativeZeroConvertedToZero() {
+    // Negative zero is a legal Decimal128 value that bigDecimalValue() rejects; it is numerically zero. It is
+    // negative-zero at any exponent, so "-0.00" must be handled too (it is not equal to Decimal128.NEGATIVE_ZERO).
+    assertEquals(extract(Decimal128.parse("-0")), BigDecimal.ZERO);
+    assertEquals(extract(Decimal128.parse("-0.00")), BigDecimal.ZERO);
+  }
+
+  @Test
   public void testBinaryConvertedToByteArray() {
     byte[] data = {1, 2, 3, 4};
     Object result = extract(new Binary(data));

--- a/pinot-plugins/pinot-input-format/pinot-bson/src/test/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-bson/src/test/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordReaderTest.java
@@ -1,0 +1,187 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.bson;
+
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.data.readers.AbstractRecordReaderTest;
+import org.apache.pinot.spi.data.readers.RecordReader;
+import org.bson.BsonBinaryWriter;
+import org.bson.Document;
+import org.bson.codecs.DocumentCodec;
+import org.bson.codecs.EncoderContext;
+import org.bson.io.BasicOutputBuffer;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+
+/// Tests [BSONRecordReader] against the shared [AbstractRecordReaderTest] contract (happy path + gzip + rewind
+/// over the generated schema), plus targeted negative / recovery cases driven by hand-built raw byte frames.
+///
+/// The generated `FLOAT` values are written as BSON doubles (BSON has no 32-bit float type), so the reader
+/// reads them back as `Double`; the base assertions compare floating values with an epsilon, so this is
+/// transparent.
+public class BSONRecordReaderTest extends AbstractRecordReaderTest {
+
+  @Override
+  protected RecordReader createRecordReader(File file)
+      throws Exception {
+    BSONRecordReader recordReader = new BSONRecordReader();
+    recordReader.init(file, _sourceFields, null);
+    return recordReader;
+  }
+
+  @Override
+  protected void writeRecordsToFile(List<Map<String, Object>> recordsToWrite)
+      throws Exception {
+    try (OutputStream out = new BufferedOutputStream(new FileOutputStream(_dataFile))) {
+      for (Map<String, Object> record : recordsToWrite) {
+        Document document = new Document();
+        for (Map.Entry<String, Object> entry : record.entrySet()) {
+          document.put(entry.getKey(), toBsonValue(entry.getValue()));
+        }
+        out.write(encode(document));
+      }
+    }
+  }
+
+  /// BSON's codec has no float codec, so normalize Float (and Floats inside arrays) to Double before encoding.
+  private static Object toBsonValue(Object value) {
+    if (value instanceof Float) {
+      return ((Float) value).doubleValue();
+    }
+    if (value instanceof List) {
+      List<Object> converted = new ArrayList<>();
+      for (Object element : (List<?>) value) {
+        converted.add(toBsonValue(element));
+      }
+      return converted;
+    }
+    return value;
+  }
+
+  @Override
+  protected String getDataFileName() {
+    return "data.bson";
+  }
+
+  // === Negative / recovery cases over hand-built raw frames ===
+
+  @Test
+  public void testEmptyFileHasNoRecords()
+      throws Exception {
+    try (BSONRecordReader reader = readerOver("empty.bson", new byte[0])) {
+      assertFalse(reader.hasNext());
+    }
+  }
+
+  @Test
+  public void testTruncatedLengthPrefixThrows()
+      throws Exception {
+    // Only 2 of the 4 length-prefix bytes are present.
+    assertInitThrowsIOException("truncated-prefix.bson", new byte[]{0x0C, 0x00});
+  }
+
+  @Test
+  public void testLengthBelowMinimumThrows()
+      throws Exception {
+    // Declared length 2 is below the 5-byte minimum for a BSON document.
+    assertInitThrowsIOException("invalid-length.bson", new byte[]{0x02, 0x00, 0x00, 0x00});
+  }
+
+  @Test
+  public void testTruncatedBodyThrows()
+      throws Exception {
+    // Declared length 16 but only 2 body bytes follow the prefix.
+    assertInitThrowsIOException("truncated-body.bson", new byte[]{0x10, 0x00, 0x00, 0x00, 0x01, 0x02});
+  }
+
+  @Test
+  public void testRecoversAfterCorruptRecord()
+      throws Exception {
+    // A corrupt frame between two valid documents: length 8, then an unknown BSON element type (0x1F).
+    byte[] corruptFrame = {0x08, 0x00, 0x00, 0x00, 0x1F, 0x00, 0x00, 0x00};
+    byte[] content =
+        concat(encode(new Document("a", 1)), corruptFrame, encode(new Document("b", 2)));
+    try (BSONRecordReader reader = readerOver("recovery.bson", content)) {
+      assertTrue(reader.hasNext());
+      assertEquals(reader.next().getValue("a"), 1);
+
+      // The corrupt frame surfaces as a skippable IOException; the reader then advances past it.
+      assertTrue(reader.hasNext());
+      assertThrows(IOException.class, reader::next);
+
+      // The trailing valid document is still returned.
+      assertTrue(reader.hasNext());
+      assertEquals(reader.next().getValue("b"), 2);
+      assertFalse(reader.hasNext());
+    }
+  }
+
+  private BSONRecordReader readerOver(String name, byte[] content)
+      throws IOException {
+    BSONRecordReader reader = new BSONRecordReader();
+    reader.init(writeTempFile(name, content), null, null);
+    return reader;
+  }
+
+  private void assertInitThrowsIOException(String name, byte[] content)
+      throws IOException {
+    File file = writeTempFile(name, content);
+    BSONRecordReader reader = new BSONRecordReader();
+    assertThrows(IOException.class, () -> reader.init(file, null, null));
+  }
+
+  private File writeTempFile(String name, byte[] content)
+      throws IOException {
+    File file = new File(_tempDir, name);
+    FileUtils.writeByteArrayToFile(file, content);
+    return file;
+  }
+
+  private static byte[] encode(Document document) {
+    DocumentCodec codec = new DocumentCodec();
+    BasicOutputBuffer buffer = new BasicOutputBuffer();
+    try (BsonBinaryWriter writer = new BsonBinaryWriter(buffer)) {
+      codec.encode(writer, document, EncoderContext.builder().build());
+    }
+    return buffer.toByteArray();
+  }
+
+  private static byte[] concat(byte[]... chunks)
+      throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    for (byte[] chunk : chunks) {
+      out.write(chunk);
+    }
+    return out.toByteArray();
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-bson/src/test/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-bson/src/test/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordReaderTest.java
@@ -146,6 +146,23 @@ public class BSONRecordReaderTest extends AbstractRecordReaderTest {
     }
   }
 
+  @Test
+  public void testValidRecordEmittedBeforeTruncatedTail()
+      throws Exception {
+    // A complete document followed by a truncated frame (declares 16 bytes, only 2 body bytes present). The
+    // valid record is still emitted; the truncation surfaces on the following next() call.
+    byte[] truncatedFrame = {0x10, 0x00, 0x00, 0x00, 0x01, 0x02};
+    byte[] content = concat(encode(new Document("a", 1)), truncatedFrame);
+    try (BSONRecordReader reader = readerOver("truncated-tail.bson", content)) {
+      assertTrue(reader.hasNext());
+      assertEquals(reader.next().getValue("a"), 1);
+
+      assertTrue(reader.hasNext());
+      assertThrows(IOException.class, reader::next);
+      assertFalse(reader.hasNext());
+    }
+  }
+
   private BSONRecordReader readerOver(String name, byte[] content)
       throws IOException {
     BSONRecordReader reader = new BSONRecordReader();

--- a/pinot-plugins/pinot-input-format/pinot-bson/src/test/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-bson/src/test/java/org/apache/pinot/plugin/inputformat/bson/BSONRecordReaderTest.java
@@ -118,6 +118,14 @@ public class BSONRecordReaderTest extends AbstractRecordReaderTest {
   }
 
   @Test
+  public void testLengthAboveMaximumThrowsInsteadOfAllocating()
+      throws Exception {
+    // Declared length 0x7FFFFFFF (~2GB) exceeds the 16MB BSON maximum. It must be rejected before `new
+    // byte[length]` runs, otherwise an OutOfMemoryError (an Error) would escape the recoverable error paths.
+    assertInitThrowsIOException("oversized-length.bson", new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x7F});
+  }
+
+  @Test
   public void testTruncatedBodyThrows()
       throws Exception {
     // Declared length 16 but only 2 body bytes follow the prefix.

--- a/pinot-plugins/pinot-input-format/pinot-bson/src/test/resources/log4j2.xml
+++ b/pinot-plugins/pinot-input-format/pinot-bson/src/test/resources/log4j2.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<Configuration>
+  <Appenders>
+    <Console name="console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
+      <AppenderRef ref="console"/>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/FileFormat.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/FileFormat.java
@@ -19,7 +19,7 @@
 package org.apache.pinot.spi.data.readers;
 
 public enum FileFormat {
-  AVRO, GZIPPED_AVRO, CSV, JSON, PINOT, THRIFT, PARQUET, ORC, PROTO, ARROW, OTHER;
+  AVRO, GZIPPED_AVRO, CSV, JSON, PINOT, THRIFT, PARQUET, ORC, PROTO, ARROW, BSON, OTHER;
 
   /**
    * Converts an input format string to the corresponding FileFormat enum.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderFactory.java
@@ -44,6 +44,7 @@ public class RecordReaderFactory {
   static final String DEFAULT_CSV_RECORD_READER_CONFIG_CLASS =
       "org.apache.pinot.plugin.inputformat.csv.CSVRecordReaderConfig";
   static final String DEFAULT_JSON_RECORD_READER_CLASS = "org.apache.pinot.plugin.inputformat.json.JSONRecordReader";
+  static final String DEFAULT_BSON_RECORD_READER_CLASS = "org.apache.pinot.plugin.inputformat.bson.BSONRecordReader";
   static final String DEFAULT_THRIFT_RECORD_READER_CLASS =
       "org.apache.pinot.plugin.inputformat.thrift.ThriftRecordReader";
   static final String DEFAULT_THRIFT_RECORD_READER_CONFIG_CLASS =
@@ -76,6 +77,7 @@ public class RecordReaderFactory {
     register(FileFormat.GZIPPED_AVRO, DEFAULT_AVRO_RECORD_READER_CLASS, DEFAULT_AVRO_RECORD_READER_CONFIG_CLASS);
     register(FileFormat.CSV, DEFAULT_CSV_RECORD_READER_CLASS, DEFAULT_CSV_RECORD_READER_CONFIG_CLASS);
     register(FileFormat.JSON, DEFAULT_JSON_RECORD_READER_CLASS, null);
+    register(FileFormat.BSON, DEFAULT_BSON_RECORD_READER_CLASS, null);
     register(FileFormat.THRIFT, DEFAULT_THRIFT_RECORD_READER_CLASS, DEFAULT_THRIFT_RECORD_READER_CONFIG_CLASS);
     register(FileFormat.ORC, DEFAULT_ORC_RECORD_READER_CLASS, null);
     register(FileFormat.PARQUET, DEFAULT_PARQUET_RECORD_READER_CLASS, DEFAULT_PARQUET_RECORD_READER_CONFIG_CLASS);

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/RecordReaderFactoryTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/RecordReaderFactoryTest.java
@@ -34,6 +34,7 @@ public class RecordReaderFactoryTest {
     assertEquals(getRecordReaderClassName("gzipped_avro"), DEFAULT_AVRO_RECORD_READER_CLASS);
     assertEquals(getRecordReaderClassName("csv"), DEFAULT_CSV_RECORD_READER_CLASS);
     assertEquals(getRecordReaderClassName("json"), DEFAULT_JSON_RECORD_READER_CLASS);
+    assertEquals(getRecordReaderClassName("bson"), DEFAULT_BSON_RECORD_READER_CLASS);
     assertEquals(getRecordReaderClassName("thrift"), DEFAULT_THRIFT_RECORD_READER_CLASS);
     assertEquals(getRecordReaderClassName("orc"), DEFAULT_ORC_RECORD_READER_CLASS);
     assertEquals(getRecordReaderClassName("parquet"), DEFAULT_PARQUET_RECORD_READER_CLASS);
@@ -46,6 +47,7 @@ public class RecordReaderFactoryTest {
     assertEquals(getRecordReaderConfigClassName("gzipped_avro"), DEFAULT_AVRO_RECORD_READER_CONFIG_CLASS);
     assertEquals(getRecordReaderConfigClassName("csv"), DEFAULT_CSV_RECORD_READER_CONFIG_CLASS);
     assertNull(getRecordReaderConfigClassName("json"));
+    assertNull(getRecordReaderConfigClassName("bson"));
     assertEquals(getRecordReaderConfigClassName("thrift"), DEFAULT_THRIFT_RECORD_READER_CONFIG_CLASS);
     assertNull(getRecordReaderConfigClassName("orc"));
     assertEquals(getRecordReaderConfigClassName("parquet"), DEFAULT_PARQUET_RECORD_READER_CONFIG_CLASS);
@@ -115,6 +117,7 @@ public class RecordReaderFactoryTest {
     assertNotNull(DEFAULT_AVRO_RECORD_READER_CLASS);
     assertNotNull(DEFAULT_CSV_RECORD_READER_CLASS);
     assertNotNull(DEFAULT_JSON_RECORD_READER_CLASS);
+    assertNotNull(DEFAULT_BSON_RECORD_READER_CLASS);
     assertNotNull(DEFAULT_THRIFT_RECORD_READER_CLASS);
     assertNotNull(DEFAULT_ORC_RECORD_READER_CLASS);
     assertNotNull(DEFAULT_PARQUET_RECORD_READER_CLASS);
@@ -124,6 +127,7 @@ public class RecordReaderFactoryTest {
     assertEquals(DEFAULT_AVRO_RECORD_READER_CLASS, "org.apache.pinot.plugin.inputformat.avro.AvroRecordReader");
     assertEquals(DEFAULT_CSV_RECORD_READER_CLASS, "org.apache.pinot.plugin.inputformat.csv.CSVRecordReader");
     assertEquals(DEFAULT_JSON_RECORD_READER_CLASS, "org.apache.pinot.plugin.inputformat.json.JSONRecordReader");
+    assertEquals(DEFAULT_BSON_RECORD_READER_CLASS, "org.apache.pinot.plugin.inputformat.bson.BSONRecordReader");
     assertEquals(DEFAULT_PROTO_RECORD_READER_CLASS,
         "org.apache.pinot.plugin.inputformat.protobuf.ProtoBufRecordReader");
   }

--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -79,6 +79,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-bson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-orc</artifactId>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@
 
     <arrow.version>19.0.0</arrow.version>
     <avro.version>1.12.1</avro.version>
+    <bson.version>5.6.1</bson.version>
     <parquet.version>1.17.1</parquet.version>
     <orc.version>1.9.8</orc.version>
     <hive.version>2.8.1</hive.version>
@@ -776,6 +777,11 @@
         <groupId>org.apache.avro</groupId>
         <artifactId>avro</artifactId>
         <version>${avro.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mongodb</groupId>
+        <artifactId>bson</artifactId>
+        <version>${bson.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.avro</groupId>


### PR DESCRIPTION
## Summary

Adds a new `pinot-bson` input-format plugin for reading MongoDB **BSON** data, for both batch and streaming ingestion. It mirrors the structure of the existing `pinot-json` plugin (reader + shared extractor + stream decoder) since a decoded BSON document (`org.bson.Document`) is itself a `Map<String, Object>`.

## What's included

- **`BSONRecordReader`** — batch reader for `mongodump`-style files (a concatenation of framed, length-prefixed BSON documents). GZIP-compressed files are supported transparently. A corrupt document surfaces as a skippable `IOException` so a single bad record doesn't abort the whole segment.
- **`BSONMessageDecoder`** — stream decoder for one BSON document per message (e.g. a MongoDB change-stream/oplog document forwarded to Kafka).
- **`BSONRecordExtractor`** — maps BSON's type system onto the standard `RecordExtractor` contract, so the downstream data-type transformer coerces values to the declared column type:

  | BSON type | Output |
  |---|---|
  | Double / Int32 / Int64 / Boolean / String | boxed pass-through |
  | Document (embedded) | `Map<String, Object>` |
  | Array | `Object[]` |
  | ObjectId | `String` (24-char hex) |
  | DateTime | `java.sql.Timestamp` |
  | Timestamp (oplog `ts` / change-stream `clusterTime`) | `java.sql.Timestamp`, second granularity (intra-second ordinal dropped) |
  | Decimal128 | `BigDecimal` (`NaN`/`Infinity` → `null`, negative zero → `BigDecimal.ZERO`) |
  | Binary (incl. UUID subtypes `0x03`/`0x04`) | `byte[]` |
  | other (rare/deprecated) | `toString()` fallback, pinned by test |

- **Registration**: `BSON` added to the `FileFormat` enum and `RecordReaderFactory`, so `dataFormat: bson` works in batch ingestion without specifying a reader class.

Uses the standalone `org.mongodb:bson` library — **no** MongoDB driver and **no** network dependency.

## Usage

Batch ingestion job spec:
```yaml
recordReaderSpec:
  dataFormat: 'bson'
  className: 'org.apache.pinot.plugin.inputformat.bson.BSONRecordReader'
```

Stream (table) config:
```json
"stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.bson.BSONMessageDecoder"
```

## Testing

- `BSONRecordExtractorTest` (23) — scalars, ObjectId, Date, BsonTimestamp, Decimal128 (incl. NaN/Infinity/negative zero), Binary, UUID binary subtypes (via a real encode/decode round trip), arrays, nested documents, null handling, and the `toString()` fallbacks pinned to their literal strings.
- `BSONRecordReaderTest` (9) — extends the shared `AbstractRecordReaderTest` (happy path + gzip + rewind over 10k records) plus raw-frame negative/recovery cases (empty file, truncated prefix, invalid length, truncated body, and skip-then-continue past a corrupt frame).
- `BSONMessageDecoderTest` (5) — scalars + logical types (including the oplog `ts` field), nested doc/array, field projection, offset/length decode, corrupt payload.
- `RecordReaderFactoryTest` (pinot-spi) — `dataFormat: bson` resolves to `BSONRecordReader`.

`checkstyle`, `license`, and `spotless` all pass.

## Release notes

New input format `bson` for reading MongoDB BSON data (batch `.bson` files and streaming). Bundles the Apache-2.0 licensed `org.mongodb:bson` library.

Note on the BSON `Timestamp` type (the oplog `ts` and change-stream `clusterTime` fields): it maps to `java.sql.Timestamp` at second granularity. The intra-second ordinal counter has no `Timestamp` representation and is dropped, so this value orders operations only to the second.
