### PR TITLE
Block UpsertCompactionTask/UpsertCompactMergeTask when metadataTTL is enabled

### DIFF
--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
@@ -301,6 +301,14 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
         "UpsertCompactionTask only supports realtime tables!");
     // check upsert enabled
     Preconditions.checkState(tableConfig.isUpsertEnabled(), "Upsert must be enabled for UpsertCompactionTask");
+    // check metadataTTL is not set: UpsertCompactionTask does not compact tombstoned rows in a way that is
+    // consistent with metadataTTL-driven cleanup, so enabling them together can leave stale rows behind or
+    // resurface aged-out keys. Block the combination to avoid silent correctness issues.
+    UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
+    assert upsertConfig != null;
+    Preconditions.checkState(upsertConfig.getMetadataTTL() <= 0,
+        "UpsertCompactionTask does not support tables with 'metadataTTL' enabled, got metadataTTL: %s",
+        upsertConfig.getMetadataTTL());
 
     // check no malformed period
     if (taskConfigs.containsKey(UpsertCompactionTask.BUFFER_TIME_PERIOD_KEY)) {
@@ -326,8 +334,6 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
         "invalidRecordsThresholdPercent or invalidRecordsThresholdCount or both must be provided");
 
     // validate validDocIdsType default logic
-    UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
-    assert upsertConfig != null;
     MinionTaskUtils.getValidDocIdsType(upsertConfig, taskConfigs, UpsertCompactionTask.VALID_DOC_IDS_TYPE);
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGenerator.java
@@ -481,6 +481,12 @@ public class UpsertCompactMergeTaskGenerator extends BaseTaskGenerator {
     // NOTE: Allow snapshot to be DEFAULT because it might be enabled at server level.
     Preconditions.checkState(upsertConfig.getSnapshot() != Enablement.DISABLE,
         "'snapshot' from UpsertConfig must not be 'DISABLE' for %s", MinionConstants.UpsertCompactMergeTask.TASK_TYPE);
+    // check metadataTTL is not set: UpsertCompactMergeTask does not compact tombstoned rows in a way that is
+    // consistent with metadataTTL-driven cleanup, so enabling them together can leave stale rows behind or
+    // resurface aged-out keys. Block the combination to avoid silent correctness issues.
+    Preconditions.checkState(upsertConfig.getMetadataTTL() <= 0,
+        "%s does not support tables with 'metadataTTL' enabled, got metadataTTL: %s",
+        MinionConstants.UpsertCompactMergeTask.TASK_TYPE, upsertConfig.getMetadataTTL());
     // check no malformed period
     if (taskConfigs.containsKey(MinionConstants.UpsertCompactMergeTask.BUFFER_TIME_PERIOD_KEY)) {
       TimeUtils.convertPeriodToMillis(taskConfigs.get(MinionConstants.UpsertCompactMergeTask.BUFFER_TIME_PERIOD_KEY));

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGeneratorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGeneratorTest.java
@@ -478,6 +478,17 @@ public class UpsertCompactionTaskGeneratorTest {
         .build();
     Assert.assertThrows(IllegalStateException.class,
         () -> _taskGenerator.validateTaskConfigs(invalidTableConfig, new Schema(), upsertCompactionTaskConfig5));
+
+    // metadataTTL enabled is not supported with UpsertCompactionTask
+    UpsertConfig ttlUpsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
+    ttlUpsertConfig.setSnapshot(Enablement.ENABLE);
+    ttlUpsertConfig.setMetadataTTL(30);
+    TableConfig metadataTtlTableConfig =
+        new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setUpsertConfig(ttlUpsertConfig)
+            .setTaskConfig(new TableTaskConfig(Map.of("UpsertCompactionTask", upsertCompactionTaskConfig)))
+            .build();
+    Assert.assertThrows(IllegalStateException.class,
+        () -> _taskGenerator.validateTaskConfigs(metadataTtlTableConfig, new Schema(), upsertCompactionTaskConfig));
   }
 
   @Test

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGeneratorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskGeneratorTest.java
@@ -164,6 +164,18 @@ public class UpsertCompactMergeTaskGeneratorTest {
     Map<String, String> upsertCompactMergeTaskConfig1 = Map.of("bufferTimePeriod", "5hd");
     Assert.assertThrows(IllegalArgumentException.class,
         () -> _taskGenerator.validateTaskConfigs(validTableConfig, new Schema(), upsertCompactMergeTaskConfig1));
+
+    // metadataTTL enabled is not supported with UpsertCompactMergeTask
+    UpsertConfig ttlUpsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
+    ttlUpsertConfig.setSnapshot(Enablement.ENABLE);
+    ttlUpsertConfig.setMetadataTTL(30);
+    TableConfig metadataTtlTableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME)
+        .setUpsertConfig(ttlUpsertConfig)
+        .setTaskConfig(
+            new TableTaskConfig(Map.of(MinionConstants.UpsertCompactMergeTask.TASK_TYPE, upsertCompactMergeTaskConfig)))
+        .build();
+    Assert.assertThrows(IllegalStateException.class,
+        () -> _taskGenerator.validateTaskConfigs(metadataTtlTableConfig, new Schema(), upsertCompactMergeTaskConfig));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Both `UpsertCompactionTask` and `UpsertCompactMergeTask` rewrite segments based on the current `validDocIds` state, but neither is aware of the `metadataTTL`-driven cleanup path in the upsert metadata manager. Enabling `metadataTTL` alongside either task can leave stale rows behind or resurface aged-out keys because the two paths operate on different notions of "valid".

This PR rejects the combination in each task generator's `validateTaskConfigs()` with an explicit error, so the misconfiguration surfaces at task-scheduling time instead of silently producing incorrect results.

## Changes

- `UpsertCompactionTaskGenerator.validateTaskConfigs()` — reject if `upsertConfig.metadataTTL > 0`.
- `UpsertCompactMergeTaskGenerator.validateTaskConfigs()` — same check.
- Regression tests added to both `*Test` classes covering the new error case.

## Backward compatibility

Any existing table config that has **both** `metadataTTL > 0` and either of these tasks scheduled will now fail validation on the next scheduling attempt. This is intended — such a configuration was already producing incorrect results silently. Operators should either disable the compaction task on such tables or unset `metadataTTL`. When you unset `metadataTTL`, server restart is needed to take that change into effect