### PR TITLE
Simplify getMovingConsumingSegments and drop per-segment stream allocation

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -2263,6 +2263,12 @@ public class TableRebalancer {
     return tierSegments.size() >= segmentsToMove.size() && tierSegments.containsAll(segmentsToMove);
   }
 
+  /// Returns the consuming segments that would be moved between the current and target assignment: those whose target
+  /// has a `CONSUMING` replica and whose assigned instances differ from the current assignment. Assumes a segment's
+  /// replicas are never a mix of `ONLINE` and `CONSUMING` (a realtime segment is either consuming or completed, and
+  /// completion flips the whole segment at once), so the scan over a segment's replicas can stop at the first `ONLINE`
+  /// replica (the segment is completed, hence not consuming) or the first `CONSUMING` replica (the segment is
+  /// consuming), skipping only `OFFLINE` replicas.
   @VisibleForTesting
   static Set<String> getMovingConsumingSegments(Map<String, Map<String, String>> currentAssignment,
       Map<String, Map<String, String>> targetAssignment) {
@@ -2271,12 +2277,21 @@ public class TableRebalancer {
       String segmentName = entry.getKey();
       Map<String, String> currentInstanceStateMap = entry.getValue();
       Map<String, String> targetInstanceStateMap = targetAssignment.get(segmentName);
-      if (targetInstanceStateMap != null && targetInstanceStateMap.values().stream()
-          .noneMatch(state -> state.equals(SegmentStateModel.ONLINE)) && targetInstanceStateMap.values().stream()
-          .anyMatch(state -> state.equals(SegmentStateModel.CONSUMING))) {
-        if (!currentInstanceStateMap.keySet().equals(targetInstanceStateMap.keySet())) {
-          movingConsumingSegments.add(segmentName);
+      if (targetInstanceStateMap == null) {
+        continue;
+      }
+      for (String state : targetInstanceStateMap.values()) {
+        if (state.equals(SegmentStateModel.ONLINE)) {
+          // Completed segment (no CONSUMING replica by the assumption above), not a moving consuming segment.
+          break;
         }
+        if (state.equals(SegmentStateModel.CONSUMING)) {
+          if (!currentInstanceStateMap.keySet().equals(targetInstanceStateMap.keySet())) {
+            movingConsumingSegments.add(segmentName);
+          }
+          break;
+        }
+        // OFFLINE replica, keep scanning for an ONLINE or CONSUMING replica.
       }
     }
     return movingConsumingSegments;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -2424,14 +2424,14 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     tgt3.put("server2", "ONLINE");
     targetAssignment.put("segment3", tgt3);
 
-    // Segment 4: one instance is ONLINE, should not be considered
+    // Segment 4: OFFLINE (no CONSUMING replica), should not be considered
     Map<String, String> cur4 = new HashMap<>();
-    cur4.put("server1", "ONLINE");
-    cur4.put("server2", "CONSUMING");
+    cur4.put("server1", "OFFLINE");
+    cur4.put("server2", "OFFLINE");
     currentAssignment.put("segment4", cur4);
     Map<String, String> tgt4 = new HashMap<>();
-    tgt4.put("server1", "ONLINE");
-    tgt4.put("server2", "CONSUMING");
+    tgt4.put("server3", "OFFLINE");
+    tgt4.put("server4", "OFFLINE");
     targetAssignment.put("segment4", tgt4);
 
     // Segment 5: no ONLINE instance, but at least one in CONSUMING, should be considered moving


### PR DESCRIPTION
## Summary

`TableRebalancer.getMovingConsumingSegments` identified a consuming segment to be moved with two stream passes over the target instance state map — `values().stream().noneMatch(ONLINE)` and `values().stream().anyMatch(CONSUMING)` — allocating stream pipelines per segment across the whole table.

A realtime segment's replicas are never a mix of `ONLINE` and `CONSUMING`: a segment is either consuming or completed, and completion flips the whole segment at once. So the scan over a segment's replicas can stop at the first `ONLINE` replica (completed, hence not consuming) or the first `CONSUMING` replica (consuming), skipping only `OFFLINE` replicas. This replaces the two stream passes with a single early-terminating loop.

Besides removing the per-segment stream allocation, this avoids fully scanning the replicas of the completed segments, which are the majority in a table — the loop breaks on the first `ONLINE` replica instead of scanning all of them looking for a `CONSUMING` replica that (by the assumption) cannot exist. The assumption is documented on the method.

Behavior is unchanged for all realistic inputs. The unit test case that constructed an `ONLINE` + `CONSUMING` mix (which the assumption forbids) is replaced with a fully-`OFFLINE` segment so the "no `CONSUMING` replica → not moved" path is still exercised.
