### PR TITLE
Fix PinotDataWriter on UnsafeArrayData and null inputs

### DIFF
--- a/pinot-connectors/pinot-spark-3-connector/src/main/scala/org/apache/pinot/connector/spark/v3/datasource/PinotDataWriter.scala
+++ b/pinot-connectors/pinot-spark-3-connector/src/main/scala/org/apache/pinot/connector/spark/v3/datasource/PinotDataWriter.scala
@@ -30,7 +30,8 @@ import org.apache.pinot.spi.data.Schema
 import org.apache.pinot.spi.ingestion.batch.spec.Constants
 import org.apache.pinot.spi.utils.DataSizeUtils
 import org.apache.spark.sql.catalyst
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.catalyst.util.ArrayData
+import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, ByteType, DataType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, StructType}
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.io.File
@@ -79,8 +80,10 @@ class PinotDataWriter[InternalRow](
   override def write(record: catalyst.InternalRow): Unit = {
     bufferedRecordReader.write(internalRowToGenericRow(record))
 
-    // Tracking startTime and endTime for segment name generation purposes
-    if (timeColumnIndex > -1 && isTimeColumnNumeric) {
+    // Tracking startTime and endTime for segment name generation purposes. Skip null values so a
+    // null time column does not silently pull `startTime` to 0 and produce a malformed segment
+    // name -- `record.getLong` returns 0 for nulls without an `isNullAt` guard.
+    if (timeColumnIndex > -1 && isTimeColumnNumeric && !record.isNullAt(timeColumnIndex)) {
       val time = record.getLong(timeColumnIndex)
       startTime = Math.min(startTime, time)
       endTime = Math.max(endTime, time)
@@ -203,57 +206,161 @@ class PinotDataWriter[InternalRow](
     logger.info("Pushed segment tar file {} to: {}", (segmentTarFile.getName, destPath))
   }
 
+  /** Converts a Spark [[catalyst.InternalRow]] to a Pinot [[GenericRow]].
+   *
+   *  Spark's DataSourceV2 write path applies an `UnsafeProjection` immediately before invoking
+   *  `DataWriter.write(...)`, so every row reaching this method is an `UnsafeRow` whose array
+   *  fields are `UnsafeArrayData`. `UnsafeArrayData.array()` throws `UnsupportedOperationException`,
+   *  so the array branch must use accessors that work on both `UnsafeArrayData` and
+   *  `GenericArrayData` -- per-element iteration over the typed `getXxx(i)` methods.
+   *
+   *  Multi-value array fields are emitted as `Object[]` (boxed primitives, `String`s, or
+   *  `byte[]`s) because Pinot's segment-generation pipeline expects this shape. Stats collectors
+   *  in `pinot-segment-local` cast every MV entry as `(Object[])`, and `GenericRow.copy()`
+   *  clones array values via `(Object[]) value` -- a primitive Spark array (`int[]`, `long[]`,
+   *  ...) returned from `ArrayData.toIntArray()` / `toLongArray()` would `ClassCastException` at
+   *  the first stats pass and never produce a segment.
+   *
+   *  Nullability is handled at the field level: a top-level `isNullAt` guard funnels every null
+   *  field through `putValue(name, null)` so the scalar `StringType` branch never NPEs on a null
+   *  `getUTF8String(...)` and primitive branches never silently substitute `0` / `false` for a
+   *  null field value. Element-level nulls within a multi-value array are rejected with
+   *  `IllegalArgumentException`: Pinot's MV stats collectors NPE on null elements, so failing
+   *  fast in the writer with a clear message is strictly better than producing a corrupt
+   *  segment or surfacing an opaque downstream crash.
+   */
   private def internalRowToGenericRow(record: catalyst.InternalRow): GenericRow = {
     val gr = new GenericRow()
 
-    writeSchema.fields.zipWithIndex foreach { case(field, idx) =>
-      field.dataType match {
-        case org.apache.spark.sql.types.StringType =>
-          gr.putValue(field.name, record.getString(idx))
-        case org.apache.spark.sql.types.IntegerType =>
-          gr.putValue(field.name, record.getInt(idx))
-        case org.apache.spark.sql.types.LongType =>
-          gr.putValue(field.name, record.getLong(idx))
-        case org.apache.spark.sql.types.FloatType =>
-          gr.putValue(field.name, record.getFloat(idx))
-        case org.apache.spark.sql.types.DoubleType =>
-          gr.putValue(field.name, record.getDouble(idx))
-        case org.apache.spark.sql.types.BooleanType =>
-          gr.putValue(field.name, record.getBoolean(idx))
-        case org.apache.spark.sql.types.ByteType =>
-          gr.putValue(field.name, record.getByte(idx))
-        case org.apache.spark.sql.types.BinaryType =>
-          gr.putValue(field.name, record.getBinary(idx))
-        case org.apache.spark.sql.types.ShortType =>
-          gr.putValue(field.name, record.getShort(idx))
-        case org.apache.spark.sql.types.ArrayType(elementType, _) =>
-          elementType match {
-            case org.apache.spark.sql.types.StringType =>
-              gr.putValue(field.name, record.getArray(idx).array.map(_.asInstanceOf[String]))
-            case org.apache.spark.sql.types.IntegerType =>
-              gr.putValue(field.name, record.getArray(idx).array.map(_.asInstanceOf[Int]))
-            case org.apache.spark.sql.types.LongType =>
-              gr.putValue(field.name, record.getArray(idx).array.map(_.asInstanceOf[Long]))
-            case org.apache.spark.sql.types.FloatType =>
-              gr.putValue(field.name, record.getArray(idx).array.map(_.asInstanceOf[Float]))
-            case org.apache.spark.sql.types.DoubleType =>
-              gr.putValue(field.name, record.getArray(idx).array.map(_.asInstanceOf[Double]))
-            case org.apache.spark.sql.types.BooleanType =>
-              gr.putValue(field.name, record.getArray(idx).array.map(_.asInstanceOf[Boolean]))
-            case org.apache.spark.sql.types.ByteType =>
-              gr.putValue(field.name, record.getArray(idx).array.map(_.asInstanceOf[Byte]))
-            case org.apache.spark.sql.types.BinaryType =>
-              gr.putValue(field.name, record.getArray(idx).array.map(_.asInstanceOf[Array[Byte]]))
-            case org.apache.spark.sql.types.ShortType =>
-              gr.putValue(field.name, record.getArray(idx).array.map(_.asInstanceOf[Short]))
-            case _ =>
-              throw new UnsupportedOperationException(s"Unsupported data type: Array[${elementType}]")
-          }
-        case _ =>
-          throw new UnsupportedOperationException("Unsupported data type: " + field.dataType)
+    writeSchema.fields.zipWithIndex foreach { case (field, idx) =>
+      if (record.isNullAt(idx)) {
+        gr.putValue(field.name, null)
+      } else {
+        field.dataType match {
+          case StringType =>
+            gr.putValue(field.name, record.getUTF8String(idx).toString)
+          case IntegerType =>
+            gr.putValue(field.name, record.getInt(idx))
+          case LongType =>
+            gr.putValue(field.name, record.getLong(idx))
+          case FloatType =>
+            gr.putValue(field.name, record.getFloat(idx))
+          case DoubleType =>
+            gr.putValue(field.name, record.getDouble(idx))
+          case BooleanType =>
+            gr.putValue(field.name, record.getBoolean(idx))
+          case ByteType =>
+            gr.putValue(field.name, record.getByte(idx))
+          case BinaryType =>
+            gr.putValue(field.name, record.getBinary(idx))
+          case ShortType =>
+            gr.putValue(field.name, record.getShort(idx))
+          case ArrayType(elementType, _) =>
+            gr.putValue(field.name, convertArrayData(record.getArray(idx), field.name, elementType))
+          case _ =>
+            throw new UnsupportedOperationException("Unsupported data type: " + field.dataType)
+        }
       }
     }
     gr
+  }
+
+  private def convertArrayData(arr: ArrayData, columnName: String, elementType: DataType): AnyRef = {
+    val n = arr.numElements()
+    elementType match {
+      case StringType =>
+        val out = new Array[String](n)
+        var i = 0
+        while (i < n) {
+          requireNoNullElement(arr, columnName, i)
+          out(i) = arr.getUTF8String(i).toString
+          i += 1
+        }
+        out
+      case BinaryType =>
+        val out = new Array[Array[Byte]](n)
+        var i = 0
+        while (i < n) {
+          requireNoNullElement(arr, columnName, i)
+          out(i) = arr.getBinary(i)
+          i += 1
+        }
+        out
+      case IntegerType =>
+        val out = new Array[AnyRef](n)
+        var i = 0
+        while (i < n) {
+          requireNoNullElement(arr, columnName, i)
+          out(i) = Integer.valueOf(arr.getInt(i))
+          i += 1
+        }
+        out
+      case LongType =>
+        val out = new Array[AnyRef](n)
+        var i = 0
+        while (i < n) {
+          requireNoNullElement(arr, columnName, i)
+          out(i) = java.lang.Long.valueOf(arr.getLong(i))
+          i += 1
+        }
+        out
+      case FloatType =>
+        val out = new Array[AnyRef](n)
+        var i = 0
+        while (i < n) {
+          requireNoNullElement(arr, columnName, i)
+          out(i) = java.lang.Float.valueOf(arr.getFloat(i))
+          i += 1
+        }
+        out
+      case DoubleType =>
+        val out = new Array[AnyRef](n)
+        var i = 0
+        while (i < n) {
+          requireNoNullElement(arr, columnName, i)
+          out(i) = java.lang.Double.valueOf(arr.getDouble(i))
+          i += 1
+        }
+        out
+      case BooleanType =>
+        val out = new Array[AnyRef](n)
+        var i = 0
+        while (i < n) {
+          requireNoNullElement(arr, columnName, i)
+          out(i) = java.lang.Boolean.valueOf(arr.getBoolean(i))
+          i += 1
+        }
+        out
+      case ByteType =>
+        val out = new Array[AnyRef](n)
+        var i = 0
+        while (i < n) {
+          requireNoNullElement(arr, columnName, i)
+          out(i) = java.lang.Byte.valueOf(arr.getByte(i))
+          i += 1
+        }
+        out
+      case ShortType =>
+        val out = new Array[AnyRef](n)
+        var i = 0
+        while (i < n) {
+          requireNoNullElement(arr, columnName, i)
+          out(i) = java.lang.Short.valueOf(arr.getShort(i))
+          i += 1
+        }
+        out
+      case _ =>
+        throw new UnsupportedOperationException(s"Unsupported data type: Array[$elementType]")
+    }
+  }
+
+  private def requireNoNullElement(arr: ArrayData, columnName: String, idx: Int): Unit = {
+    if (arr.isNullAt(idx)) {
+      throw new IllegalArgumentException(
+        s"Multi-value column '$columnName' contains a null element at index $idx. Pinot " +
+          "multi-value columns do not support null elements; filter or coalesce nulls in Spark " +
+          "before writing.")
+    }
   }
 
   private def tarSegmentDir(segmentName: String, segmentDir: File): File = {

--- a/pinot-connectors/pinot-spark-3-connector/src/test/scala/org/apache/pinot/connector/spark/v3/datasource/PinotDataWriterTest.scala
+++ b/pinot-connectors/pinot-spark-3-connector/src/test/scala/org/apache/pinot/connector/spark/v3/datasource/PinotDataWriterTest.scala
@@ -20,13 +20,16 @@ package org.apache.pinot.connector.spark.v3.datasource
 
 import org.apache.pinot.connector.spark.common.PinotDataSourceWriteOptions
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.types.{IntegerType, LongType, StringType, StructField, StructType, BinaryType}
+import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, ByteType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, StructField, StructType}
 import org.apache.spark.sql.connector.write.WriterCommitMessage
 import org.scalatest.matchers.should.Matchers
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.pinot.common.utils.TarCompressionUtils
+import org.apache.pinot.spi.data.{FieldSpec, Schema}
 import org.apache.pinot.spi.data.readers.GenericRow
-import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, UnsafeArrayData, UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.catalyst.util.GenericArrayData
+import org.apache.spark.unsafe.types.UTF8String
 import org.scalatest.BeforeAndAfter
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -153,6 +156,255 @@ class PinotDataWriterTest extends AnyFunSuite with Matchers with BeforeAndAfter 
     metadataContent should include ("segment.end.time = 1234567891")
   }
 
+  test("internalRowToGenericRow handles UnsafeArrayData and null fields") {
+    // Regression test for the original bug: the writer called ArrayData.array() on every
+    // ArrayType column. Spark's DataSourceV2 write path always feeds the writer an UnsafeRow
+    // whose array fields are UnsafeArrayData, and UnsafeArrayData.array() throws
+    // UnsupportedOperationException -- so the pre-fix writer crashed on the first row of any
+    // job projecting an ArrayType column. This test materializes an UnsafeRow via
+    // UnsafeProjection so the array fields are guaranteed to be UnsafeArrayData, then exercises
+    // every supported element type plus a null array field and null scalar fields. Element-level
+    // null handling is covered by the negative tests below.
+    val writeOptions = PinotDataSourceWriteOptions(
+      tableName = "testTable",
+      savePath = "/tmp/pinot",
+      timeColumnName = "ts",
+      timeFormat = "EPOCH|SECONDS",
+      timeGranularity = "1:SECONDS",
+      segmentNameFormat = "{table}_{partitionId:03}",
+      invertedIndexColumns = Array(),
+      noDictionaryColumns = Array(),
+      bloomFilterColumns = Array(),
+      rangeIndexColumns = Array()
+    )
+    val writeSchema = StructType(Seq(
+      StructField("ts", LongType, nullable = false),
+      StructField("name", StringType, nullable = true),
+      StructField("nullableInt", IntegerType, nullable = true),
+      StructField("strs", ArrayType(StringType), nullable = true),
+      StructField("ints", ArrayType(IntegerType), nullable = true),
+      StructField("longs", ArrayType(LongType), nullable = true),
+      StructField("floats", ArrayType(FloatType), nullable = true),
+      StructField("doubles", ArrayType(DoubleType), nullable = true),
+      StructField("bools", ArrayType(BooleanType), nullable = true),
+      StructField("bytes", ArrayType(ByteType), nullable = true),
+      StructField("shorts", ArrayType(ShortType), nullable = true),
+      StructField("bins", ArrayType(BinaryType), nullable = true),
+      StructField("nullArr", ArrayType(IntegerType), nullable = true)
+    ))
+
+    // Build the Pinot schema manually because SparkToPinotTypeTranslator does not yet map
+    // ByteType / ShortType arrays, and the writer's write() path does not consult pinotSchema
+    // (it is only used at commit time to drive segment generation).
+    val pinotSchema = new Schema.SchemaBuilder()
+      .setSchemaName(writeOptions.tableName)
+      .addDateTimeField("ts", FieldSpec.DataType.LONG,
+        writeOptions.timeFormat, writeOptions.timeGranularity)
+      .build()
+    val writer = new PinotDataWriter[InternalRow](0, 0, writeOptions, writeSchema, pinotSchema)
+
+    val genericRow = new GenericInternalRow(Array[Any](
+      1234567890L,
+      null,
+      null,
+      new GenericArrayData(Array[Any](UTF8String.fromString("a"), UTF8String.fromString("b"))),
+      new GenericArrayData(Array[Any](1, 2, 3)),
+      new GenericArrayData(Array[Any](10L, 20L)),
+      new GenericArrayData(Array[Any](1.5f, 2.5f)),
+      new GenericArrayData(Array[Any](1.5d, 2.5d)),
+      new GenericArrayData(Array[Any](true, false, true)),
+      new GenericArrayData(Array[Any](1.toByte, 2.toByte)),
+      new GenericArrayData(Array[Any](100.toShort, 200.toShort)),
+      new GenericArrayData(Array[Any]("a".getBytes, "b".getBytes)),
+      null
+    ))
+    val unsafeRow = UnsafeProjection.create(writeSchema).apply(genericRow)
+    // Self-validate that the projection actually produced an UnsafeRow whose array fields are
+    // UnsafeArrayData. Without this guard, a future change that accidentally substitutes a
+    // GenericInternalRow / GenericArrayData would silently degrade this into a non-regression test.
+    unsafeRow shouldBe an[UnsafeRow]
+    unsafeRow.getArray(writeSchema.fieldIndex("ints")) shouldBe an[UnsafeArrayData]
+    unsafeRow.getArray(writeSchema.fieldIndex("strs")) shouldBe an[UnsafeArrayData]
+
+    writer.write(unsafeRow)
+    val gr = writer.bufferedRecordReader.next()
+
+    gr.getValue("ts") shouldBe 1234567890L
+    gr.getValue("name") shouldBe null
+    gr.getValue("nullableInt") shouldBe null
+    gr.getValue("nullArr") shouldBe null
+
+    // Pinot expects MV columns as Object[] (or arrays of references) -- see GenericRow.copy()
+    // and the pinot-segment-local stats collectors which all cast to (Object[]).
+    gr.getValue("strs").asInstanceOf[Array[String]].toSeq shouldBe Seq("a", "b")
+    gr.getValue("ints").asInstanceOf[Array[AnyRef]].toSeq shouldBe Seq(Integer.valueOf(1),
+      Integer.valueOf(2), Integer.valueOf(3))
+    gr.getValue("longs").asInstanceOf[Array[AnyRef]].toSeq shouldBe Seq(java.lang.Long.valueOf(10L),
+      java.lang.Long.valueOf(20L))
+    gr.getValue("floats").asInstanceOf[Array[AnyRef]].toSeq shouldBe Seq(java.lang.Float.valueOf(1.5f),
+      java.lang.Float.valueOf(2.5f))
+    gr.getValue("doubles").asInstanceOf[Array[AnyRef]].toSeq shouldBe Seq(
+      java.lang.Double.valueOf(1.5d), java.lang.Double.valueOf(2.5d))
+    gr.getValue("bools").asInstanceOf[Array[AnyRef]].toSeq shouldBe Seq(java.lang.Boolean.TRUE,
+      java.lang.Boolean.FALSE, java.lang.Boolean.TRUE)
+    gr.getValue("bytes").asInstanceOf[Array[AnyRef]].toSeq shouldBe Seq(java.lang.Byte.valueOf(1.toByte),
+      java.lang.Byte.valueOf(2.toByte))
+    gr.getValue("shorts").asInstanceOf[Array[AnyRef]].toSeq shouldBe Seq(
+      java.lang.Short.valueOf(100.toShort), java.lang.Short.valueOf(200.toShort))
+
+    val bins = gr.getValue("bins").asInstanceOf[Array[Array[Byte]]]
+    bins.length shouldBe 2
+    bins(0).toSeq shouldBe "a".getBytes.toSeq
+    bins(1).toSeq shouldBe "b".getBytes.toSeq
+
+    writer.close()
+  }
+
+  test("internalRowToGenericRow rejects null elements in multi-value array columns") {
+    // Pinot's MV ingestion pipeline does not support null elements -- the per-type stats
+    // collectors in pinot-segment-local each cast `(Object[])` and unbox without a null check.
+    // The patched writer must therefore fail fast with IllegalArgumentException rather than
+    // either NPEing on UnsafeArrayData (pre-fix), silently emitting 0 (GenericArrayData), or
+    // letting the segment build crash later with an opaque downstream NPE.
+    val writeOptions = PinotDataSourceWriteOptions(
+      tableName = "testTable",
+      savePath = "/tmp/pinot",
+      timeColumnName = "ts",
+      timeFormat = "EPOCH|SECONDS",
+      timeGranularity = "1:SECONDS",
+      segmentNameFormat = "{table}_{partitionId:03}",
+      invertedIndexColumns = Array(),
+      noDictionaryColumns = Array(),
+      bloomFilterColumns = Array(),
+      rangeIndexColumns = Array()
+    )
+    val pinotSchema = new Schema.SchemaBuilder()
+      .setSchemaName(writeOptions.tableName)
+      .addDateTimeField("ts", FieldSpec.DataType.LONG,
+        writeOptions.timeFormat, writeOptions.timeGranularity)
+      .build()
+
+    val cases = Seq(
+      ("ints", IntegerType,
+        new GenericArrayData(Array[Any](Integer.valueOf(1), null, Integer.valueOf(3)))),
+      ("longs", LongType,
+        new GenericArrayData(Array[Any](java.lang.Long.valueOf(1L), null))),
+      ("floats", FloatType,
+        new GenericArrayData(Array[Any](java.lang.Float.valueOf(1.0f), null))),
+      ("doubles", DoubleType,
+        new GenericArrayData(Array[Any](java.lang.Double.valueOf(1.0d), null))),
+      ("bools", BooleanType,
+        new GenericArrayData(Array[Any](java.lang.Boolean.TRUE, null))),
+      ("bytes", ByteType,
+        new GenericArrayData(Array[Any](java.lang.Byte.valueOf(1.toByte), null))),
+      ("shorts", ShortType,
+        new GenericArrayData(Array[Any](java.lang.Short.valueOf(1.toShort), null))),
+      ("strs", StringType,
+        new GenericArrayData(Array[Any](UTF8String.fromString("a"), null))),
+      ("bins", BinaryType,
+        new GenericArrayData(Array[Any]("a".getBytes, null)))
+    )
+
+    cases.foreach { case (columnName, elementType, arrayData) =>
+      val writeSchema = StructType(Seq(
+        StructField("ts", LongType, nullable = false),
+        StructField(columnName, ArrayType(elementType, containsNull = true), nullable = true)
+      ))
+      val writer = new PinotDataWriter[InternalRow](0, 0, writeOptions, writeSchema, pinotSchema)
+      val row = new GenericInternalRow(Array[Any](1L, arrayData))
+      val unsafeRow = UnsafeProjection.create(writeSchema).apply(row)
+
+      val ex = intercept[IllegalArgumentException] {
+        writer.write(unsafeRow)
+      }
+      ex.getMessage should include(s"'$columnName'")
+      ex.getMessage should include("null element")
+
+      writer.close()
+    }
+  }
+
+  test("commit produces a valid segment from an UnsafeRow with multi-value array columns") {
+    // End-to-end regression: feed the writer an UnsafeRow shaped like what
+    // DataSourceV2 actually delivers in production, drive commit() to run the full
+    // SegmentIndexCreationDriverImpl pipeline, and assert the segment tarball lands.
+    // Restricted to MV element types Pinot natively supports (INT, LONG, FLOAT, DOUBLE, STRING).
+    tmpDir = Files.createTempDirectory("pinot-spark-connector-mv-commit-test").toFile
+
+    val writeOptions = PinotDataSourceWriteOptions(
+      tableName = "mvTable",
+      savePath = tmpDir.getAbsolutePath,
+      timeColumnName = "ts",
+      timeFormat = "EPOCH|SECONDS",
+      timeGranularity = "1:SECONDS",
+      segmentNameFormat = "{table}_{startTime}_{endTime}_{partitionId:03}",
+      invertedIndexColumns = Array(),
+      noDictionaryColumns = Array(),
+      bloomFilterColumns = Array(),
+      rangeIndexColumns = Array()
+    )
+    val writeSchema = StructType(Seq(
+      StructField("ts", LongType, nullable = false),
+      StructField("name", StringType, nullable = false),
+      StructField("ints", ArrayType(IntegerType), nullable = false),
+      StructField("longs", ArrayType(LongType), nullable = false),
+      StructField("floats", ArrayType(FloatType), nullable = false),
+      StructField("doubles", ArrayType(DoubleType), nullable = false),
+      StructField("strs", ArrayType(StringType), nullable = false)
+    ))
+    val pinotSchema = SparkToPinotTypeTranslator.translate(
+      writeSchema, writeOptions.tableName, writeOptions.timeColumnName,
+      writeOptions.timeFormat, writeOptions.timeGranularity)
+    val writer = new PinotDataWriter[InternalRow](0, 0, writeOptions, writeSchema, pinotSchema)
+
+    val unsafeProjection = UnsafeProjection.create(writeSchema)
+    Seq(
+      (1234567890L, "Alice", Array[Any](1, 2), Array[Any](10L, 20L),
+        Array[Any](1.5f, 2.5f), Array[Any](1.5d, 2.5d),
+        Array[Any](UTF8String.fromString("a"), UTF8String.fromString("b"))),
+      (1234567891L, "Bob", Array[Any](3), Array[Any](30L),
+        Array[Any](3.5f), Array[Any](3.5d),
+        Array[Any](UTF8String.fromString("c")))
+    ).foreach { case (ts, name, ints, longs, floats, doubles, strs) =>
+      val row = new GenericInternalRow(Array[Any](
+        ts, UTF8String.fromString(name),
+        new GenericArrayData(ints), new GenericArrayData(longs),
+        new GenericArrayData(floats), new GenericArrayData(doubles),
+        new GenericArrayData(strs)
+      ))
+      writer.write(unsafeProjection.apply(row).copy())
+    }
+
+    val commitMessage = writer.commit()
+    commitMessage shouldBe a[SuccessWriterCommitMessage]
+
+    val fs = FileSystem.get(new URI(writeOptions.savePath), new org.apache.hadoop.conf.Configuration())
+    val segmentPath = new Path(writeOptions.savePath + "/mvTable_1234567890_1234567891_000.tar.gz")
+    fs.exists(segmentPath) shouldBe true
+
+    TarCompressionUtils.untar(
+      new File(writeOptions.savePath + "/mvTable_1234567890_1234567891_000.tar.gz"),
+      new File(writeOptions.savePath))
+    val untarDir = Paths.get(writeOptions.savePath + "/mvTable_1234567890_1234567891_000/v3/")
+    Files.exists(untarDir) shouldBe true
+
+    val metadataSrc = Source.fromFile(untarDir + "/metadata.properties")
+    val metadataContent = metadataSrc.getLines.mkString("\n")
+    metadataSrc.close()
+
+    metadataContent should include("segment.name = mvTable_1234567890_1234567891_000")
+    metadataContent should include("column.ints.dataType = INT")
+    metadataContent should include("column.ints.isSingleValues = false")
+    metadataContent should include("column.longs.dataType = LONG")
+    metadataContent should include("column.longs.isSingleValues = false")
+    metadataContent should include("column.floats.dataType = FLOAT")
+    metadataContent should include("column.floats.isSingleValues = false")
+    metadataContent should include("column.doubles.dataType = DOUBLE")
+    metadataContent should include("column.doubles.isSingleValues = false")
+    metadataContent should include("column.strs.dataType = STRING")
+    metadataContent should include("column.strs.isSingleValues = false")
+  }
+
   test("getSegmentName should format segment name correctly with custom format") {
     val testCases = Seq(
       ("{table}_{partitionId}", "airlineStats_12"),
@@ -196,4 +448,13 @@ class PinotDataWriterTest extends AnyFunSuite with Matchers with BeforeAndAfter 
 
 private class TestInternalRow(values: Array[Any]) extends GenericInternalRow(values) {
   override def getString(ordinal: Int): String = values(ordinal).asInstanceOf[String]
+
+  // The production code reads strings via `getUTF8String(idx).toString` (the SpecializedGetters
+  // contract); GenericInternalRow's default would `ClassCastException` on a plain Java String.
+  override def getUTF8String(ordinal: Int): UTF8String =
+    values(ordinal) match {
+      case null => null
+      case s: String => UTF8String.fromString(s)
+      case u: UTF8String => u
+    }
 }


### PR DESCRIPTION
Spark's DataSourceV2 write path applies an UnsafeProjection immediately before invoking DataWriter.write(...), so every row reaching PinotDataWriter is an UnsafeRow whose array fields are UnsafeArrayData. The old ArrayType branch called record.getArray(idx).array.map(...), but UnsafeArrayData.array() throws UnsupportedOperationException, so every job projecting an ArrayType column failed on the first row and users had to flatten multi-value columns to comma-delimited strings in Spark SQL and rebuild them server-side via ingestionConfig.transformConfigs.

Rewrite the ArrayType branch to use accessors valid on both UnsafeArrayData and GenericArrayData -- per-element iteration over the typed getXxx(i) methods -- and emit Object[] of boxed primitives (or String[] / byte[][]) because Pinot's segment-generation path requires that shape: PinotBufferedRecordReader.next(reuse) calls GenericRow.copy() which casts every array value to (Object[]), and the pinot-segment-local stats collectors all do the same. Returning a primitive int[] / long[] would ClassCastException at the first stats pass.

Other fixes in the same write path:
- Field-level isNullAt guards in internalRowToGenericRow so the scalar StringType branch no longer NPEs on a null UTF8String and primitive scalar branches no longer silently substitute 0 / false for a null.
- Reject null elements within multi-value arrays with IllegalArgumentException naming the column and index, since Pinot's per-type stats collectors NPE on null elements anyway.
- Guard the time-column tracking in write() with isNullAt so a null time value does not silently pull startTime to 0 and corrupt getSegmentName.
- Switch the scalar StringType branch to getUTF8String(idx).toString to drop the dependency on Spark's test-only InternalRow.getString.