### PR TITLE
Load source segment with table config in RefreshSegmentTask

### DIFF
--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/refreshsegment/RefreshSegmentTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/refreshsegment/RefreshSegmentTaskExecutor.java
@@ -33,6 +33,7 @@ import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationD
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.segment.readers.PinotSegmentRecordReader;
 import org.apache.pinot.segment.spi.ColumnMetadata;
+import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderContext;
@@ -142,8 +143,11 @@ public class RefreshSegmentTaskExecutor extends BaseSingleSegmentConversionExecu
 
     // Refresh the segment. Segment reload is achieved by generating a new segment from scratch using the updated schema
     // and table configs.
+    // Load with the table-config-derived IndexLoadingConfig so column readers configured via the table config are
+    // honored (needPreprocess=false: read-only).
+    ImmutableSegment segment = ImmutableSegmentLoader.load(indexDir, indexLoadingConfig, false);
     try (PinotSegmentRecordReader recordReader = new PinotSegmentRecordReader()) {
-      recordReader.init(indexDir, null, null);
+      recordReader.init(segment);
       SegmentGeneratorConfig config = getSegmentGeneratorConfig(workingDir, tableConfig, segmentMetadata, segmentName,
           getSchema(tableNameWithType));
       SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
@@ -152,6 +156,8 @@ public class RefreshSegmentTaskExecutor extends BaseSingleSegmentConversionExecu
       _eventObserver.notifyProgress(pinotTaskConfig,
           "Segment processing stats - incomplete rows:" + driver.getIncompleteRowsFound() + ", dropped rows:"
               + driver.getSkippedRowsFound() + ", sanitized rows:" + driver.getSanitizedRowsFound());
+    } finally {
+      segment.destroy();
     }
 
     File refreshedSegmentFile = new File(workingDir, segmentName);


### PR DESCRIPTION
`RefreshSegmentTaskExecutor` reads the source segment via `PinotSegmentRecordReader.init(indexDir)`, which loads through `ImmutableSegmentLoader.load(indexDir, ReadMode)` — with no `TableConfig`/`Schema`. Column readers whose configuration is derived from the table config are therefore not honored while the segment is read for refresh.

This loads the source segment with the `IndexLoadingConfig` the executor already builds and initializes the record reader from that segment (`needPreprocess=false`, read-only); the segment is destroyed after reading. Standard columns are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
