### PR TITLE
Auto force-commit partial OFFLINE consuming segments

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -43,6 +43,10 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   LLC_ZOOKEEPER_FETCH_FAILURES("failures", false),
   LLC_ZOOKEEPER_UPDATE_FAILURES("failures", false),
   LLC_STREAM_DATA_LOSS("dataLoss", false),
+  // Auto force-commit on partial OFFLINE consuming replicas (issue #15897)
+  LLC_AUTO_FORCE_COMMIT_SUCCESS("llcAutoForceCommit", false),
+  LLC_AUTO_FORCE_COMMIT_FAILED("llcAutoForceCommitFailed", false),
+  LLC_AUTO_FORCE_COMMIT_SKIPPED("llcAutoForceCommitSkipped", false),
   CONTROLLER_PERIODIC_TASK_RUN("periodicTaskRun", false),
   CONTROLLER_PERIODIC_TASK_ERROR("periodicTaskError", false),
   CONTROLLER_TABLE_SEGMENT_UPLOAD_ERROR("TableSegmentUploadError", false),

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -233,6 +233,13 @@ public class ControllerConf extends PinotConfiguration {
         "controller.segment.error.autoReset";
     public static final String ENABLE_PARTIAL_OFFLINE_REPLICA_REPAIR =
         "controller.realtime.segment.partialOfflineReplicaRepairEnabled";
+    // When enabled, RSVM auto force-commits partitions that have mixed CONSUMING+OFFLINE replicas
+    // (issue #15897). Default false — ops must opt in. Distinct from OFFLINE→CONSUMING repair above.
+    public static final String ENABLE_AUTO_FORCE_COMMIT_ON_PARTIAL_OFFLINE =
+        "controller.realtime.segment.autoForceCommitOnPartialOfflineEnabled";
+    // Minimum segment age before auto force-commit is attempted (proxy for having consumed rows).
+    public static final String AUTO_FORCE_COMMIT_ON_PARTIAL_OFFLINE_MIN_AGE_MS =
+        "controller.realtime.segment.autoForceCommitOnPartialOfflineMinAgeMs";
     public static final String DISASTER_RECOVERY_MODE_CONFIG_KEY = "controller.segment.disaster.recovery.mode";
 
     // Initial delays
@@ -1307,6 +1314,22 @@ public class ControllerConf extends PinotConfiguration {
 
   public boolean isPartialOfflineReplicaRepairEnabled() {
     return getProperty(ControllerPeriodicTasksConf.ENABLE_PARTIAL_OFFLINE_REPLICA_REPAIR, false);
+  }
+
+  /**
+   * Whether RSVM should auto force-commit partitions with partial OFFLINE consuming replicas.
+   * Default false. See issue #15897.
+   */
+  public boolean isAutoForceCommitOnPartialOfflineEnabled() {
+    return getProperty(ControllerPeriodicTasksConf.ENABLE_AUTO_FORCE_COMMIT_ON_PARTIAL_OFFLINE, false);
+  }
+
+  /**
+   * Minimum age (ms) of an IN_PROGRESS consuming segment before auto force-commit on partial OFFLINE.
+   * Default 5 minutes. Age is derived from LLC segment name creation time (fallback: ZK creation time).
+   */
+  public long getAutoForceCommitOnPartialOfflineMinAgeMs() {
+    return getProperty(ControllerPeriodicTasksConf.AUTO_FORCE_COMMIT_ON_PARTIAL_OFFLINE_MIN_AGE_MS, 300_000L);
   }
 
   public DisasterRecoveryMode getDisasterRecoveryMode() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -1316,18 +1316,14 @@ public class ControllerConf extends PinotConfiguration {
     return getProperty(ControllerPeriodicTasksConf.ENABLE_PARTIAL_OFFLINE_REPLICA_REPAIR, false);
   }
 
-  /**
-   * Whether RSVM should auto force-commit partitions with partial OFFLINE consuming replicas.
-   * Default false. See issue #15897.
-   */
+  /// Whether RSVM should auto force-commit partitions with partial OFFLINE consuming replicas.
+  /// Default false. See issue #15897.
   public boolean isAutoForceCommitOnPartialOfflineEnabled() {
     return getProperty(ControllerPeriodicTasksConf.ENABLE_AUTO_FORCE_COMMIT_ON_PARTIAL_OFFLINE, false);
   }
 
-  /**
-   * Minimum age (ms) of an IN_PROGRESS consuming segment before auto force-commit on partial OFFLINE.
-   * Default 5 minutes. Age is derived from LLC segment name creation time (fallback: ZK creation time).
-   */
+  /// Minimum age (ms) of an IN_PROGRESS consuming segment before auto force-commit on partial OFFLINE.
+  /// Default 5 minutes. Age is derived from LLC segment name creation time (fallback: ZK creation time).
   public long getAutoForceCommitOnPartialOfflineMinAgeMs() {
     return getProperty(ControllerPeriodicTasksConf.AUTO_FORCE_COMMIT_ON_PARTIAL_OFFLINE_MIN_AGE_MS, 300_000L);
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -222,7 +222,7 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
   // Segments for which auto force-commit on partial OFFLINE has already been attempted (leader lifetime).
   // Pruned when the segment is no longer CONSUMING in IdealState for its table (see pruneAutoForceCommitTracking).
   private final Set<String> _autoForceCommitRequestedSegments = ConcurrentHashMap.newKeySet();
-  /** Hard cap so a pruning bug cannot grow this set without bound on a long-lived controller leader. */
+  /// Hard cap so a pruning bug cannot grow this set without bound on a long-lived controller leader.
   private static final int MAX_AUTO_FORCE_COMMIT_TRACKED_SEGMENTS = 10_000;
 
   private volatile boolean _isStopping = false;
@@ -1986,15 +1986,13 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     return newSegmentName;
   }
 
-  /**
-   * Auto force-commit a partition that has mixed CONSUMING + OFFLINE IdealState replicas while ZK status is
-   * IN_PROGRESS (issue #15897). Seals healthy replicas and lets completion create a new CONSUMING segment for all
-   * replicas. Gated by age (proxy for progress) and at-most-once per segment name on this controller leader.
-   *
-   * @return true if this path owns recovery for the segment (force-commit initiated, already requested, or
-   *     permanently skipped after a failed attempt) so OFFLINE→CONSUMING flip should not also run; false if gates
-   *     are not yet satisfied and another repair tool may act
-   */
+  /// Auto force-commit a partition that has mixed CONSUMING + OFFLINE IdealState replicas while ZK status is
+  /// IN_PROGRESS (issue #15897). Seals healthy replicas and lets completion create a new CONSUMING segment for all
+  /// replicas. Gated by age (proxy for progress) and at-most-once per segment name on this controller leader.
+  ///
+  /// @return true if this path owns recovery for the segment (force-commit initiated, already requested, or
+  ///     permanently skipped after a failed attempt) so OFFLINE→CONSUMING flip should not also run; false if gates
+  ///     are not yet satisfied and another repair tool may act
   @VisibleForTesting
   boolean maybeAutoForceCommitOnPartialOffline(String realtimeTableName, int partitionId, String segmentName,
       LLCSegmentName llcSegmentName, SegmentZKMetadata segmentZKMetadata, long currentTimeMs) {
@@ -2056,10 +2054,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     }
   }
 
-  /**
-   * Drop tracking entries for this table's segments that are no longer CONSUMING in IdealState so the set cannot grow
-   * without bound across segment generations on a long-lived controller leader.
-   */
+  /// Drop tracking entries for this table's segments that are no longer CONSUMING in IdealState so the set cannot grow
+  /// without bound across segment generations on a long-lived controller leader.
   @VisibleForTesting
   void pruneAutoForceCommitTracking(String realtimeTableName, Map<String, Map<String, String>> instanceStatesMap) {
     if (_autoForceCommitRequestedSegments.isEmpty()) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -212,11 +212,18 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
   private final boolean _isDeepStoreLLCSegmentUploadRetryEnabled;
   private final boolean _isTmpSegmentAsyncDeletionEnabled;
   private final boolean _isPartialOfflineReplicaRepairEnabled;
+  private final boolean _isAutoForceCommitOnPartialOfflineEnabled;
+  private final long _autoForceCommitOnPartialOfflineMinAgeMs;
   private final int _deepstoreUploadRetryTimeoutMs;
   private final FileUploadDownloadClient _fileUploadDownloadClient;
   private final AtomicInteger _numCompletingSegments = new AtomicInteger(0);
   private final ExecutorService _deepStoreUploadExecutor;
   private final Set<String> _deepStoreUploadExecutorPendingSegments;
+  // Segments for which auto force-commit on partial OFFLINE has already been attempted (leader lifetime).
+  // Pruned when the segment is no longer CONSUMING in IdealState for its table (see pruneAutoForceCommitTracking).
+  private final Set<String> _autoForceCommitRequestedSegments = ConcurrentHashMap.newKeySet();
+  /** Hard cap so a pruning bug cannot grow this set without bound on a long-lived controller leader. */
+  private static final int MAX_AUTO_FORCE_COMMIT_TRACKED_SEGMENTS = 10_000;
 
   private volatile boolean _isStopping = false;
 
@@ -241,6 +248,8 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
 
     _isTmpSegmentAsyncDeletionEnabled = controllerConf.isTmpSegmentAsyncDeletionEnabled();
     _isPartialOfflineReplicaRepairEnabled = controllerConf.isPartialOfflineReplicaRepairEnabled();
+    _isAutoForceCommitOnPartialOfflineEnabled = controllerConf.isAutoForceCommitOnPartialOfflineEnabled();
+    _autoForceCommitOnPartialOfflineMinAgeMs = controllerConf.getAutoForceCommitOnPartialOfflineMinAgeMs();
     _deepstoreUploadRetryTimeoutMs = controllerConf.getDeepStoreRetryUploadTimeoutMs();
   }
 
@@ -1819,11 +1828,14 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
               updateInstanceStatesForNewConsumingSegment(instanceStatesMap, latestSegmentName, null, segmentAssignment,
                   instancePartitionsMap);
             }
