### PR TITLE
Improve JSON decoder selected-field performance

### DIFF
--- a/pinot-perf/pom.xml
+++ b/pinot-perf/pom.xml
@@ -58,6 +58,10 @@
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-protobuf</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-json</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.pinot</groupId>

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkJsonParsing.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkJsonParsing.java
@@ -256,9 +256,7 @@ public class BenchmarkJsonParsing {
     return result;
   }
 
-  /**
-   * BASELINE DECODER: materialize the top-level map, then copy all fields into GenericRow.
-   */
+  /// BASELINE DECODER: materialize the top-level map, then copy all fields into GenericRow.
   @Benchmark
   public GenericRow mapThenExtractAllFields()
       throws IOException {
@@ -267,9 +265,7 @@ public class BenchmarkJsonParsing {
     return _allFieldsExtractor.extract(JsonUtils.bytesToMap(payload, 0, payload.length), _mapAllFieldsRow);
   }
 
-  /**
-   * OPTIMIZED DECODER: stream all top-level values directly into GenericRow.
-   */
+  /// OPTIMIZED DECODER: stream all top-level values directly into GenericRow.
   @Benchmark
   public GenericRow directToGenericRowAllFields() {
     _directAllFieldsRow.clear();
@@ -277,9 +273,7 @@ public class BenchmarkJsonParsing {
     return _allFieldsDecoder.decode(payload, _directAllFieldsRow);
   }
 
-  /**
-   * BASELINE DECODER: materialize the full top-level map, then copy selected fields into GenericRow.
-   */
+  /// BASELINE DECODER: materialize the full top-level map, then copy selected fields into GenericRow.
   @Benchmark
   public GenericRow mapThenExtractSelectedFields()
       throws IOException {
@@ -288,9 +282,7 @@ public class BenchmarkJsonParsing {
     return _selectedFieldsExtractor.extract(JsonUtils.bytesToMap(payload, 0, payload.length), _mapSelectedFieldsRow);
   }
 
-  /**
-   * OPTIMIZED DECODER: materialize selected values only and skip unselected containers.
-   */
+  /// OPTIMIZED DECODER: materialize selected values only and skip unselected containers.
   @Benchmark
   public GenericRow directToGenericRowSelectedFields() {
     _directSelectedFieldsRow.clear();

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkJsonParsing.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkJsonParsing.java
@@ -25,7 +25,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder;
+import org.apache.pinot.plugin.inputformat.json.JSONRecordExtractor;
+import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -80,9 +84,18 @@ public class BenchmarkJsonParsing {
 
   private List<byte[]> _jsonPayloads;
   private int _currentIndex = 0;
+  private JSONMessageDecoder _allFieldsDecoder;
+  private JSONMessageDecoder _selectedFieldsDecoder;
+  private JSONRecordExtractor _allFieldsExtractor;
+  private JSONRecordExtractor _selectedFieldsExtractor;
+  private GenericRow _mapAllFieldsRow;
+  private GenericRow _directAllFieldsRow;
+  private GenericRow _mapSelectedFieldsRow;
+  private GenericRow _directSelectedFieldsRow;
 
   @Setup(Level.Trial)
-  public void setUp() {
+  public void setUp()
+      throws Exception {
     _jsonPayloads = new ArrayList<>(NUM_MESSAGES);
     Random random = new Random(42);
 
@@ -90,6 +103,20 @@ public class BenchmarkJsonParsing {
       String json = generateJsonPayload(_payloadType, random, i);
       _jsonPayloads.add(json.getBytes(StandardCharsets.UTF_8));
     }
+
+    Set<String> selectedFields = selectedFields(_payloadType);
+    _allFieldsDecoder = new JSONMessageDecoder();
+    _allFieldsDecoder.init(Map.of(), null, "benchmark");
+    _selectedFieldsDecoder = new JSONMessageDecoder();
+    _selectedFieldsDecoder.init(Map.of(), selectedFields, "benchmark");
+    _allFieldsExtractor = new JSONRecordExtractor();
+    _allFieldsExtractor.init(null, null);
+    _selectedFieldsExtractor = new JSONRecordExtractor();
+    _selectedFieldsExtractor.init(selectedFields, null);
+    _mapAllFieldsRow = new GenericRow();
+    _directAllFieldsRow = new GenericRow();
+    _mapSelectedFieldsRow = new GenericRow();
+    _directSelectedFieldsRow = new GenericRow();
   }
 
   /// Generates different types of JSON payloads to simulate real-world streaming data.
@@ -227,6 +254,63 @@ public class BenchmarkJsonParsing {
     Map<String, Object> result = JsonUtils.bytesToMap(payload, 0, payload.length);
 
     return result;
+  }
+
+  /**
+   * BASELINE DECODER: materialize the top-level map, then copy all fields into GenericRow.
+   */
+  @Benchmark
+  public GenericRow mapThenExtractAllFields()
+      throws IOException {
+    _mapAllFieldsRow.clear();
+    byte[] payload = getNextPayload();
+    return _allFieldsExtractor.extract(JsonUtils.bytesToMap(payload, 0, payload.length), _mapAllFieldsRow);
+  }
+
+  /**
+   * OPTIMIZED DECODER: stream all top-level values directly into GenericRow.
+   */
+  @Benchmark
+  public GenericRow directToGenericRowAllFields() {
+    _directAllFieldsRow.clear();
+    byte[] payload = getNextPayload();
+    return _allFieldsDecoder.decode(payload, _directAllFieldsRow);
+  }
+
+  /**
+   * BASELINE DECODER: materialize the full top-level map, then copy selected fields into GenericRow.
+   */
+  @Benchmark
+  public GenericRow mapThenExtractSelectedFields()
+      throws IOException {
+    _mapSelectedFieldsRow.clear();
+    byte[] payload = getNextPayload();
+    return _selectedFieldsExtractor.extract(JsonUtils.bytesToMap(payload, 0, payload.length), _mapSelectedFieldsRow);
+  }
+
+  /**
+   * OPTIMIZED DECODER: materialize selected values only and skip unselected containers.
+   */
+  @Benchmark
+  public GenericRow directToGenericRowSelectedFields() {
+    _directSelectedFieldsRow.clear();
+    byte[] payload = getNextPayload();
+    return _selectedFieldsDecoder.decode(payload, _directSelectedFieldsRow);
+  }
+
+  private static Set<String> selectedFields(String payloadType) {
+    switch (payloadType) {
+      case "small":
+        return Set.of("id", "status");
+      case "medium":
+        return Set.of("eventId", "userId", "timestamp", "country");
+      case "large":
+        return Set.of("eventId", "timestamp");
+      case "nested":
+        return Set.of("order");
+      default:
+        return Set.of("id");
+    }
   }
 
   // Helper methods for generating realistic test data

--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONMessageDecoder.java
@@ -53,6 +53,8 @@ public class JSONMessageDecoder implements StreamMessageDecoder<byte[]> {
       "org.apache.pinot.plugin.inputformat.json.JSONRecordExtractor";
 
   private RecordExtractor<Map<String, Object>> _jsonRecordExtractor;
+  private Set<String> _fieldsToRead;
+  private boolean _usesDefaultRecordExtractor;
   // For AUTO this resolves the concrete format per message; otherwise it is the pinned format's parser.
   private JsonPayloadParser _parser;
 
@@ -70,6 +72,9 @@ public class JSONMessageDecoder implements StreamMessageDecoder<byte[]> {
     }
     _jsonRecordExtractor = PluginManager.get().createInstance(recordExtractorClass);
     _jsonRecordExtractor.init(fieldsToRead, null);
+    _fieldsToRead = fieldsToRead == null || fieldsToRead.isEmpty() ? null : Set.copyOf(fieldsToRead);
+    // A configured extractor can change conversion semantics, so only bypass Pinot's exact default class.
+    _usesDefaultRecordExtractor = _jsonRecordExtractor.getClass() == JSONRecordExtractor.class;
     _parser = JsonPayloadFormat.fromConfig(jsonFormat).getParser();
   }
 
@@ -81,7 +86,9 @@ public class JSONMessageDecoder implements StreamMessageDecoder<byte[]> {
   @Override
   public GenericRow decode(byte[] payload, int offset, int length, GenericRow destination) {
     try {
-      // Parse directly to Map, avoiding an intermediate JsonNode representation for better performance.
+      if (_usesDefaultRecordExtractor && _parser.parseTo(payload, offset, length, _fieldsToRead, destination)) {
+        return destination;
+      }
       Map<String, Object> jsonMap = _parser.parse(payload, offset, length);
       return _jsonRecordExtractor.extract(jsonMap, destination);
     } catch (Exception e) {

--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONMessageDecoder.java
@@ -21,6 +21,7 @@ package org.apache.pinot.plugin.inputformat.json;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Set;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.pinot.plugin.inputformat.json.format.JsonPayloadFormat;
 import org.apache.pinot.plugin.inputformat.json.format.JsonPayloadParser;
 import org.apache.pinot.spi.data.readers.GenericRow;
@@ -72,8 +73,9 @@ public class JSONMessageDecoder implements StreamMessageDecoder<byte[]> {
     }
     _jsonRecordExtractor = PluginManager.get().createInstance(recordExtractorClass);
     _jsonRecordExtractor.init(fieldsToRead, null);
-    _fieldsToRead = fieldsToRead == null || fieldsToRead.isEmpty() ? null : Set.copyOf(fieldsToRead);
-    // A configured extractor can change conversion semantics, so only bypass Pinot's exact default class.
+    _fieldsToRead = CollectionUtils.isNotEmpty(fieldsToRead) ? Set.copyOf(fieldsToRead) : null;
+    // Direct parsing implements JSONRecordExtractor's conversion contract and bypasses extract(). Require the
+    // exact default class so a configured extractor or subclass cannot lose custom extraction behavior.
     _usesDefaultRecordExtractor = _jsonRecordExtractor.getClass() == JSONRecordExtractor.class;
     _parser = JsonPayloadFormat.fromConfig(jsonFormat).getParser();
   }
@@ -86,7 +88,7 @@ public class JSONMessageDecoder implements StreamMessageDecoder<byte[]> {
   @Override
   public GenericRow decode(byte[] payload, int offset, int length, GenericRow destination) {
     try {
-      if (_usesDefaultRecordExtractor && _parser.parseTo(payload, offset, length, _fieldsToRead, destination)) {
+      if (_usesDefaultRecordExtractor && _parser.parse(payload, offset, length, destination, _fieldsToRead)) {
         return destination;
       }
       Map<String, Object> jsonMap = _parser.parse(payload, offset, length);

--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONRecordExtractor.java
@@ -61,7 +61,7 @@ public class JSONRecordExtractor extends BaseRecordExtractor<Map<String, Object>
   /// Walks a non-null Jackson-parsed value and produces the contract shape: `BigDecimal` for `BigInteger`
   /// (oversized ints), `Object[]` for JSON arrays, `Map<String, Object>` for JSON objects, pass-through for
   /// the other Jackson scalar types (`Boolean`, `Integer`, `Long`, `Double`, `String`).
-  private static Object convert(Object value) {
+  public static Object convert(Object value) {
     // BigInteger widens (Pinot has no BigInteger type)
     if (value instanceof BigInteger) {
       return new BigDecimal((BigInteger) value);

--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/format/AutoDetectPayloadParser.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/format/AutoDetectPayloadParser.java
@@ -42,10 +42,10 @@ class AutoDetectPayloadParser implements JsonPayloadParser {
   }
 
   @Override
-  public boolean parseTo(byte[] payload, int offset, int length, @Nullable Set<String> fields,
-      GenericRow destination)
+  public boolean parse(byte[] payload, int offset, int length, GenericRow destination,
+      @Nullable Set<String> fields)
       throws Exception {
     return JsonPayloadFormat.detectParser(payload, offset, length)
-        .parseTo(payload, offset, length, fields, destination);
+        .parse(payload, offset, length, destination, fields);
   }
 }

--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/format/AutoDetectPayloadParser.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/format/AutoDetectPayloadParser.java
@@ -19,6 +19,9 @@
 package org.apache.pinot.plugin.inputformat.json.format;
 
 import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.data.readers.GenericRow;
 
 
 /// Resolves the concrete parser per message from the payload's leading magic / version bytes, then delegates.
@@ -36,5 +39,13 @@ class AutoDetectPayloadParser implements JsonPayloadParser {
   public Map<String, Object> parse(byte[] payload, int offset, int length)
       throws Exception {
     return JsonPayloadFormat.detectParser(payload, offset, length).parse(payload, offset, length);
+  }
+
+  @Override
+  public boolean parseTo(byte[] payload, int offset, int length, @Nullable Set<String> fields,
+      GenericRow destination)
+      throws Exception {
+    return JsonPayloadFormat.detectParser(payload, offset, length)
+        .parseTo(payload, offset, length, fields, destination);
   }
 }

--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/format/JacksonPayloadParser.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/format/JacksonPayloadParser.java
@@ -19,9 +19,15 @@
 package org.apache.pinot.plugin.inputformat.json.format;
 
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.plugin.inputformat.json.JSONRecordExtractor;
+import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.JsonUtils;
 
 
@@ -31,15 +37,71 @@ import org.apache.pinot.spi.utils.JsonUtils;
 /// The [ObjectReader] is immutable and thread-safe, so a single instance is shared across all decode calls.
 abstract class JacksonPayloadParser implements JsonPayloadParser {
 
+  private final ObjectMapper _mapper;
   private final ObjectReader _mapReader;
+  private final ObjectReader _valueReader;
 
   JacksonPayloadParser(JsonFactory factory) {
-    _mapReader = new ObjectMapper(factory).readerFor(JsonUtils.MAP_TYPE_REFERENCE);
+    _mapper = new ObjectMapper(factory);
+    _mapReader = _mapper.readerFor(JsonUtils.MAP_TYPE_REFERENCE);
+    _valueReader = _mapper.readerFor(Object.class);
   }
 
   @Override
   public Map<String, Object> parse(byte[] payload, int offset, int length)
       throws Exception {
+    return parseMap(payload, offset, length);
+  }
+
+  protected final Map<String, Object> parseMap(byte[] payload, int offset, int length)
+      throws Exception {
     return _mapReader.readValue(payload, offset, length);
+  }
+
+  @Override
+  public boolean parseTo(byte[] payload, int offset, int length, @Nullable Set<String> fields,
+      GenericRow destination)
+      throws Exception {
+    return parseToRow(payload, offset, length, fields, destination);
+  }
+
+  /// Streams the top-level object fields into the row. Nested selected values still use Jackson's normal
+  /// materialization and are converted by [JSONRecordExtractor], but the top-level map is never allocated.
+  /// Unselected containers are skipped without materializing their contents.
+  protected final boolean parseToRow(byte[] payload, int offset, int length, @Nullable Set<String> fields,
+      GenericRow destination)
+      throws Exception {
+    if (fields != null) {
+      // Match JSONRecordExtractor's missing-field behavior and overwrite values left in a reused row.
+      for (String field : fields) {
+        destination.putValue(field, null);
+      }
+    }
+    try (JsonParser parser = _mapper.getFactory().createParser(payload, offset, length)) {
+      if (parser.nextToken() != JsonToken.START_OBJECT) {
+        throw new IllegalArgumentException("Top-level JSON value must be an object");
+      }
+      JsonToken token;
+      while ((token = parser.nextToken()) != JsonToken.END_OBJECT) {
+        if (token == null) {
+          throw new IllegalArgumentException("Unexpected end of JSON object");
+        }
+        if (token != JsonToken.FIELD_NAME) {
+          throw new IllegalArgumentException("Expected a JSON object field, found: " + token);
+        }
+        String fieldName = parser.currentName();
+        JsonToken valueToken = parser.nextToken();
+        if (valueToken == null) {
+          throw new IllegalArgumentException("Unexpected end of JSON value for field: " + fieldName);
+        }
+        if (fields == null || fields.contains(fieldName)) {
+          Object value = _valueReader.readValue(parser);
+          destination.putValue(fieldName, value != null ? JSONRecordExtractor.convert(value) : null);
+        } else if (valueToken.isStructStart()) {
+          parser.skipChildren();
+        }
+      }
+    }
+    return true;
   }
 }

--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/format/JacksonPayloadParser.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/format/JacksonPayloadParser.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -45,6 +46,9 @@ abstract class JacksonPayloadParser implements JsonPayloadParser {
     this(new ObjectMapper(factory).reader());
   }
 
+  /// The reader must use default deserialization features: [#readValue]'s scalar fast path bypasses databind,
+  /// so features like `USE_BIG_DECIMAL_FOR_FLOATS` would apply to containers but silently not to top-level
+  /// scalars. Every current caller passes a default-configured reader.
   JacksonPayloadParser(ObjectReader reader) {
     _factory = reader.getFactory();
     _mapReader = reader.forType(JsonUtils.MAP_TYPE_REFERENCE);
@@ -93,13 +97,42 @@ abstract class JacksonPayloadParser implements JsonPayloadParser {
           throw new IllegalArgumentException("Unexpected end of JSON value for field: " + fieldName);
         }
         if (fields == null || fields.contains(fieldName)) {
-          Object value = _valueReader.readValue(parser);
-          destination.putValue(fieldName, value != null ? JSONRecordExtractor.convert(value) : null);
+          destination.putValue(fieldName, readValue(parser, valueToken));
         } else if (valueToken.isStructStart()) {
           parser.skipChildren();
         }
       }
     }
     return true;
+  }
+
+  /// Materializes the value at the parser's current token in [JSONRecordExtractor]'s converted shape. Scalars
+  /// are read straight off the parser rather than through databind, which allocates a fresh
+  /// `DeserializationContext` per `readValue` call. `getNumberValue()` keeps the binary formats' `Float`
+  /// (never upcast to `Double`) and text JSON's `Double`, matching Jackson's untyped materialization.
+  @Nullable
+  private Object readValue(JsonParser parser, JsonToken valueToken)
+      throws IOException {
+    switch (valueToken) {
+      case VALUE_STRING:
+        return parser.getText();
+      case VALUE_NUMBER_INT:
+      case VALUE_NUMBER_FLOAT:
+        // Oversized ints widen to BigDecimal via the shared contract (Pinot has no BigInteger type)
+        return JSONRecordExtractor.convert(parser.getNumberValue());
+      case VALUE_TRUE:
+        return Boolean.TRUE;
+      case VALUE_FALSE:
+        return Boolean.FALSE;
+      case VALUE_NULL:
+        return null;
+      case VALUE_EMBEDDED_OBJECT:
+        // Binary formats' native scalars (e.g. byte[]) pass through unchanged, as in the map path.
+        return parser.getEmbeddedObject();
+      default:
+        // START_OBJECT / START_ARRAY: containers materialize through databind and convert recursively.
+        Object value = _valueReader.readValue(parser);
+        return value != null ? JSONRecordExtractor.convert(value) : null;
+    }
   }
 }

--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/format/JacksonPayloadParser.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/format/JacksonPayloadParser.java
@@ -37,14 +37,18 @@ import org.apache.pinot.spi.utils.JsonUtils;
 /// The [ObjectReader] is immutable and thread-safe, so a single instance is shared across all decode calls.
 abstract class JacksonPayloadParser implements JsonPayloadParser {
 
-  private final ObjectMapper _mapper;
+  private final JsonFactory _factory;
   private final ObjectReader _mapReader;
   private final ObjectReader _valueReader;
 
   JacksonPayloadParser(JsonFactory factory) {
-    _mapper = new ObjectMapper(factory);
-    _mapReader = _mapper.readerFor(JsonUtils.MAP_TYPE_REFERENCE);
-    _valueReader = _mapper.readerFor(Object.class);
+    this(new ObjectMapper(factory).reader());
+  }
+
+  JacksonPayloadParser(ObjectReader reader) {
+    _factory = reader.getFactory();
+    _mapReader = reader.forType(JsonUtils.MAP_TYPE_REFERENCE);
+    _valueReader = reader.forType(Object.class);
   }
 
   @Override
@@ -58,18 +62,12 @@ abstract class JacksonPayloadParser implements JsonPayloadParser {
     return _mapReader.readValue(payload, offset, length);
   }
 
-  @Override
-  public boolean parseTo(byte[] payload, int offset, int length, @Nullable Set<String> fields,
-      GenericRow destination)
-      throws Exception {
-    return parseToRow(payload, offset, length, fields, destination);
-  }
-
   /// Streams the top-level object fields into the row. Nested selected values still use Jackson's normal
   /// materialization and are converted by [JSONRecordExtractor], but the top-level map is never allocated.
   /// Unselected containers are skipped without materializing their contents.
-  protected final boolean parseToRow(byte[] payload, int offset, int length, @Nullable Set<String> fields,
-      GenericRow destination)
+  @Override
+  public boolean parse(byte[] payload, int offset, int length, GenericRow destination,
+      @Nullable Set<String> fields)
       throws Exception {
     if (fields != null) {
       // Match JSONRecordExtractor's missing-field behavior and overwrite values left in a reused row.
@@ -77,7 +75,7 @@ abstract class JacksonPayloadParser implements JsonPayloadParser {
         destination.putValue(field, null);
       }
     }
-    try (JsonParser parser = _mapper.getFactory().createParser(payload, offset, length)) {
+    try (JsonParser parser = _factory.createParser(payload, offset, length)) {
       if (parser.nextToken() != JsonToken.START_OBJECT) {
         throw new IllegalArgumentException("Top-level JSON value must be an object");
       }

--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/format/JsonPayloadParser.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/format/JsonPayloadParser.java
@@ -19,6 +19,9 @@
 package org.apache.pinot.plugin.inputformat.json.format;
 
 import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.data.readers.GenericRow;
 
 
 /// Parses a stream payload encoded in a particular (text or binary) JSON representation into a Jackson-style
@@ -51,4 +54,16 @@ public interface JsonPayloadParser {
   /// @throws Exception if the region is not valid for this format
   Map<String, Object> parse(byte[] payload, int offset, int length)
       throws Exception;
+
+  /// Parses the payload directly into {@code destination}, avoiding a top-level per-record map when the
+  /// implementation supports it.
+  ///
+  /// @param fields fields to populate, or {@code null} to populate every top-level field
+  /// @return {@code true} when the payload was decoded into {@code destination}; {@code false} when the caller
+  ///     should fall back to [#parse]
+  default boolean parseTo(byte[] payload, int offset, int length, @Nullable Set<String> fields,
+      GenericRow destination)
+      throws Exception {
+    return false;
+  }
 }

--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/format/JsonPayloadParser.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/format/JsonPayloadParser.java
@@ -55,14 +55,14 @@ public interface JsonPayloadParser {
   Map<String, Object> parse(byte[] payload, int offset, int length)
       throws Exception;
 
-  /// Parses the payload directly into {@code destination}, avoiding a top-level per-record map when the
+  /// Parses the payload directly into `destination`, avoiding a top-level per-record map when the
   /// implementation supports it.
   ///
-  /// @param fields fields to populate, or {@code null} to populate every top-level field
-  /// @return {@code true} when the payload was decoded into {@code destination}; {@code false} when the caller
+  /// @param fields fields to populate, or `null` to populate every top-level field
+  /// @return `true` when the payload was decoded into `destination`; `false` when the caller
   ///     should fall back to [#parse]
-  default boolean parseTo(byte[] payload, int offset, int length, @Nullable Set<String> fields,
-      GenericRow destination)
+  default boolean parse(byte[] payload, int offset, int length, GenericRow destination,
+      @Nullable Set<String> fields)
       throws Exception {
     return false;
   }

--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/format/JsonPayloadParser.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/format/JsonPayloadParser.java
@@ -56,7 +56,11 @@ public interface JsonPayloadParser {
       throws Exception;
 
   /// Parses the payload directly into `destination`, avoiding a top-level per-record map when the
-  /// implementation supports it.
+  /// implementation supports it. When this method returns `false`, it must leave `destination` unchanged so
+  /// the caller can safely fall back to [#parse]. When it returns `true`, it must overwrite every requested
+  /// field (using `null` for missing fields) and leave unrequested fields unchanged. When `fields` is `null`,
+  /// it must populate every top-level field present in the payload. If parsing throws, `destination` may be
+  /// partially modified and the caller must discard or clear it before reuse.
   ///
   /// @param fields fields to populate, or `null` to populate every top-level field
   /// @return `true` when the payload was decoded into `destination`; `false` when the caller

--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/format/PostgresJsonbPayloadParser.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/format/PostgresJsonbPayloadParser.java
@@ -18,11 +18,11 @@
  */
 package org.apache.pinot.plugin.inputformat.json.format;
 
-import com.fasterxml.jackson.core.JsonFactory;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.JsonUtils;
 
 
 /// Parses the PostgreSQL `jsonb` binary wire format: a single version byte (currently `1`) followed by the
@@ -43,7 +43,7 @@ class PostgresJsonbPayloadParser extends JacksonPayloadParser {
   private static final byte JSONB_VERSION = 1;
 
   PostgresJsonbPayloadParser() {
-    super(new JsonFactory());
+    super(JsonUtils.DEFAULT_READER);
   }
 
   @Override
@@ -62,11 +62,11 @@ class PostgresJsonbPayloadParser extends JacksonPayloadParser {
   }
 
   @Override
-  public boolean parseTo(byte[] payload, int offset, int length, @Nullable Set<String> fields,
-      GenericRow destination)
+  public boolean parse(byte[] payload, int offset, int length, GenericRow destination,
+      @Nullable Set<String> fields)
       throws Exception {
     validate(payload, offset, length);
-    return parseToRow(payload, offset + 1, length - 1, fields, destination);
+    return super.parse(payload, offset + 1, length - 1, destination, fields);
   }
 
   private static void validate(byte[] payload, int offset, int length) {

--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/format/PostgresJsonbPayloadParser.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/format/PostgresJsonbPayloadParser.java
@@ -18,8 +18,11 @@
  */
 package org.apache.pinot.plugin.inputformat.json.format;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import java.util.Map;
-import org.apache.pinot.spi.utils.JsonUtils;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.data.readers.GenericRow;
 
 
 /// Parses the PostgreSQL `jsonb` binary wire format: a single version byte (currently `1`) followed by the
@@ -32,12 +35,16 @@ import org.apache.pinot.spi.utils.JsonUtils;
 /// logical replication via `pgoutput` — routes through that same send function, so the version-byte + text
 /// framing is what a stream actually carries.
 ///
-/// Because the body is ordinary text JSON, values decode through [JsonUtils#bytesToMap] and therefore follow
-/// exactly the same type contract as [TextJsonPayloadParser].
-class PostgresJsonbPayloadParser implements JsonPayloadParser {
+/// Because the body is ordinary text JSON, values follow exactly the same type contract as
+/// [TextJsonPayloadParser].
+class PostgresJsonbPayloadParser extends JacksonPayloadParser {
 
   /// The only version `jsonb_recv` accepts.
   private static final byte JSONB_VERSION = 1;
+
+  PostgresJsonbPayloadParser() {
+    super(new JsonFactory());
+  }
 
   @Override
   public boolean matches(byte[] payload, int offset, int length) {
@@ -50,9 +57,21 @@ class PostgresJsonbPayloadParser implements JsonPayloadParser {
   @Override
   public Map<String, Object> parse(byte[] payload, int offset, int length)
       throws Exception {
+    validate(payload, offset, length);
+    return parseMap(payload, offset + 1, length - 1);
+  }
+
+  @Override
+  public boolean parseTo(byte[] payload, int offset, int length, @Nullable Set<String> fields,
+      GenericRow destination)
+      throws Exception {
+    validate(payload, offset, length);
+    return parseToRow(payload, offset + 1, length - 1, fields, destination);
+  }
+
+  private static void validate(byte[] payload, int offset, int length) {
     if (length < 2 || payload[offset] != JSONB_VERSION) {
       throw new IllegalArgumentException("Payload is not a version-1 PostgreSQL jsonb value");
     }
-    return JsonUtils.bytesToMap(payload, offset + 1, length - 1);
   }
 }

--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/format/TextJsonPayloadParser.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/format/TextJsonPayloadParser.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pinot.plugin.inputformat.json.format;
 
-import com.fasterxml.jackson.core.JsonFactory;
+import org.apache.pinot.spi.utils.JsonUtils;
 
 
 /// Parses UTF-8 text JSON, the historical [org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder]
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 class TextJsonPayloadParser extends JacksonPayloadParser {
 
   TextJsonPayloadParser() {
-    super(new JsonFactory());
+    super(JsonUtils.DEFAULT_READER);
   }
 
   @Override

--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/format/TextJsonPayloadParser.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/format/TextJsonPayloadParser.java
@@ -18,13 +18,16 @@
  */
 package org.apache.pinot.plugin.inputformat.json.format;
 
-import java.util.Map;
-import org.apache.pinot.spi.utils.JsonUtils;
+import com.fasterxml.jackson.core.JsonFactory;
 
 
 /// Parses UTF-8 text JSON, the historical [org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder]
-/// behavior. Delegates to [JsonUtils#bytesToMap] so the produced value types exactly match the rest of Pinot.
-class TextJsonPayloadParser implements JsonPayloadParser {
+/// behavior. Uses the same Jackson map/value materialization contract as the binary JSON parsers.
+class TextJsonPayloadParser extends JacksonPayloadParser {
+
+  TextJsonPayloadParser() {
+    super(new JsonFactory());
+  }
 
   @Override
   public boolean matches(byte[] payload, int offset, int length) {
@@ -45,11 +48,5 @@ class TextJsonPayloadParser implements JsonPayloadParser {
       return b == '{' || b == '[';
     }
     return false;
-  }
-
-  @Override
-  public Map<String, Object> parse(byte[] payload, int offset, int length)
-      throws Exception {
-    return JsonUtils.bytesToMap(payload, offset, length);
   }
 }

--- a/pinot-plugins/pinot-input-format/pinot-json/src/test/java/org/apache/pinot/plugin/inputformat/json/JSONMessageDecoderBinaryTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/test/java/org/apache/pinot/plugin/inputformat/json/JSONMessageDecoderBinaryTest.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.dataformat.cbor.CBORGenerator;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.pinot.spi.data.readers.GenericRow;
@@ -97,6 +98,23 @@ public class JSONMessageDecoderBinaryTest {
   public void testUnsetFormatIsText()
       throws Exception {
     assertRich(decode(Map.of(), RICH_FIELDS, TEXT_DOC));
+  }
+
+  /// The direct streaming path materializes top-level scalars straight off the parser; guard the binary-only
+  /// scalar shapes (Float must not upcast to Double, byte[] must pass through) at the decoder level, with and
+  /// without a field selection.
+  @Test
+  public void testDirectDecodePreservesBinaryScalars()
+      throws Exception {
+    Map<String, Object> doc = Map.of("f", 1.5f, "bin", new byte[]{1, 2, 3});
+    for (byte[] payload : List.of(smile(doc), cbor(doc))) {
+      for (Set<String> fields : Arrays.asList(null, Set.of("f", "bin"))) {
+        GenericRow row = decode(AUTO, fields, payload);
+        assertTrue(row.getValue("f") instanceof Float, "expected Float, got " + row.getValue("f").getClass());
+        assertEquals(row.getValue("f"), 1.5f);
+        assertEquals((byte[]) row.getValue("bin"), new byte[]{1, 2, 3});
+      }
+    }
   }
 
   /// An unset jsonFormat must not silently auto-detect binary payloads: those streams keep failing as they did

--- a/pinot-plugins/pinot-input-format/pinot-json/src/test/java/org/apache/pinot/plugin/inputformat/json/JSONMessageDecoderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/test/java/org/apache/pinot/plugin/inputformat/json/JSONMessageDecoderTest.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
+import java.math.BigDecimal;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -53,7 +54,7 @@ public class JSONMessageDecoderTest {
     GenericRow row = decoder.decode(payload, new GenericRow());
 
     assertEquals(row.getValue("id"), 1);
-    assertEquals(row.getValue("huge").toString(), "99999999999999999999999999");
+    assertEquals(row.getValue("huge"), new BigDecimal("99999999999999999999999999"));
     assertEquals((Object[]) ((Map<?, ?>) row.getValue("nested")).get("values"), new Object[]{1, null, 3});
     assertEquals((Object[]) row.getValue("tags"), new Object[]{"a", "b"});
   }

--- a/pinot-plugins/pinot-input-format/pinot-json/src/test/java/org/apache/pinot/plugin/inputformat/json/JSONMessageDecoderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/test/java/org/apache/pinot/plugin/inputformat/json/JSONMessageDecoderTest.java
@@ -47,16 +47,24 @@ public class JSONMessageDecoderTest {
   public void testDirectDecodePreservesValueConversion()
       throws Exception {
     byte[] payload = ("{\"id\":1,\"huge\":99999999999999999999999999,"
-        + "\"nested\":{\"values\":[1,null,3]},\"tags\":[\"a\",\"b\"]}").getBytes(StandardCharsets.UTF_8);
+        + "\"nested\":{\"values\":[1,null,3]},\"tags\":[\"a\",\"b\"],"
+        + "\"flag\":true,\"off\":false,\"gone\":null}").getBytes(StandardCharsets.UTF_8);
     JSONMessageDecoder decoder = new JSONMessageDecoder();
     decoder.init(Map.of(), null, "testTopic");
+    GenericRow row = new GenericRow();
+    // Without a field selection there is no pre-nulling pass, so an explicit JSON null must still overwrite
+    // the previous message's value in a reused row.
+    row.putValue("gone", "stale");
 
-    GenericRow row = decoder.decode(payload, new GenericRow());
+    decoder.decode(payload, row);
 
     assertEquals(row.getValue("id"), 1);
     assertEquals(row.getValue("huge"), new BigDecimal("99999999999999999999999999"));
     assertEquals((Object[]) ((Map<?, ?>) row.getValue("nested")).get("values"), new Object[]{1, null, 3});
     assertEquals((Object[]) row.getValue("tags"), new Object[]{"a", "b"});
+    assertEquals(row.getValue("flag"), Boolean.TRUE);
+    assertEquals(row.getValue("off"), Boolean.FALSE);
+    assertEquals(row.getValue("gone"), null);
   }
 
   @Test

--- a/pinot-plugins/pinot-input-format/pinot-json/src/test/java/org/apache/pinot/plugin/inputformat/json/JSONMessageDecoderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/test/java/org/apache/pinot/plugin/inputformat/json/JSONMessageDecoderTest.java
@@ -23,12 +23,15 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.stream.StreamMessageDecoder;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.annotations.Test;
 
@@ -38,6 +41,60 @@ import static org.testng.Assert.fail;
 
 
 public class JSONMessageDecoderTest {
+
+  @Test
+  public void testDirectDecodePreservesValueConversion()
+      throws Exception {
+    byte[] payload = ("{\"id\":1,\"huge\":99999999999999999999999999,"
+        + "\"nested\":{\"values\":[1,null,3]},\"tags\":[\"a\",\"b\"]}").getBytes(StandardCharsets.UTF_8);
+    JSONMessageDecoder decoder = new JSONMessageDecoder();
+    decoder.init(Map.of(), null, "testTopic");
+
+    GenericRow row = decoder.decode(payload, new GenericRow());
+
+    assertEquals(row.getValue("id"), 1);
+    assertEquals(row.getValue("huge").toString(), "99999999999999999999999999");
+    assertEquals((Object[]) ((Map<?, ?>) row.getValue("nested")).get("values"), new Object[]{1, null, 3});
+    assertEquals((Object[]) row.getValue("tags"), new Object[]{"a", "b"});
+  }
+
+  @Test
+  public void testDirectDecodeSelectedFieldsOverwritesMissingValues()
+      throws Exception {
+    JSONMessageDecoder decoder = new JSONMessageDecoder();
+    decoder.init(Map.of(), Set.of("id", "missing"), "testTopic");
+    GenericRow row = new GenericRow();
+    row.putValue("missing", "stale");
+    row.putValue("unselected", "preserved");
+
+    decoder.decode("{\"id\":1,\"ignored\":[1,2,3]}".getBytes(StandardCharsets.UTF_8), row);
+
+    assertEquals(row.getValue("id"), 1);
+    assertEquals(row.getValue("missing"), null);
+    assertEquals(row.getValue("unselected"), "preserved");
+    assertEquals(row.getFieldToValueMap().keySet(), Set.of("id", "missing", "unselected"));
+  }
+
+  @Test
+  public void testCustomExtractorUsesMapFallback()
+      throws Exception {
+    JSONMessageDecoder decoder = new JSONMessageDecoder();
+    decoder.init(Map.of(StreamMessageDecoder.RECORD_EXTRACTOR_CONFIG_KEY, CustomJSONRecordExtractor.class.getName()),
+        Set.of("id"), "testTopic");
+
+    GenericRow row = decoder.decode("{\"id\":1}".getBytes(StandardCharsets.UTF_8), new GenericRow());
+
+    assertEquals(row.getValue("id"), 1);
+    assertEquals(row.getValue("custom"), true);
+  }
+
+  public static class CustomJSONRecordExtractor extends JSONRecordExtractor {
+    @Override
+    public GenericRow extract(Map<String, Object> from, GenericRow to) {
+      to.putValue("custom", true);
+      return super.extract(from, to);
+    }
+  }
 
   @Test
   public void testJsonDecoderWithoutOutgoingTimeSpec()

--- a/pinot-plugins/pinot-input-format/pinot-json/src/test/java/org/apache/pinot/plugin/inputformat/json/JSONMessageDecoderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/test/java/org/apache/pinot/plugin/inputformat/json/JSONMessageDecoderTest.java
@@ -38,6 +38,7 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.fail;
 
 
@@ -82,6 +83,30 @@ public class JSONMessageDecoderTest {
     assertEquals(row.getValue("missing"), null);
     assertEquals(row.getValue("unselected"), "preserved");
     assertEquals(row.getFieldToValueMap().keySet(), Set.of("id", "missing", "unselected"));
+  }
+
+  @Test
+  public void testDirectDecodeHonorsOffsetAndLength()
+      throws Exception {
+    String prefix = "invalid-prefix";
+    String record = "{\"id\":1,\"name\":\"alice\"}";
+    byte[] payload = (prefix + record + "invalid-suffix").getBytes(StandardCharsets.UTF_8);
+    int offset = prefix.getBytes(StandardCharsets.UTF_8).length;
+    int length = record.getBytes(StandardCharsets.UTF_8).length;
+
+    JSONMessageDecoder allFieldsDecoder = new JSONMessageDecoder();
+    allFieldsDecoder.init(Map.of(), null, "testTopic");
+    GenericRow allFieldsRow = allFieldsDecoder.decode(payload, offset, length, new GenericRow());
+    assertEquals(allFieldsRow.getFieldToValueMap(), Map.of("id", 1, "name", "alice"));
+
+    JSONMessageDecoder selectedFieldsDecoder = new JSONMessageDecoder();
+    selectedFieldsDecoder.init(Map.of(), Set.of("id"), "testTopic");
+    GenericRow selectedFieldsRow = selectedFieldsDecoder.decode(payload, offset, length, new GenericRow());
+    assertEquals(selectedFieldsRow.getFieldToValueMap(), Map.of("id", 1));
+
+    // Exclude the closing brace to prove the parser honors length instead of reading the remaining array.
+    assertThrows(RuntimeException.class,
+        () -> allFieldsDecoder.decode(payload, offset, length - 1, new GenericRow()));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- stream top-level JSON values directly into `GenericRow` for the default JSON record extractor
- read top-level scalars straight off the `JsonParser`, skipping a per-value databind `DeserializationContext`
- skip materializing unselected containers while preserving Pinot's existing value conversion and missing-field behavior
- retain the map-based path for custom record extractors and parsers without direct-row support
- add decoder-focused JMH coverage for all-field and selected-field workloads

## Motivation

The existing decoder first materializes every top-level value in a per-row `Map`, then copies selected values into `GenericRow`. For ingestion configurations that select only a subset of a wide JSON payload, this creates avoidable parsing work and allocations.

## Performance

Focused JMH results for selected fields (`2` warmup iterations, `5` measured iterations, `5s` each, one fork, JDK 25):

| Payload | Throughput | Allocation |
| --- | ---: | ---: |
| Small | +54.7% | -47.6% |
| Medium | +63.5% | -63.3% |
| Large | +149.7% | -91.1% |
| Nested selected object | +13.4% | -5.5% |

These numbers measure decoder work rather than end-to-end Pinot ingestion.

### All fields

The direct path is also taken when no field selection is configured, so allocation was measured there as well
(`gc.alloc.rate.norm`, same JMH settings). Throughput is omitted for this table: the measuring host was too noisy
for it to be meaningful, while bytes/op is counted rather than timed and reproduced byte-identically across runs.

| Payload | Map path | Direct path | Direct + scalar fast path |
| --- | ---: | ---: | ---: |
| Small | 1542 B/op | 982 B/op | 982 B/op |
| Medium | 3209 B/op | 3177 B/op | 2529 B/op |
| Large | 10865 B/op | 10633 B/op | 10489 B/op |
| Nested | 6807 B/op | 6415 B/op | 6415 B/op |

The direct path never allocates more than the map path. Reading scalars off the parser saves roughly `72` B/op per
top-level scalar field, which is why the gain tracks scalar count (medium has nine, large has two, nested has one
top-level container) and why selected-field workloads — which materialize few top-level values — are unchanged.

To reproduce after packaging `pinot-perf`:

```bash
java -Xms2G -Xmx4G \
  -cp 'pinot-perf/target/pinot-perf-pkg/lib/*' \
  org.openjdk.jmh.Main \
  'org.apache.pinot.perf.BenchmarkJsonParsing.(mapThenExtract|directToGenericRow)(SelectedFields|AllFields)$' \
  -wi 2 -i 5 -f 1 -w 5s -r 5s -prof gc
```

## Compatibility

- Custom `RecordExtractor` implementations continue through the existing map-based path.
- Text JSON, Smile, CBOR, PostgreSQL JSONB, and auto-detected supported formats use the direct path.
- Parsers without direct-row support return `false` and retain the existing fallback.
- The scalar fast path mirrors Jackson's untyped materialization token for token, so value shapes are unchanged:
  `getNumberValue()` keeps the binary formats' `Float` (never upcast to `Double`), oversized ints still widen to
  `BigDecimal` through `JSONRecordExtractor.convert`, and embedded objects such as `byte[]` pass through.

## Validation

- `JSONMessageDecoderTest`
- `JSONMessageDecoderBinaryTest`
- `JSONRecordExtractorTest`
- `JsonPayloadFormatTest`
- 76 tests passed for `pinot-json`
- Spotless, Checkstyle, and license format/check passed for `pinot-json` and `pinot-perf`

New coverage for the direct path: binary scalar shapes (`Float` not upcast, `byte[]` pass-through) with and without
a field selection, plus boolean and explicit-null values — including that a JSON `null` overwrites a stale value in
a reused `GenericRow`.

