### PR TITLE
Clean up stale JDK 21 references left over from the JDK 25 bump

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,7 @@ This document guides AI coding assistants (Copilot, Cursor, etc.) contributing t
 
 ## Libraries and Frameworks
 
-- Most source code is written in Java 21. `pinot-spi`, `pinot-segment-spi`, `pinot-timeseries-spi`, `pinot-common`, `pinot-java-client`, and `pinot-jdbc-client` target Java 11 bytecode for external consumers.
+- Most source code is written in Java 25. `pinot-spi`, `pinot-segment-spi`, `pinot-timeseries-spi`, `pinot-common`, `pinot-java-client`, and `pinot-jdbc-client` target Java 11 bytecode for external consumers.
 - Pinot UI is a React.js frontend. It is stored in `pinot-controller/src/main/resources/`.
 - The code is compiled with Maven and follows a multimodule structure. Use each module's `pom.xml` to
   understand dependencies and configurations.

--- a/.github/workflows/build-pinot-base-docker-image.yml
+++ b/.github/workflows/build-pinot-base-docker-image.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         openJdkDist: ["amazoncorretto", "ms-openjdk"]
-        jdk_version: [21, 25]
+        jdk_version: [25]
         arch: [amd64, arm64]
         type: [build, runtime]
         include:
@@ -60,7 +60,7 @@ jobs:
     strategy:
       matrix:
         openJdkDist: ["amazoncorretto", "ms-openjdk"]
-        jdk_version: [21, 25]
+        jdk_version: [25]
         type: [build, runtime]
     steps:
       - name: Login to DockerHub

--- a/.github/workflows/scripts/docker/.pinot_base_docker_image_build_and_push.sh
+++ b/.github/workflows/scripts/docker/.pinot_base_docker_image_build_and_push.sh
@@ -28,6 +28,15 @@ if [ -z "${BASE_IMAGE_TYPE}" ]; then
   exit 1
 fi
 
+# The image contents come from JDK_VERSION while the published tag comes from TAG, so a default
+# here would silently publish a mislabeled image (e.g. a JDK 21 image tagged 25-amazoncorretto).
+# Require it explicitly, matching .pinot_compile_and_push_build_image.sh and
+# .pinot_package_single_platform.sh.
+if [ -z "${JDK_VERSION}" ]; then
+  echo "JDK_VERSION is required" >&2
+  exit 1
+fi
+
 cd docker/images/pinot-base/pinot-base-${BASE_IMAGE_TYPE}
 
 docker build \
@@ -35,7 +44,7 @@ docker build \
   --platform=${BUILD_PLATFORM} \
   --file ${OPEN_JDK_DIST}.dockerfile \
   --tag apachepinot/pinot-base-${BASE_IMAGE_TYPE}:${TAG}-${ARCH} \
-  --build-arg JAVA_VERSION=${JDK_VERSION:-21} \
+  --build-arg JAVA_VERSION=${JDK_VERSION} \
   --build-arg ARCH=${ARCH} \
   .
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,8 +93,8 @@ repo. It is intentionally short and focused on day-to-day work.
 - assembly-descriptor: Maven assembly descriptor for plugin packaging.
 
 ## Build and test
-- Build JDK: Use JDK 21+ for Pinot services and the default build; client and SPI artifacts still target Java 11 bytecode.
-- Runtime JRE: Broker/server/controller/minion run on Java 21+.
+- Build JDK: Use JDK 25+ for Pinot services and the default build; client and SPI artifacts still target Java 11 bytecode.
+- Runtime JRE: Broker/server/controller/minion run on Java 25+.
 - Default build: `./mvnw clean install`
 - Faster dev build: `./mvnw verify -Ppinot-fastdev`
 - Full binary/shaded build:
@@ -108,7 +108,7 @@ repo. It is intentionally short and focused on day-to-day work.
 
 ## Coding conventions and hygiene
 - Add class-level Javadoc for new classes; describe behavior and thread-safety.
