### PR TITLE
Follow-up to #18941: routing-filter pruner-invariant test + construction cleanup

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/LeafStageToPinotQuery.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/LeafStageToPinotQuery.java
@@ -30,7 +30,6 @@ import org.apache.calcite.rel.core.TableScan;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.pinot.common.request.DataSource;
 import org.apache.pinot.common.request.Expression;
-import org.apache.pinot.common.request.ExpressionType;
 import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.utils.request.RequestUtils;
@@ -137,11 +136,8 @@ public class LeafStageToPinotQuery {
       pinotQuery.setFilterExpression(filterExpression);
       return;
     }
-    Function andFunction = new Function(FilterKind.AND.name());
-    andFunction.setOperands(new ArrayList<>(List.of(existingFilter, filterExpression)));
-    Expression combined = new Expression(ExpressionType.FUNCTION);
-    combined.setFunctionCall(andFunction);
-    pinotQuery.setFilterExpression(combined);
+    pinotQuery.setFilterExpression(
+        RequestUtils.getFunctionExpression(FilterKind.AND.name(), existingFilter, filterExpression));
   }
 
   /**
@@ -218,24 +214,20 @@ public class LeafStageToPinotQuery {
     // don't unnecessarily scan everything.
     if (expression.getLiteral() != null && expression.getLiteral().isSetBoolValue()
         && !expression.getLiteral().getBoolValue()) {
-      Function alwaysFalse = new Function(FilterKind.EQUALS.name());
-      alwaysFalse.setOperands(new ArrayList<>(List.of(
-          RequestUtils.getLiteralExpression(0),
-          RequestUtils.getLiteralExpression(1))));
-      Expression wrapped = new Expression(ExpressionType.FUNCTION);
-      wrapped.setFunctionCall(alwaysFalse);
-      return wrapped;
+      // EQUALS(0, 1) — a predicate that is always false.
+      return RequestUtils.getFunctionExpression(FilterKind.EQUALS.name(),
+          RequestUtils.getLiteralExpression(0), RequestUtils.getLiteralExpression(1));
     }
     // LITERAL true or non-boolean literals have no filter constraint so we skip pruning
     return null;
   }
 
-  /** Wraps a boolean-valued expression as the standard predicate {@code EQUALS(expression, true)}. */
+  /**
+   * Wraps a boolean-valued expression as the standard predicate {@code EQUALS(expression, true)}. The operand list
+   * is mutable so downstream rewriters (e.g. {@code PredicateComparisonRewriter}) can modify it.
+   */
   private static Expression wrapAsEqualsTrue(Expression expression) {
-    Function equalsFunction = new Function(FilterKind.EQUALS.name());
-    equalsFunction.setOperands(new ArrayList<>(List.of(expression, RequestUtils.getLiteralExpression(true))));
-    Expression wrapped = new Expression(ExpressionType.FUNCTION);
-    wrapped.setFunctionCall(equalsFunction);
-    return wrapped;
+    return RequestUtils.getFunctionExpression(FilterKind.EQUALS.name(), expression,
+        RequestUtils.getLiteralExpression(true));
   }
 }

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/logical/LeafStageToPinotQueryTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/logical/LeafStageToPinotQueryTest.java
@@ -243,29 +243,35 @@ public class LeafStageToPinotQueryTest {
     // Shape of a reported failure: a scalar function canonicalizes to a lowercase operator
     // ("arraycontainsstring") and sits directly under AND, so pruners threw
     // "No enum constant org.apache.pinot.sql.FilterKind.arraycontainsstring".
-    // Assert the invariant pruners actually rely on: every operator they traverse resolves via
-    // FilterKind.valueOf. This covers the whole normalized tree rather than a single wrapped node.
+    // Assert the two invariants pruners actually rely on, over the whole normalized tree rather than a single
+    // wrapped node: every visited node is a FUNCTION (pruners dereference getFunctionCall() unconditionally),
+    // and every operator resolves via FilterKind.valueOf.
+    // The AND mixes all the shapes that arrive non-FUNCTION or non-FilterKind: a boolean scalar function, a
+    // bare boolean identifier, and a constant-folded FALSE literal.
     Expression notEquals = makeCompound("NOT_EQUALS",
         RequestUtils.getIdentifierExpression("label"), RequestUtils.getLiteralExpression("Low"));
     Expression scalarFn = makeCompound("arraycontainsstring",
         RequestUtils.getIdentifierExpression("groups"), RequestUtils.getLiteralExpression("y"));
-    Expression andExpr = makeCompound("AND", notEquals, scalarFn, makeEquals("status", "open"));
+    Expression andExpr = makeCompound("AND", notEquals, scalarFn, makeEquals("status", "open"),
+        RequestUtils.getIdentifierExpression("isActive"), RequestUtils.getLiteralExpression(false));
 
     Expression result = LeafStageToPinotQuery.ensureFilterIsFunctionExpression(andExpr);
 
     assertNotNull(result);
+    assertEquals(result.getFunctionCall().getOperator(), "AND");
+    assertEquals(result.getFunctionCall().getOperands().size(), 5, "No operand should be dropped");
     assertPrunerTraversableOperatorsAreFilterKinds(result);
   }
 
   /**
-   * Mirrors how segment pruners walk a filter: they call {@code FilterKind.valueOf(operator)} on each node they
-   * visit (which must not throw) and only recurse into the operands of AND/OR/NOT.
+   * Mirrors how segment pruners walk a filter: on each node they visit they dereference the function call and
+   * resolve its operator via {@code FilterKind.valueOf}, then recurse only into the operands of AND/OR/NOT.
+   * A non-FUNCTION node would NPE the pruners and an unknown operator would throw, so both are asserted here.
    */
   private static void assertPrunerTraversableOperatorsAreFilterKinds(Expression expression) {
+    // Pruners dereference getFunctionCall() unconditionally, so a non-FUNCTION node here would NPE them.
     Function function = expression.getFunctionCall();
-    if (function == null) {
-      return;
-    }
+    assertNotNull(function, "Pruner-visited node must be a FUNCTION expression, got: " + expression);
     // Must not throw — this is exactly what segment pruners call on every node they visit.
     FilterKind filterKind = FilterKind.valueOf(function.getOperator());
     if (filterKind == FilterKind.AND || filterKind == FilterKind.OR || filterKind == FilterKind.NOT) {

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/logical/LeafStageToPinotQueryTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/logical/LeafStageToPinotQueryTest.java
@@ -39,6 +39,7 @@ import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.query.type.TypeFactory;
+import org.apache.pinot.sql.FilterKind;
 import org.mockito.Mockito;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -235,6 +236,43 @@ public class LeafStageToPinotQueryTest {
     Expression operand = result.getFunctionCall().getOperands().get(0);
     assertEquals(operand.getFunctionCall().getOperator(), "EQUALS");
     assertEquals(operand.getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "contains");
+  }
+
+  @Test
+  public void testMixedPredicateYieldsOnlyFilterKindOperatorsForPruners() {
+    // Shape of a reported failure: a scalar function canonicalizes to a lowercase operator
+    // ("arraycontainsstring") and sits directly under AND, so pruners threw
+    // "No enum constant org.apache.pinot.sql.FilterKind.arraycontainsstring".
+    // Assert the invariant pruners actually rely on: every operator they traverse resolves via
+    // FilterKind.valueOf. This covers the whole normalized tree rather than a single wrapped node.
+    Expression notEquals = makeCompound("NOT_EQUALS",
+        RequestUtils.getIdentifierExpression("label"), RequestUtils.getLiteralExpression("Low"));
+    Expression scalarFn = makeCompound("arraycontainsstring",
+        RequestUtils.getIdentifierExpression("groups"), RequestUtils.getLiteralExpression("y"));
+    Expression andExpr = makeCompound("AND", notEquals, scalarFn, makeEquals("status", "open"));
+
+    Expression result = LeafStageToPinotQuery.ensureFilterIsFunctionExpression(andExpr);
+
+    assertNotNull(result);
+    assertPrunerTraversableOperatorsAreFilterKinds(result);
+  }
+
+  /**
+   * Mirrors how segment pruners walk a filter: they call {@code FilterKind.valueOf(operator)} on each node they
+   * visit (which must not throw) and only recurse into the operands of AND/OR/NOT.
+   */
+  private static void assertPrunerTraversableOperatorsAreFilterKinds(Expression expression) {
+    Function function = expression.getFunctionCall();
+    if (function == null) {
+      return;
+    }
+    // Must not throw — this is exactly what segment pruners call on every node they visit.
+    FilterKind filterKind = FilterKind.valueOf(function.getOperator());
+    if (filterKind == FilterKind.AND || filterKind == FilterKind.OR || filterKind == FilterKind.NOT) {
+      for (Expression operand : function.getOperands()) {
+        assertPrunerTraversableOperatorsAreFilterKinds(operand);
+      }
+    }
   }
 
   // --- AND/OR handling (shared logic, tested symmetrically) ---


### PR DESCRIPTION
Follow-up to #18941, which is already merged. Small, low-risk: one added test plus a behavior-preserving cleanup. No functional change.

### Background

This PR started as an independent fix for a reported error:

```
Error composing query plan: No enum constant org.apache.pinot.sql.FilterKind.arraycontainsstring
```

reproduced with `usePhysicalOptimizer=true` and a `WHERE` clause containing `arrayContainsString(mvCol, 'y')`. The scalar function canonicalizes to the lowercase operator `arraycontainsstring` and lands directly under `AND` in the routing filter, so segment pruners threw when resolving it via `FilterKind.valueOf`.

#18941 landed the same fix first (wrapping non-`FilterKind` operators as `EQUALS(fn, true)` in `LeafStageToPinotQuery.ensureFilterIsFunctionExpression`), so the production fix here has been dropped. What remains is what #18941 did not cover.

### Test

`testMixedPredicateYieldsOnlyFilterKindOperatorsForPruners` asserts the invariant segment pruners actually depend on: **every operator a pruner traverses resolves via `FilterKind.valueOf`**. The assertion helper mirrors pruner traversal exactly — it calls `FilterKind.valueOf` on each visited node and only recurses into `AND`/`OR`/`NOT` operands.

This complements the existing per-node tests in #18941 (`testBooleanScalarFunctionWrappedAsEqualsTrue` and friends) by checking the whole normalized tree rather than a single wrapped node, and it uses the shape of the reported failure (`AND(NOT_EQUALS(...), arraycontainsstring(...), EQUALS(...))`).

### Cleanup

`LeafStageToPinotQuery` hand-rolled `Expression`/`Function` plus their operand lists in three places — `addFilterExpression`, the always-false literal branch, and `wrapAsEqualsTrue`. All three now use `RequestUtils.getFunctionExpression`.

This is behavior-preserving: `RequestUtils.getFunction(String, Expression...)` already allocates a mutable `ArrayList` for operands (the existing `testIdentifierWrappedWithMutableOperandList` covers that contract). It also drops the now-unused `ExpressionType` import.

### Testing

`pinot-query-planner`: `LeafStageToPinotQueryTest` (40), `PlanNodeRoutingQueryBuilderTest` (3), and `LeafStageWorkerAssignmentRuleTest` (24) — 67 tests, all passing. `PlanNodeRoutingQueryBuilderTest` is included because it exercises the shared `addFilterExpression`.

`spotless:check`, `checkstyle:check`, and `license:check` pass clean on the module.

### Labels

`cleanup`, `multi-stage`