### PR TITLE
Default pinot.server.consuming.segment.consistency.mode to PROTECTED

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PartialUpsertTableRebalanceIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PartialUpsertTableRebalanceIntegrationTest.java
@@ -230,7 +230,8 @@ public class PartialUpsertTableRebalanceIntegrationTest extends BaseClusterInteg
     waitForAllDocsLoaded(600_000L, 300);
 
     // Partial-upsert tables need PROTECTED consuming segment consistency mode for reload to force-commit
-    // consuming segments; RESTRICTED (default) skips force-commit and reload never completes.
+    // consuming segments; RESTRICTED skips force-commit and reload never completes. Set explicitly here
+    // rather than relying on the default so this test doesn't depend on it.
     try {
       updateClusterConfig(
           Map.of(CommonConstants.ConfigChangeListenerConstants.CONSUMING_SEGMENT_CONSISTENCY_MODE,

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/ConsumingSegmentConsistencyModeListener.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/ConsumingSegmentConsistencyModeListener.java
@@ -31,7 +31,8 @@ import org.slf4j.LoggerFactory;
 /**
  * Singleton class to manage the configuration for force commit on consuming segments
  * for upsert tables with inconsistent state configurations (partial upsert or dropOutOfOrderRecord=true or
- * outOfOrderColumn). By default, the force commit and reload is disabled
+ * outOfOrderColumn). By default, force commit and reload are enabled, with the upsert metadata reverted to
+ * resolve any detected inconsistencies (PROTECTED mode).
  * This configuration is dynamically updatable via ZK cluster config without requiring a server restart.
  */
 public class ConsumingSegmentConsistencyModeListener implements PinotClusterConfigChangeListener {
@@ -59,7 +60,7 @@ public class ConsumingSegmentConsistencyModeListener implements PinotClusterConf
      */
     UNSAFE(true);
 
-    public static final Mode DEFAULT_CONSUMING_SEGMENT_CONSISTENCY_MODE = RESTRICTED;
+    public static final Mode DEFAULT_CONSUMING_SEGMENT_CONSISTENCY_MODE = PROTECTED;
 
     private final boolean _forceCommitAllowed;
 

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/ConsumingSegmentConsistencyModeListenerTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/ConsumingSegmentConsistencyModeListenerTest.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.utils;
+
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.spi.utils.ConsumingSegmentConsistencyModeListener.Mode;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+public class ConsumingSegmentConsistencyModeListenerTest {
+  private final ConsumingSegmentConsistencyModeListener _listener =
+      ConsumingSegmentConsistencyModeListener.getInstance();
+
+  @AfterMethod
+  public void tearDown() {
+    _listener.reset();
+  }
+
+  @Test
+  public void testDefaultModeIsProtected() {
+    assertEquals(Mode.DEFAULT_CONSUMING_SEGMENT_CONSISTENCY_MODE, Mode.PROTECTED);
+    assertEquals(_listener.getConsistencyMode(), Mode.PROTECTED);
+    assertTrue(_listener.isForceCommitAllowed());
+  }
+
+  @Test
+  public void testExplicitClusterConfigOverridesDefault() {
+    _listener.onChange(Set.of(_listener.getConfigKey()),
+        Map.of(_listener.getConfigKey(), Mode.RESTRICTED.name()));
+    assertEquals(_listener.getConsistencyMode(), Mode.RESTRICTED);
+    assertFalse(_listener.isForceCommitAllowed());
+
+    _listener.onChange(Set.of(_listener.getConfigKey()),
+        Map.of(_listener.getConfigKey(), Mode.UNSAFE.name()));
+    assertEquals(_listener.getConsistencyMode(), Mode.UNSAFE);
+    assertTrue(_listener.isForceCommitAllowed());
+  }
+
+  @Test
+  public void testUnchangedConfigKeyIsIgnored() {
+    _listener.onChange(Set.of(_listener.getConfigKey()),
+        Map.of(_listener.getConfigKey(), Mode.RESTRICTED.name()));
+    assertEquals(_listener.getConsistencyMode(), Mode.RESTRICTED);
+
+    // A change notification that doesn't include our key must not touch the mode, even if some
+    // unrelated cluster config value is present.
+    _listener.onChange(Set.of("some.other.config"), Map.of("some.other.config", "value"));
+    assertEquals(_listener.getConsistencyMode(), Mode.RESTRICTED);
+  }
+
+  @Test
+  public void testMissingOrBlankValueFallsBackToDefault() {
+    assertEquals(Mode.fromString(null), Mode.DEFAULT_CONSUMING_SEGMENT_CONSISTENCY_MODE);
+    assertEquals(Mode.fromString(""), Mode.DEFAULT_CONSUMING_SEGMENT_CONSISTENCY_MODE);
+    assertEquals(Mode.fromString("   "), Mode.DEFAULT_CONSUMING_SEGMENT_CONSISTENCY_MODE);
+  }
+
+  @Test
+  public void testInvalidValueFallsBackToDefault() {
+    assertEquals(Mode.fromString("not-a-real-mode"), Mode.DEFAULT_CONSUMING_SEGMENT_CONSISTENCY_MODE);
+  }
+
+  @Test
+  public void testResetRestoresDefault() {
+    _listener.setMode(Mode.RESTRICTED);
+    assertEquals(_listener.getConsistencyMode(), Mode.RESTRICTED);
+
+    _listener.reset();
+    assertEquals(_listener.getConsistencyMode(), Mode.PROTECTED);
+  }
+}


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Changed default consuming segment consistency mode from RESTRICTED to PROTECTED, enabling force\-commit/reload with metadata reconciliation\.

```mermaid
flowchart TD
  N0["Default mode#58; PROTECTED #40;F3#41;"]:::stModified
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F3: pinot\-spi/src/main/java/org/apache/pinot/spi/utils/ConsumingSegmentConsistencyModeListener\.java — [before](https://github.com/apache/pinot/blob/a979a6a0d8e173e887a68dd294e8013dc16ca43d/pinot-spi/src/main/java/org/apache/pinot/spi/utils/ConsumingSegmentConsistencyModeListener.java) · [after](https://github.com/apache/pinot/blob/637f900f054d85e894178b203c599bc8906fbb04/pinot-spi/src/main/java/org/apache/pinot/spi/utils/ConsumingSegmentConsistencyModeListener.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImE5NzlhNmEwZDhlMTczZTg4N2E2OGRkMjk0ZTgwMTNkYzE2Y2E0M2QiLCJjb250ZXh0X2hhc2giOiJmZjJmNjIzMzc0YTA0ZGRhYjBkMDQxZGQzYWEzNmVhYjg2NDU4ZTAyYmI4NWU2NGUxZWI0YWIwZDI3ZmNhMTI1IiwiZ2VuZXJhdGVkX2F0IjoxNzg5NTM4OTAyLCJoZWFkX3NoYSI6IjYzN2Y5MDBmMDU0ZDg1ZTg5NDE3OGIyMDNjNTk5YmM4OTA2ZmJiMDQiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJhOTc5YTZhMGQ4ZTE3M2U4ODdhNjhkZDI5NGU4MDEzZGMxNmNhNDNkIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 54ed4c6650ab48f6fcaaa2ecc6d94f71d876288868a365bc85a8fe2a4ead9da6 -->
<!-- pinot-pr-flow:end -->


## Summary
`pinot.server.consuming.segment.consistency.mode` was introduced in #17503 with three modes:
- `RESTRICTED` (current default) — blocks force-commit/reload during the risky consuming-segment transition window for partial-upsert and `dropOutOfOrderRecord`/`outOfOrderRecordColumn` tables. It only *prevents* the risky operation from running; it doesn't resolve anything.
- `PROTECTED` — allows force-commit/reload, and reconciles the upsert metadata back to a consistent state if a discrepancy is detected during segment commit or removal.
- `UNSAFE` — allows force-commit/reload with no reconciliation.

This PR proposes flipping the default from `RESTRICTED` to `PROTECTED`, since `RESTRICTED` alone doesn't get an affected table to a correct state — it just blocks operational flows (reload, force-commit, Segment Refresh Task, index changes) on partial-upsert / `dropOutOfOrderRecord` tables indefinitely, until an operator manually opts into `PROTECTED`. Defaulting to `PROTECTED` means these operations work out of the box, with the metadata-reconciliation safety net already in place.
