### PR TITLE
fix: signal DataTable deserialization errors immediately instead of waiting for timeout (#18866)

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java
@@ -186,6 +186,19 @@ public class AsyncQueryResponse implements QueryResponse {
     _countDownLatch.countDown();
   }
 
+  /// Handles a deserialization error for a single server response without failing the entire query. The server
+  /// response is recorded as failed (no DataTable), and the latch is decremented for this server only so that the
+  /// query can complete with partial results from the remaining servers instead of waiting for the full timeout.
+  void receiveDataTableDeserializationError(ServerRoutingInstance serverRoutingInstance) {
+    ServerResponse response = _responseMap.get(serverRoutingInstance);
+    if (response != null && response.getDataTable() == null) {
+      _failedServer = serverRoutingInstance;
+      _exception = new RuntimeException("Failed to deserialize DataTable response from server: " + serverRoutingInstance);
+      _numServersResponded.getAndIncrement();
+      _countDownLatch.countDown();
+    }
+  }
+
   void markQueryFailed(ServerRoutingInstance serverRoutingInstance, Exception exception) {
     _status.set(Status.FAILED);
     _failedServer = serverRoutingInstance;

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/DataTableHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/DataTableHandler.java
@@ -93,6 +93,9 @@ public class DataTableHandler extends SimpleChannelInboundHandler<ByteBuf> {
       LOGGER.error("Caught exception while deserializing data table of size: {} from server: {}", responseSize,
           _serverRoutingInstance, e);
       _brokerMetrics.addMeteredGlobalValue(BrokerMeter.DATA_TABLE_DESERIALIZATION_EXCEPTIONS, 1);
+      // Notify the query router so this server's response is treated as failed and the latch is decremented.
+      // Without this, the query would block until the full timeout and return a misleading BROKER_TIMEOUT.
+      _queryRouter.receiveDataTableDeserializationError(_serverRoutingInstance);
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
@@ -188,6 +188,15 @@ public class QueryRouter {
     }
   }
 
+  /// Handles a deserialization error from a server. Because the DataTable metadata (which carries the request id)
+  /// could not be read, iterate over all in-flight queries and mark the one(s) still waiting on this server.
+  /// This lets the query complete with partial results immediately instead of waiting for the full timeout.
+  void receiveDataTableDeserializationError(ServerRoutingInstance serverRoutingInstance) {
+    for (AsyncQueryResponse asyncQueryResponse : _asyncQueryResponseMap.values()) {
+      asyncQueryResponse.receiveDataTableDeserializationError(serverRoutingInstance);
+    }
+  }
+
   void markServerDown(ServerRoutingInstance serverRoutingInstance, Exception exception) {
     for (AsyncQueryResponse asyncQueryResponse : _asyncQueryResponseMap.values()) {
       asyncQueryResponse.markServerDown(serverRoutingInstance, exception);

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRoutingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRoutingTest.java
@@ -228,6 +228,35 @@ public class QueryRoutingTest {
   }
 
   @Test
+  public void testDataTableDeserializationError()
+      throws Exception {
+    long requestId = 123;
+    // Garbage bytes that cannot be deserialized into a DataTable. The server "responds" but with unusable bytes.
+    byte[] garbageBytes = new byte[]{0, 1, 2, 3, 4, 5};
+
+    // Start the server on port 0 (OS-assigned) to avoid TOCTOU race
+    _queryServer = getQueryServer(0, garbageBytes);
+    initializeTestFixtures(startAndGetPort(_queryServer));
+    String serverId = _serverInstance.getInstanceId();
+
+    long startTimeMs = System.currentTimeMillis();
+    // Use a long timeout so we can assert that the query completes well before the timeout
+    AsyncQueryResponse asyncQueryResponse =
+        _queryRouter.submitQuery(requestId, "testTable", BROKER_REQUEST, _routingTable, null, null, 10_000L);
+    Map<ServerRoutingInstance, ServerResponse> response = asyncQueryResponse.getFinalResponses();
+    assertEquals(response.size(), 1);
+    assertTrue(response.containsKey(_offlineServerRoutingInstance));
+    ServerResponse serverResponse = response.get(_offlineServerRoutingInstance);
+    // The deserialization error should be signaled so the query completes immediately with no DataTable
+    assertNull(serverResponse.getDataTable());
+    // The query should NOT block for the full timeout
+    assertTrue(System.currentTimeMillis() - startTimeMs < 1000);
+    _requestCount += 2;
+    waitForStatsUpdate(_requestCount);
+    assertEquals(_serverRoutingStatsManager.fetchNumInFlightRequestsForServer(serverId).intValue(), 0);
+  }
+
+  @Test
   public void testLatencyForQueryServerException()
       throws Exception {
     long requestId = 123;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/exception/QueryErrorCode.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/exception/QueryErrorCode.java
@@ -66,6 +66,10 @@ public enum QueryErrorCode {
   UNKNOWN_COLUMN(710, "UnknownColumnError", Response.Status.BAD_REQUEST),
   /// Error while planning the query. For example, trying to run a colocated join on non-colocated tables.
   QUERY_PLANNING(720, "QueryPlanningError", Response.Status.BAD_REQUEST),
+  /// Error deserializing a DataTable response from a server. The server sent back bytes that the broker could not
+  /// deserialize, so the query will complete with partial results from the other servers instead of waiting for the
+  /// full timeout.
+  DATA_TABLE_DESERIALIZATION_ERROR(426, "DataTableDeserializationError", Response.Status.INTERNAL_SERVER_ERROR),
   UNKNOWN(1000, "UnknownError", Response.Status.INTERNAL_SERVER_ERROR);
   private static final Logger LOGGER = LoggerFactory.getLogger(QueryErrorCode.class);
 


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

When a server response fails to deserialize, the broker notifies the router, which alerts pending queries to complete early with partial results\.

```mermaid
flowchart TD
  N0["DataTableHandler catches deserialization error and notifies router #40;F2#41;"]:::stModified
  N1["QueryRouter propagates deserialization error to all in#45;flight async queries #40;F3#41;"]:::stModified
  N2["AsyncQueryResponse records error#44; increments latch#44; allowing query to complete #40;F1#41;"]:::stModified
  N0 -->|"calls"| N1
  N1 -->|"calls"| N2
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse\.java — [before](https://github.com/apache/pinot/blob/5e7134d193ca242c3c3ee0e8c8e05c74d1ed826b/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java) · [after](https://github.com/apache/pinot/blob/d076e8b7eb9ac9273713225345ff84e2e248861c/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java)
- F2: pinot\-core/src/main/java/org/apache/pinot/core/transport/DataTableHandler\.java — [before](https://github.com/apache/pinot/blob/5e7134d193ca242c3c3ee0e8c8e05c74d1ed826b/pinot-core/src/main/java/org/apache/pinot/core/transport/DataTableHandler.java) · [after](https://github.com/apache/pinot/blob/d076e8b7eb9ac9273713225345ff84e2e248861c/pinot-core/src/main/java/org/apache/pinot/core/transport/DataTableHandler.java)
- F3: pinot\-core/src/main/java/org/apache/pinot/core/transport/QueryRouter\.java — [before](https://github.com/apache/pinot/blob/5e7134d193ca242c3c3ee0e8c8e05c74d1ed826b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java) · [after](https://github.com/apache/pinot/blob/d076e8b7eb9ac9273713225345ff84e2e248861c/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjVlNzEzNGQxOTNjYTI0MmMzYzNlZTBlOGM4ZTA1Yzc0ZDFlZDgyNmIiLCJjb250ZXh0X2hhc2giOiJhNDI1Mjk2ODZhZjZlYTg3ZDM0YTIwMWQwZDg0NmRjYTkxYjEwMTdjYWM2YmNiM2EwM2EzNzk0NDVkM2YzM2I3IiwiZ2VuZXJhdGVkX2F0IjoxNzg5Nzg4NzQyLCJoZWFkX3NoYSI6ImQwNzZlOGI3ZWI5YWM5MjczNzEzMjI1MzQ1ZmY4NGUyZTI0ODg2MWMiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI1ZTcxMzRkMTkzY2EyNDJjM2MzZWUwZThjOGUwNWM3NGQxZWQ4MjZiIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 6be4b78697af717e9137e3171a91d211e28e3acba0e9d2b35259313a2ca53761 -->
<!-- pinot-pr-flow:end -->

Fixes #18866

## Problem
When a Pinot server sends back a response that the broker cannot deserialize into a `DataTable`, the `DataTableHandler` catch block only logs the error and bumps a metric — it never signals the query. The query then blocks until the full broker timeout expires and returns a misleading `BROKER_TIMEOUT` with partial results.

**Side effects** (beyond the timeout):
- Failure detector is not notified, so the bad server keeps receiving queries
- Routing stats charge the full timeout as latency for the bad server
- Generic timeout metric hides the real cause

## Fix
1. **`QueryErrorCode.java`**: Add `DATA_TABLE_DESERIALIZATION_ERROR(426)` to distinguish deserialization failures from generic internal errors and timeouts.

2. **`AsyncQueryResponse.java`**: Add `receiveDataTableDeserializationError()` — counts down the latch for this server only (without failing the entire query), records the failed server, and sets the exception. This allows the query to complete with partial results from the remaining healthy servers.

3. **`QueryRouter.java`**: Add `receiveDataTableDeserializationError()` — iterates over in-flight queries and marks any still waiting on this server.

4. **`DataTableHandler.java`**: In the catch block, call `_queryRouter.receiveDataTableDeserializationError()` instead of silently logging.

5. **`QueryRoutingTest.java`**: Add `testDataTableDeserializationError()` — sends garbage bytes as the server response and verifies the query completes in under 1 second instead of waiting for the 10-second timeout.

## Testing
- New test: `testDataTableDeserializationError()` — sends `new byte[]{0,1,2,3,4,5}` as server response, verifies query completes in < 1s (not 10s timeout)
- Existing tests unchanged