### PR TITLE
Cache segment to tier map at rebalance start

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/BaseSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/BaseSegmentAssignment.java
@@ -71,6 +71,20 @@ public abstract class BaseSegmentAssignment implements SegmentAssignment {
   protected TableConfig _tableConfig;
   protected ControllerMetrics _controllerMetrics;
 
+  // Cache of segment name to the name of the tier it is eligible for (null value means not eligible for any tier), to
+  // avoid reading each segment's ZK metadata on every rebalanceTiers() invocation.
+  // NOTE:
+  // 1. This cache is used for table rebalance only. During rebalance, rebalanceTable() (and thus rebalanceTiers()) can
+  //    be invoked multiple times when the ideal state changes during the rebalance process. The eligible tier of a
+  //    segment is derived from its ZK metadata, which is not expected to change during a rebalance, so it is resolved
+  //    once (with a single bulk ZK read) and reused across invocations. A fresh SegmentAssignment instance is created
+  //    per rebalance (see SegmentAssignmentFactory), so the cache is scoped to a single rebalance.
+  // 2. Segments that are added after the initial bulk read (e.g. realtime segments that commit during a long
+  //    rebalance) will be absent from the cache; they are resolved on demand and merged in, so they are still routed
+  //    to the correct tier.
+  @Nullable
+  private Map<String, String> _segmentToTierName;
+
   @Override
   public void init(HelixManager helixManager, TableConfig tableConfig, @Nullable ControllerMetrics controllerMetrics) {
     _helixManager = helixManager;
@@ -102,10 +116,24 @@ public abstract class BaseSegmentAssignment implements SegmentAssignment {
     _logger.info("Rebalancing tiers: {} for table: {} with bootstrap: {}", tierInstancePartitionsMap.keySet(),
         _tableNameWithType, bootstrap);
 
+    // Resolve the eligible tier of each segment once (single bulk ZK read) and reuse it across the multiple
+    // rebalanceTiers() invocations of this rebalance, instead of reading each segment's ZK metadata every time.
+    if (_segmentToTierName == null) {
+      _segmentToTierName =
+          SegmentAssignmentUtils.getSegmentToTierNameMap(_helixManager, _tableNameWithType, sortedTiers);
+    }
+    // Resolve any segment that appeared after the initial bulk read (e.g. a segment that committed during a long
+    // rebalance) so that it is still routed to the correct tier.
+    for (String segmentName : currentAssignment.keySet()) {
+      if (!_segmentToTierName.containsKey(segmentName)) {
+        _segmentToTierName.put(segmentName,
+            SegmentAssignmentUtils.getSegmentToTierName(_helixManager, _tableNameWithType, sortedTiers, segmentName));
+      }
+    }
+
     // Get tier to segment assignment map i.e. current assignments split by tiers they are eligible for
     SegmentAssignmentUtils.TierSegmentAssignment tierSegmentAssignment =
-        new SegmentAssignmentUtils.TierSegmentAssignment(_helixManager, _tableNameWithType, sortedTiers,
-            currentAssignment);
+        new SegmentAssignmentUtils.TierSegmentAssignment(sortedTiers, currentAssignment, _segmentToTierName);
     Map<String, Map<String, Map<String, String>>> tierNameToSegmentAssignmentMap =
         tierSegmentAssignment.getTierNameToSegmentAssignmentMap();
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/BaseSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/BaseSegmentAssignment.java
@@ -118,17 +118,10 @@ public abstract class BaseSegmentAssignment implements SegmentAssignment {
 
     // Resolve the eligible tier of each segment once (single bulk ZK read) and reuse it across the multiple
     // rebalanceTiers() invocations of this rebalance, instead of reading each segment's ZK metadata every time.
+    // Any new segments come later would not be in _segmentToTierName map, and categorized in the null (default) tier.
     if (_segmentToTierName == null) {
       _segmentToTierName =
           SegmentAssignmentUtils.getSegmentToTierNameMap(_helixManager, _tableNameWithType, sortedTiers);
-    }
-    // Resolve any segment that appeared after the initial bulk read (e.g. a segment that committed during a long
-    // rebalance) so that it is still routed to the correct tier.
-    for (String segmentName : currentAssignment.keySet()) {
-      if (!_segmentToTierName.containsKey(segmentName)) {
-        _segmentToTierName.put(segmentName,
-            SegmentAssignmentUtils.getSegmentToTierName(_helixManager, _tableNameWithType, sortedTiers, segmentName));
-      }
     }
 
     // Get tier to segment assignment map i.e. current assignments split by tiers they are eligible for

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentUtils.java
@@ -454,12 +454,12 @@ public class SegmentAssignmentUtils {
 
   /**
    * Resolves, for each segment of the table, the name of the first tier (in {@code sortedTiers} order) that the segment
-   * is eligible for. The returned map contains an entry for <b>every</b> segment (so that callers can tell already
-   * resolved segments apart from segments added later via {@link Map#containsKey}); the value is the tier name, or
-   * {@code null} if the segment (including COMMITTING segments) is not eligible for any tier. This performs a single
-   * bulk ZK read for all segment ZK metadata, so it is meant to be computed once per rebalance and reused across the
-   * multiple {@code rebalanceTable()} invocations of that rebalance rather than reading each segment's ZK metadata
-   * every time.
+   * is eligible for. The value is the tier name, or {@code null} if the segment (including COMMITTING segments) is not
+   * eligible for any tier. This performs a single bulk ZK read for all segment ZK metadata, so it is meant to be
+   * computed once per rebalance and reused across the multiple {@code rebalanceTable()} invocations of that rebalance
+   * rather than reading each segment's ZK metadata every time. Segments that appear only after this map is computed
+   * (e.g. segments that commit during a long rebalance) are absent from the map and treated as not eligible for any
+   * tier.
    */
   static Map<String, String> getSegmentToTierNameMap(HelixManager helixManager, String tableNameWithType,
       List<Tier> sortedTiers) {
@@ -472,19 +472,6 @@ public class SegmentAssignmentUtils {
           segmentZKMetadata));
     }
     return segmentToTierName;
-  }
-
-  /**
-   * Resolves the name of the tier a single segment is eligible for. Used to resolve segments that were added after
-   * {@link #getSegmentToTierNameMap} was computed (e.g. realtime segments that commit during a long rebalance).
-   * Returns {@code null} if the segment does not exist, is COMMITTING, or is not eligible for any tier.
-   */
-  @Nullable
-  static String getSegmentToTierName(HelixManager helixManager, String tableNameWithType, List<Tier> sortedTiers,
-      String segmentName) {
-    SegmentZKMetadata segmentZKMetadata =
-        ZKMetadataProvider.getSegmentZKMetadata(helixManager.getHelixPropertyStore(), tableNameWithType, segmentName);
-    return segmentZKMetadata != null ? getTierName(tableNameWithType, sortedTiers, segmentZKMetadata) : null;
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentUtils.java
@@ -453,6 +453,61 @@ public class SegmentAssignmentUtils {
   }
 
   /**
+   * Resolves, for each segment of the table, the name of the first tier (in {@code sortedTiers} order) that the segment
+   * is eligible for. The returned map contains an entry for <b>every</b> segment (so that callers can tell already
+   * resolved segments apart from segments added later via {@link Map#containsKey}); the value is the tier name, or
+   * {@code null} if the segment (including COMMITTING segments) is not eligible for any tier. This performs a single
+   * bulk ZK read for all segment ZK metadata, so it is meant to be computed once per rebalance and reused across the
+   * multiple {@code rebalanceTable()} invocations of that rebalance rather than reading each segment's ZK metadata
+   * every time.
+   */
+  static Map<String, String> getSegmentToTierNameMap(HelixManager helixManager, String tableNameWithType,
+      List<Tier> sortedTiers) {
+    ZkHelixPropertyStore<ZNRecord> propertyStore = helixManager.getHelixPropertyStore();
+    List<SegmentZKMetadata> segmentsZKMetadata = ZKMetadataProvider.getSegmentsZKMetadata(propertyStore,
+        tableNameWithType);
+    Map<String, String> segmentToTierName = new HashMap<>();
+    for (SegmentZKMetadata segmentZKMetadata : segmentsZKMetadata) {
+      segmentToTierName.put(segmentZKMetadata.getSegmentName(), getTierName(tableNameWithType, sortedTiers,
+          segmentZKMetadata));
+    }
+    return segmentToTierName;
+  }
+
+  /**
+   * Resolves the name of the tier a single segment is eligible for. Used to resolve segments that were added after
+   * {@link #getSegmentToTierNameMap} was computed (e.g. realtime segments that commit during a long rebalance).
+   * Returns {@code null} if the segment does not exist, is COMMITTING, or is not eligible for any tier.
+   */
+  @Nullable
+  static String getSegmentToTierName(HelixManager helixManager, String tableNameWithType, List<Tier> sortedTiers,
+      String segmentName) {
+    SegmentZKMetadata segmentZKMetadata =
+        ZKMetadataProvider.getSegmentZKMetadata(helixManager.getHelixPropertyStore(), tableNameWithType, segmentName);
+    return segmentZKMetadata != null ? getTierName(tableNameWithType, sortedTiers, segmentZKMetadata) : null;
+  }
+
+  /**
+   * Returns the name of the first tier (in {@code sortedTiers} order) the given segment is eligible for, or
+   * {@code null} if the segment is COMMITTING or not eligible for any tier.
+   */
+  @Nullable
+  private static String getTierName(String tableNameWithType, List<Tier> sortedTiers,
+      SegmentZKMetadata segmentZKMetadata) {
+    // Skip COMMITTING segments
+    if (segmentZKMetadata.getStatus() == Status.COMMITTING) {
+      return null;
+    }
+    // Find an eligible tier for the segment, from the ordered list of tiers
+    for (Tier tier : sortedTiers) {
+      if (tier.getSegmentSelector().selectSegment(tableNameWithType, segmentZKMetadata)) {
+        return tier.getName();
+      }
+    }
+    return null;
+  }
+
+  /**
    * Takes a segment assignment and splits them up based on which tiers the segments are eligible for. Only considers
    * ONLINE segments.
    * Tiers are selected according to the order provided in the tiers list.
@@ -463,44 +518,32 @@ public class SegmentAssignmentUtils {
     private final Map<String, Map<String, String>> _nonTierSegmentAssignment = new TreeMap<>();
 
     /**
-     * Creates a TierSegmentAssignment from the given segmentAssignment
-     * @param tableNameWithType table to which the segment assignment belongs
+     * Creates a TierSegmentAssignment from the given segmentAssignment.
      * @param sortedTiers list of tiers, pre-sorted as per desired order by caller
      * @param segmentAssignment segment assignment of the table
+     * @param segmentToTierName map from segment name to the name of the tier it is eligible for (see
+     *                          {@link #getSegmentToTierNameMap}); segments absent from this map are not eligible for
+     *                          any tier
      */
-    TierSegmentAssignment(HelixManager helixManager, String tableNameWithType, List<Tier> sortedTiers,
-        Map<String, Map<String, String>> segmentAssignment) {
+    TierSegmentAssignment(List<Tier> sortedTiers, Map<String, Map<String, String>> segmentAssignment,
+        Map<String, String> segmentToTierName) {
 
       // initialize tier to segmentAssignment map
       sortedTiers.forEach(t -> _tierNameToSegmentAssignmentMap.put(t.getName(), new TreeMap<>()));
 
       // iterate over all segments
-      // TODO: Reduce ZK access
-      ZkHelixPropertyStore<ZNRecord> propertyStore = helixManager.getHelixPropertyStore();
       for (Map.Entry<String, Map<String, String>> entry : segmentAssignment.entrySet()) {
         String segmentName = entry.getKey();
         Map<String, String> instanceStateMap = entry.getValue();
-        boolean selected = false;
 
-        // only consider ONLINE segments for tiers
-        if (instanceStateMap.containsValue(SegmentStateModel.ONLINE)) {
-          // find an eligible tier for the segment, from the ordered list of tiers
-          SegmentZKMetadata segmentZKMetadata =
-              ZKMetadataProvider.getSegmentZKMetadata(propertyStore, tableNameWithType, segmentName);
-          // Skip COMMITTING segments
-          if (segmentZKMetadata != null && segmentZKMetadata.getStatus() != Status.COMMITTING) {
-            for (Tier tier : sortedTiers) {
-              if (tier.getSegmentSelector().selectSegment(tableNameWithType, segmentZKMetadata)) {
-                _tierNameToSegmentAssignmentMap.get(tier.getName()).put(segmentName, instanceStateMap);
-                selected = true;
-                break;
-              }
-            }
-          }
-        }
-
-        // if segment not eligible for any tier, put in ordinary segments map
-        if (!selected) {
+        // Only consider ONLINE segments for tiers. The eligible tier for each segment is resolved once via
+        // segmentToTierName, avoiding a per-segment ZK read on every rebalanceTable() invocation.
+        String tierName = instanceStateMap.containsValue(SegmentStateModel.ONLINE)
+            ? segmentToTierName.get(segmentName) : null;
+        if (tierName != null) {
+          _tierNameToSegmentAssignmentMap.get(tierName).put(segmentName, instanceStateMap);
+        } else {
+          // if segment not eligible for any tier, put in ordinary segments map
           _nonTierSegmentAssignment.put(segmentName, instanceStateMap);
         }
       }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineNonReplicaGroupTieredSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineNonReplicaGroupTieredSegmentAssignmentTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.controller.helix.core.assignment.segment;
 
 import com.google.common.collect.Lists;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -47,9 +48,12 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -116,6 +120,13 @@ public class OfflineNonReplicaGroupTieredSegmentAssignmentTest {
       String segmentName = path.substring(path.lastIndexOf('/') + 1);
       return new ZNRecord(segmentName);
     });
+    // Bulk read of all segment ZK metadata, used to resolve the eligible tier of each segment once per rebalance
+    List<ZNRecord> segmentZNRecords = new ArrayList<>(NUM_SEGMENTS);
+    for (String segmentName : SEGMENTS) {
+      segmentZNRecords.add(new ZNRecord(segmentName));
+    }
+    when(propertyStore.getChildren(anyString(), eq(null), eq(AccessOption.PERSISTENT), anyInt(), anyInt())).thenReturn(
+        segmentZNRecords);
     //noinspection unchecked
     when(helixManager.getHelixPropertyStore()).thenReturn(propertyStore);
 
@@ -267,6 +278,59 @@ public class OfflineNonReplicaGroupTieredSegmentAssignmentTest {
         }
       }
     }
+  }
+
+  /**
+   * A segment that is eligible for a tier can appear in the current assignment in a later rebalanceTable() invocation
+   * (e.g. after the ideal state changes during a long rebalance), i.e. after the initial bulk read that populates the
+   * tier cache. It must still be resolved (on demand, without a second bulk read) and routed to its tier rather than
+   * silently kept on the default instances.
+   */
+  @Test
+  public void testResolvesSegmentAddedAfterInitialBulkRead() {
+    HelixManager helixManager = mock(HelixManager.class);
+    //noinspection rawtypes
+    ZkHelixPropertyStore propertyStore = mock(ZkHelixPropertyStore.class);
+    when(propertyStore.get(anyString(), eq(null), eq(AccessOption.PERSISTENT))).thenAnswer(invocation -> {
+      String path = invocation.getArgument(0, String.class);
+      return new ZNRecord(path.substring(path.lastIndexOf('/') + 1));
+    });
+    // The initial bulk read only returns the segments that existed when the rebalance started (segment_0 .. 99)
+    List<ZNRecord> segmentZNRecords = new ArrayList<>(NUM_SEGMENTS);
+    for (String segmentName : SEGMENTS) {
+      segmentZNRecords.add(new ZNRecord(segmentName));
+    }
+    when(propertyStore.getChildren(anyString(), eq(null), eq(AccessOption.PERSISTENT), anyInt(), anyInt())).thenReturn(
+        segmentZNRecords);
+    //noinspection unchecked
+    when(helixManager.getHelixPropertyStore()).thenReturn(propertyStore);
+    SegmentAssignment segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(helixManager,
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setNumReplicas(NUM_REPLICAS).build(),
+        null);
+
+    Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
+    for (String segmentName : SEGMENTS) {
+      currentAssignment.put(segmentName,
+          SegmentAssignmentUtils.getInstanceStateMap(INSTANCES.subList(0, NUM_REPLICAS), SegmentStateModel.ONLINE));
+    }
+
+    // First rebalance populates the tier cache from the single bulk read
+    segmentAssignment.rebalanceTable(currentAssignment, _instancePartitionsMap, _sortedTiers,
+        _tierInstancePartitionsMap, new RebalanceConfig());
+    verify(propertyStore, times(1)).getChildren(anyString(), eq(null), eq(AccessOption.PERSISTENT), anyInt(), anyInt());
+
+    // A new segment eligible for tierC (segId >= 120) appears in the assignment after the initial bulk read
+    String newSegment = SEGMENT_NAME_PREFIX + 200;
+    currentAssignment.put(newSegment,
+        SegmentAssignmentUtils.getInstanceStateMap(INSTANCES.subList(0, NUM_REPLICAS), SegmentStateModel.ONLINE));
+    Map<String, Map<String, String>> newAssignment =
+        segmentAssignment.rebalanceTable(currentAssignment, _instancePartitionsMap, _sortedTiers,
+            _tierInstancePartitionsMap, new RebalanceConfig());
+
+    // The new segment is resolved on demand (no second bulk read) and routed to tierC
+    verify(propertyStore, times(1)).getChildren(anyString(), eq(null), eq(AccessOption.PERSISTENT), anyInt(), anyInt());
+    Assert.assertEquals(newAssignment.get(newSegment).size(), NUM_REPLICAS);
+    Assert.assertTrue(INSTANCES_TIER_C.containsAll(newAssignment.get(newSegment).keySet()));
   }
 
   /**

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineNonReplicaGroupTieredSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineNonReplicaGroupTieredSegmentAssignmentTest.java
@@ -281,25 +281,22 @@ public class OfflineNonReplicaGroupTieredSegmentAssignmentTest {
   }
 
   /**
-   * A segment that is eligible for a tier can appear in the current assignment in a later rebalanceTable() invocation
-   * (e.g. after the ideal state changes during a long rebalance), i.e. after the initial bulk read that populates the
-   * tier cache. It must still be resolved (on demand, without a second bulk read) and routed to its tier rather than
-   * silently kept on the default instances.
+   * The segment to tier resolution is computed once (single bulk ZK read) at the start of the rebalance and reused
+   * across the multiple rebalanceTable() invocations of that rebalance. A segment that appears in the current
+   * assignment only in a later invocation (e.g. after the ideal state changes during a long rebalance) is absent from
+   * the resolution map, so it is kept on the default instances rather than triggering another ZK read.
    */
   @Test
-  public void testResolvesSegmentAddedAfterInitialBulkRead() {
+  public void testSegmentAddedAfterInitialBulkReadStaysOnDefaultTier() {
     HelixManager helixManager = mock(HelixManager.class);
     //noinspection rawtypes
     ZkHelixPropertyStore propertyStore = mock(ZkHelixPropertyStore.class);
-    when(propertyStore.get(anyString(), eq(null), eq(AccessOption.PERSISTENT))).thenAnswer(invocation -> {
-      String path = invocation.getArgument(0, String.class);
-      return new ZNRecord(path.substring(path.lastIndexOf('/') + 1));
-    });
     // The initial bulk read only returns the segments that existed when the rebalance started (segment_0 .. 99)
     List<ZNRecord> segmentZNRecords = new ArrayList<>(NUM_SEGMENTS);
     for (String segmentName : SEGMENTS) {
       segmentZNRecords.add(new ZNRecord(segmentName));
     }
+    //noinspection unchecked
     when(propertyStore.getChildren(anyString(), eq(null), eq(AccessOption.PERSISTENT), anyInt(), anyInt())).thenReturn(
         segmentZNRecords);
     //noinspection unchecked
@@ -314,12 +311,14 @@ public class OfflineNonReplicaGroupTieredSegmentAssignmentTest {
           SegmentAssignmentUtils.getInstanceStateMap(INSTANCES.subList(0, NUM_REPLICAS), SegmentStateModel.ONLINE));
     }
 
-    // First rebalance populates the tier cache from the single bulk read
+    // First rebalance resolves the segment to tier map from the single bulk read
     segmentAssignment.rebalanceTable(currentAssignment, _instancePartitionsMap, _sortedTiers,
         _tierInstancePartitionsMap, new RebalanceConfig());
+    //noinspection unchecked
     verify(propertyStore, times(1)).getChildren(anyString(), eq(null), eq(AccessOption.PERSISTENT), anyInt(), anyInt());
 
-    // A new segment eligible for tierC (segId >= 120) appears in the assignment after the initial bulk read
+    // A new segment that would be eligible for tierC (segId >= 120) appears in the assignment after the initial bulk
+    // read
     String newSegment = SEGMENT_NAME_PREFIX + 200;
     currentAssignment.put(newSegment,
         SegmentAssignmentUtils.getInstanceStateMap(INSTANCES.subList(0, NUM_REPLICAS), SegmentStateModel.ONLINE));
@@ -327,10 +326,11 @@ public class OfflineNonReplicaGroupTieredSegmentAssignmentTest {
         segmentAssignment.rebalanceTable(currentAssignment, _instancePartitionsMap, _sortedTiers,
             _tierInstancePartitionsMap, new RebalanceConfig());
 
-    // The new segment is resolved on demand (no second bulk read) and routed to tierC
+    // No second bulk read happens, and the new segment is kept on the default instances (not relocated to tierC)
+    //noinspection unchecked
     verify(propertyStore, times(1)).getChildren(anyString(), eq(null), eq(AccessOption.PERSISTENT), anyInt(), anyInt());
     Assert.assertEquals(newAssignment.get(newSegment).size(), NUM_REPLICAS);
-    Assert.assertTrue(INSTANCES_TIER_C.containsAll(newAssignment.get(newSegment).keySet()));
+    Assert.assertTrue(INSTANCES.containsAll(newAssignment.get(newSegment).keySet()));
   }
 
   /**

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeNonReplicaGroupTieredSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeNonReplicaGroupTieredSegmentAssignmentTest.java
@@ -47,6 +47,7 @@ import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -126,6 +127,13 @@ public class RealtimeNonReplicaGroupTieredSegmentAssignmentTest {
       String segmentName = path.substring(path.lastIndexOf('/') + 1);
       return new ZNRecord(segmentName);
     });
+    // Bulk read of all segment ZK metadata, used to resolve the eligible tier of each segment once per rebalance
+    List<ZNRecord> segmentZNRecords = new ArrayList<>(NUM_SEGMENTS);
+    for (String segmentName : _segments) {
+      segmentZNRecords.add(new ZNRecord(segmentName));
+    }
+    when(propertyStore.getChildren(anyString(), eq(null), eq(AccessOption.PERSISTENT), anyInt(), anyInt())).thenReturn(
+        segmentZNRecords);
     //noinspection unchecked
     when(helixManager.getHelixPropertyStore()).thenReturn(propertyStore);
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/StrictRealtimeSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/StrictRealtimeSegmentAssignmentTest.java
@@ -54,6 +54,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -78,7 +79,7 @@ public class StrictRealtimeSegmentAssignmentTest {
   private static final String CONSUMING_INSTANCE_PARTITIONS_NAME =
       InstancePartitionsType.CONSUMING.getInstancePartitionsName(RAW_TABLE_NAME);
 
-  private List<String> _segments;
+  private static List<String> _segments;
   private Map<InstancePartitionsType, InstancePartitions> _instancePartitionsMap;
   private InstancePartitions _newConsumingInstancePartitions;
 
@@ -493,6 +494,17 @@ public class StrictRealtimeSegmentAssignmentTest {
       }
       return record;
     });
+    // Bulk read of all segment ZK metadata, used to resolve the eligible tier of each segment once per rebalance
+    List<ZNRecord> segmentZNRecords = new ArrayList<>(_segments.size());
+    for (String segmentName : _segments) {
+      ZNRecord record = new ZNRecord(segmentName);
+      if (tieredSegments.contains(segmentName)) {
+        record.setSimpleField(Segment.TIER, "coldTier");
+      }
+      segmentZNRecords.add(record);
+    }
+    when(propertyStore.getChildren(anyString(), eq(null), eq(AccessOption.PERSISTENT), anyInt(), anyInt())).thenReturn(
+        segmentZNRecords);
     when(helixManager.getHelixPropertyStore()).thenReturn(propertyStore);
     return helixManager;
   }


### PR DESCRIPTION
## Description
In the case where rebalance needs multiple iteration due to frequent ideal state update from other writer (e.g. realtime ingestion), if the table has any tier, a TierSegmentAssignment instance will be constructed every time in which ZK reads are requested on all segments (and it's not bulk read but individual reads).

We don't need to refresh segment to tier mapping every time. Instead, each rebalance job captures the segment to tier mapping when started, and re-use this to determine each segment's tier (if a segment changed its eligible tier mid-fly, we can rely on the next rebalance run to correct that, as we don't have strict contract on how quick tiers should reflect)

## Change 
* Add `Map<String, String> _segmentToTierName` in `BaseSegmentAssignment`
* Compute `_segmentToTierName` the first time `rebalanceTiers()` is called
* Use `_segmentToTierName` and `currentAssignment` to construct `TierSegmentAssignment`