### PR TITLE
Fix JsonIndexConfig equals/hashCode missing _indexPaths and _maxBytesSize

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/JsonIndexConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/JsonIndexConfig.java
@@ -212,13 +212,14 @@ public class JsonIndexConfig extends IndexConfig {
     return _maxLevels == config._maxLevels && _excludeArray == config._excludeArray
         && _disableCrossArrayUnnest == config._disableCrossArrayUnnest && Objects.equals(_includePaths,
         config._includePaths) && Objects.equals(_excludePaths, config._excludePaths) && Objects.equals(_excludeFields,
-        config._excludeFields) && _maxValueLength == config._maxValueLength
-        && _skipInvalidJson == config._skipInvalidJson;
+        config._excludeFields) && Objects.equals(_indexPaths, config._indexPaths)
+        && _maxValueLength == config._maxValueLength && _skipInvalidJson == config._skipInvalidJson
+        && Objects.equals(_maxBytesSize, config._maxBytesSize);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode(), _maxLevels, _excludeArray, _disableCrossArrayUnnest, _includePaths,
-        _excludePaths, _excludeFields, _maxValueLength, _skipInvalidJson);
+        _excludePaths, _excludeFields, _indexPaths, _maxValueLength, _skipInvalidJson, _maxBytesSize);
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/JsonIndexConfigTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/JsonIndexConfigTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.spi.config.table;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Set;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
@@ -105,5 +106,63 @@ public class JsonIndexConfigTest {
     assertEquals(config.getIncludePaths(), Lists.newArrayList("a"), "Unexpected includePaths");
     assertEquals(config.getExcludePaths(), Lists.newArrayList("b"), "Unexpected excludePaths");
     assertEquals(config.getExcludeFields(), Lists.newArrayList("c"), "Unexpected excludeFields");
+  }
+
+  // ---------------------------------------------------------------------------
+  // equals / hashCode — _indexPaths and _maxBytesSize must be included
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testEqualsIgnoresDifferentIndexPathsWithoutFix() {
+    // Two configs that differ only in indexPaths must NOT be equal.
+    JsonIndexConfig a = new JsonIndexConfig();
+    JsonIndexConfig b = new JsonIndexConfig();
+    b.setIndexPaths(Set.of("a.**"));
+
+    assertNotEquals(a, b, "Configs with different indexPaths must not be equal");
+  }
+
+  @Test
+  public void testEqualsIgnoresDifferentMaxBytesSizeWithoutFix() {
+    // Two configs that differ only in maxBytesSize must NOT be equal.
+    JsonIndexConfig a = new JsonIndexConfig();
+    JsonIndexConfig b = new JsonIndexConfig();
+    b.setMaxBytesSize(1024L);
+
+    assertNotEquals(a, b, "Configs with different maxBytesSize must not be equal");
+  }
+
+  @Test
+  public void testEqualsIdenticalConfigs() {
+    JsonIndexConfig a = new JsonIndexConfig();
+    a.setIndexPaths(Set.of("a.**"));
+    a.setMaxBytesSize(512L);
+
+    JsonIndexConfig b = new JsonIndexConfig();
+    b.setIndexPaths(Set.of("a.**"));
+    b.setMaxBytesSize(512L);
+
+    assertEquals(a, b, "Identical configs must be equal");
+    assertEquals(a.hashCode(), b.hashCode(), "Equal configs must have the same hashCode");
+  }
+
+  @Test
+  public void testHashCodeIncludesIndexPaths() {
+    JsonIndexConfig a = new JsonIndexConfig();
+    JsonIndexConfig b = new JsonIndexConfig();
+    b.setIndexPaths(Set.of("x.**"));
+
+    assertNotEquals(a.hashCode(), b.hashCode(),
+        "hashCode must differ when indexPaths differ");
+  }
+
+  @Test
+  public void testHashCodeIncludesMaxBytesSize() {
+    JsonIndexConfig a = new JsonIndexConfig();
+    JsonIndexConfig b = new JsonIndexConfig();
+    b.setMaxBytesSize(2048L);
+
+    assertNotEquals(a.hashCode(), b.hashCode(),
+        "hashCode must differ when maxBytesSize differs");
   }
 }


### PR DESCRIPTION
## Summary

`JsonIndexConfig.equals()` and `hashCode()` were introduced when the class had fewer fields. Two later additions were never included:

- **`_indexPaths`** (`Set<String>`) — controls which JSON sub-paths are indexed; added to support fine-grained path-level indexing
- **`_maxBytesSize`** (`Long`) — caps the mutable JSON index's on-heap footprint

As a result, two configs that differ **only** in `indexPaths` or `maxBytesSize` incorrectly compare as equal. This breaks:
- `Map`/`Set` lookups keyed by config
- Config-change detection (e.g. index reload logic comparing desired vs. stored config)
- Any unit test asserting config equality

**Fix:** add both fields to `equals()` and `hashCode()`.

**Tests:** adds 5 targeted tests to the existing `JsonIndexConfigTest` to document and verify the fix (including a "without fix" naming convention to make the intent obvious in CI history).

## Test plan
- [ ] 5 new tests in `JsonIndexConfigTest` — all green
- [ ] `./mvnw checkstyle:check -pl pinot-spi` — 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)