-- Use Javadoc comments with either `/** ... */` or `///` syntax (per JEP-467); service code targets Java 21 by default.
+- Use Javadoc comments with either `/** ... */` or `///` syntax (per JEP-467); service code targets Java 25 by default.
 - Keep license headers on all new source files.
 - Use `./mvnw license:format` to add headers to new files.
 - Preserve backward compatibility across mixed-version broker/server/controller.

--- a/docker/images/pinot-base/pinot-base-build/amazoncorretto.dockerfile
+++ b/docker/images/pinot-base/pinot-base-build/amazoncorretto.dockerfile
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-ARG JAVA_VERSION=21
+ARG JAVA_VERSION=25
 FROM debian:bookworm-slim
 
 LABEL MAINTAINER=dev@pinot.apache.org
@@ -45,7 +45,7 @@ RUN set -eux \
 # Install Amazon Corretto.
 # /etc/apt/keyrings/ is the correct path for user-managed keys referenced via
 # signed-by=; apt natively handles ASCII-armored .asc files at that path.
-ARG JAVA_VERSION=21
+ARG JAVA_VERSION=25
 RUN set -eux \
   && mkdir -p /etc/apt/keyrings \
   && wget -qO /etc/apt/keyrings/corretto.asc https://apt.corretto.aws/corretto.key \

--- a/docker/images/pinot-base/pinot-base-build/ms-openjdk.dockerfile
+++ b/docker/images/pinot-base/pinot-base-build/ms-openjdk.dockerfile
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-ARG JAVA_VERSION=21
+ARG JAVA_VERSION=25
 ARG JDK_IMAGE=mcr.microsoft.com/openjdk/jdk
 FROM ${JDK_IMAGE}:${JAVA_VERSION}-ubuntu AS pinot_build_env
 

--- a/docker/images/pinot-base/pinot-base-runtime/amazoncorretto.dockerfile
+++ b/docker/images/pinot-base/pinot-base-runtime/amazoncorretto.dockerfile
@@ -20,7 +20,7 @@
 # AL2023 image to avoid system packages (python3, etc.) that are not needed
 # at runtime and consistently accumulate CVEs. wget is used instead of curl
 # to avoid pulling in libcurl's LDAP/HTTP2 dependencies.
-ARG JAVA_VERSION=21
+ARG JAVA_VERSION=25
 FROM debian:bookworm-slim
 
 LABEL MAINTAINER=dev@pinot.apache.org
@@ -41,7 +41,7 @@ RUN set -eux \
 # Install Amazon Corretto JDK.
 # /etc/apt/keyrings/ is the correct path for user-managed keys referenced via
 # signed-by=; apt natively handles ASCII-armored .asc files at that path.
-ARG JAVA_VERSION=21
+ARG JAVA_VERSION=25
 RUN set -eux \
   && mkdir -p /etc/apt/keyrings \
   && wget -qO /etc/apt/keyrings/corretto.asc https://apt.corretto.aws/corretto.key \

--- a/docker/images/pinot-base/pinot-base-runtime/ms-openjdk.dockerfile
+++ b/docker/images/pinot-base/pinot-base-runtime/ms-openjdk.dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-ARG JAVA_VERSION=21
+ARG JAVA_VERSION=25
 ARG JDK_IMAGE=mcr.microsoft.com/openjdk/jdk
 
 FROM ${JDK_IMAGE}:${JAVA_VERSION}-ubuntu AS builder

--- a/docker/images/pinot/README.md
+++ b/docker/images/pinot/README.md
@@ -41,7 +41,7 @@ The docker image is tagged as `[Docker Tag]`.
 
 `Kafka Version`: The Kafka version to build Pinot with. Default is `3.0`.
 
