### PR TITLE
Add support for RANGE window frames with offset PRECEDING / FOLLOWING bounds

### DIFF
--- a/pinot-common/src/main/proto/plan.proto
+++ b/pinot-common/src/main/proto/plan.proto
@@ -266,6 +266,14 @@ message WindowNode {
   int32 upperBound = 6;
   repeated Literal constants = 7;
   WindowExclusion exclude = 8;
+  // Value-based frame offsets for RANGE frames with an offset PRECEDING / FOLLOWING bound (e.g. RANGE BETWEEN 5
+  // PRECEDING AND 5 FOLLOWING). Only set when the corresponding bound is an offset bound of a RANGE frame; absent for
+  // ROWS frames and for RANGE frames whose bounds are all UNBOUNDED / CURRENT ROW. For such offset bounds, lowerBound /
+  // upperBound above are set to a sign-only discriminator (-1 for PRECEDING, +1 for FOLLOWING) and the actual value
+  // distance is carried here. Message-typed for proto3 field presence (hasLowerBoundOffset/hasUpperBoundOffset), so
+  // absence is distinguishable and old peers keep the legacy int-bound behavior.
+  Literal lowerBoundOffset = 9;
+  Literal upperBoundOffset = 10;
 }
 
 // A node that doesn't carry semantic information.

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -1572,6 +1572,13 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
             + "ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING) AS SumAirlineDelayInWindow FROM mytable;";
     jsonNode = postQuery(query);
     assertNoError(jsonNode);
+
+    // Value-based RANGE offset frame (RANGE BETWEEN n PRECEDING AND n FOLLOWING).
+    query =
+        "SELECT AirlineID, ArrDelay, DaysSinceEpoch, SUM(ArrDelay) OVER(PARTITION BY AirlineID ORDER BY DaysSinceEpoch "
+            + "RANGE BETWEEN 3 PRECEDING AND 3 FOLLOWING) AS SumAirlineDelayInRange FROM mytable;";
+    jsonNode = postQuery(query);
+    assertNoError(jsonNode);
   }
 
   @Test

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotRuleUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotRuleUtils.java
@@ -25,6 +25,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.calcite.plan.Contexts;
 import org.apache.calcite.plan.hep.HepRelVertex;
+import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.Exchange;
@@ -34,6 +35,7 @@ import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.core.Window;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
@@ -42,6 +44,7 @@ import org.apache.calcite.rex.RexWindowBound;
 import org.apache.calcite.rex.RexWindowBounds;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
@@ -154,7 +157,7 @@ public class PinotRuleUtils {
       validateWindowAggCallsSupported(windowGroup);
 
       // Validate the frame
-      validateWindowFrames(windowGroup);
+      validateWindowFrames(window, windowGroup);
     }
 
     /**
@@ -228,16 +231,35 @@ public class PinotRuleUtils {
       }
     }
 
-    private static void validateWindowFrames(Window.Group windowGroup) {
+    private static void validateWindowFrames(Window window, Window.Group windowGroup) {
+      if (windowGroup.isRows) {
+        // ROWS frames support any (physical row count) offset bounds.
+        return;
+      }
+
       RexWindowBound lowerBound = windowGroup.lowerBound;
       RexWindowBound upperBound = windowGroup.upperBound;
-
-      boolean hasOffset = (lowerBound.isPreceding() && !lowerBound.isUnbounded()) || (upperBound.isFollowing()
-          && !upperBound.isUnbounded());
-
-      if (!windowGroup.isRows) {
-        Preconditions.checkState(!hasOffset, "RANGE window frame with offset PRECEDING / FOLLOWING is not supported");
+      boolean lowerIsOffset = !lowerBound.isUnbounded() && !lowerBound.isCurrentRow();
+      boolean upperIsOffset = !upperBound.isUnbounded() && !upperBound.isCurrentRow();
+      if (!lowerIsOffset && !upperIsOffset) {
+        // RANGE frame with only UNBOUNDED / CURRENT ROW bounds is always supported.
+        return;
       }
+
+      // Value-based RANGE offset frame (e.g. RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING). Calcite already guarantees a
+      // single ORDER BY key and an offset type compatible with the key's type family for RANGE offset frames, but we
+      // re-assert the single-key requirement and additionally restrict support to numeric ORDER BY keys (temporal /
+      // INTERVAL offsets are not yet supported by the runtime).
+      List<RelFieldCollation> orderKeys = windowGroup.orderKeys.getFieldCollations();
+      Preconditions.checkState(orderKeys.size() == 1,
+          "RANGE window frame with offset PRECEDING / FOLLOWING requires exactly one ORDER BY key, got %s order keys",
+          orderKeys.size());
+      int orderKeyIndex = orderKeys.get(0).getFieldIndex();
+      RelDataType orderKeyType = window.getInput().getRowType().getFieldList().get(orderKeyIndex).getType();
+      SqlTypeName orderKeyTypeName = orderKeyType.getSqlTypeName();
+      Preconditions.checkState(SqlTypeName.NUMERIC_TYPES.contains(orderKeyTypeName),
+          "RANGE window frame with offset PRECEDING / FOLLOWING is only supported for numeric ORDER BY keys, got: %s",
+          orderKeyTypeName);
     }
 
     @Nullable

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/explain/PlanNodeMerger.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/explain/PlanNodeMerger.java
@@ -438,6 +438,12 @@ class PlanNodeMerger {
       if (node.getExclude() != otherNode.getExclude()) {
         return null;
       }
+      if (!Objects.equals(node.getLowerBoundOffset(), otherNode.getLowerBoundOffset())) {
+        return null;
+      }
+      if (!Objects.equals(node.getUpperBoundOffset(), otherNode.getUpperBoundOffset())) {
+        return null;
+      }
       if (!node.getConstants().equals(otherNode.getConstants())) {
         return null;
       }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/PlanNodeToRelConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/PlanNodeToRelConverter.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelCollation;
@@ -375,7 +376,8 @@ public final class PlanNodeToRelConverter {
         }
 
         Window.Group group =
-            new Window.Group(keys, isRow, getWindowBound(node.getLowerBound()), getWindowBound(node.getUpperBound()),
+            new Window.Group(keys, isRow, getWindowBound(node.getLowerBound(), node.getLowerBoundOffset()),
+                getWindowBound(node.getUpperBound(), node.getUpperBoundOffset()),
                 toRexWindowExclusion(node.getExclude()), orderKeys, aggCalls);
 
         List<RexLiteral> constants =
@@ -409,13 +411,18 @@ public final class PlanNodeToRelConverter {
       }
     }
 
-    private RexWindowBound getWindowBound(int bound) {
+    private RexWindowBound getWindowBound(int bound, @Nullable RexExpression.Literal rangeOffset) {
       if (bound == Integer.MIN_VALUE) {
         return RexWindowBounds.UNBOUNDED_PRECEDING;
       } else if (bound == Integer.MAX_VALUE) {
         return RexWindowBounds.UNBOUNDED_FOLLOWING;
       } else if (bound == 0) {
         return RexWindowBounds.CURRENT_ROW;
+      } else if (rangeOffset != null) {
+        // RANGE offset bound: the int is only a sign discriminator (-1 preceding, +1 following); the actual value
+        // distance is carried by the offset literal.
+        RexNode offset = RexExpressionUtils.toRexLiteral(_builder, rangeOffset);
+        return bound < 0 ? RexWindowBounds.preceding(offset) : RexWindowBounds.following(offset);
       } else if (bound < 0) {
         return RexWindowBounds.preceding(_builder.literal(-bound));
       } else {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
@@ -655,32 +655,12 @@ public final class RelToPlanNodeConverter {
     WindowNode.WindowFrameType windowFrameType =
         windowGroup.isRows ? WindowNode.WindowFrameType.ROWS : WindowNode.WindowFrameType.RANGE;
 
-    int lowerBound;
-    if (windowGroup.lowerBound.isUnbounded()) {
-      // Lower bound can't be unbounded following
-      lowerBound = Integer.MIN_VALUE;
-    } else if (windowGroup.lowerBound.isCurrentRow()) {
-      lowerBound = 0;
-    } else {
-      // The literal value is extracted from the constants in the PinotWindowExchangeNodeInsertRule
-      RexLiteral offset = (RexLiteral) windowGroup.lowerBound.getOffset();
-      lowerBound = offset == null ? Integer.MIN_VALUE
-          : (windowGroup.lowerBound.isPreceding() ? -1 * RexExpressionUtils.getValueAsInt(offset)
-              : RexExpressionUtils.getValueAsInt(offset));
-    }
-    int upperBound;
-    if (windowGroup.upperBound.isUnbounded()) {
-      // Upper bound can't be unbounded preceding
-      upperBound = Integer.MAX_VALUE;
-    } else if (windowGroup.upperBound.isCurrentRow()) {
-      upperBound = 0;
-    } else {
-      // The literal value is extracted from the constants in the PinotWindowExchangeNodeInsertRule
-      RexLiteral offset = (RexLiteral) windowGroup.upperBound.getOffset();
-      upperBound = offset == null ? Integer.MAX_VALUE
-          : (windowGroup.upperBound.isFollowing() ? RexExpressionUtils.getValueAsInt(offset)
-              : -1 * RexExpressionUtils.getValueAsInt(offset));
-    }
+    // The offset literal values are extracted from the constants in the PinotWindowExchangeNodeInsertRule. For RANGE
+    // offset bounds the offset is a value distance on the ORDER BY key (carried separately), not a row count.
+    RexExpressionUtils.WindowFrameBound lower =
+        RexExpressionUtils.convertWindowFrameBound(windowGroup.lowerBound, windowGroup.isRows, true);
+    RexExpressionUtils.WindowFrameBound upper =
+        RexExpressionUtils.convertWindowFrameBound(windowGroup.upperBound, windowGroup.isRows, false);
 
     // TODO: The constants are already extracted in the PinotWindowExchangeNodeInsertRule, we can remove them from
     // the WindowNode and plan serde.
@@ -690,7 +670,8 @@ public final class RelToPlanNodeConverter {
     }
     return new WindowNode(DEFAULT_STAGE_ID, toDataSchema(node.getRowType()), NodeHint.fromRelHints(node.getHints()),
         convertInputs(node.getInputs()), windowGroup.keys.asList(), windowGroup.orderKeys.getFieldCollations(),
-        aggCalls, windowFrameType, lowerBound, upperBound, fromRexWindowExclusion(windowGroup.exclude), constants);
+        aggCalls, windowFrameType, lower.getBound(), upper.getBound(), fromRexWindowExclusion(windowGroup.exclude),
+        lower.getRangeOffset(), upper.getRangeOffset(), constants);
   }
 
   public static WindowNode.WindowExclusion fromRexWindowExclusion(RexWindowExclusion exclude) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils.java
@@ -37,6 +37,7 @@ import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexUnknownAs;
+import org.apache.calcite.rex.RexWindowBound;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
@@ -537,5 +538,65 @@ public class RexExpressionUtils {
     Preconditions.checkArgument(in instanceof RexLiteral, "expected literal, got " + in);
     RexLiteral literal = (RexLiteral) in;
     return literal.getValueAs(Integer.class);
+  }
+
+  /**
+   * Converts a Calcite window frame {@link RexWindowBound} into Pinot's {@link WindowFrameBound} representation.
+   * <p>For ROWS frames and for RANGE bounds that are UNBOUNDED / CURRENT ROW, the offset is a physical row count and
+   * only the int bound is meaningful ({@link WindowFrameBound#getRangeOffset()} is null). For a RANGE offset
+   * PRECEDING / FOLLOWING bound the offset is a value distance on the single ORDER BY key rather than a row count, so
+   * the int bound is only a sign discriminator ({@code -1} for PRECEDING, {@code +1} for FOLLOWING) and the actual
+   * value distance is returned as a {@link RexExpression.Literal}.
+   * <p>The offset {@link RexLiteral} is expected to already be inlined by
+   * {@code PinotRuleUtils.WindowUtils.updateLiteralArgumentsInWindowGroup} (it is originally a reference into the
+   * window's constants pool).
+   *
+   * @param bound the Calcite window frame bound
+   * @param isRows whether the frame is a ROWS frame (vs a RANGE frame)
+   * @param isLowerBound whether this is the lower (start) bound; controls the UNBOUNDED sentinel
+   */
+  public static WindowFrameBound convertWindowFrameBound(RexWindowBound bound, boolean isRows, boolean isLowerBound) {
+    if (bound.isUnbounded()) {
+      // Lower bound can only be UNBOUNDED PRECEDING and upper bound only UNBOUNDED FOLLOWING (ensured by Calcite)
+      return new WindowFrameBound(isLowerBound ? Integer.MIN_VALUE : Integer.MAX_VALUE, null);
+    }
+    if (bound.isCurrentRow()) {
+      return new WindowFrameBound(0, null);
+    }
+    RexLiteral offset = (RexLiteral) bound.getOffset();
+    boolean preceding = bound.isPreceding();
+    if (isRows) {
+      // ROWS offset: the value is a physical row count. Preserve the historical signed-int representation.
+      int rowOffset = offset == null ? (isLowerBound ? Integer.MIN_VALUE : Integer.MAX_VALUE)
+          : (preceding ? -1 * getValueAsInt(offset) : getValueAsInt(offset));
+      return new WindowFrameBound(rowOffset, null);
+    }
+    // RANGE offset: carry the typed value distance; the int bound is only a sign discriminator.
+    Preconditions.checkState(offset != null, "RANGE window frame offset bound must have a literal offset value");
+    return new WindowFrameBound(preceding ? -1 : 1, fromRexLiteral(offset));
+  }
+
+  /**
+   * Pinot representation of a single window frame bound: an int bound (physical row offset for ROWS, or a sentinel /
+   * sign discriminator for RANGE) plus, for RANGE offset bounds, the typed value distance.
+   */
+  public static class WindowFrameBound {
+    private final int _bound;
+    @Nullable
+    private final RexExpression.Literal _rangeOffset;
+
+    public WindowFrameBound(int bound, @Nullable RexExpression.Literal rangeOffset) {
+      _bound = bound;
+      _rangeOffset = rangeOffset;
+    }
+
+    public int getBound() {
+      return _bound;
+    }
+
+    @Nullable
+    public RexExpression.Literal getRangeOffset() {
+      return _rangeOffset;
+    }
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/PRelToPlanNodeConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/PRelToPlanNodeConverter.java
@@ -154,32 +154,12 @@ public class PRelToPlanNodeConverter {
     WindowNode.WindowFrameType windowFrameType =
         windowGroup.isRows ? WindowNode.WindowFrameType.ROWS : WindowNode.WindowFrameType.RANGE;
 
-    int lowerBound;
-    if (windowGroup.lowerBound.isUnbounded()) {
-      // Lower bound can't be unbounded following
-      lowerBound = Integer.MIN_VALUE;
-    } else if (windowGroup.lowerBound.isCurrentRow()) {
-      lowerBound = 0;
-    } else {
-      // The literal value is extracted from the constants in the PinotWindowExchangeNodeInsertRule
-      RexLiteral offset = (RexLiteral) windowGroup.lowerBound.getOffset();
-      lowerBound = offset == null ? Integer.MIN_VALUE
-          : (windowGroup.lowerBound.isPreceding() ? -1 * RexExpressionUtils.getValueAsInt(offset)
-              : RexExpressionUtils.getValueAsInt(offset));
-    }
-    int upperBound;
-    if (windowGroup.upperBound.isUnbounded()) {
-      // Upper bound can't be unbounded preceding
-      upperBound = Integer.MAX_VALUE;
-    } else if (windowGroup.upperBound.isCurrentRow()) {
-      upperBound = 0;
-    } else {
-      // The literal value is extracted from the constants in the PinotWindowExchangeNodeInsertRule
-      RexLiteral offset = (RexLiteral) windowGroup.upperBound.getOffset();
-      upperBound = offset == null ? Integer.MAX_VALUE
-          : (windowGroup.upperBound.isFollowing() ? RexExpressionUtils.getValueAsInt(offset)
-              : -1 * RexExpressionUtils.getValueAsInt(offset));
-    }
+    // The offset literal values are extracted from the constants in the PinotWindowExchangeNodeInsertRule. For RANGE
+    // offset bounds the offset is a value distance on the ORDER BY key (carried separately), not a row count.
+    RexExpressionUtils.WindowFrameBound lower =
+        RexExpressionUtils.convertWindowFrameBound(windowGroup.lowerBound, windowGroup.isRows, true);
+    RexExpressionUtils.WindowFrameBound upper =
+        RexExpressionUtils.convertWindowFrameBound(windowGroup.upperBound, windowGroup.isRows, false);
 
     // TODO: The constants are already extracted in the PinotWindowExchangeNodeInsertRule, we can remove them from
     // the WindowNode and plan serde.
@@ -189,8 +169,9 @@ public class PRelToPlanNodeConverter {
     }
     return new WindowNode(DEFAULT_STAGE_ID, toDataSchema(node.getRowType()), NodeHint.fromRelHints(node.getHints()),
         new ArrayList<>(), windowGroup.keys.asList(), windowGroup.orderKeys.getFieldCollations(),
-        aggCalls, windowFrameType, lowerBound, upperBound,
-        RelToPlanNodeConverter.fromRexWindowExclusion(windowGroup.exclude), constants);
+        aggCalls, windowFrameType, lower.getBound(), upper.getBound(),
+        RelToPlanNodeConverter.fromRexWindowExclusion(windowGroup.exclude), lower.getRangeOffset(),
+        upper.getRangeOffset(), constants);
   }
 
   public static SortNode convertSort(Sort node) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/WindowNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/WindowNode.java
