### PR TITLE
Report NOT_CALCULATED for uncomputable consuming-segment lag (#18836)

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaStreamMetadataProvider.java
@@ -235,17 +235,21 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
       // Compute records-lag
       StreamPartitionMsgOffset currentOffset = partitionState.getCurrentOffset();
       StreamPartitionMsgOffset upstreamLatest = partitionState.getUpstreamLatestOffset();
-      String offsetLagString = "UNKNOWN";
+      String offsetLagString = PartitionLagState.NOT_CALCULATED;
 
       if (currentOffset instanceof LongMsgOffset && upstreamLatest instanceof LongMsgOffset) {
         long offsetLag = ((LongMsgOffset) upstreamLatest).getOffset() - ((LongMsgOffset) currentOffset).getOffset();
         offsetLagString = String.valueOf(offsetLag);
       }
 
-      // Compute record-availability
-      String availabilityLagMs = "UNKNOWN";
+      // Compute record-availability. Only when both the last-processed wall-clock time and the record's upstream
+      // ingestion time are valid; otherwise a missing/invalid ingestion time (e.g. records without a Kafka
+      // timestamp) would turn the subtraction into an epoch-sized value that leaks to the metric and UI. Keep the
+      // NOT_CALCULATED sentinel in that case so the lag is reported as not-calculated rather than a bogus number.
+      String availabilityLagMs = PartitionLagState.NOT_CALCULATED;
       StreamMessageMetadata lastProcessedMessageMetadata = partitionState.getLastProcessedRowMetadata();
-      if (lastProcessedMessageMetadata != null && partitionState.getLastProcessedTimeMs() > 0) {
+      if (lastProcessedMessageMetadata != null && partitionState.getLastProcessedTimeMs() > 0
+          && lastProcessedMessageMetadata.getRecordIngestionTimeMs() > 0) {
         long availabilityLag =
             partitionState.getLastProcessedTimeMs() - lastProcessedMessageMetadata.getRecordIngestionTimeMs();
         availabilityLagMs = String.valueOf(availabilityLag);

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/test/java/org/apache/pinot/plugin/stream/kafka30/KafkaStreamMetadataProviderTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/test/java/org/apache/pinot/plugin/stream/kafka30/KafkaStreamMetadataProviderTest.java
@@ -30,11 +30,14 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.pinot.spi.stream.ConsumerPartitionState;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.PartitionGroupConsumptionStatus;
 import org.apache.pinot.spi.stream.PartitionGroupMetadata;
+import org.apache.pinot.spi.stream.PartitionLagState;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
+import org.apache.pinot.spi.stream.StreamMessageMetadata;
 import org.apache.pinot.spi.stream.StreamMetadataProvider;
 import org.testng.annotations.Test;
 
@@ -105,6 +108,68 @@ public class KafkaStreamMetadataProviderTest {
             .collect(Collectors.toList()), List.of(0, 1, 2, 3, 4, 5, 6, 7));
         assertEquals(partitionGroupMetadataList.stream().map(metadata -> metadata.getStartOffset().toString())
             .collect(Collectors.toList()), List.of("10", "11", "12", "13", "1004", "1005", "1006", "1007"));
+      }
+    } finally {
+      MOCK_CONSUMER.remove();
+    }
+  }
+
+  @Test
+  public void testGetCurrentPartitionLagStateHandlesInvalidIngestionTime()
+      throws Exception {
+    String topicName = "asset";
+    Consumer<Bytes, Bytes> consumer = mockConsumer(topicName, 1);
+    MOCK_CONSUMER.set(consumer);
+    try {
+      StreamConfig streamConfig = getStreamConfig(topicName);
+      try (KafkaStreamMetadataProvider provider = new MockKafkaStreamMetadataProvider("client", streamConfig)) {
+        long lastProcessedTimeMs = 1_700_000_100_000L;
+
+        // Record with a valid upstream ingestion time yields a numeric availability lag.
+        StreamMessageMetadata validMetadata = new StreamMessageMetadata.Builder()
+            .setOffset(new LongMsgOffset(5), new LongMsgOffset(6))
+            .setRecordIngestionTimeMs(lastProcessedTimeMs - 1000L)
+            .build();
+        // Records whose ingestion time is missing/invalid: unset (Builder default Long.MIN_VALUE), Kafka's
+        // NO_TIMESTAMP (-1), and epoch 0 (the exact boundary of the > 0 guard). These stand in for a topic that is
+        // unreachable/timing out or produces records without a timestamp.
+        StreamMessageMetadata unsetIngestionTime = new StreamMessageMetadata.Builder()
+            .setOffset(new LongMsgOffset(5), new LongMsgOffset(6))
+            .build();
+        StreamMessageMetadata noTimestampIngestionTime = new StreamMessageMetadata.Builder()
+            .setOffset(new LongMsgOffset(5), new LongMsgOffset(6))
+            .setRecordIngestionTimeMs(-1L)
+            .build();
+        StreamMessageMetadata zeroIngestionTime = new StreamMessageMetadata.Builder()
+            .setOffset(new LongMsgOffset(5), new LongMsgOffset(6))
+            .setRecordIngestionTimeMs(0L)
+            .build();
+
+        Map<String, ConsumerPartitionState> stateMap = new HashMap<>();
+        stateMap.put("0", new ConsumerPartitionState("0", new LongMsgOffset(5), lastProcessedTimeMs,
+            new LongMsgOffset(10), validMetadata));
+        stateMap.put("1", new ConsumerPartitionState("1", new LongMsgOffset(5), lastProcessedTimeMs,
+            new LongMsgOffset(10), unsetIngestionTime));
+        stateMap.put("2", new ConsumerPartitionState("2", new LongMsgOffset(5), lastProcessedTimeMs,
+            new LongMsgOffset(10), noTimestampIngestionTime));
+        stateMap.put("3", new ConsumerPartitionState("3", new LongMsgOffset(5), lastProcessedTimeMs,
+            new LongMsgOffset(10), zeroIngestionTime));
+        // Partition with an unknown upstream offset exercises the offset-lag fallback.
+        stateMap.put("4", new ConsumerPartitionState("4", new LongMsgOffset(5), lastProcessedTimeMs,
+            null, validMetadata));
+
+        Map<String, PartitionLagState> lagState = provider.getCurrentPartitionLagState(stateMap);
+
+        // Offset lag: numeric when both offsets are known, NOT_CALCULATED when the upstream offset is unavailable.
+        assertEquals(lagState.get("0").getRecordsLag(), "5");
+        assertEquals(lagState.get("4").getRecordsLag(), PartitionLagState.NOT_CALCULATED);
+        // Availability lag: numeric for a valid ingestion time, NOT_CALCULATED for every invalid one.
+        // Regression for issue #18836: an invalid ingestion time must not leak an epoch-sized value
+        // (lastProcessedTimeMs - Long.MIN_VALUE, or lastProcessedTimeMs - (-1) ~= now).
+        assertEquals(lagState.get("0").getAvailabilityLagMs(), "1000");
+        assertEquals(lagState.get("1").getAvailabilityLagMs(), PartitionLagState.NOT_CALCULATED);
+        assertEquals(lagState.get("2").getAvailabilityLagMs(), PartitionLagState.NOT_CALCULATED);
+        assertEquals(lagState.get("3").getAvailabilityLagMs(), PartitionLagState.NOT_CALCULATED);
       }
     } finally {
       MOCK_CONSUMER.remove();

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/main/java/org/apache/pinot/plugin/stream/kafka40/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/main/java/org/apache/pinot/plugin/stream/kafka40/KafkaStreamMetadataProvider.java
@@ -235,17 +235,21 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
       // Compute records-lag
       StreamPartitionMsgOffset currentOffset = partitionState.getCurrentOffset();
       StreamPartitionMsgOffset upstreamLatest = partitionState.getUpstreamLatestOffset();
-      String offsetLagString = "UNKNOWN";
+      String offsetLagString = PartitionLagState.NOT_CALCULATED;
 
       if (currentOffset instanceof LongMsgOffset && upstreamLatest instanceof LongMsgOffset) {
         long offsetLag = ((LongMsgOffset) upstreamLatest).getOffset() - ((LongMsgOffset) currentOffset).getOffset();
         offsetLagString = String.valueOf(offsetLag);
       }
 
-      // Compute record-availability
-      String availabilityLagMs = "UNKNOWN";
+      // Compute record-availability. Only when both the last-processed wall-clock time and the record's upstream
+      // ingestion time are valid; otherwise a missing/invalid ingestion time (e.g. records without a Kafka
+      // timestamp) would turn the subtraction into an epoch-sized value that leaks to the metric and UI. Keep the
+      // NOT_CALCULATED sentinel in that case so the lag is reported as not-calculated rather than a bogus number.
+      String availabilityLagMs = PartitionLagState.NOT_CALCULATED;
       StreamMessageMetadata lastProcessedMessageMetadata = partitionState.getLastProcessedRowMetadata();
-      if (lastProcessedMessageMetadata != null && partitionState.getLastProcessedTimeMs() > 0) {
+      if (lastProcessedMessageMetadata != null && partitionState.getLastProcessedTimeMs() > 0
+          && lastProcessedMessageMetadata.getRecordIngestionTimeMs() > 0) {
         long availabilityLag =
             partitionState.getLastProcessedTimeMs() - lastProcessedMessageMetadata.getRecordIngestionTimeMs();
         availabilityLagMs = String.valueOf(availabilityLag);

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/test/java/org/apache/pinot/plugin/stream/kafka40/KafkaStreamMetadataProviderTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/test/java/org/apache/pinot/plugin/stream/kafka40/KafkaStreamMetadataProviderTest.java
@@ -30,11 +30,14 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.pinot.spi.stream.ConsumerPartitionState;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.PartitionGroupConsumptionStatus;
 import org.apache.pinot.spi.stream.PartitionGroupMetadata;
+import org.apache.pinot.spi.stream.PartitionLagState;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
+import org.apache.pinot.spi.stream.StreamMessageMetadata;
 import org.apache.pinot.spi.stream.StreamMetadataProvider;
 import org.testng.annotations.Test;
 
@@ -105,6 +108,68 @@ public class KafkaStreamMetadataProviderTest {
             .collect(Collectors.toList()), List.of(0, 1, 2, 3, 4, 5, 6, 7));
         assertEquals(partitionGroupMetadataList.stream().map(metadata -> metadata.getStartOffset().toString())
             .collect(Collectors.toList()), List.of("10", "11", "12", "13", "1004", "1005", "1006", "1007"));
+      }
+    } finally {
+      MOCK_CONSUMER.remove();
+    }
+  }
+
+  @Test
+  public void testGetCurrentPartitionLagStateHandlesInvalidIngestionTime()
+      throws Exception {
+    String topicName = "asset";
+    Consumer<Bytes, Bytes> consumer = mockConsumer(topicName, 1);
+    MOCK_CONSUMER.set(consumer);
+    try {
+      StreamConfig streamConfig = getStreamConfig(topicName);
+      try (KafkaStreamMetadataProvider provider = new MockKafkaStreamMetadataProvider("client", streamConfig)) {
+        long lastProcessedTimeMs = 1_700_000_100_000L;
+
+        // Record with a valid upstream ingestion time yields a numeric availability lag.
+        StreamMessageMetadata validMetadata = new StreamMessageMetadata.Builder()
+            .setOffset(new LongMsgOffset(5), new LongMsgOffset(6))
+            .setRecordIngestionTimeMs(lastProcessedTimeMs - 1000L)
+            .build();
+        // Records whose ingestion time is missing/invalid: unset (Builder default Long.MIN_VALUE), Kafka's
+        // NO_TIMESTAMP (-1), and epoch 0 (the exact boundary of the > 0 guard). These stand in for a topic that is
+        // unreachable/timing out or produces records without a timestamp.
+        StreamMessageMetadata unsetIngestionTime = new StreamMessageMetadata.Builder()
+            .setOffset(new LongMsgOffset(5), new LongMsgOffset(6))
+            .build();
+        StreamMessageMetadata noTimestampIngestionTime = new StreamMessageMetadata.Builder()
+            .setOffset(new LongMsgOffset(5), new LongMsgOffset(6))
+            .setRecordIngestionTimeMs(-1L)
+            .build();
+        StreamMessageMetadata zeroIngestionTime = new StreamMessageMetadata.Builder()
+            .setOffset(new LongMsgOffset(5), new LongMsgOffset(6))
+            .setRecordIngestionTimeMs(0L)
+            .build();
+
+        Map<String, ConsumerPartitionState> stateMap = new HashMap<>();
+        stateMap.put("0", new ConsumerPartitionState("0", new LongMsgOffset(5), lastProcessedTimeMs,
+            new LongMsgOffset(10), validMetadata));
+        stateMap.put("1", new ConsumerPartitionState("1", new LongMsgOffset(5), lastProcessedTimeMs,
+            new LongMsgOffset(10), unsetIngestionTime));
+        stateMap.put("2", new ConsumerPartitionState("2", new LongMsgOffset(5), lastProcessedTimeMs,
+            new LongMsgOffset(10), noTimestampIngestionTime));
+        stateMap.put("3", new ConsumerPartitionState("3", new LongMsgOffset(5), lastProcessedTimeMs,
+            new LongMsgOffset(10), zeroIngestionTime));
+        // Partition with an unknown upstream offset exercises the offset-lag fallback.
+        stateMap.put("4", new ConsumerPartitionState("4", new LongMsgOffset(5), lastProcessedTimeMs,
+            null, validMetadata));
+
+        Map<String, PartitionLagState> lagState = provider.getCurrentPartitionLagState(stateMap);
+
+        // Offset lag: numeric when both offsets are known, NOT_CALCULATED when the upstream offset is unavailable.
+        assertEquals(lagState.get("0").getRecordsLag(), "5");
+        assertEquals(lagState.get("4").getRecordsLag(), PartitionLagState.NOT_CALCULATED);
+        // Availability lag: numeric for a valid ingestion time, NOT_CALCULATED for every invalid one.
+        // Regression for issue #18836: an invalid ingestion time must not leak an epoch-sized value
+        // (lastProcessedTimeMs - Long.MIN_VALUE, or lastProcessedTimeMs - (-1) ~= now).
+        assertEquals(lagState.get("0").getAvailabilityLagMs(), "1000");
+        assertEquals(lagState.get("1").getAvailabilityLagMs(), PartitionLagState.NOT_CALCULATED);
+        assertEquals(lagState.get("2").getAvailabilityLagMs(), PartitionLagState.NOT_CALCULATED);
+        assertEquals(lagState.get("3").getAvailabilityLagMs(), PartitionLagState.NOT_CALCULATED);
       }
     } finally {
       MOCK_CONSUMER.remove();

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisStreamMetadataProvider.java
@@ -262,10 +262,14 @@ public class KinesisStreamMetadataProvider implements StreamMetadataProvider {
     Map<String, PartitionLagState> perPartitionLag = new HashMap<>();
     for (Map.Entry<String, ConsumerPartitionState> entry : currentPartitionStateMap.entrySet()) {
       ConsumerPartitionState partitionState = entry.getValue();
-      // Compute record-availability
-      String recordAvailabilityLag = "UNKNOWN";
+      // Compute record-availability. Only when both the last-processed wall-clock time and the record's upstream
+      // ingestion time are valid; otherwise a missing/invalid ingestion time (e.g. records without a valid
+      // timestamp) would turn the subtraction into an epoch-sized value that leaks to the metric and UI. Keep the
+      // NOT_CALCULATED sentinel in that case so the lag is reported as not-calculated rather than a bogus number.
+      String recordAvailabilityLag = PartitionLagState.NOT_CALCULATED;
       StreamMessageMetadata lastProcessedMessageMetadata = partitionState.getLastProcessedRowMetadata();
-      if (lastProcessedMessageMetadata != null && partitionState.getLastProcessedTimeMs() > 0) {
+      if (lastProcessedMessageMetadata != null && partitionState.getLastProcessedTimeMs() > 0
+          && lastProcessedMessageMetadata.getRecordIngestionTimeMs() > 0) {
         long availabilityLag =
             partitionState.getLastProcessedTimeMs() - lastProcessedMessageMetadata.getRecordIngestionTimeMs();
         recordAvailabilityLag = String.valueOf(availabilityLag);

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/test/java/org/apache/pinot/plugin/stream/kinesis/KinesisStreamMetadataProviderTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/test/java/org/apache/pinot/plugin/stream/kinesis/KinesisStreamMetadataProviderTest.java
@@ -22,12 +22,16 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.spi.stream.ConsumerPartitionState;
+import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.PartitionGroupConsumer;
 import org.apache.pinot.spi.stream.PartitionGroupConsumptionStatus;
 import org.apache.pinot.spi.stream.PartitionGroupMetadata;
+import org.apache.pinot.spi.stream.PartitionLagState;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.stream.StreamConsumerFactory;
+import org.apache.pinot.spi.stream.StreamMessageMetadata;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.mockito.ArgumentCaptor;
 import org.testng.Assert;
@@ -249,5 +253,49 @@ public class KinesisStreamMetadataProviderTest {
     Assert.assertEquals(result.size(), 1);
     Assert.assertEquals(result.get(0).getPartitionGroupId(), 0);
     Assert.assertEquals(partitionGroupMetadataCapture.getValue().getSequenceNumber(), 1);
+  }
+
+  @Test
+  public void testGetCurrentPartitionLagStateHandlesInvalidIngestionTime() {
+    long lastProcessedTimeMs = 1_700_000_100_000L;
+
+    // Shard with a valid upstream ingestion time yields a numeric availability lag.
+    StreamMessageMetadata validMetadata = new StreamMessageMetadata.Builder()
+        .setOffset(new LongMsgOffset(5), new LongMsgOffset(6))
+        .setRecordIngestionTimeMs(lastProcessedTimeMs - 1000L)
+        .build();
+    // Shards whose ingestion time is missing/invalid: unset (Builder default Long.MIN_VALUE), NO_TIMESTAMP (-1),
+    // and epoch 0 (the exact boundary of the > 0 guard). These stand in for a stream that is unreachable/timing
+    // out or produces records without a timestamp.
+    StreamMessageMetadata unsetIngestionTime = new StreamMessageMetadata.Builder()
+        .setOffset(new LongMsgOffset(5), new LongMsgOffset(6))
+        .build();
+    StreamMessageMetadata noTimestampIngestionTime = new StreamMessageMetadata.Builder()
+        .setOffset(new LongMsgOffset(5), new LongMsgOffset(6))
+        .setRecordIngestionTimeMs(-1L)
+        .build();
+    StreamMessageMetadata zeroIngestionTime = new StreamMessageMetadata.Builder()
+        .setOffset(new LongMsgOffset(5), new LongMsgOffset(6))
+        .setRecordIngestionTimeMs(0L)
+        .build();
+
+    Map<String, ConsumerPartitionState> stateMap = new HashMap<>();
+    stateMap.put("0", new ConsumerPartitionState("0", new LongMsgOffset(5), lastProcessedTimeMs,
+        new LongMsgOffset(10), validMetadata));
+    stateMap.put("1", new ConsumerPartitionState("1", new LongMsgOffset(5), lastProcessedTimeMs,
+        new LongMsgOffset(10), unsetIngestionTime));
+    stateMap.put("2", new ConsumerPartitionState("2", new LongMsgOffset(5), lastProcessedTimeMs,
+        new LongMsgOffset(10), noTimestampIngestionTime));
+    stateMap.put("3", new ConsumerPartitionState("3", new LongMsgOffset(5), lastProcessedTimeMs,
+        new LongMsgOffset(10), zeroIngestionTime));
+
+    Map<String, PartitionLagState> lagState = _kinesisStreamMetadataProvider.getCurrentPartitionLagState(stateMap);
+
+    Assert.assertEquals(lagState.get("0").getAvailabilityLagMs(), "1000");
+    // Regression for issue #18836: an invalid ingestion time must report the NOT_CALCULATED sentinel instead of an
+    // epoch-sized value (lastProcessedTimeMs - Long.MIN_VALUE, or lastProcessedTimeMs - (-1) ~= now).
+    Assert.assertEquals(lagState.get("1").getAvailabilityLagMs(), PartitionLagState.NOT_CALCULATED);
+    Assert.assertEquals(lagState.get("2").getAvailabilityLagMs(), PartitionLagState.NOT_CALCULATED);
+    Assert.assertEquals(lagState.get("3").getAvailabilityLagMs(), PartitionLagState.NOT_CALCULATED);
   }
 }


### PR DESCRIPTION
## Problem

Fixes #18836.

The controller's *"View consuming segments info"* panel column **"Max Partition Availability Lag (ms)"** (and the `MAX_RECORD_AVAILABILITY_LAG_MS` metric) showed a huge, nonsensical value — essentially the current Unix time in ms (~`1.7e12`) — whenever a record's upstream ingestion timestamp was unavailable.

The availability lag is computed on the server as:

```java
availabilityLag = lastProcessedTimeMs - recordIngestionTimeMs;
```

The guard only checked `lastProcessedTimeMs > 0`; it never validated `recordIngestionTimeMs`. When a record carries no valid timestamp — Kafka `NO_TIMESTAMP` (`-1`), the unset `StreamMessageMetadata` builder default (`Long.MIN_VALUE`), or `0` — the subtraction produces an epoch-sized (or overflowed) number that is a valid `Long`, so it sails past the controller's `NumberFormatException` skip and the UI's `Number(av) > -1` filter and gets displayed as the "lag".

## Fix

In all three concrete `StreamMetadataProvider.getCurrentPartitionLagState` implementations (`pinot-kafka-3.0`, `pinot-kafka-4.0`, `pinot-kinesis`):

- Guard the availability-lag computation on `getRecordIngestionTimeMs() > 0`, so an invalid/unset ingestion time reports the SPI-defined `PartitionLagState.NOT_CALCULATED` sentinel instead of a bogus number.
- Replace the previously hard-coded `"UNKNOWN"` fallback (for **both** offset lag and availability lag) with `PartitionLagState.NOT_CALCULATED`, to align the plugins with the SPI's own default sentinel and let `RealtimeConsumerMonitor` use its fast-path skip instead of catching a `NumberFormatException`.

## Backward compatibility

The observable fallback string in the `/consumingSegmentsInfo` REST maps changes from `"UNKNOWN"` to `"NOT_CALCULATED"`. All in-tree consumers already treat both identically:
- `RealtimeConsumerMonitor` skips `NOT_CALCULATED` and try/catches `Long.parseLong` for anything else.
- The UI's `Number(lag)` yields `NaN` for both and filters it out.

External dashboards that scrape the literal string `"UNKNOWN"` from this endpoint should be updated to expect `"NOT_CALCULATED"`.

## Testing

Added a regression test per module (`KafkaStreamMetadataProviderTest` ×2, `KinesisStreamMetadataProviderTest`) covering:
- a valid ingestion time → numeric availability lag,
- unset (`Long.MIN_VALUE`), `NO_TIMESTAMP` (`-1`), and `0` ingestion times → `NOT_CALCULATED`,
- the Kafka offset-lag fallback (unknown upstream offset) → `NOT_CALCULATED`.

Each test fails on the pre-fix code (it produces the bogus value) and passes after the fix. `spotless`, `checkstyle`, and `license` checks pass on all three modules.

## Notes

Pulsar and the SPI base class have no availability-lag computation, so no sibling implementation is left on the buggy pattern.
