### PR TITLE
Fix flaky pauseless ingestion integration tests

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasePauselessRealtimeIngestionTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasePauselessRealtimeIngestionTest.java
@@ -162,17 +162,25 @@ public abstract class BasePauselessRealtimeIngestionTest extends BaseClusterInte
   }
 
   protected void injectFailure() {
+    String failurePoint = getFailurePoint();
+    if (failurePoint == null) {
+      return;
+    }
     PinotLLCRealtimeSegmentManager realtimeSegmentManager = _helixResourceManager.getRealtimeSegmentManager();
     if (realtimeSegmentManager instanceof FailureInjectingPinotLLCRealtimeSegmentManager) {
-      ((FailureInjectingPinotLLCRealtimeSegmentManager) realtimeSegmentManager).enableTestFault(getFailurePoint());
+      ((FailureInjectingPinotLLCRealtimeSegmentManager) realtimeSegmentManager).enableTestFault(failurePoint);
     }
     _failureEnabled = true;
   }
 
   protected void disableFailure() {
+    String failurePoint = getFailurePoint();
+    if (failurePoint == null) {
+      return;
+    }
     PinotLLCRealtimeSegmentManager realtimeSegmentManager = _helixResourceManager.getRealtimeSegmentManager();
     if (realtimeSegmentManager instanceof FailureInjectingPinotLLCRealtimeSegmentManager) {
-      ((FailureInjectingPinotLLCRealtimeSegmentManager) realtimeSegmentManager).disableTestFault(getFailurePoint());
+      ((FailureInjectingPinotLLCRealtimeSegmentManager) realtimeSegmentManager).disableTestFault(failurePoint);
     }
     _failureEnabled = false;
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasePauselessRealtimeIngestionTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasePauselessRealtimeIngestionTest.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.utils.PauselessConsumptionUtils;
@@ -60,6 +61,8 @@ public abstract class BasePauselessRealtimeIngestionTest extends BaseClusterInte
   protected boolean _failureEnabled = false;
   private static final Logger LOGGER = LoggerFactory.getLogger(BasePauselessRealtimeIngestionTest.class);
 
+  /// Returns the controller failure point to inject, or null when the test injects no failure.
+  @Nullable
   protected abstract String getFailurePoint();
 
   protected abstract int getExpectedSegmentsWithFailure();
@@ -105,7 +108,6 @@ public abstract class BasePauselessRealtimeIngestionTest extends BaseClusterInte
     startBroker();
     startServer();
     setupNonPauselessTable();
-    setMaxSegmentCompletionTimeMillis();
     injectFailure();
     setupPauselessTable();
     waitForAllDocsLoaded(600_000L);
@@ -155,11 +157,6 @@ public abstract class BasePauselessRealtimeIngestionTest extends BaseClusterInte
   }
 
   protected void setMaxSegmentCompletionTimeMillis() {
-    // Only shorten the completion timeout while testing an injected controller failure. Normal segment commits can
-    // legitimately take longer than this on a busy CI runner.
-    if (getFailurePoint() == null) {
-      return;
-    }
     PauselessRealtimeTestUtils.setMaxSegmentCompletionTimeoutMs(_helixResourceManager,
         FAILURE_MAX_SEGMENT_COMPLETION_TIME_MILLIS);
   }
@@ -181,8 +178,7 @@ public abstract class BasePauselessRealtimeIngestionTest extends BaseClusterInte
   }
 
   protected void restoreMaxSegmentCompletionTimeMillis() {
-    PauselessRealtimeTestUtils.setMaxSegmentCompletionTimeoutMs(_helixResourceManager,
-        PinotLLCRealtimeSegmentManager.DEFAULT_MAX_SEGMENT_COMPLETION_TIME_MILLIS);
+    PauselessRealtimeTestUtils.restoreMaxSegmentCompletionTimeoutMs(_helixResourceManager);
   }
 
   @AfterClass
