### PR TITLE
Harden schema case-collision validation with Locale.ROOT

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/util/SchemaUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/SchemaUtilsTest.java
@@ -331,6 +331,35 @@ public class SchemaUtilsTest {
     checkValidationFails(pinotSchema, true);
   }
 
+  /**
+   * Case-only column collisions (e.g. memberId / MemberID) are rejected when case-insensitive mode is on.
+   * Cluster default is enable.case.insensitive=true, so new schemas on default clusters are already protected.
+   * When case-insensitive mode is off, collisions are allowed (always-on rejection needs validation levels #6645).
+   */
+  @Test
+  public void testValidateCaseOnlyColumnCollision() {
+    Schema collidingSchema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+        .addSingleValueDimension("memberId", DataType.STRING)
+        .addSingleValueDimension("MemberID", DataType.STRING)
+        .addDateTime(TIME_COLUMN, DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
+        .build();
+
+    // Default cluster path: enable.case.insensitive=true rejects case-only collisions
+    checkValidationFails(collidingSchema, true);
+
+    // Case-sensitive mode still allows collisions (compat; do not force always-on without #6645)
+    SchemaUtils.validate(collidingSchema, false);
+
+    // Distinct after lowercasing is fine even when case-insensitive
+    Schema distinctSchema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+        .addSingleValueDimension("memberId", DataType.STRING)
+        .addSingleValueDimension("memberName", DataType.STRING)
+        .addDateTime(TIME_COLUMN, DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
+        .build();
+    SchemaUtils.validate(distinctSchema, true);
+    SchemaUtils.validate(distinctSchema, false);
+  }
+
   @Test
   public void testValidatePrimaryKeyColumns() {
     Schema pinotSchema;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
@@ -121,9 +122,10 @@ public class SchemaUtils {
     if (isIgnoreCase) {
       Set<String> lowerCaseColumnNames = new HashSet<>();
       for (String column : schema.getColumnNames()) {
-        Preconditions.checkState(lowerCaseColumnNames.add(column.toLowerCase()),
-            "When enable case insensitive, you can't use the same lowercase column name: %s",
-            column.toLowerCase());
+        // Locale.ROOT avoids locale-dependent lowercasing (e.g. Turkish dotted/dotless I)
+        String lowerCaseColumn = column.toLowerCase(Locale.ROOT);
+        Preconditions.checkState(lowerCaseColumnNames.add(lowerCaseColumn),
+            "When enable case insensitive, you can't use the same lowercase column name: %s", lowerCaseColumn);
       }
     }
     Set<String> transformedColumns = new HashSet<>();


### PR DESCRIPTION
## Why

Columns that differ only by case (`memberId` vs `MemberID`) break case-insensitive external engines (e.g. Presto/Trino) and confuse operators. Pinot already rejects these when `enable.case.insensitive=true` (**cluster default true**). This PR hardens that check and locks it with explicit tests.

**Compatibility note:** Always-on rejection even when case-insensitive mode is off still needs validation levels (#6645). This PR does **not** change that contract — it fixes Locale-safe lowercasing and adds regression tests for the default path maintainers already shipped.

## Impact

- **Prevents schema footguns** on default (case-insensitive) clusters.
- **Locale-safe** lowercasing (`Locale.ROOT`) avoids Turkish `I`/`ı` surprises.
- **Documents** the current gate so contributors do not re-open always-on without #6645.
- No behavior change for `enable.case.insensitive=false` (still allowed, as in 2021 guidance).

## How

- `SchemaUtils.validate(..., isIgnoreCase)` uses `toLowerCase(Locale.ROOT)`.
- Explicit unit tests for `memberId`/`MemberID` when ignore-case is on vs off.

## Test plan

- [x] `SchemaUtilsTest` case-collision cases for ignore-case true/false.
- [ ] `./mvnw -pl pinot-core,pinot-segment-local -am -Dtest=SchemaUtilsTest -Dsurefire.failIfNoSpecifiedTests=false test`

## Related

fixes: #6644  
related: #6645 (validation levels — not implemented here)

## Reviewers

Suggested: xiangfu0, mcvsubbu (original discussion)

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes — Grok Build (xAI)

Generated-by: Grok Build (xAI)
