### PR TITLE
Skip full target recompute on IdealState version change for strict realtime rebalance that only moves tier segments

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -42,6 +42,7 @@ import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.helix.AccessOption;
@@ -653,11 +654,22 @@ public class TableRebalancer {
           // If all the segments to be moved remain unchanged (same instance state map) in the new ideal state, apply
           // the same target instance state map for these segments to the new ideal state as the target assignment
           segmentsToMoveChanged = false;
-          if (segmentAssignment instanceof BaseStrictRealtimeSegmentAssignment) {
-            // For StrictRealtimeSegmentAssignment, we need to recompute the target assignment because the assignment
-            // for new added segments is based on the existing assignment
+          if (isStrictRealtimeSegmentAssignment
+              && !isMovingOnlyTierSegments(segmentsToMove, providedTierToSegmentsMap)) {
+            // For strict segment assignment, a newly added segment (a new consuming segment or an uploaded segment) is
+            // assigned by the instance partitions, then overridden to match the existing assignment of its partition
+            // in the IdealState when they differ, keeping the partition collocated. This rebalance moves a non-tier
+            // segment, i.e. the base placement of a partition, so a segment added to the IdealState while we wait can
+            // be placed on the partition's old placement and must be re-collocated to the target: recompute the full
+            // target assignment.
             segmentsToMoveChanged = true;
           } else {
+            // Non-strict segment assignment, or strict assignment that only moves tier segments (completed segments
+            // assigned to a tier). In the latter case the base placements do not move, so a segment added while we
+            // wait is placed consistently with the target; a full recompute is only needed if a segment we are moving
+            // actually changed state. Skipping it (a full recompute reads segment ZK metadata for the completed
+            // segments) narrows the window in which the versioned IdealState update below can lose the race to a
+            // concurrent write on a continuously-ingesting table.
             for (String segment : segmentsToMove) {
               Map<String, String> oldInstanceStateMap = oldAssignment.get(segment);
               Map<String, String> currentInstanceStateMap = currentAssignment.get(segment);
@@ -2226,6 +2238,29 @@ public class TableRebalancer {
       _instanceStateMap = instanceStateMap;
       _availableInstances = availableInstances;
     }
+  }
+
+  /// Returns whether all the segments to be moved are tier segments, i.e. contained in the provided tier-to-segments
+  /// map. When true, this rebalance only relocates completed segments onto tiers and leaves the base (non-tier)
+  /// placements of the partitions untouched, so a segment added to the IdealState mid-rebalance is still placed
+  /// consistently with the target. Returns false when the tier segments are not pre-computed (the map is null/empty),
+  /// conservatively treating the moves as base placement changes.
+  private static boolean isMovingOnlyTierSegments(List<String> segmentsToMove,
+      @Nullable Map<String, Set<String>> providedTierToSegmentsMap) {
+    if (segmentsToMove.isEmpty()) {
+      return true;
+    }
+    if (MapUtils.isEmpty(providedTierToSegmentsMap)) {
+      return false;
+    }
+    Set<String> tierSegments;
+    if (providedTierToSegmentsMap.size() == 1) {
+      tierSegments = providedTierToSegmentsMap.values().iterator().next();
+    } else {
+      tierSegments = new HashSet<>();
+      providedTierToSegmentsMap.values().forEach(tierSegments::addAll);
+    }
+    return tierSegments.size() >= segmentsToMove.size() && tierSegments.containsAll(segmentsToMove);
   }
 
   @VisibleForTesting


### PR DESCRIPTION
## Summary

During a rebalance of a strict realtime table (upsert/dedup), `TableRebalancer`'s convergence loop reads the `IdealState` at version `V`, recomputes the target assignment, then issues a version-checked update expecting `V`. On a continuously-ingesting table, consuming-segment commits bump the `IdealState` version between the read and the write, so the update loses the compare-and-set and retries.

For strict realtime segment assignment, the recompute on a version change was **unconditionally** a full `rebalanceTable`, which reads segment ZK metadata for the completed segments (`TierSegmentAssignment`, `getExistingAssignment`). That made every retry expensive and widened the window in which the version can change, so a rebalance could make very little progress while ingestion continued — e.g. a tier-relocation rebalance triggered by `SegmentRelocator` can effectively livelock against consuming-segment commits, leaving aged segments on the hot tier.

## Change

A newly added segment (a new consuming segment, or an uploaded segment) is assigned by the instance partitions and then overridden to match the existing assignment of its partition, keeping the partition collocated. So when this rebalance **only moves tier segments** (completed segments assigned to a tier), the base (non-tier) placements of the partitions are untouched, and a segment added to the `IdealState` mid-rebalance is placed consistently with the target assignment. In that case the previously computed target can be reused via the existing cheap path (the same one non-strict assignment uses when no moving segment changed state), skipping the full recompute and narrowing the update window. When any non-tier segment is moved, the full recompute is kept to re-collocate added segments.

The check (`isMovingOnlyTierSegments`) uses `providedTierToSegmentsMap` — the authoritative set of tier segments used to compute the target assignment (`getSortedTiers` → `FixedTierSegmentSelector`) — to test whether every moved segment is a tier segment. It deliberately does **not** compare target instances against tier instances, since tier and non-tier segments are not guaranteed to be hosted on disjoint instances. When the tier segments are not pre-computed (the map is null/empty, i.e. `updateTargetTier` was not run), the full recompute is kept conservatively.

## Notes

- This is the first of two changes. A follow-up will add rebase-on-conflict to the versioned `IdealState` update, so a lost compare-and-set can retry against the newest version without another ExternalView wait; this PR only reduces the cost and likelihood of the conflict.