-          } else if (latestSegmentZKMetadata.getStatus() == Status.IN_PROGRESS
-              && _isPartialOfflineReplicaRepairEnabled) {
+          } else if (latestSegmentZKMetadata.getStatus() == Status.IN_PROGRESS) {
             // Handle case where some replicas are OFFLINE while others are CONSUMING
             // This happens when one replica fails (e.g., KafkaConsumer init error) and marks itself OFFLINE
-            // while other replicas continue consuming
+            // while other replicas continue consuming.
+            //
+            // Two independent recovery tools (both default off):
+            // 1. Auto force-commit (#15897): seal healthy replicas and recreate CONSUMING for all.
+            // 2. OFFLINE→CONSUMING flip (#11314): retry failed replicas without sealing.
             List<String> offlineInstances = new ArrayList<>();
             for (Map.Entry<String, String> instanceEntry : instanceStateMap.entrySet()) {
               if (SegmentStateModel.OFFLINE.equals(instanceEntry.getValue())) {
@@ -1832,12 +1844,20 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
             }
 
             if (!offlineInstances.isEmpty()) {
-              LOGGER.info("Repairing segment: {} with {} OFFLINE replicas out of {} total replicas. "
-                      + "Setting OFFLINE replicas back to CONSUMING: {}", latestSegmentName, offlineInstances.size(),
-                  instanceStateMap.size(), offlineInstances);
-              // Set the OFFLINE replicas back to CONSUMING so they can retry
-              for (String offlineInstance : offlineInstances) {
-                instanceStateMap.put(offlineInstance, SegmentStateModel.CONSUMING);
+              boolean autoForceCommitTriggered = false;
+              if (_isAutoForceCommitOnPartialOfflineEnabled && !isTablePaused(idealState)) {
+                autoForceCommitTriggered =
+                    maybeAutoForceCommitOnPartialOffline(realtimeTableName, partitionId, latestSegmentName,
+                        latestLLCSegmentName, latestSegmentZKMetadata, currentTimeMs);
+              }
+              // Prefer force-commit when it was triggered; otherwise optionally flip OFFLINE→CONSUMING.
+              if (!autoForceCommitTriggered && _isPartialOfflineReplicaRepairEnabled) {
+                LOGGER.info("Repairing segment: {} with {} OFFLINE replicas out of {} total replicas. "
+                        + "Setting OFFLINE replicas back to CONSUMING: {}", latestSegmentName, offlineInstances.size(),
+                    instanceStateMap.size(), offlineInstances);
+                for (String offlineInstance : offlineInstances) {
+                  instanceStateMap.put(offlineInstance, SegmentStateModel.CONSUMING);
+                }
               }
             }
           }
@@ -1944,10 +1964,11 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
       }
     }
 
