### PR TITLE
Remove APIs deprecated in pre-1.0 releases (0.1.0-0.12.0 era)

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -20,7 +20,6 @@ package org.apache.pinot.broker.broker.helix;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Nullable;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants.Broker;
 import org.apache.pinot.spi.utils.CommonConstants.Helix;
@@ -32,38 +31,6 @@ import org.apache.pinot.spi.utils.CommonConstants.Helix;
 public class HelixBrokerStarter extends BaseBrokerStarter {
 
   public HelixBrokerStarter() {
-  }
-
-  @Deprecated
-  public HelixBrokerStarter(PinotConfiguration brokerConf, String clusterName, String zkServer)
-      throws Exception {
-    init(applyBrokerConfigs(brokerConf, clusterName, zkServer, null));
-  }
-
-  @Deprecated
-  public HelixBrokerStarter(PinotConfiguration brokerConf, String clusterName, String zkServer,
-      @Nullable String brokerHost)
-      throws Exception {
-    init(applyBrokerConfigs(brokerConf, clusterName, zkServer, brokerHost));
-  }
-
-  @Deprecated
-  private static PinotConfiguration applyBrokerConfigs(PinotConfiguration brokerConf, String clusterName,
-      String zkServers, @Nullable String brokerHost) {
-    brokerConf.setProperty(Helix.CONFIG_OF_CLUSTER_NAME, clusterName);
-    brokerConf.setProperty(Helix.CONFIG_OF_ZOOKEEPER_SERVER, zkServers);
-    if (brokerHost == null) {
-      brokerConf.clearProperty(Broker.CONFIG_OF_BROKER_HOSTNAME);
-    } else {
-      brokerConf.setProperty(Broker.CONFIG_OF_BROKER_HOSTNAME, brokerHost);
-    }
-    return brokerConf;
-  }
-
-  @Deprecated
-  public HelixBrokerStarter(PinotConfiguration brokerConf)
-      throws Exception {
-    init(brokerConf);
   }
 
   public static HelixBrokerStarter getDefault()

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ConnectionFactory.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ConnectionFactory.java
@@ -66,31 +66,6 @@ public class ConnectionFactory {
     }
   }
 
-  /// @param scheme controller URL scheme
-  /// @param controllerHost controller host
-  /// @param controllerPort controller port
-  /// @return A connection that connects to brokers as per the given controller
-  @Deprecated
-  public static Connection fromController(String scheme, String controllerHost, int controllerPort) {
-    return fromController(new Properties(), scheme, controllerHost, controllerPort);
-  }
-
-  /// @param scheme controller URL scheme
-  /// @param controllerHost controller host
-  /// @param controllerPort controller port
-  /// @return A connection that connects to brokers as per the given controller
-  @Deprecated
-  public static Connection fromController(Properties properties, String scheme,
-      String controllerHost, int controllerPort) {
-    try {
-      return new Connection(properties,
-          new ControllerBasedBrokerSelector(scheme, controllerHost, controllerPort, properties),
-          getDefault());
-    } catch (Exception e) {
-      throw new PinotClientException(e);
-    }
-  }
-
   /// @param controllerUrl url host:port of the controller
   /// @return A connection that connects to brokers as per the given controller
   public static Connection fromController(String controllerUrl) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/segment/generation/SegmentGenerationUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/segment/generation/SegmentGenerationUtils.java
@@ -113,11 +113,6 @@ public class SegmentGenerationUtils {
     }
   }
 