@@ -215,12 +211,15 @@ public abstract class BasePauselessRealtimeIngestionTest extends BaseClusterInte
       return segmentZKMetadataList.size() == getExpectedZKMetadataWithFailure();
     }, 1000, 100000, "New Segment ZK Metadata not created");
 
+    // Shorten the completion deadline only around the repair pass, so the validation manager treats the stuck
+    // commits as expired. Normal segment commits can legitimately take longer than this deadline on a busy CI
+    // runner, so it must never apply to them.
+    setMaxSegmentCompletionTimeMillis();
     try {
       Thread.sleep(FAILURE_MAX_SEGMENT_COMPLETION_TIME_MILLIS);
       disableFailure();
       _controllerStarter.getRealtimeSegmentValidationManager().run();
     } finally {
-      // Keep the short timeout through the repair pass, then restore the production timeout for normal commits.
       restoreMaxSegmentCompletionTimeMillis();
     }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasePauselessRealtimeIngestionTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasePauselessRealtimeIngestionTest.java
@@ -160,11 +160,8 @@ public abstract class BasePauselessRealtimeIngestionTest extends BaseClusterInte
     if (getFailurePoint() == null) {
       return;
     }
-    PinotLLCRealtimeSegmentManager realtimeSegmentManager = _helixResourceManager.getRealtimeSegmentManager();
-    if (realtimeSegmentManager instanceof FailureInjectingPinotLLCRealtimeSegmentManager) {
-      ((FailureInjectingPinotLLCRealtimeSegmentManager) realtimeSegmentManager)
-          .setMaxSegmentCompletionTimeoutMs(FAILURE_MAX_SEGMENT_COMPLETION_TIME_MILLIS);
-    }
+    PauselessRealtimeTestUtils.setMaxSegmentCompletionTimeoutMs(_helixResourceManager,
+        FAILURE_MAX_SEGMENT_COMPLETION_TIME_MILLIS);
   }
 
   protected void injectFailure() {
@@ -184,11 +181,8 @@ public abstract class BasePauselessRealtimeIngestionTest extends BaseClusterInte
   }
 
   protected void restoreMaxSegmentCompletionTimeMillis() {
-    PinotLLCRealtimeSegmentManager realtimeSegmentManager = _helixResourceManager.getRealtimeSegmentManager();
-    if (realtimeSegmentManager instanceof FailureInjectingPinotLLCRealtimeSegmentManager) {
-      ((FailureInjectingPinotLLCRealtimeSegmentManager) realtimeSegmentManager).setMaxSegmentCompletionTimeoutMs(
-          PinotLLCRealtimeSegmentManager.DEFAULT_MAX_SEGMENT_COMPLETION_TIME_MILLIS);
-    }
+    PauselessRealtimeTestUtils.setMaxSegmentCompletionTimeoutMs(_helixResourceManager,
+        PinotLLCRealtimeSegmentManager.DEFAULT_MAX_SEGMENT_COMPLETION_TIME_MILLIS);
   }
 
   @AfterClass
@@ -221,10 +215,9 @@ public abstract class BasePauselessRealtimeIngestionTest extends BaseClusterInte
       return segmentZKMetadataList.size() == getExpectedZKMetadataWithFailure();
     }, 1000, 100000, "New Segment ZK Metadata not created");
 