+    pruneAutoForceCommitTracking(realtimeTableName, instanceStatesMap);
     return idealState;
   }
 
-  private void createNewConsumingSegment(TableConfig tableConfig, StreamConfig streamConfig,
+  private String createNewConsumingSegment(TableConfig tableConfig, StreamConfig streamConfig,
       SegmentZKMetadata latestSegmentZKMetadata, long currentTimeMs,
       int numPartitions, InstancePartitions instancePartitions,
       Map<String, Map<String, String>> instanceStatesMap, SegmentAssignment segmentAssignment,
@@ -1962,6 +1983,97 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     String newSegmentName = newLLCSegmentName.getSegmentName();
     updateInstanceStatesForNewConsumingSegment(instanceStatesMap, null, newSegmentName, segmentAssignment,
         instancePartitionsMap);
+    return newSegmentName;
+  }
+
+  /**
+   * Auto force-commit a partition that has mixed CONSUMING + OFFLINE IdealState replicas while ZK status is
+   * IN_PROGRESS (issue #15897). Seals healthy replicas and lets completion create a new CONSUMING segment for all
+   * replicas. Gated by age (proxy for progress) and at-most-once per segment name on this controller leader.
+   *
+   * @return true if this path owns recovery for the segment (force-commit initiated, already requested, or
+   *     permanently skipped after a failed attempt) so OFFLINE→CONSUMING flip should not also run; false if gates
+   *     are not yet satisfied and another repair tool may act
+   */
+  @VisibleForTesting
+  boolean maybeAutoForceCommitOnPartialOffline(String realtimeTableName, int partitionId, String segmentName,
+      LLCSegmentName llcSegmentName, SegmentZKMetadata segmentZKMetadata, long currentTimeMs) {
+    if (!_autoForceCommitRequestedSegments.add(segmentName)) {
+      LOGGER.debug("Skipping auto force-commit for segment: {} of table: {} — already requested", segmentName,
+          realtimeTableName);
+      _controllerMetrics.addMeteredTableValue(realtimeTableName, ControllerMeter.LLC_AUTO_FORCE_COMMIT_SKIPPED, 1L);
+      // Still "handled" so we do not also flip OFFLINE→CONSUMING while force-commit is in flight / failed.
+      return true;
+    }
+    // Bound memory if pruning fails to keep up (long-lived leader + many tables).
+    if (_autoForceCommitRequestedSegments.size() > MAX_AUTO_FORCE_COMMIT_TRACKED_SEGMENTS) {
+      LOGGER.warn("Auto force-commit tracking set exceeded {} entries; clearing to bound memory",
+          MAX_AUTO_FORCE_COMMIT_TRACKED_SEGMENTS);
+      _autoForceCommitRequestedSegments.clear();
+      _autoForceCommitRequestedSegments.add(segmentName);
+    }
+
+    long creationTimeMs = llcSegmentName.getCreationTimeMs();
+    if (creationTimeMs <= 0) {
+      creationTimeMs = segmentZKMetadata.getCreationTime();
+    }
+    long ageMs = currentTimeMs - creationTimeMs;
+    if (ageMs < _autoForceCommitOnPartialOfflineMinAgeMs) {
+      // Allow a later RSVM tick to retry once the segment is old enough.
+      _autoForceCommitRequestedSegments.remove(segmentName);
+      LOGGER.info(
+          "Skipping auto force-commit for segment: {} of table: {} — age {}ms < minAge {}ms", segmentName,
+          realtimeTableName, ageMs, _autoForceCommitOnPartialOfflineMinAgeMs);
+      _controllerMetrics.addMeteredTableValue(realtimeTableName, ControllerMeter.LLC_AUTO_FORCE_COMMIT_SKIPPED, 1L);
+      return false;
+    }
+
+    // Skip unconfigured flush thresholds (proxy for not ready to seal).
+    if (segmentZKMetadata.getSizeThresholdToFlushSegment() <= 0) {
+      _autoForceCommitRequestedSegments.remove(segmentName);
+      LOGGER.info(
+          "Skipping auto force-commit for segment: {} of table: {} — sizeThresholdToFlushSegment={} (not positive)",
+          segmentName, realtimeTableName, segmentZKMetadata.getSizeThresholdToFlushSegment());
+      _controllerMetrics.addMeteredTableValue(realtimeTableName, ControllerMeter.LLC_AUTO_FORCE_COMMIT_SKIPPED, 1L);
+      return false;
+    }
+
+    try {
+      LOGGER.info(
+          "Auto force-committing partition: {} segment: {} of table: {} due to partial OFFLINE replicas (age={}ms)",
+          partitionId, segmentName, realtimeTableName, ageMs);
+      // Partition-scoped only — never force-commit the whole table from this path.
+      forceCommit(realtimeTableName, Integer.toString(partitionId), null, null);
+      _controllerMetrics.addMeteredTableValue(realtimeTableName, ControllerMeter.LLC_AUTO_FORCE_COMMIT_SUCCESS, 1L);
+      return true;
+    } catch (Exception e) {
+      // Includes validateForceCommitAllowed failures (partial upsert / drop-OOO RF>1). Keep segment in the
+      // requested set to avoid force-commit storms on every RSVM tick.
+      LOGGER.warn("Auto force-commit failed for partition: {} segment: {} of table: {}: {}", partitionId, segmentName,
+          realtimeTableName, e.getMessage());
+      _controllerMetrics.addMeteredTableValue(realtimeTableName, ControllerMeter.LLC_AUTO_FORCE_COMMIT_FAILED, 1L);
+      return true;
+    }
+  }
+
+  /**
+   * Drop tracking entries for this table's segments that are no longer CONSUMING in IdealState so the set cannot grow
+   * without bound across segment generations on a long-lived controller leader.
+   */
+  @VisibleForTesting
+  void pruneAutoForceCommitTracking(String realtimeTableName, Map<String, Map<String, String>> instanceStatesMap) {
+    if (_autoForceCommitRequestedSegments.isEmpty()) {
+      return;
+    }
+    String rawTableName = TableNameBuilder.extractRawTableName(realtimeTableName);
+    _autoForceCommitRequestedSegments.removeIf(segmentName -> {
+      LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentName);
+      if (llcSegmentName == null || !rawTableName.equals(llcSegmentName.getTableName())) {
+        return false;
+      }
+      Map<String, String> states = instanceStatesMap.get(segmentName);
+      return states == null || !states.containsValue(SegmentStateModel.CONSUMING);
+    });
   }
 
   private Map<Integer, StreamPartitionMsgOffset> fetchPartitionGroupIdToSmallestOffset(List<StreamConfig> streamConfigs,

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -234,6 +234,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     }
   }
 
