### PR TITLE
Rebuild HNSW vector index when dimension or distance function changes

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/vector/HnswVectorIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/vector/HnswVectorIndexCreator.java
@@ -61,10 +61,10 @@ public class HnswVectorIndexCreator implements VectorIndexCreator {
 
   public HnswVectorIndexCreator(String column, File segmentIndexDir, VectorIndexConfig vectorIndexConfig) {
     _vectorColumn = column;
+    _segmentIndexDir = segmentIndexDir;
     _vectorDimension = vectorIndexConfig.getVectorDimension();
     _vectorSimilarityFunction = VectorIndexUtils.toSimilarityFunction(vectorIndexConfig.getVectorDistanceFunction());
     _storeInSegmentFile = vectorIndexConfig.isStoreInSegmentFile();
-    _segmentIndexDir = segmentIndexDir;
     try {
       // segment generation is always in V1 and later we convert (as part of post creation processing)
       // to V3 if segmentVersion is set to V3 in SegmentGeneratorConfig.
@@ -110,6 +110,8 @@ public class HnswVectorIndexCreator implements VectorIndexCreator {
     try {
       LOGGER.info("Sealing HNSW index for column: {}", _vectorColumn);
       _indexWriter.forceMerge(1);
+      VectorIndexUtils.writeVectorIndexMetadata(_segmentIndexDir, _vectorColumn, _vectorDimension,
+          _vectorSimilarityFunction);
     } catch (Exception e) {
       throw new RuntimeException("Caught exception while sealing the HNSW index for column: " + _vectorColumn, e);
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/vector/HnswVectorIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/vector/HnswVectorIndexCreator.java
@@ -59,10 +59,10 @@ public class HnswVectorIndexCreator implements VectorIndexCreator {
 
   public HnswVectorIndexCreator(String column, File segmentIndexDir, VectorIndexConfig vectorIndexConfig) {
     _vectorColumn = column;
+    _segmentIndexDir = segmentIndexDir;
     _vectorDimension = vectorIndexConfig.getVectorDimension();
     _vectorSimilarityFunction = VectorIndexUtils.toSimilarityFunction(vectorIndexConfig.getVectorDistanceFunction());
     _storeInSegmentFile = vectorIndexConfig.isStoreInSegmentFile();
-    _segmentIndexDir = segmentIndexDir;
     // Segment generation is always in V1 and later we convert (as part of post creation processing) to V3 if
     // segmentVersion is set to V3 in SegmentGeneratorConfig.
     _hnswIndexDir =
@@ -118,6 +118,8 @@ public class HnswVectorIndexCreator implements VectorIndexCreator {
     try {
       LOGGER.info("Sealing HNSW index for column: {}", _vectorColumn);
       _indexWriter.forceMerge(1);
+      VectorIndexUtils.writeVectorIndexMetadata(_segmentIndexDir, _vectorColumn, _vectorDimension,
+          _vectorSimilarityFunction);
     } catch (Exception e) {
       throw new RuntimeException("Caught exception while sealing the HNSW index for column: " + _vectorColumn, e);
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/VectorIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/VectorIndexHandler.java
@@ -25,9 +25,11 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
+import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.pinot.segment.local.segment.creator.impl.vector.lucene99.HnswVectorIndexCombined;
 import org.apache.pinot.segment.local.segment.index.loader.BaseIndexHandler;
 import org.apache.pinot.segment.local.segment.index.loader.LoaderUtils;
@@ -122,6 +124,9 @@ public class VectorIndexHandler extends BaseIndexHandler {
           && !hasCombinedFile(indexDir, column, desiredBackend)) {
         LOGGER.info("Need to extract Vector consolidated entry to sidecar file for segment: {}, column: {}",
             segmentName, column);
+        return true;
+      }
+      if (isVectorConfigChanged(indexDir, column, desiredConfig, segmentName)) {
         return true;
       }
     }
@@ -496,7 +501,8 @@ public class VectorIndexHandler extends BaseIndexHandler {
       VectorBackendType desiredBackend = desiredConfig.resolveBackendType();
       VectorBackendType existingBackend = VectorIndexUtils.detectVectorIndexBackend(indexDir, column);
       // Storage-format comparison — see the twin check in needUpdateIndices.
-      if (existingBackend != null && existingBackend != VectorIndexUtils.storageFormatOf(desiredBackend)) {
+      if ((existingBackend != null && existingBackend != VectorIndexUtils.storageFormatOf(desiredBackend))
+          || isVectorConfigChanged(indexDir, column, desiredConfig, segmentName)) {
         LOGGER.info("Rebuilding Vector index for segment: {}, column: {} (backend changed from {} to {})",
             segmentName, column, existingBackend, desiredBackend);
         segmentWriter.removeIndex(column, StandardIndexes.vector());
@@ -543,6 +549,58 @@ public class VectorIndexHandler extends BaseIndexHandler {
         createVectorIndexForColumn(segmentWriter, columnMetadata);
       }
     }
+  }
+
+  /**
+   * Checks whether the HNSW vector index config has changed by comparing the metadata file written at index-creation
+   * time with the current {@link VectorIndexConfig}.
+   *
+   * <p>The metadata file (written by {@code HnswVectorIndexCreator}) records the vector dimension and
+   * {@link VectorSimilarityFunction} used to build the index. Changing either field
+   * produces a structurally incompatible index (wrong vector size) or silently wrong query results (wrong distance
+   * metric), so a rebuild is required.
+   *
+   * <p>Legacy segments built before this metadata was introduced have no metadata file; config-change detection is
+   * skipped for those segments (the file will be created the next time the index is rebuilt for any reason).
+   */
+  private boolean isVectorConfigChanged(File indexDir, String column, VectorIndexConfig desiredConfig,
+      String segmentName) {
+    File segmentDirectory = SegmentDirectoryPaths.segmentDirectoryFor(indexDir,
+        _segmentDirectory.getSegmentMetadata().getVersion());
+    Properties metadata = VectorIndexUtils.readVectorIndexMetadata(segmentDirectory, column);
+    if (metadata == null) {
+      // No metadata file — legacy segment; skip config-change detection.
+      return false;
+    }
+    try {
+      int storedDimension = Integer.parseInt(metadata.getProperty("dimension"));
+      int desiredDimension = desiredConfig.getVectorDimension();
+      if (storedDimension != desiredDimension) {
+        LOGGER.info("Vector index config changed for segment: {}, column: {} "
+                + "(dimension: {} → {}). Index needs to be rebuilt.",
+            segmentName, column, storedDimension, desiredDimension);
+        return true;
+      }
+
+      VectorSimilarityFunction storedFunc =
+          VectorSimilarityFunction.valueOf(metadata.getProperty("distanceFunction"));
+      VectorIndexConfig.VectorDistanceFunction desiredDistanceFunc = desiredConfig.getVectorDistanceFunction();
+      // Null distanceFunction defaults to COSINE (see VectorIndexConfig.DEFAULT_VECTOR_DISTANCE_FUNCTION).
+      if (desiredDistanceFunc == null) {
+        desiredDistanceFunc = VectorIndexConfig.VectorDistanceFunction.COSINE;
+      }
+      VectorSimilarityFunction desiredFunc = VectorIndexUtils.toSimilarityFunction(desiredDistanceFunc);
+      if (storedFunc != desiredFunc) {
+        LOGGER.info("Vector index config changed for segment: {}, column: {} "
+                + "(distanceFunction: {} → {}). Index needs to be rebuilt.",
+            segmentName, column, storedFunc, desiredFunc);
+        return true;
+      }
+    } catch (Exception e) {
+      LOGGER.warn("Failed to parse vector index metadata for segment: {}, column: {}; skipping config-change check",
+          segmentName, column, e);
+    }
+    return false;
   }
 
   private boolean shouldCreateVectorIndex(ColumnMetadata columnMetadata) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/VectorIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/VectorIndexUtils.java
@@ -20,8 +20,11 @@ package org.apache.pinot.segment.local.segment.store;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Properties;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.lucene.codecs.lucene912.Lucene912Codec;
@@ -43,7 +46,50 @@ import org.apache.pinot.segment.spi.store.SegmentDirectoryPaths;
 
 
 public class VectorIndexUtils {
+  private static final String METADATA_KEY_DIMENSION = "dimension";
+  private static final String METADATA_KEY_DISTANCE_FUNCTION = "distanceFunction";
+
   private VectorIndexUtils() {
+  }
+
+  /**
+   * Writes a lightweight metadata file next to the HNSW index directory, recording the vector dimension and
+   * similarity function. This file is used by
+   * {@link org.apache.pinot.segment.local.segment.index.loader.invertedindex.VectorIndexHandler}
+   * to detect config changes and trigger an index rebuild when necessary.
+   *
+   * <p>Legacy segments built before this method existed have no metadata file; the handler skips config-change
+   * detection for those segments (treating the absence of the file as "unknown, assume unchanged").
+   */
+  public static void writeVectorIndexMetadata(File segmentIndexDir, String column, int dimension,
+      VectorSimilarityFunction similarityFunction)
+      throws IOException {
+    File metadataFile = new File(segmentIndexDir, column + Indexes.VECTOR_HNSW_INDEX_METADATA_FILE_EXTENSION);
+    Properties props = new Properties();
+    props.setProperty(METADATA_KEY_DIMENSION, String.valueOf(dimension));
+    props.setProperty(METADATA_KEY_DISTANCE_FUNCTION, similarityFunction.name());
+    try (FileOutputStream out = new FileOutputStream(metadataFile)) {
+      props.store(out, null);
+    }
+  }
+
+  /**
+   * Reads the HNSW vector index metadata file for the given column. Returns {@code null} if the file does not
+   * exist (legacy segment) or cannot be parsed.
+   */
+  @Nullable
+  public static Properties readVectorIndexMetadata(File segmentIndexDir, String column) {
+    File metadataFile = new File(segmentIndexDir, column + Indexes.VECTOR_HNSW_INDEX_METADATA_FILE_EXTENSION);
+    if (!metadataFile.exists()) {
+      return null;
+    }
+    Properties props = new Properties();
+    try (FileInputStream in = new FileInputStream(metadataFile)) {
+      props.load(in);
+      return props;
+    } catch (IOException e) {
+      return null;
+    }
   }
 
   static void cleanupVectorIndex(File segDir, String column) {
@@ -81,6 +127,10 @@ public class VectorIndexUtils {
     // handled above via the per-version VECTOR_HNSW_INDEX_FILE_EXTENSION entries).
     File hnswCombinedFile = new File(segDir, column + Indexes.VECTOR_HNSW_COMBINED_INDEX_FILE_EXTENSION);
     FileUtils.deleteQuietly(hnswCombinedFile);
+
+    // Remove the HNSW metadata file
+    File metadataFile = new File(segDir, column + Indexes.VECTOR_HNSW_INDEX_METADATA_FILE_EXTENSION);
+    FileUtils.deleteQuietly(metadataFile);
   }
 
   /// Returns {@code true} when the V1/V2 segment directory holds a vector index file that should

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/VectorIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/VectorIndexUtils.java
@@ -20,8 +20,11 @@ package org.apache.pinot.segment.local.segment.store;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Properties;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.lucene.codecs.lucene912.Lucene912Codec;
@@ -43,7 +46,50 @@ import org.apache.pinot.segment.spi.store.SegmentDirectoryPaths;
 
 
 public class VectorIndexUtils {
+  private static final String METADATA_KEY_DIMENSION = "dimension";
+  private static final String METADATA_KEY_DISTANCE_FUNCTION = "distanceFunction";
+
   private VectorIndexUtils() {
+  }
+
+  /**
+   * Writes a lightweight metadata file next to the HNSW index directory, recording the vector dimension and
+   * similarity function. This file is used by
+   * {@link org.apache.pinot.segment.local.segment.index.loader.invertedindex.VectorIndexHandler}
+   * to detect config changes and trigger an index rebuild when necessary.
+   *
+   * <p>Legacy segments built before this method existed have no metadata file; the handler skips config-change
+   * detection for those segments (treating the absence of the file as "unknown, assume unchanged").
+   */
+  public static void writeVectorIndexMetadata(File segmentIndexDir, String column, int dimension,
+      VectorSimilarityFunction similarityFunction)
+      throws IOException {
+    File metadataFile = new File(segmentIndexDir, column + Indexes.VECTOR_HNSW_INDEX_METADATA_FILE_EXTENSION);
+    Properties props = new Properties();
+    props.setProperty(METADATA_KEY_DIMENSION, String.valueOf(dimension));
+    props.setProperty(METADATA_KEY_DISTANCE_FUNCTION, similarityFunction.name());
+    try (FileOutputStream out = new FileOutputStream(metadataFile)) {
+      props.store(out, null);
+    }
+  }
+
+  /**
+   * Reads the HNSW vector index metadata file for the given column. Returns {@code null} if the file does not
+   * exist (legacy segment) or cannot be parsed.
+   */
+  @Nullable
+  public static Properties readVectorIndexMetadata(File segmentIndexDir, String column) {
+    File metadataFile = new File(segmentIndexDir, column + Indexes.VECTOR_HNSW_INDEX_METADATA_FILE_EXTENSION);
+    if (!metadataFile.exists()) {
+      return null;
+    }
+    Properties props = new Properties();
+    try (FileInputStream in = new FileInputStream(metadataFile)) {
+      props.load(in);
+      return props;
+    } catch (IOException e) {
+      return null;
+    }
   }
 
   static void cleanupVectorIndex(File segDir, String column) {
@@ -81,6 +127,10 @@ public class VectorIndexUtils {
     // handled above via the per-version VECTOR_HNSW_INDEX_FILE_EXTENSION entries).
     File hnswCombinedFile = new File(segDir, column + Indexes.VECTOR_HNSW_COMBINED_INDEX_FILE_EXTENSION);
     FileUtils.deleteQuietly(hnswCombinedFile);
+
+    // Remove the HNSW metadata file
+    File metadataFile = new File(segDir, column + Indexes.VECTOR_HNSW_INDEX_METADATA_FILE_EXTENSION);
+    FileUtils.deleteQuietly(metadataFile);
   }
 
   /// Returns `true` when the V1/V2 segment directory holds a vector index file that should

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/VectorIndexHandlerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/VectorIndexHandlerTest.java
@@ -31,7 +31,9 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import org.apache.commons.io.FileUtils;
+import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.pinot.segment.local.segment.creator.impl.vector.lucene99.HnswVectorIndexCombined;
+import org.apache.pinot.segment.local.segment.store.VectorIndexUtils;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.creator.SegmentVersion;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
@@ -60,21 +62,35 @@ import static org.testng.Assert.fail;
 
 
 /**
- * Unit tests for {@link VectorIndexHandler} backend-drift handling.
+ * Unit tests for {@link VectorIndexHandler}.
+ *
+ * <p>Covers:
+ * <ul>
+ *   <li>Backend drift detection (HNSW → IVF_PQ triggers rebuild)</li>
+ *   <li>Dimension change detection (metadata file present, dimension differs → rebuild)</li>
+ *   <li>Distance function change detection (metadata file present, function differs → rebuild)</li>
+ *   <li>No rebuild when config is unchanged</li>
+ *   <li>Legacy segments without metadata file skip config-change detection</li>
+ *   <li>L2 and EUCLIDEAN are treated as equivalent (same Lucene similarity function)</li>
+ * </ul>
  */
 public class VectorIndexHandlerTest {
   private static final String COLUMN = "embedding";
+  private static final int DIM = 4;
+
+  // ---------------------------------------------------------------------------
+  // Backend drift
+  // ---------------------------------------------------------------------------
 
   @Test
   public void testNeedUpdateIndicesReturnsTrueWhenVectorBackendChanges()
       throws Exception {
-    File indexDir = createSegmentDirWithVectorIndex(V1Constants.Indexes.VECTOR_V912_HNSW_INDEX_FILE_EXTENSION);
+    File indexDir = createSegmentDirWithHnswIndex();
     try {
       SegmentDirectory segmentDirectory = mockSegmentDirectory(indexDir);
-      SegmentDirectory.Reader reader = mock(SegmentDirectory.Reader.class);
-      when(reader.toSegmentDirectory()).thenReturn(segmentDirectory);
+      SegmentDirectory.Reader reader = mockReader(segmentDirectory);
 
-      VectorIndexHandler handler = createHandler(segmentDirectory, vectorIndexConfig("IVF_PQ"));
+      VectorIndexHandler handler = createHandler(segmentDirectory, ivfPqConfig());
 
       assertTrue(handler.needUpdateIndices(reader));
     } finally {
@@ -85,13 +101,13 @@ public class VectorIndexHandlerTest {
   @Test
   public void testUpdateIndicesRemovesIndexWhenVectorBackendChanges()
       throws Exception {
-    File indexDir = createSegmentDirWithVectorIndex(V1Constants.Indexes.VECTOR_V912_HNSW_INDEX_FILE_EXTENSION);
+    File indexDir = createSegmentDirWithHnswIndex();
     try {
       SegmentDirectory segmentDirectory = mockSegmentDirectory(indexDir);
       SegmentDirectory.Writer writer = mock(SegmentDirectory.Writer.class);
       when(writer.toSegmentDirectory()).thenReturn(segmentDirectory);
 
-      VectorIndexHandler handler = createHandler(segmentDirectory, vectorIndexConfig("IVF_PQ"));
+      VectorIndexHandler handler = createHandler(segmentDirectory, ivfPqConfig());
       handler.updateIndices(writer);
 
       verify(writer).removeIndex(COLUMN, StandardIndexes.vector());
@@ -99,6 +115,137 @@ public class VectorIndexHandlerTest {
       FileUtils.deleteQuietly(indexDir);
     }
   }
+
+  // ---------------------------------------------------------------------------
+  // Config unchanged → no rebuild
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testNeedUpdateReturnsFalseWhenConfigUnchanged()
+      throws Exception {
+    File indexDir = createSegmentDirWithHnswIndex();
+    try {
+      File v3Dir = new File(indexDir, SegmentDirectoryPaths.V3_SUBDIRECTORY_NAME);
+      VectorIndexUtils.writeVectorIndexMetadata(v3Dir, COLUMN, DIM, VectorSimilarityFunction.COSINE);
+
+      SegmentDirectory segmentDirectory = mockSegmentDirectory(indexDir);
+      SegmentDirectory.Reader reader = mockReader(segmentDirectory);
+
+      VectorIndexHandler handler = createHandler(segmentDirectory,
+          hnswConfig(DIM, VectorIndexConfig.VectorDistanceFunction.COSINE));
+
+      assertFalse(handler.needUpdateIndices(reader));
+    } finally {
+      FileUtils.deleteQuietly(indexDir);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Dimension change
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testNeedUpdateReturnsTrueWhenDimensionChanged()
+      throws Exception {
+    File indexDir = createSegmentDirWithHnswIndex();
+    try {
+      File v3Dir = new File(indexDir, SegmentDirectoryPaths.V3_SUBDIRECTORY_NAME);
+      VectorIndexUtils.writeVectorIndexMetadata(v3Dir, COLUMN, DIM, VectorSimilarityFunction.COSINE);
+
+      SegmentDirectory segmentDirectory = mockSegmentDirectory(indexDir);
+      SegmentDirectory.Reader reader = mockReader(segmentDirectory);
+
+      // New config requests dimension 8, but index was built with dimension 4
+      VectorIndexHandler handler = createHandler(segmentDirectory,
+          hnswConfig(DIM * 2, VectorIndexConfig.VectorDistanceFunction.COSINE));
+
+      assertTrue(handler.needUpdateIndices(reader),
+          "Rebuild expected when vector dimension changes");
+    } finally {
+      FileUtils.deleteQuietly(indexDir);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Distance function change
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testNeedUpdateReturnsTrueWhenDistanceFunctionChanged()
+      throws Exception {
+    File indexDir = createSegmentDirWithHnswIndex();
+    try {
+      File v3Dir = new File(indexDir, SegmentDirectoryPaths.V3_SUBDIRECTORY_NAME);
+      VectorIndexUtils.writeVectorIndexMetadata(v3Dir, COLUMN, DIM, VectorSimilarityFunction.COSINE);
+
+      SegmentDirectory segmentDirectory = mockSegmentDirectory(indexDir);
+      SegmentDirectory.Reader reader = mockReader(segmentDirectory);
+
+      // Config now requests EUCLIDEAN but index was built with COSINE
+      VectorIndexHandler handler = createHandler(segmentDirectory,
+          hnswConfig(DIM, VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN));
+
+      assertTrue(handler.needUpdateIndices(reader),
+          "Rebuild expected when distance function changes");
+    } finally {
+      FileUtils.deleteQuietly(indexDir);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Legacy segment — no metadata file → skip config-change detection
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testLegacySegmentWithoutMetadataFileSkipsConfigChangeDetection()
+      throws Exception {
+    File indexDir = createSegmentDirWithHnswIndex();
+    try {
+      // No metadata file written — simulates a legacy segment built before this feature
+      SegmentDirectory segmentDirectory = mockSegmentDirectory(indexDir);
+      SegmentDirectory.Reader reader = mockReader(segmentDirectory);
+
+      // Even though dimension "differs" (handler doesn't know the stored value), no rebuild expected
+      VectorIndexHandler handler = createHandler(segmentDirectory,
+          hnswConfig(DIM * 2, VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN));
+
+      assertFalse(handler.needUpdateIndices(reader),
+          "No rebuild expected for legacy segments without metadata file");
+    } finally {
+      FileUtils.deleteQuietly(indexDir);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // L2 and EUCLIDEAN are equivalent
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testL2AndEuclideanAreEquivalent()
+      throws Exception {
+    File indexDir = createSegmentDirWithHnswIndex();
+    try {
+      File v3Dir = new File(indexDir, SegmentDirectoryPaths.V3_SUBDIRECTORY_NAME);
+      // Index was built with EUCLIDEAN (stored as VectorSimilarityFunction.EUCLIDEAN)
+      VectorIndexUtils.writeVectorIndexMetadata(v3Dir, COLUMN, DIM, VectorSimilarityFunction.EUCLIDEAN);
+
+      SegmentDirectory segmentDirectory = mockSegmentDirectory(indexDir);
+      SegmentDirectory.Reader reader = mockReader(segmentDirectory);
+
+      // Config uses L2 — which maps to the same Lucene similarity function as EUCLIDEAN
+      VectorIndexHandler handler = createHandler(segmentDirectory,
+          hnswConfig(DIM, VectorIndexConfig.VectorDistanceFunction.L2));
+
+      assertFalse(handler.needUpdateIndices(reader),
+          "L2 and EUCLIDEAN map to the same Lucene similarity function; no rebuild expected");
+    } finally {
+      FileUtils.deleteQuietly(indexDir);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
 
   private static VectorIndexHandler createHandler(SegmentDirectory segmentDirectory,
       VectorIndexConfig vectorIndexConfig) {
@@ -117,6 +264,7 @@ public class VectorIndexHandlerTest {
     SegmentMetadataImpl segmentMetadata = mock(SegmentMetadataImpl.class);
     when(segmentMetadata.getName()).thenReturn("testSegment");
     when(segmentMetadata.getIndexDir()).thenReturn(indexDir);
+    when(segmentMetadata.getVersion()).thenReturn(SegmentVersion.v3);
     when(segmentMetadata.getTotalDocs()).thenReturn(10);
     when(segmentMetadata.getAllColumns()).thenReturn(new TreeSet<>(Set.of(COLUMN)));
     when(segmentMetadata.getColumnMetadataMap()).thenReturn(new TreeMap<>());
@@ -128,8 +276,19 @@ public class VectorIndexHandlerTest {
     return segmentDirectory;
   }
 
-  private static VectorIndexConfig vectorIndexConfig(String backend) {
-    return new VectorIndexConfig(false, backend, 4, 1, VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN,
+  private static SegmentDirectory.Reader mockReader(SegmentDirectory segmentDirectory) {
+    SegmentDirectory.Reader reader = mock(SegmentDirectory.Reader.class);
+    when(reader.toSegmentDirectory()).thenReturn(segmentDirectory);
+    return reader;
+  }
+
+  private static VectorIndexConfig hnswConfig(int dimension,
+      VectorIndexConfig.VectorDistanceFunction distanceFunction) {
+    return new VectorIndexConfig(false, "HNSW", dimension, 1, distanceFunction, Map.of());
+  }
+
+  private static VectorIndexConfig ivfPqConfig() {
+    return new VectorIndexConfig(false, "IVF_PQ", DIM, 1, VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN,
         Map.of("nlist", "2", "pqM", "2", "pqNbits", "4", "trainSampleSize", "8"));
   }
 
@@ -857,6 +1016,11 @@ public class VectorIndexHandlerTest {
     } finally {
       FileUtils.deleteQuietly(indexDir);
     }
+  }
+
+  private static File createSegmentDirWithHnswIndex()
+      throws Exception {
+    return createSegmentDirWithVectorIndex(V1Constants.Indexes.VECTOR_V912_HNSW_INDEX_FILE_EXTENSION);
   }
 
   private static File createSegmentDirWithVectorIndex(String suffix)

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/VectorIndexHandlerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/VectorIndexHandlerTest.java
@@ -31,7 +31,9 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import org.apache.commons.io.FileUtils;
+import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.pinot.segment.local.segment.creator.impl.vector.lucene99.HnswVectorIndexCombined;
+import org.apache.pinot.segment.local.segment.store.VectorIndexUtils;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.creator.SegmentVersion;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
@@ -59,20 +61,32 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 
-/// Unit tests for [VectorIndexHandler] backend-drift handling.
+/// Unit tests for [VectorIndexHandler].
+///
+/// Covers:
+/// - Backend drift detection (HNSW → IVF_PQ triggers rebuild)
+/// - Dimension change detection (metadata file present, dimension differs → rebuild)
+/// - Distance function change detection (metadata file present, function differs → rebuild)
+/// - No rebuild when config is unchanged
+/// - Legacy segments without metadata file skip config-change detection
+/// - L2 and EUCLIDEAN are treated as equivalent (same Lucene similarity function)
 public class VectorIndexHandlerTest {
   private static final String COLUMN = "embedding";
+  private static final int DIM = 4;
+
+  // ---------------------------------------------------------------------------
+  // Backend drift
+  // ---------------------------------------------------------------------------
 
   @Test
   public void testNeedUpdateIndicesReturnsTrueWhenVectorBackendChanges()
       throws Exception {
-    File indexDir = createSegmentDirWithVectorIndex(V1Constants.Indexes.VECTOR_V912_HNSW_INDEX_FILE_EXTENSION);
+    File indexDir = createSegmentDirWithHnswIndex();
     try {
       SegmentDirectory segmentDirectory = mockSegmentDirectory(indexDir);
-      SegmentDirectory.Reader reader = mock(SegmentDirectory.Reader.class);
-      when(reader.toSegmentDirectory()).thenReturn(segmentDirectory);
+      SegmentDirectory.Reader reader = mockReader(segmentDirectory);
 
-      VectorIndexHandler handler = createHandler(segmentDirectory, vectorIndexConfig("IVF_PQ"));
+      VectorIndexHandler handler = createHandler(segmentDirectory, ivfPqConfig());
 
       assertTrue(handler.needUpdateIndices(reader));
     } finally {
@@ -83,13 +97,13 @@ public class VectorIndexHandlerTest {
   @Test
   public void testUpdateIndicesRemovesIndexWhenVectorBackendChanges()
       throws Exception {
-    File indexDir = createSegmentDirWithVectorIndex(V1Constants.Indexes.VECTOR_V912_HNSW_INDEX_FILE_EXTENSION);
+    File indexDir = createSegmentDirWithHnswIndex();
     try {
       SegmentDirectory segmentDirectory = mockSegmentDirectory(indexDir);
       SegmentDirectory.Writer writer = mock(SegmentDirectory.Writer.class);
       when(writer.toSegmentDirectory()).thenReturn(segmentDirectory);
 
-      VectorIndexHandler handler = createHandler(segmentDirectory, vectorIndexConfig("IVF_PQ"));
+      VectorIndexHandler handler = createHandler(segmentDirectory, ivfPqConfig());
       handler.updateIndices(writer);
 
       verify(writer).removeIndex(COLUMN, StandardIndexes.vector());
@@ -97,6 +111,137 @@ public class VectorIndexHandlerTest {
       FileUtils.deleteQuietly(indexDir);
     }
   }
+
+  // ---------------------------------------------------------------------------
+  // Config unchanged → no rebuild
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testNeedUpdateReturnsFalseWhenConfigUnchanged()
+      throws Exception {
+    File indexDir = createSegmentDirWithHnswIndex();
+    try {
+      File v3Dir = new File(indexDir, SegmentDirectoryPaths.V3_SUBDIRECTORY_NAME);
+      VectorIndexUtils.writeVectorIndexMetadata(v3Dir, COLUMN, DIM, VectorSimilarityFunction.COSINE);
+
+      SegmentDirectory segmentDirectory = mockSegmentDirectory(indexDir);
+      SegmentDirectory.Reader reader = mockReader(segmentDirectory);
+
+      VectorIndexHandler handler = createHandler(segmentDirectory,
+          hnswConfig(DIM, VectorIndexConfig.VectorDistanceFunction.COSINE));
+
+      assertFalse(handler.needUpdateIndices(reader));
+    } finally {
+      FileUtils.deleteQuietly(indexDir);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Dimension change
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testNeedUpdateReturnsTrueWhenDimensionChanged()
+      throws Exception {
+    File indexDir = createSegmentDirWithHnswIndex();
+    try {
+      File v3Dir = new File(indexDir, SegmentDirectoryPaths.V3_SUBDIRECTORY_NAME);
+      VectorIndexUtils.writeVectorIndexMetadata(v3Dir, COLUMN, DIM, VectorSimilarityFunction.COSINE);
+
+      SegmentDirectory segmentDirectory = mockSegmentDirectory(indexDir);
+      SegmentDirectory.Reader reader = mockReader(segmentDirectory);
+
+      // New config requests dimension 8, but index was built with dimension 4
+      VectorIndexHandler handler = createHandler(segmentDirectory,
+          hnswConfig(DIM * 2, VectorIndexConfig.VectorDistanceFunction.COSINE));
+
+      assertTrue(handler.needUpdateIndices(reader),
+          "Rebuild expected when vector dimension changes");
+    } finally {
+      FileUtils.deleteQuietly(indexDir);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Distance function change
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testNeedUpdateReturnsTrueWhenDistanceFunctionChanged()
+      throws Exception {
+    File indexDir = createSegmentDirWithHnswIndex();
+    try {
+      File v3Dir = new File(indexDir, SegmentDirectoryPaths.V3_SUBDIRECTORY_NAME);
+      VectorIndexUtils.writeVectorIndexMetadata(v3Dir, COLUMN, DIM, VectorSimilarityFunction.COSINE);
+
+      SegmentDirectory segmentDirectory = mockSegmentDirectory(indexDir);
+      SegmentDirectory.Reader reader = mockReader(segmentDirectory);
+
+      // Config now requests EUCLIDEAN but index was built with COSINE
+      VectorIndexHandler handler = createHandler(segmentDirectory,
+          hnswConfig(DIM, VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN));
+
+      assertTrue(handler.needUpdateIndices(reader),
+          "Rebuild expected when distance function changes");
+    } finally {
+      FileUtils.deleteQuietly(indexDir);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Legacy segment — no metadata file → skip config-change detection
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testLegacySegmentWithoutMetadataFileSkipsConfigChangeDetection()
+      throws Exception {
+    File indexDir = createSegmentDirWithHnswIndex();
+    try {
+      // No metadata file written — simulates a legacy segment built before this feature
+      SegmentDirectory segmentDirectory = mockSegmentDirectory(indexDir);
+      SegmentDirectory.Reader reader = mockReader(segmentDirectory);
+
+      // Even though dimension "differs" (handler doesn't know the stored value), no rebuild expected
+      VectorIndexHandler handler = createHandler(segmentDirectory,
+          hnswConfig(DIM * 2, VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN));
+
+      assertFalse(handler.needUpdateIndices(reader),
+          "No rebuild expected for legacy segments without metadata file");
+    } finally {
+      FileUtils.deleteQuietly(indexDir);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // L2 and EUCLIDEAN are equivalent
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testL2AndEuclideanAreEquivalent()
+      throws Exception {
+    File indexDir = createSegmentDirWithHnswIndex();
+    try {
+      File v3Dir = new File(indexDir, SegmentDirectoryPaths.V3_SUBDIRECTORY_NAME);
+      // Index was built with EUCLIDEAN (stored as VectorSimilarityFunction.EUCLIDEAN)
+      VectorIndexUtils.writeVectorIndexMetadata(v3Dir, COLUMN, DIM, VectorSimilarityFunction.EUCLIDEAN);
+
+      SegmentDirectory segmentDirectory = mockSegmentDirectory(indexDir);
+      SegmentDirectory.Reader reader = mockReader(segmentDirectory);
+
+      // Config uses L2 — which maps to the same Lucene similarity function as EUCLIDEAN
+      VectorIndexHandler handler = createHandler(segmentDirectory,
+          hnswConfig(DIM, VectorIndexConfig.VectorDistanceFunction.L2));
+
+      assertFalse(handler.needUpdateIndices(reader),
+          "L2 and EUCLIDEAN map to the same Lucene similarity function; no rebuild expected");
+    } finally {
+      FileUtils.deleteQuietly(indexDir);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
 
   private static VectorIndexHandler createHandler(SegmentDirectory segmentDirectory,
       VectorIndexConfig vectorIndexConfig) {
@@ -115,6 +260,7 @@ public class VectorIndexHandlerTest {
     SegmentMetadataImpl segmentMetadata = mock(SegmentMetadataImpl.class);
     when(segmentMetadata.getName()).thenReturn("testSegment");
     when(segmentMetadata.getIndexDir()).thenReturn(indexDir);
+    when(segmentMetadata.getVersion()).thenReturn(SegmentVersion.v3);
     when(segmentMetadata.getTotalDocs()).thenReturn(10);
     when(segmentMetadata.getAllColumns()).thenReturn(new TreeSet<>(Set.of(COLUMN)));
     when(segmentMetadata.getColumnMetadataMap()).thenReturn(new TreeMap<>());
@@ -126,8 +272,19 @@ public class VectorIndexHandlerTest {
     return segmentDirectory;
   }
 
-  private static VectorIndexConfig vectorIndexConfig(String backend) {
-    return new VectorIndexConfig(false, backend, 4, 1, VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN,
+  private static SegmentDirectory.Reader mockReader(SegmentDirectory segmentDirectory) {
+    SegmentDirectory.Reader reader = mock(SegmentDirectory.Reader.class);
+    when(reader.toSegmentDirectory()).thenReturn(segmentDirectory);
+    return reader;
+  }
+
+  private static VectorIndexConfig hnswConfig(int dimension,
+      VectorIndexConfig.VectorDistanceFunction distanceFunction) {
+    return new VectorIndexConfig(false, "HNSW", dimension, 1, distanceFunction, Map.of());
+  }
+
+  private static VectorIndexConfig ivfPqConfig() {
+    return new VectorIndexConfig(false, "IVF_PQ", DIM, 1, VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN,
         Map.of("nlist", "2", "pqM", "2", "pqNbits", "4", "trainSampleSize", "8"));
   }
 
@@ -819,6 +976,11 @@ public class VectorIndexHandlerTest {
     } finally {
       FileUtils.deleteQuietly(indexDir);
     }
+  }
+
+  private static File createSegmentDirWithHnswIndex()
+      throws Exception {
+    return createSegmentDirWithVectorIndex(V1Constants.Indexes.VECTOR_V912_HNSW_INDEX_FILE_EXTENSION);
   }
 
   private static File createSegmentDirWithVectorIndex(String suffix)

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
@@ -71,6 +71,7 @@ public class V1Constants {
     public static final String VECTOR_V912_INDEX_FILE_EXTENSION = ".vector.v912.index";
     public static final String VECTOR_V912_HNSW_INDEX_FILE_EXTENSION = ".vector.v912.hnsw.index";
     public static final String VECTOR_HNSW_INDEX_DOCID_MAPPING_FILE_EXTENSION = ".vector.hnsw.mapping";
+    public static final String VECTOR_HNSW_INDEX_METADATA_FILE_EXTENSION = ".vector.hnsw.metadata";
     public static final String VECTOR_IVF_FLAT_INDEX_FILE_EXTENSION = ".vector.ivfflat.index";
     public static final String VECTOR_IVF_PQ_INDEX_FILE_EXTENSION = ".vector.ivfpq.index";
     /**

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
@@ -71,6 +71,7 @@ public class V1Constants {
     public static final String VECTOR_V912_INDEX_FILE_EXTENSION = ".vector.v912.index";
     public static final String VECTOR_V912_HNSW_INDEX_FILE_EXTENSION = ".vector.v912.hnsw.index";
     public static final String VECTOR_HNSW_INDEX_DOCID_MAPPING_FILE_EXTENSION = ".vector.hnsw.mapping";
+    public static final String VECTOR_HNSW_INDEX_METADATA_FILE_EXTENSION = ".vector.hnsw.metadata";
     public static final String VECTOR_IVF_FLAT_INDEX_FILE_EXTENSION = ".vector.ivfflat.index";
     public static final String VECTOR_IVF_PQ_INDEX_FILE_EXTENSION = ".vector.ivfpq.index";
     /// Combined-form IVF file extensions. Written by the IVF creators when


### PR DESCRIPTION
## Description

Extends `VectorIndexHandler` to detect and rebuild a HNSW vector index when the vector dimension or distance function changes in the table config — mirroring the same pattern used for bloom filter (#18898) and JSON index (#18920) rebuilds.

### Problem
Previously, if a table's vector index config changed (e.g. dimension or distance function), the existing index would be silently reused without rebuilding:
- A changed **dimension** produces a structurally incompatible index that will fail or return garbage results.
- A changed **distance function** silently returns wrong query results (wrong similarity metric applied).

Neither failure was detectable without the stored build-time config.

### Solution
Write a lightweight metadata file (`.vector.hnsw.metadata`) alongside the HNSW Lucene index directory at `seal()` time, recording:
- `vectorDimension` (int)
- `vectorSimilarityFunction` (Lucene `VectorSimilarityFunction` name)

`VectorIndexHandler.needUpdateIndices()` reads this file and triggers a rebuild when either field differs from the current table config.

**Backward compatibility:** Legacy segments without a metadata file skip the check and receive the file on their next rebuild — no forced migration.

### Files changed
- `HnswVectorIndexCreator` – writes `.vector.hnsw.metadata` at seal time
- `VectorIndexHandler` – reads metadata file and triggers rebuild on mismatch
- `VectorIndexUtils` – helper for reading/writing the metadata file
- `V1Constants` – adds `VECTOR_HNSW_METADATA_FILE_EXTENSION` constant
- `VectorIndexHandlerTest` – unit tests for all rebuild/skip branches

## Test plan
- [ ] New `VectorIndexHandlerTest` covers: dimension change → rebuild, distance-function change → rebuild, no change → skip, missing metadata → skip (backward compat), metadata present + matching → skip
- [ ] Existing vector index integration tests pass