### PR TITLE
Skip empty/default geometry values when building H3 index on reload

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/H3IndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/H3IndexHandler.java
@@ -28,7 +28,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.segment.index.loader.BaseIndexHandler;
 import org.apache.pinot.segment.local.segment.index.loader.LoaderUtils;
 import org.apache.pinot.segment.local.segment.index.readers.geospatial.ImmutableH3IndexReader;
-import org.apache.pinot.segment.local.utils.GeometrySerializer;
 import org.apache.pinot.segment.spi.ColumnMetadata;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.creator.IndexCreationContext;
@@ -215,7 +214,10 @@ public class H3IndexHandler extends BaseIndexHandler {
       int numDocs = columnMetadata.getTotalDocs();
       for (int i = 0; i < numDocs; i++) {
         int dictId = forwardIndexReader.getDictId(i, readerContext);
-        h3IndexCreator.add(GeometrySerializer.deserialize(dictionary.getBytesValue(dictId)));
+        // Route through add(value, dictId) so that empty/default geometry values (e.g. old segments reloaded after
+        // the geo column was added, which have no source data to build a Point from) are tolerated the same way the
+        // segment-creation path tolerates them, instead of failing the whole reload with a BufferUnderflowException.
+        h3IndexCreator.add(dictionary.getBytesValue(dictId), dictId);
       }
       h3IndexCreator.seal();
     }
@@ -234,7 +236,8 @@ public class H3IndexHandler extends BaseIndexHandler {
         GeoSpatialIndexCreator h3IndexCreator = StandardIndexes.h3().createIndexCreator(context, config)) {
       int numDocs = columnMetadata.getTotalDocs();
       for (int i = 0; i < numDocs; i++) {
-        h3IndexCreator.add(GeometrySerializer.deserialize(forwardIndexReader.getBytes(i, readerContext)));
+        // See handleDictionaryBasedColumn: add(value, dictId) tolerates empty/default geometry values on reload.
+        h3IndexCreator.add(forwardIndexReader.getBytes(i, readerContext), -1);
       }
       h3IndexCreator.seal();
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
@@ -136,6 +136,8 @@ public class SegmentPreProcessorTest implements PinotBuffersAfterClassCheckRule 
   private static final String NEW_COLUMNS_SCHEMA_WITH_FST = "data/newColumnsSchemaWithFST.json";
   private static final String NEW_COLUMNS_SCHEMA_WITH_TEXT = "data/newColumnsSchemaWithText.json";
   private static final String NEW_COLUMNS_SCHEMA_WITH_H3_JSON = "data/newColumnsSchemaWithH3Json.json";
+  private static final String NEW_COLUMNS_SCHEMA_WITH_H3_EMPTY_DEFAULT =
+      "data/newColumnsSchemaWithH3EmptyDefault.json";
   private static final String NEW_COLUMNS_SCHEMA_WITH_NO_FORWARD_INDEX =
       "data/newColumnsSchemaWithForwardIndexDisabled.json";
   private static final String NEW_INT_METRIC_COLUMN_NAME = "newIntMetric";
@@ -164,6 +166,7 @@ public class SegmentPreProcessorTest implements PinotBuffersAfterClassCheckRule 
   private final Schema _newColumnsSchemaWithFST;
   private final Schema _newColumnsSchemaWithText;
   private final Schema _newColumnsSchemaWithH3Json;
+  private final Schema _newColumnsSchemaWithH3EmptyDefault;
   private final Schema _newColumnsSchemaWithForwardIndexDisabled;
 
   private Set<String> _noDictionaryColumns;
@@ -208,6 +211,9 @@ public class SegmentPreProcessorTest implements PinotBuffersAfterClassCheckRule 
     resourceUrl = classLoader.getResource(NEW_COLUMNS_SCHEMA_WITH_H3_JSON);
     assertNotNull(resourceUrl);
     _newColumnsSchemaWithH3Json = Schema.fromFile(new File(resourceUrl.getFile()));
+    resourceUrl = classLoader.getResource(NEW_COLUMNS_SCHEMA_WITH_H3_EMPTY_DEFAULT);
+    assertNotNull(resourceUrl);
+    _newColumnsSchemaWithH3EmptyDefault = Schema.fromFile(new File(resourceUrl.getFile()));
     resourceUrl = classLoader.getResource(NEW_COLUMNS_SCHEMA_WITH_NO_FORWARD_INDEX);
     assertNotNull(resourceUrl);
     _newColumnsSchemaWithForwardIndexDisabled = Schema.fromFile(new File(resourceUrl.getFile()));
@@ -1663,6 +1669,39 @@ public class SegmentPreProcessorTest implements PinotBuffersAfterClassCheckRule 
     resetIndexConfigs();
     runPreProcessor(_newColumnsSchemaWithH3Json);
     assertEquals(singleFileIndex.length(), initFileSize);
+  }
+
+  /// Regression test for the H3 index builder crashing a segment on empty/default geometry values.
+  ///
+  /// When a geo column is added to the schema after a segment was built, old segments have no source
+  /// data to derive it from, so the derived BYTES column is filled with its default null value -- the
+  /// empty byte array. Building an H3 index over those rows used to call
+  /// [org.apache.pinot.segment.local.utils.GeometrySerializer#deserialize(byte\[\])] directly on the
+  /// empty bytes, throwing a `BufferUnderflowException` that propagated out of the reload and parked
+  /// the segment in an ERROR state. The handler now routes through the creator's tolerant add path,
+  /// which skips undeserializable/default values when `continueOnError` is enabled (set by
+  /// [#resetIndexConfigs()]), exactly like the segment-creation path.
+  @Test(dataProvider = "bothV1AndV3")
+  public void testH3IndexCreationOnEmptyDefaultValue(SegmentVersion segmentVersion)
+      throws Exception {
+    buildSegment(segmentVersion);
+
+    // Add newH3Col as a derived column whose default null value is the empty byte array (no explicit
+    // defaultNullValue in the schema), mirroring old segments reloaded after a geo column was added.
+    runPreProcessor(_newColumnsSchemaWithH3EmptyDefault);
+    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(INDEX_DIR);
+    assertNotNull(segmentMetadata.getColumnMetadataFor("newH3Col"));
+
+    // Build the H3 index over the empty/default values. This must not throw and must produce the index.
+    _fieldConfigMap.put("newH3Col",
+        new FieldConfig("newH3Col", FieldConfig.EncodingType.DICTIONARY, List.of(FieldConfig.IndexType.H3), null,
+            Map.of("resolutions", "5")));
+    runPreProcessor(_newColumnsSchemaWithH3EmptyDefault);
+
+    try (SegmentDirectory segmentDirectory = new SegmentLocalFSDirectory(INDEX_DIR, ReadMode.mmap);
+        SegmentDirectory.Reader reader = segmentDirectory.createReader()) {
+      assertTrue(reader.hasIndexFor("newH3Col", StandardIndexes.h3()));
+    }
   }
 
   @Test(dataProvider = "bothV1AndV3")

