### PR TITLE
Fix docker-compose demo so cluster state and data survive restarts

### DIFF
--- a/docker/images/pinot/docker-compose.yml
+++ b/docker/images/pinot/docker-compose.yml
@@ -50,6 +50,8 @@ services:
       # Cluster settings
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       CLUSTER_ID: pinot-kafka-cluster-001
+      # Persist Kafka logs to the mounted volume (default is /tmp/kraft-combined-logs, which is ephemeral)
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
     volumes:
       - ./pinot-docker-demo/kafka/data:/var/lib/kafka/data
   pinot-controller:
@@ -59,7 +61,7 @@ services:
       - ./pinot-docker-demo/pinot/controller:/tmp/data/controller
     ports:
       - "9000:9000"
-    command: StartController -zkAddress zookeeper:2181
+    command: StartController -zkAddress zookeeper:2181 -controllerHost pinot-controller -dataDir /tmp/data/controller
     depends_on:
       - zookeeper
       - kafka
@@ -68,7 +70,7 @@ services:
     hostname: pinot-broker
     ports:
       - "8099:8099"
-    command: StartBroker -zkAddress zookeeper:2181
+    command: StartBroker -zkAddress zookeeper:2181 -brokerHost pinot-broker
     depends_on:
       - zookeeper
       - kafka
@@ -80,7 +82,7 @@ services:
       - ./pinot-docker-demo/pinot/server:/tmp/data/server
     ports:
       - "8098:8098"
-    command: StartServer -zkAddress zookeeper:2181
+    command: StartServer -zkAddress zookeeper:2181 -serverHost pinot-server -dataDir /tmp/data/server/data -segmentDir /tmp/data/server/segments
     depends_on:
       - zookeeper
       - kafka
@@ -92,7 +94,7 @@ services:
       - ./pinot-docker-demo/pinot/minion:/tmp/data/minion
     ports:
       - "9514:9514"
-    command: StartMinion -zkAddress zookeeper:2181
+    command: StartMinion -zkAddress zookeeper:2181 -minionHost pinot-minion
     depends_on:
       - zookeeper
       - kafka


### PR DESCRIPTION
## Problem

The docker-compose demo under `docker/images/pinot` breaks after a `docker compose down && up`. Two independent root causes:

1. **Instance IDs are derived from the container IP.** No host is passed to the start commands, so each service picks up its container IP for its Helix instance ID. On restart the containers get new IPs, so every service registers under a *new* instance ID and existing segment assignments are orphaned on the now-dead instances. Symptom: segments report as unavailable and the ExternalView is empty even though the ideal state looks fine.

2. **The data bind mounts point at container paths the processes don't use.** The controller actually writes to `/tmp/data/PinotController`, the server to `/tmp/data/pinotServerData` + `/tmp/data/pinotSegments`, and Kafka to `/tmp/kraft-combined-logs` — none of which are the mounted volumes. So all data lives on the ephemeral container layer and is lost on `down`. Only the ZooKeeper mount was correct.

The combination means even the cluster metadata that *does* survive (in ZooKeeper) points at instances and segment data that no longer exist after a restart.

## Fix

- Pass `-controllerHost` / `-brokerHost` / `-serverHost` / `-minionHost` so instance IDs are tied to the stable compose `hostname:` values instead of the container IP.
- Align each process's data directory to its mounted volume via `-dataDir` / `-segmentDir` (controller, server) and `KAFKA_LOG_DIRS` (Kafka), so segment data, the deep store, and Kafka logs persist across restarts.

## Verification

With the patched compose:

1. Created a realtime `transcript` table, produced records, and force-committed a segment.
2. Confirmed the committed segment and Kafka logs land in the mounted host directories (previously empty).
3. Ran `docker compose down && docker compose up -d` **without** wiping ZooKeeper.

Result: all instances came back with identical stable IDs (`Server_pinot-server_8098`, etc.), the committed segment returned to `ONLINE` on the same server, and queries returned the expected rows (`SELECT count(*)` → 12, no exceptions). Before the fix, the same restart left the segment orphaned/`ERROR` and unqueryable.