### PR TITLE
Safely publish lazily-initialized caches shared across threads

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
@@ -44,14 +44,20 @@ public class LiteralContext {
   /// This is used for type conversion, and is not included in {@link #equals} and {@link #hashCode}.
   private final PinotDataType _pinotDataType;
 
-  private Boolean _booleanValue;
-  private Integer _intValue;
-  private Long _longValue;
-  private Float _floatValue;
-  private Double _doubleValue;
-  private BigDecimal _bigDecimalValue;
-  private String _stringValue;
-  private byte[] _bytesValue;
+  /// Lazily converted caches of the value, one per stored type.
+  ///
+  /// `volatile` is required, not just for the null checks in the getters: a literal belongs to the query's expression
+  /// tree, which is built once per query and then read concurrently by the threads that build and run the per-segment
+  /// plans. Without it the values are published unsafely, and a racing thread can read a non-null reference whose
+  /// contents are not yet visible to it.
+  private volatile Boolean _booleanValue;
+  private volatile Integer _intValue;
+  private volatile Long _longValue;
+  private volatile Float _floatValue;
+  private volatile Double _doubleValue;
+  private volatile BigDecimal _bigDecimalValue;
+  private volatile String _stringValue;
+  private volatile byte[] _bytesValue;
 
   public LiteralContext(Literal literal) {
     switch (literal.getSetField()) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/predicate/BaseInPredicate.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/predicate/BaseInPredicate.java
@@ -27,19 +27,28 @@ import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.TimestampUtils;
 
 
-/// Base predicate for IN and NOT_IN.
+/// Base predicate for `IN` and `NOT_IN`.
+///
+/// Instances are read concurrently: a predicate belongs to the query's filter tree, which is built once per query and
+/// then shared by the threads that build and run the per-segment plans. The lazily parsed value caches are therefore
+/// published safely; see the fields.
 public abstract class BaseInPredicate extends BasePredicate {
   protected final List<String> _values;
 
-  // Cache the parsed values
-  private int[] _intValues;
-  private long[] _longValues;
-  private float[] _floatValues;
-  private double[] _doubleValues;
-  private BigDecimal[] _bigDecimalValues;
-  private int[] _booleanValues;
-  private long[] _timestampValues;
-  private ByteArray[] _bytesValues;
+  /// Lazily parsed caches of the values, one per stored type.
+  ///
+  /// `volatile` is required, not just for the null checks in the getters: a predicate is read concurrently (see the
+  /// class javadoc), and without it the arrays are published unsafely. A racing thread can then read the non-null
+  /// array reference while the element writes are still invisible to it, seeing `0` for the primitive arrays and
+  /// `null` for the object arrays — which silently matches the wrong rows rather than failing.
+  private volatile int[] _intValues;
+  private volatile long[] _longValues;
+  private volatile float[] _floatValues;
+  private volatile double[] _doubleValues;
+  private volatile BigDecimal[] _bigDecimalValues;
+  private volatile int[] _booleanValues;
+  private volatile long[] _timestampValues;
+  private volatile ByteArray[] _bytesValues;
 
   public BaseInPredicate(ExpressionContext lhs, List<String> values) {
     super(lhs);

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/predicate/RegexpLikePredicate.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/predicate/RegexpLikePredicate.java
@@ -24,11 +24,22 @@ import org.apache.pinot.common.utils.RegexpPatternConverterUtils;
 import org.apache.pinot.common.utils.regex.Pattern;
 import org.apache.pinot.common.utils.regex.PatternFactory;
 
-/// Predicate for REGEXP_LIKE with optional match parameters
+/// Predicate for `REGEXP_LIKE` with optional match parameters.
+///
+/// Instances are read concurrently: a predicate belongs to the query's filter tree, which is built once per query and
+/// then shared by the threads that build and run the per-segment plans. The lazily compiled pattern is therefore
+/// published safely; see [#getPattern].
 public class RegexpLikePredicate extends BasePredicate {
   private final String _value;
   private final boolean _caseInsensitive;
-  private Pattern _pattern = null;
+
+  /// Lazily compiled cache of [#getPattern].
+  ///
+  /// `volatile` is required, not just for the null check in [#getPattern]: without it the pattern is published
+  /// unsafely, and a racing thread can read the non-null reference while the fields written by the pattern's
+  /// construction are still invisible to it. Using such a pattern to create a matcher fails with a
+  /// `NullPointerException`.
+  private volatile Pattern _pattern;
 
   public RegexpLikePredicate(ExpressionContext lhs, String value) {
     super(lhs);
@@ -55,11 +66,17 @@ public class RegexpLikePredicate extends BasePredicate {
     return _caseInsensitive;
   }
 
+  /// Returns the compiled pattern, lazily compiling and caching it on first access.
+  ///
+  /// Uses the racy-single-check idiom: two threads may each compile the pattern, but both compile the same one, so
+  /// the duplicate work is harmless. Correctness relies on `_pattern` being `volatile`; see the field for why.
   public Pattern getPattern() {
-    if (_pattern == null) {
-      _pattern = PatternFactory.compile(_value, _caseInsensitive);
+    Pattern pattern = _pattern;
+    if (pattern == null) {
+      pattern = PatternFactory.compile(_value, _caseInsensitive);
+      _pattern = pattern;
     }
-    return _pattern;
+    return pattern;
   }
 
   @Override

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/regex/JavaUtilPattern.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/regex/JavaUtilPattern.java
@@ -21,7 +21,7 @@ package org.apache.pinot.common.utils.regex;
 import java.util.regex.Pattern;
 
 public class JavaUtilPattern implements org.apache.pinot.common.utils.regex.Pattern {
-  final Pattern _pattern;
+  private final Pattern _pattern;
 
   public JavaUtilPattern(String regex) {
     _pattern = Pattern.compile(regex, 0);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/regex/Re2jPattern.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/regex/Re2jPattern.java
@@ -22,7 +22,7 @@ import com.google.re2j.Pattern;
 
 
 public class Re2jPattern implements org.apache.pinot.common.utils.regex.Pattern {
-  Pattern _pattern;
+  private final Pattern _pattern;
 
   public Re2jPattern(String regex) {
     this(regex, false);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/AbstractIndexType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/AbstractIndexType.java
@@ -39,8 +39,15 @@ public abstract class AbstractIndexType<C extends IndexConfig, IR extends IndexR
     implements IndexType<C, IR, IC> {
 
   private final String _id;
-  private ColumnConfigDeserializer<C> _deserializer;
-  private IndexReaderFactory<IR> _readerFactory;
+
+  /// Lazily created caches of [#getConfig] and [#getReaderFactory].
+  ///
+  /// `volatile` is required, not just for the null checks in those methods: an index type is a process-wide singleton
+  /// held by [IndexService] and is used concurrently by the threads that load, reload and refresh segments. Without
+  /// `volatile` these values are published unsafely, so a racing thread can read the non-null reference while the
+  /// contents are not yet visible to it.
+  private volatile ColumnConfigDeserializer<C> _deserializer;
+  private volatile IndexReaderFactory<IR> _readerFactory;
 
   protected ColumnConfigDeserializer<C> createDeserializer() {
     ColumnConfigDeserializer<C> fromIndexes =
@@ -70,22 +77,30 @@ public abstract class AbstractIndexType<C extends IndexConfig, IR extends IndexR
 
   @Override
   public Map<String, C> getConfig(TableConfig tableConfig, Schema schema) {
-    if (_deserializer == null) {
-      _deserializer = createDeserializer();
+    ColumnConfigDeserializer<C> deserializer = _deserializer;
+    if (deserializer == null) {
+      deserializer = createDeserializer();
+      _deserializer = deserializer;
     }
     try {
-      return _deserializer.deserialize(tableConfig, schema);
+      return deserializer.deserialize(tableConfig, schema);
     } catch (MergedColumnConfigDeserializer.ConfigDeclaredTwiceException ex) {
       throw new MergedColumnConfigDeserializer.ConfigDeclaredTwiceException(ex.getColumn(), this, ex);
     }
   }
 
+  /// Returns the reader factory, lazily creating and caching it on first access.
+  ///
+  /// Uses the racy-single-check idiom: two threads may each create a factory, but the factories are equivalent, so
+  /// the duplicate work is harmless. Correctness relies on `_readerFactory` being `volatile`; see the field for why.
   @Override
   public IndexReaderFactory<IR> getReaderFactory() {
-    if (_readerFactory == null) {
-      _readerFactory = createReaderFactory();
+    IndexReaderFactory<IR> readerFactory = _readerFactory;
+    if (readerFactory == null) {
+      readerFactory = createReaderFactory();
+      _readerFactory = readerFactory;
     }
-    return _readerFactory;
+    return readerFactory;
   }
 
   public void convertToNewFormat(TableConfig tableConfig, Schema schema) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFieldSpec.java
@@ -32,8 +32,13 @@ public final class DateTimeFieldSpec extends FieldSpec {
   private String _format;
   private String _granularity;
   private Object _sampleValue;
-  private transient DateTimeFormatSpec _formatSpec;
-  private transient DateTimeGranularitySpec _granularitySpec;
+  /// Lazily derived caches of [#getFormatSpec] and [#getGranularitySpec].
+  ///
+  /// `volatile` is required, not just for the null checks in those getters: a field spec belongs to a `Schema`, which
+  /// is cached and read concurrently by query threads. Without it these values are published unsafely, so a racing
+  /// thread can read the non-null reference while the contents are not yet visible to it.
+  private transient volatile DateTimeFormatSpec _formatSpec;
+  private transient volatile DateTimeGranularitySpec _granularitySpec;
 
   public enum TimeFormat {
     EPOCH, TIMESTAMP, SIMPLE_DATE_FORMAT


### PR DESCRIPTION
## Summary

Several lazily-initialized caches on objects that are read by multiple threads are written to non-`volatile` fields, so their contents are published unsafely. On weakly-ordered hardware (e.g. AArch64/Graviton) a racing thread can observe the non-null reference while the writes that filled it are still invisible to it.

This is the same defect class as #19117 (`DataSchema.getStoredColumnDataTypes`), found by auditing for the rest of the pattern. Every getter changed here already used the racy-single-check idiom — read the field into a local, check it, publish it — so only the `volatile` was missing.

### Changes, most to least impactful

**`BaseInPredicate`** — the eight lazily parsed value arrays. A predicate belongs to the query's filter tree, which is shared across the threads `CombinePlanNode` uses to build per-segment plans in parallel; the arrays are reached from `InPredicateEvaluatorFactory`, `NotInPredicateEvaluatorFactory` and `PredicateUtils`. Arrays get no final-field protection, so a racing thread can read the array reference with its elements still at `0` — silently matching the wrong rows rather than failing. `IN` is common enough that this is the main motivation for the change.

**`RegexpLikePredicate`** and **`Re2jPattern`** — the compiled pattern, shared the same way. This is only exposed when the RE2J engine is configured: `JavaUtilPattern` holds its delegate in a `final` field, so JLS 17.5 covers it, whereas `Re2jPattern` did not. `Re2jPattern._pattern` is now `final` as well, which closes the hazard at its source for every consumer rather than only for this caller.

**`LiteralContext`** — the eight lazily converted values, in the same shared expression tree.

**`AbstractIndexType`** — an index type is a process-wide singleton held by `IndexService`, used concurrently by the threads that load, reload and refresh segments.

**`DateTimeFieldSpec`** — the format and granularity specs hang off a cached `Schema` that query threads read concurrently.

### Why `volatile` uniformly rather than case by case

Some of these values are safe today without `volatile`, because the cached object happens to have only `final` fields — JLS 17.5 covers those, and everything reachable from them, even through a data race. That is a poor thing to depend on: it makes one class's thread-safety hinge on the field modifiers of a class in another module, with nothing at either site recording the dependency, and it breaks silently when a field is added or a constructor is bypassed. The two `Pattern` implementations here already disagreed on exactly that point. So the fields are made `volatile` uniformly, and the finality argument is used only to judge which of these is urgent — not whether to fix it.

### Also

`JavaUtilPattern._pattern` and `Re2jPattern._pattern` are narrowed to `private`. Nothing outside those classes referenced them — both callers go through `getPattern()` — and the two classes are otherwise mirror images, so this keeps them consistent.

No tests are included: an unsafe-publication race is not reliably reproducible in a unit test without a `jcstress`-style harness, which this repo does not currently have. This matches how #19117 was handled.
