### PR TITLE
Update sortedness in metadata if disagree with ColumnStatistics

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
@@ -900,28 +900,7 @@ public class ForwardIndexHandler extends BaseIndexHandler {
 
     ColumnMetadata existingColMetadata = segmentMetadata.getColumnMetadataFor(column);
     FieldSpec fieldSpec = existingColMetadata.getFieldSpec();
-    String fwdIndexFileExtension;
-    if (fieldSpec.isSingleValueField()) {
-      if (existingColMetadata.isSorted()) {
-        fwdIndexFileExtension = V1Constants.Indexes.SORTED_SV_FORWARD_INDEX_FILE_EXTENSION;
-      } else {
-        fwdIndexFileExtension = V1Constants.Indexes.UNSORTED_SV_FORWARD_INDEX_FILE_EXTENSION;
-      }
-    } else {
-      fwdIndexFileExtension = V1Constants.Indexes.UNSORTED_MV_FORWARD_INDEX_FILE_EXTENSION;
-    }
-    File fwdIndexFile = new File(indexDir, column + fwdIndexFileExtension);
-
-    if (!inProgress.exists()) {
-      // Marker file does not exist, which means last run ended normally.
-      // Create a marker file.
-      FileUtils.touch(inProgress);
-    } else {
-      // Marker file exists, which means last run was interrupted.
-      // Remove forward index and dictionary files if they exist.
-      FileUtils.deleteQuietly(fwdIndexFile);
-      FileUtils.deleteQuietly(dictionaryFile);
-    }
+    File fwdIndexFile;
 
     AbstractColumnStatisticsCollector statsCollector;
     SegmentDictionaryCreator dictionaryCreator;
@@ -944,6 +923,29 @@ public class ForwardIndexHandler extends BaseIndexHandler {
         }
         statsCollector.seal();
       }