-  @Deprecated
-  public static TableConfig getTableConfig(String tableConfigURIStr) {
-    return getTableConfig(tableConfigURIStr, null);
-  }
-
   public static TableConfig getTableConfig(String tableConfigURIStr, String authToken) {
     return getTableConfig(tableConfigURIStr, authToken, null);
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -65,7 +65,6 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.ingestion.batch.spec.PushJobSpec;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
-import org.apache.pinot.spi.utils.StringUtil;
 import org.apache.pinot.spi.utils.builder.ControllerRequestURLBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.spi.utils.retry.RetryPolicies;
@@ -188,72 +187,14 @@ public class FileUploadDownloadClient implements AutoCloseable {
     return new URI(protocol, null, host, port, path, query, null);
   }
 
-  /// Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
-  ///
-  /// @see FileUploadDownloadClient#getRetrieveTableConfigURI(String, String, int, String)
-  @Deprecated
-  public static URI getRetrieveTableConfigHttpURI(String host, int port, String rawTableName)
-      throws URISyntaxException {
-    return getURI(HTTP, host, port, TABLES_PATH + "/" + rawTableName);
-  }
-
   public static URI getRetrieveTableConfigURI(String protocol, String host, int port, String rawTableName)
       throws URISyntaxException {
     return getURI(protocol, host, port, TABLES_PATH + "/" + rawTableName);
   }
 
-  /// Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
-  ///
-  /// This method calls the old segment endpoint. We will deprecate this behavior soon.
-  @Deprecated
-  public static URI getDeleteSegmentHttpUri(String host, int port, String rawTableName, String segmentName,
-      String tableType)
-      throws URISyntaxException {
-    return new URI(StringUtil.join("/", StringUtils.chomp(HTTP + "://" + host + ":" + port, "/"), OLD_SEGMENT_PATH,
-        rawTableName + "/" + URIUtils.encode(segmentName) + "?" + TYPE_DELIMITER + tableType));
-  }
-
-  /// Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
-  ///
-  /// This method calls the old segment endpoint. We will deprecate this behavior soon.
-  @Deprecated
-  public static URI getRetrieveAllSegmentWithTableTypeHttpUri(String host, int port, String rawTableName,
-      String tableType)
-      throws URISyntaxException {
-    return new URI(StringUtil.join("/", StringUtils.chomp(HTTP + "://" + host + ":" + port, "/"), OLD_SEGMENT_PATH,
-        rawTableName + "?" + TYPE_DELIMITER + tableType));
-  }
-
-  /// Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
-  ///
-  /// @see FileUploadDownloadClient#getRetrieveSchemaURI(String, String, int, String)
-  @Deprecated
-  public static URI getRetrieveSchemaHttpURI(String host, int port, String schemaName)
-      throws URISyntaxException {
-    return getURI(HTTP, host, port, SCHEMA_PATH + "/" + schemaName);
-  }
-
   public static URI getRetrieveSchemaURI(String protocol, String host, int port, String schemaName)
       throws URISyntaxException {
     return getURI(protocol, host, port, SCHEMA_PATH + "/" + schemaName);
-  }
-
-  /// Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
-  ///
-  /// @see FileUploadDownloadClient#getUploadSchemaURI(String, String, int)
-  @Deprecated
-  public static URI getUploadSchemaHttpURI(String host, int port)
-      throws URISyntaxException {
-    return getURI(HTTP, host, port, SCHEMA_PATH);
-  }
-
-  /// Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
-  ///
-  /// @see FileUploadDownloadClient#getUploadSchemaURI(String, String, int)
-  @Deprecated
-  public static URI getUploadSchemaHttpsURI(String host, int port)
-      throws URISyntaxException {
-    return getURI(HTTPS, host, port, SCHEMA_PATH);
   }
 
   public static URI getUploadSchemaURI(String protocol, String host, int port)
@@ -288,48 +229,6 @@ public class FileUploadDownloadClient implements AutoCloseable {
   public static URI getUploadSchemaURI(URI controllerURI)
       throws URISyntaxException {
     return getURI(controllerURI.getScheme(), controllerURI.getHost(), controllerURI.getPort(), SCHEMA_PATH);
-  }
-
-  /// Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
-  ///
-  /// @see FileUploadDownloadClient#getUploadSegmentURI(String, String, int)
-  ///
-  /// This method calls the old segment upload endpoint. We will deprecate this behavior soon. Please call
-  /// getUploadSegmentHttpURI to construct your request.
-  @Deprecated
-  public static URI getOldUploadSegmentHttpURI(String host, int port)
-      throws URISyntaxException {
-    return getURI(HTTP, host, port, OLD_SEGMENT_PATH);
-  }
-
-  /// Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
-  ///
-  /// @see FileUploadDownloadClient#getUploadSegmentURI(String, String, int)
-  ///
-  /// This method calls the old segment upload endpoint. We will deprecate this behavior soon. Please call
-  /// getUploadSegmentHttpsURI to construct your request.
-  @Deprecated
-  public static URI getOldUploadSegmentHttpsURI(String host, int port)
-      throws URISyntaxException {
-    return getURI(HTTPS, host, port, OLD_SEGMENT_PATH);
-  }
-
-  /// Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
-  ///
-  /// @see FileUploadDownloadClient#getUploadSegmentURI(String, String, int)
-  @Deprecated
-  public static URI getUploadSegmentHttpURI(String host, int port)
-      throws URISyntaxException {
-    return getURI(HTTP, host, port, SEGMENT_PATH);
-  }
-
-  /// Deprecated due to lack of protocol/scheme support. May break for deployments with TLS/SSL enabled
-  ///
-  /// @see FileUploadDownloadClient#getUploadSegmentURI(String, String, int)
-  @Deprecated
-  public static URI getUploadSegmentHttpsURI(String host, int port)
-      throws URISyntaxException {
-    return getURI(HTTPS, host, port, SEGMENT_PATH);
   }
 
   public static URI getUploadSegmentURI(String protocol, String host, int port)
@@ -512,24 +411,6 @@ public class FileUploadDownloadClient implements AutoCloseable {
     return new InputStreamBody(inputStream, ContentType.DEFAULT_BINARY, fileName);
   }
 
-  /// Deprecated due to lack of auth header support. May break for deployments with auth enabled
-  ///
-  /// Add schema.
-  ///
-  /// @see FileUploadDownloadClient#addSchema(URI, String, File, List, List)
-  ///
-  /// @param uri URI
-  /// @param schemaName Schema name
-  /// @param schemaFile Schema file
-  /// @return Response
-  /// @throws IOException
-  /// @throws HttpErrorStatusException
-  @Deprecated
-  public SimpleHttpResponse addSchema(URI uri, String schemaName, File schemaFile)
-      throws IOException, HttpErrorStatusException {
-    return addSchema(uri, schemaName, schemaFile, List.of(), List.of());
-  }
-
   /// Add schema.
   ///
   /// @param uri URI
@@ -545,26 +426,6 @@ public class FileUploadDownloadClient implements AutoCloseable {
       throws IOException, HttpErrorStatusException {
     return HttpClient.wrapAndThrowHttpException(
         _httpClient.sendRequest(getAddSchemaRequest(uri, schemaName, schemaFile, headers, parameters)));
-  }
-
-  /// Deprecated due to lack of auth header support. May break for deployments with auth enabled
-  ///
-  /// Update schema.
-  ///
-  /// @see FileUploadDownloadClient#updateSchema(URI, String, File, List, List)
-  ///
-  /// @param uri URI
-  /// @param schemaName Schema name
-  /// @param schemaFile Schema file
-  /// @return Response
-  /// @throws IOException
-  /// @throws HttpErrorStatusException
-  @Deprecated
-  public SimpleHttpResponse updateSchema(URI uri, String schemaName, File schemaFile)
-      throws IOException, HttpErrorStatusException {
-    return HttpClient.wrapAndThrowHttpException(_httpClient.sendRequest(
-        getUploadFileRequest(HttpPut.METHOD_NAME, uri, getContentBody(schemaName, schemaFile), null, null),
-        HttpClient.DEFAULT_SOCKET_TIMEOUT_MS));
   }
 
   /// Update schema.
@@ -601,18 +462,6 @@ public class FileUploadDownloadClient implements AutoCloseable {
       throws IOException, HttpErrorStatusException {
     return HttpClient.wrapAndThrowHttpException(_httpClient.sendRequest(
         getUploadSegmentMetadataRequest(uri, segmentName, segmentMetadataFile, headers, parameters), socketTimeoutMs));
-  }
-
-  /// Deprecated due to lack of auth header support. May break for deployments with auth enabled
-  ///
-  /// @see FileUploadDownloadClient#uploadSegment(URI, String, InputStream, List, List, int)
-  @Deprecated
-  // Upload a set of segment metadata files (e.g., meta.properties and creation.meta) to controllers.
-  public SimpleHttpResponse uploadSegmentMetadataFiles(URI uri, Map<String, File> metadataFiles,
-      int segmentUploadRequestTimeoutMs)
-      throws IOException, HttpErrorStatusException {
-    return uploadSegmentMetadataFiles(uri, metadataFiles, List.of(), List.of(),
-        segmentUploadRequestTimeoutMs);
   }
 
   // Upload a set of segment metadata files (e.g., meta.properties and creation.meta) to controllers.
@@ -1023,27 +872,6 @@ public class FileUploadDownloadClient implements AutoCloseable {
         _httpClient.sendRequest(getSendSegmentUriRequest(uri, downloadUri, headers, parameters), socketTimeoutMs));
   }
 
-  /// Deprecated due to lack of auth header support. May break for deployments with auth enabled
-  ///
-  /// Send segment uri using default settings. Include table name as a request parameter.
-  ///
-  /// @see FileUploadDownloadClient#sendSegmentUri(URI, String, List, List, int)
-  ///
-  /// @param uri URI
-  /// @param downloadUri Segment download uri
-  /// @param rawTableName Raw table name
-  /// @return Response
-  /// @throws IOException
-  /// @throws HttpErrorStatusException
-  @Deprecated
-  public SimpleHttpResponse sendSegmentUri(URI uri, String downloadUri, String rawTableName)
-      throws IOException, HttpErrorStatusException {
-    // Add table name as a request parameter
-    NameValuePair tableNameValuePair = new BasicNameValuePair(QueryParameters.TABLE_NAME, rawTableName);
-    List<NameValuePair> parameters = Arrays.asList(tableNameValuePair);
-    return sendSegmentUri(uri, downloadUri, null, parameters, HttpClient.DEFAULT_SOCKET_TIMEOUT_MS);
-  }
-
   /// Send segment json.
   ///
   /// @param uri URI
@@ -1059,23 +887,6 @@ public class FileUploadDownloadClient implements AutoCloseable {
       throws IOException, HttpErrorStatusException {
     return HttpClient.wrapAndThrowHttpException(
         _httpClient.sendRequest(getSendSegmentJsonRequest(uri, jsonString, headers, parameters), socketTimeoutMs));
-  }
-
-  /// Deprecated due to lack of auth header support. May break for deployments with auth enabled
-  ///
-  /// Send segment json using default settings.
-  ///
-  /// @see FileUploadDownloadClient#sendSegmentJson(URI, String, List, List, int)
-  ///
-  /// @param uri URI
-  /// @param jsonString Segment json string
-  /// @return Response
-  /// @throws IOException
-  /// @throws HttpErrorStatusException
-  @Deprecated
-  public SimpleHttpResponse sendSegmentJson(URI uri, String jsonString)
-      throws IOException, HttpErrorStatusException {
-    return sendSegmentJson(uri, jsonString, null, null, HttpClient.DEFAULT_SOCKET_TIMEOUT_MS);
   }
 
   /// Start replace segments with default settings.
@@ -1147,23 +958,6 @@ public class FileUploadDownloadClient implements AutoCloseable {
         getRevertReplaceSegmentRequest(uri, authProvider), socketTimeoutMs));
   }
 
-  /// Deprecated due to lack of auth header support. May break for deployments with auth enabled
-  ///
-  /// Send segment completion protocol request.
-  ///
-  /// @see FileUploadDownloadClient#sendSegmentCompletionProtocolRequest(URI, List, List, int)
-  ///
-  /// @param uri URI
-  /// @param socketTimeoutMs Socket timeout in milliseconds
-  /// @return Response
-  /// @throws IOException
-  /// @throws HttpErrorStatusException
-  @Deprecated
-  public SimpleHttpResponse sendSegmentCompletionProtocolRequest(URI uri, int socketTimeoutMs)
-      throws IOException, HttpErrorStatusException {
-    return sendSegmentCompletionProtocolRequest(uri, List.of(), List.of(), socketTimeoutMs);
-  }
-
   /// Send segment completion protocol request.
   ///
   /// @param uri URI
@@ -1178,41 +972,6 @@ public class FileUploadDownloadClient implements AutoCloseable {
       throws IOException, HttpErrorStatusException {
     return HttpClient.wrapAndThrowHttpException(
         _httpClient.sendRequest(getSegmentCompletionProtocolRequest(uri, headers, parameters), socketTimeoutMs));
-  }
-
-  /// Deprecated due to lack of auth header support. May break for deployments with auth enabled
-  ///
-  /// Download a file using default settings
-  ///
-  /// @see HttpClient#downloadFile(URI, int, File, AuthProvider, List)
-  ///
-  /// @param uri URI
-  /// @param socketTimeoutMs Socket timeout in milliseconds
-  /// @param dest File destination
-  /// @return Response status code
-  /// @throws IOException
-  /// @throws HttpErrorStatusException
-  @Deprecated
-  public int downloadFile(URI uri, int socketTimeoutMs, File dest)
-      throws IOException, HttpErrorStatusException {
-    return _httpClient.downloadFile(uri, socketTimeoutMs, dest, null, null);
-  }
-
-  /// Deprecated due to lack of auth header support. May break for deployments with auth enabled
-  ///
-  /// Download a file.
-  ///
-  /// @see FileUploadDownloadClient#downloadFile(URI, File, AuthProvider)
-  ///
-  /// @param uri URI
-  /// @param dest File destination
-  /// @return Response status code
-  /// @throws IOException
-  /// @throws HttpErrorStatusException
-  @Deprecated
-  public int downloadFile(URI uri, File dest)
-      throws IOException, HttpErrorStatusException {
-    return downloadFile(uri, dest, null);
   }
 
   /// Download a file.

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/FileUploadDownloadClientTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/FileUploadDownloadClientTest.java
@@ -107,9 +107,9 @@ public class FileUploadDownloadClientTest {
       List<Header> headers = List.of(crypterClassHeader);
       List<NameValuePair> params = null;
 
-      SimpleHttpResponse response = fileUploadDownloadClient
-          .sendSegmentUri(FileUploadDownloadClient.getUploadSegmentHttpURI(TEST_HOST, TEST_PORT), TEST_URI, headers,
-              params, HttpClient.DEFAULT_SOCKET_TIMEOUT_MS);
+      SimpleHttpResponse response = fileUploadDownloadClient.sendSegmentUri(
+          FileUploadDownloadClient.getUploadSegmentURI(CommonConstants.HTTP_PROTOCOL, TEST_HOST, TEST_PORT), TEST_URI,
+          headers, params, HttpClient.DEFAULT_SOCKET_TIMEOUT_MS);
       Assert.assertEquals(response.getStatusCode(), HttpStatus.SC_OK);
       Assert.assertEquals(response.getResponse(), "OK");
     }
@@ -122,8 +122,9 @@ public class FileUploadDownloadClientTest {
     segmentJson.put(CommonConstants.Segment.DOWNLOAD_URL, TEST_URI);
     String jsonString = segmentJson.toString();
     try (FileUploadDownloadClient fileUploadDownloadClient = new FileUploadDownloadClient()) {
-      SimpleHttpResponse response = fileUploadDownloadClient
-          .sendSegmentJson(FileUploadDownloadClient.getUploadSegmentHttpURI(TEST_HOST, TEST_PORT), jsonString);
+      SimpleHttpResponse response = fileUploadDownloadClient.sendSegmentJson(
+          FileUploadDownloadClient.getUploadSegmentURI(CommonConstants.HTTP_PROTOCOL, TEST_HOST, TEST_PORT), jsonString,
+          null, null, HttpClient.DEFAULT_SOCKET_TIMEOUT_MS);
       Assert.assertEquals(response.getStatusCode(), HttpStatus.SC_OK);
       Assert.assertEquals(response.getResponse(), "OK");
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerStarter.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.controller;
 
 import java.io.File;
-import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
 
 
@@ -27,12 +26,6 @@ import org.apache.pinot.spi.utils.CommonConstants;
 public class ControllerStarter extends BaseControllerStarter {
 
   public ControllerStarter() {
-  }
-
-  @Deprecated
-  public ControllerStarter(PinotConfiguration pinotConfiguration)
-      throws Exception {
-    init(pinotConfiguration);
   }
 
   public static ControllerStarter startDefault()

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/ServerTableSizeReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/ServerTableSizeReader.java
@@ -92,7 +92,7 @@ public class ServerTableSizeReader {
     BiMap<String, String> endpointsToServers = serverEndPoints.inverse();
     boolean requestCompressionStats = includeCompressionStats || includeColumnCompressionStats;
     for (String endpoint : endpointsToServers.keySet()) {
-      String tableSizeUri = endpoint + "/table/" + tableNameWithType + "/size"
+      String tableSizeUri = endpoint + "/tables/" + tableNameWithType + "/size"
           + (requestCompressionStats ? "?includeCompressionStats=true" : "")
           + (includeColumnCompressionStats ? "&includeColumnCompressionStats=true" : "");
       serverUrls.add(tableSizeUri);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/ServerTableSizeReaderCompressionStatsTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/ServerTableSizeReaderCompressionStatsTest.java
@@ -50,7 +50,7 @@ import static org.testng.Assert.*;
 
 /// Tests that [ServerTableSizeReader] deserializes [SegmentSizeInfo] compression-statistics fields.
 public class ServerTableSizeReaderCompressionStatsTest {
-  private static final String URI_PATH = "/table/";
+  private static final String URI_PATH = "/tables/";
   private static final int TIMEOUT_MSEC = 5000;
   private final ExecutorService _executor = Executors.newFixedThreadPool(2);
   private final PoolingHttpClientConnectionManager _connectionManager = new PoolingHttpClientConnectionManager();

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/ServerTableSizeReaderTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/ServerTableSizeReaderTest.java
@@ -53,7 +53,7 @@ public class ServerTableSizeReaderTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerTableSizeReader.class);
 
   private static final String LOOPBACK_HOST = "127.0.0.1";
-  private static final String URI_PATH = "/table/";
+  private static final String URI_PATH = "/tables/";
   private static final String TABLE_NAME = "myTable";
   private static final int TIMEOUT_MSEC = 5000;
   private static final int SERVER_COUNT = 6;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableSizeReaderCompressionStatsTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableSizeReaderCompressionStatsTest.java
@@ -84,7 +84,7 @@ import static org.testng.Assert.*;
 
 /// Tests compression-statistics aggregation in [TableSizeReader].
 public class TableSizeReaderCompressionStatsTest {
-  private static final String URI_PATH = "/table/";
+  private static final String URI_PATH = "/tables/";
   private static final int TIMEOUT_MSEC = 10000;
   private static final int NUM_REPLICAS = 2;
 
@@ -188,8 +188,16 @@ public class TableSizeReaderCompressionStatsTest {
 
   private void startServer(FakeCompressionServer server, List<SegmentSizeInfo> sizes, int metadataVersion)
       throws IOException {
-    server.start(URI_PATH, createHandler(200, sizes, metadataVersion));
-    server._httpServer.createContext("/tables/", createCompressionHandler(server, sizes, metadataVersion));
+    // Size and compression-stats share the "/tables/" prefix, so a single context dispatches on the suffix.
+    HttpHandler sizeHandler = createHandler(200, sizes, metadataVersion);
+    HttpHandler compressionHandler = createCompressionHandler(server, sizes, metadataVersion);
+    server.start(URI_PATH, httpExchange -> {
+      if (httpExchange.getRequestURI().getPath().endsWith("/compression-stats")) {
+        compressionHandler.handle(httpExchange);
+      } else {
+        sizeHandler.handle(httpExchange);
+      }
+    });
   }
 
   private HttpHandler createHandler(int status, List<SegmentSizeInfo> segmentSizes, int metadataVersion) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableSizeReaderTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableSizeReaderTest.java
@@ -71,7 +71,7 @@ import static org.testng.Assert.*;
 
 public class TableSizeReaderTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(TableSizeReaderTest.class);
-  private static final String URI_PATH = "/table/";
+  private static final String URI_PATH = "/tables/";
   private static final int TIMEOUT_MSEC = 10000;
   private static final int EXTENDED_TIMEOUT_FACTOR = 100;
   private static final int NUM_REPLICAS = 2;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/SegmentPrunerService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/SegmentPrunerService.java
@@ -80,17 +80,6 @@ public class SegmentPrunerService {
 
   /// Prunes the segments based on the query request, returns the segments that are not pruned.
   ///
-  /// @deprecated this method is here for compatibility reasons and may be removed soon.
-  /// Call [#prune(List, QueryContext, SegmentPrunerStatistics)] instead
-  /// @param segments the list of segments to be pruned. This is a destructive operation that may modify this list in an
-  ///                 undefined way. Therefore, this list should not be used after calling this method.
-  @Deprecated
-  public List<IndexSegment> prune(List<IndexSegment> segments, QueryContext query) {
-    return prune(segments, query, new SegmentPrunerStatistics());
-  }
-
-  /// Prunes the segments based on the query request, returns the segments that are not pruned.
-  ///
   /// @param segments the list of segments to be pruned. This is a destructive operation that may modify this list in an
   ///                 undefined way. Therefore, this list should not be used after calling this method.
   public List<IndexSegment> prune(List<IndexSegment> segments, QueryContext query, SegmentPrunerStatistics stats) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerInstance.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerInstance.java
@@ -159,16 +159,6 @@ public final class ServerInstance {
     return _pool;
   }
 
-  // Does not require TLS until all servers guaranteed to be on TLS
-  @Deprecated
-  public ServerRoutingInstance toServerRoutingInstance(TableType tableType, boolean preferNettyTls) {
-    if (preferNettyTls && _nettyTlsPort > 0) {
-      return new ServerRoutingInstance(_instanceId, _hostname, _nettyTlsPort, tableType, true);
-    } else {
-      return new ServerRoutingInstance(_instanceId, _hostname, _port, tableType);
-    }
-  }
-
   public ServerRoutingInstance toServerRoutingInstance(TableType tableType, RoutingType routingType) {
     switch (routingType) {
       case NETTY:

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunctionTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.util.List;
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -196,7 +197,7 @@ public class AvgAggregationFunctionTest extends AbstractAggregationFunctionTest 
             new TableConfigBuilder(TableType.OFFLINE)
                 .setTableName("testTable")
                 .addFieldConfig(
-                    new FieldConfig("key", encoding, (FieldConfig.IndexType) null, PASS_THROUGH, null))
+                    new FieldConfig("key", encoding, (List<FieldConfig.IndexType>) null, PASS_THROUGH, null))
                 .build())
         .onFirstInstance(new Object[]{7, 1}, new Object[]{6, 2}, new Object[]{5, 3}, new Object[]{4, 4})
         .andOnSecondInstance(new Object[]{7, 1}, new Object[]{6, 2}, new Object[]{5, 3}, new Object[]{4, 4})
@@ -228,9 +229,9 @@ public class AvgAggregationFunctionTest extends AbstractAggregationFunctionTest 
             new TableConfigBuilder(TableType.OFFLINE)
                 .setTableName("testTable")
                 .addFieldConfig(
-                    new FieldConfig("key1", encoding, (FieldConfig.IndexType) null, PASS_THROUGH, null))
+                    new FieldConfig("key1", encoding, (List<FieldConfig.IndexType>) null, PASS_THROUGH, null))
                 .addFieldConfig(
-                    new FieldConfig("key2", encoding, (FieldConfig.IndexType) null, PASS_THROUGH, null))
+                    new FieldConfig("key2", encoding, (List<FieldConfig.IndexType>) null, PASS_THROUGH, null))
                 .build())
         .onFirstInstance(new Object[]{7, 1}, new Object[]{6, 2}, new Object[]{5, 3}, new Object[]{4, 4})
         .andOnSecondInstance(new Object[]{7, 1}, new Object[]{6, 2}, new Object[]{5, 3}, new Object[]{4, 4})

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FastFilteredCountTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FastFilteredCountTest.java
@@ -135,7 +135,8 @@ public class FastFilteredCountTest extends BaseQueriesTest {
   // overridden in composite index test
   protected TableConfig getTableConfig() {
     List<FieldConfig> fieldConfigs = List.of(
-        new FieldConfig(TEXT_COLUMN, FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.TEXT, null, null));
+        new FieldConfig(TEXT_COLUMN, FieldConfig.EncodingType.DICTIONARY, List.of(FieldConfig.IndexType.TEXT), null,
+            null));
 
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName(RAW_TABLE_NAME)

--- a/pinot-core/src/test/java/org/apache/pinot/queries/H3IndexQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/H3IndexQueriesTest.java
@@ -70,10 +70,10 @@ public class H3IndexQueriesTest extends BaseQueriesTest {
           .addSingleValueDimension(NON_H3_INDEX_GEOMETRY_COLUMN, DataType.BYTES).build();
   private static final Map<String, String> H3_INDEX_PROPERTIES = Map.of("resolutions", "5");
   private static final List<FieldConfig> H3_FIELD_CONFIGS = List.of(
-      new FieldConfig(H3_INDEX_COLUMN, FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.H3, null,
+      new FieldConfig(H3_INDEX_COLUMN, FieldConfig.EncodingType.DICTIONARY, List.of(FieldConfig.IndexType.H3), null,
           H3_INDEX_PROPERTIES),
-      new FieldConfig(H3_INDEX_GEOMETRY_COLUMN, FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.H3, null,
-          H3_INDEX_PROPERTIES));
+      new FieldConfig(H3_INDEX_GEOMETRY_COLUMN, FieldConfig.EncodingType.DICTIONARY, List.of(FieldConfig.IndexType.H3),
+          null, H3_INDEX_PROPERTIES));
   private static final TableConfig TABLE_CONFIG = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
       .setFieldConfigList(H3_FIELD_CONFIGS).build();
   // Null handling enabled so the segment stores a null-value vector, and continueOnError enabled so the H3 index

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/StaleSegmentCheckIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/StaleSegmentCheckIntegrationTest.java
@@ -102,8 +102,8 @@ public class StaleSegmentCheckIntegrationTest extends BaseClusterIntegrationTest
   }
 
   private FieldConfig getH3FieldConfig() {
-    return new FieldConfig(H3_INDEX_COLUMN, FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.H3, null,
-        H3_INDEX_PROPERTIES);
+    return new FieldConfig(H3_INDEX_COLUMN, FieldConfig.EncodingType.DICTIONARY, List.of(FieldConfig.IndexType.H3),
+        null, H3_INDEX_PROPERTIES);
   }
 
   @Override

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/plugin/minion/tasks/TestTaskExecutorFactory.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/plugin/minion/tasks/TestTaskExecutorFactory.java
@@ -44,10 +44,6 @@ import static org.testng.Assert.assertTrue;
 public class TestTaskExecutorFactory implements PinotTaskExecutorFactory {
 
   @Override
-  public void init(MinionTaskZkMetadataManager zkMetadataManager) {
-  }
-
-  @Override
   public void init(MinionTaskZkMetadataManager zkMetadataManager, MinionConf minionConf) {
   }
 

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionStarter.java
@@ -18,35 +18,11 @@
  */
 package org.apache.pinot.minion;
 
-import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.utils.CommonConstants;
-
-
 /// The class `MinionStarter` provides methods to start and stop the Pinot Minion.
 ///
 /// Pinot Minion will automatically join the given Helix cluster as a participant.
 public class MinionStarter extends BaseMinionStarter {
 
   public MinionStarter() {
-  }
-
-  @Deprecated
-  public MinionStarter(String clusterName, String zkServers, PinotConfiguration minionConfig)
-      throws Exception {
-    init(applyMinionConfigs(minionConfig, clusterName, zkServers));
-  }
-
-  @Deprecated
-  private static PinotConfiguration applyMinionConfigs(PinotConfiguration minionConfig, String clusterName,
-      String zkServers) {
-    minionConfig.setProperty(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME, clusterName);
-    minionConfig.setProperty(CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER, zkServers);
-    return minionConfig;
-  }
-
-  @Deprecated
-  public MinionStarter(PinotConfiguration config)
-      throws Exception {
-    init(config);
   }
 }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/PinotTaskExecutorFactory.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/PinotTaskExecutorFactory.java
@@ -25,10 +25,6 @@ import org.apache.pinot.minion.MinionConf;
 public interface PinotTaskExecutorFactory {
 
   /// Initializes the task executor factory.
-  @Deprecated
-  void init(MinionTaskZkMetadataManager zkMetadataManager);
-
-  /// Initializes the task executor factory.
   void init(MinionTaskZkMetadataManager zkMetadataManager, MinionConf minionConf);
 
   /// Returns the task type of the executor.

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkSelectionOrderByFilterPruning.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkSelectionOrderByFilterPruning.java
@@ -27,6 +27,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.core.query.config.SegmentPrunerConfig;
 import org.apache.pinot.core.query.pruner.SegmentPrunerService;
+import org.apache.pinot.core.query.pruner.SegmentPrunerStatistics;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.queries.BaseQueriesTest;
@@ -189,7 +190,7 @@ public class BenchmarkSelectionOrderByFilterPruning extends BaseQueriesTest {
     // Prune first (this is what the fix affects), then execute the surviving segments through the single-stage engine.
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext(_query);
     queryContext.setSchema(SCHEMA);
-    _selectedSegments = _segmentPrunerService.prune(_allSegments, queryContext);
+    _selectedSegments = _segmentPrunerService.prune(_allSegments, queryContext, new SegmentPrunerStatistics());
     return getBrokerResponse(_query);
   }
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/materializedview/MaterializedViewTaskExecutorFactory.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/materializedview/MaterializedViewTaskExecutorFactory.java
@@ -47,11 +47,6 @@ public class MaterializedViewTaskExecutorFactory implements PinotTaskExecutorFac
   private volatile MaterializedViewQueryExecutor _queryExecutor;
 
   @Override
-  public void init(MinionTaskZkMetadataManager zkMetadataManager) {
-    _zkMetadataManager = zkMetadataManager;
-  }
-
-  @Override
   public void init(MinionTaskZkMetadataManager zkMetadataManager, MinionConf minionConf) {
     _zkMetadataManager = zkMetadataManager;
     _minionConf = minionConf;
@@ -70,9 +65,9 @@ public class MaterializedViewTaskExecutorFactory implements PinotTaskExecutorFac
           // Build the gRPC client config from the minion's own configuration, scoped to the
           // MaterializedViewTask.MINION_BROKER_GRPC_CONFIG_PREFIX prefix.  This is how operators
           // enable TLS, raise the max inbound message size for large MV result sets, and tune
-          // keepalive.  Falling back to an empty configuration (no TLS, defaults) when the minion
-          // was initialized via the legacy single-arg init(zkMetadataManager) overload — fine for
-          // local tests but production deployments should use the two-arg init.
+          // keepalive.  Falling back to an empty configuration (no TLS, defaults) when no
+          // MinionConf was provided — fine for local tests but production deployments should
+          // initialize the factory with a MinionConf.
           PinotConfiguration grpcClientConfig = _minionConf != null
               ? _minionConf.subset(MaterializedViewTask.MINION_BROKER_GRPC_CONFIG_PREFIX)
               : new PinotConfiguration();

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutorFactory.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutorFactory.java
@@ -31,10 +31,6 @@ public class MergeRollupTaskExecutorFactory implements PinotTaskExecutorFactory 
   private MinionConf _minionConf;
 
   @Override
-  public void init(MinionTaskZkMetadataManager zkMetadataManager) {
-  }
-
-  @Override
   public void init(MinionTaskZkMetadataManager zkMetadataManager, MinionConf minionConf) {
     _minionConf = minionConf;
   }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskExecutorFactory.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskExecutorFactory.java
@@ -30,10 +30,6 @@ import org.apache.pinot.spi.annotations.minion.TaskExecutorFactory;
 public class PurgeTaskExecutorFactory implements PinotTaskExecutorFactory {
 
   @Override
-  public void init(MinionTaskZkMetadataManager zkMetadataManager) {
-  }
-
-  @Override
   public void init(MinionTaskZkMetadataManager zkMetadataManager, MinionConf minionConf) {
   }
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutorFactory.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutorFactory.java
@@ -33,11 +33,6 @@ public class RealtimeToOfflineSegmentsTaskExecutorFactory implements PinotTaskEx
   private MinionConf _minionConf;
 
   @Override
-  public void init(MinionTaskZkMetadataManager zkMetadataManager) {
-    _zkMetadataManager = zkMetadataManager;
-  }
-
-  @Override
   public void init(MinionTaskZkMetadataManager zkMetadataManager, MinionConf minionConf) {
     _zkMetadataManager = zkMetadataManager;
     _minionConf = minionConf;

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/refreshsegment/RefreshSegmentTaskExecutorFactory.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/refreshsegment/RefreshSegmentTaskExecutorFactory.java
@@ -30,10 +30,6 @@ import org.apache.pinot.spi.annotations.minion.TaskExecutorFactory;
 public class RefreshSegmentTaskExecutorFactory implements PinotTaskExecutorFactory {
 
   @Override
-  public void init(MinionTaskZkMetadataManager zkMetadataManager) {
-  }
-
-  @Override
   public void init(MinionTaskZkMetadataManager zkMetadataManager, MinionConf minionConf) {
   }
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskExecutorFactory.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskExecutorFactory.java
@@ -30,10 +30,6 @@ import org.apache.pinot.spi.annotations.minion.TaskExecutorFactory;
 public class SegmentGenerationAndPushTaskExecutorFactory implements PinotTaskExecutorFactory {
 
   @Override
-  public void init(MinionTaskZkMetadataManager zkMetadataManager) {
-  }
-
-  @Override
   public void init(MinionTaskZkMetadataManager zkMetadataManager, MinionConf minionConf) {
   }
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutorFactory.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutorFactory.java
@@ -30,10 +30,6 @@ import org.apache.pinot.spi.annotations.minion.TaskExecutorFactory;
 public class UpsertCompactionTaskExecutorFactory implements PinotTaskExecutorFactory {
 
   @Override
-  public void init(MinionTaskZkMetadataManager zkMetadataManager) {
-  }
-
-  @Override
   public void init(MinionTaskZkMetadataManager zkMetadataManager, MinionConf minionConf) {
   }
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskExecutorFactory.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskExecutorFactory.java
@@ -32,10 +32,6 @@ public class UpsertCompactMergeTaskExecutorFactory implements PinotTaskExecutorF
   private MinionConf _minionConf;
 
   @Override
-  public void init(MinionTaskZkMetadataManager zkMetadataManager) {
-  }
-
-  @Override
   public void init(MinionTaskZkMetadataManager zkMetadataManager, MinionConf minionConf) {
     _minionConf = minionConf;
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/IndexCombinationValidationTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/IndexCombinationValidationTest.java
@@ -130,7 +130,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testDictEncodedWithFstIndexPasses() {
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.DICTIONARY, IndexType.FST, null, null);
+    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.DICTIONARY, List.of(IndexType.FST), null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setFieldConfigList(List.of(fc)).build();
     assertValid(tc);
@@ -171,7 +171,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testRawWithFstIndexNoExplicitDictFails() {
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, IndexType.FST, null, null);
+    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, List.of(IndexType.FST), null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -182,7 +182,7 @@ public class IndexCombinationValidationTest {
   @Test
   public void testRawWithIfstIndexNoExplicitDictFails() {
     // IFSTIndexType.validate() fires: "Cannot create IFST index on column: <col> without dictionary"
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, IndexType.IFST, null, null);
+    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, List.of(IndexType.IFST), null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -266,7 +266,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testRawWithTextIndexNoDictPasses() {
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, IndexType.TEXT, null, null);
+    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, List.of(IndexType.TEXT), null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -285,7 +285,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testRawWithJsonIndexStringColumnNoDictPasses() {
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, IndexType.JSON, null, null);
+    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, List.of(IndexType.JSON), null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -384,7 +384,7 @@ public class IndexCombinationValidationTest {
   @Test
   public void testFstIndexMvColumnFails() {
     // FST on MV column is never valid regardless of encoding
-    FieldConfig fc = new FieldConfig(INT_MV_COL, EncodingType.DICTIONARY, IndexType.FST, null, null);
+    FieldConfig fc = new FieldConfig(INT_MV_COL, EncodingType.DICTIONARY, List.of(IndexType.FST), null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setFieldConfigList(List.of(fc))
         .build();
@@ -408,7 +408,7 @@ public class IndexCombinationValidationTest {
   @Test
   public void testMixedColumnsAllValidPasses() {
     // strCol: raw + text (no dict required); intCol: dict + inverted; floatCol: dict + range
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, IndexType.TEXT, null, null);
+    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, List.of(IndexType.TEXT), null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setInvertedIndexColumns(List.of(INT_COL))
@@ -458,7 +458,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testRawWithLz4CodecPasses() {
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, (IndexType) null, CompressionCodec.LZ4, null);
+    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, (List<IndexType>) null, CompressionCodec.LZ4, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -468,7 +468,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testRawWithSnappyCodecPasses() {
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, (IndexType) null, CompressionCodec.SNAPPY, null);
+    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, (List<IndexType>) null, CompressionCodec.SNAPPY, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -478,7 +478,8 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testRawWithZstdCodecPasses() {
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, (IndexType) null, CompressionCodec.ZSTANDARD, null);
+    FieldConfig fc =
+        new FieldConfig(STR_COL, EncodingType.RAW, (List<IndexType>) null, CompressionCodec.ZSTANDARD, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -489,7 +490,7 @@ public class IndexCombinationValidationTest {
   @Test
   public void testRawWithClpCodecStringColumnPasses() {
     // CLP codecs are valid for raw STRING columns
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, (IndexType) null, CompressionCodec.CLP, null);
+    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, (List<IndexType>) null, CompressionCodec.CLP, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -500,7 +501,7 @@ public class IndexCombinationValidationTest {
   @Test
   public void testRawWithClpCodecNonStringColumnFails() {
     // CLP is only valid on STRING stored type
-    FieldConfig fc = new FieldConfig(INT_COL, EncodingType.RAW, (IndexType) null, CompressionCodec.CLP, null);
+    FieldConfig fc = new FieldConfig(INT_COL, EncodingType.RAW, (List<IndexType>) null, CompressionCodec.CLP, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(INT_COL))
         .setFieldConfigList(List.of(fc))
@@ -511,7 +512,8 @@ public class IndexCombinationValidationTest {
   @Test
   public void testDeltaDeltaCodecNonNumericColumnFails() {
     // DELTADELTA only valid on INT/LONG columns
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, (IndexType) null, CompressionCodec.DELTADELTA, null);
+    FieldConfig fc =
+        new FieldConfig(STR_COL, EncodingType.RAW, (List<IndexType>) null, CompressionCodec.DELTADELTA, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -542,7 +544,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testFstIndexNonStringColumnFails() {
-    FieldConfig fc = new FieldConfig(INT_COL, EncodingType.DICTIONARY, IndexType.FST, null, null);
+    FieldConfig fc = new FieldConfig(INT_COL, EncodingType.DICTIONARY, List.of(IndexType.FST), null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setFieldConfigList(List.of(fc))
         .build();
@@ -551,7 +553,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testTextIndexNonStringColumnFails() {
-    FieldConfig fc = new FieldConfig(INT_COL, EncodingType.DICTIONARY, IndexType.TEXT, null, null);
+    FieldConfig fc = new FieldConfig(INT_COL, EncodingType.DICTIONARY, List.of(IndexType.TEXT), null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setFieldConfigList(List.of(fc))
         .build();
@@ -561,7 +563,7 @@ public class IndexCombinationValidationTest {
   @Test
   public void testTextIndexStringColumnRawPasses() {
     // Text index does not require dictionary
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, IndexType.TEXT, null, null);
+    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, List.of(IndexType.TEXT), null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -571,7 +573,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testTextIndexStringColumnDictPasses() {
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.DICTIONARY, IndexType.TEXT, null, null);
+    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.DICTIONARY, List.of(IndexType.TEXT), null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setFieldConfigList(List.of(fc))
         .build();
@@ -580,7 +582,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testJsonIndexStringColumnRawPasses() {
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, IndexType.JSON, null, null);
+    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, List.of(IndexType.JSON), null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -590,7 +592,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testJsonIndexStringColumnDictPasses() {
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.DICTIONARY, IndexType.JSON, null, null);
+    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.DICTIONARY, List.of(IndexType.JSON), null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setFieldConfigList(List.of(fc))
         .build();
@@ -600,7 +602,7 @@ public class IndexCombinationValidationTest {
   @Test
   public void testJsonIndexIntColumnFails() {
     // JSON index not valid on non-STRING/non-MAP column
-    FieldConfig fc = new FieldConfig(INT_COL, EncodingType.DICTIONARY, IndexType.JSON, null, null);
+    FieldConfig fc = new FieldConfig(INT_COL, EncodingType.DICTIONARY, List.of(IndexType.JSON), null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setFieldConfigList(List.of(fc))
         .build();
@@ -645,7 +647,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testErrorMessageNamesFstIndex() {
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, IndexType.FST, null, null);
+    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, List.of(IndexType.FST), null, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -1467,7 +1467,8 @@ public class TableConfigUtilsTest {
 
     try {
       FieldConfig fieldConfig =
-          new FieldConfig("myCol1", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null, null);
+          new FieldConfig("myCol1", FieldConfig.EncodingType.DICTIONARY, List.of(FieldConfig.IndexType.FST), null,
+              null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       fail("Should fail for with conflicting encoding type of myCol1");
@@ -1488,7 +1489,8 @@ public class TableConfigUtilsTest {
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     try {
       FieldConfig fieldConfig =
-          new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null, null);
+          new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY, List.of(FieldConfig.IndexType.FST), null,
+              null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       fail("Should fail since FST index is enabled on multi value column");
@@ -1499,7 +1501,8 @@ public class TableConfigUtilsTest {
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     try {
       FieldConfig fieldConfig =
-          new FieldConfig("intCol", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null, null);
+          new FieldConfig("intCol", FieldConfig.EncodingType.DICTIONARY, List.of(FieldConfig.IndexType.FST), null,
+              null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       fail("Should fail since FST index is enabled on non String column");
@@ -1512,7 +1515,7 @@ public class TableConfigUtilsTest {
         .build();
     try {
       FieldConfig fieldConfig =
-          new FieldConfig("intCol", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.TEXT, null, null);
+          new FieldConfig("intCol", FieldConfig.EncodingType.RAW, List.of(FieldConfig.IndexType.TEXT), null, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       fail("Should fail since TEXT index is enabled on non String column");
@@ -1525,7 +1528,7 @@ public class TableConfigUtilsTest {
         .build();
     try {
       FieldConfig fieldConfig =
-          new FieldConfig("myCol21", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.FST, null, null);
+          new FieldConfig("myCol21", FieldConfig.EncodingType.RAW, List.of(FieldConfig.IndexType.FST), null, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       fail("Should fail since field name is not present in schema");

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
@@ -39,26 +39,6 @@ public class HelixServerStarter extends BaseServerStarter {
   public HelixServerStarter() {
   }
 
-  @Deprecated
-  public HelixServerStarter(String helixClusterName, String zkAddress, PinotConfiguration serverConf)
-      throws Exception {
-    init(applyServerConfig(serverConf, helixClusterName, zkAddress));
-  }
-
-  @Deprecated
-  private static PinotConfiguration applyServerConfig(PinotConfiguration serverConf, String helixClusterName,
-      String zkAddress) {
-    serverConf.setProperty(Helix.CONFIG_OF_CLUSTER_NAME, helixClusterName);
-    serverConf.setProperty(Helix.CONFIG_OF_ZOOKEEPER_SERVER, zkAddress);
-    return serverConf;
-  }
-
-  @Deprecated
-  public HelixServerStarter(PinotConfiguration serverConf)
-      throws Exception {
-    init(serverConf);
-  }
-
   /// This method is for reference purpose only.
   public static HelixServerStarter startDefault()
       throws Exception {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -80,12 +80,6 @@ public class FieldConfig extends BaseJsonConfig {
   private final Map<String, String> _properties;
   private final TimestampConfig _timestampConfig;
 
-  @Deprecated
-  public FieldConfig(String name, EncodingType encodingType, @Nullable IndexType indexType,
-      @Nullable CompressionCodec compressionCodec, @Nullable Map<String, String> properties) {
-    this(name, encodingType, indexType, null, compressionCodec, null, null, properties, null);
-  }
-
   public FieldConfig(String name, EncodingType encodingType, @Nullable List<IndexType> indexTypes,
       @Nullable CompressionCodec compressionCodec, @Nullable Map<String, String> properties) {
     this(name, encodingType, null, indexTypes, compressionCodec, null, null, properties, null);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -330,12 +330,6 @@ public final class Schema implements Serializable {
     _fieldSpecMap.put(columnName, fieldSpec);
   }
 
-  @Deprecated
-  // For third-eye backward compatible.
-  public void addField(String columnName, FieldSpec fieldSpec) {
-    addField(fieldSpec);
-  }
-
   public boolean removeField(String columnName) {
     FieldSpec existingFieldSpec = _fieldSpecMap.remove(columnName);
     if (existingFieldSpec != null) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow.java
@@ -265,14 +265,4 @@ public class GenericRow implements Serializable {
       throw new RuntimeException(e);
     }
   }
-
-  @Deprecated
-  public void init(Map<String, Object> fieldToValueMap) {
-    putValues(fieldToValueMap);
-  }
-
-  @Deprecated
-  public void putField(String fieldName, @Nullable Object value) {
-    putValue(fieldName, value);
-  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/PinotReflectionUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/PinotReflectionUtils.java
@@ -114,13 +114,4 @@ public class PinotReflectionUtils {
       runnable.run();
     }
   }
-
-  /// Due to the multi-threading issue in org.reflections.vfs.ZipDir, we need to put a lock before calling the
-  /// reflection related methods.
-  ///
-  /// Deprecated: use [#runWithLock(Runnable)] instead
-  @Deprecated
-  public static Object getReflectionLock() {
-    return REFLECTION_LOCK;
-  }
 }


### PR DESCRIPTION
Part of #19147.

Removes public APIs whose deprecations shipped between 2016 and 2022. This is the first in a series of per-release deprecation sweeps; each PR removes the APIs deprecated in one release line, so reviewers can reason about a single deprecation window at a time.

Every removed member was verified to have zero non-deprecated production callers via repo-wide grep. In-repo test callers were migrated to the replacements. Full-reactor `test-compile`, `checkstyle:check`, and `license:check` pass.

## Removed

| API | Replacement | Deprecated |
|---|---|---|
| `Schema.addField(String, FieldSpec)` | `addField(FieldSpec)` | 2016 (third-eye compat) |
| `FileUploadDownloadClient` legacy URI builders + scheme/auth-less overloads (incl. `getOldUploadSegmentHttp(s)URI`) | the auth-aware variants named in each `@see` | 2018, 2021 |
| `SegmentGenerationUtils.getTableConfig(String)` | the auth-token overload | 2021 |
| `GenericRow.init(Map)`, `putField(String, Object)` | `putValues`, `putValue` | 2019 |
| `ControllerStarter`, `HelixBrokerStarter`, `HelixServerStarter`, `MinionStarter` legacy ctors + `applyXxxConfig` | no-arg construction + `init(PinotConfiguration)` | 2021 |
| `PinotTaskExecutorFactory.init(MinionTaskZkMetadataManager)` + every now-empty override | `init(zkMetadataManager, minionConf)` | 2021 |
| `FieldConfig` 5-arg ctor (singular `IndexType`) | the `List<IndexType>` ctor / `Builder` | 2021 |
| `ServerInstance.toServerRoutingInstance(TableType, boolean)` | the `RoutingType` overload | 2021 |
| `SegmentPrunerService.prune(List, QueryContext)` | the 4-arg overload | 2022 |
| `PinotReflectionUtils.getReflectionLock()` | `runWithLock(Runnable)` | 2022 |
| `ConnectionFactory.fromController(scheme, host, port)` ×2 | the URL-string overloads | 2022 |

## Staged: `/table/{table}/size`

`ServerTableSizeReader` now calls the plural `GET /tables/{table}/size`. The singular `/table/...` form was deprecated in **2016** — its comment reads *"/table was by mistake. We will use plural from hereon"* — but the controller itself was still the caller, which is why it survived nine years.

The repoint is behavior-identical: the deprecated handler `getTableSizeOld` is a pure delegate to `getTableSize`, which is exactly what the plural path maps to (same `TableSizeInfo`, same params, same metadata version). It is safe because the plural endpoint has shipped on the server since well before 0.8.0, so an upgraded controller resolves it against any supported server.

The deprecated **server endpoint is intentionally retained in this PR**, so that an N-1 controller still works against an N server. It can be deleted in a follow-up once this caller migration has shipped.

One test consequence: both endpoints now share the `/tables/` prefix, so `TableSizeReaderCompressionStatsTest` can no longer separate its size and compression-stats handlers by context path (the JDK rejects duplicate contexts). It now registers a single context that dispatches on the `/compression-stats` suffix. All 24 tests across the four table-size test classes pass.

## Not removed

- `ControllerGauge.OFFLINE_TABLE_ESTIMATED_SIZE` was in the original sweep list but is still emitted by `StorageQuotaChecker`, so it stays.
- The `HeaderAdder` ThirdEye URI-rewrite hack (a 2017 `TODO HACK`) was originally included but has been pulled out. It was never `@Deprecated`, it runs `@PreMatching` on every controller request, and it has no test coverage anywhere — so it is a live, unverifiable behavior change that does not belong bundled with mechanical source-level removals. It will get its own small PR.

## backward-incompat

Please apply the **`backward-incompat`** label, and please loop in minion-task and client/connector plugin maintainers.

These are source-breaking for out-of-tree code compiled against `pinot-spi`, `pinot-common`, `pinot-java-client`, and the minion task-factory SPI. **The runtime-breaking case worth calling out to operators**: plugin jars (custom `RecordReader` / `RecordExtractor` / `RecordTransformer`) are compiled against a released `pinot-spi` and loaded at runtime, so a stale jar calling `GenericRow.putField`, `Schema.addField(String, FieldSpec)`, or the `FieldConfig` 5-arg constructor will fail with `NoSuchMethodError` rather than a clean startup error. **Out-of-tree plugin jars should be rebuilt against the new `pinot-spi` before upgrading servers and minions.**

### The Binary Compatibility Check fails on this PR, by design

`Pinot Binary Compatibility Check` runs japicmp with `--error-on-binary-incompatibility` over `pinot-spi` / `pinot-segment-spi`, and there is no allowlist or label-based bypass. It reports exactly the five removals this PR intends:

```
FieldConfig(String, EncodingType, IndexType, CompressionCodec, Map) : CONSTRUCTOR_REMOVED
GenericRow.init(Map)                                                : METHOD_REMOVED
GenericRow.putField(String, Object)                                 : METHOD_REMOVED
Schema.addField(String, FieldSpec)                                  : METHOD_REMOVED
PinotReflectionUtils.getReflectionLock()                            : METHOD_REMOVED
```

So the red X is the gate correctly doing its job on an intentionally binary-incompatible change, not an unnoticed regression. Removing these symbols *is* the point of the PR, so this check is expected to fail and can be skipped here. It is not a required check (`mergeStateStatus` is `UNSTABLE`, not `BLOCKED`), so it does not block merge.

Third-party `PinotTaskExecutorFactory` implementations must drop their empty 1-arg `init` override; that one is source-breaking but runtime-safe, since the 2-arg method was already abstract and every implementation must therefore already have it.

No config keys, wire formats, or ZK-serialized fields are touched, so there is no rolling-upgrade ordering requirement beyond the staged endpoint noted above.
