### PR TITLE
Address review feedback from the deprecation-removal PRs

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableInstances.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableInstances.java
@@ -173,8 +173,10 @@ public class PinotTableInstances {
       return _pinotHelixResourceManager.getTableToLiveBrokersMapping(headers.getHeaderString(DATABASE), tables);
     } catch (Exception e) {
       // Unknown tables are filtered out rather than reported, so anything thrown here (e.g. a missing broker
-      // ExternalView) is a server-side failure, not a lookup miss.
-      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
+      // ExternalView) is a server-side failure, not a lookup miss. Use a stable message since the cause may
+      // carry none, and let the attached cause supply the detail in the logs.
+      throw new ControllerApplicationException(LOGGER, "Failed to get table to live brokers mapping",
+          Response.Status.INTERNAL_SERVER_ERROR, e);
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableInstances.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableInstances.java
@@ -172,7 +172,9 @@ public class PinotTableInstances {
     try {
       return _pinotHelixResourceManager.getTableToLiveBrokersMapping(headers.getHeaderString(DATABASE), tables);
     } catch (Exception e) {
-      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.NOT_FOUND);
+      // Unknown tables are filtered out rather than reported, so anything thrown here (e.g. a missing broker
+      // ExternalView) is a server-side failure, not a lookup miss.
+      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
     }
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunctionTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
-import java.util.List;
 import org.apache.pinot.queries.FluentQueryTest;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -197,7 +196,7 @@ public class AvgAggregationFunctionTest extends AbstractAggregationFunctionTest 
             new TableConfigBuilder(TableType.OFFLINE)
                 .setTableName("testTable")
                 .addFieldConfig(
-                    new FieldConfig("key", encoding, (List<FieldConfig.IndexType>) null, PASS_THROUGH, null))
+                    new FieldConfig("key", encoding, null, PASS_THROUGH, null))
                 .build())
         .onFirstInstance(new Object[]{7, 1}, new Object[]{6, 2}, new Object[]{5, 3}, new Object[]{4, 4})
         .andOnSecondInstance(new Object[]{7, 1}, new Object[]{6, 2}, new Object[]{5, 3}, new Object[]{4, 4})
@@ -229,9 +228,9 @@ public class AvgAggregationFunctionTest extends AbstractAggregationFunctionTest 
             new TableConfigBuilder(TableType.OFFLINE)
                 .setTableName("testTable")
                 .addFieldConfig(
-                    new FieldConfig("key1", encoding, (List<FieldConfig.IndexType>) null, PASS_THROUGH, null))
+                    new FieldConfig("key1", encoding, null, PASS_THROUGH, null))
                 .addFieldConfig(
-                    new FieldConfig("key2", encoding, (List<FieldConfig.IndexType>) null, PASS_THROUGH, null))
+                    new FieldConfig("key2", encoding, null, PASS_THROUGH, null))
                 .build())
         .onFirstInstance(new Object[]{7, 1}, new Object[]{6, 2}, new Object[]{5, 3}, new Object[]{4, 4})
         .andOnSecondInstance(new Object[]{7, 1}, new Object[]{6, 2}, new Object[]{5, 3}, new Object[]{4, 4})

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunctionTest.java
@@ -195,8 +195,7 @@ public class AvgAggregationFunctionTest extends AbstractAggregationFunctionTest 
                 .build(),
             new TableConfigBuilder(TableType.OFFLINE)
                 .setTableName("testTable")
-                .addFieldConfig(
-                    new FieldConfig("key", encoding, null, PASS_THROUGH, null))
+                .addFieldConfig(new FieldConfig("key", encoding, null, PASS_THROUGH, null))
                 .build())
         .onFirstInstance(new Object[]{7, 1}, new Object[]{6, 2}, new Object[]{5, 3}, new Object[]{4, 4})
         .andOnSecondInstance(new Object[]{7, 1}, new Object[]{6, 2}, new Object[]{5, 3}, new Object[]{4, 4})
@@ -227,10 +226,8 @@ public class AvgAggregationFunctionTest extends AbstractAggregationFunctionTest 
                 .build(),
             new TableConfigBuilder(TableType.OFFLINE)
                 .setTableName("testTable")
