### PR TITLE
Skip selection LIMIT pruning for segments with externally-deleted docs

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/SelectionQuerySegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/SelectionQuerySegmentPruner.java
@@ -97,8 +97,12 @@ public class SelectionQuerySegmentPruner implements SegmentPruner {
       return List.of(segments.get(0));
     }
 
-    // Skip pruning segments for upsert table because valid doc index is equivalent to a filter
-    if (segments.get(0).getValidDocIds() != null) {
+    // Skip pruning when a post-selection doc mask makes the raw total-doc count overstate the surviving rows, which
+    // would otherwise under-return under LIMIT. Both signals are set uniformly across a table's segments, so the
+    // first segment suffices: upsert's valid-doc index, or an externally-supplied deleted-doc set. Skipping keeps
+    // results correct -- every segment is still scanned and the mask applied during the scan.
+    IndexSegment firstSegment = segments.get(0);
+    if (firstSegment.getValidDocIds() != null || firstSegment.hasDeletedDocIds()) {
       return segments;
     }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -85,6 +85,7 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
   private PartitionUpsertMetadataManager _partitionUpsertMetadataManager;
   private ThreadSafeMutableRoaringBitmap _validDocIds;
   private ThreadSafeMutableRoaringBitmap _queryableDocIds;
+  private volatile boolean _hasDeletedDocIds;
 
   public ImmutableSegmentImpl(
       SegmentDirectory segmentDirectory,
@@ -360,6 +361,19 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
   @Override
   public ThreadSafeMutableRoaringBitmap getQueryableDocIds() {
     return _queryableDocIds;
+  }
+
+  @Override
+  public boolean hasDeletedDocIds() {
+    return _hasDeletedDocIds;
+  }
+
+  /**
+   * Marks that this segment has externally-supplied deleted docs -- excluded at query time but still counted in
+   * total docs -- so selection LIMIT pruning skips it.
+   */
+  public void setHasDeletedDocIds(boolean hasDeletedDocIds) {
+    _hasDeletedDocIds = hasDeletedDocIds;
   }
 
   @Override

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/IndexSegment.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/IndexSegment.java
@@ -115,6 +115,13 @@ public interface IndexSegment {
     return false;
   }
 
+  /// Whether this segment has externally-supplied deleted doc ids: docs excluded from query results but still
+  /// counted in the total doc count. Independent of upsert validity ([#getValidDocIds]). Selection LIMIT pruning
+  /// reads it to skip counting these docs toward the LIMIT budget, which would otherwise under-return rows.
+  default boolean hasDeletedDocIds() {
+    return false;
+  }
+
   /**
    * Returns the record for the given document id. Virtual column values are not returned.
    * <p>NOTE: don't use this method for high performance code. Use PinotSegmentRecordReader when reading multiple


### PR DESCRIPTION
## Problem

`SelectionQuerySegmentPruner` decrements the LIMIT budget by each segment's raw `getTotalDocs()` and prunes trailing segments. When a segment applies a post-selection doc mask that removes rows at query time (beyond upsert's `validDocIds`), the raw count overstates the surviving rows, so `SELECT ... LIMIT n` and `ORDER BY ... LIMIT n` can under-return — a correct prefix, short by the removed fraction. `count(*)` / aggregations are unaffected (the pruner is not applicable to them).

## Change

- Add `IndexSegment#hasDeletedDocIds()` (default `false`): a generic signal, independent of upsert, that a segment carries externally-supplied deleted docs — counted in total docs but excluded at query time.
- `SelectionQuerySegmentPruner` skips pruning when the first segment reports it, mirroring the existing upsert `getValidDocIds()` guard.
- `ImmutableSegmentImpl` gains `setHasDeletedDocIds(...)` so callers can mark such segments.

Default-`false` on the interface keeps all existing segment types unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
