### PR TITLE
feat(open_struct): query-layer wiring for OPEN_STRUCT columns (PR 3/4)

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
+import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
@@ -62,6 +63,13 @@ public class DataFetcher implements AutoCloseable {
     int maxNumValuesPerMVEntry = 0;
     for (Map.Entry<String, DataSource> entry : dataSourceMap.entrySet()) {
       DataSource dataSource = entry.getValue();
+      // An OPEN_STRUCT parent holds no readers of its own — every value is read through a per-key data source that
+      // ProjectionBlock#getBlockValueSet(String[]) registers lazily via addDataSource. Registering the parent here
+      // would trip the forward-index precondition. (MAP parents do carry a MapIndexReader forward index, so they
+      // are registered normally.)
+      if (dataSource instanceof OpenStructDataSource) {
+        continue;
+      }
       addDataSource(entry.getKey(), dataSource);
       DataSourceMetadata dataSourceMetadata = dataSource.getDataSourceMetadata();
       if (!dataSourceMetadata.isSingleValue()) {
@@ -73,6 +81,13 @@ public class DataFetcher implements AutoCloseable {
   }
 
   public void addDataSource(String column, DataSource dataSource) {
+    // Idempotent: ProjectionBlock#getBlockValueSet(String[]) re-resolves the per-key data source on every block, and
+    // an unconditional put would orphan the displaced ColumnValueReader together with its off-heap reader context —
+    // close() only walks the readers still in the map. The key resolves to the same underlying index for the life of
+    // one ProjectionOperator, so keeping the first reader is equivalent.
+    if (_columnValueReaderMap.containsKey(column)) {
+      return;
+    }
     ForwardIndexReader<?> forwardIndexReader = dataSource.getForwardIndex();
     Preconditions.checkState(forwardIndexReader != null,
         "Forward index disabled for column: %s, cannot create DataFetcher!", column);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/ProjectionBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/ProjectionBlock.java
@@ -23,8 +23,11 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.DataBlockCache;
 import org.apache.pinot.core.operator.docvalsets.ProjectionBlockValSet;
+import org.apache.pinot.segment.local.segment.index.map.NullDataSource;
+import org.apache.pinot.segment.local.segment.index.openstruct.OpenStructNullDataSource;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.datasource.MapDataSource;
+import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
 import org.apache.pinot.spi.data.ComplexFieldSpec;
 
 
@@ -64,8 +67,22 @@ public class ProjectionBlock implements ValueBlock {
   public BlockValSet getBlockValueSet(String[] paths) {
     // TODO: only support one level of path for now, e.g. `map.key`
     assert paths.length == 2;
-    MapDataSource mapDataSource = (MapDataSource) _dataSourceMap.get(paths[0]);
-    DataSource keyDataSource = mapDataSource.getDataSource(paths[1]);
+    DataSource columnDataSource = _dataSourceMap.get(paths[0]);
+    DataSource keyDataSource;
+    if (columnDataSource instanceof MapDataSource) {
+      keyDataSource = ((MapDataSource) columnDataSource).getDataSource(paths[1]);
+      if (keyDataSource == null) {
+        keyDataSource = new NullDataSource(paths[1]);
+      }
+    } else if (columnDataSource instanceof OpenStructDataSource) {
+      OpenStructDataSource osDs = (OpenStructDataSource) columnDataSource;
+      keyDataSource = osDs.getDataSource(paths[1]);
+      if (keyDataSource == null) {
+        keyDataSource = OpenStructNullDataSource.forAbsentKey(osDs, paths[1]);
+      }
+    } else {
+      throw new IllegalStateException("Path-based access requires MAP or OPEN_STRUCT column: " + paths[0]);
+    }
     String fullColumnKeyName = ComplexFieldSpec.getFullChildName(paths);
     _dataSourceMap.put(fullColumnKeyName, keyDataSource);
     _dataBlockCache.addDataSource(fullColumnKeyName, keyDataSource);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/ProjectionBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/ProjectionBlock.java
@@ -76,6 +76,14 @@ public class ProjectionBlock implements ValueBlock {
   public BlockValSet getBlockValueSet(String[] paths) {
     // TODO: only support one level of path for now, e.g. `map.key`
     assert paths.length == 2;
+    String fullColumnKeyName = ComplexFieldSpec.getFullChildName(paths);
+    // Resolve once per ProjectionOperator, not once per block: _dataSourceMap is owned by the operator and
+    // shared across every block of the segment. Re-resolving an absent OPEN_STRUCT key rebuilds a null bitmap
+    // spanning the whole segment on each block, and DataFetcher keeps the first reader registered under the
+    // name anyway, so every later resolution is garbage that also leaves this map disagreeing with the fetcher.
+    if (_dataSourceMap.containsKey(fullColumnKeyName)) {
+      return getBlockValueSet(fullColumnKeyName);
+    }
     DataSource columnDataSource = _dataSourceMap.get(paths[0]);
     DataSource keyDataSource;
     if (columnDataSource instanceof MapDataSource) {
@@ -92,7 +100,6 @@ public class ProjectionBlock implements ValueBlock {
     } else {
       throw new IllegalStateException("Path-based access requires MAP or OPEN_STRUCT column: " + paths[0]);
     }
-    String fullColumnKeyName = ComplexFieldSpec.getFullChildName(paths);
     _dataSourceMap.put(fullColumnKeyName, keyDataSource);
     _dataBlockCache.addDataSource(fullColumnKeyName, keyDataSource);
     return getBlockValueSet(fullColumnKeyName);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/ProjectionBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/ProjectionBlock.java
@@ -29,6 +29,7 @@ import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.datasource.MapDataSource;
 import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
 import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.exception.BadQueryRequestException;
 
 
 /// ProjectionBlock holds a column name to Block Map.
@@ -60,7 +61,15 @@ public class ProjectionBlock implements ValueBlock {
 
   @Override
   public BlockValSet getBlockValueSet(String column) {
-    return new ProjectionBlockValSet(_dataBlockCache, column, _dataSourceMap.get(column));
+    DataSource dataSource = _dataSourceMap.get(column);
+    // An OPEN_STRUCT parent is only a handle for per-key resolution — it has no forward index, so DataFetcher does
+    // not register it and it cannot be read as a column. Reject it here rather than letting the missing
+    // ColumnValueReader surface as an NPE.
+    if (dataSource instanceof OpenStructDataSource) {
+      throw new BadQueryRequestException(
+          "OPEN_STRUCT column: " + column + " cannot be selected directly; use item(" + column + ", 'key')");
+    }
+    return new ProjectionBlockValSet(_dataBlockCache, column, dataSource);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/ProjectionBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/ProjectionBlock.java
@@ -67,7 +67,7 @@ public class ProjectionBlock implements ValueBlock {
     // ColumnValueReader surface as an NPE.
     if (dataSource instanceof OpenStructDataSource) {
       throw new BadQueryRequestException(
-          "OPEN_STRUCT column: " + column + " cannot be selected directly; use item(" + column + ", 'key')");
+          "OPEN_STRUCT column: " + column + " cannot be selected directly; use " + column + "['key']");
     }
     return new ProjectionBlockValSet(_dataBlockCache, column, dataSource);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MapFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MapFilterOperator.java
@@ -68,7 +68,7 @@ public class MapFilterOperator extends BaseFilterOperator {
 
   public MapFilterOperator(IndexSegment indexSegment, Predicate predicate, QueryContext queryContext,
       int numDocs) {
-    super(numDocs, false);
+    super(numDocs, queryContext.isNullHandlingEnabled());
     _predicate = predicate;
 
     List<ExpressionContext> arguments = predicate.getLhs().getFunction().getArguments();
@@ -274,6 +274,20 @@ public class MapFilterOperator extends BaseFilterOperator {
   @Override
   protected BlockDocIdSet getTrues() {
     return _delegate.getTrues();
+  }
+
+  /// Forwarded so three-valued logic survives the delegation. `NotFilterOperator.getTrues()` reads
+  /// `getFalses()`, and `And`/`OrFilterOperator.getFalses()` read `getNulls()`; leaving these on the
+  /// base implementation would report an absent key's UNKNOWN docs as FALSE, so
+  /// `NOT (col['key'] = v)` would match every doc missing the key.
+  @Override
+  protected BlockDocIdSet getNulls() {
+    return _delegate.getNulls();
+  }
+
+  @Override
+  protected BlockDocIdSet getFalses() {
+    return _delegate.getFalses();
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MapFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MapFilterOperator.java
@@ -20,7 +20,9 @@ package org.apache.pinot.core.operator.filter;
 
 import com.google.common.base.CaseFormat;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FilterContext;
 import org.apache.pinot.common.request.context.predicate.EqPredicate;
@@ -28,25 +30,36 @@ import org.apache.pinot.common.request.context.predicate.InPredicate;
 import org.apache.pinot.common.request.context.predicate.NotEqPredicate;
 import org.apache.pinot.common.request.context.predicate.NotInPredicate;
 import org.apache.pinot.common.request.context.predicate.Predicate;
+import org.apache.pinot.common.request.context.predicate.RangePredicate;
 import org.apache.pinot.core.common.BlockDocIdSet;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.ExplainAttributeBuilder;
+import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
+import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluatorProvider;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
 import org.apache.pinot.segment.spi.index.IndexService;
 import org.apache.pinot.segment.spi.index.IndexType;
 import org.apache.pinot.segment.spi.index.reader.JsonIndexReader;
+import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 
 
-/// Filter operator for Map matching that internally uses JsonMatchFilterOperator or ExpressionFilterOperator.
-/// This operator converts map predicates to JSON predicates and delegates filtering operations
-/// to JsonMatchFilterOperator.
+/// Filter operator for Map/OPEN_STRUCT matching. Dispatches in priority order:
+/// 1. Per-key materialized index (OPEN_STRUCT columns with per-key inverted/range/bloom indexes)
+/// 2. JSON index (JsonMatchFilterOperator)
+/// 3. Expression scan fallback (ExpressionFilterOperator)
 public class MapFilterOperator extends BaseFilterOperator {
   private static final String EXPLAIN_NAME = "FILTER_MAP";
 
-  private final JsonMatchFilterOperator _jsonMatchOperator;
-  private final ExpressionFilterOperator _expressionFilterOperator;
+  private enum DelegateType {
+    PER_KEY_INDEX, JSON_MATCH, EXPRESSION_FILTER
+  }
+
+  private final BaseFilterOperator _delegate;
+  private final DelegateType _delegateType;
   private final String _columnName;
   private final String _keyName;
   private final Predicate _predicate;
@@ -56,7 +69,6 @@ public class MapFilterOperator extends BaseFilterOperator {
     super(numDocs, false);
     _predicate = predicate;
 
-    // Get column name and key name from function arguments
     List<ExpressionContext> arguments = predicate.getLhs().getFunction().getArguments();
     if (arguments.size() != 2) {
       throw new IllegalStateException("Expected two arguments (column name and key name), found: " + arguments.size());
@@ -65,102 +77,161 @@ public class MapFilterOperator extends BaseFilterOperator {
     _columnName = arguments.get(0).getIdentifier();
     _keyName = arguments.get(1).getLiteral().getStringValue();
 
-    JsonIndexReader jsonIndex = null;
-    if (canUseJsonIndex(_predicate.getType())) {
-      DataSource dataSource = indexSegment.getDataSourceNullable(_columnName);
-      if (dataSource != null) {
-        jsonIndex = dataSource.getJsonIndex();
-        if (jsonIndex == null) {
-          // Fallback to Composite JSON Index if standard JSON index is not available
-          Optional<IndexType<?, ?, ?>> compositeIndex =
-              IndexService.getInstance().getOptional("composite_json_index");
-          if (compositeIndex.isPresent()) {
-            jsonIndex = (JsonIndexReader) dataSource.getIndex(compositeIndex.get());
-          }
-        }
-      }
+    // Try dispatch paths in priority order
+    DataSource columnDs = indexSegment.getDataSourceNullable(_columnName);
+
+    BaseFilterOperator perKey = tryPerKeyIndex(columnDs, queryContext, numDocs);
+    if (perKey != null) {
+      _delegate = perKey;
+      _delegateType = DelegateType.PER_KEY_INDEX;
+      return;
     }
-    if (jsonIndex != null) {
-      FilterContext filterContext = createFilterContext();
-      _jsonMatchOperator = new JsonMatchFilterOperator(jsonIndex, filterContext, numDocs);
-      _expressionFilterOperator = null;
-    } else {
-      _jsonMatchOperator = null;
-      _expressionFilterOperator = new ExpressionFilterOperator(indexSegment, queryContext, predicate, numDocs);
+
+    JsonMatchFilterOperator jsonOp = tryJsonIndex(columnDs, numDocs);
+    if (jsonOp != null) {
+      _delegate = jsonOp;
+      _delegateType = DelegateType.JSON_MATCH;
+      return;
+    }
+
+    _delegate = new ExpressionFilterOperator(indexSegment, queryContext, predicate, numDocs);
+    _delegateType = DelegateType.EXPRESSION_FILTER;
+  }
+
+  @Nullable
+  private BaseFilterOperator tryPerKeyIndex(@Nullable DataSource columnDs, QueryContext queryContext, int numDocs) {
+    if (!(columnDs instanceof OpenStructDataSource)) {
+      return null;
+    }
+    OpenStructDataSource osDs = (OpenStructDataSource) columnDs;
+
+    if (osDs.isMaterialized(_keyName)) {
+      DataSource keyDs = osDs.getDataSource(_keyName);
+      return buildPerKeyFilterOperator(keyDs, queryContext, numDocs);
+    }
+
+    // Key not materialized
+    if (osDs.isFullyMaterialized()) {
+      // Fully materialized but key absent — definitive answer
+      if (_predicate.getType() == Predicate.Type.IS_NULL) {
+        return new MatchAllFilterOperator(numDocs);
+      }
+      return EmptyFilterOperator.getInstance();
+    }
+
+    // Sparse — can't be sure, fall through to JSON/expression
+    return null;
+  }
+
+  @Nullable
+  private BaseFilterOperator buildPerKeyFilterOperator(DataSource keyDs, QueryContext queryContext, int numDocs) {
+    switch (_predicate.getType()) {
+      case IS_NULL:
+      case IS_NOT_NULL: {
+        NullValueVectorReader nullReader = keyDs.getNullValueVector();
+        if (nullReader == null) {
+          // No null vector — all values are non-null
+          return _predicate.getType() == Predicate.Type.IS_NULL
+              ? EmptyFilterOperator.getInstance()
+              : new MatchAllFilterOperator(numDocs);
+        }
+        ImmutableRoaringBitmap nullBitmap = nullReader.getNullBitmap();
+        boolean exclusive = _predicate.getType() == Predicate.Type.IS_NOT_NULL;
+        return new BitmapBasedFilterOperator(nullBitmap, exclusive, numDocs);
+      }
+      case EQ:
+      case NOT_EQ:
+      case IN:
+      case NOT_IN:
+      case RANGE: {
+        Predicate rewritten = rewritePredicateForKey(_predicate);
+        if (rewritten == null) {
+          return null;
+        }
+        PredicateEvaluator evaluator = PredicateEvaluatorProvider.getPredicateEvaluator(rewritten, keyDs, queryContext);
+        return FilterOperatorUtils.getLeafFilterOperator(queryContext, evaluator, keyDs, numDocs);
+      }
+      default:
+        return null;
     }
   }
 
-  /// Creates a FilterContext based on the original predicate type
-  private FilterContext createFilterContext() {
-    // Create identifier expression for the JSON column
+  @Nullable
+  private Predicate rewritePredicateForKey(Predicate predicate) {
     ExpressionContext keyLhs = ExpressionContext.forIdentifier(_keyName);
-
-    // Create predicate based on type
-    Predicate predicate;
-    switch (_predicate.getType()) {
+    switch (predicate.getType()) {
       case EQ:
-        predicate = new EqPredicate(keyLhs, ((EqPredicate) _predicate).getValue());
-        break;
+        return new EqPredicate(keyLhs, ((EqPredicate) predicate).getValue());
       case NOT_EQ:
-        predicate = new NotEqPredicate(keyLhs, ((NotEqPredicate) _predicate).getValue());
-        break;
+        return new NotEqPredicate(keyLhs, ((NotEqPredicate) predicate).getValue());
       case IN:
-        predicate = new InPredicate(keyLhs, ((InPredicate) _predicate).getValues());
-        break;
+        return new InPredicate(keyLhs, ((InPredicate) predicate).getValues());
       case NOT_IN:
-        predicate = new NotInPredicate(keyLhs, ((NotInPredicate) _predicate).getValues());
-        break;
+        return new NotInPredicate(keyLhs, ((NotInPredicate) predicate).getValues());
+      case RANGE: {
+        RangePredicate rp = (RangePredicate) predicate;
+        return new RangePredicate(keyLhs, rp.isLowerInclusive(), rp.getLowerBound(),
+            rp.isUpperInclusive(), rp.getUpperBound(), rp.getRangeDataType());
+      }
       default:
-        throw new IllegalStateException(
-            "Unsupported predicate type for creating filter context: " + _predicate.getType());
+        return null;
     }
+  }
 
-    return FilterContext.forPredicate(predicate);
+  @Nullable
+  private JsonMatchFilterOperator tryJsonIndex(@Nullable DataSource dataSource, int numDocs) {
+    if (!canUseJsonIndex(_predicate.getType())) {
+      return null;
+    }
+    if (dataSource == null) {
+      return null;
+    }
+    JsonIndexReader jsonIndex = dataSource.getJsonIndex();
+    if (jsonIndex == null) {
+      Optional<IndexType<?, ?, ?>> compositeIndex =
+          IndexService.getInstance().getOptional("composite_json_index");
+      if (compositeIndex.isPresent()) {
+        jsonIndex = (JsonIndexReader) dataSource.getIndex(compositeIndex.get());
+      }
+    }
+    if (jsonIndex == null) {
+      return null;
+    }
+    FilterContext filterContext = createFilterContext();
+    return new JsonMatchFilterOperator(jsonIndex, filterContext, numDocs);
+  }
+
+  private FilterContext createFilterContext() {
+    Predicate rewritten = rewritePredicateForKey(_predicate);
+    if (rewritten == null) {
+      throw new IllegalStateException("Unsupported predicate type for JSON filter context: " + _predicate.getType());
+    }
+    return FilterContext.forPredicate(rewritten);
   }
 
   @Override
   protected BlockDocIdSet getTrues() {
-    if (_jsonMatchOperator != null) {
-      return _jsonMatchOperator.getTrues();
-    } else {
-      return _expressionFilterOperator.getTrues();
-    }
+    return _delegate.getTrues();
   }
 
   @Override
   public boolean canOptimizeCount() {
-    if (_jsonMatchOperator != null) {
-      return _jsonMatchOperator.canOptimizeCount();
-    } else {
-      return _expressionFilterOperator.canOptimizeCount();
-    }
+    return _delegate.canOptimizeCount();
   }
 
   @Override
   public int getNumMatchingDocs() {
-    if (_jsonMatchOperator != null) {
-      return _jsonMatchOperator.getNumMatchingDocs();
-    } else {
-      return _expressionFilterOperator.getNumMatchingDocs();
-    }
+    return _delegate.getNumMatchingDocs();
   }
 
   @Override
   public boolean canProduceBitmaps() {
-    if (_jsonMatchOperator != null) {
-      return _jsonMatchOperator.canProduceBitmaps();
-    } else {
-      return _expressionFilterOperator.canProduceBitmaps();
-    }
+    return _delegate.canProduceBitmaps();
   }
 
   @Override
   public BitmapCollection getBitmaps() {
-    if (_jsonMatchOperator != null) {
-      return _jsonMatchOperator.getBitmaps();
-    } else {
-      return _expressionFilterOperator.getBitmaps();
-    }
+    return _delegate.getBitmaps();
   }
 
   @Override
@@ -170,18 +241,15 @@ public class MapFilterOperator extends BaseFilterOperator {
 
   @Override
   public String toExplainString() {
-    StringBuilder stringBuilder =
-        new StringBuilder(EXPLAIN_NAME).append("(column:").append(_columnName).append(",key:").append(_keyName)
-            .append(",indexLookUp:map_index").append(",operator:").append(_predicate.getType()).append(",predicate:")
-            .append(_predicate);
-
-    if (_jsonMatchOperator != null) {
-      stringBuilder.append(",delegateTo:json_match");
-    } else {
-      stringBuilder.append(",delegateTo:expression_filter");
-    }
-
-    return stringBuilder.append(')').toString();
+    return new StringBuilder(EXPLAIN_NAME)
+        .append("(column:").append(_columnName)
+        .append(",key:").append(_keyName)
+        .append(",indexLookUp:map_index")
+        .append(",operator:").append(_predicate.getType())
+        .append(",predicate:").append(_predicate)
+        .append(",delegateTo:").append(_delegateType.name().toLowerCase(Locale.ROOT))
+        .append(')')
+        .toString();
   }
 
   @Override
@@ -197,18 +265,9 @@ public class MapFilterOperator extends BaseFilterOperator {
     attributeBuilder.putString("indexLookUp", "map_index");
     attributeBuilder.putString("operator", _predicate.getType().name());
     attributeBuilder.putString("predicate", _predicate.toString());
-
-    if (_jsonMatchOperator != null) {
-      attributeBuilder.putString("delegateTo", "json_match");
-    } else {
-      attributeBuilder.putString("delegateTo", "expression_filter");
-    }
+    attributeBuilder.putString("delegateTo", _delegateType.name().toLowerCase());
   }
 
-  /// Determines whether to use JSON index for the given predicate type.
-  ///
-  /// @param predicateType The type of predicate
-  /// @return true if the predicate type is supported for JSON index, false otherwise
   private static boolean canUseJsonIndex(Predicate.Type predicateType) {
     switch (predicateType) {
       case EQ:

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MapFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MapFilterOperator.java
@@ -265,7 +265,7 @@ public class MapFilterOperator extends BaseFilterOperator {
     attributeBuilder.putString("indexLookUp", "map_index");
     attributeBuilder.putString("operator", _predicate.getType().name());
     attributeBuilder.putString("predicate", _predicate.toString());
-    attributeBuilder.putString("delegateTo", _delegateType.name().toLowerCase());
+    attributeBuilder.putString("delegateTo", _delegateType.name().toLowerCase(Locale.ROOT));
   }
 
   private static boolean canUseJsonIndex(Predicate.Type predicateType) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MapFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MapFilterOperator.java
@@ -117,7 +117,8 @@ public class MapFilterOperator extends BaseFilterOperator {
       return buildAbsentKeyFilterOperator(osDs, queryContext, numDocs);
     }
 
-    // Sparse — can't be sure, fall through to JSON/expression
+    // Sparse — the key may be in the sparse blob, which neither the JSON nor the expression path can
+    // read yet, so it evaluates as NULL. See ImmutableOpenStructDataSource#getDataSource.
     return null;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MapFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MapFilterOperator.java
@@ -37,11 +37,13 @@ import org.apache.pinot.core.operator.ExplainAttributeBuilder;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluatorProvider;
 import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.segment.local.segment.index.openstruct.OpenStructNullDataSource;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
 import org.apache.pinot.segment.spi.index.IndexService;
 import org.apache.pinot.segment.spi.index.IndexType;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.segment.spi.index.reader.JsonIndexReader;
 import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
@@ -110,17 +112,76 @@ public class MapFilterOperator extends BaseFilterOperator {
       return buildPerKeyFilterOperator(keyDs, queryContext, numDocs);
     }
 
-    // Key not materialized
+    // Key not materialized but the segment is fully materialized — definitive absence.
     if (osDs.isFullyMaterialized()) {
-      // Fully materialized but key absent — definitive answer
-      if (_predicate.getType() == Predicate.Type.IS_NULL) {
-        return new MatchAllFilterOperator(numDocs);
-      }
-      return EmptyFilterOperator.getInstance();
+      return buildAbsentKeyFilterOperator(osDs, queryContext, numDocs);
     }
 
     // Sparse — can't be sure, fall through to JSON/expression
     return null;
+  }
+
+  /// Builds the filter for a key that is definitively absent from a fully materialized segment.
+  /// Every document answers the predicate identically, so it is folded to a match-all / match-none
+  /// once instead of scanning an all-null column.
+  ///
+  /// With null handling on, three-valued logic makes every value predicate UNKNOWN and nothing
+  /// matches. With it off the key reads as its type's default null value, so the predicate is
+  /// evaluated against that single value — notably NOT_EQ / NOT_IN then match every document.
+  ///
+  /// The value comes from {@link OpenStructNullDataSource#forAbsentKey}, the same source the
+  /// projection path feeds to `item()`, so filter and projection cannot disagree. For a key with no
+  /// declared child spec that factory falls back to STRING, which means a numeric range over an
+  /// undeclared key compares lexicographically — the same answer `item()` yields for it.
+  @Nullable
+  private BaseFilterOperator buildAbsentKeyFilterOperator(OpenStructDataSource osDs, QueryContext queryContext,
+      int numDocs) {
+    Predicate.Type type = _predicate.getType();
+    if (type == Predicate.Type.IS_NULL) {
+      return new MatchAllFilterOperator(numDocs);
+    }
+    if (type == Predicate.Type.IS_NOT_NULL) {
+      return EmptyFilterOperator.getInstance();
+    }
+    Predicate rewritten = rewritePredicateForKey(_predicate);
+    if (rewritten == null) {
+      return null;
+    }
+    if (queryContext.isNullHandlingEnabled()) {
+      return EmptyFilterOperator.getInstance();
+    }
+    DataSource keyDs = OpenStructNullDataSource.forAbsentKey(osDs, _keyName);
+    PredicateEvaluator evaluator = PredicateEvaluatorProvider.getPredicateEvaluator(rewritten, keyDs, queryContext);
+    Boolean matches = matchesDefaultNullValue(evaluator, keyDs.getForwardIndex());
+    if (matches == null) {
+      return null;
+    }
+    return matches ? new MatchAllFilterOperator(numDocs) : EmptyFilterOperator.getInstance();
+  }
+
+  /// Applies the evaluator to the default null value every document of an absent key reads as.
+  /// Returns `null` for a stored type the all-null forward index cannot serve, so the caller falls
+  /// through to the expression path rather than failing the query.
+  @Nullable
+  private static Boolean matchesDefaultNullValue(PredicateEvaluator evaluator, ForwardIndexReader<?> forwardIndex) {
+    switch (forwardIndex.getStoredType()) {
+      case INT:
+        return evaluator.applySV(forwardIndex.getInt(0, null));
+      case LONG:
+        return evaluator.applySV(forwardIndex.getLong(0, null));
+      case FLOAT:
+        return evaluator.applySV(forwardIndex.getFloat(0, null));
+      case DOUBLE:
+        return evaluator.applySV(forwardIndex.getDouble(0, null));
+      case BIG_DECIMAL:
+        return evaluator.applySV(forwardIndex.getBigDecimal(0, null));
+      case STRING:
+        return evaluator.applySV(forwardIndex.getString(0, null));
+      case BYTES:
+        return evaluator.applySV(forwardIndex.getBytes(0, null));
+      default:
+        return null;
+    }
   }
 
   @Nullable

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ItemTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ItemTransformFunction.java
@@ -24,11 +24,17 @@ import java.util.Map;
 import org.apache.pinot.core.operator.ColumnContext;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.segment.local.segment.index.map.NullDataSource;
+import org.apache.pinot.segment.local.segment.index.openstruct.OpenStructNullDataSource;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
 import org.apache.pinot.segment.spi.datasource.MapDataSource;
+import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+import org.roaringbitmap.RoaringBitmap;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 
 
 /// Evaluates myMap\['foo'\]
@@ -38,6 +44,7 @@ public class ItemTransformFunction extends BaseTransformFunction {
   private String[] _keyPath;
   private Dictionary _dictionary;
   private TransformResultMetadata _resultMetadata;
+  private NullValueVectorReader _nullValueVector;
 
   @Override
   public void init(List<TransformFunction> arguments, Map<String, ColumnContext> columnContextMap) {
@@ -56,9 +63,22 @@ public class ItemTransformFunction extends BaseTransformFunction {
     _keyPath = new String[]{column, key};
 
     DataSource dataSource = columnContextMap.get(column).getDataSource();
-    Preconditions.checkState(dataSource instanceof MapDataSource, "Column: %s must be a MAP column", column);
-    MapDataSource mapDataSource = (MapDataSource) dataSource;
-    DataSource valueDataSource = mapDataSource.getDataSource(key);
+    Preconditions.checkState(dataSource instanceof MapDataSource || dataSource instanceof OpenStructDataSource,
+        "Column: %s must be a MAP or OPEN_STRUCT column", column);
+    DataSource valueDataSource;
+    if (dataSource instanceof MapDataSource) {
+      valueDataSource = ((MapDataSource) dataSource).getDataSource(key);
+      if (valueDataSource == null) {
+        valueDataSource = new NullDataSource(key);
+      }
+    } else {
+      OpenStructDataSource osDs = (OpenStructDataSource) dataSource;
+      valueDataSource = osDs.getDataSource(key);
+      if (valueDataSource == null) {
+        valueDataSource = OpenStructNullDataSource.forAbsentKey(osDs, key);
+      }
+    }
+    _nullValueVector = valueDataSource.getNullValueVector();
     // Only expose the dictionary when the forward index is dict-encoded. A column can have a dictionary alongside
     // a RAW forward index (e.g. dict + inverted/range), in which case transformToDictIdsSV would fail because
     // BlockValueSet.getDictionaryIdsSV requires a dict-encoded forward index.
@@ -83,6 +103,15 @@ public class ItemTransformFunction extends BaseTransformFunction {
   @Override
   public Dictionary getDictionary() {
     return _dictionary;
+  }
+
+  @Override
+  public RoaringBitmap getNullBitmap(ValueBlock valueBlock) {
+    if (_nullValueVector == null) {
+      return null;
+    }
+    ImmutableRoaringBitmap nullBitmap = _nullValueVector.getNullBitmap();
+    return nullBitmap != null ? nullBitmap.toRoaringBitmap() : null;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ItemTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ItemTransformFunction.java
@@ -32,9 +32,7 @@ import org.apache.pinot.segment.spi.datasource.MapDataSource;
 import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
-import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
 import org.roaringbitmap.RoaringBitmap;
-import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 
 
 /// Evaluates myMap\['foo'\]
@@ -44,7 +42,6 @@ public class ItemTransformFunction extends BaseTransformFunction {
   private String[] _keyPath;
   private Dictionary _dictionary;
   private TransformResultMetadata _resultMetadata;
-  private NullValueVectorReader _nullValueVector;
 
   @Override
   public void init(List<TransformFunction> arguments, Map<String, ColumnContext> columnContextMap) {
@@ -78,7 +75,6 @@ public class ItemTransformFunction extends BaseTransformFunction {
         valueDataSource = OpenStructNullDataSource.forAbsentKey(osDs, key);
       }
     }
-    _nullValueVector = valueDataSource.getNullValueVector();
     // Only expose the dictionary when the forward index is dict-encoded. A column can have a dictionary alongside
     // a RAW forward index (e.g. dict + inverted/range), in which case transformToDictIdsSV would fail because
     // BlockValueSet.getDictionaryIdsSV requires a dict-encoded forward index.
@@ -107,11 +103,7 @@ public class ItemTransformFunction extends BaseTransformFunction {
 
   @Override
   public RoaringBitmap getNullBitmap(ValueBlock valueBlock) {
-    if (_nullValueVector == null) {
-      return null;
-    }
-    ImmutableRoaringBitmap nullBitmap = _nullValueVector.getNullBitmap();
-    return nullBitmap != null ? nullBitmap.toRoaringBitmap() : null;
+    return valueBlock.getBlockValueSet(_keyPath).getNullBitmap();
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ItemTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ItemTransformFunction.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.operator.transform.function;
 import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.core.operator.ColumnContext;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
@@ -42,6 +43,7 @@ public class ItemTransformFunction extends BaseTransformFunction {
   private String[] _keyPath;
   private Dictionary _dictionary;
   private TransformResultMetadata _resultMetadata;
+  private boolean _perKeyNullsAvailable;
 
   @Override
   public void init(List<TransformFunction> arguments, Map<String, ColumnContext> columnContextMap) {
@@ -68,12 +70,14 @@ public class ItemTransformFunction extends BaseTransformFunction {
       if (valueDataSource == null) {
         valueDataSource = new NullDataSource(key);
       }
+      _perKeyNullsAvailable = false;
     } else {
       OpenStructDataSource osDs = (OpenStructDataSource) dataSource;
       valueDataSource = osDs.getDataSource(key);
       if (valueDataSource == null) {
         valueDataSource = OpenStructNullDataSource.forAbsentKey(osDs, key);
       }
+      _perKeyNullsAvailable = true;
     }
     // Only expose the dictionary when the forward index is dict-encoded. A column can have a dictionary alongside
     // a RAW forward index (e.g. dict + inverted/range), in which case transformToDictIdsSV would fail because
@@ -101,9 +105,21 @@ public class ItemTransformFunction extends BaseTransformFunction {
     return _dictionary;
   }
 
+  /// Null semantics differ between the two backing column types:
+  ///
+  /// - OPEN_STRUCT keeps a per-key presence bitmap (materialized into a
+  ///   {@link org.apache.pinot.segment.spi.index.reader.NullValueVectorReader} on both the mutable and sealed paths),
+  ///   so the per-key value set knows exactly which docs lack the key. Use it.
+  /// - MAP has no per-key null information — an absent key resolves to a
+  ///   {@link NullDataSource} that carries only a forward index, so the per-key value set would report "no nulls" for
+  ///   a key that is missing from every doc. Fall back to {@link BaseTransformFunction#getNullBitmap} which ORs the
+  ///   argument bitmaps, yielding the MAP column's own null bitmap: a conservative over-estimate that downstream
+  ///   null handling narrows further.
+  @Nullable
   @Override
   public RoaringBitmap getNullBitmap(ValueBlock valueBlock) {
-    return valueBlock.getBlockValueSet(_keyPath).getNullBitmap();
+    return _perKeyNullsAvailable ? valueBlock.getBlockValueSet(_keyPath).getNullBitmap()
+        : super.getNullBitmap(valueBlock);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -22,6 +22,7 @@ import java.util.EnumSet;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.FunctionContext;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
 import org.apache.pinot.core.operator.filter.BaseFilterOperator;
@@ -30,6 +31,7 @@ import org.apache.pinot.core.operator.query.EmptyAggregationOperator;
 import org.apache.pinot.core.operator.query.FastFilteredCountOperator;
 import org.apache.pinot.core.operator.query.FilteredAggregationOperator;
 import org.apache.pinot.core.operator.query.NonScanBasedAggregationOperator;
+import org.apache.pinot.core.operator.transform.function.ItemTransformFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils.AggregationInfo;
@@ -38,6 +40,8 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.MapDataSource;
+import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
 import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
 
 import static org.apache.pinot.segment.spi.AggregationFunctionType.*;
@@ -187,6 +191,15 @@ public class AggregationPlanNode implements PlanNode {
             }
             break;
           case FUNCTION:
+            DataSource resolvedDs = resolveDataSource(argument);
+            if (resolvedDs == null) {
+              return true;
+            }
+            NullValueVectorReader resolvedNullVector = resolvedDs.getNullValueVector();
+            if (resolvedNullVector != null && !resolvedNullVector.getNullBitmap().isEmpty()) {
+              return true;
+            }
+            break;
           default:
             return true;
         }
@@ -238,22 +251,64 @@ public class AggregationPlanNode implements PlanNode {
   }
 
   /// Returns the data source for the given aggregation function's argument, or {@code null} if the function has no
-  /// argument (e.g. {@code COUNT(*)}) or its argument is not a single column identifier (e.g. {@code COUNT(1)} or a
-  /// transform expression), in which case it cannot be resolved from dictionary/metadata.
+  /// argument (e.g. {@code COUNT(*)}) or its argument cannot be resolved to a single column-like data source (e.g.
+  /// {@code COUNT(1)} or an arbitrary transform expression), in which case it cannot be resolved from
+  /// dictionary/metadata. An `item(mapColumn, 'key')` argument resolves to the per-key data source when the column
+  /// materializes that key.
   ///
   /// @param aggregationFunction aggregation function whose argument data source is resolved
-  /// @return the argument's data source, or {@code null} if it has no single identifier argument
+  /// @return the argument's data source, or {@code null} if it cannot be resolved
   @Nullable
   private DataSource getDataSourceForAggregationFunction(AggregationFunction<?, ?> aggregationFunction) {
     List<ExpressionContext> inputExpressions = aggregationFunction.getInputExpressions();
     if (!inputExpressions.isEmpty()) {
-      ExpressionContext argument = inputExpressions.get(0);
-      if (argument.getType() != ExpressionContext.Type.IDENTIFIER) {
-        return null;
-      }
-      return _indexSegment.getDataSource(argument.getIdentifier(), _queryContext.getSchema());
+      return resolveDataSource(inputExpressions.get(0));
     }
 
+    return null;
+  }
+
+  @Nullable
+  private DataSource resolveDataSource(ExpressionContext expression) {
+    return resolveDataSource(expression, _indexSegment, _queryContext.getSchema());
+  }
+
+  @Nullable
+  static DataSource resolveDataSource(ExpressionContext expression, IndexSegment segment,
+      @Nullable org.apache.pinot.spi.data.Schema schema) {
+    if (expression.getType() == ExpressionContext.Type.IDENTIFIER) {
+      return segment.getDataSource(expression.getIdentifier(), schema);
+    }
+    if (expression.getType() == ExpressionContext.Type.FUNCTION) {
+      return tryResolveKeyedDataSource(expression, segment, schema);
+    }
+    return null;
+  }
+
+  @Nullable
+  static DataSource tryResolveKeyedDataSource(ExpressionContext expression, IndexSegment segment,
+      @Nullable org.apache.pinot.spi.data.Schema schema) {
+    FunctionContext function = expression.getFunction();
+    if (function == null
+        || !ItemTransformFunction.FUNCTION_NAME.equals(function.getFunctionName())) {
+      return null;
+    }
+    List<ExpressionContext> args = function.getArguments();
+    if (args.size() != 2
+        || args.get(0).getType() != ExpressionContext.Type.IDENTIFIER
+        || args.get(1).getType() != ExpressionContext.Type.LITERAL) {
+      return null;
+    }
+    String columnName = args.get(0).getIdentifier();
+    String key = args.get(1).getLiteral().getStringValue();
+    DataSource columnDs = segment.getDataSource(columnName, schema);
+    if (columnDs instanceof MapDataSource) {
+      return ((MapDataSource) columnDs).getDataSource(key);
+    }
+    if (columnDs instanceof OpenStructDataSource) {
+      OpenStructDataSource osDs = (OpenStructDataSource) columnDs;
+      return osDs.isMaterialized(key) ? osDs.getDataSource(key) : null;
+    }
     return null;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -36,14 +36,13 @@ import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils.AggregationInfo;
 import org.apache.pinot.core.query.request.context.QueryContext;
-import org.apache.pinot.segment.local.segment.index.map.NullDataSource;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.datasource.DataSource;
-import org.apache.pinot.segment.spi.datasource.MapDataSource;
 import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
 import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+import org.apache.pinot.spi.data.Schema;
 
 import static org.apache.pinot.segment.spi.AggregationFunctionType.*;
 
@@ -276,7 +275,7 @@ public class AggregationPlanNode implements PlanNode {
 
   @Nullable
   static DataSource resolveDataSource(ExpressionContext expression, IndexSegment segment,
-      @Nullable org.apache.pinot.spi.data.Schema schema) {
+      @Nullable Schema schema) {
     if (expression.getType() == ExpressionContext.Type.IDENTIFIER) {
       return segment.getDataSource(expression.getIdentifier(), schema);
     }
@@ -288,7 +287,7 @@ public class AggregationPlanNode implements PlanNode {
 
   @Nullable
   static DataSource tryResolveKeyedDataSource(ExpressionContext expression, IndexSegment segment,
-      @Nullable org.apache.pinot.spi.data.Schema schema) {
+      @Nullable Schema schema) {
     FunctionContext function = expression.getFunction();
     if (function == null
         || !ItemTransformFunction.FUNCTION_NAME.equals(function.getFunctionName())) {
@@ -303,14 +302,6 @@ public class AggregationPlanNode implements PlanNode {
     String columnName = args.get(0).getIdentifier();
     String key = args.get(1).getLiteral().getStringValue();
     DataSource columnDs = segment.getDataSource(columnName, schema);
-    if (columnDs instanceof MapDataSource) {
-      DataSource keyDs = ((MapDataSource) columnDs).getDataSource(key);
-      // An absent MAP key yields a NullDataSource whose metadata reports non-null min/max (the INT
-      // default) and which carries no null vector, so it would wrongly satisfy the metadata-based
-      // non-scan check and report hasNullValues=false. Fall back to a scan, mirroring the
-      // OPEN_STRUCT guard below.
-      return keyDs instanceof NullDataSource ? null : keyDs;
-    }
     if (columnDs instanceof OpenStructDataSource) {
       OpenStructDataSource osDs = (OpenStructDataSource) columnDs;
       DataSource keyDs = osDs.isMaterialized(key) ? osDs.getDataSource(key) : null;

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -39,14 +39,11 @@ import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.local.segment.index.map.NullDataSource;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.IndexSegment;
-import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.datasource.MapDataSource;
 import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
-import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
 import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
-import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 
 import static org.apache.pinot.segment.spi.AggregationFunctionType.*;
 
@@ -320,33 +317,12 @@ public class AggregationPlanNode implements PlanNode {
       if (keyDs == null) {
         return null;
       }
-      if (segment instanceof MutableSegment) {
-        // Consuming key columns reserve the default null value at dictId 0 (absent docs read it),
-        // so the dictionary matches the sealed segment - which folds the same default at build
-        // time - whenever the key is partially present, or fully present with the default also
-        // observed as a real value. The one poisoned case is a fully-present key whose reserved
-        // default was never observed: the dictionary then holds a phantom entry no row carries,
-        // and dictionary-based MIN/MAX/DISTINCTCOUNT would diverge from sealed. Force the scan
-        // path there. If consuming-segment aggregation latency ever matters, a dictionary view
-        // backed by observed min/max tracked in MutableKeyColumn can lift this.
-        NullValueVectorReader nullVector = keyDs.getNullValueVector();
-        boolean fullyPresent = nullVector == null || nullVector.getNullBitmap().isEmpty();
-        if (fullyPresent && !isDefaultObserved(keyDs)) {
-          return null;
-        }
-      }
-      return keyDs;
+      // A consuming key column's dictionary can contain a phantom entry (the reserved default,
+      // never observed in any doc); dictionary-based aggregation over it would diverge from the
+      // sealed segment. The segment layer owns that invariant — force the scan path when the
+      // dictionary is not exact.
+      return osDs.isKeyDictionaryExact(key) ? keyDs : null;
     }
     return null;
-  }
-
-  // Whether any doc explicitly wrote the reserved default (dictId 0) for this consuming key.
-  private static boolean isDefaultObserved(DataSource keyDs) {
-    InvertedIndexReader<?> invertedIndex = keyDs.getInvertedIndex();
-    if (invertedIndex == null) {
-      return false;
-    }
-    Object docIds = invertedIndex.getDocIds(0);
-    return docIds instanceof ImmutableRoaringBitmap && !((ImmutableRoaringBitmap) docIds).isEmpty();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -39,11 +39,14 @@ import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.local.segment.index.map.NullDataSource;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.datasource.MapDataSource;
 import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
+import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
 import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 
 import static org.apache.pinot.segment.spi.AggregationFunctionType.*;
 
@@ -313,8 +316,37 @@ public class AggregationPlanNode implements PlanNode {
     }
     if (columnDs instanceof OpenStructDataSource) {
       OpenStructDataSource osDs = (OpenStructDataSource) columnDs;
-      return osDs.isMaterialized(key) ? osDs.getDataSource(key) : null;
+      DataSource keyDs = osDs.isMaterialized(key) ? osDs.getDataSource(key) : null;
+      if (keyDs == null) {
+        return null;
+      }
+      if (segment instanceof MutableSegment) {
+        // Consuming key columns reserve the default null value at dictId 0 (absent docs read it),
+        // so the dictionary matches the sealed segment - which folds the same default at build
+        // time - whenever the key is partially present, or fully present with the default also
+        // observed as a real value. The one poisoned case is a fully-present key whose reserved
+        // default was never observed: the dictionary then holds a phantom entry no row carries,
+        // and dictionary-based MIN/MAX/DISTINCTCOUNT would diverge from sealed. Force the scan
+        // path there. If consuming-segment aggregation latency ever matters, a dictionary view
+        // backed by observed min/max tracked in MutableKeyColumn can lift this.
+        NullValueVectorReader nullVector = keyDs.getNullValueVector();
+        boolean fullyPresent = nullVector == null || nullVector.getNullBitmap().isEmpty();
+        if (fullyPresent && !isDefaultObserved(keyDs)) {
+          return null;
+        }
+      }
+      return keyDs;
     }
     return null;
+  }
+
+  // Whether any doc explicitly wrote the reserved default (dictId 0) for this consuming key.
+  private static boolean isDefaultObserved(DataSource keyDs) {
+    InvertedIndexReader<?> invertedIndex = keyDs.getInvertedIndex();
+    if (invertedIndex == null) {
+      return false;
+    }
+    Object docIds = invertedIndex.getDocIds(0);
+    return docIds instanceof ImmutableRoaringBitmap && !((ImmutableRoaringBitmap) docIds).isEmpty();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -36,6 +36,7 @@ import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils.AggregationInfo;
 import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.segment.local.segment.index.map.NullDataSource;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
@@ -303,7 +304,12 @@ public class AggregationPlanNode implements PlanNode {
     String key = args.get(1).getLiteral().getStringValue();
     DataSource columnDs = segment.getDataSource(columnName, schema);
     if (columnDs instanceof MapDataSource) {
-      return ((MapDataSource) columnDs).getDataSource(key);
+      DataSource keyDs = ((MapDataSource) columnDs).getDataSource(key);
+      // An absent MAP key yields a NullDataSource whose metadata reports non-null min/max (the INT
+      // default) and which carries no null vector, so it would wrongly satisfy the metadata-based
+      // non-scan check and report hasNullValues=false. Fall back to a scan, mirroring the
+      // OPEN_STRUCT guard below.
+      return keyDs instanceof NullDataSource ? null : keyDs;
     }
     if (columnDs instanceof OpenStructDataSource) {
       OpenStructDataSource osDs = (OpenStructDataSource) columnDs;

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/blocks/ProjectionBlockOpenStructTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/blocks/ProjectionBlockOpenStructTest.java
@@ -71,7 +71,7 @@ public class ProjectionBlockOpenStructTest {
 
   /**
    * Regression: registering the OPEN_STRUCT parent with the DataFetcher tripped its forward-index precondition, so
-   * every {@code SELECT item(metrics, 'key')} failed at ProjectionOperator construction with
+   * every {@code SELECT metrics['key']} failed at ProjectionOperator construction with
    * "Forward index disabled for column: metrics, cannot create DataFetcher!".
    */
   @Test
@@ -132,8 +132,8 @@ public class ProjectionBlockOpenStructTest {
   }
 
   /**
-   * Selecting the parent column itself is not supported. It must fail as a bad request naming the column rather than
-   * an NPE from the reader the DataFetcher never registered.
+   * Selecting the parent column itself is not supported. It must fail as a bad request pointing at the per-key syntax
+   * rather than an NPE from the reader the DataFetcher never registered.
    */
   @Test
   public void testSelectingOpenStructParentFailsWithClearMessage() {
@@ -144,6 +144,6 @@ public class ProjectionBlockOpenStructTest {
 
     BadQueryRequestException e =
         expectThrows(BadQueryRequestException.class, () -> projectionBlock.getBlockValueSet(OPEN_STRUCT_COLUMN));
-    assertTrue(e.getMessage().contains(OPEN_STRUCT_COLUMN), e.getMessage());
+    assertTrue(e.getMessage().contains(OPEN_STRUCT_COLUMN + "['key']"), e.getMessage());
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/blocks/ProjectionBlockOpenStructTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/blocks/ProjectionBlockOpenStructTest.java
@@ -1,0 +1,149 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.blocks;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.core.common.DataBlockCache;
+import org.apache.pinot.core.common.DataFetcher;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
+import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.exception.BadQueryRequestException;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+
+/**
+ * Covers projection over an OPEN_STRUCT column, where the parent data source carries no readers of its own and every
+ * value is reached through a per-key child source that {@link ProjectionBlock#getBlockValueSet(String[])} registers
+ * lazily. Also exercises the matching {@link DataFetcher} registration skip, since the two halves only make sense
+ * together.
+ */
+public class ProjectionBlockOpenStructTest {
+  private static final String OPEN_STRUCT_COLUMN = "metrics";
+  private static final String PLAIN_COLUMN = "ts";
+  private static final String KEY = "errors";
+
+  /** OPEN_STRUCT parent: an empty index container, so {@code getForwardIndex()} is null. */
+  private static OpenStructDataSource mockOpenStructDataSource() {
+    return mock(OpenStructDataSource.class);
+  }
+
+  private static DataSource mockPlainDataSource() {
+    DataSource dataSource = mock(DataSource.class);
+    ForwardIndexReader<?> forwardIndex = mock(ForwardIndexReader.class);
+    when(forwardIndex.isDictionaryEncoded()).thenReturn(false);
+    doReturn(forwardIndex).when(dataSource).getForwardIndex();
+    DataSourceMetadata metadata = mock(DataSourceMetadata.class);
+    when(metadata.isSingleValue()).thenReturn(true);
+    when(metadata.getDataType()).thenReturn(FieldSpec.DataType.LONG);
+    when(dataSource.getDataSourceMetadata()).thenReturn(metadata);
+    return dataSource;
+  }
+
+  /**
+   * Regression: registering the OPEN_STRUCT parent with the DataFetcher tripped its forward-index precondition, so
+   * every {@code SELECT item(metrics, 'key')} failed at ProjectionOperator construction with
+   * "Forward index disabled for column: metrics, cannot create DataFetcher!".
+   */
+  @Test
+  public void testDataFetcherSkipsOpenStructParent() {
+    Map<String, DataSource> dataSourceMap = new HashMap<>();
+    dataSourceMap.put(OPEN_STRUCT_COLUMN, mockOpenStructDataSource());
+    dataSourceMap.put(PLAIN_COLUMN, mockPlainDataSource());
+
+    new DataFetcher(dataSourceMap, Map.of()).close();
+  }
+
+  /**
+   * The skip is scoped to OPEN_STRUCT parents — an ordinary column with a disabled forward index must still be
+   * rejected rather than silently reading nothing.
+   */
+  @Test
+  public void testDataFetcherStillRejectsForwardIndexDisabledColumn() {
+    DataSource dataSource = mock(DataSource.class);
+    when(dataSource.getForwardIndex()).thenReturn(null);
+
+    assertThrows(IllegalStateException.class,
+        () -> new DataFetcher(Map.of(PLAIN_COLUMN, dataSource), Map.of()));
+  }
+
+  /**
+   * The parent is skipped, but the per-key child source it resolves is registered on first use, so the key remains
+   * readable.
+   */
+  @Test
+  public void testPerKeyDataSourceRegisteredOnFirstUse() {
+    OpenStructDataSource openStructDataSource = mockOpenStructDataSource();
+    DataSource keyDataSource = mockPlainDataSource();
+    when(openStructDataSource.getDataSource(KEY)).thenReturn(keyDataSource);
+
+    Map<String, DataSource> dataSourceMap = new HashMap<>();
+    dataSourceMap.put(OPEN_STRUCT_COLUMN, openStructDataSource);
+    DataBlockCache dataBlockCache = new DataBlockCache(new DataFetcher(dataSourceMap, Map.of()));
+
+    ProjectionBlock projectionBlock = new ProjectionBlock(dataSourceMap, dataBlockCache);
+    assertNotNull(projectionBlock.getBlockValueSet(new String[]{OPEN_STRUCT_COLUMN, KEY}));
+  }
+
+  /**
+   * ProjectionBlock re-resolves the per-key source on every block. Registration must be idempotent, otherwise each
+   * block orphans the displaced ColumnValueReader along with its off-heap reader context.
+   */
+  @Test
+  public void testRegisteringSameColumnTwiceKeepsFirstReader() {
+    DataFetcher dataFetcher = new DataFetcher(Map.of(), Map.of());
+    DataSource first = mockPlainDataSource();
+    DataSource second = mockPlainDataSource();
+
+    dataFetcher.addDataSource(PLAIN_COLUMN, first);
+    dataFetcher.addDataSource(PLAIN_COLUMN, second);
+
+    verify(second, never()).getForwardIndex();
+    dataFetcher.close();
+  }
+
+  /**
+   * Selecting the parent column itself is not supported. It must fail as a bad request naming the column rather than
+   * an NPE from the reader the DataFetcher never registered.
+   */
+  @Test
+  public void testSelectingOpenStructParentFailsWithClearMessage() {
+    Map<String, DataSource> dataSourceMap = new HashMap<>();
+    dataSourceMap.put(OPEN_STRUCT_COLUMN, mockOpenStructDataSource());
+    ProjectionBlock projectionBlock =
+        new ProjectionBlock(dataSourceMap, new DataBlockCache(new DataFetcher(dataSourceMap, Map.of())));
+
+    BadQueryRequestException e =
+        expectThrows(BadQueryRequestException.class, () -> projectionBlock.getBlockValueSet(OPEN_STRUCT_COLUMN));
+    assertTrue(e.getMessage().contains(OPEN_STRUCT_COLUMN), e.getMessage());
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/blocks/ProjectionBlockOpenStructTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/blocks/ProjectionBlockOpenStructTest.java
@@ -41,18 +41,16 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
 
 
-/**
- * Covers projection over an OPEN_STRUCT column, where the parent data source carries no readers of its own and every
- * value is reached through a per-key child source that {@link ProjectionBlock#getBlockValueSet(String[])} registers
- * lazily. Also exercises the matching {@link DataFetcher} registration skip, since the two halves only make sense
- * together.
- */
+/// Covers projection over an OPEN_STRUCT column, where the parent data source carries no readers of its own and every
+/// value is reached through a per-key child source that {@link ProjectionBlock#getBlockValueSet(String[])} registers
+/// lazily. Also exercises the matching {@link DataFetcher} registration skip, since the two halves only make sense
+/// together.
 public class ProjectionBlockOpenStructTest {
   private static final String OPEN_STRUCT_COLUMN = "metrics";
   private static final String PLAIN_COLUMN = "ts";
   private static final String KEY = "errors";
 
-  /** OPEN_STRUCT parent: an empty index container, so {@code getForwardIndex()} is null. */
+  /// OPEN_STRUCT parent: an empty index container, so {@code getForwardIndex()} is null.
   private static OpenStructDataSource mockOpenStructDataSource() {
     return mock(OpenStructDataSource.class);
   }
@@ -69,11 +67,9 @@ public class ProjectionBlockOpenStructTest {
     return dataSource;
   }
 
-  /**
-   * Regression: registering the OPEN_STRUCT parent with the DataFetcher tripped its forward-index precondition, so
-   * every {@code SELECT metrics['key']} failed at ProjectionOperator construction with
-   * "Forward index disabled for column: metrics, cannot create DataFetcher!".
-   */
+  /// Regression: registering the OPEN_STRUCT parent with the DataFetcher tripped its forward-index precondition, so
+  /// every {@code SELECT metrics['key']} failed at ProjectionOperator construction with
+  /// "Forward index disabled for column: metrics, cannot create DataFetcher!".
   @Test
   public void testDataFetcherSkipsOpenStructParent() {
     Map<String, DataSource> dataSourceMap = new HashMap<>();
@@ -83,10 +79,8 @@ public class ProjectionBlockOpenStructTest {
     new DataFetcher(dataSourceMap, Map.of()).close();
   }
 
-  /**
-   * The skip is scoped to OPEN_STRUCT parents — an ordinary column with a disabled forward index must still be
-   * rejected rather than silently reading nothing.
-   */
+  /// The skip is scoped to OPEN_STRUCT parents — an ordinary column with a disabled forward index must still be
+  /// rejected rather than silently reading nothing.
   @Test
   public void testDataFetcherStillRejectsForwardIndexDisabledColumn() {
     DataSource dataSource = mock(DataSource.class);
@@ -96,10 +90,8 @@ public class ProjectionBlockOpenStructTest {
         () -> new DataFetcher(Map.of(PLAIN_COLUMN, dataSource), Map.of()));
   }
 
-  /**
-   * The parent is skipped, but the per-key child source it resolves is registered on first use, so the key remains
-   * readable.
-   */
+  /// The parent is skipped, but the per-key child source it resolves is registered on first use, so the key remains
+  /// readable.
   @Test
   public void testPerKeyDataSourceRegisteredOnFirstUse() {
     OpenStructDataSource openStructDataSource = mockOpenStructDataSource();
@@ -114,10 +106,8 @@ public class ProjectionBlockOpenStructTest {
     assertNotNull(projectionBlock.getBlockValueSet(new String[]{OPEN_STRUCT_COLUMN, KEY}));
   }
 
-  /**
-   * ProjectionBlock re-resolves the per-key source on every block. Registration must be idempotent, otherwise each
-   * block orphans the displaced ColumnValueReader along with its off-heap reader context.
-   */
+  /// ProjectionBlock re-resolves the per-key source on every block. Registration must be idempotent, otherwise each
+  /// block orphans the displaced ColumnValueReader along with its off-heap reader context.
   @Test
   public void testRegisteringSameColumnTwiceKeepsFirstReader() {
     DataFetcher dataFetcher = new DataFetcher(Map.of(), Map.of());
@@ -131,10 +121,8 @@ public class ProjectionBlockOpenStructTest {
     dataFetcher.close();
   }
 
-  /**
-   * Selecting the parent column itself is not supported. It must fail as a bad request pointing at the per-key syntax
-   * rather than an NPE from the reader the DataFetcher never registered.
-   */
+  /// Selecting the parent column itself is not supported. It must fail as a bad request pointing at the per-key syntax
+  /// rather than an NPE from the reader the DataFetcher never registered.
   @Test
   public void testSelectingOpenStructParentFailsWithClearMessage() {
     Map<String, DataSource> dataSourceMap = new HashMap<>();

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/MapFilterOperatorOpenStructTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/MapFilterOperatorOpenStructTest.java
@@ -1,0 +1,244 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.filter;
+
+import java.util.Arrays;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.FunctionContext;
+import org.apache.pinot.common.request.context.predicate.EqPredicate;
+import org.apache.pinot.common.request.context.predicate.IsNotNullPredicate;
+import org.apache.pinot.common.request.context.predicate.IsNullPredicate;
+import org.apache.pinot.common.request.context.predicate.Predicate;
+import org.apache.pinot.core.operator.transform.function.ItemTransformFunction;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.segment.spi.Constants;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
+import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
+import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+
+public class MapFilterOperatorOpenStructTest {
+  private static final int NUM_DOCS = 100;
+  private static final String COLUMN = "metrics";
+  private static final String KEY = "status";
+
+  private static Predicate makeEqPredicate(String column, String key, String value) {
+    ExpressionContext colArg = ExpressionContext.forIdentifier(column);
+    ExpressionContext keyArg = ExpressionContext.forLiteral(FieldSpec.DataType.STRING, key);
+    FunctionContext fn = new FunctionContext(FunctionContext.Type.TRANSFORM,
+        ItemTransformFunction.FUNCTION_NAME, Arrays.asList(colArg, keyArg));
+    ExpressionContext itemExpr = ExpressionContext.forFunction(fn);
+    return new EqPredicate(itemExpr, value);
+  }
+
+  private static Predicate makeIsNullPredicate(String column, String key) {
+    ExpressionContext colArg = ExpressionContext.forIdentifier(column);
+    ExpressionContext keyArg = ExpressionContext.forLiteral(FieldSpec.DataType.STRING, key);
+    FunctionContext fn = new FunctionContext(FunctionContext.Type.TRANSFORM,
+        ItemTransformFunction.FUNCTION_NAME, Arrays.asList(colArg, keyArg));
+    ExpressionContext itemExpr = ExpressionContext.forFunction(fn);
+    return new IsNullPredicate(itemExpr);
+  }
+
+  private static Predicate makeIsNotNullPredicate(String column, String key) {
+    ExpressionContext colArg = ExpressionContext.forIdentifier(column);
+    ExpressionContext keyArg = ExpressionContext.forLiteral(FieldSpec.DataType.STRING, key);
+    FunctionContext fn = new FunctionContext(FunctionContext.Type.TRANSFORM,
+        ItemTransformFunction.FUNCTION_NAME, Arrays.asList(colArg, keyArg));
+    ExpressionContext itemExpr = ExpressionContext.forFunction(fn);
+    return new IsNotNullPredicate(itemExpr);
+  }
+
+  private QueryContext mockQueryContext() {
+    QueryContext qc = mock(QueryContext.class);
+    when(qc.isNullHandlingEnabled()).thenReturn(false);
+    when(qc.isIndexUseAllowed(any(DataSource.class), any())).thenReturn(true);
+    when(qc.isIndexUseAllowed(anyString(), any())).thenReturn(true);
+    return qc;
+  }
+
+  /**
+   * Materialized key with EQ predicate dispatches to PER_KEY_INDEX.
+   */
+  @Test
+  public void testPerKeyIndexEq() {
+    OpenStructDataSource osDs = mock(OpenStructDataSource.class);
+    when(osDs.isMaterialized(KEY)).thenReturn(true);
+
+    DataSource keyDs = mock(DataSource.class);
+    when(osDs.getDataSource(KEY)).thenReturn(keyDs);
+
+    DataSourceMetadata meta = mock(DataSourceMetadata.class);
+    when(meta.getDataType()).thenReturn(FieldSpec.DataType.STRING);
+    when(meta.isSorted()).thenReturn(false);
+    when(meta.isSingleValue()).thenReturn(true);
+    when(keyDs.getDataSourceMetadata()).thenReturn(meta);
+    when(keyDs.getColumnName()).thenReturn(KEY);
+
+    // Return null forward index so dictionary is always kept by getDictionaryUsableForFiltering
+    when(keyDs.getForwardIndex()).thenReturn(null);
+
+    Dictionary dict = mock(Dictionary.class);
+    when(dict.indexOf("active")).thenReturn(0);
+    when(keyDs.getDictionary()).thenReturn(dict);
+
+    InvertedIndexReader<?> invertedIndex = mock(InvertedIndexReader.class);
+    doReturn(invertedIndex).when(keyDs).getInvertedIndex();
+
+    IndexSegment segment = mock(IndexSegment.class);
+    when(segment.getDataSourceNullable(COLUMN)).thenReturn(osDs);
+
+    QueryContext qc = mockQueryContext();
+    Predicate predicate = makeEqPredicate(COLUMN, KEY, "active");
+
+    MapFilterOperator op = new MapFilterOperator(segment, predicate, qc, NUM_DOCS);
+    assertTrue(op.toExplainString().contains("delegateTo:per_key_index"));
+  }
+
+  /**
+   * Absent key on a fully materialized segment with EQ → EmptyFilterOperator (getTrues returns EOF).
+   */
+  @Test
+  public void testAbsentKeyFullyMaterializedEq() {
+    OpenStructDataSource osDs = mock(OpenStructDataSource.class);
+    when(osDs.isMaterialized("missing_key")).thenReturn(false);
+    when(osDs.isFullyMaterialized()).thenReturn(true);
+
+    IndexSegment segment = mock(IndexSegment.class);
+    when(segment.getDataSourceNullable(COLUMN)).thenReturn(osDs);
+
+    QueryContext qc = mockQueryContext();
+    Predicate predicate = makeEqPredicate(COLUMN, "missing_key", "whatever");
+
+    MapFilterOperator op = new MapFilterOperator(segment, predicate, qc, NUM_DOCS);
+    assertTrue(op.toExplainString().contains("delegateTo:per_key_index"));
+
+    // EmptyFilterOperator.getTrues() returns EmptyDocIdSet → iterator next() is EOF
+    assertEquals(op.getTrues().iterator().next(), Constants.EOF);
+  }
+
+  /**
+   * Absent key on a fully materialized segment with IS_NULL → MatchAllFilterOperator.
+   */
+  @Test
+  public void testAbsentKeyFullyMaterializedIsNull() {
+    OpenStructDataSource osDs = mock(OpenStructDataSource.class);
+    when(osDs.isMaterialized("missing_key")).thenReturn(false);
+    when(osDs.isFullyMaterialized()).thenReturn(true);
+
+    IndexSegment segment = mock(IndexSegment.class);
+    when(segment.getDataSourceNullable(COLUMN)).thenReturn(osDs);
+
+    QueryContext qc = mockQueryContext();
+    Predicate predicate = makeIsNullPredicate(COLUMN, "missing_key");
+
+    MapFilterOperator op = new MapFilterOperator(segment, predicate, qc, NUM_DOCS);
+    assertTrue(op.toExplainString().contains("delegateTo:per_key_index"));
+    assertTrue(op.canOptimizeCount());
+    assertEquals(op.getNumMatchingDocs(), NUM_DOCS);
+  }
+
+  /**
+   * Non-materialized key on a segment that is NOT fully materialized → falls to EXPRESSION_FILTER.
+   */
+  @Test
+  public void testSparseKeyFallsToExpressionFilter() {
+    OpenStructDataSource osDs = mock(OpenStructDataSource.class);
+    when(osDs.isMaterialized("sparse_key")).thenReturn(false);
+    when(osDs.isFullyMaterialized()).thenReturn(false);
+    // No JSON index
+    when(osDs.getJsonIndex()).thenReturn(null);
+
+    IndexSegment segment = mock(IndexSegment.class);
+    when(segment.getDataSourceNullable(COLUMN)).thenReturn(osDs);
+    // ExpressionFilterOperator constructor calls segment.getDataSource(column) for columns in the
+    // predicate expression. Return the osDs for the column itself.
+    when(segment.getDataSource(COLUMN)).thenReturn(osDs);
+
+    // ExpressionFilterOperator needs column metadata from the DataSource
+    DataSourceMetadata meta = mock(DataSourceMetadata.class);
+    when(meta.getDataType()).thenReturn(FieldSpec.DataType.STRING);
+    when(meta.isSingleValue()).thenReturn(true);
+    when(osDs.getDataSourceMetadata()).thenReturn(meta);
+    when(osDs.getColumnName()).thenReturn(COLUMN);
+
+    QueryContext qc = mockQueryContext();
+    Predicate predicate = makeEqPredicate(COLUMN, "sparse_key", "value");
+
+    // ExpressionFilterOperator's constructor creates a TransformFunction via the factory, which
+    // may fail on a mock segment. We verify the dispatch path via isMaterialized/isFullyMaterialized
+    // interaction: the per-key path should NOT be entered (getDataSource(key) never called).
+    try {
+      MapFilterOperator op = new MapFilterOperator(segment, predicate, qc, NUM_DOCS);
+      assertTrue(op.toExplainString().contains("delegateTo:expression_filter"));
+    } catch (Exception e) {
+      // If ExpressionFilterOperator constructor fails on mock internals, that's OK —
+      // verify the per-key path was not taken.
+      verify(osDs, never()).getDataSource("sparse_key");
+      verify(osDs).isMaterialized("sparse_key");
+      verify(osDs).isFullyMaterialized();
+    }
+  }
+
+  /**
+   * Materialized key with IS_NOT_NULL and a null bitmap → PER_KEY_INDEX (BitmapBasedFilterOperator).
+   */
+  @Test
+  public void testIsNotNullWithNullBitmap() {
+    OpenStructDataSource osDs = mock(OpenStructDataSource.class);
+    when(osDs.isMaterialized(KEY)).thenReturn(true);
+
+    DataSource keyDs = mock(DataSource.class);
+    when(osDs.getDataSource(KEY)).thenReturn(keyDs);
+
+    // Set up a null bitmap with doc 5 and 10 as null
+    MutableRoaringBitmap nullBitmap = new MutableRoaringBitmap();
+    nullBitmap.add(5);
+    nullBitmap.add(10);
+
+    NullValueVectorReader nullReader = mock(NullValueVectorReader.class);
+    when(nullReader.getNullBitmap()).thenReturn(nullBitmap);
+    when(keyDs.getNullValueVector()).thenReturn(nullReader);
+
+    IndexSegment segment = mock(IndexSegment.class);
+    when(segment.getDataSourceNullable(COLUMN)).thenReturn(osDs);
+
+    QueryContext qc = mockQueryContext();
+    Predicate predicate = makeIsNotNullPredicate(COLUMN, KEY);
+
+    MapFilterOperator op = new MapFilterOperator(segment, predicate, qc, NUM_DOCS);
+    assertTrue(op.toExplainString().contains("delegateTo:per_key_index"));
+
+    // BitmapBasedFilterOperator with exclusive=true: matches numDocs - nullCount
+    assertTrue(op.canOptimizeCount());
+    assertEquals(op.getNumMatchingDocs(), NUM_DOCS - 2);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/MapFilterOperatorOpenStructTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/MapFilterOperatorOpenStructTest.java
@@ -19,12 +19,20 @@
 package org.apache.pinot.core.operator.filter;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FunctionContext;
 import org.apache.pinot.common.request.context.predicate.EqPredicate;
+import org.apache.pinot.common.request.context.predicate.InPredicate;
 import org.apache.pinot.common.request.context.predicate.IsNotNullPredicate;
 import org.apache.pinot.common.request.context.predicate.IsNullPredicate;
+import org.apache.pinot.common.request.context.predicate.NotEqPredicate;
+import org.apache.pinot.common.request.context.predicate.NotInPredicate;
 import org.apache.pinot.common.request.context.predicate.Predicate;
+import org.apache.pinot.common.request.context.predicate.RangePredicate;
+import org.apache.pinot.common.request.context.predicate.RegexpLikePredicate;
+import org.apache.pinot.core.common.BlockDocIdIterator;
 import org.apache.pinot.core.operator.transform.function.ItemTransformFunction;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.Constants;
@@ -35,6 +43,8 @@ import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
 import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.testng.annotations.Test;
@@ -50,39 +60,89 @@ public class MapFilterOperatorOpenStructTest {
   private static final String COLUMN = "metrics";
   private static final String KEY = "status";
 
-  private static Predicate makeEqPredicate(String column, String key, String value) {
+  private static ExpressionContext itemExpr(String column, String key) {
     ExpressionContext colArg = ExpressionContext.forIdentifier(column);
     ExpressionContext keyArg = ExpressionContext.forLiteral(FieldSpec.DataType.STRING, key);
     FunctionContext fn = new FunctionContext(FunctionContext.Type.TRANSFORM,
         ItemTransformFunction.FUNCTION_NAME, Arrays.asList(colArg, keyArg));
-    ExpressionContext itemExpr = ExpressionContext.forFunction(fn);
-    return new EqPredicate(itemExpr, value);
+    return ExpressionContext.forFunction(fn);
+  }
+
+  private static Predicate makeEqPredicate(String column, String key, String value) {
+    return new EqPredicate(itemExpr(column, key), value);
+  }
+
+  private static Predicate makeNotEqPredicate(String column, String key, String value) {
+    return new NotEqPredicate(itemExpr(column, key), value);
+  }
+
+  private static Predicate makeInPredicate(String column, String key, List<String> values) {
+    return new InPredicate(itemExpr(column, key), values);
+  }
+
+  private static Predicate makeNotInPredicate(String column, String key, List<String> values) {
+    return new NotInPredicate(itemExpr(column, key), values);
   }
 
   private static Predicate makeIsNullPredicate(String column, String key) {
-    ExpressionContext colArg = ExpressionContext.forIdentifier(column);
-    ExpressionContext keyArg = ExpressionContext.forLiteral(FieldSpec.DataType.STRING, key);
-    FunctionContext fn = new FunctionContext(FunctionContext.Type.TRANSFORM,
-        ItemTransformFunction.FUNCTION_NAME, Arrays.asList(colArg, keyArg));
-    ExpressionContext itemExpr = ExpressionContext.forFunction(fn);
-    return new IsNullPredicate(itemExpr);
+    return new IsNullPredicate(itemExpr(column, key));
   }
 
   private static Predicate makeIsNotNullPredicate(String column, String key) {
-    ExpressionContext colArg = ExpressionContext.forIdentifier(column);
-    ExpressionContext keyArg = ExpressionContext.forLiteral(FieldSpec.DataType.STRING, key);
-    FunctionContext fn = new FunctionContext(FunctionContext.Type.TRANSFORM,
-        ItemTransformFunction.FUNCTION_NAME, Arrays.asList(colArg, keyArg));
-    ExpressionContext itemExpr = ExpressionContext.forFunction(fn);
-    return new IsNotNullPredicate(itemExpr);
+    return new IsNotNullPredicate(itemExpr(column, key));
   }
 
   private QueryContext mockQueryContext() {
+    return mockQueryContext(false);
+  }
+
+  private QueryContext mockQueryContext(boolean nullHandlingEnabled) {
     QueryContext qc = mock(QueryContext.class);
-    when(qc.isNullHandlingEnabled()).thenReturn(false);
+    when(qc.isNullHandlingEnabled()).thenReturn(nullHandlingEnabled);
     when(qc.isIndexUseAllowed(any(DataSource.class), any())).thenReturn(true);
     when(qc.isIndexUseAllowed(anyString(), any())).thenReturn(true);
     return qc;
+  }
+
+  /**
+   * OPEN_STRUCT source that is fully materialized but does not hold {@code key}. Stubs the field
+   * spec and doc count that {@code OpenStructNullDataSource.forAbsentKey} reads.
+   */
+  private static OpenStructDataSource mockFullyMaterializedAbsentKey(String key) {
+    return mockFullyMaterializedAbsentKey(key, Map.of());
+  }
+
+  /**
+   * OPEN_STRUCT source that is fully materialized but does not hold {@code key}. Stubs the field
+   * spec and doc count that {@code OpenStructNullDataSource.forAbsentKey} reads. {@code children}
+   * carries the declared child specs — pass an empty map for an undeclared key.
+   */
+  private static OpenStructDataSource mockFullyMaterializedAbsentKey(String key, Map<String, FieldSpec> children) {
+    OpenStructDataSource osDs = mock(OpenStructDataSource.class);
+    when(osDs.isMaterialized(key)).thenReturn(false);
+    when(osDs.isFullyMaterialized()).thenReturn(true);
+    when(osDs.getFieldSpec()).thenReturn(
+        new ComplexFieldSpec(COLUMN, FieldSpec.DataType.OPEN_STRUCT, true, children));
+    DataSourceMetadata osMeta = mock(DataSourceMetadata.class);
+    when(osMeta.getNumDocs()).thenReturn(NUM_DOCS);
+    when(osDs.getDataSourceMetadata()).thenReturn(osMeta);
+    return osDs;
+  }
+
+  private static IndexSegment mockSegment(OpenStructDataSource osDs) {
+    IndexSegment segment = mock(IndexSegment.class);
+    when(segment.getDataSourceNullable(COLUMN)).thenReturn(osDs);
+    return segment;
+  }
+
+  /// Counts matching docs by iterating. Scan-based operators do not implement getNumMatchingDocs().
+  private static int countMatches(MapFilterOperator op) {
+    BlockDocIdIterator iterator = op.getTrues().iterator();
+    int count = 0;
+    while (iterator.next() != Constants.EOF) {
+      count++;
+    }
+    return count;
   }
 
   /**
@@ -124,46 +184,191 @@ public class MapFilterOperatorOpenStructTest {
   }
 
   /**
-   * Absent key on a fully materialized segment with EQ → EmptyFilterOperator (getTrues returns EOF).
+   * Absent key on a fully materialized segment with EQ → no doc matches (getTrues returns EOF).
    */
   @Test
   public void testAbsentKeyFullyMaterializedEq() {
-    OpenStructDataSource osDs = mock(OpenStructDataSource.class);
-    when(osDs.isMaterialized("missing_key")).thenReturn(false);
-    when(osDs.isFullyMaterialized()).thenReturn(true);
+    OpenStructDataSource osDs = mockFullyMaterializedAbsentKey("missing_key");
+    IndexSegment segment = mockSegment(osDs);
 
-    IndexSegment segment = mock(IndexSegment.class);
-    when(segment.getDataSourceNullable(COLUMN)).thenReturn(osDs);
-
-    QueryContext qc = mockQueryContext();
     Predicate predicate = makeEqPredicate(COLUMN, "missing_key", "whatever");
+    MapFilterOperator op = new MapFilterOperator(segment, predicate, mockQueryContext(), NUM_DOCS);
 
-    MapFilterOperator op = new MapFilterOperator(segment, predicate, qc, NUM_DOCS);
     assertTrue(op.toExplainString().contains("delegateTo:per_key_index"));
-
-    // EmptyFilterOperator.getTrues() returns EmptyDocIdSet → iterator next() is EOF
     assertEquals(op.getTrues().iterator().next(), Constants.EOF);
   }
 
   /**
-   * Absent key on a fully materialized segment with IS_NULL → MatchAllFilterOperator.
+   * Absent key on a fully materialized segment with IS_NULL → every doc matches.
    */
   @Test
   public void testAbsentKeyFullyMaterializedIsNull() {
-    OpenStructDataSource osDs = mock(OpenStructDataSource.class);
-    when(osDs.isMaterialized("missing_key")).thenReturn(false);
-    when(osDs.isFullyMaterialized()).thenReturn(true);
+    OpenStructDataSource osDs = mockFullyMaterializedAbsentKey("missing_key");
+    IndexSegment segment = mockSegment(osDs);
 
-    IndexSegment segment = mock(IndexSegment.class);
-    when(segment.getDataSourceNullable(COLUMN)).thenReturn(osDs);
-
-    QueryContext qc = mockQueryContext();
     Predicate predicate = makeIsNullPredicate(COLUMN, "missing_key");
+    MapFilterOperator op = new MapFilterOperator(segment, predicate, mockQueryContext(), NUM_DOCS);
 
-    MapFilterOperator op = new MapFilterOperator(segment, predicate, qc, NUM_DOCS);
     assertTrue(op.toExplainString().contains("delegateTo:per_key_index"));
     assertTrue(op.canOptimizeCount());
     assertEquals(op.getNumMatchingDocs(), NUM_DOCS);
+  }
+
+  /**
+   * With null handling off, an absent key reads as its type default, so NOT_EQ against any other
+   * value must match every doc. Regression test — this previously returned EmptyFilterOperator.
+   */
+  @Test
+  public void testAbsentKeyNotEqMatchesAllWhenNullHandlingOff() {
+    OpenStructDataSource osDs = mockFullyMaterializedAbsentKey("missing_key");
+    IndexSegment segment = mockSegment(osDs);
+
+    Predicate predicate = makeNotEqPredicate(COLUMN, "missing_key", "whatever");
+    MapFilterOperator op = new MapFilterOperator(segment, predicate, mockQueryContext(), NUM_DOCS);
+
+    assertTrue(op.toExplainString().contains("delegateTo:per_key_index"));
+    assertTrue(op.canOptimizeCount());
+    assertEquals(countMatches(op), NUM_DOCS);
+  }
+
+  /**
+   * Same as above for NOT_IN.
+   */
+  @Test
+  public void testAbsentKeyNotInMatchesAllWhenNullHandlingOff() {
+    OpenStructDataSource osDs = mockFullyMaterializedAbsentKey("missing_key");
+    IndexSegment segment = mockSegment(osDs);
+
+    Predicate predicate = makeNotInPredicate(COLUMN, "missing_key", List.of("a", "b"));
+    MapFilterOperator op = new MapFilterOperator(segment, predicate, mockQueryContext(), NUM_DOCS);
+
+    assertTrue(op.toExplainString().contains("delegateTo:per_key_index"));
+    assertEquals(countMatches(op), NUM_DOCS);
+  }
+
+  /**
+   * IN against an absent key never matches, regardless of null handling.
+   */
+  @Test
+  public void testAbsentKeyInMatchesNothingWhenNullHandlingOff() {
+    OpenStructDataSource osDs = mockFullyMaterializedAbsentKey("missing_key");
+    IndexSegment segment = mockSegment(osDs);
+
+    Predicate predicate = makeInPredicate(COLUMN, "missing_key", List.of("a", "b"));
+    MapFilterOperator op = new MapFilterOperator(segment, predicate, mockQueryContext(), NUM_DOCS);
+
+    assertEquals(countMatches(op), 0);
+  }
+
+  /**
+   * A numeric RANGE over an absent key that the schema does not declare. There is no type to
+   * recover, so the key resolves through the same STRING fallback {@code item()} uses and the
+   * comparison is lexicographic: the default "null" sorts above "100", so every doc matches.
+   * Pinned deliberately — filter and projection must not disagree, even when the answer is only
+   * meaningful as a string comparison.
+   */
+  @Test
+  public void testAbsentUndeclaredKeyRangeUsesStringFallback() {
+    OpenStructDataSource osDs = mockFullyMaterializedAbsentKey("missing_key");
+    IndexSegment segment = mockSegment(osDs);
+
+    Predicate predicate = new RangePredicate(itemExpr(COLUMN, "missing_key"), false, "100", false,
+        RangePredicate.UNBOUNDED, FieldSpec.DataType.LONG);
+    MapFilterOperator op = new MapFilterOperator(segment, predicate, mockQueryContext(), NUM_DOCS);
+
+    assertEquals(countMatches(op), NUM_DOCS);
+  }
+
+  /**
+   * Same RANGE against a key the schema does declare — the declared type drives the comparison, so
+   * LONG's default (Long.MIN_VALUE) is correctly below 100 and nothing matches. The absent key is
+   * folded to a constant, so the operator stays countable instead of scanning an all-null column.
+   */
+  @Test
+  public void testAbsentDeclaredKeyRangeMatchesNothing() {
+    OpenStructDataSource osDs = mockFullyMaterializedAbsentKey("missing_key",
+        Map.of("missing_key", new DimensionFieldSpec("missing_key", FieldSpec.DataType.LONG, true)));
+    IndexSegment segment = mockSegment(osDs);
+
+    Predicate predicate = new RangePredicate(itemExpr(COLUMN, "missing_key"), false, "100", false,
+        RangePredicate.UNBOUNDED, FieldSpec.DataType.LONG);
+    MapFilterOperator op = new MapFilterOperator(segment, predicate, mockQueryContext(), NUM_DOCS);
+
+    assertTrue(op.canOptimizeCount());
+    assertEquals(op.getNumMatchingDocs(), 0);
+  }
+
+  /**
+   * With null handling on, three-valued logic makes every value predicate — including the
+   * negations — unmatched for an all-null key.
+   */
+  @Test
+  public void testAbsentKeyNotEqEmptyWhenNullHandlingOn() {
+    OpenStructDataSource osDs = mockFullyMaterializedAbsentKey("missing_key");
+    IndexSegment segment = mockSegment(osDs);
+
+    Predicate predicate = makeNotEqPredicate(COLUMN, "missing_key", "whatever");
+    MapFilterOperator op = new MapFilterOperator(segment, predicate, mockQueryContext(true), NUM_DOCS);
+
+    assertEquals(countMatches(op), 0);
+  }
+
+  @Test
+  public void testAbsentKeyEqEmptyWhenNullHandlingOn() {
+    OpenStructDataSource osDs = mockFullyMaterializedAbsentKey("missing_key");
+    IndexSegment segment = mockSegment(osDs);
+
+    Predicate predicate = makeEqPredicate(COLUMN, "missing_key", "whatever");
+    MapFilterOperator op = new MapFilterOperator(segment, predicate, mockQueryContext(true), NUM_DOCS);
+
+    assertEquals(countMatches(op), 0);
+  }
+
+  @Test
+  public void testAbsentKeyIsNullMatchesAllWhenNullHandlingOn() {
+    OpenStructDataSource osDs = mockFullyMaterializedAbsentKey("missing_key");
+    IndexSegment segment = mockSegment(osDs);
+
+    Predicate predicate = makeIsNullPredicate(COLUMN, "missing_key");
+    MapFilterOperator op = new MapFilterOperator(segment, predicate, mockQueryContext(true), NUM_DOCS);
+
+    assertTrue(op.canOptimizeCount());
+    assertEquals(op.getNumMatchingDocs(), NUM_DOCS);
+  }
+
+  @Test
+  public void testAbsentKeyIsNotNullMatchesNothing() {
+    OpenStructDataSource osDs = mockFullyMaterializedAbsentKey("missing_key");
+    IndexSegment segment = mockSegment(osDs);
+
+    Predicate predicate = makeIsNotNullPredicate(COLUMN, "missing_key");
+    MapFilterOperator op = new MapFilterOperator(segment, predicate, mockQueryContext(), NUM_DOCS);
+
+    assertEquals(op.getNumMatchingDocs(), 0);
+  }
+
+  /**
+   * A predicate the per-key path cannot rewrite (REGEXP_LIKE) must decline rather than fold the
+   * absent key to a match-all/match-none it never evaluated. Structured like
+   * {@link #testSparseKeyFallsToExpressionFilter} because ExpressionFilterOperator cannot be built
+   * against a mock segment.
+   */
+  @Test
+  public void testAbsentKeyUnsupportedPredicateFallsThrough() {
+    OpenStructDataSource osDs = mockFullyMaterializedAbsentKey("missing_key");
+    when(osDs.getJsonIndex()).thenReturn(null);
+    IndexSegment segment = mockSegment(osDs);
+    when(segment.getDataSource(COLUMN)).thenReturn(osDs);
+    when(osDs.getColumnName()).thenReturn(COLUMN);
+
+    Predicate predicate = new RegexpLikePredicate(itemExpr(COLUMN, "missing_key"), "a.*");
+    try {
+      MapFilterOperator op = new MapFilterOperator(segment, predicate, mockQueryContext(), NUM_DOCS);
+      assertFalse(op.toExplainString().contains("delegateTo:per_key_index"));
+    } catch (Exception e) {
+      // The per-key path still had to decline before the expression fallback was attempted.
+      verify(osDs).isFullyMaterialized();
+    }
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/MapFilterOperatorOpenStructTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/MapFilterOperatorOpenStructTest.java
@@ -104,19 +104,15 @@ public class MapFilterOperatorOpenStructTest {
     return qc;
   }
 
-  /**
-   * OPEN_STRUCT source that is fully materialized but does not hold {@code key}. Stubs the field
-   * spec and doc count that {@code OpenStructNullDataSource.forAbsentKey} reads.
-   */
+  /// OPEN_STRUCT source that is fully materialized but does not hold {@code key}. Stubs the field
+  /// spec and doc count that {@code OpenStructNullDataSource.forAbsentKey} reads.
   private static OpenStructDataSource mockFullyMaterializedAbsentKey(String key) {
     return mockFullyMaterializedAbsentKey(key, Map.of());
   }
 
-  /**
-   * OPEN_STRUCT source that is fully materialized but does not hold {@code key}. Stubs the field
-   * spec and doc count that {@code OpenStructNullDataSource.forAbsentKey} reads. {@code children}
-   * carries the declared child specs — pass an empty map for an undeclared key.
-   */
+  /// OPEN_STRUCT source that is fully materialized but does not hold {@code key}. Stubs the field
+  /// spec and doc count that {@code OpenStructNullDataSource.forAbsentKey} reads. {@code children}
+  /// carries the declared child specs — pass an empty map for an undeclared key.
   private static OpenStructDataSource mockFullyMaterializedAbsentKey(String key, Map<String, FieldSpec> children) {
     OpenStructDataSource osDs = mock(OpenStructDataSource.class);
     when(osDs.isMaterialized(key)).thenReturn(false);
@@ -145,9 +141,7 @@ public class MapFilterOperatorOpenStructTest {
     return count;
   }
 
-  /**
-   * Materialized key with EQ predicate dispatches to PER_KEY_INDEX.
-   */
+  /// Materialized key with EQ predicate dispatches to PER_KEY_INDEX.
   @Test
   public void testPerKeyIndexEq() {
     OpenStructDataSource osDs = mock(OpenStructDataSource.class);
@@ -183,9 +177,7 @@ public class MapFilterOperatorOpenStructTest {
     assertTrue(op.toExplainString().contains("delegateTo:per_key_index"));
   }
 
-  /**
-   * Absent key on a fully materialized segment with EQ → no doc matches (getTrues returns EOF).
-   */
+  /// Absent key on a fully materialized segment with EQ → no doc matches (getTrues returns EOF).
   @Test
   public void testAbsentKeyFullyMaterializedEq() {
     OpenStructDataSource osDs = mockFullyMaterializedAbsentKey("missing_key");
@@ -198,9 +190,7 @@ public class MapFilterOperatorOpenStructTest {
     assertEquals(op.getTrues().iterator().next(), Constants.EOF);
   }
 
-  /**
-   * Absent key on a fully materialized segment with IS_NULL → every doc matches.
-   */
+  /// Absent key on a fully materialized segment with IS_NULL → every doc matches.
   @Test
   public void testAbsentKeyFullyMaterializedIsNull() {
     OpenStructDataSource osDs = mockFullyMaterializedAbsentKey("missing_key");
@@ -214,10 +204,8 @@ public class MapFilterOperatorOpenStructTest {
     assertEquals(op.getNumMatchingDocs(), NUM_DOCS);
   }
 
-  /**
-   * With null handling off, an absent key reads as its type default, so NOT_EQ against any other
-   * value must match every doc. Regression test — this previously returned EmptyFilterOperator.
-   */
+  /// With null handling off, an absent key reads as its type default, so NOT_EQ against any other
+  /// value must match every doc. Regression test — this previously returned EmptyFilterOperator.
   @Test
   public void testAbsentKeyNotEqMatchesAllWhenNullHandlingOff() {
     OpenStructDataSource osDs = mockFullyMaterializedAbsentKey("missing_key");
@@ -231,9 +219,7 @@ public class MapFilterOperatorOpenStructTest {
     assertEquals(countMatches(op), NUM_DOCS);
   }
 
-  /**
-   * Same as above for NOT_IN.
-   */
+  /// Same as above for NOT_IN.
   @Test
   public void testAbsentKeyNotInMatchesAllWhenNullHandlingOff() {
     OpenStructDataSource osDs = mockFullyMaterializedAbsentKey("missing_key");
@@ -246,9 +232,7 @@ public class MapFilterOperatorOpenStructTest {
     assertEquals(countMatches(op), NUM_DOCS);
   }
 
-  /**
-   * IN against an absent key never matches, regardless of null handling.
-   */
+  /// IN against an absent key never matches, regardless of null handling.
   @Test
   public void testAbsentKeyInMatchesNothingWhenNullHandlingOff() {
     OpenStructDataSource osDs = mockFullyMaterializedAbsentKey("missing_key");
@@ -260,13 +244,11 @@ public class MapFilterOperatorOpenStructTest {
     assertEquals(countMatches(op), 0);
   }
 
-  /**
-   * A numeric RANGE over an absent key that the schema does not declare. There is no type to
-   * recover, so the key resolves through the same STRING fallback {@code item()} uses and the
-   * comparison is lexicographic: the default "null" sorts above "100", so every doc matches.
-   * Pinned deliberately — filter and projection must not disagree, even when the answer is only
-   * meaningful as a string comparison.
-   */
+  /// A numeric RANGE over an absent key that the schema does not declare. There is no type to
+  /// recover, so the key resolves through the same STRING fallback {@code item()} uses and the
+  /// comparison is lexicographic: the default "null" sorts above "100", so every doc matches.
+  /// Pinned deliberately — filter and projection must not disagree, even when the answer is only
+  /// meaningful as a string comparison.
   @Test
   public void testAbsentUndeclaredKeyRangeUsesStringFallback() {
     OpenStructDataSource osDs = mockFullyMaterializedAbsentKey("missing_key");
@@ -279,11 +261,9 @@ public class MapFilterOperatorOpenStructTest {
     assertEquals(countMatches(op), NUM_DOCS);
   }
 
-  /**
-   * Same RANGE against a key the schema does declare — the declared type drives the comparison, so
-   * LONG's default (Long.MIN_VALUE) is correctly below 100 and nothing matches. The absent key is
-   * folded to a constant, so the operator stays countable instead of scanning an all-null column.
-   */
+  /// Same RANGE against a key the schema does declare — the declared type drives the comparison, so
+  /// LONG's default (Long.MIN_VALUE) is correctly below 100 and nothing matches. The absent key is
+  /// folded to a constant, so the operator stays countable instead of scanning an all-null column.
   @Test
   public void testAbsentDeclaredKeyRangeMatchesNothing() {
     OpenStructDataSource osDs = mockFullyMaterializedAbsentKey("missing_key",
@@ -298,10 +278,8 @@ public class MapFilterOperatorOpenStructTest {
     assertEquals(op.getNumMatchingDocs(), 0);
   }
 
-  /**
-   * With null handling on, three-valued logic makes every value predicate — including the
-   * negations — unmatched for an all-null key.
-   */
+  /// With null handling on, three-valued logic makes every value predicate — including the
+  /// negations — unmatched for an all-null key.
   @Test
   public void testAbsentKeyNotEqEmptyWhenNullHandlingOn() {
     OpenStructDataSource osDs = mockFullyMaterializedAbsentKey("missing_key");
@@ -347,12 +325,10 @@ public class MapFilterOperatorOpenStructTest {
     assertEquals(op.getNumMatchingDocs(), 0);
   }
 
-  /**
-   * A predicate the per-key path cannot rewrite (REGEXP_LIKE) must decline rather than fold the
-   * absent key to a match-all/match-none it never evaluated. Structured like
-   * {@link #testSparseKeyFallsToExpressionFilter} because ExpressionFilterOperator cannot be built
-   * against a mock segment.
-   */
+  /// A predicate the per-key path cannot rewrite (REGEXP_LIKE) must decline rather than fold the
+  /// absent key to a match-all/match-none it never evaluated. Structured like
+  /// {@link #testSparseKeyFallsToExpressionFilter} because ExpressionFilterOperator cannot be built
+  /// against a mock segment.
   @Test
   public void testAbsentKeyUnsupportedPredicateFallsThrough() {
     OpenStructDataSource osDs = mockFullyMaterializedAbsentKey("missing_key");
@@ -371,9 +347,7 @@ public class MapFilterOperatorOpenStructTest {
     }
   }
 
-  /**
-   * Non-materialized key on a segment that is NOT fully materialized → falls to EXPRESSION_FILTER.
-   */
+  /// Non-materialized key on a segment that is NOT fully materialized → falls to EXPRESSION_FILTER.
   @Test
   public void testSparseKeyFallsToExpressionFilter() {
     OpenStructDataSource osDs = mock(OpenStructDataSource.class);
@@ -413,9 +387,7 @@ public class MapFilterOperatorOpenStructTest {
     }
   }
 
-  /**
-   * Materialized key with IS_NOT_NULL and a null bitmap → PER_KEY_INDEX (BitmapBasedFilterOperator).
-   */
+  /// Materialized key with IS_NOT_NULL and a null bitmap → PER_KEY_INDEX (BitmapBasedFilterOperator).
   @Test
   public void testIsNotNullWithNullBitmap() {
     OpenStructDataSource osDs = mock(OpenStructDataSource.class);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/MapFilterOperatorOpenStructTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/MapFilterOperatorOpenStructTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.operator.filter;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +34,7 @@ import org.apache.pinot.common.request.context.predicate.Predicate;
 import org.apache.pinot.common.request.context.predicate.RangePredicate;
 import org.apache.pinot.common.request.context.predicate.RegexpLikePredicate;
 import org.apache.pinot.core.common.BlockDocIdIterator;
+import org.apache.pinot.core.common.BlockDocIdSet;
 import org.apache.pinot.core.operator.transform.function.ItemTransformFunction;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.Constants;
@@ -417,5 +419,62 @@ public class MapFilterOperatorOpenStructTest {
     // BitmapBasedFilterOperator with exclusive=true: matches numDocs - nullCount
     assertTrue(op.canOptimizeCount());
     assertEquals(op.getNumMatchingDocs(), NUM_DOCS - 2);
+  }
+
+  /// With null handling on, docs missing the key are UNKNOWN, not FALSE. The operator delegates
+  /// getNulls()/getFalses(), so `NOT (col['key'] = v)` — which reads getFalses() — must not match
+  /// them. Without the delegation getFalses() is NOT(trues) and wrongly sweeps the null docs in.
+  @Test
+  public void testNullDocsAreUnknownNotFalseUnderNullHandling() {
+    OpenStructDataSource osDs = mock(OpenStructDataSource.class);
+    when(osDs.isMaterialized(KEY)).thenReturn(true);
+
+    DataSource keyDs = mock(DataSource.class);
+    when(osDs.getDataSource(KEY)).thenReturn(keyDs);
+
+    DataSourceMetadata meta = mock(DataSourceMetadata.class);
+    when(meta.getDataType()).thenReturn(FieldSpec.DataType.STRING);
+    when(meta.isSorted()).thenReturn(false);
+    when(meta.isSingleValue()).thenReturn(true);
+    when(keyDs.getDataSourceMetadata()).thenReturn(meta);
+    when(keyDs.getColumnName()).thenReturn(KEY);
+    when(keyDs.getForwardIndex()).thenReturn(null);
+
+    Dictionary dict = mock(Dictionary.class);
+    when(dict.indexOf("active")).thenReturn(0);
+    when(keyDs.getDictionary()).thenReturn(dict);
+
+    // Docs 0-2 carry "active"; docs 5 and 10 never set the key at all.
+    InvertedIndexReader<?> invertedIndex = mock(InvertedIndexReader.class);
+    doReturn(MutableRoaringBitmap.bitmapOf(0, 1, 2)).when(invertedIndex).getDocIds(0);
+    doReturn(invertedIndex).when(keyDs).getInvertedIndex();
+
+    NullValueVectorReader nullReader = mock(NullValueVectorReader.class);
+    when(nullReader.getNullBitmap()).thenReturn(MutableRoaringBitmap.bitmapOf(5, 10));
+    when(keyDs.getNullValueVector()).thenReturn(nullReader);
+
+    IndexSegment segment = mock(IndexSegment.class);
+    when(segment.getDataSourceNullable(COLUMN)).thenReturn(osDs);
+
+    MapFilterOperator op = new MapFilterOperator(segment, makeEqPredicate(COLUMN, KEY, "active"),
+        mockQueryContext(true), NUM_DOCS);
+    assertTrue(op.toExplainString().contains("delegateTo:per_key_index"));
+
+    assertEquals(collect(op.getTrues()), List.of(0, 1, 2));
+    assertEquals(collect(op.getNulls()), List.of(5, 10));
+
+    List<Integer> falses = collect(op.getFalses());
+    assertFalse(falses.contains(5), "doc 5 is missing the key: UNKNOWN, not FALSE");
+    assertFalse(falses.contains(10), "doc 10 is missing the key: UNKNOWN, not FALSE");
+    assertTrue(falses.contains(3), "doc 3 has the key with a non-matching value: FALSE");
+  }
+
+  private static List<Integer> collect(BlockDocIdSet docIdSet) {
+    List<Integer> docIds = new ArrayList<>();
+    BlockDocIdIterator iterator = docIdSet.iterator();
+    for (int docId = iterator.next(); docId != Constants.EOF; docId = iterator.next()) {
+      docIds.add(docId);
+    }
+    return docIds;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ItemTransformFunctionNullBitmapTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ItemTransformFunctionNullBitmapTest.java
@@ -1,0 +1,139 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.operator.ColumnContext;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
+import org.apache.pinot.segment.spi.datasource.MapDataSource;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.roaringbitmap.RoaringBitmap;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.*;
+
+
+/**
+ * Validates that {@link ItemTransformFunction#getNullBitmap} returns block-local indices
+ * (projected by {@link org.apache.pinot.core.operator.docvalsets.ProjectionBlockValSet})
+ * rather than raw segment-level doc IDs from the underlying {@link NullValueVectorReader}.
+ */
+public class ItemTransformFunctionNullBitmapTest {
+  private static final String COLUMN = "myMap";
+  private static final String KEY = "foo";
+
+  private AutoCloseable _mocks;
+
+  @Mock private ProjectionBlock _projectionBlock;
+  @Mock private BlockValSet _blockValSet;
+  @Mock private ColumnContext _columnContext;
+  @Mock private MapDataSource _mapDataSource;
+  @Mock private DataSource _keyDataSource;
+  @Mock private DataSourceMetadata _keyMetadata;
+  @Mock private NullValueVectorReader _nullValueVector;
+
+  @BeforeMethod
+  @SuppressWarnings("unchecked")
+  public void setUp() {
+    _mocks = MockitoAnnotations.openMocks(this);
+
+    ForwardIndexReader<?> forwardIndex = mock(ForwardIndexReader.class);
+    when(forwardIndex.isDictionaryEncoded()).thenReturn(false);
+
+    when(_columnContext.getDataSource()).thenReturn(_mapDataSource);
+    when(_mapDataSource.getDataSource(KEY)).thenReturn(_keyDataSource);
+    when(_keyDataSource.getDataSourceMetadata()).thenReturn(_keyMetadata);
+    doReturn(forwardIndex).when(_keyDataSource).getForwardIndex();
+    when(_keyMetadata.getDataType()).thenReturn(FieldSpec.DataType.STRING);
+    when(_keyMetadata.isSingleValue()).thenReturn(true);
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    _mocks.close();
+  }
+
+  /// Segment-level null bitmap has doc IDs {100, 200, 300}. The block contains only 5 docs and
+  /// the projected (block-local) bitmap is {0, 2}. getNullBitmap must return {0, 2}, not
+  /// {100, 200, 300}. Returning segment-level IDs causes ArrayIndexOutOfBoundsException in
+  /// callers that index into block-sized arrays.
+  @Test
+  public void testGetNullBitmapReturnsBlockLocalIndices() {
+    // Segment-level bitmap — these are NOT valid block-local indices
+    MutableRoaringBitmap segmentBitmap = new MutableRoaringBitmap();
+    segmentBitmap.add(100);
+    segmentBitmap.add(200);
+    segmentBitmap.add(300);
+    when(_nullValueVector.getNullBitmap()).thenReturn(segmentBitmap);
+    when(_keyDataSource.getNullValueVector()).thenReturn(_nullValueVector);
+
+    // Block-local projected bitmap — what callers actually expect
+    RoaringBitmap projectedBitmap = new RoaringBitmap();
+    projectedBitmap.add(0);
+    projectedBitmap.add(2);
+    when(_projectionBlock.getBlockValueSet(any(String[].class))).thenReturn(_blockValSet);
+    when(_blockValSet.getNullBitmap()).thenReturn(projectedBitmap);
+
+    ItemTransformFunction fn = initFunction();
+    RoaringBitmap result = fn.getNullBitmap(_projectionBlock);
+
+    assertNotNull(result);
+    assertEquals(result, projectedBitmap);
+    assertTrue(result.contains(0));
+    assertTrue(result.contains(2));
+    assertFalse(result.contains(100), "Must not contain segment-level doc ID");
+  }
+
+  @Test
+  public void testGetNullBitmapReturnsNullWhenNoNulls() {
+    when(_keyDataSource.getNullValueVector()).thenReturn(_nullValueVector);
+    when(_projectionBlock.getBlockValueSet(any(String[].class))).thenReturn(_blockValSet);
+    when(_blockValSet.getNullBitmap()).thenReturn(null);
+
+    ItemTransformFunction fn = initFunction();
+    assertNull(fn.getNullBitmap(_projectionBlock));
+  }
+
+  private ItemTransformFunction initFunction() {
+    IdentifierTransformFunction identifierTf = mock(IdentifierTransformFunction.class);
+    when(identifierTf.getColumnName()).thenReturn(COLUMN);
+    LiteralTransformFunction literalTf = mock(LiteralTransformFunction.class);
+    when(literalTf.getStringLiteral()).thenReturn(KEY);
+
+    ItemTransformFunction fn = new ItemTransformFunction();
+    fn.init(List.of(identifierTf, literalTf), Map.of(COLUMN, _columnContext));
+    return fn;
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ItemTransformFunctionNullBitmapTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ItemTransformFunctionNullBitmapTest.java
@@ -26,13 +26,14 @@ import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
 import org.apache.pinot.segment.spi.datasource.MapDataSource;
+import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
-import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.roaringbitmap.RoaringBitmap;
-import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -40,43 +41,67 @@ import org.testng.annotations.Test;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
 
 
 /**
- * Validates that {@link ItemTransformFunction#getNullBitmap} returns block-local indices
- * (projected by {@link org.apache.pinot.core.operator.docvalsets.ProjectionBlockValSet})
- * rather than raw segment-level doc IDs from the underlying {@link NullValueVectorReader}.
+ * Covers {@link ItemTransformFunction#getNullBitmap} for both backing column types.
+ *
+ * <p>OPEN_STRUCT keeps a per-key presence bitmap, so {@code getNullBitmap} reads the per-key value set and must return
+ * block-local indices (projected by
+ * {@link org.apache.pinot.core.operator.docvalsets.ProjectionBlockValSet}) rather than raw segment-level doc IDs.
+ *
+ * <p>MAP has no per-key null information, so {@code getNullBitmap} must fall back to
+ * {@link BaseTransformFunction#getNullBitmap} — the OR of the argument bitmaps, which yields the MAP column's own
+ * null bitmap. Reading the per-key value set for a MAP column would report "no nulls" for a key that is absent from
+ * every doc, because an absent MAP key resolves to a
+ * {@link org.apache.pinot.segment.local.segment.index.map.NullDataSource} carrying only a forward index.
  */
 public class ItemTransformFunctionNullBitmapTest {
   private static final String COLUMN = "myMap";
   private static final String KEY = "foo";
+  private static final int NUM_DOCS = 5;
 
   private AutoCloseable _mocks;
 
-  @Mock private ProjectionBlock _projectionBlock;
-  @Mock private BlockValSet _blockValSet;
-  @Mock private ColumnContext _columnContext;
-  @Mock private MapDataSource _mapDataSource;
-  @Mock private DataSource _keyDataSource;
-  @Mock private DataSourceMetadata _keyMetadata;
-  @Mock private NullValueVectorReader _nullValueVector;
+  @Mock
+  private ProjectionBlock _projectionBlock;
+  @Mock
+  private BlockValSet _perKeyBlockValSet;
+  @Mock
+  private ColumnContext _columnContext;
+  @Mock
+  private MapDataSource _mapDataSource;
+  @Mock
+  private OpenStructDataSource _openStructDataSource;
+  @Mock
+  private DataSource _keyDataSource;
+  @Mock
+  private DataSourceMetadata _keyMetadata;
+  @Mock
+  private DataSourceMetadata _parentMetadata;
+  @Mock
+  private IdentifierTransformFunction _identifierArg;
+  @Mock
+  private LiteralTransformFunction _literalArg;
 
   @BeforeMethod
-  @SuppressWarnings("unchecked")
   public void setUp() {
     _mocks = MockitoAnnotations.openMocks(this);
 
     ForwardIndexReader<?> forwardIndex = mock(ForwardIndexReader.class);
     when(forwardIndex.isDictionaryEncoded()).thenReturn(false);
-
-    when(_columnContext.getDataSource()).thenReturn(_mapDataSource);
-    when(_mapDataSource.getDataSource(KEY)).thenReturn(_keyDataSource);
-    when(_keyDataSource.getDataSourceMetadata()).thenReturn(_keyMetadata);
     doReturn(forwardIndex).when(_keyDataSource).getForwardIndex();
+    when(_keyDataSource.getDataSourceMetadata()).thenReturn(_keyMetadata);
     when(_keyMetadata.getDataType()).thenReturn(FieldSpec.DataType.STRING);
     when(_keyMetadata.isSingleValue()).thenReturn(true);
+
+    when(_identifierArg.getColumnName()).thenReturn(COLUMN);
+    when(_literalArg.getStringLiteral()).thenReturn(KEY);
+    when(_projectionBlock.getBlockValueSet(any(String[].class))).thenReturn(_perKeyBlockValSet);
   }
 
   @AfterMethod
@@ -85,55 +110,114 @@ public class ItemTransformFunctionNullBitmapTest {
     _mocks.close();
   }
 
-  /// Segment-level null bitmap has doc IDs {100, 200, 300}. The block contains only 5 docs and
-  /// the projected (block-local) bitmap is {0, 2}. getNullBitmap must return {0, 2}, not
-  /// {100, 200, 300}. Returning segment-level IDs causes ArrayIndexOutOfBoundsException in
-  /// callers that index into block-sized arrays.
+  // ---------------------------------------------------------------------------------------------
+  // OPEN_STRUCT — per-key null bitmap is authoritative
+  // ---------------------------------------------------------------------------------------------
+
+  /// The underlying {@link NullValueVectorReader} holds segment-level doc IDs {100, 200, 300}, but the block contains
+  /// only 5 docs and the projected bitmap is {0, 2}. getNullBitmap must return {0, 2}. Returning segment-level IDs
+  /// causes ArrayIndexOutOfBoundsException in callers that index into block-sized arrays.
   @Test
-  public void testGetNullBitmapReturnsBlockLocalIndices() {
-    // Segment-level bitmap — these are NOT valid block-local indices
-    MutableRoaringBitmap segmentBitmap = new MutableRoaringBitmap();
-    segmentBitmap.add(100);
-    segmentBitmap.add(200);
-    segmentBitmap.add(300);
-    when(_nullValueVector.getNullBitmap()).thenReturn(segmentBitmap);
-    when(_keyDataSource.getNullValueVector()).thenReturn(_nullValueVector);
+  public void testOpenStructReturnsBlockLocalPerKeyIndices() {
+    when(_openStructDataSource.getDataSource(KEY)).thenReturn(_keyDataSource);
 
-    // Block-local projected bitmap — what callers actually expect
-    RoaringBitmap projectedBitmap = new RoaringBitmap();
-    projectedBitmap.add(0);
-    projectedBitmap.add(2);
-    when(_projectionBlock.getBlockValueSet(any(String[].class))).thenReturn(_blockValSet);
-    when(_blockValSet.getNullBitmap()).thenReturn(projectedBitmap);
+    RoaringBitmap projectedBitmap = RoaringBitmap.bitmapOf(0, 2);
+    when(_perKeyBlockValSet.getNullBitmap()).thenReturn(projectedBitmap);
 
-    ItemTransformFunction fn = initFunction();
-    RoaringBitmap result = fn.getNullBitmap(_projectionBlock);
+    RoaringBitmap result = initFunction(_openStructDataSource).getNullBitmap(_projectionBlock);
 
     assertNotNull(result);
     assertEquals(result, projectedBitmap);
-    assertTrue(result.contains(0));
-    assertTrue(result.contains(2));
-    assertFalse(result.contains(100), "Must not contain segment-level doc ID");
+  }
+
+  /// The per-key value set is authoritative for OPEN_STRUCT: the parent column's bitmap must not be consulted, and
+  /// must not widen the result.
+  @Test
+  public void testOpenStructIgnoresParentColumnBitmap() {
+    when(_openStructDataSource.getDataSource(KEY)).thenReturn(_keyDataSource);
+    when(_perKeyBlockValSet.getNullBitmap()).thenReturn(RoaringBitmap.bitmapOf(0, 2));
+
+    RoaringBitmap result = initFunction(_openStructDataSource).getNullBitmap(_projectionBlock);
+
+    assertEquals(result, RoaringBitmap.bitmapOf(0, 2));
+    verify(_identifierArg, never()).getNullBitmap(any());
   }
 
   @Test
-  public void testGetNullBitmapReturnsNullWhenNoNulls() {
-    when(_keyDataSource.getNullValueVector()).thenReturn(_nullValueVector);
-    when(_projectionBlock.getBlockValueSet(any(String[].class))).thenReturn(_blockValSet);
-    when(_blockValSet.getNullBitmap()).thenReturn(null);
+  public void testOpenStructReturnsNullWhenNoNulls() {
+    when(_openStructDataSource.getDataSource(KEY)).thenReturn(_keyDataSource);
+    when(_perKeyBlockValSet.getNullBitmap()).thenReturn(null);
 
-    ItemTransformFunction fn = initFunction();
-    assertNull(fn.getNullBitmap(_projectionBlock));
+    assertNull(initFunction(_openStructDataSource).getNullBitmap(_projectionBlock));
   }
 
-  private ItemTransformFunction initFunction() {
-    IdentifierTransformFunction identifierTf = mock(IdentifierTransformFunction.class);
-    when(identifierTf.getColumnName()).thenReturn(COLUMN);
-    LiteralTransformFunction literalTf = mock(LiteralTransformFunction.class);
-    when(literalTf.getStringLiteral()).thenReturn(KEY);
+  /// A key absent from the OPEN_STRUCT segment resolves to an all-null
+  /// {@link org.apache.pinot.segment.local.segment.index.openstruct.OpenStructNullDataSource}, which still exposes
+  /// per-key nulls — so the per-key value set stays authoritative.
+  @Test
+  public void testOpenStructAbsentKeyStillUsesPerKeyBitmap() {
+    when(_openStructDataSource.getDataSource(KEY)).thenReturn(null);
+    when(_openStructDataSource.getFieldSpec()).thenReturn(
+        new ComplexFieldSpec(COLUMN, FieldSpec.DataType.OPEN_STRUCT, true,
+            Map.of(KEY, new DimensionFieldSpec(KEY, FieldSpec.DataType.STRING, true))));
+    when(_openStructDataSource.getDataSourceMetadata()).thenReturn(_parentMetadata);
+    when(_parentMetadata.getNumDocs()).thenReturn(NUM_DOCS);
 
+    RoaringBitmap allNull = RoaringBitmap.bitmapOf(0, 1, 2, 3, 4);
+    when(_perKeyBlockValSet.getNullBitmap()).thenReturn(allNull);
+
+    RoaringBitmap result = initFunction(_openStructDataSource).getNullBitmap(_projectionBlock);
+
+    assertEquals(result, allNull);
+    verify(_identifierArg, never()).getNullBitmap(any());
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // MAP — no per-key null info, fall back to the MAP column's own (conservative) bitmap
+  // ---------------------------------------------------------------------------------------------
+
+  /// The per-key value set reports "no nulls" (MAP keeps no per-key null vector), but the MAP column itself is null
+  /// for docs {1, 3}. getNullBitmap must report {1, 3}. Reading the per-key value set here would return null and
+  /// silently treat every doc as non-null.
+  @Test
+  public void testMapFallsBackToParentColumnBitmap() {
+    when(_mapDataSource.getDataSource(KEY)).thenReturn(_keyDataSource);
+    when(_perKeyBlockValSet.getNullBitmap()).thenReturn(null);
+    when(_identifierArg.getNullBitmap(_projectionBlock)).thenReturn(RoaringBitmap.bitmapOf(1, 3));
+
+    RoaringBitmap result = initFunction(_mapDataSource).getNullBitmap(_projectionBlock);
+
+    assertNotNull(result, "MAP must fall back to the map column's null bitmap");
+    assertEquals(result, RoaringBitmap.bitmapOf(1, 3));
+  }
+
+  /// A MAP key absent from the segment resolves to a
+  /// {@link org.apache.pinot.segment.local.segment.index.map.NullDataSource}, which carries no null value vector.
+  /// The fallback must still surface the MAP column's own nulls rather than reporting none.
+  @Test
+  public void testMapAbsentKeyFallsBackToParentColumnBitmap() {
+    when(_mapDataSource.getDataSource(KEY)).thenReturn(null);
+    when(_perKeyBlockValSet.getNullBitmap()).thenReturn(null);
+    when(_identifierArg.getNullBitmap(_projectionBlock)).thenReturn(RoaringBitmap.bitmapOf(2));
+
+    RoaringBitmap result = initFunction(_mapDataSource).getNullBitmap(_projectionBlock);
+
+    assertNotNull(result);
+    assertEquals(result, RoaringBitmap.bitmapOf(2));
+  }
+
+  @Test
+  public void testMapReturnsNullWhenMapColumnHasNoNulls() {
+    when(_mapDataSource.getDataSource(KEY)).thenReturn(_keyDataSource);
+    when(_identifierArg.getNullBitmap(_projectionBlock)).thenReturn(null);
+
+    assertNull(initFunction(_mapDataSource).getNullBitmap(_projectionBlock));
+  }
+
+  private ItemTransformFunction initFunction(DataSource columnDataSource) {
+    when(_columnContext.getDataSource()).thenReturn(columnDataSource);
     ItemTransformFunction fn = new ItemTransformFunction();
-    fn.init(List.of(identifierTf, literalTf), Map.of(COLUMN, _columnContext));
+    fn.init(List.of(_identifierArg, _literalArg), Map.of(COLUMN, _columnContext));
     return fn;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ItemTransformFunctionNullBitmapTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ItemTransformFunctionNullBitmapTest.java
@@ -47,19 +47,17 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
 
 
-/**
- * Covers {@link ItemTransformFunction#getNullBitmap} for both backing column types.
- *
- * <p>OPEN_STRUCT keeps a per-key presence bitmap, so {@code getNullBitmap} reads the per-key value set and must return
- * block-local indices (projected by
- * {@link org.apache.pinot.core.operator.docvalsets.ProjectionBlockValSet}) rather than raw segment-level doc IDs.
- *
- * <p>MAP has no per-key null information, so {@code getNullBitmap} must fall back to
- * {@link BaseTransformFunction#getNullBitmap} — the OR of the argument bitmaps, which yields the MAP column's own
- * null bitmap. Reading the per-key value set for a MAP column would report "no nulls" for a key that is absent from
- * every doc, because an absent MAP key resolves to a
- * {@link org.apache.pinot.segment.local.segment.index.map.NullDataSource} carrying only a forward index.
- */
+/// Covers {@link ItemTransformFunction#getNullBitmap} for both backing column types.
+///
+/// <p>OPEN_STRUCT keeps a per-key presence bitmap, so {@code getNullBitmap} reads the per-key value set and must return
+/// block-local indices (projected by
+/// {@link org.apache.pinot.core.operator.docvalsets.ProjectionBlockValSet}) rather than raw segment-level doc IDs.
+///
+/// <p>MAP has no per-key null information, so {@code getNullBitmap} must fall back to
+/// {@link BaseTransformFunction#getNullBitmap} — the OR of the argument bitmaps, which yields the MAP column's own
+/// null bitmap. Reading the per-key value set for a MAP column would report "no nulls" for a key that is absent from
+/// every doc, because an absent MAP key resolves to a
+/// {@link org.apache.pinot.segment.local.segment.index.map.NullDataSource} carrying only a forward index.
 public class ItemTransformFunctionNullBitmapTest {
   private static final String COLUMN = "myMap";
   private static final String KEY = "foo";

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/AggregationPlanNodeResolveDataSourceTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/AggregationPlanNodeResolveDataSourceTest.java
@@ -1,0 +1,144 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.plan;
+
+import java.util.List;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.FunctionContext;
+import org.apache.pinot.common.request.context.LiteralContext;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.MapDataSource;
+import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+
+public class AggregationPlanNodeResolveDataSourceTest {
+
+  @Test
+  public void testIdentifierResolvesToSegmentDataSource() {
+    IndexSegment segment = mock(IndexSegment.class);
+    DataSource ds = mock(DataSource.class);
+    when(segment.getDataSource("col", null)).thenReturn(ds);
+
+    ExpressionContext expr = ExpressionContext.forIdentifier("col");
+    assertSame(AggregationPlanNode.resolveDataSource(expr, segment, null), ds);
+  }
+
+  @Test
+  public void testLiteralReturnsNull() {
+    IndexSegment segment = mock(IndexSegment.class);
+    ExpressionContext expr = ExpressionContext.forLiteral(new LiteralContext(FieldSpec.DataType.STRING, "hello"));
+    assertNull(AggregationPlanNode.resolveDataSource(expr, segment, null));
+  }
+
+  @Test
+  public void testItemFunctionWithMapDataSource() {
+    IndexSegment segment = mock(IndexSegment.class);
+    MapDataSource mapDs = mock(MapDataSource.class);
+    DataSource keyDs = mock(DataSource.class);
+    when(segment.getDataSource("mapCol", null)).thenReturn(mapDs);
+    when(mapDs.getDataSource("myKey")).thenReturn(keyDs);
+
+    ExpressionContext expr = itemExpr("mapCol", "myKey");
+    assertSame(AggregationPlanNode.resolveDataSource(expr, segment, null), keyDs);
+  }
+
+  @Test
+  public void testItemFunctionWithMaterializedOpenStructDataSource() {
+    IndexSegment segment = mock(IndexSegment.class);
+    OpenStructDataSource osDs = mock(OpenStructDataSource.class);
+    DataSource keyDs = mock(DataSource.class);
+    when(segment.getDataSource("osCol", null)).thenReturn(osDs);
+    when(osDs.isMaterialized("denseKey")).thenReturn(true);
+    when(osDs.getDataSource("denseKey")).thenReturn(keyDs);
+
+    ExpressionContext expr = itemExpr("osCol", "denseKey");
+    assertSame(AggregationPlanNode.resolveDataSource(expr, segment, null), keyDs);
+  }
+
+  @Test
+  public void testItemFunctionWithUnmaterializedOpenStructKeyReturnsNull() {
+    IndexSegment segment = mock(IndexSegment.class);
+    OpenStructDataSource osDs = mock(OpenStructDataSource.class);
+    when(segment.getDataSource("osCol", null)).thenReturn(osDs);
+    when(osDs.isMaterialized("sparseKey")).thenReturn(false);
+
+    ExpressionContext expr = itemExpr("osCol", "sparseKey");
+    assertNull(AggregationPlanNode.resolveDataSource(expr, segment, null));
+  }
+
+  @Test
+  public void testNonItemFunctionReturnsNull() {
+    IndexSegment segment = mock(IndexSegment.class);
+    FunctionContext fn = new FunctionContext(FunctionContext.Type.TRANSFORM, "add",
+        List.of(ExpressionContext.forIdentifier("a"), ExpressionContext.forIdentifier("b")));
+    ExpressionContext expr = ExpressionContext.forFunction(fn);
+    assertNull(AggregationPlanNode.resolveDataSource(expr, segment, null));
+  }
+
+  @Test
+  public void testItemFunctionWrongArgCountReturnsNull() {
+    IndexSegment segment = mock(IndexSegment.class);
+    FunctionContext fn = new FunctionContext(FunctionContext.Type.TRANSFORM, "item",
+        List.of(ExpressionContext.forIdentifier("col")));
+    ExpressionContext expr = ExpressionContext.forFunction(fn);
+    assertNull(AggregationPlanNode.resolveDataSource(expr, segment, null));
+  }
+
+  @Test
+  public void testItemFunctionNonIdentifierFirstArgReturnsNull() {
+    IndexSegment segment = mock(IndexSegment.class);
+    FunctionContext fn = new FunctionContext(FunctionContext.Type.TRANSFORM, "item",
+        List.of(ExpressionContext.forLiteral(new LiteralContext(FieldSpec.DataType.STRING, "notACol")),
+            ExpressionContext.forLiteral(new LiteralContext(FieldSpec.DataType.STRING, "key"))));
+    ExpressionContext expr = ExpressionContext.forFunction(fn);
+    assertNull(AggregationPlanNode.resolveDataSource(expr, segment, null));
+  }
+
+  @Test
+  public void testItemFunctionNonLiteralSecondArgReturnsNull() {
+    IndexSegment segment = mock(IndexSegment.class);
+    FunctionContext fn = new FunctionContext(FunctionContext.Type.TRANSFORM, "item",
+        List.of(ExpressionContext.forIdentifier("col"), ExpressionContext.forIdentifier("notALiteral")));
+    ExpressionContext expr = ExpressionContext.forFunction(fn);
+    assertNull(AggregationPlanNode.resolveDataSource(expr, segment, null));
+  }
+
+  @Test
+  public void testItemFunctionOnPlainDataSourceReturnsNull() {
+    IndexSegment segment = mock(IndexSegment.class);
+    DataSource plainDs = mock(DataSource.class);
+    when(segment.getDataSource("plainCol", null)).thenReturn(plainDs);
+
+    ExpressionContext expr = itemExpr("plainCol", "key");
+    assertNull(AggregationPlanNode.resolveDataSource(expr, segment, null));
+  }
+
+  private static ExpressionContext itemExpr(String column, String key) {
+    FunctionContext fn = new FunctionContext(FunctionContext.Type.TRANSFORM, "item",
+        List.of(ExpressionContext.forIdentifier(column),
+            ExpressionContext.forLiteral(new LiteralContext(FieldSpec.DataType.STRING, key))));
+    return ExpressionContext.forFunction(fn);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/AggregationPlanNodeResolveDataSourceTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/AggregationPlanNodeResolveDataSourceTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FunctionContext;
 import org.apache.pinot.common.request.context.LiteralContext;
+import org.apache.pinot.segment.local.segment.index.map.NullDataSource;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.datasource.MapDataSource;
@@ -62,6 +63,18 @@ public class AggregationPlanNodeResolveDataSourceTest {
 
     ExpressionContext expr = itemExpr("mapCol", "myKey");
     assertSame(AggregationPlanNode.resolveDataSource(expr, segment, null), keyDs);
+  }
+
+  @Test
+  public void testItemFunctionWithAbsentMapKeyReturnsNull() {
+    IndexSegment segment = mock(IndexSegment.class);
+    MapDataSource mapDs = mock(MapDataSource.class);
+    when(segment.getDataSource("mapCol", null)).thenReturn(mapDs);
+    // An absent MAP key resolves to a NullDataSource, which must not reach the non-scan path.
+    when(mapDs.getDataSource("absentKey")).thenReturn(new NullDataSource("absentKey"));
+
+    ExpressionContext expr = itemExpr("mapCol", "absentKey");
+    assertNull(AggregationPlanNode.resolveDataSource(expr, segment, null));
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/AggregationPlanNodeResolveDataSourceTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/AggregationPlanNodeResolveDataSourceTest.java
@@ -24,15 +24,10 @@ import org.apache.pinot.common.request.context.FunctionContext;
 import org.apache.pinot.common.request.context.LiteralContext;
 import org.apache.pinot.segment.local.segment.index.map.NullDataSource;
 import org.apache.pinot.segment.spi.IndexSegment;
-import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.datasource.MapDataSource;
 import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
-import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
-import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
 import org.apache.pinot.spi.data.FieldSpec;
-import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
-import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.*;
@@ -90,6 +85,9 @@ public class AggregationPlanNodeResolveDataSourceTest {
     when(segment.getDataSource("osCol", null)).thenReturn(osDs);
     when(osDs.isMaterialized("denseKey")).thenReturn(true);
     when(osDs.getDataSource("denseKey")).thenReturn(keyDs);
+    // Mockito mocks don't invoke the interface's default method, so the always-exact default
+    // (true) needs an explicit stub here.
+    when(osDs.isKeyDictionaryExact("denseKey")).thenReturn(true);
 
     ExpressionContext expr = itemExpr("osCol", "denseKey");
     assertSame(AggregationPlanNode.resolveDataSource(expr, segment, null), keyDs);
@@ -144,58 +142,29 @@ public class AggregationPlanNodeResolveDataSourceTest {
   }
 
   @Test
-  public void testItemFunctionOnMutableSegmentPartiallyPresentKeepsFastPath() {
-    MutableSegment segment = mock(MutableSegment.class);
+  public void testItemFunctionOnOpenStructKeyDictionaryExactKeepsFastPath() {
+    IndexSegment segment = mock(IndexSegment.class);
     OpenStructDataSource osDs = mock(OpenStructDataSource.class);
     DataSource keyDs = mock(DataSource.class);
-    NullValueVectorReader nullVector = mock(NullValueVectorReader.class);
     when(segment.getDataSource("metrics", null)).thenReturn(osDs);
     when(osDs.isMaterialized("views")).thenReturn(true);
     when(osDs.getDataSource("views")).thenReturn(keyDs);
-    when(keyDs.getNullValueVector()).thenReturn(nullVector);
-    // Absent docs exist: the reserved default legitimately belongs in the aggregate, matching
-    // the sealed segment's folded default — dictionary-based non-scan stays correct.
-    when(nullVector.getNullBitmap()).thenReturn(ImmutableRoaringBitmap.bitmapOf(3, 4));
+    when(osDs.isKeyDictionaryExact("views")).thenReturn(true);
 
     assertSame(AggregationPlanNode.resolveDataSource(itemExpr("metrics", "views"), segment, null), keyDs);
   }
 
   @Test
-  public void testItemFunctionOnMutableSegmentFullyPresentPhantomDefaultForcesScan() {
-    MutableSegment segment = mock(MutableSegment.class);
+  public void testItemFunctionOnOpenStructKeyDictionaryNotExactForcesScan() {
+    IndexSegment segment = mock(IndexSegment.class);
     OpenStructDataSource osDs = mock(OpenStructDataSource.class);
     DataSource keyDs = mock(DataSource.class);
-    NullValueVectorReader nullVector = mock(NullValueVectorReader.class);
-    InvertedIndexReader<ImmutableRoaringBitmap> invertedIndex = mock(InvertedIndexReader.class);
     when(segment.getDataSource("metrics", null)).thenReturn(osDs);
     when(osDs.isMaterialized("views")).thenReturn(true);
     when(osDs.getDataSource("views")).thenReturn(keyDs);
-    when(keyDs.getNullValueVector()).thenReturn(nullVector);
-    when(nullVector.getNullBitmap()).thenReturn(new MutableRoaringBitmap());
-    doReturn(invertedIndex).when(keyDs).getInvertedIndex();
-    // No doc ever wrote the default: the reserved dictId-0 entry is a phantom no row carries.
-    when(invertedIndex.getDocIds(0)).thenReturn(new MutableRoaringBitmap());
+    when(osDs.isKeyDictionaryExact("views")).thenReturn(false);
 
     assertNull(AggregationPlanNode.resolveDataSource(itemExpr("metrics", "views"), segment, null));
-  }
-
-  @Test
-  public void testItemFunctionOnMutableSegmentFullyPresentObservedDefaultKeepsFastPath() {
-    MutableSegment segment = mock(MutableSegment.class);
-    OpenStructDataSource osDs = mock(OpenStructDataSource.class);
-    DataSource keyDs = mock(DataSource.class);
-    NullValueVectorReader nullVector = mock(NullValueVectorReader.class);
-    InvertedIndexReader<ImmutableRoaringBitmap> invertedIndex = mock(InvertedIndexReader.class);
-    when(segment.getDataSource("metrics", null)).thenReturn(osDs);
-    when(osDs.isMaterialized("views")).thenReturn(true);
-    when(osDs.getDataSource("views")).thenReturn(keyDs);
-    when(keyDs.getNullValueVector()).thenReturn(nullVector);
-    when(nullVector.getNullBitmap()).thenReturn(new MutableRoaringBitmap());
-    doReturn(invertedIndex).when(keyDs).getInvertedIndex();
-    // Some doc explicitly wrote the default, so the dictionary matches sealed contents.
-    when(invertedIndex.getDocIds(0)).thenReturn(MutableRoaringBitmap.bitmapOf(7));
-
-    assertSame(AggregationPlanNode.resolveDataSource(itemExpr("metrics", "views"), segment, null), keyDs);
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/AggregationPlanNodeResolveDataSourceTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/AggregationPlanNodeResolveDataSourceTest.java
@@ -24,10 +24,15 @@ import org.apache.pinot.common.request.context.FunctionContext;
 import org.apache.pinot.common.request.context.LiteralContext;
 import org.apache.pinot.segment.local.segment.index.map.NullDataSource;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.datasource.MapDataSource;
 import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
+import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
+import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.*;
@@ -136,6 +141,61 @@ public class AggregationPlanNodeResolveDataSourceTest {
         List.of(ExpressionContext.forIdentifier("col"), ExpressionContext.forIdentifier("notALiteral")));
     ExpressionContext expr = ExpressionContext.forFunction(fn);
     assertNull(AggregationPlanNode.resolveDataSource(expr, segment, null));
+  }
+
+  @Test
+  public void testItemFunctionOnMutableSegmentPartiallyPresentKeepsFastPath() {
+    MutableSegment segment = mock(MutableSegment.class);
+    OpenStructDataSource osDs = mock(OpenStructDataSource.class);
+    DataSource keyDs = mock(DataSource.class);
+    NullValueVectorReader nullVector = mock(NullValueVectorReader.class);
+    when(segment.getDataSource("metrics", null)).thenReturn(osDs);
+    when(osDs.isMaterialized("views")).thenReturn(true);
+    when(osDs.getDataSource("views")).thenReturn(keyDs);
+    when(keyDs.getNullValueVector()).thenReturn(nullVector);
+    // Absent docs exist: the reserved default legitimately belongs in the aggregate, matching
+    // the sealed segment's folded default — dictionary-based non-scan stays correct.
+    when(nullVector.getNullBitmap()).thenReturn(ImmutableRoaringBitmap.bitmapOf(3, 4));
+
+    assertSame(AggregationPlanNode.resolveDataSource(itemExpr("metrics", "views"), segment, null), keyDs);
+  }
+
+  @Test
+  public void testItemFunctionOnMutableSegmentFullyPresentPhantomDefaultForcesScan() {
+    MutableSegment segment = mock(MutableSegment.class);
+    OpenStructDataSource osDs = mock(OpenStructDataSource.class);
+    DataSource keyDs = mock(DataSource.class);
+    NullValueVectorReader nullVector = mock(NullValueVectorReader.class);
+    InvertedIndexReader<ImmutableRoaringBitmap> invertedIndex = mock(InvertedIndexReader.class);
+    when(segment.getDataSource("metrics", null)).thenReturn(osDs);
+    when(osDs.isMaterialized("views")).thenReturn(true);
+    when(osDs.getDataSource("views")).thenReturn(keyDs);
+    when(keyDs.getNullValueVector()).thenReturn(nullVector);
+    when(nullVector.getNullBitmap()).thenReturn(new MutableRoaringBitmap());
+    doReturn(invertedIndex).when(keyDs).getInvertedIndex();
+    // No doc ever wrote the default: the reserved dictId-0 entry is a phantom no row carries.
+    when(invertedIndex.getDocIds(0)).thenReturn(new MutableRoaringBitmap());
+
+    assertNull(AggregationPlanNode.resolveDataSource(itemExpr("metrics", "views"), segment, null));
+  }
+
+  @Test
+  public void testItemFunctionOnMutableSegmentFullyPresentObservedDefaultKeepsFastPath() {
+    MutableSegment segment = mock(MutableSegment.class);
+    OpenStructDataSource osDs = mock(OpenStructDataSource.class);
+    DataSource keyDs = mock(DataSource.class);
+    NullValueVectorReader nullVector = mock(NullValueVectorReader.class);
+    InvertedIndexReader<ImmutableRoaringBitmap> invertedIndex = mock(InvertedIndexReader.class);
+    when(segment.getDataSource("metrics", null)).thenReturn(osDs);
+    when(osDs.isMaterialized("views")).thenReturn(true);
+    when(osDs.getDataSource("views")).thenReturn(keyDs);
+    when(keyDs.getNullValueVector()).thenReturn(nullVector);
+    when(nullVector.getNullBitmap()).thenReturn(new MutableRoaringBitmap());
+    doReturn(invertedIndex).when(keyDs).getInvertedIndex();
+    // Some doc explicitly wrote the default, so the dictionary matches sealed contents.
+    when(invertedIndex.getDocIds(0)).thenReturn(MutableRoaringBitmap.bitmapOf(7));
+
+    assertSame(AggregationPlanNode.resolveDataSource(itemExpr("metrics", "views"), segment, null), keyDs);
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/AggregationPlanNodeResolveDataSourceTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/AggregationPlanNodeResolveDataSourceTest.java
@@ -22,7 +22,6 @@ import java.util.List;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FunctionContext;
 import org.apache.pinot.common.request.context.LiteralContext;
-import org.apache.pinot.segment.local.segment.index.map.NullDataSource;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.datasource.MapDataSource;
@@ -53,28 +52,19 @@ public class AggregationPlanNodeResolveDataSourceTest {
     assertNull(AggregationPlanNode.resolveDataSource(expr, segment, null));
   }
 
+  /// MAP per-key resolution is deliberately out of scope for OPEN_STRUCT query wiring: a MAP column's
+  /// per-key source carries no dictionary and no min/max, so resolving it enables no non-scan
+  /// aggregation, while letting `hasNullValues` see a key with no null vector would silently change
+  /// the plan for a shipped feature. Keep MAP on the scan path exactly as master does.
   @Test
-  public void testItemFunctionWithMapDataSource() {
+  public void testItemFunctionWithMapDataSourceIsNotResolved() {
     IndexSegment segment = mock(IndexSegment.class);
     MapDataSource mapDs = mock(MapDataSource.class);
-    DataSource keyDs = mock(DataSource.class);
     when(segment.getDataSource("mapCol", null)).thenReturn(mapDs);
-    when(mapDs.getDataSource("myKey")).thenReturn(keyDs);
 
     ExpressionContext expr = itemExpr("mapCol", "myKey");
-    assertSame(AggregationPlanNode.resolveDataSource(expr, segment, null), keyDs);
-  }
-
-  @Test
-  public void testItemFunctionWithAbsentMapKeyReturnsNull() {
-    IndexSegment segment = mock(IndexSegment.class);
-    MapDataSource mapDs = mock(MapDataSource.class);
-    when(segment.getDataSource("mapCol", null)).thenReturn(mapDs);
-    // An absent MAP key resolves to a NullDataSource, which must not reach the non-scan path.
-    when(mapDs.getDataSource("absentKey")).thenReturn(new NullDataSource("absentKey"));
-
-    ExpressionContext expr = itemExpr("mapCol", "absentKey");
     assertNull(AggregationPlanNode.resolveDataSource(expr, segment, null));
+    verify(mapDs, never()).getDataSource(anyString());
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/OpenStructIngestionCommitTestBase.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/OpenStructIngestionCommitTestBase.java
@@ -75,6 +75,11 @@ public abstract class OpenStructIngestionCommitTestBase extends CustomDataQueryC
   // Matches OpenStructIndexType.INDEX_DISPLAY_NAME (kept as a literal to avoid a creator-side import).
   private static final String OPEN_STRUCT_INDEX_NAME = "open_struct";
   protected static final int NUM_DOCS = 1000;
+  /// `errors` is set on every ERRORS_FILL_MODULUS-th row, giving a dense key that is present in
+  /// only some docs — the case the sealed-side null vector has to cover.
+  private static final int ERRORS_FILL_MODULUS = 3;
+  private static final int NUM_ERRORS_PRESENT = (NUM_DOCS + ERRORS_FILL_MODULUS - 1) / ERRORS_FILL_MODULUS;
+  private static final int NUM_ERRORS_ABSENT = NUM_DOCS - NUM_ERRORS_PRESENT;
 
   @Override
   protected long getCountStarResult() {
@@ -90,6 +95,7 @@ public abstract class OpenStructIngestionCommitTestBase extends CustomDataQueryC
     children.put("views", new DimensionFieldSpec("views", FieldSpec.DataType.LONG, true));
     children.put("cpu", new DimensionFieldSpec("cpu", FieldSpec.DataType.DOUBLE, true));
     children.put("host", new DimensionFieldSpec("host", FieldSpec.DataType.STRING, true));
+    children.put("errors", new DimensionFieldSpec("errors", FieldSpec.DataType.LONG, true));
     children.put("region", new DimensionFieldSpec("region", FieldSpec.DataType.STRING, true));
     children.put("latencyMs", new DimensionFieldSpec("latencyMs", FieldSpec.DataType.LONG, true));
     ComplexFieldSpec metricsSpec = new ComplexFieldSpec(METRICS, FieldSpec.DataType.OPEN_STRUCT, true, children);
@@ -103,8 +109,13 @@ public abstract class OpenStructIngestionCommitTestBase extends CustomDataQueryC
   ///   views  -> inverted (=> dictionary + forward + inverted)
   ///   cpu    -> DICTIONARY encoding (=> dictionary + forward, no inverted)
   ///   host   -> RAW encoding (=> raw forward only, no dict, no inverted)
-  /// region + latencyMs have no per-key config and are not in denseKeys, so the maxDenseKeys=3
-  /// budget (filled by views/cpu/host) forces them into the sparse column.
+  ///   errors -> no per-key config, present on only ~1/3 of rows; dense purely because it is listed
+  ///             in denseKeys. `classify()` admits configured dense keys ahead of the fill-rate
+  ///             loop, so a 1/3 fill still beats the 0.5 minimum — without the explicit listing it
+  ///             would silently fall into the sparse column and the null-vector coverage below
+  ///             would test nothing.
+  /// region + latencyMs have no per-key config and are not in denseKeys, so the maxDenseKeys=4
+  /// budget (filled by views/cpu/host/errors) forces them into the sparse column.
   @Override
   protected List<FieldConfig> getFieldConfigs() {
     FieldConfig viewsCfg = new FieldConfig.Builder("views")
@@ -117,8 +128,8 @@ public abstract class OpenStructIngestionCommitTestBase extends CustomDataQueryC
         .withEncodingType(FieldConfig.EncodingType.RAW)
         .build();
     // First arg is `disabled` — false => enabled.
-    OpenStructIndexConfig osConfig = new OpenStructIndexConfig(false, null, 3,
-        Set.of("views", "cpu", "host"), 0.5, List.of(viewsCfg, cpuCfg, hostCfg));
+    OpenStructIndexConfig osConfig = new OpenStructIndexConfig(false, null, 4,
+        Set.of("views", "cpu", "host", "errors"), 0.5, List.of(viewsCfg, cpuCfg, hostCfg));
     ObjectNode indexes = JsonUtils.newObjectNode();
     indexes.set(OPEN_STRUCT_INDEX_NAME, JsonUtils.objectToJsonNode(osConfig));
     FieldConfig metricsCfg = new FieldConfig.Builder(METRICS).withIndexes(indexes).build();
@@ -156,6 +167,9 @@ public abstract class OpenStructIngestionCommitTestBase extends CustomDataQueryC
         metrics.put("host", "host-" + (i % 5));              // STRING, small set (raw forward)
         metrics.put("region", "region-" + (i % 4));          // sparse
         metrics.put("latencyMs", String.valueOf(i % 100));   // sparse
+        if (i % ERRORS_FILL_MODULUS == 0) {
+          metrics.put("errors", String.valueOf(i));          // dense but only partially present
+        }
         GenericData.Record record = new GenericData.Record(avroSchema);
         record.put(METRICS, metrics);
         record.put(TIMESTAMP_FIELD_NAME, tsBase + i);
@@ -193,6 +207,7 @@ public abstract class OpenStructIngestionCommitTestBase extends CustomDataQueryC
     String views = OpenStructNaming.materializedColumnName(METRICS, "views");
     String cpu = OpenStructNaming.materializedColumnName(METRICS, "cpu");
     String host = OpenStructNaming.materializedColumnName(METRICS, "host");
+    String errors = OpenStructNaming.materializedColumnName(METRICS, "errors");
     String region = OpenStructNaming.materializedColumnName(METRICS, "region");
     String latencyMs = OpenStructNaming.materializedColumnName(METRICS, "latencyMs");
     String sparse = OpenStructNaming.sparseColumnName(METRICS);
@@ -203,9 +218,11 @@ public abstract class OpenStructIngestionCommitTestBase extends CustomDataQueryC
     assertTrue(cols.containsKey(views), "dense child metrics$views missing");
     assertTrue(cols.containsKey(cpu), "dense child metrics$cpu missing");
     assertTrue(cols.containsKey(host), "dense child metrics$host missing");
+    assertTrue(cols.containsKey(errors), "dense child metrics$errors missing");
     assertEquals(cols.get(views).getDataType(), FieldSpec.DataType.LONG);
     assertEquals(cols.get(cpu).getDataType(), FieldSpec.DataType.DOUBLE);
     assertEquals(cols.get(host).getDataType(), FieldSpec.DataType.STRING);
+    assertEquals(cols.get(errors).getDataType(), FieldSpec.DataType.LONG);
 
     // Dense/sparse split: region + latencyMs are NOT materialized; the single sparse column exists.
     assertFalse(cols.containsKey(region), "metrics$region must NOT be materialized (forced sparse)");
@@ -231,6 +248,9 @@ public abstract class OpenStructIngestionCommitTestBase extends CustomDataQueryC
       // sparse: raw forward, no dict, no inverted
       assertTrue(reader.hasIndexFor(sparse, StandardIndexes.forward()), "sparse column must have forward");
       assertFalse(reader.hasIndexFor(sparse, StandardIndexes.dictionary()), "sparse column must NOT have dictionary");
+      // errors: partially present, so the seal must have written a null vector for the absent docs
+      assertTrue(reader.hasIndexFor(errors, StandardIndexes.nullValueVector()),
+          "partially-present dense child metrics$errors must have a null value vector");
     }
 
     // Parent/child relationship + sparse flag from raw metadata.properties.
@@ -242,6 +262,35 @@ public abstract class OpenStructIngestionCommitTestBase extends CustomDataQueryC
         views, V1Constants.MetadataKeys.Column.PARENT_COLUMN)), METRICS);
     assertEquals(props.getString(V1Constants.MetadataKeys.Column.getKeyFor(
         sparse, V1Constants.MetadataKeys.Column.PARENT_COLUMN)), METRICS);
+  }
+
+  /// A dense key present on only some docs must read back as NULL — not as the type default — on
+  /// the sealed segment. Guards the null vector `OpenStructColumnSplitter` writes at seal time; if
+  /// that write is ever made conditional and the predicate is wrong, the absent docs silently
+  /// start returning 0 for this LONG key.
+  @Test
+  public void testPartiallyPresentDenseKeyNullSemantics()
+      throws Exception {
+    JsonNode nullCount = postQuery(
+        "SELECT COUNT(*) FROM " + getTableName() + " WHERE item(" + METRICS + ", 'errors') IS NULL");
+    assertEquals(nullCount.get("exceptions").size(), 0);
+    assertEquals(nullCount.get("resultTable").get("rows").get(0).get(0).asLong(), NUM_ERRORS_ABSENT);
+
+    JsonNode notNullCount = postQuery(
+        "SELECT COUNT(*) FROM " + getTableName() + " WHERE item(" + METRICS + ", 'errors') IS NOT NULL");
+    assertEquals(notNullCount.get("exceptions").size(), 0);
+    assertEquals(notNullCount.get("resultTable").get("rows").get(0).get(0).asLong(), NUM_ERRORS_PRESENT);
+
+    // The assertion that actually bites: projecting the key on an absent row must yield null rather
+    // than the LONG default. Row i=1 is absent (1 % 3 != 0) but has errors=... on i=0 and i=3.
+    JsonNode projection = postQuery("SET enableNullHandling=true; SELECT item(" + METRICS + ", 'errors') FROM "
+        + getTableName() + " WHERE item(" + METRICS + ", 'errors') IS NULL LIMIT 5");
+    assertEquals(projection.get("exceptions").size(), 0);
+    JsonNode rows = projection.get("resultTable").get("rows");
+    assertTrue(rows.size() > 0, "expected at least one absent-key row");
+    for (JsonNode row : rows) {
+      assertTrue(row.get(0).isNull(), "absent dense key must project as null, got: " + row.get(0));
+    }
   }
 
   /// Scans both server data dirs (the custom suite starts 2 servers) for a committed immutable

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/OpenStructIngestionCommitTestBase.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/OpenStructIngestionCommitTestBase.java
@@ -75,11 +75,6 @@ public abstract class OpenStructIngestionCommitTestBase extends CustomDataQueryC
   // Matches OpenStructIndexType.INDEX_DISPLAY_NAME (kept as a literal to avoid a creator-side import).
   private static final String OPEN_STRUCT_INDEX_NAME = "open_struct";
   protected static final int NUM_DOCS = 1000;
-  /// `errors` is set on every ERRORS_FILL_MODULUS-th row, giving a dense key that is present in
-  /// only some docs — the case the sealed-side null vector has to cover.
-  private static final int ERRORS_FILL_MODULUS = 3;
-  private static final int NUM_ERRORS_PRESENT = (NUM_DOCS + ERRORS_FILL_MODULUS - 1) / ERRORS_FILL_MODULUS;
-  private static final int NUM_ERRORS_ABSENT = NUM_DOCS - NUM_ERRORS_PRESENT;
 
   @Override
   protected long getCountStarResult() {
@@ -95,7 +90,6 @@ public abstract class OpenStructIngestionCommitTestBase extends CustomDataQueryC
     children.put("views", new DimensionFieldSpec("views", FieldSpec.DataType.LONG, true));
     children.put("cpu", new DimensionFieldSpec("cpu", FieldSpec.DataType.DOUBLE, true));
     children.put("host", new DimensionFieldSpec("host", FieldSpec.DataType.STRING, true));
-    children.put("errors", new DimensionFieldSpec("errors", FieldSpec.DataType.LONG, true));
     children.put("region", new DimensionFieldSpec("region", FieldSpec.DataType.STRING, true));
     children.put("latencyMs", new DimensionFieldSpec("latencyMs", FieldSpec.DataType.LONG, true));
     ComplexFieldSpec metricsSpec = new ComplexFieldSpec(METRICS, FieldSpec.DataType.OPEN_STRUCT, true, children);
@@ -109,13 +103,8 @@ public abstract class OpenStructIngestionCommitTestBase extends CustomDataQueryC
   ///   views  -> inverted (=> dictionary + forward + inverted)
   ///   cpu    -> DICTIONARY encoding (=> dictionary + forward, no inverted)
   ///   host   -> RAW encoding (=> raw forward only, no dict, no inverted)
-  ///   errors -> no per-key config, present on only ~1/3 of rows; dense purely because it is listed
-  ///             in denseKeys. `classify()` admits configured dense keys ahead of the fill-rate
-  ///             loop, so a 1/3 fill still beats the 0.5 minimum — without the explicit listing it
-  ///             would silently fall into the sparse column and the null-vector coverage below
-  ///             would test nothing.
-  /// region + latencyMs have no per-key config and are not in denseKeys, so the maxDenseKeys=4
-  /// budget (filled by views/cpu/host/errors) forces them into the sparse column.
+  /// region + latencyMs have no per-key config and are not in denseKeys, so the maxDenseKeys=3
+  /// budget (filled by views/cpu/host) forces them into the sparse column.
   @Override
   protected List<FieldConfig> getFieldConfigs() {
     FieldConfig viewsCfg = new FieldConfig.Builder("views")
@@ -128,8 +117,8 @@ public abstract class OpenStructIngestionCommitTestBase extends CustomDataQueryC
         .withEncodingType(FieldConfig.EncodingType.RAW)
         .build();
     // First arg is `disabled` — false => enabled.
-    OpenStructIndexConfig osConfig = new OpenStructIndexConfig(false, null, 4,
-        Set.of("views", "cpu", "host", "errors"), 0.5, List.of(viewsCfg, cpuCfg, hostCfg));
+    OpenStructIndexConfig osConfig = new OpenStructIndexConfig(false, null, 3,
+        Set.of("views", "cpu", "host"), 0.5, List.of(viewsCfg, cpuCfg, hostCfg));
     ObjectNode indexes = JsonUtils.newObjectNode();
     indexes.set(OPEN_STRUCT_INDEX_NAME, JsonUtils.objectToJsonNode(osConfig));
     FieldConfig metricsCfg = new FieldConfig.Builder(METRICS).withIndexes(indexes).build();
@@ -167,9 +156,6 @@ public abstract class OpenStructIngestionCommitTestBase extends CustomDataQueryC
         metrics.put("host", "host-" + (i % 5));              // STRING, small set (raw forward)
         metrics.put("region", "region-" + (i % 4));          // sparse
         metrics.put("latencyMs", String.valueOf(i % 100));   // sparse
-        if (i % ERRORS_FILL_MODULUS == 0) {
-          metrics.put("errors", String.valueOf(i));          // dense but only partially present
-        }
         GenericData.Record record = new GenericData.Record(avroSchema);
         record.put(METRICS, metrics);
         record.put(TIMESTAMP_FIELD_NAME, tsBase + i);
@@ -207,7 +193,6 @@ public abstract class OpenStructIngestionCommitTestBase extends CustomDataQueryC
     String views = OpenStructNaming.materializedColumnName(METRICS, "views");
     String cpu = OpenStructNaming.materializedColumnName(METRICS, "cpu");
     String host = OpenStructNaming.materializedColumnName(METRICS, "host");
-    String errors = OpenStructNaming.materializedColumnName(METRICS, "errors");
     String region = OpenStructNaming.materializedColumnName(METRICS, "region");
     String latencyMs = OpenStructNaming.materializedColumnName(METRICS, "latencyMs");
     String sparse = OpenStructNaming.sparseColumnName(METRICS);
@@ -218,11 +203,9 @@ public abstract class OpenStructIngestionCommitTestBase extends CustomDataQueryC
     assertTrue(cols.containsKey(views), "dense child metrics$views missing");
     assertTrue(cols.containsKey(cpu), "dense child metrics$cpu missing");
     assertTrue(cols.containsKey(host), "dense child metrics$host missing");
-    assertTrue(cols.containsKey(errors), "dense child metrics$errors missing");
     assertEquals(cols.get(views).getDataType(), FieldSpec.DataType.LONG);
     assertEquals(cols.get(cpu).getDataType(), FieldSpec.DataType.DOUBLE);
     assertEquals(cols.get(host).getDataType(), FieldSpec.DataType.STRING);
-    assertEquals(cols.get(errors).getDataType(), FieldSpec.DataType.LONG);
 
     // Dense/sparse split: region + latencyMs are NOT materialized; the single sparse column exists.
     assertFalse(cols.containsKey(region), "metrics$region must NOT be materialized (forced sparse)");
@@ -248,9 +231,6 @@ public abstract class OpenStructIngestionCommitTestBase extends CustomDataQueryC
       // sparse: raw forward, no dict, no inverted
       assertTrue(reader.hasIndexFor(sparse, StandardIndexes.forward()), "sparse column must have forward");
       assertFalse(reader.hasIndexFor(sparse, StandardIndexes.dictionary()), "sparse column must NOT have dictionary");
-      // errors: partially present, so the seal must have written a null vector for the absent docs
-      assertTrue(reader.hasIndexFor(errors, StandardIndexes.nullValueVector()),
-          "partially-present dense child metrics$errors must have a null value vector");
     }
 
     // Parent/child relationship + sparse flag from raw metadata.properties.
@@ -262,35 +242,6 @@ public abstract class OpenStructIngestionCommitTestBase extends CustomDataQueryC
         views, V1Constants.MetadataKeys.Column.PARENT_COLUMN)), METRICS);
     assertEquals(props.getString(V1Constants.MetadataKeys.Column.getKeyFor(
         sparse, V1Constants.MetadataKeys.Column.PARENT_COLUMN)), METRICS);
-  }
-
-  /// A dense key present on only some docs must read back as NULL — not as the type default — on
-  /// the sealed segment. Guards the null vector `OpenStructColumnSplitter` writes at seal time; if
-  /// that write is ever made conditional and the predicate is wrong, the absent docs silently
-  /// start returning 0 for this LONG key.
-  @Test
-  public void testPartiallyPresentDenseKeyNullSemantics()
-      throws Exception {
-    JsonNode nullCount = postQuery(
-        "SELECT COUNT(*) FROM " + getTableName() + " WHERE item(" + METRICS + ", 'errors') IS NULL");
-    assertEquals(nullCount.get("exceptions").size(), 0);
-    assertEquals(nullCount.get("resultTable").get("rows").get(0).get(0).asLong(), NUM_ERRORS_ABSENT);
-
-    JsonNode notNullCount = postQuery(
-        "SELECT COUNT(*) FROM " + getTableName() + " WHERE item(" + METRICS + ", 'errors') IS NOT NULL");
-    assertEquals(notNullCount.get("exceptions").size(), 0);
-    assertEquals(notNullCount.get("resultTable").get("rows").get(0).get(0).asLong(), NUM_ERRORS_PRESENT);
-
-    // The assertion that actually bites: projecting the key on an absent row must yield null rather
-    // than the LONG default. Row i=1 is absent (1 % 3 != 0) but has errors=... on i=0 and i=3.
-    JsonNode projection = postQuery("SET enableNullHandling=true; SELECT item(" + METRICS + ", 'errors') FROM "
-        + getTableName() + " WHERE item(" + METRICS + ", 'errors') IS NULL LIMIT 5");
-    assertEquals(projection.get("exceptions").size(), 0);
-    JsonNode rows = projection.get("resultTable").get("rows");
-    assertTrue(rows.size() > 0, "expected at least one absent-key row");
-    for (JsonNode row : rows) {
-      assertTrue(row.get(0).isNull(), "absent dense key must project as null, got: " + row.get(0));
-    }
   }
 
   /// Scans both server data dirs (the custom suite starts 2 servers) for a committed immutable

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeInvertedIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeInvertedIndex.java
@@ -57,11 +57,9 @@ public class RealtimeInvertedIndex implements MutableInvertedIndex {
     }
   }
 
-  /**
-   * Pre-creates an empty bitmap for the next dictionary id. Used by callers that reserve a
-   * dictionary id upfront (e.g. OPEN_STRUCT key columns reserve dictId 0 for the default null
-   * value) so that subsequent contiguous {@link #add} calls stay aligned with dictionary ids.
-   */
+  /// Pre-creates an empty bitmap for the next dictionary id. Used by callers that reserve a
+  /// dictionary id upfront (e.g. OPEN_STRUCT key columns reserve dictId 0 for the default null
+  /// value) so that subsequent contiguous [#add] calls stay aligned with dictionary ids.
   public void reserveNextDictId() {
     ThreadSafeMutableRoaringBitmap bitmap = new ThreadSafeMutableRoaringBitmap();
     try {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeInvertedIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeInvertedIndex.java
@@ -57,6 +57,21 @@ public class RealtimeInvertedIndex implements MutableInvertedIndex {
     }
   }
 
+  /**
+   * Pre-creates an empty bitmap for the next dictionary id. Used by callers that reserve a
+   * dictionary id upfront (e.g. OPEN_STRUCT key columns reserve dictId 0 for the default null
+   * value) so that subsequent contiguous {@link #add} calls stay aligned with dictionary ids.
+   */
+  public void reserveNextDictId() {
+    ThreadSafeMutableRoaringBitmap bitmap = new ThreadSafeMutableRoaringBitmap();
+    try {
+      _writeLock.lock();
+      _bitmaps.add(bitmap);
+    } finally {
+      _writeLock.unlock();
+    }
+  }
+
   @Override
   public MutableRoaringBitmap getDocIds(int dictId) {
     ThreadSafeMutableRoaringBitmap bitmap;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/ImmutableOpenStructDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/ImmutableOpenStructDataSource.java
@@ -84,8 +84,7 @@ public class ImmutableOpenStructDataSource extends BaseDataSource implements Ope
   @Override
   @Nullable
   public DataSource getDataSource(String key) {
-    DataSource ds = _perKeyDataSources.get(key);
-    return ds != null ? ds : _sparseDataSource;
+    return _perKeyDataSources.get(key);
   }
 
   @Override
@@ -98,6 +97,8 @@ public class ImmutableOpenStructDataSource extends BaseDataSource implements Ope
     return _sparseDataSource == null;
   }
 
+  /// Returns only the materialized (dense) key DataSources. Sparse keys are not included because
+  /// they share a single JSON column and have no individual DataSource.
   @Override
   public Map<String, DataSource> getDataSources() {
     return _perKeyDataSources;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/ImmutableOpenStructDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/ImmutableOpenStructDataSource.java
@@ -38,18 +38,22 @@ import org.apache.pinot.spi.data.FieldSpec;
 /// Always columnar — there is no blob branch. Every key that was dense enough during segment
 /// creation gets its own materialized [DataSource] (forward index + optional inverted index /
 /// dictionary). Keys that did not meet the density threshold are stored in an optional sparse
-/// column; the sparse [DataSource] is returned for any unmaterialized key lookup.
+/// column. [#getDataSource(String)] returns `null` for any unmaterialized key — the sparse
+/// {@link DataSource} is never returned from it; sparse keys are read via the JSON/expression
+/// fallback path in the query layer.
 ///
 /// Use [#isMaterialized(String)] and [#isFullyMaterialized()] together to choose
 /// the query execution path:
 /// - Materialized key → fast path via per-key DataSource (inverted/dictionary index available).
-/// - Not materialized + not fully materialized → fall back to the sparse DataSource.
+/// - Not materialized + not fully materialized → key may be in the sparse blob; fall through to
+///   the JSON/expression path (see `MapFilterOperator.tryPerKeyIndex`).
 /// - Not materialized + fully materialized → key is definitively absent; short-circuit.
 ///
 /// Thread-safety: immutable after construction; safe for concurrent reads.
 public class ImmutableOpenStructDataSource extends BaseDataSource implements OpenStructDataSource {
   private final ComplexFieldSpec _fieldSpec;
   private final Map<String, DataSource> _perKeyDataSources;
+  /// Held only as a presence flag for [#isFullyMaterialized()] — nothing reads it as a DataSource.
   @Nullable
   private final DataSource _sparseDataSource;
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/ImmutableOpenStructDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/ImmutableOpenStructDataSource.java
@@ -39,14 +39,13 @@ import org.apache.pinot.spi.data.FieldSpec;
 /// creation gets its own materialized [DataSource] (forward index + optional inverted index /
 /// dictionary). Keys that did not meet the density threshold are stored in an optional sparse
 /// column. [#getDataSource(String)] returns `null` for any unmaterialized key — the sparse
-/// {@link DataSource} is never returned from it; sparse keys are read via the JSON/expression
-/// fallback path in the query layer.
+/// {@link DataSource} is never returned from it.
 ///
 /// Use [#isMaterialized(String)] and [#isFullyMaterialized()] together to choose
 /// the query execution path:
 /// - Materialized key → fast path via per-key DataSource (inverted/dictionary index available).
-/// - Not materialized + not fully materialized → key may be in the sparse blob; fall through to
-///   the JSON/expression path (see `MapFilterOperator.tryPerKeyIndex`).
+/// - Not materialized + not fully materialized → key may be in the sparse blob, which the query
+///   layer cannot read yet; the key reads as NULL.
 /// - Not materialized + fully materialized → key is definitively absent; short-circuit.
 ///
 /// Thread-safety: immutable after construction; safe for concurrent reads.
@@ -88,6 +87,7 @@ public class ImmutableOpenStructDataSource extends BaseDataSource implements Ope
   @Override
   @Nullable
   public DataSource getDataSource(String key) {
+    // TODO: sparse keys read as NULL on the query path; wire the sparse column in (PR 4/4).
     return _perKeyDataSources.get(key);
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableKeyColumn.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableKeyColumn.java
@@ -54,6 +54,12 @@ public class MutableKeyColumn implements Closeable {
   /// the row to query threads; docIds beyond the watermark may not have allocated chunks yet.
   private volatile int _lastIndexedDocId = -1;
 
+  /// Whether any doc has explicitly written the reserved default value (dictId 0). Distinguishes
+  /// a phantom dictionary entry (default reserved but never observed) from a real one.
+  private volatile boolean _defaultObserved;
+
+  private final ForwardIndexReader<ForwardIndexReaderContext> _guardedForwardIndex = new TailGuardedReader();
+
   public MutableKeyColumn(String key, DataType storedType, Object defaultNullValue,
       PinotDataBufferMemoryManager memoryManager, int capacity) {
     this(key, storedType, defaultNullValue, memoryManager, capacity, key);
@@ -135,9 +141,18 @@ public class MutableKeyColumn implements Closeable {
   public void setValue(int docId, Object value) {
     _presenceBitmap.add(docId);
     int dictId = _dictionary.index(value);
+    if (dictId == 0) {
+      _defaultObserved = true;
+    }
     _forwardIndex.setDictId(docId, dictId);
     _invertedIndex.add(dictId, docId);
     _lastIndexedDocId = docId;
+  }
+
+  /// Whether any doc has explicitly written the reserved default value (dictId 0), as opposed to
+  /// the default being a phantom entry no doc actually carries.
+  public boolean isDefaultObserved() {
+    return _defaultObserved;
   }
 
   public Object getValue(int docId) {
@@ -168,7 +183,7 @@ public class MutableKeyColumn implements Closeable {
   /// value — matching what a sealed segment folds in at build time for absent docs. In-range
   /// holes need no guard: chunks are zero-initialized, so they already read dictId 0.
   public ForwardIndexReader<ForwardIndexReaderContext> getGuardedForwardIndex() {
-    return new TailGuardedReader();
+    return _guardedForwardIndex;
   }
 
   private final class TailGuardedReader implements ForwardIndexReader<ForwardIndexReaderContext> {
@@ -196,7 +211,10 @@ public class MutableKeyColumn implements Closeable {
     public void readDictIds(int[] docIds, int length, int[] dictIdBuffer, ForwardIndexReaderContext context) {
       int watermark = _lastIndexedDocId;
       if (length > 0 && docIds[length - 1] <= watermark) {
-        // DocIds within a block are ascending, so the last one bounds them all.
+        // Callers (block-based scan/filter) pass docIds in ascending order within a block, so the
+        // last element bounds the whole batch. This assumption is load-bearing: if it didn't hold
+        // (e.g. an unsorted batch with its max docId in the middle), a docId past the watermark
+        // could sit earlier in the array and be delegated to the raw index here without a guard.
         _forwardIndex.readDictIds(docIds, length, dictIdBuffer, null);
         return;
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableKeyColumn.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableKeyColumn.java
@@ -26,17 +26,17 @@ import org.apache.pinot.segment.local.realtime.impl.forward.FixedByteSVMutableFo
 import org.apache.pinot.segment.local.realtime.impl.invertedindex.RealtimeInvertedIndex;
 import org.apache.pinot.segment.spi.index.mutable.MutableDictionary;
 import org.apache.pinot.segment.spi.index.mutable.MutableForwardIndex;
+import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
 import org.apache.pinot.segment.spi.memory.PinotDataBufferMemoryManager;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
-import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
-import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 
 /// A single key's mutable column for an OPEN_STRUCT column: forward index (dictionary-encoded)
 /// + presence bitmap tracking which docIds had this key set.
 ///
-/// Single-writer during ingestion; presence bitmap and forward index are not thread-safe for
-/// concurrent writes.
+/// Single-writer during ingestion. The presence bitmap is a {@link ThreadSafeMutableRoaringBitmap},
+/// so queries may read it concurrently with ingestion; the forward index, dictionary and inverted
+/// index carry the same single-writer/multiple-readers contract.
 public class MutableKeyColumn implements Closeable {
   private static final int DEFAULT_AVG_STRING_LENGTH = 32;
   private static final int DEFAULT_ROWS_PER_CHUNK = 1000;
@@ -44,7 +44,7 @@ public class MutableKeyColumn implements Closeable {
   private final String _key;
   private final DataType _storedType;
   private final MutableForwardIndex _forwardIndex;
-  private final MutableRoaringBitmap _presenceBitmap;
+  private final ThreadSafeMutableRoaringBitmap _presenceBitmap;
   private final MutableDictionary _dictionary;
   private final RealtimeInvertedIndex _invertedIndex;
 
@@ -56,7 +56,7 @@ public class MutableKeyColumn implements Closeable {
       String allocationContext) {
     _key = key;
     _storedType = storedType;
-    _presenceBitmap = new MutableRoaringBitmap();
+    _presenceBitmap = new ThreadSafeMutableRoaringBitmap();
     _invertedIndex = new RealtimeInvertedIndex();
 
     int estimatedCardinality = Math.max(capacity / 100, 16);
@@ -82,7 +82,7 @@ public class MutableKeyColumn implements Closeable {
   }
 
   /// Bitmap of docIds where this key was present (non-null).
-  public ImmutableRoaringBitmap getPresenceBitmap() {
+  public ThreadSafeMutableRoaringBitmap getPresenceBitmap() {
     return _presenceBitmap;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableKeyColumn.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableKeyColumn.java
@@ -48,12 +48,17 @@ public class MutableKeyColumn implements Closeable {
   private final MutableDictionary _dictionary;
   private final RealtimeInvertedIndex _invertedIndex;
 
-  public MutableKeyColumn(String key, DataType storedType, PinotDataBufferMemoryManager memoryManager, int capacity) {
-    this(key, storedType, memoryManager, capacity, key);
+  /// Highest docId written for this key. Volatile store after the forward-index write publishes
+  /// the row to query threads; docIds beyond the watermark may not have allocated chunks yet.
+  private volatile int _lastIndexedDocId = -1;
+
+  public MutableKeyColumn(String key, DataType storedType, Object defaultNullValue,
+      PinotDataBufferMemoryManager memoryManager, int capacity) {
+    this(key, storedType, defaultNullValue, memoryManager, capacity, key);
   }
 
-  public MutableKeyColumn(String key, DataType storedType, PinotDataBufferMemoryManager memoryManager, int capacity,
-      String allocationContext) {
+  public MutableKeyColumn(String key, DataType storedType, Object defaultNullValue,
+      PinotDataBufferMemoryManager memoryManager, int capacity, String allocationContext) {
     _key = key;
     _storedType = storedType;
     _presenceBitmap = new ThreadSafeMutableRoaringBitmap();
@@ -64,6 +69,15 @@ public class MutableKeyColumn implements Closeable {
     _dictionary = MutableDictionaryFactory.getMutableDictionary(
         storedType, false, memoryManager, avgLength, estimatedCardinality,
         allocationContext + ".dict");
+    // Reserve dictId 0 for the default null value. Forward-index chunks are zero-initialized, so
+    // any doc where this key is absent reads dictId 0 and resolves to the default — the same
+    // value a sealed segment folds in at build time for absent docs. Not marked present: the
+    // presence bitmap only reflects explicit writes. Side effect: getDistinctValues() includes
+    // the default even if never observed (seal-time cardinality estimate is +1; estimation only).
+    _dictionary.index(defaultNullValue);
+    // Mirror the reservation in the inverted index: slot 0 stays empty unless a doc explicitly
+    // writes the default value, keeping dictIds and bitmap slots contiguous.
+    _invertedIndex.reserveNextDictId();
 
     _forwardIndex = new FixedByteSVMutableForwardIndex(true, DataType.INT,
         DEFAULT_ROWS_PER_CHUNK, memoryManager, allocationContext + ".fwd");
@@ -110,12 +124,18 @@ public class MutableKeyColumn implements Closeable {
     return _invertedIndex;
   }
 
+  /// Highest docId written for this key, or -1 if never written.
+  public int getLastIndexedDocId() {
+    return _lastIndexedDocId;
+  }
+
   /// Indexes `value` at `docId`. The value must already be coerced to the stored type.
   public void setValue(int docId, Object value) {
     _presenceBitmap.add(docId);
     int dictId = _dictionary.index(value);
     _forwardIndex.setDictId(docId, dictId);
     _invertedIndex.add(dictId, docId);
+    _lastIndexedDocId = docId;
   }
 
   public Object getValue(int docId) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableKeyColumn.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableKeyColumn.java
@@ -27,6 +27,8 @@ import org.apache.pinot.segment.local.realtime.impl.invertedindex.RealtimeInvert
 import org.apache.pinot.segment.spi.index.mutable.MutableDictionary;
 import org.apache.pinot.segment.spi.index.mutable.MutableForwardIndex;
 import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
 import org.apache.pinot.segment.spi.memory.PinotDataBufferMemoryManager;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
@@ -158,5 +160,55 @@ public class MutableKeyColumn implements Closeable {
     _forwardIndex.close();
     _dictionary.close();
     _invertedIndex.close();
+  }
+
+  /// Read-side view of the forward index for query threads. The raw index only has chunks
+  /// allocated up to the highest docId written for this key, but scans read every docId in
+  /// `[0, numDocs)`; docIds past the watermark read as dictId 0 — the reserved default null
+  /// value — matching what a sealed segment folds in at build time for absent docs. In-range
+  /// holes need no guard: chunks are zero-initialized, so they already read dictId 0.
+  public ForwardIndexReader<ForwardIndexReaderContext> getGuardedForwardIndex() {
+    return new TailGuardedReader();
+  }
+
+  private final class TailGuardedReader implements ForwardIndexReader<ForwardIndexReaderContext> {
+    @Override
+    public boolean isDictionaryEncoded() {
+      return true;
+    }
+
+    @Override
+    public boolean isSingleValue() {
+      return true;
+    }
+
+    @Override
+    public DataType getStoredType() {
+      return _forwardIndex.getStoredType();
+    }
+
+    @Override
+    public int getDictId(int docId, ForwardIndexReaderContext context) {
+      return docId <= _lastIndexedDocId ? _forwardIndex.getDictId(docId) : 0;
+    }
+
+    @Override
+    public void readDictIds(int[] docIds, int length, int[] dictIdBuffer, ForwardIndexReaderContext context) {
+      int watermark = _lastIndexedDocId;
+      if (length > 0 && docIds[length - 1] <= watermark) {
+        // DocIds within a block are ascending, so the last one bounds them all.
+        _forwardIndex.readDictIds(docIds, length, dictIdBuffer, null);
+        return;
+      }
+      for (int i = 0; i < length; i++) {
+        int docId = docIds[i];
+        dictIdBuffer[i] = docId <= watermark ? _forwardIndex.getDictId(docId) : 0;
+      }
+    }
+
+    @Override
+    public void close() {
+      // The raw forward index is owned and closed by MutableKeyColumn.
+    }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructDataSource.java
@@ -30,6 +30,7 @@ import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
 import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
 import org.apache.pinot.segment.spi.index.IndexReader;
 import org.apache.pinot.segment.spi.index.IndexType;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.segment.spi.index.column.ColumnIndexContainer;
 import org.apache.pinot.segment.spi.partition.PartitionFunction;
 import org.apache.pinot.spi.data.ComplexFieldSpec;
@@ -62,10 +63,13 @@ public class MutableOpenStructDataSource extends BaseDataSource implements OpenS
   @Override
   @Nullable
   public DataSource getDataSource(String key) {
-    Map<IndexType, IndexReader> indexes = _index.getIndexes(key);
-    if (indexes == null || indexes.isEmpty()) {
+    MutableKeyColumn col = _index.getKeyColumn(key);
+    if (col == null) {
       return null;
     }
+    Map<IndexType, IndexReader> indexes = new HashMap<>(_index.getIndexes(key));
+    indexes.put(StandardIndexes.nullValueVector(),
+        new PresenceBasedNullValueVector(col.getPresenceBitmap(), _numDocs));
     ColumnMetadata metadata = _index.getColumnMetadata(key);
     return new ImmutableDataSource(metadata,
         new ColumnIndexContainer.FromMap.Builder().withAll(indexes).build());

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructDataSource.java
@@ -20,6 +20,7 @@ package org.apache.pinot.segment.local.segment.index.openstruct;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 import org.apache.pinot.segment.local.segment.index.datasource.BaseDataSource;
 import org.apache.pinot.segment.local.segment.index.datasource.ImmutableDataSource;
@@ -40,12 +41,17 @@ import org.apache.pinot.spi.data.FieldSpec;
 /// Per-key [DataSource] accessor for mutable (consuming) segments with an OPEN_STRUCT column.
 ///
 /// Always columnar — no blob branch. Per-key DataSources are synthesized on demand from the
-/// underlying [MutableOpenStructIndex]; mutable mode always holds every observed key, so
+/// underlying [MutableOpenStructIndex] and memoised; mutable mode always holds every observed key, so
 /// [#isFullyMaterialized()] is unconditionally `true`.
 public class MutableOpenStructDataSource extends BaseDataSource implements OpenStructDataSource {
   private final ComplexFieldSpec _fieldSpec;
   private final MutableOpenStructIndex _index;
   private final int _numDocs;
+  /// Memoised per-key sources: `ProjectionBlock` re-resolves the key on every block, so without this each block
+  /// rebuilds the index map, metadata and null vector. Safe for this object's lifetime — it is built fresh per
+  /// `getDataSourceNullable` lookup with {@link #_numDocs} already snapshotted, and a key's {@link MutableKeyColumn}
+  /// is never replaced once allocated. Absent keys are deliberately not memoised.
+  private final Map<String, DataSource> _perKeyDataSourceCache = new ConcurrentHashMap<>();
 
   public MutableOpenStructDataSource(ComplexFieldSpec fieldSpec, MutableOpenStructIndex index, int numDocs) {
     super(new MutableOpenStructDataSourceMetadata(fieldSpec, numDocs),
@@ -63,16 +69,19 @@ public class MutableOpenStructDataSource extends BaseDataSource implements OpenS
   @Override
   @Nullable
   public DataSource getDataSource(String key) {
+    // Live lookup, outside the memo: a key not yet observed may still be created by the ingestion thread.
     MutableKeyColumn col = _index.getKeyColumn(key);
     if (col == null) {
       return null;
     }
-    Map<IndexType, IndexReader> indexes = new HashMap<>(_index.getIndexes(key));
-    indexes.put(StandardIndexes.nullValueVector(),
-        new PresenceBasedNullValueVector(col.getPresenceBitmap(), _numDocs));
-    ColumnMetadata metadata = _index.getColumnMetadata(key);
-    return new ImmutableDataSource(metadata,
-        new ColumnIndexContainer.FromMap.Builder().withAll(indexes).build());
+    return _perKeyDataSourceCache.computeIfAbsent(key, k -> {
+      Map<IndexType, IndexReader> indexes = new HashMap<>(_index.getIndexes(k));
+      indexes.put(StandardIndexes.nullValueVector(),
+          new PresenceBasedNullValueVector(col.getPresenceBitmap(), _numDocs));
+      ColumnMetadata metadata = _index.getColumnMetadata(k);
+      return new ImmutableDataSource(metadata,
+          new ColumnIndexContainer.FromMap.Builder().withAll(indexes).build());
+    });
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructDataSource.java
@@ -33,9 +33,11 @@ import org.apache.pinot.segment.spi.index.IndexReader;
 import org.apache.pinot.segment.spi.index.IndexType;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.segment.spi.index.column.ColumnIndexContainer;
+import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
 import org.apache.pinot.segment.spi.partition.PartitionFunction;
 import org.apache.pinot.spi.data.ComplexFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 
 /// Per-key [DataSource] accessor for mutable (consuming) segments with an OPEN_STRUCT column.
@@ -78,6 +80,7 @@ public class MutableOpenStructDataSource extends BaseDataSource implements OpenS
       Map<IndexType, IndexReader> indexes = new HashMap<>(_index.getIndexes(k));
       indexes.put(StandardIndexes.nullValueVector(),
           new PresenceBasedNullValueVector(col.getPresenceBitmap(), _numDocs));
+      indexes.put(StandardIndexes.inverted(), new DefaultFoldingInvertedIndex(col, _numDocs));
       ColumnMetadata metadata = _index.getColumnMetadata(k);
       return new ImmutableDataSource(metadata,
           new ColumnIndexContainer.FromMap.Builder().withAll(indexes).build());
@@ -87,6 +90,22 @@ public class MutableOpenStructDataSource extends BaseDataSource implements OpenS
   @Override
   public boolean isMaterialized(String key) {
     return _index.getKeyColumn(key) != null;
+  }
+
+  /// A consuming key column's dictionary can contain a phantom entry (the reserved default at
+  /// dictId 0, never observed on any doc). Dictionary-based aggregation over such a dictionary
+  /// would diverge from the sealed segment, which only ever folds the default into the dictionary
+  /// when a doc actually needs it. The dictionary is exact — matches what a full scan would see —
+  /// unless the key is present on every doc of this snapshot AND no doc ever wrote the default
+  /// explicitly.
+  @Override
+  public boolean isKeyDictionaryExact(String key) {
+    MutableKeyColumn col = _index.getKeyColumn(key);
+    if (col == null) {
+      return false;
+    }
+    boolean fullyPresent = col.getPresenceBitmap().rangeCardinality(0, _numDocs) == _numDocs;
+    return !fullyPresent || col.isDefaultObserved();
   }
 
   /// Mutable mode always holds every observed key in-memory; the sparse tier exists only after seal.
@@ -188,6 +207,45 @@ public class MutableOpenStructDataSource extends BaseDataSource implements OpenS
     @Nullable
     public Comparable<?> getMaxValue() {
       return null;
+    }
+  }
+
+  /// Read-side view of a key's inverted index that folds absent docs into the reserved
+  /// default's postings (dictId 0), mirroring the sealed build, which feeds the default into
+  /// the inverted index for every doc missing the key. Without this, EQ/IN on the default
+  /// match nothing on consuming, and NOT_EQ/NOT_IN (union of other dictIds) drop absent docs.
+  private static final class DefaultFoldingInvertedIndex implements InvertedIndexReader<MutableRoaringBitmap> {
+    private final MutableKeyColumn _col;
+    private final int _numDocs;
+
+    DefaultFoldingInvertedIndex(MutableKeyColumn col, int numDocs) {
+      _col = col;
+      _numDocs = numDocs;
+    }
+
+    @Override
+    public MutableRoaringBitmap getDocIds(int dictId) {
+      MutableRoaringBitmap docIds = _col.getInvertedIndex().getDocIds(dictId);
+      if (dictId != 0) {
+        return docIds;
+      }
+      // RealtimeInvertedIndex#getDocIds already hands back a fresh copy (the underlying
+      // ThreadSafeMutableRoaringBitmap clones under its monitor), so mutating docIds in place is
+      // safe here. Compute the absent set the same way PresenceBasedNullValueVector does — an
+      // explicit [0, numDocs) range with presence subtracted — rather than a raw flip, so docIds
+      // the ingestion thread has added past this snapshot's numDocs never leak in.
+      MutableRoaringBitmap absent = new MutableRoaringBitmap();
+      if (_numDocs > 0) {
+        absent.add(0L, _numDocs);
+      }
+      absent.andNot(_col.getPresenceBitmap().getMutableRoaringBitmap());
+      docIds.or(absent);
+      return docIds;
+    }
+
+    @Override
+    public void close() {
+      // Underlying index owned by MutableKeyColumn.
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructIndex.java
@@ -172,8 +172,14 @@ public class MutableOpenStructIndex implements OpenStructIndexReader<ForwardInde
   /// publishes it via volatile copy-on-write.
   private MutableKeyColumn allocateKeyColumn(String key, DataType storedType) {
     String allocationContext = _openStructColumn + "$" + key;
+    FieldSpec childSpec = _childFieldSpecs.get(key);
+    // The child spec's default is already in internal (stored-type) representation; keys without
+    // a child spec use the standard dimension default for the resolved stored type — the same
+    // default the sealed build path uses for absent docs.
+    Object defaultNullValue = childSpec != null ? childSpec.getDefaultNullValue()
+        : FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, storedType, null);
     MutableKeyColumn newCol =
-        new MutableKeyColumn(key, storedType, _memoryManager, _capacity, allocationContext);
+        new MutableKeyColumn(key, storedType, defaultNullValue, _memoryManager, _capacity, allocationContext);
     Map<String, MutableKeyColumn> updated = new HashMap<>(_keyColumns);
     updated.put(key, newCol);
     _keyColumns = updated;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructIndex.java
@@ -172,12 +172,12 @@ public class MutableOpenStructIndex implements OpenStructIndexReader<ForwardInde
   /// publishes it via volatile copy-on-write.
   private MutableKeyColumn allocateKeyColumn(String key, DataType storedType) {
     String allocationContext = _openStructColumn + "$" + key;
-    FieldSpec childSpec = _childFieldSpecs.get(key);
-    // The child spec's default is already in internal (stored-type) representation; keys without
-    // a child spec use the standard dimension default for the resolved stored type — the same
-    // default the sealed build path uses for absent docs.
-    Object defaultNullValue = childSpec != null ? childSpec.getDefaultNullValue()
-        : FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, storedType, null);
+    // Use the standard dimension default for the resolved stored type, regardless of any child
+    // spec's own default: OpenStructColumnSplitter#writeDenseKeyColumn (the sealed build path)
+    // always derives the absent-doc default from a throwaway DimensionFieldSpec(key, storedType,
+    // true) rather than the real child spec, so mirroring that exactly is what keeps a doc's
+    // resolved value identical before and after seal.
+    Object defaultNullValue = FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, storedType, null);
     MutableKeyColumn newCol =
         new MutableKeyColumn(key, storedType, defaultNullValue, _memoryManager, _capacity, allocationContext);
     Map<String, MutableKeyColumn> updated = new HashMap<>(_keyColumns);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructIndex.java
@@ -229,7 +229,7 @@ public class MutableOpenStructIndex implements OpenStructIndexReader<ForwardInde
       return Map.of();
     }
     return Map.of(
-        StandardIndexes.forward(), col.getForwardIndex(),
+        StandardIndexes.forward(), col.getGuardedForwardIndex(),
         StandardIndexes.dictionary(), col.getDictionary(),
         StandardIndexes.inverted(), col.getInvertedIndex());
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/OpenStructNullDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/OpenStructNullDataSource.java
@@ -1,0 +1,318 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.openstruct;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
+import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
+import org.apache.pinot.segment.spi.index.IndexReader;
+import org.apache.pinot.segment.spi.index.IndexType;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.segment.spi.index.column.ColumnIndexContainer;
+import org.apache.pinot.segment.spi.index.reader.BloomFilterReader;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
+import org.apache.pinot.segment.spi.index.reader.H3IndexReader;
+import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
+import org.apache.pinot.segment.spi.index.reader.JsonIndexReader;
+import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+import org.apache.pinot.segment.spi.index.reader.RangeIndexReader;
+import org.apache.pinot.segment.spi.index.reader.TextIndexReader;
+import org.apache.pinot.segment.spi.index.reader.VectorIndexReader;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+
+
+/// Typed all-null {@link DataSource} for an OPEN_STRUCT key that is absent from a segment.
+///
+/// Unlike the MAP column's {@code NullDataSource} (which is hardcoded as INT with numDocs=0),
+/// this class uses the correct {@link DataType} from the OPEN_STRUCT child {@link FieldSpec} and
+/// reports the segment's actual doc count. Every document is null: the forward index returns the
+/// type-correct default null value, and the {@link NullValueVectorReader} returns a full-segment
+/// bitmap.
+public class OpenStructNullDataSource implements DataSource {
+  private final FieldSpec _fieldSpec;
+  private final int _numDocs;
+  private final ColumnIndexContainer _indexes;
+  private final AllNullValueVector _nullVector;
+
+  public OpenStructNullDataSource(FieldSpec fieldSpec, int numDocs) {
+    _fieldSpec = fieldSpec;
+    _numDocs = numDocs;
+    _nullVector = new AllNullValueVector(numDocs);
+    _indexes = new ColumnIndexContainer.FromMap(Map.of(
+        StandardIndexes.forward(), new TypedNullForwardIndex(fieldSpec.getDataType().getStoredType()),
+        StandardIndexes.nullValueVector(), _nullVector));
+  }
+
+  /// Creates an all-null DataSource for a key absent from this OPEN_STRUCT segment.
+  /// Resolves the key's type from the child FieldSpec, falling back to STRING.
+  public static OpenStructNullDataSource forAbsentKey(OpenStructDataSource osDs, String key) {
+    FieldSpec childSpec = osDs.getFieldSpec().getChildFieldSpec(key);
+    if (childSpec == null) {
+      childSpec = new DimensionFieldSpec(key, FieldSpec.DataType.STRING, true);
+    }
+    int numDocs = osDs.getDataSourceMetadata().getNumDocs();
+    return new OpenStructNullDataSource(childSpec, numDocs);
+  }
+
+  @Override
+  public DataSourceMetadata getDataSourceMetadata() {
+    return new AllNullMetadata(_fieldSpec, _numDocs);
+  }
+
+  @Override
+  public ColumnIndexContainer getIndexContainer() {
+    return _indexes;
+  }
+
+  @Override
+  public <R extends IndexReader> R getIndex(IndexType<?, R, ?> type) {
+    return type.getIndexReader(_indexes);
+  }
+
+  @Override
+  public ForwardIndexReader<?> getForwardIndex() {
+    return getIndex(StandardIndexes.forward());
+  }
+
+  @Nullable
+  @Override
+  public Dictionary getDictionary() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public InvertedIndexReader<?> getInvertedIndex() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public RangeIndexReader<?> getRangeIndex() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public TextIndexReader getTextIndex() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public TextIndexReader getFSTIndex() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public TextIndexReader getIFSTIndex() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public JsonIndexReader getJsonIndex() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public H3IndexReader getH3Index() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public BloomFilterReader getBloomFilter() {
+    return null;
+  }
+
+  @Override
+  public NullValueVectorReader getNullValueVector() {
+    return _nullVector;
+  }
+
+  @Nullable
+  @Override
+  public VectorIndexReader getVectorIndex() {
+    return null;
+  }
+
+  /// Forward index that returns the type-correct default null value for every document.
+  static class TypedNullForwardIndex implements ForwardIndexReader<ForwardIndexReaderContext> {
+    private final DataType _storedType;
+
+    TypedNullForwardIndex(DataType storedType) {
+      _storedType = storedType;
+    }
+
+    @Override
+    public boolean isDictionaryEncoded() {
+      return false;
+    }
+
+    @Override
+    public boolean isSingleValue() {
+      return true;
+    }
+
+    @Override
+    public DataType getStoredType() {
+      return _storedType;
+    }
+
+    @Override
+    public int getInt(int docId, ForwardIndexReaderContext context) {
+      return FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_INT;
+    }
+
+    @Override
+    public long getLong(int docId, ForwardIndexReaderContext context) {
+      return FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_LONG;
+    }
+
+    @Override
+    public float getFloat(int docId, ForwardIndexReaderContext context) {
+      return FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_FLOAT;
+    }
+
+    @Override
+    public double getDouble(int docId, ForwardIndexReaderContext context) {
+      return FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_DOUBLE;
+    }
+
+    @Override
+    public BigDecimal getBigDecimal(int docId, ForwardIndexReaderContext context) {
+      return FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_BIG_DECIMAL;
+    }
+
+    @Override
+    public String getString(int docId, ForwardIndexReaderContext context) {
+      return FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_STRING;
+    }
+
+    @Override
+    public byte[] getBytes(int docId, ForwardIndexReaderContext context) {
+      return FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_BYTES;
+    }
+
+    @Override
+    public void close() {
+    }
+  }
+
+  /// {@link NullValueVectorReader} where every document is null.
+  static class AllNullValueVector implements NullValueVectorReader {
+    private final ImmutableRoaringBitmap _nullBitmap;
+
+    AllNullValueVector(int numDocs) {
+      MutableRoaringBitmap bm = new MutableRoaringBitmap();
+      if (numDocs > 0) {
+        bm.add(0L, numDocs);
+      }
+      _nullBitmap = bm.toImmutableRoaringBitmap();
+    }
+
+    @Override
+    public boolean isNull(int docId) {
+      return true;
+    }
+
+    @Override
+    public ImmutableRoaringBitmap getNullBitmap() {
+      return _nullBitmap;
+    }
+  }
+
+  private static class AllNullMetadata implements DataSourceMetadata {
+    private final FieldSpec _fieldSpec;
+    private final int _numDocs;
+
+    AllNullMetadata(FieldSpec fieldSpec, int numDocs) {
+      _fieldSpec = fieldSpec;
+      _numDocs = numDocs;
+    }
+
+    @Override
+    public FieldSpec getFieldSpec() {
+      return _fieldSpec;
+    }
+
+    @Override
+    public boolean isSorted() {
+      return false;
+    }
+
+    @Override
+    public int getNumDocs() {
+      return _numDocs;
+    }
+
+    @Override
+    public int getNumValues() {
+      return _numDocs;
+    }
+
+    @Override
+    public int getMaxNumValuesPerMVEntry() {
+      return 0;
+    }
+
+    @Override
+    public int getCardinality() {
+      return 1;
+    }
+
+    @Nullable
+    @Override
+    public Comparable getMinValue() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Comparable getMaxValue() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public PartitionFunction getPartitionFunction() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Set<Integer> getPartitions() {
+      return null;
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/OpenStructNullDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/OpenStructNullDataSource.java
@@ -22,24 +22,14 @@ import java.math.BigDecimal;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
-import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.local.segment.index.datasource.BaseDataSource;
 import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
 import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
-import org.apache.pinot.segment.spi.index.IndexReader;
-import org.apache.pinot.segment.spi.index.IndexType;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.segment.spi.index.column.ColumnIndexContainer;
-import org.apache.pinot.segment.spi.index.reader.BloomFilterReader;
-import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
-import org.apache.pinot.segment.spi.index.reader.H3IndexReader;
-import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
-import org.apache.pinot.segment.spi.index.reader.JsonIndexReader;
 import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
-import org.apache.pinot.segment.spi.index.reader.RangeIndexReader;
-import org.apache.pinot.segment.spi.index.reader.TextIndexReader;
-import org.apache.pinot.segment.spi.index.reader.VectorIndexReader;
 import org.apache.pinot.segment.spi.partition.PartitionFunction;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -48,26 +38,23 @@ import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 
-/// Typed all-null {@link DataSource} for an OPEN_STRUCT key that is absent from a segment.
+/// Typed all-null {@link org.apache.pinot.segment.spi.datasource.DataSource} for an OPEN_STRUCT key
+/// that is absent from a segment.
 ///
 /// Unlike the MAP column's {@code NullDataSource} (which is hardcoded as INT with numDocs=0),
 /// this class uses the correct {@link DataType} from the OPEN_STRUCT child {@link FieldSpec} and
 /// reports the segment's actual doc count. Every document is null: the forward index returns the
 /// type-correct default null value, and the {@link NullValueVectorReader} returns a full-segment
 /// bitmap.
-public class OpenStructNullDataSource implements DataSource {
-  private final FieldSpec _fieldSpec;
-  private final int _numDocs;
-  private final ColumnIndexContainer _indexes;
-  private final AllNullValueVector _nullVector;
-
+///
+/// Extends {@link BaseDataSource}: every other index accessor (dictionary, inverted, range, text,
+/// bloom filter, vector, etc.) resolves to {@code null} automatically since the index container
+/// only holds a forward index and a null value vector.
+public class OpenStructNullDataSource extends BaseDataSource {
   public OpenStructNullDataSource(FieldSpec fieldSpec, int numDocs) {
-    _fieldSpec = fieldSpec;
-    _numDocs = numDocs;
-    _nullVector = new AllNullValueVector(numDocs);
-    _indexes = new ColumnIndexContainer.FromMap(Map.of(
+    super(new AllNullMetadata(fieldSpec, numDocs), new ColumnIndexContainer.FromMap(Map.of(
         StandardIndexes.forward(), new TypedNullForwardIndex(fieldSpec.getDataType().getStoredType()),
-        StandardIndexes.nullValueVector(), _nullVector));
+        StandardIndexes.nullValueVector(), new AllNullValueVector(numDocs))));
   }
 
   /// Creates an all-null DataSource for a key absent from this OPEN_STRUCT segment.
@@ -79,91 +66,6 @@ public class OpenStructNullDataSource implements DataSource {
     }
     int numDocs = osDs.getDataSourceMetadata().getNumDocs();
     return new OpenStructNullDataSource(childSpec, numDocs);
-  }
-
-  @Override
-  public DataSourceMetadata getDataSourceMetadata() {
-    return new AllNullMetadata(_fieldSpec, _numDocs);
-  }
-
-  @Override
-  public ColumnIndexContainer getIndexContainer() {
-    return _indexes;
-  }
-
-  @Override
-  public <R extends IndexReader> R getIndex(IndexType<?, R, ?> type) {
-    return type.getIndexReader(_indexes);
-  }
-
-  @Override
-  public ForwardIndexReader<?> getForwardIndex() {
-    return getIndex(StandardIndexes.forward());
-  }
-
-  @Nullable
-  @Override
-  public Dictionary getDictionary() {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public InvertedIndexReader<?> getInvertedIndex() {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public RangeIndexReader<?> getRangeIndex() {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public TextIndexReader getTextIndex() {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public TextIndexReader getFSTIndex() {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public TextIndexReader getIFSTIndex() {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public JsonIndexReader getJsonIndex() {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public H3IndexReader getH3Index() {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public BloomFilterReader getBloomFilter() {
-    return null;
-  }
-
-  @Override
-  public NullValueVectorReader getNullValueVector() {
-    return _nullVector;
-  }
-
-  @Nullable
-  @Override
-  public VectorIndexReader getVectorIndex() {
-    return null;
   }
 
   /// Forward index that returns the type-correct default null value for every document.

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/PresenceBasedNullValueVector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/PresenceBasedNullValueVector.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.openstruct;
+
+import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+
+
+/// {@link NullValueVectorReader} backed by an OPEN_STRUCT key's presence bitmap.
+///
+/// A document is null for a key when the key was never set on that document, i.e. when the
+/// document is absent from the presence bitmap. The null bitmap is computed on demand (not cached)
+/// because the presence bitmap is mutable during real-time consumption.
+public class PresenceBasedNullValueVector implements NullValueVectorReader {
+  private final ImmutableRoaringBitmap _presenceBitmap;
+  private final int _numDocs;
+
+  public PresenceBasedNullValueVector(ImmutableRoaringBitmap presenceBitmap, int numDocs) {
+    _presenceBitmap = presenceBitmap;
+    _numDocs = numDocs;
+  }
+
+  @Override
+  public boolean isNull(int docId) {
+    return !_presenceBitmap.contains(docId);
+  }
+
+  @Override
+  public ImmutableRoaringBitmap getNullBitmap() {
+    MutableRoaringBitmap nullBitmap = new MutableRoaringBitmap();
+    if (_numDocs > 0) {
+      nullBitmap.add(0L, _numDocs);
+    }
+    // Clone the presence bitmap before the full-bitmap iteration — the ingestion thread may
+    // concurrently mutate the live bitmap via MutableKeyColumn.setValue().
+    nullBitmap.andNot(_presenceBitmap.clone());
+    return nullBitmap;
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/PresenceBasedNullValueVector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/PresenceBasedNullValueVector.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.segment.index.openstruct;
 
+import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
 import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
@@ -28,11 +29,16 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
 /// A document is null for a key when the key was never set on that document, i.e. when the
 /// document is absent from the presence bitmap. The null bitmap is computed on demand (not cached)
 /// because the presence bitmap is mutable during real-time consumption.
+///
+/// Reads the live presence bitmap rather than a snapshot: the bitmap is a
+/// {@link ThreadSafeMutableRoaringBitmap} and ingestion only ever appends docIds >= the numDocs
+/// captured by the enclosing DataSource, so the [0, numDocs) range this vector reports on is
+/// already frozen.
 public class PresenceBasedNullValueVector implements NullValueVectorReader {
-  private final ImmutableRoaringBitmap _presenceBitmap;
+  private final ThreadSafeMutableRoaringBitmap _presenceBitmap;
   private final int _numDocs;
 
-  public PresenceBasedNullValueVector(ImmutableRoaringBitmap presenceBitmap, int numDocs) {
+  public PresenceBasedNullValueVector(ThreadSafeMutableRoaringBitmap presenceBitmap, int numDocs) {
     _presenceBitmap = presenceBitmap;
     _numDocs = numDocs;
   }
@@ -48,9 +54,9 @@ public class PresenceBasedNullValueVector implements NullValueVectorReader {
     if (_numDocs > 0) {
       nullBitmap.add(0L, _numDocs);
     }
-    // Clone the presence bitmap before the full-bitmap iteration — the ingestion thread may
-    // concurrently mutate the live bitmap via MutableKeyColumn.setValue().
-    nullBitmap.andNot(_presenceBitmap.clone());
+    // getMutableRoaringBitmap() clones under the wrapper's monitor, so the andNot below iterates a
+    // private copy that the ingestion thread cannot mutate mid-walk.
+    nullBitmap.andNot(_presenceBitmap.getMutableRoaringBitmap());
     return nullBitmap;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/PresenceBasedNullValueVector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/openstruct/PresenceBasedNullValueVector.java
@@ -27,16 +27,22 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
 /// {@link NullValueVectorReader} backed by an OPEN_STRUCT key's presence bitmap.
 ///
 /// A document is null for a key when the key was never set on that document, i.e. when the
-/// document is absent from the presence bitmap. The null bitmap is computed on demand (not cached)
-/// because the presence bitmap is mutable during real-time consumption.
+/// document is absent from the presence bitmap.
 ///
 /// Reads the live presence bitmap rather than a snapshot: the bitmap is a
 /// {@link ThreadSafeMutableRoaringBitmap} and ingestion only ever appends docIds >= the numDocs
 /// captured by the enclosing DataSource, so the [0, numDocs) range this vector reports on is
-/// already frozen.
+/// already frozen. That also makes the null bitmap invariant for this object's lifetime, so it is
+/// computed once and memoized — recomputing per block would clone the whole presence bitmap under
+/// the wrapper's monitor and stall the ingestion thread each time.
+///
+/// As with every other {@link NullValueVectorReader}, the returned bitmap is shared; callers must
+/// not mutate it.
 public class PresenceBasedNullValueVector implements NullValueVectorReader {
   private final ThreadSafeMutableRoaringBitmap _presenceBitmap;
   private final int _numDocs;
+  /// Benign race: concurrent computations observe the same frozen [0, numDocs) range and agree.
+  private volatile ImmutableRoaringBitmap _nullBitmap;
 
   public PresenceBasedNullValueVector(ThreadSafeMutableRoaringBitmap presenceBitmap, int numDocs) {
     _presenceBitmap = presenceBitmap;
@@ -50,13 +56,18 @@ public class PresenceBasedNullValueVector implements NullValueVectorReader {
 
   @Override
   public ImmutableRoaringBitmap getNullBitmap() {
-    MutableRoaringBitmap nullBitmap = new MutableRoaringBitmap();
-    if (_numDocs > 0) {
-      nullBitmap.add(0L, _numDocs);
+    ImmutableRoaringBitmap nullBitmap = _nullBitmap;
+    if (nullBitmap == null) {
+      MutableRoaringBitmap computed = new MutableRoaringBitmap();
+      if (_numDocs > 0) {
+        computed.add(0L, _numDocs);
+      }
+      // getMutableRoaringBitmap() clones under the wrapper's monitor, so the andNot below iterates a
+      // private copy that the ingestion thread cannot mutate mid-walk.
+      computed.andNot(_presenceBitmap.getMutableRoaringBitmap());
+      nullBitmap = computed;
+      _nullBitmap = nullBitmap;
     }
-    // getMutableRoaringBitmap() clones under the wrapper's monitor, so the andNot below iterates a
-    // private copy that the ingestion thread cannot mutate mid-walk.
-    nullBitmap.andNot(_presenceBitmap.getMutableRoaringBitmap());
     return nullBitmap;
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/ImmutableOpenStructDataSourceTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/ImmutableOpenStructDataSourceTest.java
@@ -57,8 +57,8 @@ public class ImmutableOpenStructDataSourceTest {
         container);
 
     assertSame(ds.getDataSource("clicks"), clicksDs);
-    // absent key falls back to sparse
-    assertSame(ds.getDataSource("unknown"), sparseDs);
+    // absent key returns null (callers handle the fallback)
+    assertNull(ds.getDataSource("unknown"));
   }
 
   @Test

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructDataSourceTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructDataSourceTest.java
@@ -25,6 +25,7 @@ import org.apache.pinot.segment.spi.memory.PinotDataBufferMemoryManager;
 import org.apache.pinot.spi.config.table.OpenStructIndexConfig;
 import org.apache.pinot.spi.data.ComplexFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -33,6 +34,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
 
@@ -88,6 +90,68 @@ public class MutableOpenStructDataSourceTest {
       idx.index(0, Map.of("clicks", 5L, "country", "US"));
       MutableOpenStructDataSource ds = new MutableOpenStructDataSource(spec(), idx, 1);
       assertEquals(ds.getDataSources().size(), 2);
+    }
+  }
+
+  /// ProjectionBlock re-resolves the key on every block, so repeated lookups must not rebuild the source.
+  @Test
+  public void testGetDataSourceIsMemoisedPerKey()
+      throws Exception {
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex("metrics", spec(),
+        OpenStructIndexConfig.DEFAULT, _mm, 100)) {
+      idx.index(0, Map.of("clicks", 5L));
+      MutableOpenStructDataSource ds = new MutableOpenStructDataSource(spec(), idx, 1);
+      assertSame(ds.getDataSource("clicks"), ds.getDataSource("clicks"));
+    }
+  }
+
+  /// The memo must not serve a stale source. Ingest past the snapshot boundary — including a type-conflicting value,
+  /// which would reallocate the column if the never-replaced invariant regressed — and the cached source must still
+  /// report on the snapshotted window only.
+  @Test
+  public void testMemoisedDataSourceStaysCorrectAsIngestionContinues()
+      throws Exception {
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex("metrics", spec(),
+        OpenStructIndexConfig.DEFAULT, _mm, 100)) {
+      idx.index(0, Map.of("clicks", 5L));
+      MutableOpenStructDataSource ds = new MutableOpenStructDataSource(spec(), idx, 1);
+      DataSource first = ds.getDataSource("clicks");
+      assertNotNull(first);
+      assertTrue(first.getNullValueVector().getNullBitmap().isEmpty());
+
+      idx.index(1, Map.of("clicks", 7L));
+      idx.index(2, Map.of("clicks", "not-a-long"));
+
+      assertSame(ds.getDataSource("clicks"), first);
+      assertTrue(first.getNullValueVector().getNullBitmap().isEmpty());
+    }
+  }
+
+  /// Exercises a non-empty null bitmap through the memo: the key is absent on doc 0.
+  @Test
+  public void testMemoisedNullBitmapReportsAbsentDocs()
+      throws Exception {
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex("metrics", spec(),
+        OpenStructIndexConfig.DEFAULT, _mm, 100)) {
+      idx.index(0, Map.of("country", "US"));
+      idx.index(1, Map.of("clicks", 5L));
+      MutableOpenStructDataSource ds = new MutableOpenStructDataSource(spec(), idx, 2);
+      ImmutableRoaringBitmap nulls = ds.getDataSource("clicks").getNullValueVector().getNullBitmap();
+      assertTrue(nulls.contains(0));
+      assertFalse(nulls.contains(1));
+    }
+  }
+
+  /// An absent key must not be memoised: ingestion can create it after the first lookup.
+  @Test
+  public void testKeyCreatedAfterFirstLookupIsPickedUp()
+      throws Exception {
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex("metrics", spec(),
+        OpenStructIndexConfig.DEFAULT, _mm, 100)) {
+      MutableOpenStructDataSource ds = new MutableOpenStructDataSource(spec(), idx, 1);
+      assertNull(ds.getDataSource("clicks"));
+      idx.index(0, Map.of("clicks", 5L));
+      assertNotNull(ds.getDataSource("clicks"));
     }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructDataSourceTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructDataSourceTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.segment.local.segment.index.openstruct;
 import java.util.Map;
 import org.apache.pinot.segment.local.io.writer.impl.DirectMemoryManager;
 import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.segment.spi.memory.PinotDataBufferMemoryManager;
 import org.apache.pinot.spi.config.table.OpenStructIndexConfig;
 import org.apache.pinot.spi.data.ComplexFieldSpec;
@@ -189,6 +190,50 @@ public class MutableOpenStructDataSourceTest {
       assertNotNull(col);
       assertEquals(col.getLastIndexedDocId(), 2);
       assertEquals(idx.getKeyColumn("other").getLastIndexedDocId(), 1);
+    }
+  }
+
+  @Test
+  public void testForwardIndexSafeForAbsentTailDocs()
+      throws Exception {
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex("metrics", spec(),
+        OpenStructIndexConfig.DEFAULT, _mm, 3000)) {
+      idx.index(0, Map.of("clicks", 5L));
+      idx.index(3, Map.of("clicks", 9L));
+      // Docs 4..2499 never see "clicks": docs in chunk 0 are in-range holes, docs >= 1000 hit
+      // forward-index chunks that were never allocated.
+      int numDocs = 2500;
+      MutableOpenStructDataSource ds = new MutableOpenStructDataSource(spec(), idx, numDocs);
+      DataSource clicks = ds.getDataSource("clicks");
+      assertNotNull(clicks);
+      ForwardIndexReader<?> fwd = clicks.getForwardIndex();
+
+      // Single-doc reads: hole in chunk 0, then past the last allocated chunk.
+      assertEquals(fwd.getDictId(1, null), 0);
+      assertEquals(fwd.getDictId(2400, null), 0);
+      // Present docs unaffected.
+      assertEquals(clicks.getDictionary().get(fwd.getDictId(0, null)), 5L);
+      assertEquals(clicks.getDictionary().get(fwd.getDictId(3, null)), 9L);
+
+      // Bulk read spanning present docs, holes, and the unallocated tail.
+      int[] docIds = {0, 1, 3, 999, 1000, 2499};
+      int[] dictIds = new int[docIds.length];
+      fwd.readDictIds(docIds, docIds.length, dictIds, null);
+      assertEquals(clicks.getDictionary().get(dictIds[0]), 5L);
+      assertEquals(dictIds[1], 0);
+      assertEquals(clicks.getDictionary().get(dictIds[2]), 9L);
+      assertEquals(dictIds[3], 0);
+      assertEquals(dictIds[4], 0);
+      assertEquals(dictIds[5], 0);
+
+      // Bulk fast path: all docIds at or below the watermark delegate to the raw index.
+      int[] presentDocIds = {0, 1, 2, 3};
+      int[] presentDictIds = new int[4];
+      fwd.readDictIds(presentDocIds, 4, presentDictIds, null);
+      assertEquals(clicks.getDictionary().get(presentDictIds[0]), 5L);
+      assertEquals(presentDictIds[1], 0);
+      assertEquals(presentDictIds[2], 0);
+      assertEquals(clicks.getDictionary().get(presentDictIds[3]), 9L);
     }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructDataSourceTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructDataSourceTest.java
@@ -169,6 +169,11 @@ public class MutableOpenStructDataSourceTest {
       // docs as the default, matching sealed segments which fold the default at build time.
       assertEquals(clicks.getDictionary().get(0), Long.MIN_VALUE);
       assertEquals(clicks.getDictionary().get(1), 5L);
+      // The inverted index mirrors the dictionary reservation: slot 0 exists but stays empty
+      // (no doc explicitly wrote the default), slot 1 holds the doc that wrote the real value.
+      MutableKeyColumn col = idx.getKeyColumn("clicks");
+      assertTrue(col.getInvertedIndex().getDocIds(0).isEmpty());
+      assertTrue(col.getInvertedIndex().getDocIds(1).contains(0));
     }
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructDataSourceTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructDataSourceTest.java
@@ -154,4 +154,36 @@ public class MutableOpenStructDataSourceTest {
       assertNotNull(ds.getDataSource("clicks"));
     }
   }
+
+  @Test
+  public void testDictionaryReservesDefaultNullValueAtDictIdZero()
+      throws Exception {
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex("metrics", spec(),
+        OpenStructIndexConfig.DEFAULT, _mm, 100)) {
+      idx.index(0, Map.of("clicks", 5L));
+      MutableOpenStructDataSource ds = new MutableOpenStructDataSource(spec(), idx, 1);
+      DataSource clicks = ds.getDataSource("clicks");
+      assertNotNull(clicks);
+      // dictId 0 is the reserved default null value for the inferred LONG type; the first real
+      // value lands at dictId 1. Zero-initialized forward-index chunks therefore read absent
+      // docs as the default, matching sealed segments which fold the default at build time.
+      assertEquals(clicks.getDictionary().get(0), Long.MIN_VALUE);
+      assertEquals(clicks.getDictionary().get(1), 5L);
+    }
+  }
+
+  @Test
+  public void testLastIndexedDocIdWatermark()
+      throws Exception {
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex("metrics", spec(),
+        OpenStructIndexConfig.DEFAULT, _mm, 100)) {
+      idx.index(0, Map.of("clicks", 5L));
+      idx.index(1, Map.of("other", 1L));
+      idx.index(2, Map.of("clicks", 7L));
+      MutableKeyColumn col = idx.getKeyColumn("clicks");
+      assertNotNull(col);
+      assertEquals(col.getLastIndexedDocId(), 2);
+      assertEquals(idx.getKeyColumn("other").getLastIndexedDocId(), 1);
+    }
+  }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructDataSourceTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/MutableOpenStructDataSourceTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.segment.index.openstruct;
 
+import java.util.HashMap;
 import java.util.Map;
 import org.apache.pinot.segment.local.io.writer.impl.DirectMemoryManager;
 import org.apache.pinot.segment.spi.datasource.DataSource;
@@ -25,10 +26,14 @@ import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.segment.spi.memory.PinotDataBufferMemoryManager;
 import org.apache.pinot.spi.config.table.OpenStructIndexConfig;
 import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -234,6 +239,137 @@ public class MutableOpenStructDataSourceTest {
       assertEquals(presentDictIds[1], 0);
       assertEquals(presentDictIds[2], 0);
       assertEquals(clicks.getDictionary().get(presentDictIds[3]), 9L);
+    }
+  }
+
+  @Test
+  public void testInvertedIndexFoldsAbsentDocsIntoDefaultPostings()
+      throws Exception {
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex("metrics", spec(),
+        OpenStructIndexConfig.DEFAULT, _mm, 100)) {
+      // Present in docs 0 (5L) and 3 (9L) of 6; docs 1,2,4,5 never see the key.
+      idx.index(0, Map.of("clicks", 5L));
+      idx.index(3, Map.of("clicks", 9L));
+      int numDocs = 6;
+      MutableOpenStructDataSource ds = new MutableOpenStructDataSource(spec(), idx, numDocs);
+      DataSource clicks = ds.getDataSource("clicks");
+      assertNotNull(clicks);
+
+      // Absent docs are folded into the reserved default's (dictId 0) postings, matching what a
+      // sealed segment would have built for the same rows.
+      assertEquals(clicks.getInvertedIndex().getDocIds(0), MutableRoaringBitmap.bitmapOf(1, 2, 4, 5));
+      int dictIdOfFive = clicks.getDictionary().indexOf(5L);
+      assertEquals(clicks.getInvertedIndex().getDocIds(dictIdOfFive), MutableRoaringBitmap.bitmapOf(0));
+    }
+  }
+
+  @Test
+  public void testInvertedIndexFoldsAbsentDocsWithExplicitDefaultWrite()
+      throws Exception {
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex("metrics", spec(),
+        OpenStructIndexConfig.DEFAULT, _mm, 100)) {
+      // doc 0 writes a real value; doc 3 explicitly writes the LONG default itself.
+      idx.index(0, Map.of("clicks", 5L));
+      idx.index(3, Map.of("clicks", Long.MIN_VALUE));
+      int numDocs = 6;
+      MutableOpenStructDataSource ds = new MutableOpenStructDataSource(spec(), idx, numDocs);
+      DataSource clicks = ds.getDataSource("clicks");
+      assertNotNull(clicks);
+
+      // dictId 0's postings = {3} (explicit write) folded with the absent complement {1,2,4,5}.
+      assertEquals(clicks.getInvertedIndex().getDocIds(0), MutableRoaringBitmap.bitmapOf(1, 2, 3, 4, 5));
+    }
+  }
+
+  @Test
+  public void testKeyDictionaryExactWhenPartiallyPresent()
+      throws Exception {
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex("metrics", spec(),
+        OpenStructIndexConfig.DEFAULT, _mm, 100)) {
+      idx.index(0, Map.of("clicks", 5L));
+      MutableOpenStructDataSource ds = new MutableOpenStructDataSource(spec(), idx, 3);
+      // numDocs=3 but the key is only present on doc 0: dictId 0 is a legitimate value shared by
+      // absent docs 1 and 2, so the dictionary is exact.
+      assertTrue(ds.isKeyDictionaryExact("clicks"));
+    }
+  }
+
+  @Test
+  public void testKeyDictionaryNotExactWhenFullyPresentAndDefaultUnobserved()
+      throws Exception {
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex("metrics", spec(),
+        OpenStructIndexConfig.DEFAULT, _mm, 100)) {
+      idx.index(0, Map.of("clicks", 5L));
+      idx.index(1, Map.of("clicks", 7L));
+      MutableOpenStructDataSource ds = new MutableOpenStructDataSource(spec(), idx, 2);
+      // Fully present, and no doc ever wrote the reserved default: dictId 0 is a phantom entry.
+      assertFalse(ds.isKeyDictionaryExact("clicks"));
+    }
+  }
+
+  @Test
+  public void testKeyDictionaryExactWhenFullyPresentAndDefaultObserved()
+      throws Exception {
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex("metrics", spec(),
+        OpenStructIndexConfig.DEFAULT, _mm, 100)) {
+      idx.index(0, Map.of("clicks", 5L));
+      idx.index(1, Map.of("clicks", Long.MIN_VALUE));
+      MutableOpenStructDataSource ds = new MutableOpenStructDataSource(spec(), idx, 2);
+      // Fully present, and doc 1 explicitly wrote the reserved default: dictId 0 is real.
+      assertTrue(ds.isKeyDictionaryExact("clicks"));
+    }
+  }
+
+  /// Pins the sealed splitter's default-resolution rule (OpenStructColumnSplitter#writeDenseKeyColumn,
+  /// ~line 280): absent-doc defaults come from a throwaway generic DimensionFieldSpec(key, storedType,
+  /// true), not from the real child spec's own default. If `allocateKeyColumn` reverted to preferring
+  /// `childSpec.getDefaultNullValue()`, this test would fail because dictId 0 would hold 0L instead of
+  /// Long.MIN_VALUE.
+  @Test
+  public void testAllocationUsesGenericDefaultNotChildSpecCustomDefault()
+      throws Exception {
+    Map<String, FieldSpec> children = new HashMap<>();
+    children.put("clicks", new DimensionFieldSpec("clicks", DataType.LONG, true, 0L));
+    ComplexFieldSpec specWithCustomDefault =
+        new ComplexFieldSpec("metrics", DataType.OPEN_STRUCT, true, children);
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex("metrics", specWithCustomDefault,
+        OpenStructIndexConfig.DEFAULT, _mm, 100)) {
+      idx.index(0, Map.of("clicks", 5L));
+      MutableKeyColumn col = idx.getKeyColumn("clicks");
+      assertNotNull(col);
+      assertEquals(col.getDictionary().get(0), Long.MIN_VALUE);
+    }
+  }
+
+  @DataProvider(name = "storedTypes")
+  public Object[][] storedTypes() {
+    return new Object[][] {
+        {DataType.INT, 42},
+        {DataType.LONG, 5L},
+        {DataType.FLOAT, 1.5f},
+        {DataType.DOUBLE, 2.5d},
+        {DataType.STRING, "hello"},
+        {DataType.BYTES, new byte[] {1, 2, 3}},
+    };
+  }
+
+  /// Every inferable stored type reserves its own generic dimension default at dictId 0, not just LONG.
+  @Test(dataProvider = "storedTypes")
+  public void testDefaultReservationPerStoredType(DataType storedType, Object value)
+      throws Exception {
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex("metrics", spec(),
+        OpenStructIndexConfig.DEFAULT, _mm, 100)) {
+      idx.index(0, Map.of("k", value));
+      MutableKeyColumn col = idx.getKeyColumn("k");
+      assertNotNull(col);
+      assertEquals(col.getStoredType(), storedType);
+      Object expectedDefault = FieldSpec.getDefaultNullValue(FieldSpec.FieldType.DIMENSION, storedType, null);
+      Object actualDefault = col.getDictionary().get(0);
+      if (storedType == DataType.BYTES) {
+        assertEquals((byte[]) actualDefault, (byte[]) expectedDefault);
+      } else {
+        assertEquals(actualDefault, expectedDefault);
+      }
     }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/OpenStructConsumingSealedParityTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/OpenStructConsumingSealedParityTest.java
@@ -1,0 +1,189 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.openstruct;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.io.writer.impl.DirectMemoryManager;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.OpenStructDataSource;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.segment.spi.memory.PinotDataBufferMemoryManager;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.OpenStructIndexConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+
+/// Pins consuming-vs-sealed semantics for an OPEN_STRUCT key absent from some docs: with null
+/// handling off, both tiers must read the default null value for absent docs, so scans,
+/// projections and MIN/MAX/DISTINCTCOUNT agree across the seal boundary.
+public class OpenStructConsumingSealedParityTest {
+  private static final String METRICS = "metrics";
+  private static final String KEY = "views";
+  private static final int NUM_DOCS = 10;
+  // Key present in docs 0,1,2,5 — middle hole (3,4) and absent tail (6..9).
+  private static final Map<Integer, Long> PRESENT = Map.of(0, 10L, 1, 20L, 2, 30L, 5, 60L);
+  private static final File TMP_DIR =
+      new File(FileUtils.getTempDirectory(), OpenStructConsumingSealedParityTest.class.getName());
+
+  private PinotDataBufferMemoryManager _mm;
+
+  @BeforeMethod
+  public void setUp() {
+    _mm = new DirectMemoryManager(getClass().getName());
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    _mm.close();
+    FileUtils.deleteDirectory(TMP_DIR);
+  }
+
+  private ComplexFieldSpec spec() {
+    Map<String, FieldSpec> children = new HashMap<>();
+    children.put(KEY, new DimensionFieldSpec(KEY, FieldSpec.DataType.LONG, true));
+    children.put("host", new DimensionFieldSpec("host", FieldSpec.DataType.STRING, true));
+    return new ComplexFieldSpec(METRICS, FieldSpec.DataType.OPEN_STRUCT, true, children);
+  }
+
+  private static Map<String, Object> metricsForDoc(int docId) {
+    Map<String, Object> metrics = new HashMap<>();
+    metrics.put("host", "host-" + docId);
+    Long viewsValue = PRESENT.get(docId);
+    if (viewsValue != null) {
+      metrics.put(KEY, viewsValue);
+    }
+    return metrics;
+  }
+
+  private static List<Object> readAllValues(DataSource dataSource) {
+    ForwardIndexReader<?> fwd = dataSource.getForwardIndex();
+    List<Object> values = new ArrayList<>(NUM_DOCS);
+    for (int docId = 0; docId < NUM_DOCS; docId++) {
+      values.add(dataSource.getDictionary().get(fwd.getDictId(docId, null)));
+    }
+    return values;
+  }
+
+  @Test
+  public void testConsumingMatchesSealedForPartiallyPresentKey()
+      throws Exception {
+    // --- Consuming side ---
+    List<Object> consumingValues;
+    try (MutableOpenStructIndex idx = new MutableOpenStructIndex(METRICS, spec(),
+        OpenStructIndexConfig.DEFAULT, _mm, NUM_DOCS)) {
+      for (int docId = 0; docId < NUM_DOCS; docId++) {
+        idx.index(docId, metricsForDoc(docId));
+      }
+      MutableOpenStructDataSource ds = new MutableOpenStructDataSource(spec(), idx, NUM_DOCS);
+      DataSource views = ds.getDataSource(KEY);
+      assertNotNull(views);
+      consumingValues = readAllValues(views);
+    }
+
+    // --- Sealed side (same rows through the offline build) ---
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testOpenStructParity")
+        .addField(spec())
+        .build();
+
+    OpenStructIndexConfig osConfig =
+        new OpenStructIndexConfig(false, null, -1, Set.of(KEY, "host"), 0.5, List.of());
+
+    com.fasterxml.jackson.databind.node.ObjectNode indexes = JsonUtils.newObjectNode();
+    indexes.set("open_struct", JsonUtils.objectToJsonNode(osConfig));
+    FieldConfig metricsCfg = new FieldConfig.Builder(METRICS).withIndexes(indexes).build();
+
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testOpenStructParity")
+        .setFieldConfigList(List.of(metricsCfg)).build();
+
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+    config.setOutDir(TMP_DIR.getAbsolutePath());
+    config.setSegmentName("testSegmentParity");
+
+    List<GenericRow> rows = new ArrayList<>(NUM_DOCS);
+    for (int docId = 0; docId < NUM_DOCS; docId++) {
+      GenericRow row = new GenericRow();
+      row.putValue(METRICS, metricsForDoc(docId));
+      rows.add(row);
+    }
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(config, new GenericRowRecordReader(rows));
+    driver.build();
+
+    ImmutableSegment sealed = ImmutableSegmentLoader.load(driver.getOutputDirectory(), ReadMode.mmap);
+    try {
+      // Materialized OPEN_STRUCT children are grouped under the parent column; per-key access goes
+      // through OpenStructDataSource#getDataSource, mirroring the mutable side.
+      OpenStructDataSource sealedMetrics = (OpenStructDataSource) sealed.getDataSource(METRICS);
+      DataSource sealedViews = sealedMetrics.getDataSource(KEY);
+      assertNotNull(sealedViews);
+      List<Object> sealedValues = readAllValues(sealedViews);
+
+      // Projection/scan parity: identical values doc-by-doc, absent docs = LONG default.
+      assertEquals(consumingValues, sealedValues);
+      for (int docId = 0; docId < NUM_DOCS; docId++) {
+        Object expected = PRESENT.containsKey(docId) ? PRESENT.get(docId) : Long.MIN_VALUE;
+        assertEquals(consumingValues.get(docId), expected, "docId " + docId);
+      }
+
+      // Aggregation parity with null handling off: MIN/MAX/DISTINCTCOUNT over scanned values.
+      assertEquals(min(consumingValues), min(sealedValues));
+      assertEquals(max(consumingValues), max(sealedValues));
+      assertEquals(new HashSet<>(consumingValues).size(), new HashSet<>(sealedValues).size());
+    } finally {
+      sealed.destroy();
+    }
+  }
+
+  private static long min(List<Object> values) {
+    return values.stream().mapToLong(v -> ((Number) v).longValue()).min().orElseThrow();
+  }
+
+  private static long max(List<Object> values) {
+    return values.stream().mapToLong(v -> ((Number) v).longValue()).max().orElseThrow();
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/OpenStructConsumingSealedParityTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/OpenStructConsumingSealedParityTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.segment.index.openstruct;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -48,6 +49,7 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -113,6 +115,7 @@ public class OpenStructConsumingSealedParityTest {
       throws Exception {
     // --- Consuming side ---
     List<Object> consumingValues;
+    MutableRoaringBitmap consumingDefaultDocIds;
     try (MutableOpenStructIndex idx = new MutableOpenStructIndex(METRICS, spec(),
         OpenStructIndexConfig.DEFAULT, _mm, NUM_DOCS)) {
       for (int docId = 0; docId < NUM_DOCS; docId++) {
@@ -122,6 +125,7 @@ public class OpenStructConsumingSealedParityTest {
       DataSource views = ds.getDataSource(KEY);
       assertNotNull(views);
       consumingValues = readAllValues(views);
+      consumingDefaultDocIds = (MutableRoaringBitmap) views.getInvertedIndex().getDocIds(0);
     }
 
     // --- Sealed side (same rows through the offline build) ---
@@ -132,7 +136,7 @@ public class OpenStructConsumingSealedParityTest {
     OpenStructIndexConfig osConfig =
         new OpenStructIndexConfig(false, null, -1, Set.of(KEY, "host"), 0.5, List.of());
 
-    com.fasterxml.jackson.databind.node.ObjectNode indexes = JsonUtils.newObjectNode();
+    ObjectNode indexes = JsonUtils.newObjectNode();
     indexes.set("open_struct", JsonUtils.objectToJsonNode(osConfig));
     FieldConfig metricsCfg = new FieldConfig.Builder(METRICS).withIndexes(indexes).build();
 
@@ -170,10 +174,28 @@ public class OpenStructConsumingSealedParityTest {
         assertEquals(consumingValues.get(docId), expected, "docId " + docId);
       }
 
-      // Aggregation parity with null handling off: MIN/MAX/DISTINCTCOUNT over scanned values.
-      assertEquals(min(consumingValues), min(sealedValues));
-      assertEquals(max(consumingValues), max(sealedValues));
-      assertEquals(new HashSet<>(consumingValues).size(), new HashSet<>(sealedValues).size());
+      // Aggregation parity with null handling off: MIN/MAX/DISTINCTCOUNT over scanned values,
+      // pinned to independently computed constants on both tiers rather than only asserting the
+      // tiers match each other (a bug shared by both tiers wouldn't be caught by cross-tier
+      // equality alone). Values across docs 0-9: {10,20,30,MIN_VALUE,MIN_VALUE,60,MIN_VALUE x4}.
+      assertEquals(min(consumingValues), Long.MIN_VALUE);
+      assertEquals(min(sealedValues), Long.MIN_VALUE);
+      assertEquals(max(consumingValues), 60L);
+      assertEquals(max(sealedValues), 60L);
+      assertEquals(new HashSet<>(consumingValues).size(), 5);
+      assertEquals(new HashSet<>(sealedValues).size(), 5);
+
+      // EQ/NOT_EQ parity: the consuming per-key inverted index folds absent docs into dictId 0's
+      // postings, so its docIds must exactly match the docs where the sealed segment resolved the
+      // default (derived from the already-read sealedValues, since sealed segments don't build an
+      // inverted index for OPEN_STRUCT keys in this config).
+      MutableRoaringBitmap expectedDefaultDocIds = new MutableRoaringBitmap();
+      for (int docId = 0; docId < NUM_DOCS; docId++) {
+        if (sealedValues.get(docId).equals(Long.MIN_VALUE)) {
+          expectedDefaultDocIds.add(docId);
+        }
+      }
+      assertEquals(consumingDefaultDocIds, expectedDefaultDocIds);
     } finally {
       sealed.destroy();
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/OpenStructNullDataSourceTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/OpenStructNullDataSourceTest.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.openstruct;
+
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class OpenStructNullDataSourceTest {
+
+  @Test
+  public void testMetadataReportsCorrectTypeAndNumDocs() {
+    FieldSpec spec = new DimensionFieldSpec("region", FieldSpec.DataType.STRING, true);
+    OpenStructNullDataSource ds = new OpenStructNullDataSource(spec, 100);
+    DataSourceMetadata metadata = ds.getDataSourceMetadata();
+
+    assertEquals(metadata.getFieldSpec().getDataType(), FieldSpec.DataType.STRING);
+    assertEquals(metadata.getNumDocs(), 100);
+    assertEquals(metadata.getCardinality(), 1);
+  }
+
+  @Test
+  public void testNullValueVectorAllDocsNull() {
+    OpenStructNullDataSource ds = new OpenStructNullDataSource(
+        new DimensionFieldSpec("k", FieldSpec.DataType.INT, true), 50);
+    NullValueVectorReader nullReader = ds.getNullValueVector();
+
+    assertNotNull(nullReader);
+    for (int i = 0; i < 50; i++) {
+      assertTrue(nullReader.isNull(i));
+    }
+    ImmutableRoaringBitmap bitmap = nullReader.getNullBitmap();
+    assertEquals(bitmap.getCardinality(), 50);
+  }
+
+  @Test
+  public void testNullValueVectorZeroDocs() {
+    OpenStructNullDataSource ds = new OpenStructNullDataSource(
+        new DimensionFieldSpec("k", FieldSpec.DataType.INT, true), 0);
+    NullValueVectorReader nullReader = ds.getNullValueVector();
+    assertEquals(nullReader.getNullBitmap().getCardinality(), 0);
+  }
+
+  @Test
+  public void testForwardIndexReturnsDefaultNullValues() {
+    // INT
+    verifyForwardIndex(FieldSpec.DataType.INT, 10, (fwd) -> {
+      assertEquals(fwd.getInt(0, null), FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_INT);
+      assertEquals(fwd.getStoredType(), FieldSpec.DataType.INT);
+    });
+    // LONG
+    verifyForwardIndex(FieldSpec.DataType.LONG, 10, (fwd) -> {
+      assertEquals(fwd.getLong(0, null), (long) FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_LONG);
+    });
+    // FLOAT
+    verifyForwardIndex(FieldSpec.DataType.FLOAT, 10, (fwd) -> {
+      assertEquals(fwd.getFloat(0, null), FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_FLOAT);
+    });
+    // DOUBLE
+    verifyForwardIndex(FieldSpec.DataType.DOUBLE, 10, (fwd) -> {
+      assertEquals(fwd.getDouble(0, null), FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_DOUBLE);
+    });
+    // STRING
+    verifyForwardIndex(FieldSpec.DataType.STRING, 10, (fwd) -> {
+      assertEquals(fwd.getString(0, null), FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_STRING);
+      assertEquals(fwd.getStoredType(), FieldSpec.DataType.STRING);
+    });
+    // BYTES
+    verifyForwardIndex(FieldSpec.DataType.BYTES, 10, (fwd) -> {
+      assertEquals(fwd.getBytes(0, null), FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_BYTES);
+    });
+    // BIG_DECIMAL
+    verifyForwardIndex(FieldSpec.DataType.BIG_DECIMAL, 10, (fwd) -> {
+      assertEquals(fwd.getBigDecimal(0, null), FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_BIG_DECIMAL);
+    });
+  }
+
+  @Test
+  public void testForwardIndexIsSingleValueNotDictEncoded() {
+    OpenStructNullDataSource ds = new OpenStructNullDataSource(
+        new DimensionFieldSpec("k", FieldSpec.DataType.STRING, true), 5);
+    ForwardIndexReader<?> fwd = ds.getForwardIndex();
+    assertTrue(fwd.isSingleValue());
+    assertFalse(fwd.isDictionaryEncoded());
+  }
+
+  @Test
+  public void testNoDictionaryOrSecondaryIndexes() {
+    OpenStructNullDataSource ds = new OpenStructNullDataSource(
+        new DimensionFieldSpec("k", FieldSpec.DataType.STRING, true), 5);
+    assertNull(ds.getDictionary());
+    assertNull(ds.getInvertedIndex());
+    assertNull(ds.getRangeIndex());
+    assertNull(ds.getJsonIndex());
+    assertNull(ds.getBloomFilter());
+    assertNull(ds.getTextIndex());
+    assertNull(ds.getVectorIndex());
+  }
+
+  @FunctionalInterface
+  private interface ForwardIndexAssertion {
+    void check(ForwardIndexReader<?> fwd);
+  }
+
+  private void verifyForwardIndex(FieldSpec.DataType type, int numDocs, ForwardIndexAssertion assertion) {
+    OpenStructNullDataSource ds = new OpenStructNullDataSource(
+        new DimensionFieldSpec("k", type, true), numDocs);
+    assertion.check(ds.getForwardIndex());
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/PresenceBasedNullValueVectorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/PresenceBasedNullValueVectorTest.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.openstruct;
+
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class PresenceBasedNullValueVectorTest {
+
+  @Test
+  public void testIsNullReturnsInverseOfPresence() {
+    MutableRoaringBitmap presence = new MutableRoaringBitmap();
+    presence.add(0);
+    presence.add(3);
+    presence.add(7);
+    PresenceBasedNullValueVector vec = new PresenceBasedNullValueVector(presence, 10);
+
+    assertFalse(vec.isNull(0));
+    assertTrue(vec.isNull(1));
+    assertTrue(vec.isNull(2));
+    assertFalse(vec.isNull(3));
+    assertTrue(vec.isNull(4));
+    assertFalse(vec.isNull(7));
+    assertTrue(vec.isNull(9));
+  }
+
+  @Test
+  public void testGetNullBitmapComputesComplement() {
+    MutableRoaringBitmap presence = new MutableRoaringBitmap();
+    presence.add(1);
+    presence.add(4);
+    PresenceBasedNullValueVector vec = new PresenceBasedNullValueVector(presence, 6);
+
+    ImmutableRoaringBitmap nullBitmap = vec.getNullBitmap();
+    // Null docs: 0, 2, 3, 5 (complement of {1, 4} in [0, 6))
+    assertEquals(nullBitmap.getCardinality(), 4);
+    assertTrue(nullBitmap.contains(0));
+    assertFalse(nullBitmap.contains(1));
+    assertTrue(nullBitmap.contains(2));
+    assertTrue(nullBitmap.contains(3));
+    assertFalse(nullBitmap.contains(4));
+    assertTrue(nullBitmap.contains(5));
+  }
+
+  @Test
+  public void testEmptyPresenceBitmapAllDocsNull() {
+    MutableRoaringBitmap presence = new MutableRoaringBitmap();
+    PresenceBasedNullValueVector vec = new PresenceBasedNullValueVector(presence, 5);
+
+    for (int i = 0; i < 5; i++) {
+      assertTrue(vec.isNull(i));
+    }
+    assertEquals(vec.getNullBitmap().getCardinality(), 5);
+  }
+
+  @Test
+  public void testFullPresenceBitmapNoDocsNull() {
+    MutableRoaringBitmap presence = new MutableRoaringBitmap();
+    presence.add(0L, 8);
+    PresenceBasedNullValueVector vec = new PresenceBasedNullValueVector(presence, 8);
+
+    for (int i = 0; i < 8; i++) {
+      assertFalse(vec.isNull(i));
+    }
+    assertEquals(vec.getNullBitmap().getCardinality(), 0);
+  }
+
+  @Test
+  public void testZeroDocs() {
+    PresenceBasedNullValueVector vec = new PresenceBasedNullValueVector(new MutableRoaringBitmap(), 0);
+    assertEquals(vec.getNullBitmap().getCardinality(), 0);
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/PresenceBasedNullValueVectorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/openstruct/PresenceBasedNullValueVectorTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.segment.local.segment.index.openstruct;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.testng.annotations.Test;
@@ -33,7 +35,8 @@ public class PresenceBasedNullValueVectorTest {
     presence.add(0);
     presence.add(3);
     presence.add(7);
-    PresenceBasedNullValueVector vec = new PresenceBasedNullValueVector(presence, 10);
+    PresenceBasedNullValueVector vec =
+        new PresenceBasedNullValueVector(new ThreadSafeMutableRoaringBitmap(presence), 10);
 
     assertFalse(vec.isNull(0));
     assertTrue(vec.isNull(1));
@@ -49,7 +52,8 @@ public class PresenceBasedNullValueVectorTest {
     MutableRoaringBitmap presence = new MutableRoaringBitmap();
     presence.add(1);
     presence.add(4);
-    PresenceBasedNullValueVector vec = new PresenceBasedNullValueVector(presence, 6);
+    PresenceBasedNullValueVector vec =
+        new PresenceBasedNullValueVector(new ThreadSafeMutableRoaringBitmap(presence), 6);
 
     ImmutableRoaringBitmap nullBitmap = vec.getNullBitmap();
     // Null docs: 0, 2, 3, 5 (complement of {1, 4} in [0, 6))
@@ -64,8 +68,8 @@ public class PresenceBasedNullValueVectorTest {
 
   @Test
   public void testEmptyPresenceBitmapAllDocsNull() {
-    MutableRoaringBitmap presence = new MutableRoaringBitmap();
-    PresenceBasedNullValueVector vec = new PresenceBasedNullValueVector(presence, 5);
+    PresenceBasedNullValueVector vec =
+        new PresenceBasedNullValueVector(new ThreadSafeMutableRoaringBitmap(), 5);
 
     for (int i = 0; i < 5; i++) {
       assertTrue(vec.isNull(i));
@@ -77,7 +81,8 @@ public class PresenceBasedNullValueVectorTest {
   public void testFullPresenceBitmapNoDocsNull() {
     MutableRoaringBitmap presence = new MutableRoaringBitmap();
     presence.add(0L, 8);
-    PresenceBasedNullValueVector vec = new PresenceBasedNullValueVector(presence, 8);
+    PresenceBasedNullValueVector vec =
+        new PresenceBasedNullValueVector(new ThreadSafeMutableRoaringBitmap(presence), 8);
 
     for (int i = 0; i < 8; i++) {
       assertFalse(vec.isNull(i));
@@ -87,7 +92,46 @@ public class PresenceBasedNullValueVectorTest {
 
   @Test
   public void testZeroDocs() {
-    PresenceBasedNullValueVector vec = new PresenceBasedNullValueVector(new MutableRoaringBitmap(), 0);
+    PresenceBasedNullValueVector vec =
+        new PresenceBasedNullValueVector(new ThreadSafeMutableRoaringBitmap(), 0);
     assertEquals(vec.getNullBitmap().getCardinality(), 0);
+  }
+
+  /// Answers over the frozen [0, numDocs) prefix must stay stable while ingestion appends beyond it.
+  /// Swapping the presence bitmap back to a raw `MutableRoaringBitmap` makes this fail within
+  /// milliseconds with an `ArrayIndexOutOfBoundsException` out of the `getNullBitmap()` clone;
+  /// against the thread-safe wrapper it cannot.
+  @Test
+  public void testConcurrentIngestionDoesNotCorruptReads()
+      throws Exception {
+    int frozenDocs = 10_000;
+    ThreadSafeMutableRoaringBitmap presence = new ThreadSafeMutableRoaringBitmap();
+    for (int docId = 0; docId < frozenDocs; docId += 2) {
+      presence.add(docId);
+    }
+    PresenceBasedNullValueVector vec = new PresenceBasedNullValueVector(presence, frozenDocs);
+
+    AtomicBoolean stop = new AtomicBoolean();
+    Thread writer = new Thread(() -> {
+      // Stride by the RoaringBitmap container width so nearly every add inserts a new container
+      // key, forcing the backing key/value arrays to grow and copy. That structural mutation — not
+      // a bit flip inside an existing container — is what a concurrent read tears on; appending
+      // consecutive docIds only touches containers already allocated and never reproduces it.
+      for (int i = 1; i < 30_000 && !stop.get(); i++) {
+        presence.add(frozenDocs + i * 65_536);
+      }
+    });
+    writer.start();
+    try {
+      for (int iter = 0; iter < 200; iter++) {
+        for (int docId = 0; docId < frozenDocs; docId++) {
+          assertEquals(vec.isNull(docId), docId % 2 != 0);
+        }
+        assertEquals(vec.getNullBitmap().getCardinality(), frozenDocs / 2);
+      }
+    } finally {
+      stop.set(true);
+      writer.join();
+    }
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/OpenStructDataSource.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/OpenStructDataSource.java
@@ -84,4 +84,12 @@ public interface OpenStructDataSource extends DataSource {
     throw new UnsupportedOperationException(
         "Per-doc OPEN_STRUCT map reconstruction is not supported by this implementation");
   }
+
+  /// Whether the per-key dictionary's contents correspond exactly to the values readable from
+  /// the key column (absent docs folded as the default included) — i.e. dictionary-based
+  /// MIN/MAX/DISTINCTCOUNT over it matches a full scan. Sealed segments build dictionaries
+  /// from the folded values, so they are always exact.
+  default boolean isKeyDictionaryExact(String key) {
+    return true;
+  }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/OpenStructDataSource.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/OpenStructDataSource.java
@@ -34,13 +34,21 @@ public interface OpenStructDataSource extends DataSource {
 
   /// Returns the DataSource for the given key's values. The DataSource's value type is the
   /// per-key declared type (from `childFieldSpecs`) when present, otherwise auto-derived.
+  ///
+  /// Returns `null` when the key has no materialized per-key DataSource in this segment. A `null`
+  /// return does not mean the key is absent from the data — when [#isFullyMaterialized()] is
+  /// `false` the key may still live in the sparse blob. Callers that need a readable source for an
+  /// absent key should synthesize a typed all-null source rather than reading the sparse column.
+  @Nullable
   DataSource getDataSource(String key);
 
   /// Returns whether the given key has a materialized per-key index in this segment. Exact,
   /// O(1) lookup into the materialized key set.
   ///
   /// Query operators use this to choose between the fast path (per-key inverted/dictionary
-  /// index) and the fallback (expression scan over the sparse blob).
+  /// index) and the fallback (expression scan). Note the fallback does not read the sparse blob:
+  /// a non-materialized key resolves to a typed all-null source, so the scan sees NULL at every
+  /// document.
   ///
   /// A `false` return is only a definitive "absent" when [#isFullyMaterialized()] is also
   /// `true`; otherwise the key may still exist in the sparse blob.
@@ -50,17 +58,22 @@ public interface OpenStructDataSource extends DataSource {
   /// blob and the materialized key set is exhaustive.
   ///
   /// When `true`, a `false` return from [#isMaterialized(String)] is a definitive "absent"
-  /// and callers can short-circuit (e.g. a filter operator returns `EmptyFilterOperator`
-  /// for value predicates and `MatchAllFilterOperator` for IS_NULL).
+  /// and callers can treat the key as present-but-all-null — e.g. evaluate predicates against a
+  /// typed all-null DataSource, which yields the correct answer under both null-handling modes
+  /// (an absent key reads as its type default with null handling off, and as NULL with it on).
   boolean isFullyMaterialized();
 
   /// Returns DataSources for all keys present in this segment.
   Map<String, DataSource> getDataSources();
 
-  /// Returns the DataSourceMetadata for the given key's values.
+  /// Returns the DataSourceMetadata for the given key's values, or `null` when the key has no
+  /// materialized per-key DataSource in this segment. See [#getDataSource(String)].
+  @Nullable
   DataSourceMetadata getDataSourceMetadata(String key);
 
-  /// Returns the ColumnIndexContainer for the given key's values.
+  /// Returns the ColumnIndexContainer for the given key's values, or `null` when the key has no
+  /// materialized per-key DataSource in this segment. See [#getDataSource(String)].
+  @Nullable
   ColumnIndexContainer getIndexContainer(String key);
 
   /// Reconstructs the full OPEN_STRUCT value for `docId` as a `Map<String, Object>`, or

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java
@@ -481,9 +481,11 @@ public class ColumnMetadataImpl implements ColumnMetadata {
         List<String> childFieldNames =
             config.getList(String.class, Column.getKeyFor(column, Column.COMPLEX_CHILD_FIELD_NAMES));
         Map<String, FieldSpec> childFieldSpecs = new HashMap<>();
-        for (String childField : childFieldNames) {
-          childFieldSpecs.put(childField,
-              extractFieldSpec(ComplexFieldSpec.getFullChildName(column, childField), config));
+        if (childFieldNames != null) {
+          for (String childField : childFieldNames) {
+            childFieldSpecs.put(childField,
+                extractFieldSpec(ComplexFieldSpec.getFullChildName(column, childField), config));
+          }
         }
         return new ComplexFieldSpec(fieldName, dataType, true, childFieldSpecs);
       default:

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/mutable/ThreadSafeMutableRoaringBitmap.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/mutable/ThreadSafeMutableRoaringBitmap.java
@@ -68,6 +68,12 @@ public class ThreadSafeMutableRoaringBitmap {
     return _mutableRoaringBitmap.clone();
   }
 
+  /// Cardinality of docIds in `[rangeStart, rangeEnd)`. Cheaper than cloning the bitmap just to
+  /// check range coverage.
+  public synchronized long rangeCardinality(long rangeStart, long rangeEnd) {
+    return _mutableRoaringBitmap.rangeCardinality(rangeStart, rangeEnd);
+  }
+
   /// Returns a point-in-time snapshot of the bitmap as a serialized byte array.
   /// This avoids cloning the full object clone() unlike in getMutableRoaringBitmap()
   public synchronized byte[] getBytes() {


### PR DESCRIPTION
## Summary

This is **PR 3/4** in the OPEN_STRUCT stack — the query-engine changes that make `DataType.OPEN_STRUCT` columns queryable. Without it, declaring OPEN_STRUCT in a schema and ingesting data works (PR 2), but all queries crash or fall to per-doc expression scan.

RFC: https://docs.google.com/document/d/14kPmjDTKbO8l0ql4rrN7I5Yki5pqMw6GeGmxxc9grsU/edit?tab=t.0

PR 1 (SPI + data model): #18368 — merged
PR 2a (SPI utilities, index registration): #18710 — merged
PR 2b (storage layer): #18643 — merged

### What this PR adds

**Projection path (`SELECT myStruct['key']`):**
- `ItemTransformFunction` — accepts `OpenStructDataSource` alongside `MapDataSource`. When `getDataSource(key)` returns null (absent key), creates a typed `OpenStructNullDataSource` via `forAbsentKey()` factory (correct DataType from child FieldSpec, correct numDocs, full-segment null bitmap). Overrides `getNullBitmap()` to return the per-key DataSource's null bitmap directly — the base class ORs argument bitmaps, which doesn't work here because nullness depends on per-key presence, not parent column/literal nullness.
- `ProjectionBlock` — same pattern for path-based `[column, key]` value set access.

**Filter path (`WHERE myStruct['key'] = 'val'`):**
- `MapFilterOperator` — refactored from 2-way dispatch to 3-way:
  1. **PER_KEY_INDEX** (new) — for `OpenStructDataSource` columns. Uses `isMaterialized(key)` / `isFullyMaterialized()` for sub-dispatch:
     - Materialized key → rewrite predicate LHS, build `PredicateEvaluator`, delegate to `FilterOperatorUtils.getLeafFilterOperator` (picks inverted/range/sorted/scan automatically)
     - IS_NULL/IS_NOT_NULL → read `NullValueVectorReader` bitmap directly → `BitmapBasedFilterOperator`
     - Absent key (fully materialized) → IS_NULL → `MatchAllFilterOperator`, else → `EmptyFilterOperator`
     - Sparse key (not fully materialized) → fall through to expression scan
  2. **JSON_MATCH** (existing, unchanged) — MAP columns with JSON index
  3. **EXPRESSION_FILTER** (existing, unchanged) — fallback scan
- Single `_delegate` field replaces the old dual-field pattern. EXPLAIN output reports `delegateTo:per_key_index|json_match|expression_filter`.

**Aggregation path (`SELECT COUNT(DISTINCT myStruct['key'])`):**
- `AggregationPlanNode` — `resolveDataSource()` + `tryResolveKeyedDataSource()` resolve `item(col, 'key')` FUNCTION expressions to per-key DataSources. Enables dictionary/metadata-based non-scan aggregation (COUNT DISTINCT, MIN, MAX) on dense OPEN_STRUCT keys. `hasNullValues()` resolves per-key null vectors instead of pessimistically returning true for FUNCTION expressions.

**Absent key handling:**
- `ImmutableOpenStructDataSource.getDataSource(key)` — returns `null` for unmaterialized keys instead of falling back to the shared `$__sparse__` JSON column. The sparse column is an internal implementation detail used only by `getMapValue()`.
- `OpenStructNullDataSource` (new) — typed all-null DataSource for absent OPEN_STRUCT keys. Takes the correct `FieldSpec` (from `ComplexFieldSpec.getChildFieldSpec(key)`, falling back to STRING) and segment `numDocs`. Provides a typed forward index returning type-correct default null values, and a `NullValueVectorReader` with a full-segment bitmap.
- `PresenceBasedNullValueVector` (new) — `NullValueVectorReader` backed by `MutableKeyColumn.getPresenceBitmap()` complement. Exposes per-key null information on consuming segments so IS_NULL/IS_NOT_NULL work correctly. Clones the presence bitmap before full iteration to avoid concurrent mutation races with the ingestion thread.
- `MutableOpenStructDataSource.getDataSource(key)` — adds `PresenceBasedNullValueVector` to the per-key DataSource's index map.

**Segment loading:**
- `ImmutableSegmentImpl` — warn log on schema mismatch for OPEN_STRUCT columns.
- `MutableSegmentImpl` — `Preconditions.checkState` guard for OPEN_STRUCT columns with disabled index.
- `ImmutableOpenStructDataSource` — `getMapValue()` reconstructs the full map (dense + sparse) per document for seal path / minion tasks.

### Supported predicate types on per-key index path

EQ, NOT_EQ, IN, NOT_IN, RANGE, IS_NULL, IS_NOT_NULL. Other predicate types fall through to expression scan.

Known limitation: sparse OPEN_STRUCT keys read as NULL on the query path; sparse-column wiring will be added in next PR.

## Test plan

- [x] `MapFilterOperatorOpenStructTest` — 5 tests: EQ on materialized key, EQ on absent key (fully materialized) → Empty, IS_NULL on absent key → MatchAll, EQ on sparse key → expression fallback, IS_NOT_NULL with null bitmap → correct doc count
- [x] `AggregationPlanNodeResolveDataSourceTest` — 10 tests: identifier, literal, item() with MapDataSource, item() with materialized/unmaterialized OpenStructDataSource, non-item function, wrong arg count/types, plain DataSource
- [x] `OpenStructNullDataSourceTest` — 6 tests: all stored types (INT/LONG/FLOAT/DOUBLE/STRING/BYTES/BIG_DECIMAL), null vector covers all docs, zero-doc edge case, metadata correctness, no secondary indexes
- [x] `PresenceBasedNullValueVectorTest` — 5 tests: inverse of presence, complement computation, empty presence (all null), full presence (none null), zero docs
- [x] `ImmutableOpenStructDataSourceTest` — 14 tests: per-key DataSource, absent key returns null, isMaterialized, isFullyMaterialized, getMapValue dense+sparse, metadata
- [x] All existing pinot-core + pinot-segment-local tests pass
- [x] spotless/checkstyle/license clean
