### PR TITLE
Support UUID literals in request context

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
@@ -174,6 +174,9 @@ public class LiteralContext {
         return PinotDataType.BIG_DECIMAL;
       case STRING:
         return singleValue ? PinotDataType.STRING : PinotDataType.STRING_ARRAY;
+      case UUID:
+        Preconditions.checkState(singleValue, "UUID array is not supported");
+        return PinotDataType.UUID;
       default:
         throw new IllegalStateException("Unsupported DataType: " + type);
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
@@ -147,6 +147,7 @@ public class LiteralContext {
     _pinotDataType = getPinotDataType(type, value);
   }
 
+  // TODO: Revisit MV support for BOOLEAN, BIG_DECIMAL, BYTES and UUID.
   @Nullable
   private static PinotDataType getPinotDataType(DataType type, @Nullable Object value) {
     if (value == null) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.calcite.sql.SqlKind;
@@ -58,6 +59,7 @@ import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request;
 import org.apache.pinot.spi.utils.TimestampIndexUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.apache.pinot.sql.FilterKind;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.apache.pinot.sql.parsers.SqlCompilationException;
@@ -201,6 +203,9 @@ public class RequestUtils {
     }
     if (object instanceof Timestamp) {
       return getLiteral(((Timestamp) object).getTime());
+    }
+    if (object instanceof UUID) {
+      return getLiteral(UuidUtils.toBytes((UUID) object));
     }
     if (object instanceof String) {
       return getLiteral((String) object);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -204,14 +204,14 @@ public class RequestUtils {
     if (object instanceof Timestamp) {
       return getLiteral(((Timestamp) object).getTime());
     }
-    if (object instanceof UUID) {
-      return getLiteral(UuidUtils.toBytes((UUID) object));
-    }
     if (object instanceof String) {
       return getLiteral((String) object);
     }
     if (object instanceof byte[]) {
       return getLiteral((byte[]) object);
+    }
+    if (object instanceof UUID) {
+      return getLiteral(UuidUtils.toBytes((UUID) object));
     }
     if (object instanceof int[]) {
       return getLiteral((int[]) object);

--- a/pinot-common/src/test/java/org/apache/pinot/common/request/context/LiteralContextTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/request/context/LiteralContextTest.java
@@ -20,11 +20,13 @@ package org.apache.pinot.common.request.context;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+import java.util.UUID;
 import org.apache.pinot.common.request.Literal;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.CommonConstants.NullValuePlaceHolder;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
@@ -221,5 +223,14 @@ public class LiteralContextTest {
     assertEquals(literalContext.getBytesValue(), BytesUtils.toBytes("deadbeef"));
     assertFalse(literalContext.isNull());
     assertEquals(literalContext.toString(), "'deadbeef'");
+  }
+
+  @Test
+  public void testUuidLiteral() {
+    UUID uuid = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+    LiteralContext literalContext = new LiteralContext(DataType.UUID, uuid);
+
+    assertEquals(literalContext.getStringValue(), uuid.toString());
+    assertEquals(literalContext.getBytesValue(), UuidUtils.toBytes(uuid));
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/request/RequestUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/request/RequestUtilsTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.common.utils.request;
 
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlLiteral;
@@ -28,6 +29,8 @@ import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.ExpressionType;
 import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.Identifier;
+import org.apache.pinot.common.request.Literal;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.apache.pinot.sql.parsers.PinotSqlType;
 import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
@@ -86,6 +89,25 @@ public class RequestUtilsTest {
     Expression literalExpression = RequestUtils.getLiteralExpression(4500L);
     assertTrue(literalExpression.getLiteral().isSetLongValue());
     assertEquals(literalExpression.getLiteral().getLongValue(), 4500L);
+  }
+
+  @Test
+  public void testGetLiteralForUuid() {
+    UUID uuid = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+    Literal literal = RequestUtils.getLiteral(uuid);
+
+    assertTrue(literal.isSetBinaryValue());
+    assertEquals(literal.getBinaryValue(), UuidUtils.toBytes(uuid));
+  }
+
+  @Test
+  public void testUuidCastFoldsToBinaryLiteral() {
+    UUID uuid = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+    Expression expression = CalciteSqlParser.compileToPinotQuery(
+        "SELECT CAST('" + uuid + "' AS UUID) FROM myTable").getSelectList().get(0);
+
+    assertTrue(expression.isSetLiteral());
+    assertEquals(expression.getLiteral().getBinaryValue(), UuidUtils.toBytes(uuid));
   }
 
   @Test


### PR DESCRIPTION
## What

- map `DataType.UUID` to `PinotDataType.UUID` in `LiteralContext`
- serialize folded `java.util.UUID` values through the existing binary literal field
- cover direct literal conversion and `CAST(... AS UUID)` folding

## Why

PR #18872 currently carries UUID literal plumbing alongside server-side predicate and transform changes. This extracts that plumbing into a small prerequisite PR and keeps the existing request wire format unchanged.

## Validation

- `LiteralContextTest` and `RequestUtilsTest`: 33 tests, 0 failures
- `spotless:apply`, `license:format`, `checkstyle:check`, and `license:check` on `pinot-common`