+
+
+
   @Test
   public void testSetUpNewTableWithExplicitSequenceNumbers() {
     FakePinotLLCRealtimeSegmentManager segmentManager = new FakePinotLLCRealtimeSegmentManager();
@@ -271,6 +274,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     }
   }
 
+
+
+
   @Test
   public void testSetUpNewTableDefaultSequenceNumberResolvesToZero() {
     FakePinotLLCRealtimeSegmentManager segmentManager = new FakePinotLLCRealtimeSegmentManager();
@@ -307,6 +313,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     segmentManager._numPartitions = numPartitions;
     segmentManager.setUpNewTable();
   }
+
+
+
 
   @Test
   public void testCommitSegment() {
@@ -427,6 +436,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     assertNull(consumingSegmentZKMetadata);
   }
 
+
+
+
   @Test
   public void testForceCommitWithNonConsumingSegmentsIsIgnored() {
     // Set up a new table with 1 replica, 2 instances, 1 partition
@@ -446,6 +458,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
         segmentManager.forceCommit(REALTIME_TABLE_NAME, null, nonConsumingSegment, BatchConfig.of(1, 1, 5));
     assertTrue(committed.isEmpty(), "Expected no segments to be committed when only non-consuming segments provided");
   }
+
+
+
 
   @Test
   public void testForceCommitAllowsNormalTable() {
@@ -472,6 +487,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     }
   }
 
+
+
+
   @Test
   public void testForceCommitWithNullBatchConfigUsesSingleBatch() {
     FakePinotLLCRealtimeSegmentManager segmentManager = new FakePinotLLCRealtimeSegmentManager();
@@ -492,6 +510,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     assertTrue(committedSegments.contains(consumingSegment),
         "Returned segments should include the consuming segment present in ideal state");
   }
+
+
+
 
   @Test
   public void testPauseConsumptionPassesBatchConfigToForceCommit() {
@@ -525,6 +546,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
         "pauseConsumption should include consuming segments from the updated ideal state");
   }
 
