### PR TITLE
feat(upsert): add primary-key map size-in-bytes gauge

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -41,6 +41,7 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   PAUSELESS_CONSUMPTION_ENABLED("pauselessConsumptionEnabled", false),
   // Upsert metrics
   UPSERT_PRIMARY_KEYS_COUNT("upsertPrimaryKeysCount", false),
+  UPSERT_PRIMARY_KEY_MAP_SIZE_IN_BYTES("bytes", false),
   // Dedup metrics
   DEDUP_PRIMARY_KEYS_COUNT("dedupPrimaryKeysCount", false),
   CONSUMPTION_QUOTA_UTILIZATION("ratio", false),

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/models/DummyTableUpsertMetadataManager.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/models/DummyTableUpsertMetadataManager.java
@@ -68,6 +68,11 @@ public class DummyTableUpsertMetadataManager extends BaseTableUpsertMetadataMana
     }
 
     @Override
+    protected long getPrimaryKeyMapSizeInBytes() {
+      return 0;
+    }
+
+    @Override
     protected void doAddOrReplaceSegment(ImmutableSegmentImpl segment, ThreadSafeMutableRoaringBitmap validDocIds,
         @Nullable ThreadSafeMutableRoaringBitmap queryableDocIds, Iterator<RecordInfo> recordInfoIterator,
         @Nullable IndexSegment oldSegment, @Nullable MutableRoaringBitmap validDocIdsForOldSegment) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -396,20 +396,25 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
 
     // Update metrics
     long numPrimaryKeys = getNumPrimaryKeys();
-    updatePrimaryKeyGauge(numPrimaryKeys);
+    updatePrimaryKeyGauge(numPrimaryKeys, getPrimaryKeyMapSizeInBytes());
     _logger.info("Finished adding segment: {} in {}ms, current primary key count: {}", segmentName,
         System.currentTimeMillis() - startTimeMs, numPrimaryKeys);
   }
 
   protected abstract long getNumPrimaryKeys();
 
-  protected void updatePrimaryKeyGauge(long numPrimaryKeys) {
+  /// Returns the estimated size in bytes of the primary-key-to-record-location map.
+  protected abstract long getPrimaryKeyMapSizeInBytes();
+
+  protected void updatePrimaryKeyGauge(long numPrimaryKeys, long primaryKeySizeInBytes) {
     _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId, ServerGauge.UPSERT_PRIMARY_KEYS_COUNT,
         numPrimaryKeys);
+    _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId,
+        ServerGauge.UPSERT_PRIMARY_KEY_MAP_SIZE_IN_BYTES, primaryKeySizeInBytes);
   }
 
   protected void updatePrimaryKeyGauge() {
-    updatePrimaryKeyGauge(getNumPrimaryKeys());
+    updatePrimaryKeyGauge(getNumPrimaryKeys(), getPrimaryKeyMapSizeInBytes());
   }
 
   @Override
@@ -468,7 +473,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
 
     // Update metrics
     long numPrimaryKeys = getNumPrimaryKeys();
-    updatePrimaryKeyGauge(numPrimaryKeys);
+    updatePrimaryKeyGauge(numPrimaryKeys, getPrimaryKeyMapSizeInBytes());
     _logger.info("Finished preloading segment: {} in {}ms, current primary key count: {}", segmentName,
         System.currentTimeMillis() - startTimeMs, numPrimaryKeys);
   }
@@ -643,7 +648,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
 
     // Update metrics
     long numPrimaryKeys = getNumPrimaryKeys();
-    updatePrimaryKeyGauge(numPrimaryKeys);
+    updatePrimaryKeyGauge(numPrimaryKeys, getPrimaryKeyMapSizeInBytes());
     _logger.info("Finished replacing segment: {} in {}ms, current primary key count: {}", segmentName,
         System.currentTimeMillis() - startTimeMs, numPrimaryKeys);
   }
@@ -801,7 +806,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
 
     // Update metrics
     long numPrimaryKeys = getNumPrimaryKeys();
