### PR TITLE
Remove APIs deprecated in 1.0.0

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/SegmentAdminClient.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/SegmentAdminClient.java
@@ -430,14 +430,14 @@ public class SegmentAdminClient extends BaseServiceAdminClient {
       long endTimestampMs, boolean excludeReplacedSegments)
       throws PinotAdminException {
     Map<String, String> queryParams = new HashMap<>();
-    /// Controller reads startTimestamp/endTimestamp (ms); see PinotSegmentRestletResource#getSelectedSegments.
+    /// Controller reads startTimestamp/endTimestamp (ms); see PinotSegmentRestletResource#getSegments.
     queryParams.put("startTimestamp", String.valueOf(startTimestampMs));
     queryParams.put("endTimestamp", String.valueOf(endTimestampMs));
     queryParams.put("excludeReplacedSegments", String.valueOf(excludeReplacedSegments));
     if (tableType != null) {
       queryParams.put("type", tableType);
     }
-    JsonNode response = _transport.executeGet(_controllerAddress, "/segments/" + tableName + "/select",
+    JsonNode response = _transport.executeGet(_controllerAddress, "/segments/" + tableName,
         queryParams, _headers);
     return response.toString();
   }

--- a/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/admin/PinotAdminClientTest.java
+++ b/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/admin/PinotAdminClientTest.java
@@ -499,7 +499,7 @@ public class PinotAdminClientTest {
 
     _adminClient.getSegmentClient().selectSegments("tbl1", "OFFLINE", 100L, 200L, true);
 
-    verify(_mockTransport).executeGet(eq(CONTROLLER_ADDRESS), eq("/segments/tbl1/select"),
+    verify(_mockTransport).executeGet(eq(CONTROLLER_ADDRESS), eq("/segments/tbl1"),
         eq(Map.of("startTimestamp", "100", "endTimestamp", "200", "excludeReplacedSegments", "true", "type",
             "OFFLINE")), eq(HEADERS));
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -130,12 +130,6 @@ import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_K
 ///     - "GET /segments/{tableName}/servers"
 ///   - Requests with mandatory "type":
 ///     - "DELETE /segments/{tableName}"
-/// - Deprecated APIs:
-///   - "GET /tables/{tableName}/segments"
-///   - "GET /tables/{tableName}/segments/metadata"
-///   - "GET /tables/{tableName}/segments/crc"
-///   - "GET /tables/{tableName}/segments/{segmentName}"
-///   - "GET /tables/{tableName}/segments/{segmentName}/metadata"
 @Api(tags = Constants.SEGMENT_TAG, authorizations = {
     @Authorization(value = SWAGGER_AUTHORIZATION_KEY),
     @Authorization(value = DATABASE)

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1787,17 +1787,6 @@ public class PinotHelixResourceManager {
     LOGGER.info("Updated schema: {}", schemaName);
   }
 
-  /// Delete the given schema.
-  /// @param schema The schema to be deleted.
-  /// @return True on success, false otherwise.
-  @Deprecated
-  public boolean deleteSchema(Schema schema) {
-    if (schema != null) {
-      deleteSchema(schema.getSchemaName());
-    }
-    return false;
-  }
-
   /// Deletes the given schema. Returns `true` when schema exists, `false` when schema does not exist.
   public boolean deleteSchema(String schemaName) {
     LOGGER.info("Deleting schema: {}", schemaName);
@@ -1819,12 +1808,6 @@ public class PinotHelixResourceManager {
   @Nullable
   public Schema getTableSchema(String tableName) {
     return ZKMetadataProvider.getTableSchema(_propertyStore, tableName);
-  }
-
-  @Deprecated
-  @Nullable
-  public Schema getSchemaForTableConfig(TableConfig tableConfig) {
-    return ZKMetadataProvider.getTableSchema(_propertyStore, tableConfig);
   }
 
   /// Get all schema names in the cluster across all databases.

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/bloom/OnHeapGuavaBloomFilterCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/bloom/OnHeapGuavaBloomFilterCreator.java
@@ -49,14 +49,6 @@ public class OnHeapGuavaBloomFilterCreator implements BloomFilterCreator {
   private final BloomFilter<String> _bloomFilter;
   private final FieldSpec.DataType _dataType;
 
-  // TODO: This method is here for compatibility reasons, should be removed in future PRs
-  //  exit_criteria: Not needed in Apache Pinot once #10184 is merged
-  @Deprecated
-  public OnHeapGuavaBloomFilterCreator(File indexDir, String columnName, int cardinality,
-      BloomFilterConfig bloomFilterConfig) {
-    this(indexDir, columnName, cardinality, bloomFilterConfig, null);
-  }
-
   public OnHeapGuavaBloomFilterCreator(File indexDir, String columnName, int cardinality,
       BloomFilterConfig bloomFilterConfig, FieldSpec.DataType dataType) {
     _dataType = dataType;


### PR DESCRIPTION
Part of #19147.

Removes APIs whose deprecations shipped in the 1.0.0 cycle (2023 H1). Part of a series of per-release deprecation sweeps.

All removed members were verified to have zero non-deprecated production callers. Full-reactor `test-compile`, `checkstyle:check`, and `license:check` pass.

## Removed

- **`OnHeapGuavaBloomFilterCreator`** 4-arg constructor. Its own TODO named #10184 as the exit criteria, which merged long ago. Both remaining call sites already use the 5-arg form.
- **`PinotHelixResourceManager.deleteSchema(Schema)`** — also returned `false` on its success path. Every remaining `deleteSchema` call site passes a `String`.
- **`PinotHelixResourceManager.getSchemaForTableConfig(TableConfig)`** — see the correction below; this one is a 1.4.0-era deprecation, not 1.0.0.
- **Stale class javadoc** in `PinotSegmentRestletResource`: a "Deprecated APIs" section listing five `/tables/{tableName}/segments*` endpoints that no longer exist anywhere in the codebase.

## Staged: `/segments/{tableName}/select`

`SegmentAdminClient.selectSegments` is repointed from the deprecated `GET /segments/{tableName}/select` to `GET /segments/{tableName}`, which is an exact functional superset (same response shape `List<Map<TableType, List<String>>>`, same timestamp parsing and validation, equivalent authorization — both resolve to action `GetSegment` with `TargetType.TABLE`).

The **deprecated endpoint is intentionally retained in this PR**. `pinot-java-client` has been shipping a `selectSegments` that calls `/select` throughout the 1.5.x and 1.6.x train; since controllers upgrade before client fleets, deleting it now would 404 every already-deployed client. It can be deleted once this client migration has had a release to propagate.

### Two behavior changes worth calling out

Both make the client match its own documented contract, but they are observable:

1. **`selectSegments(..., excludeReplacedSegments=false)` now returns replaced segments.** The old `/select` endpoint never read that query parameter — it hardcoded `getSegmentsFor(tableNameWithType, true, ...)` — so the flag the client had always been sending was silently ignored and replaced segments were *always* excluded. The new endpoint honors it. Callers passing `false` will see a larger result set. The only in-repo caller (`LaunchBackfillIngestionJobCommand`) passes `true` and is unaffected.
2. **The `database` header is now honored** for segment selection, consistent with every other `/segments/*` endpoint. `/select` ignored it.

## Correction: one item is in the wrong release bucket

Thanks to @yashmayya for catching this. **`getSchemaForTableConfig` was not deprecated in 1.0.0** — it was still a live method with real fallback logic at `release-1.3.0`, and `@Deprecated` first appears at `release-1.4.0`, added by #15333 (Mar 2025) when schema became mandatory for all tables.

I re-verified against the tags and confirm his reading:

| tag | deprecated? |
|---|---|
| release-1.0.0 → release-1.3.0 | no |
| release-1.4.0 → release-1.5.1 | yes |

I then re-ran the same check against **every** member removed across all five PRs in this series (does it carry `@Deprecated` at `release-1.3.0`?) — this is the only one that was mis-bucketed. The root cause was my own method: I dated each group by git-blaming one representative line and assumed neighbouring members shared its vintage, which is exactly wrong for a method deprecated two years after its neighbour.

I've kept the removal here and called it out explicitly in the commit message rather than moving it, since it still has genuine runway (1.4.0, 1.5.0, 1.5.1) and no remaining callers — but say the word if you'd rather I pull it out and hold it for a 1.4.0 sweep.

## Not removed

`POST /instances/{instanceName}/state` was in the original sweep list but stays: `InstanceAdminClient.setInstanceState` is a live non-deprecated caller, and the POST handler supports a `drop` operation the replacement PUT handler does not.

## backward-incompat

Please apply the **`backward-incompat`** label. The removed `PinotHelixResourceManager` methods are source-breaking for controller plugins, and the removed bloom-filter constructor is source-breaking for out-of-tree index code. Release note should carry the two `selectSegments` behavior changes above.
