### PR TITLE
Fix TDigest accumulator serialization through generic serdes for capacity-preserving state

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileSmartTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileSmartTDigestAggregationFunction.java
@@ -25,6 +25,7 @@ import it.unimi.dsi.fastutil.doubles.DoubleListIterator;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
@@ -265,12 +266,19 @@ public class PercentileSmartTDigestAggregationFunction extends NullableSingleInp
   }
 
   @Override
-  public Object merge(Object intermediateResult1, Object intermediateResult2) {
-    if (intermediateResult1 instanceof TDigest) {
-      return mergeIntoAccumulator((TDigest) intermediateResult1, intermediateResult2);
+  @Nullable
+  public Object merge(@Nullable Object intermediateResult1, @Nullable Object intermediateResult2) {
+    if (intermediateResult1 == null) {
+      return intermediateResult2;
     }
-    if (intermediateResult2 instanceof TDigest) {
-      return mergeIntoAccumulator((TDigest) intermediateResult2, intermediateResult1);
+    if (intermediateResult2 == null) {
+      return intermediateResult1;
+    }
+    if (intermediateResult1 instanceof PercentileTDigestAccumulator) {
+      return mergeIntoAccumulator((PercentileTDigestAccumulator) intermediateResult1, intermediateResult2);
+    }
+    if (intermediateResult2 instanceof PercentileTDigestAccumulator) {
+      return mergeIntoAccumulator((PercentileTDigestAccumulator) intermediateResult2, intermediateResult1);
     }
     DoubleArrayList valueList1 = (DoubleArrayList) intermediateResult1;
     DoubleArrayList valueList2 = (DoubleArrayList) intermediateResult2;
@@ -278,14 +286,8 @@ public class PercentileSmartTDigestAggregationFunction extends NullableSingleInp
     return valueList1.size() > _threshold ? convertValueListToTDigest(valueList1) : valueList1;
   }
 
-  private static TDigest mergeIntoAccumulator(TDigest tDigest, Object intermediateResult) {
-    PercentileTDigestAccumulator accumulator;
-    if (tDigest instanceof PercentileTDigestAccumulator) {
-      accumulator = (PercentileTDigestAccumulator) tDigest;
-    } else {
-      accumulator = PercentileTDigestAccumulator.forReduction(tDigest.compression());
-      accumulator.add(tDigest);
-    }
+  private static PercentileTDigestAccumulator mergeIntoAccumulator(PercentileTDigestAccumulator accumulator,
+      Object intermediateResult) {
     if (intermediateResult instanceof TDigest) {
       accumulator.add((TDigest) intermediateResult);
     } else {
@@ -317,6 +319,8 @@ public class PercentileSmartTDigestAggregationFunction extends NullableSingleInp
   @Override
   public Object deserializeIntermediateResult(CustomObject customObject) {
     if (customObject.getType() == ObjectSerDeUtils.ObjectType.TDigest.getValue()) {
+      // Generic TDigest deserialization returns a plain MergingDigest. Keep this function's TDigest intermediates as
+      // accumulators so subsequent merges retain the capacity-preserving serialization path.
       return PercentileTDigestAccumulator.forSerializedTDigest(customObject.getBuffer());
     }
     return ObjectSerDeUtils.deserialize(customObject);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileSmartTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileSmartTDigestAggregationFunction.java
@@ -184,7 +184,7 @@ public class PercentileSmartTDigestAggregationFunction extends NullableSingleInp
   }
 
   private TDigest convertValueListToTDigest(DoubleArrayList valueList) {
-    TDigest tDigest = TDigest.createMergingDigest(_compression);
+    TDigest tDigest = new PercentileTDigestAccumulator(_compression);
     DoubleListIterator iterator = valueList.iterator();
     while (iterator.hasNext()) {
       tDigest.add(iterator.nextDouble());
@@ -267,10 +267,10 @@ public class PercentileSmartTDigestAggregationFunction extends NullableSingleInp
   @Override
   public Object merge(Object intermediateResult1, Object intermediateResult2) {
     if (intermediateResult1 instanceof TDigest) {
-      return mergeIntoTDigest((TDigest) intermediateResult1, intermediateResult2);
+      return mergeIntoAccumulator((TDigest) intermediateResult1, intermediateResult2);
     }
     if (intermediateResult2 instanceof TDigest) {
-      return mergeIntoTDigest((TDigest) intermediateResult2, intermediateResult1);
+      return mergeIntoAccumulator((TDigest) intermediateResult2, intermediateResult1);
     }
     DoubleArrayList valueList1 = (DoubleArrayList) intermediateResult1;
     DoubleArrayList valueList2 = (DoubleArrayList) intermediateResult2;
@@ -278,17 +278,24 @@ public class PercentileSmartTDigestAggregationFunction extends NullableSingleInp
     return valueList1.size() > _threshold ? convertValueListToTDigest(valueList1) : valueList1;
   }
 
-  private static TDigest mergeIntoTDigest(TDigest tDigest, Object intermediateResult) {
+  private static TDigest mergeIntoAccumulator(TDigest tDigest, Object intermediateResult) {
+    PercentileTDigestAccumulator accumulator;
+    if (tDigest instanceof PercentileTDigestAccumulator) {
+      accumulator = (PercentileTDigestAccumulator) tDigest;
+    } else {
+      accumulator = PercentileTDigestAccumulator.forReduction(tDigest.compression());
+      accumulator.add(tDigest);
+    }
     if (intermediateResult instanceof TDigest) {
-      tDigest.add((TDigest) intermediateResult);
+      accumulator.add((TDigest) intermediateResult);
     } else {
       DoubleArrayList valueList = (DoubleArrayList) intermediateResult;
       DoubleListIterator iterator = valueList.iterator();
       while (iterator.hasNext()) {
-        tDigest.add(iterator.nextDouble());
+        accumulator.add(iterator.nextDouble());
       }
     }
-    return tDigest;
+    return accumulator;
   }
 
   @Override
@@ -309,6 +316,9 @@ public class PercentileSmartTDigestAggregationFunction extends NullableSingleInp
 
   @Override
   public Object deserializeIntermediateResult(CustomObject customObject) {
+    if (customObject.getType() == ObjectSerDeUtils.ObjectType.TDigest.getValue()) {
+      return PercentileTDigestAccumulator.forSerializedTDigest(customObject.getBuffer());
+    }
     return ObjectSerDeUtils.deserialize(customObject);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAccumulator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAccumulator.java
@@ -491,6 +491,7 @@ final class PercentileTDigestAccumulator extends TDigest {
     }
     flush();
     if (requiresCapacityPreservingEncoding()) {
+      checkCapacityPreservingCentroidCount();
       return SMALL_HEADER_SIZE + SMALL_CENTROID_SIZE * _numCentroids;
     }
     normalizeCentroidCapacity();
@@ -506,6 +507,12 @@ final class PercentileTDigestAccumulator extends TDigest {
   /// wire order) regardless of the destination buffer's byte order, unlike [MergingDigest#asBytes(ByteBuffer)].
   @Override
   public void asBytes(ByteBuffer buffer) {
+    if (_pendingSerializedTDigest != null) {
+      // Same validation as serialize(), but write through without the defensive clone.
+      getSerializedTotalWeight(_pendingSerializedTDigest);
+      buffer.put(_pendingSerializedTDigest);
+      return;
+    }
     buffer.put(serialize());
   }
 
@@ -628,10 +635,7 @@ final class PercentileTDigestAccumulator extends TDigest {
   }
 
   private byte[] toCapacityPreservingBytes() {
-    if (_numCentroids > Short.MAX_VALUE) {
-      throw new IllegalStateException("TDigest has too many centroids for capacity-preserving encoding: "
-          + _numCentroids);
-    }
+    checkCapacityPreservingCentroidCount();
     int mainCapacity = Math.min(Short.MAX_VALUE, Math.max(_numCentroids, _serializedMainCapacity));
     long defaultBufferCapacity = Math.multiplyExact(DEFAULT_MERGE_BUFFER_MULTIPLIER, (long) Math.ceil(_compression));
     int bufferCapacity = Math.toIntExact(Math.min(Short.MAX_VALUE,
@@ -649,6 +653,13 @@ final class PercentileTDigestAccumulator extends TDigest {
       buffer.putFloat((float) _centroidMeans[i]);
     }
     return buffer.array();
+  }
+
+  private void checkCapacityPreservingCentroidCount() {
+    if (_numCentroids > Short.MAX_VALUE) {
+      throw new IllegalStateException("TDigest has too many centroids for capacity-preserving encoding: "
+          + _numCentroids);
+    }
   }
 
   private void flush() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAccumulator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAccumulator.java
@@ -37,8 +37,9 @@ import java.util.List;
 /// its explicit capacity is required to decode an oversized compact digest.
 ///
 /// The accumulator implements [TDigest] so process-local combine and reduction can retain the primitive state.
-/// Quantile queries and CDFs read the primitive state directly. Centroid iteration and serialization use the
-/// canonical library implementation returned from [#toTDigest()].
+/// Quantile queries and CDFs read the primitive state directly. Centroid iteration uses the canonical library
+/// implementation returned from [#toTDigest()], while [#byteSize()] and [#asBytes(ByteBuffer)] emit [#serialize()]
+/// bytes directly so generic `TDigest` serializers preserve capacity-preserving state.
 ///
 /// Serialized group state keeps its first digest pending, and allocates primitive centroid buffers only when another
 /// input must be merged. The raw-value buffer remains unallocated for serialized state until a raw value is added.
@@ -476,9 +477,24 @@ final class PercentileTDigestAccumulator extends TDigest {
     return _compression;
   }
 
+  /// Returns the length of the [#serialize()] bytes rather than the materialized [MergingDigest] byte size, so
+  /// generic `TDigest` serializers ([#byteSize()] followed by [#asBytes(ByteBuffer)]) emit the capacity-preserving
+  /// encoding. Re-encoding through a materialized [MergingDigest] can produce a verbose digest with more centroids
+  /// than a freshly allocated [MergingDigest] of the same compression can hold, which readers reject with
+  /// [ArrayIndexOutOfBoundsException]. The length is computed without materializing the bytes by mirroring the
+  /// [#serialize()] branches; the mutations here (flush, capacity normalization) are idempotent, so the following
+  /// [#asBytes(ByteBuffer)] call writes exactly this many bytes.
   @Override
   public int byteSize() {
-    return toTDigest().byteSize();
+    if (_pendingSerializedTDigest != null) {
+      return _pendingSerializedTDigest.length;
+    }
+    flush();
+    if (requiresCapacityPreservingEncoding()) {
+      return SMALL_HEADER_SIZE + SMALL_CENTROID_SIZE * _numCentroids;
+    }
+    normalizeCentroidCapacity();
+    return VERBOSE_HEADER_SIZE + VERBOSE_CENTROID_SIZE * _numCentroids;
   }
 
   @Override
@@ -486,9 +502,11 @@ final class PercentileTDigestAccumulator extends TDigest {
     return toTDigest().smallByteSize();
   }
 
+  /// Writes the [#serialize()] bytes; see [#byteSize()]. Bytes are always written in big-endian order (the t-digest
+  /// wire order) regardless of the destination buffer's byte order, unlike [MergingDigest#asBytes(ByteBuffer)].
   @Override
   public void asBytes(ByteBuffer buffer) {
-    toTDigest().asBytes(buffer);
+    buffer.put(serialize());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
@@ -300,13 +300,8 @@ public class PercentileTDigestAggregationFunction extends NullableSingleInputAgg
 
   @Override
   public SerializedIntermediateResult serializeIntermediateResult(TDigest tDigest) {
-    byte[] bytes;
-    if (tDigest instanceof PercentileTDigestAccumulator) {
-      bytes = ((PercentileTDigestAccumulator) tDigest).serialize();
-    } else {
-      bytes = ObjectSerDeUtils.TDIGEST_SER_DE.serialize(tDigest);
-    }
-    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.TDigest.getValue(), bytes);
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.TDigest.getValue(),
+        ObjectSerDeUtils.TDIGEST_SER_DE.serialize(tDigest));
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileRawTDigestAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileRawTDigestAggregationFunctionTest.java
@@ -24,10 +24,11 @@ import java.nio.ByteBuffer;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
-import org.apache.pinot.segment.local.customobject.SerializedTDigest;
 import org.apache.pinot.spi.utils.BytesUtils;
-import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 
 /// Tests that the final result of `percentileRawTDigest` stays readable by a plain t-digest
@@ -45,54 +46,24 @@ public class PercentileRawTDigestAggregationFunctionTest {
 
     // Sanity: the input itself is readable by a plain t-digest reader.
     TDigest direct = MergingDigest.fromBytes(ByteBuffer.wrap(small));
-    Assert.assertEquals(direct.size(), numCentroids);
+    assertEquals(direct.size(), numCentroids);
 
     PercentileRawTDigestAggregationFunction function =
         new PercentileRawTDigestAggregationFunction(EXPRESSION, 50.0, (int) compression, false);
     TDigest intermediateResult = function.deserializeIntermediateResult(
         new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(small)));
-    Assert.assertTrue(intermediateResult instanceof PercentileTDigestAccumulator);
+    assertTrue(intermediateResult instanceof PercentileTDigestAccumulator);
 
-    SerializedTDigest finalResult = function.extractFinalResult(intermediateResult);
-    byte[] serialized = BytesUtils.toBytes(finalResult.toString());
-    assertLegacyCompatibleShape(serialized, compression);
+    byte[] serialized = BytesUtils.toBytes(function.extractFinalResult(intermediateResult).toString());
 
     // Client side: a plain t-digest reader must be able to read the emitted bytes without losing
     // state. Before the fix this threw ArrayIndexOutOfBoundsException because the final result was
     // re-encoded as a verbose digest with more centroids than the reader allocates.
     TDigest roundTripped = MergingDigest.fromBytes(ByteBuffer.wrap(serialized));
-    assertUnitCentroidDigest(roundTripped, numCentroids);
-
-    // Also cover the materialized (merged) accumulator state, not just the serialized pass-through.
-    TDigest merged = function.merge(intermediateResult, function.deserializeIntermediateResult(
-        new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(small))));
-    byte[] mergedSerialized = BytesUtils.toBytes(function.extractFinalResult(merged).toString());
-    assertLegacyCompatibleShape(mergedSerialized, compression);
-    TDigest mergedRoundTripped = MergingDigest.fromBytes(ByteBuffer.wrap(mergedSerialized));
-    Assert.assertEquals(mergedRoundTripped.size(), 2L * numCentroids);
-    Assert.assertEquals(mergedRoundTripped.quantile(0.5), (numCentroids - 1.0) / 2.0, 1.0);
-  }
-
-  @Test
-  public void testFinalResultRoundTripForRegularDigest() {
-    double compression = 100.0;
-    TDigest input = TDigest.createMergingDigest(compression);
-    for (int i = 0; i < 1000; i++) {
-      input.add(i);
-    }
-    byte[] bytes = new byte[input.byteSize()];
-    input.asBytes(ByteBuffer.wrap(bytes));
-
-    PercentileRawTDigestAggregationFunction function =
-        new PercentileRawTDigestAggregationFunction(EXPRESSION, 50.0, (int) compression, false);
-    TDigest intermediateResult = function.deserializeIntermediateResult(
-        new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(bytes)));
-
-    SerializedTDigest finalResult = function.extractFinalResult(intermediateResult);
-    byte[] serialized = BytesUtils.toBytes(finalResult.toString());
-    TDigest roundTripped = MergingDigest.fromBytes(ByteBuffer.wrap(serialized));
-    Assert.assertEquals(roundTripped.size(), 1000);
-    Assert.assertEquals(roundTripped.quantile(0.5), input.quantile(0.5), 1e-6);
+    assertEquals(roundTripped.size(), numCentroids);
+    assertEquals(roundTripped.quantile(0.0), 0.0);
+    assertEquals(roundTripped.quantile(0.5), (numCentroids - 1.0) / 2.0, 1.0);
+    assertEquals(roundTripped.quantile(1.0), numCentroids - 1.0);
   }
 
   /// SMALL-encoded digest (encoding 2) with explicit main/buffer capacities, unit-weight centroids
@@ -115,25 +86,5 @@ public class PercentileRawTDigestAggregationFunctionTest {
       buffer.putFloat(i);
     }
     return buffer.array();
-  }
-
-  private static void assertLegacyCompatibleShape(byte[] bytes, double compression) {
-    ByteBuffer buffer = ByteBuffer.wrap(bytes);
-    int encoding = buffer.getInt();
-    if (encoding == 1) {
-      Assert.assertEquals(buffer.getDouble(Integer.BYTES + 2 * Double.BYTES), compression);
-      int centroidCount = buffer.getInt(Integer.BYTES + 3 * Double.BYTES);
-      Assert.assertTrue(centroidCount <= 2 * Math.ceil(compression) + 10,
-          "Verbose encoding exceeds the fresh MergingDigest centroid capacity: " + centroidCount);
-    } else {
-      Assert.assertEquals(encoding, 2, "Unexpected t-digest encoding");
-    }
-  }
-
-  private static void assertUnitCentroidDigest(TDigest digest, int expectedSize) {
-    Assert.assertEquals(digest.size(), expectedSize);
-    Assert.assertEquals(digest.quantile(0.0), 0.0);
-    Assert.assertEquals(digest.quantile(0.5), (expectedSize - 1.0) / 2.0, 1.0);
-    Assert.assertEquals(digest.quantile(1.0), expectedSize - 1.0);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileRawTDigestAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileRawTDigestAggregationFunctionTest.java
@@ -1,0 +1,139 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import com.tdunning.math.stats.MergingDigest;
+import com.tdunning.math.stats.TDigest;
+import java.nio.ByteBuffer;
+import org.apache.pinot.common.CustomObject;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
+import org.apache.pinot.segment.local.customobject.SerializedTDigest;
+import org.apache.pinot.spi.utils.BytesUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/// Tests that the final result of `percentileRawTDigest` stays readable by a plain t-digest
+/// [MergingDigest#fromBytes] reader when the intermediate [PercentileTDigestAccumulator] holds
+/// capacity-preserving state (a digest with more centroids than a freshly allocated
+/// [MergingDigest] of the same compression can hold).
+public class PercentileRawTDigestAggregationFunctionTest {
+  private static final ExpressionContext EXPRESSION = ExpressionContext.forIdentifier("col");
+
+  @Test
+  public void testFinalResultReadableByPlainReaderForCapacityPreservingState() {
+    int numCentroids = 51;
+    double compression = 20.0;
+    byte[] small = createSmallUnitCentroidDigest(numCentroids, compression, 60, 100);
+
+    // Sanity: the input itself is readable by a plain t-digest reader.
+    TDigest direct = MergingDigest.fromBytes(ByteBuffer.wrap(small));
+    Assert.assertEquals(direct.size(), numCentroids);
+
+    PercentileRawTDigestAggregationFunction function =
+        new PercentileRawTDigestAggregationFunction(EXPRESSION, 50.0, (int) compression, false);
+    TDigest intermediateResult = function.deserializeIntermediateResult(
+        new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(small)));
+    Assert.assertTrue(intermediateResult instanceof PercentileTDigestAccumulator);
+
+    SerializedTDigest finalResult = function.extractFinalResult(intermediateResult);
+    byte[] serialized = BytesUtils.toBytes(finalResult.toString());
+    assertLegacyCompatibleShape(serialized, compression);
+
+    // Client side: a plain t-digest reader must be able to read the emitted bytes without losing
+    // state. Before the fix this threw ArrayIndexOutOfBoundsException because the final result was
+    // re-encoded as a verbose digest with more centroids than the reader allocates.
+    TDigest roundTripped = MergingDigest.fromBytes(ByteBuffer.wrap(serialized));
+    assertUnitCentroidDigest(roundTripped, numCentroids);
+
+    // Also cover the materialized (merged) accumulator state, not just the serialized pass-through.
+    TDigest merged = function.merge(intermediateResult, function.deserializeIntermediateResult(
+        new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(small))));
+    byte[] mergedSerialized = BytesUtils.toBytes(function.extractFinalResult(merged).toString());
+    assertLegacyCompatibleShape(mergedSerialized, compression);
+    TDigest mergedRoundTripped = MergingDigest.fromBytes(ByteBuffer.wrap(mergedSerialized));
+    Assert.assertEquals(mergedRoundTripped.size(), 2L * numCentroids);
+    Assert.assertEquals(mergedRoundTripped.quantile(0.5), (numCentroids - 1.0) / 2.0, 1.0);
+  }
+
+  @Test
+  public void testFinalResultRoundTripForRegularDigest() {
+    double compression = 100.0;
+    TDigest input = TDigest.createMergingDigest(compression);
+    for (int i = 0; i < 1000; i++) {
+      input.add(i);
+    }
+    byte[] bytes = new byte[input.byteSize()];
+    input.asBytes(ByteBuffer.wrap(bytes));
+
+    PercentileRawTDigestAggregationFunction function =
+        new PercentileRawTDigestAggregationFunction(EXPRESSION, 50.0, (int) compression, false);
+    TDigest intermediateResult = function.deserializeIntermediateResult(
+        new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(bytes)));
+
+    SerializedTDigest finalResult = function.extractFinalResult(intermediateResult);
+    byte[] serialized = BytesUtils.toBytes(finalResult.toString());
+    TDigest roundTripped = MergingDigest.fromBytes(ByteBuffer.wrap(serialized));
+    Assert.assertEquals(roundTripped.size(), 1000);
+    Assert.assertEquals(roundTripped.quantile(0.5), input.quantile(0.5), 1e-6);
+  }
+
+  /// SMALL-encoded digest (encoding 2) with explicit main/buffer capacities, unit-weight centroids
+  /// at means 0..numCentroids-1. This is the layout t-digest's `asSmallBytes` produces and
+  /// `MergingDigest.fromBytes` accepts regardless of the default capacity for the compression.
+  /// Package-private: shared with [PercentileSmartTDigestAggregationFunctionTest].
+  static byte[] createSmallUnitCentroidDigest(int numCentroids, double compression, int mainCapacity,
+      int bufferCapacity) {
+    ByteBuffer buffer = ByteBuffer.allocate(Integer.BYTES + 2 * Double.BYTES + Float.BYTES + 3 * Short.BYTES
+        + 2 * Float.BYTES * numCentroids);
+    buffer.putInt(2);
+    buffer.putDouble(0.0);
+    buffer.putDouble(numCentroids - 1.0);
+    buffer.putFloat((float) compression);
+    buffer.putShort((short) mainCapacity);
+    buffer.putShort((short) bufferCapacity);
+    buffer.putShort((short) numCentroids);
+    for (int i = 0; i < numCentroids; i++) {
+      buffer.putFloat(1.0f);
+      buffer.putFloat(i);
+    }
+    return buffer.array();
+  }
+
+  private static void assertLegacyCompatibleShape(byte[] bytes, double compression) {
+    ByteBuffer buffer = ByteBuffer.wrap(bytes);
+    int encoding = buffer.getInt();
+    if (encoding == 1) {
+      Assert.assertEquals(buffer.getDouble(Integer.BYTES + 2 * Double.BYTES), compression);
+      int centroidCount = buffer.getInt(Integer.BYTES + 3 * Double.BYTES);
+      Assert.assertTrue(centroidCount <= 2 * Math.ceil(compression) + 10,
+          "Verbose encoding exceeds the fresh MergingDigest centroid capacity: " + centroidCount);
+    } else {
+      Assert.assertEquals(encoding, 2, "Unexpected t-digest encoding");
+    }
+  }
+
+  private static void assertUnitCentroidDigest(TDigest digest, int expectedSize) {
+    Assert.assertEquals(digest.size(), expectedSize);
+    Assert.assertEquals(digest.quantile(0.0), 0.0);
+    Assert.assertEquals(digest.quantile(0.5), (expectedSize - 1.0) / 2.0, 1.0);
+    Assert.assertEquals(digest.quantile(1.0), expectedSize - 1.0);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileSmartTDigestAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileSmartTDigestAggregationFunctionTest.java
@@ -18,8 +18,113 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import com.tdunning.math.stats.MergingDigest;
+import com.tdunning.math.stats.TDigest;
+import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.apache.pinot.common.CustomObject;
+import org.apache.pinot.common.request.Literal;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
 
 public class PercentileSmartTDigestAggregationFunctionTest {
+  private static final ExpressionContext EXPRESSION = ExpressionContext.forIdentifier("col");
+
+  /// The intermediate result must round-trip through the [PercentileTDigestAccumulator] so that
+  /// capacity-preserving digests (more centroids than a fresh [MergingDigest] of the same
+  /// compression can hold) are not re-encoded into bytes a receiving server cannot read.
+  @Test
+  public void testIntermediateResultRoundTripPreservesCapacityPreservingState() {
+    int numCentroids = 51;
+    double compression = 20.0;
+    byte[] small =
+        PercentileRawTDigestAggregationFunctionTest.createSmallUnitCentroidDigest(numCentroids, compression, 60, 100);
+    PercentileSmartTDigestAggregationFunction function = new PercentileSmartTDigestAggregationFunction(
+        List.of(EXPRESSION, ExpressionContext.forLiteral(Literal.doubleValue(50.0)),
+            ExpressionContext.forLiteral(Literal.stringValue("THRESHOLD=1;COMPRESSION=20"))), false);
+
+    Object intermediateResult = function.deserializeIntermediateResult(
+        new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(small)));
+    Assert.assertTrue(intermediateResult instanceof PercentileTDigestAccumulator);
+
+    AggregationFunction.SerializedIntermediateResult serialized =
+        function.serializeIntermediateResult(intermediateResult);
+    Assert.assertEquals(serialized.getType(), ObjectSerDeUtils.ObjectType.TDigest.getValue());
+    // Before the fix this was a verbose encoding with 51 centroids, which a plain
+    // MergingDigest.fromBytes reader rejects with ArrayIndexOutOfBoundsException.
+    TDigest roundTripped = MergingDigest.fromBytes(ByteBuffer.wrap(serialized.getBytes()));
+    Assert.assertEquals(roundTripped.size(), numCentroids);
+    Assert.assertEquals(roundTripped.quantile(0.5), (numCentroids - 1.0) / 2.0, 1.0);
+
+    Object merged = function.merge(
+        function.deserializeIntermediateResult(
+            new CustomObject(serialized.getType(), ByteBuffer.wrap(serialized.getBytes()))),
+        function.deserializeIntermediateResult(
+            new CustomObject(serialized.getType(), ByteBuffer.wrap(serialized.getBytes()))));
+    Assert.assertTrue(merged instanceof PercentileTDigestAccumulator);
+    Assert.assertEquals(((TDigest) merged).size(), 2L * numCentroids);
+
+    // The materialized (merged) accumulator must also serialize into plain-reader-compatible bytes.
+    TDigest mergedRoundTripped = MergingDigest.fromBytes(
+        ByteBuffer.wrap(function.serializeIntermediateResult(merged).getBytes()));
+    Assert.assertEquals(mergedRoundTripped.size(), 2L * numCentroids);
+    Assert.assertEquals(mergedRoundTripped.quantile(0.5), (numCentroids - 1.0) / 2.0, 1.0);
+  }
+
+  /// Materialized (non-pass-through) capacity-preserving state must also serialize into the small encoding through
+  /// the generic serde: merging with an empty digest materializes the oversized centroids without recompression.
+  @Test
+  public void testMaterializedCapacityPreservingStateUsesSmallEncoding() {
+    int numCentroids = 51;
+    byte[] small =
+        PercentileRawTDigestAggregationFunctionTest.createSmallUnitCentroidDigest(numCentroids, 20.0, 60, 100);
+    byte[] empty = ObjectSerDeUtils.TDIGEST_SER_DE.serialize(TDigest.createMergingDigest(20.0));
+    PercentileSmartTDigestAggregationFunction function = new PercentileSmartTDigestAggregationFunction(
+        List.of(EXPRESSION, ExpressionContext.forLiteral(Literal.doubleValue(50.0)),
+            ExpressionContext.forLiteral(Literal.stringValue("THRESHOLD=1;COMPRESSION=20"))), false);
+
+    Object merged = function.merge(
+        function.deserializeIntermediateResult(
+            new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(small))),
+        function.deserializeIntermediateResult(
+            new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(empty))));
+    byte[] serialized = function.serializeIntermediateResult(merged).getBytes();
+    Assert.assertEquals(ByteBuffer.wrap(serialized).getInt(), 2, "Expected small (capacity-preserving) encoding");
+    Assert.assertEquals(((TDigest) merged).byteSize(), serialized.length);
+    TDigest roundTripped = MergingDigest.fromBytes(ByteBuffer.wrap(serialized));
+    Assert.assertEquals(roundTripped.size(), numCentroids);
+    Assert.assertEquals(roundTripped.quantile(0.5), (numCentroids - 1.0) / 2.0, 1.0);
+  }
+
+  /// Broker reduce can merge a server that produced a t-digest with a server that stayed below the
+  /// threshold and produced a raw value list; both argument orders must route into the accumulator.
+  @Test
+  public void testMergeAccumulatorWithValueList() {
+    int numCentroids = 51;
+    byte[] small = PercentileRawTDigestAggregationFunctionTest.createSmallUnitCentroidDigest(numCentroids, 20.0, 60,
+        100);
+    PercentileSmartTDigestAggregationFunction function = new PercentileSmartTDigestAggregationFunction(
+        List.of(EXPRESSION, ExpressionContext.forLiteral(Literal.doubleValue(50.0)),
+            ExpressionContext.forLiteral(Literal.stringValue("THRESHOLD=1;COMPRESSION=20"))), false);
+
+    for (boolean accumulatorFirst : new boolean[]{true, false}) {
+      Object accumulator = function.deserializeIntermediateResult(
+          new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(small)));
+      DoubleArrayList valueList = new DoubleArrayList(new double[]{0.0, 25.0, 50.0});
+      Object merged = accumulatorFirst ? function.merge(accumulator, valueList)
+          : function.merge(valueList, accumulator);
+      Assert.assertTrue(merged instanceof PercentileTDigestAccumulator);
+      Assert.assertEquals(((TDigest) merged).size(), numCentroids + 3L);
+      Assert.assertEquals(((TDigest) merged).quantile(0.5), (numCentroids - 1.0) / 2.0, 1.0);
+      TDigest roundTripped = MergingDigest.fromBytes(
+          ByteBuffer.wrap(function.serializeIntermediateResult(merged).getBytes()));
+      Assert.assertEquals(roundTripped.size(), numCentroids + 3L);
+    }
+  }
 
   public static class WithHighThreshold extends AbstractPercentileAggregationFunctionTest {
     @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileSmartTDigestAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileSmartTDigestAggregationFunctionTest.java
@@ -27,103 +27,68 @@ import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.Literal;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
-import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 
 public class PercentileSmartTDigestAggregationFunctionTest {
   private static final ExpressionContext EXPRESSION = ExpressionContext.forIdentifier("col");
 
-  /// The intermediate result must round-trip through the [PercentileTDigestAccumulator] so that
-  /// capacity-preserving digests (more centroids than a fresh [MergingDigest] of the same
-  /// compression can hold) are not re-encoded into bytes a receiving server cannot read.
+  /// Exercises the complete capacity-preserving intermediate lifecycle: pass-through serde, materialization by
+  /// merging another digest, and raw-list merging in both argument orders.
   @Test
-  public void testIntermediateResultRoundTripPreservesCapacityPreservingState() {
-    int numCentroids = 51;
-    double compression = 20.0;
-    byte[] small =
-        PercentileRawTDigestAggregationFunctionTest.createSmallUnitCentroidDigest(numCentroids, compression, 60, 100);
-    PercentileSmartTDigestAggregationFunction function = new PercentileSmartTDigestAggregationFunction(
-        List.of(EXPRESSION, ExpressionContext.forLiteral(Literal.doubleValue(50.0)),
-            ExpressionContext.forLiteral(Literal.stringValue("THRESHOLD=1;COMPRESSION=20"))), false);
-
-    Object intermediateResult = function.deserializeIntermediateResult(
-        new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(small)));
-    Assert.assertTrue(intermediateResult instanceof PercentileTDigestAccumulator);
-
-    AggregationFunction.SerializedIntermediateResult serialized =
-        function.serializeIntermediateResult(intermediateResult);
-    Assert.assertEquals(serialized.getType(), ObjectSerDeUtils.ObjectType.TDigest.getValue());
-    // Before the fix this was a verbose encoding with 51 centroids, which a plain
-    // MergingDigest.fromBytes reader rejects with ArrayIndexOutOfBoundsException.
-    TDigest roundTripped = MergingDigest.fromBytes(ByteBuffer.wrap(serialized.getBytes()));
-    Assert.assertEquals(roundTripped.size(), numCentroids);
-    Assert.assertEquals(roundTripped.quantile(0.5), (numCentroids - 1.0) / 2.0, 1.0);
-
-    Object merged = function.merge(
-        function.deserializeIntermediateResult(
-            new CustomObject(serialized.getType(), ByteBuffer.wrap(serialized.getBytes()))),
-        function.deserializeIntermediateResult(
-            new CustomObject(serialized.getType(), ByteBuffer.wrap(serialized.getBytes()))));
-    Assert.assertTrue(merged instanceof PercentileTDigestAccumulator);
-    Assert.assertEquals(((TDigest) merged).size(), 2L * numCentroids);
-
-    // The materialized (merged) accumulator must also serialize into plain-reader-compatible bytes.
-    TDigest mergedRoundTripped = MergingDigest.fromBytes(
-        ByteBuffer.wrap(function.serializeIntermediateResult(merged).getBytes()));
-    Assert.assertEquals(mergedRoundTripped.size(), 2L * numCentroids);
-    Assert.assertEquals(mergedRoundTripped.quantile(0.5), (numCentroids - 1.0) / 2.0, 1.0);
-  }
-
-  /// Materialized (non-pass-through) capacity-preserving state must also serialize into the small encoding through
-  /// the generic serde: merging with an empty digest materializes the oversized centroids without recompression.
-  @Test
-  public void testMaterializedCapacityPreservingStateUsesSmallEncoding() {
-    int numCentroids = 51;
-    byte[] small =
-        PercentileRawTDigestAggregationFunctionTest.createSmallUnitCentroidDigest(numCentroids, 20.0, 60, 100);
-    byte[] empty = ObjectSerDeUtils.TDIGEST_SER_DE.serialize(TDigest.createMergingDigest(20.0));
-    PercentileSmartTDigestAggregationFunction function = new PercentileSmartTDigestAggregationFunction(
-        List.of(EXPRESSION, ExpressionContext.forLiteral(Literal.doubleValue(50.0)),
-            ExpressionContext.forLiteral(Literal.stringValue("THRESHOLD=1;COMPRESSION=20"))), false);
-
-    Object merged = function.merge(
-        function.deserializeIntermediateResult(
-            new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(small))),
-        function.deserializeIntermediateResult(
-            new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(empty))));
-    byte[] serialized = function.serializeIntermediateResult(merged).getBytes();
-    Assert.assertEquals(ByteBuffer.wrap(serialized).getInt(), 2, "Expected small (capacity-preserving) encoding");
-    Assert.assertEquals(((TDigest) merged).byteSize(), serialized.length);
-    TDigest roundTripped = MergingDigest.fromBytes(ByteBuffer.wrap(serialized));
-    Assert.assertEquals(roundTripped.size(), numCentroids);
-    Assert.assertEquals(roundTripped.quantile(0.5), (numCentroids - 1.0) / 2.0, 1.0);
-  }
-
-  /// Broker reduce can merge a server that produced a t-digest with a server that stayed below the
-  /// threshold and produced a raw value list; both argument orders must route into the accumulator.
-  @Test
-  public void testMergeAccumulatorWithValueList() {
+  public void testCapacityPreservingIntermediateLifecycle() {
     int numCentroids = 51;
     byte[] small = PercentileRawTDigestAggregationFunctionTest.createSmallUnitCentroidDigest(numCentroids, 20.0, 60,
         100);
-    PercentileSmartTDigestAggregationFunction function = new PercentileSmartTDigestAggregationFunction(
+    PercentileSmartTDigestAggregationFunction function = createFunction();
+
+    Object intermediateResult = function.deserializeIntermediateResult(
+        new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(small)));
+    assertTrue(intermediateResult instanceof PercentileTDigestAccumulator);
+
+    AggregationFunction.SerializedIntermediateResult passThrough =
+        function.serializeIntermediateResult(intermediateResult);
+    assertEquals(passThrough.getType(), ObjectSerDeUtils.ObjectType.TDigest.getValue());
+    // Before the fix this was a verbose encoding with 51 centroids, which a plain
+    // MergingDigest.fromBytes reader rejects with ArrayIndexOutOfBoundsException.
+    assertEquals(MergingDigest.fromBytes(ByteBuffer.wrap(passThrough.getBytes())).size(), numCentroids);
+
+    byte[] empty = ObjectSerDeUtils.TDIGEST_SER_DE.serialize(TDigest.createMergingDigest(20.0));
+    Object merged = function.merge(
+        intermediateResult,
+        function.deserializeIntermediateResult(
+            new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(empty))));
+    byte[] serialized = function.serializeIntermediateResult(merged).getBytes();
+    assertEquals(ByteBuffer.wrap(serialized).getInt(), 2, "Expected small (capacity-preserving) encoding");
+    assertEquals(((TDigest) merged).byteSize(), serialized.length);
+    TDigest roundTripped = MergingDigest.fromBytes(ByteBuffer.wrap(serialized));
+    assertEquals(roundTripped.size(), numCentroids);
+    assertEquals(roundTripped.quantile(0.5), (numCentroids - 1.0) / 2.0, 1.0);
+
+    DoubleArrayList values = new DoubleArrayList(new double[]{0.0, 25.0, 50.0});
+    assertEquals(((TDigest) function.merge(merged, values)).size(), numCentroids + 3L);
+    Object reverseOrder = function.merge(new DoubleArrayList(values), function.deserializeIntermediateResult(
+        new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(small))));
+    assertTrue(reverseOrder instanceof PercentileTDigestAccumulator);
+    assertEquals(((TDigest) reverseOrder).size(), numCentroids + 3L);
+  }
+
+  @Test
+  public void testMergeWithNullIntermediateResult() {
+    PercentileSmartTDigestAggregationFunction function = createFunction();
+    DoubleArrayList valueList = new DoubleArrayList(new double[]{1.0, 2.0});
+    assertEquals(function.merge(null, valueList), valueList);
+    assertEquals(function.merge(valueList, null), valueList);
+    assertEquals(function.merge(null, null), null);
+  }
+
+  private static PercentileSmartTDigestAggregationFunction createFunction() {
+    return new PercentileSmartTDigestAggregationFunction(
         List.of(EXPRESSION, ExpressionContext.forLiteral(Literal.doubleValue(50.0)),
             ExpressionContext.forLiteral(Literal.stringValue("THRESHOLD=1;COMPRESSION=20"))), false);
-
-    for (boolean accumulatorFirst : new boolean[]{true, false}) {
-      Object accumulator = function.deserializeIntermediateResult(
-          new CustomObject(ObjectSerDeUtils.ObjectType.TDigest.getValue(), ByteBuffer.wrap(small)));
-      DoubleArrayList valueList = new DoubleArrayList(new double[]{0.0, 25.0, 50.0});
-      Object merged = accumulatorFirst ? function.merge(accumulator, valueList)
-          : function.merge(valueList, accumulator);
-      Assert.assertTrue(merged instanceof PercentileTDigestAccumulator);
-      Assert.assertEquals(((TDigest) merged).size(), numCentroids + 3L);
-      Assert.assertEquals(((TDigest) merged).quantile(0.5), (numCentroids - 1.0) / 2.0, 1.0);
-      TDigest roundTripped = MergingDigest.fromBytes(
-          ByteBuffer.wrap(function.serializeIntermediateResult(merged).getBytes()));
-      Assert.assertEquals(roundTripped.size(), numCentroids + 3L);
-    }
   }
 
   public static class WithHighThreshold extends AbstractPercentileAggregationFunctionTest {

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunctionTest.java
@@ -458,6 +458,24 @@ public class PercentileTDigestAggregationFunctionTest {
   }
 
   @Test
+  public void testCapacityPreservingByteSizeRejectsUnencodableCentroidCount()
+      throws ReflectiveOperationException {
+    PercentileTDigestAccumulator accumulator = PercentileTDigestAccumulator.forReduction(20.0);
+    int unencodableCentroidCount = Short.MAX_VALUE + 1;
+    Field numCentroidsField = PercentileTDigestAccumulator.class.getDeclaredField("_numCentroids");
+    numCentroidsField.setAccessible(true);
+    numCentroidsField.setInt(accumulator, unencodableCentroidCount);
+    Field serializedMainCapacityField =
+        PercentileTDigestAccumulator.class.getDeclaredField("_serializedMainCapacity");
+    serializedMainCapacityField.setAccessible(true);
+    serializedMainCapacityField.setInt(accumulator, unencodableCentroidCount);
+
+    IllegalStateException exception = Assert.expectThrows(IllegalStateException.class, accumulator::byteSize);
+    Assert.assertEquals(exception.getMessage(),
+        "TDigest has too many centroids for capacity-preserving encoding: " + unencodableCentroidCount);
+  }
+
+  @Test
   public void testSerializedGroupByMVSharedInputUsesCentroidCountForInitialCapacity()
       throws ReflectiveOperationException {
     ByteBuffer oneCentroid = ByteBuffer.allocate(30 + 2 * Float.BYTES);


### PR DESCRIPTION
## Summary

Follow-up bugfix to #18996, split out of #19015 per review feedback.

`PercentileTDigestAccumulator` can legitimately hold capacity-preserving state: a t-digest with more centroids than a freshly allocated `MergingDigest` of the same compression can hold (e.g. a SMALL-encoded digest with explicit main/buffer capacities stored in a pre-aggregated `BYTES` column). #18996 handled this in the accumulator's own `serialize()`, but two paths were missed:

1. **`percentileRawTDigest` final results**: `SerializedTDigest.toString()` serializes the accumulator through the generic `TDIGEST_SER_DE` (`byteSize()` + `asBytes()`), which re-encoded the digest as a verbose payload with more centroids than a plain `MergingDigest.fromBytes` reader allocates. Any downstream reader of the emitted hex — including t-digest itself — fails with `ArrayIndexOutOfBoundsException: Index 50 out of bounds for length 50`.
2. **`percentileSmartTDigest`** still built and merged plain `MergingDigest`s and deserialized intermediates with `MergingDigest.fromBytes`, so it had the same re-encoding problem on its intermediate-result path and missed the accumulator routing entirely.

## Fix

- `PercentileTDigestAccumulator` now overrides `byteSize()`/`asBytes(ByteBuffer)` to emit its `serialize()` bytes, so every generic `TDigest` serializer (`ObjectSerDeUtils.TDIGEST_SER_DE`, `CustomSerDeUtils.TDIGEST_SER_DE`) produces capacity-preserving, plain-reader-compatible bytes polymorphically — fixing the `percentileRawTDigest` final-result path and any other call site handed an accumulator (including the generic `ObjectSerDeUtils.serialize(Object)` dispatch), with no per-call-site special casing. `byteSize()` computes the length analytically without materializing the bytes, so the serde's two-call pattern still encodes only once.
- `PercentileSmartTDigestAggregationFunction` routes value-list conversion, merging, and intermediate-result deserialization through `PercentileTDigestAccumulator`, matching the other percentile t-digest paths from #18996.
- The now-redundant accumulator special case in `PercentileTDigestAggregationFunction.serializeIntermediateResult` is simplified to the plain polymorphic serde call.

## Behavior notes

- All existing quantile results are unchanged (existing `PercentileSmartTDigestAggregationFunctionTest` behavior suites pass unmodified).
- When the accumulator carries a SMALL-encoded input digest through verbatim, the emitted final payload for `percentileRawTDigest` stays SMALL-encoded instead of being re-encoded verbose. `MergingDigest.fromBytes` reads both encodings; only a hand-written parser assuming verbose layout would notice.
- Rolling upgrade safe in both directions: emitted intermediates are verbose within reader capacity in the common case, and SMALL with explicit capacities (readable by plain `MergingDigest.fromBytes`) in the capacity-preserving case.

## Testing

- `PercentileRawTDigestAggregationFunctionTest`: one focused regression reproduces the plain-reader failure on the final-result path and validates the preserved distribution.
- `PercentileSmartTDigestAggregationFunctionTest`: one consolidated lifecycle test covers pass-through serde, materialized SMALL encoding, `byteSize()` consistency, plain-reader compatibility, and raw-list merging in both argument orders; a separate compact test covers the nullable merge contract.
- `PercentileTDigestAggregationFunctionTest`: one negative regression keeps `byteSize()` and the capacity-preserving writer aligned for an unencodable centroid count.
- 412 focused percentile/t-digest test invocations pass; `spotless`, `checkstyle`, `license`, and the 16-module compiler-warning build pass.