### PR TITLE
PinotPreparedStatement execute doesn't follow jdbc specification

### DIFF
--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotPreparedStatement.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotPreparedStatement.java
@@ -164,12 +164,7 @@ public class PinotPreparedStatement extends AbstractBasePreparedStatement {
   public boolean execute()
       throws SQLException {
     _resultSet = executeQuery();
-    if (_resultSet.next()) {
-      _resultSet.beforeFirst();
-      return true;
-    } else {
-      return false;
-    }
+    return true;
   }
 
   @Override

--- a/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/PinotPreparedStatementTest.java
+++ b/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/PinotPreparedStatementTest.java
@@ -21,13 +21,16 @@ package org.apache.pinot.client;
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.pinot.client.utils.DateTimeUtils;
 import org.apache.pinot.client.utils.DriverUtils;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -158,5 +161,66 @@ public class PinotPreparedStatementTest {
     String expectedSql =
         DriverUtils.createSetQueryOptionString(QueryOptionKey.ENABLE_NULL_HANDLING, true) + BASIC_TEST_QUERY;
     Assert.assertEquals(_dummyPinotClientTransport.getLastQuery().substring(0, expectedSql.length()), expectedSql);
+  }
+
+  @Test
+  public void testExecuteReturnsResultSetForEmptyResults()
+      throws Exception {
+    PreparedStatement preparedStatement = createPreparedStatement("{\"resultTable\":{"
+        + "\"dataSchema\":{\"columnNames\":[\"value\"],\"columnDataTypes\":[\"INT\"]},\"rows\":[]}}");
+
+    Assert.assertTrue(preparedStatement.execute());
+    ResultSet resultSet = preparedStatement.getResultSet();
+    Assert.assertNotNull(resultSet);
+    Assert.assertFalse(resultSet.next());
+  }
+
+  @Test
+  public void testExecuteDoesNotAdvanceResultSet()
+      throws Exception {
+    PreparedStatement preparedStatement = createPreparedStatement("{\"resultTable\":{"
+        + "\"dataSchema\":{\"columnNames\":[\"value\"],\"columnDataTypes\":[\"INT\"]},\"rows\":[[42]]}}");
+
+    Assert.assertTrue(preparedStatement.execute());
+    ResultSet resultSet = preparedStatement.getResultSet();
+    Assert.assertNotNull(resultSet);
+    Assert.assertTrue(resultSet.isBeforeFirst());
+    Assert.assertTrue(resultSet.next());
+    Assert.assertEquals(resultSet.getInt(1), 42);
+  }
+
+  private static PreparedStatement createPreparedStatement(String responseJson)
+      throws Exception {
+    Properties props = new Properties();
+    props.put(PinotConnection.BROKER_LIST, "dummy");
+    PinotConnection connection = new PinotConnection(props, "dummy", new ResponsePinotClientTransport(responseJson),
+        "dummy", DummyPinotControllerTransport.create());
+    return connection.prepareStatement(BASIC_TEST_QUERY);
+  }
+
+  private static class ResponsePinotClientTransport implements PinotClientTransport {
+    private final BrokerResponse _response;
+
+    ResponsePinotClientTransport(String responseJson)
+        throws Exception {
+      _response = BrokerResponse.fromJson(JsonUtils.stringToJsonNode(responseJson));
+    }
+
+    @Override
+    public BrokerResponse executeQuery(String brokerAddress, String query)
+        throws PinotClientException {
+      return _response;
+    }
+
+    @Override
+    public CompletableFuture<BrokerResponse> executeQueryAsync(String brokerAddress, String query)
+        throws PinotClientException {
+      return CompletableFuture.completedFuture(_response);
+    }
+
+    @Override
+    public void close()
+        throws PinotClientException {
+    }
   }
 }


### PR DESCRIPTION
## Summary

Updates `PinotPreparedStatement.execute()` to follow the JDBC specification.

The boolean returned by `PreparedStatement.execute()` indicates whether the first result is a `ResultSet`; it does not indicate whether that result set contains rows. Because Pinot queries produce a `ResultSet`, the method now returns `true` even when the result set is empty.

## Changes

- Remove the `ResultSet.next()` check previously used to determine the return value.
- Remove the subsequent `beforeFirst()` cursor reset.
- Return `true` after successful query execution.
- Preserve the result set's initial cursor position before the first row.
- Add regression tests verifying:
  - `execute()` returns `true` for an empty result set.
  - `getResultSet()` returns the empty result set.
  - `execute()` does not advance a non-empty result set.
  - The first row remains available to the caller.

## Testing

* `PinotPreparedStatementTest`
  
 Closes #19042.