### PR TITLE
Remove stray blank line in CaseTransformFunction

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
@@ -875,7 +875,6 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
     return _bytesValuesSV;
   }
 
-
   @Override
   public RoaringBitmap getNullBitmap(ValueBlock valueBlock) {
     int[] selected = getSelectedArray(valueBlock, true);


### PR DESCRIPTION
Follow-up to https://github.com/apache/pinot/pull/18872#discussion_r3708786277, where @Jackie-Jiang asked for this line to be removed. It was not removed — #19183 actually introduced it.

On master today:

```
875:    return _bytesValuesSV;
876:  }
877:
878:
879:  @Override
880:  public RoaringBitmap getNullBitmap(ValueBlock valueBlock) {
```

Checkstyle does not flag it: the `RegexpMultiline` rule in `config/checkstyle.xml` matches a blank line *before a closing brace*, not a double blank line between methods.

Whitespace only — no behavior change.
