### PR TITLE
Grace pauseless COMMITTING/committed real-time segments in SegmentStatusChecker

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -63,6 +63,7 @@ import org.apache.pinot.spi.utils.CommonConstants.Segment.Realtime.Status;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.TimeUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -417,30 +418,24 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
         tableCompressedSize += sizeInBytes;
       }
 
-      // NOTE: We want to skip segments that are just created/pushed/committed to avoid false alerts because it is
-      //       expected for servers to take some time to load them. We derive the "newly created" timestamp per status:
-      //         - consuming (IN_PROGRESS) and pauseless committing (COMMITTING) segments: use creation time. A
-      //           COMMITTING segment has finished consuming but its immutable segment is still being built/loaded on
-      //           the replicas, so it is expected to be transiently under-replicated during that window.
-      //         - pushed/committed segments: use push time when it is set. Real-time (LLC) committed (DONE) segments
-      //           never populate push time, so we fall back to creation time (which is populated at creation and
-      //           persists) instead of leaving it at Long.MIN_VALUE, so a just-committed real-time segment still gets
-      //           the grace window while its replicas finish loading.
+      // NOTE: We want to skip segments that were recently created/committed/pushed to avoid false alerts, because it
+      //       is expected for servers to take some time to load them. We use the segment ZK znode's modification time
+      //       (mtime), which tracks the last state change: creation for consuming (IN_PROGRESS) segments, the
+      //       CONSUMING -> COMMITTING -> ONLINE commit transition for real-time (LLC) segments, and the push time for
+      //       offline segments. Creation time is not a correct proxy for a COMMITTING/DONE segment: it marks when
+      //       consumption STARTED, which can be long before commit, so a segment still transitioning to ONLINE would
+      //       be flagged. If the znode stat is unavailable we fall back to creation time (mtime == creation for a
+      //       freshly created IN_PROGRESS segment).
       //       The grace window is _waitForPushTimeSeconds. Once a segment is older than it and still
       //       under-replicated, it is checked normally, so genuinely stuck commits and real replica losses still alert.
       //       The comparison uses evSnapshotTimestamp instead of System.currentTimeMillis() because for large tables
       //       with many segments, the status check can take several minutes. A segment updated after
       //       the EV snapshot was taken but before this individual segment check runs could be incorrectly flagged as
       //       OFFLINE when using current time.
-      Status segmentStatus = segmentZKMetadata.getStatus();
-      long creationTimeMs;
-      if (segmentStatus == Status.IN_PROGRESS || segmentStatus == Status.COMMITTING) {
-        creationTimeMs = segmentZKMetadata.getCreationTime();
-      } else {
-        long pushTimeMs = segmentZKMetadata.getPushTime();
-        creationTimeMs = pushTimeMs > 0 ? pushTimeMs : segmentZKMetadata.getCreationTime();
-      }
-      if (creationTimeMs > evSnapshotTimestamp - _waitForPushTimeSeconds * 1000L) {
+      Stat segmentStat = propertyStore == null ? null : propertyStore.getStat(
+          ZKMetadataProvider.constructPropertyStorePathForSegment(tableNameWithType, segment), AccessOption.PERSISTENT);
+      long refTimeMs = segmentStat != null ? segmentStat.getMtime() : segmentZKMetadata.getCreationTime();
+      if (refTimeMs > evSnapshotTimestamp - _waitForPushTimeSeconds * 1000L) {
         continue;
       }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -417,17 +417,29 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
         tableCompressedSize += sizeInBytes;
       }
 
