### PR TITLE
Fix realtime segment size metadata

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -2354,11 +2354,19 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     if (currentMetadata.getStatus() == Status.COMMITTING) {
       LOGGER.info("Updating ZK metadata for committing segment: {}", segmentName);
       currentMetadata.setSimpleFields(uploadedMetadata.getSimpleFields());
-    } else if (currentMetadata.getCrc() != uploadedMetadata.getCrc()) {
-      LOGGER.info("Updating CRC in ZK metadata for segment: {} from: {} to: {}", segmentName, currentMetadata.getCrc(),
-          uploadedMetadata.getCrc());
-      currentMetadata.setCrc(uploadedMetadata.getCrc());
-      currentMetadata.setDataCrc(uploadedMetadata.getDataCrc());
+    } else {
+      if (currentMetadata.getCrc() != uploadedMetadata.getCrc()) {
+        LOGGER.info("Updating CRC in ZK metadata for segment: {} from: {} to: {}", segmentName,
+            currentMetadata.getCrc(), uploadedMetadata.getCrc());
+        currentMetadata.setCrc(uploadedMetadata.getCrc());
+        currentMetadata.setDataCrc(uploadedMetadata.getDataCrc());
+      }
+      long uploadedSizeInBytes = uploadedMetadata.getSizeInBytes();
+      if (uploadedSizeInBytes >= 0 && currentMetadata.getSizeInBytes() != uploadedSizeInBytes) {
+        LOGGER.info("Updating size in ZK metadata for segment: {} from: {} to: {}", segmentName,
+            currentMetadata.getSizeInBytes(), uploadedSizeInBytes);
+        currentMetadata.setSizeInBytes(uploadedSizeInBytes);
+      }
     }
     // Merge the custom map from the server into the current metadata. The server merges segment-file customMap entries
     // into the existing ZK customMap; without this merge those entries would be dropped when we persist

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -131,6 +131,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
   private static final String REALTIME_TABLE_NAME = TableNameBuilder.REALTIME.tableNameWithType(RAW_TABLE_NAME);
   private static final String SEGMENT_LOCATION_PREFIX = "http://control_vip/segments/";
   private static final int SEGMENT_SIZE_IN_BYTES = 100000000;
+  private static final int FINALIZED_SEGMENT_SIZE_IN_BYTES = 25000000;
 
   private static final long CURRENT_TIME_MS = System.currentTimeMillis();
   private static final Random RANDOM = new Random(CURRENT_TIME_MS);
@@ -1823,11 +1824,13 @@ public class PinotLLCRealtimeSegmentManagerTest {
     Map<String, String> existingCustomMap = new HashMap<>();
     existingCustomMap.put("controllerKey", "controllerValue");
     segmentsZKMetadata.get(0).setCustomMap(existingCustomMap);
+    segmentsZKMetadata.get(0).setSizeInBytes(SEGMENT_SIZE_IN_BYTES);
 
     SegmentZKMetadata segmentZKMetadataCopy =
         new SegmentZKMetadata(new ZNRecord(segmentsZKMetadata.get(0).toZNRecord()));
 
     segmentZKMetadataCopy.setDownloadUrl(tempSegmentFileLocation.getPath());
+    segmentZKMetadataCopy.setSizeInBytes(FINALIZED_SEGMENT_SIZE_IN_BYTES);
     // Simulate the server-side merge of segment-file customMap entries into the uploaded ZK metadata. The controller
     // must propagate these entries to the persisted ZK metadata.
     Map<String, String> uploadedCustomMap = new HashMap<>();
@@ -1891,6 +1894,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     assertNotNull(persistedCustomMap);
     assertEquals(persistedCustomMap.get("segmentFileKey"), "segmentFileValue");
     assertEquals(persistedCustomMap.get("controllerKey"), "controllerValue");
+    assertEquals(
+        segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentNames.get(0), null).getSizeInBytes(),
+        FINALIZED_SEGMENT_SIZE_IN_BYTES);
 
     assertEquals(segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentNames.get(1), null).getDownloadUrl(),
         METADATA_URI_FOR_PEER_DOWNLOAD);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -59,6 +59,7 @@ import org.apache.pinot.core.data.manager.realtime.RealtimeConsumptionRateManage
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.local.dedup.DedupContext;
 import org.apache.pinot.segment.local.dedup.PartitionDedupMetadataManager;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.indexsegment.mutable.MutableSegmentImpl;
 import org.apache.pinot.segment.local.io.writer.impl.DirectMemoryManager;
 import org.apache.pinot.segment.local.io.writer.impl.MmapMemoryManager;
