### PR TITLE
Remove APIs deprecated in 1.3.0

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/utils/BrokerSelectorUtils.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/utils/BrokerSelectorUtils.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.client.utils;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -31,22 +30,6 @@ import org.apache.pinot.client.ExternalViewReader;
 public class BrokerSelectorUtils {
 
   private BrokerSelectorUtils() {
-  }
-
-  /// @param tableNames: List of table names.
-  /// @param brokerData: map holding data for table hosting on brokers.
-  /// @return list of common brokers hosting all the tables or null if no common brokers found.
-  /// @deprecated Use [#getTablesCommonBrokersSet(List, Map)] instead. It is more efficient and its semantics are
-  /// clearer (ie it returns an empty set instead of null if no common brokers are found).
-  @Nullable
-  @Deprecated
-  public static List<String> getTablesCommonBrokers(@Nullable List<String> tableNames,
-      Map<String, List<String>> brokerData) {
-    Set<String> tablesCommonBrokersSet = getTablesCommonBrokersSet(tableNames, brokerData);
-    if (tablesCommonBrokersSet == null || tablesCommonBrokersSet.isEmpty()) {
-      return null;
-    }
-    return new ArrayList<>(tablesCommonBrokersSet);
   }
 
   /// Returns a random broker from the common brokers hosting all the tables.

--- a/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/utils/BrokerSelectorUtilsTest.java
+++ b/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/utils/BrokerSelectorUtilsTest.java
@@ -36,21 +36,9 @@ public class BrokerSelectorUtilsTest {
   }
 
   @Test
-  public void getTablesCommonBrokersListNullTables() {
-    List<String> tableList = BrokerSelectorUtils.getTablesCommonBrokers(null, _brokerData);
-    Assert.assertNull(tableList);
-  }
-
-  @Test
   public void getTablesCommonBrokersSetEmptyTables() {
     Set<String> tableSet = BrokerSelectorUtils.getTablesCommonBrokersSet(List.of(), _brokerData);
     Assert.assertEquals(tableSet, Set.of());
-  }
-
-  @Test
-  public void getTablesCommonBrokersListEmptyTables() {
-    List<String> tableList = BrokerSelectorUtils.getTablesCommonBrokers(List.of(), _brokerData);
-    Assert.assertNull(tableList);
   }
 
   @Test
@@ -60,24 +48,10 @@ public class BrokerSelectorUtilsTest {
   }
 
   @Test
-  public void getTablesCommonBrokersListNotExistentTable() {
-    List<String> tableList = BrokerSelectorUtils.getTablesCommonBrokers(List.of("notExistent"), _brokerData);
-    Assert.assertNull(tableList);
-  }
-
-  @Test
   public void getTablesCommonBrokersSetOneTable() {
     _brokerData.put("table1", List.of("broker1"));
     Set<String> tableSet = BrokerSelectorUtils.getTablesCommonBrokersSet(List.of("table1"), _brokerData);
     Assert.assertEquals(tableSet, Set.of("broker1"));
-  }
-
-  @Test
-  public void getTablesCommonBrokersListOneTable() {
-    _brokerData.put("table1", List.of("broker1"));
-    List<String> tableList = BrokerSelectorUtils.getTablesCommonBrokers(List.of("table1"), _brokerData);
-    Assert.assertNotNull(tableList);
-    Assert.assertEquals(tableList, List.of("broker1"));
   }
 
   @Test
@@ -90,28 +64,11 @@ public class BrokerSelectorUtilsTest {
   }
 
   @Test
-  public void getTablesCommonBrokersListTwoTables() {
-    _brokerData.put("table1", List.of("broker1"));
-    _brokerData.put("table2", List.of("broker1"));
-    List<String> tableList = BrokerSelectorUtils.getTablesCommonBrokers(List.of("table1", "table2"), _brokerData);
-    Assert.assertNotNull(tableList);
-    Assert.assertEquals(tableList, List.of("broker1"));
-  }
-
-  @Test
   public void getTablesCommonBrokersSetTwoTablesDifferentBrokers() {
     _brokerData.put("table1", List.of("broker1"));
     _brokerData.put("table2", List.of("broker2"));
     Set<String> tableSet = BrokerSelectorUtils.getTablesCommonBrokersSet(List.of("table1", "table2"), _brokerData);
     Assert.assertEquals(tableSet, Set.of());
-  }
-
-  @Test
-  public void getTablesCommonBrokersListTwoTablesDifferentBrokers() {
-    _brokerData.put("table1", List.of("broker1"));
-    _brokerData.put("table2", List.of("broker2"));
-    List<String> tableList = BrokerSelectorUtils.getTablesCommonBrokers(List.of("table1", "table2"), _brokerData);
-    Assert.assertNull(tableList);
   }
 
   @AfterMethod

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
@@ -195,13 +195,6 @@ public class FunctionRegistry {
     return FUNCTION_MAP.containsKey(canonicalName);
   }
 
-  /// @deprecated For performance concern, use [#contains(String)] instead to avoid invoking
-  ///             [#canonicalize(String)] multiple times.
-  @Deprecated
-  public static boolean containsFunction(String name) {
-    return contains(canonicalize(name));
-  }
-
   /// Returns the [FunctionInfo] associated with the given canonical name and argument types, or `null` if
   /// there is no matching method. This method should be called after the FunctionRegistry is initialized and all
   /// methods
@@ -220,14 +213,6 @@ public class FunctionRegistry {
   public static FunctionInfo lookupFunctionInfo(String canonicalName, int numArguments) {
     PinotScalarFunction function = FUNCTION_MAP.get(canonicalName);
     return function != null ? function.getFunctionInfo(numArguments) : null;
-  }
-
-  /// @deprecated For performance concern, use [#lookupFunctionInfo(String, int)] instead to avoid invoking
-  ///             [#canonicalize(String)] multiple times.
-  @Deprecated
-  @Nullable
-  public static FunctionInfo getFunctionInfo(String name, int numArguments) {
-    return lookupFunctionInfo(canonicalize(name), numArguments);
   }
 
   public static String canonicalize(String name) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -290,11 +290,6 @@ public enum TransformFunctionType {
     return _names;
   }
 
-  @Deprecated
-  public List<String> getAlternativeNames() {
-    return _names;
-  }
-
   public SqlReturnTypeInference getReturnTypeInference() {
     return _returnTypeInference;
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
@@ -32,9 +32,10 @@ import org.apache.pinot.spi.utils.JsonUtils;
 
 /*
  * This class encapsulates the segment completion protocol used by the server and the controller for
- * low-level consumer realtime segments. The protocol has two requests: SegmentConsumedRequest
- * and SegmentCommitRequest.It has a response that may contain different status codes depending on the state machine
- * that the controller drives for that segment. All responses have two elements -- status and an offset.
+ * low-level consumer realtime segments. The protocol has a SegmentConsumedRequest and a split-commit request
+ * sequence (SegmentCommitStartRequest, segment upload, SegmentCommitEndWithMetadataRequest). It has a response that
+ * may contain different status codes depending on the state machine that the controller drives for that segment. All
+ * responses have two elements -- status and an offset.
  *
  * The overall idea is that when a server has completed consuming a segment until the "end criteria" that
  * is set (in the table configuration), it sends a SegmentConsumedRequest to the controller (leader).  The
@@ -42,8 +43,8 @@ import org.apache.pinot.spi.utils.JsonUtils;
  * to the controller after a while.
  *
  * Meanwhile, the controller co-ordinates the SegmentConsumedRequest messages from replicas and selects a server
- * to commit the segment. The server uses SegmentCommitRequest message, in which it also posts the completed
- * segment to the controller.
+ * to commit the segment. The selected server commits the segment via the split-commit sequence: it sends a
+ * SegmentCommitStartRequest, uploads the completed segment, and finishes with a SegmentCommitEndWithMetadataRequest.
  *
  * The controller may respond with a failure for this commit message, but on success, the controller changes the
  * segment state to ONLINE in idealstate, and adds new CONSUMING segments as well.
@@ -69,7 +70,7 @@ public class SegmentCompletionProtocol {
     /// Never sent by the controller, but locally used by server when sending a request fails
     NOT_SENT,
 
-    /// Server should send back a SegmentCommitRequest after processing this response
+    /// Server should start the split-commit sequence (SegmentCommitStartRequest) after processing this response
     COMMIT,
 
     /// Server should send SegmentConsumedRequest after waiting for less than MAX_HOLD_TIME_MS
@@ -112,6 +113,7 @@ public class SegmentCompletionProtocol {
   public static final String STREAM_PARTITION_MSG_OFFSET_KEY = "streamPartitionMsgOffset";
 
   public static final String MSG_TYPE_CONSUMED = "segmentConsumed";
+  // The non-split-commit endpoint is gone, but this message type remains as the segment-completion FSM lookup key.
   public static final String MSG_TYPE_COMMIT = "segmentCommit";
   public static final String MSG_TYPE_COMMIT_START = "segmentCommitStart";
   public static final String MSG_TYPE_SEGMENT_UPLOAD = "segmentUpload";
@@ -392,12 +394,6 @@ public class SegmentCompletionProtocol {
   public static class SegmentConsumedRequest extends Request {
     public SegmentConsumedRequest(Params params) {
       super(params, MSG_TYPE_CONSUMED);
-    }
-  }
-
-  public static class SegmentCommitRequest extends Request {
-    public SegmentCommitRequest(Params params) {
-      super(params, MSG_TYPE_COMMIT);
     }
   }
 

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/FastJsonPathExtractorTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/FastJsonPathExtractorTest.java
@@ -423,7 +423,8 @@ public class FastJsonPathExtractorTest {
 
   private static Object invoke(String name, Object... arguments)
       throws Exception {
-    FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(name, arguments.length);
+    FunctionInfo functionInfo =
+        FunctionRegistry.lookupFunctionInfo(FunctionRegistry.canonicalize(name), arguments.length);
     assertNotNull(functionInfo, name + "/" + arguments.length + " is not registered");
     FunctionInvoker invoker = new FunctionInvoker(functionInfo);
     Object[] copy = arguments.clone();

--- a/pinot-common/src/test/java/org/apache/pinot/common/protocols/SegmentCompletionProtocolTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/protocols/SegmentCompletionProtocolTest.java
@@ -82,9 +82,9 @@ public class SegmentCompletionProtocolTest {
         .withInstanceId("Server_localhost_8099").withReason("ROW_LIMIT").withBuildTimeMillis(1000)
         .withWaitTimeMillis(2000).withExtraTimeSec(3000).withMemoryUsedBytes(4000).withSegmentSizeBytes(5000)
         .withNumRows(6000).withSegmentLocation("/tmp/segment").withStreamPartitionMsgOffset("7000");
-    SegmentCompletionProtocol.SegmentCommitRequest segmentCommitRequest =
-        new SegmentCompletionProtocol.SegmentCommitRequest(params);
-    uri = new URI(segmentCommitRequest.getUrl("localhost:8080", "http"));
+    SegmentCompletionProtocol.SegmentCommitStartRequest commitStartRequestWithAllParams =
+        new SegmentCompletionProtocol.SegmentCommitStartRequest(params);
+    uri = new URI(commitStartRequestWithAllParams.getUrl("localhost:8080", "http"));
     paramsMap =
         Arrays.stream(uri.getQuery().split("&")).collect(Collectors.toMap(e -> e.split("=")[0], e -> e.split("=")[1]));
     Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_SEGMENT_NAME), "foo__0__0__12345Z");

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentUtils.java
@@ -307,25 +307,6 @@ public class SegmentAssignmentUtils {
     return instanceStateMap;
   }
 
-  /// Returns a map from instance name to number of segments to be moved to it.
-  @Deprecated
-  public static Map<String, Integer> getNumSegmentsToBeMovedPerInstance(Map<String, Map<String, String>> oldAssignment,
-      Map<String, Map<String, String>> newAssignment) {
-    Map<String, Integer> numSegmentsToBeMovedPerInstance = new TreeMap<>();
-    for (Map.Entry<String, Map<String, String>> entry : newAssignment.entrySet()) {
-      String segmentName = entry.getKey();
-      Set<String> newInstancesAssigned = entry.getValue().keySet();
-      Set<String> oldInstancesAssigned = oldAssignment.get(segmentName).keySet();
-      // For each new assigned instance, check if the segment needs to be moved to it
-      for (String instanceName : newInstancesAssigned) {
-        if (!oldInstancesAssigned.contains(instanceName)) {
-          numSegmentsToBeMovedPerInstance.merge(instanceName, 1, Integer::sum);
-        }
-      }
-    }
-    return numSegmentsToBeMovedPerInstance;
-  }
-
   /// Returns a map from instance name to number of segments to be added/removed.
   public static Map<String, IntIntPair> getNumSegmentsToMovePerInstance(Map<String, Map<String, String>> oldAssignment,
       Map<String, Map<String, String>> newAssignment) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -727,13 +727,6 @@ public class QueryContext {
       return this;
     }
 
-    /// @deprecated Use [#setExplain(ExplainMode)] instead.
-    @Deprecated
-    public Builder setExplain(boolean explain) {
-      _explain = explain ? ExplainMode.DESCRIPTION : ExplainMode.NONE;
-      return this;
-    }
-
     public Builder setExplain(ExplainMode explain) {
       _explain = explain;
       return this;

--- a/pinot-core/src/main/java/org/apache/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
@@ -21,7 +21,6 @@ package org.apache.pinot.server.realtime;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
@@ -44,7 +43,6 @@ import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.common.utils.http.HttpClient;
 import org.apache.pinot.common.utils.http.HttpClientConfig;
 import org.apache.pinot.core.data.manager.realtime.SegmentCompletionUtils;
-import org.apache.pinot.core.data.manager.realtime.Server2ControllerSegmentUploader;
 import org.apache.pinot.core.util.SegmentCompletionProtocolUtils;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.spi.auth.AuthProvider;
@@ -158,26 +156,6 @@ public class ServerSegmentCompletionProtocolHandler {
       return SegmentCompletionProtocol.RESP_NOT_SENT;
     }
     return sendCommitEndWithMetadataFiles(url, metadataFiles);
-  }
-
-  public SegmentCompletionProtocol.Response segmentCommit(SegmentCompletionProtocol.Request.Params params,
-      final File segmentTarFile) {
-    SegmentCompletionProtocol.SegmentCommitRequest request = new SegmentCompletionProtocol.SegmentCommitRequest(params);
-    String url = createSegmentCompletionUrl(request);
-    if (url == null) {
-      return SegmentCompletionProtocol.RESP_NOT_SENT;
-    }
-
-    Server2ControllerSegmentUploader segmentUploader = null;
-    try {
-      segmentUploader =
-          new Server2ControllerSegmentUploader(LOGGER, _fileUploadDownloadClient, url, params.getSegmentName(),
-              _segmentUploadRequestTimeoutMs, _serverMetrics, _authProvider, _rawTableName);
-    } catch (URISyntaxException e) {
-      LOGGER.error("Segment commit upload url error: ", e);
-      return SegmentCompletionProtocol.RESP_NOT_SENT;
-    }
-    return segmentUploader.uploadSegmentToController(segmentTarFile);
   }
 
   public SegmentCompletionProtocol.Response extendBuildTime(SegmentCompletionProtocol.Request.Params params) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/BasePartitionDedupMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/BasePartitionDedupMetadataManager.java
@@ -45,7 +45,6 @@ import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.spi.config.table.HashFunction;
-import org.apache.pinot.spi.data.readers.PrimaryKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,12 +99,6 @@ public abstract class BasePartitionDedupMetadataManager implements PartitionDedu
   @Override
   public DedupContext getContext() {
     return _context;
-  }
-
-  @Override
-  public boolean checkRecordPresentOrUpdate(PrimaryKey pk, IndexSegment indexSegment) {
-    throw new UnsupportedOperationException(
-        "checkRecordPresentOrUpdate(PrimaryKey pk, IndexSegment indexSegment) is " + "deprecated!");
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/PartitionDedupMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/PartitionDedupMetadataManager.java
@@ -22,7 +22,6 @@ import java.io.Closeable;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
-import org.apache.pinot.spi.data.readers.PrimaryKey;
 
 
 public interface PartitionDedupMetadataManager extends Closeable {
@@ -56,22 +55,14 @@ public interface PartitionDedupMetadataManager extends Closeable {
   /// Remove the expired primary keys from the metadata when TTL is enabled.
   void removeExpiredPrimaryKeys();
 
-  /// Add the primary key to the given segment to the dedup matadata if it is absent.
-  /// Returns true if the key was already present, i.e., the new record associated with the given [PrimaryKey]
-  /// is a duplicate and should be skipped/dropped.
-  @Deprecated
-  boolean checkRecordPresentOrUpdate(PrimaryKey pk, IndexSegment indexSegment);
-
-  /// Add the primary key to the given segment to the dedup matadata if it is absent and with in the retention time.
+  /// Add the primary key to the given segment to the dedup metadata if it is absent and within the retention time.
   /// Returns true if the key was already present, i.e., the new record associated with the given
   /// [DedupRecordInfo] is a duplicate and should be skipped/dropped.
   /// @param dedupRecordInfo  The primary key and the dedup time.
   /// @param indexSegment  The segment to which the record belongs.
   /// @return true if the key was already present, i.e., the new record associated with the given
   /// [DedupRecordInfo] is a duplicate and should be skipped/dropped.
-  default boolean checkRecordPresentOrUpdate(DedupRecordInfo dedupRecordInfo, IndexSegment indexSegment) {
-    return checkRecordPresentOrUpdate(dedupRecordInfo.getPrimaryKey(), indexSegment);
-  }
+  boolean checkRecordPresentOrUpdate(DedupRecordInfo dedupRecordInfo, IndexSegment indexSegment);
 
   /// Stops the metadata manager. After invoking this method, no access to the metadata will be accepted.
   void stop();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/RealtimeSegmentConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/RealtimeSegmentConfig.java
@@ -389,13 +389,6 @@ public class RealtimeSegmentConfig {
 
     /// Whether null handling is enabled by default. This value is only used if
     /// [Schema#isEnableColumnBasedNullHandling()] is false.
-    @Deprecated
-    public Builder setNullHandlingEnabled(boolean nullHandlingEnabled) {
-      return setDefaultNullHandlingEnabled(nullHandlingEnabled);
-    }
-
-    /// Whether null handling is enabled by default. This value is only used if
-    /// [Schema#isEnableColumnBasedNullHandling()] is false.
     public Builder setDefaultNullHandlingEnabled(boolean defaultNullHandlingEnabled) {
       _defaultNullHandlingEnabled = defaultNullHandlingEnabled;
       return this;

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/dedup/BasePartitionDedupMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/dedup/BasePartitionDedupMetadataManagerTest.java
@@ -79,6 +79,11 @@ public class BasePartitionDedupMetadataManagerTest {
     }
 
     @Override
+    public boolean checkRecordPresentOrUpdate(DedupRecordInfo dedupRecordInfo, IndexSegment indexSegment) {
+      return false;
+    }
+
+    @Override
     public long getNumPrimaryKeys() {
       return 0;
     }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -544,32 +544,14 @@ public class SegmentGeneratorConfig implements Serializable {
 
   /// Whether null handling is enabled by default. This value is only used if
   /// [Schema#isEnableColumnBasedNullHandling()] is false.
-  ///
-  /// @deprecated Use [#isDefaultNullHandlingEnabled()] instead
-  @Deprecated
-  public boolean isNullHandlingEnabled() {
-    return _defaultNullHandlingEnabled;
-  }
-
-  /// Whether null handling is enabled by default. This value is only used if
-  /// [Schema#isEnableColumnBasedNullHandling()] is false.
   public boolean isDefaultNullHandlingEnabled() {
     return _defaultNullHandlingEnabled;
   }
 
   /// Whether null handling is enabled by default. This value is only used if
   /// [Schema#isEnableColumnBasedNullHandling()] is false.
-  ///
-  /// @deprecated Use [#setDefaultNullHandlingEnabled(boolean)] instead
-  @Deprecated
-  public void setNullHandlingEnabled(boolean nullHandlingEnabled) {
-    setDefaultNullHandlingEnabled(nullHandlingEnabled);
-  }
-
-  /// Whether null handling is enabled by default. This value is only used if
-  /// [Schema#isEnableColumnBasedNullHandling()] is false.
-  public void setDefaultNullHandlingEnabled(boolean nullHandlingEnabled) {
-    _defaultNullHandlingEnabled = nullHandlingEnabled;
+  public void setDefaultNullHandlingEnabled(boolean defaultNullHandlingEnabled) {
+    _defaultNullHandlingEnabled = defaultNullHandlingEnabled;
   }
 
   public boolean isContinueOnError() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/annotations/ScalarFunction.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/annotations/ScalarFunction.java
@@ -68,6 +68,4 @@ public @interface ScalarFunction {
   /// existing function has been audited for environment-sensitive behavior. When class-level and method-level
   /// declarations coexist, the most volatile category wins.
   FunctionVolatility volatility() default FunctionVolatility.IMMUTABLE;
-
-  @Deprecated boolean isPlaceholder() default false;
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -905,22 +905,6 @@ public final class Schema implements Serializable {
     return result;
   }
 
-  /// @deprecated this method is not correctly implemented. ie doesn't call super.clone and does not create a deep copy
-  /// of the fieldSpecs.
-  @Deprecated
-  @Override
-  public Schema clone() {
-    Schema cloned = new SchemaBuilder()
-        .setSchemaName(getSchemaName())
-        .setDescription(getDescription())
-        .setTags(getTags())
-        .setPrimaryKeyColumns(getPrimaryKeyColumns())
-        .setEnableColumnBasedNullHandling(isEnableColumnBasedNullHandling())
-        .build();
-    getAllFieldSpecs().forEach(fieldSpec -> cloned.addField(fieldSpec));
-    return cloned;
-  }
-
   public static Schema cloneSchemaWithName(Schema source, String newName) {
     try {
       String json = JsonUtils.objectToString(source);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
@@ -443,15 +443,6 @@ public class ControllerRequestURLBuilder {
     return forSegmentsMetadataFromServer(tableName, (List<String>) null);
   }
 
-  @Deprecated
-  public String forSegmentsMetadataFromServer(String tableName, @Nullable String columns) {
-    String url = StringUtil.join("/", _baseUrl, "segments", tableName, "metadata");
-    if (columns != null) {
-      url += "?columns=" + columns;
-    }
-    return url;
-  }
-
   public String forSegmentsMetadataFromServer(String tableName, @Nullable List<String> columns) {
     return forSegmentsMetadataFromServer(tableName, columns, null);
   }


### PR DESCRIPTION
Part of #19147.

Removes APIs whose deprecations shipped in the 1.3.0 cycle (2024 H2 – early 2025). Part of a series of per-release deprecation sweeps.

Every removed member was verified deprecated as of the `release-1.3.0` tag and to have zero non-deprecated production callers. Full-reactor `test-compile`, `checkstyle:check`, and `license:check` pass.

## Removed

- **`FunctionRegistry.containsFunction(String)`** and **`getFunctionInfo(String, int)`** → `contains(canonicalize(name))` / `lookupFunctionInfo(canonicalize(name), n)`.
- **`TransformFunctionType.getAlternativeNames()`**.
- **`ScalarFunction.isPlaceholder()`** annotation attribute — no `@ScalarFunction` application anywhere set it, and nothing read it.
- **`SegmentGeneratorConfig.is/setNullHandlingEnabled`** and **`RealtimeSegmentConfig.Builder.setNullHandlingEnabled`** — pure aliases of the `defaultNullHandlingEnabled` accessors.
- **`Schema.clone()`** (undocumented shallow copy; `cloneSchemaWithName` is untouched).
- **`QueryContext.Builder.setExplain(boolean)`** → the `ExplainMode` overload.
- **`ControllerRequestURLBuilder.forSegmentsMetadataFromServer(String, String)`** → the `List<String>` overload.
- **`SegmentAssignmentUtils.getNumSegmentsToBeMovedPerInstance`** → `getNumSegmentsToMovePerInstance`. (The removed version also carried a latent unchecked-`get` NPE.)
- **`BrokerSelectorUtils.getTablesCommonBrokers`** → `getTablesCommonBrokersSet`, which returns an empty set rather than `null`. Its six List-variant tests were dropped; each had a parallel Set-variant test that remains.
- **Dedup SPI**: the deprecated `checkRecordPresentOrUpdate(PrimaryKey, IndexSegment)` is gone from `PartitionDedupMetadataManager`, and the surviving `DedupRecordInfo` overload is now a plain abstract method rather than a default that delegated into it. See the compat note below.
- **Dead non-split-commit residue**: `ServerSegmentCompletionProtocolHandler.segmentCommit(...)` and `SegmentCompletionProtocol.SegmentCommitRequest`, orphaned when #14559 removed the controller endpoints. These two were never annotated `@Deprecated` — they are dead code removed alongside their release-line neighbours. `MSG_TYPE_COMMIT` is **retained**, with a comment, because it is still the FSM lookup key in `SegmentCompletionManager`.

Also refreshes the `SegmentCompletionProtocol` class javadoc, which still described the removed single-shot commit flow, to document the actual split-commit sequence.

## backward-incompat

Please apply the **`backward-incompat`** label.

Two items deserve explicit release-note treatment:

1. **Custom dedup metadata managers** (`dedupConfig.metadataManagerClass`, loaded reflectively) must now implement `checkRecordPresentOrUpdate(DedupRecordInfo, IndexSegment)` directly. An implementation that only overrode the deprecated `PrimaryKey` variant previously worked via the default delegation; it will now fail with `AbstractMethodError` at ingestion time. Such implementations were already broken in practice — the base class's `PrimaryKey` override threw `UnsupportedOperationException` — but the failure mode changes.
2. **Binary-breaking `pinot-spi` / `pinot-segment-spi` / `pinot-java-client` removals**: old binaries calling e.g. `Schema.clone()` will get `NoSuchMethodError`. Replacements are listed above.

No config keys, wire formats, or ZK-serialized fields are touched.

### The Binary Compatibility Check fails on this PR, by design

`Pinot Binary Compatibility Check` runs japicmp with `--error-on-binary-incompatibility` over `pinot-spi` / `pinot-segment-spi`, with no allowlist or label-based bypass. It reports exactly the three removals this PR intends:

```
ScalarFunction.isPlaceholder()                                       : METHOD_REMOVED
Schema.clone()                                                       : METHOD_REMOVED
ControllerRequestURLBuilder.forSegmentsMetadataFromServer(String, String) : METHOD_REMOVED
```

The red X is the gate correctly doing its job on an intentionally binary-incompatible change. Removing these symbols *is* the point of the PR, so this check is expected to fail and can be skipped here. It is not a required check (`mergeStateStatus` is `UNSTABLE`, not `BLOCKED`), so it does not block merge.