-    updatePrimaryKeyGauge(numPrimaryKeys);
+    updatePrimaryKeyGauge(numPrimaryKeys, getPrimaryKeyMapSizeInBytes());
     _logger.info("Finished removing segment: {} in {}ms, current primary key count: {}", segmentName,
         System.currentTimeMillis() - startTimeMs, numPrimaryKeys);
   }
@@ -1189,7 +1194,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     // We don't remove the segment from the metadata manager when
     // it's closed. This was done to make table deletion faster. Since we don't remove the segment, we never decrease
     // the primary key count. So, we set the primary key count to 0 here.
-    updatePrimaryKeyGauge(0);
+    updatePrimaryKeyGauge(0, 0);
     _logger.info("Closed the metadata manager");
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -407,10 +407,14 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
   protected abstract long getPrimaryKeyMapSizeInBytes();
 
   protected void updatePrimaryKeyGauge(long numPrimaryKeys, long primaryKeySizeInBytes) {
-    _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId, ServerGauge.UPSERT_PRIMARY_KEYS_COUNT,
-        numPrimaryKeys);
+    updatePrimaryKeyGauge(numPrimaryKeys);
     _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId,
         ServerGauge.UPSERT_PRIMARY_KEY_MAP_SIZE_IN_BYTES, primaryKeySizeInBytes);
+  }
+
+  protected void updatePrimaryKeyGauge(long numPrimaryKeys) {
+    _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId, ServerGauge.UPSERT_PRIMARY_KEYS_COUNT,
+        numPrimaryKeys);
   }
 
   protected void updatePrimaryKeyGauge() {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentImpl;
 import org.apache.pinot.segment.local.segment.readers.LazyRow;
@@ -63,6 +64,15 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
   @Override
   protected long getNumPrimaryKeys() {
     return _primaryKeyToRecordLocationMap.size();
+  }
+
+  // Approximates ConcurrentHashMap.Node + RecordLocation object overhead per map entry.
+  private static final long PER_ENTRY_OVERHEAD_BYTES =
+      RamUsageEstimator.HASHTABLE_RAM_BYTES_PER_ENTRY + RamUsageEstimator.shallowSizeOfInstance(RecordLocation.class);
+
+  @Override
+  protected long getPrimaryKeyMapSizeInBytes() {
+    return UpsertUtils.estimatePrimaryKeyMapSizeInBytes(_primaryKeyToRecordLocationMap, PER_ENTRY_OVERHEAD_BYTES);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -420,7 +420,9 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
           }
         });
 
-    updatePrimaryKeyGauge();
+    // Per-record hot path: keep the update count-only. The byte-size gauge is refreshed at segment-lifecycle
+    // cadence instead (see BasePartitionUpsertMetadataManager#updatePrimaryKeyGauge()).
+    updatePrimaryKeyGauge(getNumPrimaryKeys());
     return !isOutOfOrderRecord.get();
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentImpl;
 import org.apache.pinot.segment.local.segment.readers.LazyRow;
@@ -82,6 +83,15 @@ public class ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes
   @Override
   protected long getNumPrimaryKeys() {
     return _primaryKeyToRecordLocationMap.size();
+  }
+
+  // Approximates ConcurrentHashMap.Node + RecordLocation object overhead per map entry.
+  private static final long PER_ENTRY_OVERHEAD_BYTES =
+      RamUsageEstimator.HASHTABLE_RAM_BYTES_PER_ENTRY + RamUsageEstimator.shallowSizeOfInstance(RecordLocation.class);
+
+  @Override
+  protected long getPrimaryKeyMapSizeInBytes() {
+    return UpsertUtils.estimatePrimaryKeyMapSizeInBytes(_primaryKeyToRecordLocationMap, PER_ENTRY_OVERHEAD_BYTES);
   }
 
   @Override
@@ -259,7 +269,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes
     }
     // Update metrics
     long numPrimaryKeys = getNumPrimaryKeys();
-    updatePrimaryKeyGauge(numPrimaryKeys);
+    updatePrimaryKeyGauge(numPrimaryKeys, getPrimaryKeyMapSizeInBytes());
     _logger.info("Finished removing segment: {} in {}ms, current primary key count: {}", segmentName,
         System.currentTimeMillis() - startTimeMs, numPrimaryKeys);
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes.java
@@ -551,7 +551,9 @@ public class ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes
           }
         });
 