+
+
+
   @Test
   public void testGetPauseStatusDetailsIncludesInactiveTopics()
       throws Exception {
@@ -545,6 +569,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     assertFalse(details.getPauseFlag());
   }
 
+
+
+
   @Test
   public void testPauseStatusDetailsJsonRoundTrip()
       throws Exception {
@@ -561,6 +588,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     assertFalse(deserialized.getPauseFlag());
     assertEquals(deserialized.getComment(), "comment");
   }
+
+
+
 
   @Test
   public void testCommitSegmentWithOffsetAutoResetOnOffset()
@@ -624,6 +654,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
       assertEquals(committedSegmentZKMetadata.getCreationTime(), CURRENT_TIME_MS);
     }
   }
+
+
+
 
   @Test
   public void testCommitSegmentWithOffsetAutoResetOnTime()
@@ -984,6 +1017,155 @@ public class PinotLLCRealtimeSegmentManagerTest {
     testRepairs(segmentManager, Lists.newArrayList(1));
   }
 
+
+
+
+  @Test
+  public void testAutoForceCommitOnPartialOffline() {
+    // RF=3, 1 OFFLINE, age gate satisfied → forceCommit once with partition filter
+    PinotHelixResourceManager mockHelixResourceManager = mock(PinotHelixResourceManager.class);
+    FakePinotLLCRealtimeSegmentManager segmentManager =
+        spy(new FakePinotLLCRealtimeSegmentManager(mockHelixResourceManager, false, true, 0L));
+    setUpNewTable(segmentManager, 3, 5, 2);
+    when(segmentManager._mockResourceManager.getTableConfig(REALTIME_TABLE_NAME)).thenReturn(
+        segmentManager._tableConfig);
+
+    String consumingSegment = new LLCSegmentName(RAW_TABLE_NAME, 0, 0, CURRENT_TIME_MS).getSegmentName();
+    Map<String, String> consumingSegmentInstanceStateMap =
+        segmentManager._idealState.getRecord().getMapFields().get(consumingSegment);
+    String offlineInstance = consumingSegmentInstanceStateMap.keySet().iterator().next();
+    consumingSegmentInstanceStateMap.put(offlineInstance, SegmentStateModel.OFFLINE);
+
+    final String[] capturedPartitions = new String[1];
+    doAnswer(invocation -> {
+      capturedPartitions[0] = invocation.getArgument(1);
+      return Set.of(consumingSegment);
+    }).when(segmentManager).forceCommit(eq(REALTIME_TABLE_NAME), any(), isNull(), isNull());
+
+    segmentManager.ensureAllPartitionsConsuming();
+
+    verify(segmentManager, times(1)).forceCommit(eq(REALTIME_TABLE_NAME), eq("0"), isNull(), isNull());
+    assertEquals(capturedPartitions[0], "0");
+    // IdealState OFFLINE replica left alone (completion will recreate CONSUMING)
+    assertEquals(consumingSegmentInstanceStateMap.get(offlineInstance), SegmentStateModel.OFFLINE);
+
+    // Second tick must not force-commit again (once per segment name)
+    segmentManager.ensureAllPartitionsConsuming();
+    verify(segmentManager, times(1)).forceCommit(eq(REALTIME_TABLE_NAME), eq("0"), isNull(), isNull());
+  }
+
+
+
+
+  @Test
+  public void testAutoForceCommitOnPartialOfflineAgeGateNotSatisfied() {
+    PinotHelixResourceManager mockHelixResourceManager = mock(PinotHelixResourceManager.class);
+    // min age 1 hour; segment creation time == CURRENT_TIME_MS → age 0 → no-op
+    FakePinotLLCRealtimeSegmentManager segmentManager =
+        spy(new FakePinotLLCRealtimeSegmentManager(mockHelixResourceManager, false, true, TimeUnit.HOURS.toMillis(1)));
+    setUpNewTable(segmentManager, 2, 4, 1);
+    when(segmentManager._mockResourceManager.getTableConfig(REALTIME_TABLE_NAME)).thenReturn(
+        segmentManager._tableConfig);
+
+    String consumingSegment = new LLCSegmentName(RAW_TABLE_NAME, 0, 0, CURRENT_TIME_MS).getSegmentName();
+    Map<String, String> instanceStateMap =
+        segmentManager._idealState.getRecord().getMapFields().get(consumingSegment);
+    instanceStateMap.put(instanceStateMap.keySet().iterator().next(), SegmentStateModel.OFFLINE);
+
+    segmentManager.ensureAllPartitionsConsuming();
+
+    verify(segmentManager, never()).forceCommit(any(), any(), any(), any());
+    // OFFLINE still OFFLINE (partial repair flag off)
+    assertTrue(instanceStateMap.containsValue(SegmentStateModel.OFFLINE));
+  }
+
+
+
+
+  @Test
+  public void testAutoForceCommitSkippedWhenAllOfflineUsesRecreate() {
+    PinotHelixResourceManager mockHelixResourceManager = mock(PinotHelixResourceManager.class);
+    FakePinotLLCRealtimeSegmentManager segmentManager =
+        spy(new FakePinotLLCRealtimeSegmentManager(mockHelixResourceManager, false, true, 0L));
+    setUpNewTable(segmentManager, 2, 4, 1);
+    when(segmentManager._mockResourceManager.getTableConfig(REALTIME_TABLE_NAME)).thenReturn(
+        segmentManager._tableConfig);
+
+    String consumingSegment = new LLCSegmentName(RAW_TABLE_NAME, 0, 0, CURRENT_TIME_MS).getSegmentName();
+    Map<String, String> instanceStateMap =
+        segmentManager._idealState.getRecord().getMapFields().get(consumingSegment);
+    for (String instance : new ArrayList<>(instanceStateMap.keySet())) {
+      instanceStateMap.put(instance, SegmentStateModel.OFFLINE);
+    }
+
+    segmentManager.ensureAllPartitionsConsuming();
+
+    // All OFFLINE uses recreate path, not force-commit
+    verify(segmentManager, never()).forceCommit(any(), any(), any(), any());
+    // New consuming segment should exist (seq 1)
+    String newConsuming = new LLCSegmentName(RAW_TABLE_NAME, 0, 1, CURRENT_TIME_MS).getSegmentName();
+    assertNotNull(segmentManager._idealState.getRecord().getMapFields().get(newConsuming));
+    assertTrue(segmentManager._idealState.getRecord().getMapFields().get(newConsuming)
+        .containsValue(SegmentStateModel.CONSUMING));
+  }
+
+
+
+
+  @Test
+  public void testAutoForceCommitSkippedWhenTablePaused() {
+    PinotHelixResourceManager mockHelixResourceManager = mock(PinotHelixResourceManager.class);
+    FakePinotLLCRealtimeSegmentManager segmentManager =
+        spy(new FakePinotLLCRealtimeSegmentManager(mockHelixResourceManager, false, true, 0L));
+    setUpNewTable(segmentManager, 2, 4, 1);
+    when(segmentManager._mockResourceManager.getTableConfig(REALTIME_TABLE_NAME)).thenReturn(
+        segmentManager._tableConfig);
+
+    String consumingSegment = new LLCSegmentName(RAW_TABLE_NAME, 0, 0, CURRENT_TIME_MS).getSegmentName();
+    Map<String, String> instanceStateMap =
+        segmentManager._idealState.getRecord().getMapFields().get(consumingSegment);
+    instanceStateMap.put(instanceStateMap.keySet().iterator().next(), SegmentStateModel.OFFLINE);
+
+    segmentManager._idealState.getRecord().setSimpleField(PinotLLCRealtimeSegmentManager.IS_TABLE_PAUSED, "true");
+
+    segmentManager.ensureAllPartitionsConsuming();
+
+    verify(segmentManager, never()).forceCommit(any(), any(), any(), any());
+  }
+
+
+
+
+  @Test
+  public void testAutoForceCommitSkippedWhenValidateForceCommitFails() {
+    PinotHelixResourceManager mockHelixResourceManager = mock(PinotHelixResourceManager.class);
+    FakePinotLLCRealtimeSegmentManager segmentManager =
+        spy(new FakePinotLLCRealtimeSegmentManager(mockHelixResourceManager, false, true, 0L));
+    setUpNewTable(segmentManager, 2, 4, 1);
+    when(segmentManager._mockResourceManager.getTableConfig(REALTIME_TABLE_NAME)).thenReturn(
+        segmentManager._tableConfig);
+
+    String consumingSegment = new LLCSegmentName(RAW_TABLE_NAME, 0, 0, CURRENT_TIME_MS).getSegmentName();
+    Map<String, String> instanceStateMap =
+        segmentManager._idealState.getRecord().getMapFields().get(consumingSegment);
+    instanceStateMap.put(instanceStateMap.keySet().iterator().next(), SegmentStateModel.OFFLINE);
+
+    doThrow(new IllegalStateException("Force commit disabled for table")).when(segmentManager)
+        .forceCommit(eq(REALTIME_TABLE_NAME), eq("0"), isNull(), isNull());
+
+    // Should not propagate; IdealState unchanged for OFFLINE replica
+    segmentManager.ensureAllPartitionsConsuming();
+    verify(segmentManager, times(1)).forceCommit(eq(REALTIME_TABLE_NAME), eq("0"), isNull(), isNull());
+    assertTrue(instanceStateMap.containsValue(SegmentStateModel.OFFLINE));
+
+    // Second tick: already requested → no second forceCommit attempt
+    segmentManager.ensureAllPartitionsConsuming();
+    verify(segmentManager, times(1)).forceCommit(eq(REALTIME_TABLE_NAME), eq("0"), isNull(), isNull());
+  }
+
+
+
+
   @Test
   public void testPartialOfflineReplicaRepair() {
     // Set up a new table with 3 replicas, 5 instances, 2 partitions
@@ -1023,6 +1205,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     assertEquals(consumingSegmentInstanceStateMap.size(), 3);
     assertEquals(consumingSegmentInstanceStateMap.get(offlineInstance), SegmentStateModel.CONSUMING);
   }
