### PR TITLE
Document and enforce the AggregationFunction null contract

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/EmptyResponseUtilsTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/EmptyResponseUtilsTest.java
@@ -29,10 +29,34 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 
 public class EmptyResponseUtilsTest {
+
+  /// An aggregation whose answer over no input is `NULL` has to survive the whole empty-response path.
+  ///
+  /// This is the path that produced the NPE this contract exists to prevent: the result table is built by calling
+  /// `extractFinalResult(extractAggregationResult(createAggregationResultHolder()))` on an untouched holder, and the
+  /// value it returns is then passed to [ColumnDataType#convert]. A function that wraps the `null` in a serializer
+  /// rather than resolving it fails at one of those two steps, not at extraction.
+  @Test
+  public void testBuildEmptyResultTableWithNullFinalResults() {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT PERCENTILERAWKLL(a, 50), MAXSTRING(b), MINSTRING(b) FROM testTable WHERE foo = 'bar'");
+    ResultTable resultTable = EmptyResponseUtils.buildEmptyResultTable(queryContext);
+    DataSchema dataSchema = resultTable.getDataSchema();
+    assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.STRING, ColumnDataType.STRING
+    });
+    List<Object[]> rows = resultTable.getRows();
+    assertEquals(rows.size(), 1);
+    Object[] row = rows.get(0);
+    assertNull(row[0]);
+    assertNull(row[1]);
+    assertNull(row[2]);
+  }
 
   @Test
   public void testBuildEmptyResultTable() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
@@ -33,6 +33,7 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.scheduler.resources.ResourceManager;
 import org.apache.pinot.core.util.QueryMultiThreadingUtils;
@@ -124,12 +125,13 @@ public abstract class IndexedTable extends BaseTable {
     int index = _numKeyColumns;
     if (!_hasFinalInput) {
       for (int i = 0; i < numAggregations; i++, index++) {
-        existingValues[index] = _aggregationFunctions[i].merge(existingValues[index], newValues[index]);
+        existingValues[index] =
+            AggregationFunctionUtils.merge(_aggregationFunctions[i], existingValues[index], newValues[index]);
       }
     } else {
       for (int i = 0; i < numAggregations; i++, index++) {
-        existingValues[index] = _aggregationFunctions[i].mergeFinalResult((Comparable) existingValues[index],
-            (Comparable) newValues[index]);
+        existingValues[index] = AggregationFunctionUtils.mergeFinalResult(_aggregationFunctions[i],
+            (Comparable) existingValues[index], (Comparable) newValues[index]);
       }
     }
     return existingRecord;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/SortedRecordsMerger.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/SortedRecordsMerger.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.function.BiFunction;
 import org.apache.pinot.core.operator.blocks.results.GroupByResultsBlock;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.util.GroupByUtils;
 import org.apache.pinot.spi.query.QueryThreadContext;
@@ -131,7 +132,8 @@ public class SortedRecordsMerger {
     int numAggregations = _aggregationFunctions.length;
     int index = _numKeyColumns;
     for (int i = 0; i < numAggregations; i++, index++) {
-      existingValues[index] = _aggregationFunctions[i].merge(existingValues[index], newValues[index]);
+      existingValues[index] =
+          AggregationFunctionUtils.merge(_aggregationFunctions[i], existingValues[index], newValues[index]);
     }
     return existingRecord;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/merger/AggregationResultsBlockMerger.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/merger/AggregationResultsBlockMerger.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.operator.combine.merger;
 import java.util.List;
 import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.query.request.context.QueryContext;
 
 
@@ -44,7 +45,8 @@ public class AggregationResultsBlockMerger implements ResultsBlockMerger<Aggrega
 
     int numAggregationFunctions = aggregationFunctions.length;
     for (int i = 0; i < numAggregationFunctions; i++) {
-      mergedResults.set(i, aggregationFunctions[i].merge(mergedResults.get(i), resultsToMerge.get(i)));
+      mergedResults.set(i,
+          AggregationFunctionUtils.merge(aggregationFunctions[i], mergedResults.get(i), resultsToMerge.get(i)));
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
@@ -36,6 +36,98 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 /// The implementation should be stateless, and can be shared among multiple segments in multiple threads. The result
 /// for each segment should be stored and passed in via the result holder.
 ///
+/// ## Null contract
+///
+/// Null handling is a per-query flag, and the two modes place different requirements on an implementation.
+///
+/// ### Null handling disabled
+///
+/// Null values are read as the column's default, so no input value is ever null. An implementation keeps a primitive
+/// result holder, performs no null tracking, and needs no null check while aggregating.
+///
+/// A row that aggregated the column's default is indistinguishable from one that aggregated nothing, so this mode has
+/// no answer to give for the empty input other than the accumulator's identity: `0` for `SUM`, `+Infinity` for `MIN`.
+/// Those answers are a backward-compatibility constraint rather than an attempt at SQL conformance, and must not
+/// change.
+///
+/// The identity is rendered by [#extractFinalResult], not carried by the accumulator. An untouched holder yields a
+/// `null` **intermediate result** in this mode too, and [#extractFinalResult] turns that `null` into the identity.
+/// Doing it there rather than substituting an empty accumulator upstream keeps one decision point, and is the only
+/// option for the types that have no empty value to substitute — `MAXSTRING`, `MINSTRING` and `ANYVALUE` are
+/// object-backed and have none.
+///
+/// ### Null handling enabled
+///
+/// SQL evaluates an aggregate over its **non-null** input values only, and separately defines what the result is when
+/// there are none. This mode models those as two distinct things:
+/// - A `null` **intermediate result** means nothing was aggregated, either because no row matched or because every
+///   matching value was null. It carries no per-function meaning, which is what makes it correct for the aggregation
+///   methods to skip null rows outright rather than fold them in.
+///   `null` is not the only way that state is represented, though: an empty accumulator — an empty set, value list,
+///   digest, sketch or map — means the same thing, and still arrives. A peer that serialized one sends it, and so do
+///   the functions in the first deviation below, which never receive the option and substitute one rather than
+///   returning `null`. So [#extractFinalResult] accepts both.
+///   `null` is the representation to produce where there is a choice, because it is the only one always available:
+///   `MAXSTRING`, `MINSTRING` and `ANYVALUE` are object-backed and have no empty value to substitute.
+/// - [#extractFinalResult] decides what that means for this aggregation, and is the only method that does. `COUNT`
+///   and the distinct counts return `0`; `SUM`, `MIN`, `MAX`, `AVG` and the percentiles return `null`.
+///
+/// An implementation switches to a nullable result holder only in this mode, which keeps the boxing cost on the opt-in
+/// path.
+///
+/// ### Both modes
+///
+/// A `null` operand is the identity of merging, and that carries no per-function meaning, so it is resolved once by the
+/// caller rather than in every implementation: merge intermediate results through [AggregationFunctionUtils#merge] and
+/// final results through [AggregationFunctionUtils#mergeFinalResult], which settle `null` operands before delegating.
+/// [#merge] and [#mergeFinalResult] are therefore handed two real values and must not be called with `null`.
+///
+/// A `null` is safe to put on the wire in either mode. The data table writer supports nulls for every column type
+/// independent of the query's option: types with an in-band null encoding keep it, and the rest are written as the
+/// column's null placeholder with the row recorded in a per-column null bitmap. So returning `null` rather than
+/// substituting an empty accumulator costs nothing in fidelity.
+///
+/// Nullability is declared rather than discovered. Whether an intermediate result can be `null` is decided by
+/// [#extractAggregationResult] and [#extractGroupByResult]; whether a final result can be is decided by
+/// [#extractFinalResult]. The `@Nullable` annotation on each is the statement of it, and everything downstream —
+/// merging, serialization, rendering — may rely on it: a function whose [#extractFinalResult] is not `@Nullable`
+/// never produces a `null` final result, so no caller needs to handle one for it. Adding `@Nullable` to one of
+/// these is therefore a behavioural change and not a documentation fix, because it widens what the rest of the
+/// engine must carry.
+///
+/// TODO: Known deviations from the above.
+///   1. Several aggregation functions never receive the query's null handling option at all, so they cannot skip
+///      null rows and fold the column's default value into the aggregate whatever the query asked for: the
+///      sketch-backed distinct counts (`DISTINCTCOUNTBITMAP`, `DISTINCTCOUNTHLL`, `DISTINCTCOUNTTHETASKETCH`,
+///      `DISTINCTCOUNTCPCSKETCH`, `FASTHLL`, `SEGMENTPARTITIONEDDISTINCTCOUNT` and the raw and smart variants of
+///      each), the tuple and frequency sketches, the covariance functions, `HISTOGRAM`, `IDSET`, `STUNION`, the
+///      array sums, and the funnel family. Whether a function takes the option is visible at its construction site,
+///      which is the reliable way to tell.
+///      The family names are not a safe shorthand for this, in either direction. The exact distinct functions
+///      (`DISTINCTCOUNT`, `DISTINCTSUM`, `DISTINCTAVG`, `DISTINCTCOUNTOFFHEAP`) do take the option and skip null
+///      rows through their shared base, as do the variance and standard-deviation functions and the
+///      first/last-with-time functions, so "the distinct-count family" and "the statistical functions" both include
+///      members that honour the option and members that cannot.
+///      These same functions also substitute an empty accumulator in [#extractAggregationResult],
+///      [#extractGroupByResult] or both, rather than returning `null` and letting [#extractFinalResult] render the
+///      disabled-mode value. That is not a separate defect: without the option [#extractFinalResult] cannot tell the
+///      two modes apart, so it has nothing to decide with and the substitution is the only thing holding the answer.
+///      Which of the two paths substitutes is inconsistent across them and sometimes within one, so such a function
+///      can answer differently depending on whether the query groups — a filtered aggregation makes that observable,
+///      since one group key space is shared by every aggregation in a query and a group created by one of them can
+///      hold no rows for another.
+///      Conforming them alongside the option is more than moving a branch. The value to preserve is often not a
+///      constant, and the function that substitutes is frequently not the one that renders: the raw variants
+///      delegate extraction to the plain function and serialize what it returns, so conforming the plain function
+///      alone changes the raw variant's answer from a serialized empty sketch to `NULL` without touching the raw
+///      variant at all.
+///   2. The multi-stage engine constructs every aggregation function with null handling enabled and never consults the
+///      query's null handling option, so a query that disables it still gets enabled-mode semantics there. The two
+///      engines can therefore answer the same query differently: with null handling disabled, `SUM` over a query
+///      whose segments are all pruned is `NULL` on the multi-stage engine and `0` on the single-stage engine. This
+///      may be intended, the multi-stage engine being the SQL-conformant one, but it means the mode described above
+///      is not actually per-query everywhere.
+///
 /// @param <IntermediateResult> Intermediate result generated from segment
 /// @param <FinalResult> Final result used in broker response
 @ThreadSafe
@@ -53,38 +145,66 @@ public interface AggregationFunction<IntermediateResult, FinalResult extends Com
   List<ExpressionContext> getInputExpressions();
 
   /// Returns an aggregation result holder for this function (aggregation only).
+  ///
+  /// A nullable holder is only warranted with null handling enabled, so that the boxing cost stays on the opt-in path.
+  /// See the null contract on [AggregationFunction].
   AggregationResultHolder createAggregationResultHolder();
 
   /// Returns a group-by result holder with the given initial capacity and max capacity for this function (aggregation
   /// group-by).
+  ///
+  /// A nullable holder is only warranted with null handling enabled, so that the boxing cost stays on the opt-in path.
+  /// See the null contract on [AggregationFunction].
   GroupByResultHolder createGroupByResultHolder(int initialCapacity, int maxCapacity);
 
   /// Performs aggregation on the given block value sets (aggregation only).
+  ///
+  /// With null handling enabled, null rows must be skipped rather than folded in as the column's default. See the null
+  /// contract on [AggregationFunction].
   void aggregate(int length, AggregationResultHolder aggregationResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap);
 
   /// Performs aggregation on the given group key array and block value sets (aggregation group-by on single-value
   /// columns).
+  ///
+  /// With null handling enabled, null rows must be skipped rather than folded in as the column's default. See the null
+  /// contract on [AggregationFunction].
   void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap);
 
   /// Performs aggregation on the given group keys array and block value sets (aggregation group-by on multi-value
   /// columns).
+  ///
+  /// With null handling enabled, null rows must be skipped rather than folded in as the column's default. See the null
+  /// contract on [AggregationFunction].
   void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap);
 
   /// Extracts the intermediate result from the aggregation result holder (aggregation only).
+  ///
+  /// The holder may be untouched, which is how a query that matched no row arrives here. With null handling enabled
+  /// that means nothing was aggregated and this returns `null`. With it disabled this returns the accumulator's
+  /// identity instead, unless the accumulator is object-backed and its type has no identity to render, in which case it
+  /// is `null` there too. See the null contract on [AggregationFunction].
   @Nullable
   IntermediateResult extractAggregationResult(AggregationResultHolder aggregationResultHolder);
 
   /// Extracts the intermediate result from the group-by result holder for the given group key (aggregation group-by).
+  ///
+  /// With null handling enabled, returns `null` when nothing was aggregated into the group. With it disabled a group
+  /// normally holds at least one value, but an object-backed accumulator still returns `null` for a group this
+  /// aggregation never wrote to: group keys are shared across the aggregations of a query, so a filtered aggregation
+  /// whose predicate matched no row in the group leaves its slot untouched. See the null contract on
+  /// [AggregationFunction].
   @Nullable
   IntermediateResult extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey);
 
-  /// Merges two intermediate results.
-  @Nullable
-  IntermediateResult merge(@Nullable IntermediateResult intermediateResult1,
-      @Nullable IntermediateResult intermediateResult2);
+  /// Merges two intermediate results, neither of which is `null`.
+  ///
+  /// Call [AggregationFunctionUtils#merge] instead of calling this directly: it settles the `null` operand, which is
+  /// the identity of this operation and means the same thing for every implementation. See the null contract on
+  /// [AggregationFunction].
+  IntermediateResult merge(IntermediateResult intermediateResult1, IntermediateResult intermediateResult2);
 
   /// Returns the [ColumnDataType] of the intermediate result.
   ///
@@ -128,13 +248,25 @@ public interface AggregationFunction<IntermediateResult, FinalResult extends Com
   ColumnDataType getFinalResultColumnType();
 
   /// Extracts the final result used in the broker response from the given intermediate result.
+  ///
+  /// A `null` intermediate result means nothing was aggregated, and this method decides what that means for this
+  /// particular aggregation. It is the only place where that per-function answer is expressed, so it must never
+  /// propagate the `null` blindly: `COUNT` and the distinct counts return `0`, while `SUM`, `MIN`, `MAX`, `AVG` and the
+  /// percentiles return `null`.
+  ///
+  /// That is the null-handling-enabled answer. With null handling disabled that state is normally rendered as the
+  /// accumulator's identity, but an object-backed accumulator still hands this method a `null`, and for `MAXSTRING`,
+  /// `MINSTRING` and `ANYVALUE` there is no identity to render in the first place. A `null` argument is therefore part
+  /// of the contract in both modes, not a defensive case. See the null contract on [AggregationFunction].
   @Nullable
   FinalResult extractFinalResult(@Nullable IntermediateResult intermediateResult);
 
-  /// Merges two final results. This can be used to optimized certain functions (e.g. DISTINCT_COUNT) when data is
-  /// partitioned on each server, where we may directly request servers to return final result and merge them on broker.
-  @Nullable
-  default FinalResult mergeFinalResult(@Nullable FinalResult finalResult1, @Nullable FinalResult finalResult2) {
+  /// Merges two final results, neither of which is `null`. This can be used to optimized certain functions (e.g.
+  /// DISTINCT_COUNT) when data is partitioned on each server, where we may directly request servers to return final
+  /// result and merge them on broker.
+  ///
+  /// Call [AggregationFunctionUtils#mergeFinalResult] instead of calling this directly, on the same terms as [#merge].
+  default FinalResult mergeFinalResult(FinalResult finalResult1, FinalResult finalResult2) {
     throw new UnsupportedOperationException("Cannot merge final results for function: " + getType());
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
@@ -36,6 +36,106 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 /// The implementation should be stateless, and can be shared among multiple segments in multiple threads. The result
 /// for each segment should be stored and passed in via the result holder.
 ///
+/// ## Null contract
+///
+/// Null handling is a per-query flag, and the two modes place different requirements on an implementation.
+///
+/// ### Null handling disabled
+///
+/// Null values are read as the column's default, so no input value is ever null. An implementation keeps a primitive
+/// result holder, performs no null tracking, and needs no null check while aggregating.
+///
+/// An untouched accumulator is indistinguishable from one that aggregated to the type's identity, so this mode cannot
+/// tell "nothing was aggregated" apart from a real result: the answer is whatever the accumulator's initial state
+/// renders to, `0` for `SUM` or `+Infinity` for `MIN`. Where the type has no identity to render, the intermediate
+/// result is `null` instead: `MAXSTRING`, `MINSTRING` and `ANYVALUE` are object-backed and have no empty value to
+/// return. So [#extractFinalResult] must accept `null` in this mode as well.
+///
+/// ### Null handling enabled
+///
+/// SQL evaluates an aggregate over its **non-null** input values only, and separately defines what the result is when
+/// there are none. This mode models those as two distinct things:
+/// - A `null` **intermediate result** means nothing was aggregated, either because no row matched or because every
+///   matching value was null. It carries no per-function meaning, which is what makes it correct for the aggregation
+///   methods to skip null rows outright rather than fold them in.
+///   `null` is not the only way that state is represented, though: an empty accumulator — an empty set, value list,
+///   digest, sketch or map — means the same thing, and still arrives. A peer that serialized one sends it, and so do
+///   the functions in the first deviation below, which never receive the option and substitute one rather than
+///   returning `null`. So [#extractFinalResult] accepts both.
+///   `null` is the representation to produce where there is a choice, because it is the only one always available:
+///   `MAXSTRING`, `MINSTRING` and `ANYVALUE` are object-backed and have no empty value to substitute.
+/// - [#extractFinalResult] decides what that means for this aggregation, and is the only method that does. `COUNT`
+///   and the distinct counts return `0`; `SUM`, `MIN`, `MAX`, `AVG` and the percentiles return `null`.
+///
+/// An implementation switches to a nullable result holder only in this mode, which keeps the boxing cost on the opt-in
+/// path.
+///
+/// ### Both modes
+///
+/// A `null` operand is the identity of merging, and that carries no per-function meaning, so it is resolved once by the
+/// caller rather than in every implementation: merge intermediate results through [AggregationFunctionUtils#merge] and
+/// final results through [AggregationFunctionUtils#mergeFinalResult], which settle `null` operands before delegating.
+/// [#merge] and [#mergeFinalResult] are therefore handed two real values and must not be called with `null`.
+///
+/// Nullability is declared rather than discovered. Whether an intermediate result can be `null` is decided by
+/// [#extractAggregationResult] and [#extractGroupByResult]; whether a final result can be is decided by
+/// [#extractFinalResult]. The `@Nullable` annotation on each is the statement of it, and everything downstream —
+/// merging, serialization, rendering — may rely on it: a function whose [#extractFinalResult] is not `@Nullable`
+/// never produces a `null` final result, so no caller needs to handle one for it. Adding `@Nullable` to one of
+/// these is therefore a behavioural change and not a documentation fix, because it widens what the rest of the
+/// engine must carry.
+///
+/// TODO: Known deviations from the above.
+///   1. Several aggregation functions never receive the query's null handling option at all, so they cannot skip
+///      null rows and fold the column's default value into the aggregate whatever the query asked for: the
+///      sketch-backed distinct counts (`DISTINCTCOUNTBITMAP`, `DISTINCTCOUNTHLL`, `DISTINCTCOUNTTHETASKETCH`,
+///      `DISTINCTCOUNTCPCSKETCH`, `FASTHLL`, `SEGMENTPARTITIONEDDISTINCTCOUNT` and the raw and smart variants of
+///      each), the tuple and frequency sketches, the covariance functions, `HISTOGRAM`, `IDSET`, `STUNION`, the
+///      array sums, and the funnel family. Whether a function takes the option is visible at its construction site,
+///      which is the reliable way to tell.
+///      The family names are not a safe shorthand for this, in either direction. The exact distinct functions
+///      (`DISTINCTCOUNT`, `DISTINCTSUM`, `DISTINCTAVG`, `DISTINCTCOUNTOFFHEAP`) do take the option and skip null
+///      rows through their shared base, as do the variance and standard-deviation functions and the
+///      first/last-with-time functions, so "the distinct-count family" and "the statistical functions" both include
+///      members that honour the option and members that cannot.
+///      These same functions also substitute an empty accumulator in [#extractAggregationResult],
+///      [#extractGroupByResult] or both, rather than returning `null` and letting [#extractFinalResult] render the
+///      disabled-mode value. That is not a separate defect: without the option [#extractFinalResult] cannot tell the
+///      two modes apart, so it has nothing to decide with and the substitution is the only thing holding the answer.
+///      Which of the two paths substitutes is inconsistent across them and sometimes within one, so such a function
+///      can answer differently depending on whether the query groups — a filtered aggregation makes that observable,
+///      since one group key space is shared by every aggregation in a query and a group created by one of them can
+///      hold no rows for another.
+///      Conforming them alongside the option is more than moving a branch. The value to preserve is often not a
+///      constant, and the function that substitutes is frequently not the one that renders: the raw variants
+///      delegate extraction to the plain function and serialize what it returns, so conforming the plain function
+///      alone silently changes the raw variant's answer from a serialized empty sketch to a `null` on a `STRING`
+///      column, which is the third deviation below.
+///   2. The multi-stage engine constructs every aggregation function with null handling enabled and never consults the
+///      query's null handling option, so a query that disables it still gets enabled-mode semantics there. The two
+///      engines can therefore answer the same query differently: with null handling disabled, `SUM` over a query
+///      whose segments are all pruned is `NULL` on the multi-stage engine and `0` on the single-stage engine. This
+///      may be intended, the multi-stage engine being the SQL-conformant one, but it means the mode described above
+///      is not actually per-query everywhere.
+///   3. **With null handling disabled, every `null` that reaches the data table is mis-serialized unless the column
+///      type is `OBJECT`.** This mode is not meant to produce nulls at all, but the object-backed accumulators
+///      described above do, and each one is corrupted on the way out. The writer falls back to the encoding
+///      reserved for `OBJECT` whatever the column type is; with null handling enabled it instead writes a
+///      placeholder alongside a null bitmap, which is correct for every type. The damage varies by type: an array
+///      column has the right width but reads back as an empty array, `STRING`, `INT` and `FLOAT` have their
+///      narrower fixed-size slot overrun, and `LONG` and `DOUBLE` read back as a value. Both the intermediate and
+///      the final result reach this path, the latter from more functions because their reported types are narrower.
+///      Aggregate values need the placeholder and null bitmap that group-by keys already use.
+///      **This change widens the deviation rather than fixing it, and that is deliberate.** Eleven functions used to
+///      throw on a `null` intermediate result and now return `null` for it, so where the server previously failed
+///      loudly it can now write a data table that no reader can interpret. `COVAR_POP`, `IDSET`, `STUNION`,
+///      `PERCENTILERAWKLL`, the frequency sketches and `SUMVALUESINTEGERTUPLESKETCH` all report a final result type
+///      the encoding mishandles. The functions conformed here are not among them: with null handling disabled they
+///      render their accumulator's identity rather than a `null`, so a raw percentile still emits a serialized empty
+///      digest. The path additionally
+///      needs the server-side final result option and no aggregated rows, so it is narrow, but a silent wrong
+///      answer is a worse failure than the exception it replaces. Fixing the writer is follow-up work.
+///
 /// @param <IntermediateResult> Intermediate result generated from segment
 /// @param <FinalResult> Final result used in broker response
 @ThreadSafe
@@ -53,38 +153,66 @@ public interface AggregationFunction<IntermediateResult, FinalResult extends Com
   List<ExpressionContext> getInputExpressions();
 
   /// Returns an aggregation result holder for this function (aggregation only).
+  ///
+  /// A nullable holder is only warranted with null handling enabled, so that the boxing cost stays on the opt-in path.
+  /// See the null contract on [AggregationFunction].
   AggregationResultHolder createAggregationResultHolder();
 
   /// Returns a group-by result holder with the given initial capacity and max capacity for this function (aggregation
   /// group-by).
+  ///
+  /// A nullable holder is only warranted with null handling enabled, so that the boxing cost stays on the opt-in path.
+  /// See the null contract on [AggregationFunction].
   GroupByResultHolder createGroupByResultHolder(int initialCapacity, int maxCapacity);
 
   /// Performs aggregation on the given block value sets (aggregation only).
+  ///
+  /// With null handling enabled, null rows must be skipped rather than folded in as the column's default. See the null
+  /// contract on [AggregationFunction].
   void aggregate(int length, AggregationResultHolder aggregationResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap);
 
   /// Performs aggregation on the given group key array and block value sets (aggregation group-by on single-value
   /// columns).
+  ///
+  /// With null handling enabled, null rows must be skipped rather than folded in as the column's default. See the null
+  /// contract on [AggregationFunction].
   void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap);
 
   /// Performs aggregation on the given group keys array and block value sets (aggregation group-by on multi-value
   /// columns).
+  ///
+  /// With null handling enabled, null rows must be skipped rather than folded in as the column's default. See the null
+  /// contract on [AggregationFunction].
   void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap);
 
   /// Extracts the intermediate result from the aggregation result holder (aggregation only).
+  ///
+  /// The holder may be untouched, which is how a query that matched no row arrives here. With null handling enabled
+  /// that means nothing was aggregated and this returns `null`. With it disabled this returns the accumulator's
+  /// identity instead, unless the accumulator is object-backed and its type has no identity to render, in which case it
+  /// is `null` there too. See the null contract on [AggregationFunction].
   @Nullable
   IntermediateResult extractAggregationResult(AggregationResultHolder aggregationResultHolder);
 
   /// Extracts the intermediate result from the group-by result holder for the given group key (aggregation group-by).
+  ///
+  /// With null handling enabled, returns `null` when nothing was aggregated into the group. With it disabled a group
+  /// normally holds at least one value, but an object-backed accumulator still returns `null` for a group this
+  /// aggregation never wrote to: group keys are shared across the aggregations of a query, so a filtered aggregation
+  /// whose predicate matched no row in the group leaves its slot untouched. See the null contract on
+  /// [AggregationFunction].
   @Nullable
   IntermediateResult extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey);
 
-  /// Merges two intermediate results.
-  @Nullable
-  IntermediateResult merge(@Nullable IntermediateResult intermediateResult1,
-      @Nullable IntermediateResult intermediateResult2);
+  /// Merges two intermediate results, neither of which is `null`.
+  ///
+  /// Call [AggregationFunctionUtils#merge] instead of calling this directly: it settles the `null` operand, which is
+  /// the identity of this operation and means the same thing for every implementation. See the null contract on
+  /// [AggregationFunction].
+  IntermediateResult merge(IntermediateResult intermediateResult1, IntermediateResult intermediateResult2);
 
   /// Returns the [ColumnDataType] of the intermediate result.
   ///
@@ -128,13 +256,25 @@ public interface AggregationFunction<IntermediateResult, FinalResult extends Com
   ColumnDataType getFinalResultColumnType();
 
   /// Extracts the final result used in the broker response from the given intermediate result.
+  ///
+  /// A `null` intermediate result means nothing was aggregated, and this method decides what that means for this
+  /// particular aggregation. It is the only place where that per-function answer is expressed, so it must never
+  /// propagate the `null` blindly: `COUNT` and the distinct counts return `0`, while `SUM`, `MIN`, `MAX`, `AVG` and the
+  /// percentiles return `null`.
+  ///
+  /// That is the null-handling-enabled answer. With null handling disabled that state is normally rendered as the
+  /// accumulator's identity, but an object-backed accumulator still hands this method a `null`, and for `MAXSTRING`,
+  /// `MINSTRING` and `ANYVALUE` there is no identity to render in the first place. A `null` argument is therefore part
+  /// of the contract in both modes, not a defensive case. See the null contract on [AggregationFunction].
   @Nullable
   FinalResult extractFinalResult(@Nullable IntermediateResult intermediateResult);
 
