### PR TITLE
Reject bucketed legacy epoch TimeFieldSpec values

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
@@ -209,6 +209,8 @@ public class SchemaUtils {
   private static void validateTimeFieldSpec(TimeFieldSpec timeFieldSpec) {
     TimeGranularitySpec incomingGranularitySpec = timeFieldSpec.getIncomingGranularitySpec();
     TimeGranularitySpec outgoingGranularitySpec = timeFieldSpec.getOutgoingGranularitySpec();
+    validateEpochTimeUnitSize(incomingGranularitySpec);
+    validateEpochTimeUnitSize(outgoingGranularitySpec);
 
     if (!incomingGranularitySpec.equals(outgoingGranularitySpec)) {
       Preconditions.checkState(!incomingGranularitySpec.getName().equals(outgoingGranularitySpec.getName()),
@@ -220,6 +222,15 @@ public class SchemaUtils {
               && outgoingGranularitySpec.getTimeFormat().equals(TimeGranularitySpec.TimeFormat.EPOCH.toString()),
           "Cannot perform time conversion for time format other than EPOCH. TimeFieldSpec: %s", timeFieldSpec);
     }
+  }
+
+  private static void validateEpochTimeUnitSize(TimeGranularitySpec timeGranularitySpec) {
+    Preconditions.checkState(
+        !timeGranularitySpec.getTimeFormat().equals(TimeGranularitySpec.TimeFormat.EPOCH.toString())
+            || timeGranularitySpec.getTimeUnitSize() == 1,
+        "TimeFieldSpec with EPOCH time format only supports timeUnitSize 1. Use DateTimeFieldSpec for bucketed epoch "
+            + "values. TimeGranularitySpec: %s",
+        timeGranularitySpec);
   }
 
   /**

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/SchemaUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/SchemaUtilsTest.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.utils;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.TimeGranularitySpec;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@SuppressWarnings("deprecation")
+public class SchemaUtilsTest {
+  @Test
+  public void testValidateRejectsBucketedEpochIncomingTimeFieldSpec() {
+    Schema schema = new Schema.SchemaBuilder()
+        .setSchemaName("testSchema")
+        .addSingleValueDimension("dimension", DataType.STRING)
+        .addTime(new TimeGranularitySpec(DataType.LONG, 5, TimeUnit.MINUTES, "eventTime"), null)
+        .build();
+
+    IllegalStateException exception = Assert.expectThrows(IllegalStateException.class,
+        () -> SchemaUtils.validate(schema));
+
+    assertThat(exception).hasMessageContaining("only supports timeUnitSize 1")
+        .hasMessageContaining("Use DateTimeFieldSpec");
+  }
+
+  @Test
+  public void testValidateRejectsBucketedEpochOutgoingTimeFieldSpec() {
+    Schema schema = new Schema.SchemaBuilder()
+        .setSchemaName("testSchema")
+        .addSingleValueDimension("dimension", DataType.STRING)
+        .addTime(new TimeGranularitySpec(DataType.LONG, TimeUnit.MILLISECONDS, "incomingTime"),
+            new TimeGranularitySpec(DataType.LONG, 5, TimeUnit.MINUTES, "eventTime"))
+        .build();
+
+    IllegalStateException exception = Assert.expectThrows(IllegalStateException.class,
+        () -> SchemaUtils.validate(schema));
+
+    assertThat(exception).hasMessageContaining("only supports timeUnitSize 1")
+        .hasMessageContaining("Use DateTimeFieldSpec");
+  }
+
+  @Test
+  public void testValidateAcceptsEpochTimeUnitSizeOneTimeFieldSpec() {
+    Schema schema = new Schema.SchemaBuilder()
+        .setSchemaName("testSchema")
+        .addSingleValueDimension("dimension", DataType.STRING)
+        .addTime(new TimeGranularitySpec(DataType.LONG, TimeUnit.MILLISECONDS, "eventTime"), null)
+        .build();
+
+    SchemaUtils.validate(schema);
+  }
+}


### PR DESCRIPTION
Fixes #6240

## What changed

This PR rejects legacy `TimeFieldSpec` definitions that use epoch time with a bucket size greater than one.

The validation is added in `SchemaUtils.validateTimeFieldSpec(...)`, which is the schema-validation boundary used when Pinot validates table schemas. A `TimeFieldSpec` with `TimeFormat.EPOCH` remains valid when the `timeUnitSize` is `1`, but values such as `5:MINUTES` or any other bucketed epoch granularity are rejected with guidance to use `DateTimeFieldSpec` for bucketed epoch values.

The change intentionally stays at validation time rather than changing low-level `TimeGranularitySpec` construction. That keeps object creation and legacy parsing behavior intact while preventing invalid legacy time-field schemas from being accepted.

## Why it matters

`TimeFieldSpec` is the legacy time-column representation. Allowing bucketed epoch granularities there is ambiguous and can lead to schemas that look valid but do not match the intended time semantics. Pinot already has `DateTimeFieldSpec` for richer date-time formats and bucketed granularities.

Rejecting bucketed epoch `TimeFieldSpec` values at schema validation makes the failure explicit and points users toward the correct schema construct.

## Impact

Schemas using legacy `TimeFieldSpec` with epoch unit size `1` continue to validate.

Schemas using legacy `TimeFieldSpec` with bucketed epoch unit sizes are rejected during schema validation.

Users who need bucketed epoch semantics should model those columns as `DateTimeFieldSpec`.

No ingestion, indexing, or query execution code paths are changed directly.

## Testing

- `./mvnw -Dmaven.repo.local=/tmp/m2-pinot-6240 -pl pinot-segment-local -am -Dtest=SchemaUtilsTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -Dmaven.repo.local=/tmp/m2-pinot-6240 -pl pinot-segment-local spotless:apply checkstyle:check license:check`
- `git diff --check`

The tests cover rejection for bucketed incoming and outgoing legacy time specs, and verify that the existing epoch unit-size-one case remains valid.

---
Drafted-by: Codex (GPT-5); human-reviewed by Vamsi-klu before marking ready for review
