### PR TITLE
Fold tier info into rebalance precheck context

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
@@ -109,12 +109,10 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
     // Check if all servers involved in the rebalance have enough disk space for rebalance operation.
     // Notice this check could have false positives (disk utilization is subject to change by other operations anytime)
     preCheckResult.put(DISK_UTILIZATION_DURING_REBALANCE,
-        checkDiskUtilization(preCheckContext.getCurrentAssignment(), preCheckContext.getTargetAssignment(),
-            preCheckContext.getTableSubTypeSizeDetails(), diskUtilizationThreshold, true));
+        checkDiskUtilization(preCheckContext, diskUtilizationThreshold, true));
     // Check if all servers involved in the rebalance will have enough disk space after the rebalance.
     preCheckResult.put(DISK_UTILIZATION_AFTER_REBALANCE,
-        checkDiskUtilization(preCheckContext.getCurrentAssignment(), preCheckContext.getTargetAssignment(),
-            preCheckContext.getTableSubTypeSizeDetails(), diskUtilizationThreshold, false));
+        checkDiskUtilization(preCheckContext, diskUtilizationThreshold, false));
 
     preCheckResult.put(REBALANCE_CONFIG_OPTIONS, checkRebalanceConfig(rebalanceConfig, tableConfig,
         preCheckContext.getCurrentAssignment(), preCheckContext.getTargetAssignment(),
@@ -274,9 +272,18 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
     return RebalancePreCheckerResult.error("Got exception when fetching instance assignment, check manually");
   }
 
-  private RebalancePreCheckerResult checkDiskUtilization(Map<String, Map<String, String>> currentAssignment,
-      Map<String, Map<String, String>> targetAssignment,
-      TableSizeReader.TableSubTypeSizeDetails tableSubTypeSizeDetails, double threshold, boolean worstCase) {
+  /**
+   * Estimates whether the servers of the target assignment stay within the disk utilization threshold, based on the
+   * average segment size and the number of segments added to (and, unless checking for the worst case, removed from)
+   * each server. Every segment is assumed to take up disk space on each server it is assigned to. Downstream projects
+   * where that does not hold (e.g. because a segment can be stored outside of the server, as indicated by
+   * {@link TierConfig#getTierBackend()}) can override this.
+   */
+  protected RebalancePreCheckerResult checkDiskUtilization(PreCheckContext preCheckContext, double threshold,
+      boolean worstCase) {
+    Map<String, Map<String, String>> currentAssignment = preCheckContext.getCurrentAssignment();
+    Map<String, Map<String, String>> targetAssignment = preCheckContext.getTargetAssignment();
+    TableSizeReader.TableSubTypeSizeDetails tableSubTypeSizeDetails = preCheckContext.getTableSubTypeSizeDetails();
     boolean isDiskUtilSafe = true;
     StringBuilder message =
         new StringBuilder("UNSAFE. Servers with unsafe disk utilization (>" + (short) (threshold * 100) + "%): ");

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalancePreChecker.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.helix.core.rebalance;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.restlet.resources.RebalanceConfig;
@@ -41,11 +42,13 @@ public interface RebalancePreChecker {
     private final TableSizeReader.TableSubTypeSizeDetails _tableSubTypeSizeDetails;
     private final RebalanceConfig _rebalanceConfig;
     private final RebalanceSummaryResult _rebalanceSummaryResult;
+    private final Map<String, Set<String>> _providedTierToSegmentsMap;
 
     public PreCheckContext(String rebalanceJobId, String tableNameWithType, TableConfig tableConfig,
         Map<String, Map<String, String>> currentAssignment, Map<String, Map<String, String>> targetAssignment,
         @Nullable TableSizeReader.TableSubTypeSizeDetails tableSubTypeSizeDetails, RebalanceConfig rebalanceConfig,
-        @Nullable RebalanceSummaryResult rebalanceSummaryResult) {
+        @Nullable RebalanceSummaryResult rebalanceSummaryResult,
+        @Nullable Map<String, Set<String>> providedTierToSegmentsMap) {
       _rebalanceJobId = rebalanceJobId;
       _tableNameWithType = tableNameWithType;
       _tableConfig = tableConfig;
@@ -54,6 +57,7 @@ public interface RebalancePreChecker {
       _tableSubTypeSizeDetails = tableSubTypeSizeDetails;
       _rebalanceConfig = rebalanceConfig;
       _rebalanceSummaryResult = rebalanceSummaryResult;
+      _providedTierToSegmentsMap = providedTierToSegmentsMap;
     }
 
     public String getRebalanceJobId() {
@@ -86,6 +90,15 @@ public interface RebalancePreChecker {
 
     public RebalanceSummaryResult getRebalanceSummaryResult() {
       return _rebalanceSummaryResult;
+    }
+
+    /**
+     * Returns the tier name to segments map computed while updating the target tiers of this rebalance, or
+     * {@code null} if the target tiers were not updated (i.e. updateTargetTier is disabled).
+     */
+    @Nullable
+    public Map<String, Set<String>> getProvidedTierToSegmentsMap() {
+      return _providedTierToSegmentsMap;
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -400,7 +400,8 @@ public class TableRebalancer {
         try {
           RebalancePreChecker.PreCheckContext preCheckContext =
               new RebalancePreChecker.PreCheckContext(rebalanceJobId, tableNameWithType, tableConfig, currentAssignment,
-                  targetAssignment, tableSubTypeSizeDetails, rebalanceConfig, summaryResult);
+                  targetAssignment, tableSubTypeSizeDetails, rebalanceConfig, summaryResult,
+                  providedTierToSegmentsMap);
           preChecksResult = _rebalancePreChecker.check(preCheckContext);
         } catch (Exception e) {
           tableRebalanceLogger.warn("Caught exception while trying to run the rebalance pre-checks, skipping", e);


### PR DESCRIPTION
## Description
Tier info is quite relevant while doing rebalance, specifically disk utilization check, as different tier implementation adds different load on disk per segment.