-    updatePrimaryKeyGauge();
+    // Per-record hot path: keep the update count-only. The byte-size gauge is refreshed at segment-lifecycle
+    // cadence instead (see BasePartitionUpsertMetadataManager#updatePrimaryKeyGauge()).
+    updatePrimaryKeyGauge(getNumPrimaryKeys());
     return !isOutOfOrderRecord.get();
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertUtils.java
@@ -38,6 +38,9 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 @SuppressWarnings("rawtypes")
 public class UpsertUtils {
+  // ponytail: bounded sample instead of a full map walk, so size estimation stays O(1) regardless of table size.
+  private static final int PRIMARY_KEY_SAMPLE_SIZE = 1000;
+
   private UpsertUtils() {
   }
 
@@ -114,6 +117,44 @@ public class UpsertUtils {
     if (currentQueryableDocIds != null) {
       currentQueryableDocIds.remove(docId);
     }
+  }
+
+  /// Estimates the total size in bytes of a primary-key-to-record-location map. Samples up to
+  /// [#PRIMARY_KEY_SAMPLE_SIZE] keys to compute the average key content size, then extrapolates over all keys,
+  /// so the cost stays bounded regardless of map size. Handles both unhashed ([PrimaryKey]) and hashed
+  /// ([ByteArray]) keys.
+  ///
+  /// @param perEntryOverheadBytes estimated fixed per-entry overhead (e.g. map node + record location object)
+  public static long estimatePrimaryKeyMapSizeInBytes(Map<Object, ?> primaryKeyToRecordLocationMap,
+      long perEntryOverheadBytes) {
+    int numKeys = primaryKeyToRecordLocationMap.size();
+    if (numKeys == 0) {
+      return 0;
+    }
+    long sampledKeyBytes = 0;
+    int numSampled = 0;
+    for (Object key : primaryKeyToRecordLocationMap.keySet()) {
+      sampledKeyBytes += getPrimaryKeyContentSizeInBytes(key);
+      if (++numSampled >= PRIMARY_KEY_SAMPLE_SIZE) {
+        break;
+      }
+    }
+    if (numSampled == 0) {
+      // ponytail: map drained concurrently between size() and keySet() iteration; nothing sampled.
+      return 0;
+    }
+    double avgKeyBytes = (double) sampledKeyBytes / numSampled;
+    return (long) (numKeys * (avgKeyBytes + perEntryOverheadBytes));
+  }
+
+  private static int getPrimaryKeyContentSizeInBytes(Object key) {
+    if (key instanceof PrimaryKey) {
+      return ((PrimaryKey) key).asBytes().length;
+    }
+    if (key instanceof ByteArray) {
+      return ((ByteArray) key).length();
+    }
+    return 0;
   }
 
   /// Returns an iterator of [RecordInfo] for all the documents from the segment.

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManagerTest.java
@@ -1099,6 +1099,11 @@ public class BasePartitionUpsertMetadataManagerTest {
     }
 
     @Override
+    protected long getPrimaryKeyMapSizeInBytes() {
+      return 0;
+    }
+
+    @Override
     protected void doAddOrReplaceSegment(ImmutableSegmentImpl segment, ThreadSafeMutableRoaringBitmap validDocIds,
         @Nullable ThreadSafeMutableRoaringBitmap queryableDocIds, Iterator<RecordInfo> recordInfoIterator,
         @Nullable IndexSegment oldSegment, @Nullable MutableRoaringBitmap validDocIdsForOldSegment) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletesTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletesTest.java
@@ -313,6 +313,28 @@ public class ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletesTest
   }
 
   @Test
