### PR TITLE
Speed up exact DISTINCT aggregations on dictionary-encoded LONG columns

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/NonScanBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/NonScanBasedAggregationOperator.java
@@ -25,7 +25,6 @@ import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.doubles.DoubleOpenHashSet;
 import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
-import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -47,6 +46,7 @@ import org.apache.pinot.core.query.aggregation.function.DistinctCountSmartHLLAgg
 import org.apache.pinot.core.query.aggregation.function.DistinctCountSmartHLLPlusAggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.DistinctCountSmartULLAggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.DistinctCountULLAggregationFunction;
+import org.apache.pinot.core.query.aggregation.utils.SortedLongDistinctSet;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.local.customobject.MinMaxRangePair;
 import org.apache.pinot.segment.local.utils.UltraLogLogUtils;
@@ -254,12 +254,26 @@ public class NonScanBasedAggregationOperator extends BaseOperator<AggregationRes
         }
         return intSet;
       case LONG:
-        LongOpenHashSet longSet = new LongOpenHashSet(dictionarySize);
+        // A numeric dictionary is value-sorted and duplicate-free, so its values are already the sorted distinct set:
+        // read them straight into a sorted run instead of hashing each one. SortedLongDistinctSet then unions the
+        // per-segment runs during combine without hashing (the dominant cost for high-cardinality DISTINCT_COUNT).
+        // Only LONG is optimized here -- it is the common high-cardinality distinct case (IDs, timestamps); INT /
+        // FLOAT / DOUBLE keep the hash-set path. The same sorted-run approach generalizes to them if profiling shows
+        // it is worthwhile.
+        // Sortedness is verified per value during the copy (near-zero cost) rather than trusting
+        // Dictionary.isSorted(), because a mis-reporting dictionary implementation would silently corrupt DISTINCT
+        // results instead of failing loudly.
+        long[] longValues = new long[dictionarySize];
+        boolean longSorted = true;
         for (int dictId = 0; dictId < dictionarySize; dictId++) {
           QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, EXPLAIN_NAME);
-          longSet.add(dictionary.getLongValue(dictId));
+          long value = dictionary.getLongValue(dictId);
+          if (dictId > 0 && value <= longValues[dictId - 1]) {
+            longSorted = false;
+          }
+          longValues[dictId] = value;
         }
-        return longSet;
+        return SortedLongDistinctSet.fromValues(longValues, dictionarySize, longSorted);
       case FLOAT:
         FloatOpenHashSet floatSet = new FloatOpenHashSet(dictionarySize);
         for (int dictId = 0; dictId < dictionarySize; dictId++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/NonScanBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/NonScanBasedAggregationOperator.java
@@ -254,26 +254,20 @@ public class NonScanBasedAggregationOperator extends BaseOperator<AggregationRes
         }
         return intSet;
       case LONG:
-        // A numeric dictionary is value-sorted and duplicate-free, so its values are already the sorted distinct set:
-        // read them straight into a sorted run instead of hashing each one. SortedLongDistinctSet then unions the
-        // per-segment runs during combine without hashing (the dominant cost for high-cardinality DISTINCT_COUNT).
+        // A dictionary is duplicate-free, and an immutable dictionary is also value-sorted, so its values are already
+        // the sorted distinct set: read them straight into a sorted run instead of hashing each one.
+        // SortedLongDistinctSet then unions the per-segment runs during combine without hashing (the dominant cost
+        // for high-cardinality DISTINCT_COUNT). Mutable (realtime) dictionaries are insertion-ordered and report
+        // isSorted() = false, in which case the values are sorted first.
         // Only LONG is optimized here -- it is the common high-cardinality distinct case (IDs, timestamps); INT /
         // FLOAT / DOUBLE keep the hash-set path. The same sorted-run approach generalizes to them if profiling shows
         // it is worthwhile.
-        // Sortedness is verified per value during the copy (near-zero cost) rather than trusting
-        // Dictionary.isSorted(), because a mis-reporting dictionary implementation would silently corrupt DISTINCT
-        // results instead of failing loudly.
         long[] longValues = new long[dictionarySize];
-        boolean longSorted = true;
         for (int dictId = 0; dictId < dictionarySize; dictId++) {
           QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, EXPLAIN_NAME);
-          long value = dictionary.getLongValue(dictId);
-          if (dictId > 0 && value <= longValues[dictId - 1]) {
-            longSorted = false;
-          }
-          longValues[dictId] = value;
+          longValues[dictId] = dictionary.getLongValue(dictId);
         }