-  /// Merges two final results. This can be used to optimized certain functions (e.g. DISTINCT_COUNT) when data is
-  /// partitioned on each server, where we may directly request servers to return final result and merge them on broker.
-  @Nullable
-  default FinalResult mergeFinalResult(@Nullable FinalResult finalResult1, @Nullable FinalResult finalResult2) {
+  /// Merges two final results, neither of which is `null`. This can be used to optimized certain functions (e.g.
+  /// DISTINCT_COUNT) when data is partitioned on each server, where we may directly request servers to return final
+  /// result and merge them on broker.
+  ///
+  /// Call [AggregationFunctionUtils#mergeFinalResult] instead of calling this directly, on the same terms as [#merge].
+  default FinalResult mergeFinalResult(FinalResult finalResult1, FinalResult finalResult2) {
     throw new UnsupportedOperationException("Cannot merge final results for function: " + getType());
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -77,13 +77,13 @@ public class AggregationFunctionFactory {
           return new PercentileKLLAggregationFunction(arguments, nullHandlingEnabled);
         }
         if (remainingFunctionName.equals("KLLMV")) {
-          return new PercentileKLLMVAggregationFunction(arguments);
+          return new PercentileKLLMVAggregationFunction(arguments, nullHandlingEnabled);
         }
         if (remainingFunctionName.equals("RAWKLL")) {
           return new PercentileRawKLLAggregationFunction(arguments, nullHandlingEnabled);
         }
         if (remainingFunctionName.equals("RAWKLLMV")) {
-          return new PercentileRawKLLMVAggregationFunction(arguments);
+          return new PercentileRawKLLMVAggregationFunction(arguments, nullHandlingEnabled);
         }
         if (numArguments == 1) {
           // Single argument percentile (e.g. Percentile99(foo), PercentileTDigest95(bar), etc.)
@@ -115,23 +115,28 @@ public class AggregationFunctionFactory {
           } else if (remainingFunctionName.matches("\\d+MV")) {
             // PercentileMV
             String percentileString = remainingFunctionName.substring(0, remainingFunctionName.length() - 2);
-            return new PercentileMVAggregationFunction(firstArgument, parsePercentileToInt(percentileString));
+            return new PercentileMVAggregationFunction(firstArgument, parsePercentileToInt(percentileString),
+                nullHandlingEnabled);
           } else if (remainingFunctionName.matches("EST\\d+MV")) {
             // PercentileEstMV
             String percentileString = remainingFunctionName.substring(3, remainingFunctionName.length() - 2);
-            return new PercentileEstMVAggregationFunction(firstArgument, parsePercentileToInt(percentileString));
+            return new PercentileEstMVAggregationFunction(firstArgument, parsePercentileToInt(percentileString),
+                nullHandlingEnabled);
           } else if (remainingFunctionName.matches("RAWEST\\d+MV")) {
             // PercentileRawEstMV
             String percentileString = remainingFunctionName.substring(6, remainingFunctionName.length() - 2);
-            return new PercentileRawEstMVAggregationFunction(firstArgument, parsePercentileToInt(percentileString));
+            return new PercentileRawEstMVAggregationFunction(firstArgument, parsePercentileToInt(percentileString),
+                nullHandlingEnabled);
           } else if (remainingFunctionName.matches("TDIGEST\\d+MV")) {
             // PercentileTDigestMV
             String percentileString = remainingFunctionName.substring(7, remainingFunctionName.length() - 2);
-            return new PercentileTDigestMVAggregationFunction(firstArgument, parsePercentileToInt(percentileString));
+            return new PercentileTDigestMVAggregationFunction(firstArgument, parsePercentileToInt(percentileString),
+                nullHandlingEnabled);
           } else if (remainingFunctionName.matches("RAWTDIGEST\\d+MV")) {
             // PercentileRawTDigestMV
             String percentileString = remainingFunctionName.substring(10, remainingFunctionName.length() - 2);
-            return new PercentileRawTDigestMVAggregationFunction(firstArgument, parsePercentileToInt(percentileString));
+            return new PercentileRawTDigestMVAggregationFunction(firstArgument, parsePercentileToInt(percentileString),
+                nullHandlingEnabled);
           }
         } else if (numArguments == 2) {
           // Double arguments percentile (e.g. percentile(foo, 99), percentileTDigest(bar, 95), etc.) where the
@@ -160,23 +165,23 @@ public class AggregationFunctionFactory {
           }
           if (remainingFunctionName.equals("MV")) {
             // PercentileMV
-            return new PercentileMVAggregationFunction(firstArgument, percentile);
+            return new PercentileMVAggregationFunction(firstArgument, percentile, nullHandlingEnabled);
           }
           if (remainingFunctionName.equals("ESTMV")) {
             // PercentileEstMV
-            return new PercentileEstMVAggregationFunction(firstArgument, percentile);
+            return new PercentileEstMVAggregationFunction(firstArgument, percentile, nullHandlingEnabled);
           }
           if (remainingFunctionName.equals("RAWESTMV")) {
             // PercentileRawEstMV
-            return new PercentileRawEstMVAggregationFunction(firstArgument, percentile);
+            return new PercentileRawEstMVAggregationFunction(firstArgument, percentile, nullHandlingEnabled);
           }
           if (remainingFunctionName.equals("TDIGESTMV")) {
             // PercentileTDigestMV
-            return new PercentileTDigestMVAggregationFunction(firstArgument, percentile);
+            return new PercentileTDigestMVAggregationFunction(firstArgument, percentile, nullHandlingEnabled);
           }
           if (remainingFunctionName.equals("RAWTDIGESTMV")) {
             // PercentileRawTDigestMV
-            return new PercentileRawTDigestMVAggregationFunction(firstArgument, percentile);
+            return new PercentileRawTDigestMVAggregationFunction(firstArgument, percentile, nullHandlingEnabled);
           }
         } else if (numArguments == 3) {
           // Triple arguments percentile (e.g. percentileTDigest(bar, 95, 1000), etc.) where the
@@ -200,11 +205,13 @@ public class AggregationFunctionFactory {
           }
           if (remainingFunctionName.equals("TDIGESTMV")) {
             // PercentileTDigestMV
-            return new PercentileTDigestMVAggregationFunction(firstArgument, percentile, compressionFactor);
+            return new PercentileTDigestMVAggregationFunction(firstArgument, percentile, compressionFactor,
+                nullHandlingEnabled);
           }
           if (remainingFunctionName.equals("RAWTDIGESTMV")) {
             // PercentileRawTDigestMV
-            return new PercentileRawTDigestMVAggregationFunction(firstArgument, percentile, compressionFactor);
+            return new PercentileRawTDigestMVAggregationFunction(firstArgument, percentile, compressionFactor,
+                nullHandlingEnabled);
           }
         }
         throw new IllegalArgumentException("Invalid percentile function: " + function);
@@ -427,7 +434,7 @@ public class AggregationFunctionFactory {
           case MINMAXRANGEMV:
             return new MinMaxRangeMVAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTCOUNTMV:
-            return new DistinctCountMVAggregationFunction(arguments);
+            return new DistinctCountMVAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTCOUNTBITMAPMV:
             return new DistinctCountBitmapMVAggregationFunction(arguments);
           case DISTINCTCOUNTHLLMV:
@@ -443,9 +450,9 @@ public class AggregationFunctionFactory {
           case DISTINCTCOUNTRAWHLLPLUSMV:
             return new DistinctCountRawHLLPlusMVAggregationFunction(arguments);
           case DISTINCTSUMMV:
-            return new DistinctSumMVAggregationFunction(arguments);
+            return new DistinctSumMVAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTAVGMV:
-            return new DistinctAvgMVAggregationFunction(arguments);
+            return new DistinctAvgMVAggregationFunction(arguments, nullHandlingEnabled);
           case STUNION:
             return new StUnionAggregationFunction(arguments);
           case HISTOGRAM:

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -119,6 +119,36 @@ public class AggregationFunctionUtils {
     return expressions;
   }
 
+  /// Merges two intermediate results, either of which may be `null`.
+  ///
+  /// A `null` intermediate result means nothing was aggregated, and is thus the identity of merging, which means the
+  /// same thing for every aggregation. Resolving it here keeps that out of the implementations, so
+  /// [AggregationFunction#merge] only ever sees two real values. See the null contract on [AggregationFunction].
+  @Nullable
+  public static <I> I merge(AggregationFunction<I, ?> aggregationFunction, @Nullable I intermediateResult1,
+      @Nullable I intermediateResult2) {
+    if (intermediateResult1 == null) {
+      return intermediateResult2;
+    }
+    if (intermediateResult2 == null) {
+      return intermediateResult1;
+    }
+    return aggregationFunction.merge(intermediateResult1, intermediateResult2);
+  }
+
+  /// Merges two final results, either of which may be `null`, on the same terms as [#merge].
+  @Nullable
+  public static <F extends Comparable> F mergeFinalResult(AggregationFunction<?, F> aggregationFunction,
+      @Nullable F finalResult1, @Nullable F finalResult2) {
+    if (finalResult1 == null) {
+      return finalResult2;
+    }
+    if (finalResult2 == null) {
+      return finalResult1;
+    }
+    return aggregationFunction.mergeFinalResult(finalResult1, finalResult2);
+  }
+
   /// Creates a map from expression required by the [AggregationFunction] to [BlockValSet] fetched from the
   /// [ValueBlock].
   public static Map<ExpressionContext, BlockValSet> getBlockValSetMap(AggregationFunction aggregationFunction,

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AnyValueAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AnyValueAggregationFunction.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -90,25 +91,27 @@ public class AnyValueAggregationFunction extends NullableSingleInputAggregationF
     return _resultType != null ? _resultType : ColumnDataType.STRING;
   }
 
+  @Nullable
   @Override
   public Object extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     return aggregationResultHolder.getResult();
   }
 
+  @Nullable
   @Override
   public Object extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     return groupByResultHolder.getResult(groupKey);
   }
 
   @Override
-  public Comparable<?> extractFinalResult(Object intermediateResult) {
+  public Comparable<?> extractFinalResult(@Nullable Object intermediateResult) {
     return (Comparable<?>) intermediateResult;
   }
 
   @Override
   public Object merge(Object left, Object right) {
-    // For ANY_VALUE, we just need any non-null value, so merge by returning the first non-null value
-    return left != null ? left : right;
+    // Any of the two values will do, and both are real values here.
+    return left;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunction.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -249,34 +250,20 @@ public class AvgAggregationFunction extends NullableSingleInputAggregationFuncti
     }
   }
 
+  @Nullable
   @Override
   public AvgPair extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
-    AvgPair avgPair = aggregationResultHolder.getResult();
-    if (avgPair == null) {
-      return _nullHandlingEnabled ? null : new AvgPair();
-    }
-    return avgPair;
+    return aggregationResultHolder.getResult();
   }
 
+  @Nullable
   @Override
   public AvgPair extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
-    AvgPair avgPair = groupByResultHolder.getResult(groupKey);
-    if (avgPair == null) {
-      return _nullHandlingEnabled ? null : new AvgPair();
-    }
-    return avgPair;
+    return groupByResultHolder.getResult(groupKey);
   }
 
   @Override
   public AvgPair merge(AvgPair intermediateResult1, AvgPair intermediateResult2) {
-    if (_nullHandlingEnabled) {
-      if (intermediateResult1 == null) {
-        return intermediateResult2;
-      }
-      if (intermediateResult2 == null) {
-        return intermediateResult1;
-      }
-    }
     intermediateResult1.apply(intermediateResult2);
     return intermediateResult1;
   }
@@ -302,10 +289,14 @@ public class AvgAggregationFunction extends NullableSingleInputAggregationFuncti
     return ColumnDataType.DOUBLE;
   }
 
+  @Nullable
   @Override
-  public Double extractFinalResult(AvgPair intermediateResult) {
+  public Double extractFinalResult(@Nullable AvgPair intermediateResult) {
+    // A null intermediate result means nothing was aggregated, and so does a zero count, which is what a
+    // deserialized empty pair carries. With null handling enabled the average of nothing is NULL; with it disabled
+    // it is what an untouched pair renders to, which is the sentinel below.
     if (intermediateResult == null) {
-      return null;
+      return _nullHandlingEnabled ? null : DEFAULT_FINAL_RESULT;
     }
     long count = intermediateResult.getCount();
     if (count == 0L) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgMVAggregationFunction.java
@@ -19,11 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
-import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.core.common.BlockValSet;
-import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
-import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
@@ -36,41 +32,5 @@ public class AvgMVAggregationFunction extends AvgAggregationFunction {
   @Override
   public AggregationFunctionType getType() {
     return AggregationFunctionType.AVGMV;
-  }
-
-  @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    BlockValSet blockValSet = blockValSetMap.get(_expression);
-
-    if (blockValSet.isSingleValue()) {
-      // star-tree pre-aggregated values: During star-tree creation, the multi-value column is pre-aggregated
-      // per star-tree node, resulting in a single value per node.
-      aggregateSerialized(blockValSet, length, aggregationResultHolder);
-      return;
-    }
-
-    aggregateMV(blockValSet, length, aggregationResultHolder);
-  }
-
-  @Override
-  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    BlockValSet blockValSet = blockValSetMap.get(_expression);
-
-    if (blockValSet.isSingleValue()) {
-      // star-tree pre-aggregated values: During star-tree creation, the multi-value column is pre-aggregated
-      // per star-tree node, resulting in a single value per node.
-      aggregateGroupBySVSerialized(blockValSet, length, groupKeyArray, groupByResultHolder);
-      return;
-    }
-
-    aggregateMVGroupBySV(blockValSet, length, groupKeyArray, groupByResultHolder);
-  }
-
-  @Override
-  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    aggregateMVGroupByMV(blockValSetMap.get(_expression), length, groupKeysArray, groupByResultHolder);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgValueIntegerTupleSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgValueIntegerTupleSketchAggregationFunction.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.datasketches.tuple.TupleSketch;
 import org.apache.datasketches.tuple.TupleSketchIterator;
 import org.apache.datasketches.tuple.aninteger.IntegerSummary;
@@ -47,8 +48,13 @@ public class AvgValueIntegerTupleSketchAggregationFunction
     return ColumnDataType.LONG;
   }
 
+  @Nullable
   @Override
-  public Comparable extractFinalResult(TupleIntSketchAccumulator accumulator) {
+  public Comparable extractFinalResult(@Nullable TupleIntSketchAccumulator accumulator) {
+    // A null intermediate result means nothing was aggregated, and there is nothing to average
+    if (accumulator == null) {
+      return null;
+    }
     accumulator.setNominalEntries(_nominalEntries);
     accumulator.setSetOperations(_setOps);
     accumulator.setThreshold(_accumulatorThreshold);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseBooleanAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseBooleanAggregationFunction.java
@@ -20,6 +20,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -175,16 +176,29 @@ public abstract class BaseBooleanAggregationFunction extends NullableSingleInput
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    int[] valueArray = blockValSetMap.get(_expression).getIntValuesSV();
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    int[] valueArray = blockValSet.getIntValuesSV();
 
-    for (int i = 0; i < length; i++) {
-      for (int groupKey : groupKeysArray[i]) {
-        int agg = groupByResultHolder.getIntResult(groupKey);
-        groupByResultHolder.setValueForKey(groupKey, _merger.merge(agg, valueArray[i]));
+    if (_nullHandlingEnabled) {
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          for (int groupKey : groupKeysArray[i]) {
+            int agg = getInt(groupByResultHolder.getResult(groupKey));
+            groupByResultHolder.setValueForKey(groupKey, (Object) _merger.merge(agg, valueArray[i]));
+          }
+        }
+      });
+    } else {
+      for (int i = 0; i < length; i++) {
+        for (int groupKey : groupKeysArray[i]) {
+          int agg = groupByResultHolder.getIntResult(groupKey);
+          groupByResultHolder.setValueForKey(groupKey, _merger.merge(agg, valueArray[i]));
+        }
       }
     }
   }
 
+  @Nullable
   @Override
   public Integer extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     if (_nullHandlingEnabled) {
@@ -194,6 +208,7 @@ public abstract class BaseBooleanAggregationFunction extends NullableSingleInput
     }
   }
 
+  @Nullable
   @Override
   public Integer extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     if (_nullHandlingEnabled) {
@@ -205,14 +220,6 @@ public abstract class BaseBooleanAggregationFunction extends NullableSingleInput
 
   @Override
   public Integer merge(Integer intermediateResult1, Integer intermediateResult2) {
-    if (_nullHandlingEnabled) {
-      if (intermediateResult1 == null) {
-        return intermediateResult2;
-      } else if (intermediateResult2 == null) {
-        return intermediateResult1;
-      }
-    }
-
     return _merger.merge(intermediateResult1, intermediateResult2);
   }
 
@@ -226,8 +233,9 @@ public abstract class BaseBooleanAggregationFunction extends NullableSingleInput
     return ColumnDataType.BOOLEAN;
   }
 
+  @Nullable
   @Override
-  public Integer extractFinalResult(Integer intermediateResult) {
+  public Integer extractFinalResult(@Nullable Integer intermediateResult) {
     return intermediateResult;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctAggregateAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctAggregateAggregationFunction.java
@@ -29,6 +29,7 @@ import it.unimi.dsi.fastutil.longs.LongSet;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import java.math.BigDecimal;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -80,13 +81,13 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
     return new ObjectGroupByResultHolder(initialCapacity, maxCapacity);
   }
 
+  @Nullable
   @Override
   public Set extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     Object result = aggregationResultHolder.getResult();
     if (result == null) {
-      return EMPTY_PLACEHOLDER;
+      return null;
     }
-
     if (result instanceof DictIdsWrapper) {
       // For dictionary-encoded expression, convert dictionary ids to values
       return convertToValueSet((DictIdsWrapper) result);
@@ -96,13 +97,13 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
     }
   }
 
+  @Nullable
   @Override
   public Set extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     Object result = groupByResultHolder.getResult(groupKey);
     if (result == null) {
-      return EMPTY_PLACEHOLDER;
+      return null;
     }
-
     if (result instanceof DictIdsWrapper) {
       // For dictionary-encoded expression, convert dictionary ids to values
       return convertToValueSet((DictIdsWrapper) result);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/ChildAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/ChildAggregationFunction.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.BlockValSet;
@@ -113,7 +114,7 @@ public abstract class ChildAggregationFunction implements AggregationFunction<Lo
   }
 
   @Override
-  public final Long extractFinalResult(Long longValue) {
+  public final Long extractFinalResult(@Nullable Long longValue) {
     return 0L;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CovarianceAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CovarianceAggregationFunction.java
@@ -22,6 +22,7 @@ package org.apache.pinot.core.query.aggregation.function;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -161,6 +162,7 @@ public class CovarianceAggregationFunction implements AggregationFunction<Covari
     }
   }
 
+  @Nullable
   @Override
   public CovarianceTuple extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     return groupByResultHolder.getResult(groupKey);
@@ -193,8 +195,16 @@ public class CovarianceAggregationFunction implements AggregationFunction<Covari
     return ColumnDataType.DOUBLE;
   }
 
+  @Nullable
   @Override
