### PR TITLE
Share Kinesis ingestion fixture and restore CI coverage

### DIFF
--- a/.github/workflows/pinot_integration_tests.yml
+++ b/.github/workflows/pinot_integration_tests.yml
@@ -111,6 +111,25 @@ jobs:
         timeout-minutes: 120
         run: |
           .github/workflows/scripts/pr-tests/.pinot_tests_integration.sh
+      - name: Kinesis Ingestion Integration Test
+        if : ${{ matrix.testset == 2 }}
+        env:
+          RUN_INTEGRATION_TESTS: true
+          RUN_TEST_SET: ${{ matrix.testset }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          MAVEN_OPTS: >
+            -Xmx2G -DskipShade -DfailIfNoTests=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
+            -Dmaven.wagon.http.retryHandler.count=30 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
+            -B -ntp
+            -XX:+IgnoreUnrecognizedVMOptions
+            --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+            --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+            --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+            --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+            --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+        timeout-minutes: 120
+        run: |
+          .github/workflows/scripts/pr-tests/.pinot_tests_kinesis_integration.sh
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         continue-on-error: true

--- a/.github/workflows/scripts/pr-tests/.pinot_tests_kinesis_integration.sh
+++ b/.github/workflows/scripts/pr-tests/.pinot_tests_kinesis_integration.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -x
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Java version
+java -version
+
+# Check network
+ifconfig
+netstat -i
+
+# Kinesis ingestion integration tests
+cd pinot-integration-tests || exit 1
+if [ "$RUN_TEST_SET" == "2" ]; then
+  mvn test \
+      -P github-actions,codecoverage,kinesis-integration-test-suite || exit 1
+fi

--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -161,6 +161,26 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>kinesis-integration-test-suite</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>false</skipTests>
+              <suiteXmlFiles>
+                <suiteXmlFile>src/test/resources/kinesis-integration-test-suite.xml</suiteXmlFile>
+              </suiteXmlFiles>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <dependencies>

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/ingestion/BaseKinesisIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/ingestion/BaseKinesisIntegrationTest.java
@@ -25,25 +25,34 @@ import cloud.localstack.docker.annotation.LocalstackDockerConfiguration;
 import cloud.localstack.docker.annotation.LocalstackDockerProperties;
 import cloud.localstack.docker.command.Command;
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.client.admin.PinotAdminClient;
+import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.integration.tests.BaseClusterIntegrationTest;
 import org.apache.pinot.integration.tests.realtime.ingestion.utils.KinesisUtils;
 import org.apache.pinot.plugin.stream.kinesis.KinesisConfig;
 import org.apache.pinot.plugin.stream.kinesis.KinesisConsumerFactory;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeSuite;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -69,17 +78,28 @@ abstract class BaseKinesisIntegrationTest extends BaseClusterIntegrationTest {
 
   static final String LOCALSTACK_IMAGE = "2.3.2";
   private static final LocalstackDockerAnnotationProcessor PROCESSOR = new LocalstackDockerAnnotationProcessor();
+  private static BaseKinesisIntegrationTest _sharedClusterTestSuite;
+
   private final Localstack _localstackDocker = Localstack.INSTANCE;
+  private final Set<String> _trackedRealtimeTables = new LinkedHashSet<>();
+  private final Set<String> _trackedSchemas = new LinkedHashSet<>();
+
   protected KinesisClient _kinesisClient;
+  private boolean _localstackStarted;
+  private boolean _streamCreated;
+  private boolean _zkStarted;
 
   private static final String REGION = "us-east-1";
   private static final String LOCALSTACK_KINESIS_ENDPOINT = "http://localhost:4566";
   protected static final String STREAM_TYPE = "kinesis";
-  protected static final String STREAM_NAME = "kinesis-test";
 
-  @BeforeClass
-  public void setUp()
+  @BeforeSuite(alwaysRun = true)
+  public void setUpSuite()
       throws Exception {
+    if (_sharedClusterTestSuite != null) {
+      return;
+    }
+
     try {
       DockerInfoCommand dockerInfoCommand = new DockerInfoCommand();
       dockerInfoCommand.execute();
@@ -88,10 +108,13 @@ abstract class BaseKinesisIntegrationTest extends BaseClusterIntegrationTest {
       throw new SkipException(e.getMessage());
     }
 
+    _sharedClusterTestSuite = this;
+
     TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
 
     // Start the Pinot cluster
     startZk();
+    _zkStarted = true;
     startController();
     startBroker();
     startServer();
@@ -99,48 +122,144 @@ abstract class BaseKinesisIntegrationTest extends BaseClusterIntegrationTest {
     startKinesis();
   }
 
-  @AfterClass
+  @AfterSuite(alwaysRun = true)
+  public void tearDownSuite()
+      throws Exception {
+    BaseKinesisIntegrationTest sharedClusterTestSuite = _sharedClusterTestSuite;
+    if (sharedClusterTestSuite == null) {
+      return;
+    }
+    _sharedClusterTestSuite = null;
+    sharedClusterTestSuite.tearDownSuiteResources();
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    BaseKinesisIntegrationTest sharedClusterTestSuite = _sharedClusterTestSuite;
+    if (sharedClusterTestSuite == null) {
+      throw new IllegalStateException("Kinesis integration test suite has not been initialized");
+    }
+    if (sharedClusterTestSuite != this) {
+      bindToSharedCluster(sharedClusterTestSuite);
+    }
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
+  }
+
+  @AfterClass(alwaysRun = true)
   public void tearDown()
       throws Exception {
-    stopServer();
-    stopBroker();
-    stopController();
-    stopZk();
-    stopKinesis();
-    FileUtils.deleteDirectory(_tempDir);
+    Throwable cleanupFailure = null;
+    try {
+      cleanupKinesisResources();
+    } catch (Throwable t) {
+      cleanupFailure = t;
+    }
+    try {
+      FileUtils.deleteDirectory(_tempDir);
+    } catch (Throwable t) {
+      cleanupFailure = addCleanupFailure(cleanupFailure, t);
+    }
+    if (cleanupFailure != null) {
+      rethrowCleanupFailure(cleanupFailure);
+    }
   }
 
   protected void createStream(int numShards) {
-    LOGGER.warn("Stream " + STREAM_NAME + " being created");
-    _kinesisClient.createStream(CreateStreamRequest.builder().streamName(STREAM_NAME).shardCount(numShards).build());
+    String streamName = getKinesisStreamName();
+    LOGGER.warn("Stream " + streamName + " being created");
+    _streamCreated = true;
+    _kinesisClient.createStream(CreateStreamRequest.builder().streamName(streamName).shardCount(numShards).build());
 
-    TestUtils.waitForCondition(aVoid -> KinesisUtils.isKinesisStreamActive(_kinesisClient, STREAM_NAME), 2000L, 60_000L,
-        "Kinesis stream " + STREAM_NAME + " is not created or is not in active state");
+    TestUtils.waitForCondition(aVoid -> KinesisUtils.isKinesisStreamActive(_kinesisClient, streamName), 2000L, 60_000L,
+        "Kinesis stream " + streamName + " is not created or is not in active state");
   }
 
   protected void deleteStream() {
+    if (!_streamCreated) {
+      return;
+    }
+    String streamName = getKinesisStreamName();
     try {
-      _kinesisClient.deleteStream(DeleteStreamRequest.builder().streamName(STREAM_NAME).build());
+      _kinesisClient.deleteStream(DeleteStreamRequest.builder().streamName(streamName).build());
     } catch (ResourceNotFoundException ignored) {
+      _streamCreated = false;
       return;
     }
     TestUtils.waitForCondition(aVoid -> {
       try {
-        KinesisUtils.getKinesisStreamStatus(_kinesisClient, STREAM_NAME);
+        KinesisUtils.getKinesisStreamStatus(_kinesisClient, streamName);
         return false;
       } catch (ResourceNotFoundException e) {
         return true;
       }
-    }, 2000L, 60_000L, "Kinesis stream " + STREAM_NAME + " is not deleted");
+    }, 2000L, 60_000L, "Kinesis stream " + streamName + " is not deleted");
 
-    LOGGER.warn("Stream " + STREAM_NAME + " deleted");
+    _streamCreated = false;
+    LOGGER.warn("Stream " + streamName + " deleted");
   }
 
   protected PutRecordResponse putRecord(String data, String partitionKey) {
     PutRecordRequest putRecordRequest =
-        PutRecordRequest.builder().streamName(STREAM_NAME).data(SdkBytes.fromUtf8String(data))
+        PutRecordRequest.builder().streamName(getKinesisStreamName()).data(SdkBytes.fromUtf8String(data))
             .partitionKey(partitionKey).build();
     return _kinesisClient.putRecord(putRecordRequest);
+  }
+
+  protected void addTrackedSchema(Schema schema)
+      throws IOException {
+    _trackedSchemas.add(schema.getSchemaName());
+    addSchema(schema);
+  }
+
+  protected void addTrackedTable(TableConfig tableConfig)
+      throws IOException {
+    _trackedRealtimeTables.add(TableNameBuilder.extractRawTableName(tableConfig.getTableName()));
+    addTableConfig(tableConfig);
+  }
+
+  protected void cleanupKinesisResources()
+      throws Exception {
+    Throwable cleanupFailure = null;
+
+    List<String> tableNames = new ArrayList<>(_trackedRealtimeTables);
+    for (int i = tableNames.size() - 1; i >= 0; i--) {
+      String tableName = tableNames.get(i);
+      try {
+        cleanupRealtimeTable(tableName);
+        _trackedRealtimeTables.remove(tableName);
+      } catch (Throwable t) {
+        cleanupFailure = addCleanupFailure(cleanupFailure, t);
+      }
+    }
+
+    List<String> schemaNames = new ArrayList<>(_trackedSchemas);
+    for (int i = schemaNames.size() - 1; i >= 0; i--) {
+      String schemaName = schemaNames.get(i);
+      if (_trackedRealtimeTables.contains(schemaName)) {
+        continue;
+      }
+      try {
+        if (_helixResourceManager != null && _helixResourceManager.getSchema(schemaName) != null) {
+          deleteSchema(schemaName);
+        }
+        _trackedSchemas.remove(schemaName);
+      } catch (Throwable t) {
+        cleanupFailure = addCleanupFailure(cleanupFailure, t);
+      }
+    }
+
+    if (_trackedRealtimeTables.isEmpty()) {
+      try {
+        deleteStream();
+      } catch (Throwable t) {
+        cleanupFailure = addCleanupFailure(cleanupFailure, t);
+      }
+    }
+
+    if (cleanupFailure != null) {
+      rethrowCleanupFailure(cleanupFailure);
+    }
   }
 
   @Override
@@ -150,7 +269,7 @@ abstract class BaseKinesisIntegrationTest extends BaseClusterIntegrationTest {
     streamConfigMap.put(StreamConfigProperties.STREAM_TYPE, streamType);
 
     streamConfigMap.put(StreamConfigProperties.constructStreamProperty(STREAM_TYPE,
-        StreamConfigProperties.STREAM_TOPIC_NAME), STREAM_NAME);
+        StreamConfigProperties.STREAM_TOPIC_NAME), getKinesisStreamName());
     streamConfigMap.put(StreamConfigProperties.constructStreamProperty(STREAM_TYPE,
         StreamConfigProperties.STREAM_FETCH_TIMEOUT_MILLIS), "30000");
     streamConfigMap.put(StreamConfigProperties.constructStreamProperty(STREAM_TYPE,
@@ -170,27 +289,118 @@ abstract class BaseKinesisIntegrationTest extends BaseClusterIntegrationTest {
   }
 
   @Override
+  protected void overrideControllerConf(Map<String, Object> properties) {
+    // Shard-change tests invoke validation explicitly and assert the state before and after each invocation.
+    properties.put(ControllerConf.ControllerPeriodicTasksConf.REALTIME_SEGMENT_VALIDATION_FREQUENCY_PERIOD, "2h");
+    properties.put(ControllerConf.ControllerPeriodicTasksConf.REALTIME_SEGMENT_VALIDATION_INITIAL_DELAY_IN_SECONDS,
+        3600);
+  }
+
+  @Override
   public TableConfig createRealtimeTableConfig(File sampleAvroFile) {
     // Calls the super class to create the table config.
     // Properties like stream configs are overridden in the getStreamConfigs() method.
     return super.createRealtimeTableConfig(sampleAvroFile);
   }
 
-  private void stopKinesis() {
-    if (_kinesisClient != null) {
-      _kinesisClient.close();
+  @Override
+  public String getHelixClusterName() {
+    return "KinesisIngestionIntegrationTest";
+  }
+
+  @Override
+  public String getZkUrl() {
+    if (_sharedClusterTestSuite != null && _sharedClusterTestSuite != this) {
+      return _sharedClusterTestSuite.getZkUrl();
     }
-    if (_localstackDocker.isRunning()) {
-      _localstackDocker.stop();
+    return super.getZkUrl();
+  }
+
+  @Override
+  protected String getBrokerBaseApiUrl() {
+    if (_sharedClusterTestSuite != null && _sharedClusterTestSuite != this) {
+      return _sharedClusterTestSuite.getBrokerBaseApiUrl();
+    }
+    return super.getBrokerBaseApiUrl();
+  }
+
+  @Override
+  protected String getBrokerGrpcEndpoint() {
+    if (_sharedClusterTestSuite != null && _sharedClusterTestSuite != this) {
+      return _sharedClusterTestSuite.getBrokerGrpcEndpoint();
+    }
+    return super.getBrokerGrpcEndpoint();
+  }
+
+  @Override
+  public int getControllerPort() {
+    if (_sharedClusterTestSuite != null && _sharedClusterTestSuite != this) {
+      return _sharedClusterTestSuite.getControllerPort();
+    }
+    return super.getControllerPort();
+  }
+
+  @Override
+  public PinotAdminClient getOrCreateAdminClient()
+      throws IOException {
+    if (_sharedClusterTestSuite != null && _sharedClusterTestSuite != this) {
+      return _sharedClusterTestSuite.getOrCreateAdminClient();
+    }
+    return super.getOrCreateAdminClient();
+  }
+
+  @Override
+  protected int getRandomBrokerPort() {
+    if (_sharedClusterTestSuite != null && _sharedClusterTestSuite != this) {
+      return _sharedClusterTestSuite.getRandomBrokerPort();
+    }
+    return super.getRandomBrokerPort();
+  }
+
+  protected abstract String getKinesisStreamName();
+
+  private void stopKinesis()
+      throws Exception {
+    Throwable cleanupFailure = null;
+    try {
+      if (_kinesisClient != null) {
+        _kinesisClient.close();
+      }
+    } catch (Throwable t) {
+      cleanupFailure = t;
+    } finally {
+      _kinesisClient = null;
+    }
+    try {
+      if (_localstackStarted && _localstackDocker.isRunning()) {
+        _localstackDocker.stop();
+      }
+    } catch (Throwable t) {
+      cleanupFailure = addCleanupFailure(cleanupFailure, t);
+    } finally {
+      _localstackStarted = false;
+    }
+    if (cleanupFailure != null) {
+      rethrowCleanupFailure(cleanupFailure);
     }
   }
 
   private void startKinesis()
       throws Exception {
     LocalstackDockerConfiguration dockerConfig = PROCESSOR.process(this.getClass());
-    StopAllLocalstackDockerCommand stopAllLocalstackDockerCommand = new StopAllLocalstackDockerCommand();
-    stopAllLocalstackDockerCommand.execute();
-    _localstackDocker.startup(dockerConfig);
+    try {
+      _localstackDocker.startup(dockerConfig);
+      _localstackStarted = true;
+    } catch (Throwable startupFailure) {
+      try {
+        if (_localstackDocker.isRunning()) {
+          _localstackDocker.stop();
+        }
+      } catch (Throwable cleanupFailure) {
+        startupFailure.addSuppressed(cleanupFailure);
+      }
+      rethrowCleanupFailure(startupFailure);
+    }
 
     _kinesisClient = KinesisClient.builder().httpClient(new ApacheSdkHttpService().createHttpClientBuilder()
             .buildWithDefaults(
@@ -199,20 +409,117 @@ abstract class BaseKinesisIntegrationTest extends BaseClusterIntegrationTest {
         .endpointOverride(new URI(LOCALSTACK_KINESIS_ENDPOINT)).build();
   }
 
-  private static class StopAllLocalstackDockerCommand extends Command {
+  private void bindToSharedCluster(BaseKinesisIntegrationTest sharedClusterTestSuite) {
+    _kinesisClient = sharedClusterTestSuite._kinesisClient;
+    _controllerStarter = sharedClusterTestSuite._controllerStarter;
+    _controllerPort = sharedClusterTestSuite._controllerPort;
+    _controllerConfig = sharedClusterTestSuite._controllerConfig;
+    _controllerBaseApiUrl = sharedClusterTestSuite._controllerBaseApiUrl;
+    _controllerRequestURLBuilder = sharedClusterTestSuite._controllerRequestURLBuilder;
+    _controllerDataDir = sharedClusterTestSuite._controllerDataDir;
+    _helixResourceManager = sharedClusterTestSuite._helixResourceManager;
+    _helixManager = sharedClusterTestSuite._helixManager;
+    _helixDataAccessor = sharedClusterTestSuite._helixDataAccessor;
+    _helixAdmin = sharedClusterTestSuite._helixAdmin;
+    _propertyStore = sharedClusterTestSuite._propertyStore;
+    _serverStarters.addAll(sharedClusterTestSuite._serverStarters);
+  }
 
-    public void execute() {
-      String runningDockerContainers =
-          dockerExe.execute(
-              Arrays.asList("ps", "-a", "-q", "-f", "ancestor=localstack/localstack:" + LOCALSTACK_IMAGE));
-      if (StringUtils.isNotBlank(runningDockerContainers) && !runningDockerContainers.toLowerCase().contains("error")) {
-        String[] containerList = runningDockerContainers.split("\n");
-
-        for (String containerId : containerList) {
-          dockerExe.execute(Arrays.asList("stop", containerId));
-        }
+  private void cleanupRealtimeTable(String tableName)
+      throws Exception {
+    String tableNameWithType = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(tableName);
+    if (_helixResourceManager != null && _helixResourceManager.getTableConfig(tableNameWithType) != null) {
+      dropRealtimeTable(tableName);
+    }
+    Throwable cleanupFailure = null;
+    if (_helixResourceManager != null) {
+      try {
+        waitForEVToDisappear(tableNameWithType);
+      } catch (Throwable t) {
+        cleanupFailure = t;
+      }
+      try {
+        waitForTableDataManagerRemoved(tableNameWithType);
+      } catch (Throwable t) {
+        cleanupFailure = addCleanupFailure(cleanupFailure, t);
       }
     }
+    if (cleanupFailure != null) {
+      rethrowCleanupFailure(cleanupFailure);
+    }
+  }
+
+  private void tearDownSuiteResources()
+      throws Exception {
+    Throwable cleanupFailure = null;
+    try {
+      if (!_serverStarters.isEmpty()) {
+        stopServer();
+      }
+    } catch (Throwable t) {
+      cleanupFailure = t;
+    }
+    try {
+      if (!_brokerStarters.isEmpty()) {
+        stopBroker();
+      }
+    } catch (Throwable t) {
+      cleanupFailure = addCleanupFailure(cleanupFailure, t);
+    }
+    try {
+      if (_controllerStarter != null) {
+        if (_controllerDataDir != null) {
+          stopController();
+        } else {
+          _controllerStarter.stop();
+          _controllerStarter = null;
+          _controllerPort = 0;
+          _controllerRequestURLBuilder = null;
+        }
+      }
+    } catch (Throwable t) {
+      cleanupFailure = addCleanupFailure(cleanupFailure, t);
+    }
+    try {
+      if (_zkStarted) {
+        stopZk();
+        _zkStarted = false;
+      }
+    } catch (Throwable t) {
+      cleanupFailure = addCleanupFailure(cleanupFailure, t);
+    }
+    try {
+      stopKinesis();
+    } catch (Throwable t) {
+      cleanupFailure = addCleanupFailure(cleanupFailure, t);
+    }
+    try {
+      FileUtils.deleteDirectory(_tempDir);
+    } catch (Throwable t) {
+      cleanupFailure = addCleanupFailure(cleanupFailure, t);
+    }
+    if (cleanupFailure != null) {
+      rethrowCleanupFailure(cleanupFailure);
+    }
+  }
+
+  private static Throwable addCleanupFailure(Throwable currentFailure, Throwable newFailure) {
+    if (currentFailure == null) {
+      return newFailure;
+    }
+    currentFailure.addSuppressed(newFailure);
+    return currentFailure;
+  }
+
+  private static void rethrowCleanupFailure(Throwable cleanupFailure)
+      throws Exception {
+    if (cleanupFailure instanceof Error) {
+      throw (Error) cleanupFailure;
+    }
+    if (cleanupFailure instanceof Exception) {
+      throw (Exception) cleanupFailure;
+    }
+    throw new RuntimeException(cleanupFailure);
   }
 
   private static class DockerInfoCommand extends Command {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/ingestion/KinesisShardChangeTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/ingestion/KinesisShardChangeTest.java
@@ -25,6 +25,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.pinot.common.restlet.resources.TableView;
 import org.apache.pinot.integration.tests.realtime.ingestion.utils.KinesisUtils;
@@ -54,23 +55,58 @@ public class KinesisShardChangeTest extends BaseKinesisIntegrationTest {
 
   private static final String SCHEMA_FILE_PATH = "kinesis/airlineStats_data_reduced.schema";
   private static final String DATA_FILE_PATH = "kinesis/airlineStats_data_reduced.json";
+  private static final String TABLE_NAME = "kinesisShardChange";
+  private static final String STREAM_NAME = "kinesis-shard-change";
   private static final Integer NUM_SHARDS = 2;
+
+  private Thread _publisherThread;
+  private volatile Throwable _publisherFailure;
 
   @BeforeMethod
   public void beforeTest()
-      throws IOException {
+      throws Exception {
+    cleanupKinesisResources();
     createStream(NUM_SHARDS);
-    addSchema(createSchema(SCHEMA_FILE_PATH));
+    Schema schema = createSchema(SCHEMA_FILE_PATH);
+    schema.setSchemaName(getTableName());
+    addTrackedSchema(schema);
     TableConfig tableConfig = createRealtimeTableConfig(null);
-    addTableConfig(tableConfig);
+    addTrackedTable(tableConfig);
   }
 
-  @AfterMethod
+  @AfterMethod(alwaysRun = true)
   public void afterTest()
-      throws IOException {
-    dropRealtimeTable(getTableName());
-    deleteSchema(getTableName());
-    deleteStream();
+      throws Exception {
+    boolean interrupted = Thread.interrupted();
+    Throwable cleanupFailure = null;
+    try {
+      stopPublisherThread();
+    } catch (Throwable t) {
+      cleanupFailure = t;
+    }
+    interrupted |= Thread.interrupted();
+    try {
+      cleanupKinesisResources();
+    } catch (Throwable t) {
+      if (cleanupFailure == null) {
+        cleanupFailure = t;
+      } else {
+        cleanupFailure.addSuppressed(t);
+      }
+    }
+    interrupted |= Thread.interrupted();
+    if (interrupted) {
+      Thread.currentThread().interrupt();
+    }
+    if (cleanupFailure != null) {
+      if (cleanupFailure instanceof Error) {
+        throw (Error) cleanupFailure;
+      }
+      if (cleanupFailure instanceof Exception) {
+        throw (Exception) cleanupFailure;
+      }
+      throw new RuntimeException(cleanupFailure);
+    }
   }
 
   /// Data provider for shard split and merge tests with different offset combinations.
@@ -127,10 +163,10 @@ public class KinesisShardChangeTest extends BaseKinesisIntegrationTest {
 
     // Perform shard operation (split or merge)
     if ("split".equals(operation)) {
-      KinesisUtils.splitNthShard(_kinesisClient, STREAM_NAME, 0); // splits shard 0 into shard 2 & 3
-      KinesisUtils.splitNthShard(_kinesisClient, STREAM_NAME, 1); // splits shard 1 into shard 4 & 5
+      KinesisUtils.splitNthShard(_kinesisClient, getKinesisStreamName(), 0); // splits shard 0 into shard 2 & 3
+      KinesisUtils.splitNthShard(_kinesisClient, getKinesisStreamName(), 1); // splits shard 1 into shard 4 & 5
     } else if ("merge".equals(operation)) {
-      KinesisUtils.mergeShards(_kinesisClient, STREAM_NAME, 0, 1); // merges shard 0 & 1 into shard 2
+      KinesisUtils.mergeShards(_kinesisClient, getKinesisStreamName(), 0, 1); // merges shard 0 & 1 into shard 2
     }
 
     // Publish more records after shard operation. These will go to the new shards
@@ -196,8 +232,8 @@ public class KinesisShardChangeTest extends BaseKinesisIntegrationTest {
     publishRecordsToKinesis(0, 50);
 
     // Split the shards
-    KinesisUtils.splitNthShard(_kinesisClient, STREAM_NAME, 0); // splits shard 0 into shard 2 & 3
-    KinesisUtils.splitNthShard(_kinesisClient, STREAM_NAME, 1); // splits shard 1 into shard 4 & 5
+    KinesisUtils.splitNthShard(_kinesisClient, getKinesisStreamName(), 0); // splits shard 0 into shard 2 & 3
+    KinesisUtils.splitNthShard(_kinesisClient, getKinesisStreamName(), 1); // splits shard 1 into shard 4 & 5
 
     // new table is created with defined offset criteria but listening to the original stream
     String name = getTableName() + "_" + offsetCriteria;
@@ -215,8 +251,6 @@ public class KinesisShardChangeTest extends BaseKinesisIntegrationTest {
 
     // Validate the final state of segments
     validateSegmentStates(name, 2, 4);
-
-    dropNewSchemaAndTable(name);
   }
 
   /// Test case to first split shards, then merge some shards.
@@ -230,15 +264,15 @@ public class KinesisShardChangeTest extends BaseKinesisIntegrationTest {
     waitForRecordsToBeConsumed(getTableName(), 50); // pinot has created 2 segments
 
     // Split the shards
-    KinesisUtils.splitNthShard(_kinesisClient, STREAM_NAME, 0); // splits shard 0 into shard 2 & 3
-    KinesisUtils.splitNthShard(_kinesisClient, STREAM_NAME, 1); // splits shard 1 into shard 4 & 5
+    KinesisUtils.splitNthShard(_kinesisClient, getKinesisStreamName(), 0); // splits shard 0 into shard 2 & 3
+    KinesisUtils.splitNthShard(_kinesisClient, getKinesisStreamName(), 1); // splits shard 1 into shard 4 & 5
 
     // Publish more records after shard operation. These will go to the new shards
     publishRecordsToKinesis(50, 175);
 
     // Merge some shards
-    KinesisUtils.mergeShards(_kinesisClient, STREAM_NAME, 2, 3); // merges shard 2 & 3 into shard 6
-    KinesisUtils.mergeShards(_kinesisClient, STREAM_NAME, 4, 5); // merges shard 4 & 5 into shard 7
+    KinesisUtils.mergeShards(_kinesisClient, getKinesisStreamName(), 2, 3); // merges shard 2 & 3 into shard 6
+    KinesisUtils.mergeShards(_kinesisClient, getKinesisStreamName(), 4, 5); // merges shard 4 & 5 into shard 7
 
     // Publish more records after shard operation. These will go to the new shards
     publishRecordsToKinesis(175, 200);
@@ -261,23 +295,27 @@ public class KinesisShardChangeTest extends BaseKinesisIntegrationTest {
   public void testConcurrentShardSplit()
       throws IOException, InterruptedException {
     // Start a background thread to continuously publish records to kinesis
-    Thread publisherThread = new Thread(() -> {
+    _publisherFailure = null;
+    _publisherThread = new Thread(() -> {
       try {
         for (int i = 0; i < 200; i += 5) {
           publishRecordsToKinesis(i, i + 5);
           Thread.sleep(1000);
         }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
       } catch (Exception e) {
+        _publisherFailure = e;
         LOGGER.error("Error while publishing records to kinesis", e);
       }
-    });
-    publisherThread.start(); // This will take ~40 secs to complete with 5 records ingested per second
+    }, "kinesis-shard-change-publisher");
+    _publisherThread.start(); // This will take ~40 secs to complete with 5 records ingested per second
 
     Thread.sleep(5000);
 
     // Split the shards
-    KinesisUtils.splitNthShard(_kinesisClient, STREAM_NAME, 0); // splits shard 0 into shard 2 & 3
-    KinesisUtils.splitNthShard(_kinesisClient, STREAM_NAME, 1); // splits shard 1 into shard 4 & 5
+    KinesisUtils.splitNthShard(_kinesisClient, getKinesisStreamName(), 0); // splits shard 0 into shard 2 & 3
+    KinesisUtils.splitNthShard(_kinesisClient, getKinesisStreamName(), 1); // splits shard 1 into shard 4 & 5
 
     Thread.sleep(5000);
 
@@ -285,8 +323,8 @@ public class KinesisShardChangeTest extends BaseKinesisIntegrationTest {
     runRealtimeSegmentValidationTask(getTableName()); // This will commit segments 0-1 and start consuming from 2-5
 
     // Merge some shards
-    KinesisUtils.mergeShards(_kinesisClient, STREAM_NAME, 2, 3); // merges shard 2 & 3 into shard 6
-    KinesisUtils.mergeShards(_kinesisClient, STREAM_NAME, 4, 5); // merges shard 4 & 5 into shard 7
+    KinesisUtils.mergeShards(_kinesisClient, getKinesisStreamName(), 2, 3); // merges shard 2 & 3 into shard 6
+    KinesisUtils.mergeShards(_kinesisClient, getKinesisStreamName(), 4, 5); // merges shard 4 & 5 into shard 7
 
     Thread.sleep(5000);
 
@@ -296,10 +334,14 @@ public class KinesisShardChangeTest extends BaseKinesisIntegrationTest {
 
     // Wait for the publisher thread to finish
     try {
-      publisherThread.join();
+      _publisherThread.join();
+      _publisherThread = null;
     } catch (InterruptedException e) {
       LOGGER.error("Error while waiting for publisher thread to finish", e);
+      Thread.currentThread().interrupt();
+      throw e;
     }
+    throwIfPublisherFailed();
 
     waitForRecordsToBeConsumed(getTableName(), 200);
 
@@ -379,7 +421,7 @@ public class KinesisShardChangeTest extends BaseKinesisIntegrationTest {
       throws IOException {
     Schema schema = createSchema(SCHEMA_FILE_PATH);
     schema.setSchemaName(name);
-    addSchema(schema);
+    addTrackedSchema(schema);
 
     TableConfigBuilder tableConfigBuilder = getTableConfigBuilder(TableType.REALTIME);
     tableConfigBuilder.setTableName(name);
@@ -388,13 +430,7 @@ public class KinesisShardChangeTest extends BaseKinesisIntegrationTest {
         StreamConfigProperties.STREAM_CONSUMER_OFFSET_CRITERIA), offsetCriteria);
     tableConfigBuilder.setStreamConfigs(streamConfigs);
     TableConfig tableConfig = tableConfigBuilder.build();
-    addTableConfig(tableConfig);
-  }
-
-  private void dropNewSchemaAndTable(String name)
-      throws IOException {
-    dropRealtimeTable(name);
-    deleteSchema(name);
+    addTrackedTable(tableConfig);
   }
 
   @Override
@@ -405,5 +441,53 @@ public class KinesisShardChangeTest extends BaseKinesisIntegrationTest {
   @Override
   public String getSortedColumn() {
     return null;
+  }
+
+  @Override
+  protected String getTableName() {
+    return TABLE_NAME;
+  }
+
+  @Override
+  protected String getKinesisStreamName() {
+    return STREAM_NAME;
+  }
+
+  private void stopPublisherThread() {
+    Thread publisherThread = _publisherThread;
+    if (publisherThread == null) {
+      throwIfPublisherFailed();
+      return;
+    }
+    publisherThread.interrupt();
+    boolean interrupted = Thread.interrupted();
+    long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+    while (publisherThread.isAlive()) {
+      long remainingNanos = deadlineNanos - System.nanoTime();
+      if (remainingNanos <= 0) {
+        break;
+      }
+      try {
+        publisherThread.join(Math.max(1L, TimeUnit.NANOSECONDS.toMillis(remainingNanos)));
+      } catch (InterruptedException e) {
+        interrupted = true;
+      }
+    }
+    if (interrupted) {
+      Thread.currentThread().interrupt();
+    }
+    if (publisherThread.isAlive()) {
+      throw new IllegalStateException("Kinesis publisher thread did not stop within 10 seconds");
+    }
+    _publisherThread = null;
+    throwIfPublisherFailed();
+  }
+
+  private void throwIfPublisherFailed() {
+    Throwable publisherFailure = _publisherFailure;
+    _publisherFailure = null;
+    if (publisherFailure != null) {
+      throw new AssertionError("Kinesis publisher thread failed", publisherFailure);
+    }
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/ingestion/RealtimeKinesisIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/ingestion/RealtimeKinesisIntegrationTest.java
@@ -36,6 +36,7 @@ import javax.activation.UnsupportedDataTypeException;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.client.ResultSet;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.StringUtil;
 import org.apache.pinot.util.TestUtils;
@@ -51,6 +52,8 @@ import software.amazon.awssdk.services.kinesis.model.PutRecordResponse;
 public class RealtimeKinesisIntegrationTest extends BaseKinesisIntegrationTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeKinesisIntegrationTest.class);
 
+  private static final String TABLE_NAME = "realtimeKinesis";
+  private static final String STREAM_NAME = "realtime-kinesis";
   private static final int NUM_SHARDS = 10;
 
   // Localstack Kinesis doesn't support large rows.
@@ -71,8 +74,10 @@ public class RealtimeKinesisIntegrationTest extends BaseKinesisIntegrationTest {
     createStream(NUM_SHARDS);
 
     // Create and upload the schema and table config
-    addSchema(createSchema(SCHEMA_FILE_PATH));
-    addTableConfig(createRealtimeTableConfig(null));
+    Schema schema = createSchema(SCHEMA_FILE_PATH);
+    schema.setSchemaName(getTableName());
+    addTrackedSchema(schema);
+    addTrackedTable(createRealtimeTableConfig(null));
 
     createH2ConnectionAndTable();
 
@@ -106,6 +111,16 @@ public class RealtimeKinesisIntegrationTest extends BaseKinesisIntegrationTest {
   @Override
   public String getSortedColumn() {
     return null;
+  }
+
+  @Override
+  protected String getTableName() {
+    return TABLE_NAME;
+  }
+
+  @Override
+  protected String getKinesisStreamName() {
+    return STREAM_NAME;
   }
 
   private void publishRecordsToKinesis() {
@@ -284,10 +299,16 @@ public class RealtimeKinesisIntegrationTest extends BaseKinesisIntegrationTest {
         _h2FieldNameAndTypes.toArray(new String[_h2FieldNameAndTypes.size()])) + ")").execute();
   }
 
-  @AfterClass
+  @AfterClass(alwaysRun = true)
   public void tearDown()
       throws Exception {
-    dropRealtimeTable(getTableName());
-    super.tearDown();
+    try {
+      if (_h2Connection != null) {
+        _h2Connection.close();
+        _h2Connection = null;
+      }
+    } finally {
+      super.tearDown();
+    }
   }
 }

--- a/pinot-integration-tests/src/test/resources/kinesis-integration-test-suite.xml
+++ b/pinot-integration-tests/src/test/resources/kinesis-integration-test-suite.xml
@@ -1,0 +1,29 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
+<suite name="KinesisIngestionIntegrationTestSuite" parallel="none">
+  <test name="KinesisIngestionIntegrationTests" preserve-order="true">
+    <classes>
+      <class name="org.apache.pinot.integration.tests.realtime.ingestion.RealtimeKinesisIntegrationTest"/>
+      <class name="org.apache.pinot.integration.tests.realtime.ingestion.KinesisShardChangeTest"/>
+    </classes>
+  </test>
+</suite>


### PR DESCRIPTION
## Summary

- add an explicit serial TestNG suite for the nested Kinesis ingestion tests, which are not selected by the current top-level alphabetical includes
- share one Pinot and LocalStack fixture across RealtimeKinesisIntegrationTest and KinesisShardChangeTest while keeping per-class tables, schemas, and streams isolated
- make setup, publisher-thread handling, and teardown failure-safe so one scenario cannot leak state into the next
- run the suite on existing test Set 2 before coverage upload; the workflow still has exactly two matrix jobs

## Validation

- full Docker-backed suite: 23 tests, 0 failures, 0 errors, 0 skips; TestSuite 900.2s, Maven 15:09
- pinot-integration-tests test-compile passed
- Spotless, Checkstyle, license format/check, and git diff check passed
- TestNG XML, shell script, workflow YAML, and effective-POM profile resolution passed
- independent lifecycle and isolation review found no remaining blocker

## Runtime note

This draft intentionally restores missing CI coverage, so it adds work even after fixture sharing. The local run took about 15 minutes. Hosted CI should establish the actual Set 2 cost and whether a narrower smoke matrix is preferable before marking the PR ready.