### PR TITLE
Fix FSDirectory resource leak when IndexWriter construction fails in HNSW vector index

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/vector/MutableVectorIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/vector/MutableVectorIndex.java
@@ -91,21 +91,42 @@ public class MutableVectorIndex implements VectorIndexReader, MutableIndex, Vect
     _commitDocs = Long.parseLong(
         vectorIndexConfig.getProperties().getOrDefault("commitDocs", String.valueOf(DEFAULT_COMMIT_DOCS)));
     _vectorSimilarityFunction = VectorIndexUtils.toSimilarityFunction(vectorIndexConfig.getVectorDistanceFunction());
+    // Use local variables so that resources opened before a failure can be closed before rethrowing,
+    // preventing file-descriptor and temp-directory leaks.
+    File indexDir = new File(FileUtils.getTempDirectory(), segmentName);
+    FSDirectory indexDirectory = null;
+    IndexWriter indexWriter = null;
     try {
       // segment generation is always in V1 and later we convert (as part of post creation processing)
       // to V3 if segmentVersion is set to V3 in SegmentGeneratorConfig.
-      _indexDir = new File(FileUtils.getTempDirectory(), segmentName);
-      _indexDirectory = FSDirectory.open(
-          new File(_indexDir, _vectorColumn + V1Constants.Indexes.VECTOR_V912_HNSW_INDEX_FILE_EXTENSION).toPath());
+      indexDirectory = FSDirectory.open(
+          new File(indexDir, _vectorColumn + V1Constants.Indexes.VECTOR_V912_HNSW_INDEX_FILE_EXTENSION).toPath());
       LOGGER.info("Creating mutable HNSW index for segment: {}, column: {} at path: {} with {}", segmentName,
-          vectorColumn, _indexDir.getAbsolutePath(), vectorIndexConfig.getProperties());
-      _indexWriter = new IndexWriter(_indexDirectory, VectorIndexUtils.getIndexWriterConfig(vectorIndexConfig));
-      _indexWriter.commit();
+          vectorColumn, indexDir.getAbsolutePath(), vectorIndexConfig.getProperties());
+      indexWriter = new IndexWriter(indexDirectory, VectorIndexUtils.getIndexWriterConfig(vectorIndexConfig));
+      indexWriter.commit();
       _lastCommitTime = System.currentTimeMillis();
     } catch (Exception e) {
+      if (indexWriter != null) {
+        try {
+          indexWriter.close();
+        } catch (IOException closeEx) {
+          e.addSuppressed(closeEx);
+        }
+      } else if (indexDirectory != null) {
+        try {
+          indexDirectory.close();
+        } catch (IOException closeEx) {
+          e.addSuppressed(closeEx);
+        }
+      }
+      FileUtils.deleteQuietly(indexDir);
       throw new RuntimeException(
           "Caught exception while instantiating the LuceneTextIndexCreator for column: " + vectorColumn, e);
     }
+    _indexDir = indexDir;
+    _indexDirectory = indexDirectory;
+    _indexWriter = indexWriter;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/vector/HnswVectorIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/vector/HnswVectorIndexCreator.java
@@ -65,20 +65,33 @@ public class HnswVectorIndexCreator implements VectorIndexCreator {
     _vectorSimilarityFunction = VectorIndexUtils.toSimilarityFunction(vectorIndexConfig.getVectorDistanceFunction());
     _storeInSegmentFile = vectorIndexConfig.isStoreInSegmentFile();
     _segmentIndexDir = segmentIndexDir;
+    // Use local variables so that, if IndexWriter construction fails after FSDirectory is already
+    // open, we can close the directory before rethrowing — preventing a file-descriptor leak.
+    Directory indexDirectory = null;
+    IndexWriter indexWriter;
     try {
       // segment generation is always in V1 and later we convert (as part of post creation processing)
       // to V3 if segmentVersion is set to V3 in SegmentGeneratorConfig.
       File indexFile = new File(segmentIndexDir, _vectorColumn
           + V1Constants.Indexes.VECTOR_V912_HNSW_INDEX_FILE_EXTENSION);
       _hnswIndexDir = indexFile;
-      _indexDirectory = FSDirectory.open(indexFile.toPath());
+      indexDirectory = FSDirectory.open(indexFile.toPath());
       LOGGER.info("Creating HNSW index for column: {} at path: {} with {} for segment: {}", column,
           indexFile.getAbsolutePath(), vectorIndexConfig.getProperties(), segmentIndexDir.getAbsolutePath());
-      _indexWriter = new IndexWriter(_indexDirectory, VectorIndexUtils.getIndexWriterConfig(vectorIndexConfig));
+      indexWriter = new IndexWriter(indexDirectory, VectorIndexUtils.getIndexWriterConfig(vectorIndexConfig));
     } catch (Exception e) {
+      if (indexDirectory != null) {
+        try {
+          indexDirectory.close();
+        } catch (IOException closeEx) {
+          e.addSuppressed(closeEx);
+        }
+      }
       throw new RuntimeException(
           "Caught exception while instantiating the HnswVectorIndexCreator for column: " + column, e);
     }
+    _indexDirectory = indexDirectory;
+    _indexWriter = indexWriter;
   }
 
   @Override


### PR DESCRIPTION
## Summary

Both `HnswVectorIndexCreator` and `MutableVectorIndex` open an `FSDirectory` in their constructors and then immediately construct an `IndexWriter` over it. If `IndexWriter` construction throws — e.g. due to a locked or corrupt index directory, a codec initialization failure, or an `OutOfMemoryError` — the already-opened `FSDirectory` is silently leaked: the `catch` block wraps and rethrows the exception without ever calling `close()` on the directory.

On servers that repeatedly create or reload vector indexes under error conditions, this accumulates unclosed file descriptors until the OS limit is hit, causing new index creations to fail with "Too many open files".

### Root cause

```java
// Both files — same pattern
_indexDirectory = FSDirectory.open(indexFile.toPath());  // succeeds
_indexWriter = new IndexWriter(_indexDirectory, ...);     // throws → _indexDirectory leaks
```

### Fix

Use local variables so the directory is accessible in the `catch` block. Close the directory (or writer, if construction succeeded) before rethrowing. In `MutableVectorIndex`, also delete the temporary index directory so stale `getTempDirectory()` subdirectories don't accumulate on failure.

```java
Directory indexDirectory = null;
IndexWriter indexWriter;
try {
    indexDirectory = FSDirectory.open(indexFile.toPath());
    indexWriter = new IndexWriter(indexDirectory, ...);
} catch (Exception e) {
    if (indexDirectory != null) {
        try { indexDirectory.close(); } catch (IOException ce) { e.addSuppressed(ce); }
    }
    throw new RuntimeException("...", e);
}
_indexDirectory = indexDirectory;
_indexWriter = indexWriter;
```

## Files changed

- `HnswVectorIndexCreator.java` — offline segment generation path
- `MutableVectorIndex.java` — realtime ingestion path (also cleans up temp dir on failure)

## Test plan
- [x] Existing unit/integration tests pass
- [x] `./mvnw checkstyle:check -pl pinot-segment-local` — 0 violations

cc @xiangfu0 @raghavyadav01 @Jackie-Jiang

