### PR TITLE
fix: add column-type precondition check in isFitForNonScanBasedPlan for MINLONG/MAXLONG/MINSTRING/MAXSTRING

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -38,6 +38,7 @@ import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+import org.apache.pinot.spi.data.FieldSpec;
 
 import static org.apache.pinot.segment.spi.AggregationFunctionType.*;
 
@@ -179,6 +180,25 @@ public class AggregationPlanNode implements PlanNode {
       }
       DataSource dataSource = _indexSegment.getDataSource(argument.getIdentifier(), _queryContext.getSchema());
       if (DICTIONARY_BASED_FUNCTIONS.contains(aggregationFunction.getType())) {
+        // MINLONG/MAXLONG can only be resolved from dictionary for INT/LONG columns, because the resolver
+        // (getMinValueLong/getMaxValueLong) requires an integer stored type.
+        AggregationFunctionType functionType = aggregationFunction.getType();
+        if (functionType == MINLONG || functionType == MAXLONG) {
+          FieldSpec.DataType storedType =
+              dataSource.getDataSourceMetadata().getDataType().getStoredType();
+          if (storedType != FieldSpec.DataType.INT && storedType != FieldSpec.DataType.LONG) {
+            return false;
+          }
+        }
+        // MINSTRING/MAXSTRING can only be resolved from dictionary for STRING columns, because the
+        // function rejects numeric columns on the scan path.
+        if (functionType == MINSTRING || functionType == MAXSTRING) {
+          FieldSpec.DataType storedType =
+              dataSource.getDataSourceMetadata().getDataType().getStoredType();
+          if (storedType != FieldSpec.DataType.STRING) {
+            return false;
+          }
+        }
         if (dataSource.getDictionary() != null) {
           continue;
         }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Adds type checks for MINLONG/MAXLONG and MINSTRING/MAXSTRING in isFitForNonScanBasedPlan to fallback to scan path\.

```mermaid
flowchart TD
  N0["dict#45;based function check #40;F1#41;"]:::stUnchanged
  N1["functionType #61;#61; MINLONG#124;#124;MAXLONG #40;F1#41;"]:::stAdded
  N2["get stored type #40;INT#47;LONG#41; #40;F1#41;"]:::stAdded
  N3["storedType not INT#47;LONG #40;F1#41;"]:::stAdded
  N4["return false #40;F1#41;"]:::stAdded
  N5["functionType #61;#61; MINSTRING#124;#124;MAXSTRING #40;F1#41;"]:::stAdded
  N6["get stored type #40;STRING#41; #40;F1#41;"]:::stAdded
  N7["storedType #33;#61; STRING #40;F1#41;"]:::stAdded
  N8["return false #40;F1#41;"]:::stAdded
  N9["dictionary #33;#61; null #40;F1#41;"]:::stUnchanged
  N10["continue #40;F1#41;"]:::stUnchanged
  N0 -->|"if true"| N1
  N1 -->|"MINLONG#47;MAXLONG true"| N2
  N1 -->|"MINLONG#47;MAXLONG false"| N5
  N2 -->|"after get type"| N3
  N3 -->|"type invalid"| N4
  N3 -->|"type valid"| N5
  N5 -->|"MINSTRING#47;MAXSTRING true"| N6
  N5 -->|"MINSTRING#47;MAXSTRING false"| N9
  N6 -->|"after get type"| N7
  N7 -->|"type invalid"| N8
  N7 -->|"type valid"| N9
  N9 -->|"dict present"| N10
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode\.java — [before](https://github.com/apache/pinot/blob/dc95530c8d5f7682eb889d2b63c4cad8697a6a9d/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java) · [after](https://github.com/apache/pinot/blob/c54d941b8df7c935a184be0517348267df87a1e5/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImRjOTU1MzBjOGQ1Zjc2ODJlYjg4OWQyYjYzYzRjYWQ4Njk3YTZhOWQiLCJjb250ZXh0X2hhc2giOiIzODY2ZGVmZDVmMTAxZDE4NDNkZGFjYjVlMmY2OTJiZmE1OGFiY2FiYjUzM2JiYWVjMTA4MDA4ZTcxZGE1NDk0IiwiZ2VuZXJhdGVkX2F0IjoxNzg5NjM3NjcyLCJoZWFkX3NoYSI6ImM1NGQ5NDFiOGRmN2M5MzVhMTg0YmUwNTE3MzQ4MjY3ZGY4N2ExZTUiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI5ZDY1NDViZGUxN2QzMTExMjljMWU1MmMzZmYyNmQ4MGYwOGZjYjcxIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature f445a574bb7642b94faf1a033f78976a77dc279a6640616bcc9c162641a63b47 -->
<!-- pinot-pr-flow:end -->

## Description

Fixes #19145

The non-scan (metadata/dictionary based) aggregation path treats `MINLONG`, `MAXLONG`, `MINSTRING`, and `MAXSTRING` as resolvable if the column merely **has a dictionary**, without checking that the column type is one the function actually supports. This causes inconsistent behavior:

- **`MINLONG`/`MAXLONG` over `FLOAT`/`DOUBLE`/`BIG_DECIMAL`**: `IllegalArgumentException` is thrown (the non-scan path is too strict — the scan path computes the result fine).
- **`MINSTRING`/`MAXSTRING` over numeric columns**: silently returns a wrong result from the dictionary (the non-scan path is too lax — the scan path correctly rejects with `BadQueryRequestException`).

### Fix

Add type precondition checks in `isFitForNonScanBasedPlan()` so unsupported column-type combinations fall back to the scan path:

- `MINLONG` / `MAXLONG`: require stored type `INT` or `LONG`
- `MINSTRING` / `MAXSTRING`: require stored type `STRING`

### Testing

- `MINLONG(doubleCol)`, `MAXLONG(doubleCol)`, `MINSTRING(intCol)`, `MAXSTRING(intCol)` on a single dictionary-encoded column with no filter now correctly fall back to the scan path, matching the behavior of mixed queries like `MINLONG(doubleCol), SUM(intCol)`.
