### PR TITLE
Render non-String scalars in jsonPathString without JSON quotes

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/JsonFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/JsonFunctions.java
@@ -31,10 +31,13 @@ import com.jayway.jsonpath.spi.cache.CacheProvider;
 import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.function.FastJsonPathExtractor;
@@ -223,10 +226,7 @@ public class JsonFunctions {
   public static String jsonPathString(Object object, String jsonPath)
       throws JsonProcessingException {
     Object jsonValue = jsonPath(object, jsonPath);
-    if (jsonValue instanceof String) {
-      return (String) jsonValue;
-    }
-    return jsonValue == null ? null : JsonUtils.objectToString(jsonValue);
+    return jsonValue != null ? jsonValueToString(jsonValue) : null;
   }
 
   /**
@@ -239,13 +239,27 @@ public class JsonFunctions {
     }
     try {
       Object jsonValue = jsonPath(object, jsonPath);
-      if (jsonValue instanceof String) {
-        return (String) jsonValue;
-      }
-      return jsonValue == null ? defaultValue : JsonUtils.objectToString(jsonValue);
+      return jsonValue != null ? jsonValueToString(jsonValue) : defaultValue;
     } catch (Exception ignore) {
       return defaultValue;
     }
+  }
+
+  /// Renders a value resolved by a JSON path to its string form for the `jsonPathString*` family. A `String`
+  /// leaf is returned verbatim (unquoted). [UUID] / [LocalDate] / [LocalTime] are non-JSON-native scalars a
+  /// record extractor can materialize; [JsonUtils#objectToString] would wrap them in JSON string quotes, so
+  /// they are rendered via their natural (canonical UUID / ISO-8601) `toString` instead. Every other value -
+  /// `Number`, `Boolean`, `Timestamp` (epoch millis), `byte[]`, and `Map` / `Collection` / array containers -
+  /// goes through [JsonUtils#objectToString], matching the json-path-to-string behavior of `jsonExtractScalar`.
+  private static String jsonValueToString(Object jsonValue)
+      throws JsonProcessingException {
+    if (jsonValue instanceof String) {
+      return (String) jsonValue;
+    }
+    if (jsonValue instanceof UUID || jsonValue instanceof LocalDate || jsonValue instanceof LocalTime) {
+      return jsonValue.toString();
+    }
+    return JsonUtils.objectToString(jsonValue);
   }
 
   /// Opt-in fast variant of [#jsonPathString(Object, String, String)] with identical results: a simple
@@ -274,10 +288,7 @@ public class JsonFunctions {
     }
     try {
       Object jsonValue = fastJsonPath(object, jsonPath, false, earlyExit);
-      if (jsonValue instanceof String) {
-        return (String) jsonValue;
-      }
-      return jsonValue == null ? defaultValue : JsonUtils.objectToString(jsonValue);
+      return jsonValue != null ? jsonValueToString(jsonValue) : defaultValue;
     } catch (Exception ignore) {
       return defaultValue;
     }

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/JsonFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/JsonFunctionsTest.java
@@ -21,10 +21,16 @@ package org.apache.pinot.common.function;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.jayway.jsonpath.InvalidJsonException;
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import org.apache.pinot.common.function.scalar.JsonFunctions;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.Assert;
@@ -453,6 +459,40 @@ public class JsonFunctionsTest {
       throws JsonProcessingException {
     String value = JsonFunctions.jsonPathString(JsonUtils.objectToString(map), path, expected);
     assertEquals(value, expected);
+  }
+
+  @Test
+  public void testJsonPathStringOnExtractedValues()
+      throws JsonProcessingException {
+    // A value resolved from an already-parsed record tree (not a JSON string) keeps its runtime Java type.
+    // UUID / LocalDate / LocalTime are non-JSON-native scalars a record extractor can materialize; they render
+    // as their natural unquoted string, never wrapped in JSON string quotes.
+    UUID uuid = UUID.fromString("657ae8f8-b702-3cf4-9a05-300348c1623e");
+    assertEquals(JsonFunctions.jsonPathString(Map.of("v", uuid), "$.v"), "657ae8f8-b702-3cf4-9a05-300348c1623e");
+    assertEquals(JsonFunctions.jsonPathString(Map.of("v", uuid), "$.v", "default"),
+        "657ae8f8-b702-3cf4-9a05-300348c1623e");
+    assertEquals(JsonFunctions.jsonPathString(Map.of("v", LocalDate.of(2026, 7, 20)), "$.v"), "2026-07-20");
+    assertEquals(JsonFunctions.jsonPathString(Map.of("v", LocalTime.of(19, 54, 37)), "$.v"), "19:54:37");
+
+    // The fast-path variants share the same rendering helper and must produce identical results.
+    assertEquals(JsonFunctions.jsonPathStringFast(Map.of("v", uuid), "$.v", "default"),
+        "657ae8f8-b702-3cf4-9a05-300348c1623e");
+    assertEquals(JsonFunctions.jsonPathStringFirstMatch(Map.of("v", LocalDate.of(2026, 7, 20)), "$.v", "default"),
+        "2026-07-20");
+
+    // Numbers, Boolean, and Map / List / Set containers follow the json-path-to-string behavior of
+    // jsonExtractScalar (i.e. JsonUtils.objectToString), so a scalar number is unquoted and a container is JSON.
+    assertEquals(JsonFunctions.jsonPathString(Map.of("v", 42), "$.v"), "42");
+    assertEquals(JsonFunctions.jsonPathString(Map.of("v", 1.5d), "$.v"), "1.5");
+    assertEquals(JsonFunctions.jsonPathString(Map.of("v", new BigDecimal("123.45")), "$.v"), "123.45");
+    assertEquals(JsonFunctions.jsonPathString(Map.of("v", true), "$.v"), "true");
+    assertEquals(JsonFunctions.jsonPathString(Map.of("v", Map.of("k", "w")), "$.v"), "{\"k\":\"w\"}");
+    assertEquals(JsonFunctions.jsonPathString(Map.of("v", List.of(1, 2, 3)), "$.v"), "[1,2,3]");
+    assertEquals(JsonFunctions.jsonPathString(Map.of("v", Set.of("x")), "$.v"), "[\"x\"]");
+
+    // Timestamp follows objectToString (portable epoch millis), not its timezone-dependent JDBC toString form.
+    Timestamp timestamp = new Timestamp(1000L);
+    assertEquals(JsonFunctions.jsonPathString(Map.of("v", timestamp), "$.v"), JsonUtils.objectToString(timestamp));
   }
 
   @DataProvider


### PR DESCRIPTION
## Summary

`jsonPathString` (and its fast variants `jsonPathStringFast` / `jsonPathStringFirstMatch`) stringified any non-`String` resolved value via `JsonUtils.objectToString`. Jackson serializes several non-JSON-native Java types — notably `java.util.UUID` — as a *quoted* JSON string, so extracting such a value produced a double-quoted result. For example, an Avro `uuid` logical-type field extracted with `JSONPATHSTRING(after, '$.customer_id')` yielded `"657ae8f8-..."` (with literal quotes) instead of the bare UUID.

These types never arise from parsing a JSON string (Jackson only yields `Boolean` / `Integer` / `Long` / `Double` / `String` / `null` / `List` / `Map`); they only appear when the function operates on an already-materialized record tree — e.g. an ingestion transform reading an extractor-produced value.

### Fix

All entry points now route the resolved value through a shared `jsonValueToString` helper:

- `String` → returned verbatim (unquoted).
- `UUID` / `LocalDate` / `LocalTime` — the non-JSON-native scalars a record extractor can materialize, which `objectToString` would wrap in quotes — render via their natural canonical / ISO-8601 `toString`.
- Everything else — `Number`, `Boolean`, `Timestamp` (portable epoch millis), `byte[]`, and `Map` / `Collection` / array containers — continues through `JsonUtils.objectToString`.

This keeps `jsonPathString` consistent with the query-time `jsonExtractScalar` on every value the query path can produce; the only deliberate divergences are the three quote-stripping overrides for types `jsonExtractScalar` never encounters.

### Compatibility note

This changes the observable output of the released `jsonPathString*` scalar functions for `UUID` / `LocalDate` / `LocalTime` leaves (old: JSON-quoted / Jackson-default form; new: unquoted canonical form). The window is narrow — these types only occur on already-materialized record trees, not JSON-string input — but during a rolling upgrade a mixed-version cluster can briefly return both forms, and previously-persisted derived-column values will differ from newly-ingested ones. The new form is the intended correctness fix, so no version gate is added.
