### PR TITLE
Fix FSDirectory resource leak when IndexWriter construction fails

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/vector/MutableVectorIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/vector/MutableVectorIndex.java
@@ -91,21 +91,42 @@ public class MutableVectorIndex implements VectorIndexReader, MutableIndex, Vect
     _commitDocs = Long.parseLong(
         vectorIndexConfig.getProperties().getOrDefault("commitDocs", String.valueOf(DEFAULT_COMMIT_DOCS)));
     _vectorSimilarityFunction = VectorIndexUtils.toSimilarityFunction(vectorIndexConfig.getVectorDistanceFunction());
+    // Use local variables so that resources opened before a failure can be closed before rethrowing,
+    // preventing file-descriptor and temp-directory leaks.
+    File indexDir = new File(FileUtils.getTempDirectory(), segmentName);
+    FSDirectory indexDirectory = null;
+    IndexWriter indexWriter = null;
     try {
       // segment generation is always in V1 and later we convert (as part of post creation processing)
       // to V3 if segmentVersion is set to V3 in SegmentGeneratorConfig.
-      _indexDir = new File(FileUtils.getTempDirectory(), segmentName);
-      _indexDirectory = FSDirectory.open(
-          new File(_indexDir, _vectorColumn + V1Constants.Indexes.VECTOR_V912_HNSW_INDEX_FILE_EXTENSION).toPath());
+      indexDirectory = FSDirectory.open(
+          new File(indexDir, _vectorColumn + V1Constants.Indexes.VECTOR_V912_HNSW_INDEX_FILE_EXTENSION).toPath());
       LOGGER.info("Creating mutable HNSW index for segment: {}, column: {} at path: {} with {}", segmentName,
-          vectorColumn, _indexDir.getAbsolutePath(), vectorIndexConfig.getProperties());
-      _indexWriter = new IndexWriter(_indexDirectory, VectorIndexUtils.getIndexWriterConfig(vectorIndexConfig));
-      _indexWriter.commit();
+          vectorColumn, indexDir.getAbsolutePath(), vectorIndexConfig.getProperties());
+      indexWriter = new IndexWriter(indexDirectory, VectorIndexUtils.getIndexWriterConfig(vectorIndexConfig));
+      indexWriter.commit();
       _lastCommitTime = System.currentTimeMillis();
     } catch (Exception e) {
+      if (indexWriter != null) {
+        try {
+          indexWriter.close();
+        } catch (IOException closeEx) {
+          e.addSuppressed(closeEx);
+        }
+      } else if (indexDirectory != null) {
+        try {
+          indexDirectory.close();
+        } catch (IOException closeEx) {
+          e.addSuppressed(closeEx);
+        }
+      }
+      FileUtils.deleteQuietly(indexDir);
       throw new RuntimeException(
           "Caught exception while instantiating the LuceneTextIndexCreator for column: " + vectorColumn, e);
     }
+    _indexDir = indexDir;
+    _indexDirectory = indexDirectory;
+    _indexWriter = indexWriter;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/vector/HnswVectorIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/vector/HnswVectorIndexCreator.java
@@ -65,20 +65,33 @@ public class HnswVectorIndexCreator implements VectorIndexCreator {
     _vectorSimilarityFunction = VectorIndexUtils.toSimilarityFunction(vectorIndexConfig.getVectorDistanceFunction());
     _storeInSegmentFile = vectorIndexConfig.isStoreInSegmentFile();
     _segmentIndexDir = segmentIndexDir;
+    // Use local variables so that, if IndexWriter construction fails after FSDirectory is already
+    // open, we can close the directory before rethrowing — preventing a file-descriptor leak.
+    Directory indexDirectory = null;
+    IndexWriter indexWriter;
     try {
       // segment generation is always in V1 and later we convert (as part of post creation processing)
       // to V3 if segmentVersion is set to V3 in SegmentGeneratorConfig.
       File indexFile = new File(segmentIndexDir, _vectorColumn
           + V1Constants.Indexes.VECTOR_V912_HNSW_INDEX_FILE_EXTENSION);
       _hnswIndexDir = indexFile;
-      _indexDirectory = FSDirectory.open(indexFile.toPath());
+      indexDirectory = FSDirectory.open(indexFile.toPath());
       LOGGER.info("Creating HNSW index for column: {} at path: {} with {} for segment: {}", column,
           indexFile.getAbsolutePath(), vectorIndexConfig.getProperties(), segmentIndexDir.getAbsolutePath());
-      _indexWriter = new IndexWriter(_indexDirectory, VectorIndexUtils.getIndexWriterConfig(vectorIndexConfig));
+      indexWriter = new IndexWriter(indexDirectory, VectorIndexUtils.getIndexWriterConfig(vectorIndexConfig));
     } catch (Exception e) {
+      if (indexDirectory != null) {
+        try {
+          indexDirectory.close();
+        } catch (IOException closeEx) {
+          e.addSuppressed(closeEx);
+        }
+      }
       throw new RuntimeException(
           "Caught exception while instantiating the HnswVectorIndexCreator for column: " + column, e);
     }
+    _indexDirectory = indexDirectory;
+    _indexWriter = indexWriter;
   }
 
   @Override


### PR DESCRIPTION
## Description

Fixes a resource leak in `HnswVectorIndexCreator` and `MutableVectorIndex` where an `FSDirectory` (backed by an OS file descriptor) was opened but not closed if the subsequent `IndexWriter` construction threw an exception.

### Problem
`FSDirectory.open(path)` acquires a file-system lock and OS resources. If `new IndexWriter(directory, config)` throws (e.g. due to a codec error or corrupted segment), the `FSDirectory` was never closed, leaking the lock and file descriptor.

### Fix
Wrap `IndexWriter` construction in a try-with-resources / try-catch that closes the `FSDirectory` on failure, ensuring the resource is always released.

## Test plan
- [ ] Existing vector index tests pass
- [ ] No functional behavior change on the happy path