### PR TITLE
Fix unsafe publication of DataSchema stored column data types

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
@@ -44,7 +44,6 @@ import java.util.UUID;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.segment.spi.memory.PinotInputStream;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
@@ -57,14 +56,27 @@ import org.apache.pinot.spi.utils.UuidUtils;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 
-/**
- * The <code>DataSchema</code> class describes the schema of {@link DataTable}.
- */
+/// Describes the schema of a [org.apache.pinot.common.datatable.DataTable].
+///
+/// Fields are never reassigned after construction, but [#getColumnNames] and [#getColumnDataTypes] hand out the
+/// internal arrays without copying, so instances are not immutable: `BaseGapfillProcessor` rewrites column names in
+/// place.
+///
+/// Read-only sharing across threads is common and must stay safe: in the multi-stage engine a stage plan is
+/// deserialized once per stage and then handed to every worker of that stage, so the `DataSchema` of each plan node is
+/// read concurrently by all worker threads on the server.
 @JsonPropertyOrder({"columnNames", "columnDataTypes"})
 public class DataSchema {
   private final String[] _columnNames;
   private final ColumnDataType[] _columnDataTypes;
-  private ColumnDataType[] _storedColumnDataTypes;
+
+  /// Lazily computed cache of [#getStoredColumnDataTypes].
+  ///
+  /// `volatile` is required, not just for the null check in [#getStoredColumnDataTypes]: without it the array
+  /// contents are published unsafely, and a racing thread can read the non-null array reference while still seeing
+  /// `null` for its elements. Downstream code (e.g. `TypeUtils.convert`, `DataBlockExtractUtils.extractValue`) then
+  /// switches on a `null` stored type and fails with a `NullPointerException`.
+  private volatile ColumnDataType[] _storedColumnDataTypes;
 
   /**
    * Used by both Broker and Server to generate results for EXPLAIN PLAN queries.
@@ -101,9 +113,11 @@ public class DataSchema {
     return _columnDataTypes;
   }
 
-  /**
-   * Lazy compute the _storeColumnDataTypes field.
-   */
+  /// Returns the stored type of each column, lazily computing and caching it on first access.
+  ///
+  /// Uses the racy-single-check idiom: two threads may each compute the array, but both compute the same values, so
+  /// the duplicate work is harmless. Correctness relies on `_storedColumnDataTypes` being `volatile`; see the field
+  /// for why.
   @JsonIgnore
   public ColumnDataType[] getStoredColumnDataTypes() {
     ColumnDataType[] storedColumnDataTypes = _storedColumnDataTypes;


### PR DESCRIPTION
## Summary

`DataSchema._storedColumnDataTypes` is a lazily computed cache, held in a **non-volatile** field:

```java
private ColumnDataType[] _storedColumnDataTypes;

public ColumnDataType[] getStoredColumnDataTypes() {
  ColumnDataType[] storedColumnDataTypes = _storedColumnDataTypes;
  if (storedColumnDataTypes == null) {
    storedColumnDataTypes = new ColumnDataType[numColumns];
    for (...) { storedColumnDataTypes[i] = _columnDataTypes[i].getStoredType(); }
    _storedColumnDataTypes = storedColumnDataTypes;   // unsafe publication
  }
  return storedColumnDataTypes;
}
```

The array contents are published unsafely. Nothing establishes a happens-before edge between the element stores in the
computing thread and the element loads in another thread, so a racing thread can observe the **non-null array reference
while still reading `null` for its elements**.

That `null` stored type then flows into code that switches on it. `switch` over an enum compiles to
`$SwitchMap[storedType.ordinal()]`, so the failure surfaces as:

```
Cannot invoke "org.apache.pinot.common.utils.DataSchema$ColumnDataType.ordinal()" because "storedType" is null
```

The two frames whose parameter is literally named `storedType`, both fed from `getStoredColumnDataTypes()`:
- `TypeUtils.convert(Object value, ColumnDataType storedType)`
- `DataBlockExtractUtils.extractValue(DataBlock, ColumnDataType storedType, int, int)`

`ColumnDataType.getStoredType()` can never return `null` (every constant sets its stored type to itself or to an
earlier constant) and plan deserialization throws on unknown types rather than yielding `null`, so a null array element
is the only way to reach this state.

### Why the schemas are shared across threads

The `DataSchema` instances hanging off plan nodes are read concurrently:
- `QueryServer.submitInternal` deserializes a stage plan **once per stage**, then passes that same instance to
  `processQuery` for every `WorkerMetadata` of the stage.
- `QueryDispatcher` builds a *list* of worker ids per server, so a server routinely runs several workers of the same
  stage.
- `QueryRunner.processQuery` runs each worker via `CompletableFuture.runAsync` on its own thread.

All those workers build their operator trees from the same plan nodes, so they hit the lazy initialization at the same
moment, deep inside query execution. Affected call sites include `MultistageGroupByExecutor`,
`MultistageAggregationExecutor`, `WindowAggregateOperator` and `LeafOperator`.

### Fix

Make the field `volatile`, which supplies the missing happens-before edge.

The racy-single-check idiom is kept intentionally: two threads may each compute the array, but they compute identical
values, so the duplicate work is harmless.

### Why not compute it eagerly in the constructor

That would remove the `volatile` read and the branch, but it is the wrong trade: most `DataSchema` instances never need
stored types. One is created per `RelNode` during planning (`RelToPlanNodeConverter`, `PRelToPlanNodeConverter`), and
there is not a single `getStoredColumnDataTypes()` call anywhere in `pinot-broker` or `pinot-query-planner` — those
schemas are serialized to proto and dropped. On the server, only the aggregate / window / leaf / send paths ask; filter,
project, sort, set-op and mailbox-receive schemas never do. Eager computation would allocate and fill an array for every
plan node of every query to serve a minority of them, and would also move any failure on a malformed schema from first
use to construction time.

### Overhead

Negligible. All 25 call sites already hoist the array into a local before looping, so the read happens once per block /
table / results-block rather than once per row. On x86-64 a volatile read of a reference field compiles to a plain
`mov`; on AArch64 it is `ldar` instead of `ldr`. The volatile write happens at most a couple of times per `DataSchema`.

Also converts the touched Javadoc to Markdown and documents the thread-safety contract. The
`org.apache.pinot.common.datatable.DataTable` import is dropped because its only use was the `{@link}` in the converted
class Javadoc, and checkstyle's `UnusedImports` does not recognize Markdown links.