-      // NOTE: We want to skip segments that are just created/pushed to avoid false alerts because it is expected for
-      //       servers to take some time to load them. For consuming (IN_PROGRESS) segments, we use creation time from
-      //       the ZK metadata; for pushed segments, we use push time from the ZK metadata. Both of them are the time
-      //       when segment is newly created. For committed segments from real-time table, push time doesn't exist, and
-      //       creationTimeMs will be Long.MIN_VALUE, which is fine because we want to include them in the check.
+      // NOTE: We want to skip segments that are just created/pushed/committed to avoid false alerts because it is
+      //       expected for servers to take some time to load them. We derive the "newly created" timestamp per status:
+      //         - consuming (IN_PROGRESS) and pauseless committing (COMMITTING) segments: use creation time. A
+      //           COMMITTING segment has finished consuming but its immutable segment is still being built/loaded on
+      //           the replicas, so it is expected to be transiently under-replicated during that window.
+      //         - pushed/committed segments: use push time when it is set. Real-time (LLC) committed (DONE) segments
+      //           never populate push time, so we fall back to creation time (which is populated at creation and
+      //           persists) instead of leaving it at Long.MIN_VALUE, so a just-committed real-time segment still gets
+      //           the grace window while its replicas finish loading.
+      //       The grace window is _waitForPushTimeSeconds. Once a segment is older than it and still
+      //       under-replicated, it is checked normally, so genuinely stuck commits and real replica losses still alert.
       //       The comparison uses evSnapshotTimestamp instead of System.currentTimeMillis() because for large tables
       //       with many segments, the status check can take several minutes. A segment updated after
       //       the EV snapshot was taken but before this individual segment check runs could be incorrectly flagged as
       //       OFFLINE when using current time.
-      long creationTimeMs = segmentZKMetadata.getStatus() == Status.IN_PROGRESS ? segmentZKMetadata.getCreationTime()
-          : segmentZKMetadata.getPushTime();
+      Status segmentStatus = segmentZKMetadata.getStatus();
+      long creationTimeMs;
+      if (segmentStatus == Status.IN_PROGRESS || segmentStatus == Status.COMMITTING) {
+        creationTimeMs = segmentZKMetadata.getCreationTime();
+      } else {
+        long pushTimeMs = segmentZKMetadata.getPushTime();
+        creationTimeMs = pushTimeMs > 0 ? pushTimeMs : segmentZKMetadata.getCreationTime();
+      }
       if (creationTimeMs > evSnapshotTimestamp - _waitForPushTimeSeconds * 1000L) {
         continue;
       }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
@@ -560,6 +560,114 @@ public class SegmentStatusCheckerTest {
     return segmentZKMetadata;
   }
 
