### PR TITLE
Skip broker pruning for pre-partitioned leaves so 1-to-1 exchanges stay aligned

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -528,7 +528,14 @@ public class WorkerManager {
   private void assignWorkersToNonPartitionedLeafFragment(PlanFragment fragment, DispatchablePlanMetadata metadata,
       DispatchablePlanContext context) {
     String tableName = metadata.getScannedTables().get(0);
-    PinotQuery routingPinotQuery = extractRoutingQuery(fragment.getFragmentRoot(), tableName, context);
+    // A worker here is the n-th server of the routing table in instance id order, so the only thing that makes worker
+    // n mean the same rows on both sides of a 1-to-1 exchange is that both sides route over the same servers. Pruning
+    // decides which servers appear, so a filter that eliminates a different server on each side renumbers one of them
+    // and the exchange pairs rows that do not belong together -- silently, because both sides of this shape carry no
+    // partition class list for MailboxAssignmentVisitor#checkPartitionClassAgreement to compare. Leave a
+    // pre-partitioned leaf unpruned rather than risk it.
+    PinotQuery routingPinotQuery =
+        metadata.isPrePartitioned() ? null : extractRoutingQuery(fragment.getFragmentRoot(), tableName, context);
     // When broker pruning is enabled, routingPinotQuery carries the leaf stage filter so that segment pruners can
     // eliminate segments. When disabled (null), fall back to an unfiltered SELECT * routing request.
     Map<String, RoutingTable> routingTableMap = null;
@@ -800,7 +807,11 @@ public class WorkerManager {
     String rawTableName = TableNameBuilder.extractRawTableName(
         logicalTableRouteInfo.hasOffline() ? logicalTableRouteInfo.getOfflineTableName()
             : logicalTableRouteInfo.getRealtimeTableName());
-    PinotQuery routingPinotQuery = extractRoutingQuery(fragment.getFragmentRoot(), rawTableName, context);
+    // A worker here is the n-th server in instance id order, exactly as on the physical-table path, so a
+    // pre-partitioned leaf is left unpruned for the same reason: a filter eliminating a different server on each side
+    // of a 1-to-1 exchange renumbers one of them, and neither side carries a partition class list to catch it.
+    PinotQuery routingPinotQuery =
+        metadata.isPrePartitioned() ? null : extractRoutingQuery(fragment.getFragmentRoot(), rawTableName, context);
 
     boolean routed = false;
     if (routingPinotQuery != null) {

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/routing/WorkerManagerTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/routing/WorkerManagerTest.java
@@ -494,6 +494,77 @@ public class WorkerManagerTest {
     assertNull(brokerRequest.getPinotQuery().getFilterExpression());
   }
 
+  @Test
+  public void testBrokerPruningSkippedForPrePartitionedNonPartitionedLeaf() {
+    // A leaf with no partition metadata gets one worker per server of its routing table, in instance id order, so
+    // worker n means "the n-th surviving server". Pruning decides which servers survive, and the two sides of a
+    // colocated join need not prune the same ones: a filter that eliminates server 1 on one side and not the other
+    // renumbers that side, and the 1-to-1 exchange then pairs rows from different servers. Nothing downstream can
+    // catch it -- neither side has a partition class list for checkPartitionClassAgreement to compare -- so a
+    // pre-partitioned leaf on this path is left unpruned.
+    Schema schema = getSchemaBuilder("testTable").build();
+    ServerInstance server1 = getServerInstance("localhost", 1);
+    ServerInstance server2 = getServerInstance("localhost", 2);
+    Map<String, ServerInstance> serverInstanceMap =
+        Map.of(server1.getInstanceId(), server1, server2.getInstanceId(), server2);
+    RoutingTable unfiltered = new RoutingTable(
+        Map.of(server1, new SegmentsToQuery(List.of("segment1"), List.of()),
+            server2, new SegmentsToQuery(List.of("segment2"), List.of())), List.of(), 0);
+    // The filter would leave only server 2, renumbering it from worker 1 to worker 0.
+    RoutingTable filtered =
+        new RoutingTable(Map.of(server2, new SegmentsToQuery(List.of("segment2"), List.of())), List.of(), 1);
+    CapturingRoutingManager routingManager =
+        new CapturingRoutingManager(serverInstanceMap, Map.of("testTable_OFFLINE", unfiltered))
+            .setFilteredRoutingTable("testTable_OFFLINE", filtered);
+
+    QueryEnvironment queryEnvironment = newQueryEnvironment(schema, routingManager);
+    try (QueryEnvironment.CompiledQuery compiledQuery = queryEnvironment.compile(
+        "SET useBrokerPruning=true; SELECT /*+ joinOptions(is_colocated_by_join_keys='true') */ t1.col2 "
+            + "FROM testTable t1 JOIN testTable t2 ON t1.col1 = t2.col1 WHERE t1.col1 = 'foo'")) {
+      DispatchableSubPlan dispatchableSubPlan = compiledQuery.planQuery(0).getQueryPlan();
+      List<DispatchablePlanFragment> leafFragments = leafFragments(dispatchableSubPlan);
+      assertEquals(leafFragments.size(), 2);
+      for (DispatchablePlanFragment leaf : leafFragments) {
+        assertEquals(leaf.getWorkerIdToSegmentsMap().size(), 2);
+      }
+      assertEquals(dispatchableSubPlan.getNumSegmentsPrunedByBroker(), 0);
+    }
+    // Nothing filtered was ever routed for this leaf.
+    BrokerRequest brokerRequest = routingManager.getCapturedRoutingRequest("testTable_OFFLINE");
+    assertNotNull(brokerRequest);
+    assertNull(brokerRequest.getPinotQuery().getFilterExpression());
+  }
+
+  @Test
+  public void testBrokerPruningStillAppliesToNonPrePartitionedNonPartitionedLeaf() {
+    // The control for the test above: the same shape without the colocation hint is shuffled, so renumbering its
+    // workers is harmless and pruning stays on.
+    Schema schema = getSchemaBuilder("testTable").build();
+    ServerInstance server1 = getServerInstance("localhost", 1);
+    ServerInstance server2 = getServerInstance("localhost", 2);
+    Map<String, ServerInstance> serverInstanceMap =
+        Map.of(server1.getInstanceId(), server1, server2.getInstanceId(), server2);
+    RoutingTable unfiltered = new RoutingTable(
+        Map.of(server1, new SegmentsToQuery(List.of("segment1"), List.of()),
+            server2, new SegmentsToQuery(List.of("segment2"), List.of())), List.of(), 0);
+    RoutingTable filtered =
+        new RoutingTable(Map.of(server2, new SegmentsToQuery(List.of("segment2"), List.of())), List.of(), 1);
+    CapturingRoutingManager routingManager =
+        new CapturingRoutingManager(serverInstanceMap, Map.of("testTable_OFFLINE", unfiltered))
+            .setFilteredRoutingTable("testTable_OFFLINE", filtered);
+
+    QueryEnvironment queryEnvironment = newQueryEnvironment(schema, routingManager);
+    try (QueryEnvironment.CompiledQuery compiledQuery = queryEnvironment.compile(
+        "SET useBrokerPruning=true; SELECT t1.col2 FROM testTable t1 JOIN testTable t2 ON t1.col1 = t2.col1 "
+            + "WHERE t1.col1 = 'foo'")) {
+      DispatchableSubPlan dispatchableSubPlan = compiledQuery.planQuery(0).getQueryPlan();
+      assertEquals(leafFragments(dispatchableSubPlan).get(0).getWorkerIdToSegmentsMap().size(), 1);
+    }
+    BrokerRequest brokerRequest = routingManager.getCapturedRoutingRequest("testTable_OFFLINE");
+    assertNotNull(brokerRequest);
+    assertNotNull(brokerRequest.getPinotQuery().getFilterExpression());
+  }
+
   /// Mimics how segment pruners consume a routing filter: operators are resolved via `FilterKind.valueOf`
   /// (which throws on non-FilterKind operators, e.g. bare boolean scalar functions like `contains`) and
   /// AND/OR/NOT operands are walked recursively. Keeps the mock routing managers honest: a routing query that would
@@ -1251,6 +1322,7 @@ public class WorkerManagerTest {
     private final Map<String, RoutingTable> _routingTableByName;
     private final boolean _throwOnFilteredRouting;
     private boolean _emptyOnFilteredRouting;
+    private final Map<String, RoutingTable> _filteredRoutingTableByName = new HashMap<>();
     private final Map<String, BrokerRequest> _capturedRoutingRequests = new LinkedHashMap<>();
 
     CapturingRoutingManager(Map<String, ServerInstance> serverInstanceMap,
@@ -1268,6 +1340,12 @@ public class WorkerManagerTest {
     /// When set, filter-bearing routing requests return an all-pruned (empty) routing table.
     void setEmptyOnFilteredRouting(boolean emptyOnFilteredRouting) {
       _emptyOnFilteredRouting = emptyOnFilteredRouting;
+    }
+
+    /// Registers the routing table a filter-bearing request gets, so that a test can make pruning drop a whole server.
+    CapturingRoutingManager setFilteredRoutingTable(String tableNameWithType, RoutingTable routingTable) {
+      _filteredRoutingTableByName.put(tableNameWithType, routingTable);
+      return this;
     }
 
     @Nullable
@@ -1289,8 +1367,14 @@ public class WorkerManagerTest {
       validatePrunableFilter(brokerRequest.getPinotQuery().getFilterExpression());
       String tableNameWithType = brokerRequest.getQuerySource().getTableName();
       _capturedRoutingRequests.put(tableNameWithType, brokerRequest);
-      if (_emptyOnFilteredRouting && brokerRequest.getPinotQuery().getFilterExpression() != null) {
-        return new RoutingTable(Map.of(), List.of(), 1);
+      if (brokerRequest.getPinotQuery().getFilterExpression() != null) {
+        if (_emptyOnFilteredRouting) {
+          return new RoutingTable(Map.of(), List.of(), 1);
+        }
+        RoutingTable filteredRoutingTable = _filteredRoutingTableByName.get(tableNameWithType);
+        if (filteredRoutingTable != null) {
+          return filteredRoutingTable;
+        }
       }
       return _routingTableByName.get(tableNameWithType);
     }


### PR DESCRIPTION
A colocated join can return wrong rows when broker pruning is on. This fixes it.

## The problem

A leaf stage without partition metadata gets one worker per server. Worker `n` means "the n-th server, in instance id order".

A colocated join (when forced via the `is_colocated_by_join_keys` hint) wires the exchange 1-to-1. Worker `n` of one side sends to worker `n` of the other side. This is correct only while both sides route over the same servers.

Broker pruning decides which servers reach that list. A filter can eliminate a different server on each side. Each side then numbers its workers differently, and the join pairs rows from two different servers.

Nothing reports the error. Neither side carries a partition class list, so `MailboxAssignmentVisitor#checkPartitionClassAgreement` returns without a comparison. The query gives wrong results and no exception.

## The fix

A pre-partitioned leaf now skips broker pruning. It routes without a filter, which is what it already does when broker pruning is off.

Two paths need the guard:

- `assignWorkersToNonPartitionedLeafFragment` for a physical table
- `assignWorkersToNonPartitionedLeafFragmentForLogicalTable` for a logical table

## The cost

These leaves lose the segment pruning that they get today. Their fan-out returns to the unpruned size.

The loss is small. This path serves tables that have no partition metadata in Pinot. The partition segment pruner needs that metadata, so it prunes nothing here. Only the empty-segment pruner and the time pruner apply.

## Tests

- `testBrokerPruningSkippedForPrePartitionedNonPartitionedLeaf` gives the two sides different filtered routing tables. Both sides keep every server, and the captured routing request carries no filter.
- `testBrokerPruningStillAppliesToNonPrePartitionedNonPartitionedLeaf` runs the same shape without the colocation hint. That plan is shuffled, so pruning stays on and the leaf keeps one worker.