-                .addFieldConfig(
-                    new FieldConfig("key1", encoding, null, PASS_THROUGH, null))
-                .addFieldConfig(
-                    new FieldConfig("key2", encoding, null, PASS_THROUGH, null))
+                .addFieldConfig(new FieldConfig("key1", encoding, null, PASS_THROUGH, null))
+                .addFieldConfig(new FieldConfig("key2", encoding, null, PASS_THROUGH, null))
                 .build())
         .onFirstInstance(new Object[]{7, 1}, new Object[]{6, 2}, new Object[]{5, 3}, new Object[]{4, 4})
         .andOnSecondInstance(new Object[]{7, 1}, new Object[]{6, 2}, new Object[]{5, 3}, new Object[]{4, 4})

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/materializedview/MaterializedViewTaskExecutorFactory.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/materializedview/MaterializedViewTaskExecutorFactory.java
@@ -60,16 +60,19 @@ public class MaterializedViewTaskExecutorFactory implements PinotTaskExecutorFac
 
   @Override
   public PinotTaskExecutor create() {
+    // Validated on every call rather than only on the first: without a MinionConf we would silently build a
+    // plaintext gRPC client with default limits instead of the configured one, and without a metadata manager
+    // we would hand a null straight to the executor.
+    Preconditions.checkState(_zkMetadataManager != null,
+        "MinionTaskZkMetadataManager is not set; init(zkMetadataManager, minionConf) must be called before create()");
+    Preconditions.checkState(_minionConf != null,
+        "MinionConf is not set; init(zkMetadataManager, minionConf) must be called before create()");
     if (_queryExecutor == null) {
       synchronized (this) {
         if (_queryExecutor == null) {
           // Build the gRPC client config from the minion's own configuration, scoped to the
           // MaterializedViewTask.MINION_BROKER_GRPC_CONFIG_PREFIX prefix.  This is how operators
-          // enable TLS, raise the max inbound message size for large MV result sets, and tune
-          // keepalive.  Defaulting silently would build a plaintext client with default limits,
-          // so fail loudly instead.
-          Preconditions.checkState(_minionConf != null,
-              "MinionConf is not set; init(zkMetadataManager, minionConf) must be called before create()");
+          // enable TLS, raise the max inbound message size for large MV result sets, and tune keepalive.
           PinotConfiguration grpcClientConfig =
               _minionConf.subset(MaterializedViewTask.MINION_BROKER_GRPC_CONFIG_PREFIX);
           _queryExecutor = new GrpcMaterializedViewQueryExecutor(

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/materializedview/MaterializedViewTaskExecutorFactory.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/materializedview/MaterializedViewTaskExecutorFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.plugin.minion.tasks.materializedview;
 
+import com.google.common.base.Preconditions;
 import org.apache.pinot.common.config.GrpcConfig;
 import org.apache.pinot.materializedview.executor.GrpcMaterializedViewQueryExecutor;
 import org.apache.pinot.materializedview.executor.MaterializedViewQueryExecutor;
@@ -65,12 +66,12 @@ public class MaterializedViewTaskExecutorFactory implements PinotTaskExecutorFac
           // Build the gRPC client config from the minion's own configuration, scoped to the
           // MaterializedViewTask.MINION_BROKER_GRPC_CONFIG_PREFIX prefix.  This is how operators
           // enable TLS, raise the max inbound message size for large MV result sets, and tune
-          // keepalive.  Falling back to an empty configuration (no TLS, defaults) when no
-          // MinionConf was provided — fine for local tests but production deployments should
-          // initialize the factory with a MinionConf.
-          PinotConfiguration grpcClientConfig = _minionConf != null
-              ? _minionConf.subset(MaterializedViewTask.MINION_BROKER_GRPC_CONFIG_PREFIX)
-              : new PinotConfiguration();
+          // keepalive.  Defaulting silently would build a plaintext client with default limits,
+          // so fail loudly instead.
+          Preconditions.checkState(_minionConf != null,
+              "MinionConf is not set; init(zkMetadataManager, minionConf) must be called before create()");
+          PinotConfiguration grpcClientConfig =
+              _minionConf.subset(MaterializedViewTask.MINION_BROKER_GRPC_CONFIG_PREFIX);
           _queryExecutor = new GrpcMaterializedViewQueryExecutor(
               MinionContext.getInstance().getHelixManager(),
               new GrpcConfig(grpcClientConfig));

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/IndexCombinationValidationTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/IndexCombinationValidationTest.java
@@ -458,7 +458,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testRawWithLz4CodecPasses() {
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, (List<IndexType>) null, CompressionCodec.LZ4, null);
+    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, null, CompressionCodec.LZ4, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -468,7 +468,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testRawWithSnappyCodecPasses() {
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, (List<IndexType>) null, CompressionCodec.SNAPPY, null);
+    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, null, CompressionCodec.SNAPPY, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -479,7 +479,7 @@ public class IndexCombinationValidationTest {
   @Test
   public void testRawWithZstdCodecPasses() {
     FieldConfig fc =
-        new FieldConfig(STR_COL, EncodingType.RAW, (List<IndexType>) null, CompressionCodec.ZSTANDARD, null);
+        new FieldConfig(STR_COL, EncodingType.RAW, null, CompressionCodec.ZSTANDARD, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -490,7 +490,7 @@ public class IndexCombinationValidationTest {
   @Test
   public void testRawWithClpCodecStringColumnPasses() {
     // CLP codecs are valid for raw STRING columns
-    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, (List<IndexType>) null, CompressionCodec.CLP, null);
+    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, null, CompressionCodec.CLP, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -501,7 +501,7 @@ public class IndexCombinationValidationTest {
   @Test
   public void testRawWithClpCodecNonStringColumnFails() {
     // CLP is only valid on STRING stored type
-    FieldConfig fc = new FieldConfig(INT_COL, EncodingType.RAW, (List<IndexType>) null, CompressionCodec.CLP, null);
+    FieldConfig fc = new FieldConfig(INT_COL, EncodingType.RAW, null, CompressionCodec.CLP, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(INT_COL))
         .setFieldConfigList(List.of(fc))
@@ -513,7 +513,7 @@ public class IndexCombinationValidationTest {
   public void testDeltaDeltaCodecNonNumericColumnFails() {
     // DELTADELTA only valid on INT/LONG columns
     FieldConfig fc =
-        new FieldConfig(STR_COL, EncodingType.RAW, (List<IndexType>) null, CompressionCodec.DELTADELTA, null);
+        new FieldConfig(STR_COL, EncodingType.RAW, null, CompressionCodec.DELTADELTA, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/IndexCombinationValidationTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/IndexCombinationValidationTest.java
@@ -478,8 +478,7 @@ public class IndexCombinationValidationTest {
 
   @Test
   public void testRawWithZstdCodecPasses() {
-    FieldConfig fc =
-        new FieldConfig(STR_COL, EncodingType.RAW, null, CompressionCodec.ZSTANDARD, null);
+    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, null, CompressionCodec.ZSTANDARD, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))
@@ -512,8 +511,7 @@ public class IndexCombinationValidationTest {
   @Test
   public void testDeltaDeltaCodecNonNumericColumnFails() {
     // DELTADELTA only valid on INT/LONG columns
-    FieldConfig fc =
-        new FieldConfig(STR_COL, EncodingType.RAW, null, CompressionCodec.DELTADELTA, null);
+    FieldConfig fc = new FieldConfig(STR_COL, EncodingType.RAW, null, CompressionCodec.DELTADELTA, null);
     TableConfig tc = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(List.of(STR_COL))
         .setFieldConfigList(List.of(fc))

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/OpenStructIndexConfigTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/OpenStructIndexConfigTest.java
@@ -54,8 +54,7 @@ public class OpenStructIndexConfigTest {
 
   @Test
   public void testNoDictionaryKeys() {
-    FieldConfig rawKey =
-        new FieldConfig("raw_payload", FieldConfig.EncodingType.RAW, null, null, null);
+    FieldConfig rawKey = new FieldConfig("raw_payload", FieldConfig.EncodingType.RAW, null, null, null);
     OpenStructIndexConfig config = new OpenStructIndexConfig(false, null, 1000, null, 0.5, List.of(rawKey));
     assertFalse(config.shouldUseDictionaryForKey("raw_payload"));
     // Unconfigured key falls back to built-in default (DICTIONARY).
@@ -125,10 +124,8 @@ public class OpenStructIndexConfigTest {
 
   @Test
   public void testShouldUseDictionaryForKeyHardOverride() {
-    FieldConfig blob =
-        new FieldConfig("blob", FieldConfig.EncodingType.RAW, null, null, null);
-    FieldConfig rawPayload =
-        new FieldConfig("raw_payload", FieldConfig.EncodingType.RAW, null, null, null);
+    FieldConfig blob = new FieldConfig("blob", FieldConfig.EncodingType.RAW, null, null, null);
+    FieldConfig rawPayload = new FieldConfig("raw_payload", FieldConfig.EncodingType.RAW, null, null, null);
     OpenStructIndexConfig config = new OpenStructIndexConfig(false, null, 1000, null, 0.5, List.of(blob, rawPayload));
     assertFalse(config.shouldUseDictionaryForKey("blob"));
     assertFalse(config.shouldUseDictionaryForKey("raw_payload"));

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/OpenStructIndexConfigTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/OpenStructIndexConfigTest.java
@@ -55,7 +55,7 @@ public class OpenStructIndexConfigTest {
   @Test
   public void testNoDictionaryKeys() {
     FieldConfig rawKey =
-        new FieldConfig("raw_payload", FieldConfig.EncodingType.RAW, (List<FieldConfig.IndexType>) null, null, null);
+        new FieldConfig("raw_payload", FieldConfig.EncodingType.RAW, null, null, null);
     OpenStructIndexConfig config = new OpenStructIndexConfig(false, null, 1000, null, 0.5, List.of(rawKey));
     assertFalse(config.shouldUseDictionaryForKey("raw_payload"));
     // Unconfigured key falls back to built-in default (DICTIONARY).
@@ -126,9 +126,9 @@ public class OpenStructIndexConfigTest {
   @Test
   public void testShouldUseDictionaryForKeyHardOverride() {
     FieldConfig blob =
-        new FieldConfig("blob", FieldConfig.EncodingType.RAW, (List<FieldConfig.IndexType>) null, null, null);
+        new FieldConfig("blob", FieldConfig.EncodingType.RAW, null, null, null);
     FieldConfig rawPayload =
-        new FieldConfig("raw_payload", FieldConfig.EncodingType.RAW, (List<FieldConfig.IndexType>) null, null, null);
+        new FieldConfig("raw_payload", FieldConfig.EncodingType.RAW, null, null, null);
     OpenStructIndexConfig config = new OpenStructIndexConfig(false, null, 1000, null, 0.5, List.of(blob, rawPayload));
     assertFalse(config.shouldUseDictionaryForKey("blob"));
     assertFalse(config.shouldUseDictionaryForKey("raw_payload"));


### PR DESCRIPTION
Part of #19147. Addresses the review comments left on #19139 and #19142, kept out of those PRs so their approvals weren't churned.

Originally stacked on #19139; now that it has merged, this is rebased onto master and the diff stands alone — 5 files, +22/−20. No API is removed, so it does not trip the Binary Compatibility Check.

## 1. Redundant `FieldConfig` casts — addresses [IndexCombinationValidationTest](https://github.com/apache/pinot/pull/19139#discussion_r3696831973) and [AvgAggregationFunctionTest](https://github.com/apache/pinot/pull/19139#discussion_r3696831979)

Copilot flagged the `(List<IndexType>) null` casts as noise. Correct: they existed only to disambiguate

```java
FieldConfig(String, EncodingType, IndexType,       CompressionCodec, Map)   // removed by #19139
FieldConfig(String, EncodingType, List<IndexType>, CompressionCodec, Map)   // stays
```

With the singular overload gone, the 5-arg form is unique (the remaining constructors are 7- and 9-arg), so bare `null` resolves unambiguously. Dropped at 12 call sites across three test files — including `OpenStructIndexConfigTest`, which has the same pattern but wasn't touched by #19139.

`AvgAggregationFunctionTest` also loses its `java.util.List` import, which #19139 had added purely for those casts and which is now unused.

## 2. `GET /tables/livebrokers` reports 404 for server-side failures — addresses [this comment](https://github.com/apache/pinot/pull/19142#discussion_r3696839996)

The endpoint declares `200` and `500`, but caught `Exception` and mapped **everything** to `404 NOT_FOUND`.

Checking `getTableToLiveBrokersMapping`, unknown tables are silently filtered out rather than reported — so nothing it throws is a lookup miss. What it *does* throw is `IllegalStateException` when the broker `ExternalView` is missing, plus whatever Helix/ZK raises. So a cluster-level misconfiguration was being reported to clients as "not found", and the documented `500` was unreachable.

Now maps to `INTERNAL_SERVER_ERROR`, matching the declared responses, and passes the cause through so it is logged.

This targets the surviving plural endpoint, not the singular one removed in #19142.

## 3. Dead `_minionConf` null-branch in `MaterializedViewTaskExecutorFactory`

Raised in review of #19139. The factory did:

```java
PinotConfiguration grpcClientConfig = _minionConf != null
    ? _minionConf.subset(MaterializedViewTask.MINION_BROKER_GRPC_CONFIG_PREFIX)
    : new PinotConfiguration();
```

`_minionConf` is assigned only by `init(zkMetadataManager, minionConf)`. With the deprecated 1-arg `init` removed in #19139, that is the only initialization path, so the fallback is unreachable. It is also the wrong thing to fall back to — an empty configuration builds a **plaintext** gRPC client with default message limits rather than the operator's configured TLS client, and does so silently.

Replaced with a `Preconditions.checkState`, so a factory used before `init` fails loudly instead of quietly downgrading the connection.

## Verification

Rebased onto master after #19139/#19141/#19142/#19143 merged, then re-verified: full `test-compile` plus `checkstyle:check` and `license:check` across all five touched modules, and the three affected test classes pass — `AvgAggregationFunctionTest` (54), `IndexCombinationValidationTest` (47), `OpenStructIndexConfigTest` (14).