+  public void testGetPrimaryKeyMapSizeInBytes() {
+    ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes upsertMetadataManager =
+        new ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes(REALTIME_TABLE_NAME, 0,
+            _contextBuilder.build());
+    assertEquals(upsertMetadataManager.getPrimaryKeyMapSizeInBytes(), 0);
+
+    Map<Object, ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes.RecordLocation> recordLocationMap =
+        upsertMetadataManager._primaryKeyToRecordLocationMap;
+    IndexSegment mockSegment = mock(IndexSegment.class);
+    recordLocationMap.put(new PrimaryKey(new Object[]{"short"}),
+        new ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes.RecordLocation(mockSegment, 0, 0, 1));
+    long shortKeyBytes = upsertMetadataManager.getPrimaryKeyMapSizeInBytes();
+    assertTrue(shortKeyBytes > 0);
+
+    recordLocationMap.clear();
+    recordLocationMap.put(new PrimaryKey(new Object[]{"a".repeat(1000)}),
+        new ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes.RecordLocation(mockSegment, 0, 0, 1));
+    long longKeyBytes = upsertMetadataManager.getPrimaryKeyMapSizeInBytes();
+    assertTrue(longKeyBytes > shortKeyBytes);
+  }
+
+  @Test
   public void testAddReplaceRemoveSegment()
       throws IOException {
     verifyAddReplaceRemoveSegment(HashFunction.NONE);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.UploadedRealtimeSegmentName;
@@ -81,11 +82,14 @@ import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
@@ -211,6 +215,23 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     recordLocationMap.put(new PrimaryKey(new Object[]{"a".repeat(1000)}), new RecordLocation(mockSegment, 0, 0));
     long longKeyBytes = upsertMetadataManager.getPrimaryKeyMapSizeInBytes();
     assertTrue(longKeyBytes > shortKeyBytes);
+  }
+
+  @Test
+  public void testAddRecordUpdatesCountGaugeOnly() {
+    ServerMetrics serverMetrics = ServerMetrics.get();
+    reset(serverMetrics);
+    ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
+        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, _contextBuilder.build());
+
+    ThreadSafeMutableRoaringBitmap validDocIds = new ThreadSafeMutableRoaringBitmap();
+    MutableSegment segment = mockMutableSegment(1, validDocIds, null);
+    upsertMetadataManager.addRecord(segment, new RecordInfo(makePrimaryKey(1), 0, 10, false));
+
+    // Per-record hot path only refreshes the count gauge, not the byte-size gauge
+    verify(serverMetrics).setValueOfPartitionGauge(REALTIME_TABLE_NAME, 0, ServerGauge.UPSERT_PRIMARY_KEYS_COUNT, 1);
+    verify(serverMetrics, never()).setValueOfPartitionGauge(eq(REALTIME_TABLE_NAME), eq(0),
+        eq(ServerGauge.UPSERT_PRIMARY_KEY_MAP_SIZE_IN_BYTES), anyLong());
   }
 
   @Test

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
@@ -196,6 +196,24 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
   }
 
   @Test
