### PR TITLE
Add equals() and hashCode() to VectorIndexConfig

### DIFF
--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/VectorIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/VectorIndexConfig.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import java.util.Map;
+import java.util.Objects;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.table.IndexConfig;
 
@@ -148,6 +149,30 @@ public class VectorIndexConfig extends IndexConfig {
    */
   public VectorBackendType resolveBackendType() {
     return VectorIndexConfigValidator.resolveBackendType(this);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    VectorIndexConfig that = (VectorIndexConfig) o;
+    return _vectorDimension == that._vectorDimension && _version == that._version
+        && Objects.equals(_vectorIndexType, that._vectorIndexType)
+        && _vectorDistanceFunction == that._vectorDistanceFunction
+        && Objects.equals(_properties, that._properties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), _vectorIndexType, _vectorDimension, _version,
+        _vectorDistanceFunction, _properties);
   }
 
   public String toString() {

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/creator/VectorIndexConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/creator/VectorIndexConfigTest.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.index.creator;
+
+import java.util.Map;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+
+/**
+ * Unit tests for {@link VectorIndexConfig#equals(Object)} and {@link VectorIndexConfig#hashCode()}.
+ */
+public class VectorIndexConfigTest {
+
+  // ---------------------------------------------------------------------------
+  // equals
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testEqualsSameInstance() {
+    VectorIndexConfig config = hnswConfig(4, VectorIndexConfig.VectorDistanceFunction.COSINE);
+    assertEquals(config, config);
+  }
+
+  @Test
+  public void testEqualsIdenticalConfigs() {
+    VectorIndexConfig a = hnswConfig(4, VectorIndexConfig.VectorDistanceFunction.COSINE);
+    VectorIndexConfig b = hnswConfig(4, VectorIndexConfig.VectorDistanceFunction.COSINE);
+    assertEquals(a, b);
+  }
+
+  @Test
+  public void testNotEqualsDifferentDimension() {
+    VectorIndexConfig a = hnswConfig(4, VectorIndexConfig.VectorDistanceFunction.COSINE);
+    VectorIndexConfig b = hnswConfig(8, VectorIndexConfig.VectorDistanceFunction.COSINE);
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  public void testNotEqualsDifferentDistanceFunction() {
+    VectorIndexConfig a = hnswConfig(4, VectorIndexConfig.VectorDistanceFunction.COSINE);
+    VectorIndexConfig b = hnswConfig(4, VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN);
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  public void testNotEqualsDifferentBackend() {
+    VectorIndexConfig a = hnswConfig(4, VectorIndexConfig.VectorDistanceFunction.COSINE);
+    VectorIndexConfig b = new VectorIndexConfig(false, "IVF_PQ", 4, 1,
+        VectorIndexConfig.VectorDistanceFunction.COSINE, Map.of());
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  public void testNotEqualsDifferentProperties() {
+    VectorIndexConfig a = new VectorIndexConfig(false, "HNSW", 4, 1,
+        VectorIndexConfig.VectorDistanceFunction.COSINE, Map.of("maxCon", "16"));
+    VectorIndexConfig b = new VectorIndexConfig(false, "HNSW", 4, 1,
+        VectorIndexConfig.VectorDistanceFunction.COSINE, Map.of("maxCon", "32"));
+    assertNotEquals(a, b);
+  }
+
+  @Test
+  public void testNotEqualsDisabledVsEnabled() {
+    VectorIndexConfig enabled = hnswConfig(4, VectorIndexConfig.VectorDistanceFunction.COSINE);
+    VectorIndexConfig disabled = new VectorIndexConfig(true);
+    assertNotEquals(enabled, disabled);
+  }
+
+  @Test
+  public void testNotEqualsNull() {
+    VectorIndexConfig config = hnswConfig(4, VectorIndexConfig.VectorDistanceFunction.COSINE);
+    assertNotEquals(config, null);
+  }
+
+  // ---------------------------------------------------------------------------
+  // hashCode
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testHashCodeConsistentWithEquals() {
+    VectorIndexConfig a = hnswConfig(4, VectorIndexConfig.VectorDistanceFunction.COSINE);
+    VectorIndexConfig b = hnswConfig(4, VectorIndexConfig.VectorDistanceFunction.COSINE);
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  @Test
+  public void testHashCodeDiffersForDifferentDimension() {
+    VectorIndexConfig a = hnswConfig(4, VectorIndexConfig.VectorDistanceFunction.COSINE);
+    VectorIndexConfig b = hnswConfig(8, VectorIndexConfig.VectorDistanceFunction.COSINE);
+    assertNotEquals(a.hashCode(), b.hashCode());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private static VectorIndexConfig hnswConfig(int dimension,
+      VectorIndexConfig.VectorDistanceFunction distanceFunction) {
+    return new VectorIndexConfig(false, "HNSW", dimension, 1, distanceFunction, Map.of());
+  }
+}


### PR DESCRIPTION
## Summary

`VectorIndexConfig` was the only index config class in the SPI that did not implement `equals()` and `hashCode()`. Every other config class (`BloomFilterConfig`, `TextIndexConfig`, `JsonIndexConfig`, `H3IndexConfig`) has these methods. Without them, two configs with identical fields compare unequal by object identity, which breaks:
- `Map`/`Set` lookups keyed by config
- Config-change detection that compares stored vs. desired config
- Any equality assertion in tests

- Adds `equals()` and `hashCode()` to `VectorIndexConfig` following the same pattern as `BloomFilterConfig`
- Adds `VectorIndexConfigTest` with 9 cases: same instance, identical configs, different dimension, different distance function, different backend, different properties, disabled vs. enabled, null comparison, and hash code consistency

## Test plan
- [ ] `VectorIndexConfigTest` — 9 unit tests covering equals/hashCode contract
- [ ] `./mvnw checkstyle:check -pl pinot-segment-spi` passes (0 violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)