### PR TITLE
fix: handle optional segments, unavailable segments, and empty partitions in WorkerManager (#18223)

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -568,8 +569,16 @@ public class WorkerManager {
       for (Map.Entry<ServerInstance, SegmentsToQuery> serverEntry : segmentsMap.entrySet()) {
         Map<String, List<String>> tableTypeToSegmentListMap =
             serverInstanceToSegmentsMap.computeIfAbsent(serverEntry.getKey(), k -> new HashMap<>());
-        // TODO: support optional segments for multi-stage engine.
-        Preconditions.checkState(tableTypeToSegmentListMap.put(tableType, serverEntry.getValue().getSegments()) == null,
+        // Merge required and optional segments for multi-stage engine.
+        List<String> segments = serverEntry.getValue().getSegments();
+        List<String> optionalSegments = serverEntry.getValue().getOptionalSegments();
+        if (optionalSegments != null && !optionalSegments.isEmpty()) {
+          List<String> combinedSegments = new ArrayList<>(segments.size() + optionalSegments.size());
+          combinedSegments.addAll(segments);
+          combinedSegments.addAll(optionalSegments);
+          segments = Collections.unmodifiableList(combinedSegments);
+        }
+        Preconditions.checkState(tableTypeToSegmentListMap.put(tableType, segments) == null,
             "Entry for server {} and table type: {} already exist!", serverEntry.getKey(), tableType);
       }
 
@@ -737,7 +746,13 @@ public class WorkerManager {
       }
     }
 
-    // TODO: Support unavailable segments and optional segments for replicated leaf stage
+    // Attach unavailable segments to metadata for replicated leaf stage
+    Map<String, RoutingTable> routingTableMap = getRoutingTable(tableName, context.getRequestId());
+    for (Map.Entry<String, RoutingTable> entry : routingTableMap.entrySet()) {
+      if (!entry.getValue().getUnavailableSegments().isEmpty()) {
+        metadata.addUnavailableSegments(tableName, entry.getValue().getUnavailableSegments());
+      }
+    }
     metadata.setReplicatedSegments(segmentsMap);
     filterReplicatedLeafStageSegments(context, metadata);
   }
@@ -918,9 +933,17 @@ public class WorkerManager {
     for (Map.Entry<ServerInstance, SegmentsToQuery> serverEntry : segmentsMap.entrySet()) {
       Map<String, List<String>> tableNameToSegmentsMap =
           serverInstanceToLogicalSegmentsMap.computeIfAbsent(serverEntry.getKey(), k -> new HashMap<>());
-      // TODO: support optional segments for multi-stage engine.
+      // Merge required and optional segments for multi-stage engine.
+      List<String> segments = serverEntry.getValue().getSegments();
+      List<String> optionalSegments = serverEntry.getValue().getOptionalSegments();
+      if (optionalSegments != null && !optionalSegments.isEmpty()) {
+        List<String> combinedSegments = new ArrayList<>(segments.size() + optionalSegments.size());
+        combinedSegments.addAll(segments);
+        combinedSegments.addAll(optionalSegments);
+        segments = Collections.unmodifiableList(combinedSegments);
+      }
       Preconditions.checkState(
-          tableNameToSegmentsMap.put(physicalTableName, serverEntry.getValue().getSegments()) == null,
+          tableNameToSegmentsMap.put(physicalTableName, segments) == null,
           "Entry for server {} and physical table: {} already exist!", serverEntry.getKey(), physicalTableName);
     }
   }
@@ -1084,10 +1107,12 @@ public class WorkerManager {
         continue;
       }
       PartitionInfo partitionInfo = partitionInfoMap[i];
-      // TODO: Currently we don't support the case when a partition doesn't contain any segment. The reason is that
-      //       the leaf stage won't be able to directly return empty response.
-      Preconditions.checkState(partitionInfo != null, "Failed to find any segment for table: %s, partition: %s",
-          tableName, i);
+      // Skip partitions that don't contain any segment. The leaf stage can handle empty partitions by
+      // returning an empty response, which is equivalent to a pruned partition.
+      if (partitionInfo == null) {
+        LOGGER.warn("No segment found for table: {}, partition: {}, skipping", tableName, i);
+        continue;
+      }
       // NOTE: Pick worker based on the request id plus the partition id (not a running counter) so that the same worker
       //       is picked across different table scans when the segments for the same partition are colocated, and so
       //       that skipping pruned partitions does not shift the server assignment of the surviving ones.


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Handles optional segments, unavailable segments, and empty partitions in WorkerManager\.

```mermaid
flowchart TD
  N0["Combine required and optional segments for non#45;partitioned leaf fragment #40;F1#41;"]:::stAdded
  N1["Attach unavailable segments to metadata for replicated leaf fragment #40;F1#41;"]:::stAdded
  N2["Skip partitions with no segments and log warning #40;F1#41;"]:::stAdded
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-query\-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager\.java — [before](https://github.com/apache/pinot/blob/dc95530c8d5f7682eb889d2b63c4cad8697a6a9d/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java) · [after](https://github.com/apache/pinot/blob/f69a29a8d7e6d6131100302e5e894d5c83f26344/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImRjOTU1MzBjOGQ1Zjc2ODJlYjg4OWQyYjYzYzRjYWQ4Njk3YTZhOWQiLCJjb250ZXh0X2hhc2giOiIwOGEwNDgyYzhmNzcxMzA2OTIwZGM3ZTI3MTFiODA2NjQxYmY2NDZkM2VmMjc0N2IyZDQzMWQ5ZjJmNWRjMDhhIiwiZ2VuZXJhdGVkX2F0IjoxNzg5NDQzMzExLCJoZWFkX3NoYSI6ImY2OWEyOWE4ZDdlNmQ2MTMxMTAwMzAyZTVlODk0ZDVjODNmMjYzNDQiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJkYzk1NTMwYzhkNWY3NjgyZWI4ODlkMmI2M2M0Y2FkODY5N2E2YTlkIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 0b0575e696c4841bb08bcf9926d5cbc7a571ee45fbb34dddee5f215a721c3106 -->
<!-- pinot-pr-flow:end -->

Closes #18223