-    Thread.sleep(FAILURE_MAX_SEGMENT_COMPLETION_TIME_MILLIS);
-    disableFailure();
-
     try {
+      Thread.sleep(FAILURE_MAX_SEGMENT_COMPLETION_TIME_MILLIS);
+      disableFailure();
       _controllerStarter.getRealtimeSegmentValidationManager().run();
     } finally {
       // Keep the short timeout through the repair pass, then restore the production timeout for normal commits.

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasePauselessRealtimeIngestionTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasePauselessRealtimeIngestionTest.java
@@ -54,7 +54,7 @@ public abstract class BasePauselessRealtimeIngestionTest extends BaseClusterInte
   protected static final int NUM_REALTIME_SEGMENTS = 48;
   protected static final long DEFAULT_COUNT_STAR_RESULT = 115545L;
   protected static final String DEFAULT_TABLE_NAME_2 = DEFAULT_TABLE_NAME + "_2";
-  private static final long MAX_SEGMENT_COMPLETION_TIME_MILLIS = 10_000;
+  private static final long FAILURE_MAX_SEGMENT_COMPLETION_TIME_MILLIS = 10_000;
 
   protected List<File> _avroFiles;
   protected boolean _failureEnabled = false;
@@ -104,8 +104,8 @@ public abstract class BasePauselessRealtimeIngestionTest extends BaseClusterInte
     startController();
     startBroker();
     startServer();
-    setMaxSegmentCompletionTimeMillis();
     setupNonPauselessTable();
+    setMaxSegmentCompletionTimeMillis();
     injectFailure();
     setupPauselessTable();
     waitForAllDocsLoaded(600_000L);
@@ -155,10 +155,15 @@ public abstract class BasePauselessRealtimeIngestionTest extends BaseClusterInte
   }
 
   protected void setMaxSegmentCompletionTimeMillis() {
+    // Only shorten the completion timeout while testing an injected controller failure. Normal segment commits can
+    // legitimately take longer than this on a busy CI runner.
+    if (getFailurePoint() == null) {
+      return;
+    }
     PinotLLCRealtimeSegmentManager realtimeSegmentManager = _helixResourceManager.getRealtimeSegmentManager();
     if (realtimeSegmentManager instanceof FailureInjectingPinotLLCRealtimeSegmentManager) {
       ((FailureInjectingPinotLLCRealtimeSegmentManager) realtimeSegmentManager)
-          .setMaxSegmentCompletionTimeoutMs(MAX_SEGMENT_COMPLETION_TIME_MILLIS);
+          .setMaxSegmentCompletionTimeoutMs(FAILURE_MAX_SEGMENT_COMPLETION_TIME_MILLIS);
     }
   }
 
@@ -171,10 +176,18 @@ public abstract class BasePauselessRealtimeIngestionTest extends BaseClusterInte
   }
 
   protected void disableFailure() {
-    _failureEnabled = false;
     PinotLLCRealtimeSegmentManager realtimeSegmentManager = _helixResourceManager.getRealtimeSegmentManager();
     if (realtimeSegmentManager instanceof FailureInjectingPinotLLCRealtimeSegmentManager) {
       ((FailureInjectingPinotLLCRealtimeSegmentManager) realtimeSegmentManager).disableTestFault(getFailurePoint());
+    }
+    _failureEnabled = false;
+  }
+
+  protected void restoreMaxSegmentCompletionTimeMillis() {
+    PinotLLCRealtimeSegmentManager realtimeSegmentManager = _helixResourceManager.getRealtimeSegmentManager();
+    if (realtimeSegmentManager instanceof FailureInjectingPinotLLCRealtimeSegmentManager) {
+      ((FailureInjectingPinotLLCRealtimeSegmentManager) realtimeSegmentManager).setMaxSegmentCompletionTimeoutMs(
+          PinotLLCRealtimeSegmentManager.DEFAULT_MAX_SEGMENT_COMPLETION_TIME_MILLIS);
     }
   }
 
@@ -208,10 +221,15 @@ public abstract class BasePauselessRealtimeIngestionTest extends BaseClusterInte
       return segmentZKMetadataList.size() == getExpectedZKMetadataWithFailure();
     }, 1000, 100000, "New Segment ZK Metadata not created");
 
-    Thread.sleep(MAX_SEGMENT_COMPLETION_TIME_MILLIS);
+    Thread.sleep(FAILURE_MAX_SEGMENT_COMPLETION_TIME_MILLIS);
     disableFailure();
 
-    _controllerStarter.getRealtimeSegmentValidationManager().run();
+    try {
+      _controllerStarter.getRealtimeSegmentValidationManager().run();
+    } finally {
+      // Keep the short timeout through the repair pass, then restore the production timeout for normal commits.
+      restoreMaxSegmentCompletionTimeMillis();
+    }
 
     waitForAllDocsLoaded(600_000L);
     waitForAllDocsLoaded(tableNameWithType2, 600_000L);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessDedupRealtimeIngestionSegmentCommitFailureTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessDedupRealtimeIngestionSegmentCommitFailureTest.java