+
+
+
 
   @Test
   public void testPartialOfflineReplicaRepairDisabled() {
@@ -1192,6 +1377,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     }
   }
 
+
+
+
   @Test
   public void testCommitSegmentWhenControllerWentThroughGC() {
     // Set up a new table with 2 replicas, 5 instances, 4 partitions
@@ -1220,6 +1408,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     }
   }
 
+
+
+
   @Test
   public void testCommitSegmentFile()
       throws Exception {
@@ -1239,6 +1430,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
         URIUtils.getUri(tableDir.toString(), URIUtils.encode(segmentName)).toString());
     assertFalse(segmentFile.exists());
   }
+
+
+
 
   @Test
   public void testSegmentAlreadyThereAndExtraneousFilesDeleted()
@@ -1268,6 +1462,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     assertFalse(extraSegmentFile.exists());
     assertTrue(otherSegmentFile.exists());
   }
+
+
+
 
   @Test
   public void testStopSegmentManager()
@@ -1320,6 +1517,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     }
   }
 
+
+
+
   @Test
   public void testCommitSegmentMetadata() {
     // Set up a new table with 2 replicas, 5 instances, 4 partition
@@ -1349,6 +1549,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     Assert.assertEquals(segmentZKMetadata.getDownloadUrl(), "");
   }
 