+  public void testGetPrimaryKeyMapSizeInBytes() {
+    ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
+        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, _contextBuilder.build());
+    assertEquals(upsertMetadataManager.getPrimaryKeyMapSizeInBytes(), 0);
+
+    Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
+    IndexSegment mockSegment = mock(IndexSegment.class);
+    recordLocationMap.put(new PrimaryKey(new Object[]{"short"}), new RecordLocation(mockSegment, 0, 0));
+    long shortKeyBytes = upsertMetadataManager.getPrimaryKeyMapSizeInBytes();
+    assertTrue(shortKeyBytes > 0);
+
+    recordLocationMap.clear();
+    recordLocationMap.put(new PrimaryKey(new Object[]{"a".repeat(1000)}), new RecordLocation(mockSegment, 0, 0));
+    long longKeyBytes = upsertMetadataManager.getPrimaryKeyMapSizeInBytes();
+    assertTrue(longKeyBytes > shortKeyBytes);
+  }
+
+  @Test
   public void testAddReplaceRemoveSegment()
       throws IOException {
     verifyAddReplaceRemoveSegment(HashFunction.NONE, false);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/UpsertUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/UpsertUtilsTest.java
@@ -19,17 +19,22 @@
 package org.apache.pinot.segment.local.upsert;
 
 import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentImpl;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.spi.data.readers.PrimaryKey;
+import org.apache.pinot.spi.utils.ByteArray;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
@@ -242,6 +247,63 @@ public class UpsertUtilsTest {
 
   /// Returns a minimal [ImmutableSegmentImpl] usable for testing the upsert-aware methods.
   /// Mirrors the pattern used in `BasePartitionUpsertMetadataManagerTest#createImmutableSegment`.
+
+  // -------- estimatePrimaryKeyMapSizeInBytes --------
+
+  @Test
+  public void testEstimatePrimaryKeyMapSizeInBytesEmptyMap() {
+    assertEquals(UpsertUtils.estimatePrimaryKeyMapSizeInBytes(new ConcurrentHashMap<>(), 100), 0);
+  }
+
+  @Test
+  public void testEstimatePrimaryKeyMapSizeInBytesScalesWithPrimaryKeyContentSize() {
+    Map<Object, Object> shortKeyMap = new ConcurrentHashMap<>();
+    Map<Object, Object> longKeyMap = new ConcurrentHashMap<>();
+    String longValuePrefix = "x".repeat(500);
+    for (int i = 0; i < 100; i++) {
+      shortKeyMap.put(new PrimaryKey(new Object[]{"k" + i}), new Object());
+      longKeyMap.put(new PrimaryKey(new Object[]{longValuePrefix + i}), new Object());
+    }
+    long shortKeyMapBytes = UpsertUtils.estimatePrimaryKeyMapSizeInBytes(shortKeyMap, 0);
+    long longKeyMapBytes = UpsertUtils.estimatePrimaryKeyMapSizeInBytes(longKeyMap, 0);
+    assertTrue(longKeyMapBytes > shortKeyMapBytes);
+  }
+
+  @Test
+  public void testEstimatePrimaryKeyMapSizeInBytesWithHashedByteArrayKeys() {
+    // Hashed primary keys (e.g. MD5) are always the same fixed length regardless of PK content.
+    Map<Object, Object> map = new ConcurrentHashMap<>();
+    for (int i = 0; i < 50; i++) {
+      byte[] bytes = new byte[16];
+      bytes[0] = (byte) i;
+      map.put(new ByteArray(bytes), new Object());
+    }
+    assertEquals(UpsertUtils.estimatePrimaryKeyMapSizeInBytes(map, 0), 50L * 16);
+  }
+
+  @Test
+  public void testEstimatePrimaryKeyMapSizeInBytesIncludesPerEntryOverhead() {
+    Map<Object, Object> map = new ConcurrentHashMap<>();
+    map.put(new ByteArray(new byte[16]), new Object());
+    assertEquals(UpsertUtils.estimatePrimaryKeyMapSizeInBytes(map, 32), 16 + 32);
+  }
+
+  @Test
+  public void testEstimatePrimaryKeyMapSizeInBytesExtrapolatesBeyondSampleSize() {
+    // With more keys than the sampling cap, only a bounded sample is scanned and the result is
+    // extrapolated over all keys. Uniform-length ByteArray keys make the result exact regardless
+    // of which keys happen to be sampled.
+    int numKeys = 2500;
+    Map<Object, Object> map = new ConcurrentHashMap<>();
+    for (int i = 0; i < numKeys; i++) {
+      byte[] bytes = new byte[16];
+      bytes[0] = (byte) i;
+      bytes[1] = (byte) (i >> 8);
+      map.put(new ByteArray(bytes), new Object());
+    }
+    assertEquals(UpsertUtils.estimatePrimaryKeyMapSizeInBytes(map, 8), (long) numKeys * (16 + 8));
+  }
+
   private static ImmutableSegmentImpl newSegment() {
     return new ImmutableSegmentImpl(
         mock(SegmentDirectory.class), mock(SegmentMetadataImpl.class), new HashMap<>(), null);


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Adds byte\-size gauge for upsert primary key map, updated at segment lifecycle via size estimation\.

```mermaid
flowchart TD
  N0["ServerGauge#46;UPSERT#95;PRIMARY#95;KEY#95;MAP#95;SIZE#95;IN#95;BYTES #40;F1#41;"]:::stAdded
  N1["BasePartitionUpsertMetadataManager#46;updatePrimaryKeyGauge#40;long#44; long#41; #40;F2#41;"]:::stAdded
  N2["BasePartitionUpsertMetadataManager#46;getPrimaryKeyMapSizeInBytes#40;#41; #40;F2#44; F3#44; F4#41;"]:::stAdded
  N3["UpsertUtils#46;estimatePrimaryKeyMapSizeInBytes#40;Map#44; long#41; #40;F5#41;"]:::stAdded
  N2 -->|"sizeInBytes arg    "| N1
  N1 -->|"update gauge     "| N0
  N2 -->|"compute size      "| N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge\.java — [before](https://github.com/apache/pinot/blob/c5f7bda6aed8cb3820332e9b4dfc122aec1fd67c/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java) · [after](https://github.com/apache/pinot/blob/b1d2de92a2ce6d4d73f5bc7cce2c20989959aacf/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java)
- F2: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager\.java — [before](https://github.com/apache/pinot/blob/c5f7bda6aed8cb3820332e9b4dfc122aec1fd67c/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java) · [after](https://github.com/apache/pinot/blob/b1d2de92a2ce6d4d73f5bc7cce2c20989959aacf/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java)
- F3: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager\.java — [before](https://github.com/apache/pinot/blob/c5f7bda6aed8cb3820332e9b4dfc122aec1fd67c/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java) · [after](https://github.com/apache/pinot/blob/b1d2de92a2ce6d4d73f5bc7cce2c20989959aacf/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java)
- F4: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes\.java — [before](https://github.com/apache/pinot/blob/c5f7bda6aed8cb3820332e9b4dfc122aec1fd67c/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes.java) · [after](https://github.com/apache/pinot/blob/b1d2de92a2ce6d4d73f5bc7cce2c20989959aacf/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes.java)
- F5: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertUtils\.java — [before](https://github.com/apache/pinot/blob/c5f7bda6aed8cb3820332e9b4dfc122aec1fd67c/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertUtils.java) · [after](https://github.com/apache/pinot/blob/b1d2de92a2ce6d4d73f5bc7cce2c20989959aacf/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertUtils.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImM1ZjdiZGE2YWVkOGNiMzgyMDMzMmU5YjRkZmMxMjJhZWMxZmQ2N2MiLCJjb250ZXh0X2hhc2giOiIxNzEwOTU5MWNhMWIwYWE1OGRlMjhkOTFlMDg4ZDExZWUzYzI3ZjlhMTYyZmNlMDhmODA1NjQzY2EwZDg0NWE2IiwiZ2VuZXJhdGVkX2F0IjoxNzg5MDA1Mzk2LCJoZWFkX3NoYSI6ImIxZDJkZTkyYTJjZTZkNGQ3M2Y1YmM3Y2NlMmMyMDk4OTk1OWFhY2YiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJjNWY3YmRhNmFlZDhjYjM4MjAzMzJlOWI0ZGZjMTIyYWVjMWZkNjdjIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 7a6fd3e07882f618eaa542fd4d1055561f685d768768d2a7a9e73dad14284eb7 -->
<!-- pinot-pr-flow:end -->

Add UPSERT_PRIMARY_KEY_MAP_SIZE_IN_BYTES ServerGauge to complement the existing key-count gauge. Tables with few large-string PKs and tables with many small UUID-like PKs can have very different memory footprints despite similar counts, so byte-size observability helps with capacity monitoring.

UpsertUtils.estimatePrimaryKeyMapSizeInBytes samples up to 1000 keys to average PK content size (via PrimaryKey.asBytes() / ByteArray.length()), adds a per-entry overhead constant for the hashmap node + RecordLocation object, and extrapolates over the full key count, keeping the cost bounded regardless of map size. Computed at the same segment-lifecycle cadence as the existing count gauge (add/replace/remove/preload/close), not on the per-record ingest path.

Wired into both ConcurrentMapPartitionUpsertMetadataManager and ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes via a new abstract getPrimaryKeyMapSizeInBytes() hook on BasePartitionUpsertMetadataManager.
