### PR TITLE
Simplify inconsistencies metrics during upserts segment replacement

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -693,16 +693,15 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       validDocIdsForOldSegment = getValidDocIdsForOldSegment(oldSegment);
     }
     if (validDocIdsForOldSegment != null && !validDocIdsForOldSegment.isEmpty()) {
-      if (_context.isTableTypeInconsistentDuringConsumption()) {
-        if (shouldRevertMetadataOnInconsistency(oldSegment)) {
-          // If there are still valid docs in the old segment, validate and revert the metadata of the
-          // consuming segment in place
-          revertSegmentUpsertMetadata(oldSegment, segmentName, validDocIdsForOldSegment);
-          return;
-        } else {
-          logInconsistentResults(segmentName, validDocIdsForOldSegment.getCardinality());
-        }
+      if (shouldRevertMetadataOnInconsistency(oldSegment)) {
+        // If there are still valid docs in the old segment, validate and revert the metadata of the
+        // consuming segment in place
+        revertSegmentUpsertMetadata(oldSegment, segmentName, validDocIdsForOldSegment);
+        return;
       }
+      _logger.warn("Found {} primary keys not replaced for segment: {}",
+          validDocIdsForOldSegment.getCardinality(), segmentName);
+      updateInconsistentRowsMetric(segmentName, validDocIdsForOldSegment.getCardinality());
       removeSegment(oldSegment, validDocIdsForOldSegment);
     }
   }
@@ -737,22 +736,20 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     }
     int numKeysStillNotReplaced = getPrevKeyToRecordLocationSize();
     if (numKeysStillNotReplaced > 0) {
-      logInconsistentResults(segmentName, numKeysStillNotReplaced);
+      _logger.warn("Found {} primary keys not replaced for segment: {} after revert attempt",
+          numKeysStillNotReplaced, segmentName);
+      updateInconsistentRowsMetric(segmentName, numKeysStillNotReplaced);
       // Clear the map when inconsistencies still exist for the consuming segments
       clearPrevKeyToRecordLocation();
     }
   }
 
-  protected void logInconsistentResults(String segmentName, int numKeysStillNotReplaced) {
-    _logger.error("Found {} primary keys not replaced for segment: {}. "
-            + "Proceeding with current state which may cause inconsistency. To correct this behaviour from now, set "
-            + "cluster config: `pinot.server.consuming.segment.consistency.mode` to `PROTECTED`",
-        numKeysStillNotReplaced, segmentName);
-    if (_context.isDropOutOfOrderRecord() || _context.getOutOfOrderRecordColumn() != null) {
-      _serverMetrics.addMeteredTableValue(_tableNameWithType, ServerMeter.REALTIME_UPSERT_INCONSISTENT_ROWS,
-          numKeysStillNotReplaced);
-    } else if (_partialUpsertHandler != null) {
+  protected void updateInconsistentRowsMetric(String segmentName, int numKeysStillNotReplaced) {
+    if (_partialUpsertHandler != null) {
       _serverMetrics.addMeteredTableValue(_tableNameWithType, ServerMeter.PARTIAL_UPSERT_KEYS_NOT_REPLACED,
+          numKeysStillNotReplaced);
+    } else {
+      _serverMetrics.addMeteredTableValue(_tableNameWithType, ServerMeter.REALTIME_UPSERT_INCONSISTENT_ROWS,
           numKeysStillNotReplaced);
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes.java
@@ -304,14 +304,13 @@ public class ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes
             oldSegment, validDocIdsForOldSegment);
       }
       if (validDocIdsForOldSegment != null && !validDocIdsForOldSegment.isEmpty()) {
-        if (_context.isTableTypeInconsistentDuringConsumption()) {
-          if (shouldRevertMetadataOnInconsistency(oldSegment)) {
-            revertSegmentUpsertMetadata(oldSegment, segmentName, validDocIdsForOldSegment);
-            return;
-          } else {
-            logInconsistentResults(segmentName, validDocIdsForOldSegment.getCardinality());
-          }
+        if (shouldRevertMetadataOnInconsistency(oldSegment)) {
+          revertSegmentUpsertMetadata(oldSegment, segmentName, validDocIdsForOldSegment);
+          return;
         }
+        _logger.warn("Found {} primary keys not replaced for segment: {}",
+            validDocIdsForOldSegment.getCardinality(), segmentName);
+        updateInconsistentRowsMetric(segmentName, validDocIdsForOldSegment.getCardinality());
       }
       // we want to always remove a segment in case of enableDeletedKeysCompactionConsistency = true
       // this is to account for the removal of primary-key in the to-be-removed segment and reduce


### PR DESCRIPTION
## Summary

1. Flatten the outer `isTableTypeInconsistentDuringConsumption()` gate in `replaceSegment` (base + ConsistentDeletes override). `shouldRevertMetadataOnInconsistency` already implies it, so the outer gate is redundant.
2. Emit a WARN + `REALTIME_UPSERT_INCONSISTENT_ROWS` (or `PARTIAL_UPSERT_KEYS_NOT_REPLACED` for partial upsert) whenever residual valid docs remain after segment replacement — previously silent for plain FULL upsert.
3. Rename `logInconsistentResults` → `updateInconsistentRowsMetric` (it no longer logs; logs are context-specific at each caller).