### PR TITLE
[core] Upgrade t-digest to 3.3 with mixed-version compatibility

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
@@ -25,7 +25,6 @@ import com.dynatrace.hash4j.distinctcount.UltraLogLog;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Longs;
-import com.tdunning.math.stats.MergingDigest;
 import com.tdunning.math.stats.TDigest;
 import it.unimi.dsi.fastutil.doubles.Double2LongMap;
 import it.unimi.dsi.fastutil.doubles.Double2LongOpenHashMap;
@@ -97,6 +96,7 @@ import org.apache.pinot.segment.local.customobject.ThetaSketchAccumulator;
 import org.apache.pinot.segment.local.customobject.TupleIntSketchAccumulator;
 import org.apache.pinot.segment.local.customobject.VarianceTuple;
 import org.apache.pinot.segment.local.utils.GeometrySerializer;
+import org.apache.pinot.segment.local.utils.TDigestUtils;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.locationtech.jts.geom.Geometry;
@@ -1124,19 +1124,17 @@ public class ObjectSerDeUtils {
 
     @Override
     public byte[] serialize(TDigest tDigest) {
-      byte[] bytes = new byte[tDigest.byteSize()];
-      tDigest.asBytes(ByteBuffer.wrap(bytes));
-      return bytes;
+      return TDigestUtils.serialize(tDigest);
     }
 
     @Override
     public TDigest deserialize(byte[] bytes) {
-      return MergingDigest.fromBytes(ByteBuffer.wrap(bytes));
+      return TDigestUtils.deserialize(bytes);
     }
 
     @Override
     public TDigest deserialize(ByteBuffer byteBuffer) {
-      return MergingDigest.fromBytes(byteBuffer);
+      return TDigestUtils.deserialize(byteBuffer);
     }
   };
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAccumulator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAccumulator.java
@@ -20,26 +20,31 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import com.tdunning.math.stats.Centroid;
 import com.tdunning.math.stats.MergingDigest;
+import com.tdunning.math.stats.ScaleFunction;
+import com.tdunning.math.stats.Sort;
 import com.tdunning.math.stats.TDigest;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import org.apache.pinot.segment.local.utils.TDigestUtils;
 
 /// Accumulates raw values and serialized TDigests into centroids without repeatedly sorting existing centroids.
 ///
 /// The accumulator is used while a percentile TDigest result, or one of its group-by results, is being built. Raw
 /// values are sorted in small batches, while serialized TDigest centroids are decoded in their existing sorted order.
-/// Both are linearly merged with the accumulated centroids and compressed using the same weight-limit rule as
-/// [MergingDigest]. [#toTDigest()] normalizes the result to a standard [MergingDigest], so the public intermediate
-/// and wire representations remain unchanged. Intermediate serialization retains the standard small encoding when
-/// its explicit capacity is required to decode an oversized compact digest.
+/// Both are linearly merged with the accumulated centroids and compressed using the same K1 weight-limit rule as the
+/// merging digests created by [TDigestUtils]. Pinot selects K1 explicitly because t-digest 3.3's new K2 default caused
+/// a material middle-quantile accuracy regression. [#toTDigest()] normalizes the result to the library's standard
+/// merging digest, so the public intermediate and wire representations remain unchanged. Intermediate serialization
+/// retains the standard small encoding when its explicit capacity is required to decode an oversized compact digest.
 ///
 /// The accumulator implements [TDigest] so process-local combine and reduction can retain the primitive state.
 /// Quantile queries and CDFs read the primitive state directly. Centroid iteration uses the canonical library
 /// implementation returned from [#toTDigest()], while [#byteSize()] and [#asBytes(ByteBuffer)] emit [#serialize()]
-/// bytes directly so generic `TDigest` serializers preserve capacity-preserving state.
+/// bytes directly so generic `TDigest` serializers preserve mixed-version-compatible state.
 ///
 /// Serialized group state keeps its first digest pending, and allocates primitive centroid buffers only when another
 /// input must be merged. The raw-value buffer remains unallocated for serialized state until a raw value is added.