@@ -112,7 +112,6 @@ public class PauselessDedupRealtimeIngestionSegmentCommitFailureTest
     startKafka();
     pushAvroIntoKafka(avroFiles);
 
-    setMaxSegmentCompletionTimeMillis();
     // create schema for non-pauseless table
     Schema schema = createSchema();
     schema.setSchemaName(getNonPauselessTableName());

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionSegmentCommitFailureTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionSegmentCommitFailureTest.java
@@ -32,9 +32,9 @@ import org.apache.pinot.controller.BaseControllerStarter;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import org.apache.pinot.integration.tests.realtime.utils.FailureInjectingControllerStarter;
-import org.apache.pinot.integration.tests.realtime.utils.FailureInjectingPinotLLCRealtimeSegmentManager;
 import org.apache.pinot.integration.tests.realtime.utils.FailureInjectingTableConfig;
 import org.apache.pinot.integration.tests.realtime.utils.FailureInjectingTableDataManagerProvider;
+import org.apache.pinot.integration.tests.realtime.utils.PauselessRealtimeTestUtils;
 import org.apache.pinot.server.starter.helix.HelixInstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -103,7 +103,6 @@ public class PauselessRealtimeIngestionSegmentCommitFailureTest extends BaseClus
     List<File> avroFiles = unpackAvroData(_tempDir);
     pushAvroIntoKafka(avroFiles);
 
-    setMaxSegmentCompletionTimeMillis();
     // create schema for non-pauseless table
     Schema schema = createSchema();
     schema.setSchemaName(DEFAULT_TABLE_NAME_2);