+
+      String fwdIndexFileExtension;
+      if (fieldSpec.isSingleValueField()) {
+        if (statsCollector.isSorted()) {
+          fwdIndexFileExtension = V1Constants.Indexes.SORTED_SV_FORWARD_INDEX_FILE_EXTENSION;
+        } else {
+          fwdIndexFileExtension = V1Constants.Indexes.UNSORTED_SV_FORWARD_INDEX_FILE_EXTENSION;
+        }
+      } else {
+        fwdIndexFileExtension = V1Constants.Indexes.UNSORTED_MV_FORWARD_INDEX_FILE_EXTENSION;
+      }
+      fwdIndexFile = new File(indexDir, column + fwdIndexFileExtension);
+
+      if (!inProgress.exists()) {
+        // Marker file does not exist, which means last run ended normally.
+        // Create a marker file.
+        FileUtils.touch(inProgress);
+      } else {
+        // Marker file exists, which means last run was interrupted.
+        // Remove forward index and dictionary files if they exist.
+        FileUtils.deleteQuietly(fwdIndexFile);
+        FileUtils.deleteQuietly(dictionaryFile);
+      }
       DictionaryIndexConfig dictConf = _fieldIndexConfigs.get(column).getConfig(StandardIndexes.dictionary());
       boolean optimizeDictionaryType = _tableConfig.getIndexingConfig().isOptimizeDictionaryType();
       boolean useVarLength = dictConf.isUseVarLengthDictionary() || DictionaryIndexType.shouldUseVarLengthDictionary(
@@ -955,19 +957,8 @@ public class ForwardIndexHandler extends BaseIndexHandler {
       LOGGER.info("Built dictionary. Rewriting dictionary enabled forward index for segment={} and column={}",
           segmentName, column);
       ForwardIndexConfig config = _fieldIndexConfigs.get(column).getConfig(StandardIndexes.forward());
-      // When it's false negative on a column's sortedness in metadata, `fwdIndexFileExtension` would be determined
-      // unsorted (.sv.unsorted.fwd), but the creator would write to .sv.sorted.fwd, because the creator factory
-      // constructs the forward index creator by statsCollector. This false negative could happen before
-      // apache/pinot#17965
-      //
-      // It should never be the other way round, fail loudly here
-      Preconditions.checkState(!existingColMetadata.isSorted() || statsCollector.isSorted(),
-          "Column %s metadata reports isSorted=true but its data is not sorted; refusing to build a sorted forward "
-              + "index for segment %s", column, segmentName);
       IndexCreationContext context =
-          new IndexCreationContext.Builder(indexDir, _tableConfig, statsCollector, true)
-              .withSorted(existingColMetadata.isSorted())
-              .build();
+          new IndexCreationContext.Builder(indexDir, _tableConfig, statsCollector, true).build();
       try (ForwardIndexCreator creator = StandardIndexes.forward().createIndexCreator(context, config)) {
         forwardIndexRewriteHelper(column, existingColMetadata, reader, creator, numDocs, dictionaryCreator, null);
       }
@@ -984,6 +975,7 @@ public class ForwardIndexHandler extends BaseIndexHandler {
 
     LOGGER.info("Created forwardIndex. Updating metadata properties for segment={} and column={}", segmentName, column);
     Map<String, String> metadataProperties = new HashMap<>();
+    metadataProperties.put(getKeyFor(column, IS_SORTED), String.valueOf(statsCollector.isSorted()));
     metadataProperties.put(getKeyFor(column, HAS_DICTIONARY), String.valueOf(true));
     metadataProperties.put(getKeyFor(column, FORWARD_INDEX_ENCODING), EncodingType.DICTIONARY.name());
     metadataProperties.put(getKeyFor(column, DICTIONARY_ELEMENT_SIZE),

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
@@ -955,8 +955,19 @@ public class ForwardIndexHandler extends BaseIndexHandler {
       LOGGER.info("Built dictionary. Rewriting dictionary enabled forward index for segment={} and column={}",
           segmentName, column);
       ForwardIndexConfig config = _fieldIndexConfigs.get(column).getConfig(StandardIndexes.forward());
+      // When it's false negative on a column's sortedness in metadata, `fwdIndexFileExtension` would be determined
+      // unsorted (.sv.unsorted.fwd), but the creator would write to .sv.sorted.fwd, because the creator factory
+      // constructs the forward index creator by statsCollector. This false negative could happen before
+      // apache/pinot#17965
+      //
+      // It should never be the other way round, fail loudly here
+      Preconditions.checkState(!existingColMetadata.isSorted() || statsCollector.isSorted(),
+          "Column %s metadata reports isSorted=true but its data is not sorted; refusing to build a sorted forward "
+              + "index for segment %s", column, segmentName);
       IndexCreationContext context =
-          new IndexCreationContext.Builder(indexDir, _tableConfig, statsCollector, true).build();
+          new IndexCreationContext.Builder(indexDir, _tableConfig, statsCollector, true)
+              .withSorted(existingColMetadata.isSorted())
+              .build();
       try (ForwardIndexCreator creator = StandardIndexes.forward().createIndexCreator(context, config)) {
         forwardIndexRewriteHelper(column, existingColMetadata, reader, creator, numDocs, dictionaryCreator, null);
       }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandlerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandlerTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import javax.annotation.Nullable;
+import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -75,8 +76,11 @@ import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.segment.spi.V1Constants.MetadataKeys.Column.IS_SORTED;
+import static org.apache.pinot.segment.spi.V1Constants.MetadataKeys.Column.getKeyFor;
 import static org.testng.Assert.*;
 
 
@@ -1762,6 +1766,119 @@ public class ForwardIndexHandlerTest {
     validateForwardIndex(DIM_RAW_SORTED_INTEGER, CompressionCodec.SNAPPY, true);
     validateMetadataProperties(new SegmentMetadataImpl(INDEX_DIR).getColumnMetadataFor(DIM_RAW_SORTED_INTEGER),
         metadata, false);
+  }
+
+  @DataProvider(name = "coincidentallySortedRawTypes")
+  public Object[][] coincidentallySortedRawTypes() {
+    // Cover a fixed-width type and both variable-length types (STRING/BYTES take a different raw writer path).
+    return new Object[][]{
+        {DataType.LONG, 0L},
+        {DataType.STRING, "sameValue"},
+        {DataType.BYTES, new byte[]{0x1, 0x2, 0x3}},
+    };
+  }
+
+  /// Regression test for enabling a dictionary on a raw column whose persisted metadata says {@code isSorted=false}
+  /// but whose values happen to be monotonic (here, all identical). This is the shape produced by a realtime segment
+  /// committed while the column was raw: raw columns are persisted with {@code isSorted=false} regardless of the data.
+  /// On reload the fresh stats collector reads the identical values and reports the column as sorted, so before the
+  /// fix the forward-index creator emitted a `.sv.sorted.fwd` index while {@link ForwardIndexHandler} derived the temp
+  /// file name from the metadata ({@code .sv.unsorted.fwd}) and never updated {@code isSorted}, throwing
+  /// {@link java.io.FileNotFoundException} and leaving a format/metadata mismatch for the next read. The fix forces
+  /// the creator to honor the persisted {@code isSorted} flag, keeping the written format, the file name, and the
+  /// metadata consistent.
+  @Test(dataProvider = "coincidentallySortedRawTypes")
+  public void testEnableDictionaryForRawColumnWithCoincidentallySortedValues(DataType dataType, Object value)
+      throws Exception {
+    File tempDir = new File(FileUtils.getTempDirectory(), "ForwardIndexHandlerCoincidentalSortTest");
+    FileUtils.deleteQuietly(tempDir);
+    try {
+      String tableName = "coincidentalSortTable";
+      String column = "coincidentallySortedColumn";
+      String segmentName = "coincidentalSortSegment";
+      int numDocs = 48;
+
+      Schema schema = new Schema.SchemaBuilder().setSchemaName(tableName)
+          .addSingleValueDimension(column, dataType)
+          .build();
+
+      // Build the segment with the column as raw (no dictionary).
+      TableConfig rawTableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(tableName)
+          .setNoDictionaryColumns(List.of(column))
+          .setFieldConfigList(
+              List.of(new FieldConfig(column, FieldConfig.EncodingType.RAW, List.of(), CompressionCodec.PASS_THROUGH,
+                  null)))
+          .build();
+
+      // All-identical values -> trivially monotonic -> the stats collector treats the column as sorted.
+      List<GenericRow> rows = new ArrayList<>();
+      for (int i = 0; i < numDocs; i++) {
+        GenericRow row = new GenericRow();
+        row.putValue(column, value);
+        rows.add(row);
+      }
+      SegmentGeneratorConfig config = new SegmentGeneratorConfig(rawTableConfig, schema);
+      config.setOutDir(tempDir.getPath());
+      config.setSegmentName(segmentName);
+      SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+      driver.init(config, new GenericRowRecordReader(rows));
+      driver.build();
+      File segmentDir = new File(tempDir, segmentName);
+
+      // Offline generation records isSorted from the data, so it would set isSorted=true for these all-equal values.
+      // Overwrite it to false to reproduce the realtime raw-segment condition.
+      PropertiesConfiguration metadataConfig = SegmentMetadataUtils.getPropertiesConfiguration(segmentDir);
+      metadataConfig.setProperty(getKeyFor(column, IS_SORTED), String.valueOf(false));
+      SegmentMetadataUtils.savePropertiesConfiguration(metadataConfig, segmentDir);
+
+      ColumnMetadata beforeMetadata = new SegmentMetadataImpl(segmentDir).getColumnMetadataFor(column);
+      assertFalse(beforeMetadata.isSorted());
+      assertFalse(beforeMetadata.hasDictionary());
+
+      // Enable a dictionary on the column and run the forward-index handler (the reload path).
+      TableConfig dictTableConfig =
+          new TableConfigBuilder(TableType.OFFLINE).setTableName(tableName).setNoDictionaryColumns(List.of()).build();
+      IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig(dictTableConfig, schema);
+      try (SegmentDirectory segmentDirectory = new SegmentLocalFSDirectory(segmentDir, ReadMode.mmap);
+          SegmentDirectory.Writer writer = segmentDirectory.createWriter()) {
+        ForwardIndexHandler handler = new ForwardIndexHandler(segmentDirectory, indexLoadingConfig);
+        assertEquals(handler.computeOperations(writer),
+            Map.of(column, List.of(ForwardIndexHandler.Operation.ENABLE_DICTIONARY)));
+        // Before the fix this threw FileNotFoundException for the missing .sv.unsorted.fwd file.
+        handler.updateIndices(writer);
+        handler.postUpdateIndicesCleanup(writer);
+      }
+
+      // The column now has a dictionary; isSorted must stay false and the unsorted dict forward index must read back
+      // the original values without corruption.
+      ColumnMetadata afterMetadata = new SegmentMetadataImpl(segmentDir).getColumnMetadataFor(column);
+      assertTrue(afterMetadata.hasDictionary());
+      assertFalse(afterMetadata.isSorted());
+      try (SegmentDirectory segmentDirectory = new SegmentLocalFSDirectory(segmentDir, ReadMode.mmap);
+          SegmentDirectory.Reader reader = segmentDirectory.createReader()) {
+        assertTrue(reader.hasIndexFor(column, StandardIndexes.forward()));
+        assertTrue(reader.hasIndexFor(column, StandardIndexes.dictionary()));
+        IndexReaderFactory<ForwardIndexReader> readerFactory = StandardIndexes.forward().getReaderFactory();
+        FieldIndexConfigs fieldIndexConfigs = createFieldIndexConfigsFromMetadata(afterMetadata);
+        try (ForwardIndexReader<?> fwdReader =
+                readerFactory.createIndexReader(reader, fieldIndexConfigs, afterMetadata);
+            Dictionary dictionary = DictionaryIndexType.read(reader, afterMetadata)) {
+          PinotSegmentColumnReader columnReader =
+              new PinotSegmentColumnReader(column, fwdReader, dictionary, null,
+                  afterMetadata.getMaxNumberOfMultiValues());
+          for (int i = 0; i < numDocs; i++) {
+            Object actual = columnReader.getValue(i);
+            if (dataType == DataType.BYTES) {
+              assertEquals((byte[]) actual, (byte[]) value);
+            } else {
+              assertEquals(actual, value);
+            }
+          }
+        }
+      }
+    } finally {
+      FileUtils.deleteQuietly(tempDir);
+    }
   }
 
   @Test

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandlerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandlerTest.java
@@ -1853,7 +1853,7 @@ public class ForwardIndexHandlerTest {
       // the original values without corruption.
       ColumnMetadata afterMetadata = new SegmentMetadataImpl(segmentDir).getColumnMetadataFor(column);
       assertTrue(afterMetadata.hasDictionary());
-      assertFalse(afterMetadata.isSorted());
+      assertTrue(afterMetadata.isSorted());
       try (SegmentDirectory segmentDirectory = new SegmentLocalFSDirectory(segmentDir, ReadMode.mmap);
           SegmentDirectory.Reader reader = segmentDirectory.createReader()) {
         assertTrue(reader.hasIndexFor(column, StandardIndexes.forward()));

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/IndexCreationContext.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/IndexCreationContext.java
@@ -121,6 +121,7 @@ public interface IndexCreationContext extends ColumnShape {
     private int _maxNumberOfMultiValues;
     private int _maxRowLengthInBytes;
     private boolean _hasDictionary;
+    private boolean _sorted;
 
     // Build-time toggles.
     private boolean _onHeap;
@@ -167,6 +168,7 @@ public interface IndexCreationContext extends ColumnShape {
       _maxNumberOfMultiValues = columnShape.getMaxNumberOfMultiValues();
       _maxRowLengthInBytes = columnShape.getMaxRowLengthInBytes();
       _hasDictionary = hasDictionary;
+      _sorted = columnShape.isSorted();
       _continueOnError = continueOnError;
     }
 
@@ -209,6 +211,11 @@ public interface IndexCreationContext extends ColumnShape {
 
     public Builder withDictionary(boolean hasDictionary) {
       _hasDictionary = hasDictionary;
+      return this;
+    }
+
+    public Builder withSorted(boolean sorted) {
+      _sorted = sorted;
       return this;
     }
 
@@ -279,6 +286,7 @@ public interface IndexCreationContext extends ColumnShape {
     private final int _maxNumberOfMultiValues;
     private final int _maxRowLengthInBytes;
     private final boolean _hasDictionary;
+    private final boolean _sorted;
 
     // Build-time toggles.
     private final boolean _onHeap;
@@ -307,6 +315,7 @@ public interface IndexCreationContext extends ColumnShape {
       _maxNumberOfMultiValues = builder._maxNumberOfMultiValues;
       _maxRowLengthInBytes = builder._maxRowLengthInBytes;
       _hasDictionary = builder._hasDictionary;
+      _sorted = builder._sorted;
       _onHeap = builder._onHeap;
       _optimizeDictionary = builder._optimizedDictionary;
       _textCommitOnClose = builder._textCommitOnClose;
@@ -358,9 +367,11 @@ public interface IndexCreationContext extends ColumnShape {
       return _columnShape.getCardinality();
     }
 
+    // When the segment metadata reports false negative on sortedness, we want to override to create index with
+    // unsorted even though _columnShape say sorted
     @Override
     public boolean isSorted() {
-      return _columnShape.isSorted();
+      return _sorted;
     }
 
     @Override

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/IndexCreationContext.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/IndexCreationContext.java
@@ -121,7 +121,6 @@ public interface IndexCreationContext extends ColumnShape {
     private int _maxNumberOfMultiValues;
     private int _maxRowLengthInBytes;
     private boolean _hasDictionary;
-    private boolean _sorted;
 
     // Build-time toggles.
     private boolean _onHeap;
@@ -168,7 +167,6 @@ public interface IndexCreationContext extends ColumnShape {
       _maxNumberOfMultiValues = columnShape.getMaxNumberOfMultiValues();
       _maxRowLengthInBytes = columnShape.getMaxRowLengthInBytes();
       _hasDictionary = hasDictionary;
-      _sorted = columnShape.isSorted();
       _continueOnError = continueOnError;
     }
 
@@ -211,11 +209,6 @@ public interface IndexCreationContext extends ColumnShape {
 
     public Builder withDictionary(boolean hasDictionary) {
       _hasDictionary = hasDictionary;
-      return this;
-    }
-
-    public Builder withSorted(boolean sorted) {
-      _sorted = sorted;
       return this;
     }
 
@@ -286,7 +279,6 @@ public interface IndexCreationContext extends ColumnShape {
     private final int _maxNumberOfMultiValues;
     private final int _maxRowLengthInBytes;
     private final boolean _hasDictionary;
-    private final boolean _sorted;
 
     // Build-time toggles.
     private final boolean _onHeap;
@@ -315,7 +307,6 @@ public interface IndexCreationContext extends ColumnShape {
       _maxNumberOfMultiValues = builder._maxNumberOfMultiValues;
       _maxRowLengthInBytes = builder._maxRowLengthInBytes;
       _hasDictionary = builder._hasDictionary;
-      _sorted = builder._sorted;
       _onHeap = builder._onHeap;
       _optimizeDictionary = builder._optimizedDictionary;
       _textCommitOnClose = builder._textCommitOnClose;
@@ -367,11 +358,9 @@ public interface IndexCreationContext extends ColumnShape {
       return _columnShape.getCardinality();
     }
 
-    // When the segment metadata reports false negative on sortedness, we want to override to create index with
-    // unsorted even though _columnShape say sorted
     @Override
     public boolean isSorted() {
-      return _sorted;
+      return _columnShape.isSorted();
     }
 
     @Override


### PR DESCRIPTION
## Description
Before #17965, we might see a raw column is unsorted according to `metadata.properties` but is actually sorted (false negative). For example: 
```
column.xxx.cardinality = -2147483648
column.xxx.totalDocs = 48
column.xxx.dataType = LONG
column.xxx.bitsPerElement = 31
column.xxx.lengthOfEachEntry = 0
column.xxx.columnType = DATE_TIME
column.xxx.isSorted = false
column.xxx.hasDictionary = false
column.xxx.isSingleValues = true
column.xxx.totalNumberOfEntries = 48
column.xxx.minValue = 0
column.xxx.maxValue = 0
```

So when the table config enables dictionary on this column, during the segment load/reload, the forward index rebuild in `updateIndicies`. Yet the forward index creator is constructed using an `AbstractColumnStatisticsCollector`, which actually read through the column and report sorted. 

Thus a `SingleValueSortedForwardIndexCreator` would be created here, write index to a file with a different file extension `.sv.sorted.fwd`. Later segment writer would try to read from `.sv.unsorted.fwd` because it determines the extension by metadata's sortedness. 

So we see 
```
java.io.FileNotFoundException: 
.../xxx.sv.unsorted.fwd (No such file or directory)
	at java.base/java.io.RandomAccessFile.open0(Native Method)
	at java.base/java.io.RandomAccessFile.open(RandomAccessFile.java:356)
	at java.base/java.io.RandomAccessFile.<init>(RandomAccessFile.java:273)
	at java.base/java.io.RandomAccessFile.<init>(RandomAccessFile.java:223)
	at org.apache.pinot.segment.spi.memory.PinotByteBuffer.readFrom(PinotByteBuffer.java:295)
	at org.apache.pinot.segment.local.segment.index.loader.LoaderUtils.writeIndexToV3Format(LoaderUtils.java:57)
```

## Change
We should follow the metadata as the source of truth. IMO the easiest change here is to override the sortedness in `IndexCreationContext` with the value in segment metadata.

## Test
Add an unit test to reproduce the failure scenario and verified it fails without the change, and pass with the change.