### PR TITLE
Give each upsert partition its own PartialUpsertHandler

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/evaluator/InbuiltFunctionEvaluator.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/evaluator/InbuiltFunctionEvaluator.java
@@ -42,6 +42,9 @@ import org.apache.pinot.spi.function.FunctionEvaluator;
 /// - FunctionNode - executes a function
 /// - ColumnNode - fetches the value of the column from the input GenericRow
 /// - ConstantNode - returns the literal value
+///
+/// NOTE: This class is not thread safe. Function nodes refill one reusable argument array on every evaluation, so
+/// two threads evaluating the same instance can read each other's argument values. Give each thread its own instance.
 public class InbuiltFunctionEvaluator implements FunctionEvaluator {
   // Root of the execution tree
   private final ExecutableNode _rootNode;

--- a/pinot-common/src/main/java/org/apache/pinot/common/evaluator/InbuiltFunctionEvaluator.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/evaluator/InbuiltFunctionEvaluator.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import javax.annotation.concurrent.NotThreadSafe;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.function.FunctionInfo;
 import org.apache.pinot.common.function.FunctionInvoker;
@@ -45,6 +46,7 @@ import org.apache.pinot.spi.function.FunctionEvaluator;
 ///
 /// NOTE: This class is not thread safe. Function nodes refill one reusable argument array on every evaluation, so
 /// two threads evaluating the same instance can read each other's argument values. Give each thread its own instance.
+@NotThreadSafe
 public class InbuiltFunctionEvaluator implements FunctionEvaluator {
   // Root of the execution tree
   private final ExecutableNode _rootNode;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
 import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.common.utils.ThrottledLogger;
 import org.apache.pinot.segment.local.utils.SchemaUtils;
@@ -51,6 +52,7 @@ import org.slf4j.LoggerFactory;
 /// NOTE: This class is not thread safe. It holds [FunctionEvaluator] instances that keep reusable evaluation
 /// state, so each thread needs its own instance.
 /// TODO: Merge this and CustomFunctionEnricher
+@NotThreadSafe
 public class ExpressionTransformer implements RecordTransformer {
   private static final Logger LOGGER = LoggerFactory.getLogger(ExpressionTransformer.class);
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
@@ -47,6 +47,9 @@ import org.slf4j.LoggerFactory;
 ///
 /// NOTE: should put this before the [DataTypeTransformer]. After this, transformed column can be treated as
 /// regular column for other record transformers.
+///
+/// NOTE: This class is not thread safe. It holds [FunctionEvaluator] instances that keep reusable evaluation
+/// state, so each thread needs its own instance.
 /// TODO: Merge this and CustomFunctionEnricher
 public class ExpressionTransformer implements RecordTransformer {
   private static final Logger LOGGER = LoggerFactory.getLogger(ExpressionTransformer.class);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.helix.HelixManager;
@@ -155,7 +156,10 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     _comparisonColumns = context.getComparisonColumns();
     _deleteRecordColumn = context.getDeleteRecordColumn();
     _hashFunction = context.getHashFunction();
-    _partialUpsertHandler = context.getPartialUpsertHandler();
+    // Build a handler owned by this partition. PartialUpsertHandler is not thread safe, and merges for a partition
+    // run on one consumer thread at a time, same as the _reusePreviousRow scratch state used alongside it.
+    Supplier<PartialUpsertHandler> partialUpsertHandlerSupplier = context.getPartialUpsertHandlerSupplier();
+    _partialUpsertHandler = partialUpsertHandlerSupplier != null ? partialUpsertHandlerSupplier.get() : null;
     _enableSnapshot = context.isSnapshotEnabled();
     _isPreloading = context.isPreloadEnabled();
     _metadataTTL = context.getMetadataTTL();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
@@ -20,6 +20,7 @@ package org.apache.pinot.segment.local.upsert;
 
 import com.google.common.base.Preconditions;
 import java.util.List;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.collections4.CollectionUtils;
@@ -68,9 +69,12 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
       }
     }
 
-    PartialUpsertHandler partialUpsertHandler = null;
+    // PartialUpsertHandler is not thread safe, so hand each partition a factory rather than one shared instance.
+    Supplier<PartialUpsertHandler> partialUpsertHandlerSupplier = null;
     if (upsertConfig.getMode() == UpsertConfig.Mode.PARTIAL) {
-      partialUpsertHandler = new PartialUpsertHandler(tableConfig, schema, comparisonColumns, upsertConfig);
+      List<String> handlerComparisonColumns = comparisonColumns;
+      partialUpsertHandlerSupplier =
+          () -> new PartialUpsertHandler(tableConfig, schema, handlerComparisonColumns, upsertConfig);
     }
 
     boolean enableSnapshot = upsertConfig.getSnapshot()
@@ -128,7 +132,7 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
         .setPrimaryKeyColumns(primaryKeyColumns)
         .setHashFunction(upsertConfig.getHashFunction())
         .setComparisonColumns(comparisonColumns)
-        .setPartialUpsertHandler(partialUpsertHandler)
+        .setPartialUpsertHandlerSupplier(partialUpsertHandlerSupplier)
         .setDeleteRecordColumn(upsertConfig.getDeleteRecordColumn())
         .setDropOutOfOrderRecord(upsertConfig.isDropOutOfOrderRecord())
         .setOutOfOrderRecordColumn(upsertConfig.getOutOfOrderRecordColumn())

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java
@@ -42,6 +42,9 @@ import org.apache.pinot.spi.recordtransformer.RecordTransformer;
 ///
 /// It is also possible to define a custom logic for merging rows by implementing [PartialUpsertMerger].
 /// If a merger for row is defined then it takes precedence and ignores column mergers.
+///
+/// NOTE: This class is not thread safe. The post partial upsert transformers keep reusable evaluation state, so a
+/// handler belongs to exactly one partition and must be used by one thread at a time.
 public class PartialUpsertHandler {
   private final List<String> _primaryKeyColumns;
   private final List<String> _comparisonColumns;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
 import org.apache.pinot.segment.local.recordtransformer.RecordTransformerUtils;
 import org.apache.pinot.segment.local.segment.readers.LazyRow;
 import org.apache.pinot.segment.local.upsert.merger.PartialUpsertMerger;
@@ -45,6 +46,7 @@ import org.apache.pinot.spi.recordtransformer.RecordTransformer;
 ///
 /// NOTE: This class is not thread safe. The post partial upsert transformers keep reusable evaluation state, so a
 /// handler belongs to exactly one partition and must be used by one thread at a time.
+@NotThreadSafe
 public class PartialUpsertHandler {
   private final List<String> _primaryKeyColumns;
   private final List<String> _comparisonColumns;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertContext.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertContext.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import java.io.File;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -41,8 +42,10 @@ public class UpsertContext {
   private final List<String> _primaryKeyColumns;
   private final HashFunction _hashFunction;
   private final List<String> _comparisonColumns;
+  // Builds a handler for one partition. PartialUpsertHandler is not thread safe, so the context hands out a factory
+  // instead of a shared instance. Null for full upsert.
   @Nullable
-  private final PartialUpsertHandler _partialUpsertHandler;
+  private final Supplier<PartialUpsertHandler> _partialUpsertHandlerSupplier;
   @Nullable
   private final String _deleteRecordColumn;
   private final boolean _dropOutOfOrderRecord;
@@ -68,7 +71,8 @@ public class UpsertContext {
   private final TableDataManager _tableDataManager;
   private final File _tableIndexDir;
   private UpsertContext(TableConfig tableConfig, Schema schema, List<String> primaryKeyColumns,
-      HashFunction hashFunction, List<String> comparisonColumns, @Nullable PartialUpsertHandler partialUpsertHandler,
+      HashFunction hashFunction, List<String> comparisonColumns,
+      @Nullable Supplier<PartialUpsertHandler> partialUpsertHandlerSupplier,
       @Nullable String deleteRecordColumn, boolean dropOutOfOrderRecord, @Nullable String outOfOrderRecordColumn,
       boolean enableSnapshot, boolean enablePreload, double metadataTTL, double deletedKeysTTL,
       boolean enableDeletedKeysCompactionConsistency, UpsertConfig.ConsistencyMode consistencyMode,
@@ -80,7 +84,7 @@ public class UpsertContext {
     _primaryKeyColumns = primaryKeyColumns;
     _hashFunction = hashFunction;
     _comparisonColumns = comparisonColumns;
-    _partialUpsertHandler = partialUpsertHandler;
+    _partialUpsertHandlerSupplier = partialUpsertHandlerSupplier;
     _deleteRecordColumn = deleteRecordColumn;
     _dropOutOfOrderRecord = dropOutOfOrderRecord;
     _outOfOrderRecordColumn = outOfOrderRecordColumn;
@@ -118,13 +122,14 @@ public class UpsertContext {
     return _comparisonColumns;
   }
 
+  /// Returns a factory that builds a [PartialUpsertHandler] for one partition, or null for full upsert.
   @Nullable
-  public PartialUpsertHandler getPartialUpsertHandler() {
-    return _partialUpsertHandler;
+  public Supplier<PartialUpsertHandler> getPartialUpsertHandlerSupplier() {
+    return _partialUpsertHandlerSupplier;
   }
 
   public UpsertConfig.Mode getUpsertMode() {
-    return _partialUpsertHandler == null ? UpsertConfig.Mode.FULL : UpsertConfig.Mode.PARTIAL;
+    return _partialUpsertHandlerSupplier == null ? UpsertConfig.Mode.FULL : UpsertConfig.Mode.PARTIAL;
   }
 
   @Nullable
@@ -197,7 +202,7 @@ public class UpsertContext {
   /// - Partial upsert is enabled (records need to be merged with previous values)
   /// - dropOutOfOrderRecord is enabled with NONE consistency mode (records may have been dropped)
   public boolean isTableTypeInconsistentDuringConsumption() {
-    return _dropOutOfOrderRecord || _outOfOrderRecordColumn != null || _partialUpsertHandler != null;
+    return _dropOutOfOrderRecord || _outOfOrderRecordColumn != null || _partialUpsertHandlerSupplier != null;
   }
 
   @Override
@@ -230,7 +235,7 @@ public class UpsertContext {
     private List<String> _primaryKeyColumns;
     private HashFunction _hashFunction = HashFunction.NONE;
     private List<String> _comparisonColumns;
-    private PartialUpsertHandler _partialUpsertHandler;
+    private Supplier<PartialUpsertHandler> _partialUpsertHandlerSupplier;
     private String _deleteRecordColumn;
     private boolean _dropOutOfOrderRecord;
     @Nullable
@@ -274,8 +279,10 @@ public class UpsertContext {
       return this;
     }
 
-    public Builder setPartialUpsertHandler(PartialUpsertHandler partialUpsertHandler) {
-      _partialUpsertHandler = partialUpsertHandler;
+    /// Sets the factory used to build one [PartialUpsertHandler] per partition. Null for full upsert.
+    public Builder setPartialUpsertHandlerSupplier(
+        @Nullable Supplier<PartialUpsertHandler> partialUpsertHandlerSupplier) {
+      _partialUpsertHandlerSupplier = partialUpsertHandlerSupplier;
       return this;
     }
 
@@ -384,8 +391,9 @@ public class UpsertContext {
         }
       }
       return new UpsertContext(_tableConfig, _schema, _primaryKeyColumns, _hashFunction, _comparisonColumns,
-          _partialUpsertHandler, _deleteRecordColumn, _dropOutOfOrderRecord, _outOfOrderRecordColumn, _enableSnapshot,
-          _enablePreload, _metadataTTL, _deletedKeysTTL, _enableDeletedKeysCompactionConsistency, _consistencyMode,
+          _partialUpsertHandlerSupplier, _deleteRecordColumn, _dropOutOfOrderRecord, _outOfOrderRecordColumn,
+          _enableSnapshot, _enablePreload, _metadataTTL, _deletedKeysTTL,
+          _enableDeletedKeysCompactionConsistency, _consistencyMode,
           _upsertViewRefreshIntervalMs, _newSegmentTrackingTimeMs, _metadataManagerConfigs,
           _allowPartialUpsertConsumptionDuringCommit, _tableDataManager, _tableIndexDir);
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
@@ -2022,7 +2022,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     // Test partial upserts with old and new segments having same number of docs
     // This test verifies that when all keys are present, no reversion occurs
     PartialUpsertHandler mockPartialUpsertHandler = mock(PartialUpsertHandler.class);
-    UpsertContext upsertContext = _contextBuilder.setPartialUpsertHandler(mockPartialUpsertHandler)
+    UpsertContext upsertContext = _contextBuilder.setPartialUpsertHandlerSupplier(() -> mockPartialUpsertHandler)
         .setConsistencyMode(UpsertConfig.ConsistencyMode.NONE).build();
 
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
@@ -2085,7 +2085,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     // Test partial upserts with consuming (mutable) segment being sealed - revert should be triggered
     // Note: Revert logic only applies when sealing a consuming segment, not for immutable segment replacement
     PartialUpsertHandler mockPartialUpsertHandler = mock(PartialUpsertHandler.class);
-    UpsertContext upsertContext = _contextBuilder.setPartialUpsertHandler(mockPartialUpsertHandler)
+    UpsertContext upsertContext = _contextBuilder.setPartialUpsertHandlerSupplier(() -> mockPartialUpsertHandler)
         .setConsistencyMode(UpsertConfig.ConsistencyMode.NONE).build();
 
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
@@ -2133,7 +2133,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
   public void testPartialUpsertOldSegmentLesserDocs() throws IOException {
     // Test partial upserts with old segment having fewer docs than new segment
     PartialUpsertHandler mockPartialUpsertHandler = mock(PartialUpsertHandler.class);
-    UpsertContext upsertContext = _contextBuilder.setPartialUpsertHandler(mockPartialUpsertHandler)
+    UpsertContext upsertContext = _contextBuilder.setPartialUpsertHandlerSupplier(() -> mockPartialUpsertHandler)
         .setConsistencyMode(UpsertConfig.ConsistencyMode.NONE).build();
 
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =


### PR DESCRIPTION
## TL;DR

A partial upsert table with `postPartialUpsertTransformConfigs` can write wrong values into its
derived columns. `PartialUpsertHandler` was built once per table and shared by every partition, but
it holds record transformers that keep reusable evaluation state, and each partition merges on its
own consumer thread. This PR moves handler creation down to the partition, so each partition owns
its own handler.

## The problem

`BaseTableUpsertMetadataManager.init()` built **one** `PartialUpsertHandler` and put it in the
shared `UpsertContext`. Every `BasePartitionUpsertMetadataManager` read that same instance. Each
partition ingests on its own consumer thread, so N partitions on a server meant N threads calling
`PartialUpsertHandler.merge()` at the same time.

`merge()` ends by running the post partial upsert transform chain. Those transformers are not thread
safe. `ExpressionTransformer` holds `FunctionEvaluator` instances, and `InbuiltFunctionEvaluator`'s
`FunctionExecutionNode` keeps a reusable `Object[] _arguments` array that it refills on every
`execute()` call:

```java
for (int i = 0; i < _argumentNodes.length; i++) {
  _arguments[i] = _argumentNodes[i].execute(row);   // shared array, refilled per row
}
...
return _functionInvoker.invoke(_arguments);
```

Two threads writing into that one array interleave. Thread A can fill in its argument, get
descheduled, and then invoke the function after thread B has overwritten the same slot. The derived
column for partition 0's row is then computed from partition 1's values. Nothing throws. The row is
just wrong, and it gets persisted.

```mermaid
sequenceDiagram
  participant P0 as Partition 0 consumer
  participant P1 as Partition 1 consumer
  participant N as FunctionExecutionNode<br/>(one shared _arguments[])
  P0->>N: _arguments[0] = 100 (row A)
  P1->>N: _arguments[0] = 999 (row B)
  P0->>N: invoke(_arguments)
  Note over P0,N: ❌ row A's derived column computed from 999
  P1->>N: invoke(_arguments)
```

The root cause is ownership granularity. The handler was owned by the table, but the mutable state
inside it can only be owned by one merging thread.

## The approach

Give each partition its own handler, which is the level the merge path already works at.

1. `UpsertContext` now carries a `Supplier<PartialUpsertHandler>` instead of a built instance.
   `BaseTableUpsertMetadataManager` sets the supplier when the mode is `PARTIAL`.
2. Each `BasePartitionUpsertMetadataManager` calls the supplier once in its constructor and keeps
   the result. One handler per partition, built when the partition manager is built.
3. `getUpsertMode()` and `isTableTypeInconsistentDuringConsumption()` now branch on whether the
   supplier is set, which is exactly the signal the old handler-nullness check gave them.

```mermaid
flowchart LR
  subgraph Before["❌ Before"]
    T[table manager] --> H[one handler]
    H --> P0[Partition 0 thread]
    H --> P1[Partition 1 thread]
  end
  subgraph After["✅ After"]
    T2[table manager] --> S[handler supplier]
    S --> H0[handler for P0] --> P2[Partition 0 thread]
    S --> H1[handler for P1] --> P3[Partition 1 thread]
  end
```

### Why per-partition is enough

`merge()` is only reachable from `doUpdateRecord()`, which already uses per-partition unsynchronized
scratch state right next to the merge call:

```java
_reusePreviousRow.init(currentSegment, currentDocId);
_partialUpsertHandler.merge(_reusePreviousRow, record, _reuseMergeResultHolder);
```

`_reusePreviousRow` and `_reuseMergeResultHolder` are plain fields on the partition manager. Partial
upsert already depends on at most one thread running `doUpdateRecord()` per partition at a time.
Consumption within a partition is serialized across segments, since a segment stops consuming before
the next one starts. So putting the handler at the partition level relies on an invariant the code
already relies on, rather than adding a new one. I have documented that invariant on the classes
involved.

A `ThreadLocal` inside `PartialUpsertHandler` would also fix the race, but it papers over the
ownership problem instead of fixing it, and leaves per-thread chains alive for as long as the thread
lives. Building the handler where its mutable state belongs is the smaller idea.

### Why not make the transformers thread safe

The other obvious option was to fix `ExpressionTransformer` and `InbuiltFunctionEvaluator` directly,
either by locking around evaluation or by allocating a fresh argument array per call. Both were
rejected because this is the ingestion hot path. These run once per ingested record, and the argument
array is refilled for every function node in the expression. Locking would put lock traffic on every
record on every partition. Allocating per call would add per-record garbage. Either way every record
ingested by every Pinot table using transform functions pays the cost, forever, to fix a problem that
only existed because one object was shared too widely.

Confining the handler to one thread costs nothing per record. So the transformers keep reusing their
scratch state, and their Javadoc now says they are not thread safe so the next caller knows to keep
one instance per thread.

## Changes

| File | Change |
|---|---|
| `UpsertContext.java` | Carries `Supplier<PartialUpsertHandler>` instead of a shared instance; `getPartialUpsertHandler()` → `getPartialUpsertHandlerSupplier()`, `setPartialUpsertHandler()` → `setPartialUpsertHandlerSupplier()` |
| `BaseTableUpsertMetadataManager.java` | Builds a supplier instead of one handler |
| `BasePartitionUpsertMetadataManager.java` | Calls the supplier to build the partition's own handler |
| `PartialUpsertHandler.java` | Javadoc: not thread safe, one instance per partition |
| `ExpressionTransformer.java` | Javadoc: not thread safe |
| `InbuiltFunctionEvaluator.java` | Javadoc: not thread safe, function nodes reuse one argument array |

No config, metric, REST, or wire format changes. Nothing is serialized or sent across nodes, so
there is no mixed-version concern.

`UpsertContext` is an internal class in `pinot-segment-local`. The two renamed methods had one
production caller each, both inside this module. Anyone maintaining an out-of-tree
`TableUpsertMetadataManager` that reads `UpsertContext.getPartialUpsertHandler()` would need the
one-line rename, so this is worth a `backward-incompat` glance even though nothing in-tree breaks.

## Performance considerations

- One handler and transform chain per partition instead of per table. Construction parses the
  transform expressions, so this is real work, but it happens once when the partition manager is
  built and never on the ingestion path.
- Memory grows with the number of partitions the server hosts for the table. Each chain is small.
- The steady-state merge path is unchanged. The chain is a plain field again, so there is no
  `ThreadLocal` lookup per merge.
- No synchronization was added anywhere. The transformers still reuse their scratch state, so the
  per-record cost of ingestion is exactly what it was before this PR.

## Testing

- `PartialUpsertHandlerTest`, `ConcurrentMapPartitionUpsertMetadataManagerTest`,
  `ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletesTest`,
  `BasePartitionUpsertMetadataManagerTest` and `ExpressionTransformerTest` all pass (80 tests).
- `ConcurrentMapPartitionUpsertMetadataManagerTest` has three tests that inject a mock handler
  through the context. They now pass `() -> mockHandler`. That is the only test change, and it is a
  mechanical rename, not new coverage.
- **No new test in this PR.** A regression test for the original race needs many threads hammering a
  shared handler and asserting no cross-thread value leaks, which is timing sensitive. I would rather
  land the fix than gate it on a test that could turn flaky in CI. Happy to add one if reviewers
  want it here.

## Labels

`bugfix`