-  public Double extractFinalResult(CovarianceTuple covarianceTuple) {
+  public Double extractFinalResult(@Nullable CovarianceTuple covarianceTuple) {
+    // A null intermediate result means nothing was aggregated, and the covariance of nothing is NULL. A zero-count
+    // tuple means the same thing and ought to answer alike, but this function never receives the query's null
+    // handling option and so cannot tell the two modes apart; it keeps its historical sentinel below. See the first
+    // known deviation on the null contract.
+    if (covarianceTuple == null) {
+      return null;
+    }
     long count = covarianceTuple.getCount();
     if (count == 0L) {
       return DEFAULT_FINAL_RESULT;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAvgAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAvgAggregationFunction.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.query.aggregation.function;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.BlockValSet;
@@ -33,7 +34,12 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 public class DistinctAvgAggregationFunction extends BaseDistinctAggregateAggregationFunction<Double> {
 
   public DistinctAvgAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
-    super(verifySingleArgument(arguments, "DISTINCT_AVG"), AggregationFunctionType.DISTINCTAVG, nullHandlingEnabled);
+    this(verifySingleArgument(arguments, "DISTINCT_AVG"), AggregationFunctionType.DISTINCTAVG, nullHandlingEnabled);
+  }
+
+  protected DistinctAvgAggregationFunction(ExpressionContext expression,
+      AggregationFunctionType aggregationFunctionType, boolean nullHandlingEnabled) {
+    super(expression, aggregationFunctionType, nullHandlingEnabled);
   }
 
   @Override
@@ -77,10 +83,14 @@ public class DistinctAvgAggregationFunction extends BaseDistinctAggregateAggrega
     return DataSchema.ColumnDataType.DOUBLE;
   }
 
+  @Nullable
   @Override
-  public Double extractFinalResult(Set intermediateResult) {
-    if (_nullHandlingEnabled && intermediateResult.isEmpty()) {
-      return null;
+  public Double extractFinalResult(@Nullable Set intermediateResult) {
+    // A null intermediate result means nothing was aggregated, and so does an empty set, which is what a
+    // deserialized peer can still carry. With null handling enabled the distinct average of nothing is NULL; with it
+    // disabled it is the zero sum divided by a zero count, which is the NaN below.
+    if (intermediateResult == null || intermediateResult.isEmpty()) {
+      return _nullHandlingEnabled ? null : Double.NaN;
     }
 
     Double distinctSum = 0.0;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAvgMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAvgMVAggregationFunction.java
@@ -19,54 +19,14 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.common.utils.DataSchema;
-import org.apache.pinot.core.common.BlockValSet;
-import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
-import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
-/// Aggregation function to compute the average of distinct values for an MV column.
-public class DistinctAvgMVAggregationFunction extends BaseDistinctAggregateAggregationFunction<Double> {
+public class DistinctAvgMVAggregationFunction extends DistinctAvgAggregationFunction {
 
-  public DistinctAvgMVAggregationFunction(List<ExpressionContext> arguments) {
-    super(verifySingleArgument(arguments, "DISTINCT_AVG_MV"), AggregationFunctionType.DISTINCTAVGMV, false);
-  }
-
-  @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    mvAggregate(blockValSetMap.get(_expression), length, aggregationResultHolder);
-  }
-
-  @Override
-  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    mvAggregateGroupBySV(blockValSetMap.get(_expression), length, groupKeyArray, groupByResultHolder);
-  }
-
-  @Override
-  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    mvAggregateGroupByMV(blockValSetMap.get(_expression), length, groupKeysArray, groupByResultHolder);
-  }
-
-  @Override
-  public DataSchema.ColumnDataType getFinalResultColumnType() {
-    return DataSchema.ColumnDataType.DOUBLE;
-  }
-
-  @Override
-  public Double extractFinalResult(Set intermediateResult) {
-    Double distinctSum = 0.0;
-
-    for (Object obj : intermediateResult) {
-      distinctSum += ((Number) obj).doubleValue();
-    }
-    Double distinctAvg = distinctSum / intermediateResult.size();
-    return distinctAvg;
+  public DistinctAvgMVAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    super(verifySingleArgument(arguments, "DISTINCT_AVG_MV"), AggregationFunctionType.DISTINCTAVGMV,
+        nullHandlingEnabled);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
@@ -34,8 +34,12 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 public class DistinctCountAggregationFunction extends BaseDistinctAggregateAggregationFunction<Integer> {
 
   public DistinctCountAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
-    super(verifySingleArgument(arguments, "DISTINCT_COUNT"), AggregationFunctionType.DISTINCTCOUNT,
-        nullHandlingEnabled);
+    this(verifySingleArgument(arguments, "DISTINCT_COUNT"), AggregationFunctionType.DISTINCTCOUNT, nullHandlingEnabled);
+  }
+
+  protected DistinctCountAggregationFunction(ExpressionContext expression,
+      AggregationFunctionType aggregationFunctionType, boolean nullHandlingEnabled) {
+    super(expression, aggregationFunctionType, nullHandlingEnabled);
   }
 
   @Override
@@ -79,7 +83,6 @@ public class DistinctCountAggregationFunction extends BaseDistinctAggregateAggre
     return ColumnDataType.INT;
   }
 
-  @Nullable
   @Override
   public Integer extractFinalResult(@Nullable Set intermediateResult) {
     return intermediateResult == null ? 0 : intermediateResult.size();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountBitmapAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountBitmapAggregationFunction.java
@@ -559,7 +559,6 @@ public class DistinctCountBitmapAggregationFunction extends BaseSingleInputAggre
     return ColumnDataType.INT;
   }
 
-  @Nullable
   @Override
   public Integer extractFinalResult(@Nullable RoaringBitmap intermediateResult) {
     return intermediateResult == null ? 0 : intermediateResult.getCardinality();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountBitmapMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountBitmapMVAggregationFunction.java
@@ -19,17 +19,10 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
-import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.core.common.BlockValSet;
-import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
-import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
-/// The `DistinctCountBitmapMVAggregationFunction` calculates the number of distinct values for a given
-/// multi-value expression using RoaringBitmap. The bitmap stores the actual values for `INT` expression, or
-/// hash code of the values for other data types (values with the same hash code will only be counted once).
 public class DistinctCountBitmapMVAggregationFunction extends DistinctCountBitmapAggregationFunction {
 
   public DistinctCountBitmapMVAggregationFunction(List<ExpressionContext> arguments) {
@@ -39,28 +32,5 @@ public class DistinctCountBitmapMVAggregationFunction extends DistinctCountBitma
   @Override
   public AggregationFunctionType getType() {
     return AggregationFunctionType.DISTINCTCOUNTBITMAPMV;
-  }
-
-  @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    BlockValSet blockValSet = blockValSetMap.get(_expression);
-    aggregateMV(length, aggregationResultHolder, blockValSet, blockValSet.getValueType().getStoredType());
-  }
-
-  @Override
-  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    BlockValSet blockValSet = blockValSetMap.get(_expression);
-    aggregateMVGroupBySV(length, groupKeyArray, groupByResultHolder, blockValSet,
-        blockValSet.getValueType().getStoredType());
-  }
-
-  @Override
-  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    BlockValSet blockValSet = blockValSetMap.get(_expression);
-    aggregateMVGroupByMV(length, groupKeysArray, groupByResultHolder, blockValSet,
-        blockValSet.getValueType().getStoredType());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountCPCSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountCPCSketchAggregationFunction.java
@@ -392,10 +392,10 @@ public class DistinctCountCPCSketchAggregationFunction
   @Override
   public CpcSketchAccumulator merge(CpcSketchAccumulator intermediateResult1,
       CpcSketchAccumulator intermediateResult2) {
-    if (intermediateResult1 == null || intermediateResult1.isEmpty()) {
+    if (intermediateResult1.isEmpty()) {
       return intermediateResult2;
     }
-    if (intermediateResult2 == null || intermediateResult2.isEmpty()) {
+    if (intermediateResult2.isEmpty()) {
       return intermediateResult1;
     }
     intermediateResult1.setLgNominalEntries(_lgNominalEntries);
@@ -425,7 +425,6 @@ public class DistinctCountCPCSketchAggregationFunction
     return DataSchema.ColumnDataType.LONG;
   }
 
-  @Nullable
   @Override
   public Comparable extractFinalResult(@Nullable CpcSketchAccumulator intermediateResult) {
     if (intermediateResult == null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
@@ -618,7 +618,6 @@ public class DistinctCountHLLAggregationFunction extends BaseSingleInputAggregat
     return ColumnDataType.LONG;
   }
 
-  @Nullable
   @Override
   public Long extractFinalResult(@Nullable HyperLogLog intermediateResult) {
     return intermediateResult == null ? 0L : intermediateResult.cardinality();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLMVAggregationFunction.java
@@ -19,11 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
-import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.core.common.BlockValSet;
-import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
-import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
@@ -36,28 +32,5 @@ public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggre
   @Override
   public AggregationFunctionType getType() {
     return AggregationFunctionType.DISTINCTCOUNTHLLMV;
-  }
-
-  @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    BlockValSet blockValSet = blockValSetMap.get(_expression);
-    aggregateMV(length, aggregationResultHolder, blockValSet, blockValSet.getValueType().getStoredType());
-  }
-
-  @Override
-  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    BlockValSet blockValSet = blockValSetMap.get(_expression);
-    aggregateMVGroupBySV(length, groupKeyArray, groupByResultHolder, blockValSet,
-        blockValSet.getValueType().getStoredType());
-  }
-
-  @Override
-  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    BlockValSet blockValSet = blockValSetMap.get(_expression);
-    aggregateMVGroupByMV(length, groupKeysArray, groupByResultHolder, blockValSet,
-        blockValSet.getValueType().getStoredType());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLPlusAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLPlusAggregationFunction.java
@@ -621,7 +621,6 @@ public class DistinctCountHLLPlusAggregationFunction extends BaseSingleInputAggr
     return ColumnDataType.LONG;
   }
 
-  @Nullable
   @Override
   public Long extractFinalResult(@Nullable HyperLogLogPlus intermediateResult) {
     return intermediateResult == null ? 0L : intermediateResult.cardinality();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLPlusMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLPlusMVAggregationFunction.java
@@ -19,11 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
-import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.core.common.BlockValSet;
-import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
-import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
@@ -36,28 +32,5 @@ public class DistinctCountHLLPlusMVAggregationFunction extends DistinctCountHLLP
   @Override
   public AggregationFunctionType getType() {
     return AggregationFunctionType.DISTINCTCOUNTHLLPLUSMV;
-  }
-
-  @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    BlockValSet blockValSet = blockValSetMap.get(_expression);
-    aggregateMV(length, aggregationResultHolder, blockValSet, blockValSet.getValueType().getStoredType());
-  }
-
-  @Override
-  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    BlockValSet blockValSet = blockValSetMap.get(_expression);
-    aggregateMVGroupBySV(length, groupKeyArray, groupByResultHolder, blockValSet,
-        blockValSet.getValueType().getStoredType());
-  }
-
-  @Override
-  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    BlockValSet blockValSet = blockValSetMap.get(_expression);
-    aggregateMVGroupByMV(length, groupKeysArray, groupByResultHolder, blockValSet,
-        blockValSet.getValueType().getStoredType());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountMVAggregationFunction.java
@@ -19,55 +19,14 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.common.utils.DataSchema;
-import org.apache.pinot.core.common.BlockValSet;
-import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
-import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
-/// Aggregation function to compute the count of distinct values for an MV column.
-public class DistinctCountMVAggregationFunction extends BaseDistinctAggregateAggregationFunction<Integer> {
+public class DistinctCountMVAggregationFunction extends DistinctCountAggregationFunction {
 
-  public DistinctCountMVAggregationFunction(List<ExpressionContext> arguments) {
-    super(verifySingleArgument(arguments, "DISTINCT_COUNT_MV"), AggregationFunctionType.DISTINCTCOUNTMV, false);
-  }
-
-  @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    mvAggregate(blockValSetMap.get(_expression), length, aggregationResultHolder);
-  }
-
-  @Override
-  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    mvAggregateGroupBySV(blockValSetMap.get(_expression), length, groupKeyArray, groupByResultHolder);
-  }
-
-  @Override
-  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    mvAggregateGroupByMV(blockValSetMap.get(_expression), length, groupKeysArray, groupByResultHolder);
-  }
-
-  @Override
-  public DataSchema.ColumnDataType getFinalResultColumnType() {
-    return DataSchema.ColumnDataType.INT;
-  }
-
-  @Nullable
-  @Override
-  public Integer extractFinalResult(@Nullable Set intermediateResult) {
-    return intermediateResult == null ? 0 : intermediateResult.size();
-  }
-
-  @Override
-  public Integer mergeFinalResult(Integer finalResult1, Integer finalResult2) {
-    return finalResult1 + finalResult2;
+  public DistinctCountMVAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    super(verifySingleArgument(arguments, "DISTINCT_COUNT_MV"), AggregationFunctionType.DISTINCTCOUNTMV,
+        nullHandlingEnabled);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountOffHeapAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountOffHeapAggregationFunction.java
@@ -45,7 +45,6 @@ public class DistinctCountOffHeapAggregationFunction
     extends NullableSingleInputAggregationFunction<BaseOffHeapSet, Integer> {
   // Use empty OffHeap32BitSet as a placeholder for empty result
   // NOTE: It is okay to close it (multiple times) since we are never adding values into it
-  private static final OffHeap32BitSet EMPTY_PLACEHOLDER = new OffHeap32BitSet(0);
 
   private final int _initialCapacity;
   private final int _hashBits;
@@ -282,11 +281,12 @@ public class DistinctCountOffHeapAggregationFunction
     throw new UnsupportedOperationException();
   }
 
+  @Nullable
   @Override
   public BaseOffHeapSet extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     Object result = aggregationResultHolder.getResult();
     if (result == null) {
-      return EMPTY_PLACEHOLDER;
+      return null;
     }
     if (result instanceof DictIdsWrapper) {
       return extractAggregationResult((DictIdsWrapper) result);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartHLLPlusAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartHLLPlusAggregationFunction.java
@@ -240,14 +240,7 @@ public class DistinctCountSmartHLLPlusAggregationFunction extends BaseDistinctCo
   }
 
   @Override
-  public Object merge(@Nullable Object intermediateResult1, @Nullable Object intermediateResult2) {
-    if (intermediateResult1 == null) {
-      return intermediateResult2;
-    }
-    if (intermediateResult2 == null) {
-      return intermediateResult1;
-    }
-
+  public Object merge(Object intermediateResult1, Object intermediateResult2) {
     if (intermediateResult1 instanceof HyperLogLogPlus) {
       return mergeIntoHLLPlus((HyperLogLogPlus) intermediateResult1, intermediateResult2);
     }
@@ -338,13 +331,7 @@ public class DistinctCountSmartHLLPlusAggregationFunction extends BaseDistinctCo
   }
 
   @Override
-  public Integer mergeFinalResult(@Nullable Integer finalResult1, @Nullable Integer finalResult2) {
-    if (finalResult1 == null) {
-      return finalResult2 == null ? 0 : finalResult2;
-    }
-    if (finalResult2 == null) {
-      return finalResult1;
-    }
+  public Integer mergeFinalResult(Integer finalResult1, Integer finalResult2) {
     return finalResult1 + finalResult2;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartULLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartULLAggregationFunction.java
@@ -24,6 +24,7 @@ import it.unimi.dsi.fastutil.objects.ObjectSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
@@ -348,7 +349,7 @@ public class DistinctCountSmartULLAggregationFunction extends BaseDistinctCountS
   }
 
   @Override
-  public Integer extractFinalResult(Object intermediateResult) {
+  public Integer extractFinalResult(@Nullable Object intermediateResult) {
     if (intermediateResult == null) {
       return 0;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
@@ -1071,7 +1071,6 @@ public class DistinctCountThetaSketchAggregationFunction
     return ColumnDataType.LONG;
   }
 
-  @Nullable
   @Override
   public Comparable extractFinalResult(@Nullable List<ThetaSketchAccumulator> accumulators) {
     if (accumulators == null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountULLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountULLAggregationFunction.java
@@ -340,15 +340,8 @@ public class DistinctCountULLAggregationFunction extends BaseSingleInputAggregat
     }
   }
 
-  @Nullable
   @Override
-  public UltraLogLog merge(@Nullable UltraLogLog intermediateResult1, @Nullable UltraLogLog intermediateResult2) {
-    if (intermediateResult1 == null) {
-      return intermediateResult2;
-    }
-    if (intermediateResult2 == null) {
-      return intermediateResult1;
-    }
+  public UltraLogLog merge(UltraLogLog intermediateResult1, UltraLogLog intermediateResult2) {
     // UltraLogLog object doesn't support merging a smaller p object into a larger p object.
     if (intermediateResult1.getP() > intermediateResult2.getP()) {
       return intermediateResult2.add(intermediateResult1);
@@ -377,7 +370,6 @@ public class DistinctCountULLAggregationFunction extends BaseSingleInputAggregat
     return ColumnDataType.LONG;
   }
 
-  @Nullable
   @Override
   public Comparable extractFinalResult(@Nullable UltraLogLog intermediateResult) {
     return intermediateResult == null ? 0L : Math.round(intermediateResult.getDistinctCountEstimate());

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctSumAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctSumAggregationFunction.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.query.aggregation.function;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.BlockValSet;
@@ -33,7 +34,12 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 public class DistinctSumAggregationFunction extends BaseDistinctAggregateAggregationFunction<Double> {
 
   public DistinctSumAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
-    super(verifySingleArgument(arguments, "DISTINCT_SUM"), AggregationFunctionType.DISTINCTSUM, nullHandlingEnabled);
+    this(verifySingleArgument(arguments, "DISTINCT_SUM"), AggregationFunctionType.DISTINCTSUM, nullHandlingEnabled);
+  }
+
+  protected DistinctSumAggregationFunction(ExpressionContext expression,
+      AggregationFunctionType aggregationFunctionType, boolean nullHandlingEnabled) {
+    super(expression, aggregationFunctionType, nullHandlingEnabled);
   }
 
   @Override
@@ -77,10 +83,14 @@ public class DistinctSumAggregationFunction extends BaseDistinctAggregateAggrega
     return DataSchema.ColumnDataType.DOUBLE;
   }
 
+  @Nullable
   @Override
-  public Double extractFinalResult(Set intermediateResult) {
-    if (_nullHandlingEnabled && intermediateResult.isEmpty()) {
-      return null;
+  public Double extractFinalResult(@Nullable Set intermediateResult) {
+    // A null intermediate result means nothing was aggregated, and so does an empty set, which is what a
+    // deserialized peer can still carry. With null handling enabled the distinct sum of nothing is NULL; with it
+    // disabled it is the sum of no values, which is the zero below.
+    if (intermediateResult == null || intermediateResult.isEmpty()) {
+      return _nullHandlingEnabled ? null : 0.0;
     }
 
     Double distinctSum = 0.0;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctSumMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctSumMVAggregationFunction.java
@@ -19,59 +19,14 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.common.utils.DataSchema;
-import org.apache.pinot.core.common.BlockValSet;
-import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
-import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
-/// Aggregation function to compute the sum of distinct values for an MV column.
-public class DistinctSumMVAggregationFunction extends BaseDistinctAggregateAggregationFunction<Double> {
+public class DistinctSumMVAggregationFunction extends DistinctSumAggregationFunction {
 
-  public DistinctSumMVAggregationFunction(List<ExpressionContext> arguments) {
-    super(verifySingleArgument(arguments, "DISTINCT_SUM_MV"), AggregationFunctionType.DISTINCTSUMMV, false);
-  }
-
-  @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    mvAggregate(blockValSetMap.get(_expression), length, aggregationResultHolder);
-  }
-
-  @Override
-  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    mvAggregateGroupBySV(blockValSetMap.get(_expression), length, groupKeyArray, groupByResultHolder);
-  }
-
-  @Override
-  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    mvAggregateGroupByMV(blockValSetMap.get(_expression), length, groupKeysArray, groupByResultHolder);
-  }
-
-  @Override
-  public DataSchema.ColumnDataType getFinalResultColumnType() {
-    return DataSchema.ColumnDataType.DOUBLE;
-  }
-
-  @Override
-  public Double extractFinalResult(Set intermediateResult) {
-    Double distinctSum = 0.0;
-
-    for (Object obj : intermediateResult) {
-      distinctSum += ((Number) obj).doubleValue();
-    }
-
-    return distinctSum;
-  }
-
-  @Override
-  public Double mergeFinalResult(Double finalResult1, Double finalResult2) {
-    return finalResult1 + finalResult2;
+  public DistinctSumMVAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    super(verifySingleArgument(arguments, "DISTINCT_SUM_MV"), AggregationFunctionType.DISTINCTSUMMV,
+        nullHandlingEnabled);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
@@ -22,6 +22,7 @@ import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -185,8 +186,9 @@ public class FastHLLAggregationFunction extends BaseSingleInputAggregationFuncti
   }
 
   @Override
-  public Long extractFinalResult(HyperLogLog intermediateResult) {
-    return intermediateResult.cardinality();
+  public Long extractFinalResult(@Nullable HyperLogLog intermediateResult) {
+    // A null intermediate result means nothing was aggregated, and a distinct count of nothing is 0
+    return intermediateResult != null ? intermediateResult.cardinality() : 0L;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstWithTimeAggregationFunction.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.query.aggregation.function;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -240,8 +241,10 @@ public abstract class FirstWithTimeAggregationFunction<V extends Comparable<V>>
     return ColumnDataType.OBJECT;
   }
 
+  @Nullable
   @Override
-  public V extractFinalResult(ValueLongPair<V> intermediateResult) {
-    return intermediateResult.getValue();
+  public V extractFinalResult(@Nullable ValueLongPair<V> intermediateResult) {
+    // A null intermediate result means nothing was aggregated, and there is no first value
+    return intermediateResult != null ? intermediateResult.getValue() : null;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FourthMomentAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FourthMomentAggregationFunction.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -164,8 +165,9 @@ public class FourthMomentAggregationFunction extends BaseSingleInputAggregationF
     return ColumnDataType.DOUBLE;
   }
 
+  @Nullable
   @Override
-  public Double extractFinalResult(PinotFourthMoment m4) {
+  public Double extractFinalResult(@Nullable PinotFourthMoment m4) {
     if (m4 == null) {
       return null;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FrequentLongsSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FrequentLongsSketchAggregationFunction.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 import java.lang.foreign.MemorySegment;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.datasketches.frequencies.FrequentLongsSketch;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
@@ -210,11 +211,13 @@ public class FrequentLongsSketchAggregationFunction
     return sketches;
   }
 
+  @Nullable
   @Override
   public FrequentLongsSketch extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     return aggregationResultHolder.getResult();
   }
 
+  @Nullable
   @Override
   public FrequentLongsSketch extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     return groupByResultHolder.getResult(groupKey);
@@ -223,12 +226,8 @@ public class FrequentLongsSketchAggregationFunction
   @Override
   public FrequentLongsSketch merge(FrequentLongsSketch sketch1, FrequentLongsSketch sketch2) {
     FrequentLongsSketch union = new FrequentLongsSketch(_maxMapSize);
-    if (sketch1 != null) {
-      union.merge(sketch1);
-    }
-    if (sketch2 != null) {
-      union.merge(sketch2);
-    }
+    union.merge(sketch1);
+    union.merge(sketch2);
     return union;
   }
 
@@ -259,8 +258,10 @@ public class FrequentLongsSketchAggregationFunction
         + "(" + _expression + ")";
   }
 
+  @Nullable
   @Override
-  public Comparable<?> extractFinalResult(FrequentLongsSketch sketch) {
-    return new SerializedFrequentLongsSketch(sketch);
+  public Comparable<?> extractFinalResult(@Nullable FrequentLongsSketch sketch) {
+    // A null intermediate result means nothing was aggregated, and there is no sketch to serialize
+    return sketch != null ? new SerializedFrequentLongsSketch(sketch) : null;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FrequentStringsSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FrequentStringsSketchAggregationFunction.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 import java.lang.foreign.MemorySegment;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.datasketches.common.ArrayOfStringsSerDe;
 import org.apache.datasketches.frequencies.FrequentItemsSketch;
 import org.apache.pinot.common.CustomObject;
@@ -194,11 +195,13 @@ public class FrequentStringsSketchAggregationFunction
     return sketches;
   }
 
+  @Nullable
   @Override
   public FrequentItemsSketch<String> extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     return aggregationResultHolder.getResult();
   }
 
+  @Nullable
   @Override
   public FrequentItemsSketch<String> extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     return groupByResultHolder.getResult(groupKey);
@@ -207,12 +210,8 @@ public class FrequentStringsSketchAggregationFunction
   @Override
   public FrequentItemsSketch<String> merge(FrequentItemsSketch<String> sketch1, FrequentItemsSketch<String> sketch2) {
     FrequentItemsSketch<String> union = new FrequentItemsSketch<>(_maxMapSize);
-    if (sketch1 != null) {
-      union.merge(sketch1);
-    }
-    if (sketch2 != null) {
-      union.merge(sketch2);
-    }
+    union.merge(sketch1);
+    union.merge(sketch2);
     return union;
   }
 
@@ -243,8 +242,10 @@ public class FrequentStringsSketchAggregationFunction
         + "(" + _expression + ")";
   }
 
+  @Nullable
   @Override
-  public Comparable<?> extractFinalResult(FrequentItemsSketch<String> sketch) {
-    return new SerializedFrequentStringsSketch(sketch);
+  public Comparable<?> extractFinalResult(@Nullable FrequentItemsSketch<String> sketch) {
+    // A null intermediate result means nothing was aggregated, and there is no sketch to serialize
+    return sketch != null ? new SerializedFrequentStringsSketch(sketch) : null;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/HistogramAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/HistogramAggregationFunction.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -200,6 +201,7 @@ public class HistogramAggregationFunction extends BaseSingleInputAggregationFunc
     }
   }
 
+  @Nullable
   @Override
   public DoubleArrayList extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     return groupByResultHolder.getResult(groupKey);
@@ -232,8 +234,9 @@ public class HistogramAggregationFunction extends BaseSingleInputAggregationFunc
     return ColumnDataType.DOUBLE_ARRAY;
   }
 
+  @Nullable
   @Override
-  public DoubleArrayList extractFinalResult(DoubleArrayList doubleArrayList) {
+  public DoubleArrayList extractFinalResult(@Nullable DoubleArrayList doubleArrayList) {
     return doubleArrayList;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IdSetAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IdSetAggregationFunction.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
@@ -486,8 +487,13 @@ public class IdSetAggregationFunction extends BaseSingleInputAggregationFunction
     return ColumnDataType.STRING;
   }
 
+  @Nullable
   @Override
-  public String extractFinalResult(IdSet intermediateResult) {
+  public String extractFinalResult(@Nullable IdSet intermediateResult) {
+    // A null intermediate result means nothing was aggregated, and there is no id set to serialize
+    if (intermediateResult == null) {
+      return null;
+    }
     try {
       return intermediateResult.toBase64String();
     } catch (IOException e) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
@@ -232,6 +232,7 @@ public class IntegerTupleSketchAggregationFunction
     return result;
   }
 
+  @Nullable
   @Override
   public TupleIntSketchAccumulator extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     return groupByResultHolder.getResult(groupKey);
@@ -240,10 +241,10 @@ public class IntegerTupleSketchAggregationFunction
   @Override
   public TupleIntSketchAccumulator merge(TupleIntSketchAccumulator intermediateResult1,
       TupleIntSketchAccumulator intermediateResult2) {
-    if (intermediateResult1 == null || intermediateResult1.isEmpty()) {
+    if (intermediateResult1.isEmpty()) {
       return intermediateResult2;
     }
-    if (intermediateResult2 == null || intermediateResult2.isEmpty()) {
+    if (intermediateResult2.isEmpty()) {
       return intermediateResult1;
     }
     intermediateResult1.setThreshold(_accumulatorThreshold);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastWithTimeAggregationFunction.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.query.aggregation.function;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -236,8 +237,10 @@ public abstract class LastWithTimeAggregationFunction<V extends Comparable<V>>
     return ColumnDataType.OBJECT;
   }
 
+  @Nullable
   @Override
-  public V extractFinalResult(ValueLongPair<V> intermediateResult) {
-    return intermediateResult.getValue();
+  public V extractFinalResult(@Nullable ValueLongPair<V> intermediateResult) {
+    // A null intermediate result means nothing was aggregated, and there is no last value
+    return intermediateResult != null ? intermediateResult.getValue() : null;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.query.aggregation.function;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -333,6 +334,7 @@ public class MaxAggregationFunction extends NullableSingleInputAggregationFuncti
     }
   }
 
+  @Nullable
   @Override
   public Double extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     if (_nullHandlingEnabled) {
@@ -341,6 +343,7 @@ public class MaxAggregationFunction extends NullableSingleInputAggregationFuncti
     return aggregationResultHolder.getDoubleResult();
   }
 
+  @Nullable
   @Override
   public Double extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     if (_nullHandlingEnabled) {
@@ -351,15 +354,6 @@ public class MaxAggregationFunction extends NullableSingleInputAggregationFuncti
 
   @Override
   public Double merge(Double intermediateMaxResult1, Double intermediateMaxResult2) {
-    if (_nullHandlingEnabled) {
-      if (intermediateMaxResult1 == null) {
-        return intermediateMaxResult2;
-      }
-      if (intermediateMaxResult2 == null) {
-        return intermediateMaxResult1;
-      }
-    }
-
     if (intermediateMaxResult1 > intermediateMaxResult2) {
       return intermediateMaxResult1;
     }
@@ -376,8 +370,9 @@ public class MaxAggregationFunction extends NullableSingleInputAggregationFuncti
     return ColumnDataType.DOUBLE;
   }
 
+  @Nullable
   @Override
-  public Double extractFinalResult(Double intermediateResult) {
+  public Double extractFinalResult(@Nullable Double intermediateResult) {
     return intermediateResult;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxLongAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxLongAggregationFunction.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -260,6 +261,7 @@ public class MaxLongAggregationFunction extends NullableSingleInputAggregationFu
     }
   }
 
+  @Nullable
   @Override
   public Long extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     if (_nullHandlingEnabled) {
@@ -268,6 +270,7 @@ public class MaxLongAggregationFunction extends NullableSingleInputAggregationFu
     return aggregationResultHolder.getLongResult();
   }
 
+  @Nullable
   @Override
   public Long extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     if (_nullHandlingEnabled) {
@@ -278,15 +281,6 @@ public class MaxLongAggregationFunction extends NullableSingleInputAggregationFu
 
   @Override
   public Long merge(Long intermediateMaxResult1, Long intermediateMaxResult2) {
-    if (_nullHandlingEnabled) {
-      if (intermediateMaxResult1 == null) {
-        return intermediateMaxResult2;
-      }
-      if (intermediateMaxResult2 == null) {
-        return intermediateMaxResult1;
-      }
-    }
-
     if (intermediateMaxResult1 > intermediateMaxResult2) {
       return intermediateMaxResult1;
     }
@@ -303,8 +297,9 @@ public class MaxLongAggregationFunction extends NullableSingleInputAggregationFu
     return ColumnDataType.LONG;
   }
 
+  @Nullable
   @Override
-  public Long extractFinalResult(Long intermediateResult) {
+  public Long extractFinalResult(@Nullable Long intermediateResult) {
     return intermediateResult;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxMVAggregationFunction.java
@@ -19,11 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
-import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.core.common.BlockValSet;
-import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
-import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
@@ -36,23 +32,5 @@ public class MaxMVAggregationFunction extends MaxAggregationFunction {
   @Override
   public AggregationFunctionType getType() {
     return AggregationFunctionType.MAXMV;
-  }
-
-  @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    aggregateMV(blockValSetMap.get(_expression), length, aggregationResultHolder);
-  }
-
-  @Override
-  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    aggregateMVGroupBySV(blockValSetMap.get(_expression), length, groupKeyArray, groupByResultHolder);
-  }
-
-  @Override
-  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    aggregateMVGroupByMV(blockValSetMap.get(_expression), length, groupKeysArray, groupByResultHolder);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxStringAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxStringAggregationFunction.java
@@ -121,24 +121,20 @@ public class MaxStringAggregationFunction extends NullableSingleInputAggregation
     });
   }
 
+  @Nullable
   @Override
   public String extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     return aggregationResultHolder.getResult();
   }
 
+  @Nullable
   @Override
   public String extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     return groupByResultHolder.getResult(groupKey);
   }
 
   @Override
-  public String merge(@Nullable String intermediateResult1, @Nullable String intermediateResult2) {
-    if (intermediateResult1 == null) {
-      return intermediateResult2;
-    }
-    if (intermediateResult2 == null) {
-      return intermediateResult1;
-    }
+  public String merge(String intermediateResult1, String intermediateResult2) {
     return intermediateResult1.compareTo(intermediateResult2) > 0 ? intermediateResult1 : intermediateResult2;
   }
 
@@ -152,8 +148,9 @@ public class MaxStringAggregationFunction extends NullableSingleInputAggregation
     return ColumnDataType.STRING;
   }
 
+  @Nullable
   @Override
-  public String extractFinalResult(String intermediateResult) {
+  public String extractFinalResult(@Nullable String intermediateResult) {
     return intermediateResult;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.query.aggregation.function;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -333,6 +334,7 @@ public class MinAggregationFunction extends NullableSingleInputAggregationFuncti
     }
   }
 
+  @Nullable
   @Override
   public Double extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     if (_nullHandlingEnabled) {
@@ -341,6 +343,7 @@ public class MinAggregationFunction extends NullableSingleInputAggregationFuncti
     return aggregationResultHolder.getDoubleResult();
   }
 
+  @Nullable
   @Override
   public Double extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     if (_nullHandlingEnabled) {
@@ -351,15 +354,6 @@ public class MinAggregationFunction extends NullableSingleInputAggregationFuncti
 
   @Override
   public Double merge(Double intermediateMinResult1, Double intermediateMinResult2) {
-    if (_nullHandlingEnabled) {
-      if (intermediateMinResult1 == null) {
-        return intermediateMinResult2;
-      }
-      if (intermediateMinResult2 == null) {
-        return intermediateMinResult1;
-      }
-    }
-
     if (intermediateMinResult1 < intermediateMinResult2) {
       return intermediateMinResult1;
     }
@@ -376,8 +370,9 @@ public class MinAggregationFunction extends NullableSingleInputAggregationFuncti
     return ColumnDataType.DOUBLE;
   }
 
+  @Nullable
   @Override
-  public Double extractFinalResult(Double intermediateResult) {
+  public Double extractFinalResult(@Nullable Double intermediateResult) {
     return intermediateResult;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinLongAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinLongAggregationFunction.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.BlockValSet;
@@ -259,6 +260,7 @@ public class MinLongAggregationFunction extends NullableSingleInputAggregationFu
     }
   }
 
+  @Nullable
   @Override
   public Long extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     if (_nullHandlingEnabled) {
@@ -267,6 +269,7 @@ public class MinLongAggregationFunction extends NullableSingleInputAggregationFu
     return aggregationResultHolder.getLongResult();
   }
 
+  @Nullable
   @Override
   public Long extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     if (_nullHandlingEnabled) {
@@ -277,15 +280,6 @@ public class MinLongAggregationFunction extends NullableSingleInputAggregationFu
 
   @Override
   public Long merge(Long intermediateMinResult1, Long intermediateMinResult2) {
-    if (_nullHandlingEnabled) {
-      if (intermediateMinResult1 == null) {
-        return intermediateMinResult2;
-      }
-      if (intermediateMinResult2 == null) {
-        return intermediateMinResult1;
-      }
-    }
-
     if (intermediateMinResult1 < intermediateMinResult2) {
       return intermediateMinResult1;
     }
@@ -302,8 +296,9 @@ public class MinLongAggregationFunction extends NullableSingleInputAggregationFu
     return DataSchema.ColumnDataType.LONG;
   }
 
+  @Nullable
   @Override
-  public Long extractFinalResult(Long intermediateResult) {
+  public Long extractFinalResult(@Nullable Long intermediateResult) {
     return intermediateResult;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMVAggregationFunction.java
@@ -19,11 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
-import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.core.common.BlockValSet;
-import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
-import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
@@ -36,23 +32,5 @@ public class MinMVAggregationFunction extends MinAggregationFunction {
   @Override
   public AggregationFunctionType getType() {
     return AggregationFunctionType.MINMV;
-  }
-
-  @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    aggregateMV(blockValSetMap.get(_expression), length, aggregationResultHolder);
-  }
-
-  @Override
-  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    aggregateMVGroupBySV(blockValSetMap.get(_expression), length, groupKeyArray, groupByResultHolder);
-  }
-
-  @Override
-  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    aggregateMVGroupByMV(blockValSetMap.get(_expression), length, groupKeysArray, groupByResultHolder);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -35,6 +36,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public class MinMaxRangeAggregationFunction extends NullableSingleInputAggregationFunction<MinMaxRangePair, Double> {
+  private static final double DEFAULT_FINAL_RESULT = Double.NEGATIVE_INFINITY;
 
   public MinMaxRangeAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
     super(verifySingleArgument(arguments, "MIN_MAX_RANGE"), nullHandlingEnabled);
@@ -254,36 +256,20 @@ public class MinMaxRangeAggregationFunction extends NullableSingleInputAggregati
     }
   }
 
+  @Nullable
   @Override
   public MinMaxRangePair extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
-    MinMaxRangePair minMaxRangePair = aggregationResultHolder.getResult();
-    if (minMaxRangePair == null && !_nullHandlingEnabled) {
-      return new MinMaxRangePair();
-    } else {
-      return minMaxRangePair;
-    }
+    return aggregationResultHolder.getResult();
   }
 
+  @Nullable
   @Override
   public MinMaxRangePair extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
-    MinMaxRangePair minMaxRangePair = groupByResultHolder.getResult(groupKey);
-    if (minMaxRangePair == null && !_nullHandlingEnabled) {
-      return new MinMaxRangePair();
-    } else {
-      return minMaxRangePair;
-    }
+    return groupByResultHolder.getResult(groupKey);
   }
 
   @Override
   public MinMaxRangePair merge(MinMaxRangePair intermediateResult1, MinMaxRangePair intermediateResult2) {
-    if (_nullHandlingEnabled) {
-      if (intermediateResult1 == null) {
-        return intermediateResult2;
-      }
-      if (intermediateResult2 == null) {
-        return intermediateResult1;
-      }
-    }
     intermediateResult1.apply(intermediateResult2);
     return intermediateResult1;
   }
@@ -309,10 +295,13 @@ public class MinMaxRangeAggregationFunction extends NullableSingleInputAggregati
     return ColumnDataType.DOUBLE;
   }
 
+  @Nullable
   @Override
-  public Double extractFinalResult(MinMaxRangePair intermediateResult) {
+  public Double extractFinalResult(@Nullable MinMaxRangePair intermediateResult) {
+    // A null intermediate result means nothing was aggregated. With null handling enabled the range of nothing is
+    // NULL; with it disabled it is what an untouched pair renders to, which is the sentinel below.
     if (intermediateResult == null) {
-      return null;
+      return _nullHandlingEnabled ? null : DEFAULT_FINAL_RESULT;
     }
     return intermediateResult.getMax() - intermediateResult.getMin();
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMaxRangeMVAggregationFunction.java
@@ -19,12 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
-import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.core.common.BlockValSet;
-import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
-import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
-import org.apache.pinot.segment.local.customobject.MinMaxRangePair;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
@@ -37,28 +32,5 @@ public class MinMaxRangeMVAggregationFunction extends MinMaxRangeAggregationFunc
   @Override
   public AggregationFunctionType getType() {
     return AggregationFunctionType.MINMAXRANGEMV;
-  }
-
-  @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    MinMaxRangePair minMax = new MinMaxRangePair();
-    aggregateMV(blockValSetMap.get(_expression), length, minMax);
-
-    if (minMax.getMax() >= minMax.getMin()) {
-      setAggregationResult(aggregationResultHolder, minMax.getMin(), minMax.getMax());
-    }
-  }
-
-  @Override
-  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    aggregateMVGroupBySV(blockValSetMap.get(_expression), length, groupKeyArray, groupByResultHolder);
-  }
-
-  @Override
-  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    aggregateMVGroupByMV(blockValSetMap.get(_expression), length, groupKeysArray, groupByResultHolder);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinStringAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinStringAggregationFunction.java
@@ -120,24 +120,20 @@ public class MinStringAggregationFunction extends NullableSingleInputAggregation
     });
   }
 
+  @Nullable
   @Override
   public String extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     return aggregationResultHolder.getResult();
   }
 
+  @Nullable
   @Override
   public String extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     return groupByResultHolder.getResult(groupKey);
   }
 
   @Override
-  public String merge(@Nullable String intermediateResult1, @Nullable String intermediateResult2) {
-    if (intermediateResult1 == null) {
-      return intermediateResult2;
-    }
-    if (intermediateResult2 == null) {
-      return intermediateResult1;
-    }
+  public String merge(String intermediateResult1, String intermediateResult2) {
     return intermediateResult1.compareTo(intermediateResult2) < 0 ? intermediateResult1 : intermediateResult2;
   }
 
@@ -151,8 +147,9 @@ public class MinStringAggregationFunction extends NullableSingleInputAggregation
     return ColumnDataType.STRING;
   }
 
+  @Nullable
   @Override
-  public String extractFinalResult(String intermediateResult) {
+  public String extractFinalResult(@Nullable String intermediateResult) {
     return intermediateResult;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/ModeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/ModeAggregationFunction.java
@@ -504,8 +504,15 @@ public class ModeAggregationFunction
     return ColumnDataType.DOUBLE;
   }
 
+  @Nullable
   @Override
-  public Double extractFinalResult(Map<? extends Number, Long> intermediateResult) {
+  public Double extractFinalResult(@Nullable Map<? extends Number, Long> intermediateResult) {
+    // A null intermediate result means nothing was aggregated, and the mode of nothing is NULL. An empty map is a
+    // different thing: it is what an untouched single-stage result holder produces, and it keeps its historical
+    // sentinel below so that path is not silently changed.
+    if (intermediateResult == null) {
+      return null;
+    }
     if (intermediateResult.isEmpty()) {
       if (_nullHandlingEnabled) {
         return null;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/ParentExprMinMaxAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/ParentExprMinMaxAggregationFunction.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.query.aggregation.function;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
@@ -266,6 +267,7 @@ public class ParentExprMinMaxAggregationFunction extends ParentAggregationFuncti
     }
   }
 
+  @Nullable
   @Override
   public ExprMinMaxObject extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     return groupByResultHolder.getResult(groupKey);
@@ -292,8 +294,9 @@ public class ParentExprMinMaxAggregationFunction extends ParentAggregationFuncti
     return ObjectSerDeUtils.ARG_MIN_MAX_OBJECT_SER_DE.deserialize(customObject.getBuffer());
   }
 
+  @Nullable
   @Override
-  public ExprMinMaxObject extractFinalResult(ExprMinMaxObject exprMinMaxObject) {
+  public ExprMinMaxObject extractFinalResult(@Nullable ExprMinMaxObject exprMinMaxObject) {
     return exprMinMaxObject;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.query.aggregation.function;
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import java.util.Arrays;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -186,22 +187,12 @@ public class PercentileAggregationFunction extends NullableSingleInputAggregatio
 
   @Override
   public DoubleArrayList extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
-    DoubleArrayList doubleArrayList = aggregationResultHolder.getResult();
-    if (doubleArrayList == null) {
-      return new DoubleArrayList();
-    } else {
-      return doubleArrayList;
-    }
+    return aggregationResultHolder.getResult();
   }
 
   @Override
   public DoubleArrayList extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
-    DoubleArrayList doubleArrayList = groupByResultHolder.getResult(groupKey);
-    if (doubleArrayList == null) {
-      return new DoubleArrayList();
-    } else {
-      return doubleArrayList;
-    }
+    return groupByResultHolder.getResult(groupKey);
   }
 
   @Override
@@ -231,24 +222,22 @@ public class PercentileAggregationFunction extends NullableSingleInputAggregatio
     return ColumnDataType.DOUBLE;
   }
 
+  @Nullable
   @Override
-  public Double extractFinalResult(DoubleArrayList intermediateResult) {
-    int size = intermediateResult.size();
-    if (size == 0) {
-      if (_nullHandlingEnabled) {
-        return null;
-      } else {
-        return DEFAULT_FINAL_RESULT;
-      }
-    } else {
-      double[] values = intermediateResult.elements();
-      Arrays.sort(values, 0, size);
-      if (_percentile == 100) {
-        return values[size - 1];
-      } else {
-        return values[(int) ((long) size * _percentile / 100)];
-      }
+  public Double extractFinalResult(@Nullable DoubleArrayList intermediateResult) {
+    // A null intermediate result means nothing was aggregated, and so does an empty list, which is what a
+    // deserialized peer can still carry. With null handling enabled the percentile of nothing is NULL; with it
+    // disabled it is the sentinel this function has always rendered for an untouched accumulator.
+    if (intermediateResult == null || intermediateResult.isEmpty()) {
+      return _nullHandlingEnabled ? null : DEFAULT_FINAL_RESULT;
     }
+    int size = intermediateResult.size();
+    double[] values = intermediateResult.elements();
+    Arrays.sort(values, 0, size);
+    if (_percentile == 100) {
+      return values[size - 1];
+    }
+    return values[(int) ((long) size * _percentile / 100)];
   }
 
   /// Returns the value list from the result holder or creates a new one if it does not exist.

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -246,22 +247,12 @@ public class PercentileEstAggregationFunction extends NullableSingleInputAggrega
 
   @Override
   public QuantileDigest extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
-    QuantileDigest quantileDigest = aggregationResultHolder.getResult();
-    if (quantileDigest == null) {
-      return new QuantileDigest(DEFAULT_MAX_ERROR);
-    } else {
-      return quantileDigest;
-    }
+    return aggregationResultHolder.getResult();
   }
 
   @Override
   public QuantileDigest extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
-    QuantileDigest quantileDigest = groupByResultHolder.getResult(groupKey);
-    if (quantileDigest == null) {
-      return new QuantileDigest(DEFAULT_MAX_ERROR);
-    } else {
-      return quantileDigest;
-    }
+    return groupByResultHolder.getResult(groupKey);
   }
 
   @Override
@@ -297,10 +288,14 @@ public class PercentileEstAggregationFunction extends NullableSingleInputAggrega
     return ColumnDataType.LONG;
   }
 
+  @Nullable
   @Override
-  public Long extractFinalResult(QuantileDigest intermediateResult) {
-    if (intermediateResult.getCount() == 0 && _nullHandlingEnabled) {
-      return null;
+  public Long extractFinalResult(@Nullable QuantileDigest intermediateResult) {
+    // A null intermediate result means nothing was aggregated, and so does a zero-count digest, which is what a
+    // deserialized peer can still carry. With null handling enabled the percentile of nothing is NULL; with it
+    // disabled it is what an empty digest renders, which is the seed of its running maximum.
+    if (intermediateResult == null || intermediateResult.getCount() == 0) {
+      return _nullHandlingEnabled ? null : Long.MIN_VALUE;
     }
     return intermediateResult.getQuantile(_percentile / 100.0);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstMVAggregationFunction.java
@@ -18,22 +18,20 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
-import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.core.common.BlockValSet;
-import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
-import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
 public class PercentileEstMVAggregationFunction extends PercentileEstAggregationFunction {
 
-  public PercentileEstMVAggregationFunction(ExpressionContext expression, int percentile) {
-    super(expression, percentile, false);
+  public PercentileEstMVAggregationFunction(ExpressionContext expression, int percentile,
+      boolean nullHandlingEnabled) {
+    super(expression, percentile, nullHandlingEnabled);
   }
 
-  public PercentileEstMVAggregationFunction(ExpressionContext expression, double percentile) {
-    super(expression, percentile, false);
+  public PercentileEstMVAggregationFunction(ExpressionContext expression, double percentile,
+      boolean nullHandlingEnabled) {
+    super(expression, percentile, nullHandlingEnabled);
   }
 
   @Override
@@ -47,23 +45,5 @@ public class PercentileEstMVAggregationFunction extends PercentileEstAggregation
         + _expression + ")"
         : AggregationFunctionType.PERCENTILEEST.getName().toLowerCase() + "mv(" + _expression + ", " + _percentile
             + ")";
-  }
-
-  @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    aggregateMV(length, aggregationResultHolder, blockValSetMap.get(_expression));
-  }
-
-  @Override
-  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    aggregateMVGroupBySV(length, groupKeyArray, groupByResultHolder, blockValSetMap.get(_expression));
-  }
-
-  @Override
-  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    aggregateMVGroupByMV(length, groupKeysArray, groupByResultHolder, blockValSetMap.get(_expression));
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileKLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileKLLAggregationFunction.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import java.lang.foreign.MemorySegment;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.datasketches.kll.KllDoublesSketch;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
@@ -274,11 +275,13 @@ public class PercentileKLLAggregationFunction
     return sketches;
   }
 
+  @Nullable
   @Override
   public KllDoublesSketch extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     return aggregationResultHolder.getResult();
   }
 
+  @Nullable
   @Override
   public KllDoublesSketch extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     return groupByResultHolder.getResult(groupKey);
@@ -287,12 +290,8 @@ public class PercentileKLLAggregationFunction
   @Override
   public KllDoublesSketch merge(KllDoublesSketch sketch1, KllDoublesSketch sketch2) {
     KllDoublesSketch union = KllDoublesSketch.newHeapInstance(_kValue);
-    if (sketch1 != null) {
-      union.merge(sketch1);
-    }
-    if (sketch2 != null) {
-      union.merge(sketch2);
-    }
+    union.merge(sketch1);
+    union.merge(sketch2);
     return union;
   }
 
@@ -322,9 +321,11 @@ public class PercentileKLLAggregationFunction
     return AggregationFunctionType.PERCENTILEKLL.getName().toLowerCase() + "(" + _expression + ", " + _percentile + ")";
   }
 
+  @Nullable
   @Override
-  public Comparable<?> extractFinalResult(KllDoublesSketch sketch) {
-    if (sketch.isEmpty() && _nullHandlingEnabled) {
+  public Comparable<?> extractFinalResult(@Nullable KllDoublesSketch sketch) {
+    // A null intermediate result means nothing was aggregated, resolved the same way as an empty sketch
+    if (sketch == null || (_nullHandlingEnabled && sketch.isEmpty())) {
       return null;
     }
     return sketch.getQuantile(_percentile / 100);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileKLLMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileKLLMVAggregationFunction.java
@@ -19,37 +19,14 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
-import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.core.common.BlockValSet;
-import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
-import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
 public class PercentileKLLMVAggregationFunction extends PercentileKLLAggregationFunction {
 
-  public PercentileKLLMVAggregationFunction(List<ExpressionContext> arguments) {
-    super(arguments, false);
-  }
-
-  @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    BlockValSet valueSet = blockValSetMap.get(_expression);
-    aggregateMV(length, aggregationResultHolder, valueSet, getOrCreateSketch(aggregationResultHolder));
-  }
-
-  @Override
-  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    aggregateMVGroupBySV(length, groupKeyArray, groupByResultHolder, blockValSetMap.get(_expression));
-  }
-
-  @Override
-  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    aggregateMVGroupByMV(length, groupKeysArray, groupByResultHolder, blockValSetMap.get(_expression));
+  public PercentileKLLMVAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    super(arguments, nullHandlingEnabled);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileMVAggregationFunction.java
@@ -18,22 +18,19 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
-import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.core.common.BlockValSet;
-import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
-import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
 public class PercentileMVAggregationFunction extends PercentileAggregationFunction {
 
-  public PercentileMVAggregationFunction(ExpressionContext expression, int percentile) {
-    super(expression, percentile, false);
+  public PercentileMVAggregationFunction(ExpressionContext expression, int percentile, boolean nullHandlingEnabled) {
+    super(expression, percentile, nullHandlingEnabled);
   }
 
-  public PercentileMVAggregationFunction(ExpressionContext expression, double percentile) {
-    super(expression, percentile, false);
+  public PercentileMVAggregationFunction(ExpressionContext expression, double percentile,
+      boolean nullHandlingEnabled) {
+    super(expression, percentile, nullHandlingEnabled);
   }
 
   @Override
@@ -46,23 +43,5 @@ public class PercentileMVAggregationFunction extends PercentileAggregationFuncti
     return _version == 0 ? AggregationFunctionType.PERCENTILE.getName().toLowerCase() + (int) _percentile + "mv("
         + _expression + ")"
         : AggregationFunctionType.PERCENTILE.getName().toLowerCase() + "mv(" + _expression + ", " + _percentile + ")";
-  }
-
-  @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    aggregateMV(length, aggregationResultHolder, blockValSetMap.get(_expression));
-  }
-
-  @Override
-  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    aggregateMVGroupBySV(length, groupKeyArray, groupByResultHolder, blockValSetMap.get(_expression));
-  }
-
-  @Override
-  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    aggregateMVGroupByMV(length, groupKeysArray, groupByResultHolder, blockValSetMap.get(_expression));
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileRawEstAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileRawEstAggregationFunction.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -131,8 +132,17 @@ public class PercentileRawEstAggregationFunction
     return ColumnDataType.STRING;
   }
 
+  @Nullable
   @Override
-  public SerializedQuantileDigest extractFinalResult(QuantileDigest intermediateResult) {
+  public SerializedQuantileDigest extractFinalResult(@Nullable QuantileDigest intermediateResult) {
+    // A null intermediate result means nothing was aggregated. With null handling enabled that is NULL; with it
+    // disabled the answer has to stay what it has always been, which is an empty digest serialized, so the empty
+    // accumulator the delegate no longer substitutes is built here where it is rendered.
+    if (intermediateResult == null) {
+      return _percentileEstAggregationFunction._nullHandlingEnabled ? null
+          : new SerializedQuantileDigest(new QuantileDigest(PercentileEstAggregationFunction.DEFAULT_MAX_ERROR),
+              _percentileEstAggregationFunction._percentile);
+    }
     return new SerializedQuantileDigest(intermediateResult, _percentileEstAggregationFunction._percentile);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileRawEstMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileRawEstMVAggregationFunction.java
@@ -22,16 +22,18 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
-/// The `PercentileRawEstMVAggregationFunction` returns the serialized `QuantileDigest` data structure of
-/// the `PercentileEstMVAggregationFunction`.
 public class PercentileRawEstMVAggregationFunction extends PercentileRawEstAggregationFunction {
 
-  public PercentileRawEstMVAggregationFunction(ExpressionContext expressionContext, int percentile) {
-    super(expressionContext, new PercentileEstMVAggregationFunction(expressionContext, percentile));
+  public PercentileRawEstMVAggregationFunction(ExpressionContext expressionContext, int percentile,
+      boolean nullHandlingEnabled) {
+    super(expressionContext,
+        new PercentileEstMVAggregationFunction(expressionContext, percentile, nullHandlingEnabled));
   }
 
-  public PercentileRawEstMVAggregationFunction(ExpressionContext expressionContext, double percentile) {
-    super(expressionContext, new PercentileEstMVAggregationFunction(expressionContext, percentile));
+  public PercentileRawEstMVAggregationFunction(ExpressionContext expressionContext, double percentile,
+      boolean nullHandlingEnabled) {
+    super(expressionContext,
+        new PercentileEstMVAggregationFunction(expressionContext, percentile, nullHandlingEnabled));
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileRawKLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileRawKLLAggregationFunction.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.datasketches.kll.KllDoublesSketch;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -48,8 +49,14 @@ public class PercentileRawKLLAggregationFunction extends PercentileKLLAggregatio
         + ")";
   }
 
+  @Nullable
   @Override
-  public SerializedKLL extractFinalResult(KllDoublesSketch sketch) {
+  public SerializedKLL extractFinalResult(@Nullable KllDoublesSketch sketch) {
+    // There is no sketch to serialize when nothing was aggregated, and the wrapper dereferences whatever it is handed,
+    // so resolve it here instead of deferring the failure to the point where the value is rendered.
+    if (sketch == null) {
+      return null;
+    }
     return new SerializedKLL(sketch, _percentile);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileRawKLLMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileRawKLLMVAggregationFunction.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.datasketches.kll.KllDoublesSketch;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -28,8 +29,8 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 public class PercentileRawKLLMVAggregationFunction extends PercentileKLLMVAggregationFunction {
 
-  public PercentileRawKLLMVAggregationFunction(List<ExpressionContext> arguments) {
-    super(arguments);
+  public PercentileRawKLLMVAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    super(arguments, nullHandlingEnabled);
   }
 
   @Override
@@ -48,8 +49,14 @@ public class PercentileRawKLLMVAggregationFunction extends PercentileKLLMVAggreg
         + ")";
   }
 
+  @Nullable
   @Override
-  public SerializedKLL extractFinalResult(KllDoublesSketch sketch) {
+  public SerializedKLL extractFinalResult(@Nullable KllDoublesSketch sketch) {
+    // There is no sketch to serialize when nothing was aggregated, and the wrapper dereferences whatever it is handed,
+    // so resolve it here instead of deferring the failure to the point where the value is rendered.
+    if (sketch == null) {
+      return null;
+    }
     return new SerializedKLL(sketch, _percentile);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileRawTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileRawTDigestAggregationFunction.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import com.tdunning.math.stats.TDigest;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -27,6 +28,7 @@ import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.local.customobject.SerializedTDigest;
+import org.apache.pinot.segment.local.utils.TDigestUtils;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
@@ -143,8 +145,18 @@ public class PercentileRawTDigestAggregationFunction
     return ColumnDataType.STRING;
   }
 
+  @Nullable
   @Override
-  public SerializedTDigest extractFinalResult(TDigest intermediateResult) {
+  public SerializedTDigest extractFinalResult(@Nullable TDigest intermediateResult) {
+    // A null intermediate result means nothing was aggregated. With null handling enabled that is NULL; with it
+    // disabled the answer has to stay what it has always been, which is an empty digest serialized, so the empty
+    // accumulator the delegate no longer substitutes is built here where it is rendered.
+    if (intermediateResult == null) {
+      return _percentileTDigestAggregationFunction._nullHandlingEnabled ? null
+          : new SerializedTDigest(
+              TDigestUtils.createMergingDigest(_percentileTDigestAggregationFunction._compressionFactor),
+              _percentileTDigestAggregationFunction._percentile);
+    }
     return new SerializedTDigest(intermediateResult, _percentileTDigestAggregationFunction._percentile);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileRawTDigestMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileRawTDigestMVAggregationFunction.java
@@ -22,22 +22,25 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
-/// The `PercentileRawTDigestMVAggregationFunction` returns the serialized `TDigest` data structure of the
-/// `PercentileTDigestMVAggregationFunction`.
 public class PercentileRawTDigestMVAggregationFunction extends PercentileRawTDigestAggregationFunction {
 
-  public PercentileRawTDigestMVAggregationFunction(ExpressionContext expressionContext, int percentile) {
-    super(expressionContext, new PercentileTDigestMVAggregationFunction(expressionContext, percentile));
-  }
-
-  public PercentileRawTDigestMVAggregationFunction(ExpressionContext expressionContext, double percentile) {
-    super(expressionContext, new PercentileTDigestMVAggregationFunction(expressionContext, percentile));
+  public PercentileRawTDigestMVAggregationFunction(ExpressionContext expressionContext, int percentile,
+      boolean nullHandlingEnabled) {
+    super(expressionContext,
+        new PercentileTDigestMVAggregationFunction(expressionContext, percentile, nullHandlingEnabled));
   }
 
   public PercentileRawTDigestMVAggregationFunction(ExpressionContext expressionContext, double percentile,
-      int compressionFactor) {
+      boolean nullHandlingEnabled) {
     super(expressionContext,
-        new PercentileTDigestMVAggregationFunction(expressionContext, percentile, compressionFactor));
+        new PercentileTDigestMVAggregationFunction(expressionContext, percentile, nullHandlingEnabled));
+  }
+
+  public PercentileRawTDigestMVAggregationFunction(ExpressionContext expressionContext, double percentile,
+      int compressionFactor, boolean nullHandlingEnabled) {
+    super(expressionContext,
+        new PercentileTDigestMVAggregationFunction(expressionContext, percentile, compressionFactor,
+            nullHandlingEnabled));
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileSmartTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileSmartTDigestAggregationFunction.java
@@ -254,25 +254,16 @@ public class PercentileSmartTDigestAggregationFunction extends NullableSingleInp
 
   @Override
   public Object extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
-    Object result = aggregationResultHolder.getResult();
-    return result != null ? result : new DoubleArrayList();
+    return aggregationResultHolder.getResult();
   }
 
   @Override
   public Object extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
-    Object result = groupByResultHolder.getResult(groupKey);
-    return result != null ? result : new DoubleArrayList();
+    return groupByResultHolder.getResult(groupKey);
   }
 
   @Override
-  @Nullable
-  public Object merge(@Nullable Object intermediateResult1, @Nullable Object intermediateResult2) {
-    if (intermediateResult1 == null) {
-      return intermediateResult2;
-    }
-    if (intermediateResult2 == null) {
-      return intermediateResult1;
-    }
+  public Object merge(Object intermediateResult1, Object intermediateResult2) {
     if (intermediateResult1 instanceof PercentileTDigestAccumulator) {
       return mergeIntoAccumulator((PercentileTDigestAccumulator) intermediateResult1, intermediateResult2);
     }
@@ -330,10 +321,23 @@ public class PercentileSmartTDigestAggregationFunction extends NullableSingleInp
     return ColumnDataType.DOUBLE;
   }
 
+  @Nullable
   @Override
-  public Double extractFinalResult(Object intermediateResult) {
+  public Double extractFinalResult(@Nullable Object intermediateResult) {
+    // A null intermediate result means nothing was aggregated, and so do an empty digest and an empty value list,
+    // which is what a deserialized peer can still carry. With null handling enabled the percentile of nothing is
+    // NULL; with it disabled it is the sentinel this function has always rendered for an untouched accumulator.
+    if (intermediateResult == null) {
+      return _nullHandlingEnabled ? null : DEFAULT_FINAL_RESULT;
+    }
     if (intermediateResult instanceof TDigest) {
-      return ((TDigest) intermediateResult).quantile(_percentile / 100.0);
+      TDigest tDigest = (TDigest) intermediateResult;
+      // An empty digest holds the same state as the empty value list below, so the two branches must answer alike:
+      // which one a query lands in depends only on whether the accumulator crossed the conversion threshold.
+      if (_nullHandlingEnabled && tDigest.size() == 0L) {
+        return null;
+      }
+      return tDigest.quantile(_percentile / 100.0);
     } else {
       DoubleArrayList valueList = (DoubleArrayList) intermediateResult;
       int size = valueList.size();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import com.tdunning.math.stats.TDigest;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -260,22 +261,12 @@ public class PercentileTDigestAggregationFunction extends NullableSingleInputAgg
 
   @Override
   public TDigest extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
-    PercentileTDigestAccumulator accumulator = aggregationResultHolder.getResult();
-    if (accumulator == null) {
-      return TDigestUtils.createMergingDigest(_compressionFactor);
-    } else {
-      return accumulator;
-    }
+    return aggregationResultHolder.getResult();
   }
 
   @Override
   public TDigest extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
-    Object result = groupByResultHolder.getResult(groupKey);
-    if (result == null) {
-      return TDigestUtils.createMergingDigest(_compressionFactor);
-    } else {
-      return (TDigest) result;
-    }
+    return (TDigest) groupByResultHolder.getResult(groupKey);
   }
 
   @Override
@@ -330,8 +321,15 @@ public class PercentileTDigestAggregationFunction extends NullableSingleInputAgg
     return ColumnDataType.DOUBLE;
   }
 
+  @Nullable
   @Override
-  public Double extractFinalResult(TDigest intermediateResult) {
+  public Double extractFinalResult(@Nullable TDigest intermediateResult) {
+    // A null intermediate result means nothing was aggregated, and so does an empty digest, which is what a
+    // deserialized peer can still carry. With null handling enabled the percentile of nothing is NULL; with it
+    // disabled it is what `quantile` returns for an empty digest, which is NaN.
+    if (intermediateResult == null || intermediateResult.size() == 0L) {
+      return _nullHandlingEnabled ? null : Double.NaN;
+    }
     return intermediateResult.quantile(_percentile / 100.0);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunction.java
@@ -18,27 +18,25 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
-import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.core.common.BlockValSet;
-import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
-import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
 public class PercentileTDigestMVAggregationFunction extends PercentileTDigestAggregationFunction {
 
-  public PercentileTDigestMVAggregationFunction(ExpressionContext expression, int percentile) {
-    super(expression, percentile, false);
-  }
-
-  public PercentileTDigestMVAggregationFunction(ExpressionContext expression, double percentile) {
-    super(expression, percentile, false);
+  public PercentileTDigestMVAggregationFunction(ExpressionContext expression, int percentile,
+      boolean nullHandlingEnabled) {
+    super(expression, percentile, nullHandlingEnabled);
   }
 
   public PercentileTDigestMVAggregationFunction(ExpressionContext expression, double percentile,
-      int compressionFactor) {
-    super(expression, percentile, compressionFactor, false);
+      boolean nullHandlingEnabled) {
+    super(expression, percentile, nullHandlingEnabled);
+  }
+
+  public PercentileTDigestMVAggregationFunction(ExpressionContext expression, double percentile,
+      int compressionFactor, boolean nullHandlingEnabled) {
+    super(expression, percentile, compressionFactor, nullHandlingEnabled);
   }
 
   @Override
@@ -55,23 +53,5 @@ public class PercentileTDigestMVAggregationFunction extends PercentileTDigestAgg
                 + _percentile + ")")
             : (AggregationFunctionType.PERCENTILETDIGEST.getName().toLowerCase() + "mv(" + _expression + ", "
                 + _percentile + ", " + _compressionFactor + ")"));
-  }
-
-  @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    aggregateMV(length, aggregationResultHolder, blockValSetMap.get(_expression));
-  }
-
-  @Override
-  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    aggregateMVGroupBySV(length, groupKeyArray, groupByResultHolder, blockValSetMap.get(_expression));
-  }
-
-  @Override
-  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    aggregateMVGroupByMV(length, groupKeysArray, groupByResultHolder, blockValSetMap.get(_expression));
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/StUnionAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/StUnionAggregationFunction.java
@@ -109,7 +109,7 @@ public class StUnionAggregationFunction extends BaseSingleInputAggregationFuncti
   }
 
   @Override
-  public Geometry merge(@Nullable Geometry intermediateResult1, @Nullable Geometry intermediateResult2) {
+  public Geometry merge(Geometry intermediateResult1, Geometry intermediateResult2) {
     return union(intermediateResult1, intermediateResult2);
   }
 
@@ -134,9 +134,11 @@ public class StUnionAggregationFunction extends BaseSingleInputAggregationFuncti
     return DataSchema.ColumnDataType.BYTES;
   }
 
+  @Nullable
   @Override
-  public ByteArray extractFinalResult(Geometry geometry) {
-    return new ByteArray(GeometrySerializer.serialize(geometry));
+  public ByteArray extractFinalResult(@Nullable Geometry geometry) {
+    // A null intermediate result means nothing was aggregated; the union of no geometries is NULL, matching ST_Union
+    return geometry != null ? new ByteArray(GeometrySerializer.serialize(geometry)) : null;
   }
 
   /// Returns the union of the supplied geometries.

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.query.aggregation.function;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
@@ -315,6 +316,7 @@ public class SumAggregationFunction extends NullableSingleInputAggregationFuncti
     }
   }
 
+  @Nullable
   @Override
   public Double extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     if (_nullHandlingEnabled) {
@@ -323,6 +325,7 @@ public class SumAggregationFunction extends NullableSingleInputAggregationFuncti
     return aggregationResultHolder.getDoubleResult();
   }
 
+  @Nullable
   @Override
   public Double extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     if (_nullHandlingEnabled) {
@@ -333,14 +336,6 @@ public class SumAggregationFunction extends NullableSingleInputAggregationFuncti
 
   @Override
   public Double merge(Double intermediateResult1, Double intermediateResult2) {
-    if (_nullHandlingEnabled) {
-      if (intermediateResult1 == null) {
-        return intermediateResult2;
-      }
-      if (intermediateResult2 == null) {
-        return intermediateResult1;
-      }
-    }
     return intermediateResult1 + intermediateResult2;
   }
 
@@ -354,8 +349,9 @@ public class SumAggregationFunction extends NullableSingleInputAggregationFuncti
     return ColumnDataType.DOUBLE;
   }
 
+  @Nullable
   @Override
-  public Double extractFinalResult(Double intermediateResult) {
+  public Double extractFinalResult(@Nullable Double intermediateResult) {
     return intermediateResult;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumIntAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumIntAggregationFunction.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.BlockValSet;
@@ -155,6 +156,7 @@ public class SumIntAggregationFunction extends NullableSingleInputAggregationFun
     }
   }
 
+  @Nullable
   @Override
   public Long extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     if (_nullHandlingEnabled) {
@@ -163,6 +165,7 @@ public class SumIntAggregationFunction extends NullableSingleInputAggregationFun
     return aggregationResultHolder.getLongResult();
   }
 
+  @Nullable
   @Override
   public Long extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     if (_nullHandlingEnabled) {
@@ -173,20 +176,7 @@ public class SumIntAggregationFunction extends NullableSingleInputAggregationFun
 
   @Override
   public Long merge(Long intermediateResult1, Long intermediateResult2) {
-    if (_nullHandlingEnabled) {
-      if (intermediateResult1 == null) {
-        return intermediateResult2;
-      }
-      if (intermediateResult2 == null) {
-        return intermediateResult1;
-      }
-      // Both are non-null
-      return intermediateResult1 + intermediateResult2;
-    } else {
-      long val1 = (intermediateResult1 != null) ? intermediateResult1 : 0L;
-      long val2 = (intermediateResult2 != null) ? intermediateResult2 : 0L;
-      return val1 + val2;
-    }
+    return intermediateResult1 + intermediateResult2;
   }
 
   @Override
@@ -199,8 +189,9 @@ public class SumIntAggregationFunction extends NullableSingleInputAggregationFun
     return DataSchema.ColumnDataType.LONG;
   }
 
+  @Nullable
   @Override
-  public Long extractFinalResult(Long intermediateResult) {
+  public Long extractFinalResult(@Nullable Long intermediateResult) {
     return intermediateResult;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumLongAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumLongAggregationFunction.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.BlockValSet;
@@ -267,6 +268,7 @@ public class SumLongAggregationFunction extends NullableSingleInputAggregationFu
     }
   }
 
+  @Nullable
   @Override
   public Long extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     if (_nullHandlingEnabled) {
@@ -275,6 +277,7 @@ public class SumLongAggregationFunction extends NullableSingleInputAggregationFu
     return aggregationResultHolder.getLongResult();
   }
 
+  @Nullable
   @Override
   public Long extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     if (_nullHandlingEnabled) {
@@ -285,20 +288,7 @@ public class SumLongAggregationFunction extends NullableSingleInputAggregationFu
 
   @Override
   public Long merge(Long intermediateResult1, Long intermediateResult2) {
-    if (_nullHandlingEnabled) {
-      if (intermediateResult1 == null) {
-        return intermediateResult2;
-      }
-      if (intermediateResult2 == null) {
-        return intermediateResult1;
-      }
-      // Both are non-null
-      return intermediateResult1 + intermediateResult2;
-    } else {
-      long val1 = (intermediateResult1 != null) ? intermediateResult1 : 0L;
-      long val2 = (intermediateResult2 != null) ? intermediateResult2 : 0L;
-      return val1 + val2;
-    }
+    return intermediateResult1 + intermediateResult2;
   }
 
   @Override
@@ -311,8 +301,9 @@ public class SumLongAggregationFunction extends NullableSingleInputAggregationFu
     return DataSchema.ColumnDataType.LONG;
   }
 
+  @Nullable
   @Override
-  public Long extractFinalResult(Long intermediateResult) {
+  public Long extractFinalResult(@Nullable Long intermediateResult) {
     return intermediateResult;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumMVAggregationFunction.java
@@ -19,11 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
-import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.core.common.BlockValSet;
-import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
-import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
@@ -36,46 +32,5 @@ public class SumMVAggregationFunction extends SumAggregationFunction {
   @Override
   public AggregationFunctionType getType() {
     return AggregationFunctionType.SUMMV;
-  }
-
-  @Override
-  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    BlockValSet blockValSet = blockValSetMap.get(_expression);
-
-    if (blockValSet.isSingleValue()) {
-      // star-tree pre-aggregated values: During star-tree creation, the multi-value column is pre-aggregated
-      // per star-tree node, resulting in a single value per node.
-      double[] valueArray = blockValSet.getDoubleValuesSV();
-      double sum = 0.0;
-      for (int i = 0; i < length; i++) {
-        sum += valueArray[i];
-      }
-      updateAggregationResultHolder(aggregationResultHolder, sum);
-      return;
-    }
-
-    aggregateMV(blockValSet, length, aggregationResultHolder);
-  }
-
-  @Override
-  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    BlockValSet blockValSet = blockValSetMap.get(_expression);
-
-    if (blockValSet.isSingleValue()) {
-      // star-tree pre-aggregated values: During star-tree creation, the multi-value column is pre-aggregated
-      // per star-tree node, resulting in a single value per node.
-      aggregateSVGroupBySV(blockValSet, length, groupKeyArray, groupByResultHolder);
-      return;
-    }
-
-    aggregateMVGroupBySV(blockValSet, length, groupKeyArray, groupByResultHolder);
-  }
-
-  @Override
-  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
-      Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    aggregateMVGroupByMV(blockValSetMap.get(_expression), length, groupKeysArray, groupByResultHolder);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumPrecisionAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumPrecisionAggregationFunction.java
@@ -24,6 +24,7 @@ import java.math.MathContext;
 import java.math.RoundingMode;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -314,6 +315,7 @@ public class SumPrecisionAggregationFunction extends NullableSingleInputAggregat
     }
   }
 
+  @Nullable
   @Override
   public BigDecimal extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     BigDecimal result = aggregationResultHolder.getResult();
@@ -323,6 +325,7 @@ public class SumPrecisionAggregationFunction extends NullableSingleInputAggregat
     return result;
   }
 
+  @Nullable
   @Override
   public BigDecimal extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     BigDecimal result = groupByResultHolder.getResult(groupKey);
@@ -334,14 +337,6 @@ public class SumPrecisionAggregationFunction extends NullableSingleInputAggregat
 
   @Override
   public BigDecimal merge(BigDecimal intermediateResult1, BigDecimal intermediateResult2) {
-    if (_nullHandlingEnabled) {
-      if (intermediateResult1 == null) {
-        return intermediateResult2;
-      }
-      if (intermediateResult2 == null) {
-        return intermediateResult1;
-      }
-    }
     return intermediateResult1.add(intermediateResult2);
   }
 
@@ -368,8 +363,9 @@ public class SumPrecisionAggregationFunction extends NullableSingleInputAggregat
     return ColumnDataType.STRING;
   }
 
+  @Nullable
   @Override
-  public BigDecimal extractFinalResult(BigDecimal intermediateResult) {
+  public BigDecimal extractFinalResult(@Nullable BigDecimal intermediateResult) {
     if (intermediateResult == null) {
       return null;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumValuesIntegerTupleSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumValuesIntegerTupleSketchAggregationFunction.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.datasketches.tuple.TupleSketch;
 import org.apache.datasketches.tuple.TupleSketchIterator;
 import org.apache.datasketches.tuple.aninteger.IntegerSummary;
@@ -45,8 +46,13 @@ public class SumValuesIntegerTupleSketchAggregationFunction extends IntegerTuple
     return ColumnDataType.LONG;
   }
 
+  @Nullable
   @Override
-  public Comparable extractFinalResult(TupleIntSketchAccumulator accumulator) {
+  public Comparable extractFinalResult(@Nullable TupleIntSketchAccumulator accumulator) {
+    // A null intermediate result means nothing was aggregated, and there is nothing to sum
+    if (accumulator == null) {
+      return null;
+    }
     double retainedTotal = 0L;
     accumulator.setNominalEntries(_nominalEntries);
     accumulator.setSetOperations(_setOps);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/TimeSeriesAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/TimeSeriesAggregationFunction.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.Literal;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FunctionContext;
@@ -184,11 +185,13 @@ public class TimeSeriesAggregationFunction implements AggregationFunction<BaseTi
     throw new UnsupportedOperationException("MV not supported yet");
   }
 
+  @Nullable
   @Override
   public BaseTimeSeriesBuilder extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     return aggregationResultHolder.getResult();
   }
 
+  @Nullable
   @Override
   public BaseTimeSeriesBuilder extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     return groupByResultHolder.getResult(groupKey);
@@ -210,8 +213,13 @@ public class TimeSeriesAggregationFunction implements AggregationFunction<BaseTi
     return DataSchema.ColumnDataType.OBJECT;
   }
 
+  @Nullable
   @Override
-  public DoubleArrayList extractFinalResult(BaseTimeSeriesBuilder seriesBuilder) {
+  public DoubleArrayList extractFinalResult(@Nullable BaseTimeSeriesBuilder seriesBuilder) {
+    // A null intermediate result means nothing was aggregated, and there is no series to build
+    if (seriesBuilder == null) {
+      return null;
+    }
     Double[] doubleValues = seriesBuilder.build().getDoubleValues();
     return new DoubleArrayList(Arrays.asList(doubleValues));
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/VarianceAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/VarianceAggregationFunction.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
@@ -139,16 +140,13 @@ public class VarianceAggregationFunction extends NullableSingleInputAggregationF
     });
   }
 
+  @Nullable
   @Override
   public VarianceTuple extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
-    VarianceTuple varianceTuple = aggregationResultHolder.getResult();
-    if (varianceTuple == null) {
-      return _nullHandlingEnabled ? null : new VarianceTuple(0L, 0.0, 0.0);
-    } else {
-      return varianceTuple;
-    }
+    return aggregationResultHolder.getResult();
   }
 
+  @Nullable
   @Override
   public VarianceTuple extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     return groupByResultHolder.getResult(groupKey);
@@ -156,13 +154,6 @@ public class VarianceAggregationFunction extends NullableSingleInputAggregationF
 
   @Override
   public VarianceTuple merge(VarianceTuple intermediateResult1, VarianceTuple intermediateResult2) {
-    if (_nullHandlingEnabled) {
-      if (intermediateResult1 == null) {
-        return intermediateResult2;
-      } else if (intermediateResult2 == null) {
-        return intermediateResult1;
-      }
-    }
     intermediateResult1.apply(intermediateResult2);
     return intermediateResult1;
   }
@@ -188,10 +179,14 @@ public class VarianceAggregationFunction extends NullableSingleInputAggregationF
     return DataSchema.ColumnDataType.DOUBLE;
   }
 
+  @Nullable
   @Override
-  public Double extractFinalResult(VarianceTuple varianceTuple) {
+  public Double extractFinalResult(@Nullable VarianceTuple varianceTuple) {
+    // A null intermediate result means nothing was aggregated, and so does a zero count, which is what a
+    // deserialized empty tuple carries. With null handling enabled the variance of nothing is NULL; with it disabled
+    // it is what an untouched tuple renders to, which is the sentinel below.
     if (varianceTuple == null) {
-      return null;
+      return _nullHandlingEnabled ? null : DEFAULT_FINAL_RESULT;
     }
     long count = varianceTuple.getCount();
     if (count == 0L) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function.array;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
@@ -64,11 +65,13 @@ public abstract class BaseArrayAggFunction<I, F extends Comparable>
     return _resultColumnType;
   }
 
+  @Nullable
   @Override
   public I extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     return aggregationResultHolder.getResult();
   }
 
+  @Nullable
   @Override
   public I extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     return groupByResultHolder.getResult(groupKey);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ListAggFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ListAggFunction.java
@@ -22,6 +22,7 @@ import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectCollection;
 import java.util.Arrays;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
@@ -156,11 +157,13 @@ public class ListAggFunction extends NullableSingleInputAggregationFunction<Obje
     }
   }
 
+  @Nullable
   @Override
   public ObjectCollection<String> extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     return aggregationResultHolder.getResult();
   }
 
+  @Nullable
   @Override
   public ObjectCollection<String> extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     return groupByResultHolder.getResult(groupKey);
@@ -169,12 +172,6 @@ public class ListAggFunction extends NullableSingleInputAggregationFunction<Obje
   @Override
   public ObjectCollection<String> merge(ObjectCollection<String> intermediateResult1,
       ObjectCollection<String> intermediateResult2) {
-    if (intermediateResult1 == null) {
-      return intermediateResult2;
-    }
-    if (intermediateResult2 == null) {
-      return intermediateResult1;
-    }
     intermediateResult1.addAll(intermediateResult2);
     return intermediateResult1;
   }
@@ -201,8 +198,9 @@ public class ListAggFunction extends NullableSingleInputAggregationFunction<Obje
     return ColumnDataType.STRING;
   }
 
+  @Nullable
   @Override
-  public String extractFinalResult(ObjectCollection<String> strings) {
+  public String extractFinalResult(@Nullable ObjectCollection<String> strings) {
     if (strings == null) {
       return null;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/SumArrayDoubleAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/SumArrayDoubleAggregationFunction.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.query.aggregation.function.array;
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
@@ -112,11 +113,13 @@ public class SumArrayDoubleAggregationFunction
     }
   }
 
+  @Nullable
   @Override
   public DoubleArrayList extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     return aggregationResultHolder.getResult();
   }
 
+  @Nullable
   @Override
   public DoubleArrayList extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     return groupByResultHolder.getResult(groupKey);
@@ -160,8 +163,9 @@ public class SumArrayDoubleAggregationFunction
     return DataSchema.ColumnDataType.DOUBLE_ARRAY;
   }
 
+  @Nullable
   @Override
-  public DoubleArrayList extractFinalResult(DoubleArrayList result) {
+  public DoubleArrayList extractFinalResult(@Nullable DoubleArrayList result) {
     return result;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/SumArrayLongAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/SumArrayLongAggregationFunction.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.query.aggregation.function.array;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
@@ -111,11 +112,13 @@ public class SumArrayLongAggregationFunction extends BaseSingleInputAggregationF
     }
   }
 
+  @Nullable
   @Override
   public LongArrayList extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     return aggregationResultHolder.getResult();
   }
 
+  @Nullable
   @Override
   public LongArrayList extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     return groupByResultHolder.getResult(groupKey);
@@ -159,8 +162,9 @@ public class SumArrayLongAggregationFunction extends BaseSingleInputAggregationF
     return DataSchema.ColumnDataType.LONG_ARRAY;
   }
 
+  @Nullable
   @Override
-  public LongArrayList extractFinalResult(LongArrayList result) {
+  public LongArrayList extractFinalResult(@Nullable LongArrayList result) {
     return result;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/FunnelCountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/FunnelCountAggregationFunction.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -146,12 +147,6 @@ public class FunnelCountAggregationFunction<A, I> implements AggregationFunction
 
   @Override
   public I merge(I a, I b) {
-    if (a == null) {
-      return b;
-    }
-    if (b == null) {
-      return a;
-    }
     return _mergeStrategy.merge(a, b);
   }
 
@@ -179,7 +174,7 @@ public class FunnelCountAggregationFunction<A, I> implements AggregationFunction
   }
 
   @Override
-  public LongArrayList extractFinalResult(I intermediateResult) {
+  public LongArrayList extractFinalResult(@Nullable I intermediateResult) {
     if (intermediateResult == null) {
       return LongArrayList.wrap(new long[_numSteps]);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/window/FunnelBaseAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/window/FunnelBaseAggregationFunction.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -217,11 +218,13 @@ public abstract class FunnelBaseAggregationFunction<F extends Comparable>
     return stepEvents;
   }
 
+  @Nullable
   @Override
   public PriorityQueue<FunnelStepEvent> extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     return aggregationResultHolder.getResult();
   }
 
+  @Nullable
   @Override
   public PriorityQueue<FunnelStepEvent> extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     return groupByResultHolder.getResult(groupKey);
@@ -230,13 +233,6 @@ public abstract class FunnelBaseAggregationFunction<F extends Comparable>
   @Override
   public PriorityQueue<FunnelStepEvent> merge(PriorityQueue<FunnelStepEvent> intermediateResult1,
       PriorityQueue<FunnelStepEvent> intermediateResult2) {
-    if (intermediateResult1 == null) {
-      return intermediateResult2;
-    }
-    if (intermediateResult2 == null) {
-      return intermediateResult1;
-    }
-
     QueryThreadContext.checkTerminationAndSampleUsage(this::getResultColumnName);
 
     intermediateResult1.addAll(intermediateResult2);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/window/FunnelCompleteCountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/window/FunnelCompleteCountAggregationFunction.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.query.aggregation.function.funnel.window;
 import java.util.ArrayDeque;
 import java.util.List;
 import java.util.PriorityQueue;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.query.aggregation.function.funnel.FunnelStepEvent;
@@ -45,7 +46,7 @@ public class FunnelCompleteCountAggregationFunction extends FunnelBaseAggregatio
   }
 
   @Override
-  public Integer extractFinalResult(PriorityQueue<FunnelStepEvent> stepEvents) {
+  public Integer extractFinalResult(@Nullable PriorityQueue<FunnelStepEvent> stepEvents) {
     int totalCompletedRounds = 0;
     if (stepEvents == null || stepEvents.isEmpty()) {
       return totalCompletedRounds;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/window/FunnelEventsFunctionEvalAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/window/FunnelEventsFunctionEvalAggregationFunction.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
@@ -304,12 +305,14 @@ public class FunnelEventsFunctionEvalAggregationFunction
     return stepEvents;
   }
 
+  @Nullable
   @Override
   public PriorityQueue<FunnelStepEventWithExtraFields> extractAggregationResult(
       AggregationResultHolder aggregationResultHolder) {
     return aggregationResultHolder.getResult();
   }
 
+  @Nullable
   @Override
   public PriorityQueue<FunnelStepEventWithExtraFields> extractGroupByResult(GroupByResultHolder groupByResultHolder,
       int groupKey) {
@@ -320,12 +323,6 @@ public class FunnelEventsFunctionEvalAggregationFunction
   public PriorityQueue<FunnelStepEventWithExtraFields> merge(
       PriorityQueue<FunnelStepEventWithExtraFields> intermediateResult1,
       PriorityQueue<FunnelStepEventWithExtraFields> intermediateResult2) {
-    if (intermediateResult1 == null) {
-      return intermediateResult2;
-    }
-    if (intermediateResult2 == null) {
-      return intermediateResult1;
-    }
     intermediateResult1.addAll(intermediateResult2);
     return intermediateResult1;
   }
@@ -451,7 +448,8 @@ public class FunnelEventsFunctionEvalAggregationFunction
   }
 
   @Override
-  public ObjectArrayList<String> extractFinalResult(PriorityQueue<FunnelStepEventWithExtraFields> stepEvents) {
+  public ObjectArrayList<String> extractFinalResult(
+      @Nullable PriorityQueue<FunnelStepEventWithExtraFields> stepEvents) {
     ObjectArrayList<String> finalResults = new ObjectArrayList<>();
     List<List<Object[]>> matchedFunnelEventsExtraFields = new ArrayList<>(_numExtraFields);
     if (stepEvents == null || stepEvents.isEmpty()) {
@@ -552,12 +550,6 @@ public class FunnelEventsFunctionEvalAggregationFunction
   @Override
   public ObjectArrayList<String> mergeFinalResult(ObjectArrayList<String> finalResult1,
       ObjectArrayList<String> finalResult2) {
-    if (finalResult1 == null) {
-      return finalResult2;
-    }
-    if (finalResult2 == null) {
-      return finalResult1;
-    }
     finalResult1.addAll(finalResult2);
     return finalResult1;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/window/FunnelMatchStepAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/window/FunnelMatchStepAggregationFunction.java
@@ -22,6 +22,7 @@ import it.unimi.dsi.fastutil.ints.IntArrayList;
 import java.util.ArrayDeque;
 import java.util.List;
 import java.util.PriorityQueue;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.query.aggregation.function.funnel.FunnelStepEvent;
@@ -46,7 +47,7 @@ public class FunnelMatchStepAggregationFunction extends FunnelBaseAggregationFun
   }
 
   @Override
-  public IntArrayList extractFinalResult(PriorityQueue<FunnelStepEvent> stepEvents) {
+  public IntArrayList extractFinalResult(@Nullable PriorityQueue<FunnelStepEvent> stepEvents) {
     int finalMaxStep = 0;
     IntArrayList result = new IntArrayList(_numSteps);
     for (int i = 0; i < _numSteps; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/window/FunnelMaxStepAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/window/FunnelMaxStepAggregationFunction.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.query.aggregation.function.funnel.window;
 import java.util.ArrayDeque;
 import java.util.List;
 import java.util.PriorityQueue;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.query.aggregation.function.funnel.FunnelStepEvent;
@@ -45,7 +46,7 @@ public class FunnelMaxStepAggregationFunction extends FunnelBaseAggregationFunct
   }
 
   @Override
-  public Integer extractFinalResult(PriorityQueue<FunnelStepEvent> stepEvents) {
+  public Integer extractFinalResult(@Nullable PriorityQueue<FunnelStepEvent> stepEvents) {
     int finalMaxStep = 0;
     if (stepEvents == null || stepEvents.isEmpty()) {
       return finalMaxStep;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/window/FunnelStepDurationStatsAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/window/FunnelStepDurationStatsAggregationFunction.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.query.aggregation.function.funnel.FunnelStepEvent;
@@ -92,7 +93,7 @@ public class FunnelStepDurationStatsAggregationFunction extends FunnelBaseAggreg
   }
 
   @Override
-  public DoubleArrayList extractFinalResult(PriorityQueue<FunnelStepEvent> stepEvents) {
+  public DoubleArrayList extractFinalResult(@Nullable PriorityQueue<FunnelStepEvent> stepEvents) {
     if (stepEvents == null || stepEvents.isEmpty()) {
       return new DoubleArrayList();
     }
@@ -257,9 +258,6 @@ public class FunnelStepDurationStatsAggregationFunction extends FunnelBaseAggreg
 
   @Override
   public DoubleArrayList mergeFinalResult(DoubleArrayList finalResult1, DoubleArrayList finalResult2) {
-    if (finalResult1 == null) {
-      return finalResult2;
-    }
     return finalResult1;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/AggregationDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/AggregationDataTableReducer.java
@@ -114,12 +114,8 @@ public class AggregationDataTableReducer implements DataTableReducer {
           intermediateResultToMerge =
               AggregationFunctionUtils.getIntermediateResult(aggregationFunction, dataTable, columnDataType, 0, i);
         }
-        Object mergedIntermediateResult = intermediateResults[i];
-        if (mergedIntermediateResult == null) {
-          intermediateResults[i] = intermediateResultToMerge;
-        } else {
-          intermediateResults[i] = aggregationFunction.merge(mergedIntermediateResult, intermediateResultToMerge);
-        }
+        intermediateResults[i] =
+            AggregationFunctionUtils.merge(aggregationFunction, intermediateResults[i], intermediateResultToMerge);
       }
     }
     return intermediateResults;
@@ -238,12 +234,8 @@ public class AggregationDataTableReducer implements DataTableReducer {
         } else {
           finalResultToMerge = AggregationFunctionUtils.getFinalResult(dataTable, columnDataType, 0, i);
         }
-        Comparable mergedFinalResult = finalResults[i];
-        if (mergedFinalResult == null) {
-          finalResults[i] = finalResultToMerge;
-        } else {
-          finalResults[i] = _aggregationFunctions[i].mergeFinalResult(mergedFinalResult, finalResultToMerge);
-        }
+        finalResults[i] =
+            AggregationFunctionUtils.mergeFinalResult(_aggregationFunctions[i], finalResults[i], finalResultToMerge);
       }
     }
     Object[] convertedFinalResults = new Object[numAggregationFunctions];

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/AggregationDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/AggregationDataTableReducer.java
@@ -111,12 +111,8 @@ public class AggregationDataTableReducer implements DataTableReducer {
           intermediateResultToMerge =
               AggregationFunctionUtils.getIntermediateResult(aggregationFunction, dataTable, columnDataType, 0, i);
         }
-        Object mergedIntermediateResult = intermediateResults[i];
-        if (mergedIntermediateResult == null) {
-          intermediateResults[i] = intermediateResultToMerge;
-        } else {
-          intermediateResults[i] = aggregationFunction.merge(mergedIntermediateResult, intermediateResultToMerge);
-        }
+        intermediateResults[i] =
+            AggregationFunctionUtils.merge(aggregationFunction, intermediateResults[i], intermediateResultToMerge);
       }
     }
     return intermediateResults;
@@ -197,12 +193,8 @@ public class AggregationDataTableReducer implements DataTableReducer {
         } else {
           finalResultToMerge = AggregationFunctionUtils.getFinalResult(dataTable, columnDataType, 0, i);
         }
-        Comparable mergedFinalResult = finalResults[i];
-        if (mergedFinalResult == null) {
-          finalResults[i] = finalResultToMerge;
-        } else {
-          finalResults[i] = _aggregationFunctions[i].mergeFinalResult(mergedFinalResult, finalResultToMerge);
-        }
+        finalResults[i] =
+            AggregationFunctionUtils.mergeFinalResult(_aggregationFunctions[i], finalResults[i], finalResultToMerge);
       }
     }
     Object[] convertedFinalResults = new Object[numAggregationFunctions];

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/SyntheticBlockValSets.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/SyntheticBlockValSets.java
@@ -21,7 +21,9 @@ package org.apache.pinot.core.common;
 import com.google.common.base.Preconditions;
 import java.math.BigDecimal;
 import java.util.function.DoubleSupplier;
+import java.util.function.IntSupplier;
 import java.util.function.LongSupplier;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
@@ -246,6 +248,154 @@ public class SyntheticBlockValSets {
 
     @Override
     public double[] getDoubleValuesSV() {
+      return _values;
+    }
+  }
+
+  /// A simple [BlockValSet] for nullable, not dictionary-encoded string values.
+  ///
+  /// Named `Str` rather than `String`: a nested class called `String` shadows `java.lang.String` across
+  /// the whole of the enclosing class, which silently changes the signature of every `getString*` method
+  /// declared here so that it no longer implements [BlockValSet].
+  public static class Str extends Base {
+
+    @Nullable
+    final RoaringBitmap _nullBitmap;
+    final String[] _values;
+
+    private Str(@Nullable RoaringBitmap nullBitmap, String[] values) {
+      _nullBitmap = nullBitmap;
+      _values = values;
+    }
+
+    public static Str create(int numDocs, @Nullable RoaringBitmap nullBitmap, Supplier<String> supplier) {
+      Preconditions.checkArgument(nullBitmap == null || nullBitmap.last() < numDocs,
+          "null bitmap larger than numDocs");
+      String[] values = new String[numDocs];
+      for (int i = 0; i < numDocs; i++) {
+        values[i] = supplier.get();
+      }
+      return new Str(nullBitmap, values);
+    }
+
+    public static Str create(@Nullable RoaringBitmap nullBitmap, String[] values) {
+      return new Str(nullBitmap, values);
+    }
+
+    @Nullable
+    @Override
+    public RoaringBitmap getNullBitmap() {
+      return _nullBitmap;
+    }
+
+    @Override
+    public FieldSpec.DataType getValueType() {
+      return FieldSpec.DataType.STRING;
+    }
+
+    @Override
+    public boolean isSingleValue() {
+      return true;
+    }
+
+    @Override
+    public String[] getStringValuesSV() {
+      return _values;
+    }
+  }
+
+  /// A simple [BlockValSet] for nullable, not dictionary-encoded byte array values.
+  public static class Bytes extends Base {
+
+    @Nullable
+    final RoaringBitmap _nullBitmap;
+    final byte[][] _values;
+
+    private Bytes(@Nullable RoaringBitmap nullBitmap, byte[][] values) {
+      _nullBitmap = nullBitmap;
+      _values = values;
+    }
+
+    public static Bytes create(int numDocs, @Nullable RoaringBitmap nullBitmap, Supplier<byte[]> supplier) {
+      Preconditions.checkArgument(nullBitmap == null || nullBitmap.last() < numDocs,
+          "null bitmap larger than numDocs");
+      byte[][] values = new byte[numDocs][];
+      for (int i = 0; i < numDocs; i++) {
+        values[i] = supplier.get();
+      }
+      return new Bytes(nullBitmap, values);
+    }
+
+    public static Bytes create(@Nullable RoaringBitmap nullBitmap, byte[][] values) {
+      return new Bytes(nullBitmap, values);
+    }
+
+    @Nullable
+    @Override
+    public RoaringBitmap getNullBitmap() {
+      return _nullBitmap;
+    }
+
+    @Override
+    public FieldSpec.DataType getValueType() {
+      return FieldSpec.DataType.BYTES;
+    }
+
+    @Override
+    public boolean isSingleValue() {
+      return true;
+    }
+
+    @Override
+    public byte[][] getBytesValuesSV() {
+      return _values;
+    }
+  }
+
+  /// A simple [BlockValSet] for nullable, not dictionary-encoded int values.
+  public static class Int extends Base {
+
+    @Nullable
+    final RoaringBitmap _nullBitmap;
+    final int[] _values;
+
+    private Int(@Nullable RoaringBitmap nullBitmap, int[] values) {
+      _nullBitmap = nullBitmap;
+      _values = values;
+    }
+
+    public static Int create(int numDocs, @Nullable RoaringBitmap nullBitmap, IntSupplier supplier) {
+      Preconditions.checkArgument(nullBitmap == null || nullBitmap.last() < numDocs,
+          "null bitmap larger than numDocs");
+      int[] values = new int[numDocs];
+      for (int i = 0; i < numDocs; i++) {
+        values[i] = supplier.getAsInt();
+      }
+      return new Int(nullBitmap, values);
+    }
+
+    public static Int create(@Nullable RoaringBitmap nullBitmap, int[] values) {
+      return new Int(nullBitmap, values);
+    }
+
+    @Nullable
+    @Override
+    public RoaringBitmap getNullBitmap() {
+      return _nullBitmap;
+    }
+
+    @Override
+    public FieldSpec.DataType getValueType() {
+      return FieldSpec.DataType.INT;
+    }
+
+    @Override
+    public boolean isSingleValue() {
+      return true;
+    }
+
+    @Override
+    public int[] getIntValuesSV() {
       return _values;
     }
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionNullContractTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionNullContractTest.java
@@ -1,0 +1,435 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.FunctionContext;
+import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.SyntheticBlockValSets;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.roaringbitmap.RoaringBitmap;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+/// Enforces the null contract documented on [AggregationFunction] across every aggregation function that can be
+/// constructed generically, so that a new function cannot quietly opt out of it.
+///
+/// The case this guards is the one that has repeatedly reached production: a query whose segments are all pruned
+/// produces no intermediate result at all, and the broker still has to render a row for it. Both `EmptyResponseUtils`
+/// (via an untouched result holder) and the multi-stage executors (via an uninitialized `Object[]` slot) hand that to
+/// [AggregationFunction#extractFinalResult], and a function that dereferences the argument throws instead of returning
+/// the SQL answer for zero rows.
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class AggregationFunctionNullContractTest {
+
+  private static final int NUM_DOCS = 10;
+
+  /// Argument shapes tried in order until the factory accepts one. Functions needing an argument list that none of
+  /// these match are reported by [#testEverySkippedTypeIsAccountedFor] rather than silently skipped.
+  private static final String[] ARGUMENT_SHAPES = {
+      "(column)", "(*)", "(column, 50)", "(column, column2)", "(column, 50, 100)", "(column, column2, column3)",
+      // arrayAgg(dataColumn, 'dataType')
+      "(column, 'LONG')",
+      // firstWithTime / lastWithTime(dataColumn, timeColumn, 'dataType')
+      "(column, column2, 'LONG')",
+      // histogram(column, lower, upper, numBins)
+      "(column, 0, 1000, 10)",
+      // the funnel family: (timestampColumn, windowMillis, numSteps, stepPredicate...)
+      "(column, '1000', 2, column2 = 'a', column2 = 'b')",
+      // funnelStepDurationStats takes a trailing settings literal
+      "(column, '1000', 2, column2 = 'a', column2 = 'b', 'durationFunctions=count')",
+      // funnelEventsFunctionEval takes a trailing (numExtraFields, extraColumns...) tail, where the count must match
+      // the number of columns that follow it
+      "(column, '1000', 2, column2 = 'a', column2 = 'b', 2, column, column2)",
+      // funnelCount uses named options rather than positional arguments
+      "(STEPS(column2 = 'a', column2 = 'b'), CORRELATE_BY(column))"
+  };
+
+  /// Types that are not user-facing aggregates, so "what does this return when nothing was aggregated" is not a
+  /// meaningful question. Keep this list short and justified: anything added here stops being checked.
+  ///
+  /// - `FOURTHMOMENT` is the shared accumulator behind `SKEWNESS` and `KURTOSIS` and throws from `extractFinalResult`
+  ///   by design. The same class is still covered through those two types.
+  /// - The parent/child `EXPRMIN` / `EXPRMAX` types are produced by the query rewriter, not written by users. The
+  ///   parent returns a nested data block rather than a scalar, and the child always returns `0`.
+  private static final Set<AggregationFunctionType> INTERNAL_TYPES = Set.of(
+      AggregationFunctionType.FOURTHMOMENT,
+      AggregationFunctionType.PINOTPARENTAGGEXPRMIN,
+      AggregationFunctionType.PINOTPARENTAGGEXPRMAX,
+      AggregationFunctionType.PINOTCHILDAGGEXPRMIN,
+      AggregationFunctionType.PINOTCHILDAGGEXPRMAX
+  );
+
+  /// Types that cannot be constructed from a bare [FunctionContext] at all, and so cannot be checked here.
+  ///
+  /// - `EXPRMIN` / `EXPRMAX` are rejected by the factory outright; they are only legal in a selection without an alias,
+  ///   and are rewritten into the parent/child pair above before execution.
+  /// - `TIMESERIESAGGREGATE` needs time-series plan context that a bare function context cannot supply.
+  ///
+  /// [#testEverySkippedTypeIsAccountedFor] pins this exactly, in both directions, so a newly added function cannot drop
+  /// out of the contract unnoticed.
+  private static final Set<AggregationFunctionType> EXPECTED_UNCONSTRUCTIBLE = Set.of(
+      AggregationFunctionType.EXPRMIN,
+      AggregationFunctionType.EXPRMAX,
+      AggregationFunctionType.TIMESERIESAGGREGATE
+  );
+
+  @DataProvider(name = "aggregationFunctions")
+  public Object[][] aggregationFunctions() {
+    List<Object[]> cases = new ArrayList<>();
+    for (AggregationFunctionType type : AggregationFunctionType.values()) {
+      if (INTERNAL_TYPES.contains(type)) {
+        continue;
+      }
+      for (boolean nullHandlingEnabled : new boolean[]{false, true}) {
+        AggregationFunction function = tryCreate(type, nullHandlingEnabled);
+        if (function != null) {
+          cases.add(new Object[]{type, nullHandlingEnabled, function});
+        }
+      }
+    }
+    return cases.toArray(new Object[0][]);
+  }
+
+  /// An empty result holder must survive the whole extract path, which is what an all-pruned query does.
+  @Test(dataProvider = "aggregationFunctions")
+  public void testEmptyHolderExtractsWithoutThrowing(AggregationFunctionType type, boolean nullHandlingEnabled,
+      AggregationFunction function) {
+    Object intermediate;
+    try {
+      intermediate = function.extractAggregationResult(function.createAggregationResultHolder());
+    } catch (Exception e) {
+      throw new AssertionError(
+          describe(type, nullHandlingEnabled) + ": extractAggregationResult failed on an empty holder", e);
+    }
+    try {
+      render(function, function.extractFinalResult(intermediate));
+    } catch (Exception e) {
+      throw new AssertionError(
+          describe(type, nullHandlingEnabled) + ": extractFinalResult failed on the empty intermediate result", e);
+    }
+  }
+
+  /// A `null` intermediate result means nothing was aggregated and must be resolved, never propagated by dereference.
+  @Test(dataProvider = "aggregationFunctions")
+  public void testNullIntermediateResultIsResolved(AggregationFunctionType type, boolean nullHandlingEnabled,
+      AggregationFunction function) {
+    try {
+      render(function, function.extractFinalResult(null));
+    } catch (Exception e) {
+      throw new AssertionError(
+          describe(type, nullHandlingEnabled) + ": extractFinalResult(null) must return the answer for no input", e);
+    }
+  }
+
+  /// Forces the final result through both steps the broker response performs on it.
+  ///
+  /// Returning is not enough to prove the `null` was resolved: a function can wrap the `null` in a serializer that only
+  /// dereferences it when the value is rendered, which moves the failure out of this method and into the response path.
+  /// [ColumnDataType#convert] is the step that threw in production, so it is exercised alongside `toString`; a
+  /// serializer wrapping a `null` can survive one and fail the other.
+  private static void render(AggregationFunction function, @Nullable Object finalResult) {
+    if (finalResult != null) {
+      finalResult.toString();
+      function.getFinalResultColumnType().convert(finalResult);
+    }
+  }
+
+  /// `null` is the identity of merging, settled once by the caller so no implementation needs its own null branch.
+  ///
+  /// Both helpers resolve the `null` operand without delegating, so this holds for every function, including those that
+  /// do not support merging final results at all.
+  @Test(dataProvider = "aggregationFunctions")
+  public void testNullIsTheMergeIdentity(AggregationFunctionType type, boolean nullHandlingEnabled,
+      AggregationFunction function) {
+    String description = describe(type, nullHandlingEnabled);
+    Comparable value = "value";
+    assertSame(AggregationFunctionUtils.merge(function, null, value), value, description);
+    assertSame(AggregationFunctionUtils.merge(function, value, null), value, description);
+    assertNull(AggregationFunctionUtils.merge(function, null, null), description);
+    assertSame(AggregationFunctionUtils.mergeFinalResult(function, null, value), value, description);
+    assertSame(AggregationFunctionUtils.mergeFinalResult(function, value, null), value, description);
+    assertNull(AggregationFunctionUtils.mergeFinalResult(function, null, null), description);
+  }
+
+  /// The functions that SQL fixes at `0` rather than `NULL` when nothing was aggregated.
+  @Test
+  public void testCountingFunctionsReturnZeroWhenNothingAggregated() {
+    assertEquals(create("COUNT", "(*)", true).extractFinalResult(null), 0L);
+    assertEquals(create("DISTINCTCOUNT", "(column)", true).extractFinalResult(null), 0);
+    assertEquals(create("DISTINCTCOUNTHLL", "(column)", true).extractFinalResult(null), 0L);
+    assertEquals(create("DISTINCTCOUNTBITMAP", "(column)", true).extractFinalResult(null), 0);
+  }
+
+  /// The functions that return SQL `NULL` when nothing was aggregated.
+  ///
+  /// Both representations of that state are checked. A `null` intermediate result is the obvious one, but several of
+  /// these substitute an empty accumulator for an untouched holder and never produce a `null` at all on the
+  /// single-stage engine, so testing only the `null` would pass without exercising them.
+  @Test
+  public void testValueFunctionsReturnNullWhenNothingAggregated() {
+    for (AggregationFunctionType type : new AggregationFunctionType[]{
+        AggregationFunctionType.SUM, AggregationFunctionType.MIN, AggregationFunctionType.MAX,
+        AggregationFunctionType.AVG, AggregationFunctionType.MINMAXRANGE, AggregationFunctionType.VARPOP,
+        AggregationFunctionType.STDDEVPOP, AggregationFunctionType.PERCENTILE,
+        AggregationFunctionType.PERCENTILEEST, AggregationFunctionType.PERCENTILETDIGEST,
+        AggregationFunctionType.PERCENTILEKLL, AggregationFunctionType.PERCENTILESMARTTDIGEST}) {
+      // built through the shared argument shapes: the percentile families disagree on whether the percentile is a
+      // name suffix or an argument, and only some accept both
+      AggregationFunction function = tryCreate(type, true);
+      assertNotNull(function, "Could not construct " + type.getName());
+      String name = type.getName();
+      assertNull(function.extractFinalResult(null), name + " over a null intermediate result must be NULL");
+      Object empty = function.extractAggregationResult(function.createAggregationResultHolder());
+      assertNull(function.extractFinalResult(empty), name + " over an empty accumulator must be NULL");
+    }
+  }
+
+  /// Pins exactly which functions answer differently once null handling is enabled.
+  ///
+  /// Aggregating a block whose rows are all null separates the two modes: enabled skips every row and reports
+  /// nothing aggregated, disabled reads each one as the column default and aggregates it. A function shows up here
+  /// only if it both has null-aware aggregation and receives the query's option, so the set is a direct read-out of
+  /// which functions the option actually reaches.
+  ///
+  /// The multi-value entries are the interesting ones: they used to hard-code the option off, so it had no effect on
+  /// them whatever the query asked for. The raw variants reach the option through the function they delegate to, so
+  /// threading it into one of those changes the raw variant alongside it.
+  ///
+  /// The set is bounded by what the harness can drive, so it is a read-out of the functions the option reaches among
+  /// those, not of every function that takes it — see [#NOT_EXERCISABLE_BY_SYNTHETIC_BLOCK].
+  private static final Set<AggregationFunctionType> HONOURS_NULL_HANDLING = Set.of(
+      // single-value functions, which have always taken the option
+      AggregationFunctionType.COUNT, AggregationFunctionType.MIN, AggregationFunctionType.MAX,
+      AggregationFunctionType.SUM, AggregationFunctionType.SUM0, AggregationFunctionType.AVG,
+      AggregationFunctionType.MODE, AggregationFunctionType.ANYVALUE, AggregationFunctionType.MINMAXRANGE,
+      AggregationFunctionType.DISTINCTCOUNT, AggregationFunctionType.DISTINCTCOUNTOFFHEAP,
+      AggregationFunctionType.DISTINCTSUM, AggregationFunctionType.DISTINCTAVG,
+      AggregationFunctionType.DISTINCTCOUNTRAWHLL, AggregationFunctionType.DISTINCTCOUNTRAWHLLPLUS,
+      AggregationFunctionType.DISTINCTCOUNTRAWULL, AggregationFunctionType.PERCENTILE,
+      AggregationFunctionType.PERCENTILEEST, AggregationFunctionType.PERCENTILERAWEST,
+      AggregationFunctionType.PERCENTILETDIGEST, AggregationFunctionType.PERCENTILERAWTDIGEST,
+      AggregationFunctionType.PERCENTILESMARTTDIGEST, AggregationFunctionType.PERCENTILEKLL,
+      AggregationFunctionType.PERCENTILERAWKLL, AggregationFunctionType.VARPOP, AggregationFunctionType.VARSAMP,
+      AggregationFunctionType.STDDEVPOP, AggregationFunctionType.STDDEVSAMP,
+      // multi-value variants that already took the option
+      AggregationFunctionType.MINMV, AggregationFunctionType.MAXMV, AggregationFunctionType.SUMMV,
+      AggregationFunctionType.AVGMV, AggregationFunctionType.MINMAXRANGEMV,
+      AggregationFunctionType.DISTINCTCOUNTRAWHLLMV, AggregationFunctionType.DISTINCTCOUNTRAWHLLPLUSMV,
+      // multi-value variants this change threads the option into; they hard-coded it off before
+      AggregationFunctionType.DISTINCTCOUNTMV, AggregationFunctionType.DISTINCTSUMMV,
+      AggregationFunctionType.DISTINCTAVGMV, AggregationFunctionType.PERCENTILEMV,
+      AggregationFunctionType.PERCENTILEESTMV, AggregationFunctionType.PERCENTILERAWESTMV,
+      AggregationFunctionType.PERCENTILEKLLMV, AggregationFunctionType.PERCENTILETDIGESTMV,
+      AggregationFunctionType.PERCENTILERAWTDIGESTMV, AggregationFunctionType.PERCENTILERAWKLLMV,
+      // functions the harness reaches only once it probes block shapes and feeds every input column; they have
+      // always taken the option, so these entries are a gain in measurement rather than a change in behaviour
+      AggregationFunctionType.MINSTRING, AggregationFunctionType.MAXSTRING, AggregationFunctionType.MINLONG,
+      AggregationFunctionType.MAXLONG, AggregationFunctionType.SUMINT, AggregationFunctionType.SUMLONG,
+      AggregationFunctionType.SUMPRECISION, AggregationFunctionType.FIRSTWITHTIME,
+      AggregationFunctionType.LASTWITHTIME, AggregationFunctionType.DISTINCTCOUNTRAWCPCSKETCH,
+      AggregationFunctionType.FREQUENTSTRINGSSKETCH, AggregationFunctionType.FREQUENTLONGSSKETCH,
+      AggregationFunctionType.ARRAYAGG, AggregationFunctionType.LISTAGG
+  );
+
+  /// Functions this test cannot drive with a one-column synthetic block, pinned so that a silent drop-out is always a
+  /// reviewed decision. Derived from a run rather than predicted.
+  ///
+  /// The block implements only single-value `long` and `double`, so a function lands here when it reads another value
+  /// type, needs a multi-value block, or takes more than the one input column the shared argument shapes supply. The
+  /// exclusion is scoped to this test: the rest of the contract is still checked against these functions, since the
+  /// other cases construct them and call [AggregationFunction#extractFinalResult] without aggregating first.
+  private static final Set<AggregationFunctionType> NOT_EXERCISABLE_BY_SYNTHETIC_BLOCK = Set.of(
+      AggregationFunctionType.FASTHLL, AggregationFunctionType.DISTINCTCOUNTTUPLESKETCH,
+      AggregationFunctionType.DISTINCTCOUNTRAWINTEGERSUMTUPLESKETCH,
+      AggregationFunctionType.SUMVALUESINTEGERSUMTUPLESKETCH, AggregationFunctionType.AVGVALUEINTEGERSUMTUPLESKETCH,
+      AggregationFunctionType.STUNION, AggregationFunctionType.BOOLAND, AggregationFunctionType.BOOLOR,
+      AggregationFunctionType.SUMARRAYLONG, AggregationFunctionType.SUMARRAYDOUBLE,
+      AggregationFunctionType.FUNNELMAXSTEP, AggregationFunctionType.FUNNELCOMPLETECOUNT,
+      AggregationFunctionType.FUNNELSTEPDURATIONSTATS, AggregationFunctionType.FUNNELMATCHSTEP,
+      AggregationFunctionType.FUNNELEVENTSFUNCTIONEVAL, AggregationFunctionType.FUNNELCOUNT
+  );
+
+  /// Checks every function rather than a fixed list, so that a function gaining or losing null awareness is caught.
+  ///
+  /// Failing with something extra means a function started honouring the option and should be added to
+  /// [#HONOURS_NULL_HANDLING]; failing with something missing means one stopped, which is a regression unless the
+  /// entry is stale. Functions the synthetic block cannot feed — because they read a value type it does not
+  /// implement, or reject the column outright — are not counted either way.
+  @Test
+  public void testNullHandlingOptionReachesEveryFunctionThatHonoursIt() {
+    Set<AggregationFunctionType> honours = new TreeSet<>();
+    Set<AggregationFunctionType> notExercisable = new TreeSet<>();
+    for (AggregationFunctionType type : AggregationFunctionType.values()) {
+      if (INTERNAL_TYPES.contains(type) || tryCreate(type, false) == null) {
+        continue;
+      }
+      Object enabled = null;
+      Object disabled = null;
+      boolean driven = false;
+      for (Supplier<BlockValSet> shape : BLOCK_SHAPES) {
+        try {
+          // the same shape drives both modes, so that the comparison below is between the modes and not the inputs
+          enabled = aggregateAllNulls(type, true, shape);
+          disabled = aggregateAllNulls(type, false, shape);
+          driven = true;
+          break;
+        } catch (RuntimeException e) {
+          // this shape reads a value type the function rejects; fall through to the next
+        }
+      }
+      if (!driven) {
+        notExercisable.add(type);
+        continue;
+      }
+      if (!Objects.equals(enabled, disabled)) {
+        honours.add(type);
+      }
+    }
+
+    Set<AggregationFunctionType> newlySkipped = new TreeSet<>(notExercisable);
+    newlySkipped.removeAll(NOT_EXERCISABLE_BY_SYNTHETIC_BLOCK);
+    Set<AggregationFunctionType> staleSkip = new TreeSet<>(NOT_EXERCISABLE_BY_SYNTHETIC_BLOCK);
+    staleSkip.removeAll(notExercisable);
+    assertTrue(newlySkipped.isEmpty() && staleSkip.isEmpty(),
+        "The set of functions this test cannot drive has changed.\n  Newly undrivable, so they stopped being checked "
+            + "and need the same review as an entry in EXPECTED_UNCONSTRUCTIBLE: " + newlySkipped
+            + "\n  Drivable again, so remove them from NOT_EXERCISABLE_BY_SYNTHETIC_BLOCK: " + staleSkip);
+
+    Set<AggregationFunctionType> gained = new TreeSet<>(honours);
+    gained.removeAll(HONOURS_NULL_HANDLING);
+    Set<AggregationFunctionType> lost = new TreeSet<>(HONOURS_NULL_HANDLING);
+    lost.removeAll(honours);
+    assertTrue(gained.isEmpty() && lost.isEmpty(),
+        "The null handling option now reaches a different set of functions.\n  Newly honouring it, so add to "
+            + "HONOURS_NULL_HANDLING once the behaviour change is intended: " + gained
+            + "\n  No longer honouring it, which is a regression unless the entry is stale: " + lost);
+  }
+
+  /// Aggregates a block whose rows are all null and returns the final result.
+  ///
+  /// Every input expression the function declares is given a block, not just the first, so that the functions taking
+  /// more than one column are driven rather than failing on a missing entry.
+  private static Object aggregateAllNulls(AggregationFunctionType type, boolean nullHandlingEnabled,
+      Supplier<BlockValSet> blockShape) {
+    AggregationFunction function = tryCreate(type, nullHandlingEnabled);
+    assertNotNull(function, "Could not construct " + type.getName());
+    Map<ExpressionContext, BlockValSet> blockValSetMap = new HashMap<>();
+    for (Object inputExpression : function.getInputExpressions()) {
+      // every declared input gets a block, literals included: a function that took a literal for one of its columns
+      // still looks that expression up in the map, and a missing entry makes it throw and drop out of the census
+      blockValSetMap.put((ExpressionContext) inputExpression, blockShape.get());
+    }
+    // a function whose only argument is a literal, such as COUNT(*), still needs one block to read a length from
+    if (blockValSetMap.isEmpty()) {
+      blockValSetMap.put(ExpressionContext.forIdentifier("column"), blockShape.get());
+    }
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    function.aggregate(NUM_DOCS, resultHolder, blockValSetMap);
+    return function.extractFinalResult(function.extractAggregationResult(resultHolder));
+  }
+
+  /// All-null block shapes, tried in order until one drives the function.
+  ///
+  /// Probed rather than pinned per function: which value type an accumulator reads is an implementation detail that
+  /// changes, and a hard-coded mapping silently drops a function out of the census when it feeds the wrong width.
+  private static final List<Supplier<BlockValSet>> BLOCK_SHAPES = List.of(
+      () -> SyntheticBlockValSets.Double.create(NUM_DOCS, allNullBitmap(), () -> 0.0),
+      () -> SyntheticBlockValSets.Long.create(NUM_DOCS, allNullBitmap(), () -> 0L),
+      () -> SyntheticBlockValSets.Int.create(NUM_DOCS, allNullBitmap(), () -> 0),
+      () -> SyntheticBlockValSets.Str.create(NUM_DOCS, allNullBitmap(), () -> ""),
+      () -> SyntheticBlockValSets.Bytes.create(NUM_DOCS, allNullBitmap(), () -> new byte[0])
+  );
+
+  private static RoaringBitmap allNullBitmap() {
+    RoaringBitmap allNull = new RoaringBitmap();
+    allNull.add(0L, NUM_DOCS);
+    return allNull;
+  }
+
+  /// Pins exactly which types go unchecked, so a skip is always a reviewed decision rather than a silent one.
+  ///
+  /// Failing in the "not accounted for" direction means a function could not be built from [#ARGUMENT_SHAPES] and is
+  /// therefore not being checked at all: either add the argument shape it needs, or classify it. Failing in the "no
+  /// longer skipped" direction means an entry here is stale and should be deleted.
+  @Test
+  public void testEverySkippedTypeIsAccountedFor() {
+    Set<AggregationFunctionType> skipped = new TreeSet<>();
+    for (AggregationFunctionType type : AggregationFunctionType.values()) {
+      if (!INTERNAL_TYPES.contains(type) && tryCreate(type, false) == null) {
+        skipped.add(type);
+      }
+    }
+
+    Set<AggregationFunctionType> unaccounted = new TreeSet<>(skipped);
+    unaccounted.removeAll(EXPECTED_UNCONSTRUCTIBLE);
+    assertTrue(unaccounted.isEmpty(),
+        "These types are silently excluded from the null contract; extend ARGUMENT_SHAPES or classify them: "
+            + unaccounted);
+
+    Set<AggregationFunctionType> stale = new TreeSet<>(EXPECTED_UNCONSTRUCTIBLE);
+    stale.removeAll(skipped);
+    assertTrue(stale.isEmpty(), "These types can now be constructed and should be removed from "
+        + "EXPECTED_UNCONSTRUCTIBLE so they are checked: " + stale);
+  }
+
+  private static AggregationFunction create(String name, String args, boolean nullHandlingEnabled) {
+    FunctionContext context = RequestContextUtils.getExpression(name + args).getFunction();
+    AggregationFunction function = AggregationFunctionFactory.getAggregationFunction(context, nullHandlingEnabled);
+    if (function == null) {
+      fail("Could not construct " + name + args);
+    }
+    return function;
+  }
+
+  @Nullable
+  private static AggregationFunction tryCreate(AggregationFunctionType type, boolean nullHandlingEnabled) {
+    for (String args : ARGUMENT_SHAPES) {
+      try {
+        FunctionContext context = RequestContextUtils.getExpression(type.getName() + args).getFunction();
+        AggregationFunction function = AggregationFunctionFactory.getAggregationFunction(context, nullHandlingEnabled);
+        if (function != null) {
+          return function;
+        }
+      } catch (Exception e) {
+        // Wrong argument shape for this function, or a function that cannot be built outside a real query plan (e.g.
+        // the parent/child and time-series functions). Try the next shape.
+      }
+    }
+    return null;
+  }
+
+  private static String describe(AggregationFunctionType type, boolean nullHandlingEnabled) {
+    return type.getName() + (nullHandlingEnabled ? " [nullHandlingEnabled]" : " [nullHandlingDisabled]");
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionNullContractTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionNullContractTest.java
@@ -1,0 +1,432 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.FunctionContext;
+import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.SyntheticBlockValSets;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.roaringbitmap.RoaringBitmap;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+/// Enforces the null contract documented on [AggregationFunction] across every aggregation function that can be
+/// constructed generically, so that a new function cannot quietly opt out of it.
+///
+/// The case this guards is the one that has repeatedly reached production: a query whose segments are all pruned
+/// produces no intermediate result at all, and the broker still has to render a row for it. Both `EmptyResponseUtils`
+/// (via an untouched result holder) and the multi-stage executors (via an uninitialized `Object[]` slot) hand that to
+/// [AggregationFunction#extractFinalResult], and a function that dereferences the argument throws instead of returning
+/// the SQL answer for zero rows.
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class AggregationFunctionNullContractTest {
+
+  private static final int NUM_DOCS = 10;
+
+  /// Argument shapes tried in order until the factory accepts one. Functions needing an argument list that none of
+  /// these match are reported by [#testEverySkippedTypeIsAccountedFor] rather than silently skipped.
+  private static final String[] ARGUMENT_SHAPES = {
+      "(column)", "(*)", "(column, 50)", "(column, column2)", "(column, 50, 100)", "(column, column2, column3)",
+      // arrayAgg(dataColumn, 'dataType')
+      "(column, 'LONG')",
+      // firstWithTime / lastWithTime(dataColumn, timeColumn, 'dataType')
+      "(column, column2, 'LONG')",
+      // histogram(column, lower, upper, numBins)
+      "(column, 0, 1000, 10)",
+      // the funnel family: (timestampColumn, windowMillis, numSteps, stepPredicate...)
+      "(column, '1000', 2, column2 = 'a', column2 = 'b')",
+      // funnelStepDurationStats takes a trailing settings literal
+      "(column, '1000', 2, column2 = 'a', column2 = 'b', 'durationFunctions=count')",
+      // funnelEventsFunctionEval takes a trailing (numExtraFields, extraColumns...) tail, where the count must match
+      // the number of columns that follow it
+      "(column, '1000', 2, column2 = 'a', column2 = 'b', 2, column, column2)",
+      // funnelCount uses named options rather than positional arguments
+      "(STEPS(column2 = 'a', column2 = 'b'), CORRELATE_BY(column))"
+  };
+
+  /// Types that are not user-facing aggregates, so "what does this return when nothing was aggregated" is not a
+  /// meaningful question. Keep this list short and justified: anything added here stops being checked.
+  ///
+  /// - `FOURTHMOMENT` is the shared accumulator behind `SKEWNESS` and `KURTOSIS` and throws from `extractFinalResult`
+  ///   by design. The same class is still covered through those two types.
+  /// - The parent/child `EXPRMIN` / `EXPRMAX` types are produced by the query rewriter, not written by users. The
+  ///   parent returns a nested data block rather than a scalar, and the child always returns `0`.
+  private static final Set<AggregationFunctionType> INTERNAL_TYPES = Set.of(
+      AggregationFunctionType.FOURTHMOMENT,
+      AggregationFunctionType.PINOTPARENTAGGEXPRMIN,
+      AggregationFunctionType.PINOTPARENTAGGEXPRMAX,
+      AggregationFunctionType.PINOTCHILDAGGEXPRMIN,
+      AggregationFunctionType.PINOTCHILDAGGEXPRMAX
+  );
+
+  /// Types that cannot be constructed from a bare [FunctionContext] at all, and so cannot be checked here.
+  ///
+  /// - `EXPRMIN` / `EXPRMAX` are rejected by the factory outright; they are only legal in a selection without an alias,
+  ///   and are rewritten into the parent/child pair above before execution.
+  /// - `TIMESERIESAGGREGATE` needs time-series plan context that a bare function context cannot supply.
+  ///
+  /// [#testEverySkippedTypeIsAccountedFor] pins this exactly, in both directions, so a newly added function cannot drop
+  /// out of the contract unnoticed.
+  private static final Set<AggregationFunctionType> EXPECTED_UNCONSTRUCTIBLE = Set.of(
+      AggregationFunctionType.EXPRMIN,
+      AggregationFunctionType.EXPRMAX,
+      AggregationFunctionType.TIMESERIESAGGREGATE
+  );
+
+  @DataProvider(name = "aggregationFunctions")
+  public Object[][] aggregationFunctions() {
+    List<Object[]> cases = new ArrayList<>();
+    for (AggregationFunctionType type : AggregationFunctionType.values()) {
+      if (INTERNAL_TYPES.contains(type)) {
+        continue;
+      }
+      for (boolean nullHandlingEnabled : new boolean[]{false, true}) {
+        AggregationFunction function = tryCreate(type, nullHandlingEnabled);
+        if (function != null) {
+          cases.add(new Object[]{type, nullHandlingEnabled, function});
+        }
+      }
+    }
+    return cases.toArray(new Object[0][]);
+  }
+
+  /// An empty result holder must survive the whole extract path, which is what an all-pruned query does.
+  @Test(dataProvider = "aggregationFunctions")
+  public void testEmptyHolderExtractsWithoutThrowing(AggregationFunctionType type, boolean nullHandlingEnabled,
+      AggregationFunction function) {
+    Object intermediate;
+    try {
+      intermediate = function.extractAggregationResult(function.createAggregationResultHolder());
+    } catch (Exception e) {
+      throw new AssertionError(
+          describe(type, nullHandlingEnabled) + ": extractAggregationResult failed on an empty holder", e);
+    }
+    try {
+      render(function.extractFinalResult(intermediate));
+    } catch (Exception e) {
+      throw new AssertionError(
+          describe(type, nullHandlingEnabled) + ": extractFinalResult failed on the empty intermediate result", e);
+    }
+  }
+
+  /// A `null` intermediate result means nothing was aggregated and must be resolved, never propagated by dereference.
+  @Test(dataProvider = "aggregationFunctions")
+  public void testNullIntermediateResultIsResolved(AggregationFunctionType type, boolean nullHandlingEnabled,
+      AggregationFunction function) {
+    try {
+      render(function.extractFinalResult(null));
+    } catch (Exception e) {
+      throw new AssertionError(
+          describe(type, nullHandlingEnabled) + ": extractFinalResult(null) must return the answer for no input", e);
+    }
+  }
+
+  /// Forces the final result into the form the broker response needs.
+  ///
+  /// Returning is not enough to prove the `null` was resolved: a function can wrap the `null` in a serializer that only
+  /// dereferences it when the value is rendered, which moves the failure out of this method and into the response path.
+  private static void render(@Nullable Object finalResult) {
+    if (finalResult != null) {
+      finalResult.toString();
+    }
+  }
+
+  /// `null` is the identity of merging, settled once by the caller so no implementation needs its own null branch.
+  ///
+  /// Both helpers resolve the `null` operand without delegating, so this holds for every function, including those that
+  /// do not support merging final results at all.
+  @Test(dataProvider = "aggregationFunctions")
+  public void testNullIsTheMergeIdentity(AggregationFunctionType type, boolean nullHandlingEnabled,
+      AggregationFunction function) {
+    String description = describe(type, nullHandlingEnabled);
+    Comparable value = "value";
+    assertSame(AggregationFunctionUtils.merge(function, null, value), value, description);
+    assertSame(AggregationFunctionUtils.merge(function, value, null), value, description);
+    assertNull(AggregationFunctionUtils.merge(function, null, null), description);
+    assertSame(AggregationFunctionUtils.mergeFinalResult(function, null, value), value, description);
+    assertSame(AggregationFunctionUtils.mergeFinalResult(function, value, null), value, description);
+    assertNull(AggregationFunctionUtils.mergeFinalResult(function, null, null), description);
+  }
+
+  /// The functions that SQL fixes at `0` rather than `NULL` when nothing was aggregated.
+  @Test
+  public void testCountingFunctionsReturnZeroWhenNothingAggregated() {
+    assertEquals(create("COUNT", "(*)", true).extractFinalResult(null), 0L);
+    assertEquals(create("DISTINCTCOUNT", "(column)", true).extractFinalResult(null), 0);
+    assertEquals(create("DISTINCTCOUNTHLL", "(column)", true).extractFinalResult(null), 0L);
+    assertEquals(create("DISTINCTCOUNTBITMAP", "(column)", true).extractFinalResult(null), 0);
+  }
+
+  /// The functions that return SQL `NULL` when nothing was aggregated.
+  ///
+  /// Both representations of that state are checked. A `null` intermediate result is the obvious one, but several of
+  /// these substitute an empty accumulator for an untouched holder and never produce a `null` at all on the
+  /// single-stage engine, so testing only the `null` would pass without exercising them.
+  @Test
+  public void testValueFunctionsReturnNullWhenNothingAggregated() {
+    for (AggregationFunctionType type : new AggregationFunctionType[]{
+        AggregationFunctionType.SUM, AggregationFunctionType.MIN, AggregationFunctionType.MAX,
+        AggregationFunctionType.AVG, AggregationFunctionType.MINMAXRANGE, AggregationFunctionType.VARPOP,
+        AggregationFunctionType.STDDEVPOP, AggregationFunctionType.PERCENTILE,
+        AggregationFunctionType.PERCENTILEEST, AggregationFunctionType.PERCENTILETDIGEST,
+        AggregationFunctionType.PERCENTILEKLL, AggregationFunctionType.PERCENTILESMARTTDIGEST}) {
+      // built through the shared argument shapes: the percentile families disagree on whether the percentile is a
+      // name suffix or an argument, and only some accept both
+      AggregationFunction function = tryCreate(type, true);
+      assertNotNull(function, "Could not construct " + type.getName());
+      String name = type.getName();
+      assertNull(function.extractFinalResult(null), name + " over a null intermediate result must be NULL");
+      Object empty = function.extractAggregationResult(function.createAggregationResultHolder());
+      assertNull(function.extractFinalResult(empty), name + " over an empty accumulator must be NULL");
+    }
+  }
+
+  /// Pins exactly which functions answer differently once null handling is enabled.
+  ///
+  /// Aggregating a block whose rows are all null separates the two modes: enabled skips every row and reports
+  /// nothing aggregated, disabled reads each one as the column default and aggregates it. A function shows up here
+  /// only if it both has null-aware aggregation and receives the query's option, so the set is a direct read-out of
+  /// which functions the option actually reaches.
+  ///
+  /// The multi-value entries are the interesting ones: they used to hard-code the option off, so it had no effect on
+  /// them whatever the query asked for. The raw variants reach the option through the function they delegate to, so
+  /// threading it into one of those changes the raw variant alongside it.
+  ///
+  /// The set is bounded by what the harness can drive, so it is a read-out of the functions the option reaches among
+  /// those, not of every function that takes it — see [#NOT_EXERCISABLE_BY_SYNTHETIC_BLOCK].
+  private static final Set<AggregationFunctionType> HONOURS_NULL_HANDLING = Set.of(
+      // single-value functions, which have always taken the option
+      AggregationFunctionType.COUNT, AggregationFunctionType.MIN, AggregationFunctionType.MAX,
+      AggregationFunctionType.SUM, AggregationFunctionType.SUM0, AggregationFunctionType.AVG,
+      AggregationFunctionType.MODE, AggregationFunctionType.ANYVALUE, AggregationFunctionType.MINMAXRANGE,
+      AggregationFunctionType.DISTINCTCOUNT, AggregationFunctionType.DISTINCTCOUNTOFFHEAP,
+      AggregationFunctionType.DISTINCTSUM, AggregationFunctionType.DISTINCTAVG,
+      AggregationFunctionType.DISTINCTCOUNTRAWHLL, AggregationFunctionType.DISTINCTCOUNTRAWHLLPLUS,
+      AggregationFunctionType.DISTINCTCOUNTRAWULL, AggregationFunctionType.PERCENTILE,
+      AggregationFunctionType.PERCENTILEEST, AggregationFunctionType.PERCENTILERAWEST,
+      AggregationFunctionType.PERCENTILETDIGEST, AggregationFunctionType.PERCENTILERAWTDIGEST,
+      AggregationFunctionType.PERCENTILESMARTTDIGEST, AggregationFunctionType.PERCENTILEKLL,
+      AggregationFunctionType.PERCENTILERAWKLL, AggregationFunctionType.VARPOP, AggregationFunctionType.VARSAMP,
+      AggregationFunctionType.STDDEVPOP, AggregationFunctionType.STDDEVSAMP,
+      // multi-value variants that already took the option
+      AggregationFunctionType.MINMV, AggregationFunctionType.MAXMV, AggregationFunctionType.SUMMV,
+      AggregationFunctionType.AVGMV, AggregationFunctionType.MINMAXRANGEMV,
+      AggregationFunctionType.DISTINCTCOUNTRAWHLLMV, AggregationFunctionType.DISTINCTCOUNTRAWHLLPLUSMV,
+      // multi-value variants this change threads the option into; they hard-coded it off before
+      AggregationFunctionType.DISTINCTCOUNTMV, AggregationFunctionType.DISTINCTSUMMV,
+      AggregationFunctionType.DISTINCTAVGMV, AggregationFunctionType.PERCENTILEMV,
+      AggregationFunctionType.PERCENTILEESTMV, AggregationFunctionType.PERCENTILERAWESTMV,
+      AggregationFunctionType.PERCENTILEKLLMV, AggregationFunctionType.PERCENTILETDIGESTMV,
+      AggregationFunctionType.PERCENTILERAWTDIGESTMV, AggregationFunctionType.PERCENTILERAWKLLMV,
+      // functions the harness reaches only once it probes block shapes and feeds every input column; they have
+      // always taken the option, so these entries are a gain in measurement rather than a change in behaviour
+      AggregationFunctionType.MINSTRING, AggregationFunctionType.MAXSTRING, AggregationFunctionType.MINLONG,
+      AggregationFunctionType.MAXLONG, AggregationFunctionType.SUMINT, AggregationFunctionType.SUMLONG,
+      AggregationFunctionType.SUMPRECISION, AggregationFunctionType.FIRSTWITHTIME,
+      AggregationFunctionType.LASTWITHTIME, AggregationFunctionType.DISTINCTCOUNTRAWCPCSKETCH,
+      AggregationFunctionType.FREQUENTSTRINGSSKETCH, AggregationFunctionType.FREQUENTLONGSSKETCH,
+      AggregationFunctionType.ARRAYAGG, AggregationFunctionType.LISTAGG
+  );
+
+  /// Functions this test cannot drive with a one-column synthetic block, pinned so that a silent drop-out is always a
+  /// reviewed decision. Derived from a run rather than predicted.
+  ///
+  /// The block implements only single-value `long` and `double`, so a function lands here when it reads another value
+  /// type, needs a multi-value block, or takes more than the one input column the shared argument shapes supply. The
+  /// exclusion is scoped to this test: the rest of the contract is still checked against these functions, since the
+  /// other cases construct them and call [AggregationFunction#extractFinalResult] without aggregating first.
+  private static final Set<AggregationFunctionType> NOT_EXERCISABLE_BY_SYNTHETIC_BLOCK = Set.of(
+      AggregationFunctionType.FASTHLL, AggregationFunctionType.DISTINCTCOUNTTUPLESKETCH,
+      AggregationFunctionType.DISTINCTCOUNTRAWINTEGERSUMTUPLESKETCH,
+      AggregationFunctionType.SUMVALUESINTEGERSUMTUPLESKETCH, AggregationFunctionType.AVGVALUEINTEGERSUMTUPLESKETCH,
+      AggregationFunctionType.STUNION, AggregationFunctionType.BOOLAND, AggregationFunctionType.BOOLOR,
+      AggregationFunctionType.SUMARRAYLONG, AggregationFunctionType.SUMARRAYDOUBLE,
+      AggregationFunctionType.FUNNELMAXSTEP, AggregationFunctionType.FUNNELCOMPLETECOUNT,
+      AggregationFunctionType.FUNNELSTEPDURATIONSTATS, AggregationFunctionType.FUNNELMATCHSTEP,
+      AggregationFunctionType.FUNNELEVENTSFUNCTIONEVAL, AggregationFunctionType.FUNNELCOUNT
+  );
+
+  /// Checks every function rather than a fixed list, so that a function gaining or losing null awareness is caught.
+  ///
+  /// Failing with something extra means a function started honouring the option and should be added to
+  /// [#HONOURS_NULL_HANDLING]; failing with something missing means one stopped, which is a regression unless the
+  /// entry is stale. Functions the synthetic block cannot feed — because they read a value type it does not
+  /// implement, or reject the column outright — are not counted either way.
+  @Test
+  public void testNullHandlingOptionReachesEveryFunctionThatHonoursIt() {
+    Set<AggregationFunctionType> honours = new TreeSet<>();
+    Set<AggregationFunctionType> notExercisable = new TreeSet<>();
+    for (AggregationFunctionType type : AggregationFunctionType.values()) {
+      if (INTERNAL_TYPES.contains(type) || tryCreate(type, false) == null) {
+        continue;
+      }
+      Object enabled = null;
+      Object disabled = null;
+      boolean driven = false;
+      for (Supplier<BlockValSet> shape : BLOCK_SHAPES) {
+        try {
+          // the same shape drives both modes, so that the comparison below is between the modes and not the inputs
+          enabled = aggregateAllNulls(type, true, shape);
+          disabled = aggregateAllNulls(type, false, shape);
+          driven = true;
+          break;
+        } catch (RuntimeException e) {
+          // this shape reads a value type the function rejects; fall through to the next
+        }
+      }
+      if (!driven) {
+        notExercisable.add(type);
+        continue;
+      }
+      if (!Objects.equals(enabled, disabled)) {
+        honours.add(type);
+      }
+    }
+
+    Set<AggregationFunctionType> newlySkipped = new TreeSet<>(notExercisable);
+    newlySkipped.removeAll(NOT_EXERCISABLE_BY_SYNTHETIC_BLOCK);
+    Set<AggregationFunctionType> staleSkip = new TreeSet<>(NOT_EXERCISABLE_BY_SYNTHETIC_BLOCK);
+    staleSkip.removeAll(notExercisable);
+    assertTrue(newlySkipped.isEmpty() && staleSkip.isEmpty(),
+        "The set of functions this test cannot drive has changed.\n  Newly undrivable, so they stopped being checked "
+            + "and need the same review as an entry in EXPECTED_UNCONSTRUCTIBLE: " + newlySkipped
+            + "\n  Drivable again, so remove them from NOT_EXERCISABLE_BY_SYNTHETIC_BLOCK: " + staleSkip);
+
+    Set<AggregationFunctionType> gained = new TreeSet<>(honours);
+    gained.removeAll(HONOURS_NULL_HANDLING);
+    Set<AggregationFunctionType> lost = new TreeSet<>(HONOURS_NULL_HANDLING);
+    lost.removeAll(honours);
+    assertTrue(gained.isEmpty() && lost.isEmpty(),
+        "The null handling option now reaches a different set of functions.\n  Newly honouring it, so add to "
+            + "HONOURS_NULL_HANDLING once the behaviour change is intended: " + gained
+            + "\n  No longer honouring it, which is a regression unless the entry is stale: " + lost);
+  }
+
+  /// Aggregates a block whose rows are all null and returns the final result.
+  ///
+  /// Every input expression the function declares is given a block, not just the first, so that the functions taking
+  /// more than one column are driven rather than failing on a missing entry.
+  private static Object aggregateAllNulls(AggregationFunctionType type, boolean nullHandlingEnabled,
+      Supplier<BlockValSet> blockShape) {
+    AggregationFunction function = tryCreate(type, nullHandlingEnabled);
+    assertNotNull(function, "Could not construct " + type.getName());
+    Map<ExpressionContext, BlockValSet> blockValSetMap = new HashMap<>();
+    for (Object inputExpression : function.getInputExpressions()) {
+      // every declared input gets a block, literals included: a function that took a literal for one of its columns
+      // still looks that expression up in the map, and a missing entry makes it throw and drop out of the census
+      blockValSetMap.put((ExpressionContext) inputExpression, blockShape.get());
+    }
+    // a function whose only argument is a literal, such as COUNT(*), still needs one block to read a length from
+    if (blockValSetMap.isEmpty()) {
+      blockValSetMap.put(ExpressionContext.forIdentifier("column"), blockShape.get());
+    }
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    function.aggregate(NUM_DOCS, resultHolder, blockValSetMap);
+    return function.extractFinalResult(function.extractAggregationResult(resultHolder));
+  }
+
+  /// All-null block shapes, tried in order until one drives the function.
+  ///
+  /// Probed rather than pinned per function: which value type an accumulator reads is an implementation detail that
+  /// changes, and a hard-coded mapping silently drops a function out of the census when it feeds the wrong width.
+  private static final List<Supplier<BlockValSet>> BLOCK_SHAPES = List.of(
+      () -> SyntheticBlockValSets.Double.create(NUM_DOCS, allNullBitmap(), () -> 0.0),
+      () -> SyntheticBlockValSets.Long.create(NUM_DOCS, allNullBitmap(), () -> 0L),
+      () -> SyntheticBlockValSets.Int.create(NUM_DOCS, allNullBitmap(), () -> 0),
+      () -> SyntheticBlockValSets.Str.create(NUM_DOCS, allNullBitmap(), () -> ""),
+      () -> SyntheticBlockValSets.Bytes.create(NUM_DOCS, allNullBitmap(), () -> new byte[0])
+  );
+
+  private static RoaringBitmap allNullBitmap() {
+    RoaringBitmap allNull = new RoaringBitmap();
+    allNull.add(0L, NUM_DOCS);
+    return allNull;
+  }
+
+  /// Pins exactly which types go unchecked, so a skip is always a reviewed decision rather than a silent one.
+  ///
+  /// Failing in the "not accounted for" direction means a function could not be built from [#ARGUMENT_SHAPES] and is
+  /// therefore not being checked at all: either add the argument shape it needs, or classify it. Failing in the "no
+  /// longer skipped" direction means an entry here is stale and should be deleted.
+  @Test
+  public void testEverySkippedTypeIsAccountedFor() {
+    Set<AggregationFunctionType> skipped = new TreeSet<>();
+    for (AggregationFunctionType type : AggregationFunctionType.values()) {
+      if (!INTERNAL_TYPES.contains(type) && tryCreate(type, false) == null) {
+        skipped.add(type);
+      }
+    }
+
+    Set<AggregationFunctionType> unaccounted = new TreeSet<>(skipped);
+    unaccounted.removeAll(EXPECTED_UNCONSTRUCTIBLE);
+    assertTrue(unaccounted.isEmpty(),
+        "These types are silently excluded from the null contract; extend ARGUMENT_SHAPES or classify them: "
+            + unaccounted);
+
+    Set<AggregationFunctionType> stale = new TreeSet<>(EXPECTED_UNCONSTRUCTIBLE);
+    stale.removeAll(skipped);
+    assertTrue(stale.isEmpty(), "These types can now be constructed and should be removed from "
+        + "EXPECTED_UNCONSTRUCTIBLE so they are checked: " + stale);
+  }
+
+  private static AggregationFunction create(String name, String args, boolean nullHandlingEnabled) {
+    FunctionContext context = RequestContextUtils.getExpression(name + args).getFunction();
+    AggregationFunction function = AggregationFunctionFactory.getAggregationFunction(context, nullHandlingEnabled);
+    if (function == null) {
+      fail("Could not construct " + name + args);
+    }
+    return function;
+  }
+
+  @Nullable
+  private static AggregationFunction tryCreate(AggregationFunctionType type, boolean nullHandlingEnabled) {
+    for (String args : ARGUMENT_SHAPES) {
+      try {
+        FunctionContext context = RequestContextUtils.getExpression(type.getName() + args).getFunction();
+        AggregationFunction function = AggregationFunctionFactory.getAggregationFunction(context, nullHandlingEnabled);
+        if (function != null) {
+          return function;
+        }
+      } catch (Exception e) {
+        // Wrong argument shape for this function, or a function that cannot be built outside a real query plan (e.g.
+        // the parent/child and time-series functions). Try the next shape.
+      }
+    }
+    return null;
+  }
+
+  private static String describe(AggregationFunctionType type, boolean nullHandlingEnabled) {
+    return type.getName() + (nullHandlingEnabled ? " [nullHandlingEnabled]" : " [nullHandlingDisabled]");
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MaxStringAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MaxStringAggregationFunctionTest.java
@@ -37,7 +37,6 @@ import org.testng.annotations.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -137,11 +136,6 @@ public class MaxStringAggregationFunctionTest extends AbstractAggregationFunctio
     assertEquals(function.merge("banana", "apple"), "banana");
     assertEquals(function.merge("", "apple"), "apple");
     assertEquals(function.merge("apple", ""), "apple");
-
-    // Test null handling
-    assertEquals(function.merge("apple", null), "apple");
-    assertEquals(function.merge(null, "apple"), "apple");
-    assertNull(function.merge(null, null));
     assertEquals(function.merge("apple", "null"), "null");
 
     // Test final result merging

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MaxStringAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MaxStringAggregationFunctionTest.java
@@ -36,7 +36,6 @@ import org.testng.annotations.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -130,11 +129,6 @@ public class MaxStringAggregationFunctionTest extends AbstractAggregationFunctio
     assertEquals(function.merge("banana", "apple"), "banana");
     assertEquals(function.merge("", "apple"), "apple");
     assertEquals(function.merge("apple", ""), "apple");
-
-    // Test null handling
-    assertEquals(function.merge("apple", null), "apple");
-    assertEquals(function.merge(null, "apple"), "apple");
-    assertNull(function.merge(null, null));
     assertEquals(function.merge("apple", "null"), "null");
 
     // Test final result merging

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinStringAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/MinStringAggregationFunctionTest.java
@@ -36,7 +36,6 @@ import org.testng.annotations.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -128,11 +127,6 @@ public class MinStringAggregationFunctionTest extends AbstractAggregationFunctio
     assertEquals(function.merge("banana", "apple"), "apple");
     assertEquals(function.merge("", "apple"), "");
     assertEquals(function.merge("apple", ""), "");
-
-    // Test null handling
-    assertEquals(function.merge("apple", null), "apple");
-    assertEquals(function.merge(null, "apple"), "apple");
-    assertNull(function.merge(null, null));
 
     // Test final result merging
     assertEquals(function.mergeFinalResult("apple", "banana"), "apple");

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileSmartTDigestAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileSmartTDigestAggregationFunctionTest.java
@@ -123,15 +123,6 @@ public class PercentileSmartTDigestAggregationFunctionTest {
     assertEquals(roundTripped.quantile(0.5), (numCentroids - 1.0) / 2.0, 1.0);
   }
 
-  @Test
-  public void testMergeWithNullIntermediateResult() {
-    PercentileSmartTDigestAggregationFunction function = newFunction();
-    DoubleArrayList valueList = new DoubleArrayList(new double[]{1.0, 2.0});
-    assertEquals(function.merge(null, valueList), valueList);
-    assertEquals(function.merge(valueList, null), valueList);
-    assertEquals(function.merge(null, null), null);
-  }
-
   /// Broker reduce can merge a server that produced a t-digest with a server that stayed below the
   /// threshold and produced a raw value list; both argument orders must route into the accumulator.
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunctionTest.java
@@ -344,10 +344,7 @@ public class PercentileTDigestAggregationFunctionTest {
     RoaringBitmap nullBitmap = new RoaringBitmap();
     nullBitmap.add(0L, values.length);
 
-    TDigest result = aggregateSerialized(values, nullBitmap, true);
-    Assert.assertEquals(result.size(), 0L);
-    Assert.assertEquals(result.compression(), PercentileTDigestAggregationFunction.DEFAULT_TDIGEST_COMPRESSION);
-    Assert.assertTrue(Double.isNaN(result.quantile(0.75)));
+    Assert.assertNull(aggregateSerialized(values, nullBitmap, true));
   }
 
   @Test
@@ -413,7 +410,7 @@ public class PercentileTDigestAggregationFunctionTest {
         (99.0 * numDigests + 10.0) / denominator);
     assertGroupResult(function, resultHolder, 2, 8L * valuesPerDigest, compression, 2.0 / denominator,
         (99.0 * numDigests + 11.0) / denominator);
-    Assert.assertEquals(function.extractGroupByResult(resultHolder, 3).size(), 0L);
+    Assert.assertNull(function.extractGroupByResult(resultHolder, 3));
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BooleanAggQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BooleanAggQueriesTest.java
@@ -69,11 +69,13 @@ public class BooleanAggQueriesTest extends BaseQueriesTest {
 
   private static final String BOOLEAN_COLUMN = "boolColumn";
   private static final String GROUP_BY_COLUMN = "groupByColumn";
+  private static final String MV_GROUP_BY_COLUMN = "mvGroupByColumn";
 
   private static final Schema SCHEMA =
       new Schema.SchemaBuilder()
           .addSingleValueDimension(BOOLEAN_COLUMN, FieldSpec.DataType.BOOLEAN)
-          .addSingleValueDimension(GROUP_BY_COLUMN, FieldSpec.DataType.STRING).build();
+          .addSingleValueDimension(GROUP_BY_COLUMN, FieldSpec.DataType.STRING)
+          .addMultiValueDimension(MV_GROUP_BY_COLUMN, FieldSpec.DataType.STRING).build();
 
   private static final TableConfig TABLE_CONFIG =
       new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
@@ -109,23 +111,26 @@ public class BooleanAggQueriesTest extends BaseQueriesTest {
       throws Exception {
     FileUtils.deleteDirectory(INDEX_DIR);
 
+    // The multi-value groupings are what route the aggregation through aggregateGroupByMV: rows carrying more than one
+    // tag land in several groups at once, and "mvNullAndTrue" / "mvOnlyNulls" separate skipping a null from folding it
+    // in as the column default.
     Object[][] recordContents = new Object[][]{
-        new Object[]{true, "allTrue"},
-        new Object[]{true, "allTrue"},
-        new Object[]{true, "allTrue"},
-        new Object[]{false, "allFalse"},
-        new Object[]{false, "allFalse"},
-        new Object[]{false, "allFalse"},
-        new Object[]{true, "mixedOne"},
-        new Object[]{true, "mixedOne"},
-        new Object[]{false, "mixedOne"},
-        new Object[]{false, "mixedTwo"},
-        new Object[]{true, "mixedTwo"},
-        new Object[]{false, "mixedTwo"},
-        new Object[]{null, "withNulls"},
-        new Object[]{true, "withNulls"},
-        new Object[]{false, "withNulls"},
-        new Object[]{null, "onlyNulls"},
+        new Object[]{true, "allTrue", List.of("mvAllTrue", "mvNullAndTrue")},
+        new Object[]{true, "allTrue", List.of("mvAllTrue")},
+        new Object[]{true, "allTrue", List.of("mvAllTrue")},
+        new Object[]{false, "allFalse", List.of("mvAllFalse", "mvNullAndFalse")},
+        new Object[]{false, "allFalse", List.of("mvAllFalse")},
+        new Object[]{false, "allFalse", List.of("mvAllFalse")},
+        new Object[]{true, "mixedOne", List.of("mvAllTrue")},
+        new Object[]{true, "mixedOne", List.of("mvAllTrue")},
+        new Object[]{false, "mixedOne", List.of("mvAllFalse")},
+        new Object[]{false, "mixedTwo", List.of("mvAllFalse")},
+        new Object[]{true, "mixedTwo", List.of("mvAllTrue")},
+        new Object[]{false, "mixedTwo", List.of("mvAllFalse")},
+        new Object[]{null, "withNulls", List.of("mvOnlyNulls", "mvNullAndTrue", "mvNullAndFalse")},
+        new Object[]{true, "withNulls", List.of("mvAllTrue")},
+        new Object[]{false, "withNulls", List.of("mvAllFalse")},
+        new Object[]{null, "onlyNulls", List.of("mvOnlyNulls")},
     };
 
     List<GenericRow> records = new ArrayList<>(NUM_RECORDS);
@@ -133,6 +138,7 @@ public class BooleanAggQueriesTest extends BaseQueriesTest {
       GenericRow genericRow = new GenericRow();
       genericRow.putValue(BOOLEAN_COLUMN, record[0]);
       genericRow.putValue(GROUP_BY_COLUMN, record[1]);
+      genericRow.putValue(MV_GROUP_BY_COLUMN, record[2]);
       records.add(genericRow);
     }
 
@@ -231,6 +237,78 @@ public class BooleanAggQueriesTest extends BaseQueriesTest {
           Assert.assertEquals(aggregates.getResultForGroupId(0, key._groupId), 0);
           break;
         case "onlyNulls":
+          Assert.assertEquals(aggregates.getResultForGroupId(0, key._groupId), isNullHandlingEnabled ? null : 0);
+          break;
+        default:
+          throw new IllegalStateException("Unexpected grouping: " + key._keys[0]);
+      }
+    }
+  }
+
+  /// Grouping by a multi-value column dispatches to `aggregateGroupByMV`, where a row contributes to every group it is
+  /// tagged with. The `mvNullAndTrue` group is what distinguishes the two modes: with null handling enabled the null
+  /// row is skipped and the conjunction is over `{true}`, while with it disabled the null reads as the column default
+  /// `false` and drags the conjunction down.
+  @Test(dataProvider = "nullHandling")
+  public void testBooleanAndGroupByMultiValue(boolean isNullHandlingEnabled) {
+    // Given:
+    String query = "SELECT BOOL_AND(boolColumn) FROM testTable GROUP BY mvGroupByColumn";
+    GroupByOperator operator = getOperator(query, isNullHandlingEnabled);
+
+    // When:
+    GroupByResultsBlock result = operator.nextBlock();
+
+    // Then:
+    AggregationGroupByResult aggregates = result.getAggregationGroupByResult();
+    Iterator<GroupKeyGenerator.GroupKey> keys = aggregates.getGroupKeyIterator();
+    while (keys.hasNext()) {
+      GroupKeyGenerator.GroupKey key = keys.next();
+      switch ((String) key._keys[0]) {
+        case "mvAllTrue":
+          Assert.assertEquals(aggregates.getResultForGroupId(0, key._groupId), 1);
+          break;
+        case "mvAllFalse":
+        case "mvNullAndFalse":
+          Assert.assertEquals(aggregates.getResultForGroupId(0, key._groupId), 0);
+          break;
+        case "mvNullAndTrue":
+          Assert.assertEquals(aggregates.getResultForGroupId(0, key._groupId), isNullHandlingEnabled ? 1 : 0);
+          break;
+        case "mvOnlyNulls":
+          Assert.assertEquals(aggregates.getResultForGroupId(0, key._groupId), isNullHandlingEnabled ? null : 0);
+          break;
+        default:
+          throw new IllegalStateException("Unexpected grouping: " + key._keys[0]);
+      }
+    }
+  }
+
+  /// The multi-value counterpart for disjunction. Only `mvOnlyNulls` separates the two modes here: a null read as the
+  /// default `false` cannot change a disjunction that already contains a real value.
+  @Test(dataProvider = "nullHandling")
+  public void testBooleanOrGroupByMultiValue(boolean isNullHandlingEnabled) {
+    // Given:
+    String query = "SELECT BOOL_OR(boolColumn) FROM testTable GROUP BY mvGroupByColumn";
+    GroupByOperator operator = getOperator(query, isNullHandlingEnabled);
+
+    // When:
+    GroupByResultsBlock result = operator.nextBlock();
+
+    // Then:
+    AggregationGroupByResult aggregates = result.getAggregationGroupByResult();
+    Iterator<GroupKeyGenerator.GroupKey> keys = aggregates.getGroupKeyIterator();
+    while (keys.hasNext()) {
+      GroupKeyGenerator.GroupKey key = keys.next();
+      switch ((String) key._keys[0]) {
+        case "mvAllTrue":
+        case "mvNullAndTrue":
+          Assert.assertEquals(aggregates.getResultForGroupId(0, key._groupId), 1);
+          break;
+        case "mvAllFalse":
+        case "mvNullAndFalse":
+          Assert.assertEquals(aggregates.getResultForGroupId(0, key._groupId), 0);
+          break;
+        case "mvOnlyNulls":
           Assert.assertEquals(aggregates.getResultForGroupId(0, key._groupId), isNullHandlingEnabled ? null : 0);
           break;
         default:

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentAggregationSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentAggregationSingleValueQueriesTest.java
@@ -18,12 +18,16 @@
  */
 package org.apache.pinot.queries;
 
+import java.util.List;
 import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.GroupByResultsBlock;
 import org.apache.pinot.core.operator.query.AggregationOperator;
 import org.apache.pinot.core.operator.query.FilteredAggregationOperator;
 import org.apache.pinot.core.operator.query.GroupByOperator;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 
 public class InnerSegmentAggregationSingleValueQueriesTest extends BaseSingleValueQueriesTest {
@@ -88,8 +92,13 @@ public class InnerSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
     resultsBlock = aggregationOperator.nextBlock();
     QueriesTestUtils.testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), 120000L, 0L,
         90000L, 30000L);
-    QueriesTestUtils.testInnerSegmentAggregationResult(resultsBlock.getResults(), 22266008882250L, 30000, 2147419555,
-        32289159189150L, 0L, 0L);
+    List<Object> results = resultsBlock.getResults();
+    assertEquals(((Number) results.get(0)).longValue(), 22266008882250L);
+    assertEquals(((Number) results.get(1)).longValue(), 30000L);
+    assertEquals(((Number) results.get(2)).longValue(), 2147419555L);
+    assertEquals(((Number) results.get(3)).longValue(), 32289159189150L);
+    // no row passes this filter, so nothing was aggregated for the average
+    assertNull(results.get(4));
   }
 
   @Test

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageAggregationExecutor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageAggregationExecutor.java
@@ -25,6 +25,7 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.query.planner.plannode.AggregateNode.AggType;
 import org.apache.pinot.query.runtime.blocks.MseBlock;
 import org.apache.pinot.query.runtime.operator.utils.TypeUtils;
@@ -146,16 +147,8 @@ public class MultistageAggregationExecutor {
       AggregationFunction aggFunction = _aggFunctions[i];
       Object[] intermediateResults = AggregateOperator.getIntermediateResults(aggFunction, block);
       for (Object intermediateResult : intermediateResults) {
-        // Not all V1 aggregation functions have null-handling logic. Handle null values before calling merge.
-        // TODO: Fix it
-        if (intermediateResult == null) {
-          continue;
-        }
-        if (_mergeResultHolder[i] == null) {
-          _mergeResultHolder[i] = intermediateResult;
-        } else {
-          _mergeResultHolder[i] = aggFunction.merge(_mergeResultHolder[i], intermediateResult);
-        }
+        _mergeResultHolder[i] =
+            AggregationFunctionUtils.merge(aggFunction, _mergeResultHolder[i], intermediateResult);
       }
     }
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java
@@ -34,6 +34,7 @@ import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.common.utils.config.QueryOptionsUtils;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
 import org.apache.pinot.core.util.DataBlockExtractUtils;
@@ -389,18 +390,8 @@ public class MultistageGroupByExecutor {
           mergedResults = (Comparable[]) _mergeResultHolder.get(groupByKey);
         }
         for (int j = 0; j < numFunctions; j++) {
-          AggregationFunction aggFunction = _aggFunctions[j];
           Comparable finalResult = (Comparable) intermediateResults[j][i];
-          // Not all V1 aggregation functions have null-handling logic. Handle null values before calling merge.
-          // TODO: Fix it
-          if (finalResult == null) {
-            continue;
-          }
-          if (mergedResults[j] == null) {
-            mergedResults[j] = finalResult;
-          } else {
-            mergedResults[j] = aggFunction.mergeFinalResult(mergedResults[j], finalResult);
-          }
+          mergedResults[j] = AggregationFunctionUtils.mergeFinalResult(_aggFunctions[j], mergedResults[j], finalResult);
         }
       }
     } else {
@@ -417,18 +408,8 @@ public class MultistageGroupByExecutor {
           mergedResults = _mergeResultHolder.get(groupByKey);
         }
         for (int j = 0; j < numFunctions; j++) {
-          AggregationFunction aggFunction = _aggFunctions[j];
-          Object intermediateResult = intermediateResults[j][i];
-          // Not all V1 aggregation functions have null-handling logic. Handle null values before calling merge.
-          // TODO: Fix it
-          if (intermediateResult == null) {
-            continue;
-          }
-          if (mergedResults[j] == null) {
-            mergedResults[j] = intermediateResult;
-          } else {
-            mergedResults[j] = aggFunction.merge(mergedResults[j], intermediateResult);
-          }
+          mergedResults[j] =
+              AggregationFunctionUtils.merge(_aggFunctions[j], mergedResults[j], intermediateResults[j][i]);
         }
       }
     }


### PR DESCRIPTION
Part of #19218.

## Summary

Null handling is a per-query flag, and the two modes place very different requirements on an `AggregationFunction` — but that contract was never written down. Implementations drifted apart as a result: some resolved the "nothing was aggregated" case, some threw on it, some carried defensive null branches no caller could reach, and `@Nullable` annotations disagreed with the code they annotated.

This writes the contract onto `AggregationFunction` and brings the implementations in line with it.

### Behavior change: ten multi-value functions now honour `enableNullHandling`

`DISTINCT_COUNT_MV`, `DISTINCT_SUM_MV`, `DISTINCT_AVG_MV`, `PERCENTILE_MV`, `PERCENTILE_EST_MV`, `PERCENTILE_KLL_MV` and `PERCENTILE_TDIGEST_MV` hard-coded `nullHandlingEnabled = false` in their constructors — they did not accept the parameter at all, so the query option had no effect on them whatever it was set to.

The null-aware machinery was already present and correct in the shared base classes; it was simply switched off. Threading the option through the constructors is the whole fix.

`PERCENTILE_RAW_EST_MV`, `PERCENTILE_RAW_TDIGEST_MV` and `PERCENTILE_RAW_KLL_MV` change with them. Each one extends or wraps one of the seven, so it reaches the option through the function it delegates to and needed no edit of its own — seven constructors, ten functions whose answers move.

For a query with `enableNullHandling=true`, these functions now skip null rows instead of folding in the column default, which changes their results. `DISTINCT_SUM_MV` over an all-null input returns `NULL` rather than `0`, for example.

**On the multi-stage engine the change is unconditional, and no query option controls it.** `AggregateOperator` builds every aggregation function with null handling enabled and never consults the query's option, so these functions previously discarded a flag that the engine had already set to `true`. They now honour it. For a multi-stage query with default options, over an input where nothing was aggregated:

| function | before | after |
|---|---|---|
| `percentileMV(mv, 50)` | `-Infinity` | `NULL` |
| `distinctSumMV(mv)` | `0.0` | `NULL` |
| `distinctAvgMV(mv)` | `NaN` | `NULL` |

The new answers are the correct ones, but the change needs calling out in the release notes rather than being read as opt-in. On the single-stage engine, a query with the option disabled is unaffected.

### Fixes an NPE in the broker response path

`PERCENTILERAWEST`, `PERCENTILERAWKLL`, `PERCENTILERAWTDIGEST` and their MV variants wrapped the intermediate result in a serializer (`SerializedQuantileDigest` / `SerializedKLL` / `SerializedTDigest`) without checking it. Those wrappers dereference what they are handed in both `toString()` and `compareTo()`, so a `null` intermediate did not fail at extraction — it failed later, when the broker rendered the value.

For the KLL variants this is reachable on the single-stage engine in **both** modes, because `PercentileKLLAggregationFunction.extractAggregationResult` returns the holder's value directly and that is `null` for an untouched holder. A query whose segments are all pruned hits it.

### Fixes `PERCENTILETDIGEST` answering `NaN` where the contract says `NULL`

`PercentileTDigestAggregationFunction.extractFinalResult` had no empty-accumulator branch, and its `extractAggregationResult` builds an empty digest rather than returning `null` for an untouched holder. `TDigest.quantile()` returns `NaN` for an empty digest, so `PERCENTILETDIGEST` over an all-null column with `enableNullHandling=true` answered `NaN` while `PERCENTILE`, `PERCENTILEEST` and `PERCENTILEKLL` answered `NULL` for the same query.

The branch now matches its three siblings, which already had it. `PERCENTILETDIGESTMV` inherits the method, and `PERCENTILESMARTTDIGEST` gets the same test on its t-digest branch so that it agrees with its own value-list branch — which of the two a query lands in depends only on whether the accumulator crossed the conversion threshold.

The test is gated on the null handling option, so the disabled mode is unchanged.

### Makes `extractFinalResult` the sole decision point wherever the option is available

Substituting an empty accumulator in the extraction methods destroys the "nothing was aggregated" signal before `extractFinalResult` can act on it, and forces every later stage to re-derive it with a per-type emptiness probe. Every function that *receives* the null handling option now returns `null` from both extraction methods and renders the disabled-mode value in `extractFinalResult` instead:

- `AVG`, `MIN_MAX_RANGE`, `VAR_POP`/`VAR_SAMP`/`STDDEV_POP`/`STDDEV_SAMP`
- `DISTINCT_COUNT`, `DISTINCT_SUM`, `DISTINCT_AVG` (via their shared base) and `DISTINCT_COUNT_OFF_HEAP`
- `PERCENTILE`, `PERCENTILE_EST`, `PERCENTILE_TDIGEST`, `PERCENTILE_SMART_TDIGEST`, with the raw and multi-value variants of each

Answers are unchanged in both modes. Each disabled-mode value was read off what that function's substituted accumulator rendered — `0.0` for a distinct sum over an empty set, `NaN` for a distinct average, `Long.MIN_VALUE` for an empty `QuantileDigest`, `NaN` for an empty `TDigest`. The raw percentile wrappers changed with their delegates rather than after them: they build the empty digest where it is rendered and serialize it, so a raw percentile still emits a serialized empty digest with the option off.

Two answers do change, both toward the contract. `VAR_POP` answered `NULL` for a group with no rows while `MIN_MAX_RANGE` answered `-Infinity` for the identical query, because the two disagreed about which extraction path substitutes — reachable through a filtered aggregation, where one group key space is shared across every aggregation and a group created by one can hold no rows for another. And `DISTINCT_COUNT_OFF_HEAP` no longer calls `close()` on a shared placeholder set.

The functions that never receive the option are left alone. They cannot be conformed separately: without it, `extractFinalResult` has nothing to decide with. That is now recorded as part of the first known deviation rather than as a deviation of its own.

### The contract

- **Null handling disabled** — nulls read as the column default, the accumulator is primitive, and no null tracking happens. A row that aggregated the default is indistinguishable from one that aggregated nothing, so this mode has no answer for the empty input other than the accumulator's identity (`0` for `SUM`, `+Infinity` for `MIN`). This is a performance path, and those answers are a backward-compatibility constraint rather than an attempt at SQL conformance.
- **Null handling enabled** — SQL semantics. A `null` intermediate result means nothing was aggregated, and `extractFinalResult` decides what that means for a given function: `0` for the counting functions, `null` for the value functions.

In both modes the identity is rendered by `extractFinalResult` rather than carried by the accumulator, so an untouched holder yields a `null` intermediate result either way and `extractFinalResult` accepts `null` in both. One decision point, and the only workable arrangement for the types that have no empty value to substitute — `MAXSTRING`, `MINSTRING` and `ANYVALUE` are object-backed and have none.

### Settles the merge identity once, in the caller

The "nothing was aggregated" case is the identity of merging and means the same thing for every aggregation, so it does not belong in each implementation. `AggregationFunctionUtils#merge` and `#mergeFinalResult` resolve a `null` operand and only then delegate, and all six call sites route through them.

Two of those call sites — `AggregationResultsBlockMerger` and `SortedRecordsMerger` — previously had no null handling at all; two others carried `// TODO: Fix it` blocks that this removes. With the identity settled in one place, `merge` implementations only ever see two real values, so the null branches inside them are unreachable and have been dropped.

### Collapses the multi-value variants onto their single-value implementations

Fifteen MV classes were carrying code they did not need:

- Twelve (`MaxMV`, `MinMV`, `SumMV`, `AvgMV`, `MinMaxRangeMV`, the percentile MVs, the HLL MVs) overrode all three `aggregate*` methods purely to force the multi-value path. Their parents already dispatch on `blockValSet.isSingleValue()` in all three, and select the same method for a multi-value column, so the overrides only re-derived a decision the parent already makes.
- Three (`DistinctCountMV`, `DistinctSumMV`, `DistinctAvgMV`) were siblings of their single-value counterparts rather than subclasses, duplicating `extractFinalResult`, `mergeFinalResult` and `getFinalResultColumnType`. Those copies had already drifted — the MV ones disagreed with the SV ones on the empty-input answer, which this also fixes.

This removes 52 methods. It is not purely cosmetic: the deleted overrides called `aggregateMV` unconditionally, which fails on a single-value block set, whereas the parent's dispatch handles it.

### Also

- `extractFinalResult` resolves the "nothing was aggregated" case across the remaining functions instead of dereferencing it.
- `@Nullable` annotations are aligned with what each implementation actually does — added where a method genuinely returns `null`, removed from `merge` parameters where the annotation contradicted the contract.
- `BaseBooleanAggregationFunction.aggregateGroupByMV` mirrors its single-value counterpart and skips null rows when null handling is enabled.

### Tests

The test harness now probes block value types until one drives the function, rather than consulting a hard-coded map of which function reads which type, and feeds every input expression the function declares instead of only the first. Single-value `string`, `bytes` and `int` blocks were added alongside the existing `long` and `double` ones.

That brought 18 functions into the census that were previously skipped, including `MINSTRING`, `MAXSTRING`, `SUMINT`, `SUMLONG`, `SUMPRECISION`, `FIRSTWITHTIME`, `LASTWITHTIME`, `COVARPOP`, `ARRAYAGG` and `LISTAGG`. Fourteen of them turned out to honour the query's null handling option and had never been checked.

`AggregationFunctionNullContractTest` enforces the contract against every aggregation function that can be constructed generically — 95 of the 103 `AggregationFunctionType` values, under both flag settings. The eight it cannot construct are pinned in both directions, so a newly added function cannot drop out of the contract unnoticed and a stale exclusion cannot linger.

It asserts that the final result *renders*, not merely that extraction returned. That distinction is what the raw percentile bug turned on: extraction succeeded and the failure surfaced downstream.

It also covers the behavior change directly. `testNullHandlingOptionReachesEveryFunctionThatHonoursIt` aggregates an all-null block through every function under both settings and pins the exact set whose answer depends on the option, in both directions: a function that starts honouring it has to be added deliberately, and one that stops is a regression. All ten above were absent from that set before this change.

The harness drives single-value `long` and `double` columns, so functions that read another value type, need a multi-value block, or take more than one input column cannot be aggregated through it. Those are pinned in a second set rather than skipped silently, and the rest of the contract is still asserted against them.

`BooleanAggQueriesTest` gains multi-value group-by coverage for `BOOL_AND` / `BOOL_OR`, including groups that separate skipping a null from folding it in as the column default.

### Known deviations

Two are recorded as a `TODO` on the interface rather than addressed here:

- **Several aggregation functions never receive the query's null handling option at all**, so they fold the column's default into the aggregate whatever the query asked for: the sketch-backed distinct counts (`DISTINCTCOUNTBITMAP`, `DISTINCTCOUNTHLL`, `DISTINCTCOUNTTHETASKETCH`, `DISTINCTCOUNTCPCSKETCH`, `FASTHLL`, `SEGMENTPARTITIONEDDISTINCTCOUNT` and their raw and smart variants), the tuple and frequency sketches, the covariance functions, `HISTOGRAM`, `IDSET`, `STUNION`, the array sums, and the funnel family.

  Family names are not a safe shorthand here, in either direction. The exact distinct functions (`DISTINCTCOUNT`, `DISTINCTSUM`, `DISTINCTAVG`, `DISTINCTCOUNTOFFHEAP`) do take the option and skip null rows through their shared base, as do the variance and standard-deviation functions and the first/last-with-time functions. Whether a function takes the option is visible at its construction site, which is the reliable way to tell.

  These are also exactly the functions that still substitute an empty accumulator instead of returning `null`. That is not a separate defect: without the option, `extractFinalResult` cannot tell the two modes apart, so it has nothing to decide with and the substitution is the only thing holding the answer. Conforming them belongs with the work that gives them the option.

- **The multi-stage engine constructs every aggregation function with null handling enabled** and never consults the query option, so a query that disables it still gets enabled-mode semantics there. `SUM` over an all-pruned query is `NULL` on the multi-stage engine and `0` on the single-stage engine. This may well be intended, given the multi-stage engine is the SQL-conformant one — flagging it rather than changing it.

The data-table serialization deviation this PR previously recorded is gone: [#19201](https://github.com/apache/pinot/pull/19201) made the writer support nulls for every column type independent of the query option, so a `null` intermediate or final result now travels safely in both modes. That is what makes returning `null` rather than substituting an empty accumulator free of fidelity cost.