-`Java Version`: The Java build and runtime image version. Default is `21`.
+`Java Version`: The Java build and runtime image version. Default is `25`.
 
 * Example of building and tagging a snapshot:
 ```SHELL
@@ -59,13 +59,13 @@ On Apple Silicon (M1/M2) or any arm64 host, pass `--platform linux/arm64`:
 
 ```SHELL
 docker build -t pinot:latest --platform linux/arm64 --no-cache --network=host \
-  --build-arg PINOT_GIT_REF=master --build-arg JDK_VERSION=21 -f Dockerfile .
+  --build-arg PINOT_GIT_REF=master --build-arg JDK_VERSION=25 -f Dockerfile .
 ```
 
 On an x86 machine with QEMU installed, add `--platform linux/arm64` the same way:
 ```SHELL
 docker build -t pinot:latest --platform linux/arm64 --no-cache \
-  --build-arg PINOT_GIT_REF=master --build-arg JDK_VERSION=21 -f Dockerfile .
+  --build-arg PINOT_GIT_REF=master --build-arg JDK_VERSION=25 -f Dockerfile .
 ```
 
 ## How to publish a docker image

--- a/docker/images/pinot/docker-build.sh
+++ b/docker/images/pinot/docker-build.sh
@@ -46,7 +46,7 @@ if [[ "$#" -gt 3 ]]
 then
   JAVA_VERSION=$4
 else
-  JAVA_VERSION=21
+  JAVA_VERSION=25
 fi
 
 echo "Trying to build Pinot docker image on git ref: [ ${PINOT_GIT_REF} ] and tag it as: [ ${DOCKER_TAG} ]. Kafka Dependencies: [ ${KAFKA_VERSION} ]. Java Version: [ ${JAVA_VERSION} ]."

--- a/pinot-clients/pinot-cli/README.md
+++ b/pinot-clients/pinot-cli/README.md
@@ -24,7 +24,7 @@ An interactive and batch command-line client for Apache Pinot. It supports a ric
 
 ## Requirements
 
-- Java 21+ on PATH
+- Java 25+ on PATH
 
 ## Build
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/MseBlock.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/MseBlock.java
@@ -36,7 +36,7 @@ import org.apache.pinot.core.common.Block;
 /// Instead, they are used as a common sub-interface for [data][Data] and [end-of-stream][Eos] blocks,
 /// which are then subclassed to provide the actual functionality.
 /// This pattern follows the principles of sealed interfaces.
-/// Pinot now targets Java 21, so a follow-up could model these blocks with sealed interfaces and pattern matching,
+/// Pinot now targets Java 25, so a follow-up could model these blocks with sealed interfaces and pattern matching,
 /// removing the need for the [Visitor] pattern.
 ///
 /// Meanwhile, the API force callers to do some castings, but it is a trade-off to have a more robust and maintainable

--- a/pinot-tools/src/main/resources/appAssemblerScriptTemplate
+++ b/pinot-tools/src/main/resources/appAssemblerScriptTemplate
@@ -172,36 +172,21 @@ if $cygwin; then
 fi
 
 
-jdk_version() {
-  IFS='
-'
-  # remove \r for Cygwin
-  lines=$(java -Xms32M -Xmx32M -version 2>&1 | tr '\r' '\n')
-  for line in $lines; do
-    if test -z $result && echo "$line" | grep -q 'version "'
-    then
-      ver=$(echo $line | sed -e 's/.*version "\(.*\)"\(.*\)/\1/; 1q')
-      # on macOS, sed doesn't support '?'
-      if case $ver in "1."*) true;; *) false;; esac;
-      then
-        result=$(echo $ver | sed -e 's/1\.\([0-9]*\)\(.*\)/\1/; 1q')
-      else
-        result=$(echo $ver | sed -e 's/\([0-9]*\)\(.*\)/\1/; 1q')
-      fi
-    fi
-  done
-  unset IFS
-  echo "$result"
-}
-
 if [ -z "$JAVA_OPTS" ] ; then
   ALL_JAVA_OPTS="@EXTRA_JVM_ARGUMENTS@"
 else
   ALL_JAVA_OPTS=$JAVA_OPTS
 fi
 
-if [ "$(jdk_version)" -gt 11 ]; then
-  ALL_JAVA_OPTS="--add-opens=java.base/java.nio=ALL-UNNAMED \
+# Pinot is compiled with maven.compiler.release=25, so its classes cannot load on a pre-25 JRE
+# at all and these module-access flags are always required.
+#
+# NOTE: this overwrites the assignment above rather than appending to it, so the extra JVM
+# arguments substituted from the per-program jvmSettings in pinot-tools/pom.xml (heap sizes, the
+# log4j2 configuration path, -Dpinot.admin.system.exit) are discarded whenever JAVA_OPTS is
+# unset. Appending them instead would change the effective heap, logging configuration and admin
+# exit behavior of every generated script, so it needs to be a deliberate behavior change.
+ALL_JAVA_OPTS="--add-opens=java.base/java.nio=ALL-UNNAMED \
   --add-opens=java.base/sun.nio.ch=ALL-UNNAMED \
   --add-opens=java.base/java.lang=ALL-UNNAMED \
   --add-opens=java.base/java.util=ALL-UNNAMED \
@@ -210,7 +195,6 @@ if [ "$(jdk_version)" -gt 11 ]; then
   -Dio.netty.tryReflectionSetAccessible=true \
   -Dio.grpc.netty.shaded.io.netty.tryReflectionSetAccessible=true \
   $JAVA_OPTS"
-fi
 
 if [ -z "$PLUGINS_DIR" ] ; then
   PLUGINS_DIR=$BASEDIR/plugins


### PR DESCRIPTION
The JDK 25 bump (#19014) left a number of JDK 21 references behind. Most are cosmetic, but two are functional breakages. Follow-up to #19102.

### Functional fixes

**`docker/images/pinot/docker-build.sh` could not build Pinot at all.** With no 4th argument it defaulted to `JAVA_VERSION=21`, which sets `PINOT_BASE_IMAGE_TAG=21-amazoncorretto`. That image ships Corretto 21.0.11, and the root pom's enforcer requires `[25,)`, so the build failed in `validate`. Verified locally by running Pinot's exact `requireJavaVersion` rule inside both base images:

```
apachepinot/pinot-base-build:21-amazoncorretto -> [ERROR] Apache Pinot requires JDK 25 or newer to build.  BUILD FAILURE
apachepinot/pinot-base-build:25-amazoncorretto -> BUILD SUCCESS
```

**`.pinot_base_docker_image_build_and_push.sh` could publish a mislabeled base image.** It passed `--build-arg JAVA_VERSION=${JDK_VERSION:-21}`, and the image *contents* come from `JDK_VERSION` while the published *tag* comes from the independent `TAG` variable. An invocation with `TAG=25-amazoncorretto` and `JDK_VERSION` unset would have built a JDK 21 image, succeeded, and pushed it as `pinot-base-runtime:25-amazoncorretto` — a base image whose JRE cannot load Pinot's `release=25` bytecode. This is `workflow_dispatch`-only so CI always set the variable, but the fallback made the failure silent and unrecoverable once pushed. Now hard-fails when unset, matching `.pinot_compile_and_push_build_image.sh` and `.pinot_package_single_platform.sh`. Note this `--build-arg` also *overrode* the dockerfile `ARG` defaults, so fixing those without this would have had no effect through the only script that builds them.

### Stale configuration

- `build-pinot-base-docker-image.yml`: dropped `21` from both matrices. **This stops publishing `pinot-base-{build,runtime}:21-*`**, so those tags freeze and stop receiving OS/JDK CVE patches — worth a line in the release notes. Nothing references them: every consumer derives its tag from a JDK-25-only source.
- The four `pinot-base` dockerfiles: `ARG JAVA_VERSION` default 21 → 25.
- Docs stating the wrong baseline: `AGENTS.md` (3 places; its counterpart in `CLAUDE.md` was already updated, so the two disagreed and `AGENTS.md` contradicted itself), `.github/copilot-instructions.md`, `docker/images/pinot/README.md`, and `MseBlock.java`'s class Javadoc.
- `pinot-clients/pinot-cli/README.md` said "Java 21+ on PATH". That one was wrong rather than conservative: `pinot-cli` compiles at `${jdk.version}` with no `release=11` override, so the shipped CLI throws `UnsupportedClassVersionError` on a JDK 21 PATH.

### Dead JDK version guard in the launcher template

`appAssemblerScriptTemplate` gated the `--add-opens` flags behind `if [ "$(jdk_version)" -gt 11 ]`, which can no longer be false. Removing it also fixes a latent bug: `jdk_version()` probed bare `java` on `PATH` rather than the `$JAVACMD` actually exec'd, so a stale or missing PATH `java` made the guard false (or printed `integer expression expected`) and silently dropped the module-access flags while running on 25 — producing exactly the `InaccessibleObjectException` those flags exist to prevent. It also forked a JVM on every script invocation.

Verified behavior-identical: compared the old and new logic across `{JAVA_OPTS unset, set, set + PLUGINS_INCLUDE}` (byte-identical `ALL_JAVA_OPTS` in all three), then built `-Pbin-dist` and traced the real generated `pinot-admin.sh` to confirm the exec line still carries all six `--add-opens`, both Netty properties and `-Dplugins.dir`. `bin/pinot-admin.sh -help` runs clean.

### Deliberately not fixed here

Removing the guard exposes that this assignment *overwrites* `@EXTRA_JVM_ARGUMENTS@` instead of appending, so the per-program `jvmSettings` in `pinot-tools/pom.xml` — heap sizes, `-Dlog4j2.configurationFile`, `-Dpinot.admin.system.exit` — are discarded whenever `JAVA_OPTS` is unset. That is long-standing behavior (the guard was always true, so they were already being dropped), and appending them would change the effective heap, logging config and admin exit behavior of every generated script. It needs to be a deliberate change, not a side effect of a cleanup, so it is left as-is with a comment. Happy to file a separate issue if that's preferred.

I also kept the now-provably-dead `if [ -z "$JAVA_OPTS" ]` block rather than deleting it: removing it would drop the `@EXTRA_JVM_ARGUMENTS@` token from the template entirely and leave the pom's `jvmSettings` with no representation at all, making that config silently inert and foreclosing the fix above.

Stale JDK 21 mentions in `kb/` and `pinot-perf/README.md` are left for a separate pass — they describe agent/benchmark guidance rather than build or runtime configuration.

### Testing

Beyond the enforcer probe and script verification above, built both runtime base images with the new default ARG (no `--build-arg`) and confirmed the JDK inside:

```
amazoncorretto -> Corretto-25.0.4.7.1, JAVA_HOME=/usr/lib/jvm/java-25-amazon-corretto
ms-openjdk     -> Microsoft build 25.0.4+7-LTS, JAVA_HOME=/usr/lib/jvm/msopenjdk-25
```

The `ms-openjdk` files re-declare `ARG JAVA_VERSION` without a value in the second stage, which correctly inherits the pre-`FROM` default — hence only one default needed changing there versus two in the corretto files. Confirmed the new `JDK_VERSION` guard exits 1 before invoking `docker build`. `spotless`, `checkstyle` and `license:check` pass on `pinot-tools`, `pinot-query-runtime` and `pinot-cli`; `pinot-query-runtime` test-compiles clean.

I did not rebuild the `pinot-base-build` images locally (the corretto one compiles Thrift from source); their JDK 25 variants are already published by CI, and the JDK acquisition steps are identical to the runtime images verified above.