@@ -149,11 +148,13 @@ public class PauselessRealtimeIngestionSegmentCommitFailureTest extends BaseClus
   }
 
   protected void setMaxSegmentCompletionTimeMillis() {
-    PinotLLCRealtimeSegmentManager realtimeSegmentManager = _helixResourceManager.getRealtimeSegmentManager();
-    if (realtimeSegmentManager instanceof FailureInjectingPinotLLCRealtimeSegmentManager) {
-      ((FailureInjectingPinotLLCRealtimeSegmentManager) realtimeSegmentManager).setMaxSegmentCompletionTimeoutMs(
-          MAX_SEGMENT_COMPLETION_TIME_MILLIS);
-    }
+    PauselessRealtimeTestUtils.setMaxSegmentCompletionTimeoutMs(_helixResourceManager,
+        MAX_SEGMENT_COMPLETION_TIME_MILLIS);
+  }
+
+  protected void restoreMaxSegmentCompletionTimeMillis() {
+    PauselessRealtimeTestUtils.setMaxSegmentCompletionTimeoutMs(_helixResourceManager,
+        PinotLLCRealtimeSegmentManager.DEFAULT_MAX_SEGMENT_COMPLETION_TIME_MILLIS);
   }
 
   protected int getNumErrorSegmentsInEV(String realtimeTableName) {
@@ -182,9 +183,17 @@ public class PauselessRealtimeIngestionSegmentCommitFailureTest extends BaseClus
     List<String> erroredSegments = getSegmentsInEV(pauselessTableName, SegmentStateModel.ERROR);
     assertFalse(erroredSegments.isEmpty(), "No segments found in ERROR state, expected at least one.");
 
-    // Let the RealtimeSegmentValidationManager run so it can fix up segments
-    Thread.sleep(MAX_SEGMENT_COMPLETION_TIME_MILLIS);
-    _controllerStarter.getRealtimeSegmentValidationManager().run();
+    // Shorten the completion deadline only around the repair pass, so the validation manager treats the failed
+    // commits as expired. Normal segment commits (e.g. the non-pauseless comparison table during setup) must not run
+    // against this artificial deadline.
+    setMaxSegmentCompletionTimeMillis();
+    try {
+      // Let the RealtimeSegmentValidationManager run so it can fix up segments
+      Thread.sleep(MAX_SEGMENT_COMPLETION_TIME_MILLIS);
+      _controllerStarter.getRealtimeSegmentValidationManager().run();
+    } finally {
+      restoreMaxSegmentCompletionTimeMillis();
+    }
 
     // Wait until there are no ERROR segments in the ExternalView
     TestUtils.waitForCondition(aVoid -> getSegmentsInEV(pauselessTableName, SegmentStateModel.ERROR).isEmpty(),

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionSegmentCommitFailureTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionSegmentCommitFailureTest.java
@@ -30,7 +30,6 @@ import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.controller.BaseControllerStarter;
 import org.apache.pinot.controller.ControllerConf;
-import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import org.apache.pinot.integration.tests.realtime.utils.FailureInjectingControllerStarter;
 import org.apache.pinot.integration.tests.realtime.utils.FailureInjectingTableConfig;
 import org.apache.pinot.integration.tests.realtime.utils.FailureInjectingTableDataManagerProvider;
@@ -58,13 +57,13 @@ import static org.testng.Assert.assertNotNull;
 
 public class PauselessRealtimeIngestionSegmentCommitFailureTest extends BaseClusterIntegrationTest {
   private static final String DEFAULT_TABLE_NAME_2 = DEFAULT_TABLE_NAME + "_2";
-  private static final long MAX_SEGMENT_COMPLETION_TIME_MILLIS = 10_000L;
+  private static final long FAILURE_MAX_SEGMENT_COMPLETION_TIME_MILLIS = 10_000L;
 
   protected void overrideControllerConf(Map<String, Object> properties) {
     properties.put(ControllerConf.ControllerPeriodicTasksConf.PINOT_TASK_MANAGER_SCHEDULER_ENABLED, true);
     properties.put(ControllerConf.ControllerPeriodicTasksConf.ENABLE_DEEP_STORE_RETRY_UPLOAD_LLC_SEGMENT, true);
     // Set the delay more than the time we sleep before triggering RealtimeSegmentValidationManager manually, i.e.
-    // MAX_SEGMENT_COMPLETION_TIME_MILLIS, to ensure that the segment level validations are performed.
+    // FAILURE_MAX_SEGMENT_COMPLETION_TIME_MILLIS, to ensure that the segment level validations are performed.
     properties.put(ControllerConf.ControllerPeriodicTasksConf.REALTIME_SEGMENT_VALIDATION_INITIAL_DELAY_IN_SECONDS,
         500);
   }
@@ -149,12 +148,11 @@ public class PauselessRealtimeIngestionSegmentCommitFailureTest extends BaseClus
 
   protected void setMaxSegmentCompletionTimeMillis() {
     PauselessRealtimeTestUtils.setMaxSegmentCompletionTimeoutMs(_helixResourceManager,
-        MAX_SEGMENT_COMPLETION_TIME_MILLIS);
+        FAILURE_MAX_SEGMENT_COMPLETION_TIME_MILLIS);
   }
 
   protected void restoreMaxSegmentCompletionTimeMillis() {
-    PauselessRealtimeTestUtils.setMaxSegmentCompletionTimeoutMs(_helixResourceManager,
-        PinotLLCRealtimeSegmentManager.DEFAULT_MAX_SEGMENT_COMPLETION_TIME_MILLIS);
+    PauselessRealtimeTestUtils.restoreMaxSegmentCompletionTimeoutMs(_helixResourceManager);
   }
 
   protected int getNumErrorSegmentsInEV(String realtimeTableName) {
@@ -189,7 +187,7 @@ public class PauselessRealtimeIngestionSegmentCommitFailureTest extends BaseClus
     setMaxSegmentCompletionTimeMillis();
     try {
       // Let the RealtimeSegmentValidationManager run so it can fix up segments
-      Thread.sleep(MAX_SEGMENT_COMPLETION_TIME_MILLIS);
+      Thread.sleep(FAILURE_MAX_SEGMENT_COMPLETION_TIME_MILLIS);
       _controllerStarter.getRealtimeSegmentValidationManager().run();
     } finally {
       restoreMaxSegmentCompletionTimeMillis();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TableRebalancePauselessIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TableRebalancePauselessIntegrationTest.java
@@ -82,7 +82,6 @@ public class TableRebalancePauselessIntegrationTest extends BasePauselessRealtim
     startServer();
     createServerTenant(getServerTenant(), 0, 1);
     createBrokerTenant(getBrokerTenant(), 1);
-    setMaxSegmentCompletionTimeMillis();
     setupNonPauselessTable();
     injectFailure();
     setupPauselessTable();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/FailureInjectingPinotLLCRealtimeSegmentManager.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/FailureInjectingPinotLLCRealtimeSegmentManager.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
 public class FailureInjectingPinotLLCRealtimeSegmentManager extends PinotLLCRealtimeSegmentManager {
   @VisibleForTesting
   private final Map<String, String> _failureConfig;
-  private long _maxSegmentCompletionTimeoutMs = 300000L;
+  private volatile long _maxSegmentCompletionTimeoutMs = DEFAULT_MAX_SEGMENT_COMPLETION_TIME_MILLIS;
   private static final Logger LOGGER = LoggerFactory.getLogger(FailureInjectingPinotLLCRealtimeSegmentManager.class);
 
   public FailureInjectingPinotLLCRealtimeSegmentManager(PinotHelixResourceManager helixResourceManager,

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/PauselessRealtimeTestUtils.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/PauselessRealtimeTestUtils.java
@@ -26,6 +26,8 @@ import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.helix.HelixHelper;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import org.apache.pinot.spi.utils.CommonConstants;
 
 import static org.testng.Assert.assertEquals;
@@ -34,6 +36,19 @@ import static org.testng.Assert.assertEquals;
 public class PauselessRealtimeTestUtils {
 
   private PauselessRealtimeTestUtils() {
+  }
+
+  /// Overrides the segment-completion deadline on the failure-injecting segment manager, if one is installed. Tests
+  /// shorten the deadline right before a validation repair pass and restore
+  /// [PinotLLCRealtimeSegmentManager#DEFAULT_MAX_SEGMENT_COMPLETION_TIME_MILLIS] afterwards, so that normal segment
+  /// commits never race against an artificially short deadline.
+  public static void setMaxSegmentCompletionTimeoutMs(PinotHelixResourceManager helixResourceManager,
+      long timeoutMs) {
+    PinotLLCRealtimeSegmentManager realtimeSegmentManager = helixResourceManager.getRealtimeSegmentManager();
+    if (realtimeSegmentManager instanceof FailureInjectingPinotLLCRealtimeSegmentManager) {
+      ((FailureInjectingPinotLLCRealtimeSegmentManager) realtimeSegmentManager)
+          .setMaxSegmentCompletionTimeoutMs(timeoutMs);
+    }
   }
 
   public static void verifyIdealState(String tableName, int numSegmentsExpected, HelixManager helixManager) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/PauselessRealtimeTestUtils.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/PauselessRealtimeTestUtils.java
@@ -38,17 +38,26 @@ public class PauselessRealtimeTestUtils {
   private PauselessRealtimeTestUtils() {
   }
 
-  /// Overrides the segment-completion deadline on the failure-injecting segment manager, if one is installed. Tests
-  /// shorten the deadline right before a validation repair pass and restore
-  /// [PinotLLCRealtimeSegmentManager#DEFAULT_MAX_SEGMENT_COMPLETION_TIME_MILLIS] afterwards, so that normal segment
-  /// commits never race against an artificially short deadline.
+  /// Overrides the segment-completion deadline on the [FailureInjectingPinotLLCRealtimeSegmentManager] installed by
+  /// the failure-injecting controller. Tests shorten the deadline right before a validation repair pass and call
+  /// [#restoreMaxSegmentCompletionTimeoutMs] afterwards, so that normal segment commits never race against an
+  /// artificially short deadline.
   public static void setMaxSegmentCompletionTimeoutMs(PinotHelixResourceManager helixResourceManager,
       long timeoutMs) {
     PinotLLCRealtimeSegmentManager realtimeSegmentManager = helixResourceManager.getRealtimeSegmentManager();
-    if (realtimeSegmentManager instanceof FailureInjectingPinotLLCRealtimeSegmentManager) {
-      ((FailureInjectingPinotLLCRealtimeSegmentManager) realtimeSegmentManager)
-          .setMaxSegmentCompletionTimeoutMs(timeoutMs);
+    if (!(realtimeSegmentManager instanceof FailureInjectingPinotLLCRealtimeSegmentManager)) {
+      throw new IllegalStateException("Expected FailureInjectingPinotLLCRealtimeSegmentManager but got: "
+          + realtimeSegmentManager.getClass().getName());
     }
+    ((FailureInjectingPinotLLCRealtimeSegmentManager) realtimeSegmentManager)
+        .setMaxSegmentCompletionTimeoutMs(timeoutMs);
+  }
+
+  /// Restores the production segment-completion deadline
+  /// ([PinotLLCRealtimeSegmentManager#DEFAULT_MAX_SEGMENT_COMPLETION_TIME_MILLIS]) after a validation repair pass.
+  public static void restoreMaxSegmentCompletionTimeoutMs(PinotHelixResourceManager helixResourceManager) {
+    setMaxSegmentCompletionTimeoutMs(helixResourceManager,
+        PinotLLCRealtimeSegmentManager.DEFAULT_MAX_SEGMENT_COMPLETION_TIME_MILLIS);
   }
 
   public static void verifyIdealState(String tableName, int numSegmentsExpected, HelixManager helixManager) {


### PR DESCRIPTION
## Summary

- Scope the 10-second segment-completion deadline to the controller failure-injection tests that require it.
- Configure the short deadline only after the non-pauseless comparison table finishes setup.
- Keep the short deadline through the explicit validation repair pass, then restore the normal 5-minute deadline.

## Root cause

`BasePauselessRealtimeIngestionTest` globally replaced the controller segment-completion deadline with 10 seconds. That affected ordinary pauseless tests, table rebalance tests, and the non-pauseless comparison table even when no controller fault was injected. On a busy CI runner, normal segment commits exceeded the artificial deadline and were repeatedly repaired, causing otherwise unrelated tests to hit their 20-minute timeout.

## How to reproduce

Run the Set 2 integration-test shard containing the pauseless suites under CI load. In [the failing job](https://github.com/apache/pinot/actions/runs/30516372127/job/90787057324?pr=19091), the basic pauseless test logged 38 segment-completion deadline expirations, the rebalance test logged 14, and the ideal-state failure test logged 2 before five tests timed out. The [passing run on the same branch](https://github.com/apache/pinot/actions/runs/30509418502/job/90766056417) and a [passing master run](https://github.com/apache/pinot/actions/runs/30503923617/job/90749450030) logged no such expirations for those classes.

## Testing

- JDK 25 focused reactor run: `./mvnw -pl pinot-integration-tests -am -Dtest=PauselessRealtimeIngestionIntegrationTest,TableRebalancePauselessIntegrationTest,PauselessRealtimeIngestionIdealStateUpdateFailureTest,PauselessRealtimeIngestionNewSegmentMetadataCreationFailureTest,PauselessRealtimeIngestionCommitEndMetadataFailureTest -Dsurefire.failIfNoSpecifiedTests=false test` (6 tests, 0 failures)
- `./mvnw spotless:apply -pl pinot-integration-tests`
- `./mvnw license:format -pl pinot-integration-tests`
- `./mvnw checkstyle:check -pl pinot-integration-tests`
- `./mvnw license:check -pl pinot-integration-tests`
- JDK 25 warning-enabled reactor `test-compile` with `-Xlint:all`