### PR TITLE
Fix SchemaUtils to include validation failure reason in error message

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
@@ -477,7 +477,7 @@ public class PinotSchemaRestletResource {
     } catch (SchemaBackwardIncompatibleException e) {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_SCHEMA_UPLOAD_ERROR, 1L);
       throw new ControllerApplicationException(LOGGER,
-          String.format("Backward incompatible schema %s. Only allow adding new columns", schemaName),
+          String.format("Backward incompatible schema %s. Reason: %s", schemaName, e.getMessage()),
           Response.Status.BAD_REQUEST, e);
     } catch (TableNotFoundException e) {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_SCHEMA_UPLOAD_ERROR, 1L);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSchemaRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSchemaRestletResourceTest.java
@@ -107,9 +107,10 @@ public class PinotSchemaRestletResourceTest {
     // Update the schema with addSchema api and override on
     expectValidationException(() -> adminClient.getSchemaClient().createSchema(schema.toSingleLineJsonString()));
 
-    // Update the schema with updateSchema api
-    expectValidationException(
-        () -> adminClient.getSchemaClient().updateSchema(schemaName, schema.toSingleLineJsonString()));
+    // Update the schema with updateSchema api - verify the error message includes the actual reason
+    expectValidationExceptionWithMessage(
+        () -> adminClient.getSchemaClient().updateSchema(schemaName, schema.toSingleLineJsonString()),
+        "Incompatible field specifications");
 
     // Change the column data type from STRING to BOOLEAN
     newColumnFieldSpec.setDataType(DataType.BOOLEAN);
@@ -274,6 +275,15 @@ public class PinotSchemaRestletResourceTest {
         expectThrows(RuntimeException.class, () -> runUnchecked(runnable));
     Throwable cause = unwrap(runtimeException);
     assertTrue(cause instanceof PinotAdminValidationException, "Unexpected exception: " + cause);
+  }
+
+  private void expectValidationExceptionWithMessage(ThrowingRunnable runnable, String expectedMessageSubstring) {
+    RuntimeException runtimeException =
+        expectThrows(RuntimeException.class, () -> runUnchecked(runnable));
+    Throwable cause = unwrap(runtimeException);
+    assertTrue(cause instanceof PinotAdminValidationException, "Unexpected exception: " + cause);
+    assertTrue(cause.getMessage().contains(expectedMessageSubstring),
+        "Expected message to contain '" + expectedMessageSubstring + "' but was: " + cause.getMessage());
   }
 
   private void expectNotFoundException(ThrowingRunnable runnable) {


### PR DESCRIPTION
## Description

The `updateSchema` endpoint in `PinotSchemaRestletResource` was catching `SchemaBackwardIncompatibleException` but returning only a generic message (`"Only allow adding new columns"`) without including the actual reason from the exception.

This made it difficult for operators to understand why a schema update was rejected — they had to dig through server logs to find the real cause.

### Fix
Include `e.getMessage()` in the error response, which contains detailed incompatibility information such as:
- Missing or renamed columns
- Incompatible field type changes
- Primary key changes
- Suggested fixes

A test is added/updated in `PinotSchemaRestletResourceTest` to assert the detailed reason appears in the response.

## Test plan
- [ ] `PinotSchemaRestletResourceTest` passes
- [ ] Manual: attempt a backward-incompatible schema update and verify the response body contains the specific reason