### PR TITLE
Fix missing expired query callbacks and improve secondary workload queue thread wakeup

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/AbstractSchedulerGroup.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/AbstractSchedulerGroup.java
@@ -19,7 +19,9 @@
 package org.apache.pinot.core.query.scheduler;
 
 import com.google.common.base.Preconditions;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -64,14 +66,20 @@ public abstract class AbstractSchedulerGroup implements SchedulerGroup {
   }
 
   @Override
-  public void trimExpired(long deadlineMillis) {
+  public List<SchedulerQueryContext> trimExpired(long deadlineMillis) {
+    List<SchedulerQueryContext> expired = List.of();
     Iterator<SchedulerQueryContext> iter = _pendingQueries.iterator();
     while (iter.hasNext()) {
       SchedulerQueryContext next = iter.next();
       if (next.getArrivalTimeMs() < deadlineMillis) {
         iter.remove();
+        if (expired.isEmpty()) {
+          expired = new ArrayList<>();
+        }
+        expired.add(next);
       }
     }
+    return expired;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/BinaryWorkloadScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/BinaryWorkloadScheduler.java
@@ -35,6 +35,7 @@ import org.apache.pinot.core.query.scheduler.resources.BinaryWorkloadResourceMan
 import org.apache.pinot.core.query.scheduler.resources.QueryExecutorService;
 import org.apache.pinot.spi.accounting.ThreadAccountant;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,7 +73,7 @@ public class BinaryWorkloadScheduler extends QueryScheduler {
     super(config, instanceId, queryExecutor, threadAccountant, latestQueryTime,
         new BinaryWorkloadResourceManager(config));
 
-    _secondaryQueryQ = new SecondaryWorkloadQueue(config, _resourceManager);
+    _secondaryQueryQ = new SecondaryWorkloadQueue(config, _resourceManager, this::onQueryExpired);
     _numSecondaryRunners = config.getProperty(MAX_SECONDARY_QUERIES, DEFAULT_MAX_SECONDARY_QUERIES);
     LOGGER.info("numSecondaryRunners={}", _numSecondaryRunners);
     _secondaryRunnerSemaphore = new Semaphore(_numSecondaryRunners);
@@ -157,6 +158,7 @@ public class BinaryWorkloadScheduler extends QueryScheduler {
               public void run() {
                 executorService.releaseWorkers();
                 schedulerGroup.endQuery();
+                _secondaryQueryQ.signalWorkersReleased();
                 _secondaryRunnerSemaphore.release();
                 checkStopResourceManager();
               }
@@ -209,8 +211,25 @@ public class BinaryWorkloadScheduler extends QueryScheduler {
   synchronized private void failAllPendingQueries() {
     List<SchedulerQueryContext> pending = _secondaryQueryQ.drain();
     for (SchedulerQueryContext queryContext : pending) {
-      ListenableFuture<byte[]> serverShuttingDown = shuttingDown(queryContext.getQueryRequest());
-      queryContext.setResultFuture(serverShuttingDown);
+      try {
+        ListenableFuture<byte[]> serverShuttingDown = shuttingDown(queryContext.getQueryRequest());
+        queryContext.setResultFuture(serverShuttingDown);
+      } catch (Throwable t) {
+        LOGGER.error("Failed to fail pending query: {} on shutdown", queryContext.getQueryRequest().getRequestId(), t);
+        // Last resort, so one bad query does not leave the remaining ones without a response.
+        // No-op if the handler already completed the future.
+        queryContext.getResultFuture().setException(t);
+      }
     }
+  }
+
+  private void onQueryExpired(SchedulerQueryContext queryContext) {
+    ServerQueryRequest queryRequest = queryContext.getQueryRequest();
+    long waitMs = System.currentTimeMillis() - queryRequest.getTimerContext().getQueryArrivalTimeMs();
+    LOGGER.warn("Dropping secondary query: {} for table: {} after waiting: {}ms in the queue",
+        queryRequest.getRequestId(), queryRequest.getTableNameWithType(), waitMs);
+    _serverMetrics.addMeteredTableValue(queryRequest.getTableNameWithType(), ServerMeter.SCHEDULING_TIMEOUT_EXCEPTIONS,
+        1L);
+    queryContext.setResultFuture(immediateErrorResponse(queryRequest, QueryErrorCode.QUERY_SCHEDULING_TIMEOUT));
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/BinaryWorkloadScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/BinaryWorkloadScheduler.java
@@ -147,6 +147,9 @@ public class BinaryWorkloadScheduler extends QueryScheduler {
           try {
             SchedulerQueryContext request = _secondaryQueryQ.take();
             if (request == null) {
+              // mirrors query completion callback functionality.
+              _secondaryRunnerSemaphore.release();
+              checkStopResourceManager();
               continue;
             }
             ServerQueryRequest queryRequest = request.getQueryRequest();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/BinaryWorkloadScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/BinaryWorkloadScheduler.java
@@ -221,7 +221,9 @@ public class BinaryWorkloadScheduler extends QueryScheduler {
         LOGGER.error("Failed to fail pending query: {} on shutdown", queryContext.getQueryRequest().getRequestId(), t);
         // Last resort, so one bad query does not leave the remaining ones without a response.
         // No-op if the handler already completed the future.
-        queryContext.getResultFuture().setException(t);
+        if (queryContext.getResultFuture() != null) {
+          queryContext.getResultFuture().setException(t);
+        }
       }
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/SchedulerGroup.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/SchedulerGroup.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.core.query.scheduler;
 
+import java.util.List;
+
+
 /// Scheduler group is a sub-queue in multi-level scheduling queues.
 /// This class maintains context information for each of the scheduling
 /// queues. Each SchedulerGroup is a queue of requests and related accounting.
@@ -41,7 +44,8 @@ public interface SchedulerGroup extends SchedulerGroupAccountant {
   SchedulerQueryContext removeFirst();
 
   /// Remove all the pending queries with arrival time earlier than the deadline
-  void trimExpired(long deadlineMillis);
+  /// @return the removed queries, so the caller can complete their result futures. Never null.
+  List<SchedulerQueryContext> trimExpired(long deadlineMillis);
 
   /// @return true if there are no pending queries for this group
   boolean isEmpty();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/SecondaryWorkloadQueue.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/SecondaryWorkloadQueue.java
@@ -131,7 +131,9 @@ public class SecondaryWorkloadQueue {
         } catch (Throwable t) {
           LOGGER.error("Failed to complete expired query: {}", queryContext.getQueryRequest().getRequestId(), t);
           // Last resort, so the request always gets a response. No-op if the handler already completed the future.
-          queryContext.getResultFuture().setException(t);
+          if (queryContext.getResultFuture() != null) {
+            queryContext.getResultFuture().setException(t);
+          }
         }
       }
       if (schedulerQueryContext != null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/SecondaryWorkloadQueue.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/SecondaryWorkloadQueue.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.scheduler.fcfs.FCFSSchedulerGroup;
@@ -58,10 +59,13 @@ public class SecondaryWorkloadQueue {
   private final Condition _queryReaderCondition = _queueLock.newCondition();
   private final ResourceManager _resourceManager;
   private final int _queryDeadlineMs;
+  private final Consumer<SchedulerQueryContext> _expiredQueryHandler;
 
-  public SecondaryWorkloadQueue(PinotConfiguration config, ResourceManager resourceManager) {
+  public SecondaryWorkloadQueue(PinotConfiguration config, ResourceManager resourceManager,
+      Consumer<SchedulerQueryContext> expiredQueryHandler) {
     Preconditions.checkNotNull(config);
     Preconditions.checkNotNull(resourceManager);
+    Preconditions.checkNotNull(expiredQueryHandler);
 
     _queryDeadlineMs =
         config.getProperty(SECONDARY_QUEUE_QUERY_TIMEOUT, DEFAULT_SECONDARY_QUEUE_QUERY_TIMEOUT_SEC) * 1000;
@@ -71,6 +75,7 @@ public class SecondaryWorkloadQueue {
         _maxPendingPerGroup);
     _schedulerGroup = new FCFSSchedulerGroup(SECONDARY_WORKLOAD_GROUP_NAME);
     _resourceManager = resourceManager;
+    _expiredQueryHandler = expiredQueryHandler;
   }
 
   /// Adds a query to the secondary workload queue.
@@ -94,21 +99,50 @@ public class SecondaryWorkloadQueue {
   /// @return
   @Nullable
   public SchedulerQueryContext take() {
-    _queueLock.lock();
-    try {
-      while (true) {
-        SchedulerQueryContext schedulerQueryContext;
-        while ((schedulerQueryContext = takeNextInternal()) == null) {
+    while (true) {
+      SchedulerQueryContext schedulerQueryContext = null;
+      List<SchedulerQueryContext> expired;
+      _queueLock.lock();
+      try {
+        expired = _schedulerGroup.trimExpired(System.currentTimeMillis() - _queryDeadlineMs);
+        if (!_schedulerGroup.isEmpty() && _resourceManager.canSchedule(_schedulerGroup)) {
+          schedulerQueryContext = _schedulerGroup.removeFirst();
+        } else if (expired.isEmpty()) {
+          // Nothing to dispatch and nothing to clean up, so wait for a signal.
           try {
-            _queryReaderCondition.await(_wakeUpTimeMs, TimeUnit.MILLISECONDS);
+            if (_schedulerGroup.isEmpty()) {
+              _queryReaderCondition.await(); // woken by put()
+            } else {
+              _queryReaderCondition.await(_wakeUpTimeMs, TimeUnit.MILLISECONDS); // TTL sweep safety net
+            }
           } catch (InterruptedException e) {
             return null;
           }
         }
+      } finally {
+        _queueLock.unlock();
+      }
+
+      // Complete expired queries outside the lock, since the handler writes to the request channel.
+      // A failure must not escape: it would drop the query dequeued above and leak the caller's runner permit.
+      for (SchedulerQueryContext queryContext : expired) {
+        try {
+          _expiredQueryHandler.accept(queryContext);
+        } catch (Throwable t) {
+          LOGGER.error("Failed to complete expired query: {}", queryContext.getQueryRequest().getRequestId(), t);
+          // Last resort, so the request always gets a response. No-op if the handler already completed the future.
+          queryContext.getResultFuture().setException(t);
+        }
+      }
+      if (schedulerQueryContext != null) {
+        if (LOGGER.isDebugEnabled()) {
+          ServerQueryRequest queryRequest = schedulerQueryContext.getQueryRequest();
+          LOGGER.debug("Scheduling query: {} for group: {} with arrivalTimeMs: {} and numSegments: {}",
+              queryRequest.getRequestId(), _schedulerGroup.name(),
+              queryRequest.getTimerContext().getQueryArrivalTimeMs(), queryRequest.getSegmentsToQuery().size());
+        }
         return schedulerQueryContext;
       }
-    } finally {
-      _queueLock.unlock();
     }
   }
 
@@ -125,28 +159,6 @@ public class SecondaryWorkloadQueue {
     return pending;
   }
 
-  private SchedulerQueryContext takeNextInternal() {
-    long startTimeMs = System.currentTimeMillis();
-    long deadlineEpochMillis = startTimeMs - _queryDeadlineMs;
-
-    _schedulerGroup.trimExpired(deadlineEpochMillis);
-    if (_schedulerGroup.isEmpty() || !_resourceManager.canSchedule(_schedulerGroup)) {
-      return null;
-    }
-
-    if (LOGGER.isDebugEnabled()) {
-      StringBuilder sb = new StringBuilder("SchedulerInfo:");
-      sb.append(_schedulerGroup.toString());
-      ServerQueryRequest queryRequest = _schedulerGroup.peekFirst().getQueryRequest();
-      sb.append(" Group: " + _schedulerGroup.name() + ": [" + queryRequest.getTimerContext().getQueryArrivalTimeMs()
-          + "," + queryRequest.getRequestId() + "," + queryRequest.getSegmentsToQuery().size() + "," + startTimeMs
-          + "]");
-      LOGGER.debug(sb.toString());
-    }
-
-    return _schedulerGroup.removeFirst();
-  }
-
   private void checkSchedulerGroupCapacity(SchedulerQueryContext query)
       throws OutOfCapacityException {
     if (_schedulerGroup.numPending() >= _maxPendingPerGroup
@@ -156,6 +168,16 @@ public class SecondaryWorkloadQueue {
               + _schedulerGroup.numPending() + ", maxPending: " + _maxPendingPerGroup + ", reservedThreads: "
               + _schedulerGroup.totalReservedThreads() + " threadsHardLimit: "
               + _resourceManager.getTableThreadsHardLimit());
+    }
+  }
+
+  /// Signals the reader that reserved threads were released, so canSchedule() may now pass.
+  public void signalWorkersReleased() {
+    _queueLock.lock();
+    try {
+      _queryReaderCondition.signal();
+    } finally {
+      _queueLock.unlock();
     }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/scheduler/SecondaryWorkloadQueueTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/scheduler/SecondaryWorkloadQueueTest.java
@@ -1,0 +1,300 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.scheduler;
+
+import com.google.common.util.concurrent.Futures;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.core.query.scheduler.resources.ResourceManager;
+import org.apache.pinot.core.query.scheduler.resources.UnboundedResourceManager;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.metrics.PinotMetricUtils;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.pinot.core.query.scheduler.TestHelper.createQueryRequest;
+import static org.testng.Assert.*;
+
+
+public class SecondaryWorkloadQueueTest {
+  private static final ServerMetrics METRICS = new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
+  private static final String TABLE = "secondaryTable";
+  private static final byte[] RESPONSE = new byte[]{1, 2, 3};
+
+  private static final long AWAIT_MS = 10_000L;
+  private static final long NEVER_AWAIT_MS = 500L;
+  private static final long TIMEOUT_MS = 60_000L;
+
+  /// Expires queries after 1s, so a query with an older arrival time is dropped by the TTL sweep.
+  private static final Map<String, Object> SHORT_DEADLINE =
+      Map.of(SecondaryWorkloadQueue.SECONDARY_QUEUE_QUERY_TIMEOUT, 1);
+  /// A wakeup interval far larger than AWAIT_MS, so only an explicit signal can wake a blocked reader in time.
+  private static final Map<String, Object> NO_POLLING = Map.of(SecondaryWorkloadQueue.QUEUE_WAKEUP_MS, 60_000);
+
+  private final List<ResourceManager> _resourceManagers = new ArrayList<>();
+  private ExecutorService _executor;
+
+  @BeforeMethod
+  public void beforeMethod() {
+    _executor = Executors.newCachedThreadPool();
+  }
+
+  @AfterMethod
+  public void afterMethod() {
+    _executor.shutdownNow();
+    _resourceManagers.forEach(ResourceManager::stop);
+    _resourceManagers.clear();
+  }
+
+  // verify that queries are returned in the order they were added,
+  // and that the expiry handler is not called for live queries.
+  @Test
+  public void testTakeReturnsQueriesInArrivalOrder()
+      throws Exception {
+    List<SchedulerQueryContext> expiredQueries = new CopyOnWriteArrayList<>();
+    SecondaryWorkloadQueue queue = createQueue(Map.of(), expiredQueries::add);
+
+    SchedulerQueryContext first = liveQuery();
+    SchedulerQueryContext second = liveQuery();
+    queue.put(first);
+    queue.put(second);
+
+    assertSame(queue.take(), first);
+    assertSame(queue.take(), second);
+    assertTrue(expiredQueries.isEmpty());
+  }
+
+  // verify that drain() returns all pending queries in arrival order,
+  // and that the queue is empty afterwards.
+  @Test
+  public void testDrainRemovesAllPendingQueries()
+      throws Exception {
+    SecondaryWorkloadQueue queue = createQueue(Map.of(), ignored -> { });
+
+    SchedulerQueryContext first = liveQuery();
+    SchedulerQueryContext second = liveQuery();
+    queue.put(first);
+    queue.put(second);
+
+    assertEquals(queue.drain(), List.of(first, second));
+    assertTrue(queue.drain().isEmpty());
+  }
+
+  /// A query dropped for exceeding the queue deadline must be handed to the expiry handler and have its future
+  /// completed, otherwise the request never gets a response. Expiring the head must also not stall a live query
+  /// queued behind it.
+  @Test
+  public void testExpiredQueryIsCompletedAndDoesNotBlockLiveQuery()
+      throws Exception {
+    List<SchedulerQueryContext> expiredQueries = new CopyOnWriteArrayList<>();
+    SecondaryWorkloadQueue queue = createQueue(SHORT_DEADLINE, queryContext -> {
+      expiredQueries.add(queryContext);
+      queryContext.setResultFuture(Futures.immediateFuture(RESPONSE));
+    });
+
+    SchedulerQueryContext expired = expiredQuery();
+    SchedulerQueryContext live = liveQuery();
+    queue.put(expired);
+    queue.put(live);
+
+    assertSame(queue.take(), live);
+    assertEquals(expiredQueries, List.of(expired));
+    assertSame(expired.getResultFuture().get(AWAIT_MS, MILLISECONDS), RESPONSE);
+  }
+
+  /// Expiry is not a dispatch event, so a reader with nothing but expired queries keeps waiting. This is the only
+  /// case that exercises the sweep running with no query to hand back.
+  @Test(timeOut = TIMEOUT_MS)
+  public void testExpiredQueryDoesNotWakeReader()
+      throws Exception {
+    CountDownLatch handled = new CountDownLatch(1);
+    SecondaryWorkloadQueue queue = createQueue(SHORT_DEADLINE, queryContext -> handled.countDown());
+
+    queue.put(expiredQuery());
+    Future<SchedulerQueryContext> reader = _executor.submit(queue::take);
+
+    assertTrue(handled.await(AWAIT_MS, MILLISECONDS), "Expired query was never handed to the handler");
+    assertThrows(TimeoutException.class, () -> reader.get(NEVER_AWAIT_MS, MILLISECONDS));
+
+    // The reader is still usable once a live query arrives.
+    SchedulerQueryContext live = liveQuery();
+    queue.put(live);
+    assertSame(reader.get(AWAIT_MS, MILLISECONDS), live);
+  }
+
+  /// A failing expiry handler must not break take(): the live query is still returned and the expired query is
+  /// still completed so its request gets a response.
+  @Test
+  public void testExpiryHandlerFailureStillCompletesExpiredQuery()
+      throws Exception {
+    SecondaryWorkloadQueue queue = createQueue(SHORT_DEADLINE, queryContext -> {
+      throw new IllegalStateException("error");
+    });
+
+    SchedulerQueryContext expired = expiredQuery();
+    SchedulerQueryContext live = liveQuery();
+    queue.put(expired);
+    queue.put(live);
+
+    assertSame(queue.take(), live);
+    ExecutionException e =
+        expectThrows(ExecutionException.class, () -> expired.getResultFuture().get(AWAIT_MS, MILLISECONDS));
+    assertTrue(e.getCause() instanceof IllegalStateException);
+  }
+
+  /// The handler writes to the request channel, so it must not run while the queue lock is held, otherwise Netty
+  /// threads calling put() would block behind it.
+  @Test(timeOut = TIMEOUT_MS)
+  public void testExpiryHandlerRunsWithoutHoldingQueueLock()
+      throws Exception {
+    CountDownLatch handlerEntered = new CountDownLatch(1);
+    CountDownLatch releaseHandler = new CountDownLatch(1);
+    SecondaryWorkloadQueue queue = createQueue(SHORT_DEADLINE, queryContext -> {
+      handlerEntered.countDown();
+      await(releaseHandler);
+    });
+
+    queue.put(expiredQuery());
+    Future<SchedulerQueryContext> reader = _executor.submit(queue::take);
+    assertTrue(handlerEntered.await(AWAIT_MS, MILLISECONDS));
+
+    // The handler is still running. This blocks forever if take() holds the lock across the callback.
+    SchedulerQueryContext live = liveQuery();
+    queue.put(live);
+
+    releaseHandler.countDown();
+    assertSame(reader.get(AWAIT_MS, MILLISECONDS), live);
+  }
+
+  /// With an empty queue the reader waits untimed, so put() is the only thing that can wake it.
+  @Test(timeOut = TIMEOUT_MS)
+  public void testTakeBlocksUntilPutSignals()
+      throws Exception {
+    SecondaryWorkloadQueue queue = createQueue(NO_POLLING, ignored -> { });
+
+    Future<SchedulerQueryContext> reader = _executor.submit(queue::take);
+    assertThrows(TimeoutException.class, () -> reader.get(NEVER_AWAIT_MS, MILLISECONDS));
+
+    SchedulerQueryContext live = liveQuery();
+    queue.put(live);
+    assertSame(reader.get(AWAIT_MS, MILLISECONDS), live, "put() did not wake the reader");
+  }
+
+  /// A query that cannot be scheduled because the group is at its thread limit must be dispatched as soon as threads
+  /// are released, without waiting for the TTL sweep.
+  @Test(timeOut = TIMEOUT_MS)
+  public void testTakeWakesOnSignalWorkersReleased()
+      throws Exception {
+    PinotConfiguration config = new PinotConfiguration(NO_POLLING);
+    TestResourceManager resourceManager = newResourceManager(config);
+    resourceManager._canSchedule = false;
+    SecondaryWorkloadQueue queue = new SecondaryWorkloadQueue(config, resourceManager, ignored -> { });
+
+    SchedulerQueryContext live = liveQuery();
+    queue.put(live);
+    Future<SchedulerQueryContext> reader = _executor.submit(queue::take);
+    assertThrows(TimeoutException.class, () -> reader.get(NEVER_AWAIT_MS, MILLISECONDS));
+
+    resourceManager._canSchedule = true;
+    queue.signalWorkersReleased();
+    assertSame(reader.get(AWAIT_MS, MILLISECONDS), live, "signalWorkersReleased() did not wake the reader");
+  }
+
+  /// Admission control ANDs the two conditions, so the pending limit alone never rejects a query.
+  @Test
+  public void testOutOfCapacityRequiresPendingAndThreadLimit()
+      throws Exception {
+    PinotConfiguration config = new PinotConfiguration(Map.of(SecondaryWorkloadQueue.MAX_PENDING_SECONDARY_QUERIES, 2));
+
+    TestResourceManager belowThreadLimit = newResourceManager(config);
+    belowThreadLimit._tableThreadsHardLimit = Integer.MAX_VALUE;
+    SecondaryWorkloadQueue lenientQueue = new SecondaryWorkloadQueue(config, belowThreadLimit, ignored -> { });
+    for (int i = 0; i < 5; i++) {
+      lenientQueue.put(liveQuery());
+    }
+
+    TestResourceManager atThreadLimit = newResourceManager(config);
+    atThreadLimit._tableThreadsHardLimit = 0;
+    SecondaryWorkloadQueue strictQueue = new SecondaryWorkloadQueue(config, atThreadLimit, ignored -> { });
+    strictQueue.put(liveQuery());
+    strictQueue.put(liveQuery());
+    assertThrows(OutOfCapacityException.class, () -> strictQueue.put(liveQuery()));
+  }
+
+  private static SchedulerQueryContext liveQuery() {
+    return createQueryRequest(TABLE, METRICS);
+  }
+
+  /// Older than the SHORT_DEADLINE queue deadline, so the TTL sweep drops it.
+  private static SchedulerQueryContext expiredQuery() {
+    return createQueryRequest(TABLE, METRICS, System.currentTimeMillis() - TimeUnit.SECONDS.toMillis(10));
+  }
+
+  private static void await(CountDownLatch latch) {
+    try {
+      latch.await();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private SecondaryWorkloadQueue createQueue(Map<String, Object> properties,
+      Consumer<SchedulerQueryContext> expiredQueryHandler) {
+    PinotConfiguration config = new PinotConfiguration(properties);
+    return new SecondaryWorkloadQueue(config, newResourceManager(config), expiredQueryHandler);
+  }
+
+  private TestResourceManager newResourceManager(PinotConfiguration config) {
+    TestResourceManager resourceManager = new TestResourceManager(config);
+    _resourceManagers.add(resourceManager);
+    return resourceManager;
+  }
+
+  private static class TestResourceManager extends UnboundedResourceManager {
+    volatile boolean _canSchedule = true;
+    volatile int _tableThreadsHardLimit = Integer.MAX_VALUE;
+
+    TestResourceManager(PinotConfiguration config) {
+      super(config);
+    }
+
+    @Override
+    public boolean canSchedule(SchedulerGroupAccountant accountant) {
+      return _canSchedule;
+    }
+
+    @Override
+    public int getTableThreadsHardLimit() {
+      return _tableThreadsHardLimit;
+    }
+  }
+}


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Flow for handling an expired secondary query: dispatcher trims expired queries and completes them with an error response\.

```mermaid
flowchart TD
  N0["BinaryWorkloadScheduler#46;dispatchThread#46;run#40;#41; #40;F2#41;"]:::stModified
  N1["SecondaryWorkloadQueue#46;take#40;#41; #40;F4#41;"]:::stModified
  N2["AbstractSchedulerGroup#46;trimExpired#40;#41; #40;F1#41;"]:::stModified
  N3["BinaryWorkloadScheduler#46;onQueryExpired#40;#41; #40;F2#41;"]:::stAdded
  N0 -->|"calls"| N1
  N1 -->|"calls"| N2
  N1 -->|"calls handler for expired queries"| N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/query/scheduler/AbstractSchedulerGroup\.java — [before](https://github.com/apache/pinot/blob/14333f3f927b165caa9affa8ff656ca5aa9c86d9/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/AbstractSchedulerGroup.java) · [after](https://github.com/apache/pinot/blob/33079efe7d89b694ca91d199ccb203344163afcb/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/AbstractSchedulerGroup.java)
- F2: pinot\-core/src/main/java/org/apache/pinot/core/query/scheduler/BinaryWorkloadScheduler\.java — [before](https://github.com/apache/pinot/blob/14333f3f927b165caa9affa8ff656ca5aa9c86d9/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/BinaryWorkloadScheduler.java) · [after](https://github.com/apache/pinot/blob/33079efe7d89b694ca91d199ccb203344163afcb/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/BinaryWorkloadScheduler.java)
- F4: pinot\-core/src/main/java/org/apache/pinot/core/query/scheduler/SecondaryWorkloadQueue\.java — [before](https://github.com/apache/pinot/blob/14333f3f927b165caa9affa8ff656ca5aa9c86d9/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/SecondaryWorkloadQueue.java) · [after](https://github.com/apache/pinot/blob/33079efe7d89b694ca91d199ccb203344163afcb/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/SecondaryWorkloadQueue.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjE0MzMzZjNmOTI3YjE2NWNhYTlhZmZhOGZmNjU2Y2E1YWE5Yzg2ZDkiLCJjb250ZXh0X2hhc2giOiJlNTdkMWQxODE2ZDQ5NzA4ZDY4MmRiYTZlM2E4NTdkNmM5YTRiNGY3MzI1NzFlOTE5Y2UyYjgxOWQzZTNiMzAxIiwiZ2VuZXJhdGVkX2F0IjoxNzg5Nzg4NjQ1LCJoZWFkX3NoYSI6IjMzMDc5ZWZlN2Q4OWI2OTRjYTkxZDE5OWNjYjIwMzM0NDE2M2FmY2IiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJkZTIwODk2MzkzOTI4YTJlOGYxNDI1YWEzZmM4Njk5ZjU5YTdlNGJhIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 93e531f0253a3d8912d1ee2ae73c776fe1c26a9f1f38717de9a4f5c4f9ec829e -->
<!-- pinot-pr-flow:end -->

Problems:
1. The `BinaryWorkloadScheduler` dispatch thread polls SecondaryWorkloadQueue every 1 ms (default) regardless of whether any secondary queries exist. Secondary queries are not frequent, So on a server with no secondary queries, there are ~1000 needless wakeups per min, per server, on a Thread.MAX_PRIORITY daemon thread. 
2. Also, SecondaryWorkloadQueue removing expired queries without ever completing its result future. so the server never sent a response for it and leaked the entry tracking it.

Changes
1. Problem#1: (perf improvement) (Changed `BinaryWorkloadScheduler` only to begin with, `PriorityScheduler` is untouched)
   * Untimed wait when the queue is empty. put() already signals _queryReaderCondition under _queueLock, so nothing else can make the queue non-empty without waking the reader. This eliminates 100% of idle wakeups.
   * Signal when reserved threads are released.
   * Timed wait retained when the queue is non-empty. The timed branch keeps that sweep running and now only ticks in the rare state where secondary queries are queued and the group is at its thread limit.
2. Problem#2: (bug fix) (fixed for `SecondaryWorkloadQueue` only to begin with, `MultiLevelPriorityQueue` is untouched)
   * SchedulerGroup.trimExpired now returns the removed queries so the caller can complete them.
   * SecondaryWorkloadQueue takes a Consumer<SchedulerQueryContext> expiry handler and invokes it for each.

Testing:
Unit tests `SecondaryWorkloadQueueTest`