### PR TITLE
Fix /tables status diff viewer crash (React error #130)

### DIFF
--- a/pinot-controller/src/main/resources/vite.config.ts
+++ b/pinot-controller/src/main/resources/vite.config.ts
@@ -114,7 +114,15 @@ export default defineConfig(({ mode }) => {
         transformMixedEsModules: true,
         // Ensure CommonJS modules are properly handled
         include: [/node_modules/],
-        defaultIsModuleExports: true,
+        // Use 'auto' (the plugin default) so the default import honors a CJS
+        // module's `__esModule`/`exports.default` marker. Forcing `true` here
+        // made `import X from 'cjs-pkg'` resolve to the entire module.exports
+        // object for Babel-compiled packages like `react-diff-viewer` (which
+        // sets `__esModule` and `exports.default = DiffViewer`). Rendering that
+        // object as a component crashed the /tables status diff viewer with
+        // React error #130 ("Element type is invalid ... got: object"). 'auto'
+        // matches the esbuild interop used by optimizeDeps in dev.
+        defaultIsModuleExports: 'auto',
       },
     },
 


### PR DESCRIPTION
The Status diff modal for BAD/UPDATING tables renders `<ReactDiffViewer/>`. `react-diff-viewer@3.1.1` is a Babel CJS module (`__esModule=true`, `exports.default = DiffViewer`), but the Vite build forced `commonjsOptions.defaultIsModuleExports: true`, making the default import resolve to the whole `module.exports` object instead of `.default`. Rendering that object as an element threw React error #130 ("got: object"). This only reproduced in the production build; dev worked because optimizeDeps pre-bundles the package via esbuild's `__esModule`-aware interop.

Set `defaultIsModuleExports` to `'auto'` so the default import honors `__esModule`/`exports.default`, matching the esbuild interop used in dev. Plain-CJS default imports (no `__esModule`) are unaffected.

I relied on claude for this fix since I don't understand the vite build stuff well. But I tested it against our internal QA where opening the "diff viewer" for segment status was breaking, and this indeed fixed it. And generally navigating through the UI is unbroken.