### PR TITLE
Expose authorization header in Swagger API docs

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/swagger/SwaggerSetupUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/swagger/SwaggerSetupUtils.java
@@ -18,12 +18,18 @@
  */
 package org.apache.pinot.common.swagger;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.swagger.jaxrs.config.BeanConfig;
+import io.swagger.models.SecurityRequirement;
+import io.swagger.models.Swagger;
+import io.swagger.models.auth.ApiKeyAuthDefinition;
+import io.swagger.models.auth.In;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Objects;
 import java.util.Properties;
+import javax.ws.rs.core.HttpHeaders;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.utils.PinotStaticHttpHandler;
 import org.apache.pinot.spi.utils.CommonConstants;
@@ -37,6 +43,24 @@ public class SwaggerSetupUtils {
 
   public static void setupSwagger(String componentType, String resourcePackage, boolean useHttps, String basePath,
       HttpServer httpServer) {
+    BeanConfig beanConfig = buildSwaggerConfig(componentType, resourcePackage, useHttps, basePath);
+    beanConfig.setScan(true);
+
+    ClassLoader classLoader = SwaggerSetupUtils.class.getClassLoader();
+    CLStaticHttpHandler staticHttpHandler = new CLStaticHttpHandler(classLoader, "/api/");
+    // map both /api and /help to swagger docs. /api because it looks nice. /help for backward compatibility
+    httpServer.getServerConfiguration().addHttpHandler(staticHttpHandler, "/api/", "/help/");
+
+    String swaggerVersion = findSwaggerVersion(classLoader);
+    URL swaggerDistLocation = classLoader.getResource(
+            CommonConstants.CONFIG_OF_SWAGGER_RESOURCES_PATH + swaggerVersion + "/");
+    CLStaticHttpHandler swaggerDist = new PinotStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}));
+    httpServer.getServerConfiguration().addHttpHandler(swaggerDist, "/swaggerui-dist/");
+  }
+
+  @VisibleForTesting
+  static BeanConfig buildSwaggerConfig(String componentType, String resourcePackage, boolean useHttps,
+      String basePath) {
     BeanConfig beanConfig = new BeanConfig();
     beanConfig.setTitle(String.format("Pinot %s API", componentType));
     beanConfig.setDescription(String.format("APIs for accessing Pinot %s information", componentType));
@@ -50,18 +74,16 @@ public class SwaggerSetupUtils {
     }
     beanConfig.setBasePath(basePath);
     beanConfig.setResourcePackage(resourcePackage);
-    beanConfig.setScan(true);
+    addAuthorizationHeaderSecurity(beanConfig.getSwagger());
+    return beanConfig;
+  }
 