+
+
+
   @Test
   public void testCommitSegmentMetadataSkipsIdealStateFetchWhenPartitionIdsAvailable() {
     PinotHelixResourceManager mockHelixResourceManager = mock(PinotHelixResourceManager.class);
@@ -1363,6 +1566,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
 
     verify(segmentManager, atLeastOnce()).getIdealState(REALTIME_TABLE_NAME);
   }
+
+
+
 
   @Test
   public void testCommitSegmentMetadataFetchesIdealStateWhenPartitionIdsFallbackNeeded() {
@@ -1382,6 +1588,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
 
     verify(segmentManager, atLeastOnce()).getIdealState(REALTIME_TABLE_NAME);
   }
+
+
+
 
   @Test
   public void testCommitSegmentMetadataSkipsCreatingNewMetadataWhenTopicPausedIfPartitionIdsFallbackNeeded() {
@@ -1409,6 +1618,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     verify(propertyStore, never()).remove(anyString(), eq(AccessOption.PERSISTENT));
   }
 
+
+
+
   @Test
   public void testCommitSegmentMetadataCleansUpMetadataWhenTablePaused() {
     FakePinotLLCRealtimeSegmentManager segmentManager = new FakePinotLLCRealtimeSegmentManager();
@@ -1435,6 +1647,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
         AccessOption.PERSISTENT);
   }
 
+
+
+
   @Test
   public void testCommitSegmentMetadataCleansUpMetadataWhenTopicPaused() {
     FakePinotLLCRealtimeSegmentManager segmentManager = new FakePinotLLCRealtimeSegmentManager();
@@ -1457,6 +1672,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
         ZKMetadataProvider.constructPropertyStorePathForSegment(REALTIME_TABLE_NAME, newConsumingSegment),
         AccessOption.PERSISTENT);
   }
+
+
+
 
   @Test
   public void testCommitSegmentMetadataCleansUpMetadataWhenCommittingSegmentNotConsuming() {
@@ -1739,6 +1957,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     assertNull(segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentNames.get(4), null).getDownloadUrl());
   }
 
+
+
+
   @Test
   public void testUploadCommittedSegment()
       throws HttpErrorStatusException, IOException, URISyntaxException {
@@ -1883,6 +2104,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     assertNull(segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentNames.get(4), null).getDownloadUrl());
   }
 
+
+
+
   @Test
   public void testDeleteTmpSegmentFiles()
       throws Exception {
@@ -1923,6 +2147,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     assertFalse(segmentFile.exists());
     assertEquals(numDeletedTmpSegments, 1);
   }
+
+
+
 
   @Test
   public void testGetPartitionIds()
@@ -2018,6 +2245,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     }
   }
 
+
+
+
   @Test
   public void testReduceSegmentSizeAndReset() {
     // Set up a new table with 2 replicas, 5 instances, 4 partitions
@@ -2038,6 +2268,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     Assert.assertEquals(Math.min(100 / 2, prevRowSize / 2),
         segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentName, null).getSizeThresholdToFlushSegment());
   }
+
+
+
 
   @Test
   public void testGetInstanceToConsumingSegments() {
@@ -2064,6 +2297,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
             new LinkedList<>(List.of("seg2", "seg3", "seg4")), "i4", new LinkedList<>(List.of("seg3")), "i5",
             new LinkedList<>(List.of("seg4"))));
   }
+
+
+
 
   @Test
   public void getSegmentBatchList() {
@@ -2095,6 +2331,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     assertEquals(segmentBatchList, List.of(Set.of("seg0", "seg1", "seg2", "seg3"), Set.of("seg4", "seg5", "seg6")));
   }
 
+
+
+
   @Test
   public void getSegmentsYetToBeCommitted() {
     PinotHelixResourceManager mockHelixResourceManager = mock(PinotHelixResourceManager.class);
@@ -2124,6 +2363,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     Set<String> segmentsYetToBeCommitted = realtimeSegmentManager.getSegmentsYetToBeCommitted("test", segmentsToCheck);
     assert ImmutableSet.of("s2", "s4", "s5").equals(segmentsYetToBeCommitted);
   }
+
+
+
 
   @Test
   public void testGetCommittingSegments() {
@@ -2206,6 +2448,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     assertTrue(result.isEmpty());
   }
 
+
+
+
   @Test
   public void testSyncCommittingSegments()
       throws Exception {
@@ -2281,6 +2526,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     assertFalse(segmentManager.syncCommittingSegments(realtimeTableName, newSegments));
   }
 