-        return SortedLongDistinctSet.fromValues(longValues, dictionarySize, longSorted);
+        return SortedLongDistinctSet.fromValues(longValues, dictionarySize, dictionary.isSorted());
       case FLOAT:
         FloatOpenHashSet floatSet = new FloatOpenHashSet(dictionarySize);
         for (int dictId = 0; dictId < dictionarySize; dictId++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/NonScanBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/NonScanBasedAggregationOperator.java
@@ -25,6 +25,7 @@ import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.doubles.DoubleOpenHashSet;
 import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -132,7 +133,8 @@ public class NonScanBasedAggregationOperator extends BaseOperator<AggregationRes
         case DISTINCTCOUNTMV:
         case DISTINCTSUMMV:
         case DISTINCTAVGMV:
-          result = getDistinctValueSet(Objects.requireNonNull(dataSource.getDictionary()));
+          result = getDistinctValueSet(Objects.requireNonNull(dataSource.getDictionary()),
+              _queryContext.getFilter() == null);
           break;
         case DISTINCTCOUNTOFFHEAP:
           result = ((DistinctCountOffHeapAggregationFunction) aggregationFunction).extractAggregationResult(
@@ -163,11 +165,13 @@ public class NonScanBasedAggregationOperator extends BaseOperator<AggregationRes
           result = (long) Objects.requireNonNull(dataSource.getDictionary()).length();
           break;
         case DISTINCTCOUNTSMARTHLL:
-          result = getDistinctCountSmartHLLResult(Objects.requireNonNull(dataSource.getDictionary()),
+          result = getDistinctCountSmartHLLResult(_queryContext.getFilter() == null,
+              Objects.requireNonNull(dataSource.getDictionary()),
               (DistinctCountSmartHLLAggregationFunction) aggregationFunction);
           break;
         case DISTINCTCOUNTSMARTHLLPLUS:
-          result = getDistinctCountSmartHLLPlusResult(Objects.requireNonNull(dataSource.getDictionary()),
+          result = getDistinctCountSmartHLLPlusResult(_queryContext.getFilter() == null,
+              Objects.requireNonNull(dataSource.getDictionary()),
               (DistinctCountSmartHLLPlusAggregationFunction) aggregationFunction);
           break;
         case DISTINCTCOUNTULL:
@@ -175,7 +179,8 @@ public class NonScanBasedAggregationOperator extends BaseOperator<AggregationRes
               (DistinctCountULLAggregationFunction) aggregationFunction);
           break;
         case DISTINCTCOUNTSMARTULL:
-          result = getDistinctCountSmartULLResult(Objects.requireNonNull(dataSource.getDictionary()),
+          result = getDistinctCountSmartULLResult(_queryContext.getFilter() == null,
+              Objects.requireNonNull(dataSource.getDictionary()),
               (DistinctCountSmartULLAggregationFunction) aggregationFunction);
           break;
         case DISTINCTCOUNTRAWULL:
@@ -243,7 +248,7 @@ public class NonScanBasedAggregationOperator extends BaseOperator<AggregationRes
     }
   }
 
-  private static Set getDistinctValueSet(Dictionary dictionary) {
+  private static Set getDistinctValueSet(Dictionary dictionary, boolean useSortedRuns) {
     int dictionarySize = dictionary.length();
     switch (dictionary.getValueType()) {
       case INT:
@@ -259,15 +264,27 @@ public class NonScanBasedAggregationOperator extends BaseOperator<AggregationRes
         // SortedLongDistinctSet then unions the per-segment runs during combine without hashing (the dominant cost
         // for high-cardinality DISTINCT_COUNT). Mutable (realtime) dictionaries are insertion-ordered and report
         // isSorted() = false, in which case the values are sorted first.
+        // Sorted runs are used only for filterless queries: then every segment takes the no-scan path and produces
+        // the same representation. With a filter, segments where the filter matches only some documents take the
+        // scan path and produce hash sets, and merging mixed representations is never faster than the plain hash
+        // merge -- so filtered queries keep the hash-set path everywhere and behave exactly as before.
         // Only LONG is optimized here -- it is the common high-cardinality distinct case (IDs, timestamps); INT /
         // FLOAT / DOUBLE keep the hash-set path. The same sorted-run approach generalizes to them if profiling shows
         // it is worthwhile.
-        long[] longValues = new long[dictionarySize];
+        if (useSortedRuns) {
+          long[] longValues = new long[dictionarySize];
+          for (int dictId = 0; dictId < dictionarySize; dictId++) {
+            QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, EXPLAIN_NAME);
+            longValues[dictId] = dictionary.getLongValue(dictId);
+          }
+          return SortedLongDistinctSet.fromValues(longValues, dictionarySize, dictionary.isSorted());
+        }
+        LongOpenHashSet longSet = new LongOpenHashSet(dictionarySize);
         for (int dictId = 0; dictId < dictionarySize; dictId++) {
           QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, EXPLAIN_NAME);
-          longValues[dictId] = dictionary.getLongValue(dictId);
+          longSet.add(dictionary.getLongValue(dictId));
         }
-        return SortedLongDistinctSet.fromValues(longValues, dictionarySize, dictionary.isSorted());
+        return longSet;
       case FLOAT:
         FloatOpenHashSet floatSet = new FloatOpenHashSet(dictionarySize);
         for (int dictId = 0; dictId < dictionarySize; dictId++) {
@@ -381,23 +398,23 @@ public class NonScanBasedAggregationOperator extends BaseOperator<AggregationRes
     }
   }
 
-  private static Object getDistinctCountSmartHLLResult(Dictionary dictionary,
+  private static Object getDistinctCountSmartHLLResult(boolean useSortedRuns, Dictionary dictionary,
       DistinctCountSmartHLLAggregationFunction function) {
     if (dictionary.length() > function.getThreshold()) {
       // Store values into a HLL when the dictionary size exceeds the conversion threshold
       return getDistinctValueHLL(dictionary, function.getLog2m());
     } else {
-      return getDistinctValueSet(dictionary);
+      return getDistinctValueSet(dictionary, useSortedRuns);
     }
   }
 
-  private static Object getDistinctCountSmartHLLPlusResult(Dictionary dictionary,
+  private static Object getDistinctCountSmartHLLPlusResult(boolean useSortedRuns, Dictionary dictionary,
       DistinctCountSmartHLLPlusAggregationFunction function) {
     if (dictionary.length() > function.getThreshold()) {
       // Store values into a HLLPlus when the dictionary size exceeds the conversion threshold
       return getDistinctValueHLLPlus(dictionary, function.getP(), function.getSp());
     } else {
-      return getDistinctValueSet(dictionary);
+      return getDistinctValueSet(dictionary, useSortedRuns);
     }
   }
 
@@ -422,12 +439,12 @@ public class NonScanBasedAggregationOperator extends BaseOperator<AggregationRes
     }
   }
 
-  private static Object getDistinctCountSmartULLResult(Dictionary dictionary,
+  private static Object getDistinctCountSmartULLResult(boolean useSortedRuns, Dictionary dictionary,
       DistinctCountSmartULLAggregationFunction function) {
     if (dictionary.length() > function.getThreshold()) {
       return getDistinctValueULL(dictionary, function.getP());
     } else {
-      return getDistinctValueSet(dictionary);
+      return getDistinctValueSet(dictionary, useSortedRuns);
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctAggregateAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctAggregateAggregationFunction.java
@@ -38,6 +38,7 @@ import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.core.query.aggregation.utils.SortedLongDistinctSet;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
@@ -125,8 +126,9 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
 
     QueryThreadContext.checkTerminationAndSampleUsage(this::getResultColumnName);
 
-    intermediateResult1.addAll(intermediateResult2);
-    return intermediateResult1;
+    // Segments may mix the no-scan path (SortedLongDistinctSet) with the scan path (hash set); the union helper
+    // makes the sorted set the absorbing side regardless of block merge order.
+    return SortedLongDistinctSet.union(intermediateResult1, intermediateResult2);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctAggregateAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctAggregateAggregationFunction.java
@@ -126,8 +126,9 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
 
     QueryThreadContext.checkTerminationAndSampleUsage(this::getResultColumnName);
 
-    // Segments may mix the no-scan path (SortedLongDistinctSet) with the scan path (hash set); the union helper
-    // makes the sorted set the absorbing side regardless of block merge order.
+    // Segments may mix the no-scan path (SortedLongDistinctSet) with the scan path (hash set); on a mixed merge the
+    // union helper degrades to hash-set semantics (plain O(n) inserts, no sorting) so the worst case matches the
+    // pre-optimization behavior regardless of block merge order.
     return SortedLongDistinctSet.union(intermediateResult1, intermediateResult2);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartHLLAggregationFunction.java
@@ -33,6 +33,7 @@ import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.utils.SortedLongDistinctSet;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
@@ -311,7 +312,9 @@ public class DistinctCountSmartHLLAggregationFunction extends BaseDistinctCountS
     if (valueSet2.isEmpty()) {
       return valueSet1;
     }
-    valueSet1.addAll(valueSet2);
+    // Segments may mix the no-scan path (SortedLongDistinctSet) with the scan path (hash set); the union
+    // helper makes the sorted set the absorbing side regardless of block merge order.
+    valueSet1 = SortedLongDistinctSet.union(valueSet1, valueSet2);
 
     // Convert to HLL if the set size exceeds the threshold
     if (valueSet1.size() > _threshold) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartHLLPlusAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartHLLPlusAggregationFunction.java
@@ -32,6 +32,7 @@ import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.utils.SortedLongDistinctSet;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
@@ -265,7 +266,9 @@ public class DistinctCountSmartHLLPlusAggregationFunction extends BaseDistinctCo
     if (valueSet2.isEmpty()) {
       return valueSet1;
     }
-    valueSet1.addAll(valueSet2);
+    // Segments may mix the no-scan path (SortedLongDistinctSet) with the scan path (hash set); the union
+    // helper makes the sorted set the absorbing side regardless of block merge order.
+    valueSet1 = SortedLongDistinctSet.union(valueSet1, valueSet2);
 
     // Convert to HLLPlus if the set size exceeds the threshold
     if (valueSet1.size() > _threshold) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartULLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartULLAggregationFunction.java
@@ -31,6 +31,7 @@ import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.utils.SortedLongDistinctSet;
 import org.apache.pinot.segment.local.utils.UltraLogLogUtils;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
@@ -282,7 +283,9 @@ public class DistinctCountSmartULLAggregationFunction extends BaseDistinctCountS
     if (valueSet2.isEmpty()) {
       return valueSet1;
     }
-    valueSet1.addAll(valueSet2);
+    // Segments may mix the no-scan path (SortedLongDistinctSet) with the scan path (hash set); the union
+    // helper makes the sorted set the absorbing side regardless of block merge order.
+    valueSet1 = SortedLongDistinctSet.union(valueSet1, valueSet2);
 
     if (valueSet1.size() > _threshold) {
       if (valueSet1 instanceof ObjectSet && valueSet1.iterator().next() instanceof ByteArray) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/SortedLongDistinctSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/SortedLongDistinctSet.java
@@ -21,47 +21,42 @@ package org.apache.pinot.core.query.aggregation.utils;
 import it.unimi.dsi.fastutil.longs.AbstractLongSet;
 import it.unimi.dsi.fastutil.longs.LongCollection;
 import it.unimi.dsi.fastutil.longs.LongIterator;
-import it.unimi.dsi.fastutil.longs.LongSet;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.pinot.spi.query.QueryThreadContext;
 
 
-/**
- * A {@link LongSet} for exact DISTINCT aggregation over LONG columns that stores distinct values as sorted runs and
- * unions them lazily.
- *
- * <p>Distinct LONG values read from a value-sorted dictionary (the whole dictionary, as the unfiltered no-scan
- * aggregation path does; a filtered path iterating matched dictionary ids in ascending order could adopt the same
- * approach) are already sorted and duplicate-free, so they are kept as a {@code long[]} run without hashing. Merging
- * two of these sets during the (serial) combine phase appends the other set's runs instead of inserting every element
- * into a hash table; the accumulated runs are unioned into one sorted, duplicate-free array on demand, the first time
- * {@link #size()}, {@link #iterator()} or {@link #contains(long)} is called (i.e. when the result is serialized or
- * its distinct count / sum / average is extracted). The union runs on the calling query thread as a multi-pass merge
- * between two pre-sized buffers -- a single up-front allocation instead of one per pairwise merge, no shared
- * ForkJoin/common-pool usage -- and checks query termination between passes. To bound retained memory when many
- * segments carry overlapping values, pending runs are eagerly compacted (deduplicated) once their total length
- * crosses an internal threshold, so pending memory does not grow unboundedly with segment count.
- *
- * <p>This replaces per-element hashing (which dominated the wall-clock cost of high-cardinality DISTINCT_COUNT
- * queries) with sorted merging. Serialization as a {@code LongSet} and DISTINCT_SUM / DISTINCT_AVG value iteration
- * work unchanged. Inputs that are not already sorted-and-distinct (e.g. a {@code LongOpenHashSet} arriving via a
- * mixed merge) are sorted and de-duplicated before being added. One documented contract deviation:
- * {@link #addAll(LongCollection)} returns {@code true} for any non-empty operand, even if every element was already
- * present -- computing the exact "changed" answer would force the union eagerly. No caller on the aggregation path
- * reads the return value.
- *
- * <p>Not thread-safe, and more strongly so than a typical mutable collection: the read accessors {@link #size()},
- * {@link #contains(long)} and {@link #iterator()} are <em>not</em> pure reads -- the first such call triggers
- * {@code materialize()}, which reassigns internal state to union the pending runs. Instances are therefore built per
- * segment and both mutated and first-read only by the single-threaded combine phase; a finished result must be safely
- * published before any other thread reads it, and the first read must not race a mutation.
- *
- * <p>Element removal is unsupported: {@code remove}/{@code rem} and the iterator's {@code remove()} are not
- * implemented, so the inherited {@code removeAll}/{@code retainAll} throw {@link UnsupportedOperationException}. The
- * DISTINCT aggregation path never removes elements (it only builds, merges, counts, sums, iterates and serializes).
- */
+/// A `LongSet` for exact DISTINCT aggregation over LONG columns that stores distinct values as sorted runs and unions
+/// them lazily.
+///
+/// Distinct LONG values read from a dictionary are duplicate-free, and value-sorted for immutable segments, so they
+/// are kept as a `long[]` run without hashing (mutable/realtime dictionaries are insertion-ordered and get sorted
+/// first). Merging two of these sets during the (serial) combine phase appends the other set's runs instead of
+/// inserting every element into a hash table; the accumulated runs are unioned into one sorted, duplicate-free array
+/// on demand, the first time [#size()], [#iterator()] or [#contains(long)] is called (i.e. when the result is
+/// serialized or its distinct count / sum / average is extracted). The union runs on the calling query thread as a
+/// multi-pass merge between two pre-sized buffers -- a single up-front allocation instead of one per pairwise merge,
+/// no shared ForkJoin/common-pool usage -- and checks query termination between passes. To bound retained memory when
+/// many segments carry overlapping values, pending runs are eagerly compacted (deduplicated) once their total length
+/// crosses an internal threshold, so pending memory does not grow unboundedly with segment count.
+///
+/// This replaces per-element hashing (which dominated the wall-clock cost of high-cardinality DISTINCT_COUNT queries)
+/// with sorted merging. Serialization as a `LongSet` and DISTINCT_SUM / DISTINCT_AVG value iteration work unchanged.
+/// Inputs that are not already sorted-and-distinct (e.g. a `LongOpenHashSet` arriving via a mixed merge) are sorted
+/// and de-duplicated before being added. One documented contract deviation: [#addAll(LongCollection)] returns `true`
+/// for any non-empty operand, even if every element was already present -- computing the exact "changed" answer would
+/// force the union eagerly. No caller on the aggregation path reads the return value.
+///
+/// Not thread-safe, and more strongly so than a typical mutable collection: the read accessors [#size()],
+/// [#contains(long)] and [#iterator()] are *not* pure reads -- the first such call triggers `materialize()`, which
+/// reassigns internal state to union the pending runs. Instances are therefore built per segment and both mutated and
+/// first-read only by the single-threaded combine phase; a finished result must be safely published before any other
+/// thread reads it, and the first read must not race a mutation.
+///
+/// Element removal is unsupported: `remove`/`rem` and the iterator's `remove()` are not implemented, so the inherited
+/// `removeAll`/`retainAll` throw [UnsupportedOperationException]. The DISTINCT aggregation path never removes
+/// elements (it only builds, merges, counts, sums, iterates and serializes).
 public final class SortedLongDistinctSet extends AbstractLongSet {
   private static final long[] EMPTY = new long[0];
   private static final String SCOPE = "SortedLongDistinctSet";
@@ -89,11 +84,9 @@ public final class SortedLongDistinctSet extends AbstractLongSet {
   private long[] _values;
   private int _size;
 
-  /**
-   * Wraps a single run that is already sorted ascending and duplicate-free. Private so the checked {@link #fromValues}
-   * factory is the only entry point: an unsorted or duplicate-bearing array here would silently corrupt results
-   * ({@link #size()} over-counts, {@link #contains(long)} misreports) rather than fail loudly.
-   */
+  /// Wraps a single run that is already sorted ascending and duplicate-free. Private so the checked [#fromValues]
+  /// factory is the only entry point: an unsorted or duplicate-bearing array here would silently corrupt results
+  /// ([#size()] over-counts, [#contains(long)] misreports) rather than fail loudly.
   private SortedLongDistinctSet(long[] sortedDistinct) {
     _runs = new ArrayList<>(4);
     if (sortedDistinct.length > 0) {
@@ -102,22 +95,19 @@ public final class SortedLongDistinctSet extends AbstractLongSet {
     }
   }
 
-  /**
-   * Creates a set from the prefix {@code [0, size)} of {@code values}. When {@code sortedDistinct} is false the prefix
-   * is sorted and de-duplicated first (which reorders the caller's {@code values} array in place) so the sorted-run
-   * invariant always holds; when true the caller guarantees the prefix is already sorted ascending and duplicate-free.
-   * The set takes ownership of {@code values} (it is retained without copying when {@code size == values.length}), so
-   * the caller must not modify the array after this call.
-   */
-  public static SortedLongDistinctSet fromValues(long[] values, int size, boolean sortedDistinct) {
-    if (!sortedDistinct) {
+  /// Creates a set from the prefix `[0, size)` of `values`, which must be duplicate-free (dictionary values are, by
+  /// construction). When `sorted` is false (mutable/realtime dictionaries are insertion-ordered) the prefix is sorted
+  /// first; when true the caller guarantees it is already sorted ascending. The set takes ownership of `values` (it
+  /// is retained without copying when `size == values.length`), so the caller must not modify the array after this
+  /// call.
+  public static SortedLongDistinctSet fromValues(long[] values, int size, boolean sorted) {
+    if (!sorted) {
       Arrays.sort(values, 0, size);
-      size = dedupeSorted(values, size);
     }
     return new SortedLongDistinctSet(size == values.length ? values : Arrays.copyOf(values, size));
   }
 
-  /** Removes consecutive duplicates from the sorted prefix {@code [0, size)}; returns the distinct count. */
+  /// Removes consecutive duplicates from the sorted prefix `[0, size)`; returns the distinct count.
   private static int dedupeSorted(long[] values, int size) {
     if (size <= 1) {
       return size;
@@ -131,10 +121,8 @@ public final class SortedLongDistinctSet extends AbstractLongSet {
     return w;
   }
 
-  /**
-   * Appends a sorted, duplicate-free, exact-length run to the pending list, guarding the representable-size cap and
-   * eagerly compacting when pending memory crosses {@link #COMPACT_THRESHOLD}.
-   */
+  /// Appends a sorted, duplicate-free, exact-length run to the pending list, guarding the representable-size cap and
+  /// eagerly compacting when pending memory crosses [#COMPACT_THRESHOLD].
   private void appendRun(long[] run) {
     if (run.length == 0) {
       return;
@@ -155,12 +143,10 @@ public final class SortedLongDistinctSet extends AbstractLongSet {
     }
   }
 
-  /**
-   * Unions sorted, duplicate-free runs into one sorted, duplicate-free sequence via a multi-pass adjacent-pair merge
-   * between two pre-sized buffers on the calling thread: exactly two array allocations regardless of run count, no
-   * per-merge garbage, and a query-termination check between passes. Returns the buffer holding the result; the
-   * logical size is written to {@code sizeOut[0]} and may be smaller than the buffer where duplicates collapsed.
-   */
+  /// Unions sorted, duplicate-free runs into one sorted, duplicate-free sequence via a multi-pass adjacent-pair merge
+  /// between two pre-sized buffers on the calling thread: exactly two array allocations regardless of run count, no
+  /// per-merge garbage, and a query-termination check between passes. Returns the buffer holding the result; the
+  /// logical size is written to `sizeOut[0]` and may be smaller than the buffer where duplicates collapsed.
   private static long[] mergeRuns(List<long[]> runs, int[] sizeOut) {
     int numRuns = runs.size();
     if (numRuns == 1) {
@@ -211,17 +197,15 @@ public final class SortedLongDistinctSet extends AbstractLongSet {
     return src;
   }
 
-  /** Like {@link #mergeRuns} but always returns an exact-length array, preserving the run-length invariant. */
+  /// Like [#mergeRuns] but always returns an exact-length array, preserving the run-length invariant.
   private static long[] mergeRunsExact(List<long[]> runs) {
     int[] sizeOut = new int[1];
     long[] merged = mergeRuns(runs, sizeOut);
     return sizeOut[0] == merged.length ? merged : Arrays.copyOf(merged, sizeOut[0]);
   }
 
-  /**
-   * Two-pointer union with dedupe of the adjacent sorted, duplicate-free chunks {@code [aFrom, aTo)} and
-   * {@code [aTo, bTo)} of {@code src} into {@code dst} starting at {@code w}; returns the new write position.
-   */
+  /// Two-pointer union with dedupe of the adjacent sorted, duplicate-free chunks `[aFrom, aTo)` and `[aTo, bTo)` of
+  /// `src` into `dst` starting at `w`; returns the new write position.
   private static int unionInto(long[] src, int aFrom, int aTo, int bTo, long[] dst, int w) {
     int i = aFrom;
     int j = aTo;
@@ -249,7 +233,7 @@ public final class SortedLongDistinctSet extends AbstractLongSet {
     return w;
   }
 
-  /** Unions all pending runs into the materialized array, trimming when the dedupe waste is material (>= 25%). */
+  /// Unions all pending runs into the materialized array, trimming when the dedupe waste is material (>= 25%).
   private void materialize() {
     if (_runs == null) {
       return;
@@ -268,7 +252,7 @@ public final class SortedLongDistinctSet extends AbstractLongSet {
     _size = size;
   }
 
-  /** Converts a materialized set back into a single-run pending state so more runs can be appended cheaply. */
+  /// Converts a materialized set back into a single-run pending state so more runs can be appended cheaply.
   private void demoteToRuns() {
     List<long[]> runs = new ArrayList<>(4);
     if (_size > 0) {
@@ -315,10 +299,8 @@ public final class SortedLongDistinctSet extends AbstractLongSet {
     };
   }
 
-  /**
-   * Merges another collection of longs into this set by appending its runs. Contract deviation (documented in the
-   * class Javadoc): returns {@code true} for any non-empty operand even if no new element was added.
-   */
+  /// Merges another collection of longs into this set by appending its runs. Contract deviation (documented in the
+  /// class doc): returns `true` for any non-empty operand even if no new element was added.
   @Override
   public boolean addAll(LongCollection c) {
     if (c.isEmpty()) {
@@ -346,12 +328,10 @@ public final class SortedLongDistinctSet extends AbstractLongSet {
     return true;
   }
 
-  /**
-   * Inserts a single value, keeping the sorted invariant. This is an O(n) operation (materialize + binary search +
-   * array copy) provided only to honor the {@link LongSet} contract; it is not used on the aggregation path (which
-   * builds via {@link #fromValues} and merges via {@link #addAll}). Do not call it in a loop -- repeated single
-   * inserts are O(n^2). Use {@link #addAll} to combine sets.
-   */
+  /// Inserts a single value, keeping the sorted invariant. This is an O(n) operation (materialize + binary search +
+  /// array copy) provided only to honor the `LongSet` contract; it is not used on the aggregation path (which builds
+  /// via [#fromValues] and merges via [#addAll]). Do not call it in a loop -- repeated single inserts are O(n^2). Use
+  /// [#addAll] to combine sets.
   @Override
   public boolean add(long k) {
     materialize();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/SortedLongDistinctSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/SortedLongDistinctSet.java
@@ -1,0 +1,373 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.utils;
+
+import it.unimi.dsi.fastutil.longs.AbstractLongSet;
+import it.unimi.dsi.fastutil.longs.LongCollection;
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.fastutil.longs.LongSet;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.pinot.spi.query.QueryThreadContext;
+
+
+/**
+ * A {@link LongSet} for exact DISTINCT aggregation over LONG columns that stores distinct values as sorted runs and
+ * unions them lazily.
+ *
+ * <p>Distinct LONG values read from a value-sorted dictionary (the whole dictionary, as the unfiltered no-scan
+ * aggregation path does; a filtered path iterating matched dictionary ids in ascending order could adopt the same
+ * approach) are already sorted and duplicate-free, so they are kept as a {@code long[]} run without hashing. Merging
+ * two of these sets during the (serial) combine phase appends the other set's runs instead of inserting every element
+ * into a hash table; the accumulated runs are unioned into one sorted, duplicate-free array on demand, the first time
+ * {@link #size()}, {@link #iterator()} or {@link #contains(long)} is called (i.e. when the result is serialized or
+ * its distinct count / sum / average is extracted). The union runs on the calling query thread as a multi-pass merge
+ * between two pre-sized buffers -- a single up-front allocation instead of one per pairwise merge, no shared
+ * ForkJoin/common-pool usage -- and checks query termination between passes. To bound retained memory when many
+ * segments carry overlapping values, pending runs are eagerly compacted (deduplicated) once their total length
+ * crosses an internal threshold, so pending memory does not grow unboundedly with segment count.
+ *
+ * <p>This replaces per-element hashing (which dominated the wall-clock cost of high-cardinality DISTINCT_COUNT
+ * queries) with sorted merging. Serialization as a {@code LongSet} and DISTINCT_SUM / DISTINCT_AVG value iteration
+ * work unchanged. Inputs that are not already sorted-and-distinct (e.g. a {@code LongOpenHashSet} arriving via a
+ * mixed merge) are sorted and de-duplicated before being added. One documented contract deviation:
+ * {@link #addAll(LongCollection)} returns {@code true} for any non-empty operand, even if every element was already
+ * present -- computing the exact "changed" answer would force the union eagerly. No caller on the aggregation path
+ * reads the return value.
+ *
+ * <p>Not thread-safe, and more strongly so than a typical mutable collection: the read accessors {@link #size()},
+ * {@link #contains(long)} and {@link #iterator()} are <em>not</em> pure reads -- the first such call triggers
+ * {@code materialize()}, which reassigns internal state to union the pending runs. Instances are therefore built per
+ * segment and both mutated and first-read only by the single-threaded combine phase; a finished result must be safely
+ * published before any other thread reads it, and the first read must not race a mutation.
+ *
+ * <p>Element removal is unsupported: {@code remove}/{@code rem} and the iterator's {@code remove()} are not
+ * implemented, so the inherited {@code removeAll}/{@code retainAll} throw {@link UnsupportedOperationException}. The
+ * DISTINCT aggregation path never removes elements (it only builds, merges, counts, sums, iterates and serializes).
+ */
+public final class SortedLongDistinctSet extends AbstractLongSet {
+  private static final long[] EMPTY = new long[0];
+  private static final String SCOPE = "SortedLongDistinctSet";
+
+  // Hard cap on the total pending values: beyond this the exact distinct result cannot be represented in one array.
+  private static final long MAX_PENDING_TOTAL = Integer.MAX_VALUE - 8;
+
+  // When the pending runs' total length crosses this, they are eagerly compacted into one deduplicated run inside
+  // addAll(). This bounds peak retained memory to roughly the threshold plus the incoming run, instead of the sum of
+  // all per-segment distinct counts -- which, when many segments carry overlapping values, can far exceed the global
+  // distinct count. Large enough that it never triggers for typical segment counts and cardinalities.
+  private static final long COMPACT_THRESHOLD = 8L << 20;
+
+  // Pending sorted, duplicate-free, exact-length runs awaiting union. Non-null exactly when not yet materialized.
+  private List<long[]> _runs;
+  private long _pendingTotal;
+  // Next pending total that triggers eager compaction. Doubles with the compacted size (geometric backoff) so that
+  // when the true distinct count exceeds COMPACT_THRESHOLD, appends do not each trigger a full re-merge (which would
+  // be quadratic in segment count); amortized compaction work stays O(n log n) and retained memory stays proportional
+  // to the actual distinct count rather than the number of segments.
+  private long _compactMin = COMPACT_THRESHOLD;
+
+  // Materialized sorted, duplicate-free values in [0, _size). Non-null exactly when materialized. The array may be
+  // longer than _size when the dedupe waste was immaterial (< 25%); every consumer bounds accesses by _size.
+  private long[] _values;
+  private int _size;
+
+  /**
+   * Wraps a single run that is already sorted ascending and duplicate-free. Private so the checked {@link #fromValues}
+   * factory is the only entry point: an unsorted or duplicate-bearing array here would silently corrupt results
+   * ({@link #size()} over-counts, {@link #contains(long)} misreports) rather than fail loudly.
+   */
+  private SortedLongDistinctSet(long[] sortedDistinct) {
+    _runs = new ArrayList<>(4);
+    if (sortedDistinct.length > 0) {
+      _runs.add(sortedDistinct);
+      _pendingTotal = sortedDistinct.length;
+    }
+  }
+
+  /**
+   * Creates a set from the prefix {@code [0, size)} of {@code values}. When {@code sortedDistinct} is false the prefix
+   * is sorted and de-duplicated first (which reorders the caller's {@code values} array in place) so the sorted-run
+   * invariant always holds; when true the caller guarantees the prefix is already sorted ascending and duplicate-free.
+   * The set takes ownership of {@code values} (it is retained without copying when {@code size == values.length}), so
+   * the caller must not modify the array after this call.
+   */
+  public static SortedLongDistinctSet fromValues(long[] values, int size, boolean sortedDistinct) {
+    if (!sortedDistinct) {
+      Arrays.sort(values, 0, size);
+      size = dedupeSorted(values, size);
+    }
+    return new SortedLongDistinctSet(size == values.length ? values : Arrays.copyOf(values, size));
+  }
+
+  /** Removes consecutive duplicates from the sorted prefix {@code [0, size)}; returns the distinct count. */
+  private static int dedupeSorted(long[] values, int size) {
+    if (size <= 1) {
+      return size;
+    }
+    int w = 1;
+    for (int r = 1; r < size; r++) {
+      if (values[r] != values[w - 1]) {
+        values[w++] = values[r];
+      }
+    }
+    return w;
+  }
+
+  /**
+   * Appends a sorted, duplicate-free, exact-length run to the pending list, guarding the representable-size cap and
+   * eagerly compacting when pending memory crosses {@link #COMPACT_THRESHOLD}.
+   */
+  private void appendRun(long[] run) {
+    if (run.length == 0) {
+      return;
+    }
+    if (_pendingTotal + run.length > MAX_PENDING_TOTAL) {
+      throw new IllegalStateException(
+          "Too many pending values for exact DISTINCT aggregation: " + (_pendingTotal + run.length)
+              + ", consider an approximate function such as DISTINCT_COUNT_HLL");
+    }
+    _runs.add(run);
+    _pendingTotal += run.length;
+    if (_pendingTotal >= _compactMin && _runs.size() > 1) {
+      long[] compacted = mergeRunsExact(_runs);
+      _runs.clear();
+      _runs.add(compacted);
+      _pendingTotal = compacted.length;
+      _compactMin = Math.max(COMPACT_THRESHOLD, 2L * _pendingTotal);
+    }
+  }
+
+  /**
+   * Unions sorted, duplicate-free runs into one sorted, duplicate-free sequence via a multi-pass adjacent-pair merge
+   * between two pre-sized buffers on the calling thread: exactly two array allocations regardless of run count, no
+   * per-merge garbage, and a query-termination check between passes. Returns the buffer holding the result; the
+   * logical size is written to {@code sizeOut[0]} and may be smaller than the buffer where duplicates collapsed.
+   */
+  private static long[] mergeRuns(List<long[]> runs, int[] sizeOut) {
+    int numRuns = runs.size();
+    if (numRuns == 1) {
+      long[] only = runs.get(0);
+      sizeOut[0] = only.length;
+      return only;
+    }
+    long totalLong = 0;
+    for (long[] run : runs) {
+      totalLong += run.length;
+    }
+    int total = (int) totalLong; // guarded by MAX_PENDING_TOTAL in appendRun
+    long[] src = new long[total];
+    long[] dst = new long[total];
+    int[] bounds = new int[numRuns + 1];
+    int[] nextBounds = new int[numRuns + 1];
+    int p = 0;
+    int b = 0;
+    for (long[] run : runs) {
+      System.arraycopy(run, 0, src, p, run.length);
+      p += run.length;
+      bounds[++b] = p;
+    }
+    while (numRuns > 1) {
+      QueryThreadContext.checkTerminationAndSampleUsage(SCOPE);
+      int w = 0;
+      int nb = 0;
+      for (int i = 0; i + 1 < numRuns; i += 2) {
+        w = unionInto(src, bounds[i], bounds[i + 1], bounds[i + 2], dst, w);
+        nextBounds[++nb] = w;
+      }
+      if ((numRuns & 1) == 1) {
+        int from = bounds[numRuns - 1];
+        int len = bounds[numRuns] - from;
+        System.arraycopy(src, from, dst, w, len);
+        w += len;
+        nextBounds[++nb] = w;
+      }
+      long[] tmp = src;
+      src = dst;
+      dst = tmp;
+      int[] tmpBounds = bounds;
+      bounds = nextBounds;
+      nextBounds = tmpBounds;
+      numRuns = nb;
+    }
+    sizeOut[0] = bounds[1];
+    return src;
+  }
+
+  /** Like {@link #mergeRuns} but always returns an exact-length array, preserving the run-length invariant. */
+  private static long[] mergeRunsExact(List<long[]> runs) {
+    int[] sizeOut = new int[1];
+    long[] merged = mergeRuns(runs, sizeOut);
+    return sizeOut[0] == merged.length ? merged : Arrays.copyOf(merged, sizeOut[0]);
+  }
+
+  /**
+   * Two-pointer union with dedupe of the adjacent sorted, duplicate-free chunks {@code [aFrom, aTo)} and
+   * {@code [aTo, bTo)} of {@code src} into {@code dst} starting at {@code w}; returns the new write position.
+   */
+  private static int unionInto(long[] src, int aFrom, int aTo, int bTo, long[] dst, int w) {
+    int i = aFrom;
+    int j = aTo;
+    while (i < aTo && j < bTo) {
+      long av = src[i];
+      long bv = src[j];
+      if (av < bv) {
+        dst[w++] = av;
+        i++;
+      } else if (av > bv) {
+        dst[w++] = bv;
+        j++;
+      } else {
+        dst[w++] = av;
+        i++;
+        j++;
+      }
+    }
+    while (i < aTo) {
+      dst[w++] = src[i++];
+    }
+    while (j < bTo) {
+      dst[w++] = src[j++];
+    }
+    return w;
+  }
+
+  /** Unions all pending runs into the materialized array, trimming when the dedupe waste is material (>= 25%). */
+  private void materialize() {
+    if (_runs == null) {
+      return;
+    }
+    List<long[]> runs = _runs;
+    _runs = null;
+    if (runs.isEmpty()) {
+      _values = EMPTY;
+      _size = 0;
+      return;
+    }
+    int[] sizeOut = new int[1];
+    long[] merged = mergeRuns(runs, sizeOut);
+    int size = sizeOut[0];
+    _values = size + (size >> 2) < merged.length ? Arrays.copyOf(merged, size) : merged;
+    _size = size;
+  }
+
+  /** Converts a materialized set back into a single-run pending state so more runs can be appended cheaply. */
+  private void demoteToRuns() {
+    List<long[]> runs = new ArrayList<>(4);
+    if (_size > 0) {
+      runs.add(_size == _values.length ? _values : Arrays.copyOf(_values, _size));
+    }
+    _runs = runs;
+    _pendingTotal = _size;
+    _values = null;
+    _size = 0;
+  }
+
+  @Override
+  public int size() {
+    materialize();
+    return _size;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return _runs != null ? _pendingTotal == 0 : _size == 0;
+  }
+
+  @Override
+  public boolean contains(long k) {
+    materialize();
+    return Arrays.binarySearch(_values, 0, _size, k) >= 0;
+  }
+
+  @Override
+  public LongIterator iterator() {
+    materialize();
+    return new LongIterator() {
+      private int _idx;
+
+      @Override
+      public boolean hasNext() {
+        return _idx < _size;
+      }
+
+      @Override
+      public long nextLong() {
+        return _values[_idx++];
+      }
+    };
+  }
+
+  /**
+   * Merges another collection of longs into this set by appending its runs. Contract deviation (documented in the
+   * class Javadoc): returns {@code true} for any non-empty operand even if no new element was added.
+   */
+  @Override
+  public boolean addAll(LongCollection c) {
+    if (c.isEmpty()) {
+      return false;
+    }
+    if (_runs == null) {
+      demoteToRuns();
+    }
+    if (c instanceof SortedLongDistinctSet) {
+      SortedLongDistinctSet other = (SortedLongDistinctSet) c;
+      if (other._runs != null) {
+        // Sharing run references is safe: runs are never mutated in place once appended.
+        for (long[] run : other._runs) {
+          appendRun(run);
+        }
+      } else {
+        appendRun(Arrays.copyOf(other._values, other._size));
+      }
+      return true;
+    }
+    long[] run = c.toLongArray();
+    Arrays.sort(run);
+    int n = dedupeSorted(run, run.length);
+    appendRun(n == run.length ? run : Arrays.copyOf(run, n));
+    return true;
+  }
+
+  /**
+   * Inserts a single value, keeping the sorted invariant. This is an O(n) operation (materialize + binary search +
+   * array copy) provided only to honor the {@link LongSet} contract; it is not used on the aggregation path (which
+   * builds via {@link #fromValues} and merges via {@link #addAll}). Do not call it in a loop -- repeated single
+   * inserts are O(n^2). Use {@link #addAll} to combine sets.
+   */
+  @Override
+  public boolean add(long k) {
+    materialize();
+    int pos = Arrays.binarySearch(_values, 0, _size, k);
+    if (pos >= 0) {
+      return false;
+    }
+    int insert = -(pos + 1);
+    // Build a fresh array rather than mutating in place: after a merge, _values may alias a run still referenced by
+    // another set, so an in-place shift could corrupt it.
+    long[] updated = new long[_size + 1];
+    System.arraycopy(_values, 0, updated, 0, insert);
+    updated[insert] = k;
+    System.arraycopy(_values, insert, updated, insert + 1, _size - insert);
+    _values = updated;
+    _size++;
+    return true;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/SortedLongDistinctSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/SortedLongDistinctSet.java
@@ -24,6 +24,7 @@ import it.unimi.dsi.fastutil.longs.LongIterator;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import org.apache.pinot.spi.query.QueryThreadContext;
 
 
@@ -105,6 +106,23 @@ public final class SortedLongDistinctSet extends AbstractLongSet {
       Arrays.sort(values, 0, size);
     }
     return new SortedLongDistinctSet(size == values.length ? values : Arrays.copyOf(values, size));
+  }
+
+  /// Unions two distinct-value sets when segments may mix the no-scan path (which produces this class) with the scan
+  /// path (which produces hash sets), e.g. a filter that matches all documents in only some segments: whichever side
+  /// the `SortedLongDistinctSet` arrives on, it absorbs the other operand. Merge order of segment blocks is
+  /// nondeterministic, and letting a hash set absorb a sorted set would re-hash every dictionary-sourced value,
+  /// silently losing the sorted-run optimization. For any other type combination this behaves exactly like
+  /// `set1.addAll(set2)`.
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public static Set union(Set set1, Set set2) {
+    if (set2 instanceof SortedLongDistinctSet && !(set1 instanceof SortedLongDistinctSet)
+        && set1 instanceof LongCollection) {
+      ((SortedLongDistinctSet) set2).addAll((LongCollection) set1);
+      return set2;
+    }
+    set1.addAll(set2);
+    return set1;
   }
 
   /// Removes consecutive duplicates from the sorted prefix `[0, size)`; returns the distinct count.

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/SortedLongDistinctSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/SortedLongDistinctSet.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.query.aggregation.utils;
 
 import it.unimi.dsi.fastutil.longs.AbstractLongSet;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongCollection;
 import it.unimi.dsi.fastutil.longs.LongIterator;
 import java.util.ArrayList;
@@ -147,19 +148,17 @@ public final class SortedLongDistinctSet extends AbstractLongSet {
   }
 
   /// Inserts every value of this set into `sink` without forcing the pending union: values are streamed run by run
-  /// (a value may repeat across runs; a set sink deduplicates on insert). This is the mixed-merge degrade path -- the
-  /// per-value cost is a plain hash insert, identical to the pre-optimization behavior.
+  /// (a value may repeat across runs; a set sink deduplicates on insert). Runs are passed as zero-copy
+  /// [LongArrayList#wrap] views so a hash-set sink can pre-size once per run instead of rehashing mid-stream --
+  /// matching how it grows when merging another hash set. This is the mixed-merge degrade path; the per-value cost
+  /// is a plain hash insert, identical to the pre-optimization behavior.
   public void drainTo(LongCollection sink) {
     if (_runs != null) {
       for (long[] run : _runs) {
-        for (long value : run) {
-          sink.add(value);
-        }
+        sink.addAll(LongArrayList.wrap(run));
       }
     } else {
-      for (int i = 0; i < _size; i++) {
-        sink.add(_values[i]);
-      }
+      sink.addAll(LongArrayList.wrap(_values, _size));
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/SortedLongDistinctSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/SortedLongDistinctSet.java
@@ -112,24 +112,38 @@ public final class SortedLongDistinctSet extends AbstractLongSet {
 
   /// Unions two distinct-value sets when segments may mix the no-scan path (which produces this class) with the scan
   /// path (which produces hash sets), e.g. a filter that matches all documents in only some segments. On a mixed
-  /// merge the sorted set is drained into the hash set with plain O(n) hash inserts ([#drainTo]) -- no sorting and no
-  /// forced union -- so a mixed query costs what it did before this optimization existed; the sorted-run optimization
-  /// applies only while every merged block is sorted (the unfiltered case it targets). Merge order of segment blocks
-  /// is nondeterministic, so both operand orders are handled. For any other type combination this behaves exactly
-  /// like `set1.addAll(set2)`.
+  /// merge the smaller side is absorbed into the larger side's representation: when the hash set is smaller than the
+  /// sorted set's value count it is sorted (`O(m log m)` with small `m`) and appended as a run, keeping the sorted
+  /// representation; otherwise the sorted values are drained into the hash set with plain O(n) inserts ([#drainTo]),
+  /// which is exactly the pre-optimization behavior -- in particular a pure scan query (no sorted blocks) is
+  /// unchanged, and a large accumulated hash set is never sorted. Merge order of segment blocks is nondeterministic,
+  /// so both operand orders are handled. For any other type combination this behaves exactly like `set1.addAll(set2)`.
   @SuppressWarnings({"rawtypes", "unchecked"})
   public static Set union(Set set1, Set set2) {
     if (set1 instanceof SortedLongDistinctSet) {
       if (!(set2 instanceof SortedLongDistinctSet) && set2 instanceof LongCollection) {
-        ((SortedLongDistinctSet) set1).drainTo((LongCollection) set2);
-        return set2;
+        return mixedUnion((SortedLongDistinctSet) set1, (LongCollection) set2);
       }
     } else if (set2 instanceof SortedLongDistinctSet && set1 instanceof LongCollection) {
-      ((SortedLongDistinctSet) set2).drainTo((LongCollection) set1);
-      return set1;
+      return mixedUnion((SortedLongDistinctSet) set2, (LongCollection) set1);
     }
     set1.addAll(set2);
     return set1;
+  }
+
+  /// Absorbs the cheaper operand into the other's representation; see [#union]. Sorting the hash side costs roughly
+  /// as much per element as hash-inserting the sorted side at these scales, so the sorted representation is kept only
+  /// when the hash side is at least 4x smaller -- a conservative margin that makes sorting the clear winner (e.g. one
+  /// small scan segment among many no-scan segments). Otherwise the sorted values are drained into the hash set,
+  /// which is exactly the pre-optimization cost, and the accumulator stays a hash set from then on.
+  private static Set mixedUnion(SortedLongDistinctSet sorted, LongCollection hash) {
+    long sortedCount = sorted._runs != null ? sorted._pendingTotal : sorted._size;
+    if (hash.size() * 4L < sortedCount) {
+      sorted.addAll(hash);
+      return sorted;
+    }
+    sorted.drainTo(hash);
+    return (Set) hash;
   }
 
   /// Inserts every value of this set into `sink` without forcing the pending union: values are streamed run by run

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/SortedLongDistinctSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/SortedLongDistinctSet.java
@@ -44,8 +44,10 @@ import org.apache.pinot.spi.query.QueryThreadContext;
 ///
 /// This replaces per-element hashing (which dominated the wall-clock cost of high-cardinality DISTINCT_COUNT queries)
 /// with sorted merging. Serialization as a `LongSet` and DISTINCT_SUM / DISTINCT_AVG value iteration work unchanged.
-/// Inputs that are not already sorted-and-distinct (e.g. a `LongOpenHashSet` arriving via a mixed merge) are sorted
-/// and de-duplicated before being added. One documented contract deviation: [#addAll(LongCollection)] returns `true`
+/// When scan-based (hash set) and no-scan (this class) segment results mix within one query, [#union] degrades the
+/// merge to plain hash inserts so the worst case matches the pre-optimization behavior; a non-sorted collection
+/// passed directly to [#addAll(LongCollection)] is sorted and de-duplicated before being added. One documented
+/// contract deviation: [#addAll(LongCollection)] returns `true`
 /// for any non-empty operand, even if every element was already present -- computing the exact "changed" answer would
 /// force the union eagerly. No caller on the aggregation path reads the return value.
 ///
@@ -109,20 +111,42 @@ public final class SortedLongDistinctSet extends AbstractLongSet {
   }
 
   /// Unions two distinct-value sets when segments may mix the no-scan path (which produces this class) with the scan
-  /// path (which produces hash sets), e.g. a filter that matches all documents in only some segments: whichever side
-  /// the `SortedLongDistinctSet` arrives on, it absorbs the other operand. Merge order of segment blocks is
-  /// nondeterministic, and letting a hash set absorb a sorted set would re-hash every dictionary-sourced value,
-  /// silently losing the sorted-run optimization. For any other type combination this behaves exactly like
-  /// `set1.addAll(set2)`.
+  /// path (which produces hash sets), e.g. a filter that matches all documents in only some segments. On a mixed
+  /// merge the sorted set is drained into the hash set with plain O(n) hash inserts ([#drainTo]) -- no sorting and no
+  /// forced union -- so a mixed query costs what it did before this optimization existed; the sorted-run optimization
+  /// applies only while every merged block is sorted (the unfiltered case it targets). Merge order of segment blocks
+  /// is nondeterministic, so both operand orders are handled. For any other type combination this behaves exactly
+  /// like `set1.addAll(set2)`.
   @SuppressWarnings({"rawtypes", "unchecked"})
   public static Set union(Set set1, Set set2) {
-    if (set2 instanceof SortedLongDistinctSet && !(set1 instanceof SortedLongDistinctSet)
-        && set1 instanceof LongCollection) {
-      ((SortedLongDistinctSet) set2).addAll((LongCollection) set1);
-      return set2;
+    if (set1 instanceof SortedLongDistinctSet) {
+      if (!(set2 instanceof SortedLongDistinctSet) && set2 instanceof LongCollection) {
+        ((SortedLongDistinctSet) set1).drainTo((LongCollection) set2);
+        return set2;
+      }
+    } else if (set2 instanceof SortedLongDistinctSet && set1 instanceof LongCollection) {
+      ((SortedLongDistinctSet) set2).drainTo((LongCollection) set1);
+      return set1;
     }
     set1.addAll(set2);
     return set1;
+  }
+
+  /// Inserts every value of this set into `sink` without forcing the pending union: values are streamed run by run
+  /// (a value may repeat across runs; a set sink deduplicates on insert). This is the mixed-merge degrade path -- the
+  /// per-value cost is a plain hash insert, identical to the pre-optimization behavior.
+  public void drainTo(LongCollection sink) {
+    if (_runs != null) {
+      for (long[] run : _runs) {
+        for (long value : run) {
+          sink.add(value);
+        }
+      }
+    } else {
+      for (int i = 0; i < _size; i++) {
+        sink.add(_values[i]);
+      }
+    }
   }
 
   /// Removes consecutive duplicates from the sorted prefix `[0, size)`; returns the distinct count.

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/query/NonScanBasedAggregationOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/query/NonScanBasedAggregationOperatorTest.java
@@ -30,12 +30,10 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
 
-/**
- * Unit tests for the dictionary-based distinct value extraction in {@link NonScanBasedAggregationOperator},
- * specifically the LONG sortedness-detection loop: immutable dictionaries are value-sorted (fast path), while mutable
- * (realtime consuming segment) dictionaries are insertion-ordered and may contain any order — the detection must
- * classify them correctly, or DISTINCT results would silently over-count.
- */
+/// Unit tests for the dictionary-based distinct value extraction in [NonScanBasedAggregationOperator] for LONG
+/// columns: immutable dictionaries are value-sorted (`isSorted()` = true, wrapped as-is), while mutable (realtime
+/// consuming segment) dictionaries are insertion-ordered (`isSorted()` = false) and must be sorted first — otherwise
+/// DISTINCT results would be silently wrong.
 public class NonScanBasedAggregationOperatorTest {
 
   private static Set invokeGetDistinctValueSet(Dictionary dictionary)
@@ -45,10 +43,11 @@ public class NonScanBasedAggregationOperatorTest {
     return (Set) method.invoke(null, dictionary);
   }
 
-  private static Dictionary mockLongDictionary(long... values) {
+  private static Dictionary mockLongDictionary(boolean sorted, long... values) {
     Dictionary dictionary = mock(Dictionary.class);
     when(dictionary.getValueType()).thenReturn(DataType.LONG);
     when(dictionary.length()).thenReturn(values.length);
+    when(dictionary.isSorted()).thenReturn(sorted);
     for (int i = 0; i < values.length; i++) {
       when(dictionary.getLongValue(i)).thenReturn(values[i]);
     }
@@ -59,7 +58,7 @@ public class NonScanBasedAggregationOperatorTest {
   public void testLongDistinctValuesFromSortedDictionary()
       throws Exception {
     // Immutable dictionary: value-sorted, duplicate-free
-    Set set = invokeGetDistinctValueSet(mockLongDictionary(-5L, 0L, 3L, 42L, 1_000_000L));
+    Set set = invokeGetDistinctValueSet(mockLongDictionary(true, -5L, 0L, 3L, 42L, 1_000_000L));
     assertEquals(set.size(), 5);
     assertEquals(new LongOpenHashSet(set), new LongOpenHashSet(new long[]{-5L, 0L, 3L, 42L, 1_000_000L}));
   }
@@ -67,18 +66,19 @@ public class NonScanBasedAggregationOperatorTest {
   @Test
   public void testLongDistinctValuesFromUnsortedDictionary()
       throws Exception {
-    // Mutable (realtime) dictionary: insertion-ordered, arbitrary order — the detection loop must fall back to
-    // sort + dedupe rather than trusting sortedness
-    Set set = invokeGetDistinctValueSet(mockLongDictionary(42L, -5L, 1_000_000L, 0L, 3L, 42L));
+    // Mutable (realtime) dictionary: insertion-ordered (isSorted() = false), so the values must be sorted before
+    // being wrapped as a sorted run
+    Set set = invokeGetDistinctValueSet(mockLongDictionary(false, 42L, -5L, 1_000_000L, 0L, 3L));
     assertEquals(set.size(), 5);
     assertEquals(new LongOpenHashSet(set), new LongOpenHashSet(new long[]{-5L, 0L, 3L, 42L, 1_000_000L}));
   }
 
   @Test
-  public void testLongDistinctValuesWithAdjacentDuplicates()
+  public void testLongDistinctValuesFromAscendingDictionaryReportedUnsorted()
       throws Exception {
-    // Ascending but with equal neighbors: must be classified as not sorted-distinct and deduped
-    Set set = invokeGetDistinctValueSet(mockLongDictionary(1L, 1L, 2L, 3L, 3L));
+    // A mutable dictionary whose insertions happened to arrive ascending still reports isSorted() = false; the
+    // redundant sort must not change the result
+    Set set = invokeGetDistinctValueSet(mockLongDictionary(false, 1L, 2L, 3L));
     assertEquals(set.size(), 3);
     assertEquals(new LongOpenHashSet(set), new LongOpenHashSet(new long[]{1L, 2L, 3L}));
   }
@@ -86,7 +86,7 @@ public class NonScanBasedAggregationOperatorTest {
   @Test
   public void testLongDistinctValuesEmptyAndSingle()
       throws Exception {
-    assertEquals(invokeGetDistinctValueSet(mockLongDictionary()).size(), 0);
-    assertEquals(invokeGetDistinctValueSet(mockLongDictionary(7L)).size(), 1);
+    assertEquals(invokeGetDistinctValueSet(mockLongDictionary(true)).size(), 0);
+    assertEquals(invokeGetDistinctValueSet(mockLongDictionary(false, 7L)).size(), 1);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/query/NonScanBasedAggregationOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/query/NonScanBasedAggregationOperatorTest.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.query;
+
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import java.lang.reflect.Method;
+import java.util.Set;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+
+/**
+ * Unit tests for the dictionary-based distinct value extraction in {@link NonScanBasedAggregationOperator},
+ * specifically the LONG sortedness-detection loop: immutable dictionaries are value-sorted (fast path), while mutable
+ * (realtime consuming segment) dictionaries are insertion-ordered and may contain any order — the detection must
+ * classify them correctly, or DISTINCT results would silently over-count.
+ */
+public class NonScanBasedAggregationOperatorTest {
+
+  private static Set invokeGetDistinctValueSet(Dictionary dictionary)
+      throws Exception {
+    Method method = NonScanBasedAggregationOperator.class.getDeclaredMethod("getDistinctValueSet", Dictionary.class);
+    method.setAccessible(true);
+    return (Set) method.invoke(null, dictionary);
+  }
+
+  private static Dictionary mockLongDictionary(long... values) {
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.LONG);
+    when(dictionary.length()).thenReturn(values.length);
+    for (int i = 0; i < values.length; i++) {
+      when(dictionary.getLongValue(i)).thenReturn(values[i]);
+    }
+    return dictionary;
+  }
+
+  @Test
+  public void testLongDistinctValuesFromSortedDictionary()
+      throws Exception {
+    // Immutable dictionary: value-sorted, duplicate-free
+    Set set = invokeGetDistinctValueSet(mockLongDictionary(-5L, 0L, 3L, 42L, 1_000_000L));
+    assertEquals(set.size(), 5);
+    assertEquals(new LongOpenHashSet(set), new LongOpenHashSet(new long[]{-5L, 0L, 3L, 42L, 1_000_000L}));
+  }
+
+  @Test
+  public void testLongDistinctValuesFromUnsortedDictionary()
+      throws Exception {
+    // Mutable (realtime) dictionary: insertion-ordered, arbitrary order — the detection loop must fall back to
+    // sort + dedupe rather than trusting sortedness
+    Set set = invokeGetDistinctValueSet(mockLongDictionary(42L, -5L, 1_000_000L, 0L, 3L, 42L));
+    assertEquals(set.size(), 5);
+    assertEquals(new LongOpenHashSet(set), new LongOpenHashSet(new long[]{-5L, 0L, 3L, 42L, 1_000_000L}));
+  }
+
+  @Test
+  public void testLongDistinctValuesWithAdjacentDuplicates()
+      throws Exception {
+    // Ascending but with equal neighbors: must be classified as not sorted-distinct and deduped
+    Set set = invokeGetDistinctValueSet(mockLongDictionary(1L, 1L, 2L, 3L, 3L));
+    assertEquals(set.size(), 3);
+    assertEquals(new LongOpenHashSet(set), new LongOpenHashSet(new long[]{1L, 2L, 3L}));
+  }
+
+  @Test
+  public void testLongDistinctValuesEmptyAndSingle()
+      throws Exception {
+    assertEquals(invokeGetDistinctValueSet(mockLongDictionary()).size(), 0);
+    assertEquals(invokeGetDistinctValueSet(mockLongDictionary(7L)).size(), 1);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/query/NonScanBasedAggregationOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/query/NonScanBasedAggregationOperatorTest.java
@@ -28,6 +28,7 @@ import org.testng.annotations.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 
 /// Unit tests for the dictionary-based distinct value extraction in [NonScanBasedAggregationOperator] for LONG
@@ -38,9 +39,15 @@ public class NonScanBasedAggregationOperatorTest {
 
   private static Set invokeGetDistinctValueSet(Dictionary dictionary)
       throws Exception {
-    Method method = NonScanBasedAggregationOperator.class.getDeclaredMethod("getDistinctValueSet", Dictionary.class);
+    return invokeGetDistinctValueSet(dictionary, true);
+  }
+
+  private static Set invokeGetDistinctValueSet(Dictionary dictionary, boolean useSortedRuns)
+      throws Exception {
+    Method method =
+        NonScanBasedAggregationOperator.class.getDeclaredMethod("getDistinctValueSet", Dictionary.class, boolean.class);
     method.setAccessible(true);
-    return (Set) method.invoke(null, dictionary);
+    return (Set) method.invoke(null, dictionary, useSortedRuns);
   }
 
   private static Dictionary mockLongDictionary(boolean sorted, long... values) {
@@ -88,5 +95,15 @@ public class NonScanBasedAggregationOperatorTest {
       throws Exception {
     assertEquals(invokeGetDistinctValueSet(mockLongDictionary(true)).size(), 0);
     assertEquals(invokeGetDistinctValueSet(mockLongDictionary(false, 7L)).size(), 1);
+  }
+
+  @Test
+  public void testLongDistinctValuesFilteredQueryKeepsHashSet()
+      throws Exception {
+    // With a filter in the query, some segments may take the scan path (hash sets); to avoid mixed-representation
+    // merges the no-scan path must also produce a hash set, keeping filtered queries identical to the old behavior
+    Set set = invokeGetDistinctValueSet(mockLongDictionary(true, -5L, 0L, 3L), false);
+    assertTrue(set instanceof LongOpenHashSet);
+    assertEquals(set.size(), 3);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/utils/SortedLongDistinctSetTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/utils/SortedLongDistinctSetTest.java
@@ -20,13 +20,18 @@ package org.apache.pinot.core.query.aggregation.utils;
 
 import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.TreeSet;
+import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
+import org.apache.pinot.core.query.aggregation.function.DistinctCountAggregationFunction;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
@@ -259,6 +264,52 @@ public class SortedLongDistinctSetTest {
     assertFalse(acc.contains(6_000_001L)); // not a multiple of 3, above the even/odd range
     assertTrue(acc.contains(8_999_997L));
     assertFalse(acc.contains(8_999_998L));
+  }
+
+  @Test
+  public void testUnionNormalizesMixedTypes() {
+    // Whichever side the sorted set arrives on, it must absorb the hash set — a hash set absorbing a sorted set
+    // would re-hash every value and lose the sorted-run optimization (block merge order is nondeterministic when
+    // scan-based and no-scan segments mix within one query).
+    LongOpenHashSet expected = new LongOpenHashSet(new long[]{1L, 2L, 3L, 4L, 5L});
+
+    Set merged = SortedLongDistinctSet.union(new LongOpenHashSet(new long[]{2L, 4L}),
+        sortedSet(sortedDistinct(1L, 3L, 5L)));
+    assertTrue(merged instanceof SortedLongDistinctSet);
+    assertEquals(new LongOpenHashSet(merged), expected);
+
+    merged = SortedLongDistinctSet.union(sortedSet(sortedDistinct(1L, 3L, 5L)),
+        new LongOpenHashSet(new long[]{2L, 4L}));
+    assertTrue(merged instanceof SortedLongDistinctSet);
+    assertEquals(new LongOpenHashSet(merged), expected);
+
+    // Same-type unions keep the plain addAll behavior
+    merged = SortedLongDistinctSet.union(new LongOpenHashSet(new long[]{1L, 2L, 3L}),
+        new LongOpenHashSet(new long[]{4L, 5L}));
+    assertTrue(merged instanceof LongOpenHashSet);
+    assertEquals(merged, expected);
+
+    SortedLongDistinctSet first = sortedSet(sortedDistinct(1L, 2L, 3L));
+    merged = SortedLongDistinctSet.union(first, sortedSet(sortedDistinct(4L, 5L)));
+    assertSame(merged, first);
+    assertEquals(new LongOpenHashSet(merged), expected);
+  }
+
+  @Test
+  public void testAggregationFunctionMergeNormalizesMixedTypes() {
+    // End-to-end through DistinctCountAggregationFunction.merge, the path the combine phase actually uses
+    DistinctCountAggregationFunction function =
+        new DistinctCountAggregationFunction(List.of(ExpressionContext.forIdentifier("col")), false);
+    LongOpenHashSet expected = new LongOpenHashSet(new long[]{1L, 2L, 3L, 4L, 5L});
+
+    Set merged = function.merge(new LongOpenHashSet(new long[]{2L, 4L}), sortedSet(sortedDistinct(1L, 3L, 5L)));
+    assertTrue(merged instanceof SortedLongDistinctSet);
+    assertEquals(new LongOpenHashSet(merged), expected);
+    assertEquals((int) function.extractFinalResult(merged), 5);
+
+    merged = function.merge(sortedSet(sortedDistinct(1L, 3L, 5L)), new LongOpenHashSet(new long[]{2L, 4L}));
+    assertTrue(merged instanceof SortedLongDistinctSet);
+    assertEquals((int) function.extractFinalResult(merged), 5);
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/utils/SortedLongDistinctSetTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/utils/SortedLongDistinctSetTest.java
@@ -1,0 +1,286 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.utils;
+
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import java.util.Random;
+import java.util.TreeSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Unit tests for {@link SortedLongDistinctSet}, the sorted-run backed {@code LongSet} used by the no-scan DISTINCT
+ * aggregation path. These verify that it upholds the {@code LongSet} contract and, critically, that its lazy sorted
+ * union produces exactly the same distinct set as a {@link LongOpenHashSet} across the code paths the combine phase
+ * exercises: single run, multi-run merges, merges with a non-sorted collection, unsorted input, duplicates spanning
+ * runs, empty inputs, and post-materialization mutation.
+ */
+public class SortedLongDistinctSetTest {
+
+  /** Builds a set from an already sorted, duplicate-free run (the constructor is private; use the checked factory). */
+  private static SortedLongDistinctSet sortedSet(long[] sortedDistinct) {
+    return SortedLongDistinctSet.fromValues(sortedDistinct, sortedDistinct.length, true);
+  }
+
+  private static long[] sortedDistinct(long... values) {
+    // Input is authored already sorted and distinct; assert that so tests stay honest.
+    for (int i = 1; i < values.length; i++) {
+      assertTrue(values[i] > values[i - 1], "test input must be sorted and distinct");
+    }
+    return values;
+  }
+
+  private static void assertSameAsHashSet(SortedLongDistinctSet actual, LongOpenHashSet expected) {
+    assertEquals(actual.size(), expected.size());
+    assertEquals(actual.isEmpty(), expected.isEmpty());
+    // Values match (order-independent).
+    LongOpenHashSet actualValues = new LongOpenHashSet(actual);
+    assertEquals(actualValues, expected);
+    // Iteration yields exactly `size` ascending, distinct values.
+    long prev = Long.MIN_VALUE;
+    int count = 0;
+    for (long v : actual) {
+      assertTrue(count == 0 || v > prev, "iteration must be strictly ascending");
+      assertTrue(expected.contains(v));
+      assertTrue(actual.contains(v));
+      prev = v;
+      count++;
+    }
+    assertEquals(count, expected.size());
+    // Serialization round-trips to the same distinct set (this is how the server ships the intermediate result).
+    LongOpenHashSet roundTrip = (LongOpenHashSet) ObjectSerDeUtils.LONG_SET_SER_DE.deserialize(
+        ObjectSerDeUtils.LONG_SET_SER_DE.serialize(actual));
+    assertEquals(roundTrip, expected);
+  }
+
+  @Test
+  public void testEmpty() {
+    SortedLongDistinctSet set = sortedSet(new long[0]);
+    assertTrue(set.isEmpty());
+    assertEquals(set.size(), 0);
+    assertFalse(set.contains(1L));
+    assertFalse(set.iterator().hasNext());
+  }
+
+  @Test
+  public void testSingleRun() {
+    SortedLongDistinctSet set = sortedSet(sortedDistinct(-5L, 0L, 3L, 9L));
+    assertSameAsHashSet(set, new LongOpenHashSet(new long[]{-5L, 0L, 3L, 9L}));
+    assertTrue(set.contains(3L));
+    assertFalse(set.contains(4L));
+  }
+
+  @Test
+  public void testFromValuesUnsortedWithDuplicates() {
+    // fromValues must sort and de-duplicate when told the input is not already sorted-distinct.
+    long[] raw = {7L, 3L, 7L, 1L, 3L, 9L, 1L};
+    SortedLongDistinctSet set = SortedLongDistinctSet.fromValues(raw, raw.length, false);
+    assertSameAsHashSet(set, new LongOpenHashSet(new long[]{1L, 3L, 7L, 9L}));
+  }
+
+  @Test
+  public void testFromValuesPrefix() {
+    long[] raw = {1L, 2L, 3L, 999L, 999L};
+    SortedLongDistinctSet set = SortedLongDistinctSet.fromValues(raw, 3, true);
+    assertSameAsHashSet(set, new LongOpenHashSet(new long[]{1L, 2L, 3L}));
+  }
+
+  @Test
+  public void testMergeDisjointRuns() {
+    SortedLongDistinctSet a = sortedSet(sortedDistinct(1L, 3L, 5L));
+    SortedLongDistinctSet b = sortedSet(sortedDistinct(2L, 4L, 6L));
+    assertTrue(a.addAll(b));
+    assertSameAsHashSet(a, new LongOpenHashSet(new long[]{1L, 2L, 3L, 4L, 5L, 6L}));
+  }
+
+  @Test
+  public void testMergeOverlappingRuns() {
+    SortedLongDistinctSet a = sortedSet(sortedDistinct(1L, 2L, 3L, 4L));
+    SortedLongDistinctSet b = sortedSet(sortedDistinct(3L, 4L, 5L, 6L));
+    a.addAll(b);
+    assertSameAsHashSet(a, new LongOpenHashSet(new long[]{1L, 2L, 3L, 4L, 5L, 6L}));
+  }
+
+  @Test
+  public void testMergeManyRunsLikeCombinePhase() {
+    // Mirrors the combine phase: one run per segment appended one at a time, unioned lazily at the end.
+    SortedLongDistinctSet acc = sortedSet(new long[0]);
+    LongOpenHashSet expected = new LongOpenHashSet();
+    Random random = new Random(42);
+    for (int segment = 0; segment < 11; segment++) {
+      TreeSet<Long> run = new TreeSet<>();
+      for (int i = 0; i < 500; i++) {
+        long v = random.nextInt(2000);
+        run.add(v);
+        expected.add(v);
+      }
+      long[] runArray = new long[run.size()];
+      int idx = 0;
+      for (long v : run) {
+        runArray[idx++] = v;
+      }
+      acc.addAll(sortedSet(runArray));
+    }
+    assertSameAsHashSet(acc, expected);
+  }
+
+  @Test
+  public void testMergeWithNonSortedLongCollection() {
+    // A mixed merge where the other operand is a plain hash set (unordered) must still produce the correct union.
+    SortedLongDistinctSet a = sortedSet(sortedDistinct(1L, 5L, 9L));
+    LongOpenHashSet other = new LongOpenHashSet(new long[]{9L, 2L, 5L, 7L});
+    a.addAll(other);
+    assertSameAsHashSet(a, new LongOpenHashSet(new long[]{1L, 2L, 5L, 7L, 9L}));
+  }
+
+  @Test
+  public void testMergeEmptyOperands() {
+    SortedLongDistinctSet a = sortedSet(sortedDistinct(1L, 2L));
+    assertFalse(a.addAll(sortedSet(new long[0])));
+    assertFalse(a.addAll(new LongOpenHashSet()));
+    assertSameAsHashSet(a, new LongOpenHashSet(new long[]{1L, 2L}));
+
+    SortedLongDistinctSet empty = sortedSet(new long[0]);
+    empty.addAll(sortedSet(sortedDistinct(3L, 4L)));
+    assertSameAsHashSet(empty, new LongOpenHashSet(new long[]{3L, 4L}));
+  }
+
+  @Test
+  public void testAddSingleElements() {
+    SortedLongDistinctSet set = sortedSet(sortedDistinct(2L, 4L, 6L));
+    assertTrue(set.add(5L));
+    assertFalse(set.add(4L));
+    assertTrue(set.add(1L));
+    assertTrue(set.add(9L));
+    assertSameAsHashSet(set, new LongOpenHashSet(new long[]{1L, 2L, 4L, 5L, 6L, 9L}));
+  }
+
+  @Test
+  public void testLargeMultiPassMerge() {
+    // Many large overlapping runs exercise the multi-pass ping-pong merge (several passes, odd run counts, dedupe
+    // shrinking between passes); results must be identical to a hash set.
+    SortedLongDistinctSet acc = sortedSet(new long[0]);
+    LongOpenHashSet expected = new LongOpenHashSet();
+    Random random = new Random(7);
+    for (int segment = 0; segment < 4; segment++) {
+      int n = 300_000;
+      long[] run = new long[n];
+      long v = random.nextLong() % 1_000_000_000L;
+      for (int i = 0; i < n; i++) {
+        v += 1 + random.nextInt(5); // strictly ascending, overlapping ranges across segments
+        run[i] = v;
+        expected.add(v);
+      }
+      acc.addAll(SortedLongDistinctSet.fromValues(run, n, true));
+    }
+    assertTrue(expected.size() > 1 << 20, "test must be large enough for a multi-pass merge");
+    assertSameAsHashSet(acc, expected);
+  }
+
+  @Test
+  public void testMergeFromMaterializedArgumentWithDedupeSlack() {
+    // Materializing overlapping runs with immaterial dedupe waste (< 25%) leaves _values longer than _size (trailing
+    // garbage beyond the logical size). Using such a set as the addAll argument, and as the receiver (demote path),
+    // must copy exactly [0, _size) -- copying the full array would silently inflate DISTINCT counts.
+    long[] runA = new long[100];
+    long[] runB = new long[100];
+    LongOpenHashSet expected = new LongOpenHashSet();
+    for (int i = 0; i < 100; i++) {
+      runA[i] = i + 1; // 1..100
+      runB[i] = i + 95; // 95..194, overlap of 6 values
+      expected.add(runA[i]);
+      expected.add(runB[i]);
+    }
+    SortedLongDistinctSet slacked = sortedSet(runA);
+    slacked.addAll(sortedSet(runB));
+    assertEquals(slacked.size(), 194); // materializes: buffer 200, size 194 -> slack retained (waste < 25%)
+
+    // As the argument of a merge into a fresh set
+    SortedLongDistinctSet fresh = sortedSet(sortedDistinct(1000L, 2000L));
+    fresh.addAll(slacked);
+    LongOpenHashSet expectedFresh = new LongOpenHashSet(expected);
+    expectedFresh.add(1000L);
+    expectedFresh.add(2000L);
+    assertSameAsHashSet(fresh, expectedFresh);
+
+    // As the receiver (demoteToRuns must also honor _size, not _values.length)
+    slacked.addAll(sortedSet(sortedDistinct(3000L, 4000L)));
+    LongOpenHashSet expectedReceiver = new LongOpenHashSet(expected);
+    expectedReceiver.add(3000L);
+    expectedReceiver.add(4000L);
+    assertSameAsHashSet(slacked, expectedReceiver);
+  }
+
+  @Test
+  public void testEagerCompactionOfPendingRuns() {
+    // Three 3M-value runs cross the internal compaction threshold (8M pending), forcing eager dedupe inside addAll.
+    // Union size is arithmetically known: evens < 6M (3M) + odds < 6M (3M) = all ints < 6M, plus multiples of 3 in
+    // [6M, 9M) (1M) = 7M distinct.
+    int n = 3_000_000;
+    long[] evens = new long[n];
+    long[] mult3 = new long[n];
+    long[] odds = new long[n];
+    for (int i = 0; i < n; i++) {
+      evens[i] = 2L * i;
+      mult3[i] = 3L * i;
+      odds[i] = 2L * i + 1;
+    }
+    SortedLongDistinctSet acc = sortedSet(evens);
+    acc.addAll(sortedSet(mult3));
+    acc.addAll(sortedSet(odds));
+    assertEquals(acc.size(), 7_000_000);
+    assertTrue(acc.contains(0L));
+    assertTrue(acc.contains(5_999_999L));
+    assertTrue(acc.contains(6_000_000L)); // multiple of 3 above the even/odd range
+    assertFalse(acc.contains(6_000_001L)); // not a multiple of 3, above the even/odd range
+    assertTrue(acc.contains(8_999_997L));
+    assertFalse(acc.contains(8_999_998L));
+  }
+
+  @Test
+  public void testRemovalUnsupported() {
+    SortedLongDistinctSet set = sortedSet(sortedDistinct(1L, 2L, 3L));
+    assertThrows(UnsupportedOperationException.class, () -> set.rem(2L));
+    assertThrows(UnsupportedOperationException.class, () -> {
+      LongIterator it = set.iterator();
+      it.nextLong();
+      it.remove();
+    });
+    assertThrows(UnsupportedOperationException.class, () -> set.removeAll(new LongOpenHashSet(new long[]{2L})));
+    assertThrows(UnsupportedOperationException.class, () -> set.retainAll(new LongOpenHashSet(new long[]{2L})));
+    // The set must be untouched by the failed removals
+    assertSameAsHashSet(set, new LongOpenHashSet(new long[]{1L, 2L, 3L}));
+  }
+
+  @Test
+  public void testMergeAfterMaterialization() {
+    // size() materializes; a subsequent addAll must demote back to runs and still union correctly.
+    SortedLongDistinctSet a = sortedSet(sortedDistinct(1L, 2L, 3L));
+    assertEquals(a.size(), 3);
+    a.addAll(sortedSet(sortedDistinct(3L, 4L, 5L)));
+    assertSameAsHashSet(a, new LongOpenHashSet(new long[]{1L, 2L, 3L, 4L, 5L}));
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/utils/SortedLongDistinctSetTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/utils/SortedLongDistinctSetTest.java
@@ -94,16 +94,17 @@ public class SortedLongDistinctSetTest {
   }
 
   @Test
-  public void testFromValuesUnsortedWithDuplicates() {
-    // fromValues must sort and de-duplicate when told the input is not already sorted-distinct.
-    long[] raw = {7L, 3L, 7L, 1L, 3L, 9L, 1L};
+  public void testFromValuesUnsorted() {
+    // fromValues must sort when told the input is not already sorted (mutable/realtime dictionaries are
+    // insertion-ordered). Input is duplicate-free per the dictionary contract.
+    long[] raw = {7L, 3L, 1L, 9L, -2L};
     SortedLongDistinctSet set = SortedLongDistinctSet.fromValues(raw, raw.length, false);
-    assertSameAsHashSet(set, new LongOpenHashSet(new long[]{1L, 3L, 7L, 9L}));
+    assertSameAsHashSet(set, new LongOpenHashSet(new long[]{-2L, 1L, 3L, 7L, 9L}));
   }
 
   @Test
   public void testFromValuesPrefix() {
-    long[] raw = {1L, 2L, 3L, 999L, 999L};
+    long[] raw = {1L, 2L, 3L, 999L, 998L};
     SortedLongDistinctSet set = SortedLongDistinctSet.fromValues(raw, 3, true);
     assertSameAsHashSet(set, new LongOpenHashSet(new long[]{1L, 2L, 3L}));
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/utils/SortedLongDistinctSetTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/utils/SortedLongDistinctSetTest.java
@@ -36,16 +36,14 @@ import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 
-/**
- * Unit tests for {@link SortedLongDistinctSet}, the sorted-run backed {@code LongSet} used by the no-scan DISTINCT
- * aggregation path. These verify that it upholds the {@code LongSet} contract and, critically, that its lazy sorted
- * union produces exactly the same distinct set as a {@link LongOpenHashSet} across the code paths the combine phase
- * exercises: single run, multi-run merges, merges with a non-sorted collection, unsorted input, duplicates spanning
- * runs, empty inputs, and post-materialization mutation.
- */
+/// Unit tests for [SortedLongDistinctSet], the sorted-run backed `LongSet` used by the no-scan DISTINCT aggregation
+/// path. These verify that it upholds the `LongSet` contract and, critically, that its lazy sorted union produces
+/// exactly the same distinct set as a `LongOpenHashSet` across the code paths the combine phase exercises: single
+/// run, multi-run merges, mixed-type merges in both operand orders, unsorted input, duplicates spanning runs, empty
+/// inputs, and post-materialization mutation.
 public class SortedLongDistinctSetTest {
 
-  /** Builds a set from an already sorted, duplicate-free run (the constructor is private; use the checked factory). */
+  /// Builds a set from an already sorted, duplicate-free run (the constructor is private; use the checked factory).
   private static SortedLongDistinctSet sortedSet(long[] sortedDistinct) {
     return SortedLongDistinctSet.fromValues(sortedDistinct, sortedDistinct.length, true);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/utils/SortedLongDistinctSetTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/utils/SortedLongDistinctSetTest.java
@@ -267,57 +267,71 @@ public class SortedLongDistinctSetTest {
   }
 
   @Test
-  public void testUnionDegradesMixedTypesToHashSet() {
-    // When scan-based (hash) and no-scan (sorted) segment results mix within one query, the union must degrade to
-    // plain hash inserts — never sort the hash set's values (that would be O(n log n) where the pre-optimization
-    // hash merge was O(n)). Block merge order is nondeterministic, so both operand orders must behave the same.
-    LongOpenHashSet expected = new LongOpenHashSet(new long[]{1L, 2L, 3L, 4L, 5L});
+  public void testUnionAbsorbsSmallerSideOnMixedTypes() {
+    // When scan-based (hash) and no-scan (sorted) segment results mix within one query, the smaller side must be
+    // absorbed into the larger side's representation: a hash set smaller than the sorted set is sorted and appended
+    // (cheap — only the small side is sorted), while a hash set at least as large absorbs the sorted values via
+    // plain hash inserts (exactly the pre-optimization cost). Block merge order is nondeterministic, so both operand
+    // orders must behave the same.
+    LongOpenHashSet expected = new LongOpenHashSet(new long[]{1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L});
 
-    LongOpenHashSet hashFirst = new LongOpenHashSet(new long[]{2L, 4L});
-    Set merged = SortedLongDistinctSet.union(hashFirst, sortedSet(sortedDistinct(1L, 3L, 5L)));
-    assertSame(merged, hashFirst);
+    // Hash clearly smaller than sorted (4x margin) -> sorted representation wins, both operand orders
+    SortedLongDistinctSet bigSorted = sortedSet(sortedDistinct(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L));
+    Set merged = SortedLongDistinctSet.union(new LongOpenHashSet(new long[]{9L}), bigSorted);
+    assertSame(merged, bigSorted);
+    assertEquals(new LongOpenHashSet(merged), expected);
+
+    bigSorted = sortedSet(sortedDistinct(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L));
+    merged = SortedLongDistinctSet.union(bigSorted, new LongOpenHashSet(new long[]{9L}));
+    assertSame(merged, bigSorted);
+    assertEquals(new LongOpenHashSet(merged), expected);
+
+    // Hash not clearly smaller -> sorted values drain into the hash set, both operand orders
+    LongOpenHashSet comparableHash = new LongOpenHashSet(new long[]{2L, 4L, 6L, 8L, 9L});
+    merged = SortedLongDistinctSet.union(comparableHash, sortedSet(sortedDistinct(1L, 3L, 5L, 7L)));
+    assertSame(merged, comparableHash);
     assertEquals(merged, expected);
 
-    LongOpenHashSet hashSecond = new LongOpenHashSet(new long[]{2L, 4L});
-    merged = SortedLongDistinctSet.union(sortedSet(sortedDistinct(1L, 3L, 5L)), hashSecond);
-    assertSame(merged, hashSecond);
+    comparableHash = new LongOpenHashSet(new long[]{2L, 4L, 6L, 8L, 9L});
+    merged = SortedLongDistinctSet.union(sortedSet(sortedDistinct(1L, 3L, 5L, 7L)), comparableHash);
+    assertSame(merged, comparableHash);
     assertEquals(merged, expected);
 
     // Draining a multi-run (never materialized) sorted set must also produce the correct union
     SortedLongDistinctSet multiRun = sortedSet(sortedDistinct(1L, 3L));
     multiRun.addAll(sortedSet(sortedDistinct(3L, 5L)));
-    LongOpenHashSet sink = new LongOpenHashSet(new long[]{2L, 4L});
+    LongOpenHashSet sink = new LongOpenHashSet(new long[]{2L, 4L, 6L, 7L, 8L, 9L});
     merged = SortedLongDistinctSet.union(sink, multiRun);
     assertSame(merged, sink);
     assertEquals(merged, expected);
 
     // Same-type unions keep the plain addAll behavior
+    LongOpenHashSet expectedSameType = new LongOpenHashSet(new long[]{1L, 2L, 3L, 4L, 5L});
     merged = SortedLongDistinctSet.union(new LongOpenHashSet(new long[]{1L, 2L, 3L}),
         new LongOpenHashSet(new long[]{4L, 5L}));
     assertTrue(merged instanceof LongOpenHashSet);
-    assertEquals(merged, expected);
+    assertEquals(merged, expectedSameType);
 
     SortedLongDistinctSet first = sortedSet(sortedDistinct(1L, 2L, 3L));
     merged = SortedLongDistinctSet.union(first, sortedSet(sortedDistinct(4L, 5L)));
     assertSame(merged, first);
-    assertEquals(new LongOpenHashSet(merged), expected);
+    assertEquals(new LongOpenHashSet(merged), expectedSameType);
   }
 
   @Test
   public void testAggregationFunctionMergeMixedTypes() {
     // End-to-end through DistinctCountAggregationFunction.merge, the path the combine phase actually uses: mixed
-    // operands degrade to the hash set in both orders and the final count stays correct
+    // operands in both orders produce the correct count regardless of which representation wins
     DistinctCountAggregationFunction function =
         new DistinctCountAggregationFunction(List.of(ExpressionContext.forIdentifier("col")), false);
     LongOpenHashSet expected = new LongOpenHashSet(new long[]{1L, 2L, 3L, 4L, 5L});
 
     Set merged = function.merge(new LongOpenHashSet(new long[]{2L, 4L}), sortedSet(sortedDistinct(1L, 3L, 5L)));
-    assertTrue(merged instanceof LongOpenHashSet);
-    assertEquals(merged, expected);
+    assertEquals(new LongOpenHashSet(merged), expected);
     assertEquals((int) function.extractFinalResult(merged), 5);
 
     merged = function.merge(sortedSet(sortedDistinct(1L, 3L, 5L)), new LongOpenHashSet(new long[]{2L, 4L}));
-    assertTrue(merged instanceof LongOpenHashSet);
+    assertEquals(new LongOpenHashSet(merged), expected);
     assertEquals((int) function.extractFinalResult(merged), 5);
 
     // Pure sorted merges keep the sorted representation (the optimized path)

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/utils/SortedLongDistinctSetTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/utils/SortedLongDistinctSetTest.java
@@ -267,21 +267,29 @@ public class SortedLongDistinctSetTest {
   }
 
   @Test
-  public void testUnionNormalizesMixedTypes() {
-    // Whichever side the sorted set arrives on, it must absorb the hash set — a hash set absorbing a sorted set
-    // would re-hash every value and lose the sorted-run optimization (block merge order is nondeterministic when
-    // scan-based and no-scan segments mix within one query).
+  public void testUnionDegradesMixedTypesToHashSet() {
+    // When scan-based (hash) and no-scan (sorted) segment results mix within one query, the union must degrade to
+    // plain hash inserts — never sort the hash set's values (that would be O(n log n) where the pre-optimization
+    // hash merge was O(n)). Block merge order is nondeterministic, so both operand orders must behave the same.
     LongOpenHashSet expected = new LongOpenHashSet(new long[]{1L, 2L, 3L, 4L, 5L});
 
-    Set merged = SortedLongDistinctSet.union(new LongOpenHashSet(new long[]{2L, 4L}),
-        sortedSet(sortedDistinct(1L, 3L, 5L)));
-    assertTrue(merged instanceof SortedLongDistinctSet);
-    assertEquals(new LongOpenHashSet(merged), expected);
+    LongOpenHashSet hashFirst = new LongOpenHashSet(new long[]{2L, 4L});
+    Set merged = SortedLongDistinctSet.union(hashFirst, sortedSet(sortedDistinct(1L, 3L, 5L)));
+    assertSame(merged, hashFirst);
+    assertEquals(merged, expected);
 
-    merged = SortedLongDistinctSet.union(sortedSet(sortedDistinct(1L, 3L, 5L)),
-        new LongOpenHashSet(new long[]{2L, 4L}));
-    assertTrue(merged instanceof SortedLongDistinctSet);
-    assertEquals(new LongOpenHashSet(merged), expected);
+    LongOpenHashSet hashSecond = new LongOpenHashSet(new long[]{2L, 4L});
+    merged = SortedLongDistinctSet.union(sortedSet(sortedDistinct(1L, 3L, 5L)), hashSecond);
+    assertSame(merged, hashSecond);
+    assertEquals(merged, expected);
+
+    // Draining a multi-run (never materialized) sorted set must also produce the correct union
+    SortedLongDistinctSet multiRun = sortedSet(sortedDistinct(1L, 3L));
+    multiRun.addAll(sortedSet(sortedDistinct(3L, 5L)));
+    LongOpenHashSet sink = new LongOpenHashSet(new long[]{2L, 4L});
+    merged = SortedLongDistinctSet.union(sink, multiRun);
+    assertSame(merged, sink);
+    assertEquals(merged, expected);
 
     // Same-type unions keep the plain addAll behavior
     merged = SortedLongDistinctSet.union(new LongOpenHashSet(new long[]{1L, 2L, 3L}),
@@ -296,18 +304,24 @@ public class SortedLongDistinctSetTest {
   }
 
   @Test
-  public void testAggregationFunctionMergeNormalizesMixedTypes() {
-    // End-to-end through DistinctCountAggregationFunction.merge, the path the combine phase actually uses
+  public void testAggregationFunctionMergeMixedTypes() {
+    // End-to-end through DistinctCountAggregationFunction.merge, the path the combine phase actually uses: mixed
+    // operands degrade to the hash set in both orders and the final count stays correct
     DistinctCountAggregationFunction function =
         new DistinctCountAggregationFunction(List.of(ExpressionContext.forIdentifier("col")), false);
     LongOpenHashSet expected = new LongOpenHashSet(new long[]{1L, 2L, 3L, 4L, 5L});
 
     Set merged = function.merge(new LongOpenHashSet(new long[]{2L, 4L}), sortedSet(sortedDistinct(1L, 3L, 5L)));
-    assertTrue(merged instanceof SortedLongDistinctSet);
-    assertEquals(new LongOpenHashSet(merged), expected);
+    assertTrue(merged instanceof LongOpenHashSet);
+    assertEquals(merged, expected);
     assertEquals((int) function.extractFinalResult(merged), 5);
 
     merged = function.merge(sortedSet(sortedDistinct(1L, 3L, 5L)), new LongOpenHashSet(new long[]{2L, 4L}));
+    assertTrue(merged instanceof LongOpenHashSet);
+    assertEquals((int) function.extractFinalResult(merged), 5);
+
+    // Pure sorted merges keep the sorted representation (the optimized path)
+    merged = function.merge(sortedSet(sortedDistinct(1L, 3L, 5L)), sortedSet(sortedDistinct(2L, 4L)));
     assertTrue(merged instanceof SortedLongDistinctSet);
     assertEquals((int) function.extractFinalResult(merged), 5);
   }


### PR DESCRIPTION
## Motivation

While benchmarking `DISTINCTCOUNT` on ClickBench data (10M rows, `UserID` LONG with ~1.53M distinct values) I profiled the server with async-profiler and found ~80% of CPU in `LongOpenHashSet` add/rehash/addAll, even though the query runs on the no-scan path where values come straight out of the dictionary — which is already sorted and duplicate-free for immutable segments.

`NonScanBasedAggregationOperator.getDistinctValueSet()` hashes every dictionary value into a per-segment `LongOpenHashSet`, and the combine phase then hash-merges the per-segment sets. For high-cardinality LONG columns basically the whole query is spent re-deduplicating values the dictionary already deduplicated.

## Change

Added `SortedLongDistinctSet` (a `LongSet` backed by sorted runs) and used it in the LONG branch of `getDistinctValueSet()`:

- Per segment, dictionary values are copied into a sorted run with no hashing. Sortedness is verified during the copy (near-zero cost), so mutable/realtime dictionaries, which are insertion-ordered, fall back to sort+dedupe instead of being trusted blindly.
- `merge()` during the combine phase just appends the other set's runs.
- The actual union happens once, lazily, when the result is first read (count extraction or serialization): a multi-pass merge between two pre-allocated buffers on the query thread, with a query-termination check between passes. No per-merge garbage, no ForkJoin common pool.
- Pending runs are eagerly compacted (with geometric backoff) once they cross an internal threshold, so peak memory stays proportional to the distinct count rather than to the number of segments when segments carry overlapping values.

Only LONG is changed for now — it's the common high-cardinality case (IDs, timestamps). INT/FLOAT/DOUBLE keep the hash-set path; the same approach applies if profiling justifies it.

The intermediate result still serializes through the existing `ObjectType.LongSet` layout (`size` + values), so nothing changes on the wire and mixed-version brokers/servers are unaffected. `DISTINCTSUM`/`DISTINCTAVG` and the SMARTHLL/SMARTULL under-threshold paths consume the same set through the `Set`/`LongSet` interfaces and are covered by tests.

## Numbers

ClickBench `hits`, 10M rows / 10 segments, single server (M-series laptop), warm best-of-4:

| query | before | after |
|---|---|---|
| `DISTINCTCOUNT(UserID)` (1.53M distinct) | 37ms | 19ms |
| `COUNT(DISTINCT UserID)` | 37ms | 19ms |
| `DISTINCTCOUNT(RegionID)` (3.6K distinct) | 1ms | 1ms |
| `DISTINCTCOUNT(UserID)` group by RegionID | 66ms | 66ms (unchanged, scan path) |
| `DISTINCTCOUNTHLL` / `SMARTHLL` / `HLLPLUS` | — | unchanged |

Results are identical to the hash-set implementation (verified value-for-value, not just counts).

An isolated microbenchmark of the union itself (10 runs matching the real per-segment cardinalities, ~1.59M values): balanced pairwise merge 2.8ms, k-way heap merge 7.3ms, concat+sort 2.3ms — pairwise multi-pass merging with reused buffers was chosen; the allocation reduction mattered more than the merge strategy (the old per-level allocations produced ~50MB of garbage per query and GC showed up at ~12% of profile samples, ~2% after).

## Testing

- `SortedLongDistinctSetTest` (15 cases): single/multi runs, overlapping and disjoint merges, mixed merges with `LongOpenHashSet` in both directions, unsorted input fallback, merge-after-materialization, dedupe-slack handling, eager compaction (3x3M runs with an arithmetically known union of 7M), serde round-trip, and the unsupported-removal contract.
- `NonScanBasedAggregationOperatorTest` (4 cases): the sortedness-detection loop against mocked sorted, unsorted, and duplicate-bearing dictionaries (the realtime/mutable case).
- Existing `DistinctCountQueriesTest`, `DistinctQueriesTest`, `DistinctSum/AvgAggregationFunctionTest`, `SegmentPartitionedDistinctCountQueriesTest` all pass.
- Additionally ran a randomized differential fuzz (200 trials, random run counts/sizes/overlaps/ranges) comparing size/iteration/contains/sum against `LongOpenHashSet` ground truth.
