### PR TITLE
[upsert] Make snapshot segmentLock tryLock  with timeout and configurable via cluster config

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -961,17 +961,11 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       // major cleanup steps in the cleanDirectory() method.
       String segmentName = segment.getSegmentName();
       Lock segmentLock = tableDataManager.getSegmentLock(segmentName);
-      boolean locked;
-      try {
-        // Wait a bounded time for the segmentLock instead of returning immediately, so a briefly-held segmentLock
-        // (e.g. a Helix task thread mid-swap) does not force us to skip an otherwise-snapshottable segment. The
-        // timeout is server-scoped and live-updatable via cluster config; setting it to 0 preserves the legacy
-        // non-blocking behavior.
-        locked = segmentLock.tryLock(segmentLockTimeoutMs, TimeUnit.MILLISECONDS);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        locked = false;
-      }
+      // Wait a bounded time for the segmentLock instead of returning immediately, so a briefly-held segmentLock
+      // (e.g. a Helix task thread mid-swap) does not force us to skip an otherwise-snapshottable segment. The
+      // timeout is server-scoped and live-updatable via cluster config; setting it to 0 preserves the legacy
+      // non-blocking behavior.
+      boolean locked = tryAcquireSegmentLock(segmentLock, segmentLockTimeoutMs);
       if (!locked) {
         // Skip this segment when its lock can't be acquired within the timeout: another thread (typically a Helix
         // task mid-replacement) is actively mutating the segment, so any validDocIds/queryableDocIds snapshot we
@@ -1025,13 +1019,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       for (ImmutableSegmentImpl segment : segmentsWithoutSnapshot) {
         String segmentName = segment.getSegmentName();
         Lock segmentLock = tableDataManager.getSegmentLock(segmentName);
-        boolean locked;
-        try {
-          locked = segmentLock.tryLock(segmentLockTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-          locked = false;
-        }
+        boolean locked = tryAcquireSegmentLock(segmentLock, segmentLockTimeoutMs);
         if (!locked) {
           _logger.warn("Could not get segmentLock to take snapshot for segment: {} w/o snapshot within {}ms, skipping",
               segmentName, segmentLockTimeoutMs);
@@ -1153,6 +1141,18 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
    * Removes all primary keys that have comparison value smaller than (largestSeenComparisonValue - TTL).
    */
   protected abstract void doRemoveExpiredPrimaryKeys();
+
+  /// Attempts to acquire {@code lock} with a bounded wait. Returns true iff the lock was acquired within
+  /// {@code timeoutMs}. On interruption, restores the interrupt flag and returns false so the caller treats
+  /// the segment as skipped, matching the timeout branch.
+  private static boolean tryAcquireSegmentLock(Lock lock, long timeoutMs) {
+    try {
+      return lock.tryLock(timeoutMs, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    }
+  }
 
   protected synchronized boolean startOperation() {
     if (_stopped || _numPendingOperations == 0) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -924,6 +924,9 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     int numTrackedSegments = _trackedSegments.size();
     long numPrimaryKeysInSnapshot = 0L;
     long numQueryableDocIdsInSnapshot = 0L;
+    // Snapshot the segmentLock timeout once so every segment in this cycle uses the same value even if the cluster
+    // config is PATCHed mid-snapshot.
+    long segmentLockTimeoutMs = UpsertSnapshotConfig.getSegmentLockTimeoutMs();
     _logger.info("Taking snapshot for {} segments", numTrackedSegments);
     long startTimeMs = System.currentTimeMillis();
 
@@ -958,16 +961,25 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       // major cleanup steps in the cleanDirectory() method.
       String segmentName = segment.getSegmentName();
       Lock segmentLock = tableDataManager.getSegmentLock(segmentName);
-      boolean locked = segmentLock.tryLock();
+      boolean locked;
+      try {
+        // Wait a bounded time for the segmentLock instead of returning immediately, so a briefly-held segmentLock
+        // (e.g. a Helix task thread mid-swap) does not force us to skip an otherwise-snapshottable segment. The
+        // timeout is server-scoped and live-updatable via cluster config; setting it to 0 preserves the legacy
+        // non-blocking behavior.
+        locked = segmentLock.tryLock(segmentLockTimeoutMs, TimeUnit.MILLISECONDS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        locked = false;
+      }
       if (!locked) {
-        // Try to get the segmentLock in a non-blocking manner to avoid deadlock. The Helix task thread takes
-        // segmentLock first and then the snapshot RLock when replacing a segment. However, the consuming thread has
-        // already acquired the snapshot WLock when reaching here, and if it has to wait for segmentLock, it may
-        // enter deadlock with the Helix task threads waiting for snapshot RLock.
-        // If we can't get the segmentLock, we'd better skip taking snapshot for this tracked segment, because its
-        // validDocIds/queryableDocIds might become stale or wrong when the segment is being processed by another
-        // thread right now.
-        _logger.warn("Could not get segmentLock to take snapshot for segment: {}, skipping", segmentName);
+        // Skip this segment when its lock can't be acquired within the timeout: another thread (typically a Helix
+        // task mid-replacement) is actively mutating the segment, so any validDocIds/queryableDocIds snapshot we
+        // wrote right now could be stale or wrong. Skipping also causes the second loop below to be gated
+        // (via isSegmentSkipped) so we do not write new snapshot files for segments-without-snapshot in this cycle,
+        // preserving the on-disk disjoint-snapshots invariant.
+        _logger.warn("Could not get segmentLock to take snapshot for segment: {} within {}ms, skipping", segmentName,
+            segmentLockTimeoutMs);
         isSegmentSkipped = true;
         continue;
       }
@@ -1013,10 +1025,16 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       for (ImmutableSegmentImpl segment : segmentsWithoutSnapshot) {
         String segmentName = segment.getSegmentName();
         Lock segmentLock = tableDataManager.getSegmentLock(segmentName);
-        boolean locked = segmentLock.tryLock();
+        boolean locked;
+        try {
+          locked = segmentLock.tryLock(segmentLockTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          locked = false;
+        }
         if (!locked) {
-          _logger.warn("Could not get segmentLock to take snapshot for segment: {} w/o snapshot, skipping",
-              segmentName);
+          _logger.warn("Could not get segmentLock to take snapshot for segment: {} w/o snapshot within {}ms, skipping",
+              segmentName, segmentLockTimeoutMs);
           continue;
         }
         try {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertSnapshotConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertSnapshotConfig.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.upsert;
+
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.spi.config.provider.PinotClusterConfigChangeListener;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/// Holds server-scoped, live-updatable configuration for the upsert snapshot path.
+///
+/// The value is read at server startup from [PinotConfiguration] and refreshed at runtime through the
+/// [PinotClusterConfigChangeListener] SPI when the corresponding cluster config key
+/// ([CommonConstants.Server#CONFIG_OF_UPSERT_SNAPSHOT_SEGMENT_LOCK_TIMEOUT_MS]) is PATCHed via the cluster-config API.
+/// Callers should read the value directly with [#getSegmentLockTimeoutMs()] on every use so a change in cluster
+/// config takes effect on the next call.
+///
+/// Thread-safety: all reads and writes to the timeout value are atomic (backed by a `volatile long`). Concurrent
+/// readers on the snapshot path may observe a stale value across an in-flight `onChange()`; callers that require a
+/// consistent value within a critical section should snapshot the value into a local variable up-front.
+public final class UpsertSnapshotConfig implements PinotClusterConfigChangeListener {
+  private static final Logger LOGGER = LoggerFactory.getLogger(UpsertSnapshotConfig.class);
+
+  private static volatile long _segmentLockTimeoutMs =
+      CommonConstants.Server.DEFAULT_UPSERT_SNAPSHOT_SEGMENT_LOCK_TIMEOUT_MS;
+
+  private UpsertSnapshotConfig() {
+  }
+
+  private static final UpsertSnapshotConfig INSTANCE = new UpsertSnapshotConfig();
+
+  public static UpsertSnapshotConfig getInstance() {
+    return INSTANCE;
+  }
+
+  public static long getSegmentLockTimeoutMs() {
+    return _segmentLockTimeoutMs;
+  }
+
+  /// Initialize the holder from the server startup configuration. Safe to call multiple times; only the last value
+  /// wins, matching the behavior of a cluster-config PATCH.
+  public static void init(PinotConfiguration serverConfig) {
+    long configured = serverConfig.getProperty(CommonConstants.Server.CONFIG_OF_UPSERT_SNAPSHOT_SEGMENT_LOCK_TIMEOUT_MS,
+        CommonConstants.Server.DEFAULT_UPSERT_SNAPSHOT_SEGMENT_LOCK_TIMEOUT_MS);
+    setSegmentLockTimeoutMs(configured);
+  }
+
+  private static void setSegmentLockTimeoutMs(long value) {
+    if (value < 0) {
+      LOGGER.warn("Ignoring negative upsert snapshot segment lock timeout: {} ms", value);
+      return;
+    }
+    long previous = _segmentLockTimeoutMs;
+    if (previous != value) {
+      _segmentLockTimeoutMs = value;
+      LOGGER.info("Updated upsert snapshot segment lock timeout: {} ms -> {} ms", previous, value);
+    }
+  }
+
+  @Override
+  public void onChange(Set<String> changedConfigs, Map<String, String> clusterConfigs) {
+    if (changedConfigs == null
+        || !changedConfigs.contains(CommonConstants.Server.CONFIG_OF_UPSERT_SNAPSHOT_SEGMENT_LOCK_TIMEOUT_MS)) {
+      return;
+    }
+    String raw = clusterConfigs.get(CommonConstants.Server.CONFIG_OF_UPSERT_SNAPSHOT_SEGMENT_LOCK_TIMEOUT_MS);
+    if (raw == null) {
+      // Cluster config was cleared; revert to default.
+      setSegmentLockTimeoutMs(CommonConstants.Server.DEFAULT_UPSERT_SNAPSHOT_SEGMENT_LOCK_TIMEOUT_MS);
+      return;
+    }
+    try {
+      setSegmentLockTimeoutMs(Long.parseLong(raw.trim()));
+    } catch (NumberFormatException e) {
+      LOGGER.warn("Cluster config {} has non-numeric value: '{}', keeping current: {} ms",
+          CommonConstants.Server.CONFIG_OF_UPSERT_SNAPSHOT_SEGMENT_LOCK_TIMEOUT_MS, raw, _segmentLockTimeoutMs);
+    }
+  }
+}

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -102,6 +102,7 @@ import org.apache.pinot.query.runtime.operator.factory.QueryOperatorFactoryProvi
 import org.apache.pinot.segment.local.realtime.impl.invertedindex.RealtimeLuceneIndexRefreshManager;
 import org.apache.pinot.segment.local.realtime.impl.invertedindex.RealtimeLuceneTextIndexSearcherPool;
 import org.apache.pinot.segment.local.segment.store.TextIndexUtils;
+import org.apache.pinot.segment.local.upsert.UpsertSnapshotConfig;
 import org.apache.pinot.segment.local.utils.ClusterConfigForTable;
 import org.apache.pinot.segment.local.utils.SegmentOperationsThrottler;
 import org.apache.pinot.segment.local.utils.SegmentOperationsThrottlerSet;
@@ -838,6 +839,8 @@ public abstract class BaseServerStarter implements ServiceStartable {
       LOGGER.error("Failed to register DefaultClusterConfigChangeHandler as the Helix ClusterConfigChangeListener", e);
     }
     _clusterConfigChangeHandler.registerClusterConfigChangeListener(_segmentOperationsThrottlerSet);
+    UpsertSnapshotConfig.init(_serverConf);
+    _clusterConfigChangeHandler.registerClusterConfigChangeListener(UpsertSnapshotConfig.getInstance());
     _clusterConfigChangeHandler.registerClusterConfigChangeListener(keepPipelineBreakerStatsPredicate);
     ResourceManager resourceManager = _serverInstance.getQueryScheduler().getResourceManager();
     _clusterConfigChangeHandler.registerClusterConfigChangeListener(

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1742,6 +1742,13 @@ public class CommonConstants {
         "pinot.server.environmentProvider.factory";
     public static final String ENVIRONMENT_PROVIDER_CLASS_NAME = "pinot.server.environmentProvider.className";
 
+    // Upsert snapshot: bounded wait when doTakeSnapshot() tries to acquire a segment's per-segment lock.
+    // Read from cluster config; live-updated via PinotClusterConfigChangeListener. Set to 0 to preserve the legacy
+    // non-blocking behavior (skip immediately on contention).
+    public static final String CONFIG_OF_UPSERT_SNAPSHOT_SEGMENT_LOCK_TIMEOUT_MS =
+        "pinot.server.upsert.snapshot.segment.lock.timeout.ms";
+    public static final long DEFAULT_UPSERT_SNAPSHOT_SEGMENT_LOCK_TIMEOUT_MS = 2000L;
+
     /// All the keys should be prefixed with {@link #INSTANCE_DATA_MANAGER_CONFIG_PREFIX}
     public static class Upsert {
       public static final String CONFIG_PREFIX = "upsert";


### PR DESCRIPTION
## Summary
- `doTakeSnapshot()` previously called `segmentLock.tryLock()` non-blocking; briefly-held segmentLocks (typically Helix tasks mid-swap) forced us to skip otherwise-snapshottable segments.
- Change both call sites to `tryLock(timeoutMs, MILLISECONDS)` where the timeout is a **server-scoped, cluster-config-live-updatable** value.
- Default: `2000` ms. Set to `0` to preserve legacy non-blocking behavior.

## Why
- Motivated by production incidents where `UpsertCompactionTask` ran 4 consecutive 6-hourly cycles at ~100% subtask failure — 257 subtask failures total with `"Unable to retrieve validDocIds bitmap"`. Root cause: `doTakeSnapshot()` on a new consuming segment races with the **previous consuming segment's commit path**, which holds `segmentLock` throughout `commitSegment()` (replaceSegment → releaseConsumerSemaphore → close segment → close buffers → delete consumer dir → "Replaced CONSUMING segment"). The new segment hits `tryLock()` mid-close and skips, logging `Could not get segmentLock to take snapshot for segment: ..., skipping`.

- **About the ms delay**: in the two traces we analyzed, the new segment's `tryLock()` fired only **11–16 ms before** the previous segment's `commitSegment()` released the lock on its final line — i.e., the snapshot skip fired in a window a hair narrower than one video frame. A 1–2 second bounded wait would have won the race in both cases and let the snapshot succeed instead of triggering the downstream `UpsertCompactionTask` failures on the next scheduling cycle.

## What changed
- **New cluster config key**: `pinot.server.upsert.snapshot.segment.lock.timeout.ms` (in `CommonConstants.Server`).
- **New singleton holder**: `UpsertSnapshotConfig` — `volatile long` value, exposes `getSegmentLockTimeoutMs()`, implements `PinotClusterConfigChangeListener` for live reload.
- **Registration** wired in `BaseServerStarter` alongside `SegmentOperationsThrottlerSet` and the other cluster-config listeners.
- **Call sites** in `BasePartitionUpsertMetadataManager.doTakeSnapshot()` snapshot the timeout once per cycle (a mid-cycle PATCH does not cause per-segment divergence).
- **Interrupt handling**: preserves the thread's interrupt flag and treats the segment as skipped.
