### PR TITLE
Include stage/worker/server provenance in MSE error block logs

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -368,8 +368,8 @@ public class QueryRunner {
     StageMetadata stageMetadata = stagePlan.getStageMetadata();
     QueryExecutionContext queryContext = QueryThreadContext.get().getExecutionContext();
     long requestId = queryContext.getRequestId();
-    LOGGER.error("Error executing stage for request: {}, stage: {}, sending error block: {}", requestId,
-        stageMetadata.getStageId(), errorBlock);
+    // The stage/worker/server are already rendered by errorBlock.toString(); only requestId is added here.
+    LOGGER.error("Error executing stage for request: {}, sending error block: {}", requestId, errorBlock);
     try {
       OpChainExecutionContext executionContext =
           OpChainExecutionContext.fromQueryContext(_mailboxService, opChainMetadata, stageMetadata, workerMetadata,

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/ErrorMseBlock.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/ErrorMseBlock.java
@@ -131,6 +131,12 @@ public class ErrorMseBlock implements MseBlock.Eos {
     try {
       ObjectNode root = JsonUtils.newObjectNode();
       root.put("type", "error");
+      // Provenance of the error: the stage, worker and server where the error originated. This is mostly useful when
+      // the block reaches downstream logs (e.g. the broker or an intermediate stage), so operators can quickly find
+      // where the failure actually happened. -1 / null means the origin could not be determined (see #fromMap).
+      root.put("stageId", _stageId);
+      root.put("workerId", _workerId);
+      root.put("serverId", _serverId);
       root.set("errorMessages", JsonUtils.objectToJsonNode(_errorMessages));
       return JsonUtils.objectToString(root);
     } catch (JsonProcessingException e) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
@@ -207,8 +207,11 @@ public class OpChainSchedulerService {
         statsRef.set(stats);
         if (result.isError()) {
           ErrorMseBlock errorBlock = (ErrorMseBlock) result;
+          String serverId = errorBlock.getServerId() != null ? errorBlock.getServerId() : "unknown";
           throw errorBlock.getMainErrorCode().asException("Error block "
-              + "from " + errorBlock.getServerId()
+              + "from stage " + errorBlock.getStageId()
+              + " worker " + errorBlock.getWorkerId()
+              + " on " + serverId
               + ". Msg: " + errorBlock.getErrorMessages()
               + ". Stats: " + stats);
         } else {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/blocks/ErrorMseBlockTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/blocks/ErrorMseBlockTest.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.blocks;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Map;
+import org.apache.pinot.spi.exception.QueryErrorCode;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+public class ErrorMseBlockTest {
+
+  @Test
+  public void toStringIncludesProvenance()
+      throws Exception {
+    ErrorMseBlock block =
+        new ErrorMseBlock(3, 7, "Server_localhost_8000", Map.of(QueryErrorCode.INTERNAL, "boom"));
+
+    JsonNode json = JsonUtils.stringToJsonNode(block.toString());
+
+    assertEquals(json.get("type").asText(), "error");
+    // stage/worker/server are surfaced so downstream logs can locate where the failure originated.
+    assertEquals(json.get("stageId").asInt(), 3);
+    assertEquals(json.get("workerId").asInt(), 7);
+    assertEquals(json.get("serverId").asText(), "Server_localhost_8000");
+    assertTrue(json.get("errorMessages").toString().contains("boom"));
+  }
+
+  @Test
+  public void toStringHandlesUnknownProvenance()
+      throws Exception {
+    // The deprecated constructor leaves the origin undetermined: stageId/workerId = -1, serverId = null.
+    @SuppressWarnings("deprecation")
+    ErrorMseBlock block = new ErrorMseBlock(Map.of(QueryErrorCode.UNKNOWN, "no context"));
+
+    JsonNode json = JsonUtils.stringToJsonNode(block.toString());
+
+    assertEquals(json.get("stageId").asInt(), -1);
+    assertEquals(json.get("workerId").asInt(), -1);
+    assertTrue(json.get("serverId").isNull(), "serverId should serialize as null when the origin is unknown");
+  }
+}


### PR DESCRIPTION
## Summary

When an MSE query fails, an `ErrorMseBlock` is created and propagated downstream, where it is usually logged before the error reaches the user. `ErrorMseBlock` already carries the **stage id**, **worker id** and **server id** where the error originated (populated from `QueryThreadContext` in `ErrorMseBlock.fromMap`), but `ErrorMseBlock.toString()` only rendered the error messages. As a result, the log lines that print the block did not show *where* the failure actually happened, which makes it harder to pinpoint the offending stage/worker/host in a distributed query.

This PR surfaces the provenance that is already captured, **in the logs only**:

1. `ErrorMseBlock.toString()` now includes `stageId`, `workerId` and `serverId`. Every log line that prints an error block gains the provenance for free (e.g. `QueryRunner`'s `"...sending error block: {}"`).
2. `OpChainSchedulerService`'s op-chain-failure message now includes the stage and worker (it previously printed only the server), and falls back to `"unknown"` when the origin could not be determined, consistent with `fromMap`.
3. `QueryRunner` no longer logs the stage id separately in its "sending error block" line, since `toString()` now carries it (avoids duplicating the stage in the same log line).

No customer-facing error message and no wire/serialization format is changed — the provenance was already serialized across gRPC via `MetadataBlock`; this only affects logging/`toString()` rendering.

## Example: `QueryRunner` error log (`toString()`)

**Before** (stage was printed twice once `toString()` carried it — hence the de-dup in point 3)
```
Error executing stage for request: 8123456789, stage: 2, sending error block: {"type":"error","errorMessages":{"INTERNAL":"Caught exception while processing query"}}
```

**After**
```
Error executing stage for request: 8123456789, sending error block: {"type":"error","stageId":2,"workerId":0,"serverId":"Server_10.0.12.7_8098","errorMessages":{"INTERNAL":"Caught exception while processing query"}}
```

## Example: `OpChainSchedulerService` op-chain failure log

**Before**
```
Failed to execute operator chain: Error block from Server_10.0.12.7_8098. Msg: {INTERNAL=Caught exception while processing query}. Stats: {...}
```

**After**
```
Failed to execute operator chain: Error block from stage 2 worker 0 on Server_10.0.12.7_8098. Msg: {INTERNAL=Caught exception while processing query}. Stats: {...}
```

When the origin is undetermined (e.g. an error built outside a query thread context), the fields render as `"stageId":-1,"workerId":-1,"serverId":null` in `toString()` and as `from stage -1 worker -1 on unknown` in the `OpChainSchedulerService` message.

## Testing

- New unit test `ErrorMseBlockTest` covers both the populated-provenance and unknown-origin (`-1`/`null`) rendering of `toString()`.
- `spotless`, `checkstyle` and `license` checks pass on `pinot-query-runtime`.
