### PR TITLE
Render MAP projections straight from the serialized frame

### DIFF
--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkMapProjection.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkMapProjection.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.spi.utils.MapUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.CommandLineOptions;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+/// Measures projecting a whole MAP column as a JSON string - the `SELECT attributes` / `LASTWITHTIME(attributes)`
+/// shape - rendering straight from the serialized frame versus deserializing into a map and serializing it again.
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(value = 2)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@State(Scope.Thread)
+public class BenchmarkMapProjection {
+
+  public static void main(String[] args)
+      throws Exception {
+    ChainedOptionsBuilder opt = new OptionsBuilder().parent(new CommandLineOptions(args))
+        .include(BenchmarkMapProjection.class.getSimpleName());
+    new Runner(opt.build()).run();
+  }
+
+  @Param({"4", "16", "64"})
+  private int _numEntries;
+
+  /// `flat` models scalar attribute maps; `nested` models object-valued entries, where the deserializing path pays
+  /// to materialize a container per value.
+  @Param({"flat", "nested"})
+  private String _valueShape;
+
+  private byte[] _serialized;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    boolean nested = "nested".equals(_valueShape);
+    Map<String, Object> map = new LinkedHashMap<>();
+    for (int i = 0; i < _numEntries; i++) {
+      String value = "value-with-enough-bytes-to-exercise-json-parsing-" + i;
+      map.put(String.format("k8s.attribute.%03d.name", i), nested ? Map.of("value", value) : value);
+    }
+    _serialized = MapUtils.serializeMap(map);
+  }
+
+  /// The existing path: parse every entry into a map, then serialize the map back to JSON.
+  @Benchmark
+  public String deserializeThenSerialize() {
+    return MapUtils.toString(MapUtils.deserializeMap(_serialized));
+  }
+
+  /// The optimized path: copy the already-JSON value bytes through and quote only the keys.
+  @Benchmark
+  public String renderFromFrame() {
+    return MapUtils.frameToJsonString(_serialized);
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/VarByteSVMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/VarByteSVMutableForwardIndex.java
@@ -109,6 +109,11 @@ public class VarByteSVMutableForwardIndex implements MutableForwardIndex {
   }
 
   @Override
+  public String getMapAsJsonString(int docId, ForwardIndexReaderContext context) {
+    return MapUtils.frameToJsonString(getBytes(docId));
+  }
+
+  @Override
   public void setBigDecimal(int docId, BigDecimal value) {
     setBytes(docId, BigDecimalUtils.serialize(value));
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/VarByteSVMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/VarByteSVMutableForwardIndex.java
@@ -101,6 +101,11 @@ public class VarByteSVMutableForwardIndex implements MutableForwardIndex {
   }
 
   @Override
+  public String getMapAsJsonString(int docId, ForwardIndexReaderContext context) {
+    return MapUtils.frameToJsonString(getBytes(docId));
+  }
+
+  @Override
   public void setBigDecimal(int docId, BigDecimal value) {
     setBytes(docId, BigDecimalUtils.serialize(value));
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkForwardIndexReaderV4.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkForwardIndexReaderV4.java
@@ -139,6 +139,11 @@ public class VarByteChunkForwardIndexReaderV4
   }
 
   @Override
+  public String getMapAsJsonString(int docId, ReaderContext context) {
+    return MapUtils.frameToJsonString(context.getValue(docId));
+  }
+
+  @Override
   public int getIntMV(int docId, int[] valueBuffer, VarByteChunkForwardIndexReaderV4.ReaderContext context) {
     return ArraySerDeUtils.deserializeIntArrayWithLength(context.getValue(docId), valueBuffer);
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkSVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkSVForwardIndexReader.java
@@ -130,6 +130,11 @@ public final class VarByteChunkSVForwardIndexReader extends BaseChunkForwardInde
     return MapUtils.deserializeMap(getBytes(docId, context));
   }
 
+  @Override
+  public String getMapAsJsonString(int docId, ChunkReaderContext context) {
+    return MapUtils.frameToJsonString(getBytes(docId, context));
+  }
+
   /// Helper method to read BYTES value from the compressed index.
   private byte[] getBytesCompressed(int docId, ChunkReaderContext context) {
     int chunkRowId = docId % _numDocsPerChunk;

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
@@ -385,7 +385,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
         break;
       case MAP:
         for (int i = 0; i < length; i++) {
-          values[i] = MapUtils.toString(getMap(docIds[i], context));
+          values[i] = getMapAsJsonString(docIds[i], context);
         }
         break;
       default:
@@ -484,6 +484,19 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
   @Nullable
   default Object getMapEntryValue(int docId, T context, PreparedMapKey key) {
     return getMap(docId, context).get(key.getKey());
+  }
+
+  /// Reads the MAP type single-value at the given document id, rendered as a JSON object string.
+  ///
+  /// Readers that store the map as a serialized frame should override this to render straight from those bytes
+  /// (see [MapUtils#frameToJsonString(byte\[\])]); the default here materializes the map first and serializes it
+  /// again, which is what a reader holding the map columnar-decomposed has to do anyway.
+  ///
+  /// @param docId Document id
+  /// @param context Reader context
+  /// @return MAP type single-value at the given document id, as JSON
+  default String getMapAsJsonString(int docId, T context) {
+    return MapUtils.toString(getMap(docId, context));
   }
 
   default int get32BitsMurmur3Hash(int docId, T context) {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
@@ -384,7 +384,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
         break;
       case MAP:
         for (int i = 0; i < length; i++) {
-          values[i] = MapUtils.toString(getMap(docIds[i], context));
+          values[i] = getMapAsJsonString(docIds[i], context);
         }
         break;
       default:
@@ -464,6 +464,19 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
     throw new UnsupportedOperationException("This ForwardIndexReader does not support MAP types. "
         + "This indicates that either the column is getting mistyped or the wrong "
         + "ForwardIndexReader is being created to read this column.");
+  }
+
+  /// Reads the MAP type single-value at the given document id, rendered as a JSON object string.
+  ///
+  /// Readers that store the map as a serialized frame should override this to render straight from those bytes
+  /// (see [MapUtils#frameToJsonString(byte\[\])]); the default here materializes the map first and serializes it
+  /// again, which is what a reader holding the map columnar-decomposed has to do anyway.
+  ///
+  /// @param docId Document id
+  /// @param context Reader context
+  /// @return MAP type single-value at the given document id, as JSON
+  default String getMapAsJsonString(int docId, T context) {
+    return MapUtils.toString(getMap(docId, context));
   }
 
   default int get32BitsMurmur3Hash(int docId, T context) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/MapUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/MapUtils.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.spi.utils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.base.Preconditions;
@@ -28,6 +29,7 @@ import java.io.OutputStream;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -296,6 +298,114 @@ public class MapUtils {
   private static void checkLength(ByteBuffer byteBuffer, int length) {
     if (length < 0 || length > byteBuffer.remaining()) {
       throw new BufferUnderflowException();
+    }
+  }
+
+  /// Renders a serialized MAP frame as a JSON object without materializing the map.
+  ///
+  /// The frame already stores each value as the JSON bytes that [#serializeMap] produced, so the values are copied
+  /// through verbatim and only the keys are quoted. That skips the parse-into-`HashMap`-then-serialize-again round
+  /// trip [#toString(Map)] performs, and it skips Jackson entirely.
+  ///
+  /// Entries are emitted in frame order. Both forward-index write paths (`ForwardIndexCreator#putValue` at segment
+  /// build and `MutableSegmentImpl` while consuming) frame maps through the key-sorting [#serializeMap(Map)], so for
+  /// those frames this is byte-identical to `toString(deserializeMap(frame))`. A frame written through
+  /// [#serializeMap(Map, boolean)] with `sortByKey = false` renders in its own insertion order instead.
+  public static String frameToJsonString(byte[] bytes) {
+    return frameToJsonString(ByteBuffer.wrap(bytes));
+  }
+
+  /// Variant of [#frameToJsonString(byte\[\])] reading from the buffer's current position.
+  public static String frameToJsonString(ByteBuffer byteBuffer) {
+    byteBuffer.order(ByteOrder.BIG_ENDIAN);
+    int size = byteBuffer.getInt();
+    if (size == 0) {
+      return "{}";
+    }
+    // Quoting a key adds 2 bytes and the separators add 2, while the two length prefixes it replaces free up 8, so
+    // an unescaped rendering never exceeds the remaining frame bytes. Escaping is the only path that can grow.
+    JsonBuilder builder = new JsonBuilder(byteBuffer.remaining() + 2);
+    builder.append((byte) '{');
+    for (int i = 0; i < size; i++) {
+      if (i > 0) {
+        builder.append((byte) ',');
+      }
+      int keyLength = byteBuffer.getInt();
+      checkLength(byteBuffer, keyLength);
+      builder.appendQuotedKey(byteBuffer, keyLength);
+      byteBuffer.position(byteBuffer.position() + keyLength);
+      builder.append((byte) ':');
+      int valueLength = byteBuffer.getInt();
+      checkLength(byteBuffer, valueLength);
+      builder.appendRaw(byteBuffer, valueLength);
+      byteBuffer.position(byteBuffer.position() + valueLength);
+    }
+    builder.append((byte) '}');
+    return builder.toUtf8String();
+  }
+
+  /// Growable byte sink for [#frameToJsonString]. Assembling UTF-8 bytes and decoding once at the end avoids
+  /// decoding every key individually, which is what makes the common all-ASCII frame allocation-light.
+  private static final class JsonBuilder {
+    private byte[] _bytes;
+    private int _length;
+
+    private JsonBuilder(int capacity) {
+      _bytes = new byte[capacity];
+    }
+
+    private void ensure(int extra) {
+      if (_length + extra > _bytes.length) {
+        _bytes = Arrays.copyOf(_bytes, Math.max(_length + extra, _bytes.length * 2));
+      }
+    }
+
+    private void append(byte b) {
+      ensure(1);
+      _bytes[_length++] = b;
+    }
+
+    /// Copies `length` bytes from the buffer's current position without advancing it.
+    private void appendRaw(ByteBuffer byteBuffer, int length) {
+      ensure(length);
+      int offset = byteBuffer.position();
+      for (int i = 0; i < length; i++) {
+        _bytes[_length++] = byteBuffer.get(offset + i);
+      }
+    }
+
+    /// Writes the key as a JSON string. Keys needing no escaping - the overwhelming majority - are copied as raw
+    /// UTF-8; anything else falls back to decoding the key and letting Jackson escape it.
+    private void appendQuotedKey(ByteBuffer byteBuffer, int length) {
+      int offset = byteBuffer.position();
+      boolean clean = true;
+      for (int i = 0; i < length; i++) {
+        byte b = byteBuffer.get(offset + i);
+        // Signed bytes below 0x20 are control characters; continuation bytes of multi-byte UTF-8 are negative and
+        // need no escaping, so only the ASCII range is inspected.
+        if ((b >= 0 && b < 0x20) || b == '"' || b == '\\') {
+          clean = false;
+          break;
+        }
+      }
+      append((byte) '"');
+      if (clean) {
+        appendRaw(byteBuffer, length);
+      } else {
+        byte[] keyBytes = new byte[length];
+        for (int i = 0; i < length; i++) {
+          keyBytes[i] = byteBuffer.get(offset + i);
+        }
+        byte[] escaped = JsonStringEncoder.getInstance().quoteAsUTF8(Utf8Utils.decode(keyBytes));
+        ensure(escaped.length);
+        System.arraycopy(escaped, 0, _bytes, _length, escaped.length);
+        _length += escaped.length;
+      }
+      append((byte) '"');
+    }
+
+    private String toUtf8String() {
+      return new String(_bytes, 0, _length, StandardCharsets.UTF_8);
     }
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/MapUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/MapUtils.java
@@ -19,13 +19,17 @@
 package org.apache.pinot.spi.utils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -188,6 +192,120 @@ public class MapUtils {
     byte[] bytes = new byte[length];
     byteBuffer.get(bytes);
     return bytes;
+  }
+
+  private static void checkLength(ByteBuffer byteBuffer, int length) {
+    if (length < 0 || length > byteBuffer.remaining()) {
+      throw new BufferUnderflowException();
+    }
+  }
+
+  /// Renders a serialized MAP frame as a JSON object without materializing the map.
+  ///
+  /// The frame already stores each value as the JSON bytes that [#serializeMap] produced, so the values are copied
+  /// through verbatim and only the keys are quoted. That skips the parse-into-`HashMap`-then-serialize-again round
+  /// trip [#toString(Map)] performs, and it skips Jackson entirely.
+  ///
+  /// Entries are emitted in frame order. Both forward-index write paths (`ForwardIndexCreator#putValue` at segment
+  /// build and `MutableSegmentImpl` while consuming) frame maps through the key-sorting [#serializeMap(Map)], so for
+  /// those frames this is byte-identical to `toString(deserializeMap(frame))`. A frame written through
+  /// [#serializeMap(Map, boolean)] with `sortByKey = false` renders in its own insertion order instead.
+  public static String frameToJsonString(byte[] bytes) {
+    return frameToJsonString(ByteBuffer.wrap(bytes));
+  }
+
+  /// Variant of [#frameToJsonString(byte\[\])] reading from the buffer's current position.
+  public static String frameToJsonString(ByteBuffer byteBuffer) {
+    byteBuffer.order(ByteOrder.BIG_ENDIAN);
+    int size = byteBuffer.getInt();
+    if (size == 0) {
+      return "{}";
+    }
+    // Quoting a key adds 2 bytes and the separators add 2, while the two length prefixes it replaces free up 8, so
+    // an unescaped rendering never exceeds the remaining frame bytes. Escaping is the only path that can grow.
+    JsonBuilder builder = new JsonBuilder(byteBuffer.remaining() + 2);
+    builder.append((byte) '{');
+    for (int i = 0; i < size; i++) {
+      if (i > 0) {
+        builder.append((byte) ',');
+      }
+      int keyLength = byteBuffer.getInt();
+      checkLength(byteBuffer, keyLength);
+      builder.appendQuotedKey(byteBuffer, keyLength);
+      byteBuffer.position(byteBuffer.position() + keyLength);
+      builder.append((byte) ':');
+      int valueLength = byteBuffer.getInt();
+      checkLength(byteBuffer, valueLength);
+      builder.appendRaw(byteBuffer, valueLength);
+      byteBuffer.position(byteBuffer.position() + valueLength);
+    }
+    builder.append((byte) '}');
+    return builder.toUtf8String();
+  }
+
+  /// Growable byte sink for [#frameToJsonString]. Assembling UTF-8 bytes and decoding once at the end avoids
+  /// decoding every key individually, which is what makes the common all-ASCII frame allocation-light.
+  private static final class JsonBuilder {
+    private byte[] _bytes;
+    private int _length;
+
+    private JsonBuilder(int capacity) {
+      _bytes = new byte[capacity];
+    }
+
+    private void ensure(int extra) {
+      if (_length + extra > _bytes.length) {
+        _bytes = Arrays.copyOf(_bytes, Math.max(_length + extra, _bytes.length * 2));
+      }
+    }
+
+    private void append(byte b) {
+      ensure(1);
+      _bytes[_length++] = b;
+    }
+
+    /// Copies `length` bytes from the buffer's current position without advancing it.
+    private void appendRaw(ByteBuffer byteBuffer, int length) {
+      ensure(length);
+      int offset = byteBuffer.position();
+      for (int i = 0; i < length; i++) {
+        _bytes[_length++] = byteBuffer.get(offset + i);
+      }
+    }
+
+    /// Writes the key as a JSON string. Keys needing no escaping - the overwhelming majority - are copied as raw
+    /// UTF-8; anything else falls back to decoding the key and letting Jackson escape it.
+    private void appendQuotedKey(ByteBuffer byteBuffer, int length) {
+      int offset = byteBuffer.position();
+      boolean clean = true;
+      for (int i = 0; i < length; i++) {
+        byte b = byteBuffer.get(offset + i);
+        // Signed bytes below 0x20 are control characters; continuation bytes of multi-byte UTF-8 are negative and
+        // need no escaping, so only the ASCII range is inspected.
+        if ((b >= 0 && b < 0x20) || b == '"' || b == '\\') {
+          clean = false;
+          break;
+        }
+      }
+      append((byte) '"');
+      if (clean) {
+        appendRaw(byteBuffer, length);
+      } else {
+        byte[] keyBytes = new byte[length];
+        for (int i = 0; i < length; i++) {
+          keyBytes[i] = byteBuffer.get(offset + i);
+        }
+        byte[] escaped = JsonStringEncoder.getInstance().quoteAsUTF8(Utf8Utils.decode(keyBytes));
+        ensure(escaped.length);
+        System.arraycopy(escaped, 0, _bytes, _length, escaped.length);
+        _length += escaped.length;
+      }
+      append((byte) '"');
+    }
+
+    private String toUtf8String() {
+      return new String(_bytes, 0, _length, StandardCharsets.UTF_8);
+    }
   }
 
   public static String toString(Map<String, Object> map) {

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/MapUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/MapUtilsTest.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.spi.utils;
 
 import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.HashMap;
@@ -289,5 +291,63 @@ public class MapUtilsTest {
     Map<String, Object> map = new HashMap<>();
     map.put("nested", nested);
     assertEquals(MapUtils.toString(map), "{\"nested\":{\"d\":\"2022-02-08\"}}");
+  }
+
+  /// The contract that lets the forward-index read path swap `toString(deserializeMap(frame))` for
+  /// `frameToJsonString(frame)`: for any frame written through the key-sorting [MapUtils#serializeMap(Map)] - which
+  /// is what both forward-index write paths use - the two must produce identical output.
+  @Test
+  void testFrameToJsonStringMatchesToString() {
+    Map<String, Object> nested = new LinkedHashMap<>();
+    nested.put("z", 1);
+    nested.put("a", List.of(1, 2, 3));
+
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("k8s.workload.name", "pinot-server");
+    map.put("int", 42);
+    map.put("long", 9999999999L);
+    map.put("double", 1.5);
+    map.put("bool", true);
+    map.put("nullValue", null);
+    map.put("nested", nested);
+    map.put("list", List.of("a", "b"));
+    map.put("emptyString", "");
+    map.put("unicodeValue", "çöğüşÇÖĞÜŞéÉ");
+    map.put("命名空间", "namespace");
+    map.put("date", LocalDate.of(2022, 2, 8));
+    map.put("quote\"key", "quoted");
+    map.put("back\\slash", "escaped");
+    map.put("tab\tkey", "control");
+    map.put("value with \"quotes\" and \\ backslash", "in value");
+
+    assertEquals(MapUtils.frameToJsonString(MapUtils.serializeMap(map)), MapUtils.toString(map));
+  }
+
+  @Test
+  void testFrameToJsonStringHandlesEmptyMap() {
+    assertEquals(MapUtils.frameToJsonString(MapUtils.serializeMap(Map.of())), "{}");
+    assertEquals(MapUtils.frameToJsonString(MapUtils.serializeMap(Map.of())), MapUtils.toString(Map.of()));
+  }
+
+  /// Rendering must round-trip back through the JSON reader to the same map, independent of the string comparison
+  /// above - that guards against two implementations agreeing on malformed output.
+  @Test
+  void testFrameToJsonStringRoundTrips() {
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("a", "value");
+    map.put("b", List.of(1, 2));
+    map.put("çö", Map.of("inner", true));
+    assertEquals(MapUtils.fromString(MapUtils.frameToJsonString(MapUtils.serializeMap(map))),
+        MapUtils.deserializeMap(MapUtils.serializeMap(map)));
+  }
+
+  /// An off-heap forward-index view arrives in the platform's native byte order while the frame is written
+  /// big-endian, so the renderer has to force the order rather than trust the buffer.
+  @Test
+  void testFrameToJsonStringForcesBigEndian() {
+    byte[] serialized = MapUtils.serializeMap(Map.of("k8s.workload.name", "pinot-server"));
+    ByteBuffer littleEndian = ByteBuffer.wrap(serialized).order(ByteOrder.LITTLE_ENDIAN);
+
+    assertEquals(MapUtils.frameToJsonString(littleEndian), "{\"k8s.workload.name\":\"pinot-server\"}");
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/MapUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/MapUtilsTest.java
@@ -381,4 +381,62 @@ public class MapUtilsTest {
     map.put("nested", nested);
     assertEquals(MapUtils.toString(map), "{\"nested\":{\"d\":\"2022-02-08\"}}");
   }
+
+  /// The contract that lets the forward-index read path swap `toString(deserializeMap(frame))` for
+  /// `frameToJsonString(frame)`: for any frame written through the key-sorting [MapUtils#serializeMap(Map)] - which
+  /// is what both forward-index write paths use - the two must produce identical output.
+  @Test
+  void testFrameToJsonStringMatchesToString() {
+    Map<String, Object> nested = new LinkedHashMap<>();
+    nested.put("z", 1);
+    nested.put("a", List.of(1, 2, 3));
+
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("k8s.workload.name", "pinot-server");
+    map.put("int", 42);
+    map.put("long", 9999999999L);
+    map.put("double", 1.5);
+    map.put("bool", true);
+    map.put("nullValue", null);
+    map.put("nested", nested);
+    map.put("list", List.of("a", "b"));
+    map.put("emptyString", "");
+    map.put("unicodeValue", "çöğüşÇÖĞÜŞéÉ");
+    map.put("命名空间", "namespace");
+    map.put("date", LocalDate.of(2022, 2, 8));
+    map.put("quote\"key", "quoted");
+    map.put("back\\slash", "escaped");
+    map.put("tab\tkey", "control");
+    map.put("value with \"quotes\" and \\ backslash", "in value");
+
+    assertEquals(MapUtils.frameToJsonString(MapUtils.serializeMap(map)), MapUtils.toString(map));
+  }
+
+  @Test
+  void testFrameToJsonStringHandlesEmptyMap() {
+    assertEquals(MapUtils.frameToJsonString(MapUtils.serializeMap(Map.of())), "{}");
+    assertEquals(MapUtils.frameToJsonString(MapUtils.serializeMap(Map.of())), MapUtils.toString(Map.of()));
+  }
+
+  /// Rendering must round-trip back through the JSON reader to the same map, independent of the string comparison
+  /// above - that guards against two implementations agreeing on malformed output.
+  @Test
+  void testFrameToJsonStringRoundTrips() {
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("a", "value");
+    map.put("b", List.of(1, 2));
+    map.put("çö", Map.of("inner", true));
+    assertEquals(MapUtils.fromString(MapUtils.frameToJsonString(MapUtils.serializeMap(map))),
+        MapUtils.deserializeMap(MapUtils.serializeMap(map)));
+  }
+
+  /// An off-heap forward-index view arrives in the platform's native byte order while the frame is written
+  /// big-endian, so the renderer has to force the order rather than trust the buffer.
+  @Test
+  void testFrameToJsonStringForcesBigEndian() {
+    byte[] serialized = MapUtils.serializeMap(Map.of("k8s.workload.name", "pinot-server"));
+    ByteBuffer littleEndian = ByteBuffer.wrap(serialized).order(ByteOrder.LITTLE_ENDIAN);
+
+    assertEquals(MapUtils.frameToJsonString(littleEndian), "{\"k8s.workload.name\":\"pinot-server\"}");
+  }
 }


### PR DESCRIPTION
## Description

Projecting a whole `MAP` column as a string — `SELECT attributes`, `LASTWITHTIME(attributes, ...)` — parses every entry into a `HashMap` and then serializes that map back to JSON, once per row.

Both steps are avoidable. The frame already stores each value as the JSON bytes `serializeMap` produced, so values can be copied through verbatim and only keys need quoting.

## Changes

- Add `MapUtils#frameToJsonString`, rendering a frame to JSON without Jackson and without materializing the map.
- Add a `ForwardIndexReader#getMapAsJsonString` hook and route the `case MAP` branch of `readValuesSV` through it.
- Override it in the three readers that hold the map as a frame: `VarByteSVMutableForwardIndex`, `VarByteChunkSVForwardIndexReader`, `VarByteChunkForwardIndexReaderV4`. The default still materializes the map, so a reader holding the map columnar-decomposed is unaffected.

## Output is unchanged

Both forward-index write paths — `ForwardIndexCreator#putValue` at segment build and `MutableSegmentImpl` while consuming — frame maps through the key-sorting `serializeMap(Map)`, and nested values are sorted by that same writer. So emitting entries in frame order reproduces exactly what `toString(deserializeMap(frame))` produced. `testFrameToJsonStringMatchesToString` pins that equivalence across scalars, nesting, unicode, and keys that need escaping.

## Performance

Isolated JMH (`BenchmarkMapProjection`), JDK 25, 2 forks x 5x1s, `-prof gc`:

| entries | shape | before us/op | after us/op | speedup | before B/op | after B/op |
|--------:|:------|-------------:|------------:|--------:|------------:|-----------:|
| 4  | flat   | 0.866 | 0.258 | 3.4x | 4,768 | 768 |
| 4  | nested | 1.312 | 0.274 | 4.8x | 7,320 | 848 |
| 16 | flat   | 3.261 | 1.018 | 3.2x | 16,936 | 2,688 |
| 16 | nested | 5.352 | 1.049 | 5.1x | 26,968 | 3,008 |
| 64 | flat   | 14.111 | 3.885 | 3.6x | 65,656 | 10,464 |
| 64 | nested | 24.071 | 4.227 | 5.7x | 104,312 | 11,744 |

Nested values cost the old path 71% more than flat ones at 64 entries, because Jackson materializes a container per value. The new path stays within 9% of flat since it never looks inside a value. The allocation that remains is the output buffer and the returned `String`.

This is an isolated forward-index measurement, not an end-to-end query latency result.

## Validation

- `MapUtilsTest` 25/25 (4 new)
- `TableIndexingTest` 506, `DataBlockBuilderTest` 97, `GenericRowSerDeTest` 7, `DataTableSerDeTest` 5, `OpenStructDataTypeTest` 5 — all passing
- `spotless:apply`, `license:check`, `checkstyle:check` clean on `pinot-spi`, `pinot-segment-spi`, `pinot-segment-local`, `pinot-perf`