@@ -20,6 +20,7 @@ package org.apache.pinot.query.planner.plannode;
 
 import java.util.List;
 import java.util.Objects;
+import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
@@ -30,17 +31,35 @@ public class WindowNode extends BasePlanNode {
   private final List<RelFieldCollation> _collations;
   private final List<RexExpression.FunctionCall> _aggCalls;
   private final WindowFrameType _windowFrameType;
-  // Both these bounds are relative to current row; 0 means current row, -1 means previous row, 1 means next row, etc.
-  // Integer.MIN_VALUE represents UNBOUNDED PRECEDING which is only allowed for the lower bound (ensured by Calcite).
-  // Integer.MAX_VALUE represents UNBOUNDED FOLLOWING which is only allowed for the upper bound (ensured by Calcite).
+  // For ROWS frames, both bounds are physical row offsets relative to current row: 0 means current row, -1 means
+  // previous row, 1 means next row, etc. Integer.MIN_VALUE represents UNBOUNDED PRECEDING (only allowed for the lower
+  // bound) and Integer.MAX_VALUE represents UNBOUNDED FOLLOWING (only allowed for the upper bound).
+  // For RANGE frames, the offset (if any) is a value distance on the single ORDER BY key, not a row count, and is
+  // carried by _lowerBoundOffset / _upperBoundOffset below. In that case the int bound is only a discriminator:
+  // Integer.MIN_VALUE / Integer.MAX_VALUE for UNBOUNDED, 0 for CURRENT ROW, -1 for an offset PRECEDING bound and +1 for
+  // an offset FOLLOWING bound (the magnitude is meaningless; read the value from the offset literal instead).
   private final int _lowerBound;
   private final int _upperBound;
   private final WindowExclusion _exclude;
+  // Value-based RANGE frame offsets. Non-null only for a RANGE frame bound that is an offset PRECEDING / FOLLOWING
+  // bound; null for ROWS frames and for RANGE bounds that are UNBOUNDED / CURRENT ROW.
+  @Nullable
+  private final RexExpression.Literal _lowerBoundOffset;
+  @Nullable
+  private final RexExpression.Literal _upperBoundOffset;
   private final List<RexExpression.Literal> _constants;
 
   public WindowNode(int stageId, DataSchema dataSchema, NodeHint nodeHint, List<PlanNode> inputs, List<Integer> keys,
       List<RelFieldCollation> collations, List<RexExpression.FunctionCall> aggCalls, WindowFrameType windowFrameType,
       int lowerBound, int upperBound, WindowExclusion exclude, List<RexExpression.Literal> constants) {
+    this(stageId, dataSchema, nodeHint, inputs, keys, collations, aggCalls, windowFrameType, lowerBound, upperBound,
+        exclude, null, null, constants);
+  }
+
+  public WindowNode(int stageId, DataSchema dataSchema, NodeHint nodeHint, List<PlanNode> inputs, List<Integer> keys,
+      List<RelFieldCollation> collations, List<RexExpression.FunctionCall> aggCalls, WindowFrameType windowFrameType,
+      int lowerBound, int upperBound, WindowExclusion exclude, @Nullable RexExpression.Literal lowerBoundOffset,
+      @Nullable RexExpression.Literal upperBoundOffset, List<RexExpression.Literal> constants) {
     super(stageId, dataSchema, nodeHint, inputs);
     _keys = keys;
     _collations = collations;
@@ -49,6 +68,8 @@ public class WindowNode extends BasePlanNode {
     _lowerBound = lowerBound;
     _upperBound = upperBound;
     _exclude = exclude;
+    _lowerBoundOffset = lowerBoundOffset;
+    _upperBoundOffset = upperBoundOffset;
     _constants = constants;
   }
 
@@ -80,6 +101,16 @@ public class WindowNode extends BasePlanNode {
     return _exclude;
   }
 
+  @Nullable
+  public RexExpression.Literal getLowerBoundOffset() {
+    return _lowerBoundOffset;
+  }
+
+  @Nullable
+  public RexExpression.Literal getUpperBoundOffset() {
+    return _upperBoundOffset;
+  }
+
   public List<RexExpression.Literal> getConstants() {
     return _constants;
   }
@@ -97,7 +128,7 @@ public class WindowNode extends BasePlanNode {
   @Override
   public PlanNode withInputs(List<PlanNode> inputs) {
     return new WindowNode(_stageId, _dataSchema, _nodeHint, inputs, _keys, _collations, _aggCalls, _windowFrameType,
-        _lowerBound, _upperBound, _exclude, _constants);
+        _lowerBound, _upperBound, _exclude, _lowerBoundOffset, _upperBoundOffset, _constants);
   }
 
   @Override
@@ -115,13 +146,14 @@ public class WindowNode extends BasePlanNode {
     return _lowerBound == that._lowerBound && _upperBound == that._upperBound && Objects.equals(_aggCalls,
         that._aggCalls) && Objects.equals(_keys, that._keys) && Objects.equals(_collations, that._collations)
         && _windowFrameType == that._windowFrameType && _exclude == that._exclude
-        && Objects.equals(_constants, that._constants);
+        && Objects.equals(_lowerBoundOffset, that._lowerBoundOffset)
+        && Objects.equals(_upperBoundOffset, that._upperBoundOffset) && Objects.equals(_constants, that._constants);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode(), _aggCalls, _keys, _collations, _windowFrameType, _lowerBound, _upperBound,
-        _exclude, _constants);
+        _exclude, _lowerBoundOffset, _upperBoundOffset, _constants);
   }
 
   /**

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/PlanNodeDeserializer.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/PlanNodeDeserializer.java
@@ -209,12 +209,18 @@ public class PlanNodeDeserializer {
 
   private static WindowNode deserializeWindowNode(Plan.PlanNode protoNode) {
     Plan.WindowNode protoWindowNode = protoNode.getWindowNode();
+    // Value-based offsets for RANGE offset frames. Absent (hasXxx() == false) for ROWS frames, UNBOUNDED / CURRENT ROW
+    // bounds, and plans serialized by older brokers that predate RANGE offset support.
+    RexExpression.Literal lowerBoundOffset = protoWindowNode.hasLowerBoundOffset()
+        ? ProtoExpressionToRexExpression.convertLiteral(protoWindowNode.getLowerBoundOffset()) : null;
+    RexExpression.Literal upperBoundOffset = protoWindowNode.hasUpperBoundOffset()
+        ? ProtoExpressionToRexExpression.convertLiteral(protoWindowNode.getUpperBoundOffset()) : null;
     return new WindowNode(protoNode.getStageId(), extractDataSchema(protoNode), extractNodeHint(protoNode),
         extractInputs(protoNode), protoWindowNode.getKeysList(), convertCollations(protoWindowNode.getCollationsList()),
         convertFunctionCalls(protoWindowNode.getAggCallsList()),
         convertWindowFrameType(protoWindowNode.getWindowFrameType()), protoWindowNode.getLowerBound(),
-        protoWindowNode.getUpperBound(), convertWindowExclusion(protoWindowNode.getExclude()),
-        convertLiterals(protoWindowNode.getConstantsList()));
+        protoWindowNode.getUpperBound(), convertWindowExclusion(protoWindowNode.getExclude()), lowerBoundOffset,
+        upperBoundOffset, convertLiterals(protoWindowNode.getConstantsList()));
   }
 
   private static ExplainedNode deserializeExplainedNode(Plan.PlanNode protoNode) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/PlanNodeSerializer.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/PlanNodeSerializer.java
@@ -254,7 +254,7 @@ public class PlanNodeSerializer {
 
     @Override
     public Void visitWindow(WindowNode node, Plan.PlanNode.Builder builder) {
-      Plan.WindowNode windowNode = Plan.WindowNode.newBuilder()
+      Plan.WindowNode.Builder windowNodeBuilder = Plan.WindowNode.newBuilder()
           .addAllAggCalls(convertFunctionCalls(node.getAggCalls()))
           .addAllKeys(node.getKeys())
           .addAllCollations(convertCollations(node.getCollations()))
@@ -262,9 +262,17 @@ public class PlanNodeSerializer {
           .setLowerBound(node.getLowerBound())
           .setUpperBound(node.getUpperBound())
           .setExclude(convertWindowExclusion(node.getExclude()))
-          .addAllConstants(convertLiterals(node.getConstants()))
-          .build();
-      builder.setWindowNode(windowNode);
+          .addAllConstants(convertLiterals(node.getConstants()));
+      // Value-based offsets for RANGE offset frames (absent for ROWS / UNBOUNDED / CURRENT ROW bounds).
+      RexExpression.Literal lowerBoundOffset = node.getLowerBoundOffset();
+      if (lowerBoundOffset != null) {
+        windowNodeBuilder.setLowerBoundOffset(RexExpressionToProtoExpression.convertLiteral(lowerBoundOffset));
+      }
+      RexExpression.Literal upperBoundOffset = node.getUpperBoundOffset();
+      if (upperBoundOffset != null) {
+        windowNodeBuilder.setUpperBoundOffset(RexExpressionToProtoExpression.convertLiteral(upperBoundOffset));
+      }
+      builder.setWindowNode(windowNodeBuilder.build());
       return null;
     }
 

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
@@ -757,13 +757,25 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
             + "FROM a";
     _queryEnvironment.planQuery(queryWithValidBounds);
 
-    // Custom RANGE window frame is not currently supported by Pinot
-    String sumQueryWithCustomRangeWindow =
+    // Value-based RANGE window frames with a numeric ORDER BY key are supported.
+    String sumQueryWithRangeOffsetUnboundedPrecedingAndFollowing =
         "SELECT col1, col2, SUM(col3) OVER (PARTITION BY col1 ORDER BY col3 RANGE BETWEEN UNBOUNDED PRECEDING AND 1 "
             + "FOLLOWING) FROM a";
-    e = expectThrows(RuntimeException.class, () -> _queryEnvironment.planQuery(sumQueryWithCustomRangeWindow));
+    _queryEnvironment.planQuery(sumQueryWithRangeOffsetUnboundedPrecedingAndFollowing);
+
+    String sumQueryWithRangeOffsetPrecedingAndFollowing =
+        "SELECT col1, col2, SUM(col3) OVER (PARTITION BY col1 ORDER BY col3 RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING) "
+            + "FROM a";
+    _queryEnvironment.planQuery(sumQueryWithRangeOffsetPrecedingAndFollowing);
+
+    // Value-based RANGE offset frames are only supported for numeric ORDER BY keys. A temporal ORDER BY key with an
+    // INTERVAL offset is accepted by Calcite but rejected by Pinot for now.
+    String rangeOffsetWithTimestampOrderKey =
+        "SELECT col1, SUM(col3) OVER (ORDER BY ts_timestamp RANGE BETWEEN INTERVAL '1' DAY PRECEDING AND CURRENT ROW) "
+            + "FROM a";
+    e = expectThrows(RuntimeException.class, () -> _queryEnvironment.planQuery(rangeOffsetWithTimestampOrderKey));
     assertTrue(e.getCause().getMessage()
-        .contains("RANGE window frame with offset PRECEDING / FOLLOWING is not supported"));
+        .contains("RANGE window frame with offset PRECEDING / FOLLOWING is only supported for numeric ORDER BY keys"));
 
     // RANK, DENSE_RANK, ROW_NUMBER, NTILE, LAG, LEAD with custom window frame are invalid
     String rankQuery =

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/serde/PlanNodeSerDeTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/serde/PlanNodeSerDeTest.java
@@ -20,6 +20,8 @@ package org.apache.pinot.query.planner.serde;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.QueryEnvironmentTestBase;
@@ -28,6 +30,7 @@ import org.apache.pinot.query.planner.physical.DispatchablePlanFragment;
 import org.apache.pinot.query.planner.physical.DispatchableSubPlan;
 import org.apache.pinot.query.planner.plannode.PlanNode;
 import org.apache.pinot.query.planner.plannode.UnnestNode;
+import org.apache.pinot.query.planner.plannode.WindowNode;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -43,6 +46,43 @@ public class PlanNodeSerDeTest extends QueryEnvironmentTestBase {
       PlanNode deserializedStagePlan = PlanNodeDeserializer.process(PlanNodeSerializer.process(stagePlan));
       assertEquals(stagePlan, deserializedStagePlan);
     }
+  }
+
+  @Test
+  public void testRangeOffsetWindowNodeSerDe() {
+    // Round-trips the value-based RANGE offset frame wire fields (lowerBoundOffset / upperBoundOffset). The int bounds
+    // are sign discriminators (-1 PRECEDING, +1 FOLLOWING) and the value distances are carried by the Literal fields.
+    DataSchema dataSchema = new DataSchema(new String[]{"key", "value", "sum"},
+        new ColumnDataType[]{ColumnDataType.INT, ColumnDataType.INT, ColumnDataType.DOUBLE});
+    RexExpression.FunctionCall sum =
+        new RexExpression.FunctionCall(ColumnDataType.INT, SqlKind.SUM.name(), List.of(new RexExpression.InputRef(1)));
+    WindowNode node = new WindowNode(1, dataSchema, PlanNode.NodeHint.EMPTY, new ArrayList<>(), List.of(),
+        List.of(new RelFieldCollation(0)), List.of(sum), WindowNode.WindowFrameType.RANGE, -1, 1,
+        WindowNode.WindowExclusion.NO_OTHERS, new RexExpression.Literal(ColumnDataType.INT, 5),
+        new RexExpression.Literal(ColumnDataType.INT, 10), List.of());
+
+    WindowNode deserialized = (WindowNode) PlanNodeDeserializer.process(PlanNodeSerializer.process(node));
+    assertEquals(deserialized, node);
+    assertEquals(deserialized.getLowerBoundOffset(), new RexExpression.Literal(ColumnDataType.INT, 5));
+    assertEquals(deserialized.getUpperBoundOffset(), new RexExpression.Literal(ColumnDataType.INT, 10));
+  }
+
+  @Test
+  public void testLegacyWindowNodeSerDe() {
+    // A ROWS / non-offset-RANGE WindowNode must round-trip with null offset fields (the wire default an old broker
+    // produces), preserving the historical int-bound behavior.
+    DataSchema dataSchema = new DataSchema(new String[]{"key", "value", "sum"},
+        new ColumnDataType[]{ColumnDataType.INT, ColumnDataType.INT, ColumnDataType.DOUBLE});
+    RexExpression.FunctionCall sum =
+        new RexExpression.FunctionCall(ColumnDataType.INT, SqlKind.SUM.name(), List.of(new RexExpression.InputRef(1)));
+    WindowNode node = new WindowNode(1, dataSchema, PlanNode.NodeHint.EMPTY, new ArrayList<>(), List.of(),
+        List.of(new RelFieldCollation(0)), List.of(sum), WindowNode.WindowFrameType.ROWS, -2, 2,
+        WindowNode.WindowExclusion.NO_OTHERS, List.of());
+
+    WindowNode deserialized = (WindowNode) PlanNodeDeserializer.process(PlanNodeSerializer.process(node));
+    assertEquals(deserialized, node);
+    assertEquals(deserialized.getLowerBoundOffset(), null);
+    assertEquals(deserialized.getUpperBoundOffset(), null);
   }
 
   @Test

--- a/pinot-query-planner/src/test/resources/queries/WindowFunctionPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/WindowFunctionPlans.json
@@ -3541,6 +3541,20 @@
         ]
       },
       {
+        "description": "Custom RANGE based window frame with offset PRECEDING / FOLLOWING",
+        "sql": "EXPLAIN PLAN FOR SELECT AVG(a.col3) OVER(PARTITION BY a.col1 ORDER BY a.col3 RANGE BETWEEN 5 PRECEDING AND 10 FOLLOWING) FROM a WHERE a.col3 >= 0",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(EXPR$0=[$2])",
+          "\n  LogicalWindow(window#0=[window(partition {0} order by [1] range between 5 PRECEDING and 10 FOLLOWING aggs [AVG($1)])], constants=[[5, 10]])",
+          "\n    PinotLogicalSortExchange(distribution=[hash[0]], collation=[[1]], isSortOnSender=[false], isSortOnReceiver=[true])",
+          "\n      LogicalProject(col1=[$0], col3=[$2])",
+          "\n        LogicalFilter(condition=[>=($2, 0)])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
+          "\n"
+        ]
+      },
+      {
         "description": "Custom RANGE based window frame with ORDER BY",
         "sql": "EXPLAIN PLAN FOR SELECT MIN(a.col3) OVER(ORDER BY a.col3 RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) FROM a",
         "output": [

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperator.java
@@ -123,13 +123,15 @@ public class WindowAggregateOperator extends MultiStageOperator {
     for (int i = 0; i < numKeys; i++) {
       _keys[i] = keys.get(i);
     }
-    WindowFrame windowFrame =
-        new WindowFrame(node.getWindowFrameType(), node.getLowerBound(), node.getUpperBound(), node.getExclude());
-    Preconditions.checkState(
-        windowFrame.isRowType() || ((windowFrame.isUnboundedPreceding() || windowFrame.isLowerBoundCurrentRow()) && (
-            windowFrame.isUnboundedFollowing() || windowFrame.isUpperBoundCurrentRow())),
-        "RANGE window frame with offset PRECEDING / FOLLOWING is not supported");
-    Preconditions.checkState(windowFrame.getLowerBound() <= windowFrame.getUpperBound(),
+    RexExpression.Literal lowerBoundOffset = node.getLowerBoundOffset();
+    RexExpression.Literal upperBoundOffset = node.getUpperBoundOffset();
+    WindowFrame windowFrame = new WindowFrame(node.getWindowFrameType(), node.getLowerBound(), node.getUpperBound(),
+        node.getExclude(), lowerBoundOffset != null ? (Number) lowerBoundOffset.getValue() : null,
+        upperBoundOffset != null ? (Number) upperBoundOffset.getValue() : null);
+    // The lower <= upper check only applies to ROWS frames where the int bounds are physical row offsets. For RANGE
+    // frames the int bounds are sentinels / sign discriminators; the validity of value-based offsets and the single
+    // numeric ORDER BY key requirement are enforced during planning (see PinotRuleUtils.WindowUtils).
+    Preconditions.checkState(!windowFrame.isRowType() || windowFrame.getLowerBound() <= windowFrame.getUpperBound(),
         "Window frame lower bound can't be greater than upper bound");
     List<RelFieldCollation> collations = node.getCollations();
     List<RexExpression.FunctionCall> aggCalls = node.getAggCalls();

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/RangeWindowFrameBounds.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/RangeWindowFrameBounds.java
@@ -1,0 +1,331 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.window;
+
+import java.math.BigDecimal;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+
+
+/**
+ * Computes, for each row of a partition, the inclusive index range {@code [start, end]} of a value-based RANGE window
+ * frame with an offset PRECEDING / FOLLOWING bound (e.g. {@code RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING}).
+ *
+ * <p>Unlike a ROWS frame whose bounds are physical row counts, a RANGE frame is defined over the value of the single
+ * ORDER BY key: a row {@code R} belongs to the frame of the current row {@code C} iff {@code R}'s order-key value lies
+ * in the value interval {@code [lo, hi]} derived from {@code C}'s value and the offsets. The interval endpoints and the
+ * inequalities flip depending on the sort direction (ASC vs DESC).
+ *
+ * <p>The rows are assumed to be already sorted by the single ORDER BY key (the multi-stage window operator receives
+ * rows sorted by the collation, and RANGE offset frames require an ORDER BY clause). Because both endpoints move
+ * monotonically as the current row advances, the bounds for the whole partition are computed with a two-pointer sweep
+ * in {@code O(n)} time.
+ *
+ * <p>NULL order-key values form their own peer group. A NULL current row's frame is the NULL peer group, extended to
+ * the partition start / end when the corresponding bound is UNBOUNDED (matching PostgreSQL semantics). A non-NULL
+ * current row never includes NULL rows in its frame.
+ */
+public final class RangeWindowFrameBounds {
+  private RangeWindowFrameBounds() {
+  }
+
+  /**
+   * Computes the inclusive frame bounds for every row.
+   *
+   * @param rows the partition rows, sorted by the single ORDER BY key
+   * @param orderKeyIndex the column index of the single ORDER BY key
+   * @param orderKeyStoredType the stored type of the ORDER BY key column (must be numeric)
+   * @param ascending whether the ORDER BY key is sorted ascending
+   * @param frame the window frame
+   * @return a two-element array {@code {starts, ends}}; for row {@code i} the frame is {@code rows[starts[i]..ends[i]]}
+   *         inclusive, and the frame is empty when {@code ends[i] < starts[i]}
+   */
+  public static int[][] compute(List<Object[]> rows, int orderKeyIndex, ColumnDataType orderKeyStoredType,
+      boolean ascending, WindowFrame frame) {
+    int numRows = rows.size();
+    int[] starts = new int[numRows];
+    int[] ends = new int[numRows];
+
+    // Identify the (contiguous) NULL and non-NULL regions. NULLs are grouped at one end of the partition since there is
+    // a single ORDER BY key with a single null direction.
+    int nonNullLo = -1;
+    int nonNullHi = -1;
+    int nullLo = -1;
+    int nullHi = -1;
+    for (int i = 0; i < numRows; i++) {
+      if (rows.get(i)[orderKeyIndex] == null) {
+        if (nullLo < 0) {
+          nullLo = i;
+        }
+        nullHi = i;
+      } else {
+        if (nonNullLo < 0) {
+          nonNullLo = i;
+        }
+        nonNullHi = i;
+      }
+    }
+
+    // UNBOUNDED PRECEDING / FOLLOWING refer to position in the collation order, so they extend the frame to the
+    // partition start (index 0) / end (numRows - 1) and thus DO include leading / trailing NULL rows. CURRENT ROW and
+    // value-offset bounds are value comparisons that a NULL never satisfies, so they exclude NULL rows.
+    boolean unboundedPreceding = frame.isUnboundedPreceding();
+    boolean unboundedFollowing = frame.isUnboundedFollowing();
+
+    // NULL current rows: their (NULL) peer group, extended to the partition start / end for UNBOUNDED bounds.
+    if (nullLo >= 0) {
+      int nullStart = unboundedPreceding ? 0 : nullLo;
+      int nullEnd = unboundedFollowing ? numRows - 1 : nullHi;
+      for (int i = nullLo; i <= nullHi; i++) {
+        starts[i] = nullStart;
+        ends[i] = nullEnd;
+      }
+    }
+
+    if (nonNullLo < 0) {
+      // All rows have a NULL order key.
+      return new int[][]{starts, ends};
+    }
+
+    // Non-NULL current rows: two-pointer sweep of the value-based bounds over the non-NULL region. An UNBOUNDED side
+    // instead extends to the partition edge (index 0 / numRows - 1) to include any leading / trailing NULL rows.
+    ValueBounds bounds = createValueBounds(rows, orderKeyIndex, orderKeyStoredType, ascending, frame);
+    int start = nonNullLo;
+    int end = nonNullLo - 1;
+    for (int i = nonNullLo; i <= nonNullHi; i++) {
+      if (ascending) {
+        // Values increase with index: extend the end while rows stay within the upper value edge, then advance the
+        // start past rows below the lower value edge.
+        while (end + 1 <= nonNullHi && bounds.withinUpper(end + 1, i)) {
+          end++;
+        }
+        while (start <= end && !bounds.withinLower(start, i)) {
+          start++;
+        }
+      } else {
+        // Values decrease with index: extend the end while rows stay within the lower value edge, then advance the
+        // start past rows above the upper value edge.
+        while (end + 1 <= nonNullHi && bounds.withinLower(end + 1, i)) {
+          end++;
+        }
+        while (start <= end && !bounds.withinUpper(start, i)) {
+          start++;
+        }
+      }
+      starts[i] = unboundedPreceding ? 0 : start;
+      ends[i] = unboundedFollowing ? numRows - 1 : end;
+    }
+    return new int[][]{starts, ends};
+  }
+
+  private static ValueBounds createValueBounds(List<Object[]> rows, int orderKeyIndex,
+      ColumnDataType orderKeyStoredType, boolean ascending, WindowFrame frame) {
+    switch (orderKeyStoredType) {
+      case INT:
+      case LONG:
+        // Fast path: exact integer arithmetic with no per-row allocation. Falls back to BigDecimal for the (unusual)
+        // case of a non-integral offset on an integer order key.
+        if (isIntegral(frame.getLowerRangeOffset()) && isIntegral(frame.getUpperRangeOffset())) {
+          return new LongValueBounds(rows, orderKeyIndex, ascending, frame);
+        }
+        return new BigDecimalValueBounds(rows, orderKeyIndex, ascending, frame);
+      case BIG_DECIMAL:
+        return new BigDecimalValueBounds(rows, orderKeyIndex, ascending, frame);
+      case FLOAT:
+      case DOUBLE:
+        return new DoubleValueBounds(rows, orderKeyIndex, ascending, frame);
+      default:
+        throw new IllegalStateException(
+            "RANGE window frame with offset PRECEDING / FOLLOWING is not supported for ORDER BY key stored type: "
+                + orderKeyStoredType);
+    }
+  }
+
+  /** Whether the offset is null (not an offset bound) or an integral value. */
+  private static boolean isIntegral(@Nullable Number offset) {
+    if (offset == null || offset instanceof Integer || offset instanceof Long) {
+      return true;
+    }
+    if (offset instanceof BigDecimal) {
+      return ((BigDecimal) offset).stripTrailingZeros().scale() <= 0;
+    }
+    double value = offset.doubleValue();
+    return !Double.isInfinite(value) && value == Math.floor(value);
+  }
+
+  /** Adds two longs, saturating at {@link Long#MIN_VALUE} / {@link Long#MAX_VALUE} instead of overflowing. */
+  private static long saturatingAdd(long a, long b) {
+    long result = a + b;
+    // Overflow occurred iff a and b share a sign that differs from the result's sign.
+    if (((a ^ result) & (b ^ result)) < 0) {
+      return b < 0 ? Long.MIN_VALUE : Long.MAX_VALUE;
+    }
+    return result;
+  }
+
+  /**
+   * Evaluates whether the order-key value at a given row index falls within the lower / upper value edge of the frame
+   * defined by the current row. The value edges are {@code lo = value(cur) + loDelta} and {@code hi = value(cur) +
+   * hiDelta} (unless the corresponding side is UNBOUNDED, in which case that edge is always satisfied).
+   */
+  private interface ValueBounds {
+    boolean withinLower(int index, int currentRow);
+
+    boolean withinUpper(int index, int currentRow);
+  }
+
+  private static final class LongValueBounds implements ValueBounds {
+    private final long[] _values;
+    private final boolean _lowerUnbounded;
+    private final boolean _upperUnbounded;
+    private final long _loDelta;
+    private final long _hiDelta;
+
+    private LongValueBounds(List<Object[]> rows, int orderKeyIndex, boolean ascending, WindowFrame frame) {
+      int numRows = rows.size();
+      _values = new long[numRows];
+      for (int i = 0; i < numRows; i++) {
+        Object value = rows.get(i)[orderKeyIndex];
+        _values[i] = value == null ? 0L : ((Number) value).longValue();
+      }
+      long lowerOffset = frame.isLowerBoundRangeOffset() ? frame.getLowerRangeOffset().longValue() : 0L;
+      long upperOffset = frame.isUpperBoundRangeOffset() ? frame.getUpperRangeOffset().longValue() : 0L;
+      long signedLower = frame.isLowerRangeOffsetPreceding() ? -lowerOffset : lowerOffset;
+      long signedUpper = frame.isUpperRangeOffsetFollowing() ? upperOffset : -upperOffset;
+      if (ascending) {
+        _lowerUnbounded = frame.isUnboundedPreceding();
+        _loDelta = frame.isLowerBoundCurrentRow() ? 0L : signedLower;
+        _upperUnbounded = frame.isUnboundedFollowing();
+        _hiDelta = frame.isUpperBoundCurrentRow() ? 0L : signedUpper;
+      } else {
+        _lowerUnbounded = frame.isUnboundedFollowing();
+        _loDelta = frame.isUpperBoundCurrentRow() ? 0L : -signedUpper;
+        _upperUnbounded = frame.isUnboundedPreceding();
+        _hiDelta = frame.isLowerBoundCurrentRow() ? 0L : -signedLower;
+      }
+    }
+
+    @Override
+    public boolean withinLower(int index, int currentRow) {
+      return _lowerUnbounded || _values[index] >= saturatingAdd(_values[currentRow], _loDelta);
+    }
+
+    @Override
+    public boolean withinUpper(int index, int currentRow) {
+      return _upperUnbounded || _values[index] <= saturatingAdd(_values[currentRow], _hiDelta);
+    }
+  }
+
+  private static final class DoubleValueBounds implements ValueBounds {
+    private final double[] _values;
+    private final boolean _lowerUnbounded;
+    private final boolean _upperUnbounded;
+    private final double _loDelta;
+    private final double _hiDelta;
+
+    private DoubleValueBounds(List<Object[]> rows, int orderKeyIndex, boolean ascending, WindowFrame frame) {
+      int numRows = rows.size();
+      _values = new double[numRows];
+      for (int i = 0; i < numRows; i++) {
+        Object value = rows.get(i)[orderKeyIndex];
+        _values[i] = value == null ? 0.0 : ((Number) value).doubleValue();
+      }
+      double lowerOffset = frame.isLowerBoundRangeOffset() ? frame.getLowerRangeOffset().doubleValue() : 0.0;
+      double upperOffset = frame.isUpperBoundRangeOffset() ? frame.getUpperRangeOffset().doubleValue() : 0.0;
+      double signedLower = frame.isLowerRangeOffsetPreceding() ? -lowerOffset : lowerOffset;
+      double signedUpper = frame.isUpperRangeOffsetFollowing() ? upperOffset : -upperOffset;
+      if (ascending) {
+        _lowerUnbounded = frame.isUnboundedPreceding();
+        _loDelta = frame.isLowerBoundCurrentRow() ? 0.0 : signedLower;
+        _upperUnbounded = frame.isUnboundedFollowing();
+        _hiDelta = frame.isUpperBoundCurrentRow() ? 0.0 : signedUpper;
+      } else {
+        _lowerUnbounded = frame.isUnboundedFollowing();
+        _loDelta = frame.isUpperBoundCurrentRow() ? 0.0 : -signedUpper;
+        _upperUnbounded = frame.isUnboundedPreceding();
+        _hiDelta = frame.isLowerBoundCurrentRow() ? 0.0 : -signedLower;
+      }
+    }
+
+    @Override
+    public boolean withinLower(int index, int currentRow) {
+      return _lowerUnbounded || _values[index] >= _values[currentRow] + _loDelta;
+    }
+
+    @Override
+    public boolean withinUpper(int index, int currentRow) {
+      return _upperUnbounded || _values[index] <= _values[currentRow] + _hiDelta;
+    }
+  }
+
+  private static final class BigDecimalValueBounds implements ValueBounds {
+    private final BigDecimal[] _values;
+    private final boolean _lowerUnbounded;
+    private final boolean _upperUnbounded;
+    private final BigDecimal _loDelta;
+    private final BigDecimal _hiDelta;
+
+    private BigDecimalValueBounds(List<Object[]> rows, int orderKeyIndex, boolean ascending, WindowFrame frame) {
+      int numRows = rows.size();
+      _values = new BigDecimal[numRows];
+      for (int i = 0; i < numRows; i++) {
+        Object value = rows.get(i)[orderKeyIndex];
+        _values[i] = value == null ? null : toBigDecimal((Number) value);
+      }
+      BigDecimal lowerOffset =
+          frame.isLowerBoundRangeOffset() ? toBigDecimal(frame.getLowerRangeOffset()) : BigDecimal.ZERO;
+      BigDecimal upperOffset =
+          frame.isUpperBoundRangeOffset() ? toBigDecimal(frame.getUpperRangeOffset()) : BigDecimal.ZERO;
+      BigDecimal signedLower = frame.isLowerRangeOffsetPreceding() ? lowerOffset.negate() : lowerOffset;
+      BigDecimal signedUpper = frame.isUpperRangeOffsetFollowing() ? upperOffset : upperOffset.negate();
+      if (ascending) {
+        _lowerUnbounded = frame.isUnboundedPreceding();
+        _loDelta = frame.isLowerBoundCurrentRow() ? BigDecimal.ZERO : signedLower;
+        _upperUnbounded = frame.isUnboundedFollowing();
+        _hiDelta = frame.isUpperBoundCurrentRow() ? BigDecimal.ZERO : signedUpper;
+      } else {
+        _lowerUnbounded = frame.isUnboundedFollowing();
+        _loDelta = frame.isUpperBoundCurrentRow() ? BigDecimal.ZERO : signedUpper.negate();
+        _upperUnbounded = frame.isUnboundedPreceding();
+        _hiDelta = frame.isLowerBoundCurrentRow() ? BigDecimal.ZERO : signedLower.negate();
+      }
+    }
+
+    @Override
+    public boolean withinLower(int index, int currentRow) {
+      return _lowerUnbounded || _values[index].compareTo(_values[currentRow].add(_loDelta)) >= 0;
+    }
+
+    @Override
+    public boolean withinUpper(int index, int currentRow) {
+      return _upperUnbounded || _values[index].compareTo(_values[currentRow].add(_hiDelta)) <= 0;
+    }
+
+    private static BigDecimal toBigDecimal(Number value) {
+      if (value instanceof BigDecimal) {
+        return (BigDecimal) value;
+      }
+      if (value instanceof Integer || value instanceof Long) {
+        return BigDecimal.valueOf(value.longValue());
+      }
+      return BigDecimal.valueOf(value.doubleValue());
+    }
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/WindowFrame.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/WindowFrame.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.runtime.operator.window;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.query.planner.plannode.WindowNode;
 
 
@@ -25,6 +26,14 @@ import org.apache.pinot.query.planner.plannode.WindowNode;
  * Defines the window frame to be used for a window function. The 'lowerBound' and 'upperBound' indicate the frame
  * boundaries to be used. The frame can be of two types: ROWS or RANGE. Optionally an {@code EXCLUDE} clause may
  * specify a subset of rows around the current row to be excluded from the frame.
+ *
+ * <p>For a RANGE frame, an offset bound (e.g. {@code RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING}) is a value distance on
+ * the single ORDER BY key, not a physical row count. Such an offset value is carried by
+ * {@link #getLowerRangeOffset()} / {@link #getUpperRangeOffset()}, and the corresponding int bound is only a sign
+ * discriminator: {@code -1} for a
+ * PRECEDING offset bound and {@code +1} for a FOLLOWING offset bound (its magnitude is meaningless). UNBOUNDED and
+ * CURRENT ROW RANGE bounds continue to use the {@link Integer#MIN_VALUE} / {@link Integer#MAX_VALUE} / {@code 0}
+ * sentinels and carry no range offset.
  */
 public class WindowFrame {
   // Enum to denote the FRAME type, can be either ROWS or RANGE types
@@ -32,16 +41,31 @@ public class WindowFrame {
   // Both these bounds are relative to current row; 0 means current row, -1 means previous row, 1 means next row, etc.
   // Integer.MIN_VALUE represents UNBOUNDED PRECEDING which is only allowed for the lower bound (ensured by Calcite).
   // Integer.MAX_VALUE represents UNBOUNDED FOLLOWING which is only allowed for the upper bound (ensured by Calcite).
+  // For a RANGE offset bound, the int is only a sign discriminator (-1 PRECEDING, +1 FOLLOWING) and the value distance
+  // lives in _lowerRangeOffset / _upperRangeOffset.
   private final int _lowerBound;
   private final int _upperBound;
   private final WindowNode.WindowExclusion _exclude;
+  // Value distance for a RANGE offset PRECEDING / FOLLOWING bound; null otherwise. When non-null, this is the numeric
+  // offset value (Integer / Long / Float / Double / BigDecimal) applied to the single ORDER BY key.
+  @Nullable
+  private final Number _lowerRangeOffset;
+  @Nullable
+  private final Number _upperRangeOffset;
 
   public WindowFrame(WindowNode.WindowFrameType type, int lowerBound, int upperBound,
       WindowNode.WindowExclusion exclude) {
+    this(type, lowerBound, upperBound, exclude, null, null);
+  }
+
+  public WindowFrame(WindowNode.WindowFrameType type, int lowerBound, int upperBound,
+      WindowNode.WindowExclusion exclude, @Nullable Number lowerRangeOffset, @Nullable Number upperRangeOffset) {
     _type = type;
     _lowerBound = lowerBound;
     _upperBound = upperBound;
     _exclude = exclude;
+    _lowerRangeOffset = lowerRangeOffset;
+    _upperRangeOffset = upperRangeOffset;
   }
 
   public boolean isUnboundedPreceding() {
@@ -62,6 +86,61 @@ public class WindowFrame {
 
   public boolean isRowType() {
     return _type == WindowNode.WindowFrameType.ROWS;
+  }
+
+  public boolean isRangeType() {
+    return _type == WindowNode.WindowFrameType.RANGE;
+  }
+
+  /**
+   * Whether the lower bound is a value-based RANGE offset PRECEDING / FOLLOWING bound.
+   */
+  public boolean isLowerBoundRangeOffset() {
+    return _lowerRangeOffset != null;
+  }
+
+  /**
+   * Whether the upper bound is a value-based RANGE offset PRECEDING / FOLLOWING bound.
+   */
+  public boolean isUpperBoundRangeOffset() {
+    return _upperRangeOffset != null;
+  }
+
+  /**
+   * Whether this is a RANGE frame with at least one value-based offset PRECEDING / FOLLOWING bound.
+   */
+  public boolean isRangeOffsetFrame() {
+    return isLowerBoundRangeOffset() || isUpperBoundRangeOffset();
+  }
+
+  /**
+   * The value distance for the lower RANGE offset bound, or null if the lower bound is not an offset bound.
+   */
+  @Nullable
+  public Number getLowerRangeOffset() {
+    return _lowerRangeOffset;
+  }
+
+  /**
+   * The value distance for the upper RANGE offset bound, or null if the upper bound is not an offset bound.
+   */
+  @Nullable
+  public Number getUpperRangeOffset() {
+    return _upperRangeOffset;
+  }
+
+  /**
+   * Whether the lower RANGE offset bound is PRECEDING (only meaningful when {@link #isLowerBoundRangeOffset()}).
+   */
+  public boolean isLowerRangeOffsetPreceding() {
+    return _lowerBound < 0;
+  }
+
+  /**
+   * Whether the upper RANGE offset bound is FOLLOWING (only meaningful when {@link #isUpperBoundRangeOffset()}).
+   */
+  public boolean isUpperRangeOffsetFollowing() {
+    return _upperBound > 0;
   }
 
   public int getLowerBound() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/WindowFunction.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/WindowFunction.java
@@ -20,8 +20,10 @@ package org.apache.pinot.query.runtime.operator.window;
 
 import java.util.List;
 import java.util.Objects;
+import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.planner.plannode.WindowNode;
 import org.apache.pinot.query.runtime.operator.WindowAggregateOperator;
@@ -37,6 +39,11 @@ public abstract class WindowFunction extends AggregationUtils.Accumulator {
   protected final int[] _orderKeys;
   protected final int[] _inputRefs;
   protected final WindowFrame _windowFrame;
+  // Metadata for the single ORDER BY key, needed to evaluate value-based RANGE offset frames. For RANGE offset frames
+  // Calcite guarantees exactly one ORDER BY key, so these describe that key. Null / default when there is no ORDER BY.
+  @Nullable
+  protected final ColumnDataType _orderKeyStoredType;
+  protected final boolean _orderKeyAscending;
 
   public WindowFunction(RexExpression.FunctionCall aggCall, DataSchema inputSchema, List<RelFieldCollation> collations,
       WindowFrame windowFrame) {
@@ -47,11 +54,28 @@ public abstract class WindowFunction extends AggregationUtils.Accumulator {
       _orderKeys[i] = collations.get(i).getFieldIndex();
     }
     _windowFrame = windowFrame;
+    if (numOrderKeys > 0) {
+      RelFieldCollation firstCollation = collations.get(0);
+      _orderKeyStoredType = inputSchema.getColumnDataType(firstCollation.getFieldIndex()).getStoredType();
+      _orderKeyAscending = !firstCollation.getDirection().isDescending();
+    } else {
+      _orderKeyStoredType = null;
+      _orderKeyAscending = true;
+    }
     if (WindowAggregateOperator.RANKING_FUNCTION_NAMES.contains(aggCall.getFunctionName())) {
       _inputRefs = _orderKeys;
     } else {
       _inputRefs = new int[]{_inputRef};
     }
+  }
+
+  /**
+   * Computes the inclusive base frame bounds {@code {starts, ends}} for a value-based RANGE offset frame over the given
+   * partition rows, via an O(n) two-pointer sweep. Only valid for RANGE offset frames with a single numeric ORDER BY
+   * key. See {@link RangeWindowFrameBounds}. Any EXCLUDE clause is applied on top of these base bounds by the caller.
+   */
+  protected int[][] computeRangeFrameBounds(List<Object[]> rows) {
+    return RangeWindowFrameBounds.compute(rows, _orderKeys[0], _orderKeyStoredType, _orderKeyAscending, _windowFrame);
   }
 
   /**

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/AggregateWindowFunction.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/AggregateWindowFunction.java
@@ -43,7 +43,8 @@ public class AggregateWindowFunction extends WindowFunction {
     _functionName = aggCall.getFunctionName();
     // Removal support is required for sliding ROWS frames and whenever an EXCLUDE clause forces per-row corrections.
     boolean nonDefaultExclude = !windowFrame.isExcludeNoOthers();
-    boolean supportRemoval = nonDefaultExclude || (windowFrame.isRowType() && !(
+    // Removal is also required for value-based RANGE offset frames, which slide over the ORDER BY value.
+    boolean supportRemoval = nonDefaultExclude || windowFrame.isRangeOffsetFrame() || (windowFrame.isRowType() && !(
         windowFrame.isUnboundedPreceding() && windowFrame.isUnboundedFollowing()));
     _windowValueAggregator = WindowValueAggregatorFactory.getWindowValueAggregator(_functionName, _dataType,
         supportRemoval, nonDefaultExclude);
@@ -173,8 +174,45 @@ public class AggregateWindowFunction extends WindowFunction {
       }
       return results;
     } else {
-      throw new IllegalStateException("RANGE window frame with offset PRECEDING / FOLLOWING is not supported");
+      // Value-based RANGE offset frame (e.g. RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING) without an EXCLUDE clause.
+      return processRangeOffsetWindow(rows);
     }
+  }
+
+  /**
+   * Processes a value-based RANGE offset frame by sliding an incremental aggregator over the base frame bounds computed
+   * from the ORDER BY value. Both frame endpoints advance monotonically, so this is O(n) per partition (with O(1) /
+   * amortized-O(1) incremental aggregator updates).
+   */
+  private List<Object> processRangeOffsetWindow(List<Object[]> rows) {
+    int numRows = rows.size();
+    int[][] frameBounds = computeRangeFrameBounds(rows);
+    int[] starts = frameBounds[0];
+    int[] ends = frameBounds[1];
+
+    List<Object> result = new ArrayList<>(numRows);
+    // The aggregator currently holds the rows in [curLeft, curRight - 1]. Both pointers only move forward.
+    int curLeft = 0;
+    int curRight = 0;
+    for (int i = 0; i < numRows; i++) {
+      int start = starts[i];
+      int end = ends[i];
+      while (curRight <= end) {
+        _windowValueAggregator.addValue(extractValueFromRow(rows.get(curRight)));
+        curRight++;
+      }
+      // Advance past rows before 'start'. Only remove rows that were actually added (guards against empty-frame gaps).
+      while (curLeft < start) {
+        if (curLeft < curRight) {
+          _windowValueAggregator.removeValue(extractValueFromRow(rows.get(curLeft)));
+        }
+        curLeft++;
+      }
+      // When the frame is empty (start > end) the aggregator holds no values and returns the identity (NULL for
+      // SUM/AVG/MIN/MAX, 0 for COUNT), matching standard SQL semantics.
+      result.add(_windowValueAggregator.getCurrentAggregatedValue());
+    }
+    return result;
   }
 
   /**
@@ -321,7 +359,55 @@ public class AggregateWindowFunction extends WindowFunction {
       return result;
     }
 
-    throw new IllegalStateException("RANGE window frame with offset PRECEDING / FOLLOWING is not supported");
+    // Value-based RANGE offset frame (e.g. RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING) with a non-default EXCLUDE.
+    return processRangeOffsetWindowWithExclude(rows);
+  }
+
+  /**
+   * Value-based RANGE offset frame with a non-default EXCLUDE clause. Slides the aggregator over the base frame bounds
+   * computed from the ORDER BY value (like {@link #processRangeOffsetWindow}) and applies the per-row EXCLUDE
+   * corrections on top of that base frame. The aggregator supports arbitrary removal (MIN / MAX use a sorted multiset)
+   * since EXCLUDE re-adds previously removed values.
+   */
+  private List<Object> processRangeOffsetWindowWithExclude(List<Object[]> rows) {
+    int numRows = rows.size();
+    int[][] frameBounds = computeRangeFrameBounds(rows);
+    int[] starts = frameBounds[0];
+    int[] ends = frameBounds[1];
+    WindowNode.WindowExclusion exclude = _windowFrame.getExclude();
+    int[] peerStart = null;
+    int[] peerEnd = null;
+    if (needsPeerBoundaries(exclude)) {
+      peerStart = new int[numRows];
+      peerEnd = new int[numRows];
+      computePeerBoundaries(rows, peerStart, peerEnd);
+    }
+
+    List<Object> result = new ArrayList<>(numRows);
+    // The aggregator holds the base frame [curLeft, curRight - 1]; both pointers only move forward.
+    int curLeft = 0;
+    int curRight = 0;
+    for (int i = 0; i < numRows; i++) {
+      int start = starts[i];
+      int end = ends[i];
+      while (curRight <= end) {
+        _windowValueAggregator.addValue(extractValueFromRow(rows.get(curRight)));
+        curRight++;
+      }
+      while (curLeft < start) {
+        if (curLeft < curRight) {
+          _windowValueAggregator.removeValue(extractValueFromRow(rows.get(curLeft)));
+        }
+        curLeft++;
+      }
+      int pStart = peerStart != null ? peerStart[i] : i;
+      int pEnd = peerEnd != null ? peerEnd[i] : i;
+      // Remove the EXCLUDE set from the base frame [start, end], read the result, then re-add it for the next row.
+      applyExclude(rows, i, start, end, pStart, pEnd, exclude, true);
+      result.add(_windowValueAggregator.getCurrentAggregatedValue());
+      applyExclude(rows, i, start, end, pStart, pEnd, exclude, false);
+    }
+    return result;
   }
 
   /**

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/FirstValueWindowFunction.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/FirstValueWindowFunction.java
@@ -76,13 +76,21 @@ public class FirstValueWindowFunction extends ValueWindowFunction {
       peerEnd = new int[numRows];
       computePeerBoundaries(rows, peerStart, peerEnd);
     }
+    // For a value-based RANGE offset frame the base frame is the ORDER BY value range, not the peer group.
+    int[] rangeStarts = null;
+    int[] rangeEnds = null;
+    if (_windowFrame.isRangeOffsetFrame()) {
+      int[][] frameBounds = computeRangeFrameBounds(rows);
+      rangeStarts = frameBounds[0];
+      rangeEnds = frameBounds[1];
+    }
 
     List<Object> result = new ArrayList<>(numRows);
     for (int i = 0; i < numRows; i++) {
       int pStart = peerStart != null ? peerStart[i] : i;
       int pEnd = peerEnd != null ? peerEnd[i] : i;
-      int fs = frameStartForRow(i, pStart, numRows);
-      int fe = frameEndForRow(i, pEnd, numRows);
+      int fs = rangeStarts != null ? rangeStarts[i] : frameStartForRow(i, pStart, numRows);
+      int fe = rangeEnds != null ? rangeEnds[i] : frameEndForRow(i, pEnd, numRows);
       int idx = firstNonExcluded(fs, fe, i, pStart, pEnd, exclude);
       if (_ignoreNulls) {
         while (idx != -1 && extractValueFromRow(rows.get(idx)) == null) {
@@ -187,13 +195,17 @@ public class FirstValueWindowFunction extends ValueWindowFunction {
   private List<Object> processRangeWindow(List<Object[]> rows) {
     int numRows = rows.size();
 
+    if (_windowFrame.isRangeOffsetFrame()) {
+      return processRangeOffsetWindow(rows);
+    }
+
     if (_windowFrame.isUnboundedPreceding()) {
       return Collections.nCopies(numRows, extractValueFromRow(rows.get(0)));
     }
 
-    // The lower bound has to be CURRENT ROW since we don't support RANGE windows with offset value
+    // The lower bound has to be CURRENT ROW since the RANGE offset case is handled above
     Preconditions.checkState(_windowFrame.isLowerBoundCurrentRow(),
-        "RANGE window frame with offset PRECEDING / FOLLOWING is not supported");
+        "Unexpected RANGE window frame lower bound: " + _windowFrame);
 
     List<Object> result = new ArrayList<>(numRows);
 
@@ -219,6 +231,10 @@ public class FirstValueWindowFunction extends ValueWindowFunction {
 
   private List<Object> processRangeWindowIgnoreNulls(List<Object[]> rows) {
     int numRows = rows.size();
+
+    if (_windowFrame.isRangeOffsetFrame()) {
+      return processRangeOffsetWindowIgnoreNulls(rows);
+    }
 
     if (_windowFrame.isUnboundedPreceding() && _windowFrame.isUnboundedFollowing()) {
       return processUnboundedWindowIgnoreNulls(rows);
@@ -303,7 +319,52 @@ public class FirstValueWindowFunction extends ValueWindowFunction {
       return result;
     }
 
-    throw new IllegalStateException("RANGE window frame with offset PRECEDING / FOLLOWING is not supported");
+    // Unreachable: value-based RANGE offset frames are handled by processRangeOffsetWindowIgnoreNulls above.
+    throw new IllegalStateException("Unexpected RANGE window frame: " + _windowFrame);
+  }
+
+  /**
+   * FIRST_VALUE over a value-based RANGE offset frame: the first row of each frame (as computed from the ORDER BY
+   * value), computed in O(n) using {@link #computeRangeFrameBounds(List)}.
+   */
+  private List<Object> processRangeOffsetWindow(List<Object[]> rows) {
+    int numRows = rows.size();
+    int[][] frameBounds = computeRangeFrameBounds(rows);
+    int[] starts = frameBounds[0];
+    int[] ends = frameBounds[1];
+    List<Object> result = new ArrayList<>(numRows);
+    for (int i = 0; i < numRows; i++) {
+      // Empty frame (start > end) yields null.
+      result.add(starts[i] <= ends[i] ? extractValueFromRow(rows.get(starts[i])) : null);
+    }
+    return result;
+  }
+
+  /**
+   * FIRST_VALUE IGNORE NULLS over a value-based RANGE offset frame: the first non-null value within each frame. Uses a
+   * precomputed "next non-null index" array so the whole partition is processed in O(n).
+   */
+  private List<Object> processRangeOffsetWindowIgnoreNulls(List<Object[]> rows) {
+    int numRows = rows.size();
+    int[][] frameBounds = computeRangeFrameBounds(rows);
+    int[] starts = frameBounds[0];
+    int[] ends = frameBounds[1];
+    // nextNonNull[i] = smallest index >= i whose (target column) value is non-null, or numRows if none.
+    int[] nextNonNull = new int[numRows + 1];
+    nextNonNull[numRows] = numRows;
+    for (int i = numRows - 1; i >= 0; i--) {
+      nextNonNull[i] = extractValueFromRow(rows.get(i)) != null ? i : nextNonNull[i + 1];
+    }
+    List<Object> result = new ArrayList<>(numRows);
+    for (int i = 0; i < numRows; i++) {
+      if (starts[i] > ends[i]) {
+        result.add(null);
+        continue;
+      }
+      int idx = nextNonNull[starts[i]];
+      result.add(idx <= ends[i] ? extractValueFromRow(rows.get(idx)) : null);
+    }
+    return result;
   }
 
   private List<Object> processUnboundedWindowIgnoreNulls(List<Object[]> rows) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/LastValueWindowFunction.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/LastValueWindowFunction.java
@@ -76,13 +76,21 @@ public class LastValueWindowFunction extends ValueWindowFunction {
       peerEnd = new int[numRows];
       computePeerBoundaries(rows, peerStart, peerEnd);
     }
+    // For a value-based RANGE offset frame the base frame is the ORDER BY value range, not the peer group.
+    int[] rangeStarts = null;
+    int[] rangeEnds = null;
+    if (_windowFrame.isRangeOffsetFrame()) {
+      int[][] frameBounds = computeRangeFrameBounds(rows);
+      rangeStarts = frameBounds[0];
+      rangeEnds = frameBounds[1];
+    }
 
     List<Object> result = new ArrayList<>(numRows);
     for (int i = 0; i < numRows; i++) {
       int pStart = peerStart != null ? peerStart[i] : i;
       int pEnd = peerEnd != null ? peerEnd[i] : i;
-      int fs = frameStartForRow(i, pStart, numRows);
-      int fe = frameEndForRow(i, pEnd, numRows);
+      int fs = rangeStarts != null ? rangeStarts[i] : frameStartForRow(i, pStart, numRows);
+      int fe = rangeEnds != null ? rangeEnds[i] : frameEndForRow(i, pEnd, numRows);
       int idx = lastNonExcluded(fs, fe, i, pStart, pEnd, exclude);
       if (_ignoreNulls) {
         while (idx != -1 && extractValueFromRow(rows.get(idx)) == null) {
@@ -182,13 +190,18 @@ public class LastValueWindowFunction extends ValueWindowFunction {
 
   private List<Object> processRangeWindow(List<Object[]> rows) {
     int numRows = rows.size();
+
+    if (_windowFrame.isRangeOffsetFrame()) {
+      return processRangeOffsetWindow(rows);
+    }
+
     if (_windowFrame.isUnboundedFollowing()) {
       return Collections.nCopies(numRows, extractValueFromRow(rows.get(numRows - 1)));
     }
 
-    // The upper bound has to be CURRENT ROW here since we don't support RANGE windows with offset value
+    // The upper bound has to be CURRENT ROW here since the RANGE offset case is handled above
     Preconditions.checkState(_windowFrame.isUpperBoundCurrentRow(),
-        "RANGE window frame with offset PRECEDING / FOLLOWING is not supported");
+        "Unexpected RANGE window frame upper bound: " + _windowFrame);
 
     List<Object> result = new ArrayList<>(numRows);
     Map<Key, Object> lastValueForKey = new HashMap<>();
@@ -216,6 +229,10 @@ public class LastValueWindowFunction extends ValueWindowFunction {
 
   private List<Object> processRangeWindowIgnoreNulls(List<Object[]> rows) {
     int numRows = rows.size();
+
+    if (_windowFrame.isRangeOffsetFrame()) {
+      return processRangeOffsetWindowIgnoreNulls(rows);
+    }
 
     if (_windowFrame.isUnboundedPreceding() && _windowFrame.isUnboundedFollowing()) {
       return processUnboundedWindowIgnoreNulls(rows);
@@ -290,7 +307,55 @@ public class LastValueWindowFunction extends ValueWindowFunction {
       return new DualValueList<>(lastNonNullValue, fillBoundary, null, numRows - fillBoundary);
     }
 
-    throw new IllegalStateException("RANGE window frame with offset PRECEDING / FOLLOWING is not supported");
+    // Unreachable: value-based RANGE offset frames are handled by processRangeOffsetWindowIgnoreNulls above.
+    throw new IllegalStateException("Unexpected RANGE window frame: " + _windowFrame);
+  }
+
+  /**
+   * LAST_VALUE over a value-based RANGE offset frame: the last row of each frame (as computed from the ORDER BY value),
+   * computed in O(n) using {@link #computeRangeFrameBounds(List)}.
+   */
+  private List<Object> processRangeOffsetWindow(List<Object[]> rows) {
+    int numRows = rows.size();
+    int[][] frameBounds = computeRangeFrameBounds(rows);
+    int[] starts = frameBounds[0];
+    int[] ends = frameBounds[1];
+    List<Object> result = new ArrayList<>(numRows);
+    for (int i = 0; i < numRows; i++) {
+      // Empty frame (start > end) yields null.
+      result.add(starts[i] <= ends[i] ? extractValueFromRow(rows.get(ends[i])) : null);
+    }
+    return result;
+  }
+
+  /**
+   * LAST_VALUE IGNORE NULLS over a value-based RANGE offset frame: the last non-null value within each frame. Uses a
+   * precomputed "previous non-null index" array so the whole partition is processed in O(n).
+   */
+  private List<Object> processRangeOffsetWindowIgnoreNulls(List<Object[]> rows) {
+    int numRows = rows.size();
+    int[][] frameBounds = computeRangeFrameBounds(rows);
+    int[] starts = frameBounds[0];
+    int[] ends = frameBounds[1];
+    // prevNonNull[i] = largest index <= i whose (target column) value is non-null, or -1 if none.
+    int[] prevNonNull = new int[numRows];
+    int last = -1;
+    for (int i = 0; i < numRows; i++) {
+      if (extractValueFromRow(rows.get(i)) != null) {
+        last = i;
+      }
+      prevNonNull[i] = last;
+    }
+    List<Object> result = new ArrayList<>(numRows);
+    for (int i = 0; i < numRows; i++) {
+      if (starts[i] > ends[i]) {
+        result.add(null);
+        continue;
+      }
+      int idx = prevNonNull[ends[i]];
+      result.add(idx >= starts[i] ? extractValueFromRow(rows.get(idx)) : null);
+    }
+    return result;
   }
 
   private List<Object> processUnboundedWindowIgnoreNulls(List<Object[]> rows) {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperatorTest.java
@@ -2952,6 +2952,42 @@ public class WindowAggregateOperatorTest {
         windowFrameUpperBound, input);
   }
 
+  /**
+   * Prepares an operator for a value-based RANGE offset frame. {@code lowerBoundSign} / {@code upperBoundSign} are the
+   * int-bound discriminators (-1 PRECEDING, +1 FOLLOWING, 0 CURRENT ROW, MIN_VALUE / MAX_VALUE for UNBOUNDED), and
+   * {@code lowerOffset} / {@code upperOffset} carry the value distances (null when the corresponding bound is not an
+   * offset bound). Input rows must already be sorted per the collation.
+   */
+  private WindowAggregateOperator prepareRangeOffsetData(String[] inputSchemaCols,
+      ColumnDataType[] inputSchemaColTypes, ColumnDataType outputType, List<Integer> partitionKeys,
+      int collationFieldIndex, boolean ascending, int lowerBoundSign, int upperBoundSign,
+      RexExpression.Literal lowerOffset, RexExpression.Literal upperOffset, RexExpression.FunctionCall functionCall,
+      Object[][] rows) {
+    DataSchema inputSchema = new DataSchema(inputSchemaCols, inputSchemaColTypes);
+    MultiStageOperator input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addBlock(OperatorTestUtil.block(inputSchema, rows))
+        .buildWithEos();
+
+    String[] outputSchemaCols = new String[inputSchemaCols.length + 1];
+    System.arraycopy(inputSchemaCols, 0, outputSchemaCols, 0, inputSchemaCols.length);
+    outputSchemaCols[inputSchemaCols.length] = functionCall.getFunctionName().toLowerCase();
+
+    ColumnDataType[] outputSchemaColTypes = new ColumnDataType[inputSchemaColTypes.length + 1];
+    System.arraycopy(inputSchemaColTypes, 0, outputSchemaColTypes, 0, inputSchemaColTypes.length);
+    outputSchemaColTypes[inputSchemaCols.length] = outputType;
+
+    DataSchema resultSchema = new DataSchema(outputSchemaCols, outputSchemaColTypes);
+    List<RexExpression.FunctionCall> aggCalls = List.of(functionCall);
+    RelFieldCollation.Direction direction =
+        ascending ? RelFieldCollation.Direction.ASCENDING : RelFieldCollation.Direction.DESCENDING;
+    List<RelFieldCollation> collations = List.of(new RelFieldCollation(collationFieldIndex, direction));
+    WindowNode node = new WindowNode(-1, resultSchema, PlanNode.NodeHint.EMPTY, List.of(), partitionKeys, collations,
+        aggCalls, WindowNode.WindowFrameType.RANGE, lowerBoundSign, upperBoundSign,
+        WindowNode.WindowExclusion.NO_OTHERS, lowerOffset, upperOffset, List.of());
+    return new WindowAggregateOperator(OperatorTestUtil.getTracingContext(), input, inputSchema, node);
+  }
+
+
   @Test
   public void testShouldThrowOnWindowFrameWithInvalidOffsetBounds() {
     // Given:
@@ -2975,28 +3011,218 @@ public class WindowAggregateOperatorTest {
   }
 
   @Test
-  public void testShouldThrowOnWindowFrameWithOffsetBoundsForRange() {
-    // TODO: Remove this test when support for RANGE window frames with offset PRECEDING / FOLLOWING is added
-    // Given:
-    DataSchema inputSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, STRING});
-    MultiStageOperator input = new BlockListMultiStageOperator.Builder(inputSchema)
-        .addBlock(OperatorTestUtil.block(inputSchema, new Object[]{2, "foo"}))
-        .buildWithEos();
-    DataSchema resultSchema =
-        new DataSchema(new String[]{"group", "arg", "sum"}, new ColumnDataType[]{INT, STRING, DOUBLE});
-    List<Integer> keys = List.of(0);
-    List<RexExpression.FunctionCall> aggCalls = List.of(getSum(new RexExpression.InputRef(1)));
+  public void testSumWithRangeOffsetPrecedingAndFollowing() {
+    // SUM(value) OVER (PARTITION BY name ORDER BY year RANGE BETWEEN 2 PRECEDING AND 2 FOLLOWING)
+    // Note the RANGE (value-based) semantics differ from ROWS: rows within +/- 2 of the current YEAR value are summed.
+    WindowAggregateOperator operator = prepareRangeOffsetData(new String[]{"name", "value", "year"},
+        new ColumnDataType[]{STRING, INT, INT}, DOUBLE, List.of(0), 2, true, -1, 1,
+        new RexExpression.Literal(INT, 2), new RexExpression.Literal(INT, 2), getSum(new RexExpression.InputRef(1)),
+        new Object[][]{
+            new Object[]{"A", 14, 2000},
+            new Object[]{"A", 10, 2002},
+            new Object[]{"A", 20, 2008},
+            new Object[]{"A", 15, 2008},
+            new Object[]{"B", 10, 2000},
+            new Object[]{"B", 20, 2005}
+        });
 
-    // Then:
-    IllegalStateException e = Assert.expectThrows(IllegalStateException.class,
-        () -> getOperator(inputSchema, resultSchema, keys, List.of(), aggCalls, WindowNode.WindowFrameType.RANGE, 5,
-            Integer.MAX_VALUE, input));
-    assertEquals(e.getMessage(), "RANGE window frame with offset PRECEDING / FOLLOWING is not supported");
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
 
-    e = Assert.expectThrows(IllegalStateException.class,
-        () -> getOperator(inputSchema, resultSchema, keys, List.of(), aggCalls, WindowNode.WindowFrameType.RANGE,
-            Integer.MAX_VALUE, 5, input));
-    assertEquals(e.getMessage(), "RANGE window frame with offset PRECEDING / FOLLOWING is not supported");
+    verifyResultRows(resultRows, List.of(0), Map.of(
+        "A", List.of(
+            new Object[]{"A", 14, 2000, 24.0},   // years within [1998, 2002]: 2000, 2002 -> 14 + 10
+            new Object[]{"A", 10, 2002, 24.0},   // years within [2000, 2004]: 2000, 2002 -> 14 + 10
+            new Object[]{"A", 20, 2008, 35.0},   // years within [2006, 2010]: 2008, 2008 -> 20 + 15
+            new Object[]{"A", 15, 2008, 35.0}
+        ),
+        "B", List.of(
+            new Object[]{"B", 10, 2000, 10.0},   // years within [1998, 2002]: 2000
+            new Object[]{"B", 20, 2005, 20.0}    // years within [2003, 2007]: 2005
+        )));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
+  }
+
+  @Test
+  public void testSumWithRangeOffsetProducingEmptyFrames() {
+    // SUM(value) OVER (ORDER BY key RANGE BETWEEN 3 PRECEDING AND 2 PRECEDING) - an empty frame yields NULL.
+    WindowAggregateOperator operator = prepareRangeOffsetData(new String[]{"name", "value", "key"},
+        new ColumnDataType[]{STRING, INT, INT}, DOUBLE, List.of(0), 2, true, -1, -1,
+        new RexExpression.Literal(INT, 3), new RexExpression.Literal(INT, 2), getSum(new RexExpression.InputRef(1)),
+        new Object[][]{
+            new Object[]{"A", 10, 1},
+            new Object[]{"A", 20, 2},
+            new Object[]{"A", 30, 3},
+            new Object[]{"A", 50, 5}
+        });
+
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    verifyResultRows(resultRows, List.of(0), Map.of(
+        "A", List.of(
+            new Object[]{"A", 10, 1, null},      // keys within [-2, -1]: none -> NULL
+            new Object[]{"A", 20, 2, null},      // keys within [-1, 0]: none -> NULL
+            new Object[]{"A", 30, 3, 10.0},      // keys within [0, 1]: key 1 -> 10
+            new Object[]{"A", 50, 5, 50.0}       // keys within [2, 3]: keys 2, 3 -> 20 + 30
+        )));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
+  }
+
+  @Test
+  public void testMaxWithRangeOffsetDescending() {
+    // MAX(value) OVER (ORDER BY key DESC RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING). Exercises the DESC path and the
+    // monotonic-deque sliding MAX aggregator. Rows must be provided already sorted per the DESC collation.
+    WindowAggregateOperator operator = prepareRangeOffsetData(new String[]{"name", "value", "key"},
+        new ColumnDataType[]{STRING, INT, INT}, INT, List.of(0), 2, false, -1, 1,
+        new RexExpression.Literal(INT, 1), new RexExpression.Literal(INT, 1), getMax(new RexExpression.InputRef(1)),
+        new Object[][]{
+            new Object[]{"A", 5, 7},
+            new Object[]{"A", 9, 5},
+            new Object[]{"A", 2, 2},
+            new Object[]{"A", 8, 2},
+            new Object[]{"A", 1, 1}
+        });
+
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    verifyResultRows(resultRows, List.of(0), Map.of(
+        "A", List.of(
+            new Object[]{"A", 5, 7, 5},          // keys within [6, 8]: key 7 -> max(5)
+            new Object[]{"A", 9, 5, 9},          // keys within [4, 6]: key 5 -> max(9)
+            new Object[]{"A", 2, 2, 8},          // keys within [1, 3]: keys 2, 2, 1 -> max(2, 8, 1)
+            new Object[]{"A", 8, 2, 8},          // keys within [1, 3]: keys 2, 2, 1 -> max(2, 8, 1)
+            new Object[]{"A", 1, 1, 8}           // keys within [0, 2]: keys 2, 2, 1 -> max(2, 8, 1)
+        )));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
+  }
+
+  @Test
+  public void testBoolAndWithRangeOffset() {
+    // BOOL_AND(value) OVER (ORDER BY key RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING). Exercises the incremental
+    // add/remove of the BOOL_AND aggregator over a value-based sliding frame.
+    WindowAggregateOperator operator = prepareRangeOffsetData(new String[]{"name", "value", "key"},
+        new ColumnDataType[]{STRING, BOOLEAN, INT}, BOOLEAN, List.of(0), 2, true, -1, 1,
+        new RexExpression.Literal(INT, 1), new RexExpression.Literal(INT, 1), getBoolAnd(new RexExpression.InputRef(1)),
+        new Object[][]{
+            new Object[]{"A", 1, 1},
+            new Object[]{"A", 1, 2},
+            new Object[]{"A", 0, 3},
+            new Object[]{"A", 1, 5}
+        });
+
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    verifyResultRows(resultRows, List.of(0), Map.of(
+        "A", List.of(
+            new Object[]{"A", 1, 1, 1},          // keys within [0, 2]: keys 1, 2 -> AND(true, true) = true
+            new Object[]{"A", 1, 2, 0},          // keys within [1, 3]: keys 1, 2, 3 -> AND(true, true, false) = false
+            new Object[]{"A", 0, 3, 0},          // keys within [2, 4]: keys 2, 3 -> AND(true, false) = false
+            new Object[]{"A", 1, 5, 1}           // keys within [4, 6]: key 5 -> AND(true) = true
+        )));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
+  }
+
+  @Test
+  public void testFirstValueWithRangeOffset() {
+    // FIRST_VALUE(value) OVER (ORDER BY key RANGE BETWEEN 3 PRECEDING AND 3 FOLLOWING) - value at the frame start.
+    WindowAggregateOperator operator = prepareRangeOffsetData(new String[]{"name", "value", "key"},
+        new ColumnDataType[]{STRING, INT, INT}, INT, List.of(0), 2, true, -1, 1,
+        new RexExpression.Literal(INT, 3), new RexExpression.Literal(INT, 3),
+        getFirstValue(new RexExpression.InputRef(1)),
+        new Object[][]{
+            new Object[]{"A", 10, 1},
+            new Object[]{"A", null, 3},
+            new Object[]{"A", 30, 5},
+            new Object[]{"A", null, 7}
+        });
+
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    verifyResultRows(resultRows, List.of(0), Map.of(
+        "A", List.of(
+            new Object[]{"A", 10, 1, 10},        // keys within [-2, 4]: keys 1, 3 -> first value at key 1 = 10
+            new Object[]{"A", null, 3, 10},      // keys within [0, 6]: keys 1, 3, 5 -> first value at key 1 = 10
+            new Object[]{"A", 30, 5, null},      // keys within [2, 8]: keys 3, 5, 7 -> first value at key 3 = null
+            new Object[]{"A", null, 7, 30}       // keys within [4, 10]: keys 5, 7 -> first value at key 5 = 30
+        )));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
+  }
+
+  @Test
+  public void testLastValueWithRangeOffset() {
+    // LAST_VALUE(value) OVER (ORDER BY key RANGE BETWEEN 3 PRECEDING AND 3 FOLLOWING) - value at the frame end.
+    WindowAggregateOperator operator = prepareRangeOffsetData(new String[]{"name", "value", "key"},
+        new ColumnDataType[]{STRING, INT, INT}, INT, List.of(0), 2, true, -1, 1,
+        new RexExpression.Literal(INT, 3), new RexExpression.Literal(INT, 3),
+        getLastValue(new RexExpression.InputRef(1)),
+        new Object[][]{
+            new Object[]{"A", 10, 1},
+            new Object[]{"A", null, 3},
+            new Object[]{"A", 30, 5},
+            new Object[]{"A", null, 7}
+        });
+
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    verifyResultRows(resultRows, List.of(0), Map.of(
+        "A", List.of(
+            new Object[]{"A", 10, 1, null},      // keys within [-2, 4]: keys 1, 3 -> last value at key 3 = null
+            new Object[]{"A", null, 3, 30},      // keys within [0, 6]: keys 1, 3, 5 -> last value at key 5 = 30
+            new Object[]{"A", 30, 5, null},      // keys within [2, 8]: keys 3, 5, 7 -> last value at key 7 = null
+            new Object[]{"A", null, 7, null}     // keys within [4, 10]: keys 5, 7 -> last value at key 7 = null
+        )));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
+  }
+
+  @Test
+  public void testFirstValueIgnoreNullsWithRangeOffset() {
+    // FIRST_VALUE(value) IGNORE NULLS OVER (ORDER BY key RANGE BETWEEN 3 PRECEDING AND 3 FOLLOWING).
+    WindowAggregateOperator operator = prepareRangeOffsetData(new String[]{"name", "value", "key"},
+        new ColumnDataType[]{STRING, INT, INT}, INT, List.of(0), 2, true, -1, 1,
+        new RexExpression.Literal(INT, 3), new RexExpression.Literal(INT, 3),
+        getFirstValue(new RexExpression.InputRef(1), true),
+        new Object[][]{
+            new Object[]{"A", 10, 1},
+            new Object[]{"A", null, 3},
+            new Object[]{"A", 30, 5},
+            new Object[]{"A", null, 7}
+        });
+
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    verifyResultRows(resultRows, List.of(0), Map.of(
+        "A", List.of(
+            new Object[]{"A", 10, 1, 10},        // keys 1, 3 -> first non-null = 10
+            new Object[]{"A", null, 3, 10},      // keys 1, 3, 5 -> first non-null = 10
+            new Object[]{"A", 30, 5, 30},        // keys 3, 5, 7 -> first non-null (skip key 3 null) = 30
+            new Object[]{"A", null, 7, 30}       // keys 5, 7 -> first non-null = 30
+        )));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
+  }
+
+  @Test
+  public void testLastValueIgnoreNullsWithRangeOffset() {
+    // LAST_VALUE(value) IGNORE NULLS OVER (ORDER BY key RANGE BETWEEN 3 PRECEDING AND 3 FOLLOWING).
+    WindowAggregateOperator operator = prepareRangeOffsetData(new String[]{"name", "value", "key"},
+        new ColumnDataType[]{STRING, INT, INT}, INT, List.of(0), 2, true, -1, 1,
+        new RexExpression.Literal(INT, 3), new RexExpression.Literal(INT, 3),
+        getLastValue(new RexExpression.InputRef(1), true),
+        new Object[][]{
+            new Object[]{"A", 10, 1},
+            new Object[]{"A", null, 3},
+            new Object[]{"A", 30, 5},
+            new Object[]{"A", null, 7}
+        });
+
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    verifyResultRows(resultRows, List.of(0), Map.of(
+        "A", List.of(
+            new Object[]{"A", 10, 1, 10},        // keys 1, 3 -> last non-null = 10
+            new Object[]{"A", null, 3, 30},      // keys 1, 3, 5 -> last non-null = 30
+            new Object[]{"A", 30, 5, 30},        // keys 3, 5, 7 -> last non-null (skip key 7 null) = 30
+            new Object[]{"A", null, 7, 30}       // keys 5, 7 -> last non-null = 30
+        )));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
   }
 
   @Test

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/window/RangeWindowFrameBoundsTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/window/RangeWindowFrameBoundsTest.java
@@ -1,0 +1,211 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.window;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.query.planner.plannode.WindowNode.WindowExclusion;
+import org.apache.pinot.query.planner.plannode.WindowNode.WindowFrameType;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Unit tests for {@link RangeWindowFrameBounds}, the O(n) two-pointer computation of value-based RANGE offset window
+ * frame boundaries. The order key is always column 0. Frames are asserted as normalized inclusive index ranges, where
+ * an empty frame is represented by {@code {}} (the exact start/end of an empty frame is an implementation detail).
+ */
+public class RangeWindowFrameBoundsTest {
+
+  private static List<Object[]> rows(Object... orderKeyValues) {
+    List<Object[]> rows = new ArrayList<>(orderKeyValues.length);
+    for (Object value : orderKeyValues) {
+      rows.add(new Object[]{value});
+    }
+    return rows;
+  }
+
+  /**
+   * Builds a RANGE offset frame. {@code lowerSign} / {@code upperSign} are the int-bound discriminators (-1 PRECEDING,
+   * +1 FOLLOWING, 0 CURRENT ROW, MIN_VALUE UNBOUNDED PRECEDING, MAX_VALUE UNBOUNDED FOLLOWING).
+   */
+  private static WindowFrame frame(int lowerSign, Number lowerOffset, int upperSign, Number upperOffset) {
+    return new WindowFrame(WindowFrameType.RANGE, lowerSign, upperSign, WindowExclusion.NO_OTHERS, lowerOffset,
+        upperOffset);
+  }
+
+  private static void assertFrames(List<Object[]> rows, ColumnDataType type, boolean ascending, WindowFrame frame,
+      int[][] expectedFrames) {
+    int[][] bounds = RangeWindowFrameBounds.compute(rows, 0, type, ascending, frame);
+    int[] starts = bounds[0];
+    int[] ends = bounds[1];
+    int numRows = rows.size();
+    assertEquals(starts.length, numRows);
+    assertEquals(ends.length, numRows);
+    for (int i = 0; i < numRows; i++) {
+      int[] actual = starts[i] > ends[i] ? new int[]{} : new int[]{starts[i], ends[i]};
+      assertEquals(actual, expectedFrames[i], "frame mismatch at row " + i);
+      // Bounds should stay within the partition.
+      if (starts[i] <= ends[i]) {
+        assertTrue(starts[i] >= 0 && ends[i] < numRows, "out-of-range frame at row " + i);
+      }
+    }
+  }
+
+  @Test
+  public void testAscBetweenOnePrecedingAndOneFollowing() {
+    // values: 1, 2, 2, 5, 7  |  frame value interval = [v-1, v+1]
+    assertFrames(rows(1, 2, 2, 5, 7), ColumnDataType.INT, true, frame(-1, 1, 1, 1),
+        new int[][]{{0, 2}, {0, 2}, {0, 2}, {3, 3}, {4, 4}});
+  }
+
+  @Test
+  public void testDescBetweenOnePrecedingAndOneFollowing() {
+    // values sorted desc: 7, 5, 2, 2, 1  |  symmetric frame, value interval still [v-1, v+1]
+    assertFrames(rows(7, 5, 2, 2, 1), ColumnDataType.INT, false, frame(-1, 1, 1, 1),
+        new int[][]{{0, 0}, {1, 1}, {2, 4}, {2, 4}, {2, 4}});
+  }
+
+  @Test
+  public void testAscBetweenTwoPrecedingAndCurrentRow() {
+    // values: 1, 2, 3, 10  |  frame = [v-2, v]
+    assertFrames(rows(1, 2, 3, 10), ColumnDataType.INT, true, frame(-1, 2, 0, null),
+        new int[][]{{0, 0}, {0, 1}, {0, 2}, {3, 3}});
+  }
+
+  @Test
+  public void testAscBetweenCurrentRowAndTwoFollowing() {
+    // values: 1, 2, 3, 10  |  frame = [v, v+2]
+    assertFrames(rows(1, 2, 3, 10), ColumnDataType.INT, true, frame(0, null, 1, 2),
+        new int[][]{{0, 2}, {1, 2}, {2, 2}, {3, 3}});
+  }
+
+  @Test
+  public void testAscEmptyFrameBetweenOnePrecedingAndOnePreceding() {
+    // values: 1, 2, 3  |  frame = [v-1, v-1]; the first row's frame is empty
+    assertFrames(rows(1, 2, 3), ColumnDataType.INT, true, frame(-1, 1, -1, 1),
+        new int[][]{{}, {0, 0}, {1, 1}});
+  }
+
+  @Test
+  public void testAscBothFollowingWithTrailingEmptyFrame() {
+    // values: 1, 2, 3, 4  |  frame = [v+1, v+2] (excludes current row); last row's frame is empty
+    assertFrames(rows(1, 2, 3, 4), ColumnDataType.INT, true, frame(1, 1, 1, 2),
+        new int[][]{{1, 2}, {2, 3}, {3, 3}, {}});
+  }
+
+  @Test
+  public void testAscNullsFirstBetweenOnePrecedingAndOneFollowing() {
+    // values: null, null, 1, 2, 3; NULL rows form their own peer group [0,1]
+    assertFrames(rows(null, null, 1, 2, 3), ColumnDataType.INT, true, frame(-1, 1, 1, 1),
+        new int[][]{{0, 1}, {0, 1}, {2, 3}, {2, 4}, {3, 4}});
+  }
+
+  @Test
+  public void testAscNullsFirstUnboundedPrecedingAndOneFollowing() {
+    // values: null, null, 1, 2, 3; UNBOUNDED PRECEDING extends to index 0, including the leading NULL rows
+    assertFrames(rows(null, null, 1, 2, 3), ColumnDataType.INT, true, frame(Integer.MIN_VALUE, null, 1, 1),
+        new int[][]{{0, 1}, {0, 1}, {0, 3}, {0, 4}, {0, 4}});
+  }
+
+  @Test
+  public void testAscNullsLastOnePrecedingAndUnboundedFollowing() {
+    // values: 1, 2, 3, null, null; UNBOUNDED FOLLOWING extends to index n-1, including the trailing NULL rows
+    assertFrames(rows(1, 2, 3, null, null), ColumnDataType.INT, true, frame(-1, 1, Integer.MAX_VALUE, null),
+        new int[][]{{0, 4}, {0, 4}, {1, 4}, {3, 4}, {3, 4}});
+  }
+
+  @Test
+  public void testDoubleOrderKey() {
+    // values: 1.0, 1.5, 2.0, 4.0  |  frame = [v-0.5, v+0.5]
+    assertFrames(rows(1.0, 1.5, 2.0, 4.0), ColumnDataType.DOUBLE, true, frame(-1, 0.5, 1, 0.5),
+        new int[][]{{0, 1}, {0, 2}, {1, 2}, {3, 3}});
+  }
+
+  @Test
+  public void testBigDecimalOrderKey() {
+    // values (BIG_DECIMAL): 1, 2, 2, 5, 7  |  frame = [v-1, v+1]
+    assertFrames(rows(new java.math.BigDecimal(1), new java.math.BigDecimal(2), new java.math.BigDecimal(2),
+            new java.math.BigDecimal(5), new java.math.BigDecimal(7)), ColumnDataType.BIG_DECIMAL, true,
+        frame(-1, 1, 1, 1), new int[][]{{0, 2}, {0, 2}, {0, 2}, {3, 3}, {4, 4}});
+  }
+
+  @Test
+  public void testAllNullOrderKeys() {
+    // All rows are NULL peers -> the frame is the whole (NULL) partition
+    assertFrames(rows(null, null, null), ColumnDataType.INT, true, frame(-1, 1, 1, 1),
+        new int[][]{{0, 2}, {0, 2}, {0, 2}});
+  }
+
+  @Test
+  public void testDescAsymmetricOffsets() {
+    // values sorted desc: 5, 4, 3, 2, 1  |  frame BETWEEN 1 PRECEDING AND 2 FOLLOWING (asymmetric).
+    // A swap of the lower/upper deltas in the DESC branch would produce a different result than this.
+    assertFrames(rows(5, 4, 3, 2, 1), ColumnDataType.INT, false, frame(-1, 1, 1, 2),
+        new int[][]{{0, 2}, {0, 3}, {1, 4}, {2, 4}, {3, 4}});
+  }
+
+  @Test
+  public void testDescBetweenTwoPrecedingAndCurrentRow() {
+    // values sorted desc: 5, 4, 3, 2, 1  |  frame BETWEEN 2 PRECEDING AND CURRENT ROW.
+    assertFrames(rows(5, 4, 3, 2, 1), ColumnDataType.INT, false, frame(-1, 2, 0, null),
+        new int[][]{{0, 0}, {0, 1}, {0, 2}, {1, 3}, {2, 4}});
+  }
+
+  @Test
+  public void testDescNullsLastUnboundedPrecedingAndOneFollowing() {
+    // values sorted desc: 5, 3, 1, null, null  |  UNBOUNDED PRECEDING extends to index 0, NULLs included via the edge.
+    assertFrames(rows(5, 3, 1, null, null), ColumnDataType.INT, false, frame(Integer.MIN_VALUE, null, 1, 1),
+        new int[][]{{0, 0}, {0, 1}, {0, 2}, {0, 4}, {0, 4}});
+  }
+
+  @Test
+  public void testLongOrderKey() {
+    // LONG order key exercises the primitive long fast path.
+    assertFrames(rows(1L, 2L, 2L, 5L, 7L), ColumnDataType.LONG, true, frame(-1, 1, 1, 1),
+        new int[][]{{0, 2}, {0, 2}, {0, 2}, {3, 3}, {4, 4}});
+  }
+
+  @Test
+  public void testFloatOrderKey() {
+    // FLOAT order key exercises the double value-bounds path with Float-typed values.
+    assertFrames(rows(1.0f, 1.5f, 2.0f, 4.0f), ColumnDataType.FLOAT, true, frame(-1, 0.5, 1, 0.5),
+        new int[][]{{0, 1}, {0, 2}, {1, 2}, {3, 3}});
+  }
+
+  @Test
+  public void testIntOrderKeyWithNonIntegralOffsetFallsBackToBigDecimal() {
+    // A non-integral offset on an INT order key must fall back to exact BigDecimal arithmetic.
+    // values: 1, 2, 3, 4  |  frame = [v-1.5, v+1.5]
+    assertFrames(rows(1, 2, 3, 4), ColumnDataType.INT, true,
+        frame(-1, new java.math.BigDecimal("1.5"), 1, new java.math.BigDecimal("1.5")),
+        new int[][]{{0, 1}, {0, 2}, {1, 3}, {2, 3}});
+  }
+
+  @Test
+  public void testLongOrderKeyOffsetSaturatesInsteadOfOverflowing() {
+    // Order-key values near Long.MAX_VALUE with a positive offset: the upper edge must saturate at Long.MAX_VALUE
+    // rather than overflowing to a negative value (which would drop rows from the frame).
+    assertFrames(rows(Long.MAX_VALUE - 2, Long.MAX_VALUE - 1, Long.MAX_VALUE), ColumnDataType.LONG, true,
+        frame(-1, 5, 1, 5), new int[][]{{0, 2}, {0, 2}, {0, 2}});
+  }
+}

--- a/pinot-query-runtime/src/test/resources/queries/WindowFunctions.json
+++ b/pinot-query-runtime/src/test/resources/queries/WindowFunctions.json
@@ -5742,5 +5742,155 @@
         ]
       }
     ]
+  },
+  "range_offset_window_function_aggregations": {
+    "comment": "Value-based RANGE offset window frames (RANGE BETWEEN n PRECEDING AND n FOLLOWING). These queries omit 'outputs' so they are validated against H2 as the oracle. Order keys are non-null numeric columns (single ORDER BY key required for RANGE offset frames).",
+    "tables": {
+      "tbl": {
+        "schema": [
+          {"name": "int_col", "type": "INT"},
+          {"name": "double_col", "type": "DOUBLE"},
+          {"name": "string_col", "type": "STRING"},
+          {"name": "bool_col", "type": "BOOLEAN"},
+          {"name": "nullable_int_col", "type": "INT"}
+        ],
+        "inputs": [
+          [2, 300, "a", true, 1],
+          [2, 400, "a", true, null],
+          [3, 100, "b", false, null],
+          [3, 100, "c", true, 3],
+          [100, 1, "b", false, 1],
+          [42, 50.5, "e", true, 2],
+          [42, 42, "d", false, null],
+          [42, 75, "a", true, 5],
+          [42, 42, "a", false, 4],
+          [42, 50.5, "a", true, null],
+          [42, 42, "e", false, null],
+          [-101, 1.01, "c", false, 7],
+          [150, 1.5, "c", false, 6],
+          [50, 1.6, "c", false, 8],
+          [150, -1.53, "h", false, null],
+          [3, 100, "g", true, 10],
+          [2, 400, "c", false, null]
+        ]
+      }
+    },
+    "extraProps": {
+      "enableColumnBasedNullHandling": true
+    },
+    "queries": [
+      {
+        "description": "SUM with RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING",
+        "sql": "SELECT string_col, int_col, SUM(int_col) OVER(PARTITION BY string_col ORDER BY int_col RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING) FROM {tbl}"
+      },
+      {
+        "description": "AVG with RANGE BETWEEN 10 PRECEDING AND 10 FOLLOWING",
+        "sql": "SELECT string_col, int_col, AVG(int_col) OVER(PARTITION BY string_col ORDER BY int_col RANGE BETWEEN 10 PRECEDING AND 10 FOLLOWING) FROM {tbl}"
+      },
+      {
+        "description": "COUNT(*) with RANGE BETWEEN 20 PRECEDING AND CURRENT ROW",
+        "sql": "SELECT string_col, int_col, COUNT(*) OVER(PARTITION BY string_col ORDER BY int_col RANGE BETWEEN 20 PRECEDING AND CURRENT ROW) FROM {tbl}"
+      },
+      {
+        "description": "MIN with RANGE BETWEEN 50 PRECEDING AND 50 FOLLOWING",
+        "sql": "SELECT string_col, int_col, MIN(int_col) OVER(PARTITION BY string_col ORDER BY int_col RANGE BETWEEN 50 PRECEDING AND 50 FOLLOWING) FROM {tbl}"
+      },
+      {
+        "description": "MAX with RANGE BETWEEN 50 PRECEDING AND 50 FOLLOWING",
+        "sql": "SELECT string_col, int_col, MAX(int_col) OVER(PARTITION BY string_col ORDER BY int_col RANGE BETWEEN 50 PRECEDING AND 50 FOLLOWING) FROM {tbl}"
+      },
+      {
+        "description": "SUM with RANGE offset and DESC ordering",
+        "sql": "SELECT string_col, int_col, SUM(int_col) OVER(PARTITION BY string_col ORDER BY int_col DESC RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING) FROM {tbl}"
+      },
+      {
+        "description": "SUM with RANGE offset producing empty frames",
+        "sql": "SELECT string_col, int_col, SUM(int_col) OVER(PARTITION BY string_col ORDER BY int_col RANGE BETWEEN 100 PRECEDING AND 60 PRECEDING) FROM {tbl}"
+      },
+      {
+        "description": "SUM with RANGE BETWEEN UNBOUNDED PRECEDING AND offset FOLLOWING",
+        "sql": "SELECT string_col, int_col, SUM(int_col) OVER(PARTITION BY string_col ORDER BY int_col RANGE BETWEEN UNBOUNDED PRECEDING AND 5 FOLLOWING) FROM {tbl}"
+      },
+      {
+        "description": "SUM with RANGE BETWEEN offset PRECEDING AND UNBOUNDED FOLLOWING",
+        "sql": "SELECT string_col, int_col, SUM(int_col) OVER(PARTITION BY string_col ORDER BY int_col RANGE BETWEEN 5 PRECEDING AND UNBOUNDED FOLLOWING) FROM {tbl}"
+      },
+      {
+        "description": "SUM with RANGE BETWEEN CURRENT ROW AND offset FOLLOWING",
+        "sql": "SELECT string_col, int_col, SUM(int_col) OVER(PARTITION BY string_col ORDER BY int_col RANGE BETWEEN CURRENT ROW AND 5 FOLLOWING) FROM {tbl}"
+      },
+      {
+        "description": "SUM over DOUBLE order key with RANGE offset",
+        "sql": "SELECT string_col, double_col, SUM(int_col) OVER(PARTITION BY string_col ORDER BY double_col RANGE BETWEEN 50.0 PRECEDING AND 50.0 FOLLOWING) FROM {tbl}"
+      },
+      {
+        "description": "SUM of nullable values over RANGE offset frame",
+        "sql": "SELECT string_col, int_col, SUM(nullable_int_col) OVER(PARTITION BY string_col ORDER BY int_col RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING) FROM {tbl}"
+      },
+      {
+        "description": "FIRST_VALUE with RANGE offset frame over unique order keys",
+        "sql": "SELECT int_col, FIRST_VALUE(nullable_int_col) OVER(PARTITION BY string_col ORDER BY int_col RANGE BETWEEN 100 PRECEDING AND 100 FOLLOWING) FROM {tbl} WHERE string_col = 'c'"
+      },
+      {
+        "description": "LAST_VALUE with RANGE offset frame over unique order keys",
+        "sql": "SELECT int_col, LAST_VALUE(nullable_int_col) OVER(PARTITION BY string_col ORDER BY int_col RANGE BETWEEN 100 PRECEDING AND 100 FOLLOWING) FROM {tbl} WHERE string_col = 'c'"
+      },
+      {
+        "description": "SUM with RANGE offset over a nullable order key (NULLS LAST) - NULL rows form their own peer group",
+        "sql": "SELECT nullable_int_col, SUM(int_col) OVER(PARTITION BY string_col ORDER BY nullable_int_col NULLS LAST RANGE BETWEEN 2 PRECEDING AND 2 FOLLOWING) FROM {tbl}"
+      },
+      {
+        "description": "SUM with RANGE offset over a nullable order key (NULLS FIRST)",
+        "sql": "SELECT nullable_int_col, SUM(int_col) OVER(PARTITION BY string_col ORDER BY nullable_int_col NULLS FIRST RANGE BETWEEN 2 PRECEDING AND 2 FOLLOWING) FROM {tbl}"
+      },
+      {
+        "description": "SUM with RANGE offset over a nullable order key, UNBOUNDED PRECEDING (NULLS LAST) - includes preceding NULLs",
+        "sql": "SELECT nullable_int_col, SUM(int_col) OVER(PARTITION BY string_col ORDER BY nullable_int_col NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND 2 FOLLOWING) FROM {tbl}"
+      },
+      {
+        "description": "SUM with RANGE offset over a nullable order key with DESC ordering (NULLS LAST)",
+        "sql": "SELECT nullable_int_col, SUM(int_col) OVER(PARTITION BY string_col ORDER BY nullable_int_col DESC NULLS LAST RANGE BETWEEN 2 PRECEDING AND 2 FOLLOWING) FROM {tbl}"
+      },
+      {
+        "description": "FIRST_VALUE IGNORE NULLS with RANGE offset frame over unique order keys",
+        "sql": "SELECT int_col, FIRST_VALUE(nullable_int_col) IGNORE NULLS OVER(PARTITION BY string_col ORDER BY int_col RANGE BETWEEN 100 PRECEDING AND 100 FOLLOWING) FROM {tbl} WHERE string_col = 'c'"
+      },
+      {
+        "description": "LAST_VALUE IGNORE NULLS with RANGE offset frame over unique order keys",
+        "sql": "SELECT int_col, LAST_VALUE(nullable_int_col) IGNORE NULLS OVER(PARTITION BY string_col ORDER BY int_col RANGE BETWEEN 100 PRECEDING AND 100 FOLLOWING) FROM {tbl} WHERE string_col = 'c'"
+      },
+      {
+        "description": "SUM with RANGE offset frame and EXCLUDE CURRENT ROW",
+        "sql": "SELECT string_col, int_col, SUM(int_col) OVER(PARTITION BY string_col ORDER BY int_col RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING EXCLUDE CURRENT ROW) FROM {tbl}"
+      },
+      {
+        "description": "SUM with RANGE offset frame and EXCLUDE GROUP",
+        "sql": "SELECT string_col, int_col, SUM(int_col) OVER(PARTITION BY string_col ORDER BY int_col RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING EXCLUDE GROUP) FROM {tbl}"
+      },
+      {
+        "description": "SUM with RANGE offset frame and EXCLUDE TIES",
+        "sql": "SELECT string_col, int_col, SUM(int_col) OVER(PARTITION BY string_col ORDER BY int_col RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING EXCLUDE TIES) FROM {tbl}"
+      },
+      {
+        "description": "AVG with RANGE offset frame and EXCLUDE GROUP",
+        "sql": "SELECT string_col, int_col, AVG(int_col) OVER(PARTITION BY string_col ORDER BY int_col RANGE BETWEEN 10 PRECEDING AND 10 FOLLOWING EXCLUDE GROUP) FROM {tbl}"
+      },
+      {
+        "description": "MAX with RANGE offset frame and EXCLUDE CURRENT ROW (exercises arbitrary-removal aggregator)",
+        "sql": "SELECT string_col, int_col, MAX(int_col) OVER(PARTITION BY string_col ORDER BY int_col RANGE BETWEEN 50 PRECEDING AND 50 FOLLOWING EXCLUDE CURRENT ROW) FROM {tbl}"
+      },
+      {
+        "description": "MIN with RANGE offset frame and EXCLUDE TIES (exercises arbitrary-removal aggregator)",
+        "sql": "SELECT string_col, int_col, MIN(int_col) OVER(PARTITION BY string_col ORDER BY int_col RANGE BETWEEN 50 PRECEDING AND 50 FOLLOWING EXCLUDE TIES) FROM {tbl}"
+      },
+      {
+        "description": "FIRST_VALUE with RANGE offset frame and EXCLUDE CURRENT ROW over unique order keys",
+        "sql": "SELECT int_col, FIRST_VALUE(nullable_int_col) OVER(PARTITION BY string_col ORDER BY int_col RANGE BETWEEN 100 PRECEDING AND 100 FOLLOWING EXCLUDE CURRENT ROW) FROM {tbl} WHERE string_col = 'c'"
+      },
+      {
+        "description": "LAST_VALUE with RANGE offset frame and EXCLUDE GROUP over unique order keys",
+        "sql": "SELECT int_col, LAST_VALUE(nullable_int_col) OVER(PARTITION BY string_col ORDER BY int_col RANGE BETWEEN 100 PRECEDING AND 100 FOLLOWING EXCLUDE GROUP) FROM {tbl} WHERE string_col = 'c'"
+      }
+    ]
   }
 }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Adds RANGE offset frame support via planning validation, bound conversion, WindowNode offset storage, and two‑pointer frame bound computation for aggregation\.

```mermaid
flowchart TD
  N0["Validate RANGE offset frame #40;F2#41;"]:::stModified
  N1["Convert Calcite bound to WindowFrameBound #40;F6#41;"]:::stModified
  N2["WindowNode stores offset literals #40;F8#41;"]:::stModified
  N3["WindowNode serialization#47;deserialization #40;F9#44; F10#41;"]:::stModified
  N4["WindowAggregateOperator builds WindowFrame #40;F11#41;"]:::stModified
  N5["WindowFrame range offset accessors #40;F13#41;"]:::stModified
  N6["RangeWindowFrameBounds computes frame bounds #40;F12#41;"]:::stAdded
  N7["AggregateWindowFunction processes RANGE offset window #40;F15#41;"]:::stModified
  N8["FIRST#95;VALUE#47;LAST#95;VALUE use frame bounds #40;F16#44; F17#41;"]:::stModified
  N1 -->|"pass bound and offset literal"| N2
  N2 -->|"provide offset literals"| N3
  N3 -->|"pass WindowNode"| N4
  N4 -->|"construct WindowFrame"| N5
  N5 -->|"supply range offsets"| N6
  N6 -->|"deliver frame bounds"| N7
  N6 -->|"deliver frame bounds"| N8
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F2: pinot\-query\-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotRuleUtils\.java — [before](https://github.com/apache/pinot/blob/f216ed25ac2319fd3654febe062c9b097b2f74b3/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotRuleUtils.java) · [after](https://github.com/apache/pinot/blob/c46a3cc7b276b788e2f44575f6b99a5c1768d9a2/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotRuleUtils.java)
- F6: pinot\-query\-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils\.java — [before](https://github.com/apache/pinot/blob/f216ed25ac2319fd3654febe062c9b097b2f74b3/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils.java) · [after](https://github.com/apache/pinot/blob/c46a3cc7b276b788e2f44575f6b99a5c1768d9a2/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils.java)
- F8: pinot\-query\-planner/src/main/java/org/apache/pinot/query/planner/plannode/WindowNode\.java — [before](https://github.com/apache/pinot/blob/f216ed25ac2319fd3654febe062c9b097b2f74b3/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/WindowNode.java) · [after](https://github.com/apache/pinot/blob/c46a3cc7b276b788e2f44575f6b99a5c1768d9a2/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/WindowNode.java)
- F9: pinot\-query\-planner/src/main/java/org/apache/pinot/query/planner/serde/PlanNodeDeserializer\.java — [before](https://github.com/apache/pinot/blob/f216ed25ac2319fd3654febe062c9b097b2f74b3/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/PlanNodeDeserializer.java) · [after](https://github.com/apache/pinot/blob/c46a3cc7b276b788e2f44575f6b99a5c1768d9a2/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/PlanNodeDeserializer.java)
- F10: pinot\-query\-planner/src/main/java/org/apache/pinot/query/planner/serde/PlanNodeSerializer\.java — [before](https://github.com/apache/pinot/blob/f216ed25ac2319fd3654febe062c9b097b2f74b3/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/PlanNodeSerializer.java) · [after](https://github.com/apache/pinot/blob/c46a3cc7b276b788e2f44575f6b99a5c1768d9a2/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/PlanNodeSerializer.java)
- F11: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperator\.java — [before](https://github.com/apache/pinot/blob/f216ed25ac2319fd3654febe062c9b097b2f74b3/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperator.java) · [after](https://github.com/apache/pinot/blob/c46a3cc7b276b788e2f44575f6b99a5c1768d9a2/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperator.java)
- F12: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/RangeWindowFrameBounds\.java — [after](https://github.com/apache/pinot/blob/c46a3cc7b276b788e2f44575f6b99a5c1768d9a2/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/RangeWindowFrameBounds.java)
- F13: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/WindowFrame\.java — [before](https://github.com/apache/pinot/blob/f216ed25ac2319fd3654febe062c9b097b2f74b3/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/WindowFrame.java) · [after](https://github.com/apache/pinot/blob/c46a3cc7b276b788e2f44575f6b99a5c1768d9a2/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/WindowFrame.java)
- F15: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/AggregateWindowFunction\.java — [before](https://github.com/apache/pinot/blob/f216ed25ac2319fd3654febe062c9b097b2f74b3/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/AggregateWindowFunction.java) · [after](https://github.com/apache/pinot/blob/c46a3cc7b276b788e2f44575f6b99a5c1768d9a2/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/AggregateWindowFunction.java)
- F16: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/FirstValueWindowFunction\.java — [before](https://github.com/apache/pinot/blob/f216ed25ac2319fd3654febe062c9b097b2f74b3/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/FirstValueWindowFunction.java) · [after](https://github.com/apache/pinot/blob/c46a3cc7b276b788e2f44575f6b99a5c1768d9a2/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/FirstValueWindowFunction.java)
- F17: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/LastValueWindowFunction\.java — [before](https://github.com/apache/pinot/blob/f216ed25ac2319fd3654febe062c9b097b2f74b3/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/LastValueWindowFunction.java) · [after](https://github.com/apache/pinot/blob/c46a3cc7b276b788e2f44575f6b99a5c1768d9a2/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/LastValueWindowFunction.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImYyMTZlZDI1YWMyMzE5ZmQzNjU0ZmViZTA2MmM5YjA5N2IyZjc0YjMiLCJjb250ZXh0X2hhc2giOiJlYTYwZjEwMjk4ZmQ0MDExMjIxZmRjY2Q2ODYwNzJkYzhiZmI3MDA5ZGI0ZThmNDg5ZjEwNjRkMWZjZjFlNGYyIiwiZ2VuZXJhdGVkX2F0IjoxNzg5NTI5NjMyLCJoZWFkX3NoYSI6ImM0NmEzY2M3YjI3NmI3ODhlMmY0NDU3NWY2Yjk5YTVjMTc2OGQ5YTIiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJmMjE2ZWQyNWFjMjMxOWZkMzY1NGZlYmUwNjJjOWIwOTdiMmY3NGIzIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature f8cf7c28edb5ca3c4050513baf73108457c33cd24f306c18c088a75593acf092 -->
<!-- pinot-pr-flow:end -->

Add support for value-based RANGE window frames with offset `PRECEDING` / `FOLLOWING` bounds (e.g. `RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING`) in the multi-stage query engine. Previously only `ROWS` offset frames and `RANGE` frames bounded solely by `UNBOUNDED` / `CURRENT ROW` were supported; `RANGE` offset frames were rejected both at planning and execution.

## Newly supported

`RANGE` frames with numeric offset bounds in any valid combination — `n PRECEDING`, `n FOLLOWING`, `CURRENT ROW`, `UNBOUNDED PRECEDING/FOLLOWING`:

```sql
... OVER (ORDER BY k RANGE BETWEEN 5 PRECEDING AND 5 FOLLOWING)
... OVER (ORDER BY k RANGE BETWEEN 10 PRECEDING AND CURRENT ROW)
... OVER (ORDER BY k RANGE BETWEEN CURRENT ROW AND 3 FOLLOWING)
... OVER (ORDER BY k RANGE BETWEEN UNBOUNDED PRECEDING AND 7 FOLLOWING)
... OVER (ORDER BY k RANGE BETWEEN 3 PRECEDING AND UNBOUNDED FOLLOWING)
... OVER (ORDER BY k DESC RANGE BETWEEN 1 PRECEDING AND 3 FOLLOWING)   -- ASC and DESC
```

- Works for every frame-respecting window function: `SUM`, `COUNT`, `AVG`, `MIN`, `MAX`, `BOOL_AND`, `BOOL_OR`, `FIRST_VALUE`, `LAST_VALUE` (including `IGNORE NULLS`).
- Composes with the recently added `EXCLUDE` clause: `RANGE BETWEEN n PRECEDING AND n FOLLOWING EXCLUDE {CURRENT ROW | GROUP | TIES | NO OTHERS}`.
- Standard SQL / PostgreSQL semantics: the frame is a value range over the single `ORDER BY` key (not a row count); peers (equal order-key values) share a frame; `NULL` order keys form their own peer group (honoring `NULLS FIRST/LAST`); leading/trailing `NULL`s are included only for `UNBOUNDED` bounds; empty frames yield `NULL` (`SUM`/`AVG`/`MIN`/`MAX`) or `0` (`COUNT`).
- Both the legacy (v1) and physical-optimizer (v2) planning paths.

## Example use cases

- Windowed aggregates over a *value* neighborhood rather than a row count — e.g. "sum of order amounts within ±100 of the current order value", "count of events whose score is within 5 of the current row", "min/max over a numeric band".
- Coarse time-series aggregation over a numeric time key (e.g. epoch seconds) — e.g. "average over the preceding and following 3600 seconds".

## Design & performance

- Frame bounds are computed with an `O(n)` two-pointer sweep over the (already sorted) partition, and computed **once per partition and shared across all window functions** in the same window (`RangeWindowFrameBounds`).
- Incremental aggregation keeps each function at its optimal complexity: `SUM`/`COUNT`/`AVG` `O(1)` per slide, `MIN`/`MAX` via the existing monotonic deque (amortized `O(1)`), `BOOL_AND`/`BOOL_OR` via counts `O(1)`; `FIRST_VALUE`/`LAST_VALUE` `O(1)` per row (`O(n)` prefix arrays for `IGNORE NULLS`). Net: `O(n)` per partition (the sort is already done upstream by the sort exchange).
- Type-appropriate arithmetic: a primitive `long` fast path with overflow-saturating arithmetic for `INT`/`LONG` order keys, exact `BigDecimal` for `BIG_DECIMAL` (and for non-integral offsets on integer keys), and `double` for `FLOAT`/`DOUBLE`.

## Wire / rolling-upgrade compatibility

- The value offset is carried in two new additive, message-typed protobuf fields (`WindowNode.lowerBoundOffset` / `upperBoundOffset`) — backward compatible; absence is distinguishable from a real value.
- A new broker sending a `RANGE` offset query to a server that predates this change fails fast with a clear error rather than producing wrong results. **Upgrade servers before brokers.**

## Limitations / future work

- Supported only for **numeric** `ORDER BY` keys (`INT`/`LONG`/`FLOAT`/`DOUBLE`/`BIG_DECIMAL`). Temporal keys with `INTERVAL` offsets (e.g. `RANGE BETWEEN INTERVAL '7' DAY PRECEDING AND CURRENT ROW`) are accepted by Calcite but rejected at planning with a clear message — a natural follow-up.

## Testing

- `RangeWindowFrameBoundsTest`: the two-pointer calculator across ASC/DESC, symmetric/asymmetric offsets, `CURRENT ROW`, `UNBOUNDED`, empty frames, `NULLS FIRST/LAST`, `INT`/`LONG`/`FLOAT`/`DOUBLE`/`BIG_DECIMAL`, non-integral-offset fallback, and `LONG` overflow saturation.
- `WindowAggregateOperatorTest`: operator-level `SUM`/`MAX`/`BOOL_AND` and `FIRST_VALUE`/`LAST_VALUE` (respect + `IGNORE NULLS`) over RANGE offset frames.
- `WindowFunctions.json` (H2-oracle end-to-end, both optimizer paths): aggregates + value functions, ASC/DESC, empty/unbounded/current-row combos, `DOUBLE` keys, nullable values, and nullable order keys.
- Plan-shape (`WindowFunctionPlans.json`), plan serde round-trip incl. backward-compat (`PlanNodeSerDeTest`), planner validation (`QueryCompilationTest`, numeric-only rejection), and a multi-stage integration smoke test.