-    ClassLoader classLoader = SwaggerSetupUtils.class.getClassLoader();
-    CLStaticHttpHandler staticHttpHandler = new CLStaticHttpHandler(classLoader, "/api/");
-    // map both /api and /help to swagger docs. /api because it looks nice. /help for backward compatibility
-    httpServer.getServerConfiguration().addHttpHandler(staticHttpHandler, "/api/", "/help/");
-
-    String swaggerVersion = findSwaggerVersion(classLoader);
-    URL swaggerDistLocation = classLoader.getResource(
-            CommonConstants.CONFIG_OF_SWAGGER_RESOURCES_PATH + swaggerVersion + "/");
-    CLStaticHttpHandler swaggerDist = new PinotStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}));
-    httpServer.getServerConfiguration().addHttpHandler(swaggerDist, "/swaggerui-dist/");
+  private static void addAuthorizationHeaderSecurity(Swagger swagger) {
+    ApiKeyAuthDefinition authorizationHeader =
+        new ApiKeyAuthDefinition(HttpHeaders.AUTHORIZATION, In.HEADER);
+    authorizationHeader.setDescription("Pinot authentication token. Use \"Basic <token>\" or \"Bearer <token>\".");
+    swagger.securityDefinition(CommonConstants.SWAGGER_AUTHORIZATION_KEY, authorizationHeader);
+    swagger.security(new SecurityRequirement().requirement(CommonConstants.SWAGGER_AUTHORIZATION_KEY));
   }
 
   private static String findSwaggerVersion(ClassLoader classLoader) {

--- a/pinot-common/src/test/java/org/apache/pinot/common/swagger/SwaggerSetupUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/swagger/SwaggerSetupUtilsTest.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.swagger;
+
+import io.swagger.jaxrs.config.BeanConfig;
+import io.swagger.models.SecurityRequirement;
+import io.swagger.models.Swagger;
+import io.swagger.models.auth.ApiKeyAuthDefinition;
+import io.swagger.models.auth.In;
+import io.swagger.models.auth.SecuritySchemeDefinition;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.core.HttpHeaders;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class SwaggerSetupUtilsTest {
+  @Test
+  public void testBuildSwaggerConfigAddsAuthorizationHeaderSecurityDefinition() {
+    BeanConfig beanConfig =
+        SwaggerSetupUtils.buildSwaggerConfig("Controller", "org.apache.pinot.common.swagger", false, "/");
+    beanConfig.setScan(true);
+    Swagger swagger = beanConfig.getSwagger();
+
+    Map<String, SecuritySchemeDefinition> securityDefinitions = swagger.getSecurityDefinitions();
+    Assert.assertNotNull(securityDefinitions);
+    Assert.assertFalse(securityDefinitions.isEmpty());
+    SecuritySchemeDefinition securityDefinition = securityDefinitions.get(CommonConstants.SWAGGER_AUTHORIZATION_KEY);
+    Assert.assertTrue(securityDefinition instanceof ApiKeyAuthDefinition);
+
+    ApiKeyAuthDefinition apiKeyAuthDefinition = (ApiKeyAuthDefinition) securityDefinition;
+    Assert.assertEquals(apiKeyAuthDefinition.getName(), HttpHeaders.AUTHORIZATION);
+    Assert.assertEquals(apiKeyAuthDefinition.getIn(), In.HEADER);
+    Assert.assertEquals(apiKeyAuthDefinition.getType(), "apiKey");
+
+    List<SecurityRequirement> securityRequirements = swagger.getSecurity();
+    Assert.assertNotNull(securityRequirements);
+    Assert.assertEquals(securityRequirements.size(), 1);
+    Map<String, List<String>> requirements = securityRequirements.get(0).getRequirements();
+    Assert.assertTrue(requirements.containsKey(CommonConstants.SWAGGER_AUTHORIZATION_KEY));
+    Assert.assertTrue(requirements.get(CommonConstants.SWAGGER_AUTHORIZATION_KEY).isEmpty());
+  }
+}


### PR DESCRIPTION
Fixes #7805

## What changed

This PR adds the configured authorization header to Pinot's generated Swagger API documentation.

`SwaggerSetupUtils` now builds a Swagger security definition for the existing `Authorization` header and applies that security requirement to the generated API config. The runtime authentication behavior is unchanged; this only makes the OpenAPI/Swagger description accurately expose the header that secured Pinot APIs already expect.

The PR also extracts the Swagger config construction into a testable helper so the generated API metadata can be validated without starting a controller.

## Why it matters

When Swagger does not describe the authorization header, users can see secured endpoints in the API docs but have no standard way to supply credentials from the Swagger UI or generated clients. That makes secured controller APIs harder to try, document, and integrate with.

Pinot already has a shared `Authorization` header constant for Swagger auth. Surfacing it in the Swagger config aligns the documentation with the actual authentication contract and avoids forcing users to infer or manually patch the header into requests.

## Impact

Swagger/OpenAPI consumers now see an API-key-style `Authorization` header security definition.

Swagger UI users can provide the authorization header through the documented security mechanism instead of manually editing each request.

Existing runtime auth behavior, filters, and controller authorization checks are not changed.

## Testing

- `./mvnw -pl pinot-common -Dtest=SwaggerSetupUtilsTest test`
- `./mvnw -pl pinot-common spotless:apply`
- `./mvnw -pl pinot-common checkstyle:check`
- `./mvnw -pl pinot-common license:check`
- `git diff --check`

The test verifies that the generated Swagger config contains the `Authorization` header security definition, uses the expected API key auth scheme, and attaches the security requirement to the API config.

---
Drafted-by: Codex (GPT-5); human-reviewed by Vamsi-klu before marking ready for review
