### PR TITLE
Add a generic response-metadata extension point to BrokerResponse

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -877,6 +877,13 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       }
 
       brokerResponse.setTimeUsedMs(totalTimeMs);
+      // Surface any generic response metadata registered during query handling (e.g. a
+      // degraded-engine note) into the response. Entries are registered via
+      // QueryThreadContext#addResponseMetadata; the core engine attaches no semantics to them.
+      QueryThreadContext queryThreadContext = QueryThreadContext.getIfAvailable();
+      if (queryThreadContext != null) {
+        queryThreadContext.getExecutionContext().getResponseMetadata().forEach(brokerResponse::putResponseMetadata);
+      }
       augmentStatistics(requestContext, brokerResponse);
       if (QueryOptionsUtils.shouldDropResults(query.getOptions())) {
         brokerResponse.setResultTable(null);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -883,7 +883,8 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       brokerResponse.setTimeUsedMs(totalTimeMs);
       // Surface any generic response metadata registered during query handling (e.g. a
       // degraded-engine note) into the response. Entries are registered via
-      // QueryThreadContext#addResponseMetadata; the core engine attaches no semantics to them.
+      // QueryThreadContext#addResponseBrokerMetadata; the core engine attaches no semantics to them.
+      // The sink is broker-local for now, so this only picks up entries registered on the broker.
       QueryThreadContext queryThreadContext = QueryThreadContext.getIfAvailable();
       if (queryThreadContext != null) {
         queryThreadContext.getExecutionContext().getResponseMetadata().forEach(brokerResponse::putResponseMetadata);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -881,6 +881,13 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       }
 
       brokerResponse.setTimeUsedMs(totalTimeMs);
+      // Surface any generic response metadata registered during query handling (e.g. a
+      // degraded-engine note) into the response. Entries are registered via
+      // QueryThreadContext#addResponseMetadata; the core engine attaches no semantics to them.
+      QueryThreadContext queryThreadContext = QueryThreadContext.getIfAvailable();
+      if (queryThreadContext != null) {
+        queryThreadContext.getExecutionContext().getResponseMetadata().forEach(brokerResponse::putResponseMetadata);
+      }
       augmentStatistics(requestContext, brokerResponse);
       if (QueryOptionsUtils.shouldDropResults(query.getOptions())) {
         brokerResponse.setResultTable(null);

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
@@ -19,7 +19,9 @@
 package org.apache.pinot.common.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
@@ -455,5 +457,31 @@ public interface BrokerResponse {
   @Nullable
   default String getMaterializedViewQueried() {
     return null;
+  }
+
+  /// Returns generic, product-agnostic response metadata: a free-form string-to-[JsonNode] map that
+  /// any component can populate to surface non-fatal, informational notes about how the query was
+  /// handled (for example that it was executed with an alternate or degraded strategy). Values are
+  /// arbitrary JSON, so a note can be a scalar, an object, or an array. This is intentionally a
+  /// generic extension point: the core engine attaches no semantics to the keys or values, so
+  /// extensions can add their own entries without a dedicated typed field on this interface.
+  ///
+  /// This is distinct from [#getTraceInfo()] (per-server trace strings, only populated when tracing
+  /// is enabled) and from [#getExceptions()] (the error/warning list). The default is an empty,
+  /// unmodifiable map for implementations that do not support response metadata.
+  default Map<String, JsonNode> getResponseMetadata() {
+    return Map.of();
+  }
+
+  /// Records a generic response-metadata entry (arbitrary JSON value; see [#getResponseMetadata()]).
+  /// The default is a no-op, so implementations that do not support response metadata silently
+  /// ignore it.
+  default void putResponseMetadata(String key, JsonNode value) {
+  }
+
+  /// String convenience for [#putResponseMetadata(String, JsonNode)] — the common case — wrapping the
+  /// value in a JSON string node.
+  default void putResponseMetadata(String key, String value) {
+    putResponseMetadata(key, TextNode.valueOf(value));
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
@@ -469,6 +469,14 @@ public interface BrokerResponse {
   /// This is distinct from [#getTraceInfo()] (per-server trace strings, only populated when tracing
   /// is enabled) and from [#getExceptions()] (the error/warning list). The default is an empty,
   /// unmodifiable map for implementations that do not support response metadata.
+  ///
+  /// Marked [JsonIgnore] on the interface default so it does not register `responseMetadata` as a
+  /// known (setterless) property on deserializable implementations such as `BrokerResponseNative`
+  /// that do not override it. Otherwise Jackson would try to populate the immutable [Map#of()]
+  /// returned here via USE_GETTERS_AS_SETTERS and fail with an [UnsupportedOperationException] when
+  /// a legacy response carries a non-empty `responseMetadata`. Concrete implementations that support
+  /// the field re-expose it by overriding this method with an explicit [JsonProperty].
+  @JsonIgnore
   default Map<String, JsonNode> getResponseMetadata() {
     return Map.of();
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
@@ -334,6 +334,19 @@ public interface BrokerResponse {
   /// is enabled) and from [#getExceptions()] (the error/warning list). The default is an empty,
   /// unmodifiable map for implementations that do not support response metadata.
   ///
+  /// Today entries can only be registered **on the broker**: they are collected in the broker-side
+  /// `QueryExecutionContext` while the query is being handled, and that sink is never sent over the
+  /// wire — an entry registered by a worker (server) on its own copy of the execution context is
+  /// silently dropped. So in practice this map currently carries broker metadata only.
+  ///
+  /// That is a limitation of the current implementation, not of this contract: the plumbing may
+  /// later be extended so that workers can contribute entries too, propagated back to the broker
+  /// with the rest of the per-server metadata. Hence the deliberately generic name — where an entry
+  /// was produced is an internal detail, and surfacing it in the client-facing response as a
+  /// `brokerMetadata` field that would eventually need a sibling `serverMetadata` field would only
+  /// make the response more complex for no benefit to the user. Worker entries, when supported, will
+  /// go into this same map.
+  ///
   /// Marked [JsonIgnore] on the interface default so it does not register `responseMetadata` as a
   /// known (setterless) property on deserializable implementations such as `BrokerResponseNative`
   /// that do not override it. Otherwise Jackson would try to populate the immutable [Map#of()]

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
@@ -19,7 +19,9 @@
 package org.apache.pinot.common.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
@@ -319,5 +321,31 @@ public interface BrokerResponse {
   @Nullable
   default String getMaterializedViewQueried() {
     return null;
+  }
+
+  /// Returns generic, product-agnostic response metadata: a free-form string-to-[JsonNode] map that
+  /// any component can populate to surface non-fatal, informational notes about how the query was
+  /// handled (for example that it was executed with an alternate or degraded strategy). Values are
+  /// arbitrary JSON, so a note can be a scalar, an object, or an array. This is intentionally a
+  /// generic extension point: the core engine attaches no semantics to the keys or values, so
+  /// extensions can add their own entries without a dedicated typed field on this interface.
+  ///
+  /// This is distinct from [#getTraceInfo()] (per-server trace strings, only populated when tracing
+  /// is enabled) and from [#getExceptions()] (the error/warning list). The default is an empty,
+  /// unmodifiable map for implementations that do not support response metadata.
+  default Map<String, JsonNode> getResponseMetadata() {
+    return Map.of();
+  }
+
+  /// Records a generic response-metadata entry (arbitrary JSON value; see [#getResponseMetadata()]).
+  /// The default is a no-op, so implementations that do not support response metadata silently
+  /// ignore it.
+  default void putResponseMetadata(String key, JsonNode value) {
+  }
+
+  /// String convenience for [#putResponseMetadata(String, JsonNode)] — the common case — wrapping the
+  /// value in a JSON string node.
+  default void putResponseMetadata(String key, String value) {
+    putResponseMetadata(key, TextNode.valueOf(value));
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
@@ -333,6 +333,14 @@ public interface BrokerResponse {
   /// This is distinct from [#getTraceInfo()] (per-server trace strings, only populated when tracing
   /// is enabled) and from [#getExceptions()] (the error/warning list). The default is an empty,
   /// unmodifiable map for implementations that do not support response metadata.
+  ///
+  /// Marked [JsonIgnore] on the interface default so it does not register `responseMetadata` as a
+  /// known (setterless) property on deserializable implementations such as `BrokerResponseNative`
+  /// that do not override it. Otherwise Jackson would try to populate the immutable [Map#of()]
+  /// returned here via USE_GETTERS_AS_SETTERS and fail with an [UnsupportedOperationException] when
+  /// a legacy response carries a non-empty `responseMetadata`. Concrete implementations that support
+  /// the field re-expose it by overriding this method with an explicit [JsonProperty].
+  @JsonIgnore
   default Map<String, JsonNode> getResponseMetadata() {
     return Map.of();
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
@@ -21,9 +21,11 @@ package org.apache.pinot.common.response.broker;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -53,7 +55,8 @@ import org.apache.pinot.common.response.ProcessingException;
     "offlineThreadMemAllocatedBytes", "realtimeThreadMemAllocatedBytes", "offlineResponseSerMemAllocatedBytes",
     "realtimeResponseSerMemAllocatedBytes", "offlineTotalMemAllocatedBytes", "realtimeTotalMemAllocatedBytes",
     "pools", "rlsFiltersApplied", "groupsTrimmed",
-    "mseLiteLeafStageLimitReached", "mseLiteLeafStageEffectiveLimit", "mseLiteFanOutAdjustedLimitApplied"
+    "mseLiteLeafStageLimitReached", "mseLiteLeafStageEffectiveLimit", "mseLiteFanOutAdjustedLimitApplied",
+    "responseMetadata"
 })
 public class BrokerResponseNativeV2 implements BrokerResponse {
   private final StatMap<StatKey> _brokerStats = new StatMap<>(StatKey.class);
@@ -99,6 +102,7 @@ public class BrokerResponseNativeV2 implements BrokerResponse {
   private Integer _mseLiteLeafStageEffectiveLimit;
   @Nullable
   private Boolean _mseLiteFanOutAdjustedLimitApplied;
+  private final Map<String, JsonNode> _responseMetadata = new HashMap<>();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
   @Nullable
@@ -489,6 +493,18 @@ public class BrokerResponseNativeV2 implements BrokerResponse {
   @Override
   public Map<String, String> getTraceInfo() {
     return Map.of();
+  }
+
+  @JsonProperty("responseMetadata")
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  @Override
+  public Map<String, JsonNode> getResponseMetadata() {
+    return _responseMetadata;
+  }
+
+  @Override
+  public void putResponseMetadata(String key, JsonNode value) {
+    _responseMetadata.put(key, value);
   }
 
   @Override

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.response.broker;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -495,6 +496,10 @@ public class BrokerResponseNativeV2 implements BrokerResponse {
     return Map.of();
   }
 
+  // JsonIgnore(false) re-enables the property here: the interface default getter is @JsonIgnore
+  // (so it does not register responseMetadata as a known setterless property on legacy impls that
+  // don't override it), and that ignore would otherwise be inherited by this override.
+  @JsonIgnore(false)
   @JsonProperty("responseMetadata")
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   @Override

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
@@ -21,9 +21,11 @@ package org.apache.pinot.common.response.broker;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -51,7 +53,8 @@ import org.apache.pinot.common.response.ProcessingException;
     "offlineThreadMemAllocatedBytes", "realtimeThreadMemAllocatedBytes", "offlineResponseSerMemAllocatedBytes",
     "realtimeResponseSerMemAllocatedBytes", "offlineTotalMemAllocatedBytes", "realtimeTotalMemAllocatedBytes",
     "pools", "rlsFiltersApplied", "groupsTrimmed",
-    "mseLiteLeafStageLimitReached", "mseLiteLeafStageEffectiveLimit", "mseLiteFanOutAdjustedLimitApplied"
+    "mseLiteLeafStageLimitReached", "mseLiteLeafStageEffectiveLimit", "mseLiteFanOutAdjustedLimitApplied",
+    "responseMetadata"
 })
 public class BrokerResponseNativeV2 implements BrokerResponse {
   private final StatMap<StatKey> _brokerStats = new StatMap<>(StatKey.class);
@@ -91,6 +94,7 @@ public class BrokerResponseNativeV2 implements BrokerResponse {
   private Integer _mseLiteLeafStageEffectiveLimit;
   @Nullable
   private Boolean _mseLiteFanOutAdjustedLimitApplied;
+  private final Map<String, JsonNode> _responseMetadata = new HashMap<>();
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
   @Nullable
@@ -475,6 +479,18 @@ public class BrokerResponseNativeV2 implements BrokerResponse {
   @Override
   public Map<String, String> getTraceInfo() {
     return Map.of();
+  }
+
+  @JsonProperty("responseMetadata")
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  @Override
+  public Map<String, JsonNode> getResponseMetadata() {
+    return _responseMetadata;
+  }
+
+  @Override
+  public void putResponseMetadata(String key, JsonNode value) {
+    _responseMetadata.put(key, value);
   }
 
   @Override

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.response.broker;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -481,6 +482,10 @@ public class BrokerResponseNativeV2 implements BrokerResponse {
     return Map.of();
   }
 
+  // JsonIgnore(false) re-enables the property here: the interface default getter is @JsonIgnore
+  // (so it does not register responseMetadata as a known setterless property on legacy impls that
+  // don't override it), and that ignore would otherwise be inherited by this override.
+  @JsonIgnore(false)
   @JsonProperty("responseMetadata")
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   @Override

--- a/pinot-common/src/test/java/org/apache/pinot/common/response/broker/BrokerResponseNativeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/response/broker/BrokerResponseNativeTest.java
@@ -113,4 +113,24 @@ public class BrokerResponseNativeTest {
   public void testServerStatsDefaultsToNull() {
     Assert.assertNull(new BrokerResponseNative().getServerStats());
   }
+
+  /**
+   * Regression test for backward-compatible deserialization: {@link BrokerResponseNative} does not
+   * override {@code getResponseMetadata()}, so the interface default (marked {@code @JsonIgnore})
+   * must keep {@code responseMetadata} an unknown property. Otherwise Jackson would treat it as a
+   * known setterless Map property and try to populate the immutable {@code Map.of()} default via
+   * USE_GETTERS_AS_SETTERS, failing with an {@link UnsupportedOperationException} when a response
+   * produced by a newer broker (e.g. {@code BrokerResponseNativeV2}) carries a non-empty
+   * {@code responseMetadata}.
+   */
+  @Test
+  public void testResponseMetadataDeserializationCompatibility()
+      throws IOException {
+    String json = "{\"responseMetadata\":{\"note\":\"executed with fallback strategy\","
+        + "\"details\":{\"count\":2}},\"numDocsScanned\":5}";
+    BrokerResponseNative actual = BrokerResponseNative.fromJsonString(json);
+    // The unknown field is ignored on the legacy impl; other fields still deserialize correctly.
+    Assert.assertEquals(actual.getNumDocsScanned(), 5);
+    Assert.assertTrue(actual.getResponseMetadata().isEmpty());
+  }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/response/broker/BrokerResponseNativeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/response/broker/BrokerResponseNativeTest.java
@@ -114,15 +114,12 @@ public class BrokerResponseNativeTest {
     Assert.assertNull(new BrokerResponseNative().getServerStats());
   }
 
-  /**
-   * Regression test for backward-compatible deserialization: {@link BrokerResponseNative} does not
-   * override {@code getResponseMetadata()}, so the interface default (marked {@code @JsonIgnore})
-   * must keep {@code responseMetadata} an unknown property. Otherwise Jackson would treat it as a
-   * known setterless Map property and try to populate the immutable {@code Map.of()} default via
-   * USE_GETTERS_AS_SETTERS, failing with an {@link UnsupportedOperationException} when a response
-   * produced by a newer broker (e.g. {@code BrokerResponseNativeV2}) carries a non-empty
-   * {@code responseMetadata}.
-   */
+  /// Regression test for backward-compatible deserialization: [BrokerResponseNative] does not
+  /// override `getResponseMetadata()`, so the interface default (marked `@JsonIgnore`) must keep
+  /// `responseMetadata` an unknown property. Otherwise Jackson would treat it as a known setterless
+  /// Map property and try to populate the immutable `Map.of()` default via USE_GETTERS_AS_SETTERS,
+  /// failing with an [UnsupportedOperationException] when a response produced by a newer broker
+  /// (e.g. `BrokerResponseNativeV2`) carries a non-empty `responseMetadata`.
   @Test
   public void testResponseMetadataDeserializationCompatibility()
       throws IOException {

--- a/pinot-common/src/test/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2Test.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2Test.java
@@ -18,14 +18,19 @@
  */
 package org.apache.pinot.common.response.broker;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.pinot.common.datatable.StatMap;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -45,6 +50,32 @@ public class BrokerResponseNativeV2Test {
     assertEquals(brokerResponse.getEarlyTerminationReasons(),
         List.of("DISTINCT_MAX_ROWS", "DISTINCT_MAX_ROWS_WITHOUT_CHANGE", "DISTINCT_MAX_EXECUTION_TIME"));
     assertTrue(brokerResponse.isPartialResult());
+  }
+
+  @Test
+  public void testResponseMetadataSerialization()
+      throws Exception {
+    BrokerResponseNativeV2 brokerResponse = new BrokerResponseNativeV2();
+    // Empty by default and omitted from JSON (NON_EMPTY).
+    assertTrue(brokerResponse.getResponseMetadata().isEmpty());
+    JsonNode emptyNode = JsonUtils.stringToJsonNode(brokerResponse.toJsonString());
+    assertNull(emptyNode.get("responseMetadata"));
+
+    // A boolean via the JsonNode overload, a string via the convenience overload, and a nested
+    // object to exercise arbitrary (complex) JSON values.
+    brokerResponse.putResponseMetadata("boolEntry", BooleanNode.getTrue());
+    brokerResponse.putResponseMetadata("stringEntry", "hello");
+    ObjectNode nested = JsonUtils.newObjectNode();
+    nested.put("count", 2);
+    nested.put("label", "example");
+    brokerResponse.putResponseMetadata("objectEntry", nested);
+
+    JsonNode node = JsonUtils.stringToJsonNode(brokerResponse.toJsonString()).get("responseMetadata");
+    assertTrue(node.get("boolEntry").isBoolean());
+    assertTrue(node.get("boolEntry").asBoolean());
+    assertEquals(node.get("stringEntry").asText(), "hello");
+    assertEquals(node.get("objectEntry").get("count").asInt(), 2);
+    assertEquals(node.get("objectEntry").get("label").asText(), "example");
   }
 
   private static Set<String> stringSet(String... values) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/query/QueryExecutionContext.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/query/QueryExecutionContext.java
@@ -19,10 +19,13 @@
 package org.apache.pinot.spi.query;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
@@ -84,6 +87,17 @@ public class QueryExecutionContext {
 
   /// Guards single-emission of the scan-based killing dry-run log line and metric for this query
   private final AtomicBoolean _scanKillingDryRunEmitted = new AtomicBoolean(false);
+
+  /// Generic, product-agnostic response metadata registered during query handling — a free-form
+  /// string-to-[JsonNode] map that any component can populate to surface an informational note about
+  /// how the query was handled (for example that it was executed with an alternate/degraded
+  /// strategy). Values are arbitrary JSON, so a note can be a scalar, an object, or an array. It is
+  /// read by the broker when assembling the [org.apache.pinot.common...BrokerResponse]. This context
+  /// instance is shared by reference across the query's [QueryThreadContext]-aware executors (e.g.
+  /// the broker's async compile/plan threads re-open the context with the same instance), so a writer
+  /// on any of those threads is visible to the response-assembly thread. Concurrent because those
+  /// writes and the final read can happen on different threads.
+  private final Map<String, JsonNode> _responseMetadata = new ConcurrentHashMap<>();
 
   public QueryExecutionContext(QueryType queryType, long requestId, String cid, String workloadName, long startTimeMs,
       long activeDeadlineMs, long passiveDeadlineMs, String brokerId, String instanceId, String queryHash) {
@@ -212,6 +226,24 @@ public class QueryExecutionContext {
   @Nullable
   public TerminationException getTerminateException() {
     return _terminateException;
+  }
+
+  /// Registers a generic response-metadata entry (arbitrary JSON value) to be surfaced in the query
+  /// response. See [#getResponseMetadata()]. Prefer [QueryThreadContext#addResponseMetadata] from
+  /// code that does not already hold this context.
+  public void addResponseMetadata(String key, JsonNode value) {
+    _responseMetadata.put(key, value);
+  }
+
+  /// String convenience for [#addResponseMetadata(String, JsonNode)] — the common case — wrapping the
+  /// value in a JSON string node.
+  public void addResponseMetadata(String key, String value) {
+    _responseMetadata.put(key, TextNode.valueOf(value));
+  }
+
+  /// Returns the generic response metadata registered for this query (never null; possibly empty).
+  public Map<String, JsonNode> getResponseMetadata() {
+    return _responseMetadata;
   }
 
   @Nullable

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/query/QueryExecutionContext.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/query/QueryExecutionContext.java
@@ -91,12 +91,22 @@ public class QueryExecutionContext {
   /// Generic, product-agnostic response metadata registered during query handling — a free-form
   /// string-to-[JsonNode] map that any component can populate to surface an informational note about
   /// how the query was handled (for example that it was executed with an alternate/degraded
-  /// strategy). Values are arbitrary JSON, so a note can be a scalar, an object, or an array. It is
-  /// read by the broker when assembling the [org.apache.pinot.common...BrokerResponse]. This context
-  /// instance is shared by reference across the query's [QueryThreadContext]-aware executors (e.g.
-  /// the broker's async compile/plan threads re-open the context with the same instance), so a writer
-  /// on any of those threads is visible to the response-assembly thread. Concurrent because those
-  /// writes and the final read can happen on different threads.
+  /// strategy). Values are arbitrary JSON, so a note can be a scalar, an object, or an array. The
+  /// broker copies these entries into the query response it sends back to the client.
+  ///
+  /// This context instance is shared by reference across the query's [QueryThreadContext]-aware
+  /// executors (e.g. the broker's async compile/plan threads re-open the context with the same
+  /// instance), so a writer on any of those threads is visible to the response-assembly thread.
+  /// Concurrent because those writes and the final read can happen on different threads.
+  ///
+  /// This sink is **broker-local**: it is not part of the context state serialized to workers, and
+  /// nothing propagates it back from a worker, so only entries registered while running on the
+  /// broker reach the response. An entry registered on a server's copy of the execution context is
+  /// silently dropped. This is a limitation of the current implementation rather than a design
+  /// decision — the plumbing may later be extended so workers can contribute entries as well. The
+  /// registration API records the restriction where it matters ([QueryThreadContext] exposes it as
+  /// `addResponseBrokerMetadata`); this sink and the response field it feeds stay generic, so worker
+  /// entries can later be merged into the very same map.
   private final Map<String, JsonNode> _responseMetadata = new ConcurrentHashMap<>();
 
   public QueryExecutionContext(QueryType queryType, long requestId, String cid, String workloadName, long startTimeMs,
@@ -229,8 +239,10 @@ public class QueryExecutionContext {
   }
 
   /// Registers a generic response-metadata entry (arbitrary JSON value) to be surfaced in the query
-  /// response. See [#getResponseMetadata()]. Prefer [QueryThreadContext#addResponseMetadata] from
-  /// code that does not already hold this context.
+  /// response. See [#getResponseMetadata()] — in particular, only entries registered on the broker
+  /// currently reach the response, which is why the [QueryThreadContext] entry point is named
+  /// [QueryThreadContext#addResponseBrokerMetadata]. Prefer that one from code that does not already
+  /// hold this context.
   public void addResponseMetadata(String key, JsonNode value) {
     _responseMetadata.put(key, value);
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/query/QueryThreadContext.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/query/QueryThreadContext.java
@@ -20,6 +20,7 @@ package org.apache.pinot.spi.query;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -225,6 +226,29 @@ public class QueryThreadContext implements AutoCloseable {
   @Nullable
   public static QueryThreadContext getIfAvailable() {
     return THREAD_LOCAL.get();
+  }
+
+  /// Registers a generic response-metadata entry (arbitrary JSON value) on the current query's
+  /// [QueryExecutionContext], to be surfaced in the query response by the broker (see
+  /// [QueryExecutionContext#getResponseMetadata()]). This is the entry point for code — including
+  /// product extensions — that wants to attach an informational note to the response without a
+  /// dedicated typed field or knowledge of the response object.
+  ///
+  /// No-op when no [QueryThreadContext] is active on the current thread (e.g. tests or planning paths
+  /// that run outside a query context), so callers never need a null check.
+  public static void addResponseMetadata(String key, JsonNode value) {
+    QueryThreadContext threadContext = getIfAvailable();
+    if (threadContext != null) {
+      threadContext.getExecutionContext().addResponseMetadata(key, value);
+    }
+  }
+
+  /// String convenience for [#addResponseMetadata(String, JsonNode)] — the common case.
+  public static void addResponseMetadata(String key, String value) {
+    QueryThreadContext threadContext = getIfAvailable();
+    if (threadContext != null) {
+      threadContext.getExecutionContext().addResponseMetadata(key, value);
+    }
   }
 
   /// Returns a new [ExecutorService] whose tasks will be executed with the [QueryThreadContext] initialized with the

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/query/QueryThreadContext.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/query/QueryThreadContext.java
@@ -234,17 +234,24 @@ public class QueryThreadContext implements AutoCloseable {
   /// product extensions — that wants to attach an informational note to the response without a
   /// dedicated typed field or knowledge of the response object.
   ///
+  /// Must be called from **broker-side** code: the sink lives in the broker's execution context and
+  /// is not propagated from workers, so an entry registered while running on a server would be
+  /// silently dropped. The `Broker` in the name records that restriction, which is a limit of the
+  /// current implementation rather than of the response field it feeds: when worker-side metadata
+  /// becomes supported, this method can either be renamed or joined by an `addResponseMetadata` that
+  /// servers may call too, with both feeding the same generic `responseMetadata` response field.
+  ///
   /// No-op when no [QueryThreadContext] is active on the current thread (e.g. tests or planning paths
   /// that run outside a query context), so callers never need a null check.
-  public static void addResponseMetadata(String key, JsonNode value) {
+  public static void addResponseBrokerMetadata(String key, JsonNode value) {
     QueryThreadContext threadContext = getIfAvailable();
     if (threadContext != null) {
       threadContext.getExecutionContext().addResponseMetadata(key, value);
     }
   }
 
-  /// String convenience for [#addResponseMetadata(String, JsonNode)] — the common case.
-  public static void addResponseMetadata(String key, String value) {
+  /// String convenience for [#addResponseBrokerMetadata(String, JsonNode)] — the common case.
+  public static void addResponseBrokerMetadata(String key, String value) {
     QueryThreadContext threadContext = getIfAvailable();
     if (threadContext != null) {
       threadContext.getExecutionContext().addResponseMetadata(key, value);


### PR DESCRIPTION
## Motivation

There is currently no generic way for a component to attach a small, non-fatal informational note to a query response (e.g. "this query was executed with an alternate/degraded strategy", "a fallback was applied", diagnostic hints). Today the options are to add a dedicated typed field to `BrokerResponse` for each such case, or to piggyback on `traceInfo` (which is semantically per-server trace strings and not populated for the multi-stage engine). Neither scales.

## Change

Add a generic, product-agnostic response-metadata channel:

- **`BrokerResponse`**: `getResponseMetadata()` / `putResponseMetadata(...)` — a `Map<String, JsonNode>` (default empty), implemented on `BrokerResponseNativeV2` and serialized as a `responseMetadata` object (omitted when empty). A `String` convenience overload wraps the value in a `TextNode`. Values are arbitrary JSON, so a note can be a scalar, an object, or an array.
- **`QueryExecutionContext`**: a concurrent response-metadata sink. Because this context instance is propagated *by reference* across `QueryThreadContext`-aware executors, a writer on an async compile/plan thread is visible when the broker assembles the response.
- **`QueryThreadContext.addResponseBrokerMetadata(key, value)`**: the registration API (`JsonNode` and `String` overloads). It is a no-op when no query context is active, so callers never need a null check.
- **`MultiStageBrokerRequestHandler`**: copies the sink into the response after execution.

The core engine attaches no semantics to the keys or values — it is purely an extension point.

## Scope: broker-local today, and why the name is generic

- **Only the broker can populate it right now.** The sink lives in the broker-side `QueryExecutionContext` and is **not sent over the wire**: it is not part of the context state serialized to workers, and nothing propagates it back from a worker. An entry registered on a server's copy of the execution context is silently dropped. So in practice the map currently carries broker metadata only.
- **That is an implementation limit, not a design decision.** The internal plumbing may later be extended so workers (servers) can contribute entries too, propagated back to the broker together with the rest of the per-server metadata.
- **Hence the deliberately generic `responseMetadata` name in the response.** Where an entry was produced is an internal detail and should not leak into the client-facing response: naming the field `brokerMetadata` today would force a sibling `serverMetadata` field once worker support lands, making the response more complex for no benefit to the user. Worker entries, when supported, go into this same map.
- **The restriction is instead recorded in the SPI**, where it does apply: the registration method is `QueryThreadContext.addResponseBrokerMetadata(...)`, making it explicit that metadata registered outside the broker is not reported back. When worker-side metadata becomes supported, that method can be renamed or joined by an `addResponseMetadata(...)` callable from servers too — both feeding the same `responseMetadata` response field.

This is also spelled out in the javadoc of `BrokerResponse#getResponseMetadata()`, `QueryExecutionContext` and `QueryThreadContext#addResponseBrokerMetadata(...)`.

## Example

Any broker-side code can register entries during query handling:

```java
// boolean via the JsonNode overload
QueryThreadContext.addResponseBrokerMetadata("fallbackApplied", BooleanNode.getTrue());
// string via the convenience overload
QueryThreadContext.addResponseBrokerMetadata("note", "served from cache");
// arbitrary/complex JSON value (object, array, ...)
ObjectNode detail = JsonUtils.newObjectNode();
detail.put("stage", 2);
detail.put("strategy", "broadcast");
QueryThreadContext.addResponseBrokerMetadata("detail", detail);
```

These are surfaced in the query response under a top-level `responseMetadata` object:

```json
{
  "resultTable": { "...": "..." },
  "numDocsScanned": 12345,
  "timeUsedMs": 42,
  "responseMetadata": {
    "fallbackApplied": true,
    "note": "served from cache",
    "detail": { "stage": 2, "strategy": "broadcast" }
  }
}
```

Note that:
- values keep their JSON type — `fallbackApplied` is a JSON boolean `true`, not the string `"true"`;
- a complex value (`detail`) is embedded as a nested JSON object, not stringified;
- when nothing is registered the `responseMetadata` field is omitted entirely (`@JsonInclude(NON_EMPTY)`).

## Testing

`BrokerResponseNativeV2Test` covers the empty-map case (field omitted from JSON), boolean/string entries, and a nested object value round-tripping through serialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
