### PR TITLE
Remove APIs deprecated in 1.2.0

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
@@ -110,12 +110,6 @@ public interface BrokerResponse {
   /// Returns the processing exceptions encountered during the query execution.
   List<QueryProcessingException> getExceptions();
 
-  @Deprecated
-  @JsonIgnore
-  default List<QueryProcessingException> getProcessingExceptions() {
-    return getExceptions();
-  }
-
   @JsonIgnore
   default int getExceptionsSize() {
     return getExceptions().size();

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -524,15 +524,6 @@ public class RequestUtils {
     return getFunctionExpression(getFunction(canonicalName, operands));
   }
 
-  @Deprecated
-  public static Expression getFunctionExpression(String canonicalName) {
-    assert canonicalName.equalsIgnoreCase(canonicalizeFunctionNamePreservingSpecialKey(canonicalName));
-    Expression expression = new Expression(ExpressionType.FUNCTION);
-    Function function = new Function(canonicalName);
-    expression.setFunctionCall(function);
-    return expression;
-  }
-
   /// Converts the function name into its canonical form.
   public static String canonicalizeFunctionName(String functionName) {
     return StringUtils.remove(functionName, '_').toLowerCase();
@@ -682,11 +673,6 @@ public class RequestUtils {
 
   public static Set<String> getTableNames(PinotQuery pinotQuery) {
     return getTableNames(pinotQuery.getDataSource());
-  }
-
-  @Deprecated
-  public static Map<String, String> getOptionsFromJson(JsonNode request, String optionsKey) {
-    return getOptionsFromString(request.get(optionsKey).asText());
   }
 
   public static Map<String, String> getOptionsFromString(String optionStr) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableInstances.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableInstances.java
@@ -50,7 +50,6 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.pinot.common.exception.TableNotFoundException;
 import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.common.utils.SimpleHttpResponse;
 import org.apache.pinot.common.utils.http.HttpClient;
@@ -156,28 +155,6 @@ public class PinotTableInstances {
     ret.set("brokers", brokers);
     ret.set("server", servers);   // Keeping compatibility with previous API, so "server" and "brokers"
     return ret.toString();
-  }
-
-  @Deprecated
-  @GET
-  @Path("/tables/{tableName}/livebrokers")
-  @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_BROKER)
-  @Produces(MediaType.APPLICATION_JSON)
-  @ApiOperation(value = "List the brokers serving a table", notes = "List live brokers of the given table based on EV")
-  @ApiResponses(value = {
-      @ApiResponse(code = 200, message = "Success"),
-      @ApiResponse(code = 404, message = "Table not found"),
-      @ApiResponse(code = 500, message = "Internal server error")
-  })
-  public List<String> getLiveBrokersForTable(
-      @ApiParam(value = "Table name (with or without type)", required = true)
-      @PathParam("tableName") String tableName, @Context HttpHeaders headers) {
-    tableName = DatabaseUtils.translateTableName(tableName, headers);
-    try {
-      return _pinotHelixResourceManager.getLiveBrokersForTable(tableName);
-    } catch (TableNotFoundException e) {
-      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.NOT_FOUND);
-    }
   }
 
   @GET


### PR DESCRIPTION
Part of #19147.

Removes APIs whose deprecations shipped in the 1.2.0 cycle (2024). Part of a series of per-release deprecation sweeps.

All removed members were verified to have zero non-deprecated production callers. Full-reactor `test-compile`, `checkstyle:check`, and `license:check` pass. No test changes were needed — nothing referenced any removed API.

## Removed

- **`GET /tables/{tableName}/livebrokers`** (singular). The plural `GET /tables/livebrokers` remains. Note the two return different shapes, so external callers of the singular form need more than a path change — see below.
- **`RequestUtils.getFunctionExpression(String)`** and **`getOptionsFromJson(JsonNode, String)`**. Both had zero callers; the non-deprecated `getFunctionExpression(Function)` overload is untouched and still used by `ClpRewriter`.
- **`BrokerResponse.getProcessingExceptions()`** — a `@JsonIgnore` default method with no callers, so the broker JSON response shape is unchanged. (The same-named methods on `RequestContext` are an unrelated interface and are untouched.)

## Deliberately excluded

Two items from the original sweep were dropped after investigation:

**`POST /segments/{tableName}/delete`** — removing this requires migrating `SegmentAdminClient` to `DELETE /segments/{tableName}` first, and that migration turned out to be unsafe in two independent ways: the DELETE endpoint treats a *missing* `segments` parameter as "delete every segment in the table" (so an empty list silently escalates from a 400 into whole-table deletion), and its `@QueryParam("segments") List<String>` binding only populates from repeated `segments=a&segments=b` parameters, so a comma-joined value arrives as one bogus segment name and silently no-ops. Both bugs appear to exist in the current client's DELETE path independently of this PR and deserve their own fix.

**`SegmentLocks`** static factories — `ConcurrentMapPartitionUpsertMetadataManagerForConsistentDeletes` still calls the deprecated static `getSegmentLock`. Migrating it to the instance method would change lock scoping from a global static cache to per-`TableDataManager` locks, which is a concurrency-semantics change that does not belong in a deprecation sweep.

**`TableAndSchemaConfig`** was also left in place: it is still the request-body DTO of `PinotUpsertRestletResource`, and its JSON shape (`{tableConfig, schema}`) differs from `TableConfigs` (`{tableName, schema, offline, realtime}`), so swapping it would break the public REST contract.

## backward-incompat

Please apply the **`backward-incompat`** label.

The removed **`GET /tables/{tableName}/livebrokers`** endpoint 404s for external clients after upgrade, and the replacement is not a drop-in: `GET /tables/livebrokers` returns `Map<String, List<InstanceInfo>>` rather than the singular endpoint's `List<String>`. The removed `RequestUtils` public statics are source-breaking for out-of-tree code compiled against `pinot-common`.