--- a/pinot-segment-local/src/test/resources/data/newColumnsSchemaWithH3EmptyDefault.json
+++ b/pinot-segment-local/src/test/resources/data/newColumnsSchemaWithH3EmptyDefault.json
@@ -1,0 +1,72 @@
+{
+  "schemaName": "testDataMV",
+  "dimensionFieldSpecs": [
+    {
+      "name": "column1",
+      "dataType": "INT"
+    },
+    {
+      "name": "column2",
+      "dataType": "INT"
+    },
+    {
+      "name": "column3",
+      "dataType": "STRING"
+    },
+    {
+      "name": "column4",
+      "dataType": "STRING"
+    },
+    {
+      "name": "column5",
+      "dataType": "STRING"
+    },
+    {
+      "name": "newH3Col",
+      "dataType": "BYTES"
+    },
+    {
+      "name": "column6",
+      "dataType": "INT",
+      "singleValueField": false
+    },
+    {
+      "name": "column7",
+      "dataType": "INT",
+      "singleValueField": false
+    },
+    {
+      "name": "column8",
+      "dataType": "INT"
+    },
+    {
+      "name": "column9",
+      "dataType": "INT"
+    },
+    {
+      "name": "column10",
+      "dataType": "INT"
+    },
+    {
+      "name": "column13",
+      "dataType": "INT"
+    },
+    {
+      "name": "weeksSinceEpochSunday",
+      "dataType": "INT"
+    }
+  ],
+  "metricFieldSpecs": [
+    {
+      "name": "count",
+      "dataType": "INT"
+    }
+  ],
+  "timeFieldSpec": {
+    "incomingGranularitySpec": {
+      "timeType": "DAYS",
+      "dataType": "INT",
+      "name": "daysSinceEpoch"
+    }
+  }
+}


### PR DESCRIPTION
## Problem

When a geo column with an H3 index (plus a transform such as `ST_Point(lat, long)`) is added to a table's schema, segments created **before** the source columns existed have no data to derive the geometry from. On reload, the derived `BYTES` column is filled with its default null value — the empty byte array (`FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_BYTES`).

Building the H3 index over those rows during segment reload called `GeometrySerializer.deserialize()` directly on the empty bytes:

```
java.nio.BufferUnderflowException
    at org.apache.pinot.segment.local.utils.GeometrySerializer.readGeometry(GeometrySerializer.java:83)
    at org.apache.pinot.segment.local.utils.GeometrySerializer.deserialize(GeometrySerializer.java:68)
    at org.apache.pinot.segment.local.segment.index.loader.invertedindex.H3IndexHandler.handleDictionaryBasedColumn(H3IndexHandler.java:218)
    at ...H3IndexHandler.updateIndices(H3IndexHandler.java:147)
```

The exception propagated out of the Helix state transition and parked the segment in an `ERROR` state, blocking upgrades (old segments never come online).

## Root cause

The segment-**creation** path builds the H3 index via the `GeoSpatialIndexCreator` default `add(Object value, int dictId)`, which wraps `deserialize()` in a try/catch and treats failures as `null` geometry (skipped when `continueOnError` is enabled). The segment-**reload** path in `H3IndexHandler` bypassed that — it called the static `GeometrySerializer.deserialize(bytes)` directly and fed the result to `add(Geometry)`, so an empty/default value threw before the `add()` guard could skip it.

## Fix

Route both `H3IndexHandler` reload paths (`handleDictionaryBasedColumn`, `handleNonDictionaryBasedColumn`) through the same tolerant `add(value, dictId)` the creation path uses. Empty/default geometry is now skipped when `continueOnError` is enabled, consistent with ingestion, instead of crashing the reload.

## Test

Added `SegmentPreProcessorTest#testH3IndexCreationOnEmptyDefaultValue` (v1 and v3), which adds a derived H3 column whose default null value is the empty byte array and then builds the H3 index over it. Verified as a real regression guard: it fails with `BufferUnderflowException` without the fix and passes with it. `H3IndexTest` and the existing H3 preprocessor tests remain green.