@@ -1286,7 +1287,18 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         FileUtils.deleteQuietly(tempSegmentFolder);
       }
 
-      long segmentSizeBytes = FileUtils.sizeOfDirectory(indexDir);
+      try {
+        IndexLoadingConfig latestIndexLoadingConfig = _realtimeTableDataManager.fetchIndexLoadingConfig();
+        ImmutableSegmentLoader.preprocess(indexDir, latestIndexLoadingConfig,
+            _realtimeTableDataManager.getSegmentOperationsThrottlerSet(), _segmentZKMetadata);
+      } catch (Exception e) {
+        String errorMessage = "Could not finalize segment with the latest index configuration";
+        reportSegmentBuildFailure(errorMessage, e);
+        throw new SegmentBuildFailureException(errorMessage, e);
+      }
+
+      long segmentSizeBytes =
+          FileUtils.sizeOfDirectory(SegmentDirectoryPaths.findSegmentDirectory(indexDir));
       _serverMetrics.setValueOfTableGauge(_clientId, ServerGauge.LAST_REALTIME_SEGMENT_CREATION_DURATION_SECONDS,
           TimeUnit.MILLISECONDS.toSeconds(buildTimeMillis));
       _serverMetrics.setValueOfTableGauge(_clientId, ServerGauge.LAST_REALTIME_SEGMENT_CREATION_WAIT_TIME_SECONDS,

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -816,8 +816,9 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     File indexDir = new File(_indexDir, segmentName);
     // Get a new index loading config with latest table config and schema to load the segment
     IndexLoadingConfig indexLoadingConfig = fetchIndexLoadingConfig();
-    ImmutableSegment immutableSegment =
-        ImmutableSegmentLoader.load(indexDir, indexLoadingConfig, _segmentOperationsThrottlerSet, zkMetadata);
+    boolean needPreprocess = ImmutableSegmentLoader.needPreprocess(indexDir, indexLoadingConfig, zkMetadata);
+    ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(indexDir, indexLoadingConfig, needPreprocess,
+        _segmentOperationsThrottlerSet, zkMetadata);
 
     addSegment(immutableSegment, zkMetadata);
     _ingestionDelayTracker.markPartitionForVerification(segmentName);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
@@ -48,6 +48,8 @@ import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConsumerFactory;
 import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamMessageDecoder;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.indexsegment.mutable.MutableSegmentImpl;
 import org.apache.pinot.segment.local.realtime.impl.RealtimeSegmentStatsHistory;
 import org.apache.pinot.segment.local.segment.creator.Fixtures;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
@@ -55,6 +57,7 @@ import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.local.utils.SegmentLocks;
 import org.apache.pinot.segment.local.utils.ServerReloadJobStatusCache;
+import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
@@ -789,6 +792,44 @@ public class RealtimeSegmentDataManagerTest {
     }
   }
 