@@ -48,7 +53,10 @@ import java.util.List;
 final class PercentileTDigestAccumulator extends TDigest {
   private static final int MIN_RAW_BUFFER_SIZE = 256;
   private static final int MAX_RAW_BUFFER_SIZE = 10_000;
-  private static final int CENTROID_CAPACITY_PADDING = 10;
+  private static final int MIN_COMPRESSION = 10;
+  private static final int DEFAULT_CENTROID_CAPACITY_PADDING = 10;
+  private static final int LOW_COMPRESSION_CAPACITY_PADDING = 30;
+  private static final int TWO_LEVEL_COMPRESSION_MULTIPLIER = 2;
   private static final int VERBOSE_ENCODING = 1;
   private static final int SMALL_ENCODING = 2;
   private static final int VERBOSE_HEADER_SIZE = 32;
@@ -58,7 +66,11 @@ final class PercentileTDigestAccumulator extends TDigest {
   private static final int DEFAULT_MERGE_BUFFER_MULTIPLIER = 5;
 
   private final double _compression;
+  private final double _workingCompression;
+  private final double _publicMaxWeightScale;
+  private final double _workingMaxWeightScale;
   private final int _centroidCapacity;
+  private final int _pendingCentroidCapacity;
   private double[] _rawValues;
   private double[] _centroidMeans;
   private double[] _centroidWeights;
@@ -66,15 +78,24 @@ final class PercentileTDigestAccumulator extends TDigest {
   private double[] _outputWeights;
   private double[] _incomingMeans;
   private double[] _incomingWeights;
+  private double[] _sortedIncomingMeans;
+  private double[] _sortedIncomingWeights;
+  private int[] _incomingOrder;
+  private SerializedTDigestInput _serializedTDigestInput;
   private byte[] _pendingSerializedTDigest;
   private double _pendingSerializedTotalWeight = Double.NaN;
   private boolean _hasSerializedInput;
 
   private int _numRawValues;
   private int _numCentroids;
+  private int _numIncomingCentroids;
   private int _serializedMainCapacity;
   private int _serializedBufferCapacity;
+  private int _mergeCount;
+  private boolean _publiclyCompressed;
+  private boolean _incomingCentroidsSorted = true;
   private double _totalWeight;
+  private double _incomingWeight;
   private double _min = Double.POSITIVE_INFINITY;
   private double _max = Double.NEGATIVE_INFINITY;
 
@@ -86,9 +107,14 @@ final class PercentileTDigestAccumulator extends TDigest {
     if (!(compression > 0.0) || !Double.isFinite(compression)) {
       throw new IllegalArgumentException("TDigest compression must be positive: " + compression);
     }
-    _compression = compression;
-    long roundedCompression = (long) Math.ceil(compression);
-    _centroidCapacity = getCentroidCapacity(compression);
+    super.setScaleFunction(ScaleFunction.K_1);
+    _compression = Math.max(MIN_COMPRESSION, compression);
+    _workingCompression = TWO_LEVEL_COMPRESSION_MULTIPLIER * _compression;
+    _publicMaxWeightScale = calculateK1MaxWeightScale(_compression);
+    _workingMaxWeightScale = calculateK1MaxWeightScale(_workingCompression);
+    long roundedCompression = (long) Math.ceil(_compression);
+    _centroidCapacity = getCentroidCapacity(_compression);
+    _pendingCentroidCapacity = getPendingCentroidCapacity(_centroidCapacity);
     if (allocateRawBuffer) {
       _rawValues = new double[getRawBufferSize(roundedCompression)];
     }
@@ -131,7 +157,12 @@ final class PercentileTDigestAccumulator extends TDigest {
     materializePendingSerializedTDigest();
     ensureRawBuffer();
     while (from < toExclusive) {
-      int numValues = Math.min(toExclusive - from, _rawValues.length - _numRawValues);
+      if (_numRawValues == _rawValues.length
+          || _numRawValues + _numIncomingCentroids == getPendingInputLimit()) {
+        flush();
+      }
+      int numValues = Math.min(toExclusive - from, Math.min(_rawValues.length - _numRawValues,
+          getPendingInputLimit() - _numRawValues - _numIncomingCentroids));
       int rawOffset = _numRawValues;
       for (int i = 0; i < numValues; i++) {
         double value = values[from + i];
@@ -142,7 +173,8 @@ final class PercentileTDigestAccumulator extends TDigest {
       }
       from += numValues;
       _numRawValues += numValues;
-      if (_numRawValues == _rawValues.length) {
+      if (_numRawValues == _rawValues.length
+          || _numRawValues + _numIncomingCentroids == getPendingInputLimit()) {
         flush();
       }
     }
@@ -155,7 +187,8 @@ final class PercentileTDigestAccumulator extends TDigest {
     }
     materializePendingSerializedTDigest();
     ensureRawBuffer();
-    if (_numRawValues == _rawValues.length) {
+    if (_numRawValues == _rawValues.length
+        || _numRawValues + _numIncomingCentroids == getPendingInputLimit()) {
       flush();
     }
     _rawValues[_numRawValues++] = value;
@@ -171,14 +204,9 @@ final class PercentileTDigestAccumulator extends TDigest {
       throw new IllegalArgumentException("Cannot add NaN to t-digest");
     }
     materializePendingSerializedTDigest();
-    flush();
-    ensureIncomingCapacity(1);
-    _incomingMeans[0] = value;
-    _incomingWeights[0] = weight;
-    if (mergeSorted(_incomingMeans, _incomingWeights, 1, weight)) {
-      _min = Math.min(_min, value);
-      _max = Math.max(_max, value);
-    }
+    bufferIncomingCentroid(value, weight);
+    _min = Math.min(_min, value);
+    _max = Math.max(_max, value);
   }
 
   @Override
@@ -187,25 +215,20 @@ final class PercentileTDigestAccumulator extends TDigest {
       addAccumulator((PercentileTDigestAccumulator) other);
       return;
     }
+    if (other instanceof MergingDigest && other.size() > Integer.MAX_VALUE) {
+      // Centroid.count() exposes an int even though MergingDigest stores double weights internally. Preserve large
+      // pre-aggregated weights by ingesting the serialized double-precision representation instead.
+      addSerializedTDigest(TDigestUtils.serialize(other));
+      return;
+    }
 
-    other.compress();
-    int numCentroids = other.centroidCount();
+    Collection<Centroid> centroids = other.centroids();
     materializePendingSerializedTDigest();
-    flush();
-    ensureIncomingCapacity(numCentroids);
-    int index = 0;
-    double incomingWeight = 0.0;
-    for (Centroid centroid : other.centroids()) {
-      _incomingMeans[index] = centroid.mean();
-      double weight = centroid.count();
-      _incomingWeights[index] = weight;
-      incomingWeight += weight;
-      index++;
+    for (Centroid centroid : centroids) {
+      bufferIncomingCentroid(centroid.mean(), centroid.count());
     }
-    if (mergeSorted(_incomingMeans, _incomingWeights, index, incomingWeight)) {
-      _min = Math.min(_min, other.getMin());
-      _max = Math.max(_max, other.getMax());
-    }
+    _min = Math.min(_min, other.getMin());
+    _max = Math.max(_max, other.getMax());
   }
 
   @Override
@@ -223,31 +246,35 @@ final class PercentileTDigestAccumulator extends TDigest {
 
     other.compress();
     materializePendingSerializedTDigest();
-    flush();
     preserveSerializedCapacity(other._serializedMainCapacity, other._serializedBufferCapacity);
-    if (mergeSorted(other._centroidMeans, other._centroidWeights, other._numCentroids, other._totalWeight)) {
-      _min = Math.min(_min, other._min);
-      _max = Math.max(_max, other._max);
-    }
+    bufferIncomingCentroids(other._centroidMeans, other._centroidWeights, other._numCentroids);
+    _min = Math.min(_min, other._min);
+    _max = Math.max(_max, other._max);
   }
 
   void addSerializedTDigest(byte[] bytes) {
-    flush();
-    if (!_hasSerializedInput && _numCentroids == 0 && _totalWeight == 0.0) {
-      _pendingSerializedTotalWeight = getSerializedTotalWeight(bytes);
-      _pendingSerializedTDigest = bytes;
+    if (!_hasSerializedInput && _numCentroids == 0 && _totalWeight == 0.0 && _numRawValues == 0
+        && _numIncomingCentroids == 0) {
+      byte[] retainedBytes = bytes.clone();
+      _pendingSerializedTotalWeight = getSerializedTotalWeight(retainedBytes);
+      _pendingSerializedTDigest = retainedBytes;
       _hasSerializedInput = true;
       return;
     }
     materializePendingSerializedTDigest();
-    mergeSerializedTDigest(bytes);
+    if (_serializedTDigestInput == null) {
+      _serializedTDigestInput = new SerializedTDigestInput();
+    }
+    _serializedTDigestInput.reset(bytes);
+    _serializedTDigestInput.decode();
+    mergeSerializedTDigest(_serializedTDigestInput);
     _hasSerializedInput = true;
   }
 
   void addSerializedTDigest(SerializedTDigestInput input) {
-    flush();
-    if (!_hasSerializedInput && _numCentroids == 0 && _totalWeight == 0.0) {
-      _pendingSerializedTDigest = input._bytes;
+    if (!_hasSerializedInput && _numCentroids == 0 && _totalWeight == 0.0 && _numRawValues == 0
+        && _numIncomingCentroids == 0) {
+      _pendingSerializedTDigest = input.retainBytes();
       _pendingSerializedTotalWeight = Double.NaN;
       _hasSerializedInput = true;
       return;
@@ -255,6 +282,41 @@ final class PercentileTDigestAccumulator extends TDigest {
     materializePendingSerializedTDigest();
     input.decode();
     mergeSerializedTDigest(input);
+    _hasSerializedInput = true;
+  }
+
+  void addSerializedTDigestDirect(SerializedTDigestInput input) {
+    if (!_hasSerializedInput && _numCentroids == 0 && _totalWeight == 0.0 && _numRawValues == 0
+        && _numIncomingCentroids == 0) {
+      _pendingSerializedTDigest = input.retainBytes();
+      _pendingSerializedTotalWeight = Double.NaN;
+      _hasSerializedInput = true;
+      return;
+    }
+    materializePendingSerializedTDigest();
+    input.decode();
+    preserveSerializedCapacity(input._mainCapacity, input._bufferCapacity);
+    boolean initialize = _numCentroids == 0 && _totalWeight == 0.0 && _numRawValues == 0
+        && _numIncomingCentroids == 0;
+    if (initialize) {
+      if (input._totalWeight != 0.0) {
+        ensureCentroidCapacity(input._numCentroids);
+        System.arraycopy(input._means, 0, _centroidMeans, 0, input._numCentroids);
+        System.arraycopy(input._weights, 0, _centroidWeights, 0, input._numCentroids);
+        _numCentroids = input._numCentroids;
+        _totalWeight = input._totalWeight;
+        _min = input._min;
+        _max = input._max;
+      }
+    } else {
+      flush();
+      boolean runBackwards = (_mergeCount++ & 1) != 0;
+      if (mergeSorted(input._means, input._weights, input._numCentroids, input._totalWeight, _workingCompression,
+          runBackwards)) {
+        _min = Math.min(_min, input._min);
+        _max = Math.max(_max, input._max);
+      }
+    }
     _hasSerializedInput = true;
   }
 
@@ -269,7 +331,8 @@ final class PercentileTDigestAccumulator extends TDigest {
     int numCentroids;
     int mainCapacity = 0;
     int bufferCapacity = 0;
-    boolean initialize = _numCentroids == 0 && _totalWeight == 0.0;
+    boolean initialize = _numCentroids == 0 && _totalWeight == 0.0 && _numRawValues == 0
+        && _numIncomingCentroids == 0;
     double[] incomingMeans;
     double[] incomingWeights;
     if (encoding == VERBOSE_ENCODING) {
@@ -279,13 +342,12 @@ final class PercentileTDigestAccumulator extends TDigest {
       checkCentroidsAvailable(input, numCentroids, VERBOSE_CENTROID_SIZE);
       checkVerboseCentroidCapacity(serializedCompression, numCentroids);
       if (initialize) {
-        ensureCentroidCapacity(numCentroids);
+        ensureCentroidCapacity(Math.addExact(numCentroids, 2));
         incomingMeans = _centroidMeans;
         incomingWeights = _centroidWeights;
       } else {
-        ensureIncomingCapacity(numCentroids);
-        incomingMeans = _incomingMeans;
-        incomingWeights = _incomingWeights;
+        incomingMeans = new double[Math.addExact(numCentroids, 2)];
+        incomingWeights = new double[Math.addExact(numCentroids, 2)];
       }
       for (int i = 0; i < numCentroids; i++) {
         incomingWeights[i] = input.getDouble();
@@ -302,19 +364,19 @@ final class PercentileTDigestAccumulator extends TDigest {
       checkCentroidsAvailable(input, numCentroids, SMALL_CENTROID_SIZE);
       checkSmallCentroidCapacity(mainCapacity, numCentroids);
       if (initialize) {
-        ensureCentroidCapacity(numCentroids);
+        ensureCentroidCapacity(Math.addExact(numCentroids, 2));
         incomingMeans = _centroidMeans;
         incomingWeights = _centroidWeights;
       } else {
-        ensureIncomingCapacity(numCentroids);
-        incomingMeans = _incomingMeans;
-        incomingWeights = _incomingWeights;
+        incomingMeans = new double[Math.addExact(numCentroids, 2)];
+        incomingWeights = new double[Math.addExact(numCentroids, 2)];
       }
       for (int i = 0; i < numCentroids; i++) {
         incomingWeights[i] = input.getFloat();
         incomingMeans[i] = input.getFloat();
       }
     }
+    numCentroids = normalizeBoundaries(incomingMeans, incomingWeights, numCentroids, min, max);
     preserveSerializedCapacity(mainCapacity, bufferCapacity);
 
     if (initialize) {
@@ -325,7 +387,8 @@ final class PercentileTDigestAccumulator extends TDigest {
         _min = min;
         _max = max;
       }
-    } else if (mergeSorted(incomingMeans, incomingWeights, numCentroids)) {
+    } else {
+      bufferIncomingCentroids(incomingMeans, incomingWeights, numCentroids);
       _min = Math.min(_min, min);
       _max = Math.max(_max, max);
     }
@@ -333,7 +396,8 @@ final class PercentileTDigestAccumulator extends TDigest {
 
   private void mergeSerializedTDigest(SerializedTDigestInput input) {
     preserveSerializedCapacity(input._mainCapacity, input._bufferCapacity);
-    boolean initialize = _numCentroids == 0 && _totalWeight == 0.0;
+    boolean initialize = _numCentroids == 0 && _totalWeight == 0.0 && _numRawValues == 0
+        && _numIncomingCentroids == 0;
     if (initialize) {
       if (input._totalWeight != 0.0) {
         ensureCentroidCapacity(input._numCentroids);
@@ -344,7 +408,8 @@ final class PercentileTDigestAccumulator extends TDigest {
         _min = input._min;
         _max = input._max;
       }
-    } else if (mergeSorted(input._means, input._weights, input._numCentroids, input._totalWeight)) {
+    } else {
+      bufferIncomingCentroids(input._means, input._weights, input._numCentroids);
       _min = Math.min(_min, input._min);
       _max = Math.max(_max, input._max);
     }
@@ -353,7 +418,15 @@ final class PercentileTDigestAccumulator extends TDigest {
   @Override
   public void compress() {
     materializePendingSerializedTDigest();
-    flush();
+    if (_numRawValues > 0 || _numIncomingCentroids > 0) {
+      // MergingDigest 3.3 combines pending values and existing centroids directly at public compression. Flushing at
+      // working compression first would add an extra lossy merge pass and materially increase reducer rank error.
+      flush(_compression);
+      _publiclyCompressed = true;
+    } else if (!_publiclyCompressed && _numCentroids > 0) {
+      recompressCentroids(_compression);
+      _publiclyCompressed = true;
+    }
   }
 
   @Override
@@ -364,12 +437,16 @@ final class PercentileTDigestAccumulator extends TDigest {
       }
       return (long) _pendingSerializedTotalWeight;
     }
-    return (long) (_totalWeight + _numRawValues);
+    return (long) (_totalWeight + _incomingWeight + _numRawValues);
   }
 
   @Override
   public double cdf(double value) {
-    compress();
+    if (Double.isNaN(value) || Double.isInfinite(value)) {
+      throw new IllegalArgumentException(String.format("Invalid value: %f", value));
+    }
+    materializePendingSerializedTDigest();
+    flush();
     if (_numCentroids == 0) {
       return Double.NaN;
     }
@@ -385,42 +462,69 @@ final class PercentileTDigestAccumulator extends TDigest {
         return (value - _min) / width;
       }
     }
-    if (value <= _min) {
+    if (value < _min) {
       return 0.0;
     }
-    if (value >= _max) {
+    if (value > _max) {
       return 1.0;
     }
-    if (value <= _centroidMeans[0]) {
+    if (value < _centroidMeans[0]) {
       double width = _centroidMeans[0] - _min;
-      return width > 0.0 ? (value - _min) / width * _centroidWeights[0] / _totalWeight / 2.0 : 0.0;
+      if (width > 0.0) {
+        return value == _min ? 0.5 / _totalWeight
+            : (1.0 + (value - _min) / width * (_centroidWeights[0] / 2.0 - 1.0)) / _totalWeight;
+      }
+      return 0.0;
     }
     int lastIndex = _numCentroids - 1;
-    if (value >= _centroidMeans[lastIndex]) {
+    if (value > _centroidMeans[lastIndex]) {
       double width = _max - _centroidMeans[lastIndex];
-      return width > 0.0
-          ? 1.0 - (_max - value) / width * _centroidWeights[lastIndex] / _totalWeight / 2.0 : 1.0;
+      if (width > 0.0) {
+        return value == _max ? 1.0 - 0.5 / _totalWeight
+            : 1.0 - (1.0 + (_max - value) / width * (_centroidWeights[lastIndex] / 2.0 - 1.0))
+                / _totalWeight;
+      }
+      return 1.0;
     }
 
-    double weightSoFar = _centroidWeights[0] / 2.0;
+    double weightSoFar = 0.0;
     for (int i = 0; i < lastIndex; i++) {
       if (_centroidMeans[i] == value) {
-        double startWeight = weightSoFar;
+        double equalWeight = 0.0;
         int equalIndex = i;
-        while (equalIndex < lastIndex && _centroidMeans[equalIndex + 1] == value) {
-          weightSoFar += _centroidWeights[equalIndex] + _centroidWeights[equalIndex + 1];
+        while (equalIndex < _numCentroids && _centroidMeans[equalIndex] == value) {
+          equalWeight += _centroidWeights[equalIndex];
           equalIndex++;
         }
-        return (startWeight + weightSoFar) / 2.0 / _totalWeight;
+        return (weightSoFar + equalWeight / 2.0) / _totalWeight;
       }
       if (_centroidMeans[i] <= value && _centroidMeans[i + 1] > value) {
+        if (!Double.isFinite(_centroidMeans[i]) || !Double.isFinite(_centroidMeans[i + 1])) {
+          return (weightSoFar + _centroidWeights[i]) / _totalWeight;
+        }
         double width = _centroidMeans[i + 1] - _centroidMeans[i];
-        double halfWeight = (_centroidWeights[i] + _centroidWeights[i + 1]) / 2.0;
-        return width > 0.0
-            ? (weightSoFar + halfWeight * (value - _centroidMeans[i]) / width) / _totalWeight
-            : weightSoFar + halfWeight / _totalWeight;
+        if (width > 0.0) {
+          double leftExcludedWeight = 0.0;
+          double rightExcludedWeight = 0.0;
+          if (_centroidWeights[i] == 1.0) {
+            if (_centroidWeights[i + 1] == 1.0) {
+              return (weightSoFar + 1.0) / _totalWeight;
+            }
+            leftExcludedWeight = 0.5;
+          } else if (_centroidWeights[i + 1] == 1.0) {
+            rightExcludedWeight = 0.5;
+          }
+          double halfWeight = (_centroidWeights[i] + _centroidWeights[i + 1]) / 2.0;
+          double interpolatedWeight = halfWeight - leftExcludedWeight - rightExcludedWeight;
+          double base = weightSoFar + _centroidWeights[i] / 2.0 + leftExcludedWeight;
+          return (base + interpolatedWeight * (value - _centroidMeans[i]) / width) / _totalWeight;
+        }
+        return (weightSoFar + (_centroidWeights[i] + _centroidWeights[i + 1]) / 2.0) / _totalWeight;
       }
-      weightSoFar += (_centroidWeights[i] + _centroidWeights[i + 1]) / 2.0;
+      weightSoFar += _centroidWeights[i];
+    }
+    if (value == _centroidMeans[lastIndex]) {
+      return 1.0 - 0.5 / _totalWeight;
     }
     throw new IllegalStateException("Unable to compute TDigest CDF");
   }
@@ -430,7 +534,8 @@ final class PercentileTDigestAccumulator extends TDigest {
     if (quantile < 0.0 || quantile > 1.0) {
       throw new IllegalArgumentException("q should be in [0,1], got " + quantile);
     }
-    compress();
+    materializePendingSerializedTDigest();
+    flush();
     if (_numCentroids == 0) {
       return Double.NaN;
     }
@@ -439,23 +544,49 @@ final class PercentileTDigestAccumulator extends TDigest {
     }
 
     double index = quantile * _totalWeight;
-    if (index < _centroidWeights[0] / 2.0) {
-      return _min + 2.0 * index / _centroidWeights[0] * (_centroidMeans[0] - _min);
+    if (index < 1.0) {
+      return _min;
     }
-    double weightSoFar = _centroidWeights[0] / 2.0;
+    if (_centroidWeights[0] > 1.0 && index < _centroidWeights[0] / 2.0) {
+      return _min + (index - 1.0) / (_centroidWeights[0] / 2.0 - 1.0) * (_centroidMeans[0] - _min);
+    }
     int lastIndex = _numCentroids - 1;
+    if (index > _totalWeight - 1.0) {
+      return _max;
+    }
+    if (_centroidWeights[lastIndex] > 1.0
+        && _totalWeight - index <= _centroidWeights[lastIndex] / 2.0) {
+      return _max - (_totalWeight - index - 1.0) / (_centroidWeights[lastIndex] / 2.0 - 1.0)
+          * (_max - _centroidMeans[lastIndex]);
+    }
+
+    double weightSoFar = _centroidWeights[0] / 2.0;
     for (int i = 0; i < lastIndex; i++) {
       double halfWeight = (_centroidWeights[i] + _centroidWeights[i + 1]) / 2.0;
       if (weightSoFar + halfWeight > index) {
-        double leftWeight = index - weightSoFar;
-        double rightWeight = weightSoFar + halfWeight - index;
+        double leftUnitWeight = 0.0;
+        if (_centroidWeights[i] == 1.0) {
+          if (index - weightSoFar < 0.5) {
+            return _centroidMeans[i];
+          }
+          leftUnitWeight = 0.5;
+        }
+        double rightUnitWeight = 0.0;
+        if (_centroidWeights[i + 1] == 1.0) {
+          if (weightSoFar + halfWeight - index <= 0.5) {
+            return _centroidMeans[i + 1];
+          }
+          rightUnitWeight = 0.5;
+        }
+        double leftWeight = index - weightSoFar - leftUnitWeight;
+        double rightWeight = weightSoFar + halfWeight - index - rightUnitWeight;
         return weightedAverage(_centroidMeans[i], rightWeight, _centroidMeans[i + 1], leftWeight);
       }
       weightSoFar += halfWeight;
     }
-    double leftWeight = index - _totalWeight - _centroidWeights[lastIndex] / 2.0;
-    double rightWeight = _centroidWeights[lastIndex] / 2.0 - leftWeight;
-    return weightedAverage(_centroidMeans[lastIndex], leftWeight, _max, rightWeight);
+    double weightToMax = index - _totalWeight - _centroidWeights[lastIndex] / 2.0;
+    double weightFromLastCentroid = _centroidWeights[lastIndex] / 2.0 - weightToMax;
+    return weightedAverage(_centroidMeans[lastIndex], weightToMax, _max, weightFromLastCentroid);
   }
 
   private static double weightedAverage(double firstValue, double firstWeight, double secondValue,
@@ -463,13 +594,30 @@ final class PercentileTDigestAccumulator extends TDigest {
     if (firstValue > secondValue) {
       return weightedAverage(secondValue, secondWeight, firstValue, firstWeight);
     }
+    if (firstWeight == 0.0) {
+      return secondValue;
+    }
+    if (secondWeight == 0.0 || firstValue == secondValue) {
+      return firstValue;
+    }
+    if (!Double.isFinite(firstValue)) {
+      return firstValue;
+    }
+    if (!Double.isFinite(secondValue)) {
+      return secondValue;
+    }
     double average = (firstValue * firstWeight + secondValue * secondWeight) / (firstWeight + secondWeight);
     return Math.max(firstValue, Math.min(average, secondValue));
   }
 
   @Override
   public Collection<Centroid> centroids() {
-    return toTDigest().centroids();
+    compress();
+    List<Centroid> centroids = new ArrayList<>(_numCentroids);
+    for (int i = 0; i < _numCentroids; i++) {
+      centroids.add(Centroid.createWeighted(_centroidMeans[i], Math.toIntExact((long) _centroidWeights[i]), null));
+    }
+    return centroids;
   }
 
   @Override
@@ -477,48 +625,32 @@ final class PercentileTDigestAccumulator extends TDigest {
     return _compression;
   }
 
-  /// Returns the length of the [#serialize()] bytes rather than the materialized [MergingDigest] byte size, so
-  /// generic `TDigest` serializers ([#byteSize()] followed by [#asBytes(ByteBuffer)]) emit the capacity-preserving
-  /// encoding. Re-encoding through a materialized [MergingDigest] can produce a verbose digest with more centroids
-  /// than a freshly allocated [MergingDigest] of the same compression can hold, which readers reject with
-  /// [ArrayIndexOutOfBoundsException]. The length is computed without materializing the bytes by mirroring the
-  /// [#serialize()] branches; the mutations here (flush, capacity normalization) are idempotent, so the following
-  /// [#asBytes(ByteBuffer)] call writes exactly this many bytes.
+  /// Returns the length of the [#serialize()] bytes rather than the raw verbose byte size, so generic `TDigest`
+  /// serializers ([#byteSize()] followed by [#asBytes(ByteBuffer)]) emit the mixed-version-compatible encoding.
+  /// Emitting raw verbose bytes here could produce a digest with more centroids than an old reader of the same
+  /// compression allocates, which it rejects with [ArrayIndexOutOfBoundsException].
   @Override
   public int byteSize() {
-    if (_pendingSerializedTDigest != null) {
-      return _pendingSerializedTDigest.length;
-    }
-    flush();
-    if (requiresCapacityPreservingEncoding()) {
-      checkCapacityPreservingCentroidCount();
-      return SMALL_HEADER_SIZE + SMALL_CENTROID_SIZE * _numCentroids;
-    }
-    normalizeCentroidCapacity();
-    return VERBOSE_HEADER_SIZE + VERBOSE_CENTROID_SIZE * _numCentroids;
+    return serialize().length;
   }
 
   @Override
   public int smallByteSize() {
-    return toTDigest().smallByteSize();
+    compress();
+    return Math.addExact(SMALL_HEADER_SIZE, Math.multiplyExact(SMALL_CENTROID_SIZE, _numCentroids));
   }
 
   /// Writes the [#serialize()] bytes; see [#byteSize()]. Bytes are always written in big-endian order (the t-digest
-  /// wire order) regardless of the destination buffer's byte order, unlike [MergingDigest#asBytes(ByteBuffer)].
+  /// wire order) regardless of the destination buffer's byte order, unlike the library's `asBytes`.
   @Override
   public void asBytes(ByteBuffer buffer) {
-    if (_pendingSerializedTDigest != null) {
-      // Same validation as serialize(), but write through without the defensive clone.
-      getSerializedTotalWeight(_pendingSerializedTDigest);
-      buffer.put(_pendingSerializedTDigest);
-      return;
-    }
     buffer.put(serialize());
   }
 
   @Override
   public void asSmallBytes(ByteBuffer buffer) {
-    toTDigest().asSmallBytes(buffer);
+    compress();
+    buffer.put(toCapacityPreservingBytes());
   }
 
   @Override
@@ -532,12 +664,19 @@ final class PercentileTDigestAccumulator extends TDigest {
   }
 
   @Override
+  public void setScaleFunction(ScaleFunction scaleFunction) {
+    if (scaleFunction != ScaleFunction.K_1) {
+      throw new UnsupportedOperationException("PercentileTDigestAccumulator only supports ScaleFunction.K_1");
+    }
+    super.setScaleFunction(scaleFunction);
+  }
+
+  @Override
   public int centroidCount() {
     if (_pendingSerializedTDigest != null) {
       return getSerializedCentroidCount(_pendingSerializedTDigest);
     }
     flush();
-    normalizeCentroidCapacity();
     return _numCentroids;
   }
 
@@ -562,31 +701,42 @@ final class PercentileTDigestAccumulator extends TDigest {
   byte[] serialize() {
     if (_pendingSerializedTDigest != null) {
       getSerializedTotalWeight(_pendingSerializedTDigest);
+      if (ByteBuffer.wrap(_pendingSerializedTDigest).getInt() == VERBOSE_ENCODING) {
+        byte[] serialized = TDigestUtils.makeLegacyCompatible(_pendingSerializedTDigest);
+        return serialized == _pendingSerializedTDigest ? serialized.clone() : serialized;
+      }
       return _pendingSerializedTDigest.clone();
     }
-    flush();
-    if (requiresCapacityPreservingEncoding()) {
-      return toCapacityPreservingBytes();
-    }
-    TDigest tDigest = toTDigest();
-    byte[] bytes = new byte[tDigest.byteSize()];
-    tDigest.asBytes(ByteBuffer.wrap(bytes));
-    return bytes;
+    compress();
+    return TDigestUtils.makeLegacyCompatible(toVerboseBytes());
   }
 
   TDigest toTDigest() {
     if (_pendingSerializedTDigest != null) {
-      return MergingDigest.fromBytes(ByteBuffer.wrap(_pendingSerializedTDigest));
+      return TDigestUtils.deserialize(_pendingSerializedTDigest);
     }
-    flush();
+    compress();
     if (_numCentroids == 0) {
-      return TDigest.createMergingDigest(_compression);
+      return TDigestUtils.createMergingDigest(_compression);
     }
+    return TDigestUtils.deserialize(TDigestUtils.makeLegacyCompatible(toVerboseBytes()));
+  }
 
-    if (requiresCapacityPreservingEncoding()) {
-      return toCapacityPreservingTDigest();
+  private void recompressCentroids(double compression) {
+    normalizeBoundaryCentroids();
+    double[] means = _centroidMeans;
+    double[] weights = _centroidWeights;
+    int numCentroids = _numCentroids;
+    double totalWeight = _totalWeight;
+    _numCentroids = 0;
+    _totalWeight = 0.0;
+    boolean runBackwards = (_mergeCount++ & 1) != 0;
+    if (!mergeSorted(means, weights, numCentroids, totalWeight, compression, runBackwards)) {
+      throw new IllegalStateException("Cannot recompress an empty TDigest");
     }
-    normalizeCentroidCapacity();
+  }
+
+  private byte[] toVerboseBytes() {
     ByteBuffer buffer = ByteBuffer.allocate(VERBOSE_HEADER_SIZE + VERBOSE_CENTROID_SIZE * _numCentroids);
     buffer.putInt(VERBOSE_ENCODING);
     buffer.putDouble(_min);
@@ -597,47 +747,13 @@ final class PercentileTDigestAccumulator extends TDigest {
       buffer.putDouble(_centroidWeights[i]);
       buffer.putDouble(_centroidMeans[i]);
     }
-    buffer.flip();
-    return MergingDigest.fromBytes(buffer);
-  }
-
-  private boolean requiresCapacityPreservingEncoding() {
-    return _numCentroids > _centroidCapacity && _serializedMainCapacity >= _numCentroids
-        && (double) (float) _compression == _compression;
-  }
-
-  private void recompressCentroids() {
-    double[] means = _centroidMeans;
-    double[] weights = _centroidWeights;
-    int numCentroids = _numCentroids;
-    double totalWeight = _totalWeight;
-    _numCentroids = 0;
-    _totalWeight = 0.0;
-    if (!mergeSorted(means, weights, numCentroids, totalWeight)) {
-      throw new IllegalStateException("Cannot recompress an empty TDigest");
-    }
-  }
-
-  private void normalizeCentroidCapacity() {
-    if (_numCentroids <= _centroidCapacity || _serializedMainCapacity < _numCentroids
-        || (double) (float) _compression == _compression) {
-      return;
-    }
-    recompressCentroids();
-    if (_numCentroids > _centroidCapacity) {
-      throw new IllegalStateException("Unable to recompress TDigest to its default centroid capacity: "
-          + _numCentroids);
-    }
-  }
-
-  private TDigest toCapacityPreservingTDigest() {
-    return MergingDigest.fromBytes(ByteBuffer.wrap(toCapacityPreservingBytes()));
+    return buffer.array();
   }
 
   private byte[] toCapacityPreservingBytes() {
     checkCapacityPreservingCentroidCount();
     int mainCapacity = Math.min(Short.MAX_VALUE, Math.max(_numCentroids, _serializedMainCapacity));
-    long defaultBufferCapacity = Math.multiplyExact(DEFAULT_MERGE_BUFFER_MULTIPLIER, (long) Math.ceil(_compression));
+    long defaultBufferCapacity = Math.multiplyExact(DEFAULT_MERGE_BUFFER_MULTIPLIER, (long) mainCapacity);
     int bufferCapacity = Math.toIntExact(Math.min(Short.MAX_VALUE,
         Math.max(Math.max((long) _serializedBufferCapacity, mainCapacity + 1L), defaultBufferCapacity)));
     ByteBuffer buffer = ByteBuffer.allocate(SMALL_HEADER_SIZE + SMALL_CENTROID_SIZE * _numCentroids);
@@ -663,30 +779,50 @@ final class PercentileTDigestAccumulator extends TDigest {
   }
 
   private void flush() {
+    flush(_workingCompression);
+  }
+
+  private void flush(double compression) {
+    if (_numIncomingCentroids > 0) {
+      flushIncoming(compression);
+      return;
+    }
     if (_numRawValues == 0) {
       return;
     }
 
     Arrays.sort(_rawValues, 0, _numRawValues);
+    normalizeBoundaryCentroids();
     int preferredOutputCapacity = getPreferredOutputCapacity(_numRawValues);
     ensureOutputCapacity(1);
     double newTotalWeight = _totalWeight + _numRawValues;
-    double normalizer = _compression / (Math.PI * newTotalWeight);
-    int rawIndex = 0;
-    int centroidIndex = 0;
+    double totalWeightNormalizer = 1.0 / newTotalWeight;
+    double weightNormalizer = totalWeightNormalizer / getK1MaxWeightScale(compression);
+    boolean runBackwards = (_mergeCount++ & 1) != 0;
+    int rawIndex = runBackwards ? _numRawValues - 1 : 0;
+    int centroidIndex = runBackwards ? _numCentroids - 1 : 0;
+    int rawLimit = runBackwards ? -1 : _numRawValues;
+    int centroidLimit = runBackwards ? -1 : _numCentroids;
+    int direction = runBackwards ? -1 : 1;
+    int numInputs = _numRawValues + _numCentroids;
+    int inputIndex = 0;
     int numOutputCentroids = 0;
     double weightSoFar = 0.0;
 
-    while (rawIndex < _numRawValues || centroidIndex < _numCentroids) {
+    while (rawIndex != rawLimit || centroidIndex != centroidLimit) {
       double mean;
       double weight;
-      if (centroidIndex == _numCentroids || (rawIndex < _numRawValues
-          && _rawValues[rawIndex] <= _centroidMeans[centroidIndex])) {
-        mean = _rawValues[rawIndex++];
+      boolean takeRaw = centroidIndex == centroidLimit || (rawIndex != rawLimit
+          && (runBackwards ? _rawValues[rawIndex] > _centroidMeans[centroidIndex]
+              : _rawValues[rawIndex] <= _centroidMeans[centroidIndex]));
+      if (takeRaw) {
+        mean = _rawValues[rawIndex];
         weight = 1.0;
+        rawIndex += direction;
       } else {
         mean = _centroidMeans[centroidIndex];
-        weight = _centroidWeights[centroidIndex++];
+        weight = _centroidWeights[centroidIndex];
+        centroidIndex += direction;
       }
       if (numOutputCentroids == 0) {
         _outputMeans[0] = mean;
@@ -695,12 +831,20 @@ final class PercentileTDigestAccumulator extends TDigest {
       } else {
         int currentIndex = numOutputCentroids - 1;
         double proposedWeight = _outputWeights[currentIndex] + weight;
-        double z = proposedWeight * normalizer;
-        double q0 = weightSoFar / newTotalWeight;
-        double q2 = (weightSoFar + proposedWeight) / newTotalWeight;
-        if (z * z <= q0 * (1.0 - q0) && z * z <= q2 * (1.0 - q2)) {
+        double q0 = weightSoFar * totalWeightNormalizer;
+        double q2 = (weightSoFar + proposedWeight) * totalWeightNormalizer;
+        double normalizedWeight = proposedWeight * weightNormalizer;
+        double normalizedWeightSquared = normalizedWeight * normalizedWeight;
+        boolean canMerge = canMergeMeans(_outputMeans[currentIndex], mean)
+            && normalizedWeightSquared <= q0 * (1.0 - q0)
+            && normalizedWeightSquared <= q2 * (1.0 - q2);
+        if (inputIndex == 1 || inputIndex == numInputs - 1) {
+          canMerge = false;
+        }
+        if (canMerge) {
           _outputWeights[currentIndex] = proposedWeight;
-          _outputMeans[currentIndex] += (mean - _outputMeans[currentIndex]) * weight / proposedWeight;
+          _outputMeans[currentIndex] = mergeMeans(_outputMeans[currentIndex], proposedWeight - weight, mean, weight,
+              proposedWeight);
         } else {
           weightSoFar += _outputWeights[currentIndex];
           ensureOutputCapacity(Math.max(preferredOutputCapacity, numOutputCentroids + 1));
@@ -709,42 +853,101 @@ final class PercentileTDigestAccumulator extends TDigest {
           numOutputCentroids++;
         }
       }
+      inputIndex++;
     }
+    if (runBackwards) {
+      reverse(_outputMeans, numOutputCentroids);
+      reverse(_outputWeights, numOutputCentroids);
+    }
+    double rawMin = _rawValues[0];
+    double rawMax = _rawValues[_numRawValues - 1];
     finishMerge(numOutputCentroids, newTotalWeight);
     _numRawValues = 0;
-    _min = Math.min(_min, _centroidMeans[0]);
-    _max = Math.max(_max, _centroidMeans[_numCentroids - 1]);
+    _min = Math.min(_min, rawMin);
+    _max = Math.max(_max, rawMax);
   }
 
-  private boolean mergeSorted(double[] incomingMeans, double[] incomingWeights, int incomingCount) {
-    return mergeSorted(incomingMeans, incomingWeights, incomingCount,
-        getTotalWeight(incomingWeights, incomingCount));
+  private void flushIncoming(double compression) {
+    double rawMin = Double.POSITIVE_INFINITY;
+    double rawMax = Double.NEGATIVE_INFINITY;
+    if (_numRawValues > 0) {
+      Arrays.sort(_rawValues, 0, _numRawValues);
+      rawMin = _rawValues[0];
+      rawMax = _rawValues[_numRawValues - 1];
+      ensureIncomingCapacity(Math.addExact(_numIncomingCentroids, _numRawValues));
+      System.arraycopy(_incomingMeans, 0, _incomingMeans, _numRawValues, _numIncomingCentroids);
+      System.arraycopy(_incomingWeights, 0, _incomingWeights, _numRawValues, _numIncomingCentroids);
+      for (int i = 0; i < _numRawValues; i++) {
+        _incomingMeans[i] = _rawValues[i];
+        _incomingWeights[i] = 1.0;
+      }
+      _numIncomingCentroids += _numRawValues;
+      _incomingWeight += _numRawValues;
+      _numRawValues = 0;
+      _incomingCentroidsSorted = false;
+    }
+
+    int incomingCount = _numIncomingCentroids;
+    double incomingWeight = _incomingWeight;
+    double[] incomingMeans = _incomingMeans;
+    double[] incomingWeights = _incomingWeights;
+    if (!_incomingCentroidsSorted) {
+      ensureIncomingSortCapacity(incomingCount);
+      Sort.stableSort(_incomingOrder, _incomingMeans, incomingCount);
+      for (int i = 0; i < incomingCount; i++) {
+        int sourceIndex = _incomingOrder[i];
+        _sortedIncomingMeans[i] = _incomingMeans[sourceIndex];
+        _sortedIncomingWeights[i] = _incomingWeights[sourceIndex];
+      }
+      incomingMeans = _sortedIncomingMeans;
+      incomingWeights = _sortedIncomingWeights;
+    }
+    _numIncomingCentroids = 0;
+    _incomingWeight = 0.0;
+    _incomingCentroidsSorted = true;
+    boolean runBackwards = (_mergeCount++ & 1) != 0;
+    if (!mergeSorted(incomingMeans, incomingWeights, incomingCount, incomingWeight, compression, runBackwards)) {
+      throw new IllegalStateException("Cannot flush an empty TDigest input buffer");
+    }
+    _min = Math.min(_min, rawMin);
+    _max = Math.max(_max, rawMax);
   }
 
   private boolean mergeSorted(double[] incomingMeans, double[] incomingWeights, int incomingCount,
-      double incomingWeight) {
+      double incomingWeight, double compression, boolean runBackwards) {
     if (incomingWeight == 0.0) {
       return false;
     }
 
+    normalizeBoundaryCentroids();
     int preferredOutputCapacity = getPreferredOutputCapacity(incomingCount);
     ensureOutputCapacity(1);
     double newTotalWeight = _totalWeight + incomingWeight;
-    double normalizer = _compression / (Math.PI * newTotalWeight);
-    int incomingIndex = 0;
-    int centroidIndex = 0;
+    double totalWeightNormalizer = 1.0 / newTotalWeight;
+    double weightNormalizer = totalWeightNormalizer / getK1MaxWeightScale(compression);
+    int incomingIndex = runBackwards ? incomingCount - 1 : 0;
+    int centroidIndex = runBackwards ? _numCentroids - 1 : 0;
+    int incomingLimit = runBackwards ? -1 : incomingCount;
+    int centroidLimit = runBackwards ? -1 : _numCentroids;
+    int direction = runBackwards ? -1 : 1;
+    int numInputs = incomingCount + _numCentroids;
+    int inputIndex = 0;
     int numOutputCentroids = 0;
     double weightSoFar = 0.0;
-    while (incomingIndex < incomingCount || centroidIndex < _numCentroids) {
+    while (incomingIndex != incomingLimit || centroidIndex != centroidLimit) {
       double mean;
       double weight;
-      if (centroidIndex == _numCentroids || (incomingIndex < incomingCount
-          && incomingMeans[incomingIndex] <= _centroidMeans[centroidIndex])) {
+      boolean takeIncoming = centroidIndex == centroidLimit || (incomingIndex != incomingLimit
+          && (runBackwards ? incomingMeans[incomingIndex] > _centroidMeans[centroidIndex]
+              : incomingMeans[incomingIndex] <= _centroidMeans[centroidIndex]));
+      if (takeIncoming) {
         mean = incomingMeans[incomingIndex];
-        weight = incomingWeights[incomingIndex++];
+        weight = incomingWeights[incomingIndex];
+        incomingIndex += direction;
       } else {
         mean = _centroidMeans[centroidIndex];
-        weight = _centroidWeights[centroidIndex++];
+        weight = _centroidWeights[centroidIndex];
+        centroidIndex += direction;
       }
       if (numOutputCentroids == 0) {
         _outputMeans[0] = mean;
@@ -753,12 +956,20 @@ final class PercentileTDigestAccumulator extends TDigest {
       } else {
         int currentIndex = numOutputCentroids - 1;
         double proposedWeight = _outputWeights[currentIndex] + weight;
-        double z = proposedWeight * normalizer;
-        double q0 = weightSoFar / newTotalWeight;
-        double q2 = (weightSoFar + proposedWeight) / newTotalWeight;
-        if (z * z <= q0 * (1.0 - q0) && z * z <= q2 * (1.0 - q2)) {
+        double q0 = weightSoFar * totalWeightNormalizer;
+        double q2 = (weightSoFar + proposedWeight) * totalWeightNormalizer;
+        double normalizedWeight = proposedWeight * weightNormalizer;
+        double normalizedWeightSquared = normalizedWeight * normalizedWeight;
+        boolean canMerge = canMergeMeans(_outputMeans[currentIndex], mean)
+            && normalizedWeightSquared <= q0 * (1.0 - q0)
+            && normalizedWeightSquared <= q2 * (1.0 - q2);
+        if (inputIndex == 1 || inputIndex == numInputs - 1) {
+          canMerge = false;
+        }
+        if (canMerge) {
           _outputWeights[currentIndex] = proposedWeight;
-          _outputMeans[currentIndex] += (mean - _outputMeans[currentIndex]) * weight / proposedWeight;
+          _outputMeans[currentIndex] = mergeMeans(_outputMeans[currentIndex], proposedWeight - weight, mean, weight,
+              proposedWeight);
         } else {
           weightSoFar += _outputWeights[currentIndex];
           ensureOutputCapacity(Math.max(preferredOutputCapacity, numOutputCentroids + 1));
@@ -767,6 +978,11 @@ final class PercentileTDigestAccumulator extends TDigest {
           numOutputCentroids++;
         }
       }
+      inputIndex++;
+    }
+    if (runBackwards) {
+      reverse(_outputMeans, numOutputCentroids);
+      reverse(_outputWeights, numOutputCentroids);
     }
     finishMerge(numOutputCentroids, newTotalWeight);
     return true;
@@ -781,13 +997,94 @@ final class PercentileTDigestAccumulator extends TDigest {
     _outputWeights = temporary;
     _numCentroids = numOutputCentroids;
     _totalWeight = totalWeight;
+    _publiclyCompressed = false;
   }
 
   private void ensureIncomingCapacity(int capacity) {
     if (_incomingMeans == null || capacity > _incomingMeans.length) {
-      int newCapacity = Math.max(capacity, _centroidCapacity);
-      _incomingMeans = new double[newCapacity];
-      _incomingWeights = new double[newCapacity];
+      int newCapacity = _incomingMeans == null ? Math.max(capacity, _centroidCapacity)
+          : Math.max(capacity, Math.min(_pendingCentroidCapacity,
+              Math.multiplyExact(_incomingMeans.length, DEFAULT_MERGE_BUFFER_MULTIPLIER)));
+      _incomingMeans = _incomingMeans == null ? new double[newCapacity] : Arrays.copyOf(_incomingMeans, newCapacity);
+      _incomingWeights =
+          _incomingWeights == null ? new double[newCapacity] : Arrays.copyOf(_incomingWeights, newCapacity);
+    }
+  }
+
+  private void ensureIncomingSortCapacity(int capacity) {
+    ensureSortedIncomingCapacity(capacity);
+    if (_incomingOrder == null || capacity > _incomingOrder.length) {
+      int newCapacity = _incomingOrder == null ? Math.max(capacity, _centroidCapacity)
+          : Math.max(capacity, Math.multiplyExact(_incomingOrder.length, 2));
+      _incomingOrder = new int[newCapacity];
+    }
+  }
+
+  private void ensureSortedIncomingCapacity(int capacity) {
+    if (_sortedIncomingMeans == null || capacity > _sortedIncomingMeans.length) {
+      int newCapacity = _sortedIncomingMeans == null ? Math.max(capacity, _centroidCapacity)
+          : Math.max(capacity, Math.multiplyExact(_sortedIncomingMeans.length, 2));
+      _sortedIncomingMeans = new double[newCapacity];
+      _sortedIncomingWeights = new double[newCapacity];
+    }
+  }
+
+  private void bufferIncomingCentroid(double mean, double weight) {
+    if (_numRawValues + _numIncomingCentroids == getPendingInputLimit()) {
+      flush();
+    }
+    ensureIncomingCapacity(_numIncomingCentroids + 1);
+    if (_incomingCentroidsSorted && _numIncomingCentroids > 0
+        && mean < _incomingMeans[_numIncomingCentroids - 1]) {
+      _incomingCentroidsSorted = false;
+    }
+    _incomingMeans[_numIncomingCentroids] = mean;
+    _incomingWeights[_numIncomingCentroids] = weight;
+    _numIncomingCentroids++;
+    _incomingWeight += weight;
+  }
+
+  private void bufferIncomingCentroids(double[] means, double[] weights, int count) {
+    int offset = 0;
+    while (offset < count) {
+      if (_numRawValues + _numIncomingCentroids == getPendingInputLimit()) {
+        flush();
+      }
+      int copied = Math.min(count - offset,
+          getPendingInputLimit() - _numRawValues - _numIncomingCentroids);
+      int existingCount = _numIncomingCentroids;
+      int combinedCount = Math.addExact(existingCount, copied);
+      if (existingCount == 0 || !_incomingCentroidsSorted) {
+        ensureIncomingCapacity(combinedCount);
+        System.arraycopy(means, offset, _incomingMeans, existingCount, copied);
+        System.arraycopy(weights, offset, _incomingWeights, existingCount, copied);
+      } else {
+        ensureIncomingCapacity(combinedCount);
+        int existingIndex = existingCount - 1;
+        int addedIndex = offset + copied - 1;
+        int outputIndex = combinedCount - 1;
+        while (existingIndex >= 0 && addedIndex >= offset) {
+          // Choose the added centroid on equality while merging backwards so existing equal centroids retain stable
+          // order before the newly added run.
+          if (_incomingMeans[existingIndex] > means[addedIndex]) {
+            _incomingMeans[outputIndex] = _incomingMeans[existingIndex];
+            _incomingWeights[outputIndex--] = _incomingWeights[existingIndex--];
+          } else {
+            _incomingMeans[outputIndex] = means[addedIndex];
+            _incomingWeights[outputIndex--] = weights[addedIndex--];
+          }
+        }
+        if (addedIndex >= offset) {
+          int remaining = addedIndex - offset + 1;
+          System.arraycopy(means, offset, _incomingMeans, 0, remaining);
+          System.arraycopy(weights, offset, _incomingWeights, 0, remaining);
+        }
+      }
+      for (int i = 0; i < copied; i++) {
+        _incomingWeight += weights[offset + i];
+      }
+      offset += copied;
+      _numIncomingCentroids = combinedCount;
     }
   }
 
@@ -807,6 +1104,111 @@ final class PercentileTDigestAccumulator extends TDigest {
     }
   }
 
+  private void normalizeBoundaryCentroids() {
+    if (_numCentroids == 0 || (_centroidWeights[0] == 1.0
+        && _centroidWeights[_numCentroids - 1] == 1.0)) {
+      return;
+    }
+    int requiredCapacity = Math.addExact(_numCentroids, 2);
+    if (_centroidMeans.length < requiredCapacity) {
+      _centroidMeans = Arrays.copyOf(_centroidMeans, requiredCapacity);
+      _centroidWeights = Arrays.copyOf(_centroidWeights, requiredCapacity);
+    }
+
+    if (_numCentroids == 1) {
+      double weight = _centroidWeights[0];
+      if (weight <= 1.0) {
+        return;
+      }
+      double mean = _centroidMeans[0];
+      _centroidMeans[0] = _min;
+      _centroidWeights[0] = 1.0;
+      if (weight == 2.0) {
+        _centroidMeans[1] = _max;
+        _centroidWeights[1] = 1.0;
+        _numCentroids = 2;
+      } else {
+        _centroidMeans[1] = residualMean(mean, weight, _min, _max, weight - 2.0, _min, _max);
+        _centroidWeights[1] = weight - 2.0;
+        _centroidMeans[2] = _max;
+        _centroidWeights[2] = 1.0;
+        _numCentroids = 3;
+      }
+      return;
+    }
+
+    if (_centroidWeights[0] > 1.0) {
+      System.arraycopy(_centroidMeans, 1, _centroidMeans, 2, _numCentroids - 1);
+      System.arraycopy(_centroidWeights, 1, _centroidWeights, 2, _numCentroids - 1);
+      double weight = _centroidWeights[0];
+      double mean = _centroidMeans[0];
+      _centroidMeans[0] = _min;
+      _centroidWeights[0] = 1.0;
+      _centroidMeans[1] = residualMean(mean, weight, _min, 0.0, weight - 1.0, _min, _centroidMeans[2]);
+      _centroidWeights[1] = weight - 1.0;
+      _numCentroids++;
+    }
+    int lastIndex = _numCentroids - 1;
+    if (_centroidWeights[lastIndex] > 1.0) {
+      double weight = _centroidWeights[lastIndex];
+      double mean = _centroidMeans[lastIndex];
+      _centroidMeans[lastIndex] = residualMean(mean, weight, _max, 0.0, weight - 1.0,
+          _centroidMeans[lastIndex - 1], _max);
+      _centroidWeights[lastIndex] = weight - 1.0;
+      _centroidMeans[_numCentroids] = _max;
+      _centroidWeights[_numCentroids] = 1.0;
+      _numCentroids++;
+    }
+  }
+
+  private static int normalizeBoundaries(double[] means, double[] weights, int count, double min, double max) {
+    if (count == 0 || (weights[0] == 1.0 && weights[count - 1] == 1.0)) {
+      return count;
+    }
+    if (count == 1) {
+      double weight = weights[0];
+      if (weight <= 1.0) {
+        return count;
+      }
+      double mean = means[0];
+      means[0] = min;
+      weights[0] = 1.0;
+      if (weight == 2.0) {
+        means[1] = max;
+        weights[1] = 1.0;
+        return 2;
+      }
+      means[1] = residualMean(mean, weight, min, max, weight - 2.0, min, max);
+      weights[1] = weight - 2.0;
+      means[2] = max;
+      weights[2] = 1.0;
+      return 3;
+    }
+
+    if (weights[0] > 1.0) {
+      System.arraycopy(means, 1, means, 2, count - 1);
+      System.arraycopy(weights, 1, weights, 2, count - 1);
+      double weight = weights[0];
+      double mean = means[0];
+      means[0] = min;
+      weights[0] = 1.0;
+      means[1] = residualMean(mean, weight, min, 0.0, weight - 1.0, min, means[2]);
+      weights[1] = weight - 1.0;
+      count++;
+    }
+    int lastIndex = count - 1;
+    if (weights[lastIndex] > 1.0) {
+      double weight = weights[lastIndex];
+      double mean = means[lastIndex];
+      means[lastIndex] = residualMean(mean, weight, max, 0.0, weight - 1.0, means[lastIndex - 1], max);
+      weights[lastIndex] = weight - 1.0;
+      means[count] = max;
+      weights[count] = 1.0;
+      count++;
+    }
+    return count;
+  }
+
   private void ensureRawBuffer() {
     if (_rawValues == null) {
       _rawValues = new double[getRawBufferSize((long) Math.ceil(_compression))];
@@ -818,9 +1220,19 @@ final class PercentileTDigestAccumulator extends TDigest {
   }
 
   private static int getCentroidCapacity(double compression) {
-    long roundedCompression = (long) Math.ceil(compression);
-    return Math.toIntExact(
-        Math.addExact(Math.multiplyExact(2L, roundedCompression), CENTROID_CAPACITY_PADDING));
+    double normalizedCompression = Math.max(MIN_COMPRESSION, compression);
+    int padding = normalizedCompression < 30.0 ? LOW_COMPRESSION_CAPACITY_PADDING
+        : DEFAULT_CENTROID_CAPACITY_PADDING;
+    return Math.toIntExact((long) Math.ceil(2.0 * normalizedCompression + padding));
+  }
+
+  private static int getPendingCentroidCapacity(int centroidCapacity) {
+    return Math.min(MAX_RAW_BUFFER_SIZE,
+        Math.max(MIN_RAW_BUFFER_SIZE, Math.multiplyExact(DEFAULT_MERGE_BUFFER_MULTIPLIER, centroidCapacity)));
+  }
+
+  private int getPendingInputLimit() {
+    return Math.max(1, _pendingCentroidCapacity - _numCentroids - 1);
   }
 
   private void preserveSerializedCapacity(int mainCapacity, int bufferCapacity) {
@@ -854,6 +1266,59 @@ final class PercentileTDigestAccumulator extends TDigest {
       totalWeight += weights[i];
     }
     return totalWeight;
+  }
+
+  private double getK1MaxWeightScale(double compression) {
+    return compression == _compression ? _publicMaxWeightScale : _workingMaxWeightScale;
+  }
+
+  private static double calculateK1MaxWeightScale(double compression) {
+    return 2.0 * Math.sin(Math.PI / compression);
+  }
+
+  private static void reverse(double[] values, int length) {
+    for (int i = 0; i < length / 2; i++) {
+      int otherIndex = length - i - 1;
+      double value = values[i];
+      values[i] = values[otherIndex];
+      values[otherIndex] = value;
+    }
+  }
+
+  private static double clamp(double value, double min, double max) {
+    return Math.max(min, Math.min(value, max));
+  }
+
+  private static boolean canMergeMeans(double firstMean, double secondMean) {
+    return firstMean == secondMean || (Double.isFinite(firstMean) && Double.isFinite(secondMean));
+  }
+
+  private static double mergeMeans(double firstMean, double firstWeight, double secondMean, double secondWeight,
+      double totalWeight) {
+    if (firstMean == secondMean) {
+      return firstMean;
+    }
+    if (Math.copySign(1.0, firstMean) == Math.copySign(1.0, secondMean)) {
+      return firstMean + (secondMean - firstMean) * secondWeight / totalWeight;
+    }
+    return firstMean * (firstWeight / totalWeight) + secondMean * (secondWeight / totalWeight);
+  }
+
+  private static double residualMean(double mean, double weight, double firstRemovedValue,
+      double secondRemovedValue, double residualWeight, double min, double max) {
+    if (!Double.isFinite(mean) || !Double.isFinite(firstRemovedValue)
+        || !Double.isFinite(secondRemovedValue)) {
+      return clamp(mean, min, max);
+    }
+    boolean removedTwoValues = weight - residualWeight == 2.0;
+    int scaleShift = removedTwoValues ? 2 : 1;
+    double scaledMean = Math.scalb(mean, -scaleShift);
+    double scaledCorrection = scaledMean - Math.scalb(firstRemovedValue, -scaleShift);
+    if (removedTwoValues) {
+      scaledCorrection += scaledMean - Math.scalb(secondRemovedValue, -scaleShift);
+    }
+    double correction = Math.scalb(scaledCorrection / residualWeight, scaleShift);
+    return clamp(mean + correction, min, max);
   }
 
   private static double readCompression(byte[] bytes) {
@@ -941,9 +1406,12 @@ final class PercentileTDigestAccumulator extends TDigest {
   ///
   /// [#reset(byte\[\])] parses and validates the header once per input row. Centroid arrays are decoded lazily and
   /// reused across rows, so all groups for a row merge the same primitive input without sharing mutable accumulator
-  /// state. The input must remain thread-confined and must not outlive the aggregation call that owns it.
+  /// state. A pending accumulator requests an immutable byte snapshot, created at most once per reset and shared by
+  /// the row's group fanout. The input must remain thread-confined and must not outlive the aggregation call that owns
+  /// it.
   static final class SerializedTDigestInput {
     private byte[] _bytes;
+    private byte[] _retainedBytes;
     private double _min;
     private double _max;
     private double _compression;
@@ -958,6 +1426,7 @@ final class PercentileTDigestAccumulator extends TDigest {
     private boolean _decoded;
 
     void reset(byte[] bytes) {
+      _retainedBytes = null;
       ByteBuffer input = ByteBuffer.wrap(bytes);
       int encoding = input.getInt();
       if (encoding != VERBOSE_ENCODING && encoding != SMALL_ENCODING) {
@@ -992,29 +1461,38 @@ final class PercentileTDigestAccumulator extends TDigest {
       _decoded = false;
     }
 
+    private byte[] retainBytes() {
+      if (_retainedBytes == null) {
+        _retainedBytes = _bytes.clone();
+      }
+      return _retainedBytes;
+    }
+
     private void decode() {
       if (_decoded) {
         return;
       }
-      ensureCapacity(_numCentroids);
+      int encodedCentroidCount = _numCentroids;
+      ensureCapacity(Math.addExact(encodedCentroidCount, 2));
       ByteBuffer input = ByteBuffer.wrap(_bytes);
       input.position(_centroidOffset);
       double totalWeight = 0.0;
       if (_centroidSize == VERBOSE_CENTROID_SIZE) {
-        for (int i = 0; i < _numCentroids; i++) {
+        for (int i = 0; i < encodedCentroidCount; i++) {
           double weight = input.getDouble();
           _weights[i] = weight;
           _means[i] = input.getDouble();
           totalWeight += weight;
         }
       } else {
-        for (int i = 0; i < _numCentroids; i++) {
+        for (int i = 0; i < encodedCentroidCount; i++) {
           double weight = input.getFloat();
           _weights[i] = weight;
           _means[i] = input.getFloat();
           totalWeight += weight;
         }
       }
+      _numCentroids = normalizeBoundaries(_means, _weights, encodedCentroidCount, _min, _max);
       _totalWeight = totalWeight;
       _decoded = true;
     }
@@ -1057,12 +1535,14 @@ final class PercentileTDigestAccumulator extends TDigest {
   }
 
   private static void checkVerboseCentroidCapacity(double compression, int numCentroids) {
-    checkSmallCentroidCapacity(getSerializedDefaultCentroidCapacity(compression), numCentroids);
+    int defaultCapacity = getSerializedDefaultCentroidCapacity(compression);
+    int legacyCapacity = Math.addExact(Math.multiplyExact(2, (int) Math.ceil(compression)),
+        DEFAULT_CENTROID_CAPACITY_PADDING);
+    checkSmallCentroidCapacity(Math.max(defaultCapacity, legacyCapacity), numCentroids);
   }
 
   private static int getSerializedDefaultCentroidCapacity(double compression) {
-    int capacity = (int) (2.0 * Math.ceil(compression));
-    capacity += CENTROID_CAPACITY_PADDING;
+    int capacity = getCentroidCapacity(compression);
     if (capacity < 0) {
       throw new NegativeArraySizeException(Integer.toString(capacity));
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAccumulator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAccumulator.java
@@ -531,7 +531,7 @@ final class PercentileTDigestAccumulator extends TDigest {
 
   @Override
   public double quantile(double quantile) {
-    if (quantile < 0.0 || quantile > 1.0) {
+    if (Double.isNaN(quantile) || quantile < 0.0 || quantile > 1.0) {
       throw new IllegalArgumentException("q should be in [0,1], got " + quantile);
     }
     materializePendingSerializedTDigest();
@@ -614,8 +614,10 @@ final class PercentileTDigestAccumulator extends TDigest {
   public Collection<Centroid> centroids() {
     compress();
     List<Centroid> centroids = new ArrayList<>(_numCentroids);
+    // `Centroid` holds the weight as an `int`. Narrow it the same way `MergingDigest.centroids()` does, which
+    // saturates at `Integer.MAX_VALUE`, instead of throwing on digests whose centroid weight exceeds it.
     for (int i = 0; i < _numCentroids; i++) {
-      centroids.add(Centroid.createWeighted(_centroidMeans[i], Math.toIntExact((long) _centroidWeights[i]), null));
+      centroids.add(Centroid.createWeighted(_centroidMeans[i], (int) _centroidWeights[i], null));
     }
     return centroids;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAccumulator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAccumulator.java
@@ -57,6 +57,7 @@ final class PercentileTDigestAccumulator extends TDigest {
   private static final int DEFAULT_CENTROID_CAPACITY_PADDING = 10;
   private static final int LOW_COMPRESSION_CAPACITY_PADDING = 30;
   private static final int TWO_LEVEL_COMPRESSION_MULTIPLIER = 2;
+  private static final int MIN_INCREMENTAL_COMPRESSION = 50;
   private static final int VERBOSE_ENCODING = 1;
   private static final int SMALL_ENCODING = 2;
   private static final int VERBOSE_HEADER_SIZE = 32;
@@ -311,7 +312,8 @@ final class PercentileTDigestAccumulator extends TDigest {
     } else {
       flush();
       boolean runBackwards = (_mergeCount++ & 1) != 0;
-      if (mergeSorted(input._means, input._weights, input._numCentroids, input._totalWeight, _workingCompression,
+      if (mergeSorted(input._means, input._weights, input._numCentroids, input._totalWeight,
+          getIncrementalCompression(),
           runBackwards)) {
         _min = Math.min(_min, input._min);
         _max = Math.max(_max, input._max);
@@ -781,7 +783,16 @@ final class PercentileTDigestAccumulator extends TDigest {
   }
 
   private void flush() {
-    flush(_workingCompression);
+    // Raw aggregation and the serialized direct path already merge incrementally. Keeping twice as many centroids
+    // for every small flush increases their hot-path cost without avoiding a later merge, so use the configured
+    // compression there. Buffered reducer inputs retain the two-level merge for its accuracy benefit.
+    flush(_numIncomingCentroids == 0 ? getIncrementalCompression() : _workingCompression);
+  }
+
+  private double getIncrementalCompression() {
+    // Very low compression leaves too little centroid headroom for incremental public-compression merges to retain
+    // t-digest 3.3's accuracy. Keep the two-level strategy for those uncommon configurations.
+    return _compression >= MIN_INCREMENTAL_COMPRESSION ? _compression : _workingCompression;
   }
 
   private void flush(double compression) {
@@ -810,6 +821,12 @@ final class PercentileTDigestAccumulator extends TDigest {
     int inputIndex = 0;
     int numOutputCentroids = 0;
     double weightSoFar = 0.0;
+    double firstInputMean = _numCentroids == 0 ? _rawValues[0]
+        : Math.min(_rawValues[0], _centroidMeans[0]);
+    double lastInputMean = _numCentroids == 0 ? _rawValues[_numRawValues - 1]
+        : Math.max(_rawValues[_numRawValues - 1], _centroidMeans[_numCentroids - 1]);
+    boolean allFiniteMeans = Double.isFinite(firstInputMean) && Double.isFinite(lastInputMean);
+    boolean sameSignMeans = firstInputMean > 0.0 || lastInputMean < 0.0;
 
     while (rawIndex != rawLimit || centroidIndex != centroidLimit) {
       double mean;
@@ -837,7 +854,7 @@ final class PercentileTDigestAccumulator extends TDigest {
         double q2 = (weightSoFar + proposedWeight) * totalWeightNormalizer;
         double normalizedWeight = proposedWeight * weightNormalizer;
         double normalizedWeightSquared = normalizedWeight * normalizedWeight;
-        boolean canMerge = canMergeMeans(_outputMeans[currentIndex], mean)
+        boolean canMerge = (allFiniteMeans || canMergeMeans(_outputMeans[currentIndex], mean))
             && normalizedWeightSquared <= q0 * (1.0 - q0)
             && normalizedWeightSquared <= q2 * (1.0 - q2);
         if (inputIndex == 1 || inputIndex == numInputs - 1) {
@@ -845,8 +862,9 @@ final class PercentileTDigestAccumulator extends TDigest {
         }
         if (canMerge) {
           _outputWeights[currentIndex] = proposedWeight;
-          _outputMeans[currentIndex] = mergeMeans(_outputMeans[currentIndex], proposedWeight - weight, mean, weight,
-              proposedWeight);
+          _outputMeans[currentIndex] =
+              mergeMeans(_outputMeans[currentIndex], proposedWeight - weight, mean, weight, proposedWeight,
+                  sameSignMeans);
         } else {
           weightSoFar += _outputWeights[currentIndex];
           ensureOutputCapacity(Math.max(preferredOutputCapacity, numOutputCentroids + 1));
@@ -863,7 +881,7 @@ final class PercentileTDigestAccumulator extends TDigest {
     }
     double rawMin = _rawValues[0];
     double rawMax = _rawValues[_numRawValues - 1];
-    finishMerge(numOutputCentroids, newTotalWeight);
+    finishMerge(numOutputCentroids, newTotalWeight, compression);
     _numRawValues = 0;
     _min = Math.min(_min, rawMin);
     _max = Math.max(_max, rawMax);
@@ -936,6 +954,12 @@ final class PercentileTDigestAccumulator extends TDigest {
     int inputIndex = 0;
     int numOutputCentroids = 0;
     double weightSoFar = 0.0;
+    double firstInputMean = _numCentroids == 0 ? incomingMeans[0]
+        : Math.min(incomingMeans[0], _centroidMeans[0]);
+    double lastInputMean = _numCentroids == 0 ? incomingMeans[incomingCount - 1]
+        : Math.max(incomingMeans[incomingCount - 1], _centroidMeans[_numCentroids - 1]);
+    boolean allFiniteMeans = Double.isFinite(firstInputMean) && Double.isFinite(lastInputMean);
+    boolean sameSignMeans = firstInputMean > 0.0 || lastInputMean < 0.0;
     while (incomingIndex != incomingLimit || centroidIndex != centroidLimit) {
       double mean;
       double weight;
@@ -962,7 +986,7 @@ final class PercentileTDigestAccumulator extends TDigest {
         double q2 = (weightSoFar + proposedWeight) * totalWeightNormalizer;
         double normalizedWeight = proposedWeight * weightNormalizer;
         double normalizedWeightSquared = normalizedWeight * normalizedWeight;
-        boolean canMerge = canMergeMeans(_outputMeans[currentIndex], mean)
+        boolean canMerge = (allFiniteMeans || canMergeMeans(_outputMeans[currentIndex], mean))
             && normalizedWeightSquared <= q0 * (1.0 - q0)
             && normalizedWeightSquared <= q2 * (1.0 - q2);
         if (inputIndex == 1 || inputIndex == numInputs - 1) {
@@ -970,8 +994,9 @@ final class PercentileTDigestAccumulator extends TDigest {
         }
         if (canMerge) {
           _outputWeights[currentIndex] = proposedWeight;
-          _outputMeans[currentIndex] = mergeMeans(_outputMeans[currentIndex], proposedWeight - weight, mean, weight,
-              proposedWeight);
+          _outputMeans[currentIndex] =
+              mergeMeans(_outputMeans[currentIndex], proposedWeight - weight, mean, weight, proposedWeight,
+                  sameSignMeans);
         } else {
           weightSoFar += _outputWeights[currentIndex];
           ensureOutputCapacity(Math.max(preferredOutputCapacity, numOutputCentroids + 1));
@@ -986,11 +1011,11 @@ final class PercentileTDigestAccumulator extends TDigest {
       reverse(_outputMeans, numOutputCentroids);
       reverse(_outputWeights, numOutputCentroids);
     }
-    finishMerge(numOutputCentroids, newTotalWeight);
+    finishMerge(numOutputCentroids, newTotalWeight, compression);
     return true;
   }
 
-  private void finishMerge(int numOutputCentroids, double totalWeight) {
+  private void finishMerge(int numOutputCentroids, double totalWeight, double compression) {
     double[] temporary = _centroidMeans;
     _centroidMeans = _outputMeans;
     _outputMeans = temporary;
@@ -999,7 +1024,7 @@ final class PercentileTDigestAccumulator extends TDigest {
     _outputWeights = temporary;
     _numCentroids = numOutputCentroids;
     _totalWeight = totalWeight;
-    _publiclyCompressed = false;
+    _publiclyCompressed = compression == _compression;
   }
 
   private void ensureIncomingCapacity(int capacity) {
@@ -1296,11 +1321,11 @@ final class PercentileTDigestAccumulator extends TDigest {
   }
 
   private static double mergeMeans(double firstMean, double firstWeight, double secondMean, double secondWeight,
-      double totalWeight) {
+      double totalWeight, boolean sameSignMeans) {
     if (firstMean == secondMean) {
       return firstMean;
     }
-    if (Math.copySign(1.0, firstMean) == Math.copySign(1.0, secondMean)) {
+    if (sameSignMeans || Math.copySign(1.0, firstMean) == Math.copySign(1.0, secondMean)) {
       return firstMean + (secondMean - firstMean) * secondWeight / totalWeight;
     }
     return firstMean * (firstWeight / totalWeight) + secondMean * (secondWeight / totalWeight);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
@@ -29,6 +29,7 @@ import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.segment.local.utils.TDigestUtils;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.Constants;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
@@ -108,6 +109,8 @@ public class PercentileTDigestAggregationFunction extends NullableSingleInputAgg
     if (blockValSet.getValueType() == DataType.BYTES) {
       // Serialized TDigest
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
+      PercentileTDigestAccumulator.SerializedTDigestInput input =
+          new PercentileTDigestAccumulator.SerializedTDigestInput();
       foldNotNull(length, blockValSet,
           (PercentileTDigestAccumulator) aggregationResultHolder.getResult(), (current, from, toExclusive) -> {
             if (current == null) {
@@ -115,7 +118,8 @@ public class PercentileTDigestAggregationFunction extends NullableSingleInputAgg
               aggregationResultHolder.setValue(current);
             }
             for (int i = from; i < toExclusive; i++) {
-              current.addSerializedTDigest(bytesValues[i]);
+              input.reset(bytesValues[i]);
+              current.addSerializedTDigestDirect(input);
             }
             return current;
           }
@@ -154,11 +158,13 @@ public class PercentileTDigestAggregationFunction extends NullableSingleInputAgg
     if (blockValSet.getValueType() == DataType.BYTES) {
       // Serialized TDigest
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
+      PercentileTDigestAccumulator.SerializedTDigestInput input =
+          new PercentileTDigestAccumulator.SerializedTDigestInput();
       forEachNotNull(length, blockValSet, (from, to) -> {
         for (int i = from; i < to; i++) {
           int groupKey = groupKeyArray[i];
-          getSerializedAccumulator(groupByResultHolder, groupKey, bytesValues[i])
-              .addSerializedTDigest(bytesValues[i]);
+          input.reset(bytesValues[i]);
+          getSerializedAccumulator(groupByResultHolder, groupKey, input).addSerializedTDigestDirect(input);
         }
       });
       return;
@@ -211,7 +217,7 @@ public class PercentileTDigestAggregationFunction extends NullableSingleInputAgg
           }
           input.reset(bytesValues[i]);
           for (int groupKey : groupKeys) {
-            getSerializedAccumulator(groupByResultHolder, groupKey, input).addSerializedTDigest(input);
+            getSerializedAccumulator(groupByResultHolder, groupKey, input).addSerializedTDigestDirect(input);
           }
         }
       });
@@ -258,7 +264,7 @@ public class PercentileTDigestAggregationFunction extends NullableSingleInputAgg
   public TDigest extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     PercentileTDigestAccumulator accumulator = aggregationResultHolder.getResult();
     if (accumulator == null) {
-      return TDigest.createMergingDigest(_compressionFactor);
+      return TDigestUtils.createMergingDigest(_compressionFactor);
     } else {
       return accumulator;
     }
@@ -268,7 +274,7 @@ public class PercentileTDigestAggregationFunction extends NullableSingleInputAgg
   public TDigest extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     Object result = groupByResultHolder.getResult(groupKey);
     if (result == null) {
-      return TDigest.createMergingDigest(_compressionFactor);
+      return TDigestUtils.createMergingDigest(_compressionFactor);
     } else {
       return (TDigest) result;
     }
@@ -290,6 +296,18 @@ public class PercentileTDigestAggregationFunction extends NullableSingleInputAgg
         PercentileTDigestAccumulator.forReduction(intermediateResult1.compression());
     accumulator.add(intermediateResult1);
     accumulator.add(intermediateResult2);
+    return accumulator;
+  }
+
+  /// Merges both digests using the compression configured for this aggregation function.
+  ///
+  /// Segment merge-and-rollup uses this method because its configured output compression can differ from the
+  /// compression stored in either input digest.
+  public TDigest mergeWithConfiguredCompression(TDigest intermediateResult1, TDigest intermediateResult2) {
+    PercentileTDigestAccumulator accumulator = PercentileTDigestAccumulator.forReduction(_compressionFactor);
+    accumulator.add(intermediateResult1);
+    accumulator.add(intermediateResult2);
+    accumulator.compress();
     return accumulator;
   }
 
@@ -342,7 +360,7 @@ public class PercentileTDigestAggregationFunction extends NullableSingleInputAgg
   protected static TDigest getDefaultTDigest(AggregationResultHolder aggregationResultHolder, int compressionFactor) {
     TDigest tDigest = aggregationResultHolder.getResult();
     if (tDigest == null) {
-      tDigest = TDigest.createMergingDigest(compressionFactor);
+      tDigest = TDigestUtils.createMergingDigest(compressionFactor);
       aggregationResultHolder.setValue(tDigest);
     }
     return tDigest;
@@ -354,16 +372,6 @@ public class PercentileTDigestAggregationFunction extends NullableSingleInputAgg
     if (accumulator == null) {
       accumulator = new PercentileTDigestAccumulator(compressionFactor);
       aggregationResultHolder.setValue(accumulator);
-    }
-    return accumulator;
-  }
-
-  private static PercentileTDigestAccumulator getSerializedAccumulator(GroupByResultHolder groupByResultHolder,
-      int groupKey, byte[] bytes) {
-    PercentileTDigestAccumulator accumulator = groupByResultHolder.getResult(groupKey);
-    if (accumulator == null) {
-      accumulator = PercentileTDigestAccumulator.forSerializedTDigest(bytes);
-      groupByResultHolder.setValueForKey(groupKey, accumulator);
     }
     return accumulator;
   }
@@ -390,7 +398,7 @@ public class PercentileTDigestAggregationFunction extends NullableSingleInputAgg
       int compressionFactor) {
     TDigest tDigest = groupByResultHolder.getResult(groupKey);
     if (tDigest == null) {
-      tDigest = TDigest.createMergingDigest(compressionFactor);
+      tDigest = new PercentileTDigestAccumulator(compressionFactor);
       groupByResultHolder.setValueForKey(groupKey, tDigest);
     }
     return tDigest;

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/aggregator/PercentileTDigestAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/aggregator/PercentileTDigestAggregator.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.segment.processing.aggregator;
 
 import com.tdunning.math.stats.TDigest;
 import java.util.Map;
+import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.function.PercentileTDigestAggregationFunction;
 import org.apache.pinot.segment.spi.Constants;
@@ -47,10 +48,10 @@ public class PercentileTDigestAggregator implements ValueAggregator {
     int compression = getCompression(functionParameters);
     TDigest first = ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(bytes1);
     TDigest second = ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(bytes2);
-    TDigest merged = TDigest.createMergingDigest(compression);
-    merged.add(first);
-    merged.add(second);
-    return ObjectSerDeUtils.TDIGEST_SER_DE.serialize(merged);
+    PercentileTDigestAggregationFunction function = new PercentileTDigestAggregationFunction(
+        ExpressionContext.forIdentifier("tdigest"), 50.0, compression, false);
+    TDigest merged = function.mergeWithConfiguredCompression(first, second);
+    return function.serializeIntermediateResult(merged).getBytes();
   }
 
   private int getCompression(Map<String, String> functionParameters) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileRawTDigestAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileRawTDigestAggregationFunctionTest.java
@@ -24,6 +24,7 @@ import java.nio.ByteBuffer;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
+import org.apache.pinot.segment.local.customobject.SerializedTDigest;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.testng.annotations.Test;
 
@@ -54,16 +55,82 @@ public class PercentileRawTDigestAggregationFunctionTest {
         new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(small)));
     assertTrue(intermediateResult instanceof PercentileTDigestAccumulator);
 
-    byte[] serialized = BytesUtils.toBytes(function.extractFinalResult(intermediateResult).toString());
+    SerializedTDigest finalResult = function.extractFinalResult(intermediateResult);
+    byte[] serialized = BytesUtils.toBytes(finalResult.toString());
+    assertLegacyCompatibleShape(serialized, compression);
 
     // Client side: a plain t-digest reader must be able to read the emitted bytes without losing
     // state. Before the fix this threw ArrayIndexOutOfBoundsException because the final result was
     // re-encoded as a verbose digest with more centroids than the reader allocates.
     TDigest roundTripped = MergingDigest.fromBytes(ByteBuffer.wrap(serialized));
-    assertEquals(roundTripped.size(), numCentroids);
-    assertEquals(roundTripped.quantile(0.0), 0.0);
-    assertEquals(roundTripped.quantile(0.5), (numCentroids - 1.0) / 2.0, 1.0);
-    assertEquals(roundTripped.quantile(1.0), numCentroids - 1.0);
+    assertUnitCentroidDigest(roundTripped, numCentroids);
+
+    // Also cover the materialized (merged) accumulator state, not just the serialized pass-through.
+    TDigest merged = function.merge(intermediateResult, function.deserializeIntermediateResult(
+        new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(small))));
+    byte[] mergedSerialized = BytesUtils.toBytes(function.extractFinalResult(merged).toString());
+    assertLegacyCompatibleShape(mergedSerialized, compression);
+    TDigest mergedRoundTripped = MergingDigest.fromBytes(ByteBuffer.wrap(mergedSerialized));
+    assertEquals(mergedRoundTripped.size(), 2L * numCentroids);
+    assertEquals(mergedRoundTripped.quantile(0.5), (numCentroids - 1.0) / 2.0, 1.0);
+  }
+
+  @Test
+  public void testFinalResultRoundTripForRegularDigest() {
+    double compression = 100.0;
+    TDigest input = TDigest.createMergingDigest(compression);
+    for (int i = 0; i < 1000; i++) {
+      input.add(i);
+    }
+    byte[] bytes = new byte[input.byteSize()];
+    input.asBytes(ByteBuffer.wrap(bytes));
+
+    PercentileRawTDigestAggregationFunction function =
+        new PercentileRawTDigestAggregationFunction(EXPRESSION, 50.0, (int) compression, false);
+    TDigest intermediateResult = function.deserializeIntermediateResult(
+        new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(bytes)));
+
+    SerializedTDigest finalResult = function.extractFinalResult(intermediateResult);
+    byte[] serialized = BytesUtils.toBytes(finalResult.toString());
+    TDigest roundTripped = MergingDigest.fromBytes(ByteBuffer.wrap(serialized));
+    assertEquals(roundTripped.size(), 1000);
+    assertEquals(roundTripped.quantile(0.5), input.quantile(0.5), 1e-6);
+  }
+
+  /// A verbose digest with more centroids than a t-digest 3.2 reader of the same compression allocates is accepted
+  /// since the 3.3 upgrade, but the emitted final result must stay readable by legacy readers.
+  @Test
+  public void testAccumulatorFinalSerializationIsLegacyCompatibleAtLowCompression() {
+    PercentileRawTDigestAggregationFunction function =
+        new PercentileRawTDigestAggregationFunction(EXPRESSION, 50.0, 20, false);
+    byte[] verbose = createVerboseUnitCentroidDigest(51, 20.0);
+    TDigest intermediateResult = function.deserializeIntermediateResult(
+        new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(verbose)));
+    assertTrue(intermediateResult instanceof PercentileTDigestAccumulator);
+
+    SerializedTDigest finalResult = function.extractFinalResult(intermediateResult);
+    byte[] serialized = BytesUtils.toBytes(finalResult.toString());
+    assertLegacyCompatibleShape(serialized, 20.0);
+
+    TDigest roundTripped = ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(serialized);
+    assertEquals(roundTripped.compression(), 20.0);
+    assertUnitCentroidDigest(roundTripped, 51);
+  }
+
+  /// Verbose-encoded digest (encoding 1) with unit-weight centroids at means 0..numCentroids-1. Package-private:
+  /// shared with [PercentileSmartTDigestAggregationFunctionTest].
+  static byte[] createVerboseUnitCentroidDigest(int numCentroids, double compression) {
+    ByteBuffer buffer = ByteBuffer.allocate(4 * Integer.BYTES + 2 * Double.BYTES + 2 * Double.BYTES * numCentroids);
+    buffer.putInt(1);
+    buffer.putDouble(0.0);
+    buffer.putDouble(numCentroids - 1.0);
+    buffer.putDouble(compression);
+    buffer.putInt(numCentroids);
+    for (int i = 0; i < numCentroids; i++) {
+      buffer.putDouble(1.0);
+      buffer.putDouble(i);
+    }
+    return buffer.array();
   }
 
   /// SMALL-encoded digest (encoding 2) with explicit main/buffer capacities, unit-weight centroids
@@ -86,5 +153,25 @@ public class PercentileRawTDigestAggregationFunctionTest {
       buffer.putFloat(i);
     }
     return buffer.array();
+  }
+
+  private static void assertLegacyCompatibleShape(byte[] bytes, double compression) {
+    ByteBuffer buffer = ByteBuffer.wrap(bytes);
+    int encoding = buffer.getInt();
+    if (encoding == 1) {
+      assertEquals(buffer.getDouble(Integer.BYTES + 2 * Double.BYTES), compression);
+      int centroidCount = buffer.getInt(Integer.BYTES + 3 * Double.BYTES);
+      assertTrue(centroidCount <= 2 * Math.ceil(compression) + 10,
+          "Verbose encoding exceeds the fresh MergingDigest centroid capacity: " + centroidCount);
+    } else {
+      assertEquals(encoding, 2, "Unexpected t-digest encoding");
+    }
+  }
+
+  private static void assertUnitCentroidDigest(TDigest digest, int expectedSize) {
+    assertEquals(digest.size(), expectedSize);
+    assertEquals(digest.quantile(0.0), 0.0);
+    assertEquals(digest.quantile(0.5), (expectedSize - 1.0) / 2.0, 1.0);
+    assertEquals(digest.quantile(1.0), expectedSize - 1.0);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileSmartTDigestAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileSmartTDigestAggregationFunctionTest.java
@@ -18,77 +18,212 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import com.tdunning.math.stats.Centroid;
 import com.tdunning.math.stats.MergingDigest;
 import com.tdunning.math.stats.TDigest;
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.Literal;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
+import org.apache.pinot.core.common.SyntheticBlockValSets;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 
 public class PercentileSmartTDigestAggregationFunctionTest {
   private static final ExpressionContext EXPRESSION = ExpressionContext.forIdentifier("col");
 
-  /// Exercises the complete capacity-preserving intermediate lifecycle: pass-through serde, materialization by
-  /// merging another digest, and raw-list merging in both argument orders.
   @Test
-  public void testCapacityPreservingIntermediateLifecycle() {
+  public void testAccumulatorIntermediateSerializationIsLegacyCompatibleAtLowCompression() {
+    PercentileSmartTDigestAggregationFunction function = newFunction();
+    byte[] verbose = PercentileRawTDigestAggregationFunctionTest.createVerboseUnitCentroidDigest(51, 20.0);
+    Object intermediateResult = function.deserializeIntermediateResult(
+        new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(verbose)));
+    assertTrue(intermediateResult instanceof PercentileTDigestAccumulator);
+
+    AggregationFunction.SerializedIntermediateResult serialized =
+        function.serializeIntermediateResult(intermediateResult);
+    assertEquals(serialized.getType(), ObjectSerDeUtils.ObjectType.TDigest.getValue());
+    assertLegacyCompatibleShape(serialized.getBytes(), 20.0);
+
+    Object roundTripped = function.deserializeIntermediateResult(
+        new CustomObject(serialized.getType(), ByteBuffer.wrap(serialized.getBytes())));
+    assertTrue(roundTripped instanceof PercentileTDigestAccumulator);
+    assertUnitCentroidDigest((TDigest) roundTripped, 51, 20.0);
+    assertLegacyCompatibleShape(function.serializeIntermediateResult(roundTripped).getBytes(), 20.0);
+  }
+
+  /// The intermediate result must round-trip through the [PercentileTDigestAccumulator] so that
+  /// capacity-preserving digests (more centroids than a fresh legacy [MergingDigest] of the same
+  /// compression can hold) are not re-encoded into bytes a receiving server cannot read.
+  @Test
+  public void testIntermediateResultRoundTripPreservesCapacityPreservingState() {
     int numCentroids = 51;
-    byte[] small = PercentileRawTDigestAggregationFunctionTest.createSmallUnitCentroidDigest(numCentroids, 20.0, 60,
-        100);
-    PercentileSmartTDigestAggregationFunction function = createFunction();
+    byte[] small =
+        PercentileRawTDigestAggregationFunctionTest.createSmallUnitCentroidDigest(numCentroids, 20.0, 60, 100);
+    PercentileSmartTDigestAggregationFunction function = newFunction();
 
     Object intermediateResult = function.deserializeIntermediateResult(
         new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(small)));
     assertTrue(intermediateResult instanceof PercentileTDigestAccumulator);
 
-    AggregationFunction.SerializedIntermediateResult passThrough =
+    AggregationFunction.SerializedIntermediateResult serialized =
         function.serializeIntermediateResult(intermediateResult);
-    assertEquals(passThrough.getType(), ObjectSerDeUtils.ObjectType.TDigest.getValue());
-    // Before the fix this was a verbose encoding with 51 centroids, which a plain
-    // MergingDigest.fromBytes reader rejects with ArrayIndexOutOfBoundsException.
-    assertEquals(MergingDigest.fromBytes(ByteBuffer.wrap(passThrough.getBytes())).size(), numCentroids);
+    assertEquals(serialized.getType(), ObjectSerDeUtils.ObjectType.TDigest.getValue());
+    // A verbose re-encoding with 51 centroids would be rejected by a plain legacy MergingDigest.fromBytes reader
+    // with ArrayIndexOutOfBoundsException.
+    TDigest roundTripped = MergingDigest.fromBytes(ByteBuffer.wrap(serialized.getBytes()));
+    assertEquals(roundTripped.size(), numCentroids);
+    assertEquals(roundTripped.quantile(0.5), (numCentroids - 1.0) / 2.0, 1.0);
 
-    byte[] empty = ObjectSerDeUtils.TDIGEST_SER_DE.serialize(TDigest.createMergingDigest(20.0));
     Object merged = function.merge(
-        intermediateResult,
+        function.deserializeIntermediateResult(
+            new CustomObject(serialized.getType(), ByteBuffer.wrap(serialized.getBytes()))),
+        function.deserializeIntermediateResult(
+            new CustomObject(serialized.getType(), ByteBuffer.wrap(serialized.getBytes()))));
+    assertTrue(merged instanceof PercentileTDigestAccumulator);
+    assertEquals(((TDigest) merged).size(), 2L * numCentroids);
+
+    // The materialized (merged) accumulator must also serialize into plain-reader-compatible bytes.
+    TDigest mergedRoundTripped = MergingDigest.fromBytes(
+        ByteBuffer.wrap(function.serializeIntermediateResult(merged).getBytes()));
+    assertEquals(mergedRoundTripped.size(), 2L * numCentroids);
+    assertEquals(mergedRoundTripped.quantile(0.5), (numCentroids - 1.0) / 2.0, 1.0);
+  }
+
+  /// Materialized (non-pass-through) capacity-preserving state must also serialize into legacy-compatible bytes
+  /// through the generic serde, with `byteSize()` agreeing with the serialized length.
+  @Test
+  public void testMaterializedCapacityPreservingStateSerializesLegacyCompatible() {
+    int numCentroids = 51;
+    byte[] small =
+        PercentileRawTDigestAggregationFunctionTest.createSmallUnitCentroidDigest(numCentroids, 20.0, 60, 100);
+    byte[] empty = ObjectSerDeUtils.TDIGEST_SER_DE.serialize(TDigest.createMergingDigest(20.0));
+    PercentileSmartTDigestAggregationFunction function = newFunction();
+
+    Object merged = function.merge(
+        function.deserializeIntermediateResult(
+            new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(small))),
         function.deserializeIntermediateResult(
             new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(empty))));
     byte[] serialized = function.serializeIntermediateResult(merged).getBytes();
-    assertEquals(ByteBuffer.wrap(serialized).getInt(), 2, "Expected small (capacity-preserving) encoding");
+    assertLegacyCompatibleShape(serialized, 20.0);
     assertEquals(((TDigest) merged).byteSize(), serialized.length);
     TDigest roundTripped = MergingDigest.fromBytes(ByteBuffer.wrap(serialized));
     assertEquals(roundTripped.size(), numCentroids);
     assertEquals(roundTripped.quantile(0.5), (numCentroids - 1.0) / 2.0, 1.0);
-
-    DoubleArrayList values = new DoubleArrayList(new double[]{0.0, 25.0, 50.0});
-    assertEquals(((TDigest) function.merge(merged, values)).size(), numCentroids + 3L);
-    Object reverseOrder = function.merge(new DoubleArrayList(values), function.deserializeIntermediateResult(
-        new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(small))));
-    assertTrue(reverseOrder instanceof PercentileTDigestAccumulator);
-    assertEquals(((TDigest) reverseOrder).size(), numCentroids + 3L);
   }
 
   @Test
   public void testMergeWithNullIntermediateResult() {
-    PercentileSmartTDigestAggregationFunction function = createFunction();
+    PercentileSmartTDigestAggregationFunction function = newFunction();
     DoubleArrayList valueList = new DoubleArrayList(new double[]{1.0, 2.0});
     assertEquals(function.merge(null, valueList), valueList);
     assertEquals(function.merge(valueList, null), valueList);
     assertEquals(function.merge(null, null), null);
   }
 
-  private static PercentileSmartTDigestAggregationFunction createFunction() {
+  /// Broker reduce can merge a server that produced a t-digest with a server that stayed below the
+  /// threshold and produced a raw value list; both argument orders must route into the accumulator.
+  @Test
+  public void testMergeAccumulatorWithValueList() {
+    int numCentroids = 51;
+    byte[] small =
+        PercentileRawTDigestAggregationFunctionTest.createSmallUnitCentroidDigest(numCentroids, 20.0, 60, 100);
+    PercentileSmartTDigestAggregationFunction function = newFunction();
+
+    for (boolean accumulatorFirst : new boolean[]{true, false}) {
+      Object accumulator = function.deserializeIntermediateResult(
+          new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(small)));
+      DoubleArrayList valueList = new DoubleArrayList(new double[]{0.0, 25.0, 50.0});
+      Object merged = accumulatorFirst ? function.merge(accumulator, valueList)
+          : function.merge(valueList, accumulator);
+      assertTrue(merged instanceof PercentileTDigestAccumulator);
+      assertEquals(((TDigest) merged).size(), numCentroids + 3L);
+      assertEquals(((TDigest) merged).quantile(0.5), (numCentroids - 1.0) / 2.0, 1.0);
+      TDigest roundTripped = MergingDigest.fromBytes(
+          ByteBuffer.wrap(function.serializeIntermediateResult(merged).getBytes()));
+      assertEquals(roundTripped.size(), numCentroids + 3L);
+    }
+  }
+
+  @Test
+  public void testThresholdConversionPreservesDuplicateInfiniteValues() {
+    int repetitions = 1_000;
+    double[] values = new double[3 * repetitions];
+    Arrays.fill(values, 0, repetitions, Double.NEGATIVE_INFINITY);
+    Arrays.fill(values, repetitions, 2 * repetitions, 0.0);
+    Arrays.fill(values, 2 * repetitions, values.length, Double.POSITIVE_INFINITY);
+    PercentileSmartTDigestAggregationFunction function = newFunction();
+
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    function.aggregate(values.length, resultHolder,
+        Map.of(EXPRESSION, SyntheticBlockValSets.Double.create(null, values)));
+    Object intermediateResult = function.extractAggregationResult(resultHolder);
+    assertTrue(intermediateResult instanceof PercentileTDigestAccumulator);
+    TDigest result = (TDigest) intermediateResult;
+    assertDuplicateInfinityResult(result, values.length);
+    TDigest roundTripped = ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(
+        function.serializeIntermediateResult(intermediateResult).getBytes());
+    assertDuplicateInfinityResult(roundTripped, values.length);
+
+    AggregationFunction.SerializedIntermediateResult serialized =
+        function.serializeIntermediateResult(intermediateResult);
+    Object first = function.deserializeIntermediateResult(
+        new CustomObject(serialized.getType(), ByteBuffer.wrap(serialized.getBytes())));
+    Object second = function.deserializeIntermediateResult(
+        new CustomObject(serialized.getType(), ByteBuffer.wrap(serialized.getBytes())));
+    Object merged = function.merge(first, second);
+    assertTrue(merged instanceof PercentileTDigestAccumulator);
+    assertDuplicateInfinityResult((TDigest) merged, 2L * values.length);
+  }
+
+  private static PercentileSmartTDigestAggregationFunction newFunction() {
     return new PercentileSmartTDigestAggregationFunction(
         List.of(EXPRESSION, ExpressionContext.forLiteral(Literal.doubleValue(50.0)),
             ExpressionContext.forLiteral(Literal.stringValue("THRESHOLD=1;COMPRESSION=20"))), false);
+  }
+
+  private static void assertDuplicateInfinityResult(TDigest result, long expectedSize) {
+    assertEquals(result.size(), expectedSize);
+    assertEquals(result.getMin(), Double.NEGATIVE_INFINITY);
+    assertEquals(result.getMax(), Double.POSITIVE_INFINITY);
+    for (Centroid centroid : result.centroids()) {
+      assertFalse(Double.isNaN(centroid.mean()));
+    }
+    assertEquals(result.quantile(0.0), Double.NEGATIVE_INFINITY);
+    assertEquals(result.quantile(0.5), 0.0);
+    assertEquals(result.quantile(1.0), Double.POSITIVE_INFINITY);
+  }
+
+  private static void assertLegacyCompatibleShape(byte[] bytes, double compression) {
+    ByteBuffer buffer = ByteBuffer.wrap(bytes);
+    int encoding = buffer.getInt();
+    if (encoding == 1) {
+      assertEquals(buffer.getDouble(Integer.BYTES + 2 * Double.BYTES), compression);
+      int centroidCount = buffer.getInt(Integer.BYTES + 3 * Double.BYTES);
+      assertTrue(centroidCount <= 2 * Math.ceil(compression) + 10,
+          "Verbose encoding exceeds the t-digest 3.2 centroid capacity: " + centroidCount);
+    } else {
+      assertEquals(encoding, 2, "Unexpected t-digest encoding");
+    }
+  }
+
+  private static void assertUnitCentroidDigest(TDigest digest, int expectedSize, double compression) {
+    assertEquals(digest.size(), expectedSize);
+    assertEquals(digest.compression(), compression);
+    assertEquals(digest.quantile(0.0), 0.0);
+    assertEquals(digest.quantile(0.5), (expectedSize - 1.0) / 2.0, 1.0);
+    assertEquals(digest.quantile(1.0), expectedSize - 1.0);
   }
 
   public static class WithHighThreshold extends AbstractPercentileAggregationFunctionTest {
@@ -106,37 +241,27 @@ public class PercentileSmartTDigestAggregationFunctionTest {
 
     @Override
     String expectedAggrWithNull10(Scenario scenario) {
-      return "0.5";
+      return "1.0";
     }
 
     @Override
     String expectedAggrWithNull30(Scenario scenario) {
-      return "2.5";
+      return "3.0";
     }
 
     @Override
     String expectedAggrWithNull50(Scenario scenario) {
-      return "4.5";
+      return "5.0";
     }
 
     @Override
     String expectedAggrWithNull70(Scenario scenario) {
-      return "6.5";
+      return "7.0";
     }
 
     @Override
     String expectedAggrWithoutNull55(Scenario scenario) {
-      switch (scenario.getDataType()) {
-        case INT:
-          return "-6.442450943999939E8";
-        case LONG:
-          return "-2.7670116110564065E18";
-        case FLOAT:
-        case DOUBLE:
-          return "-Infinity";
-        default:
-          throw new IllegalArgumentException("Unsupported datatype " + scenario.getDataType());
-      }
+      return "0.0";
     }
 
     @Override
@@ -146,7 +271,7 @@ public class PercentileSmartTDigestAggregationFunctionTest {
 
     @Override
     String expectedAggrWithoutNull90(Scenario scenario) {
-      return "7.100000000000001";
+      return "7.0";
     }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunctionTest.java
@@ -186,6 +186,23 @@ public class PercentileTDigestAggregationFunctionTest {
   }
 
   @Test
+  public void testReverseMergeDoesNotTreatSignedZeroAsSameSign() {
+    PercentileTDigestAccumulator accumulator = new PercentileTDigestAccumulator(10);
+    accumulator.add(-0.0);
+    accumulator.compress();
+    accumulator.add(0.0);
+    accumulator.add(Double.MIN_VALUE);
+    accumulator.add(Double.MAX_VALUE, 9);
+    accumulator.compress();
+
+    List<Centroid> centroids = new ArrayList<>(accumulator.centroids());
+    Assert.assertEquals(centroids.size(), 3);
+    Assert.assertEquals(centroids.get(1).count(), 2);
+    Assert.assertEquals(Double.doubleToRawLongBits(centroids.get(1).mean()),
+        Double.doubleToRawLongBits(0.0));
+  }
+
+  @Test
   public void testDuplicateInfiniteValuesAcrossRawAndSerializedReduction() {
     int repetitions = 1_000;
     double[] values = new double[3 * repetitions];
@@ -629,6 +646,26 @@ public class PercentileTDigestAggregationFunctionTest {
     Assert.assertNull(rawValuesField.get(
         PercentileTDigestAccumulator.forSerializedTDigestWithMergeBuffers(serializedDigest)));
     Assert.assertNotNull(rawValuesField.get(new PercentileTDigestAccumulator(100)));
+  }
+
+  @Test
+  public void testDirectMergeAtConfiguredCompressionIsNotRepeated()
+      throws ReflectiveOperationException {
+    byte[][] serializedDigests = createSerializedDigests(2, 100, 100.0, ignored -> false);
+    PercentileTDigestAccumulator accumulator =
+        PercentileTDigestAccumulator.forSerializedTDigestWithMergeBuffers(serializedDigests[0]);
+    PercentileTDigestAccumulator.SerializedTDigestInput input =
+        new PercentileTDigestAccumulator.SerializedTDigestInput();
+    for (byte[] serializedDigest : serializedDigests) {
+      input.reset(serializedDigest);
+      accumulator.addSerializedTDigestDirect(input);
+    }
+
+    int mergeCount = (int) getAccumulatorField(accumulator, "_mergeCount");
+    Assert.assertTrue((boolean) getAccumulatorField(accumulator, "_publiclyCompressed"));
+    accumulator.compress();
+    Assert.assertEquals(getAccumulatorField(accumulator, "_mergeCount"), mergeCount);
+    Assert.assertEquals(accumulator.size(), 200L);
   }
 
   @Test
@@ -1077,6 +1114,38 @@ public class PercentileTDigestAggregationFunctionTest {
         "Pinot accumulator diverges from t-digest 3.3 K1 at compression " + compression);
   }
 
+  @Test
+  public void testRawAndDirectLowCompressionHeavyTailAccuracy() {
+    int numDigests = 32;
+    int valuesPerDigest = 512;
+    int compression = 20;
+    int numValues = numDigests * valuesPerDigest;
+    double[] values = new double[numValues];
+    byte[][] serializedDigests = new byte[numDigests][];
+    for (int digestIndex = 0; digestIndex < numDigests; digestIndex++) {
+      TDigest digest = TDigestUtils.createMergingDigest(compression);
+      SplittableRandom random = new SplittableRandom(0x5EEDL + digestIndex);
+      for (int valueIndex = 0; valueIndex < valuesPerDigest; valueIndex++) {
+        double value = ReducerDistribution.HEAVY_TAIL.value(random.nextDouble());
+        values[digestIndex * valuesPerDigest + valueIndex] = value;
+        digest.add(value);
+      }
+      serializedDigests[digestIndex] = ObjectSerDeUtils.TDIGEST_SER_DE.serialize(digest);
+    }
+
+    PercentileTDigestAggregationFunction function =
+        new PercentileTDigestAggregationFunction(EXPRESSION, 75.0, compression, false);
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    function.aggregate(values.length, resultHolder,
+        Map.of(EXPRESSION, SyntheticBlockValSets.Double.create(null, values)));
+    TDigest rawResult = function.extractAggregationResult(resultHolder);
+    TDigest directResult = aggregateSerialized(serializedDigests, null, false);
+
+    Arrays.sort(values);
+    assertValidReducerResult(rawResult, values, "raw/20/heavy-tail", 0.06);
+    assertValidReducerResult(directResult, values, "direct/20/heavy-tail", 0.06);
+  }
+
   @Test(expectedExceptions = IllegalArgumentException.class,
       expectedExceptionsMessageRegExp = "Cannot add NaN to t-digest")
   public void testNaNRejected() {
@@ -1395,6 +1464,13 @@ public class PercentileTDigestAggregationFunctionTest {
     Field field = PercentileTDigestAccumulator.class.getDeclaredField(name);
     field.setAccessible(true);
     field.set(accumulator, value);
+  }
+
+  private static Object getAccumulatorField(PercentileTDigestAccumulator accumulator, String name)
+      throws ReflectiveOperationException {
+    Field field = PercentileTDigestAccumulator.class.getDeclaredField(name);
+    field.setAccessible(true);
+    return field.get(accumulator);
   }
 
   private enum MergeOrder {

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunctionTest.java
@@ -37,6 +37,7 @@ import org.apache.pinot.core.common.SyntheticBlockValSets;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction.SerializedIntermediateResult;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.segment.local.utils.TDigestUtils;
 import org.apache.pinot.segment.spi.Constants;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.roaringbitmap.RoaringBitmap;
@@ -179,9 +180,92 @@ public class PercentileTDigestAggregationFunctionTest {
     Assert.assertEquals(result.size(), specialValues.length);
     Assert.assertEquals(result.getMin(), Double.NEGATIVE_INFINITY);
     Assert.assertEquals(result.getMax(), Double.POSITIVE_INFINITY);
-    Assert.assertTrue(Double.isNaN(result.quantile(0.0)));
-    Assert.assertTrue(Double.isNaN(result.quantile(1.0)));
+    Assert.assertEquals(result.quantile(0.0), Double.NEGATIVE_INFINITY);
+    Assert.assertEquals(result.quantile(1.0), Double.POSITIVE_INFINITY);
     Assert.assertEquals(result.quantile(0.5), 0.0);
+  }
+
+  @Test
+  public void testDuplicateInfiniteValuesAcrossRawAndSerializedReduction() {
+    int repetitions = 1_000;
+    double[] values = new double[3 * repetitions];
+    Arrays.fill(values, 0, repetitions, Double.NEGATIVE_INFINITY);
+    Arrays.fill(values, repetitions, 2 * repetitions, 0.0);
+    Arrays.fill(values, 2 * repetitions, values.length, Double.POSITIVE_INFINITY);
+
+    PercentileTDigestAggregationFunction function =
+        new PercentileTDigestAggregationFunction(EXPRESSION, 50.0, 20, false);
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    function.aggregate(values.length, resultHolder,
+        Map.of(EXPRESSION, SyntheticBlockValSets.Double.create(null, values)));
+    TDigest rawResult = function.extractAggregationResult(resultHolder);
+    assertDuplicateInfinityResult(rawResult, values.length);
+    Assert.assertEquals(rawResult.cdf(-1.0), 1.0 / 3.0, 1e-12);
+    Assert.assertEquals(rawResult.cdf(0.0), 0.5, 1e-12);
+    Assert.assertEquals(rawResult.cdf(1.0), 2.0 / 3.0, 1e-12);
+
+    byte[] serialized = function.serializeIntermediateResult(rawResult).getBytes();
+    TDigest reducedResult = aggregateSerialized(new byte[][]{serialized, serialized}, null, false);
+    assertDuplicateInfinityResult(reducedResult, 2L * values.length);
+    Assert.assertEquals(reducedResult.cdf(-1.0), 1.0 / 3.0, 1e-12);
+    Assert.assertEquals(reducedResult.cdf(0.0), 0.5, 1e-12);
+    Assert.assertEquals(reducedResult.cdf(1.0), 2.0 / 3.0, 1e-12);
+  }
+
+  @Test
+  public void testOnlyInfiniteValuesProduceMonotonicQuantiles() {
+    int repetitions = 1_000;
+    double[] values = new double[2 * repetitions];
+    Arrays.fill(values, 0, repetitions, Double.NEGATIVE_INFINITY);
+    Arrays.fill(values, repetitions, values.length, Double.POSITIVE_INFINITY);
+    PercentileTDigestAccumulator accumulator = new PercentileTDigestAccumulator(20);
+    accumulator.add(values, 0, values.length);
+
+    double previous = Double.NEGATIVE_INFINITY;
+    for (double quantile : new double[]{0.0, 0.25, 0.5, 0.75, 1.0}) {
+      double value = accumulator.quantile(quantile);
+      Assert.assertFalse(Double.isNaN(value));
+      Assert.assertTrue(value >= previous);
+      previous = value;
+    }
+    Assert.assertEquals(accumulator.cdf(0.0), 0.5, 1e-12);
+  }
+
+  @Test
+  public void testLegacyWeightedBoundariesUseTheirSourceExtrema() {
+    ByteBuffer legacy = ByteBuffer.allocate(64);
+    legacy.putInt(1);
+    legacy.putDouble(0.0);
+    legacy.putDouble(10.0);
+    legacy.putDouble(20.0);
+    legacy.putInt(2);
+    legacy.putDouble(2.0);
+    legacy.putDouble(1.0);
+    legacy.putDouble(1.0);
+    legacy.putDouble(10.0);
+
+    ByteBuffer shifted = ByteBuffer.allocate(64);
+    shifted.putInt(1);
+    shifted.putDouble(-100.0);
+    shifted.putDouble(100.0);
+    shifted.putDouble(20.0);
+    shifted.putInt(2);
+    shifted.putDouble(1.0);
+    shifted.putDouble(-100.0);
+    shifted.putDouble(1.0);
+    shifted.putDouble(100.0);
+
+    PercentileTDigestAccumulator actual = PercentileTDigestAccumulator.forReduction(20.0);
+    actual.addSerializedTDigest(legacy.array());
+    actual.addSerializedTDigest(shifted.array());
+    PercentileTDigestAccumulator expected = new PercentileTDigestAccumulator(20);
+    expected.add(new double[]{0.0, 2.0, 10.0, -100.0, 100.0}, 0, 5);
+
+    Assert.assertEquals(actual.size(), 5L);
+    for (double quantile : new double[]{0.0, 0.25, 0.5, 0.75, 1.0}) {
+      Assert.assertEquals(actual.quantile(quantile), expected.quantile(quantile), 1e-12,
+          "Legacy boundary repair used extrema from another source at p" + quantile * 100);
+    }
   }
 
   @Test
@@ -204,7 +288,9 @@ public class PercentileTDigestAggregationFunctionTest {
       Assert.assertEquals(result.getMax(), (expectedSize - 1.0) / expectedSize, 0.000_001);
       Assert.assertTrue(((PercentileTDigestAccumulator) result).toTDigest() instanceof MergingDigest);
     }
-    Assert.assertEquals(smallResult.quantile(0.75), verboseResult.quantile(0.75), 0.001);
+    // The compact source narrows centroids to floats and can take a different valid merge path. Both results are
+    // independently bounded against the exact percentile above, so keep their cross-encoding envelope equally tight.
+    Assert.assertEquals(smallResult.quantile(0.75), verboseResult.quantile(0.75), 0.005);
   }
 
   @Test
@@ -406,7 +492,7 @@ public class PercentileTDigestAggregationFunctionTest {
         new PercentileTDigestAggregationFunction(EXPRESSION, 75.0, false);
     TDigest lazyResult = function.deserializeIntermediateResult(
         new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(oversizedSmall.array())));
-    assertOversizedSmallIntermediateRoundTrip(function, lazyResult, numCentroids);
+    assertOversizedSmallIntermediateRoundTrip(function, lazyResult, numCentroids, 2, numCentroids);
 
     GroupByResultHolder resultHolder = function.createGroupByResultHolder(1, 1);
     function.aggregateGroupByMV(2, new int[][]{{0}, {0}}, resultHolder,
@@ -419,7 +505,7 @@ public class PercentileTDigestAggregationFunctionTest {
     Assert.assertEquals(result.getMin(), 0.0);
     Assert.assertEquals(result.getMax(), numCentroids - 1.0);
     Assert.assertEquals(result.quantile(0.75), 59.5, 1.0);
-    assertOversizedSmallIntermediateRoundTrip(function, result, numCentroids);
+    assertOversizedSmallIntermediateRoundTrip(function, result, numCentroids, 1, 70);
     result.add(numCentroids);
     Assert.assertEquals(result.size(), numCentroids + 1L);
 
@@ -432,21 +518,22 @@ public class PercentileTDigestAggregationFunctionTest {
     TDigest preciseResult = function.extractGroupByResult(preciseResultHolder, 0);
     Assert.assertEquals(preciseResult.compression(), preciseCompression);
     Assert.assertEquals(preciseResult.size(), numCentroids);
-    Assert.assertTrue(preciseResult.centroidCount() <= 2 * Math.ceil(preciseCompression) + 10);
+    preciseResult.compress();
+    Assert.assertTrue(preciseResult.centroidCount() <= 2 * Math.ceil(preciseCompression) + 30);
   }
 
   private static void assertOversizedSmallIntermediateRoundTrip(PercentileTDigestAggregationFunction function,
-      TDigest result, int numCentroids) {
+      TDigest result, int expectedSize, int expectedEncoding, int maxCentroids) {
     SerializedIntermediateResult serializedResult = function.serializeIntermediateResult(result);
     Assert.assertEquals(serializedResult.getType(), ObjectSerDeUtils.ObjectType.TDigest.getValue());
     byte[] serializedBytes = serializedResult.getBytes();
-    Assert.assertEquals(ByteBuffer.wrap(serializedBytes).getInt(), 2);
+    Assert.assertEquals(ByteBuffer.wrap(serializedBytes).getInt(), expectedEncoding);
     TDigest roundTripped = ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(serializedBytes);
-    Assert.assertEquals(roundTripped.size(), numCentroids);
-    Assert.assertEquals(roundTripped.centroidCount(), numCentroids);
+    Assert.assertEquals(roundTripped.size(), expectedSize);
+    Assert.assertTrue(roundTripped.centroidCount() <= maxCentroids);
     Assert.assertEquals(roundTripped.compression(), 20.0);
     Assert.assertEquals(roundTripped.getMin(), 0.0);
-    Assert.assertEquals(roundTripped.getMax(), numCentroids - 1.0);
+    Assert.assertEquals(roundTripped.getMax(), expectedSize - 1.0);
     double previousValue = Double.NEGATIVE_INFINITY;
     for (double quantile : new double[]{0.0, 0.5, 0.75, 0.95, 0.99, 1.0}) {
       double value = roundTripped.quantile(quantile);
@@ -458,25 +545,7 @@ public class PercentileTDigestAggregationFunctionTest {
   }
 
   @Test
-  public void testCapacityPreservingByteSizeRejectsUnencodableCentroidCount()
-      throws ReflectiveOperationException {
-    PercentileTDigestAccumulator accumulator = PercentileTDigestAccumulator.forReduction(20.0);
-    int unencodableCentroidCount = Short.MAX_VALUE + 1;
-    Field numCentroidsField = PercentileTDigestAccumulator.class.getDeclaredField("_numCentroids");
-    numCentroidsField.setAccessible(true);
-    numCentroidsField.setInt(accumulator, unencodableCentroidCount);
-    Field serializedMainCapacityField =
-        PercentileTDigestAccumulator.class.getDeclaredField("_serializedMainCapacity");
-    serializedMainCapacityField.setAccessible(true);
-    serializedMainCapacityField.setInt(accumulator, unencodableCentroidCount);
-
-    IllegalStateException exception = Assert.expectThrows(IllegalStateException.class, accumulator::byteSize);
-    Assert.assertEquals(exception.getMessage(),
-        "TDigest has too many centroids for capacity-preserving encoding: " + unencodableCentroidCount);
-  }
-
-  @Test
-  public void testSerializedGroupByMVSharedInputUsesCentroidCountForInitialCapacity()
+  public void testSerializedGroupByMVSharedInputReservesBoundaryCapacity()
       throws ReflectiveOperationException {
     ByteBuffer oneCentroid = ByteBuffer.allocate(30 + 2 * Float.BYTES);
     oneCentroid.putInt(2);
@@ -499,7 +568,7 @@ public class PercentileTDigestAggregationFunctionTest {
 
     Field meansField = PercentileTDigestAccumulator.SerializedTDigestInput.class.getDeclaredField("_means");
     meansField.setAccessible(true);
-    Assert.assertEquals(((double[]) meansField.get(input)).length, 1);
+    Assert.assertEquals(((double[]) meansField.get(input)).length, 3);
     Assert.assertEquals(accumulator.toTDigest().size(), 1L);
   }
 
@@ -582,6 +651,27 @@ public class PercentileTDigestAggregationFunctionTest {
     Assert.assertEquals(function.extractGroupByResult(resultHolder, 1).size(), 2L);
   }
 
+  @Test
+  public void testDuplicateInfiniteValuesInRawGroupBy() {
+    int repetitions = 1_000;
+    double[] values = new double[3 * repetitions];
+    Arrays.fill(values, 0, repetitions, Double.NEGATIVE_INFINITY);
+    Arrays.fill(values, repetitions, 2 * repetitions, 0.0);
+    Arrays.fill(values, 2 * repetitions, values.length, Double.POSITIVE_INFINITY);
+
+    PercentileTDigestAggregationFunction function =
+        new PercentileTDigestAggregationFunction(EXPRESSION, 50.0, 20, false);
+    GroupByResultHolder resultHolder = function.createGroupByResultHolder(1, 1);
+    function.aggregateGroupBySV(values.length, new int[values.length], resultHolder,
+        Map.of(EXPRESSION, SyntheticBlockValSets.Double.create(null, values)));
+
+    TDigest result = function.extractGroupByResult(resultHolder, 0);
+    assertDuplicateInfinityResult(result, values.length);
+    TDigest roundTripped = ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(
+        function.serializeIntermediateResult(result).getBytes());
+    assertDuplicateInfinityResult(roundTripped, values.length);
+  }
+
   @DataProvider(name = "malformedSerializedDigests")
   public static Object[][] malformedSerializedDigests() {
     ByteBuffer invalidEncoding = ByteBuffer.allocate(Integer.BYTES);
@@ -606,18 +696,6 @@ public class PercentileTDigestAggregationFunctionTest {
     oversizedVerbose.putDouble(1.0);
     oversizedVerbose.putDouble(100.0);
     oversizedVerbose.putInt(10_000_000);
-    int numOversizedVerboseCentroids = 51;
-    ByteBuffer populatedOversizedVerbose = ByteBuffer.allocate(4 * Integer.BYTES + 2 * Double.BYTES
-        + 2 * Double.BYTES * numOversizedVerboseCentroids);
-    populatedOversizedVerbose.putInt(1);
-    populatedOversizedVerbose.putDouble(0.0);
-    populatedOversizedVerbose.putDouble(numOversizedVerboseCentroids - 1.0);
-    populatedOversizedVerbose.putDouble(20.0);
-    populatedOversizedVerbose.putInt(numOversizedVerboseCentroids);
-    for (int i = 0; i < numOversizedVerboseCentroids; i++) {
-      populatedOversizedVerbose.putDouble(1.0);
-      populatedOversizedVerbose.putDouble(i);
-    }
     ByteBuffer oversizedSmall = ByteBuffer.allocate(3 * Integer.BYTES + 2 * Double.BYTES + Short.BYTES);
     oversizedSmall.putInt(2);
     oversizedSmall.putDouble(0.0);
@@ -656,9 +734,137 @@ public class PercentileTDigestAggregationFunctionTest {
     centroidsExceedMainCapacity.putFloat(1.0F);
     return new Object[][]{
         {invalidEncoding.array()}, {truncatedVerbose.array()}, {truncatedSmall.array()}, {oversizedVerbose.array()},
-        {populatedOversizedVerbose.array()}, {oversizedSmall.array()}, {negativeMainCapacity.array()},
-        {negativeBufferCapacity.array()}, {centroidsExceedMainCapacity.array()}
+        {oversizedSmall.array()}, {negativeMainCapacity.array()}, {negativeBufferCapacity.array()},
+        {centroidsExceedMainCapacity.array()}
     };
+  }
+
+  @Test
+  public void testLowCompressionVerboseCapacityAddedIn33() {
+    int numCentroids = 51;
+    byte[] verbose = createVerboseUnitCentroidDigest(numCentroids, 20.0);
+
+    TDigest deserialized = ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(verbose);
+    Assert.assertEquals(deserialized.size(), numCentroids);
+    Assert.assertEquals(deserialized.centroidCount(), numCentroids);
+    Assert.assertEquals(deserialized.getMin(), 0.0);
+    Assert.assertEquals(deserialized.getMax(), numCentroids - 1.0);
+  }
+
+  @Test
+  public void testFractionalCompressionVerboseCapacityAcrossVersions() {
+    for (Object[] testCase : new Object[][]{{42.125, 95}, {100.1, 212}}) {
+      double compression = (double) testCase[0];
+      int numCentroids = (int) testCase[1];
+      byte[] verbose = createVerboseUnitCentroidDigest(numCentroids, compression);
+
+      TDigest result = aggregateSerialized(new byte[][]{verbose}, null, false);
+      Assert.assertEquals(result.size(), numCentroids);
+      Assert.assertEquals(result.compression(), compression);
+      Assert.assertEquals(result.getMin(), 0.0);
+      Assert.assertEquals(result.getMax(), numCentroids - 1.0);
+
+      byte[] serialized = ((PercentileTDigestAccumulator) result).serialize();
+      TDigest roundTripped = ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(serialized);
+      Assert.assertEquals(roundTripped.size(), numCentroids);
+      Assert.assertEquals(roundTripped.compression(), compression);
+      Assert.assertEquals(roundTripped.getMin(), 0.0);
+      Assert.assertEquals(roundTripped.getMax(), numCentroids - 1.0);
+    }
+  }
+
+  @Test
+  public void testPendingLowCompressionDigestSerializesWithLegacyCompatibleCapacity() {
+    int numCentroids = 51;
+    byte[] verbose = createVerboseUnitCentroidDigest(numCentroids, 20.0);
+    PercentileTDigestAccumulator accumulator = PercentileTDigestAccumulator.forSerializedTDigest(verbose);
+    accumulator.addSerializedTDigest(verbose);
+
+    ByteBuffer serialized = ByteBuffer.wrap(accumulator.serialize());
+    Assert.assertEquals(serialized.getInt(), 2);
+    serialized.position(Integer.BYTES + 2 * Double.BYTES + Float.BYTES);
+    int mainCapacity = serialized.getShort();
+    serialized.getShort();
+    Assert.assertTrue(mainCapacity >= numCentroids);
+    Assert.assertEquals(serialized.getShort(), numCentroids);
+
+    TDigest roundTripped = ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(serialized.array());
+    Assert.assertEquals(roundTripped.size(), numCentroids);
+    Assert.assertEquals(roundTripped.getMin(), 0.0);
+    Assert.assertEquals(roundTripped.getMax(), numCentroids - 1.0);
+  }
+
+  @Test
+  public void testPendingSerializedDigestOwnsInputBytes() {
+    assertPendingSerializedDigestOwnsInputBytes(false);
+    assertPendingSerializedDigestOwnsInputBytes(true);
+  }
+
+  @Test
+  public void testAccumulatorSerializationDoesNotNarrowLargeMeans()
+      throws ReflectiveOperationException {
+    int centroidCount = 51;
+    double min = 1.0e18;
+    PercentileTDigestAccumulator accumulator = new PercentileTDigestAccumulator(20);
+    double[] means = new double[70];
+    double[] weights = new double[70];
+    for (int i = 0; i < centroidCount; i++) {
+      means[i] = min + 256.0 * i;
+      weights[i] = 1.0;
+    }
+    setAccumulatorField(accumulator, "_centroidMeans", means);
+    setAccumulatorField(accumulator, "_centroidWeights", weights);
+    setAccumulatorField(accumulator, "_numCentroids", centroidCount);
+    setAccumulatorField(accumulator, "_totalWeight", (double) centroidCount);
+    setAccumulatorField(accumulator, "_min", means[0]);
+    setAccumulatorField(accumulator, "_max", means[centroidCount - 1]);
+    setAccumulatorField(accumulator, "_publiclyCompressed", true);
+
+    byte[] serialized = accumulator.serialize();
+    ByteBuffer header = ByteBuffer.wrap(serialized);
+    Assert.assertEquals(header.getInt(), 1);
+    header.position(Integer.BYTES + 3 * Double.BYTES);
+    Assert.assertEquals(header.getInt(), 50);
+    TDigest roundTripped = ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(serialized);
+    Assert.assertEquals(roundTripped.size(), centroidCount);
+    Assert.assertEquals(roundTripped.getMin(), means[0]);
+    Assert.assertEquals(roundTripped.getMax(), means[centroidCount - 1]);
+    Assert.assertTrue(Double.isFinite(roundTripped.quantile(0.5)));
+  }
+
+  @Test
+  public void testCentroidInspectionPreservesWeightedHighMagnitudeMean() {
+    PercentileTDigestAccumulator accumulator = new PercentileTDigestAccumulator(100);
+    accumulator.add(1.0e308, 2);
+
+    long weight = 0L;
+    for (Centroid centroid : accumulator.centroids()) {
+      Assert.assertEquals(centroid.mean(), 1.0e308);
+      weight += centroid.count();
+    }
+    Assert.assertEquals(weight, 2L);
+  }
+
+  @Test
+  public void testSerializedBoundaryRepairDoesNotOverflowFirstMoment() {
+    double min = 8.0e307;
+    double mean = 1.0e308;
+    double max = 1.2e308;
+    ByteBuffer verbose = ByteBuffer.allocate(32 + 2 * Double.BYTES);
+    verbose.putInt(1);
+    verbose.putDouble(min);
+    verbose.putDouble(max);
+    verbose.putDouble(100.0);
+    verbose.putInt(1);
+    verbose.putDouble(3.0);
+    verbose.putDouble(mean);
+
+    TDigest result = aggregateSerialized(new byte[][]{verbose.array()}, null, false);
+    List<Centroid> centroids = List.copyOf(result.centroids());
+    Assert.assertEquals(centroids.size(), 3);
+    Assert.assertEquals(centroids.get(0).mean(), min);
+    Assert.assertEquals(centroids.get(1).mean(), mean, 4.0 * Math.ulp(mean));
+    Assert.assertEquals(centroids.get(2).mean(), max);
   }
 
   @Test(dataProvider = "malformedSerializedDigests")
@@ -723,6 +929,7 @@ public class PercentileTDigestAggregationFunctionTest {
     int numValues = fanIn * valuesPerDigest;
     double[] rawValues = new double[numValues];
     TDigest[] sources = new TDigest[fanIn];
+    TDigest[] referenceSources = new TDigest[fanIn];
     for (int digestIndex = 0; digestIndex < fanIn; digestIndex++) {
       SplittableRandom random = new SplittableRandom(0x5EEDL + digestIndex);
       double[] sourceValues = new double[valuesPerDigest];
@@ -732,30 +939,64 @@ public class PercentileTDigestAggregationFunctionTest {
         sourceValues[valueIndex] = value;
       }
       sources[digestIndex] = createReducerSource(sourceValues, compression, reducerInput);
+      referenceSources[digestIndex] = createReferenceReducerSource(sourceValues, compression, reducerInput);
     }
 
     PercentileTDigestAggregationFunction function =
         new PercentileTDigestAggregationFunction(EXPRESSION, 75.0, compression, false);
     TDigest result = TDigest.createMergingDigest(compression);
+    TDigest referenceResult = TDigest.createMergingDigest(compression);
+    AssertionError referenceFailure = null;
     for (int sourceIndex : mergeOrder.sourceIndexes(fanIn)) {
       result = function.merge(result, sources[sourceIndex]);
+      if (referenceFailure == null) {
+        try {
+          if (referenceResult.size() == 0L) {
+            referenceResult = referenceSources[sourceIndex];
+          } else {
+            referenceResult.add(referenceSources[sourceIndex]);
+          }
+        } catch (AssertionError e) {
+          // t-digest 3.3 can violate its own singleton-endpoint assertion when many duplicate-valued digests merge.
+          referenceFailure = e;
+        }
+      }
     }
 
     Arrays.sort(rawValues);
     String caseDescription =
         fanIn + "/" + compression + "/" + distribution + "/" + mergeOrder + "/" + reducerInput;
-    double maxRankError = compression == 20 ? 0.06 : 0.02;
-    assertValidReducerResult(result, rawValues, caseDescription, maxRankError);
+    // Interpolation between large equal-valued centroid runs can land inside the empirical CDF jump. Keep a fixed
+    // envelope for that discontinuous distribution instead of requiring every merge order to match the reference's
+    // particular centroid partition.
+    double frozenRankError = compression == 20 || distribution == ReducerDistribution.DUPLICATE_HEAVY ? 0.06 : 0.02;
+    double[] referenceRankErrors = null;
+    if (referenceFailure == null) {
+      try {
+        referenceRankErrors = getReducerRankErrors(referenceResult, rawValues, caseDescription + "/reference");
+      } catch (AssertionError e) {
+        referenceFailure = e;
+      }
+    }
+    double[] maxRankErrors = new double[6];
+    if (referenceFailure == null) {
+      for (int i = 0; i < referenceRankErrors.length; i++) {
+        maxRankErrors[i] = Math.max(frozenRankError, referenceRankErrors[i] + 1e-12);
+      }
+    } else {
+      Arrays.fill(maxRankErrors, compression == 20 ? 0.25 : compression == 100 ? 0.06 : 0.02);
+    }
+    assertValidReducerResult(result, rawValues, caseDescription, maxRankErrors);
 
     SerializedIntermediateResult serializedResult = function.serializeIntermediateResult(result);
     Assert.assertEquals(serializedResult.getType(), ObjectSerDeUtils.ObjectType.TDigest.getValue());
     TDigest roundTripped = ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(serializedResult.getBytes());
     Assert.assertTrue(roundTripped instanceof MergingDigest);
-    assertValidReducerResult(roundTripped, rawValues, caseDescription + "/standard-wire", maxRankError);
     for (double quantile : new double[]{0.0, 0.5, 0.75, 0.95, 0.99, 1.0}) {
-      Assert.assertEquals(result.quantile(quantile), roundTripped.quantile(quantile),
+      Assert.assertEquals(result.quantile(quantile), roundTripped.quantile(quantile), 1e-15,
           "Wire round trip changed p" + quantile * 100 + " for " + caseDescription);
     }
+    getReducerRankErrors(roundTripped, rawValues, caseDescription + "/standard-wire");
   }
 
   @Test
@@ -792,7 +1033,16 @@ public class PercentileTDigestAggregationFunctionTest {
     Assert.assertEquals(result.compression(), compression);
     double[] sortedValues = values.clone();
     Arrays.sort(sortedValues);
-    Assert.assertEquals(function.extractFinalResult(result), sortedValues[numRows * 75 / 100], 0.02);
+    double actual = function.extractFinalResult(result);
+    double maxAbsoluteError = compression == 10 ? 0.03 : 0.02;
+    Assert.assertEquals(actual, sortedValues[numRows * 75 / 100], maxAbsoluteError);
+
+    TDigest reference = TDigestUtils.createMergingDigest(compression);
+    for (double value : values) {
+      reference.add(value);
+    }
+    Assert.assertEquals(actual, reference.quantile(0.75), 0.001,
+        "Pinot accumulator diverges from t-digest 3.3 K1 at compression " + compression);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class,
@@ -837,7 +1087,7 @@ public class PercentileTDigestAggregationFunctionTest {
       IntPredicate useSmallEncoding) {
     byte[][] serializedDigests = new byte[numDigests][];
     for (int digestIndex = 0; digestIndex < numDigests; digestIndex++) {
-      TDigest digest = TDigest.createMergingDigest(compression);
+      TDigest digest = TDigestUtils.createMergingDigest(compression);
       for (int valueIndex = 0; valueIndex < valuesPerDigest; valueIndex++) {
         digest.add(serializedValue(digestIndex, valueIndex, numDigests, valuesPerDigest));
       }
@@ -850,6 +1100,44 @@ public class PercentileTDigestAggregationFunctionTest {
       }
     }
     return serializedDigests;
+  }
+
+  private static byte[] createVerboseUnitCentroidDigest(int numCentroids, double compression) {
+    ByteBuffer verbose = ByteBuffer.allocate(4 * Integer.BYTES + 2 * Double.BYTES
+        + 2 * Double.BYTES * numCentroids);
+    verbose.putInt(1);
+    verbose.putDouble(0.0);
+    verbose.putDouble(numCentroids - 1.0);
+    verbose.putDouble(compression);
+    verbose.putInt(numCentroids);
+    for (int i = 0; i < numCentroids; i++) {
+      verbose.putDouble(1.0);
+      verbose.putDouble(i);
+    }
+    return verbose.array();
+  }
+
+  private static void assertPendingSerializedDigestOwnsInputBytes(boolean reusableInput) {
+    byte[] bytes = createVerboseUnitCentroidDigest(3, 20.0);
+    byte[] expected = bytes.clone();
+    PercentileTDigestAccumulator accumulator;
+    if (reusableInput) {
+      PercentileTDigestAccumulator.SerializedTDigestInput input =
+          new PercentileTDigestAccumulator.SerializedTDigestInput();
+      input.reset(bytes);
+      accumulator = PercentileTDigestAccumulator.forSerializedTDigest(input);
+      accumulator.addSerializedTDigest(input);
+    } else {
+      accumulator = PercentileTDigestAccumulator.forSerializedTDigest(bytes);
+      accumulator.addSerializedTDigest(bytes);
+    }
+
+    Arrays.fill(bytes, (byte) 0);
+    Assert.assertEquals(accumulator.size(), 3L);
+    Assert.assertEquals(accumulator.centroidCount(), 3);
+    Assert.assertEquals(accumulator.getMin(), 0.0);
+    Assert.assertEquals(accumulator.getMax(), 2.0);
+    Assert.assertEquals(accumulator.serialize(), expected);
   }
 
   private static double serializedValue(int digestIndex, int valueIndex, int numDigests, int valuesPerDigest) {
@@ -887,6 +1175,23 @@ public class PercentileTDigestAggregationFunctionTest {
 
   private static void assertValidReducerResult(TDigest result, double[] sortedValues, String caseDescription,
       double maxRankError) {
+    double[] maxRankErrors = new double[6];
+    Arrays.fill(maxRankErrors, maxRankError);
+    assertValidReducerResult(result, sortedValues, caseDescription, maxRankErrors);
+  }
+
+  private static void assertValidReducerResult(TDigest result, double[] sortedValues, String caseDescription,
+      double[] maxRankErrors) {
+    double[] rankErrors = getReducerRankErrors(result, sortedValues, caseDescription);
+    double[] quantiles = {0.0, 0.5, 0.75, 0.95, 0.99, 1.0};
+    for (int i = 0; i < quantiles.length; i++) {
+      Assert.assertTrue(rankErrors[i] <= maxRankErrors[i],
+          "Rank error " + rankErrors[i] + " exceeds the t-digest 3.3 reference envelope for p"
+              + quantiles[i] * 100 + " in " + caseDescription);
+    }
+  }
+
+  private static double[] getReducerRankErrors(TDigest result, double[] sortedValues, String caseDescription) {
     Assert.assertEquals(result.size(), sortedValues.length, "Total weight differs for " + caseDescription);
     long centroidWeight = 0L;
     double previousMean = Double.NEGATIVE_INFINITY;
@@ -901,8 +1206,11 @@ public class PercentileTDigestAggregationFunctionTest {
     Assert.assertEquals(centroidWeight, sortedValues.length,
         "Centroid weights do not sum to the input size for " + caseDescription);
 
+    double[] quantiles = {0.0, 0.5, 0.75, 0.95, 0.99, 1.0};
+    double[] rankErrors = new double[quantiles.length];
     double previousQuantile = Double.NEGATIVE_INFINITY;
-    for (double quantile : new double[]{0.0, 0.5, 0.75, 0.95, 0.99, 1.0}) {
+    for (int i = 0; i < quantiles.length; i++) {
+      double quantile = quantiles[i];
       double value = result.quantile(quantile);
       Assert.assertTrue(Double.isFinite(value), "Non-finite p" + quantile * 100 + " for " + caseDescription);
       Assert.assertTrue(value >= previousQuantile, "Quantiles are not monotonic for " + caseDescription);
@@ -913,15 +1221,42 @@ public class PercentileTDigestAggregationFunctionTest {
         Assert.assertEquals(value, sortedValues[sortedValues.length - 1],
             "Incorrect maximum for " + caseDescription);
       } else {
-        int lowerRank = lowerBound(sortedValues, value);
-        int upperRank = upperBound(sortedValues, value);
-        double rankError = Math.max(0.0, Math.max(lowerRank / (double) sortedValues.length - quantile,
+        double rankValue = snapToObservedValue(sortedValues, value);
+        int lowerRank = lowerBound(sortedValues, rankValue);
+        int upperRank = upperBound(sortedValues, rankValue);
+        rankErrors[i] = Math.max(0.0, Math.max(lowerRank / (double) sortedValues.length - quantile,
             quantile - upperRank / (double) sortedValues.length));
-        Assert.assertTrue(rankError <= maxRankError,
-            "Rank error " + rankError + " exceeds the frozen envelope for p" + quantile * 100 + " in "
-                + caseDescription);
       }
     }
+    return rankErrors;
+  }
+
+  private static double snapToObservedValue(double[] sortedValues, double value) {
+    int insertionPoint = lowerBound(sortedValues, value);
+    if (insertionPoint < sortedValues.length && nearlyEqual(value, sortedValues[insertionPoint])) {
+      return sortedValues[insertionPoint];
+    }
+    if (insertionPoint > 0 && nearlyEqual(value, sortedValues[insertionPoint - 1])) {
+      return sortedValues[insertionPoint - 1];
+    }
+    return value;
+  }
+
+  private static boolean nearlyEqual(double first, double second) {
+    return Math.abs(first - second) <= 1e-12 * Math.max(1.0, Math.max(Math.abs(first), Math.abs(second)));
+  }
+
+  private static void assertDuplicateInfinityResult(TDigest result, long expectedSize) {
+    Assert.assertEquals(result.size(), expectedSize);
+    Assert.assertEquals(result.getMin(), Double.NEGATIVE_INFINITY);
+    Assert.assertEquals(result.getMax(), Double.POSITIVE_INFINITY);
+    for (Centroid centroid : result.centroids()) {
+      Assert.assertFalse(Double.isNaN(centroid.mean()));
+      Assert.assertTrue(centroid.count() > 0);
+    }
+    Assert.assertEquals(result.quantile(0.0), Double.NEGATIVE_INFINITY);
+    Assert.assertEquals(result.quantile(0.5), 0.0);
+    Assert.assertEquals(result.quantile(1.0), Double.POSITIVE_INFINITY);
   }
 
   private static TDigest createReducerSource(double[] values, int compression, ReducerInput reducerInput) {
@@ -941,6 +1276,18 @@ public class PercentileTDigestAggregationFunctionTest {
     byte[] bytes = ObjectSerDeUtils.TDIGEST_SER_DE.serialize(digest);
     return function.deserializeIntermediateResult(new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(),
         ByteBuffer.wrap(bytes)));
+  }
+
+  private static TDigest createReferenceReducerSource(double[] values, int compression,
+      ReducerInput reducerInput) {
+    TDigest digest = TDigest.createMergingDigest(compression);
+    for (double value : values) {
+      digest.add(value);
+    }
+    if (reducerInput == ReducerInput.DISTRIBUTED) {
+      return ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(ObjectSerDeUtils.TDIGEST_SER_DE.serialize(digest));
+    }
+    return digest;
   }
 
   private static int lowerBound(double[] sortedValues, double value) {
@@ -1009,6 +1356,13 @@ public class PercentileTDigestAggregationFunctionTest {
   private enum ReducerInput {
     SERVER_LOCAL,
     DISTRIBUTED
+  }
+
+  private static void setAccumulatorField(PercentileTDigestAccumulator accumulator, String name, Object value)
+      throws ReflectiveOperationException {
+    Field field = PercentileTDigestAccumulator.class.getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(accumulator, value);
   }
 
   private enum MergeOrder {

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunctionTest.java
@@ -544,6 +544,38 @@ public class PercentileTDigestAggregationFunctionTest {
     }
   }
 
+  /// `quantile()` must reject `NaN` like the non-finite-aware digest does, instead of letting it slip past the
+  /// range guard (every `NaN` comparison is false) and propagate through the computation.
+  @Test
+  public void testQuantileRejectsNaN() {
+    PercentileTDigestAccumulator accumulator = PercentileTDigestAccumulator.forReduction(100.0);
+    accumulator.add(1.0);
+    IllegalArgumentException exception =
+        Assert.expectThrows(IllegalArgumentException.class, () -> accumulator.quantile(Double.NaN));
+    Assert.assertEquals(exception.getMessage(), "q should be in [0,1], got NaN");
+  }
+
+  /// `Centroid` stores the weight as an `int`, so `centroids()` must saturate like `MergingDigest.centroids()`
+  /// rather than throwing on a centroid whose weight exceeds `Integer.MAX_VALUE`.
+  @Test
+  public void testCentroidsSaturateWeightExceedingIntegerMaxValue()
+      throws ReflectiveOperationException {
+    PercentileTDigestAccumulator accumulator = PercentileTDigestAccumulator.forReduction(100.0);
+    accumulator.add(1.0);
+    accumulator.compress();
+
+    // A centroid weight above Integer.MAX_VALUE is only reachable from an externally produced digest, since
+    // add(double, int) caps a single contribution at Integer.MAX_VALUE.
+    double oversizedWeight = Integer.MAX_VALUE + 1_000.0;
+    setAccumulatorField(accumulator, "_centroidWeights", new double[]{oversizedWeight});
+    setAccumulatorField(accumulator, "_totalWeight", oversizedWeight);
+
+    List<Centroid> centroids = new ArrayList<>(accumulator.centroids());
+    Assert.assertEquals(centroids.size(), 1);
+    Assert.assertEquals(centroids.get(0).mean(), 1.0);
+    Assert.assertEquals(centroids.get(0).count(), Integer.MAX_VALUE);
+  }
+
   @Test
   public void testSerializedGroupByMVSharedInputReservesBoundaryCapacity()
       throws ReflectiveOperationException {

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunctionTest.java
@@ -41,9 +41,9 @@ public class PercentileTDigestMVAggregationFunctionTest extends AbstractAggregat
         .andOnSecondInstance(
             new Object[]{"6.0;7.0;8.0;9.0;10.0"}
         )
-        // All values: 1-10, p50 should be around 5
+        // t-digest 3.3 keeps singleton centroids discrete, so p50 selects 6 for the values 1-10.
         .whenQuery("select percentiletdigest(mv, 50) from testTable")
-        .thenResultIs("DOUBLE", "5.5");
+        .thenResultIs("DOUBLE", "6.0");
   }
 
   @Test
@@ -66,7 +66,7 @@ public class PercentileTDigestMVAggregationFunctionTest extends AbstractAggregat
         )
         .whenQuery("select sv, percentiletdigest(mv, 50) from testTable group by sv order by sv")
         .thenResultIs("STRING | DOUBLE",
-            "k1 | 5.5",   // values: 1-10, p50 ~= 5.5
+            "k1 | 6.0",   // values: 1-10, p50 = 6 with discrete singleton centroids
             "k2 | 30.0"); // values: 10, 20, 30, 40, 50, p50 ~= 30
   }
 
@@ -89,7 +89,7 @@ public class PercentileTDigestMVAggregationFunctionTest extends AbstractAggregat
         )
         .whenQuery("select tags, percentiletdigest(nums, 50) from testTable group by tags order by tags")
         .thenResultIs("STRING | DOUBLE",
-            "tag1 | 3.5",  // nums: 1, 2, 3, 4, 5, 6, p50 ~= 3.5
-            "tag2 | 3.5"); // nums: 1, 2, 3, 4, 5, 6, p50 ~= 3.5
+            "tag1 | 4.0",  // nums: 1, 2, 3, 4, 5, 6, p50 = 4 with discrete singleton centroids
+            "tag2 | 4.0"); // nums: 1, 2, 3, 4, 5, 6, p50 = 4 with discrete singleton centroids
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/aggregator/PercentileTDigestAggregatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/aggregator/PercentileTDigestAggregatorTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.segment.processing.aggregator;
 
 import com.tdunning.math.stats.TDigest;
+import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
@@ -29,12 +30,12 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 
 public class PercentileTDigestAggregatorTest {
-
   private PercentileTDigestAggregator _aggregator;
 
   @BeforeMethod
@@ -87,7 +88,65 @@ public class PercentileTDigestAggregatorTest {
     TDigest resultDigest = ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(result);
     assertNotNull(resultDigest);
     assertEquals(resultDigest.size(), 100);
+    assertEquals(resultDigest.compression(), 200.0);
     assertEquals(resultDigest.quantile(0.5), 49.5, 1);
+  }
+
+  @Test
+  public void testAggregateEncodedEmptyDigestUsesConfiguredCompression() {
+    TDigest empty = TDigest.createMergingDigest(20);
+    TDigest values = TDigest.createMergingDigest(100);
+    for (int i = 0; i < 50; i++) {
+      values.add(i);
+    }
+
+    Map<String, String> functionParameters =
+        Map.of(Constants.PERCENTILETDIGEST_COMPRESSION_FACTOR_KEY, "200");
+    byte[] emptyBytes = ObjectSerDeUtils.TDIGEST_SER_DE.serialize(empty);
+    byte[] valueBytes = ObjectSerDeUtils.TDIGEST_SER_DE.serialize(values);
+    for (byte[][] inputs : new byte[][][]{new byte[][]{emptyBytes, valueBytes}, new byte[][]{valueBytes, emptyBytes}}) {
+      byte[] result = (byte[]) _aggregator.aggregate(inputs[0], inputs[1], functionParameters);
+
+      TDigest resultDigest = ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(result);
+      assertEquals(resultDigest.size(), values.size());
+      assertEquals(resultDigest.compression(), 200.0);
+      assertEquals(resultDigest.quantile(0.5), values.quantile(0.5), 1e-10);
+    }
+  }
+
+  @Test
+  public void testMergeAndRollupPreservesLargeWeightedInfiniteBoundaries() {
+    byte[] source = createVerboseLargeWeightedDigest();
+    Map<String, String> functionParameters =
+        Map.of(Constants.PERCENTILETDIGEST_COMPRESSION_FACTOR_KEY, "200");
+    byte[] result = (byte[]) _aggregator.aggregate(source, source, functionParameters);
+
+    TDigest resultDigest = ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(result);
+    assertEquals(resultDigest.size(), 6_000_000_004L);
+    assertEquals(resultDigest.compression(), 200.0);
+    assertEquals(resultDigest.getMin(), Double.NEGATIVE_INFINITY);
+    assertEquals(resultDigest.getMax(), Double.POSITIVE_INFINITY);
+    assertTrue(resultDigest.centroids().stream().anyMatch(centroid -> Double.isFinite(centroid.mean())));
+    resultDigest.centroids().forEach(centroid -> assertFalse(Double.isNaN(centroid.mean())));
+    assertEquals(resultDigest.quantile(0.0), Double.NEGATIVE_INFINITY);
+    assertEquals(resultDigest.quantile(0.5), 0.0);
+    assertEquals(resultDigest.quantile(1.0), Double.POSITIVE_INFINITY);
+  }
+
+  private static byte[] createVerboseLargeWeightedDigest() {
+    ByteBuffer buffer = ByteBuffer.allocate(4 * Integer.BYTES + 2 * Double.BYTES + 6 * Double.BYTES);
+    buffer.putInt(1);
+    buffer.putDouble(Double.NEGATIVE_INFINITY);
+    buffer.putDouble(Double.POSITIVE_INFINITY);
+    buffer.putDouble(20.0);
+    buffer.putInt(3);
+    buffer.putDouble(1.0);
+    buffer.putDouble(Double.NEGATIVE_INFINITY);
+    buffer.putDouble(3_000_000_000.0);
+    buffer.putDouble(0.0);
+    buffer.putDouble(1.0);
+    buffer.putDouble(Double.POSITIVE_INFINITY);
+    return buffer.array();
   }
 
   @Test

--- a/pinot-perf/benchmark-results/percentile-tdigest-aggregation-100m-results.md
+++ b/pinot-perf/benchmark-results/percentile-tdigest-aggregation-100m-results.md
@@ -19,28 +19,47 @@
 
 -->
 
-# TDigest Percentile Aggregation: 100-Million-Row Benchmark
+# TDigest 3.2 to 3.3 Upgrade: Compatibility and Performance
 
-- Date: 2026-07-15
-- Baseline: `068b458883d6`
-- Reducer baseline: `633aab66c6`
-- Host: Apple M4 Pro (14 cores, 24 GiB), macOS 26.5.2 aarch64, OpenJDK 21.0.10
+- Date: 2026-07-19
+- Baseline: `fae8080bc7`, t-digest 3.2
+- Candidate: t-digest 3.3 with Pinot compatibility and accumulator changes
+- Host: Apple M4 Pro (14 cores, 24 GiB), macOS 26.5.2 aarch64
+- Runtime: OpenJDK 25, JMH 1.37
 
-These benchmarks measure single-threaded TDigest aggregation-function performance over deterministic pseudo-random
-`DOUBLE` values. The raw-value workload exercises the production block aggregation API over 100 million rows. The
-star-tree query workload merges 10,000 stored TDigest entries that represent 100 million source rows, and the construction
-workload isolates the raw-value aggregator used to build those entries. These numbers describe aggregation kernels on
-one machine, not distributed end-to-end query latency or complete segment-generation time.
+## Decision
 
-## User guide
+Upgrade Pinot to t-digest 3.3 and keep Pinot's existing TDigest API and serialized state. Do not replace it with the
+Apache DataSketches quantiles implementation as part of this dependency upgrade. A DataSketches replacement would
+change the user-visible aggregation type and wire format and therefore needs a separate format, migration, and
+mixed-version design.
 
-The optimizations are automatic and require no query changes. `PERCENTILETDIGEST` maintains bounded, mergeable
-aggregation state, and a star-tree can pre-aggregate it.
+Pinot explicitly selects `ScaleFunction.K_1`. T-digest 3.3 changed its default scale function, and retaining K1 avoids
+the middle-quantile accuracy regression measured with the new default. Pinot also centralizes construction and
+serialization, repairs legacy weighted boundary centroids, and uses a primitive accumulator for serialized and
+reducer paths.
 
-| Function | Result | Aggregation state |
-|---|---|---|
-| `PERCENTILETDIGEST(metric, 75)` | Approximate P75, default compression `100` | Bounded TDigest |
-| `PERCENTILETDIGEST(metric, 75, 200)` | Approximate P75 with higher compression | Larger TDigest with potentially better accuracy |
+The performance result is mixed and should be considered during rollout. Raw query aggregation is 5.2% slower, and
+the measured StarTree query kernels are 21.7-22.6% slower. Raw segment construction is 7.9% faster, serialized
+leaf-to-parent construction is 62.8% faster, and the production-shaped reducer path is 83.9-84.3% faster while
+allocating about half as much. The reducer and construction gains come from avoiding repeated digest
+materialization, sorting, and serialization; they are not claims that every t-digest 3.3 operation is faster.
+
+## User and rollout guide
+
+For finite values produced by Pinot, the upgrade requires no SQL, schema, table-config, or segment rebuild change.
+The compatibility serializer emits compact or verbose `MergingDigest` state readable by both t-digest 3.2 and 3.3,
+so finite intermediate results can flow in either direction during a rolling upgrade. Existing stored TDigest values
+continue to be readable. Exact bytes, centroid counts, and approximate percentile answers can change across versions.
+
+Compression values below 10 continue to run, but t-digest 3.3 normalizes their effective compression to 10. This is
+upstream 3.3 behavior. Compression 10 and above retains the configured value.
+
+Repeated positive or negative infinity values need special care during a mixed-version rollout. Pinot's 3.3 path
+preserves them, but the generic t-digest 3.2 reader can return `NaN` or incorrect middle quantiles for a structurally
+valid digest containing infinity centroids. Sanitize or filter non-finite values while any 3.2 reader can consume new
+partial results, or complete the reader upgrade before relying on non-finite percentile semantics. `NaN` input remains
+rejected.
 
 ### Sample queries
 
@@ -53,17 +72,16 @@ FROM myTable;
 SELECT PERCENTILETDIGEST(latencyMs, 75, 200) AS p75Approx
 FROM myTable;
 
--- Approximate P75 per region; a matching star-tree can serve the stored TDigest metric.
+-- Approximate P75 per region; a matching StarTree can serve the stored TDigest metric.
 SELECT region, PERCENTILETDIGEST(latencyMs, 75) AS p75Approx
 FROM myTable
 GROUP BY region;
 ```
 
-### Sample star-tree table config
+### Sample StarTree table config
 
-Add the TDigest function-column pair to a star-tree index when common queries group or filter on a stable set of
-dimensions. This sample uses the default compression `100` and matches the two-argument `PERCENTILETDIGEST` query
-shown above; a query with an explicit compression must match the compression configured for the index.
+The compression in the query must match the compression used by the StarTree function-column pair. This example uses
+the default compression of 100.
 
 ```json
 {
@@ -81,134 +99,85 @@ shown above; a query with an explicit compression must match the compression con
 ```
 
 Choose the split order and leaf size for the table's query patterns and cardinalities. The benchmark below isolates
-the stored-metric aggregation path after star-tree traversal; it does not measure planner, traversal, or forward-index
-I/O. The optimized serialized merge applies to both non-grouped and group-by aggregation. Each serialized group keeps
-its first digest pending and allocates primitive merge buffers only if another stored digest reaches that group; its
-raw-value buffer remains lazy unless a raw value is added.
+stored-metric aggregation after traversal; it does not measure planning, StarTree traversal, forward-index I/O, or
+network transfer.
+
+## Methodology
+
+Each comparison used independently built runtime packages containing exactly one t-digest JAR. The baseline and
+candidate used matched benchmark logic, deterministic input, parameters, JVM, and JMH settings. T-digest 3.3 and
+the 3.2 control both use K1 in the benchmark helper. Reducer sources are immutable so one invocation cannot mutate the
+next invocation's input.
+
+Unless stated otherwise, JMH ran two forks, two one-second warmup iterations, five one-second measurement iterations,
+one thread, an 8 GiB maximum heap, and the GC profiler. Scores therefore contain ten measured iterations. Dataset and
+exact-oracle creation occurs outside the timed methods.
+
+The raw aggregation and construction workloads process 100 million deterministic values. The StarTree query workload
+merges 10,000 stored digests representing 100 million source rows. Its group-by case distributes them across 1,000
+groups. The leaf-to-parent construction benchmark merges ten serialized leaves into each parent. The reducer control
+uses 32 fixed verbose inputs at compression 100; the accuracy workload uses 128 native immutable inputs in randomized
+order.
 
 ## Results
 
-JMH 1.37 ran two forks, five one-second measurement iterations, one thread, an 8 GiB maximum heap, and the GC profiler
-for each matched comparison. The raw-value and construction comparisons used two one-second warmup iterations; the
-serialized star-tree query comparison used three. Each reported comparison contains ten measured iterations.
+Positive deltas are regressions; negative deltas are improvements. Allocation is normalized bytes per benchmark
+operation.
 
-### TDigest percentile
+### Raw and StarTree query aggregation
 
-| Benchmark | Baseline (ms/op) | Optimized (ms/op) | Latency reduction | Speedup |
-|---|---:|---:|---:|---:|
-| Aggregation plus TDigest P75 | 5,677.240 ± 149.058 | 2,555.127 ± 49.673 | 54.994% | 2.222x |
+| Workload | 3.2 (ms/op) | 3.3 (ms/op) | Latency delta | 3.2 allocation | 3.3 allocation | Allocation delta |
+|---|---:|---:|---:|---:|---:|---:|
+| Raw aggregation plus P75, 100M rows | 2,682.977 ± 15.698 | 2,823.342 ± 24.426 | +5.2% | 15,960 | 16,024 | +0.4% |
+| StarTree merge plus P75, 10K stored digests | 7.383 ± 0.062 | 9.051 ± 0.164 | +22.6% | 10,487 | 11,605 | +10.7% |
+| StarTree group-by, 1,000 groups | 10.582 ± 0.862 | 12.880 ± 0.381 | +21.7% | 13,168,776 | 15,155,464 | +15.1% |
 
-TDigest throughput improved from 17.614 million to 39.137 million rows per second. The optimized result was
-`0.7499280847`, compared with the exact result `0.7499315464`, for an absolute error of `0.0000034617`. Neither TDigest
-run triggered garbage collection; normalized allocation changed from 20,520 to 31,872 bytes per operation.
+These paths expose a measurable t-digest 3.3 cost even after retaining K1. The allocation increase is small for raw
+aggregation but material for stored-digest group-by.
 
-### Star-tree TDigest query path
+### Segment construction
 
-| Benchmark | Baseline (ms/op) | Optimized (ms/op) | Latency reduction | Speedup |
-|---|---:|---:|---:|---:|
-| Merge 10,000 stored digests representing 100 million rows, then P75 | 85.658 ± 1.211 | 7.100 ± 0.186 | 91.711% | 12.065x |
+| Workload | 3.2 (ms/op) | 3.3 (ms/op) | Latency delta | 3.2 allocation | 3.3 allocation | Allocation delta |
+|---|---:|---:|---:|---:|---:|---:|
+| Aggregate and serialize raw values | 5,999.450 ± 539.794 | 5,528.188 ± 346.021 | -7.9% | 1,569,923,324 | 1,581,851,411 | +0.8% |
+| Merge and serialize pre-aggregated leaves | 1,256.659 ± 380.261 | 466.930 ± 58.190 | -62.8% | 1,926,851,492 | 1,795,782,790 | -6.8% |
 
-Normalized allocation fell from 198,223,964 bytes to 26,361 bytes per operation, and measured GC events fell from ten
-to zero. The optimized digest retained an exact size of 100 million and produced P75 `0.7498860479`, versus the fully
-sorted oracle `0.7499315464` (absolute error `0.0000454985`). Profiling showed the baseline repeatedly materializing,
-shuffling, and sorting centroids as each stored digest was added. The optimized path decodes already-sorted serialized
-centroids and linearly merges them into the accumulator.
+Both workloads use 100 million source rows and 1,000 rows per leaf group. The pre-aggregated case merges ten serialized
+leaves into each parent and validates total size and a finite median. Accuracy is measured separately below.
 
-### Star-tree TDigest group-by query path
+### Server-local and distributed reduction
 
-This incremental comparison uses commit `4a950bde9455`, the preceding version of this change with the optimized
-non-grouped path but the original group-by implementation, as its baseline. Every workload aggregates 10,000 stored
-digests representing 100 million source rows. Entries are distributed round-robin, and the timed operation extracts
-and validates every group result.
+This table compares the 3.2 production-style pairwise merge with the 3.3 serialized accumulator used by the updated
+reducer. All inputs use the same fixed verbose centroid layout.
 
-| Groups | Stored digests per group | Baseline (ms/op) | Optimized (ms/op) | Latency reduction | Speedup | Baseline allocation (B/op) | Optimized allocation (B/op) |
-|---:|---:|---:|---:|---:|---:|---:|---:|
-| 100 | 100 | 119.244 ± 66.230 | 9.275 ± 0.161 | 92.222% | 12.856x | 197,636,620 | 2,894,952 |
-| 1,000 | 10 | 96.039 ± 11.979 | 11.371 ± 0.257 | 88.159% | 8.446x | 192,278,646 | 28,821,662 |
-| 10,000 | 1 | 12.107 ± 6.227 | 9.078 ± 0.412 | Not distinguishable | Parity | 136,520,147 | 137,480,126 |
+| Workload | 3.2 pairwise (ms/op) | 3.3 accumulator (ms/op) | Latency delta | 3.2 allocation | 3.3 allocation | Allocation delta |
+|---|---:|---:|---:|---:|---:|---:|
+| Merge kernel | 0.2444 ± 0.0039 | 0.0385 ± 0.0013 | -84.3% | 77,930 | 36,552 | -53.1% |
+| `IndexedTable` combine | 0.2452 ± 0.0036 | 0.0394 ± 0.0010 | -83.9% | 81,626 | 40,248 | -50.7% |
+| Combine plus final percentile extraction | 0.2602 ± 0.0045 | 0.0412 ± 0.0016 | -84.2% | 81,722 | 40,345 | -50.6% |
 
-The 100- and 1,000-group workloads exercise centroid merging and reduce normalized allocation by 98.535% and 85.010%,
-respectively. With 10,000 groups, each group receives exactly one stored digest, so there is no source digest merge to
-optimize; extraction dominates and allocation is effectively unchanged (+0.703%). Its baseline and optimized latency
-confidence intervals overlap, so the nominal difference between their means is not claimed as a speedup. That
-high-cardinality case keeps the first
-serialized digest pending, constructs only the final result digest, and does not allocate the accumulator's raw-value
-buffer. The baseline had isolated latency outliers, reflected in its wider confidence intervals.
+The accumulator decodes sorted serialized centroids and linearly merges them rather than repeatedly materializing and
+sorting a `MergingDigest`. The benchmark also retains pairwise and accumulator controls under both dependency versions
+to distinguish library changes from the production implementation change.
 
-### Server-local and distributed TDigest reduction
+### Reducer accuracy
 
-The reducer benchmark runs on the same host with OpenJDK 25. It prebuilds segment digests and exact raw-value oracles
-outside the timed region, creates fresh targets per invocation, and measures both the merge kernel and the complete
-`ConcurrentIndexedTable` update path. `PROMOTED_LOCAL` models raw group-by segment results that arrive as ordinary
-`MergingDigest` objects. `ACCUMULATOR_LOCAL` models materialized accumulator results from non-grouped and StarTree
-segment execution. `ACCUMULATOR_WIRE` models lazy broker-side deserialization of standard TDigest bytes.
+The accuracy counters report mean absolute quantile-value error in parts per billion against fully sorted raw-value
+oracles. Duplicate-heavy input is exact at the displayed precision. The candidate reduces the number of resulting
+centroids for the skewed distribution; P75 and P99 errors increase, while P95 improves. All displayed candidate errors
+remain below 147,000 ppb (`0.000147` absolute value error for values in `[0, 1]`).
 
-The representative comparison uses 32 segment results, compression 100, uniform input, two forks, and five measured
-iterations per fork.
+| Distribution | Implementation | P75 error (ppb) | P95 error (ppb) | P99 error (ppb) | Mean centroids |
+|---|---|---:|---:|---:|---:|
+| Skewed | 3.2 pairwise | 43,245 | 54,095 | 103,181 | 12.7 |
+| Skewed | 3.3 accumulator | 130,164 | 4,309 | 146,550 | 6.6 |
+| Duplicate-heavy | 3.2 pairwise | 0 | 0 | approximately 0 | 14.0 |
+| Duplicate-heavy | 3.3 accumulator | 0 | 0 | 0 | 7.2 |
 
-| Benchmark | Pairwise 3.2 (ms/op) | Promoted local | Accumulator local | Serialized/wire |
-|---|---:|---:|---:|---:|
-| Merge kernel | 0.2573 | 0.0325 (7.92x) | 0.0186 (13.82x) | 0.0220 (11.68x) |
-| Full `IndexedTable` combine | 0.2683 | 0.0340 (7.90x) | 0.0201 (13.33x) | 0.0233 (11.52x) |
-| Full combine plus final percentile extraction | 0.2983 | 0.0353 (8.46x) | 0.0201 (14.83x) | 0.0239 (12.47x) |
-
-Normalized kernel allocation fell from 205,162 B/op to 24,000 B/op for promoted local state (-88.3%), 11,936 B/op
-for accumulator-local state (-94.2%), and 15,328 B/op for wire state (-92.5%). Direct percentile extraction reads the
-primitive centroid buffers and does not construct a temporary source digest.
-
-The production-shaped workload uses 1,440 groups, seven TDigest metrics, fan-in 32, and distinct prebuilt source
-objects for every group and metric. This removes the cache-locality advantage of the smaller shared-corpus kernel.
-
-| Path | Full combine (ms/op) | Speedup | Allocation (B/op) | Allocation reduction |
-|---|---:|---:|---:|---:|
-| TDigest 3.2 pairwise | 4,574.358 ± 309.333 | 1.00x | 2,074,920,845 | - |
-| Promoted raw group-by state | 856.308 ± 176.240 | 5.34x | 248,823,888 | 88.01% |
-| Materialized accumulator / StarTree-local | 222.986 ± 2.308 | 20.51x | 127,215,599 | 93.87% |
-| Lazy distributed wire state | 283.015 ± 6.168 | 16.16x | 161,407,415 | 92.22% |
-
-A separate non-forked `/usr/bin/time -l` diagnostic over the same unique-source shape measured maximum RSS of
-5,701 MB for pairwise, 5,773 MB for promoted local (+1.26%), 3,042 MB for accumulator-local (-46.65%), and 3,017 MB
-for wire state (-47.09%). It is a peak-memory check only; the two-fork JMH results above are the latency measurements.
-
-The improvement holds across configured compression factors:
-
-| Compression | Promoted local | Accumulator local | Serialized/wire |
-|---:|---:|---:|---:|
-| 50 | 7.17x / -84.8% allocation | 12.14x / -90.5% | 10.98x / -88.8% |
-| 100 | 7.67x / -86.7% allocation | 13.63x / -92.5% | 11.80x / -90.9% |
-| 200 | 8.62x / -87.9% allocation | 15.27x / -93.6% | 12.75x / -92.1% |
-
-A 36-shape fan-in/distribution/order sweep covered fan-in 8/32/128; uniform, skewed, bimodal, and duplicate-heavy
-inputs; and original, reversed, and seeded-random order across all four implementations (144 implementation/shape
-cases). Every result retained exact total weight, finite positive centroids, and monotonic p0/p50/p75/p95/p99/p100.
-Mean P75 error improved from 0.000175 for pairwise 3.2 to 0.000144 for every primitive-accumulator mode; the maximum
-sample error was 0.001353 for pairwise and 0.000709 for the candidates. The focused correctness suite additionally
-covers compression 20, 100, and 1,000 for the full parameter cross-product and round-trips every reduced result
-through standard TDigest 3.2 bytes.
-
-#### TDigest 3.3 dependency-only experiment
-
-A separate build changed only the TDigest dependency from 3.2 to 3.3. The control harness supplies the same 128
-verbose centroids to both versions. Across 36 workload shapes, the geometric mean speedup was 4.47x in the kernel and
-4.03x through `IndexedTable`, with 70.7% and 65.6% lower allocation. It is not used by this change: mean P75 error
-increased 18.9x, the maximum sampled P75 error reached 0.01138, and mean resulting centroids changed from 123.1 to
-42.2. A high-compression small-encoding mixed-version boundary also failed. In a separate 3.3 representative run,
-`add(List.of(source))` was 2.27x slower than pairwise and bounded batches were 1.31-1.52x slower while allocating more.
-The accepted reducer therefore stays on TDigest 3.2 and preserves standard TDigest wire bytes.
-
-### Star-tree TDigest construction kernel
-
-| Workload | Baseline (ms/op) | Optimized (ms/op) | Latency reduction | Speedup |
-|---|---:|---:|---:|---:|
-| 1 million rows, 1,000 rows per dimension group | 1,840.391 ± 47.275 | 53.770 ± 1.470 | 97.078% | 34.227x |
-
-The previous size-accounting call compressed the TDigest after every input value, defeating the digest's batching.
-The optimized path maintains a safe serialized-size bound without compressing and defers compression until
-serialization. A separate optimized 100-million-row run with 1,000 rows per group completed in 5,455.170 ms, or
-18.331 million rows per second. The 100-million-row number is an actual optimized measurement; no unmeasured baseline
-is extrapolated for it.
-This construction benchmark includes one serialization per group but excludes dimension sorting and forward-index
-I/O.
+Every measured result retained exact total weight, positive centroid weights, sorted finite centroid means, and
+monotonic P0/P50/P75/P95/P99/P100. Unit tests separately cover standard wire round-trips, compression 20, 100, and
+1,000, compact and verbose encodings, fractional compression, large double-precision weights, weighted legacy
+boundaries, and repeated infinities.
 
 ## Reproduce
 
@@ -218,71 +187,61 @@ Build the benchmark package from the repository root:
 ./mvnw -pl pinot-perf -am clean package -DskipTests
 ```
 
-Run the TDigest benchmark:
+Run raw aggregation:
 
 ```bash
-java -Xms4g -Xmx8g \
-  -cp 'pinot-perf/target/pinot-perf-pkg/lib/*' \
+java -cp 'pinot-perf/target/pinot-perf-pkg/lib/*' \
   org.openjdk.jmh.Main \
-  'org.apache.pinot.perf.aggregation.BenchmarkPercentileTDigestAggregation.*' \
-  -wi 2 -i 5 -f 2 -w 1s -r 1s -t 1 -to 30m -gc true -prof gc
+  'org.apache.pinot.perf.aggregation.BenchmarkPercentileTDigestAggregation.aggregatePercentileTDigest75' \
+  -wi 2 -i 5 -f 2 -w 1s -r 1s -t 1 -to 30m -gc true -foe true -prof gc
 ```
 
-Run the stored star-tree TDigest query benchmark. Its 10,000 input entries represent 100 million source rows:
+Run the stored StarTree query paths:
 
 ```bash
-java -Xms4g -Xmx8g \
-  -cp 'pinot-perf/target/pinot-perf-pkg/lib/*' \
+java -cp 'pinot-perf/target/pinot-perf-pkg/lib/*' \
   org.openjdk.jmh.Main \
   'org.apache.pinot.perf.aggregation.BenchmarkPercentileTDigestStarTreeAggregation.*' \
-  -wi 3 -i 5 -f 2 -w 1s -r 1s -t 1 -to 30m -gc true -prof gc
+  -p _numGroups=1000 \
+  -wi 2 -i 5 -f 2 -w 1s -r 1s -t 1 -to 30m -gc true -foe true -prof gc
 ```
 
-Run the star-tree construction kernel over 100 million raw rows with 1,000 rows per dimension group:
+Run raw and pre-aggregated construction:
 
 ```bash
-java -Xms4g -Xmx8g \
-  -cp 'pinot-perf/target/pinot-perf-pkg/lib/*' \
+java -cp 'pinot-perf/target/pinot-perf-pkg/lib/*' \
   org.openjdk.jmh.Main \
   'org.apache.pinot.perf.aggregation.BenchmarkPercentileTDigestValueAggregator.*' \
   -p _numRows=100000000 -p _rowsPerGroup=1000 \
-  -wi 1 -i 3 -f 1 -w 1s -r 1s -t 1 -to 30m -gc true -prof gc
+  -wi 2 -i 5 -f 2 -w 1s -r 1s -t 1 -to 30m -gc true -foe true -prof gc
 ```
 
-Run the representative reducer comparison:
+Run the controlled reducer comparison:
 
 ```bash
-java -Xms4g -Xmx8g \
-  -cp 'pinot-perf/target/pinot-perf-pkg/lib/*' \
+java -cp 'pinot-perf/target/pinot-perf-pkg/lib/*' \
   org.openjdk.jmh.Main \
-  'org.apache.pinot.perf.aggregation.BenchmarkPercentileTDigestCombine.*' \
+  'org.apache.pinot.perf.aggregation.BenchmarkPercentileTDigestCombine.(mergeKernel|combineIndexedTable|combineIndexedTableAndExtract)' \
   -p _numGroups=1 -p _numMetrics=1 -p _fanIn=32 -p _compression=100 \
   -p _distribution=UNIFORM -p _mergeOrder=ORIGINAL \
-  -p _implementation=PAIRWISE,PROMOTED_LOCAL,ACCUMULATOR_LOCAL,ACCUMULATOR_WIRE \
-  -p _sourceLayout=NATIVE -p _sourceReuse=SHARED \
-  -wi 2 -i 5 -f 2 -w 1s -r 1s -t 1 -prof gc
+  -p _sourceLayout=FIXED_VERBOSE -p _sourceReuse=SHARED \
+  -p _implementation=PAIRWISE,ACCUMULATOR_WIRE \
+  -wi 2 -i 5 -f 2 -w 1s -r 1s -t 1 -to 30m -gc true -foe true -prof gc
 ```
 
-Run the production-shaped combine with unique prebuilt source state:
+Run reducer accuracy over skewed and duplicate-heavy inputs:
 
 ```bash
-java -Xms4g -Xmx8g \
-  -cp 'pinot-perf/target/pinot-perf-pkg/lib/*' \
+java -cp 'pinot-perf/target/pinot-perf-pkg/lib/*' \
   org.openjdk.jmh.Main \
-  'org.apache.pinot.perf.aggregation.BenchmarkPercentileTDigestCombine.combineIndexedTable$' \
-  -p _numGroups=1440 -p _numMetrics=7 -p _fanIn=32 -p _compression=100 \
-  -p _distribution=UNIFORM -p _mergeOrder=ORIGINAL \
-  -p _implementation=PAIRWISE,PROMOTED_LOCAL,ACCUMULATOR_LOCAL,ACCUMULATOR_WIRE \
-  -p _sourceLayout=NATIVE -p _sourceReuse=UNIQUE \
-  -wi 2 -i 5 -f 2 -w 1s -r 1s -t 1 -prof gc
+  'org.apache.pinot.perf.aggregation.BenchmarkPercentileTDigestCombine.mergeKernel' \
+  -p _numGroups=1 -p _numMetrics=1 -p _fanIn=128 -p _compression=100 \
+  -p _distribution=SKEWED,DUPLICATE_HEAVY -p _mergeOrder=RANDOMIZED \
+  -p _sourceLayout=NATIVE -p _sourceReuse=SHARED \
+  -p _implementation=PAIRWISE,ACCUMULATOR_WIRE \
+  -wi 2 -i 5 -f 2 -w 1s -r 1s -t 1 -to 30m -gc true -foe true -prof gc
 ```
 
-For the dependency-only experiment, change only `<t-digest.version>` in the root `pom.xml` from `3.2` to `3.3`,
-rebuild `pinot-core` and `pinot-perf`, and run the same command for each build with `_implementation=PAIRWISE` and
-`_sourceLayout=FIXED_VERBOSE`. Write each result with `-rf json -rff <result-file>` and construct the runtime
-classpath with exactly one `t-digest` JAR; a package directory reused across builds can otherwise retain both JARs.
-
-The raw-value benchmark generates the same 100 million values from `SplittableRandom(42)` during trial setup. The
-timed methods include result extraction and validation. Dataset generation and exact-oracle construction are outside
-the measured region. The star-tree query benchmark similarly generates its stored digests during trial setup. The
-construction benchmark generates a reusable deterministic value block before measurement.
+For a strict dependency comparison, build the baseline and candidate into separate package directories and verify that
+each `lib` directory contains only its intended `t-digest-3.2.jar` or `t-digest-3.3.jar`. Reusing one package directory
+can leave both versions on the classpath and invalidate the result.

--- a/pinot-perf/benchmark-results/percentile-tdigest-aggregation-100m-results.md
+++ b/pinot-perf/benchmark-results/percentile-tdigest-aggregation-100m-results.md
@@ -21,9 +21,9 @@
 
 # TDigest 3.2 to 3.3 Upgrade: Compatibility and Performance
 
-- Date: 2026-07-19
-- Baseline: `fae8080bc7`, t-digest 3.2
-- Candidate: t-digest 3.3 with Pinot compatibility and accumulator changes
+- Date: 2026-07-23
+- Follow-up baseline: `706b772334e`, t-digest 3.2
+- Follow-up candidate: PR #19015 rebased onto the baseline, plus the path-aware accumulator optimization below
 - Host: Apple M4 Pro (14 cores, 24 GiB), macOS 26.5.2 aarch64
 - Runtime: OpenJDK 25, JMH 1.37
 
@@ -39,11 +39,16 @@ the middle-quantile accuracy regression measured with the new default. Pinot als
 serialization, repairs legacy weighted boundary centroids, and uses a primitive accumulator for serialized and
 reducer paths.
 
-The performance result is mixed and should be considered during rollout. Raw query aggregation is 5.2% slower, and
-the measured StarTree query kernels are 21.7-22.6% slower. Raw segment construction is 7.9% faster, serialized
-leaf-to-parent construction is 62.8% faster, and the production-shaped reducer path is 83.9-84.3% faster while
-allocating about half as much. The reducer and construction gains come from avoiding repeated digest
-materialization, sorting, and serialization; they are not claims that every t-digest 3.3 operation is faster.
+The follow-up removes the query-path regressions measured in the original PR. Raw query aggregation is 1.3% faster.
+With dependency-native stored digests, the StarTree query kernels are 35.5-43.4% faster. The group-by improvement also
+reduces allocation by 34.8%. Raw and direct serialized aggregation now merge incrementally at the configured public
+compression when it is at least 50, avoiding a redundant final recompression. Buffered reducer inputs and compression
+below 50 retain the two-level working compression for accuracy.
+
+This does not establish that every synthetic operation is always faster. With byte-for-byte fixed verbose inputs, the
+non-grouped StarTree kernel is 6.4% faster, while the 1,000-group kernel is 1.3% slower and allocates 8.6% less. That
+small residual control-case regression is reported rather than hidden; every measured production-shaped `NATIVE`
+query path is faster.
 
 ## User and rollout guide
 
@@ -104,20 +109,26 @@ network transfer.
 
 ## Methodology
 
-Each comparison used independently built runtime packages containing exactly one t-digest JAR. The baseline and
-candidate used matched benchmark logic, deterministic input, parameters, JVM, and JMH settings. T-digest 3.3 and
-the 3.2 control both use K1 in the benchmark helper. Reducer sources are immutable so one invocation cannot mutate the
-next invocation's input.
+Each follow-up comparison used independently built runtime packages containing exactly one t-digest JAR. The baseline
+and candidate used matched benchmark bytecode, deterministic input, parameters, JVM, and JMH settings. T-digest 3.3
+and the 3.2 control both use K1 in the benchmark helper. Reducer sources are immutable so one invocation cannot mutate
+the next invocation's input.
 
-Unless stated otherwise, JMH ran two forks, two one-second warmup iterations, five one-second measurement iterations,
-one thread, an 8 GiB maximum heap, and the GC profiler. Scores therefore contain ten measured iterations. Dataset and
+The affected query paths were run in `3.2, 3.3, 3.3, 3.2` order to reduce machine-drift bias. Each run used one fork,
+two one-second warmup iterations, five one-second measurement iterations, one thread, an 8 GiB maximum heap, and the
+GC profiler. Each displayed score is therefore the mean of two runs and ten measured iterations. Dataset and
 exact-oracle creation occurs outside the timed methods.
 
 The raw aggregation and construction workloads process 100 million deterministic values. The StarTree query workload
 merges 10,000 stored digests representing 100 million source rows. Its group-by case distributes them across 1,000
-groups. The leaf-to-parent construction benchmark merges ten serialized leaves into each parent. The reducer control
-uses 32 fixed verbose inputs at compression 100; the accuracy workload uses 128 native immutable inputs in randomized
-order.
+groups. `NATIVE` includes each dependency version's production serialization and centroid layout. `FIXED_VERBOSE`
+uses the same deterministic bytes, including singleton endpoint centroids, with both versions to isolate query-time
+merging from source-layout differences. The leaf-to-parent construction benchmark merges ten serialized leaves into
+each parent. The reducer control uses 32 fixed verbose inputs at compression 100. The accuracy sweep uses 128 native
+immutable inputs and 32 independent deterministic source orders for randomized-order cases.
+
+The segment-construction and reducer-throughput tables are the original PR characterization against `fae8080bc7`.
+They are retained as context and were not used to decide whether the follow-up fixed the affected query paths.
 
 ## Results
 
@@ -126,16 +137,20 @@ operation.
 
 ### Raw and StarTree query aggregation
 
-| Workload | 3.2 (ms/op) | 3.3 (ms/op) | Latency delta | 3.2 allocation | 3.3 allocation | Allocation delta |
-|---|---:|---:|---:|---:|---:|---:|
-| Raw aggregation plus P75, 100M rows | 2,682.977 ± 15.698 | 2,823.342 ± 24.426 | +5.2% | 15,960 | 16,024 | +0.4% |
-| StarTree merge plus P75, 10K stored digests | 7.383 ± 0.062 | 9.051 ± 0.164 | +22.6% | 10,487 | 11,605 | +10.7% |
-| StarTree group-by, 1,000 groups | 10.582 ± 0.862 | 12.880 ± 0.381 | +21.7% | 13,168,776 | 15,155,464 | +15.1% |
+| Workload | Source layout | 3.2 (ms/op) | 3.3 (ms/op) | Latency delta | 3.2 allocation | 3.3 allocation | Allocation delta |
+|---|---|---:|---:|---:|---:|---:|---:|
+| Raw aggregation plus P75, 100M rows | N/A | 3,377.903 | 3,334.669 | -1.3% | 15,954 | 16,018 | +0.4% |
+| StarTree merge plus P75, 10K stored digests | Native | 10.763 | 6.947 | -35.5% | 10,524 | 11,573 | +10.0% |
+| StarTree group-by, 1,000 groups | Native | 15.395 | 8.711 | -43.4% | 13,168,809 | 8,590,700 | -34.8% |
+| StarTree merge plus P75, 10K stored digests | Fixed verbose | 11.200 | 10.479 | -6.4% | 10,528 | 11,488 | +9.1% |
+| StarTree group-by, 1,000 groups | Fixed verbose | 14.674 | 14.860 | +1.3% | 13,124,164 | 11,990,374 | -8.6% |
 
-These paths expose a measurable t-digest 3.3 cost even after retaining K1. The allocation increase is small for raw
-aggregation but material for stored-digest group-by.
+The native rows represent the end-to-end production layout and improve materially because 3.3 emits fewer source
+centroids and the accumulator merges them without a redundant public recompression. The fixed rows are an attribution
+control. They show a query-kernel improvement without group-by and a near-parity group-by latency result with lower
+allocation.
 
-### Segment construction
+### Earlier segment-construction characterization
 
 | Workload | 3.2 (ms/op) | 3.3 (ms/op) | Latency delta | 3.2 allocation | 3.3 allocation | Allocation delta |
 |---|---:|---:|---:|---:|---:|---:|
@@ -145,7 +160,7 @@ aggregation but material for stored-digest group-by.
 Both workloads use 100 million source rows and 1,000 rows per leaf group. The pre-aggregated case merges ten serialized
 leaves into each parent and validates total size and a finite median. Accuracy is measured separately below.
 
-### Server-local and distributed reduction
+### Earlier server-local and distributed-reduction characterization
 
 This table compares the 3.2 production-style pairwise merge with the 3.3 serialized accumulator used by the updated
 reducer. All inputs use the same fixed verbose centroid layout.
@@ -163,16 +178,22 @@ to distinguish library changes from the production implementation change.
 ### Reducer accuracy
 
 The accuracy counters report mean absolute quantile-value error in parts per billion against fully sorted raw-value
-oracles. Duplicate-heavy input is exact at the displayed precision. The candidate reduces the number of resulting
-centroids for the skewed distribution; P75 and P99 errors increase, while P95 improves. All displayed candidate errors
-remain below 147,000 ppb (`0.000147` absolute value error for values in `[0, 1]`).
+oracles. The randomized-order sweep now uses 32 independent deterministic source orders instead of repeating one
+order, which exposes the merge-order sensitivity hidden by the earlier table. JMH event counters are normalized over
+measurement iterations and forks. Duplicate-heavy input is exact or within floating-point noise. The largest
+candidate P99 error observed across the 32 source orders was 1,870,494 ppb (`0.001870494` absolute value error for
+values in `[0, 1]`).
 
 | Distribution | Implementation | P75 error (ppb) | P95 error (ppb) | P99 error (ppb) | Mean centroids |
 |---|---|---:|---:|---:|---:|
-| Skewed | 3.2 pairwise | 43,245 | 54,095 | 103,181 | 12.7 |
-| Skewed | 3.3 accumulator | 130,164 | 4,309 | 146,550 | 6.6 |
-| Duplicate-heavy | 3.2 pairwise | 0 | 0 | approximately 0 | 14.0 |
-| Duplicate-heavy | 3.3 accumulator | 0 | 0 | 0 | 7.2 |
+| Uniform | 3.2 pairwise | 84,669 | 190,823 | 152,434 | 125 |
+| Uniform | 3.3 accumulator | 192,884 | 255,414 | 210,463 | 65 |
+| Skewed | 3.2 pairwise | 459,832 | 591,766 | 979,104 | 127 |
+| Skewed | 3.3 accumulator | 1,095,175 | 277,086 | 1,262,052 | 64 |
+| Bimodal | 3.2 pairwise | 23,796 | 18,924 | 61,153 | 124 |
+| Bimodal | 3.3 accumulator | 27,069 | 84,881 | 170,251 | 66 |
+| Duplicate-heavy | 3.2 pairwise | 0 | 0 | 0 | 141 |
+| Duplicate-heavy | 3.3 accumulator | 0 | 117 | 0 | 71 |
 
 Every measured result retained exact total weight, positive centroid weights, sorted finite centroid means, and
 monotonic P0/P50/P75/P95/P99/P100. Unit tests separately cover standard wire round-trips, compression 20, 100, and
@@ -202,7 +223,7 @@ Run the stored StarTree query paths:
 java -cp 'pinot-perf/target/pinot-perf-pkg/lib/*' \
   org.openjdk.jmh.Main \
   'org.apache.pinot.perf.aggregation.BenchmarkPercentileTDigestStarTreeAggregation.*' \
-  -p _numGroups=1000 \
+  -p _numGroups=1000 -p _sourceLayout=NATIVE,FIXED_VERBOSE \
   -wi 2 -i 5 -f 2 -w 1s -r 1s -t 1 -to 30m -gc true -foe true -prof gc
 ```
 

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkPercentileTDigestCombine.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkPercentileTDigestCombine.java
@@ -71,8 +71,9 @@ import org.openjdk.jmh.infra.BenchmarkParams;
 ///
 /// Source digests and the exact raw-value oracle are built once per trial. Each invocation receives fresh merge
 /// targets so a previous invocation cannot change its input. Accuracy and centroid statistics come from an untimed
-/// 32-merge quality sweep. Run with JMH's GC profiler to report allocation and GC metrics, for example `-prof gc`.
-/// Error counters report absolute error in billionths because all generated distributions are bounded to `[0, 1]`.
+/// quality sweep: 32 deterministic independent source orders for `RANDOMIZED`, and one order for fixed-order modes.
+/// Run with JMH's GC profiler to report allocation and GC metrics, for example `-prof gc`. Error counters report
+/// absolute error in billionths because all generated distributions are bounded to `[0, 1]`.
 ///
 /// The TDigest dependency version is deliberately a build-level dimension. Compare identical `PAIRWISE` runs from a
 /// 3.2 build and a 3.3 build. Use `_sourceLayout=FIXED_VERBOSE` to hold the serialized centroid shape constant for the
@@ -93,6 +94,7 @@ import org.openjdk.jmh.infra.BenchmarkParams;
 public class BenchmarkPercentileTDigestCombine {
   private static final int VALUES_PER_DIGEST = 10_000;
   private static final int QUALITY_SAMPLES = 32;
+  private static final long QUALITY_ORDER_SEED = 0x3C6EF372FE94F82BL;
   private static final double ERROR_SCALE = 1_000_000_000.0;
   private static final Pattern TDIGEST_JAR_VERSION = Pattern.compile("t-digest-(\\d+)\\.(\\d+)(?:\\.[^/]*)?\\.jar");
 
@@ -361,40 +363,6 @@ public class BenchmarkPercentileTDigestCombine {
     }
   }
 
-  private static byte[] createFixedVerboseBytes(double[] sortedValues, double compression) {
-    int numCentroids = Math.min(sortedValues.length, (int) Math.ceil(compression * 1.28));
-    ByteBuffer buffer = ByteBuffer.allocate(32 + numCentroids * 16);
-    buffer.putInt(1);
-    buffer.putDouble(sortedValues[0]);
-    buffer.putDouble(sortedValues[sortedValues.length - 1]);
-    buffer.putDouble(compression);
-    buffer.putInt(numCentroids);
-    for (int centroidId = 0; centroidId < numCentroids; centroidId++) {
-      int start;
-      int end;
-      if (centroidId == 0) {
-        start = 0;
-        end = 1;
-      } else if (centroidId == numCentroids - 1) {
-        start = sortedValues.length - 1;
-        end = sortedValues.length;
-      } else {
-        int numInteriorCentroids = numCentroids - 2;
-        int numInteriorValues = sortedValues.length - 2;
-        start = 1 + (centroidId - 1) * numInteriorValues / numInteriorCentroids;
-        end = 1 + centroidId * numInteriorValues / numInteriorCentroids;
-      }
-      double sum = 0.0;
-      for (int valueId = start; valueId < end; valueId++) {
-        sum += sortedValues[valueId];
-      }
-      double weight = end - start;
-      buffer.putDouble(weight);
-      buffer.putDouble(sum / weight);
-    }
-    return buffer.array();
-  }
-
   private void buildMergeOrder() {
     _sourceOrder = new int[_fanIn];
     for (int i = 0; i < _fanIn; i++) {
@@ -454,11 +422,15 @@ public class BenchmarkPercentileTDigestCombine {
     double maxP95Error = 0.0;
     double totalP99Error = 0.0;
     double maxP99Error = 0.0;
-    for (int sampleId = 0; sampleId < QUALITY_SAMPLES; sampleId++) {
+    int qualitySamples = _mergeOrder == MergeOrder.RANDOMIZED ? QUALITY_SAMPLES : 1;
+    SplittableRandom qualityOrderRandom = new SplittableRandom(QUALITY_ORDER_SEED);
+    for (int sampleId = 0; sampleId < qualitySamples; sampleId++) {
+      int[] sourceOrder =
+          _mergeOrder == MergeOrder.RANDOMIZED ? buildRandomizedSourceOrder(qualityOrderRandom.split()) : _sourceOrder;
       resetPending();
-      TDigest digest = newFirstSource(sourceSlot(0, 0), 0);
+      TDigest digest = newFirstSource(sourceSlot(sourceOrder, 0, 0), 0);
       for (int position = 1; position < _fanIn; position++) {
-        digest = _functions[0].merge(digest, _sources[sourceSlot(position, 0)]);
+        digest = _functions[0].merge(digest, _sources[sourceSlot(sourceOrder, position, 0)]);
       }
       flushPending();
       digest.compress();
@@ -476,11 +448,25 @@ public class BenchmarkPercentileTDigestCombine {
       totalP99Error += p99Error;
       maxP99Error = Math.max(maxP99Error, p99Error);
     }
-    _qualityStats = new QualityStats(_averageInputCentroidCount, totalResultingCentroids / QUALITY_SAMPLES,
-        maxResultingCentroids, totalP75Error / QUALITY_SAMPLES, maxP75Error, totalP95Error / QUALITY_SAMPLES,
-        maxP95Error, totalP99Error / QUALITY_SAMPLES, maxP99Error);
+    _qualityStats = new QualityStats(_averageInputCentroidCount, totalResultingCentroids / qualitySamples,
+        maxResultingCentroids, totalP75Error / qualitySamples, maxP75Error, totalP95Error / qualitySamples,
+        maxP95Error, totalP99Error / qualitySamples, maxP99Error);
     prepareFirstSources();
     validateIndexedTable(buildIndexedTable(false));
+  }
+
+  private int[] buildRandomizedSourceOrder(SplittableRandom random) {
+    int[] sourceOrder = new int[_fanIn];
+    for (int i = 0; i < _fanIn; i++) {
+      sourceOrder[i] = i;
+    }
+    for (int i = _fanIn - 1; i > 0; i--) {
+      int other = random.nextInt(i + 1);
+      int value = sourceOrder[i];
+      sourceOrder[i] = sourceOrder[other];
+      sourceOrder[other] = value;
+    }
+    return sourceOrder;
   }
 
   private void validateIndexedTable(IndexedTable table) {
@@ -524,7 +510,11 @@ public class BenchmarkPercentileTDigestCombine {
   }
 
   private int sourceSlot(int position, int targetIndex) {
-    int sourceId = _sourceOrder[position];
+    return sourceSlot(_sourceOrder, position, targetIndex);
+  }
+
+  private int sourceSlot(int[] sourceOrder, int position, int targetIndex) {
+    int sourceId = sourceOrder[position];
     return _sourceReuse == SourceReuse.SHARED ? sourceId : sourceId * _numGroups * _numMetrics + targetIndex;
   }
 
@@ -676,6 +666,7 @@ public class BenchmarkPercentileTDigestCombine {
 
     @Setup(Level.Trial)
     public void setUp(BenchmarkParams benchmarkParams) {
+      // Event counters are summed across measurement iterations and forks in the final JMH result.
       _aggregationDivisor = (double) benchmarkParams.getMeasurement().getCount()
           * Math.max(1, benchmarkParams.getForks());
     }
@@ -760,7 +751,7 @@ public class BenchmarkPercentileTDigestCombine {
     private final List<Centroid> _centroids;
 
     private FixedTDigest(double[] sortedValues, double compression) {
-      this(createFixedVerboseBytes(sortedValues, compression));
+      this(TDigestBenchmarkUtils.createFixedVerboseBytes(sortedValues, compression));
     }
 
     private FixedTDigest(byte[] bytes) {

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkPercentileTDigestCombine.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkPercentileTDigestCombine.java
@@ -276,10 +276,10 @@ public class BenchmarkPercentileTDigestCombine {
     double[] rawValues = new double[_fanIn * VALUES_PER_DIGEST];
     int totalInputCentroids = 0;
     for (int sourceId = 0; sourceId < _fanIn; sourceId++) {
-      MergingDigest nativeDigest = null;
+      ImmutableMergingDigest nativeDigest = null;
       if (_sourceLayout == SourceLayout.NATIVE) {
-        nativeDigest = _implementation == Implementation.PAIRWISE ? new MergingDigest(_compression)
-            : new ImmutableMergingDigest(_compression);
+        nativeDigest = new ImmutableMergingDigest(_compression);
+        TDigestBenchmarkUtils.usePinotScaleFunction(nativeDigest);
       }
       double[] sourceValues = new double[VALUES_PER_DIGEST];
       SplittableRandom random = new SplittableRandom(0x6A09E667F3BCC909L + sourceId);
@@ -295,11 +295,7 @@ public class BenchmarkPercentileTDigestCombine {
       TDigest digest;
       byte[] fixedBytes = null;
       if (nativeDigest != null) {
-        if (nativeDigest instanceof ImmutableMergingDigest immutableDigest) {
-          immutableDigest.freeze();
-        } else {
-          nativeDigest.compress();
-        }
+        nativeDigest.freeze();
         digest = nativeDigest;
       } else {
         Arrays.sort(sourceValues);
@@ -374,8 +370,20 @@ public class BenchmarkPercentileTDigestCombine {
     buffer.putDouble(compression);
     buffer.putInt(numCentroids);
     for (int centroidId = 0; centroidId < numCentroids; centroidId++) {
-      int start = centroidId * sortedValues.length / numCentroids;
-      int end = (centroidId + 1) * sortedValues.length / numCentroids;
+      int start;
+      int end;
+      if (centroidId == 0) {
+        start = 0;
+        end = 1;
+      } else if (centroidId == numCentroids - 1) {
+        start = sortedValues.length - 1;
+        end = sortedValues.length;
+      } else {
+        int numInteriorCentroids = numCentroids - 2;
+        int numInteriorValues = sortedValues.length - 2;
+        start = 1 + (centroidId - 1) * numInteriorValues / numInteriorCentroids;
+        end = 1 + centroidId * numInteriorValues / numInteriorCentroids;
+      }
       double sum = 0.0;
       for (int valueId = start; valueId < end; valueId++) {
         sum += sortedValues[valueId];
@@ -969,7 +977,7 @@ public class BenchmarkPercentileTDigestCombine {
       if (pending.isEmpty()) {
         return;
       }
-      TDigest batch = TDigest.createMergingDigest(_compressionFactor);
+      TDigest batch = TDigestBenchmarkUtils.usePinotScaleFunction(TDigest.createMergingDigest(_compressionFactor));
       batch.add(pending);
       pending.clear();
       target.add(batch);

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkPercentileTDigestStarTreeAggregation.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkPercentileTDigestStarTreeAggregation.java
@@ -154,8 +154,8 @@ public class BenchmarkPercentileTDigestStarTreeAggregation {
     SplittableRandom random = new SplittableRandom(42);
     byte[][] serializedDigests = new byte[NUM_STAR_TREE_ROWS][];
     for (int rowId = 0; rowId < NUM_STAR_TREE_ROWS; rowId++) {
-      TDigest digest =
-          TDigest.createMergingDigest(PercentileTDigestAggregationFunction.DEFAULT_TDIGEST_COMPRESSION);
+      TDigest digest = TDigestBenchmarkUtils.usePinotScaleFunction(
+          TDigest.createMergingDigest(PercentileTDigestAggregationFunction.DEFAULT_TDIGEST_COMPRESSION));
       for (int i = 0; i < SOURCE_ROWS_PER_DIGEST; i++) {
         digest.add(random.nextDouble());
       }

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkPercentileTDigestStarTreeAggregation.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkPercentileTDigestStarTreeAggregation.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.perf.aggregation;
 
 import com.tdunning.math.stats.TDigest;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.SplittableRandom;
 import java.util.concurrent.TimeUnit;
@@ -53,6 +54,10 @@ import org.roaringbitmap.RoaringBitmap;
 /// Pinot-sized block through the production `BYTES` aggregation path. The group-by workload distributes those entries
 /// round-robin across 100, 1,000, or 10,000 result groups. It measures query-time deserialization, merging, and result
 /// extraction, but deliberately excludes segment generation and forward-index I/O.
+///
+/// `NATIVE` measures the production end-to-end layout, including the dependency version's source compression.
+/// `FIXED_VERBOSE` serializes the same raw values into a deterministic verbose centroid layout, including singleton
+/// endpoint centroids, so a TDigest 3.2 build and a 3.3 build receive byte-for-byte identical query inputs.
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Warmup(iterations = 2, time = 1)
@@ -67,9 +72,18 @@ public class BenchmarkPercentileTDigestStarTreeAggregation {
   private static final double MAX_ABSOLUTE_ERROR = 0.001;
   private static final ExpressionContext EXPRESSION = ExpressionContext.forIdentifier("col");
 
+  /// Selects dependency-native serialized inputs or byte-identical verbose control inputs.
+  public enum SourceLayout {
+    NATIVE,
+    FIXED_VERBOSE
+  }
+
   /// State for the serialized star-tree aggregation benchmark.
   @State(Scope.Benchmark)
   public static class AggregationState {
+    @Param({"NATIVE", "FIXED_VERBOSE"})
+    private SourceLayout _sourceLayout;
+
     private PercentileTDigestAggregationFunction _function;
     private Map<ExpressionContext, BlockValSet> _blockValSetMap;
 
@@ -78,7 +92,7 @@ public class BenchmarkPercentileTDigestStarTreeAggregation {
       if (NUM_SOURCE_ROWS % NUM_STAR_TREE_ROWS != 0) {
         throw new IllegalStateException("NUM_SOURCE_ROWS must be divisible by NUM_STAR_TREE_ROWS");
       }
-      _blockValSetMap = Map.of(EXPRESSION, new BytesBlockValSet(createSerializedDigests()));
+      _blockValSetMap = Map.of(EXPRESSION, new BytesBlockValSet(createSerializedDigests(_sourceLayout)));
       _function = new PercentileTDigestAggregationFunction(EXPRESSION, 75.0, false);
     }
   }
@@ -86,6 +100,9 @@ public class BenchmarkPercentileTDigestStarTreeAggregation {
   /// State for the serialized star-tree group-by aggregation benchmark.
   @State(Scope.Benchmark)
   public static class GroupByAggregationState {
+    @Param({"NATIVE", "FIXED_VERBOSE"})
+    private SourceLayout _sourceLayout;
+
     @Param({"100", "1000", "10000"})
     private int _numGroups;
 
@@ -98,7 +115,7 @@ public class BenchmarkPercentileTDigestStarTreeAggregation {
       if (NUM_STAR_TREE_ROWS % _numGroups != 0) {
         throw new IllegalStateException("NUM_STAR_TREE_ROWS must be divisible by the number of groups");
       }
-      _blockValSetMap = Map.of(EXPRESSION, new BytesBlockValSet(createSerializedDigests()));
+      _blockValSetMap = Map.of(EXPRESSION, new BytesBlockValSet(createSerializedDigests(_sourceLayout)));
       _function = new PercentileTDigestAggregationFunction(EXPRESSION, 75.0, false);
       _groupKeys = new int[NUM_STAR_TREE_ROWS];
       for (int rowId = 0; rowId < NUM_STAR_TREE_ROWS; rowId++) {
@@ -150,16 +167,26 @@ public class BenchmarkPercentileTDigestStarTreeAggregation {
     return percentileChecksum;
   }
 
-  private static byte[][] createSerializedDigests() {
+  private static byte[][] createSerializedDigests(SourceLayout sourceLayout) {
     SplittableRandom random = new SplittableRandom(42);
     byte[][] serializedDigests = new byte[NUM_STAR_TREE_ROWS][];
     for (int rowId = 0; rowId < NUM_STAR_TREE_ROWS; rowId++) {
-      TDigest digest = TDigestBenchmarkUtils.usePinotScaleFunction(
-          TDigest.createMergingDigest(PercentileTDigestAggregationFunction.DEFAULT_TDIGEST_COMPRESSION));
-      for (int i = 0; i < SOURCE_ROWS_PER_DIGEST; i++) {
-        digest.add(random.nextDouble());
+      if (sourceLayout == SourceLayout.NATIVE) {
+        TDigest digest = TDigestBenchmarkUtils.usePinotScaleFunction(
+            TDigest.createMergingDigest(PercentileTDigestAggregationFunction.DEFAULT_TDIGEST_COMPRESSION));
+        for (int i = 0; i < SOURCE_ROWS_PER_DIGEST; i++) {
+          digest.add(random.nextDouble());
+        }
+        serializedDigests[rowId] = ObjectSerDeUtils.TDIGEST_SER_DE.serialize(digest);
+      } else {
+        double[] values = new double[SOURCE_ROWS_PER_DIGEST];
+        for (int i = 0; i < SOURCE_ROWS_PER_DIGEST; i++) {
+          values[i] = random.nextDouble();
+        }
+        Arrays.sort(values);
+        serializedDigests[rowId] = TDigestBenchmarkUtils.createFixedVerboseBytes(values,
+            PercentileTDigestAggregationFunction.DEFAULT_TDIGEST_COMPRESSION);
       }
-      serializedDigests[rowId] = ObjectSerDeUtils.TDIGEST_SER_DE.serialize(digest);
     }
     return serializedDigests;
   }

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkPercentileTDigestValueAggregator.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkPercentileTDigestValueAggregator.java
@@ -36,13 +36,13 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
-/// Measures the raw-value TDigest aggregation kernel used while constructing a star-tree index.
+/// Measures the raw-value and pre-aggregated TDigest kernels used while constructing a star-tree index.
 ///
 /// The default models one million source rows split into groups of 1,000 rows with identical dimension keys. Each
-/// group is serialized because every aggregate eventually becomes a star-tree forward-index entry. Use
-/// `-p _numRows=100000000` for a 100-million-row run and vary `_rowsPerGroup` to model the table's dimension
-/// cardinality. This deliberately excludes dimension sorting and forward-index I/O so it isolates
-/// [PercentileTDigestValueAggregator].
+/// leaf group is serialized because every aggregate eventually becomes a star-tree forward-index entry. The second
+/// workload merges ten serialized leaves into each parent entry. Use `-p _numRows=100000000` for a 100-million-row
+/// run and vary `_rowsPerGroup` to model the table's dimension cardinality. This deliberately excludes dimension
+/// sorting and forward-index I/O so it isolates [PercentileTDigestValueAggregator].
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
@@ -52,6 +52,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Threads(1)
 public class BenchmarkPercentileTDigestValueAggregator {
   private static final int VALUE_BLOCK_SIZE = 1 << 16;
+  private static final int LEAVES_PER_PARENT = 10;
 
   @Param({"1000000"})
   int _numRows;
@@ -60,6 +61,7 @@ public class BenchmarkPercentileTDigestValueAggregator {
   int _rowsPerGroup;
 
   private double[] _values;
+  private byte[][] _serializedLeaves;
 
   @Setup
   public void setUp() {
@@ -73,6 +75,17 @@ public class BenchmarkPercentileTDigestValueAggregator {
     SplittableRandom random = new SplittableRandom(42);
     for (int i = 0; i < VALUE_BLOCK_SIZE; i++) {
       _values[i] = random.nextDouble();
+    }
+    PercentileTDigestValueAggregator aggregator = new PercentileTDigestValueAggregator(List.of());
+    _serializedLeaves = new byte[(_numRows + _rowsPerGroup - 1) / _rowsPerGroup][];
+    for (int leafId = 0; leafId < _serializedLeaves.length; leafId++) {
+      int from = leafId * _rowsPerGroup;
+      int to = Math.min(_numRows, from + _rowsPerGroup);
+      TDigest digest = aggregator.getInitialAggregatedValue(_values[from & (VALUE_BLOCK_SIZE - 1)]);
+      for (int i = from + 1; i < to; i++) {
+        aggregator.applyRawValue(digest, _values[i & (VALUE_BLOCK_SIZE - 1)]);
+      }
+      _serializedLeaves[leafId] = aggregator.serializeAggregatedValue(digest);
     }
   }
 
@@ -98,6 +111,30 @@ public class BenchmarkPercentileTDigestValueAggregator {
     }
     if (totalAggregatedRows != _numRows) {
       throw new IllegalStateException("Unexpected aggregated row count: " + totalAggregatedRows);
+    }
+    return totalSerializedBytes;
+  }
+
+  @Benchmark
+  public long mergeAndSerializePreAggregatedValues() {
+    PercentileTDigestValueAggregator aggregator = new PercentileTDigestValueAggregator(List.of());
+    long totalAggregatedRows = 0L;
+    long totalSerializedBytes = 0L;
+    for (int from = 0; from < _serializedLeaves.length; from += LEAVES_PER_PARENT) {
+      int to = Math.min(_serializedLeaves.length, from + LEAVES_PER_PARENT);
+      TDigest digest = aggregator.deserializeAggregatedValue(_serializedLeaves[from]);
+      for (int i = from + 1; i < to; i++) {
+        aggregator.applyAggregatedValue(digest, aggregator.deserializeAggregatedValue(_serializedLeaves[i]));
+      }
+      double median = digest.quantile(0.5);
+      if (!Double.isFinite(median) || median < 0.0 || median > 1.0) {
+        throw new IllegalStateException("Invalid merged median: " + median);
+      }
+      totalAggregatedRows += digest.size();
+      totalSerializedBytes += aggregator.serializeAggregatedValue(digest).length;
+    }
+    if (totalAggregatedRows != _numRows) {
+      throw new IllegalStateException("Unexpected merged row count: " + totalAggregatedRows);
     }
     return totalSerializedBytes;
   }

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/TDigestBenchmarkUtils.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/TDigestBenchmarkUtils.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf.aggregation;
+
+import com.tdunning.math.stats.TDigest;
+
+/// Keeps benchmark inputs on Pinot's K1 policy while allowing the same benchmark bytecode to run with t-digest 3.2.
+final class TDigestBenchmarkUtils {
+  private static final String SCALE_FUNCTION_CLASS = "com.tdunning.math.stats.ScaleFunction";
+
+  private TDigestBenchmarkUtils() {
+  }
+
+  static <T extends TDigest> T usePinotScaleFunction(T digest) {
+    try {
+      Class<?> scaleFunctionClass = Class.forName(SCALE_FUNCTION_CLASS);
+      Object k1 = scaleFunctionClass.getField("K_1").get(null);
+      digest.getClass().getMethod("setScaleFunction", scaleFunctionClass).invoke(digest, k1);
+      return digest;
+    } catch (ClassNotFoundException e) {
+      // T-digest 3.2 predates configurable scale functions and already uses the K1 weight limit.
+      return digest;
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("Cannot configure the TDigest benchmark scale function", e);
+    }
+  }
+}

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/TDigestBenchmarkUtils.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/TDigestBenchmarkUtils.java
@@ -19,10 +19,14 @@
 package org.apache.pinot.perf.aggregation;
 
 import com.tdunning.math.stats.TDigest;
+import java.nio.ByteBuffer;
 
 /// Keeps benchmark inputs on Pinot's K1 policy while allowing the same benchmark bytecode to run with t-digest 3.2.
 final class TDigestBenchmarkUtils {
   private static final String SCALE_FUNCTION_CLASS = "com.tdunning.math.stats.ScaleFunction";
+  private static final int VERBOSE_ENCODING = 1;
+  private static final int VERBOSE_HEADER_SIZE = 32;
+  private static final int VERBOSE_CENTROID_SIZE = 16;
 
   private TDigestBenchmarkUtils() {
   }
@@ -39,5 +43,46 @@ final class TDigestBenchmarkUtils {
     } catch (ReflectiveOperationException e) {
       throw new IllegalStateException("Cannot configure the TDigest benchmark scale function", e);
     }
+  }
+
+  /// Creates a deterministic verbose TDigest encoding from sorted raw values.
+  ///
+  /// The endpoint values remain singleton centroids, matching the TDigest boundary invariant. This layout is used as
+  /// a byte-for-byte dependency-version control by benchmarks that otherwise consume native 3.2 or 3.3 encodings.
+  static byte[] createFixedVerboseBytes(double[] sortedValues, double compression) {
+    if (sortedValues.length < 2) {
+      throw new IllegalArgumentException("Fixed verbose benchmark input requires at least two values");
+    }
+    int numCentroids = Math.min(sortedValues.length, Math.max(2, (int) Math.ceil(compression * 1.28)));
+    ByteBuffer buffer = ByteBuffer.allocate(VERBOSE_HEADER_SIZE + numCentroids * VERBOSE_CENTROID_SIZE);
+    buffer.putInt(VERBOSE_ENCODING);
+    buffer.putDouble(sortedValues[0]);
+    buffer.putDouble(sortedValues[sortedValues.length - 1]);
+    buffer.putDouble(compression);
+    buffer.putInt(numCentroids);
+    for (int centroidId = 0; centroidId < numCentroids; centroidId++) {
+      int start;
+      int end;
+      if (centroidId == 0) {
+        start = 0;
+        end = 1;
+      } else if (centroidId == numCentroids - 1) {
+        start = sortedValues.length - 1;
+        end = sortedValues.length;
+      } else {
+        int numInteriorCentroids = numCentroids - 2;
+        int numInteriorValues = sortedValues.length - 2;
+        start = 1 + (centroidId - 1) * numInteriorValues / numInteriorCentroids;
+        end = 1 + centroidId * numInteriorValues / numInteriorCentroids;
+      }
+      double sum = 0.0;
+      for (int valueId = start; valueId < end; valueId++) {
+        sum += sortedValues[valueId];
+      }
+      double weight = end - start;
+      buffer.putDouble(weight);
+      buffer.putDouble(sum / weight);
+    }
+    return buffer.array();
   }
 }

--- a/pinot-query-runtime/src/test/resources/queries/UDFAggregates.json
+++ b/pinot-query-runtime/src/test/resources/queries/UDFAggregates.json
@@ -150,15 +150,15 @@
       },
       {
         "sql": "SELECT PERCENTILE_TDIGEST(float_col, 50), PERCENTILE_TDIGEST(double_col, 5), PERCENTILE_TDIGEST(int_col, 75), PERCENTILE_TDIGEST(long_col, 75) FROM {tbl}",
-        "outputs": [[1.75, 1.0, 137.75, 137.75]]
+        "outputs": [[1.75, 1.0, 150, 150]]
       },
       {
         "sql": "SELECT bool_col, PERCENTILE_TDIGEST(float_col, 50), PERCENTILE_TDIGEST(double_col, 5), PERCENTILE_TDIGEST(int_col, 75), PERCENTILE_TDIGEST(long_col, 75) FROM {tbl} GROUP BY bool_col",
-        "outputs": [[false, 1.255, 1.0, 125.5, 125.5], [true, 300, 1.75, 131.75, 131.75]]
+        "outputs": [[false, 1.5, 1.0, 150, 150], [true, 300, 1.75, 175, 175]]
       },
       {
         "sql": "SELECT /*+ aggOptions(is_skip_leaf_stage_aggregate='true') */ string_col, PERCENTILE_TDIGEST(float_col, 50), PERCENTILE_TDIGEST(double_col, 5), PERCENTILE_TDIGEST(int_col, 75), PERCENTILE_TDIGEST(long_col, 75) FROM {tbl} GROUP BY string_col",
-        "outputs": [["a", 350, 300, 2, 2], ["b", 50.5, 1, 100, 100], ["c", 1.5, 1.01, 168.75, 168.75]]
+        "outputs": [["a", 400, 300, 2, 2], ["b", 100, 1, 100, 100], ["c", 1.5, 1.01, 175, 175]]
       },
       {
         "sql": "SELECT PERCENTILE_KLL(float_col, 50), PERCENTILE_KLL(double_col, 5), PERCENTILE_KLL(int_col, 75), PERCENTILE_KLL(long_col, 75) FROM {tbl}",

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/PercentileTDigestValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/PercentileTDigestValueAggregator.java
@@ -18,11 +18,15 @@
  */
 package org.apache.pinot.segment.local.aggregator;
 
+import com.tdunning.math.stats.Centroid;
+import com.tdunning.math.stats.ScaleFunction;
 import com.tdunning.math.stats.TDigest;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.segment.local.utils.CustomSerDeUtils;
+import org.apache.pinot.segment.local.utils.TDigestUtils;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
@@ -32,11 +36,14 @@ public class PercentileTDigestValueAggregator implements ValueAggregator<Object,
 
   // TODO: This is copied from PercentileTDigestAggregationFunction.
   public static final int DEFAULT_TDIGEST_COMPRESSION = 100;
-  private static final int CENTROID_CAPACITY_PADDING = 10;
+  private static final int MIN_COMPRESSION = 10;
+  private static final int DEFAULT_CENTROID_CAPACITY_PADDING = 10;
+  private static final int LOW_COMPRESSION_CAPACITY_PADDING = 30;
   private static final int VERBOSE_HEADER_SIZE = Integer.BYTES + 3 * Double.BYTES + Integer.BYTES;
   private static final int VERBOSE_CENTROID_SIZE = 2 * Double.BYTES;
   private final int _compressionFactor;
   private int _maxByteSize;
+  private ByteBuffer _serializationBuffer;
 
   public PercentileTDigestValueAggregator(List<ExpressionContext> arguments) {
     if (!arguments.isEmpty()) {
@@ -65,7 +72,7 @@ public class PercentileTDigestValueAggregator implements ValueAggregator<Object,
       byte[] bytes = (byte[]) rawValue;
       initialValue = deserializeAggregatedValue(bytes);
     } else {
-      initialValue = TDigest.createMergingDigest(_compressionFactor);
+      initialValue = new NonFiniteAwareTDigest(_compressionFactor);
       addToDigest(initialValue, rawValue);
     }
     updateMaxByteSize(initialValue);
@@ -74,6 +81,7 @@ public class PercentileTDigestValueAggregator implements ValueAggregator<Object,
 
   @Override
   public TDigest applyRawValue(TDigest value, Object rawValue) {
+    value = asNonFiniteAware(value);
     if (rawValue instanceof byte[]) {
       value.add(deserializeAggregatedValue((byte[]) rawValue));
     } else {
@@ -99,6 +107,7 @@ public class PercentileTDigestValueAggregator implements ValueAggregator<Object,
 
   @Override
   public TDigest applyAggregatedValue(TDigest value, TDigest aggregatedValue) {
+    value = asNonFiniteAware(value);
     value.add(aggregatedValue);
     updateMaxByteSize(value);
     return value;
@@ -106,7 +115,7 @@ public class PercentileTDigestValueAggregator implements ValueAggregator<Object,
 
   @Override
   public TDigest cloneAggregatedValue(TDigest value) {
-    return deserializeAggregatedValue(serializeAggregatedValue(value));
+    return asNonFiniteAware(value).copy();
   }
 
   @Override
@@ -121,28 +130,32 @@ public class PercentileTDigestValueAggregator implements ValueAggregator<Object,
 
   @Override
   public byte[] serializeAggregatedValue(TDigest value) {
-    value.compress();
-    byte[] bytes;
-    if (value.centroidCount() > getDefaultCentroidCapacity(value.compression())) {
-      // Verbose decoding recreates the default centroid capacity, while compact decoding preserves the stored one.
-      ByteBuffer buffer = ByteBuffer.allocate(value.smallByteSize());
-      value.asSmallBytes(buffer);
-      bytes = buffer.array();
-    } else {
-      bytes = CustomSerDeUtils.TDIGEST_SER_DE.serialize(value);
+    int requiredCapacity = getMaxVerboseByteSize(getDefaultCentroidCapacity(value.compression()));
+    if (_serializationBuffer == null || _serializationBuffer.capacity() < requiredCapacity) {
+      _serializationBuffer = ByteBuffer.allocate(requiredCapacity);
     }
+    byte[] bytes = asNonFiniteAware(value).serialize(_serializationBuffer);
     _maxByteSize = Math.max(_maxByteSize, bytes.length);
     return bytes;
   }
 
   @Override
   public TDigest deserializeAggregatedValue(byte[] bytes) {
-    return CustomSerDeUtils.TDIGEST_SER_DE.deserialize(bytes);
+    return NonFiniteAwareTDigest.fromBytes(bytes);
+  }
+
+  private static NonFiniteAwareTDigest asNonFiniteAware(TDigest value) {
+    if (value instanceof NonFiniteAwareTDigest) {
+      return (NonFiniteAwareTDigest) value;
+    }
+    NonFiniteAwareTDigest wrapper = new NonFiniteAwareTDigest(value.compression());
+    wrapper.add(value);
+    return wrapper;
   }
 
   private void updateMaxByteSize(TDigest value) {
     long defaultCapacity = getDefaultCentroidCapacity(value.compression());
-    long maxCentroids = Math.max(value.centroidCount(), Math.min(value.size(), defaultCapacity));
+    long maxCentroids = Math.min(value.size(), defaultCapacity);
     _maxByteSize = Math.max(_maxByteSize, getMaxVerboseByteSize(maxCentroids));
   }
 
@@ -153,6 +166,526 @@ public class PercentileTDigestValueAggregator implements ValueAggregator<Object,
   }
 
   private static long getDefaultCentroidCapacity(double compression) {
-    return Math.addExact(Math.multiplyExact(2L, (long) Math.ceil(compression)), CENTROID_CAPACITY_PADDING);
+    double normalizedCompression = Math.max(MIN_COMPRESSION, compression);
+    int padding = normalizedCompression < 30.0 ? LOW_COMPRESSION_CAPACITY_PADDING
+        : DEFAULT_CENTROID_CAPACITY_PADDING;
+    long defaultCapacity = (long) Math.ceil(2.0 * normalizedCompression + padding);
+    long legacyCapacity = Math.addExact(Math.multiplyExact(2L, (long) Math.ceil(compression)),
+        DEFAULT_CENTROID_CAPACITY_PADDING);
+    return Math.max(defaultCapacity, legacyCapacity);
+  }
+
+  /// Keeps non-finite values as exact tail masses while delegating all finite values to the standard implementation.
+  ///
+  /// The wrapper emits the standard `MergingDigest` wire format. It is mutable, externally synchronized by the
+  /// segment-creation pipeline, and not safe for concurrent mutation.
+  private static final class NonFiniteAwareTDigest extends TDigest {
+    private static final int VERBOSE_ENCODING = 1;
+    private static final int SMALL_ENCODING = 2;
+    private static final int VERBOSE_HEADER_SIZE = 32;
+    private static final int VERBOSE_CENTROID_SIZE = 16;
+
+    private final TDigest _finiteDigest;
+    private long _negativeInfinityWeight;
+    private long _positiveInfinityWeight;
+    private byte[] _finiteSerializedBytes;
+    private List<Centroid> _finiteCentroids;
+    private byte[] _serializedBytes;
+
+    private NonFiniteAwareTDigest(double compression) {
+      this(TDigestUtils.createMergingDigestWithLegacyBuffer(compression), 0L, 0L);
+    }
+
+    private NonFiniteAwareTDigest(TDigest finiteDigest, long negativeInfinityWeight, long positiveInfinityWeight) {
+      _finiteDigest = finiteDigest;
+      _negativeInfinityWeight = negativeInfinityWeight;
+      _positiveInfinityWeight = positiveInfinityWeight;
+    }
+
+    private NonFiniteAwareTDigest copy() {
+      invalidateCaches();
+      int minimumMainCapacity = Math.addExact(_finiteDigest.centroidCount(), 2);
+      TDigest finiteDigest = TDigestUtils.createMergingDigestWithLegacyBuffer(compression(), minimumMainCapacity);
+      if (_finiteDigest.size() > 0L) {
+        finiteDigest.add(List.of(_finiteDigest));
+      }
+      return new NonFiniteAwareTDigest(finiteDigest, _negativeInfinityWeight, _positiveInfinityWeight);
+    }
+
+    private static NonFiniteAwareTDigest fromBytes(byte[] bytes) {
+      TDigestUtils.validateSerialized(bytes);
+      ByteBuffer input = ByteBuffer.wrap(bytes);
+      int encoding = input.getInt();
+      double encodedMin = input.getDouble();
+      double encodedMax = input.getDouble();
+      double compression;
+      int centroidCount;
+      boolean verbose;
+      if (encoding == VERBOSE_ENCODING) {
+        compression = input.getDouble();
+        centroidCount = input.getInt();
+        verbose = true;
+      } else if (encoding == SMALL_ENCODING) {
+        compression = input.getFloat();
+        input.getShort();
+        input.getShort();
+        centroidCount = input.getShort();
+        verbose = false;
+      } else {
+        throw new IllegalStateException("Invalid format for serialized histogram");
+      }
+
+      int centroidOffset = input.position();
+      long negativeInfinityWeight = 0L;
+      long positiveInfinityWeight = 0L;
+      for (int i = 0; i < centroidCount; i++) {
+        double weight = verbose ? input.getDouble() : input.getFloat();
+        double mean = verbose ? input.getDouble() : input.getFloat();
+        if (mean == Double.NEGATIVE_INFINITY) {
+          negativeInfinityWeight = Math.addExact(negativeInfinityWeight, toLongWeight(weight));
+        } else if (mean == Double.POSITIVE_INFINITY) {
+          positiveInfinityWeight = Math.addExact(positiveInfinityWeight, toLongWeight(weight));
+        } else if (Double.isNaN(mean)) {
+          throw new IllegalArgumentException("Cannot deserialize a TDigest with a NaN centroid mean");
+        }
+      }
+      if (negativeInfinityWeight == 0L && positiveInfinityWeight == 0L) {
+        return new NonFiniteAwareTDigest(TDigestUtils.deserializeFiniteWithLegacyBuffer(bytes), 0L, 0L);
+      }
+
+      double[] finiteMeans = new double[centroidCount];
+      double[] finiteWeights = new double[centroidCount];
+      int finiteCount = 0;
+      input.position(centroidOffset);
+      for (int i = 0; i < centroidCount; i++) {
+        double weight = verbose ? input.getDouble() : input.getFloat();
+        double mean = verbose ? input.getDouble() : input.getFloat();
+        if (Double.isFinite(mean)) {
+          finiteWeights[finiteCount] = weight;
+          finiteMeans[finiteCount] = mean;
+          finiteCount++;
+        }
+      }
+
+      TDigest finiteDigest;
+      if (finiteCount == 0) {
+        finiteDigest = TDigestUtils.createMergingDigestWithLegacyBuffer(compression);
+      } else {
+        double finiteMin = Double.isFinite(encodedMin) ? encodedMin : finiteMeans[0];
+        double finiteMax = Double.isFinite(encodedMax) ? encodedMax : finiteMeans[finiteCount - 1];
+        byte[] finiteBytes = toVerboseBytes(finiteMin, finiteMax, compression, finiteMeans, finiteWeights, finiteCount);
+        finiteDigest = TDigestUtils.deserializeFiniteWithLegacyBuffer(
+            TDigestUtils.makeLegacyCompatible(finiteBytes));
+      }
+      return new NonFiniteAwareTDigest(finiteDigest, negativeInfinityWeight, positiveInfinityWeight);
+    }
+
+    @Override
+    public void add(double value) {
+      add(value, 1);
+    }
+
+    @Override
+    public void add(double value, int weight) {
+      if (Double.isNaN(value)) {
+        throw new IllegalArgumentException("Cannot add NaN to t-digest");
+      }
+      if (weight <= 0) {
+        throw new IllegalArgumentException("TDigest weight must be positive: " + weight);
+      }
+      invalidateCaches();
+      if (value == Double.NEGATIVE_INFINITY) {
+        _negativeInfinityWeight = Math.addExact(_negativeInfinityWeight, weight);
+      } else if (value == Double.POSITIVE_INFINITY) {
+        _positiveInfinityWeight = Math.addExact(_positiveInfinityWeight, weight);
+      } else {
+        _finiteDigest.add(value, weight);
+      }
+    }
+
+    @Override
+    public void add(TDigest other) {
+      if (other instanceof NonFiniteAwareTDigest) {
+        NonFiniteAwareTDigest wrapped = (NonFiniteAwareTDigest) other;
+        long negativeInfinityWeight = wrapped._negativeInfinityWeight;
+        long positiveInfinityWeight = wrapped._positiveInfinityWeight;
+        // MergingDigest.add(List) copies the implementation's double-precision weight arrays directly. The generic
+        // add(TDigest) path goes through Centroid.count(), which is limited to an int and truncates large weights.
+        wrapped.invalidateCaches();
+        invalidateCaches();
+        if (wrapped._finiteDigest.size() > 0L) {
+          _finiteDigest.add(List.of(wrapped._finiteDigest));
+        }
+        _negativeInfinityWeight = Math.addExact(_negativeInfinityWeight, negativeInfinityWeight);
+        _positiveInfinityWeight = Math.addExact(_positiveInfinityWeight, positiveInfinityWeight);
+        return;
+      }
+
+      if (other.size() == 0L) {
+        return;
+      }
+      invalidateCaches();
+      if (Double.isFinite(other.getMin()) && Double.isFinite(other.getMax())) {
+        _finiteDigest.add(List.of(other));
+        return;
+      }
+      for (Centroid centroid : other.centroids()) {
+        add(centroid.mean(), centroid.count());
+      }
+    }
+
+    @Override
+    public void add(List<? extends TDigest> others) {
+      for (TDigest other : others) {
+        add(other);
+      }
+    }
+
+    @Override
+    public void compress() {
+      getFiniteSerializedBytes();
+    }
+
+    @Override
+    public long size() {
+      return Math.addExact(Math.addExact(_finiteDigest.size(), _negativeInfinityWeight), _positiveInfinityWeight);
+    }
+
+    @Override
+    public double cdf(double value) {
+      if (Double.isNaN(value) || Double.isInfinite(value)) {
+        throw new IllegalArgumentException(String.format("Invalid value: %f", value));
+      }
+      long size = size();
+      if (size == 0L) {
+        return Double.NaN;
+      }
+      long finiteSize = _finiteDigest.size();
+      double finiteWeight = finiteSize == 0L ? 0.0 : _finiteDigest.cdf(value) * finiteSize;
+      return (_negativeInfinityWeight + finiteWeight) / size;
+    }
+
+    @Override
+    public double quantile(double quantile) {
+      if (Double.isNaN(quantile) || quantile < 0.0 || quantile > 1.0) {
+        throw new IllegalArgumentException("q should be in [0,1], got " + quantile);
+      }
+      long size = size();
+      if (size == 0L) {
+        return Double.NaN;
+      }
+      double index = quantile * size;
+      if (_negativeInfinityWeight > 0L && index < _negativeInfinityWeight) {
+        return Double.NEGATIVE_INFINITY;
+      }
+      if (_positiveInfinityWeight > 0L && index >= size - _positiveInfinityWeight) {
+        return Double.POSITIVE_INFINITY;
+      }
+      long finiteSize = _finiteDigest.size();
+      if (finiteSize == 0L) {
+        return _negativeInfinityWeight > 0L ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
+      }
+      double finiteQuantile = (index - _negativeInfinityWeight) / finiteSize;
+      return _finiteDigest.quantile(Math.max(0.0, Math.min(finiteQuantile, 1.0)));
+    }
+
+    @Override
+    public Collection<Centroid> centroids() {
+      List<Centroid> centroids = getAllCentroids();
+      List<Centroid> copies = new ArrayList<>(centroids.size());
+      for (Centroid centroid : centroids) {
+        copies.add(Centroid.createWeighted(centroid.mean(), centroid.count(), centroid.data()));
+      }
+      return copies;
+    }
+
+    @Override
+    public double compression() {
+      return _finiteDigest.compression();
+    }
+
+    @Override
+    public int byteSize() {
+      return getSerializedBytes().length;
+    }
+
+    @Override
+    public int smallByteSize() {
+      return getSerializedBytes().length;
+    }
+
+    @Override
+    public void asBytes(ByteBuffer buffer) {
+      buffer.put(getSerializedBytes());
+    }
+
+    @Override
+    public void asSmallBytes(ByteBuffer buffer) {
+      buffer.put(getSerializedBytes());
+    }
+
+    @Override
+    public TDigest recordAllData() {
+      invalidateCaches();
+      _finiteDigest.recordAllData();
+      return this;
+    }
+
+    @Override
+    public boolean isRecording() {
+      return _finiteDigest.isRecording();
+    }
+
+    @Override
+    public void setScaleFunction(ScaleFunction scaleFunction) {
+      invalidateCaches();
+      _finiteDigest.setScaleFunction(scaleFunction);
+      super.setScaleFunction(scaleFunction);
+    }
+
+    @Override
+    public int centroidCount() {
+      return getAllCentroids().size();
+    }
+
+    @Override
+    public double getMin() {
+      if (_negativeInfinityWeight > 0L) {
+        return Double.NEGATIVE_INFINITY;
+      }
+      if (_finiteDigest.size() > 0L) {
+        return _finiteDigest.getMin();
+      }
+      return Double.POSITIVE_INFINITY;
+    }
+
+    @Override
+    public double getMax() {
+      if (_positiveInfinityWeight > 0L) {
+        return Double.POSITIVE_INFINITY;
+      }
+      if (_finiteDigest.size() > 0L) {
+        return _finiteDigest.getMax();
+      }
+      return Double.NEGATIVE_INFINITY;
+    }
+
+    private byte[] serialize(ByteBuffer scratchBuffer) {
+      return getSerializedBytes(scratchBuffer).clone();
+    }
+
+    private List<Centroid> getFiniteCentroids() {
+      if (_finiteCentroids == null) {
+        ByteBuffer input = ByteBuffer.wrap(getFiniteSerializedBytes());
+        int encoding = input.getInt();
+        input.position(input.position() + 2 * Double.BYTES);
+        int centroidCount;
+        boolean verbose;
+        if (encoding == VERBOSE_ENCODING) {
+          input.getDouble();
+          centroidCount = input.getInt();
+          verbose = true;
+        } else if (encoding == SMALL_ENCODING) {
+          input.getFloat();
+          input.getShort();
+          input.getShort();
+          centroidCount = input.getShort();
+          verbose = false;
+        } else {
+          throw new IllegalStateException("Invalid format for serialized histogram");
+        }
+        _finiteCentroids = new ArrayList<>(centroidCount);
+        for (int i = 0; i < centroidCount; i++) {
+          double weight = verbose ? input.getDouble() : input.getFloat();
+          double mean = verbose ? input.getDouble() : input.getFloat();
+          appendCentroids(_finiteCentroids, mean, toLongWeight(weight), false, false);
+        }
+      }
+      return _finiteCentroids;
+    }
+
+    private List<Centroid> getAllCentroids() {
+      List<Centroid> finiteCentroids = getFiniteCentroids();
+      boolean hasFiniteValues = _finiteDigest.size() > 0L;
+      List<Centroid> centroids = new ArrayList<>(finiteCentroids.size() + 6);
+      appendInfinityCentroids(centroids, Double.NEGATIVE_INFINITY, _negativeInfinityWeight, true,
+          !hasFiniteValues && _positiveInfinityWeight == 0L);
+      centroids.addAll(finiteCentroids);
+      appendInfinityCentroids(centroids, Double.POSITIVE_INFINITY, _positiveInfinityWeight,
+          !hasFiniteValues && _negativeInfinityWeight == 0L, true);
+      return centroids;
+    }
+
+    private byte[] getSerializedBytes() {
+      return getSerializedBytes(null);
+    }
+
+    private byte[] getSerializedBytes(ByteBuffer scratchBuffer) {
+      if (_serializedBytes == null) {
+        byte[] finiteBytes = getFiniteSerializedBytes(scratchBuffer);
+        if (_negativeInfinityWeight == 0L && _positiveInfinityWeight == 0L) {
+          _serializedBytes = finiteBytes;
+          return _serializedBytes;
+        }
+
+        ByteBuffer finite = ByteBuffer.wrap(finiteBytes);
+        int encoding = finite.getInt();
+        finite.position(finite.position() + 2 * Double.BYTES);
+        int finiteCentroidCount;
+        boolean finiteVerbose;
+        if (encoding == VERBOSE_ENCODING) {
+          finite.getDouble();
+          finiteCentroidCount = finite.getInt();
+          finiteVerbose = true;
+        } else if (encoding == SMALL_ENCODING) {
+          finite.getFloat();
+          finite.getShort();
+          finite.getShort();
+          finiteCentroidCount = finite.getShort();
+          finiteVerbose = false;
+        } else {
+          throw new IllegalStateException("Invalid format for serialized histogram");
+        }
+
+        boolean hasFiniteValues = _finiteDigest.size() > 0L;
+        int negativeInfinityCentroidCount = getInfinityCentroidCount(_negativeInfinityWeight, true,
+            !hasFiniteValues && _positiveInfinityWeight == 0L);
+        int positiveInfinityCentroidCount = getInfinityCentroidCount(_positiveInfinityWeight,
+            !hasFiniteValues && _negativeInfinityWeight == 0L, true);
+        int centroidCount = Math.addExact(finiteCentroidCount,
+            Math.addExact(negativeInfinityCentroidCount, positiveInfinityCentroidCount));
+        ByteBuffer verbose = ByteBuffer.allocate(VERBOSE_HEADER_SIZE + VERBOSE_CENTROID_SIZE * centroidCount);
+        verbose.putInt(VERBOSE_ENCODING);
+        verbose.putDouble(getMin());
+        verbose.putDouble(getMax());
+        verbose.putDouble(compression());
+        verbose.putInt(centroidCount);
+        appendInfinityCentroids(verbose, Double.NEGATIVE_INFINITY, _negativeInfinityWeight, true,
+            !hasFiniteValues && _positiveInfinityWeight == 0L);
+        for (int i = 0; i < finiteCentroidCount; i++) {
+          verbose.putDouble(finiteVerbose ? finite.getDouble() : finite.getFloat());
+          verbose.putDouble(finiteVerbose ? finite.getDouble() : finite.getFloat());
+        }
+        appendInfinityCentroids(verbose, Double.POSITIVE_INFINITY, _positiveInfinityWeight,
+            !hasFiniteValues && _negativeInfinityWeight == 0L, true);
+        _serializedBytes = TDigestUtils.makeLegacyCompatible(verbose.array());
+      }
+      return _serializedBytes;
+    }
+
+    private byte[] getFiniteSerializedBytes() {
+      return getFiniteSerializedBytes(null);
+    }
+
+    private byte[] getFiniteSerializedBytes(ByteBuffer scratchBuffer) {
+      if (_finiteSerializedBytes == null) {
+        // Serialization performs the single final compression pass. Keep these bytes coupled to the derived
+        // centroid/final-wire caches so later reads cannot return state from before another destructive compression.
+        _finiteSerializedBytes = TDigestUtils.serialize(_finiteDigest, scratchBuffer);
+        _finiteCentroids = null;
+        _serializedBytes = null;
+      }
+      return _finiteSerializedBytes;
+    }
+
+    private void invalidateCaches() {
+      _finiteSerializedBytes = null;
+      _finiteCentroids = null;
+      _serializedBytes = null;
+    }
+
+    private static void appendInfinityCentroids(List<Centroid> centroids, double value, long weight,
+        boolean unitWeightAtStart, boolean unitWeightAtEnd) {
+      appendCentroids(centroids, value, weight, unitWeightAtStart, unitWeightAtEnd);
+    }
+
+    private static void appendCentroids(List<Centroid> centroids, double value, long weight,
+        boolean unitWeightAtStart, boolean unitWeightAtEnd) {
+      if (weight == 0L) {
+        return;
+      }
+      if (unitWeightAtStart) {
+        centroids.add(Centroid.createWeighted(value, 1, null));
+        weight--;
+      }
+      boolean appendUnitWeightAtEnd = unitWeightAtEnd && weight > 0L;
+      if (appendUnitWeightAtEnd) {
+        weight--;
+      }
+      while (weight > 0L) {
+        int centroidWeight = (int) Math.min(weight, Integer.MAX_VALUE);
+        centroids.add(Centroid.createWeighted(value, centroidWeight, null));
+        weight -= centroidWeight;
+      }
+      if (appendUnitWeightAtEnd) {
+        centroids.add(Centroid.createWeighted(value, 1, null));
+      }
+    }
+
+    private static void appendInfinityCentroids(ByteBuffer buffer, double value, long weight,
+        boolean unitWeightAtStart, boolean unitWeightAtEnd) {
+      if (weight == 0L) {
+        return;
+      }
+      if (unitWeightAtStart) {
+        buffer.putDouble(1.0);
+        buffer.putDouble(value);
+        weight--;
+      }
+      boolean appendUnitWeightAtEnd = unitWeightAtEnd && weight > 0L;
+      if (appendUnitWeightAtEnd) {
+        weight--;
+      }
+      while (weight > 0L) {
+        int centroidWeight = (int) Math.min(weight, Integer.MAX_VALUE);
+        buffer.putDouble(centroidWeight);
+        buffer.putDouble(value);
+        weight -= centroidWeight;
+      }
+      if (appendUnitWeightAtEnd) {
+        buffer.putDouble(1.0);
+        buffer.putDouble(value);
+      }
+    }
+
+    private static int getInfinityCentroidCount(long weight, boolean unitWeightAtStart, boolean unitWeightAtEnd) {
+      if (weight == 0L) {
+        return 0;
+      }
+      int count = 0;
+      if (unitWeightAtStart) {
+        count++;
+        weight--;
+      }
+      if (unitWeightAtEnd && weight > 0L) {
+        count++;
+        weight--;
+      }
+      long fullCentroids = weight / Integer.MAX_VALUE;
+      long partialCentroid = weight % Integer.MAX_VALUE == 0L ? 0L : 1L;
+      return Math.addExact(count, Math.toIntExact(fullCentroids + partialCentroid));
+    }
+
+    private static long toLongWeight(double weight) {
+      if (!(weight > 0.0) || weight >= 0x1p63 || weight != Math.rint(weight)) {
+        throw new IllegalArgumentException("Invalid TDigest centroid weight: " + weight);
+      }
+      return (long) weight;
+    }
+
+    private static byte[] toVerboseBytes(double min, double max, double compression, double[] means,
+        double[] weights, int count) {
+      ByteBuffer buffer = ByteBuffer.allocate(VERBOSE_HEADER_SIZE + VERBOSE_CENTROID_SIZE * count);
+      buffer.putInt(VERBOSE_ENCODING);
+      buffer.putDouble(min);
+      buffer.putDouble(max);
+      buffer.putDouble(compression);
+      buffer.putInt(count);
+      for (int i = 0; i < count; i++) {
+        buffer.putDouble(weights[i]);
+        buffer.putDouble(means[i]);
+      }
+      return buffer.array();
+    }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/CustomSerDeUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/CustomSerDeUtils.java
@@ -22,7 +22,6 @@ import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import com.clearspring.analytics.stream.cardinality.HyperLogLogPlus;
 import com.dynatrace.hash4j.distinctcount.UltraLogLog;
 import com.google.common.primitives.Longs;
-import com.tdunning.math.stats.MergingDigest;
 import com.tdunning.math.stats.TDigest;
 import java.io.IOException;
 import java.lang.foreign.MemorySegment;
@@ -224,19 +223,17 @@ public class CustomSerDeUtils {
 
     @Override
     public byte[] serialize(TDigest tDigest) {
-      byte[] bytes = new byte[tDigest.byteSize()];
-      tDigest.asBytes(ByteBuffer.wrap(bytes));
-      return bytes;
+      return TDigestUtils.serialize(tDigest);
     }
 
     @Override
     public TDigest deserialize(byte[] bytes) {
-      return MergingDigest.fromBytes(ByteBuffer.wrap(bytes));
+      return TDigestUtils.deserialize(bytes);
     }
 
     @Override
     public TDigest deserialize(ByteBuffer byteBuffer) {
-      return MergingDigest.fromBytes(byteBuffer);
+      return TDigestUtils.deserialize(byteBuffer);
     }
   };
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TDigestUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TDigestUtils.java
@@ -1,0 +1,642 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.utils;
+
+import com.tdunning.math.stats.MergingDigest;
+import com.tdunning.math.stats.ScaleFunction;
+import com.tdunning.math.stats.TDigest;
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/// Compatibility helpers for the serialized t-digest format shared by t-digest 3.2 and 3.3.
+///
+/// Version 3.3 requires the first and last centroid to have unit weight whenever a digest is recompressed. Version
+/// 3.2 did not maintain that invariant, so an otherwise valid 3.2 digest can fail an assertion after being read by
+/// 3.3. Deserialization repairs only those legacy boundary centroids, preserving their total weight and first moment.
+/// Serialization uses the compact form when 3.3's larger low-compression centroid buffer would not fit in a 3.2
+/// default buffer and every centroid is exactly representable in that format. Otherwise, it merges the nearest
+/// interior centroids until the verbose representation fits the 3.2 capacity. This keeps intermediate values readable
+/// in both directions during a rolling upgrade without silently narrowing double-precision values to floats.
+///
+/// Pinot explicitly uses [ScaleFunction#K_1] for new and deserialized merging digests. T-digest 3.3 changed its default
+/// to `K_2`, whose smaller middle-quantile centroid count caused a material P75 accuracy regression in Pinot's
+/// deterministic 100-million-row workload. `K_1` retains the accuracy profile of t-digest 3.2 while using the 3.3
+/// implementation and its two-level compression.
+public final class TDigestUtils {
+  private static final int VERBOSE_ENCODING = 1;
+  private static final int SMALL_ENCODING = 2;
+  private static final int LEGACY_CAPACITY_PADDING = 10;
+  private static final int VERBOSE_HEADER_SIZE = 32;
+  private static final int VERBOSE_CENTROID_SIZE = 16;
+  private static final int SMALL_HEADER_SIZE = 30;
+  private static final int SMALL_CENTROID_SIZE = 8;
+  private static final int DEFAULT_MERGE_BUFFER_MULTIPLIER = 5;
+
+  private TDigestUtils() {
+  }
+
+  /// Creates a merging digest with Pinot's accuracy-preserving scale function.
+  public static TDigest createMergingDigest(double compression) {
+    return configureScaleFunction(new MergingDigest(compression));
+  }
+
+  /// Creates a merging digest with the temporary-buffer footprint used by t-digest 3.2.
+  ///
+  /// Segment aggregation can keep many digests live at once. T-digest 3.3 more than doubled the default temporary
+  /// buffer to support two-level compression, adding about 11 KiB to every compression-100 digest. This factory keeps
+  /// the 3.3 main-buffer capacity and Pinot's K1 policy, but restores the smaller temporary buffer for that
+  /// high-cardinality use case.
+  public static TDigest createMergingDigestWithLegacyBuffer(double compression) {
+    return createMergingDigestWithLegacyBuffer(compression, 0);
+  }
+
+  /// Creates a reduced-buffer merging digest whose main array can hold at least `minimumMainCapacity` centroids.
+  public static TDigest createMergingDigestWithLegacyBuffer(double compression, int minimumMainCapacity) {
+    if (minimumMainCapacity < 0) {
+      throw new IllegalArgumentException("Minimum main capacity must not be negative: " + minimumMainCapacity);
+    }
+    double normalizedCompression = Math.max(compression, 10.0);
+    int mainCapacity = Math.max(minimumMainCapacity, getDefaultCentroidCapacity(normalizedCompression));
+    int legacyBufferCapacity = Math.toIntExact(Math.multiplyExact(5L, (long) Math.ceil(normalizedCompression)));
+    int bufferCapacity = Math.max(legacyBufferCapacity, Math.addExact(mainCapacity, 1));
+    return configureScaleFunction(new MergingDigest(compression, bufferCapacity, mainCapacity));
+  }
+
+  /// Serializes a digest in a representation readable by both t-digest 3.2 and 3.3.
+  public static byte[] serialize(TDigest tDigest) {
+    return serialize(tDigest, null);
+  }
+
+  /// Serializes a digest using `scratchBuffer` for the temporary verbose representation when it is large enough.
+  ///
+  /// The returned array is independently owned. The scratch buffer is cleared and may be reused by the caller after
+  /// this method returns.
+  public static byte[] serialize(TDigest tDigest, ByteBuffer scratchBuffer) {
+    ByteOrder scratchOrder = scratchBuffer != null ? scratchBuffer.order() : null;
+    try {
+      if (!(tDigest instanceof MergingDigest)) {
+        // Pinot has always decoded TDigest values as MergingDigest. Preserve the previous serialization behavior for
+        // other implementations instead of interpreting their implementation-specific payload as MergingDigest
+        // bytes.
+        ByteBuffer buffer = prepareScratchBuffer(scratchBuffer, tDigest.byteSize());
+        tDigest.asBytes(buffer);
+        byte[] bytes = new byte[buffer.position()];
+        buffer.flip();
+        buffer.get(bytes);
+        return bytes;
+      }
+
+      int defaultCapacity = getDefaultCentroidCapacity(tDigest.compression());
+      int legacyCapacity = getLegacyDefaultCentroidCapacity(tDigest.compression());
+      // centroidCount() drains pending values at the digest's internal (two-level) compression, but does not perform
+      // the final, destructive compression used by asBytes(). It therefore gives us a safe bound for digests
+      // deserialized from the compact encoding with an explicitly enlarged main array while still allowing asBytes()
+      // to run once.
+      int currentCentroidCount = tDigest.centroidCount();
+      long sizeBound = Math.min(Math.max(0L, tDigest.size()), Math.max(defaultCapacity, legacyCapacity));
+      int maxCentroids = Math.max(currentCentroidCount, (int) sizeBound);
+      int requiredCapacity = Math.addExact(VERBOSE_HEADER_SIZE,
+          Math.multiplyExact(VERBOSE_CENTROID_SIZE, maxCentroids));
+      ByteBuffer verboseBuffer = prepareScratchBuffer(scratchBuffer, requiredCapacity);
+      // MergingDigest.asBytes() force-compresses in 3.3. Calling byteSize() first would force a second, destructive
+      // pass.
+      tDigest.asBytes(verboseBuffer);
+      int encodedSize = verboseBuffer.position();
+      byte[] verboseBytes = new byte[encodedSize];
+      verboseBuffer.flip();
+      verboseBuffer.get(verboseBytes);
+
+      return makeLegacyCompatible(verboseBytes);
+    } finally {
+      if (scratchBuffer != null) {
+        scratchBuffer.order(scratchOrder);
+      }
+    }
+  }
+
+  private static ByteBuffer prepareScratchBuffer(ByteBuffer scratchBuffer, int requiredCapacity) {
+    if (scratchBuffer == null || scratchBuffer.isReadOnly() || scratchBuffer.capacity() < requiredCapacity) {
+      return ByteBuffer.allocate(requiredCapacity);
+    }
+    scratchBuffer.clear();
+    scratchBuffer.limit(requiredCapacity);
+    scratchBuffer.order(ByteOrder.BIG_ENDIAN);
+    return scratchBuffer;
+  }
+
+  /// Converts a verbose `MergingDigest` payload to a representation readable by t-digest 3.2 and 3.3.
+  ///
+  /// The input must use the standard verbose `MergingDigest` encoding. The returned payload stays verbose when it
+  /// already fits the 3.2 default capacity, uses the compact encoding only when every narrowed field is exact, and
+  /// otherwise reduces interior centroids without narrowing doubles.
+  public static byte[] makeLegacyCompatible(byte[] verboseBytes) {
+    ByteBuffer verbose = ByteBuffer.wrap(verboseBytes);
+    if (verbose.getInt() != VERBOSE_ENCODING) {
+      throw new IllegalArgumentException("Expected verbose TDigest encoding");
+    }
+    verbose.getDouble();
+    verbose.getDouble();
+    double compression = verbose.getDouble();
+    if (!(compression > 0.0) || !Double.isFinite(compression)) {
+      throw new IllegalArgumentException("Invalid TDigest compression: " + compression);
+    }
+    int centroidCount = verbose.getInt();
+    if (centroidCount < 0 || centroidCount > verbose.remaining() / VERBOSE_CENTROID_SIZE) {
+      throw new IllegalArgumentException("Invalid TDigest centroid count: " + centroidCount);
+    }
+
+    int mainCapacity = Math.max(getDefaultCentroidCapacity(compression), centroidCount);
+    long bufferCapacity = DEFAULT_MERGE_BUFFER_MULTIPLIER * (long) mainCapacity;
+    int legacyCapacity = getLegacyDefaultCentroidCapacity(compression);
+    boolean compactFieldsExact = true;
+    ByteBuffer centroids = verbose.duplicate();
+    for (int i = 0; i < centroidCount; i++) {
+      double weight = centroids.getDouble();
+      double mean = centroids.getDouble();
+      if (!(weight > 0.0) || !Double.isFinite(weight) || Double.isNaN(mean)) {
+        throw new IllegalArgumentException("Invalid TDigest centroid: mean=" + mean + ", weight=" + weight);
+      }
+      compactFieldsExact &= (double) (float) weight == weight && (double) (float) mean == mean;
+    }
+    if (centroidCount <= legacyCapacity) {
+      return verboseBytes;
+    }
+    if ((double) (float) compression != compression || centroidCount > Short.MAX_VALUE
+        || mainCapacity > Short.MAX_VALUE || bufferCapacity > Short.MAX_VALUE || !compactFieldsExact) {
+      return reduceVerboseCentroids(verboseBytes, legacyCapacity);
+    }
+
+    ByteBuffer small = ByteBuffer.allocate(SMALL_HEADER_SIZE + SMALL_CENTROID_SIZE * centroidCount);
+    verbose.rewind();
+    verbose.getInt();
+    small.putInt(SMALL_ENCODING);
+    small.putDouble(verbose.getDouble());
+    small.putDouble(verbose.getDouble());
+    verbose.getDouble();
+    verbose.getInt();
+    small.putFloat((float) compression);
+    small.putShort((short) mainCapacity);
+    small.putShort((short) bufferCapacity);
+    small.putShort((short) centroidCount);
+    for (int i = 0; i < centroidCount; i++) {
+      small.putFloat((float) verbose.getDouble());
+      small.putFloat((float) verbose.getDouble());
+    }
+    return small.array();
+  }
+
+  /// Deserializes a digest and repairs boundary centroids produced by t-digest 3.2 when necessary.
+  public static TDigest deserialize(byte[] bytes) {
+    return deserialize(ByteBuffer.wrap(bytes));
+  }
+
+  /// Validates the structure and declared capacities of a serialized merging digest.
+  public static void validateSerialized(byte[] bytes) {
+    validateEncodedDigest(ByteBuffer.wrap(bytes));
+  }
+
+  /// Deserializes a finite-valued digest into a merging digest with the temporary-buffer footprint used by 3.2.
+  ///
+  /// Unlike the standard verbose decoder, this method does not retain the substantially larger default 3.3
+  /// temporary arrays. It also repairs legacy weighted boundary centroids before the first 3.3 merge.
+  public static TDigest deserializeFiniteWithLegacyBuffer(byte[] bytes) {
+    ByteBuffer input = ByteBuffer.wrap(bytes);
+    validateEncodedDigest(input.duplicate());
+
+    int encoding = input.getInt();
+    double min = input.getDouble();
+    double max = input.getDouble();
+    double compression;
+    int centroidCount;
+    boolean verbose;
+    if (encoding == VERBOSE_ENCODING) {
+      compression = input.getDouble();
+      centroidCount = input.getInt();
+      verbose = true;
+    } else if (encoding == SMALL_ENCODING) {
+      compression = input.getFloat();
+      input.getShort();
+      input.getShort();
+      centroidCount = input.getShort();
+      verbose = false;
+    } else {
+      throw new IllegalStateException("Invalid format for serialized histogram");
+    }
+
+    if (centroidCount == 0) {
+      return createMergingDigestWithLegacyBuffer(compression);
+    }
+    double[] means = new double[centroidCount + 2];
+    double[] weights = new double[centroidCount + 2];
+    for (int i = 0; i < centroidCount; i++) {
+      double weight = verbose ? input.getDouble() : input.getFloat();
+      double mean = verbose ? input.getDouble() : input.getFloat();
+      if (!(weight > 0.0) || !Double.isFinite(weight)) {
+        throw new IllegalArgumentException("Invalid TDigest centroid weight: " + weight);
+      }
+      if (!Double.isFinite(mean)) {
+        throw new IllegalArgumentException("Expected a finite TDigest centroid mean: " + mean);
+      }
+      weights[i] = weight;
+      means[i] = mean;
+    }
+
+    int normalizedCount = weights[0] != 1.0 || weights[centroidCount - 1] != 1.0
+        ? normalizeBoundaries(means, weights, centroidCount, min, max) : centroidCount;
+    long addCount = 0L;
+    for (int i = 0; i < normalizedCount; i++) {
+      double weight = weights[i];
+      if (weight != Math.rint(weight) || weight >= 0x1p63) {
+        return copyIntoLegacyBuffer(
+            deserialize(toVerboseBytes(min, max, compression, means, weights, normalizedCount)), normalizedCount);
+      }
+      long integralWeight = (long) weight;
+      addCount = Math.addExact(addCount, 1L + (integralWeight - 1L) / Integer.MAX_VALUE);
+    }
+
+    int minimumMainCapacity = Math.addExact(Math.toIntExact(addCount), 2);
+    TDigest digest = createMergingDigestWithLegacyBuffer(compression, minimumMainCapacity);
+    for (int i = 0; i < normalizedCount; i++) {
+      long remainingWeight = (long) weights[i];
+      while (remainingWeight > 0L) {
+        int weight = (int) Math.min(remainingWeight, Integer.MAX_VALUE);
+        digest.add(means[i], weight);
+        remainingWeight -= weight;
+      }
+    }
+    return digest;
+  }
+
+  /// Deserializes a digest and advances `input` past its encoded bytes.
+  public static TDigest deserialize(ByteBuffer input) {
+    ByteBuffer encoded = input.slice();
+    validateEncodedDigest(encoded.duplicate());
+
+    int encoding = encoded.getInt();
+    double min = encoded.getDouble();
+    double max = encoded.getDouble();
+    double compression;
+    int mainCapacity;
+    int bufferCapacity;
+    int centroidCount;
+    int centroidSize;
+    if (encoding == VERBOSE_ENCODING) {
+      compression = encoded.getDouble();
+      centroidCount = encoded.getInt();
+      mainCapacity = getDefaultCentroidCapacity(compression);
+      bufferCapacity = 5 * mainCapacity;
+      centroidSize = VERBOSE_CENTROID_SIZE;
+    } else if (encoding == SMALL_ENCODING) {
+      compression = encoded.getFloat();
+      mainCapacity = encoded.getShort();
+      bufferCapacity = encoded.getShort();
+      centroidCount = encoded.getShort();
+      centroidSize = SMALL_CENTROID_SIZE;
+    } else {
+      // MergingDigest.fromBytes() has already produced the canonical exception for this case.
+      throw new IllegalStateException("Invalid format for serialized histogram");
+    }
+    int centroidOffset = encoded.position();
+    if (centroidCount == 0) {
+      return configureScaleFunction(MergingDigest.fromBytes(input));
+    }
+
+    double firstWeight = readWeight(encoded, centroidOffset, centroidSize);
+    double lastWeight = readWeight(encoded, centroidOffset + (centroidCount - 1) * centroidSize, centroidSize);
+    int defaultMainCapacity = getDefaultCentroidCapacity(compression);
+    boolean needsBoundaryRepair = firstWeight != 1.0 || lastWeight != 1.0;
+    boolean exceedsDefaultVerboseCapacity = encoding == VERBOSE_ENCODING && centroidCount > defaultMainCapacity;
+    if (!needsBoundaryRepair && !exceedsDefaultVerboseCapacity) {
+      return configureScaleFunction(MergingDigest.fromBytes(input));
+    }
+
+    double[] means = new double[centroidCount + 2];
+    double[] weights = new double[centroidCount + 2];
+    encoded.position(centroidOffset);
+    for (int i = 0; i < centroidCount; i++) {
+      if (centroidSize == VERBOSE_CENTROID_SIZE) {
+        weights[i] = encoded.getDouble();
+        means[i] = encoded.getDouble();
+      } else {
+        weights[i] = encoded.getFloat();
+        means[i] = encoded.getFloat();
+      }
+    }
+    int encodedLength = encoded.position();
+    int normalizedCount = needsBoundaryRepair
+        ? normalizeBoundaries(means, weights, centroidCount, min, max) : centroidCount;
+    byte[] normalizedBytes = toVerboseBytes(min, max, compression, means, weights, normalizedCount);
+    MergingDigest result;
+    if (normalizedCount <= defaultMainCapacity) {
+      result = MergingDigest.fromBytes(ByteBuffer.wrap(normalizedBytes));
+    } else {
+      int resolvedMainCapacity = mainCapacity == -1 ? defaultMainCapacity : mainCapacity;
+      int resolvedBufferCapacity = bufferCapacity == -1
+          ? DEFAULT_MERGE_BUFFER_MULTIPLIER * resolvedMainCapacity : bufferCapacity;
+      int smallMainCapacity = Math.max(resolvedMainCapacity, normalizedCount);
+      long smallBufferCapacity = Math.max(Math.max((long) resolvedBufferCapacity, smallMainCapacity + 1L),
+          2L * smallMainCapacity + 1L);
+      if ((double) (float) compression == compression && normalizedCount <= Short.MAX_VALUE
+          && smallMainCapacity <= Short.MAX_VALUE && smallBufferCapacity <= Short.MAX_VALUE
+          && areFloatExact(means, weights, normalizedCount)) {
+        ByteBuffer normalized = ByteBuffer.allocate(SMALL_HEADER_SIZE + SMALL_CENTROID_SIZE * normalizedCount);
+        normalized.putInt(SMALL_ENCODING);
+        normalized.putDouble(min);
+        normalized.putDouble(max);
+        normalized.putFloat((float) compression);
+        normalized.putShort((short) smallMainCapacity);
+        normalized.putShort((short) smallBufferCapacity);
+        normalized.putShort((short) normalizedCount);
+        for (int i = 0; i < normalizedCount; i++) {
+          normalized.putFloat((float) weights[i]);
+          normalized.putFloat((float) means[i]);
+        }
+        normalized.flip();
+        result = MergingDigest.fromBytes(normalized);
+      } else {
+        result = MergingDigest.fromBytes(
+            ByteBuffer.wrap(reduceVerboseCentroids(normalizedBytes, defaultMainCapacity)));
+      }
+    }
+    input.position(Math.addExact(input.position(), encodedLength));
+    return configureScaleFunction(result);
+  }
+
+  private static TDigest configureScaleFunction(MergingDigest digest) {
+    digest.setScaleFunction(ScaleFunction.K_1);
+    return digest;
+  }
+
+  private static TDigest copyIntoLegacyBuffer(TDigest source, int centroidCount) {
+    TDigest digest = createMergingDigestWithLegacyBuffer(source.compression(), Math.addExact(centroidCount, 2));
+    digest.add(java.util.List.of(source));
+    return digest;
+  }
+
+  private static boolean areFloatExact(double[] means, double[] weights, int count) {
+    for (int i = 0; i < count; i++) {
+      if ((double) (float) weights[i] != weights[i] || (double) (float) means[i] != means[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static byte[] toVerboseBytes(double min, double max, double compression, double[] means, double[] weights,
+      int count) {
+    ByteBuffer normalized = ByteBuffer.allocate(VERBOSE_HEADER_SIZE + VERBOSE_CENTROID_SIZE * count);
+    normalized.putInt(VERBOSE_ENCODING);
+    normalized.putDouble(min);
+    normalized.putDouble(max);
+    normalized.putDouble(compression);
+    normalized.putInt(count);
+    for (int i = 0; i < count; i++) {
+      normalized.putDouble(weights[i]);
+      normalized.putDouble(means[i]);
+    }
+    return normalized.array();
+  }
+
+  private static double readWeight(ByteBuffer encoded, int offset, int centroidSize) {
+    return centroidSize == VERBOSE_CENTROID_SIZE ? encoded.getDouble(offset) : encoded.getFloat(offset);
+  }
+
+  private static void validateEncodedDigest(ByteBuffer input) {
+    int encoding = input.getInt();
+    if (encoding != VERBOSE_ENCODING && encoding != SMALL_ENCODING) {
+      throw new IllegalStateException("Invalid format for serialized histogram");
+    }
+    input.getDouble();
+    input.getDouble();
+    double compression;
+    int mainCapacity;
+    int centroidCount;
+    int centroidSize;
+    if (encoding == VERBOSE_ENCODING) {
+      compression = input.getDouble();
+      mainCapacity = getDefaultCentroidCapacity(compression);
+      centroidCount = input.getInt();
+      centroidSize = VERBOSE_CENTROID_SIZE;
+    } else {
+      compression = input.getFloat();
+      mainCapacity = input.getShort();
+      int bufferCapacity = input.getShort();
+      checkSmallArrayCapacity(mainCapacity);
+      checkSmallArrayCapacity(bufferCapacity);
+      if (mainCapacity == -1) {
+        mainCapacity = getDefaultCentroidCapacity(compression);
+      }
+      centroidCount = input.getShort();
+      centroidSize = SMALL_CENTROID_SIZE;
+    }
+    if (centroidCount < 0) {
+      throw new IllegalArgumentException("Invalid negative TDigest centroid count: " + centroidCount);
+    }
+    if (centroidCount > input.remaining() / centroidSize) {
+      throw new BufferUnderflowException();
+    }
+    int readableMainCapacity = mainCapacity;
+    if (encoding == VERBOSE_ENCODING && compression > 0.0 && Double.isFinite(compression)) {
+      readableMainCapacity = Math.max(mainCapacity, getLegacyDefaultCentroidCapacity(compression));
+    }
+    if (centroidCount > readableMainCapacity) {
+      throw new ArrayIndexOutOfBoundsException(
+          "Index " + readableMainCapacity + " out of bounds for length " + readableMainCapacity);
+    }
+  }
+
+  private static void checkSmallArrayCapacity(int capacity) {
+    if (capacity < -1) {
+      throw new NegativeArraySizeException(Integer.toString(capacity));
+    }
+  }
+
+  private static int normalizeBoundaries(double[] means, double[] weights, int count, double min, double max) {
+    if (count == 1) {
+      double weight = weights[0];
+      if (weight <= 1.0) {
+        return count;
+      }
+      double mean = means[0];
+      means[0] = min;
+      weights[0] = 1.0;
+      if (weight == 2.0) {
+        means[1] = max;
+        weights[1] = 1.0;
+        return 2;
+      }
+      means[1] = residualMean(mean, weight, min, max, weight - 2.0, min, max);
+      weights[1] = weight - 2.0;
+      means[2] = max;
+      weights[2] = 1.0;
+      return 3;
+    }
+
+    if (weights[0] > 1.0) {
+      System.arraycopy(means, 1, means, 2, count - 1);
+      System.arraycopy(weights, 1, weights, 2, count - 1);
+      double weight = weights[0];
+      double mean = means[0];
+      means[0] = min;
+      weights[0] = 1.0;
+      means[1] = residualMean(mean, weight, min, 0.0, weight - 1.0, min, means[2]);
+      weights[1] = weight - 1.0;
+      count++;
+    }
+    int lastIndex = count - 1;
+    if (weights[lastIndex] > 1.0) {
+      double weight = weights[lastIndex];
+      double mean = means[lastIndex];
+      means[lastIndex] = residualMean(mean, weight, max, 0.0, weight - 1.0, means[lastIndex - 1], max);
+      weights[lastIndex] = weight - 1.0;
+      means[count] = max;
+      weights[count] = 1.0;
+      count++;
+    }
+    return count;
+  }
+
+  private static double clamp(double value, double min, double max) {
+    return Math.max(min, Math.min(value, max));
+  }
+
+  private static double residualMean(double mean, double weight, double firstRemovedValue,
+      double secondRemovedValue, double residualWeight, double min, double max) {
+    if (!Double.isFinite(mean) || !Double.isFinite(firstRemovedValue)
+        || !Double.isFinite(secondRemovedValue)) {
+      return clamp(mean, min, max);
+    }
+    boolean removedTwoValues = weight - residualWeight == 2.0;
+    int scaleShift = removedTwoValues ? 2 : 1;
+    double scaledMean = Math.scalb(mean, -scaleShift);
+    double scaledCorrection = scaledMean - Math.scalb(firstRemovedValue, -scaleShift);
+    if (removedTwoValues) {
+      scaledCorrection += scaledMean - Math.scalb(secondRemovedValue, -scaleShift);
+    }
+    double correction = Math.scalb(scaledCorrection / residualWeight, scaleShift);
+    return clamp(mean + correction, min, max);
+  }
+
+  private static byte[] reduceVerboseCentroids(byte[] verboseBytes, int maxCentroids) {
+    ByteBuffer input = ByteBuffer.wrap(verboseBytes);
+    input.getInt();
+    double min = input.getDouble();
+    double max = input.getDouble();
+    double compression = input.getDouble();
+    int centroidCount = input.getInt();
+    double[] weights = new double[centroidCount];
+    double[] means = new double[centroidCount];
+    for (int i = 0; i < centroidCount; i++) {
+      weights[i] = input.getDouble();
+      means[i] = input.getDouble();
+    }
+
+    while (centroidCount > maxCentroids) {
+      int mergeIndex = findNearestInteriorCentroids(means, weights, centroidCount);
+      double combinedWeight = weights[mergeIndex] + weights[mergeIndex + 1];
+      means[mergeIndex] = weightedMean(means[mergeIndex], weights[mergeIndex], means[mergeIndex + 1],
+          weights[mergeIndex + 1], combinedWeight);
+      weights[mergeIndex] = combinedWeight;
+      int numMoved = centroidCount - mergeIndex - 2;
+      if (numMoved > 0) {
+        System.arraycopy(means, mergeIndex + 2, means, mergeIndex + 1, numMoved);
+        System.arraycopy(weights, mergeIndex + 2, weights, mergeIndex + 1, numMoved);
+      }
+      centroidCount--;
+    }
+
+    ByteBuffer reduced = ByteBuffer.allocate(VERBOSE_HEADER_SIZE + VERBOSE_CENTROID_SIZE * centroidCount);
+    reduced.putInt(VERBOSE_ENCODING);
+    reduced.putDouble(min);
+    reduced.putDouble(max);
+    reduced.putDouble(compression);
+    reduced.putInt(centroidCount);
+    for (int i = 0; i < centroidCount; i++) {
+      reduced.putDouble(weights[i]);
+      reduced.putDouble(means[i]);
+    }
+    return reduced.array();
+  }
+
+  private static int findNearestInteriorCentroids(double[] means, double[] weights, int centroidCount) {
+    int firstFiniteIndex = -1;
+    int lastFiniteIndex = -1;
+    for (int i = 0; i < centroidCount; i++) {
+      if (Double.isFinite(means[i])) {
+        if (firstFiniteIndex == -1) {
+          firstFiniteIndex = i;
+        }
+        lastFiniteIndex = i;
+      }
+    }
+
+    int nearestIndex = -1;
+    double nearestDistance = Double.POSITIVE_INFINITY;
+    double nearestWeight = Double.POSITIVE_INFINITY;
+    for (int i = 1; i < centroidCount - 2; i++) {
+      if (i == firstFiniteIndex || i + 1 == firstFiniteIndex
+          || i == lastFiniteIndex || i + 1 == lastFiniteIndex) {
+        continue;
+      }
+      double distance = centroidDistance(means[i], means[i + 1]);
+      double combinedWeight = weights[i] + weights[i + 1];
+      if (distance < nearestDistance || (distance == nearestDistance && combinedWeight < nearestWeight)) {
+        nearestIndex = i;
+        nearestDistance = distance;
+        nearestWeight = combinedWeight;
+      }
+    }
+    if (nearestIndex == -1) {
+      throw new IllegalStateException("Cannot reduce TDigest centroids without merging an endpoint");
+    }
+    return nearestIndex;
+  }
+
+  private static double centroidDistance(double first, double second) {
+    return first == second ? 0.0 : Math.abs(second - first);
+  }
+
+  private static double weightedMean(double firstMean, double firstWeight, double secondMean,
+      double secondWeight, double totalWeight) {
+    if (firstMean == secondMean) {
+      return firstMean;
+    }
+    if (!Double.isFinite(firstMean) || !Double.isFinite(secondMean)) {
+      if (firstMean == Double.NEGATIVE_INFINITY || secondMean == Double.NEGATIVE_INFINITY) {
+        return Double.NEGATIVE_INFINITY;
+      }
+      return Double.POSITIVE_INFINITY;
+    }
+    if (Math.copySign(1.0, firstMean) == Math.copySign(1.0, secondMean)) {
+      return firstMean + (secondMean - firstMean) * secondWeight / totalWeight;
+    }
+    return firstMean * (firstWeight / totalWeight) + secondMean * (secondWeight / totalWeight);
+  }
+
+  private static int getLegacyDefaultCentroidCapacity(double compression) {
+    return Math.addExact(Math.multiplyExact(2, (int) Math.ceil(compression)), LEGACY_CAPACITY_PADDING);
+  }
+
+  private static int getDefaultCentroidCapacity(double compression) {
+    double normalizedCompression = Math.max(compression, 10.0);
+    int padding = normalizedCompression < 30.0 ? 30 : 10;
+    return (int) Math.ceil(2.0 * normalizedCompression + padding);
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/PercentileTDigestValueAggregatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/PercentileTDigestValueAggregatorTest.java
@@ -18,23 +18,26 @@
  */
 package org.apache.pinot.segment.local.aggregator;
 
+import com.tdunning.math.stats.Centroid;
 import com.tdunning.math.stats.TDigest;
 import java.nio.ByteBuffer;
 import java.util.List;
 import org.apache.pinot.common.request.Literal;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.segment.local.utils.CustomSerDeUtils;
+import org.apache.pinot.segment.local.utils.TDigestUtils;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 /// Tests the serialization-size contract and deferred compression used by [PercentileTDigestValueAggregator].
 public class PercentileTDigestValueAggregatorTest {
 
   @Test(dataProvider = "compressionBounds")
-  public void testRawValuesTrackMaxVerboseSizeWithoutCompression(int compression, int numValues,
+  public void testRawValuesTrackMaxVerboseSize(int compression, int numValues,
       int expectedMaxByteSize) {
     PercentileTDigestValueAggregator aggregator = newAggregator(compression);
     assertEquals(aggregator.getMaxAggregatedValueByteSize(), 0);
@@ -43,7 +46,6 @@ public class PercentileTDigestValueAggregatorTest {
     for (int i = 1; i < numValues; i++) {
       aggregator.applyRawValue(digest, i);
     }
-    assertEquals(digest.centroidCount(), 0);
     assertEquals(aggregator.getMaxAggregatedValueByteSize(), expectedMaxByteSize);
     byte[] serialized = aggregator.serializeAggregatedValue(digest);
     assertTrue(serialized.length <= expectedMaxByteSize);
@@ -67,7 +69,6 @@ public class PercentileTDigestValueAggregatorTest {
     }
 
     assertEquals(digest.size(), 256L);
-    assertEquals(digest.centroidCount(), 0);
     int maxByteSize = aggregator.getMaxAggregatedValueByteSize();
     byte[] serialized = aggregator.serializeAggregatedValue(digest);
     assertTrue(digest.centroidCount() > 0);
@@ -93,6 +94,25 @@ public class PercentileTDigestValueAggregatorTest {
   }
 
   @Test
+  public void testFractionalPreAggregatedCompressionUsesLegacyCompatibleBound() {
+    int centroidCount = 96;
+    double[] means = new double[centroidCount];
+    double[] weights = new double[centroidCount];
+    for (int i = 0; i < centroidCount; i++) {
+      means[i] = i;
+      weights[i] = 1.0;
+    }
+
+    PercentileTDigestValueAggregator aggregator = newAggregator(10);
+    TDigest result = aggregator.getInitialAggregatedValue(createVerboseEncoding(means, weights, 42.125));
+
+    assertEquals(result.size(), centroidCount);
+    assertEquals(result.compression(), 42.125);
+    assertEquals(aggregator.getMaxAggregatedValueByteSize(), 32 + 16 * centroidCount);
+    assertTrue(aggregator.serializeAggregatedValue(result).length <= aggregator.getMaxAggregatedValueByteSize());
+  }
+
+  @Test
   public void testOversizedSmallEncodedDigestRemainsReadable() {
     int centroidCount = 300;
     byte[] smallEncoding = createSmallEncoding(10, 400, 500, centroidCount);
@@ -103,14 +123,13 @@ public class PercentileTDigestValueAggregatorTest {
     byte[] serialized = aggregator.serializeAggregatedValue(result);
     TDigest clone = aggregator.cloneAggregatedValue(result);
 
-    assertEquals(result.centroidCount(), centroidCount);
-    assertEquals(maxByteSize, 4_832);
-    assertEquals(ByteBuffer.wrap(serialized).getInt(), 2);
-    assertEquals(serialized.length, smallEncoding.length);
+    assertEquals(maxByteSize, 832);
+    assertEquals(ByteBuffer.wrap(serialized).getInt(), 1);
     assertTrue(serialized.length <= maxByteSize);
     assertEquals(clone.size(), result.size());
-    assertEquals(clone.centroidCount(), result.centroidCount());
-    assertEquals(clone.quantile(0.75), result.quantile(0.75));
+    assertEquals(clone.getMin(), result.getMin());
+    assertEquals(clone.getMax(), result.getMax());
+    assertTrue(Double.isFinite(clone.quantile(0.75)));
   }
 
   @Test
@@ -124,10 +143,155 @@ public class PercentileTDigestValueAggregatorTest {
     aggregator.applyAggregatedValue(destination, source);
 
     assertEquals(destination.size(), 3L);
-    assertEquals(destination.centroidCount(), 0);
     int maxByteSize = aggregator.getMaxAggregatedValueByteSize();
     byte[] serialized = aggregator.serializeAggregatedValue(destination);
     assertTrue(serialized.length <= maxByteSize);
+  }
+
+  @Test
+  public void testRepeatedInfinitiesAcrossRawAggregationAndSerialization() {
+    int repetitions = 1_000;
+    Object[] values = new Object[3 * repetitions];
+    for (int i = 0; i < repetitions; i++) {
+      values[3 * i] = Double.NEGATIVE_INFINITY;
+      values[3 * i + 1] = 0.0;
+      values[3 * i + 2] = Double.POSITIVE_INFINITY;
+    }
+
+    PercentileTDigestValueAggregator aggregator = newAggregator(20);
+    TDigest digest = aggregator.getInitialAggregatedValue(values);
+    TDigest aggregatedValue = aggregator.cloneAggregatedValue(digest);
+    digest = aggregator.applyAggregatedValue(digest, aggregatedValue);
+
+    long expectedSize = 2L * values.length;
+    assertInfinityDistribution(digest, expectedSize);
+    byte[] serialized = aggregator.serializeAggregatedValue(digest);
+    TDigest standardDigest = CustomSerDeUtils.TDIGEST_SER_DE.deserialize(serialized);
+    assertEquals(standardDigest.size(), expectedSize);
+    assertEquals(standardDigest.getMin(), Double.NEGATIVE_INFINITY);
+    assertEquals(standardDigest.getMax(), Double.POSITIVE_INFINITY);
+    TDigest roundTripped = aggregator.deserializeAggregatedValue(serialized);
+    assertInfinityDistribution(roundTripped, expectedSize);
+  }
+
+  @Test
+  public void testNonFiniteQuantileRejectsNaN() {
+    PercentileTDigestValueAggregator aggregator = newAggregator(20);
+    TDigest digest = aggregator.getInitialAggregatedValue(
+        new Object[]{Double.NEGATIVE_INFINITY, 0.0, Double.POSITIVE_INFINITY});
+
+    assertThrows(IllegalArgumentException.class, () -> digest.quantile(Double.NaN));
+  }
+
+  @Test
+  public void testCompatibilityReductionPreservesFiniteExtremaBetweenInfiniteTails() {
+    int finiteCount = 50;
+    double finiteMin = 0.123456789;
+    double finiteMax = finiteMin + finiteCount - 1.0;
+    double[] means = new double[finiteCount + 2];
+    double[] weights = new double[means.length];
+    means[0] = Double.NEGATIVE_INFINITY;
+    weights[0] = 1.0;
+    for (int i = 0; i < finiteCount; i++) {
+      means[i + 1] = finiteMin + i;
+      weights[i + 1] = 1.0;
+    }
+    means[means.length - 1] = Double.POSITIVE_INFINITY;
+    weights[weights.length - 1] = 1.0;
+
+    byte[] compatible = TDigestUtils.makeLegacyCompatible(createVerboseEncoding(means, weights, 20.0));
+    assertEquals(ByteBuffer.wrap(compatible).getInt(), 1);
+    PercentileTDigestValueAggregator aggregator = newAggregator(20);
+    TDigest digest = aggregator.deserializeAggregatedValue(compatible);
+    double firstFiniteQuantile = 1.0 / means.length;
+    double lastFiniteQuantile = Math.nextDown((means.length - 1.0) / means.length);
+    assertEquals(digest.quantile(firstFiniteQuantile), finiteMin);
+    assertEquals(digest.quantile(lastFiniteQuantile), finiteMax);
+
+    TDigest roundTripped = aggregator.deserializeAggregatedValue(aggregator.serializeAggregatedValue(digest));
+    assertEquals(roundTripped.quantile(firstFiniteQuantile), finiteMin);
+    assertEquals(roundTripped.quantile(lastFiniteQuantile), finiteMax);
+  }
+
+  @Test
+  public void testLargeFiniteCentroidWeightWithInfinitiesIsNotNarrowed() {
+    long finiteWeight = 3_000_000_000L;
+    byte[] input = createVerboseEncoding(
+        new double[]{Double.NEGATIVE_INFINITY, 1.0e308, Double.POSITIVE_INFINITY},
+        new double[]{1.0, finiteWeight, 1.0});
+
+    PercentileTDigestValueAggregator aggregator = newAggregator(100);
+    TDigest digest = aggregator.deserializeAggregatedValue(input);
+    assertEquals(digest.size(), finiteWeight + 2L);
+    assertCentroidWeight(digest, finiteWeight + 2L);
+    assertHasFiniteCentroid(digest, 1.0e308);
+
+    TDigest clone = aggregator.cloneAggregatedValue(digest);
+    assertEquals(clone.size(), finiteWeight + 2L);
+    digest = aggregator.applyAggregatedValue(digest, clone);
+    assertEquals(digest.size(), 2L * finiteWeight + 4L);
+    assertCentroidWeight(digest, 2L * finiteWeight + 4L);
+    assertHasFiniteCentroid(digest, 1.0e308);
+
+    byte[] serialized = aggregator.serializeAggregatedValue(digest);
+    assertEquals(CustomSerDeUtils.TDIGEST_SER_DE.deserialize(serialized).size(), 2L * finiteWeight + 4L);
+    assertEquals(aggregator.deserializeAggregatedValue(serialized).size(), 2L * finiteWeight + 4L);
+  }
+
+  @Test
+  public void testCentroidInspectionDoesNotInvalidateCachedSerialization() {
+    PercentileTDigestValueAggregator aggregator = newAggregator(20);
+    TDigest digest = aggregator.getInitialAggregatedValue(
+        new Object[]{Double.NEGATIVE_INFINITY, 0.0, 1.0, 2.0, Double.POSITIVE_INFINITY});
+    byte[] beforeInspection = aggregator.serializeAggregatedValue(digest);
+
+    digest.compress();
+    assertTrue(digest.centroidCount() > 0);
+    assertCentroidWeight(digest, digest.size());
+
+    assertEquals(aggregator.serializeAggregatedValue(digest), beforeInspection);
+  }
+
+  private static void assertInfinityDistribution(TDigest digest, long expectedSize) {
+    assertEquals(digest.size(), expectedSize);
+    assertEquals(digest.getMin(), Double.NEGATIVE_INFINITY);
+    assertEquals(digest.getMax(), Double.POSITIVE_INFINITY);
+    assertEquals(digest.quantile(0.0), Double.NEGATIVE_INFINITY);
+    assertEquals(digest.quantile(0.5), 0.0);
+    assertEquals(digest.quantile(1.0), Double.POSITIVE_INFINITY);
+    assertEquals(digest.cdf(-1.0), 1.0 / 3.0, 1.0e-12);
+    assertEquals(digest.cdf(0.0), 0.5, 1.0e-12);
+    assertEquals(digest.cdf(1.0), 2.0 / 3.0, 1.0e-12);
+
+    long centroidWeight = 0L;
+    double previousMean = Double.NEGATIVE_INFINITY;
+    for (Centroid centroid : digest.centroids()) {
+      assertTrue(!Double.isNaN(centroid.mean()));
+      assertTrue(centroid.mean() >= previousMean);
+      assertTrue(centroid.count() > 0);
+      centroidWeight += centroid.count();
+      previousMean = centroid.mean();
+    }
+    assertEquals(centroidWeight, expectedSize);
+  }
+
+  private static void assertCentroidWeight(TDigest digest, long expectedWeight) {
+    long centroidWeight = 0L;
+    for (Centroid centroid : digest.centroids()) {
+      centroidWeight += centroid.count();
+    }
+    assertEquals(centroidWeight, expectedWeight);
+  }
+
+  private static void assertHasFiniteCentroid(TDigest digest, double expectedMean) {
+    boolean found = false;
+    for (Centroid centroid : digest.centroids()) {
+      if (Double.isFinite(centroid.mean())) {
+        assertEquals(centroid.mean(), expectedMean);
+        found = true;
+      }
+    }
+    assertTrue(found);
   }
 
   private static PercentileTDigestValueAggregator newAggregator(int compression) {
@@ -148,6 +312,24 @@ public class PercentileTDigestValueAggregatorTest {
     for (int i = 0; i < centroidCount; i++) {
       buffer.putFloat(1.0F);
       buffer.putFloat(i);
+    }
+    return buffer.array();
+  }
+
+  private static byte[] createVerboseEncoding(double[] means, double[] weights) {
+    return createVerboseEncoding(means, weights, 100.0);
+  }
+
+  private static byte[] createVerboseEncoding(double[] means, double[] weights, double compression) {
+    ByteBuffer buffer = ByteBuffer.allocate(32 + means.length * 2 * Double.BYTES);
+    buffer.putInt(1);
+    buffer.putDouble(means[0]);
+    buffer.putDouble(means[means.length - 1]);
+    buffer.putDouble(compression);
+    buffer.putInt(means.length);
+    for (int i = 0; i < means.length; i++) {
+      buffer.putDouble(weights[i]);
+      buffer.putDouble(means[i]);
     }
     return buffer.array();
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TDigestUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TDigestUtilsTest.java
@@ -1,0 +1,423 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.utils;
+
+import com.tdunning.math.stats.Centroid;
+import com.tdunning.math.stats.MergingDigest;
+import com.tdunning.math.stats.ScaleFunction;
+import com.tdunning.math.stats.TDigest;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TDigestUtilsTest {
+  private static final int VERBOSE_ENCODING = 1;
+  private static final int SMALL_ENCODING = 2;
+  private static final int VERBOSE_HEADER_SIZE = 32;
+
+  @Test
+  public void testPinotMergingDigestUsesAccuracyPreservingScaleFunction() {
+    MergingDigest digest = (MergingDigest) TDigestUtils.createMergingDigest(100.0);
+    assertEquals(digest.getScaleFunction(), ScaleFunction.K_1);
+    for (int i = 0; i < 1_000; i++) {
+      digest.add(i);
+    }
+
+    MergingDigest roundTripped = (MergingDigest) TDigestUtils.deserialize(TDigestUtils.serialize(digest));
+    assertEquals(roundTripped.getScaleFunction(), ScaleFunction.K_1);
+    assertEquals(roundTripped.size(), digest.size());
+  }
+
+  @Test
+  public void testLegacyBufferFactoryLimitsHighCardinalityState() {
+    MergingDigest digest = (MergingDigest) TDigestUtils.createMergingDigestWithLegacyBuffer(100.0);
+    assertEquals(digest.getScaleFunction(), ScaleFunction.K_1);
+    for (int i = 0; i < 1_000; i++) {
+      digest.add(i);
+    }
+
+    ByteBuffer small = ByteBuffer.allocate(4_096);
+    digest.asSmallBytes(small);
+    small.flip();
+    assertEquals(small.getInt(), SMALL_ENCODING);
+    small.position(Integer.BYTES + 2 * Double.BYTES + Float.BYTES);
+    assertEquals(small.getShort(), 210, "The main buffer must retain the t-digest 3.3 capacity");
+    assertEquals(small.getShort(), 500, "The temporary buffer must retain the t-digest 3.2 footprint");
+  }
+
+  @Test
+  public void testFiniteDeserializationRetainsLegacyBufferFootprint() {
+    TDigest source = TDigestUtils.createMergingDigest(100.0);
+    for (int i = 0; i < 1_000; i++) {
+      source.add(i);
+    }
+
+    MergingDigest digest = (MergingDigest) TDigestUtils.deserializeFiniteWithLegacyBuffer(
+        TDigestUtils.serialize(source));
+    ByteBuffer small = ByteBuffer.allocate(4_096);
+    digest.asSmallBytes(small);
+    small.flip();
+    assertEquals(small.getInt(), SMALL_ENCODING);
+    small.position(Integer.BYTES + 2 * Double.BYTES + Float.BYTES);
+    assertEquals(small.getShort(), 210);
+    assertEquals(small.getShort(), 500);
+    assertEquals(digest.size(), source.size());
+  }
+
+  @Test
+  public void testSerializeReusesCallerScratchWithoutSharingOutput() {
+    TDigest digest = TDigestUtils.createMergingDigestWithLegacyBuffer(100.0);
+    for (int i = 0; i < 1_000; i++) {
+      digest.add(i);
+    }
+    ByteBuffer scratch = ByteBuffer.allocate(4_096);
+
+    byte[] bytes = TDigestUtils.serialize(digest, scratch);
+    assertTrue(scratch.position() >= bytes.length);
+    scratch.put(0, (byte) 0);
+    assertEquals(ByteBuffer.wrap(bytes).getInt(), VERBOSE_ENCODING);
+    assertEquals(TDigestUtils.deserialize(bytes).size(), digest.size());
+  }
+
+  @Test
+  public void testSerializeUsesNetworkOrderWithoutChangingScratchOrder() {
+    TDigest digest = TDigestUtils.createMergingDigestWithLegacyBuffer(100.0);
+    digest.add(42.0);
+    ByteBuffer scratch = ByteBuffer.allocate(4_096).order(ByteOrder.LITTLE_ENDIAN);
+
+    byte[] bytes = TDigestUtils.serialize(digest, scratch);
+
+    assertEquals(scratch.order(), ByteOrder.LITTLE_ENDIAN);
+    assertEquals(ByteBuffer.wrap(bytes).getInt(), VERBOSE_ENCODING);
+    assertEquals(TDigestUtils.deserialize(bytes).quantile(0.5), 42.0);
+  }
+
+  @Test
+  public void testLowCompressionLargeMeansRemainDoublePrecision() {
+    int centroidCount = 51;
+    double firstValue = 1.0e18;
+    double[] means = new double[centroidCount];
+    double[] weights = new double[centroidCount];
+    for (int i = 0; i < centroidCount; i++) {
+      means[i] = firstValue + 256.0 * i;
+      weights[i] = 1.0;
+    }
+
+    byte[] bytes = TDigestUtils.serialize(craftedVerboseDigest(20.0, means, weights));
+    ByteBuffer serialized = ByteBuffer.wrap(bytes);
+    assertEquals(serialized.getInt(), VERBOSE_ENCODING);
+    assertEquals(serialized.getDouble(), means[0]);
+    assertEquals(serialized.getDouble(), means[centroidCount - 1]);
+    assertEquals(serialized.getDouble(), 20.0);
+    assertEquals(serialized.getInt(), 50, "Verbose output must fit the t-digest 3.2 centroid capacity");
+
+    TDigest roundTripped = TDigestUtils.deserialize(bytes);
+    assertEquals(roundTripped.size(), centroidCount);
+    assertEquals(roundTripped.getMin(), means[0]);
+    assertEquals(roundTripped.getMax(), means[centroidCount - 1]);
+    assertTrue(roundTripped.quantile(0.5) >= means[0]);
+    assertTrue(roundTripped.quantile(0.5) <= means[centroidCount - 1]);
+  }
+
+  @Test
+  public void testLowCompressionFloatExactMeansUseCapacityPreservingEncoding() {
+    int centroidCount = 51;
+    double[] means = new double[centroidCount];
+    double[] weights = new double[centroidCount];
+    for (int i = 0; i < centroidCount; i++) {
+      means[i] = i;
+      weights[i] = 1.0;
+    }
+
+    byte[] bytes = TDigestUtils.serialize(craftedVerboseDigest(20.0, means, weights));
+    ByteBuffer serialized = ByteBuffer.wrap(bytes);
+    assertEquals(serialized.getInt(), SMALL_ENCODING);
+    serialized.position(28);
+    assertEquals(serialized.getShort(), centroidCount);
+
+    TDigest roundTripped = TDigestUtils.deserialize(bytes);
+    assertEquals(roundTripped.size(), centroidCount);
+    assertEquals(roundTripped.getMin(), 0.0);
+    assertEquals(roundTripped.getMax(), centroidCount - 1.0);
+  }
+
+  @Test
+  public void testNonFloatCompressionUsesLegacyVerboseCapacity() {
+    double compression = 20.0000001;
+    int centroidCount = 53;
+    double[] means = new double[centroidCount];
+    double[] weights = new double[centroidCount];
+    for (int i = 0; i < centroidCount; i++) {
+      means[i] = i;
+      weights[i] = 1.0;
+    }
+
+    ByteBuffer serialized = ByteBuffer.wrap(TDigestUtils.serialize(craftedVerboseDigest(compression, means, weights)));
+    assertEquals(serialized.getInt(), VERBOSE_ENCODING);
+    serialized.position(Integer.BYTES + 2 * Double.BYTES);
+    assertEquals(serialized.getDouble(), compression);
+    assertEquals(serialized.getInt(), 52, "Verbose output must fit the t-digest 3.2 centroid capacity");
+  }
+
+  @Test
+  public void testSerializeUsesActualCentroidCountForFractionalCompression() {
+    double compression = 100.1;
+    int centroidCount = 212;
+    double[] means = new double[centroidCount];
+    double[] weights = new double[centroidCount];
+    for (int i = 0; i < centroidCount; i++) {
+      means[i] = i;
+      weights[i] = 1.0;
+    }
+
+    ByteBuffer serialized = ByteBuffer.wrap(TDigestUtils.serialize(craftedVerboseDigest(compression, means, weights)));
+    assertEquals(serialized.getInt(), VERBOSE_ENCODING);
+    serialized.position(Integer.BYTES + 2 * Double.BYTES);
+    assertEquals(serialized.getDouble(), compression);
+    assertEquals(serialized.getInt(), centroidCount,
+        "Serialization buffer must accommodate the t-digest 3.2 fractional-compression capacity");
+  }
+
+  @Test
+  public void testSerializeForceCompressesOnce() {
+    AtomicInteger compressionCount = new AtomicInteger();
+    MergingDigest digest = new MergingDigest(100.0) {
+      @Override
+      public void compress() {
+        compressionCount.incrementAndGet();
+        super.compress();
+      }
+    };
+    for (int i = 0; i < 1_000; i++) {
+      digest.add(i);
+    }
+
+    TDigestUtils.serialize(digest);
+    assertEquals(compressionCount.get(), 1,
+        "Sizing the output must not invoke the final destructive compression pass");
+  }
+
+  @Test
+  public void testFractionalCompressionLegacyCapacityIsRepairedBeforeDecode() {
+    double compression = 100.1;
+    int centroidCount = 212;
+    double firstValue = 1.0e18;
+    double[] means = new double[centroidCount];
+    double[] weights = new double[centroidCount];
+    double expectedWeight = 0.0;
+    double expectedFirstMoment = 0.0;
+    for (int i = 0; i < centroidCount; i++) {
+      means[i] = firstValue + 256.0 * i;
+      weights[i] = i == 0 || i == centroidCount - 1 ? 2.0 : 1.0;
+      expectedWeight += weights[i];
+      expectedFirstMoment += means[i] * weights[i];
+    }
+
+    byte[] bytes = verboseBytes(compression, means, weights);
+    int prefixSize = 3;
+    int trailingValue = 0x12345678;
+    ByteBuffer input = ByteBuffer.allocate(prefixSize + bytes.length + Integer.BYTES);
+    input.put(new byte[prefixSize]);
+    input.put(bytes);
+    input.putInt(trailingValue);
+    input.flip();
+    input.position(prefixSize);
+
+    TDigest digest = TDigestUtils.deserialize(input);
+    assertEquals(input.position(), prefixSize + bytes.length);
+    assertEquals(input.getInt(), trailingValue);
+    assertEquals(digest.getMin(), means[0]);
+    assertEquals(digest.getMax(), means[centroidCount - 1]);
+
+    assertEquals(digest.centroidCount(), 211, "The payload must fit the t-digest 3.3 default main array");
+    List<Centroid> centroids = List.copyOf(digest.centroids());
+    assertTrue(centroids.size() <= 211);
+    assertEquals(centroids.get(0).mean(), means[0]);
+    assertEquals(centroids.get(0).count(), 1L);
+    assertEquals(centroids.get(centroids.size() - 1).mean(), means[centroidCount - 1]);
+    assertEquals(centroids.get(centroids.size() - 1).count(), 1L);
+    double actualWeight = 0.0;
+    double actualFirstMoment = 0.0;
+    for (Centroid centroid : centroids) {
+      actualWeight += centroid.count();
+      actualFirstMoment += centroid.mean() * centroid.count();
+    }
+    assertEquals(actualWeight, expectedWeight);
+    assertEquals(actualFirstMoment, expectedFirstMoment, Math.ulp(expectedFirstMoment) * 16.0);
+
+    ByteBuffer roundTripped = ByteBuffer.wrap(TDigestUtils.serialize(digest));
+    assertEquals(roundTripped.getInt(), VERBOSE_ENCODING,
+        "Non-float-exact compression must remain in the double-precision wire format");
+    roundTripped.position(Integer.BYTES + 2 * Double.BYTES);
+    assertEquals(roundTripped.getDouble(), compression);
+    assertTrue(roundTripped.getInt() <= centroidCount,
+        "The result must remain within the t-digest 3.2 verbose capacity");
+  }
+
+  @Test
+  public void testSmallBoundaryRepairDoesNotNarrowExtrema() {
+    double min = 0.1;
+    double max = 0.9;
+    ByteBuffer small = ByteBuffer.allocate(30 + 2 * Float.BYTES);
+    small.putInt(SMALL_ENCODING);
+    small.putDouble(min);
+    small.putDouble(max);
+    small.putFloat(20.0F);
+    small.putShort((short) 50);
+    small.putShort((short) 250);
+    small.putShort((short) 1);
+    small.putFloat(2.0F);
+    small.putFloat(0.5F);
+
+    TDigest digest = TDigestUtils.deserialize(small.array());
+    assertEquals(digest.getMin(), min);
+    assertEquals(digest.getMax(), max);
+    List<Centroid> centroids = List.copyOf(digest.centroids());
+    assertEquals(centroids.get(0).mean(), min);
+    assertEquals(centroids.get(centroids.size() - 1).mean(), max);
+  }
+
+  @Test
+  public void testFullVerboseCapacityBoundaryRepairPreservesFirstMoment() {
+    int centroidCount = 70;
+    double min = 1.0e18;
+    double[] means = new double[centroidCount];
+    double[] weights = new double[centroidCount];
+    double expectedWeight = 0.0;
+    double expectedFirstMoment = 0.0;
+    for (int i = 0; i < centroidCount; i++) {
+      means[i] = min + 256.0 * i;
+      weights[i] = i == 0 || i == centroidCount - 1 ? 2.0 : 1.0;
+      expectedWeight += weights[i];
+      expectedFirstMoment += means[i] * weights[i];
+    }
+
+    TDigest digest = TDigestUtils.deserialize(verboseBytes(20.0, means, weights));
+    double actualWeight = 0.0;
+    double actualFirstMoment = 0.0;
+    for (Centroid centroid : digest.centroids()) {
+      assertTrue(Double.isFinite(centroid.mean()));
+      actualWeight += centroid.count();
+      actualFirstMoment += centroid.mean() * centroid.count();
+    }
+    assertEquals(actualWeight, expectedWeight);
+    assertEquals(actualFirstMoment, expectedFirstMoment, Math.ulp(expectedFirstMoment) * 4.0);
+    assertEquals(digest.getMin(), means[0]);
+    assertEquals(digest.getMax(), means[centroidCount - 1]);
+  }
+
+  @Test
+  public void testLegacyWeightedInfiniteBoundariesDoNotCreateNaN() {
+    ByteBuffer verbose = ByteBuffer.allocate(64);
+    verbose.putInt(VERBOSE_ENCODING);
+    verbose.putDouble(Double.NEGATIVE_INFINITY);
+    verbose.putDouble(Double.POSITIVE_INFINITY);
+    verbose.putDouble(20.0);
+    verbose.putInt(2);
+    verbose.putDouble(2.0);
+    verbose.putDouble(Double.NEGATIVE_INFINITY);
+    verbose.putDouble(2.0);
+    verbose.putDouble(Double.POSITIVE_INFINITY);
+
+    TDigest digest = TDigestUtils.deserialize(verbose.array());
+    assertEquals(digest.size(), 4L);
+    assertEquals(digest.getMin(), Double.NEGATIVE_INFINITY);
+    assertEquals(digest.getMax(), Double.POSITIVE_INFINITY);
+    for (Centroid centroid : digest.centroids()) {
+      assertFalse(Double.isNaN(centroid.mean()));
+      assertTrue(centroid.count() > 0);
+    }
+    assertEquals(digest.quantile(0.0), Double.NEGATIVE_INFINITY);
+    assertEquals(digest.quantile(1.0), Double.POSITIVE_INFINITY);
+  }
+
+  @Test
+  public void testBoundaryRepairDoesNotOverflowFirstMoment() {
+    double min = 8.0e307;
+    double mean = 1.0e308;
+    double max = 1.2e308;
+    ByteBuffer verbose = ByteBuffer.allocate(VERBOSE_HEADER_SIZE + 2 * Double.BYTES);
+    verbose.putInt(VERBOSE_ENCODING);
+    verbose.putDouble(min);
+    verbose.putDouble(max);
+    verbose.putDouble(100.0);
+    verbose.putInt(1);
+    verbose.putDouble(3.0);
+    verbose.putDouble(mean);
+
+    List<Centroid> centroids = List.copyOf(TDigestUtils.deserialize(verbose.array()).centroids());
+    assertEquals(centroids.size(), 3);
+    assertEquals(centroids.get(0).mean(), min);
+    assertEquals(centroids.get(1).mean(), mean, 4.0 * Math.ulp(mean));
+    assertEquals(centroids.get(2).mean(), max);
+  }
+
+  private static MergingDigest craftedVerboseDigest(double compression, double[] means, double[] weights) {
+    return new MergingDigest(compression) {
+      @Override
+      public long size() {
+        return means.length;
+      }
+
+      @Override
+      public double compression() {
+        return compression;
+      }
+
+      @Override
+      public int centroidCount() {
+        return means.length;
+      }
+
+      @Override
+      public void asBytes(ByteBuffer buffer) {
+        buffer.putInt(VERBOSE_ENCODING);
+        buffer.putDouble(means[0]);
+        buffer.putDouble(means[means.length - 1]);
+        buffer.putDouble(compression);
+        buffer.putInt(means.length);
+        for (int i = 0; i < means.length; i++) {
+          buffer.putDouble(weights[i]);
+          buffer.putDouble(means[i]);
+        }
+      }
+    };
+  }
+
+  private static byte[] verboseBytes(double compression, double[] means, double[] weights) {
+    ByteBuffer buffer = ByteBuffer.allocate(4 * Integer.BYTES + 2 * Double.BYTES
+        + 2 * Double.BYTES * means.length);
+    buffer.putInt(VERBOSE_ENCODING);
+    buffer.putDouble(means[0]);
+    buffer.putDouble(means[means.length - 1]);
+    buffer.putDouble(compression);
+    buffer.putInt(means.length);
+    for (int i = 0; i < means.length; i++) {
+      buffer.putDouble(weights[i]);
+      buffer.putDouble(means[i]);
+    }
+    return buffer.array();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
     <hadoop-shaded-protobuf_3_25.version>1.5.0</hadoop-shaded-protobuf_3_25.version>
     <clearspring-stream-lib.version>2.9.8</clearspring-stream-lib.version>
     <datasketches-java.version>9.0.0</datasketches-java.version>
-    <t-digest.version>3.2</t-digest.version>
+    <t-digest.version>3.3</t-digest.version>
     <picocli.version>4.7.7</picocli.version>
     <tyrus-standalone-client.version>2.2.2</tyrus-standalone-client.version>
     <jopt-simple.version>5.0.4</jopt-simple.version>


### PR DESCRIPTION
> **Update:** #19017 has merged, and this branch is rebased onto current `master`. This PR now contains the t-digest 3.3 upgrade plus its compatibility, accumulator, benchmark, and query-path performance work. The capacity-preserving generic-serde fix and `percentileSmartTDigest` routing remain sourced from #19017.

## Summary

- upgrade `com.tdunning:t-digest` from 3.2 to 3.3 while retaining Pinot's K1 scale function
- preserve mixed-version serialization and deserialization, including legacy buffer limits, boundary repair, low and fractional compression, double-precision weights, and non-finite values
- route raw, Smart, standard, StarTree, and merge-and-rollup paths through a primitive accumulator that avoids repeated digest materialization and sorting
- optimize raw and direct serialized query aggregation so the measured production-shaped 3.3 paths are faster than 3.2
- add matched 3.2/3.3 JMH controls, accuracy sweeps, rollout guidance, sample SQL, and a sample StarTree configuration

## Query-path regression and fix

The original 3.3 benchmark retained twice the configured compression during every merge and then recompressed for the public result. That two-level strategy helps buffered reducer accuracy, but raw aggregation and direct serialized StarTree aggregation already merge incrementally, so keeping the extra centroids added redundant work.

The follow-up:

- merges raw and direct serialized inputs at the configured public compression when compression is at least 50
- retains two-level working compression for buffered reducer inputs and compression below 50
- marks public-compression merges complete so final extraction does not recompress them again
- hoists finite-value and same-sign checks out of the inner centroid-merge loop when sorted endpoints prove that is safe
- preserves the signed-zero, mixed-sign, infinity, and low-compression fallbacks

## Why upgrade instead of switching to DataSketches

This keeps Pinot's existing t-digest SQL behavior and serialized intermediate-state format. Replacing it with DataSketches would require a separate wire format, API, migration, and mixed-version design rather than being a dependency upgrade.

## Compatibility and rollout

- finite t-digest state is readable in both directions between 3.2 and 3.3; no SQL, schema, table-config, or segment rebuild change is required
- exact serialized bytes, centroid counts, and approximate percentile answers can differ across versions
- compression values below 10 have an effective compression of 10 in t-digest 3.3
- non-finite centroids remain structurally readable by 3.2, but generic 3.2 readers can produce incorrect quantiles for them; filter or sanitize non-finite inputs until all readers are upgraded

The detailed operator guide is in [`percentile-tdigest-aggregation-100m-results.md`](pinot-perf/benchmark-results/percentile-tdigest-aggregation-100m-results.md).

## Usage

Existing queries continue to work unchanged:

```sql
-- Default compression of 100.
SELECT PERCENTILETDIGEST(latencyMs, 75) AS p75Approx
FROM myTable;

-- Explicit compression.
SELECT region, PERCENTILETDIGEST(latencyMs, 75, 200) AS p75Approx
FROM myTable
GROUP BY region;
```

For StarTree queries, the query compression must match the compression used by the StarTree function-column pair. The report linked above includes a complete sample StarTree configuration.

## Performance

The affected query paths were measured in `3.2, 3.3, 3.3, 3.2` order to reduce machine-drift bias. Each run used JDK 25, JMH 1.37, one fork, two 1-second warmups, five 1-second measurements, one thread, an 8 GiB maximum heap, and the GC profiler. Each displayed score is the mean of two runs and ten measured iterations. Each independently built runtime package contained exactly one intended t-digest JAR.

Negative deltas are improvements.

| Path | Source layout | 3.3 latency vs 3.2 | 3.3 allocation vs 3.2 |
|---|---|---:|---:|
| Raw P75 query, 100M rows | N/A | -1.3% | +0.4% |
| StarTree query, no groups | Native | -35.5% | +10.0% |
| StarTree query, 1,000 groups | Native | -43.4% | -34.8% |
| StarTree query, no groups | Fixed verbose | -6.4% | +9.1% |
| StarTree query, 1,000 groups | Fixed verbose | +1.3% | -8.6% |

`NATIVE` is the end-to-end production layout and includes each dependency version's source compression. `FIXED_VERBOSE` feeds byte-for-byte identical serialized inputs to both versions as an attribution control. Every measured production-shaped native path is faster. The fixed-input 1,000-group control remains near parity at +1.3% latency while allocating 8.6% less; this PR does not claim that every synthetic operation is universally faster.

The earlier construction and reducer characterization remains in the report: raw construction was 7.9% faster, serialized leaf-to-parent construction 62.8% faster, and the production-shaped reducer paths 83.9-84.3% faster while allocating about half as much.

## Accuracy

The randomized accuracy sweep now uses 32 independent deterministic source orders instead of repeating one order. JMH event counters are normalized over measurement iterations and forks; a harness check confirmed identical centroid and P99 values with one versus two measurement iterations.

Across the 32 orders, the largest candidate P99 error was `0.001870494` for values in `[0, 1]`. Every result retained exact total weight, positive centroid weights, sorted finite centroid means, and monotonic P0/P50/P75/P95/P99/P100. Duplicate-heavy input remained exact or within floating-point noise.

## Reproduce

Build a clean benchmark package:

```bash
./mvnw -pl pinot-perf -am clean package -DskipTests
```

Run the affected query benchmarks:

```bash
java -cp 'pinot-perf/target/pinot-perf-pkg/lib/*' \
  org.openjdk.jmh.Main \
  'org.apache.pinot.perf.aggregation.BenchmarkPercentileTDigestAggregation.aggregatePercentileTDigest75|org.apache.pinot.perf.aggregation.BenchmarkPercentileTDigestStarTreeAggregation.*' \
  -p _numGroups=1000 -p _sourceLayout=NATIVE,FIXED_VERBOSE \
  -wi 2 -i 5 -f 2 -w 1s -r 1s -t 1 -to 30m -gc true -foe true -prof gc
```

For a strict dependency comparison, build 3.2 and 3.3 into separate package directories and verify that each `lib` directory contains only its intended `t-digest-3.2.jar` or `t-digest-3.3.jar`. The report contains the complete reducer, construction, and accuracy commands.

## Validation

- 469 focused t-digest tests under JDK 25, including all 327 `PercentileTDigestAggregationFunctionTest` cases
- signed-zero, redundant-recompression, and low-compression heavy-tail regressions
- clean `pinot-perf` package build with exactly one `t-digest-3.3.jar`
- JMH counter stability check across different measurement-iteration counts
- `spotless:apply`, `checkstyle:check`, `license:format`, and `license:check` for `pinot-core` and `pinot-perf`
- independent eight-domain review with no unresolved findings
