### PR TITLE
Skip active-tasks validation in table config validate/tune preflight

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -455,7 +455,7 @@ public class TableConfigsRestletResource {
   @ManualAuthorization // performed after parsing TableConfigs
   public String validateConfig(String tableConfigsStr,
       @ApiParam(value = "comma separated list of validation type(s) to skip. supported types: "
-          + "(ALL|TASK|UPSERT|TENANT|MINION_INSTANCES|ACTIVE_TASKS)")
+          + "(ALL|TASK|UPSERT|TENANT|MINION_INSTANCES)")
       @QueryParam("validationTypesToSkip") @Nullable String typesToSkip, @Context HttpHeaders httpHeaders,
       @Context Request request) {
     Pair<TableConfigs, Map<String, Object>> tableConfigsAndUnrecognizedProps =
@@ -479,7 +479,7 @@ public class TableConfigsRestletResource {
   @ManualAuthorization // performed after parsing TableConfigs
   public String tuneConfig(String tableConfigsStr,
       @ApiParam(value = "comma separated list of validation type(s) to skip. supported types: "
-          + "(ALL|TASK|UPSERT|TENANT|MINION_INSTANCES|ACTIVE_TASKS)")
+          + "(ALL|TASK|UPSERT|TENANT|MINION_INSTANCES)")
       @QueryParam("validationTypesToSkip") @Nullable String typesToSkip, @Context HttpHeaders httpHeaders,
       @Context Request request) {
     Pair<TableConfigs, Map<String, Object>> tableConfigsAndUnrecognizedProps =
@@ -515,8 +515,10 @@ public class TableConfigsRestletResource {
     tableConfigs.setTableName(rawTableName);
 
     // Cluster-aware validations are exclusive to the validate/tune pre-flight endpoints so that users get fail-fast
-    // feedback on tenant/minion/active-task issues without re-running them in the create/update paths (which already
-    // perform the equivalent checks inline or via PinotHelixResourceManager).
+    // feedback on tenant/minion issues without re-running them in the create/update paths (which already perform the
+    // equivalent checks inline or via PinotHelixResourceManager). Active-task validation is intentionally excluded
+    // here: it applies only on the create/update path (gated by the ignoreActiveTasks flag) so that validate/tune of an
+    // existing table with running tasks is not blocked.
     Set<TableConfigUtils.ValidationType> skipTypes = TableConfigUtils.parseTypesToSkipString(typesToSkip);
     try {
       if (tableConfigs.getOffline() != null) {
@@ -552,9 +554,6 @@ public class TableConfigsRestletResource {
     }
     if (!skipTypes.contains(TableConfigUtils.ValidationType.MINION_INSTANCES)) {
       _pinotHelixResourceManager.validateTableTaskMinionInstanceTagConfig(tableConfig);
-    }
-    if (!skipTypes.contains(TableConfigUtils.ValidationType.ACTIVE_TASKS)) {
-      PinotTableRestletResource.tableTasksValidation(tableConfig, _pinotHelixTaskResourceManager);
     }
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableConfigsRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableConfigsRestletResourceTest.java
@@ -797,14 +797,16 @@ public class TableConfigsRestletResourceTest extends ControllerTest {
         adminClient.getTableClient().validateTableConfigs(tableConfigs.toPrettyJsonString(), "MINION_INSTANCES");
     Assert.assertNotNull(responseWithMinionSkip);
 
-    // Test validation with ACTIVE_TASKS skip type - should pass even with potential task conflicts
+    // ACTIVE_TASKS is still accepted as a skip type for backward compatibility, but the validate/tune preflight
+    // endpoints no longer run active-task validation (it applies only on the create/update path), so passing it is a
+    // no-op here.
     String responseWithTasksSkip =
         adminClient.getTableClient().validateTableConfigs(tableConfigs.toPrettyJsonString(), "ACTIVE_TASKS");
     Assert.assertNotNull(responseWithTasksSkip);
 
     // Test validation with multiple skip types
     String responseWithMultipleSkips = adminClient.getTableClient()
-        .validateTableConfigs(tableConfigs.toPrettyJsonString(), "TENANT,MINION_INSTANCES,ACTIVE_TASKS");
+        .validateTableConfigs(tableConfigs.toPrettyJsonString(), "TENANT,MINION_INSTANCES");
     Assert.assertNotNull(responseWithMultipleSkips);
 
     // Test validation with ALL skip type - should skip all validations

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -2067,6 +2067,10 @@ public final class TableConfigUtils {
   }
 
   // enum of all the skip-able validation types.
+  // ACTIVE_TASKS is retained for backward compatibility: it is still accepted as a validationTypesToSkip value so
+  // existing clients do not break, but it is no longer consumed by any production path. Active-task validation runs
+  // only on the create/update path (see PinotTableRestletResource.tableTasksValidation, gated by ignoreActiveTasks),
+  // not on the validate/tune preflight endpoints, so passing ACTIVE_TASKS there is a no-op.
   public enum ValidationType {
     ALL, TASK, UPSERT, TENANT, MINION_INSTANCES, ACTIVE_TASKS
   }


### PR DESCRIPTION
## Summary

The table config `validate`/`tune` preflight endpoints (`validateClusterAwareConfig` in `TableConfigsRestletResource`) previously ran active-tasks validation (regression introduced in https://github.com/apache/pinot/pull/16675) `PinotTableRestletResource.tableTasksValidation`. This blocked the basic validate/tune APIs for a table that **already exists and has tasks running** — even though those endpoints are read-only pre-flight checks.

Active-tasks validation is a runtime-conflict guard that only matters when a table is being **created or deleted**. This PR removes it from the read-only preflight path so validate/tune are no longer blocked by in-flight tasks.

## Changes

- Remove the `ACTIVE_TASKS` branch from `validateClusterAwareConfig` (the validate/tune preflight path).
- Drop `ACTIVE_TASKS` from the `validate`/`tune` `@ApiParam` documentation.
- Retain `ValidationType.ACTIVE_TASKS` as an accepted-but-no-op `validationTypesToSkip` value for backward compatibility (documented on the enum), so existing clients passing it do not break.
- Update the now-vacuous `ACTIVE_TASKS` assertions in `TableConfigsRestletResourceTest`.

## Where active-tasks validation still runs

The check is **not lost** — it is still enforced on the mutating paths:

- **Create**: `tableTasksValidation`, gated by the `ignoreActiveTasks` query param (`TableConfigsRestletResource`, `PinotDdlRestletResource`, `PinotTableRestletResource`).
- **Delete**: `tableTasksCleanup`.

## Backward compatibility

Behavior relaxation on the public `/tableConfigs/validate` and `/tableConfigs/tune` endpoints: configs for an existing table with running tasks that previously failed preflight now pass. The `ACTIVE_TASKS` skip type is still accepted (no-op) so no client request breaks.

## Testing

- `spotless`, `checkstyle`, `license`, and `-Xlint` compiler checks pass on the touched modules (`pinot-controller`, `pinot-segment-local`).
- Updated the preflight skip-type test to reflect the new behavior.

> Note: a dedicated regression test asserting the split (validate/tune accepts an active-task conflict while create rejects it unless `ignoreActiveTasks`) would require seeding a live minion task and is better suited to an integration test — happy to follow up if reviewers prefer.