+
+
+
   @Test
   public void testShouldRepairErrorSegmentsForPartialUpsertOrDedup() {
     PinotLLCRealtimeSegmentManager pinotLLCRealtimeSegmentManager = new FakePinotLLCRealtimeSegmentManager();
@@ -2289,6 +2537,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     Assert.assertTrue(
         pinotLLCRealtimeSegmentManager.shouldRepairErrorSegmentsForPartialUpsertOrDedup(DisasterRecoveryMode.ALWAYS));
   }
+
+
+
 
   @Test
   public void testOnChangeUpdatesMaxSegmentCompletionTime() {
@@ -2339,6 +2590,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     segmentManager.onChange(Set.of("some.other.config"), clusterConfigs);
     assertEquals(segmentManager.getMaxSegmentCompletionTimeMillis(), 600_000L);
   }
+
+
+
 
   @Test
   public void testGetPartitionMetadataFromTableConfig() {
@@ -2434,16 +2688,32 @@ public class PinotLLCRealtimeSegmentManagerTest {
 
     FakePinotLLCRealtimeSegmentManager(PinotHelixResourceManager pinotHelixResourceManager,
         boolean enablePartialOfflineReplicaRepair) {
-      super(pinotHelixResourceManager, createControllerConf(enablePartialOfflineReplicaRepair),
-          mock(ControllerMetrics.class));
+      this(pinotHelixResourceManager, enablePartialOfflineReplicaRepair, false, 300_000L);
+    }
+
+    FakePinotLLCRealtimeSegmentManager(PinotHelixResourceManager pinotHelixResourceManager,
+        boolean enablePartialOfflineReplicaRepair, boolean enableAutoForceCommitOnPartialOffline,
+        long autoForceCommitMinAgeMs) {
+      super(pinotHelixResourceManager,
+          createControllerConf(enablePartialOfflineReplicaRepair, enableAutoForceCommitOnPartialOffline,
+              autoForceCommitMinAgeMs), mock(ControllerMetrics.class));
       _mockResourceManager = pinotHelixResourceManager;
     }
 
     private static ControllerConf createControllerConf(boolean enablePartialOfflineReplicaRepair) {
+      return createControllerConf(enablePartialOfflineReplicaRepair, false, 300_000L);
+    }
+
+    private static ControllerConf createControllerConf(boolean enablePartialOfflineReplicaRepair,
+        boolean enableAutoForceCommitOnPartialOffline, long autoForceCommitMinAgeMs) {
       ControllerConf config = new ControllerConf();
       config.setDataDir(TEMP_DIR.toString());
       config.setProperty(ControllerConf.ControllerPeriodicTasksConf.ENABLE_PARTIAL_OFFLINE_REPLICA_REPAIR,
           enablePartialOfflineReplicaRepair);
+      config.setProperty(ControllerConf.ControllerPeriodicTasksConf.ENABLE_AUTO_FORCE_COMMIT_ON_PARTIAL_OFFLINE,
+          enableAutoForceCommitOnPartialOffline);
+      config.setProperty(ControllerConf.ControllerPeriodicTasksConf.AUTO_FORCE_COMMIT_ON_PARTIAL_OFFLINE_MIN_AGE_MS,
+          autoForceCommitMinAgeMs);
       return config;
     }
 


### PR DESCRIPTION
## Why

When a server hits fatal consumption errors it marks its replica **OFFLINE** in IdealState. RSVM already recreates a consuming segment when **all** replicas are OFFLINE, but **partial** OFFLINE (common after transient stream blips) was left alone. Queries then fan in to the remaining CONSUMING replicas indefinitely — imbalance and partial-result risk.

There is a separate flag that only flips OFFLINE→CONSUMING (#11314 path). This PR implements the issue’s requested approach: **partition-scoped force-commit** when enough progress is likely, behind an **opt-in** config.

## Impact

- **Heals chronic under-replication** of consuming segments without manual force-commit.
- **Rebalances** sealed data onto a new CONSUMING generation for all replicas.
- **Safe by default**: feature flag off; age gate avoids force-committing brand-new empty segments; once-per-segment tracking avoids RSVM storms; reuses `validateForceCommitAllowed` (partial upsert / drop-OOO guards).
- New meters: success / failed / skipped auto force-commit.

## How

- Config:
  - `controller.realtime.segment.autoForceCommitOnPartialOfflineEnabled` (default **false**)
  - `controller.realtime.segment.autoForceCommitOnPartialOfflineMinAgeMs` (default 5 minutes)
- In `ensureAllPartitionsConsuming`, when IdealState shows mixed CONSUMING+OFFLINE for an IN_PROGRESS segment and age gate passes, call existing partition-scoped `forceCommit`.
- Do not combine with OFFLINE→CONSUMING repair in the same tick when force-commit fires.

## Test plan

- [x] `PinotLLCRealtimeSegmentManagerTest`: force-commit when partial OFFLINE + age ok; age gate skip; all-OFFLINE still recreates; paused table skip; validateForceCommit failure skip.
- [ ] `./mvnw -pl pinot-controller -am -Dtest=PinotLLCRealtimeSegmentManagerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- [ ] Staging: enable flag on a non-prod realtime table, mark one replica OFFLINE after the segment is aged, confirm force-commit + new CONSUMING.

## Related

fixes: #15897

## Reviewers

Suggested: sajjad-moradi (issue author), maintainers of LLC realtime

## Config / release notes

New controller configs (default off) — consider `release-notes` label.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes — Grok Build (xAI)

Generated-by: Grok Build (xAI)