+  // A pauseless COMMITTING segment: done consuming but its immutable segment is still being built/loaded on the
+  // replicas. Like an LLC committed (DONE) segment, it never populates push time, so the grace check must fall back
+  // to creation time.
+  private SegmentZKMetadata mockCommittingSegmentZKMetadata(long creationTimeMs) {
+    SegmentZKMetadata segmentZKMetadata = mock(SegmentZKMetadata.class);
+    when(segmentZKMetadata.getStatus()).thenReturn(Status.COMMITTING);
+    when(segmentZKMetadata.getSizeInBytes()).thenReturn(-1L);
+    when(segmentZKMetadata.getPushTime()).thenReturn(Long.MIN_VALUE);
+    when(segmentZKMetadata.getCreationTime()).thenReturn(creationTimeMs);
+    return segmentZKMetadata;
+  }
+
+  /**
+   * A pauseless COMMITTING segment whose replicas are still building (only 1/3 ONLINE in the external view) must not
+   * be counted as under-replicated while it is within the grace window, so percentOfReplicas stays at 100. Regression
+   * test for the SegmentReplicasCriticallyLowForHATable false positive on pauseless tables.
+   */
+  @Test
+  public void realtimeCommittingSegmentWithinGraceNotUnderReplicated() {
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setTimeColumnName("timeColumn")
+            .setNumReplicas(3).setStreamConfigs(getStreamConfigMap()).build();
+
+    String seg = new LLCSegmentName(RAW_TABLE_NAME, 1, 5, System.currentTimeMillis()).getSegmentName();
+    IdealState idealState = new IdealState(REALTIME_TABLE_NAME);
+    idealState.setPartitionState(seg, "pinot1", "ONLINE");
+    idealState.setPartitionState(seg, "pinot2", "ONLINE");
+    idealState.setPartitionState(seg, "pinot3", "ONLINE");
+    idealState.setReplicas("3");
+    idealState.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
+
+    // Just committed: only 1 of 3 replicas ONLINE, the other two still building the immutable segment.
+    ExternalView externalView = new ExternalView(REALTIME_TABLE_NAME);
+    externalView.setState(seg, "pinot1", "ONLINE");
+    externalView.setState(seg, "pinot2", "OFFLINE");
+    externalView.setState(seg, "pinot3", "OFFLINE");
+
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    when(resourceManager.getHelixInstanceConfig(any())).thenReturn(newQuerableInstanceConfig("any"));
+    when(resourceManager.getTableConfig(REALTIME_TABLE_NAME)).thenReturn(tableConfig);
+    when(resourceManager.getAllTables()).thenReturn(List.of(REALTIME_TABLE_NAME));
+    when(resourceManager.getTableIdealState(REALTIME_TABLE_NAME)).thenReturn(idealState);
+    when(resourceManager.getTableExternalView(REALTIME_TABLE_NAME)).thenReturn(externalView);
+    SegmentZKMetadata committingSegmentZKMetadata = mockCommittingSegmentZKMetadata(System.currentTimeMillis());
+    when(resourceManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, seg)).thenReturn(committingSegmentZKMetadata);
+
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    when(resourceManager.getPropertyStore()).thenReturn(propertyStore);
+    ZNRecord znRecord = new ZNRecord("0");
+    znRecord.setSimpleField(CommonConstants.Segment.Realtime.END_OFFSET, "10000");
+    when(propertyStore.get(anyString(), any(), anyInt())).thenReturn(znRecord);
+
+    // 1h grace window; the segment was just created, so it must be skipped and the table stays fully replicated.
+    runSegmentStatusChecker(resourceManager, 3600);
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, REALTIME_TABLE_NAME,
+        ControllerGauge.PERCENT_OF_REPLICAS), 100);
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, REALTIME_TABLE_NAME,
+        ControllerGauge.SEGMENTS_WITH_LESS_REPLICAS), 0);
+  }
+
+  /**
+   * A COMMITTING segment that has been under-replicated for longer than the grace window is a genuinely stuck commit
+   * and must still be flagged (percentOfReplicas drops), so the grace does not mask real problems.
+   */
+  @Test
+  public void realtimeCommittingSegmentBeyondGraceUnderReplicated() {
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setTimeColumnName("timeColumn")
+            .setNumReplicas(3).setStreamConfigs(getStreamConfigMap()).build();
+
+    String seg = new LLCSegmentName(RAW_TABLE_NAME, 1, 5, System.currentTimeMillis()).getSegmentName();
+    IdealState idealState = new IdealState(REALTIME_TABLE_NAME);
+    idealState.setPartitionState(seg, "pinot1", "ONLINE");
+    idealState.setPartitionState(seg, "pinot2", "ONLINE");
+    idealState.setPartitionState(seg, "pinot3", "ONLINE");
+    idealState.setReplicas("3");
+    idealState.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
+
+    ExternalView externalView = new ExternalView(REALTIME_TABLE_NAME);
+    externalView.setState(seg, "pinot1", "ONLINE");
+    externalView.setState(seg, "pinot2", "OFFLINE");
+    externalView.setState(seg, "pinot3", "OFFLINE");
+
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    when(resourceManager.getHelixInstanceConfig(any())).thenReturn(newQuerableInstanceConfig("any"));
+    when(resourceManager.getTableConfig(REALTIME_TABLE_NAME)).thenReturn(tableConfig);
+    when(resourceManager.getAllTables()).thenReturn(List.of(REALTIME_TABLE_NAME));
+    when(resourceManager.getTableIdealState(REALTIME_TABLE_NAME)).thenReturn(idealState);
+    when(resourceManager.getTableExternalView(REALTIME_TABLE_NAME)).thenReturn(externalView);
+    // Created 2h ago, still under-replicated -> a stuck commit, must not be graced.
+    SegmentZKMetadata committingSegmentZKMetadata =
+        mockCommittingSegmentZKMetadata(System.currentTimeMillis() - 7200000L);
+    when(resourceManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, seg)).thenReturn(committingSegmentZKMetadata);
+
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    when(resourceManager.getPropertyStore()).thenReturn(propertyStore);
+    ZNRecord znRecord = new ZNRecord("0");
+    znRecord.setSimpleField(CommonConstants.Segment.Realtime.END_OFFSET, "10000");
+    when(propertyStore.get(anyString(), any(), anyInt())).thenReturn(znRecord);
+
+    // 1h grace window; the segment is 2h old and still 1/3 replicas up, so it must be flagged (33%).
+    runSegmentStatusChecker(resourceManager, 3600);
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, REALTIME_TABLE_NAME,
+        ControllerGauge.PERCENT_OF_REPLICAS), 33);
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, REALTIME_TABLE_NAME,
+        ControllerGauge.SEGMENTS_WITH_LESS_REPLICAS), 1);
+  }
+
   @Test
   public void missingEVPartitionTest() {
     IdealState idealState = new IdealState(OFFLINE_TABLE_NAME);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
@@ -801,6 +801,12 @@ public class SegmentStatusCheckerTest {
 
     ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
     when(resourceManager.getPropertyStore()).thenReturn(propertyStore);
+    // myTable_2 was just pushed (znode mtime is now) so it is within the grace window and skipped; the others were
+    // pushed long ago.
+    when(propertyStore.getStat(anyString(), anyInt())).thenAnswer(inv -> {
+      String path = inv.getArgument(0);
+      return mockStatWithMTime(path.endsWith("myTable_2") ? System.currentTimeMillis() : 11111L);
+    });
 
     runSegmentStatusChecker(resourceManager, 600);
     verifyControllerMetrics(OFFLINE_TABLE_NAME, 0, 3, 3, 2, 100, 0, 100, 0, 3702);
@@ -824,6 +830,8 @@ public class SegmentStatusCheckerTest {
 
     ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
     when(resourceManager.getPropertyStore()).thenReturn(propertyStore);
+    // Both segments were just updated/created (znode mtime is now), so they are within the grace window and skipped.
+    when(propertyStore.getStat(anyString(), anyInt())).thenReturn(mockStatWithMTime(System.currentTimeMillis()));
 
     runSegmentStatusChecker(resourceManager, 600);
     verifyControllerMetrics(REALTIME_TABLE_NAME, 0, 2, 2, 1, 100, 0, 100, 0, 1234);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
@@ -578,11 +578,9 @@ public class SegmentStatusCheckerTest {
     return stat;
   }
 
-  /**
-   * A pauseless COMMITTING segment whose replicas are still building (only 1/3 ONLINE in the external view) must not
-   * be counted as under-replicated while it is within the grace window, so percentOfReplicas stays at 100. Regression
-   * test for the SegmentReplicasCriticallyLowForHATable false positive on pauseless tables.
-   */
+  /// A pauseless COMMITTING segment whose replicas are still building (only 1/3 ONLINE in the external view) must not
+  /// be counted as under-replicated while it is within the grace window, so percentOfReplicas stays at 100. Regression
+  /// test for the SegmentReplicasCriticallyLowForHATable false positive on pauseless tables.
   @Test
   public void realtimeCommittingSegmentWithinGraceNotUnderReplicated() {
     TableConfig tableConfig =
@@ -628,10 +626,8 @@ public class SegmentStatusCheckerTest {
         ControllerGauge.SEGMENTS_WITH_LESS_REPLICAS), 0);
   }
 
-  /**
-   * A COMMITTING segment that has been under-replicated for longer than the grace window is a genuinely stuck commit
-   * and must still be flagged (percentOfReplicas drops), so the grace does not mask real problems.
-   */
+  /// A COMMITTING segment that has been under-replicated for longer than the grace window is a genuinely stuck commit
+  /// and must still be flagged (percentOfReplicas drops), so the grace does not mask real problems.
   @Test
   public void realtimeCommittingSegmentBeyondGraceUnderReplicated() {
     TableConfig tableConfig =

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
@@ -57,6 +57,7 @@ import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.TimeUtils;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.zookeeper.data.Stat;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -561,15 +562,20 @@ public class SegmentStatusCheckerTest {
   }
 
   // A pauseless COMMITTING segment: done consuming but its immutable segment is still being built/loaded on the
-  // replicas. Like an LLC committed (DONE) segment, it never populates push time, so the grace check must fall back
-  // to creation time.
-  private SegmentZKMetadata mockCommittingSegmentZKMetadata(long creationTimeMs) {
+  // replicas. The grace check keys off the segment znode's modification time (mtime), which the test drives via
+  // propertyStore.getStat(...); the metadata here only supplies status and size.
+  private SegmentZKMetadata mockCommittingSegmentZKMetadata() {
     SegmentZKMetadata segmentZKMetadata = mock(SegmentZKMetadata.class);
     when(segmentZKMetadata.getStatus()).thenReturn(Status.COMMITTING);
     when(segmentZKMetadata.getSizeInBytes()).thenReturn(-1L);
-    when(segmentZKMetadata.getPushTime()).thenReturn(Long.MIN_VALUE);
-    when(segmentZKMetadata.getCreationTime()).thenReturn(creationTimeMs);
     return segmentZKMetadata;
+  }
+
+  // A ZK Stat whose modification time (mtime) is set to the given epoch millis, used to drive the grace-window check.
+  private Stat mockStatWithMTime(long mTimeMs) {
+    Stat stat = new Stat();
+    stat.setMtime(mTimeMs);
+    return stat;
   }
 
   /**
@@ -603,7 +609,7 @@ public class SegmentStatusCheckerTest {
     when(resourceManager.getAllTables()).thenReturn(List.of(REALTIME_TABLE_NAME));
     when(resourceManager.getTableIdealState(REALTIME_TABLE_NAME)).thenReturn(idealState);
     when(resourceManager.getTableExternalView(REALTIME_TABLE_NAME)).thenReturn(externalView);
-    SegmentZKMetadata committingSegmentZKMetadata = mockCommittingSegmentZKMetadata(System.currentTimeMillis());
+    SegmentZKMetadata committingSegmentZKMetadata = mockCommittingSegmentZKMetadata();
     when(resourceManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, seg)).thenReturn(committingSegmentZKMetadata);
 
     ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
@@ -611,6 +617,8 @@ public class SegmentStatusCheckerTest {
     ZNRecord znRecord = new ZNRecord("0");
     znRecord.setSimpleField(CommonConstants.Segment.Realtime.END_OFFSET, "10000");
     when(propertyStore.get(anyString(), any(), anyInt())).thenReturn(znRecord);
+    // Just committed: znode mtime is now, within the grace window.
+    when(propertyStore.getStat(anyString(), anyInt())).thenReturn(mockStatWithMTime(System.currentTimeMillis()));
 
     // 1h grace window; the segment was just created, so it must be skipped and the table stays fully replicated.
     runSegmentStatusChecker(resourceManager, 3600);
@@ -649,9 +657,7 @@ public class SegmentStatusCheckerTest {
     when(resourceManager.getAllTables()).thenReturn(List.of(REALTIME_TABLE_NAME));
     when(resourceManager.getTableIdealState(REALTIME_TABLE_NAME)).thenReturn(idealState);
     when(resourceManager.getTableExternalView(REALTIME_TABLE_NAME)).thenReturn(externalView);
-    // Created 2h ago, still under-replicated -> a stuck commit, must not be graced.
-    SegmentZKMetadata committingSegmentZKMetadata =
-        mockCommittingSegmentZKMetadata(System.currentTimeMillis() - 7200000L);
+    SegmentZKMetadata committingSegmentZKMetadata = mockCommittingSegmentZKMetadata();
     when(resourceManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, seg)).thenReturn(committingSegmentZKMetadata);
 
     ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
@@ -659,6 +665,9 @@ public class SegmentStatusCheckerTest {
     ZNRecord znRecord = new ZNRecord("0");
     znRecord.setSimpleField(CommonConstants.Segment.Realtime.END_OFFSET, "10000");
     when(propertyStore.get(anyString(), any(), anyInt())).thenReturn(znRecord);
+    // Committed 2h ago (znode mtime), still under-replicated -> a stuck commit, must not be graced.
+    when(propertyStore.getStat(anyString(), anyInt()))
+        .thenReturn(mockStatWithMTime(System.currentTimeMillis() - 7200000L));
 
     // 1h grace window; the segment is 2h old and still 1/3 replicas up, so it must be flagged (33%).
     runSegmentStatusChecker(resourceManager, 3600);


### PR DESCRIPTION
## Problem

`SegmentStatusChecker` computes `percentOfReplicas` (which drives the `SegmentReplicasCriticallyLowForHATable` alert) as a min across segments of `replicasUpInEV / replicasInIS`. It skips just-created/pushed segments for a grace window (`controller.statuschecker.waitForPushTimePeriod`) so servers have time to load them. The grace timestamp was derived as:

```java
long creationTimeMs = segmentZKMetadata.getStatus() == Status.IN_PROGRESS
    ? segmentZKMetadata.getCreationTime()
    : segmentZKMetadata.getPushTime();
```

Real-time (LLC) committed segments **never populate push time** (it stays `Long.MIN_VALUE`), so a just-committed real-time segment is never graced — it is included in the replica check the moment it commits, while its replicas are still loading.

**Pauseless ingestion makes this a frequent false positive.** A pauseless segment enters the `COMMITTING` status ("done consuming, immutable segment not yet committed") and its replicas rebuild/reload the immutable segment for the build window (tens of seconds to a few minutes). During that window it is transiently under-replicated in the ExternalView, but `COMMITTING` was treated as non-`IN_PROGRESS` and checked immediately. Because the gauge is a min across segments, one just-committed segment drags the table's `percentOfReplicas` down and fires the alert even though the table is fully redundant. High-ingest tables (a segment sealing every few minutes per partition) page repeatedly.

## Fix

Key the grace window on the segment ZK znode's **modification time (`mtime`)** instead of trying to pick a status-appropriate field. `mtime` tracks the last state change of the segment metadata:

- `IN_PROGRESS` → creation time (the znode is written once at creation and not rewritten during consumption, so `mtime == creationTime`)
- `COMMITTING` / `DONE` → the `CONSUMING -> COMMITTING -> ONLINE` commit transition time (which is exactly the moment replicas start loading the immutable segment)
- offline / pushed → push time

Creation time is the wrong grace clock for a `COMMITTING`/`DONE` segment: it marks when consumption *started*, which can be long before commit, so a segment still transitioning to ONLINE would be checked as if the grace had already elapsed. `mtime` reflects the actual commit moment, so the grace window covers the real post-commit load period.

`mtime` is read via `propertyStore.getStat(...)` alongside the existing metadata read, falling back to `getCreationTime()` if the stat is unavailable. The existing `waitForPushTime` window is reused (no new config). Once a segment's `mtime` is older than the window and it is still under-replicated, it is checked normally — so genuinely stuck commits and real replica losses still alert.

## Tests

Added to `SegmentStatusCheckerTest`:
- `realtimeCommittingSegmentWithinGraceNotUnderReplicated` — a `COMMITTING` segment at 1/3 replicas ONLINE whose znode `mtime` is now (within the grace window) → `percentOfReplicas` stays 100, `segmentsWithLessReplicas` = 0 (the false-alert case is now graced).
- `realtimeCommittingSegmentBeyondGraceUnderReplicated` — same segment with `mtime` 2h ago (past the grace) → `percentOfReplicas` drops to 33 and `segmentsWithLessReplicas` = 1 (a stuck commit is still flagged).

Both tests drive the grace clock via a mocked `propertyStore.getStat(...)` returning a `Stat` with the desired `mtime`. Existing `SegmentStatusCheckerTest` cases pass unchanged — they don't stub `getStat`, so it returns `null` and the code falls back to creation time, preserving their prior behavior.

## Release Notes

Fixes false `SegmentReplicasCriticallyLowForHATable` / low `percentOfReplicas` alerts caused by real-time committed and pauseless `COMMITTING` segments being counted as under-replicated during their normal post-commit load window.