+  @Test
+  public void testSegmentBuildSizeUsesLatestIndexConfiguration()
+      throws Exception {
+    TableConfig buildConfig = createTableConfig();
+    buildConfig.getIndexingConfig().setSegmentFormatVersion("v3");
+    buildConfig.getIndexingConfig().setInvertedIndexColumns(List.of("d"));
+
+    try (FakeRealtimeSegmentDataManager segmentDataManager =
+        createFakeSegmentManager(false, new TimeSupplier(), null, null, buildConfig)) {
+      Schema schema = Fixtures.createSchema();
+      TableConfig latestConfig = createTableConfig();
+      latestConfig.getIndexingConfig().setSegmentFormatVersion("v3");
+      IndexLoadingConfig latestIndexLoadingConfig =
+          new IndexLoadingConfig(FakeRealtimeSegmentDataManager.makeInstanceDataManagerConfig(), latestConfig, schema);
+      when(segmentDataManager._tableDataManager.fetchIndexLoadingConfig()).thenReturn(latestIndexLoadingConfig);
+
+      for (int i = 0; i < 1_000; i++) {
+        GenericRow row = Fixtures.createSingleRow(i);
+        row.putValue("m", (long) i);
+        row.putValue("d", "value_" + i % 10);
+        row.putValue("minutesSinceEpoch", (long) i);
+        segmentDataManager.index(row);
+      }
+
+      RealtimeSegmentDataManager.SegmentBuildDescriptor descriptor =
+          segmentDataManager.invokeRealBuildSegment(false);
+      File indexDir = new File(new File(TEMP_DIR, REALTIME_TABLE_NAME), SEGMENT_NAME_STR);
+      Assert.assertFalse(ImmutableSegmentLoader.needPreprocess(indexDir, latestIndexLoadingConfig, null));
+      ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(indexDir, latestIndexLoadingConfig, false);
+      try {
+        Assert.assertEquals(descriptor.getSegmentSizeBytes(), immutableSegment.getSegmentSizeBytes());
+        Assert.assertNull(immutableSegment.getInvertedIndex("d"));
+      } finally {
+        immutableSegment.destroy();
+      }
+    }
+  }
+
   private long buildRealSegmentAndGetCrc(File resourceDir, String segmentName)
       throws Exception {
     Schema schema = Fixtures.createSchema();
@@ -1452,6 +1493,18 @@ public class RealtimeSegmentDataManagerTest {
         throws SegmentBuildFailureException {
       super.buildSegmentForCommit(leaseTime);
       return getSegmentBuildDescriptor();
+    }
+
+    public SegmentBuildDescriptor invokeRealBuildSegment(boolean forCommit)
+        throws SegmentBuildFailureException {
+      return super.buildSegmentInternal(forCommit);
+    }
+
+    public void index(GenericRow row)
+        throws Exception {
+      Field field = RealtimeSegmentDataManager.class.getDeclaredField("_realtimeSegment");
+      field.setAccessible(true);
+      ((MutableSegmentImpl) field.get(this)).index(row, null);
     }
 
     public boolean invokeCommit()

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
@@ -301,6 +301,28 @@ public class ImmutableSegmentLoader {
     return new SegmentPreProcessor(segmentDirectory, indexLoadingConfig).needProcess();
   }
 
+  /// Checks whether a local segment directory needs preprocessing for the supplied index loading configuration.
+  ///
+  /// @param indexDir local segment index directory
+  /// @param indexLoadingConfig index loading configuration to check against
+  /// @param zkMetadata segment metadata used to resolve segment custom configuration, or `null`
+  /// @return `true` when loading the segment requires preprocessing
+  public static boolean needPreprocess(File indexDir, IndexLoadingConfig indexLoadingConfig,
+      @Nullable SegmentZKMetadata zkMetadata)
+      throws Exception {
+    Preconditions.checkArgument(indexDir.isDirectory(), "Index directory: %s does not exist or is not a directory",
+        indexDir);
+
+    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(indexDir);
+    if (segmentMetadata.getTotalDocs() == 0) {
+      return false;
+    }
+    try (SegmentDirectory segmentDirectory = loadSegmentDirectoryForPreprocess(indexDir, segmentMetadata.getName(),
+        segmentMetadata.getCrc(), indexLoadingConfig, zkMetadata)) {
+      return needPreprocess(segmentDirectory, indexLoadingConfig);
+    }
+  }
+
   private static boolean needConvertSegmentFormat(IndexLoadingConfig indexLoadingConfig,
       SegmentMetadataImpl segmentMetadata) {
     SegmentVersion segmentVersionToLoad = indexLoadingConfig.getSegmentVersion();
@@ -334,6 +356,16 @@ public class ImmutableSegmentLoader {
       IndexLoadingConfig indexLoadingConfig, @Nullable SegmentOperationsThrottlerSet segmentOperationsThrottlerSet,
       SegmentZKMetadata zkMetadata)
       throws Exception {
+    SegmentDirectory segmentDirectory =
+        loadSegmentDirectoryForPreprocess(indexDir, segmentName, segmentCrc, indexLoadingConfig, zkMetadata);
+    try (SegmentPreProcessor preProcessor = new SegmentPreProcessor(segmentDirectory, indexLoadingConfig)) {
+      preProcessor.process(segmentOperationsThrottlerSet);
+    }
+  }
+
+  private static SegmentDirectory loadSegmentDirectoryForPreprocess(File indexDir, String segmentName,
+      String segmentCrc, IndexLoadingConfig indexLoadingConfig, @Nullable SegmentZKMetadata zkMetadata)
+      throws Exception {
     SegmentDirectoryLoaderContext segmentLoaderContext = new SegmentDirectoryLoaderContext.Builder()
         .setReadMode(indexLoadingConfig.getReadMode())
         .setTableConfig(indexLoadingConfig.getTableConfig())
@@ -343,10 +375,7 @@ public class ImmutableSegmentLoader {
         .setSegmentCrc(segmentCrc)
         .setSegmentCustomConfigs(zkMetadata != null ? zkMetadata.getCustomMap() : Map.of())
         .build();
-    SegmentDirectory segmentDirectory =
-        SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader().load(indexDir.toURI(), segmentLoaderContext);
-    try (SegmentPreProcessor preProcessor = new SegmentPreProcessor(segmentDirectory, indexLoadingConfig)) {
-      preProcessor.process(segmentOperationsThrottlerSet);
-    }
+    return SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader().load(indexDir.toURI(),
+        segmentLoaderContext);
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/LoaderTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/LoaderTest.java
@@ -163,6 +163,9 @@ public class LoaderTest {
 
     // The newly generated segment is consistent with table config and schema, thus
     // in follow checks, whether it needs reprocess or not depends on segment format.
+    assertFalse(ImmutableSegmentLoader.needPreprocess(_indexDir, new IndexLoadingConfig(), null));
+    assertFalse(ImmutableSegmentLoader.needPreprocess(_indexDir, _v1IndexLoadingConfig, null));
+    assertTrue(ImmutableSegmentLoader.needPreprocess(_indexDir, _v3IndexLoadingConfig, null));
     try (SegmentDirectory segmentDirectory = new SegmentLocalFSDirectory(_indexDir, ReadMode.mmap)) {
       // The segmentVersionToLoad is null, not leading to reprocess.
       assertFalse(ImmutableSegmentLoader.needPreprocess(segmentDirectory, new IndexLoadingConfig()));
@@ -177,6 +180,7 @@ public class LoaderTest {
 
     // Need to reset `segmentDirectory` to point to the correct index directory after the above load since the path
     // changes
+    assertFalse(ImmutableSegmentLoader.needPreprocess(_indexDir, _v3IndexLoadingConfig, null));
     try (SegmentDirectory segmentDirectory = new SegmentLocalFSDirectory(_indexDir, ReadMode.mmap)) {
       assertFalse(ImmutableSegmentLoader.needPreprocess(segmentDirectory, _v3IndexLoadingConfig));
     }

--- a/pinot-tools/src/main/resources/examples/compression-stats/README.md
+++ b/pinot-tools/src/main/resources/examples/compression-stats/README.md
@@ -35,6 +35,36 @@ resolved chunk-compression type. Dictionary-encoded columns record uncompressed 
 `forwardIndexAndDictionaryStorageSizeInBytes` includes both the dictionary and forward-index files. Columns without a
 forward index and old segments without value-size metadata are excluded from compression ratios.
 
+## Inspect realtime segment size metadata
+
+For a completed realtime segment, `segment.size.in.bytes` is the logical size of the finalized, uncompressed immutable
+segment. Before publishing this value, the committing server applies the latest table index configuration. For example,
+if an inverted index was removed while the segment was consuming, the removed index is not included in the published
+size. Deep-store recovery also refreshes the value from the immutable segment loaded by the selected server.
+
+This field is not the compressed archive size and does not represent filesystem-allocated blocks reported by tools
+such as `du`. A later segment reload can also make replica sizes differ from the shared metadata snapshot.
+
+To compare the metadata snapshot with the currently loaded copies of one realtime segment:
+
+```bash
+CONTROLLER='http://localhost:9000'
+TABLE='events'
+SEGMENT='events__0__0__20260714T0000Z'
+
+curl -sS "$CONTROLLER/segments/${TABLE}_REALTIME/$SEGMENT/metadata" \
+  | jq '{segmentSizeInBytes: (."segment.size.in.bytes" | tonumber)}'
+
+curl -sS "$CONTROLLER/tables/$TABLE/size?verbose=true" \
+  | jq --arg segment "$SEGMENT" \
+    '.realtimeSegments.segments[$segment].serverInfo
+     | to_entries[]
+     | {server: .key, diskSizeInBytes: .value.diskSizeInBytes}'
+```
+
+The first value is one shared segment metadata snapshot and does not include replication. The second request reports
+each loaded replica separately.
+
 ## Query statistics
 
 Request the table-size summary and per-segment details:


### PR DESCRIPTION
## Summary

- Finalize locally generated realtime segments with the latest index configuration before calculating `segmentSizeBytes` and creating the commit archive.
- Calculate the normal uncompressed size from the active segment directory so it matches the loaded immutable segment's `getSegmentSizeBytes()` value.
- Avoid an immediate duplicate preprocessing pass when the finalized files still match the latest configuration, while retaining the recheck in case the configuration changed again.
- Refresh stale `segment.size.in.bytes` metadata from the loaded immutable segment during deep-store recovery of an already-DONE segment.
- Document the field semantics and provide example metadata/table-size API queries.

This change does **not** add compressed-size metadata or change the segment completion protocol.

## Before and after

| Area | Before | After |
| --- | --- | --- |
| Seal-time flow | Convert with the configuration snapshot captured when consumption started, then measure and publish the size **before** latest-config preprocessing. | Convert, preprocess with the latest `IndexLoadingConfig`, then measure and publish the finalized files. |
| `segment.size.in.bytes` | Could describe indexes that were removed or rebuilt later. In the regression fixture, metadata published `37,452` bytes while the loaded segment used `35,174` bytes. | Publishes `35,174` bytes for the same fixture, matching `ImmutableSegment#getSegmentSizeBytes()` when the segment is loaded. |
| Commit archive | Contained the pre-finalization segment representation. | Contains the same latest-config representation that was measured. |
| Local replacement | Performed latest-config preprocessing only after the stale size had already been published. | Rechecks whether preprocessing is needed and skips duplicate work unless the configuration changed again. |
| DONE-segment recovery | Refreshed the CRC and download URL but kept the stale size. | Also refreshes the size from the immutable segment loaded by the selected server. |
| Completion protocol | Uses the existing `segmentSizeBytes` value. | Unchanged; no compressed-size field is introduced. |

```text
Before: convert(old snapshot) -> measure/publish -> preprocess(latest config) -> load
After:  convert(old snapshot) -> preprocess(latest config) -> measure/publish -> load
```

## Why the old value was wrong

`RealtimeSegmentDataManager` retains the table configuration captured when consumption starts. At seal time, the realtime converter used that construction-time snapshot and immediately measured the generated directory. That value was sent to the controller and persisted as `segment.size.in.bytes`.

The segment was not necessarily in its final on-disk form yet. When the consuming segment was replaced, `RealtimeTableDataManager` fetched the latest table configuration and `ImmutableSegmentLoader` preprocessed the files. Preprocessing can remove indexes that were deleted from the table config or rebuild indexes whose definitions changed. For a long-running consuming segment, the preprocessed directory could therefore be substantially smaller than the directory measured before finalization.

The result was a stale pre-finalization byte count in ZK metadata, even though every loaded replica contained the smaller finalized immutable segment. In the regression fixture, the old path published `37,452` bytes while the finalized loaded segment occupied `35,174` bytes.

The deep-store recovery path had a second stale-value case. The selected server already returned `ImmutableSegment#getSegmentSizeBytes()`, but the controller only copied the full response for a COMMITTING segment. For an already-DONE segment it updated CRC fields and the download URL while preserving the old size, so recovery could not repair the confusing value.

## Fix

Before publishing a locally generated segment, the server now:

1. Fetches the latest `IndexLoadingConfig`.
2. Preprocesses the generated segment with that configuration.
3. Measures the active V1/V2/V3 segment directory.
4. Creates the commit archive from those finalized files.

The local replacement path checks whether another preprocessing pass is actually needed. It skips the pass when the just-finalized files still match the current configuration, but preprocesses again if the configuration changed between build and replacement.

For deep-store recovery, the controller accepts a non-negative size returned by the selected server for DONE segments, just as it already accepts refreshed CRC metadata.

`segment.size.in.bytes` remains the logical uncompressed footprint of the finalized immutable segment. It is not the compressed archive length and is not filesystem-allocated block usage from `du`. It is one shared metadata snapshot; later reloads can still make individual replica footprints differ.

## User guide and sample queries

`pinot-tools/src/main/resources/examples/compression-stats/README.md` now explains the field and includes `curl`/`jq` examples comparing:

- `segment.size.in.bytes` from the segment metadata API; and
- each loaded replica's `diskSizeInBytes` from `/tables/{table}/size?verbose=true`.

There is no sample table-config change because this fix introduces no configuration option.

## Testing

- `RealtimeSegmentDataManagerTest`: 28 tests passed, including a regression that changes the inverted-index configuration while a segment is consuming and verifies the published size equals the finalized loaded size.
- `LoaderTest#testIfNeedConvertSegmentFormat`: verifies file-based preprocessing decisions before and after format conversion.
- `PinotLLCRealtimeSegmentManagerTest#testUploadCommittedSegment`: verifies DONE-segment recovery replaces stale size metadata with the loaded server value.
- `spotless:apply`, `checkstyle:check`, `license:format`, and `license:check` passed for `pinot-segment-local`, `pinot-core`, `pinot-controller`, and `pinot-tools`.
