### PR TITLE
Add API to update segment ZK metadata without uploading

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadataCustomMapModifier.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadataCustomMapModifier.java
@@ -54,16 +54,38 @@ public class SegmentZKMetadataCustomMapModifier {
   public SegmentZKMetadataCustomMapModifier(String jsonString)
       throws IOException {
     JsonNode jsonNode = JsonUtils.stringToJsonNode(jsonString);
-    _modifyMode = ModifyMode.valueOf(jsonNode.get(MAP_MODIFY_MODE_KEY).asText());
+    if (!jsonNode.isObject()) {
+      throw new IOException("Segment ZK metadata custom map modifier must be a JSON object");
+    }
+    JsonNode modifyMode = jsonNode.get(MAP_MODIFY_MODE_KEY);
+    if (modifyMode == null || !modifyMode.isTextual()) {
+      throw new IOException("Segment ZK metadata custom map modifier mode must be a string");
+    }
+    try {
+      _modifyMode = ModifyMode.valueOf(modifyMode.textValue());
+    } catch (IllegalArgumentException e) {
+      throw new IOException("Invalid segment ZK metadata custom map modifier mode: " + modifyMode.textValue(), e);
+    }
     JsonNode jsonMap = jsonNode.get(MAP_KEY);
-    if (jsonMap == null || jsonMap.isEmpty()) {
+    if (jsonMap == null || jsonMap.isNull()) {
       _map = null;
     } else {
-      _map = new HashMap<>();
-      Iterator<String> keys = jsonMap.fieldNames();
-      while (keys.hasNext()) {
-        String key = keys.next();
-        _map.put(key, jsonMap.get(key).asText());
+      if (!jsonMap.isObject()) {
+        throw new IOException("Segment ZK metadata custom map must be an object or null");
+      }
+      if (jsonMap.isEmpty()) {
+        _map = null;
+      } else {
+        _map = new HashMap<>();
+        Iterator<String> keys = jsonMap.fieldNames();
+        while (keys.hasNext()) {
+          String key = keys.next();
+          JsonNode value = jsonMap.get(key);
+          if (!value.isTextual()) {
+            throw new IOException("Segment ZK metadata custom map value must be a string for key: " + key);
+          }
+          _map.put(key, value.textValue());
+        }
       }
     }
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -241,6 +241,14 @@ public class FileUploadDownloadClient implements AutoCloseable {
     return getURI(controllerURI.getScheme(), controllerURI.getHost(), controllerURI.getPort(), SEGMENT_PATH);
   }
 
+  /// Returns the URI for updating the ZK metadata custom map of a segment.
+  public static URI getUpdateSegmentZKMetadataURI(URI controllerURI, String tableNameWithType, String segmentName)
+      throws URISyntaxException {
+    return getURI(controllerURI.getScheme(), controllerURI.getHost(), controllerURI.getPort(),
+        OLD_SEGMENT_PATH + "/" + URIUtils.encode(tableNameWithType) + "/" + URIUtils.encode(segmentName)
+            + "/metadata");
+  }
+
   public static URI getReingestedSegmentUploadURI(URI controllerURI)
       throws URISyntaxException {
     return getURI(controllerURI.getScheme(), controllerURI.getHost(), controllerURI.getPort(),
@@ -887,6 +895,18 @@ public class FileUploadDownloadClient implements AutoCloseable {
       throws IOException, HttpErrorStatusException {
     return HttpClient.wrapAndThrowHttpException(
         _httpClient.sendRequest(getSendSegmentJsonRequest(uri, jsonString, headers, parameters), socketTimeoutMs));
+  }
+
+  /// Updates the ZK metadata custom map of a segment without uploading the segment.
+  public SimpleHttpResponse updateSegmentZKMetadata(URI uri, String customMapModifierJson,
+      @Nullable List<Header> headers, int socketTimeoutMs)
+      throws IOException, HttpErrorStatusException {
+    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.put(uri).setVersion(HttpVersion.HTTP_1_1)
+        .setEntity(new StringEntity(customMapModifierJson, ContentType.APPLICATION_JSON));
+    if (headers != null) {
+      headers.forEach(requestBuilder::addHeader);
+    }
+    return HttpClient.wrapAndThrowHttpException(_httpClient.sendRequest(requestBuilder.build(), socketTimeoutMs));
   }
 
   /// Start replace segments with default settings.

--- a/pinot-common/src/test/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadataCustomMapModifierTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadataCustomMapModifierTest.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.metadata.segment;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class SegmentZKMetadataCustomMapModifierTest {
+  @Test
+  public void testValidJsonModifier()
+      throws IOException {
+    SegmentZKMetadataCustomMapModifier modifier =
+        new SegmentZKMetadataCustomMapModifier("{\"mapModifyMode\":\"UPDATE\",\"map\":{\"key\":\"value\"}}");
+
+    Assert.assertEquals(modifier.modifyMap(new HashMap<>(Map.of("existing", "value"))),
+        Map.of("existing", "value", "key", "value"));
+  }
+
+  @Test(dataProvider = "invalidJsonModifiers")
+  public void testRejectsMalformedJsonModifier(String jsonModifier) {
+    Assert.expectThrows(IOException.class, () -> new SegmentZKMetadataCustomMapModifier(jsonModifier));
+  }
+
+  @DataProvider(name = "invalidJsonModifiers")
+  public Object[][] invalidJsonModifiers() {
+    return new Object[][]{
+        {"[]"},
+        {"\"modifier\""},
+        {"{}"},
+        {"{\"mapModifyMode\":null,\"map\":{}}"},
+        {"{\"mapModifyMode\":1,\"map\":{}}"},
+        {"{\"mapModifyMode\":\"INVALID\",\"map\":{}}"},
+        {"{\"mapModifyMode\":\"UPDATE\",\"map\":[]}"},
+        {"{\"mapModifyMode\":\"UPDATE\",\"map\":\"value\"}"},
+        {"{\"mapModifyMode\":\"UPDATE\",\"map\":{\"key\":1}}"},
+        {"{\"mapModifyMode\":\"UPDATE\",\"map\":{\"key\":null}}"},
+        {"{\"mapModifyMode\":\"UPDATE\",\"map\":{\"key\":{\"nested\":\"value\"}}}"}
+    };
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -49,7 +49,9 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.Encoded;
 import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -70,6 +72,7 @@ import org.apache.pinot.common.lineage.SegmentLineage;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifier;
 import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.PauselessConsumptionUtils;
@@ -116,6 +119,8 @@ import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_K
 ///   - "/segments/{tableNameWithType}/{segmentName}/reset": reset a segment
 ///   - "/segments/{tableNameWithType}/reset": reset all segments
 ///   - "/segments/{tableName}/delete": delete the segments in the payload
+/// - PUT requests:
+///   - "/segments/{tableNameWithType}/{segmentName}/metadata": update the custom map in segment ZK metadata
 /// - DELETE requests:
 ///   - "/segments/{tableName}/{segmentName}": delete a segment
 ///   - "/segments/{tableName}: delete all segments
@@ -315,6 +320,75 @@ public class PinotSegmentRestletResource {
       throw new ControllerApplicationException(LOGGER,
           "Failed to find segment: " + segmentName + " in table: " + tableName, Status.NOT_FOUND);
     }
+  }
+
+  @PUT
+  @Path("segments/{tableNameWithType}/{segmentName}/metadata")
+  @Authorize(targetType = TargetType.TABLE, paramName = "tableNameWithType", action = Actions.Table.UPLOAD_SEGMENT)
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Update the custom map in the ZK metadata for a segment",
+      notes = "Updates only the segment ZK metadata custom map without uploading or refreshing the segment")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Success"),
+      @ApiResponse(code = 400, message = "Invalid table name, CRC, or custom map modifier"),
+      @ApiResponse(code = 404, message = "Table or segment not found"),
+      @ApiResponse(code = 409, message = "Segment metadata changed concurrently"),
+      @ApiResponse(code = 412, message = "Segment CRC does not match")
+  })
+  public SuccessResponse updateSegmentZKMetadataCustomMap(
+      @ApiParam(value = "Table name with type", required = true, example = "myTable_OFFLINE")
+      @PathParam("tableNameWithType") String tableNameWithType,
+      @ApiParam(value = "Name of the segment", required = true) @PathParam("segmentName") @Encoded String segmentName,
+      @ApiParam(value = "Expected segment CRC", required = true) @HeaderParam(HttpHeaders.IF_MATCH)
+      String expectedCrcString,
+      @ApiParam(value = "Custom map modifier", required = true) String customMapModifierJson,
+      @Context HttpHeaders headers) {
+    tableNameWithType = DatabaseUtils.translateTableName(tableNameWithType, headers);
+    segmentName = URIUtils.decode(segmentName);
+    if (TableNameBuilder.getTableTypeFromTableName(tableNameWithType) == null) {
+      throw new ControllerApplicationException(LOGGER,
+          String.format("Table type not provided with table name: %s", tableNameWithType), Status.BAD_REQUEST);
+    }
+
+    long expectedCrc;
+    try {
+      expectedCrc = Long.parseLong(expectedCrcString);
+    } catch (Exception e) {
+      throw new ControllerApplicationException(LOGGER, "Missing or invalid If-Match segment CRC", Status.BAD_REQUEST,
+          e);
+    }
+
+    SegmentZKMetadataCustomMapModifier customMapModifier;
+    try {
+      customMapModifier = new SegmentZKMetadataCustomMapModifier(customMapModifierJson);
+    } catch (Exception e) {
+      throw new ControllerApplicationException(LOGGER, "Invalid segment ZK metadata custom map modifier",
+          Status.BAD_REQUEST, e);
+    }
+
+    ZNRecord segmentMetadataRecord =
+        _pinotHelixResourceManager.getSegmentMetadataZnRecord(tableNameWithType, segmentName);
+    if (segmentMetadataRecord == null) {
+      throw new ControllerApplicationException(LOGGER,
+          String.format("Failed to find segment: %s in table: %s", segmentName, tableNameWithType), Status.NOT_FOUND);
+    }
+    SegmentZKMetadata segmentZKMetadata = new SegmentZKMetadata(segmentMetadataRecord);
+    if (segmentZKMetadata.getCrc() != expectedCrc) {
+      throw new ControllerApplicationException(LOGGER,
+          String.format("Segment CRC does not match for segment: %s in table: %s", segmentName, tableNameWithType),
+          Status.PRECONDITION_FAILED);
+    }
+    segmentZKMetadata.setCustomMap(customMapModifier.modifyMap(segmentZKMetadata.getCustomMap()));
+    if (!_pinotHelixResourceManager.updateZkMetadata(tableNameWithType, segmentZKMetadata,
+        segmentMetadataRecord.getVersion())) {
+      throw new ControllerApplicationException(LOGGER,
+          String.format("Segment metadata changed concurrently for segment: %s in table: %s", segmentName,
+              tableNameWithType), Status.CONFLICT);
+    }
+    return new SuccessResponse(
+        String.format("Successfully updated ZK metadata for segment: %s in table: %s", segmentName,
+            tableNameWithType));
   }
 
   private JsonNode getExtraMetaData(String tableName, String segmentName, List<String> columns) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -325,6 +325,7 @@ public class PinotSegmentRestletResource {
   @PUT
   @Path("segments/{tableNameWithType}/{segmentName}/metadata")
   @Authorize(targetType = TargetType.TABLE, paramName = "tableNameWithType", action = Actions.Table.UPLOAD_SEGMENT)
+  @Authenticate(AccessType.UPDATE)
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Update the custom map in the ZK metadata for a segment",

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -379,6 +379,7 @@ public class PinotSegmentRestletResource {
           String.format("Segment CRC does not match for segment: %s in table: %s", segmentName, tableNameWithType),
           Status.PRECONDITION_FAILED);
     }
+    segmentZKMetadata.setRefreshTime(System.currentTimeMillis());
     segmentZKMetadata.setCustomMap(customMapModifier.modifyMap(segmentZKMetadata.getCustomMap()));
     if (!_pinotHelixResourceManager.updateZkMetadata(tableNameWithType, segmentZKMetadata,
         segmentMetadataRecord.getVersion())) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSegmentRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSegmentRestletResourceTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.api;
 
+import java.net.URI;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -25,9 +26,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
+import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.pinot.client.admin.PinotAdminClient;
 import org.apache.pinot.common.lineage.SegmentLineage;
 import org.apache.pinot.common.lineage.SegmentLineageAccessHelper;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifier;
+import org.apache.pinot.common.utils.SimpleHttpResponse;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.utils.SegmentMetadataMockUtils;
@@ -174,6 +179,54 @@ public class PinotSegmentRestletResourceTest {
 
     // Check crc api
     checkCrcRequest(adminClient, rawTableName, segmentMetadataTable, 9);
+  }
+
+  @Test
+  public void testUpdateSegmentZKMetadataCustomMapApi()
+      throws Exception {
+    String rawTableName = "metadataUpdateTestTable";
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(rawTableName);
+    String segmentName = "metadataUpdateSegment";
+    TEST_INSTANCE.addDummySchema(rawTableName);
+    TEST_INSTANCE.getHelixResourceManager().addTable(
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(rawTableName).setNumReplicas(1).build());
+    SegmentMetadata segmentMetadata = SegmentMetadataMockUtils.mockSegmentMetadata(rawTableName, segmentName);
+    TEST_INSTANCE.getHelixResourceManager().addNewSegment(offlineTableName, segmentMetadata, "downloadUrl");
+
+    SegmentZKMetadata originalMetadata =
+        TEST_INSTANCE.getHelixResourceManager().getSegmentZKMetadata(offlineTableName, segmentName);
+    assertNotNull(originalMetadata);
+    long originalCrc = originalMetadata.getCrc();
+    String endpoint = TEST_INSTANCE.getControllerBaseApiUrl() + "/segments/" + offlineTableName + "/" + segmentName
+        + "/metadata";
+    String modifier = new SegmentZKMetadataCustomMapModifier(
+        SegmentZKMetadataCustomMapModifier.ModifyMode.UPDATE, Map.of("task.lastProcessedTime", "1234"))
+        .toJsonString();
+
+    SimpleHttpResponse response = ControllerTest.getHttpClient().sendJsonPutRequest(URI.create(endpoint), modifier,
+        Map.of(HttpHeaders.IF_MATCH, Long.toString(originalCrc)));
+    assertEquals(response.getStatusCode(), 200);
+    SegmentZKMetadata updatedMetadata =
+        TEST_INSTANCE.getHelixResourceManager().getSegmentZKMetadata(offlineTableName, segmentName);
+    assertNotNull(updatedMetadata);
+    assertEquals(updatedMetadata.getCustomMap(), Map.of("task.lastProcessedTime", "1234"));
+    assertEquals(updatedMetadata.getCrc(), originalCrc);
+    assertEquals(updatedMetadata.getDownloadUrl(), "downloadUrl");
+
+    response = ControllerTest.getHttpClient().sendJsonPutRequest(URI.create(endpoint), modifier, Map.of());
+    assertEquals(response.getStatusCode(), 400);
+
+    response = ControllerTest.getHttpClient().sendJsonPutRequest(URI.create(endpoint), "not-json",
+        Map.of(HttpHeaders.IF_MATCH, Long.toString(originalCrc)));
+    assertEquals(response.getStatusCode(), 400);
+
+    response = ControllerTest.getHttpClient().sendJsonPutRequest(URI.create(endpoint), modifier,
+        Map.of(HttpHeaders.IF_MATCH, Long.toString(originalCrc + 1)));
+    assertEquals(response.getStatusCode(), 412);
+
+    response = ControllerTest.getHttpClient().sendJsonPutRequest(URI.create(endpoint + "-missing"), modifier,
+        Map.of(HttpHeaders.IF_MATCH, Long.toString(originalCrc)));
+    assertEquals(response.getStatusCode(), 404);
   }
 
   @Test

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSegmentRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSegmentRestletResourceTest.java
@@ -222,6 +222,19 @@ public class PinotSegmentRestletResourceTest {
         Map.of(HttpHeaders.IF_MATCH, Long.toString(originalCrc)));
     assertEquals(response.getStatusCode(), 400);
 
+    for (String malformedModifier : List.of(
+        "[]",
+        "{}",
+        "{\"mapModifyMode\":null,\"map\":{}}",
+        "{\"mapModifyMode\":1,\"map\":{}}",
+        "{\"mapModifyMode\":\"UPDATE\",\"map\":[]}",
+        "{\"mapModifyMode\":\"UPDATE\",\"map\":{\"key\":1}}",
+        "{\"mapModifyMode\":\"UPDATE\",\"map\":{\"key\":{\"nested\":\"value\"}}}")) {
+      response = ControllerTest.getHttpClient().sendJsonPutRequest(URI.create(endpoint), malformedModifier,
+          Map.of(HttpHeaders.IF_MATCH, Long.toString(originalCrc)));
+      assertEquals(response.getStatusCode(), 400);
+    }
+
     response = ControllerTest.getHttpClient().sendJsonPutRequest(URI.create(endpoint), modifier,
         Map.of(HttpHeaders.IF_MATCH, Long.toString(originalCrc + 1)));
     assertEquals(response.getStatusCode(), 412);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSegmentRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSegmentRestletResourceTest.java
@@ -197,6 +197,7 @@ public class PinotSegmentRestletResourceTest {
         TEST_INSTANCE.getHelixResourceManager().getSegmentZKMetadata(offlineTableName, segmentName);
     assertNotNull(originalMetadata);
     long originalCrc = originalMetadata.getCrc();
+    long originalRefreshTime = originalMetadata.getRefreshTime();
     String endpoint = TEST_INSTANCE.getControllerBaseApiUrl() + "/segments/" + offlineTableName + "/" + segmentName
         + "/metadata";
     String modifier = new SegmentZKMetadataCustomMapModifier(
@@ -209,6 +210,7 @@ public class PinotSegmentRestletResourceTest {
     SegmentZKMetadata updatedMetadata =
         TEST_INSTANCE.getHelixResourceManager().getSegmentZKMetadata(offlineTableName, segmentName);
     assertNotNull(updatedMetadata);
+    assertTrue(updatedMetadata.getRefreshTime() > originalRefreshTime);
     assertEquals(updatedMetadata.getCustomMap(), Map.of("task.lastProcessedTime", "1234"));
     assertEquals(updatedMetadata.getCrc(), originalCrc);
     assertEquals(updatedMetadata.getDownloadUrl(), "downloadUrl");

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutor.java
@@ -153,13 +153,14 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
               tableNameWithType);
           return segmentConversionResult;
         } catch (HttpErrorStatusException e) {
-          if (e.getStatusCode() != HttpStatus.SC_NOT_FOUND) {
+          if (e.getStatusCode() != HttpStatus.SC_NOT_FOUND
+              && e.getStatusCode() != HttpStatus.SC_METHOD_NOT_ALLOWED) {
             _minionMetrics.addMeteredTableValue(tableNameWithType, MinionMeter.SEGMENT_UPLOAD_FAIL_COUNT, 1L);
             _eventObserver.notifyTaskError(_pinotTaskConfig, e);
             throw e;
           }
-          // The endpoint is additive. Fall back to the existing upload path when a mixed-version controller does not
-          // expose it yet. A missing segment also follows the fallback and is rejected by the refresh-only upload.
+          // Older controllers return 405 because this path only supports GET. Controllers without the path return 404.
+          // A missing segment can also return 404 and is rejected by the refresh-only upload fallback.
           LOGGER.info("Segment ZK metadata update API is unavailable for segment: {} of table: {}, falling back to "
               + "segment upload", segmentName, tableNameWithType);
         } catch (Exception e) {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutor.java
@@ -29,9 +29,11 @@ import java.util.UUID;
 import org.apache.commons.io.FileUtils;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.pinot.common.auth.AuthProviderUtils;
+import org.apache.pinot.common.exception.HttpErrorStatusException;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifier;
 import org.apache.pinot.common.metrics.MinionMeter;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
@@ -129,9 +131,6 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
         return segmentConversionResult;
       }
 
-      // Publish metrics related to segment upload
-      reportSegmentUploadMetrics(workingDir, tableNameWithType, taskType);
-
       // Collect the task processing metrics from various single segment executors and publish them here.
       SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(indexDir);
       Object numRecordsPurged = segmentConversionResult.getCustomProperty(PurgeTaskExecutor.NUM_RECORDS_PURGED_KEY);
@@ -141,6 +140,37 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
       } else {
         reportTaskProcessingMetrics(tableNameWithType, taskType, segmentMetadata.getTotalDocs());
       }
+
+      SegmentZKMetadataCustomMapModifier segmentZKMetadataCustomMapModifier =
+          getSegmentZKMetadataCustomMapModifier(pinotTaskConfig, segmentConversionResult);
+      if (convertedSegmentDir.getCanonicalFile().equals(indexDir.getCanonicalFile())) {
+        _eventObserver.notifyProgress(_pinotTaskConfig,
+            "Updating ZK metadata without uploading unchanged segment: " + segmentName);
+        try {
+          SegmentConversionUtils.updateSegmentZKMetadata(tableNameWithType, segmentName, uploadURL,
+              originalSegmentCrc, segmentZKMetadataCustomMapModifier, authProvider);
+          LOGGER.info("Updated ZK metadata without uploading unchanged segment: {} of table: {}", segmentName,
+              tableNameWithType);
+          return segmentConversionResult;
+        } catch (HttpErrorStatusException e) {
+          if (e.getStatusCode() != HttpStatus.SC_NOT_FOUND) {
+            _minionMetrics.addMeteredTableValue(tableNameWithType, MinionMeter.SEGMENT_UPLOAD_FAIL_COUNT, 1L);
+            _eventObserver.notifyTaskError(_pinotTaskConfig, e);
+            throw e;
+          }
+          // The endpoint is additive. Fall back to the existing upload path when a mixed-version controller does not
+          // expose it yet. A missing segment also follows the fallback and is rejected by the refresh-only upload.
+          LOGGER.info("Segment ZK metadata update API is unavailable for segment: {} of table: {}, falling back to "
+              + "segment upload", segmentName, tableNameWithType);
+        } catch (Exception e) {
+          _minionMetrics.addMeteredTableValue(tableNameWithType, MinionMeter.SEGMENT_UPLOAD_FAIL_COUNT, 1L);
+          _eventObserver.notifyTaskError(_pinotTaskConfig, e);
+          throw e;
+        }
+      }
+
+      // Publish metrics related to segment upload
+      reportSegmentUploadMetrics(workingDir, tableNameWithType, taskType);
 
       // Tar the converted segment
       _eventObserver.notifyProgress(_pinotTaskConfig, "Compressing segment: " + segmentName);
@@ -172,10 +202,6 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
       Header refreshOnlyHeader = new BasicHeader(FileUploadDownloadClient.CustomHeaders.REFRESH_ONLY, "true");
 
       // Set segment ZK metadata custom map modifier into HTTP header to modify the segment ZK metadata
-      // NOTE: even segment is not changed, still need to upload the segment to update the segment ZK metadata so that
-      // segment will not be submitted again
-      SegmentZKMetadataCustomMapModifier segmentZKMetadataCustomMapModifier =
-          getSegmentZKMetadataCustomMapModifier(pinotTaskConfig, segmentConversionResult);
       Header segmentZKMetadataCustomMapModifierHeader =
           new BasicHeader(FileUploadDownloadClient.CustomHeaders.SEGMENT_ZK_METADATA_CUSTOM_MAP_MODIFIER,
               segmentZKMetadataCustomMapModifier.toJsonString());

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/SegmentConversionUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/SegmentConversionUtils.java
@@ -21,6 +21,7 @@ package org.apache.pinot.plugin.minion.tasks;
 import com.google.common.net.InetAddresses;
 import java.io.File;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -33,7 +34,9 @@ import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.message.BasicHeader;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.common.exception.HttpErrorStatusException;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifier;
 import org.apache.pinot.common.restlet.resources.EndReplaceSegmentsRequest;
 import org.apache.pinot.common.restlet.resources.StartReplaceSegmentsRequest;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
@@ -165,6 +168,25 @@ public class SegmentConversionUtils {
           return false;
         }
       });
+    }
+  }
+
+  /// Updates the custom map in the segment ZK metadata without uploading the segment.
+  public static void updateSegmentZKMetadata(String tableNameWithType, String segmentName, String uploadURL,
+      String originalSegmentCrc,
+      SegmentZKMetadataCustomMapModifier customMapModifier, @Nullable AuthProvider authProvider)
+      throws Exception {
+    URI controllerBaseUri = FileUploadDownloadClient.extractBaseURI(new URI(uploadURL));
+    URI updateUri = FileUploadDownloadClient.getUpdateSegmentZKMetadataURI(controllerBaseUri, tableNameWithType,
+        segmentName);
+    List<Header> headers = new ArrayList<>(AuthProviderUtils.toRequestHeaders(authProvider));
+    headers.add(new BasicHeader(HttpHeaders.IF_MATCH, originalSegmentCrc));
+    SSLContext sslContext = MinionContext.getInstance().getSSLContext();
+    try (FileUploadDownloadClient client = new FileUploadDownloadClient(sslContext)) {
+      SimpleHttpResponse response = client.updateSegmentZKMetadata(updateUri, customMapModifier.toJsonString(),
+          headers, HttpClient.DEFAULT_SOCKET_TIMEOUT_MS);
+      LOGGER.info("Got response {}: {} while updating ZK metadata for table: {}, segment: {}",
+          response.getStatusCode(), response.getResponse(), tableNameWithType, segmentName);
     }
   }
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutorTest.java
@@ -52,6 +52,7 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
@@ -151,13 +152,13 @@ public class BaseSingleSegmentConversionExecutorTest {
     }
   }
 
-  @Test
-  public void testExecuteTaskFallsBackToUploadWhenMetadataApiIsUnavailable()
+  @Test(dataProvider = "metadataApiUnavailableStatusCodes")
+  public void testExecuteTaskFallsBackToUploadWhenMetadataApiIsUnavailable(int statusCode)
       throws Exception {
     try (MockedStatic<SegmentConversionUtils> mocked = Mockito.mockStatic(SegmentConversionUtils.class)) {
       mocked.when(() -> SegmentConversionUtils.updateSegmentZKMetadata(Mockito.anyString(), Mockito.anyString(),
               Mockito.anyString(), Mockito.anyString(), Mockito.any(), Mockito.any()))
-          .thenThrow(new HttpErrorStatusException("metadata API not found", HttpStatus.SC_NOT_FOUND));
+          .thenThrow(new HttpErrorStatusException("metadata API unavailable", statusCode));
 
       TestSingleSegmentConversionExecutor executor = new TestSingleSegmentConversionExecutor(true);
       SegmentConversionResult result = executor.executeTask(createTaskConfig());
@@ -166,6 +167,11 @@ public class BaseSingleSegmentConversionExecutorTest {
       mocked.verify(() -> SegmentConversionUtils.uploadSegment(Mockito.any(), Mockito.any(), Mockito.any(),
           Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.any(File.class)));
     }
+  }
+
+  @DataProvider(name = "metadataApiUnavailableStatusCodes")
+  public Object[][] metadataApiUnavailableStatusCodes() {
+    return new Object[][]{{HttpStatus.SC_NOT_FOUND}, {HttpStatus.SC_METHOD_NOT_ALLOWED}};
   }
 
   private PinotTaskConfig createTaskConfig() {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutorTest.java
@@ -25,6 +25,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.pinot.common.exception.HttpErrorStatusException;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifier;
 import org.apache.pinot.common.metrics.MinionMetrics;
 import org.apache.pinot.core.common.MinionConstants;
@@ -134,6 +136,38 @@ public class BaseSingleSegmentConversionExecutorTest {
     }
   }
 
+  @Test
+  public void testExecuteTaskUpdatesMetadataWithoutUploadingUnchangedSegment()
+      throws Exception {
+    try (MockedStatic<SegmentConversionUtils> mocked = Mockito.mockStatic(SegmentConversionUtils.class)) {
+      TestSingleSegmentConversionExecutor executor = new TestSingleSegmentConversionExecutor(true);
+      SegmentConversionResult result = executor.executeTask(createTaskConfig());
+
+      Assert.assertEquals(result.getSegmentName(), SEGMENT_NAME);
+      mocked.verify(() -> SegmentConversionUtils.updateSegmentZKMetadata(Mockito.eq(TABLE_NAME_WITH_TYPE),
+          Mockito.eq(SEGMENT_NAME), Mockito.anyString(), Mockito.eq(Long.toString(SEGMENT_CRC)), Mockito.any(),
+          Mockito.any()));
+      mocked.verifyNoMoreInteractions();
+    }
+  }
+
+  @Test
+  public void testExecuteTaskFallsBackToUploadWhenMetadataApiIsUnavailable()
+      throws Exception {
+    try (MockedStatic<SegmentConversionUtils> mocked = Mockito.mockStatic(SegmentConversionUtils.class)) {
+      mocked.when(() -> SegmentConversionUtils.updateSegmentZKMetadata(Mockito.anyString(), Mockito.anyString(),
+              Mockito.anyString(), Mockito.anyString(), Mockito.any(), Mockito.any()))
+          .thenThrow(new HttpErrorStatusException("metadata API not found", HttpStatus.SC_NOT_FOUND));
+
+      TestSingleSegmentConversionExecutor executor = new TestSingleSegmentConversionExecutor(true);
+      SegmentConversionResult result = executor.executeTask(createTaskConfig());
+
+      Assert.assertEquals(result.getSegmentName(), SEGMENT_NAME);
+      mocked.verify(() -> SegmentConversionUtils.uploadSegment(Mockito.any(), Mockito.any(), Mockito.any(),
+          Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.any(File.class)));
+    }
+  }
+
   private PinotTaskConfig createTaskConfig() {
     Map<String, String> configs = new HashMap<>();
     configs.put(MinionConstants.TABLE_NAME_KEY, TABLE_NAME_WITH_TYPE);
@@ -204,6 +238,16 @@ public class BaseSingleSegmentConversionExecutorTest {
   /// Minimal concrete executor that stubs out the infrastructure-dependent hooks (download, CRC check, conversion, ZK
   /// metadata modifier) so `executeTask` runs to the upload step without a server, controller, or deep store.
   private class TestSingleSegmentConversionExecutor extends BaseSingleSegmentConversionExecutor {
+    private final boolean _returnInputSegment;
+
+    private TestSingleSegmentConversionExecutor() {
+      this(false);
+    }
+
+    private TestSingleSegmentConversionExecutor(boolean returnInputSegment) {
+      _returnInputSegment = returnInputSegment;
+    }
+
     @Override
     protected File downloadSegmentToLocalAndUntar(String tableNameWithType, String segmentName, String deepstoreURL,
         String taskType, File tempDataDir, String suffix)
@@ -221,6 +265,11 @@ public class BaseSingleSegmentConversionExecutorTest {
     @Override
     protected SegmentConversionResult convert(PinotTaskConfig pinotTaskConfig, File indexDir, File workingDir)
         throws Exception {
+      if (_returnInputSegment) {
+        return new SegmentConversionResult.Builder().setFile(indexDir)
+            .setTableNameWithType(pinotTaskConfig.getConfigs().get(MinionConstants.TABLE_NAME_KEY))
+            .setSegmentName(SEGMENT_NAME).build();
+      }
       File convertedDir = new File(workingDir, SEGMENT_NAME);
       FileUtils.copyDirectory(indexDir, convertedDir);
       return new SegmentConversionResult.Builder().setFile(convertedDir)


### PR DESCRIPTION
Closes #10458

## What this PR does

- Adds a dedicated `PUT /segments/{tableNameWithType}/{segmentName}/metadata` API for updating the segment ZK metadata custom map.
- Validates the expected segment CRC through `If-Match` and uses the ZK record version for compare-and-set protection.
- Routes unchanged single-segment conversions through the metadata-only API, avoiding segment compression and upload.
- Falls back to the existing refresh-only upload path when a mixed-version controller does not expose the new endpoint.

## Backward compatibility

The endpoint is additive. Existing upload behavior is unchanged for modified segments, and older controllers continue to work through the fallback path.

## Tests

- `PinotSegmentRestletResourceTest`
- `BaseSingleSegmentConversionExecutorTest`
- Pinot pre-commit checks for `pinot-common`, `pinot-controller`, and `pinot-minion-builtin-tasks`

