### PR TITLE
Support Kafka config providers in realtime table configs

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConnectionHandler.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConnectionHandler.java
@@ -35,6 +35,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.serialization.BytesDeserializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.pinot.plugin.stream.kafka.KafkaAdminClientManager;
@@ -98,16 +99,18 @@ public abstract class KafkaPartitionLevelConnectionHandler {
     return consumerProp;
   }
 
-  /// Filter properties to only include the specified Kafka configurations.
-  /// This prevents "was supplied but isn't a known config" warnings from Kafka clients.
+  /// Filter properties to include the specified Kafka configurations and the dynamic config-provider namespace.
+  /// This prevents "was supplied but isn't a known config" warnings without dropping config-provider settings.
   ///
   /// @param props The properties to filter
   /// @param validConfigNames The set of valid configuration names for the target Kafka client
   /// @return A new Properties object containing only the valid configurations
-  private Properties filterKafkaProperties(Properties props, Set<String> validConfigNames) {
+  @VisibleForTesting
+  static Properties filterKafkaProperties(Properties props, Set<String> validConfigNames) {
     Properties filteredProps = new Properties();
     for (String key : props.stringPropertyNames()) {
-      if (validConfigNames.contains(key)) {
+      if (validConfigNames.contains(key) || key.equals(AbstractConfig.CONFIG_PROVIDERS_CONFIG)
+          || key.startsWith(AbstractConfig.CONFIG_PROVIDERS_CONFIG + ".")) {
         filteredProps.put(key, props.get(key));
       }
     }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConnectionHandler.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConnectionHandler.java
@@ -169,7 +169,8 @@ public abstract class KafkaPartitionLevelConnectionHandler {
       synchronized (this) {
         ref = _sharedAdminClientRef;
         if (ref == null) {
-          ref = KafkaAdminClientManager.getInstance().getOrCreateAdminClient(_consumerProp);
+          ref = KafkaAdminClientManager.getInstance()
+              .getOrCreateAdminClient(filterKafkaProperties(_consumerProp, ADMIN_CLIENT_CONFIG_NAMES));
           _sharedAdminClientRef = ref;
         }
       }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConnectionHandler.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConnectionHandler.java
@@ -35,10 +35,10 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.serialization.BytesDeserializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.pinot.plugin.stream.kafka.KafkaAdminClientManager;
+import org.apache.pinot.plugin.stream.kafka.KafkaConfigUtils;
 import org.apache.pinot.plugin.stream.kafka.KafkaPartitionLevelStreamConfig;
 import org.apache.pinot.plugin.stream.kafka.KafkaSSLUtils;
 import org.apache.pinot.spi.stream.StreamConfig;
@@ -99,30 +99,13 @@ public abstract class KafkaPartitionLevelConnectionHandler {
     return consumerProp;
   }
 
-  /// Filter properties to include the specified Kafka configurations and the dynamic config-provider namespace.
-  /// This prevents "was supplied but isn't a known config" warnings without dropping config-provider settings.
-  ///
-  /// @param props The properties to filter
-  /// @param validConfigNames The set of valid configuration names for the target Kafka client
-  /// @return A new Properties object containing only the valid configurations
-  @VisibleForTesting
-  static Properties filterKafkaProperties(Properties props, Set<String> validConfigNames) {
-    Properties filteredProps = new Properties();
-    for (String key : props.stringPropertyNames()) {
-      if (validConfigNames.contains(key) || key.equals(AbstractConfig.CONFIG_PROVIDERS_CONFIG)
-          || key.startsWith(AbstractConfig.CONFIG_PROVIDERS_CONFIG + ".")) {
-        filteredProps.put(key, props.get(key));
-      }
-    }
-    return filteredProps;
-  }
-
   private Consumer<Bytes, Bytes> createConsumer(Properties consumerProp, RetryPolicy retryPolicy) {
     AtomicReference<Consumer<Bytes, Bytes>> consumer = new AtomicReference<>();
     try {
       retryPolicy.attempt(() -> {
         try {
-          consumer.set(new KafkaConsumer<>(filterKafkaProperties(consumerProp, CONSUMER_CONFIG_NAMES)));
+          consumer.set(new KafkaConsumer<>(KafkaConfigUtils.filterAndValidateKafkaProperties(consumerProp,
+              CONSUMER_CONFIG_NAMES)));
           return true;
         } catch (Exception e) {
           LOGGER.warn("Caught exception while creating Kafka consumer, retrying.", e);
@@ -138,11 +121,13 @@ public abstract class KafkaPartitionLevelConnectionHandler {
 
   @VisibleForTesting
   protected Consumer<Bytes, Bytes> createConsumer(Properties consumerProp) {
-    return retry(() -> new KafkaConsumer<>(filterKafkaProperties(consumerProp, CONSUMER_CONFIG_NAMES)), 5);
+    return retry(() -> new KafkaConsumer<>(KafkaConfigUtils.filterAndValidateKafkaProperties(consumerProp,
+        CONSUMER_CONFIG_NAMES)), 5);
   }
 
   protected AdminClient createAdminClient() {
-    return retry(() -> AdminClient.create(filterKafkaProperties(_consumerProp, ADMIN_CLIENT_CONFIG_NAMES)), 5);
+    return retry(() -> AdminClient.create(KafkaConfigUtils.filterAndValidateKafkaProperties(_consumerProp,
+        ADMIN_CLIENT_CONFIG_NAMES)), 5);
   }
 
   /// Gets or creates a reusable admin client instance. The admin client is lazily initialized
@@ -170,7 +155,8 @@ public abstract class KafkaPartitionLevelConnectionHandler {
         ref = _sharedAdminClientRef;
         if (ref == null) {
           ref = KafkaAdminClientManager.getInstance()
-              .getOrCreateAdminClient(filterKafkaProperties(_consumerProp, ADMIN_CLIENT_CONFIG_NAMES));
+              .getOrCreateAdminClient(KafkaConfigUtils.filterAndValidateKafkaProperties(_consumerProp,
+                  ADMIN_CLIENT_CONFIG_NAMES));
           _sharedAdminClientRef = ref;
         }
       }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConnectionHandler.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConnectionHandler.java
@@ -100,12 +100,13 @@ public abstract class KafkaPartitionLevelConnectionHandler {
   }
 
   private Consumer<Bytes, Bytes> createConsumer(Properties consumerProp, RetryPolicy retryPolicy) {
+    Properties filteredConsumerProp =
+        KafkaConfigUtils.filterAndValidateKafkaProperties(consumerProp, CONSUMER_CONFIG_NAMES);
     AtomicReference<Consumer<Bytes, Bytes>> consumer = new AtomicReference<>();
     try {
       retryPolicy.attempt(() -> {
         try {
-          consumer.set(new KafkaConsumer<>(KafkaConfigUtils.filterAndValidateKafkaProperties(consumerProp,
-              CONSUMER_CONFIG_NAMES)));
+          consumer.set(new KafkaConsumer<>(filteredConsumerProp));
           return true;
         } catch (Exception e) {
           LOGGER.warn("Caught exception while creating Kafka consumer, retrying.", e);
@@ -121,13 +122,15 @@ public abstract class KafkaPartitionLevelConnectionHandler {
 
   @VisibleForTesting
   protected Consumer<Bytes, Bytes> createConsumer(Properties consumerProp) {
-    return retry(() -> new KafkaConsumer<>(KafkaConfigUtils.filterAndValidateKafkaProperties(consumerProp,
-        CONSUMER_CONFIG_NAMES)), 5);
+    Properties filteredConsumerProp =
+        KafkaConfigUtils.filterAndValidateKafkaProperties(consumerProp, CONSUMER_CONFIG_NAMES);
+    return retry(() -> new KafkaConsumer<>(filteredConsumerProp), 5);
   }
 
   protected AdminClient createAdminClient() {
-    return retry(() -> AdminClient.create(KafkaConfigUtils.filterAndValidateKafkaProperties(_consumerProp,
-        ADMIN_CLIENT_CONFIG_NAMES)), 5);
+    Properties filteredAdminClientProp =
+        KafkaConfigUtils.filterAndValidateKafkaProperties(_consumerProp, ADMIN_CLIENT_CONFIG_NAMES);
+    return retry(() -> AdminClient.create(filteredAdminClientProp), 5);
   }
 
   /// Gets or creates a reusable admin client instance. The admin client is lazily initialized
@@ -154,9 +157,9 @@ public abstract class KafkaPartitionLevelConnectionHandler {
       synchronized (this) {
         ref = _sharedAdminClientRef;
         if (ref == null) {
-          ref = KafkaAdminClientManager.getInstance()
-              .getOrCreateAdminClient(KafkaConfigUtils.filterAndValidateKafkaProperties(_consumerProp,
-                  ADMIN_CLIENT_CONFIG_NAMES));
+          Properties filteredAdminClientProp =
+              KafkaConfigUtils.filterAndValidateKafkaProperties(_consumerProp, ADMIN_CLIENT_CONFIG_NAMES);
+          ref = KafkaAdminClientManager.getInstance().getOrCreateAdminClient(filteredAdminClientProp);
           _sharedAdminClientRef = ref;
         }
       }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/test/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConnectionHandlerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/test/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConnectionHandlerTest.java
@@ -18,11 +18,22 @@
  */
 package org.apache.pinot.plugin.stream.kafka30;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.config.provider.FileConfigProvider;
+import org.apache.kafka.common.serialization.BytesDeserializer;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 
@@ -42,6 +53,43 @@ public class KafkaPartitionLevelConnectionHandlerTest {
     streamConfigMap.put("stream.kafka.consumer.factory.class.name", KafkaConsumerFactory.class.getName());
     streamConfigMap.put("stream.kafka.decoder.class.name", "decoderClass");
     return new StreamConfig("testTable_REALTIME", streamConfigMap);
+  }
+
+  @Test
+  public void testFilterKafkaPropertiesPreservesConfigProviders()
+      throws Exception {
+    Path providerFile = Files.createTempFile("kafka-config-provider", ".properties");
+    try {
+      Files.writeString(providerFile, "keystore.password=test-password\n");
+
+      Properties properties = new Properties();
+      properties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+      properties.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class.getName());
+      properties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class.getName());
+      properties.setProperty(AbstractConfig.CONFIG_PROVIDERS_CONFIG, "file");
+      properties.setProperty("config.providers.file.class", FileConfigProvider.class.getName());
+      properties.setProperty(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG,
+          "${file:" + providerFile + ":keystore.password}");
+      properties.setProperty("streamType", "kafka");
+
+      Properties consumerProperties =
+          KafkaPartitionLevelConnectionHandler.filterKafkaProperties(properties, ConsumerConfig.configNames());
+      assertEquals(consumerProperties.getProperty(AbstractConfig.CONFIG_PROVIDERS_CONFIG), "file");
+      assertEquals(consumerProperties.getProperty("config.providers.file.class"), FileConfigProvider.class.getName());
+      assertFalse(consumerProperties.containsKey("streamType"));
+      assertEquals(new ConsumerConfig(consumerProperties).getPassword(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG).value(),
+          "test-password");
+
+      Properties adminProperties =
+          KafkaPartitionLevelConnectionHandler.filterKafkaProperties(properties, AdminClientConfig.configNames());
+      assertEquals(adminProperties.getProperty(AbstractConfig.CONFIG_PROVIDERS_CONFIG), "file");
+      assertEquals(adminProperties.getProperty("config.providers.file.class"), FileConfigProvider.class.getName());
+      assertFalse(adminProperties.containsKey("streamType"));
+      assertEquals(new AdminClientConfig(adminProperties).getPassword(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG).value(),
+          "test-password");
+    } finally {
+      Files.deleteIfExists(providerFile);
+    }
   }
 
   @Test

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/test/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConnectionHandlerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/test/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConnectionHandlerTest.java
@@ -18,28 +18,12 @@
  */
 package org.apache.pinot.plugin.stream.kafka30;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
-import org.apache.kafka.clients.admin.AdminClientConfig;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.common.config.AbstractConfig;
-import org.apache.kafka.common.config.SslConfigs;
-import org.apache.kafka.common.config.provider.FileConfigProvider;
-import org.apache.kafka.common.serialization.BytesDeserializer;
-import org.apache.kafka.common.utils.Bytes;
-import org.apache.pinot.plugin.stream.kafka.KafkaAdminClientManager;
-import org.apache.pinot.spi.config.ConfigUtils;
-import org.apache.pinot.spi.config.table.IndexingConfig;
+import org.apache.pinot.plugin.stream.kafka.KafkaConfigProviderTestUtils;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -64,58 +48,7 @@ public class KafkaPartitionLevelConnectionHandlerTest {
   @Test
   public void testConfigProviderReferencesReachKafkaClients()
       throws Exception {
-    Path providerFile = Files.createTempFile("kafka-config-provider", ".properties");
-    try {
-      Files.writeString(providerFile, "keystore.password=test-password\n");
-
-      String passwordReference = "${file:" + providerFile + ":keystore.password}";
-      Map<String, String> streamConfigs = new HashMap<>();
-      streamConfigs.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-      streamConfigs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class.getName());
-      streamConfigs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class.getName());
-      streamConfigs.put(AbstractConfig.CONFIG_PROVIDERS_CONFIG, "file");
-      streamConfigs.put("config.providers.file.class", FileConfigProvider.class.getName());
-      streamConfigs.put("config.providers.file.param.allowed.paths", providerFile.getParent().toString());
-      streamConfigs.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, passwordReference);
-      streamConfigs.put("streamType", "kafka");
-
-      IndexingConfig indexingConfig = new IndexingConfig();
-      indexingConfig.setStreamConfigs(streamConfigs);
-      IndexingConfig resolvedIndexingConfig =
-          ConfigUtils.applyConfigWithEnvVariablesAndSystemProperties(Map.of(), indexingConfig);
-      Properties properties = new Properties();
-      properties.putAll(resolvedIndexingConfig.getStreamConfigs());
-      assertEquals(properties.getProperty(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG), passwordReference);
-
-      Properties consumerProperties =
-          KafkaPartitionLevelConnectionHandler.filterKafkaProperties(properties, ConsumerConfig.configNames());
-      assertEquals(consumerProperties.getProperty(AbstractConfig.CONFIG_PROVIDERS_CONFIG), "file");
-      assertEquals(consumerProperties.getProperty("config.providers.file.class"), FileConfigProvider.class.getName());
-      assertEquals(consumerProperties.getProperty("config.providers.file.param.allowed.paths"),
-          providerFile.getParent().toString());
-      assertFalse(consumerProperties.containsKey("streamType"));
-      assertEquals(new ConsumerConfig(consumerProperties).getPassword(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG).value(),
-          "test-password");
-      try (KafkaConsumer<Bytes, Bytes> consumer = new KafkaConsumer<>(consumerProperties)) {
-        assertNotNull(consumer);
-      }
-
-      Properties adminProperties =
-          KafkaPartitionLevelConnectionHandler.filterKafkaProperties(properties, AdminClientConfig.configNames());
-      assertEquals(adminProperties.getProperty(AbstractConfig.CONFIG_PROVIDERS_CONFIG), "file");
-      assertEquals(adminProperties.getProperty("config.providers.file.class"), FileConfigProvider.class.getName());
-      assertEquals(adminProperties.getProperty("config.providers.file.param.allowed.paths"),
-          providerFile.getParent().toString());
-      assertFalse(adminProperties.containsKey("streamType"));
-      assertEquals(new AdminClientConfig(adminProperties).getPassword(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG).value(),
-          "test-password");
-      try (KafkaAdminClientManager.AdminClientReference adminClientReference =
-          KafkaAdminClientManager.getInstance().getOrCreateAdminClient(adminProperties)) {
-        assertNotNull(adminClientReference.getAdminClient());
-      }
-    } finally {
-      Files.deleteIfExists(providerFile);
-    }
+    KafkaConfigProviderTestUtils.assertConfigProviderReferencesReachKafkaClients();
   }
 
   @Test

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/test/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConnectionHandlerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/test/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConnectionHandlerTest.java
@@ -25,15 +25,21 @@ import java.util.Map;
 import java.util.Properties;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.provider.FileConfigProvider;
 import org.apache.kafka.common.serialization.BytesDeserializer;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.pinot.plugin.stream.kafka.KafkaAdminClientManager;
+import org.apache.pinot.spi.config.ConfigUtils;
+import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -56,37 +62,57 @@ public class KafkaPartitionLevelConnectionHandlerTest {
   }
 
   @Test
-  public void testFilterKafkaPropertiesPreservesConfigProviders()
+  public void testConfigProviderReferencesReachKafkaClients()
       throws Exception {
     Path providerFile = Files.createTempFile("kafka-config-provider", ".properties");
     try {
       Files.writeString(providerFile, "keystore.password=test-password\n");
 
+      String passwordReference = "${file:" + providerFile + ":keystore.password}";
+      Map<String, String> streamConfigs = new HashMap<>();
+      streamConfigs.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+      streamConfigs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class.getName());
+      streamConfigs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class.getName());
+      streamConfigs.put(AbstractConfig.CONFIG_PROVIDERS_CONFIG, "file");
+      streamConfigs.put("config.providers.file.class", FileConfigProvider.class.getName());
+      streamConfigs.put("config.providers.file.param.allowed.paths", providerFile.getParent().toString());
+      streamConfigs.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, passwordReference);
+      streamConfigs.put("streamType", "kafka");
+
+      IndexingConfig indexingConfig = new IndexingConfig();
+      indexingConfig.setStreamConfigs(streamConfigs);
+      IndexingConfig resolvedIndexingConfig =
+          ConfigUtils.applyConfigWithEnvVariablesAndSystemProperties(Map.of(), indexingConfig);
       Properties properties = new Properties();
-      properties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-      properties.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class.getName());
-      properties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class.getName());
-      properties.setProperty(AbstractConfig.CONFIG_PROVIDERS_CONFIG, "file");
-      properties.setProperty("config.providers.file.class", FileConfigProvider.class.getName());
-      properties.setProperty(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG,
-          "${file:" + providerFile + ":keystore.password}");
-      properties.setProperty("streamType", "kafka");
+      properties.putAll(resolvedIndexingConfig.getStreamConfigs());
+      assertEquals(properties.getProperty(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG), passwordReference);
 
       Properties consumerProperties =
           KafkaPartitionLevelConnectionHandler.filterKafkaProperties(properties, ConsumerConfig.configNames());
       assertEquals(consumerProperties.getProperty(AbstractConfig.CONFIG_PROVIDERS_CONFIG), "file");
       assertEquals(consumerProperties.getProperty("config.providers.file.class"), FileConfigProvider.class.getName());
+      assertEquals(consumerProperties.getProperty("config.providers.file.param.allowed.paths"),
+          providerFile.getParent().toString());
       assertFalse(consumerProperties.containsKey("streamType"));
       assertEquals(new ConsumerConfig(consumerProperties).getPassword(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG).value(),
           "test-password");
+      try (KafkaConsumer<Bytes, Bytes> consumer = new KafkaConsumer<>(consumerProperties)) {
+        assertNotNull(consumer);
+      }
 
       Properties adminProperties =
           KafkaPartitionLevelConnectionHandler.filterKafkaProperties(properties, AdminClientConfig.configNames());
       assertEquals(adminProperties.getProperty(AbstractConfig.CONFIG_PROVIDERS_CONFIG), "file");
       assertEquals(adminProperties.getProperty("config.providers.file.class"), FileConfigProvider.class.getName());
+      assertEquals(adminProperties.getProperty("config.providers.file.param.allowed.paths"),
+          providerFile.getParent().toString());
       assertFalse(adminProperties.containsKey("streamType"));
       assertEquals(new AdminClientConfig(adminProperties).getPassword(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG).value(),
           "test-password");
+      try (KafkaAdminClientManager.AdminClientReference adminClientReference =
+          KafkaAdminClientManager.getInstance().getOrCreateAdminClient(adminProperties)) {
+        assertNotNull(adminClientReference.getAdminClient());
+      }
     } finally {
       Files.deleteIfExists(providerFile);
     }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/main/java/org/apache/pinot/plugin/stream/kafka40/KafkaPartitionLevelConnectionHandler.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/main/java/org/apache/pinot/plugin/stream/kafka40/KafkaPartitionLevelConnectionHandler.java
@@ -35,6 +35,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.serialization.BytesDeserializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.pinot.plugin.stream.kafka.KafkaAdminClientManager;
@@ -98,16 +99,18 @@ public abstract class KafkaPartitionLevelConnectionHandler {
     return consumerProp;
   }
 
-  /// Filter properties to only include the specified Kafka configurations.
-  /// This prevents "was supplied but isn't a known config" warnings from Kafka clients.
+  /// Filter properties to include the specified Kafka configurations and the dynamic config-provider namespace.
+  /// This prevents "was supplied but isn't a known config" warnings without dropping config-provider settings.
   ///
   /// @param props The properties to filter
   /// @param validConfigNames The set of valid configuration names for the target Kafka client
   /// @return A new Properties object containing only the valid configurations
-  private Properties filterKafkaProperties(Properties props, Set<String> validConfigNames) {
+  @VisibleForTesting
+  static Properties filterKafkaProperties(Properties props, Set<String> validConfigNames) {
     Properties filteredProps = new Properties();
     for (String key : props.stringPropertyNames()) {
-      if (validConfigNames.contains(key)) {
+      if (validConfigNames.contains(key) || key.equals(AbstractConfig.CONFIG_PROVIDERS_CONFIG)
+          || key.startsWith(AbstractConfig.CONFIG_PROVIDERS_CONFIG + ".")) {
         filteredProps.put(key, props.get(key));
       }
     }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/main/java/org/apache/pinot/plugin/stream/kafka40/KafkaPartitionLevelConnectionHandler.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/main/java/org/apache/pinot/plugin/stream/kafka40/KafkaPartitionLevelConnectionHandler.java
@@ -169,7 +169,8 @@ public abstract class KafkaPartitionLevelConnectionHandler {
       synchronized (this) {
         ref = _sharedAdminClientRef;
         if (ref == null) {
-          ref = KafkaAdminClientManager.getInstance().getOrCreateAdminClient(_consumerProp);
+          ref = KafkaAdminClientManager.getInstance()
+              .getOrCreateAdminClient(filterKafkaProperties(_consumerProp, ADMIN_CLIENT_CONFIG_NAMES));
           _sharedAdminClientRef = ref;
         }
       }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/main/java/org/apache/pinot/plugin/stream/kafka40/KafkaPartitionLevelConnectionHandler.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/main/java/org/apache/pinot/plugin/stream/kafka40/KafkaPartitionLevelConnectionHandler.java
@@ -35,10 +35,10 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.serialization.BytesDeserializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.pinot.plugin.stream.kafka.KafkaAdminClientManager;
+import org.apache.pinot.plugin.stream.kafka.KafkaConfigUtils;
 import org.apache.pinot.plugin.stream.kafka.KafkaPartitionLevelStreamConfig;
 import org.apache.pinot.plugin.stream.kafka.KafkaSSLUtils;
 import org.apache.pinot.spi.stream.StreamConfig;
@@ -99,30 +99,13 @@ public abstract class KafkaPartitionLevelConnectionHandler {
     return consumerProp;
   }
 
-  /// Filter properties to include the specified Kafka configurations and the dynamic config-provider namespace.
-  /// This prevents "was supplied but isn't a known config" warnings without dropping config-provider settings.
-  ///
-  /// @param props The properties to filter
-  /// @param validConfigNames The set of valid configuration names for the target Kafka client
-  /// @return A new Properties object containing only the valid configurations
-  @VisibleForTesting
-  static Properties filterKafkaProperties(Properties props, Set<String> validConfigNames) {
-    Properties filteredProps = new Properties();
-    for (String key : props.stringPropertyNames()) {
-      if (validConfigNames.contains(key) || key.equals(AbstractConfig.CONFIG_PROVIDERS_CONFIG)
-          || key.startsWith(AbstractConfig.CONFIG_PROVIDERS_CONFIG + ".")) {
-        filteredProps.put(key, props.get(key));
-      }
-    }
-    return filteredProps;
-  }
-
   private Consumer<Bytes, Bytes> createConsumer(Properties consumerProp, RetryPolicy retryPolicy) {
     AtomicReference<Consumer<Bytes, Bytes>> consumer = new AtomicReference<>();
     try {
       retryPolicy.attempt(() -> {
         try {
-          consumer.set(new KafkaConsumer<>(filterKafkaProperties(consumerProp, CONSUMER_CONFIG_NAMES)));
+          consumer.set(new KafkaConsumer<>(KafkaConfigUtils.filterAndValidateKafkaProperties(consumerProp,
+              CONSUMER_CONFIG_NAMES)));
           return true;
         } catch (Exception e) {
           LOGGER.warn("Caught exception while creating Kafka consumer, retrying.", e);
@@ -138,11 +121,13 @@ public abstract class KafkaPartitionLevelConnectionHandler {
 
   @VisibleForTesting
   protected Consumer<Bytes, Bytes> createConsumer(Properties consumerProp) {
-    return retry(() -> new KafkaConsumer<>(filterKafkaProperties(consumerProp, CONSUMER_CONFIG_NAMES)), 5);
+    return retry(() -> new KafkaConsumer<>(KafkaConfigUtils.filterAndValidateKafkaProperties(consumerProp,
+        CONSUMER_CONFIG_NAMES)), 5);
   }
 
   protected AdminClient createAdminClient() {
-    return retry(() -> AdminClient.create(filterKafkaProperties(_consumerProp, ADMIN_CLIENT_CONFIG_NAMES)), 5);
+    return retry(() -> AdminClient.create(KafkaConfigUtils.filterAndValidateKafkaProperties(_consumerProp,
+        ADMIN_CLIENT_CONFIG_NAMES)), 5);
   }
 
   /// Gets or creates a reusable admin client instance. The admin client is lazily initialized
@@ -170,7 +155,8 @@ public abstract class KafkaPartitionLevelConnectionHandler {
         ref = _sharedAdminClientRef;
         if (ref == null) {
           ref = KafkaAdminClientManager.getInstance()
-              .getOrCreateAdminClient(filterKafkaProperties(_consumerProp, ADMIN_CLIENT_CONFIG_NAMES));
+              .getOrCreateAdminClient(KafkaConfigUtils.filterAndValidateKafkaProperties(_consumerProp,
+                  ADMIN_CLIENT_CONFIG_NAMES));
           _sharedAdminClientRef = ref;
         }
       }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/main/java/org/apache/pinot/plugin/stream/kafka40/KafkaPartitionLevelConnectionHandler.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/main/java/org/apache/pinot/plugin/stream/kafka40/KafkaPartitionLevelConnectionHandler.java
@@ -100,12 +100,13 @@ public abstract class KafkaPartitionLevelConnectionHandler {
   }
 
   private Consumer<Bytes, Bytes> createConsumer(Properties consumerProp, RetryPolicy retryPolicy) {
+    Properties filteredConsumerProp =
+        KafkaConfigUtils.filterAndValidateKafkaProperties(consumerProp, CONSUMER_CONFIG_NAMES);
     AtomicReference<Consumer<Bytes, Bytes>> consumer = new AtomicReference<>();
     try {
       retryPolicy.attempt(() -> {
         try {
-          consumer.set(new KafkaConsumer<>(KafkaConfigUtils.filterAndValidateKafkaProperties(consumerProp,
-              CONSUMER_CONFIG_NAMES)));
+          consumer.set(new KafkaConsumer<>(filteredConsumerProp));
           return true;
         } catch (Exception e) {
           LOGGER.warn("Caught exception while creating Kafka consumer, retrying.", e);
@@ -121,13 +122,15 @@ public abstract class KafkaPartitionLevelConnectionHandler {
 
   @VisibleForTesting
   protected Consumer<Bytes, Bytes> createConsumer(Properties consumerProp) {
-    return retry(() -> new KafkaConsumer<>(KafkaConfigUtils.filterAndValidateKafkaProperties(consumerProp,
-        CONSUMER_CONFIG_NAMES)), 5);
+    Properties filteredConsumerProp =
+        KafkaConfigUtils.filterAndValidateKafkaProperties(consumerProp, CONSUMER_CONFIG_NAMES);
+    return retry(() -> new KafkaConsumer<>(filteredConsumerProp), 5);
   }
 
   protected AdminClient createAdminClient() {
-    return retry(() -> AdminClient.create(KafkaConfigUtils.filterAndValidateKafkaProperties(_consumerProp,
-        ADMIN_CLIENT_CONFIG_NAMES)), 5);
+    Properties filteredAdminClientProp =
+        KafkaConfigUtils.filterAndValidateKafkaProperties(_consumerProp, ADMIN_CLIENT_CONFIG_NAMES);
+    return retry(() -> AdminClient.create(filteredAdminClientProp), 5);
   }
 
   /// Gets or creates a reusable admin client instance. The admin client is lazily initialized
@@ -154,9 +157,9 @@ public abstract class KafkaPartitionLevelConnectionHandler {
       synchronized (this) {
         ref = _sharedAdminClientRef;
         if (ref == null) {
-          ref = KafkaAdminClientManager.getInstance()
-              .getOrCreateAdminClient(KafkaConfigUtils.filterAndValidateKafkaProperties(_consumerProp,
-                  ADMIN_CLIENT_CONFIG_NAMES));
+          Properties filteredAdminClientProp =
+              KafkaConfigUtils.filterAndValidateKafkaProperties(_consumerProp, ADMIN_CLIENT_CONFIG_NAMES);
+          ref = KafkaAdminClientManager.getInstance().getOrCreateAdminClient(filteredAdminClientProp);
           _sharedAdminClientRef = ref;
         }
       }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/test/java/org/apache/pinot/plugin/stream/kafka40/KafkaPartitionLevelConnectionHandlerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/test/java/org/apache/pinot/plugin/stream/kafka40/KafkaPartitionLevelConnectionHandlerTest.java
@@ -25,15 +25,21 @@ import java.util.Map;
 import java.util.Properties;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.provider.FileConfigProvider;
 import org.apache.kafka.common.serialization.BytesDeserializer;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.pinot.plugin.stream.kafka.KafkaAdminClientManager;
+import org.apache.pinot.spi.config.ConfigUtils;
+import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -56,37 +62,57 @@ public class KafkaPartitionLevelConnectionHandlerTest {
   }
 
   @Test
-  public void testFilterKafkaPropertiesPreservesConfigProviders()
+  public void testConfigProviderReferencesReachKafkaClients()
       throws Exception {
     Path providerFile = Files.createTempFile("kafka-config-provider", ".properties");
     try {
       Files.writeString(providerFile, "keystore.password=test-password\n");
 
+      String passwordReference = "${file:" + providerFile + ":keystore.password}";
+      Map<String, String> streamConfigs = new HashMap<>();
+      streamConfigs.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+      streamConfigs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class.getName());
+      streamConfigs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class.getName());
+      streamConfigs.put(AbstractConfig.CONFIG_PROVIDERS_CONFIG, "file");
+      streamConfigs.put("config.providers.file.class", FileConfigProvider.class.getName());
+      streamConfigs.put("config.providers.file.param.allowed.paths", providerFile.getParent().toString());
+      streamConfigs.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, passwordReference);
+      streamConfigs.put("streamType", "kafka");
+
+      IndexingConfig indexingConfig = new IndexingConfig();
+      indexingConfig.setStreamConfigs(streamConfigs);
+      IndexingConfig resolvedIndexingConfig =
+          ConfigUtils.applyConfigWithEnvVariablesAndSystemProperties(Map.of(), indexingConfig);
       Properties properties = new Properties();
-      properties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-      properties.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class.getName());
-      properties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class.getName());
-      properties.setProperty(AbstractConfig.CONFIG_PROVIDERS_CONFIG, "file");
-      properties.setProperty("config.providers.file.class", FileConfigProvider.class.getName());
-      properties.setProperty(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG,
-          "${file:" + providerFile + ":keystore.password}");
-      properties.setProperty("streamType", "kafka");
+      properties.putAll(resolvedIndexingConfig.getStreamConfigs());
+      assertEquals(properties.getProperty(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG), passwordReference);
 
       Properties consumerProperties =
           KafkaPartitionLevelConnectionHandler.filterKafkaProperties(properties, ConsumerConfig.configNames());
       assertEquals(consumerProperties.getProperty(AbstractConfig.CONFIG_PROVIDERS_CONFIG), "file");
       assertEquals(consumerProperties.getProperty("config.providers.file.class"), FileConfigProvider.class.getName());
+      assertEquals(consumerProperties.getProperty("config.providers.file.param.allowed.paths"),
+          providerFile.getParent().toString());
       assertFalse(consumerProperties.containsKey("streamType"));
       assertEquals(new ConsumerConfig(consumerProperties).getPassword(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG).value(),
           "test-password");
+      try (KafkaConsumer<Bytes, Bytes> consumer = new KafkaConsumer<>(consumerProperties)) {
+        assertNotNull(consumer);
+      }
 
       Properties adminProperties =
           KafkaPartitionLevelConnectionHandler.filterKafkaProperties(properties, AdminClientConfig.configNames());
       assertEquals(adminProperties.getProperty(AbstractConfig.CONFIG_PROVIDERS_CONFIG), "file");
       assertEquals(adminProperties.getProperty("config.providers.file.class"), FileConfigProvider.class.getName());
+      assertEquals(adminProperties.getProperty("config.providers.file.param.allowed.paths"),
+          providerFile.getParent().toString());
       assertFalse(adminProperties.containsKey("streamType"));
       assertEquals(new AdminClientConfig(adminProperties).getPassword(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG).value(),
           "test-password");
+      try (KafkaAdminClientManager.AdminClientReference adminClientReference =
+          KafkaAdminClientManager.getInstance().getOrCreateAdminClient(adminProperties)) {
+        assertNotNull(adminClientReference.getAdminClient());
+      }
     } finally {
       Files.deleteIfExists(providerFile);
     }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/test/java/org/apache/pinot/plugin/stream/kafka40/KafkaPartitionLevelConnectionHandlerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/test/java/org/apache/pinot/plugin/stream/kafka40/KafkaPartitionLevelConnectionHandlerTest.java
@@ -18,28 +18,12 @@
  */
 package org.apache.pinot.plugin.stream.kafka40;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
-import org.apache.kafka.clients.admin.AdminClientConfig;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.common.config.AbstractConfig;
-import org.apache.kafka.common.config.SslConfigs;
-import org.apache.kafka.common.config.provider.FileConfigProvider;
-import org.apache.kafka.common.serialization.BytesDeserializer;
-import org.apache.kafka.common.utils.Bytes;
-import org.apache.pinot.plugin.stream.kafka.KafkaAdminClientManager;
-import org.apache.pinot.spi.config.ConfigUtils;
-import org.apache.pinot.spi.config.table.IndexingConfig;
+import org.apache.pinot.plugin.stream.kafka.KafkaConfigProviderTestUtils;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -64,58 +48,7 @@ public class KafkaPartitionLevelConnectionHandlerTest {
   @Test
   public void testConfigProviderReferencesReachKafkaClients()
       throws Exception {
-    Path providerFile = Files.createTempFile("kafka-config-provider", ".properties");
-    try {
-      Files.writeString(providerFile, "keystore.password=test-password\n");
-
-      String passwordReference = "${file:" + providerFile + ":keystore.password}";
-      Map<String, String> streamConfigs = new HashMap<>();
-      streamConfigs.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-      streamConfigs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class.getName());
-      streamConfigs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class.getName());
-      streamConfigs.put(AbstractConfig.CONFIG_PROVIDERS_CONFIG, "file");
-      streamConfigs.put("config.providers.file.class", FileConfigProvider.class.getName());
-      streamConfigs.put("config.providers.file.param.allowed.paths", providerFile.getParent().toString());
-      streamConfigs.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, passwordReference);
-      streamConfigs.put("streamType", "kafka");
-
-      IndexingConfig indexingConfig = new IndexingConfig();
-      indexingConfig.setStreamConfigs(streamConfigs);
-      IndexingConfig resolvedIndexingConfig =
-          ConfigUtils.applyConfigWithEnvVariablesAndSystemProperties(Map.of(), indexingConfig);
-      Properties properties = new Properties();
-      properties.putAll(resolvedIndexingConfig.getStreamConfigs());
-      assertEquals(properties.getProperty(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG), passwordReference);
-
-      Properties consumerProperties =
-          KafkaPartitionLevelConnectionHandler.filterKafkaProperties(properties, ConsumerConfig.configNames());
-      assertEquals(consumerProperties.getProperty(AbstractConfig.CONFIG_PROVIDERS_CONFIG), "file");
-      assertEquals(consumerProperties.getProperty("config.providers.file.class"), FileConfigProvider.class.getName());
-      assertEquals(consumerProperties.getProperty("config.providers.file.param.allowed.paths"),
-          providerFile.getParent().toString());
-      assertFalse(consumerProperties.containsKey("streamType"));
-      assertEquals(new ConsumerConfig(consumerProperties).getPassword(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG).value(),
-          "test-password");
-      try (KafkaConsumer<Bytes, Bytes> consumer = new KafkaConsumer<>(consumerProperties)) {
-        assertNotNull(consumer);
-      }
-
-      Properties adminProperties =
-          KafkaPartitionLevelConnectionHandler.filterKafkaProperties(properties, AdminClientConfig.configNames());
-      assertEquals(adminProperties.getProperty(AbstractConfig.CONFIG_PROVIDERS_CONFIG), "file");
-      assertEquals(adminProperties.getProperty("config.providers.file.class"), FileConfigProvider.class.getName());
-      assertEquals(adminProperties.getProperty("config.providers.file.param.allowed.paths"),
-          providerFile.getParent().toString());
-      assertFalse(adminProperties.containsKey("streamType"));
-      assertEquals(new AdminClientConfig(adminProperties).getPassword(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG).value(),
-          "test-password");
-      try (KafkaAdminClientManager.AdminClientReference adminClientReference =
-          KafkaAdminClientManager.getInstance().getOrCreateAdminClient(adminProperties)) {
-        assertNotNull(adminClientReference.getAdminClient());
-      }
-    } finally {
-      Files.deleteIfExists(providerFile);
-    }
+    KafkaConfigProviderTestUtils.assertConfigProviderReferencesReachKafkaClients();
   }
 
   @Test

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/test/java/org/apache/pinot/plugin/stream/kafka40/KafkaPartitionLevelConnectionHandlerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/test/java/org/apache/pinot/plugin/stream/kafka40/KafkaPartitionLevelConnectionHandlerTest.java
@@ -18,11 +18,22 @@
  */
 package org.apache.pinot.plugin.stream.kafka40;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.config.provider.FileConfigProvider;
+import org.apache.kafka.common.serialization.BytesDeserializer;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 
@@ -42,6 +53,43 @@ public class KafkaPartitionLevelConnectionHandlerTest {
     streamConfigMap.put("stream.kafka.consumer.factory.class.name", KafkaConsumerFactory.class.getName());
     streamConfigMap.put("stream.kafka.decoder.class.name", "decoderClass");
     return new StreamConfig("testTable_REALTIME", streamConfigMap);
+  }
+
+  @Test
+  public void testFilterKafkaPropertiesPreservesConfigProviders()
+      throws Exception {
+    Path providerFile = Files.createTempFile("kafka-config-provider", ".properties");
+    try {
+      Files.writeString(providerFile, "keystore.password=test-password\n");
+
+      Properties properties = new Properties();
+      properties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+      properties.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class.getName());
+      properties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class.getName());
+      properties.setProperty(AbstractConfig.CONFIG_PROVIDERS_CONFIG, "file");
+      properties.setProperty("config.providers.file.class", FileConfigProvider.class.getName());
+      properties.setProperty(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG,
+          "${file:" + providerFile + ":keystore.password}");
+      properties.setProperty("streamType", "kafka");
+
+      Properties consumerProperties =
+          KafkaPartitionLevelConnectionHandler.filterKafkaProperties(properties, ConsumerConfig.configNames());
+      assertEquals(consumerProperties.getProperty(AbstractConfig.CONFIG_PROVIDERS_CONFIG), "file");
+      assertEquals(consumerProperties.getProperty("config.providers.file.class"), FileConfigProvider.class.getName());
+      assertFalse(consumerProperties.containsKey("streamType"));
+      assertEquals(new ConsumerConfig(consumerProperties).getPassword(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG).value(),
+          "test-password");
+
+      Properties adminProperties =
+          KafkaPartitionLevelConnectionHandler.filterKafkaProperties(properties, AdminClientConfig.configNames());
+      assertEquals(adminProperties.getProperty(AbstractConfig.CONFIG_PROVIDERS_CONFIG), "file");
+      assertEquals(adminProperties.getProperty("config.providers.file.class"), FileConfigProvider.class.getName());
+      assertFalse(adminProperties.containsKey("streamType"));
+      assertEquals(new AdminClientConfig(adminProperties).getPassword(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG).value(),
+          "test-password");
+    } finally {
+      Files.deleteIfExists(providerFile);
+    }
   }
 
   @Test

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaConfigUtils.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaConfigUtils.java
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.kafka;
+
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Matcher;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.ConfigTransformer;
+import org.apache.kafka.common.config.provider.FileConfigProvider;
+
+
+/// Shared helpers for preparing Kafka client configuration. The helpers are stateless and thread-safe.
+public class KafkaConfigUtils {
+  private static final String CONFIG_PROVIDERS_PREFIX = AbstractConfig.CONFIG_PROVIDERS_CONFIG + ".";
+  private static final String CONFIG_PROVIDER_CLASS_SUFFIX = ".class";
+  private static final String CONFIG_PROVIDER_PARAM_PREFIX = ".param.";
+
+  private KafkaConfigUtils() {
+  }
+
+  /// Filters properties to the target Kafka client's known configurations and Kafka's dynamic ConfigProvider
+  /// namespace. Kafka may still report the provider keys themselves as unknown after using them for resolution.
+  ///
+  /// @param properties properties to filter
+  /// @param validConfigNames configuration names recognized by the target Kafka client
+  /// @return a new Properties object containing the client and ConfigProvider settings
+  /// @throws ConfigException if a referenced provider is undeclared, has no class, or is a FileConfigProvider
+  /// without an allowed-path restriction
+  public static Properties filterAndValidateKafkaProperties(Properties properties, Set<String> validConfigNames) {
+    Properties filteredProperties = new Properties();
+    for (String key : properties.stringPropertyNames()) {
+      if (validConfigNames.contains(key) || key.equals(AbstractConfig.CONFIG_PROVIDERS_CONFIG)
+          || key.startsWith(CONFIG_PROVIDERS_PREFIX)) {
+        filteredProperties.put(key, properties.get(key));
+      }
+    }
+    validateConfigProviderReferences(filteredProperties);
+    return filteredProperties;
+  }
+
+  private static void validateConfigProviderReferences(Properties properties) {
+    Set<String> configuredProviders = getConfiguredProviders(properties);
+    for (String key : properties.stringPropertyNames()) {
+      Matcher matcher = ConfigTransformer.DEFAULT_PATTERN.matcher(properties.getProperty(key));
+      while (matcher.find()) {
+        String provider = matcher.group(1);
+        if (!configuredProviders.contains(provider)) {
+          throw new ConfigException("Kafka ConfigProvider alias '" + provider + "' referenced by '" + key
+              + "' is not listed in '" + AbstractConfig.CONFIG_PROVIDERS_CONFIG + "'");
+        }
+        validateProviderConfiguration(properties, provider, key);
+      }
+    }
+  }
+
+  private static Set<String> getConfiguredProviders(Properties properties) {
+    Set<String> configuredProviders = new HashSet<>();
+    String providers = properties.getProperty(AbstractConfig.CONFIG_PROVIDERS_CONFIG, "");
+    for (String provider : providers.split(",")) {
+      String trimmedProvider = provider.trim();
+      if (!trimmedProvider.isEmpty()) {
+        configuredProviders.add(trimmedProvider);
+      }
+    }
+    return configuredProviders;
+  }
+
+  private static void validateProviderConfiguration(Properties properties, String provider, String referencingKey) {
+    String providerPrefix = CONFIG_PROVIDERS_PREFIX + provider;
+    String providerClassKey = providerPrefix + CONFIG_PROVIDER_CLASS_SUFFIX;
+    String providerClass = properties.getProperty(providerClassKey);
+    if (providerClass == null || providerClass.trim().isEmpty()) {
+      throw new ConfigException("Kafka ConfigProvider alias '" + provider + "' referenced by '" + referencingKey
+          + "' does not define '" + providerClassKey + "'");
+    }
+    if (providerClass.equals(FileConfigProvider.class.getName())) {
+      String allowedPathsKey = providerPrefix + CONFIG_PROVIDER_PARAM_PREFIX + FileConfigProvider.ALLOWED_PATHS_CONFIG;
+      String allowedPaths = properties.getProperty(allowedPathsKey);
+      if (allowedPaths == null || allowedPaths.trim().isEmpty()) {
+        throw new ConfigException("Kafka FileConfigProvider alias '" + provider + "' referenced by '" + referencingKey
+            + "' must define '" + allowedPathsKey + "'");
+      }
+    }
+  }
+}

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaSSLUtils.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaSSLUtils.java
@@ -22,23 +22,34 @@ import com.google.common.annotations.VisibleForTesting;
 import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.FileAlreadyExistsException;
+import java.io.OutputStream;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.security.KeyFactory;
 import java.security.KeyStore;
 import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Signature;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
+import java.security.interfaces.DSAKey;
+import java.security.interfaces.EdECKey;
+import java.security.interfaces.RSAKey;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.PSSParameterSpec;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Locale;
 import java.util.Properties;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.common.config.ConfigTransformer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,10 +92,22 @@ public class KafkaSSLUtils {
     String trustStoreLocation = consumerProps.getProperty(SSL_TRUSTSTORE_LOCATION);
     String trustStorePassword = consumerProps.getProperty(SSL_TRUSTSTORE_PASSWORD);
     String serverCertificate = consumerProps.getProperty(STREAM_KAFKA_SSL_SERVER_CERTIFICATE);
+    if (StringUtils.isNotEmpty(serverCertificate)) {
+      validateAutoSslProperties(consumerProps, SSL_TRUSTSTORE_LOCATION, SSL_TRUSTSTORE_PASSWORD,
+          STREAM_KAFKA_SSL_SERVER_CERTIFICATE, STREAM_KAFKA_SSL_CERTIFICATE_TYPE, SSL_TRUSTSTORE_TYPE);
+
+      String clientCertificate = consumerProps.getProperty(STREAM_KAFKA_SSL_CLIENT_CERTIFICATE);
+      if (StringUtils.isNotEmpty(clientCertificate)) {
+        validateAutoSslProperties(consumerProps, SSL_KEYSTORE_LOCATION, SSL_KEYSTORE_PASSWORD, SSL_KEY_PASSWORD,
+            STREAM_KAFKA_SSL_CLIENT_CERTIFICATE, STREAM_KAFKA_SSL_CLIENT_KEY,
+            STREAM_KAFKA_SSL_CLIENT_KEY_ALGORITHM, SSL_KEYSTORE_TYPE);
+      }
+    }
     if (StringUtils.isAnyEmpty(trustStoreLocation, trustStorePassword, serverCertificate)) {
       LOGGER.info("Skipping auto SSL server validation since it's not configured.");
       return;
     }
+    validateAutoSslMaterial(consumerProps);
     if (shouldRenewTrustStore(consumerProps)) {
       initTrustStore(consumerProps);
     }
@@ -108,23 +131,52 @@ public class KafkaSSLUtils {
     }
   }
 
+  private static void validateAutoSslProperties(Properties consumerProps, String... propertyNames) {
+    for (String propertyName : propertyNames) {
+      String value = consumerProps.getProperty(propertyName);
+      if (value != null && ConfigTransformer.DEFAULT_PATTERN.matcher(value).find()) {
+        throw new IllegalArgumentException("Kafka ConfigProvider references are not supported for '" + propertyName
+            + "' when Pinot auto-generates Kafka SSL stores; use a prebuilt keystore or truststore file instead");
+      }
+    }
+  }
+
+  private static void validateAutoSslMaterial(Properties consumerProps) {
+    try {
+      Paths.get(consumerProps.getProperty(SSL_TRUSTSTORE_LOCATION));
+      String certificateType = consumerProps.getProperty(STREAM_KAFKA_SSL_CERTIFICATE_TYPE, DEFAULT_CERTIFICATE_TYPE);
+      CertificateFactory certificateFactory = CertificateFactory.getInstance(certificateType);
+      certificateFactory.generateCertificate(new ByteArrayInputStream(
+          Base64.getDecoder().decode(consumerProps.getProperty(STREAM_KAFKA_SSL_SERVER_CERTIFICATE))));
+      KeyStore.getInstance(consumerProps.getProperty(SSL_TRUSTSTORE_TYPE, DEFAULT_TRUSTSTORE_TYPE));
+
+      String keyStoreLocation = consumerProps.getProperty(SSL_KEYSTORE_LOCATION);
+      String keyStorePassword = consumerProps.getProperty(SSL_KEYSTORE_PASSWORD);
+      String keyPassword = consumerProps.getProperty(SSL_KEY_PASSWORD);
+      String clientCertificate = consumerProps.getProperty(STREAM_KAFKA_SSL_CLIENT_CERTIFICATE);
+      if (StringUtils.isAnyEmpty(keyStoreLocation, keyStorePassword, keyPassword, clientCertificate)) {
+        return;
+      }
+
+      Paths.get(keyStoreLocation);
+      Certificate parsedClientCertificate = certificateFactory.generateCertificate(
+          new ByteArrayInputStream(Base64.getDecoder().decode(clientCertificate)));
+      KeyStore.getInstance(consumerProps.getProperty(SSL_KEYSTORE_TYPE, DEFAULT_KEYSTORE_TYPE));
+      byte[] privateKey = Base64.getDecoder().decode(consumerProps.getProperty(STREAM_KAFKA_SSL_CLIENT_KEY));
+      String privateKeyAlgorithm = consumerProps.getProperty(STREAM_KAFKA_SSL_CLIENT_KEY_ALGORITHM,
+          DEFAULT_KEY_ALGORITHM);
+      PrivateKey parsedPrivateKey =
+          KeyFactory.getInstance(privateKeyAlgorithm).generatePrivate(new PKCS8EncodedKeySpec(privateKey));
+      validatePrivateKeyMatchesPublicKey(parsedPrivateKey, parsedClientCertificate.getPublicKey());
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Invalid configuration for Pinot-generated Kafka SSL stores", e);
+    }
+  }
+
   @VisibleForTesting
   static void initTrustStore(Properties consumerProps) {
     Path trustStorePath = getTrustStorePath(consumerProps);
-    if (Files.exists(trustStorePath)) {
-      deleteFile(trustStorePath);
-    }
     LOGGER.info("Initializing the SSL trust store");
-    try {
-      // Create the trust store path
-      createFile(trustStorePath);
-    } catch (FileAlreadyExistsException fex) {
-      LOGGER.warn("SSL trust store initialization failed as trust store already exists.");
-      return;
-    } catch (IOException iex) {
-      throw new RuntimeException(String.format("Failed to create the trust store path: %s", trustStorePath), iex);
-    }
-
     try {
       String trustStorePassword = consumerProps.getProperty(SSL_TRUSTSTORE_PASSWORD);
       String serverCertificate = consumerProps.getProperty(STREAM_KAFKA_SSL_SERVER_CERTIFICATE);
@@ -149,10 +201,7 @@ public class KafkaSSLUtils {
       // Add the server certificate to the truststore
       trustStore.setCertificateEntry(DEFAULT_SERVER_ALIAS, certificate);
 
-      // Save the keystore to a file
-      try (FileOutputStream fos = new FileOutputStream(trustStorePath.toString())) {
-        trustStore.store(fos, trustStorePassword.toCharArray());
-      }
+      writeKeyStoreAtomically(trustStorePath, trustStore, trustStorePassword);
       LOGGER.info("Initialized the SSL trust store.");
     } catch (Exception ex) {
       throw new RuntimeException("Error initializing the SSL trust store", ex);
@@ -162,20 +211,7 @@ public class KafkaSSLUtils {
   @VisibleForTesting
   static void initKeyStore(Properties consumerProps) {
     Path keyStorePath = getKeyStorePath(consumerProps);
-    if (Files.exists(keyStorePath)) {
-      deleteFile(keyStorePath);
-    }
     LOGGER.info("Initializing the SSL key store");
-    try {
-      // Create the key store path
-      createFile(keyStorePath);
-    } catch (FileAlreadyExistsException fex) {
-      LOGGER.warn("SSL key store initialization failed as key store already exists.");
-      return;
-    } catch (IOException iex) {
-      throw new RuntimeException(String.format("Failed to create the key store path: %s", keyStorePath), iex);
-    }
-
     String keyStorePassword = consumerProps.getProperty(SSL_KEYSTORE_PASSWORD);
     String keyPassword = consumerProps.getProperty(SSL_KEY_PASSWORD);
     String clientCertificate = consumerProps.getProperty(STREAM_KAFKA_SSL_CLIENT_CERTIFICATE);
@@ -200,6 +236,7 @@ public class KafkaSSLUtils {
       CertificateFactory certFactory = CertificateFactory.getInstance(certificateType);
       InputStream certInputStream = new ByteArrayInputStream(certBytes);
       Certificate certificate = certFactory.generateCertificate(certInputStream);
+      validatePrivateKeyMatchesPublicKey(privateKey, certificate.getPublicKey());
 
       // Create a KeyStore object and load a new empty keystore
       KeyStore keyStore = KeyStore.getInstance(keyStoreType);
@@ -212,10 +249,7 @@ public class KafkaSSLUtils {
       KeyStore.PasswordProtection keyPasswordProtection = new KeyStore.PasswordProtection(keyPassword.toCharArray());
       keyStore.setEntry(DEFAULT_CLIENT_ALIAS, privateKeyEntry, keyPasswordProtection);
 
-      // Save the keystore to the specified location
-      try (FileOutputStream fos = new FileOutputStream(keyStorePath.toString())) {
-        keyStore.store(fos, keyStorePassword.toCharArray());
-      }
+      writeKeyStoreAtomically(keyStorePath, keyStore, keyStorePassword);
       LOGGER.info("Initialized the SSL key store.");
     } catch (Exception ex) {
       throw new RuntimeException("Error initializing the SSL key store", ex);
@@ -230,6 +264,103 @@ public class KafkaSSLUtils {
   private static Path getKeyStorePath(Properties consumerProps) {
     String keyStoreLocation = consumerProps.getProperty(SSL_KEYSTORE_LOCATION);
     return Paths.get(keyStoreLocation);
+  }
+
+  private static void writeKeyStoreAtomically(Path storePath, KeyStore keyStore, String password)
+      throws Exception {
+    Path absoluteStorePath = storePath.toAbsolutePath();
+    Path parentDirectory = absoluteStorePath.getParent();
+    Files.createDirectories(parentDirectory);
+    Path temporaryStorePath = Files.createTempFile(parentDirectory, "pinot-kafka-ssl-", ".tmp");
+    try {
+      try (OutputStream outputStream = Files.newOutputStream(temporaryStorePath)) {
+        keyStore.store(outputStream, password.toCharArray());
+      }
+      try {
+        Files.move(temporaryStorePath, absoluteStorePath, StandardCopyOption.ATOMIC_MOVE,
+            StandardCopyOption.REPLACE_EXISTING);
+      } catch (AtomicMoveNotSupportedException e) {
+        throw new IOException("Atomic replacement is not supported for Kafka SSL store: " + absoluteStorePath, e);
+      }
+    } finally {
+      Files.deleteIfExists(temporaryStorePath);
+    }
+  }
+
+  @VisibleForTesting
+  static void validatePrivateKeyMatchesPublicKey(PrivateKey privateKey, PublicKey publicKey)
+      throws Exception {
+    String privateKeyFamily = getKeyFamily(privateKey.getAlgorithm());
+    String publicKeyFamily = getKeyFamily(publicKey.getAlgorithm());
+    if (!privateKeyFamily.equals(publicKeyFamily)) {
+      throw new IllegalArgumentException("Kafka SSL client private key algorithm does not match the certificate");
+    }
+
+    String signatureAlgorithm;
+    PSSParameterSpec pssParameterSpec = null;
+    if (privateKey instanceof EdECKey) {
+      signatureAlgorithm = ((EdECKey) privateKey).getParams().getName();
+    } else if (privateKey.getAlgorithm().equalsIgnoreCase("RSASSA-PSS")
+        || publicKey.getAlgorithm().equalsIgnoreCase("RSASSA-PSS")) {
+      signatureAlgorithm = "RSASSA-PSS";
+      pssParameterSpec = getPssParameterSpec(privateKey, publicKey);
+    } else {
+      switch (privateKey.getAlgorithm().toUpperCase(Locale.ROOT)) {
+        case "RSA":
+          signatureAlgorithm = "SHA256withRSA";
+          break;
+        case "EC":
+          signatureAlgorithm = "SHA256withECDSA";
+          break;
+        case "DSA":
+          int qSize = ((DSAKey) privateKey).getParams().getQ().bitLength();
+          signatureAlgorithm = qSize <= 160 ? "SHA1withDSA" : qSize <= 224 ? "SHA224withDSA" : "SHA256withDSA";
+          break;
+        default:
+          throw new IllegalArgumentException("Unsupported Kafka SSL client private key algorithm: "
+              + privateKey.getAlgorithm());
+      }
+    }
+
+    byte[] proof = "pinot-kafka-ssl-key-check".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    Signature signature = Signature.getInstance(signatureAlgorithm);
+    if (pssParameterSpec != null) {
+      signature.setParameter(pssParameterSpec);
+    }
+    signature.initSign(privateKey);
+    signature.update(proof);
+    byte[] signedProof = signature.sign();
+    signature.initVerify(publicKey);
+    signature.update(proof);
+    if (!signature.verify(signedProof)) {
+      throw new IllegalArgumentException("Kafka SSL client private key does not match the certificate");
+    }
+  }
+
+  private static String getKeyFamily(String algorithm) {
+    String normalizedAlgorithm = algorithm.toUpperCase(Locale.ROOT);
+    if (normalizedAlgorithm.equals("RSA") || normalizedAlgorithm.equals("RSASSA-PSS")) {
+      return "RSA";
+    }
+    if (normalizedAlgorithm.equals("EDDSA") || normalizedAlgorithm.equals("ED25519")
+        || normalizedAlgorithm.equals("ED448")) {
+      return "EDDSA";
+    }
+    return normalizedAlgorithm;
+  }
+
+  private static PSSParameterSpec getPssParameterSpec(PrivateKey privateKey, PublicKey publicKey) {
+    AlgorithmParameterSpec privateKeyParameters =
+        privateKey instanceof RSAKey ? ((RSAKey) privateKey).getParams() : null;
+    if (privateKeyParameters instanceof PSSParameterSpec) {
+      return (PSSParameterSpec) privateKeyParameters;
+    }
+    AlgorithmParameterSpec publicKeyParameters =
+        publicKey instanceof RSAKey ? ((RSAKey) publicKey).getParams() : null;
+    if (publicKeyParameters instanceof PSSParameterSpec) {
+      return (PSSParameterSpec) publicKeyParameters;
+    }
+    return new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
   }
 
   // Renew the trust store if needed.
@@ -312,27 +443,5 @@ public class KafkaSSLUtils {
       LOGGER.warn("Key store certificate and private key comparison checks failed.", ex);
     }
     return renewKeyStore;
-  }
-
-  private static void deleteFile(Path path) {
-    try {
-      Files.deleteIfExists(path);
-      LOGGER.info(String.format("Successfully deleted file: %s", path));
-    } catch (IOException iex) {
-      LOGGER.warn(String.format("Failed to delete the file: %s", path));
-    }
-  }
-
-  private static void createFile(Path path)
-      throws IOException {
-    Path parentDir = path.getParent();
-    if (parentDir != null) {
-      Files.createDirectories(parentDir);
-    }
-    Path filePath = path.toAbsolutePath();
-    if (!Files.exists(filePath)) {
-      Files.createFile(filePath);
-      LOGGER.info(String.format("Successfully created file: %s", path));
-    }
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaSSLUtils.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaSSLUtils.java
@@ -22,31 +22,21 @@ import com.google.common.annotations.VisibleForTesting;
 import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 import java.security.KeyFactory;
 import java.security.KeyStore;
 import java.security.PrivateKey;
-import java.security.PublicKey;
-import java.security.Signature;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
-import java.security.interfaces.DSAKey;
-import java.security.interfaces.EdECKey;
-import java.security.interfaces.RSAKey;
-import java.security.spec.AlgorithmParameterSpec;
-import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.PKCS8EncodedKeySpec;
-import java.security.spec.PSSParameterSpec;
 import java.util.Arrays;
 import java.util.Base64;
-import java.util.Locale;
 import java.util.Properties;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.common.config.ConfigTransformer;
@@ -107,7 +97,6 @@ public class KafkaSSLUtils {
       LOGGER.info("Skipping auto SSL server validation since it's not configured.");
       return;
     }
-    validateAutoSslMaterial(consumerProps);
     if (shouldRenewTrustStore(consumerProps)) {
       initTrustStore(consumerProps);
     }
@@ -141,42 +130,23 @@ public class KafkaSSLUtils {
     }
   }
 
-  private static void validateAutoSslMaterial(Properties consumerProps) {
-    try {
-      Paths.get(consumerProps.getProperty(SSL_TRUSTSTORE_LOCATION));
-      String certificateType = consumerProps.getProperty(STREAM_KAFKA_SSL_CERTIFICATE_TYPE, DEFAULT_CERTIFICATE_TYPE);
-      CertificateFactory certificateFactory = CertificateFactory.getInstance(certificateType);
-      certificateFactory.generateCertificate(new ByteArrayInputStream(
-          Base64.getDecoder().decode(consumerProps.getProperty(STREAM_KAFKA_SSL_SERVER_CERTIFICATE))));
-      KeyStore.getInstance(consumerProps.getProperty(SSL_TRUSTSTORE_TYPE, DEFAULT_TRUSTSTORE_TYPE));
-
-      String keyStoreLocation = consumerProps.getProperty(SSL_KEYSTORE_LOCATION);
-      String keyStorePassword = consumerProps.getProperty(SSL_KEYSTORE_PASSWORD);
-      String keyPassword = consumerProps.getProperty(SSL_KEY_PASSWORD);
-      String clientCertificate = consumerProps.getProperty(STREAM_KAFKA_SSL_CLIENT_CERTIFICATE);
-      if (StringUtils.isAnyEmpty(keyStoreLocation, keyStorePassword, keyPassword, clientCertificate)) {
-        return;
-      }
-
-      Paths.get(keyStoreLocation);
-      Certificate parsedClientCertificate = certificateFactory.generateCertificate(
-          new ByteArrayInputStream(Base64.getDecoder().decode(clientCertificate)));
-      KeyStore.getInstance(consumerProps.getProperty(SSL_KEYSTORE_TYPE, DEFAULT_KEYSTORE_TYPE));
-      byte[] privateKey = Base64.getDecoder().decode(consumerProps.getProperty(STREAM_KAFKA_SSL_CLIENT_KEY));
-      String privateKeyAlgorithm = consumerProps.getProperty(STREAM_KAFKA_SSL_CLIENT_KEY_ALGORITHM,
-          DEFAULT_KEY_ALGORITHM);
-      PrivateKey parsedPrivateKey =
-          KeyFactory.getInstance(privateKeyAlgorithm).generatePrivate(new PKCS8EncodedKeySpec(privateKey));
-      validatePrivateKeyMatchesPublicKey(parsedPrivateKey, parsedClientCertificate.getPublicKey());
-    } catch (Exception e) {
-      throw new IllegalArgumentException("Invalid configuration for Pinot-generated Kafka SSL stores", e);
-    }
-  }
-
   @VisibleForTesting
   static void initTrustStore(Properties consumerProps) {
     Path trustStorePath = getTrustStorePath(consumerProps);
+    if (Files.exists(trustStorePath)) {
+      deleteFile(trustStorePath);
+    }
     LOGGER.info("Initializing the SSL trust store");
+    try {
+      // Create the trust store path
+      createFile(trustStorePath);
+    } catch (FileAlreadyExistsException fex) {
+      LOGGER.warn("SSL trust store initialization failed as trust store already exists.");
+      return;
+    } catch (IOException iex) {
+      throw new RuntimeException(String.format("Failed to create the trust store path: %s", trustStorePath), iex);
+    }
+
     try {
       String trustStorePassword = consumerProps.getProperty(SSL_TRUSTSTORE_PASSWORD);
       String serverCertificate = consumerProps.getProperty(STREAM_KAFKA_SSL_SERVER_CERTIFICATE);
@@ -201,7 +171,10 @@ public class KafkaSSLUtils {
       // Add the server certificate to the truststore
       trustStore.setCertificateEntry(DEFAULT_SERVER_ALIAS, certificate);
 
-      writeKeyStoreAtomically(trustStorePath, trustStore, trustStorePassword);
+      // Save the keystore to a file
+      try (FileOutputStream fos = new FileOutputStream(trustStorePath.toString())) {
+        trustStore.store(fos, trustStorePassword.toCharArray());
+      }
       LOGGER.info("Initialized the SSL trust store.");
     } catch (Exception ex) {
       throw new RuntimeException("Error initializing the SSL trust store", ex);
@@ -211,7 +184,20 @@ public class KafkaSSLUtils {
   @VisibleForTesting
   static void initKeyStore(Properties consumerProps) {
     Path keyStorePath = getKeyStorePath(consumerProps);
+    if (Files.exists(keyStorePath)) {
+      deleteFile(keyStorePath);
+    }
     LOGGER.info("Initializing the SSL key store");
+    try {
+      // Create the key store path
+      createFile(keyStorePath);
+    } catch (FileAlreadyExistsException fex) {
+      LOGGER.warn("SSL key store initialization failed as key store already exists.");
+      return;
+    } catch (IOException iex) {
+      throw new RuntimeException(String.format("Failed to create the key store path: %s", keyStorePath), iex);
+    }
+
     String keyStorePassword = consumerProps.getProperty(SSL_KEYSTORE_PASSWORD);
     String keyPassword = consumerProps.getProperty(SSL_KEY_PASSWORD);
     String clientCertificate = consumerProps.getProperty(STREAM_KAFKA_SSL_CLIENT_CERTIFICATE);
@@ -236,7 +222,6 @@ public class KafkaSSLUtils {
       CertificateFactory certFactory = CertificateFactory.getInstance(certificateType);
       InputStream certInputStream = new ByteArrayInputStream(certBytes);
       Certificate certificate = certFactory.generateCertificate(certInputStream);
-      validatePrivateKeyMatchesPublicKey(privateKey, certificate.getPublicKey());
 
       // Create a KeyStore object and load a new empty keystore
       KeyStore keyStore = KeyStore.getInstance(keyStoreType);
@@ -249,7 +234,10 @@ public class KafkaSSLUtils {
       KeyStore.PasswordProtection keyPasswordProtection = new KeyStore.PasswordProtection(keyPassword.toCharArray());
       keyStore.setEntry(DEFAULT_CLIENT_ALIAS, privateKeyEntry, keyPasswordProtection);
 
-      writeKeyStoreAtomically(keyStorePath, keyStore, keyStorePassword);
+      // Save the keystore to the specified location
+      try (FileOutputStream fos = new FileOutputStream(keyStorePath.toString())) {
+        keyStore.store(fos, keyStorePassword.toCharArray());
+      }
       LOGGER.info("Initialized the SSL key store.");
     } catch (Exception ex) {
       throw new RuntimeException("Error initializing the SSL key store", ex);
@@ -264,103 +252,6 @@ public class KafkaSSLUtils {
   private static Path getKeyStorePath(Properties consumerProps) {
     String keyStoreLocation = consumerProps.getProperty(SSL_KEYSTORE_LOCATION);
     return Paths.get(keyStoreLocation);
-  }
-
-  private static void writeKeyStoreAtomically(Path storePath, KeyStore keyStore, String password)
-      throws Exception {
-    Path absoluteStorePath = storePath.toAbsolutePath();
-    Path parentDirectory = absoluteStorePath.getParent();
-    Files.createDirectories(parentDirectory);
-    Path temporaryStorePath = Files.createTempFile(parentDirectory, "pinot-kafka-ssl-", ".tmp");
-    try {
-      try (OutputStream outputStream = Files.newOutputStream(temporaryStorePath)) {
-        keyStore.store(outputStream, password.toCharArray());
-      }
-      try {
-        Files.move(temporaryStorePath, absoluteStorePath, StandardCopyOption.ATOMIC_MOVE,
-            StandardCopyOption.REPLACE_EXISTING);
-      } catch (AtomicMoveNotSupportedException e) {
-        throw new IOException("Atomic replacement is not supported for Kafka SSL store: " + absoluteStorePath, e);
-      }
-    } finally {
-      Files.deleteIfExists(temporaryStorePath);
-    }
-  }
-
-  @VisibleForTesting
-  static void validatePrivateKeyMatchesPublicKey(PrivateKey privateKey, PublicKey publicKey)
-      throws Exception {
-    String privateKeyFamily = getKeyFamily(privateKey.getAlgorithm());
-    String publicKeyFamily = getKeyFamily(publicKey.getAlgorithm());
-    if (!privateKeyFamily.equals(publicKeyFamily)) {
-      throw new IllegalArgumentException("Kafka SSL client private key algorithm does not match the certificate");
-    }
-
-    String signatureAlgorithm;
-    PSSParameterSpec pssParameterSpec = null;
-    if (privateKey instanceof EdECKey) {
-      signatureAlgorithm = ((EdECKey) privateKey).getParams().getName();
-    } else if (privateKey.getAlgorithm().equalsIgnoreCase("RSASSA-PSS")
-        || publicKey.getAlgorithm().equalsIgnoreCase("RSASSA-PSS")) {
-      signatureAlgorithm = "RSASSA-PSS";
-      pssParameterSpec = getPssParameterSpec(privateKey, publicKey);
-    } else {
-      switch (privateKey.getAlgorithm().toUpperCase(Locale.ROOT)) {
-        case "RSA":
-          signatureAlgorithm = "SHA256withRSA";
-          break;
-        case "EC":
-          signatureAlgorithm = "SHA256withECDSA";
-          break;
-        case "DSA":
-          int qSize = ((DSAKey) privateKey).getParams().getQ().bitLength();
-          signatureAlgorithm = qSize <= 160 ? "SHA1withDSA" : qSize <= 224 ? "SHA224withDSA" : "SHA256withDSA";
-          break;
-        default:
-          throw new IllegalArgumentException("Unsupported Kafka SSL client private key algorithm: "
-              + privateKey.getAlgorithm());
-      }
-    }
-
-    byte[] proof = "pinot-kafka-ssl-key-check".getBytes(java.nio.charset.StandardCharsets.UTF_8);
-    Signature signature = Signature.getInstance(signatureAlgorithm);
-    if (pssParameterSpec != null) {
-      signature.setParameter(pssParameterSpec);
-    }
-    signature.initSign(privateKey);
-    signature.update(proof);
-    byte[] signedProof = signature.sign();
-    signature.initVerify(publicKey);
-    signature.update(proof);
-    if (!signature.verify(signedProof)) {
-      throw new IllegalArgumentException("Kafka SSL client private key does not match the certificate");
-    }
-  }
-
-  private static String getKeyFamily(String algorithm) {
-    String normalizedAlgorithm = algorithm.toUpperCase(Locale.ROOT);
-    if (normalizedAlgorithm.equals("RSA") || normalizedAlgorithm.equals("RSASSA-PSS")) {
-      return "RSA";
-    }
-    if (normalizedAlgorithm.equals("EDDSA") || normalizedAlgorithm.equals("ED25519")
-        || normalizedAlgorithm.equals("ED448")) {
-      return "EDDSA";
-    }
-    return normalizedAlgorithm;
-  }
-
-  private static PSSParameterSpec getPssParameterSpec(PrivateKey privateKey, PublicKey publicKey) {
-    AlgorithmParameterSpec privateKeyParameters =
-        privateKey instanceof RSAKey ? ((RSAKey) privateKey).getParams() : null;
-    if (privateKeyParameters instanceof PSSParameterSpec) {
-      return (PSSParameterSpec) privateKeyParameters;
-    }
-    AlgorithmParameterSpec publicKeyParameters =
-        publicKey instanceof RSAKey ? ((RSAKey) publicKey).getParams() : null;
-    if (publicKeyParameters instanceof PSSParameterSpec) {
-      return (PSSParameterSpec) publicKeyParameters;
-    }
-    return new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
   }
 
   // Renew the trust store if needed.
@@ -443,5 +334,27 @@ public class KafkaSSLUtils {
       LOGGER.warn("Key store certificate and private key comparison checks failed.", ex);
     }
     return renewKeyStore;
+  }
+
+  private static void deleteFile(Path path) {
+    try {
+      Files.deleteIfExists(path);
+      LOGGER.info(String.format("Successfully deleted file: %s", path));
+    } catch (IOException iex) {
+      LOGGER.warn(String.format("Failed to delete the file: %s", path));
+    }
+  }
+
+  private static void createFile(Path path)
+      throws IOException {
+    Path parentDir = path.getParent();
+    if (parentDir != null) {
+      Files.createDirectories(parentDir);
+    }
+    Path filePath = path.toAbsolutePath();
+    if (!Files.exists(filePath)) {
+      Files.createFile(filePath);
+      LOGGER.info(String.format("Successfully created file: %s", path));
+    }
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/test/java/org/apache/pinot/plugin/stream/kafka/KafkaConfigProviderTestUtils.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/test/java/org/apache/pinot/plugin/stream/kafka/KafkaConfigProviderTestUtils.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.kafka;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.config.provider.FileConfigProvider;
+import org.apache.kafka.common.serialization.BytesDeserializer;
+import org.apache.pinot.spi.config.ConfigUtils;
+import org.apache.pinot.spi.config.table.IndexingConfig;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+
+/// Test helper that verifies ConfigProvider resolution against the Kafka client version on the caller's classpath.
+public class KafkaConfigProviderTestUtils {
+  private KafkaConfigProviderTestUtils() {
+  }
+
+  public static void assertConfigProviderReferencesReachKafkaClients()
+      throws Exception {
+    Path providerFile = Files.createTempFile("kafka-config-provider", ".properties");
+    try {
+      Files.writeString(providerFile, "keystore.password=test-password\n");
+
+      String passwordReference = "${file:" + providerFile + ":keystore.password}";
+      Map<String, String> streamConfigs = new HashMap<>();
+      streamConfigs.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+      streamConfigs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class.getName());
+      streamConfigs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class.getName());
+      streamConfigs.put(AbstractConfig.CONFIG_PROVIDERS_CONFIG, "file");
+      streamConfigs.put("config.providers.file.class", FileConfigProvider.class.getName());
+      streamConfigs.put("config.providers.file.param.allowed.paths", providerFile.getParent().toString());
+      streamConfigs.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, "$" + passwordReference);
+      streamConfigs.put("streamType", "kafka");
+
+      IndexingConfig indexingConfig = new IndexingConfig();
+      indexingConfig.setStreamConfigs(streamConfigs);
+      IndexingConfig resolvedIndexingConfig =
+          ConfigUtils.applyConfigWithEnvVariablesAndSystemProperties(Map.of(), indexingConfig);
+      Properties properties = new Properties();
+      properties.putAll(resolvedIndexingConfig.getStreamConfigs());
+      assertEquals(properties.getProperty(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG), passwordReference);
+
+      Properties consumerProperties =
+          KafkaConfigUtils.filterAndValidateKafkaProperties(properties, ConsumerConfig.configNames());
+      assertProviderProperties(consumerProperties, providerFile);
+      assertEquals(new ConsumerConfig(consumerProperties).getPassword(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG).value(),
+          "test-password");
+
+      Properties adminProperties =
+          KafkaConfigUtils.filterAndValidateKafkaProperties(properties, AdminClientConfig.configNames());
+      assertProviderProperties(adminProperties, providerFile);
+      assertEquals(new AdminClientConfig(adminProperties).getPassword(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG).value(),
+          "test-password");
+    } finally {
+      Files.deleteIfExists(providerFile);
+    }
+  }
+
+  private static void assertProviderProperties(Properties properties, Path providerFile) {
+    assertEquals(properties.getProperty(AbstractConfig.CONFIG_PROVIDERS_CONFIG), "file");
+    assertEquals(properties.getProperty("config.providers.file.class"), FileConfigProvider.class.getName());
+    assertEquals(properties.getProperty("config.providers.file.param.allowed.paths"),
+        providerFile.getParent().toString());
+    assertFalse(properties.containsKey("streamType"));
+  }
+}

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/test/java/org/apache/pinot/plugin/stream/kafka/KafkaConfigUtilsTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/test/java/org/apache/pinot/plugin/stream/kafka/KafkaConfigUtilsTest.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.kafka;
+
+import java.util.Properties;
+import java.util.Set;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.provider.FileConfigProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.expectThrows;
+
+
+public class KafkaConfigUtilsTest {
+
+  @Test
+  public void testFilterKafkaPropertiesPreservesConfigProviders() {
+    Properties properties = createFileProviderProperties();
+    properties.setProperty("bootstrap.servers", "localhost:9092");
+    properties.setProperty("streamType", "kafka");
+
+    Properties filteredProperties =
+        KafkaConfigUtils.filterAndValidateKafkaProperties(properties,
+            Set.of("bootstrap.servers", "ssl.keystore.password"));
+
+    assertEquals(filteredProperties.getProperty("bootstrap.servers"), "localhost:9092");
+    assertEquals(filteredProperties.getProperty(AbstractConfig.CONFIG_PROVIDERS_CONFIG), "file");
+    assertEquals(filteredProperties.getProperty("config.providers.file.class"), FileConfigProvider.class.getName());
+    assertEquals(filteredProperties.getProperty("config.providers.file.param.allowed.paths"), "/vault/secrets");
+    assertFalse(filteredProperties.containsKey("streamType"));
+  }
+
+  @Test
+  public void testFilterKafkaPropertiesRejectsUndeclaredProvider() {
+    Properties properties = new Properties();
+    properties.setProperty("ssl.keystore.password", "${file:/vault/secrets/kafka.properties:password}");
+
+    ConfigException exception = expectThrows(ConfigException.class,
+        () -> KafkaConfigUtils.filterAndValidateKafkaProperties(properties, Set.of("ssl.keystore.password")));
+
+    assertEquals(exception.getMessage(), "Kafka ConfigProvider alias 'file' referenced by 'ssl.keystore.password' "
+        + "is not listed in 'config.providers'");
+  }
+
+  @Test
+  public void testFilterKafkaPropertiesRejectsProviderWithoutClass() {
+    Properties properties = new Properties();
+    properties.setProperty(AbstractConfig.CONFIG_PROVIDERS_CONFIG, "file");
+    properties.setProperty("ssl.keystore.password", "${file:/vault/secrets/kafka.properties:password}");
+
+    ConfigException exception = expectThrows(ConfigException.class,
+        () -> KafkaConfigUtils.filterAndValidateKafkaProperties(properties, Set.of("ssl.keystore.password")));
+
+    assertEquals(exception.getMessage(), "Kafka ConfigProvider alias 'file' referenced by 'ssl.keystore.password' "
+        + "does not define 'config.providers.file.class'");
+  }
+
+  @Test
+  public void testFilterKafkaPropertiesRequiresAllowedPathsForFileProvider() {
+    Properties properties = createFileProviderProperties();
+    properties.remove("config.providers.file.param.allowed.paths");
+
+    ConfigException exception = expectThrows(ConfigException.class,
+        () -> KafkaConfigUtils.filterAndValidateKafkaProperties(properties, Set.of("ssl.keystore.password")));
+
+    assertEquals(exception.getMessage(), "Kafka FileConfigProvider alias 'file' referenced by "
+        + "'ssl.keystore.password' must define 'config.providers.file.param.allowed.paths'");
+  }
+
+  private static Properties createFileProviderProperties() {
+    Properties properties = new Properties();
+    properties.setProperty(AbstractConfig.CONFIG_PROVIDERS_CONFIG, "file");
+    properties.setProperty("config.providers.file.class", FileConfigProvider.class.getName());
+    properties.setProperty("config.providers.file.param.allowed.paths", "/vault/secrets");
+    properties.setProperty("ssl.keystore.password", "${file:/vault/secrets/kafka.properties:password}");
+    return properties;
+  }
+}

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/test/java/org/apache/pinot/plugin/stream/kafka/KafkaSSLUtilsTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/test/java/org/apache/pinot/plugin/stream/kafka/KafkaSSLUtilsTest.java
@@ -32,12 +32,8 @@ import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.SecureRandom;
 import java.security.Security;
-import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.security.spec.MGF1ParameterSpec;
-import java.security.spec.PSSParameterSpec;
-import java.security.spec.RSAKeyGenParameterSpec;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Enumeration;
@@ -216,85 +212,6 @@ public class KafkaSSLUtilsTest {
     Assert.assertTrue(Arrays.equals(Files.readAllBytes(Paths.get(_trustStorePath)), originalTrustStore));
   }
 
-  @Test
-  public void testInitSSLValidatesAllMaterialBeforeRenewingExistingStore()
-      throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, NoSuchProviderException,
-             IOException {
-    Properties consumerProps = new Properties();
-    setTrustStoreProps(consumerProps);
-    KafkaSSLUtils.initSSL(consumerProps);
-    byte[] originalTrustStore = Files.readAllBytes(Paths.get(_trustStorePath));
-
-    setTrustStoreProps(consumerProps);
-    setKeyStoreProps(consumerProps);
-    consumerProps.setProperty("stream.kafka.ssl.client.key", "not-base64");
-
-    Assert.expectThrows(IllegalArgumentException.class, () -> KafkaSSLUtils.initSSL(consumerProps));
-
-    Assert.assertTrue(Arrays.equals(Files.readAllBytes(Paths.get(_trustStorePath)), originalTrustStore));
-  }
-
-  @Test
-  public void testInitSSLRejectsMismatchedClientKeyBeforeRenewingExistingStore()
-      throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, NoSuchProviderException,
-             IOException {
-    Properties consumerProps = new Properties();
-    setTrustStoreProps(consumerProps);
-    KafkaSSLUtils.initSSL(consumerProps);
-    byte[] originalTrustStore = Files.readAllBytes(Paths.get(_trustStorePath));
-
-    setTrustStoreProps(consumerProps);
-    setKeyStoreProps(consumerProps);
-    consumerProps.setProperty("stream.kafka.ssl.client.key", generateSelfSignedCertificate()[0]);
-
-    Assert.expectThrows(IllegalArgumentException.class, () -> KafkaSSLUtils.initSSL(consumerProps));
-
-    Assert.assertTrue(Arrays.equals(Files.readAllBytes(Paths.get(_trustStorePath)), originalTrustStore));
-  }
-
-  @Test
-  public void testPrivateKeyProofSupportsConfiguredAlgorithms()
-      throws Exception {
-    for (String algorithm : new String[]{"RSA", "RSASSA-PSS", "EC", "DSA", "Ed25519", "Ed448"}) {
-      KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(algorithm);
-      if (algorithm.equals("RSA") || algorithm.equals("RSASSA-PSS")) {
-        keyPairGenerator.initialize(2048);
-      } else if (algorithm.equals("EC")) {
-        keyPairGenerator.initialize(256);
-      } else if (algorithm.equals("DSA")) {
-        keyPairGenerator.initialize(1024);
-      }
-      KeyPair keyPair = keyPairGenerator.generateKeyPair();
-
-      KafkaSSLUtils.validatePrivateKeyMatchesPublicKey(keyPair.getPrivate(), keyPair.getPublic());
-    }
-
-    PSSParameterSpec sha384Pss =
-        new PSSParameterSpec("SHA-384", "MGF1", MGF1ParameterSpec.SHA384, 48, 1);
-    KeyPairGenerator constrainedPssGenerator = KeyPairGenerator.getInstance("RSASSA-PSS");
-    constrainedPssGenerator.initialize(
-        new RSAKeyGenParameterSpec(2048, RSAKeyGenParameterSpec.F4, sha384Pss));
-    KeyPair constrainedPssKeyPair = constrainedPssGenerator.generateKeyPair();
-    KafkaSSLUtils.validatePrivateKeyMatchesPublicKey(constrainedPssKeyPair.getPrivate(),
-        constrainedPssKeyPair.getPublic());
-  }
-
-  @Test
-  public void testInitTrustStoreFailureKeepsExistingStore()
-      throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, NoSuchProviderException,
-             IOException {
-    Properties consumerProps = new Properties();
-    setTrustStoreProps(consumerProps);
-    KafkaSSLUtils.initTrustStore(consumerProps);
-    byte[] originalTrustStore = Files.readAllBytes(Paths.get(_trustStorePath));
-
-    consumerProps.setProperty("stream.kafka.ssl.server.certificate", "not-base64");
-
-    Assert.expectThrows(RuntimeException.class, () -> KafkaSSLUtils.initTrustStore(consumerProps));
-
-    Assert.assertTrue(Arrays.equals(Files.readAllBytes(Paths.get(_trustStorePath)), originalTrustStore));
-  }
-
   @Test (expectedExceptions = java.io.FileNotFoundException.class)
   public void testInitSSLKeyStoreOnly()
       throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, NoSuchProviderException,
@@ -312,38 +229,19 @@ public class KafkaSSLUtilsTest {
   @Test
   public void testInitSSLAndRenewCertificates()
       throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, NoSuchProviderException,
-             IOException, KeyStoreException, UnrecoverableKeyException {
+             IOException, KeyStoreException {
     Properties consumerProps = new Properties();
     setTrustStoreProps(consumerProps);
     setKeyStoreProps(consumerProps);
     KafkaSSLUtils.initSSL(consumerProps);
-    byte[] firstServerCertificate =
-        loadTrustStore().getCertificate("ServerAlias").getEncoded();
-    byte[] firstClientCertificate =
-        loadKeyStore().getCertificate("ClientAlias").getEncoded();
-    byte[] firstClientKey = loadKeyStore().getKey("ClientAlias", "mykeypwd".toCharArray()).getEncoded();
-
     // renew the truststore and keystore
     setTrustStoreProps(consumerProps);
     setKeyStoreProps(consumerProps);
-    byte[] expectedServerCertificate =
-        Base64.decode(consumerProps.getProperty("stream.kafka.ssl.server.certificate"));
-    byte[] expectedClientCertificate =
-        Base64.decode(consumerProps.getProperty("stream.kafka.ssl.client.certificate"));
-    byte[] expectedClientKey = Base64.decode(consumerProps.getProperty("stream.kafka.ssl.client.key"));
     KafkaSSLUtils.initSSL(consumerProps);
 
-    byte[] renewedServerCertificate =
-        loadTrustStore().getCertificate("ServerAlias").getEncoded();
-    byte[] renewedClientCertificate =
-        loadKeyStore().getCertificate("ClientAlias").getEncoded();
-    byte[] renewedClientKey = loadKeyStore().getKey("ClientAlias", "mykeypwd".toCharArray()).getEncoded();
-    Assert.assertTrue(Arrays.equals(renewedServerCertificate, expectedServerCertificate));
-    Assert.assertTrue(Arrays.equals(renewedClientCertificate, expectedClientCertificate));
-    Assert.assertTrue(Arrays.equals(renewedClientKey, expectedClientKey));
-    Assert.assertFalse(Arrays.equals(renewedServerCertificate, firstServerCertificate));
-    Assert.assertFalse(Arrays.equals(renewedClientCertificate, firstClientCertificate));
-    Assert.assertFalse(Arrays.equals(renewedClientKey, firstClientKey));
+    // validate
+    validateTrustStoreCertificateCount(1);
+    validateKeyStoreCertificateCount(1);
   }
 
   @Test
@@ -374,7 +272,10 @@ public class KafkaSSLUtilsTest {
   private void validateTrustStoreCertificateCount(int expCount)
       throws CertificateException, IOException, NoSuchAlgorithmException, KeyStoreException {
     // Validate that certificate is installed in the trust store
-    KeyStore trustStore = loadTrustStore();
+    KeyStore trustStore = KeyStore.getInstance("JKS");
+    try (FileInputStream fis = new FileInputStream(_trustStorePath)) {
+      trustStore.load(fis, DEFAULT_TRUSTSTORE_PASSWORD.toCharArray());
+    }
 
     int certCount = 0;
     // Iterate through the aliases in the TrustStore
@@ -392,7 +293,10 @@ public class KafkaSSLUtilsTest {
   private void validateKeyStoreCertificateCount(int expCount)
       throws CertificateException, IOException, NoSuchAlgorithmException, KeyStoreException {
     // Validate that certificate is installed in the key store
-    KeyStore keyStore = loadKeyStore();
+    KeyStore keyStore = KeyStore.getInstance("PKCS12");
+    try (FileInputStream fis = new FileInputStream(_keyStorePath)) {
+      keyStore.load(fis, DEFAULT_KEYSTORE_PASSWORD.toCharArray());
+    }
 
     int certCount = 0;
     // Iterate through the aliases in the TrustStore
@@ -405,24 +309,6 @@ public class KafkaSSLUtilsTest {
       }
     }
     Assert.assertEquals(expCount, certCount);
-  }
-
-  private KeyStore loadTrustStore()
-      throws KeyStoreException, IOException, CertificateException, NoSuchAlgorithmException {
-    KeyStore trustStore = KeyStore.getInstance("JKS");
-    try (FileInputStream fis = new FileInputStream(_trustStorePath)) {
-      trustStore.load(fis, DEFAULT_TRUSTSTORE_PASSWORD.toCharArray());
-    }
-    return trustStore;
-  }
-
-  private KeyStore loadKeyStore()
-      throws KeyStoreException, IOException, CertificateException, NoSuchAlgorithmException {
-    KeyStore keyStore = KeyStore.getInstance("PKCS12");
-    try (FileInputStream fis = new FileInputStream(_keyStorePath)) {
-      keyStore.load(fis, DEFAULT_KEYSTORE_PASSWORD.toCharArray());
-    }
-    return keyStore;
   }
 
   private void setTrustStoreProps(Properties consumerProps)

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/test/java/org/apache/pinot/plugin/stream/kafka/KafkaSSLUtilsTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/test/java/org/apache/pinot/plugin/stream/kafka/KafkaSSLUtilsTest.java
@@ -32,8 +32,13 @@ import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.SecureRandom;
 import java.security.Security;
+import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.PSSParameterSpec;
+import java.security.spec.RSAKeyGenParameterSpec;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.Properties;
@@ -141,6 +146,155 @@ public class KafkaSSLUtilsTest {
     validateTrustStoreCertificateCount(1);
   }
 
+  @Test
+  public void testInitSSLRejectsConfigProviderTrustStorePassword() {
+    Properties consumerProps = new Properties();
+    consumerProps.setProperty("ssl.truststore.location", _trustStorePath);
+    consumerProps.setProperty("ssl.truststore.password", "${file:/vault/secrets/kafka.properties:password}");
+    consumerProps.setProperty("stream.kafka.ssl.server.certificate", "certificate");
+
+    IllegalArgumentException exception =
+        Assert.expectThrows(IllegalArgumentException.class, () -> KafkaSSLUtils.initSSL(consumerProps));
+
+    Assert.assertEquals(exception.getMessage(), "Kafka ConfigProvider references are not supported for "
+        + "'ssl.truststore.password' when Pinot auto-generates Kafka SSL stores; use a prebuilt keystore or "
+        + "truststore file instead");
+  }
+
+  @Test
+  public void testInitSSLRejectsConfigProviderKeyStorePassword()
+      throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, NoSuchProviderException {
+    Properties consumerProps = new Properties();
+    setTrustStoreProps(consumerProps);
+    setKeyStoreProps(consumerProps);
+    consumerProps.setProperty("ssl.keystore.password", "${file:/vault/secrets/kafka.properties:password}");
+
+    IllegalArgumentException exception =
+        Assert.expectThrows(IllegalArgumentException.class, () -> KafkaSSLUtils.initSSL(consumerProps));
+
+    Assert.assertEquals(exception.getMessage(), "Kafka ConfigProvider references are not supported for "
+        + "'ssl.keystore.password' when Pinot auto-generates Kafka SSL stores; use a prebuilt keystore or truststore "
+        + "file instead");
+  }
+
+  @Test
+  public void testInitSSLRejectsConfigProviderKeyPassword()
+      throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, NoSuchProviderException {
+    Properties consumerProps = new Properties();
+    setTrustStoreProps(consumerProps);
+    setKeyStoreProps(consumerProps);
+    consumerProps.setProperty("ssl.key.password", "${file:/vault/secrets/kafka.properties:password}");
+
+    IllegalArgumentException exception =
+        Assert.expectThrows(IllegalArgumentException.class, () -> KafkaSSLUtils.initSSL(consumerProps));
+
+    Assert.assertEquals(exception.getMessage(), "Kafka ConfigProvider references are not supported for "
+        + "'ssl.key.password' when Pinot auto-generates Kafka SSL stores; use a prebuilt keystore or truststore file "
+        + "instead");
+  }
+
+  @Test
+  public void testInitSSLRejectsConfigProviderBeforeRenewingExistingStore()
+      throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, NoSuchProviderException,
+             IOException {
+    Properties consumerProps = new Properties();
+    setTrustStoreProps(consumerProps);
+    KafkaSSLUtils.initSSL(consumerProps);
+    byte[] originalTrustStore = Files.readAllBytes(Paths.get(_trustStorePath));
+
+    setTrustStoreProps(consumerProps);
+    setKeyStoreProps(consumerProps);
+    consumerProps.setProperty("stream.kafka.ssl.client.key.algorithm",
+        "${file:/vault/secrets/kafka.properties:algorithm}");
+
+    IllegalArgumentException exception =
+        Assert.expectThrows(IllegalArgumentException.class, () -> KafkaSSLUtils.initSSL(consumerProps));
+
+    Assert.assertEquals(exception.getMessage(), "Kafka ConfigProvider references are not supported for "
+        + "'stream.kafka.ssl.client.key.algorithm' when Pinot auto-generates Kafka SSL stores; use a prebuilt "
+        + "keystore or truststore file instead");
+    Assert.assertTrue(Arrays.equals(Files.readAllBytes(Paths.get(_trustStorePath)), originalTrustStore));
+  }
+
+  @Test
+  public void testInitSSLValidatesAllMaterialBeforeRenewingExistingStore()
+      throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, NoSuchProviderException,
+             IOException {
+    Properties consumerProps = new Properties();
+    setTrustStoreProps(consumerProps);
+    KafkaSSLUtils.initSSL(consumerProps);
+    byte[] originalTrustStore = Files.readAllBytes(Paths.get(_trustStorePath));
+
+    setTrustStoreProps(consumerProps);
+    setKeyStoreProps(consumerProps);
+    consumerProps.setProperty("stream.kafka.ssl.client.key", "not-base64");
+
+    Assert.expectThrows(IllegalArgumentException.class, () -> KafkaSSLUtils.initSSL(consumerProps));
+
+    Assert.assertTrue(Arrays.equals(Files.readAllBytes(Paths.get(_trustStorePath)), originalTrustStore));
+  }
+
+  @Test
+  public void testInitSSLRejectsMismatchedClientKeyBeforeRenewingExistingStore()
+      throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, NoSuchProviderException,
+             IOException {
+    Properties consumerProps = new Properties();
+    setTrustStoreProps(consumerProps);
+    KafkaSSLUtils.initSSL(consumerProps);
+    byte[] originalTrustStore = Files.readAllBytes(Paths.get(_trustStorePath));
+
+    setTrustStoreProps(consumerProps);
+    setKeyStoreProps(consumerProps);
+    consumerProps.setProperty("stream.kafka.ssl.client.key", generateSelfSignedCertificate()[0]);
+
+    Assert.expectThrows(IllegalArgumentException.class, () -> KafkaSSLUtils.initSSL(consumerProps));
+
+    Assert.assertTrue(Arrays.equals(Files.readAllBytes(Paths.get(_trustStorePath)), originalTrustStore));
+  }
+
+  @Test
+  public void testPrivateKeyProofSupportsConfiguredAlgorithms()
+      throws Exception {
+    for (String algorithm : new String[]{"RSA", "RSASSA-PSS", "EC", "DSA", "Ed25519", "Ed448"}) {
+      KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(algorithm);
+      if (algorithm.equals("RSA") || algorithm.equals("RSASSA-PSS")) {
+        keyPairGenerator.initialize(2048);
+      } else if (algorithm.equals("EC")) {
+        keyPairGenerator.initialize(256);
+      } else if (algorithm.equals("DSA")) {
+        keyPairGenerator.initialize(1024);
+      }
+      KeyPair keyPair = keyPairGenerator.generateKeyPair();
+
+      KafkaSSLUtils.validatePrivateKeyMatchesPublicKey(keyPair.getPrivate(), keyPair.getPublic());
+    }
+
+    PSSParameterSpec sha384Pss =
+        new PSSParameterSpec("SHA-384", "MGF1", MGF1ParameterSpec.SHA384, 48, 1);
+    KeyPairGenerator constrainedPssGenerator = KeyPairGenerator.getInstance("RSASSA-PSS");
+    constrainedPssGenerator.initialize(
+        new RSAKeyGenParameterSpec(2048, RSAKeyGenParameterSpec.F4, sha384Pss));
+    KeyPair constrainedPssKeyPair = constrainedPssGenerator.generateKeyPair();
+    KafkaSSLUtils.validatePrivateKeyMatchesPublicKey(constrainedPssKeyPair.getPrivate(),
+        constrainedPssKeyPair.getPublic());
+  }
+
+  @Test
+  public void testInitTrustStoreFailureKeepsExistingStore()
+      throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, NoSuchProviderException,
+             IOException {
+    Properties consumerProps = new Properties();
+    setTrustStoreProps(consumerProps);
+    KafkaSSLUtils.initTrustStore(consumerProps);
+    byte[] originalTrustStore = Files.readAllBytes(Paths.get(_trustStorePath));
+
+    consumerProps.setProperty("stream.kafka.ssl.server.certificate", "not-base64");
+
+    Assert.expectThrows(RuntimeException.class, () -> KafkaSSLUtils.initTrustStore(consumerProps));
+
+    Assert.assertTrue(Arrays.equals(Files.readAllBytes(Paths.get(_trustStorePath)), originalTrustStore));
+  }
+
   @Test (expectedExceptions = java.io.FileNotFoundException.class)
   public void testInitSSLKeyStoreOnly()
       throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, NoSuchProviderException,
@@ -158,20 +312,38 @@ public class KafkaSSLUtilsTest {
   @Test
   public void testInitSSLAndRenewCertificates()
       throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, NoSuchProviderException,
-             IOException, KeyStoreException {
+             IOException, KeyStoreException, UnrecoverableKeyException {
     Properties consumerProps = new Properties();
     setTrustStoreProps(consumerProps);
     setKeyStoreProps(consumerProps);
     KafkaSSLUtils.initSSL(consumerProps);
+    byte[] firstServerCertificate =
+        loadTrustStore().getCertificate("ServerAlias").getEncoded();
+    byte[] firstClientCertificate =
+        loadKeyStore().getCertificate("ClientAlias").getEncoded();
+    byte[] firstClientKey = loadKeyStore().getKey("ClientAlias", "mykeypwd".toCharArray()).getEncoded();
 
     // renew the truststore and keystore
     setTrustStoreProps(consumerProps);
     setKeyStoreProps(consumerProps);
+    byte[] expectedServerCertificate =
+        Base64.decode(consumerProps.getProperty("stream.kafka.ssl.server.certificate"));
+    byte[] expectedClientCertificate =
+        Base64.decode(consumerProps.getProperty("stream.kafka.ssl.client.certificate"));
+    byte[] expectedClientKey = Base64.decode(consumerProps.getProperty("stream.kafka.ssl.client.key"));
     KafkaSSLUtils.initSSL(consumerProps);
 
-    // validate
-    validateTrustStoreCertificateCount(1);
-    validateKeyStoreCertificateCount(1);
+    byte[] renewedServerCertificate =
+        loadTrustStore().getCertificate("ServerAlias").getEncoded();
+    byte[] renewedClientCertificate =
+        loadKeyStore().getCertificate("ClientAlias").getEncoded();
+    byte[] renewedClientKey = loadKeyStore().getKey("ClientAlias", "mykeypwd".toCharArray()).getEncoded();
+    Assert.assertTrue(Arrays.equals(renewedServerCertificate, expectedServerCertificate));
+    Assert.assertTrue(Arrays.equals(renewedClientCertificate, expectedClientCertificate));
+    Assert.assertTrue(Arrays.equals(renewedClientKey, expectedClientKey));
+    Assert.assertFalse(Arrays.equals(renewedServerCertificate, firstServerCertificate));
+    Assert.assertFalse(Arrays.equals(renewedClientCertificate, firstClientCertificate));
+    Assert.assertFalse(Arrays.equals(renewedClientKey, firstClientKey));
   }
 
   @Test
@@ -202,10 +374,7 @@ public class KafkaSSLUtilsTest {
   private void validateTrustStoreCertificateCount(int expCount)
       throws CertificateException, IOException, NoSuchAlgorithmException, KeyStoreException {
     // Validate that certificate is installed in the trust store
-    KeyStore trustStore = KeyStore.getInstance("JKS");
-    try (FileInputStream fis = new FileInputStream(_trustStorePath)) {
-      trustStore.load(fis, DEFAULT_TRUSTSTORE_PASSWORD.toCharArray());
-    }
+    KeyStore trustStore = loadTrustStore();
 
     int certCount = 0;
     // Iterate through the aliases in the TrustStore
@@ -223,10 +392,7 @@ public class KafkaSSLUtilsTest {
   private void validateKeyStoreCertificateCount(int expCount)
       throws CertificateException, IOException, NoSuchAlgorithmException, KeyStoreException {
     // Validate that certificate is installed in the key store
-    KeyStore keyStore = KeyStore.getInstance("PKCS12");
-    try (FileInputStream fis = new FileInputStream(_keyStorePath)) {
-      keyStore.load(fis, DEFAULT_KEYSTORE_PASSWORD.toCharArray());
-    }
+    KeyStore keyStore = loadKeyStore();
 
     int certCount = 0;
     // Iterate through the aliases in the TrustStore
@@ -239,6 +405,24 @@ public class KafkaSSLUtilsTest {
       }
     }
     Assert.assertEquals(expCount, certCount);
+  }
+
+  private KeyStore loadTrustStore()
+      throws KeyStoreException, IOException, CertificateException, NoSuchAlgorithmException {
+    KeyStore trustStore = KeyStore.getInstance("JKS");
+    try (FileInputStream fis = new FileInputStream(_trustStorePath)) {
+      trustStore.load(fis, DEFAULT_TRUSTSTORE_PASSWORD.toCharArray());
+    }
+    return trustStore;
+  }
+
+  private KeyStore loadKeyStore()
+      throws KeyStoreException, IOException, CertificateException, NoSuchAlgorithmException {
+    KeyStore keyStore = KeyStore.getInstance("PKCS12");
+    try (FileInputStream fis = new FileInputStream(_keyStorePath)) {
+      keyStore.load(fis, DEFAULT_KEYSTORE_PASSWORD.toCharArray());
+    }
+    return keyStore;
   }
 
   private void setTrustStoreProps(Properties consumerProps)

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/ConfigUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/ConfigUtils.java
@@ -24,7 +24,9 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import org.apache.pinot.spi.utils.JsonUtils;
 
 
@@ -33,6 +35,7 @@ public class ConfigUtils {
   }
 
   private static final Map<String, String> ENVIRONMENT_VARIABLES = System.getenv();
+  private static final String CONFIG_PROVIDERS = "config.providers";
 
   /// Apply system properties and environment variables to any given BaseJsonConfig.
   /// Environment variables take precedence over system properties.
@@ -72,12 +75,19 @@ public class ConfigUtils {
 
   private static JsonNode applyConfigWithEnvVariablesAndSystemProperties(Map<String, String> configValues,
       JsonNode jsonNode) {
+    return applyConfigWithEnvVariablesAndSystemProperties(configValues, jsonNode, Set.of());
+  }
+
+  private static JsonNode applyConfigWithEnvVariablesAndSystemProperties(Map<String, String> configValues,
+      JsonNode jsonNode, Set<String> inheritedConfigProviders) {
     final JsonNodeType nodeType = jsonNode.getNodeType();
     switch (nodeType) {
       case OBJECT:
         if (!jsonNode.isEmpty()) {
+          Set<String> configProviders = getConfigProviders(jsonNode, inheritedConfigProviders);
           for (Map.Entry<String, JsonNode> next : jsonNode.properties()) {
-            next.setValue(applyConfigWithEnvVariablesAndSystemProperties(configValues, next.getValue()));
+            next.setValue(
+                applyConfigWithEnvVariablesAndSystemProperties(configValues, next.getValue(), configProviders));
           }
         }
         break;
@@ -86,13 +96,17 @@ public class ConfigUtils {
           ArrayNode arrayNode = (ArrayNode) jsonNode;
           for (int i = 0; i < arrayNode.size(); i++) {
             JsonNode arrayElement = arrayNode.get(i);
-            arrayNode.set(i, applyConfigWithEnvVariablesAndSystemProperties(configValues, arrayElement));
+            arrayNode.set(i,
+                applyConfigWithEnvVariablesAndSystemProperties(configValues, arrayElement, inheritedConfigProviders));
           }
         }
         break;
       case STRING:
         final String field = jsonNode.asText();
-        if (field.startsWith("${") && field.endsWith("}")) {
+        // Kafka ConfigProvider references share Pinot's ${name:value} syntax. Keep references for providers declared
+        // in the containing config object so Kafka can resolve them when constructing the client.
+        if (field.startsWith("${") && field.endsWith("}")
+            && !isConfigProviderReference(field, inheritedConfigProviders)) {
           String[] envVarSplits = field.substring(2, field.length() - 1).split(":", 2);
           String envVarKey = envVarSplits[0];
           String value = configValues.get(envVarKey);
@@ -108,5 +122,30 @@ public class ConfigUtils {
         break;
     }
     return jsonNode;
+  }
+
+  private static Set<String> getConfigProviders(JsonNode jsonNode, Set<String> inheritedConfigProviders) {
+    JsonNode configProvidersNode = jsonNode.get(CONFIG_PROVIDERS);
+    if (configProvidersNode == null || !configProvidersNode.isTextual()) {
+      return inheritedConfigProviders;
+    }
+
+    Set<String> configProviders = new HashSet<>(inheritedConfigProviders);
+    for (String configProvider : configProvidersNode.asText().split(",")) {
+      String trimmedConfigProvider = configProvider.trim();
+      if (!trimmedConfigProvider.isEmpty()) {
+        configProviders.add(trimmedConfigProvider);
+      }
+    }
+    return configProviders;
+  }
+
+  private static boolean isConfigProviderReference(String field, Set<String> configProviders) {
+    for (String configProvider : configProviders) {
+      if (field.startsWith("${" + configProvider + ":")) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/ConfigUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/ConfigUtils.java
@@ -24,9 +24,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import org.apache.pinot.spi.utils.JsonUtils;
 
 
@@ -35,7 +33,6 @@ public class ConfigUtils {
   }
 
   private static final Map<String, String> ENVIRONMENT_VARIABLES = System.getenv();
-  private static final String CONFIG_PROVIDERS = "config.providers";
 
   /// Apply system properties and environment variables to any given BaseJsonConfig.
   /// Environment variables take precedence over system properties.
@@ -51,7 +48,8 @@ public class ConfigUtils {
     return applyConfigWithEnvVariablesAndSystemProperties(combinedMap, config);
   }
 
-  /// Apply a map of config to any given BaseJsonConfig with templates.
+  /// Apply a map of config to any given BaseJsonConfig with templates. Prefix a template with an additional '$'
+  /// (for example, `$${name:value}`) to preserve it as a literal `${name:value}` for downstream processing.
   ///
   /// @return Config with the configs applied.
   public static <T extends BaseJsonConfig> T applyConfigWithEnvVariablesAndSystemProperties(
@@ -75,19 +73,12 @@ public class ConfigUtils {
 
   private static JsonNode applyConfigWithEnvVariablesAndSystemProperties(Map<String, String> configValues,
       JsonNode jsonNode) {
-    return applyConfigWithEnvVariablesAndSystemProperties(configValues, jsonNode, Set.of());
-  }
-
-  private static JsonNode applyConfigWithEnvVariablesAndSystemProperties(Map<String, String> configValues,
-      JsonNode jsonNode, Set<String> inheritedConfigProviders) {
     final JsonNodeType nodeType = jsonNode.getNodeType();
     switch (nodeType) {
       case OBJECT:
         if (!jsonNode.isEmpty()) {
-          Set<String> configProviders = getConfigProviders(jsonNode, inheritedConfigProviders);
           for (Map.Entry<String, JsonNode> next : jsonNode.properties()) {
-            next.setValue(
-                applyConfigWithEnvVariablesAndSystemProperties(configValues, next.getValue(), configProviders));
+            next.setValue(applyConfigWithEnvVariablesAndSystemProperties(configValues, next.getValue()));
           }
         }
         break;
@@ -96,17 +87,16 @@ public class ConfigUtils {
           ArrayNode arrayNode = (ArrayNode) jsonNode;
           for (int i = 0; i < arrayNode.size(); i++) {
             JsonNode arrayElement = arrayNode.get(i);
-            arrayNode.set(i,
-                applyConfigWithEnvVariablesAndSystemProperties(configValues, arrayElement, inheritedConfigProviders));
+            arrayNode.set(i, applyConfigWithEnvVariablesAndSystemProperties(configValues, arrayElement));
           }
         }
         break;
       case STRING:
         final String field = jsonNode.asText();
-        // Kafka ConfigProvider references share Pinot's ${name:value} syntax. Keep references for providers declared
-        // in the containing config object so Kafka can resolve them when constructing the client.
-        if (field.startsWith("${") && field.endsWith("}")
-            && !isConfigProviderReference(field, inheritedConfigProviders)) {
+        if (field.startsWith("$${") && field.endsWith("}")) {
+          return JsonNodeFactory.instance.textNode(field.substring(1));
+        }
+        if (field.startsWith("${") && field.endsWith("}")) {
           String[] envVarSplits = field.substring(2, field.length() - 1).split(":", 2);
           String envVarKey = envVarSplits[0];
           String value = configValues.get(envVarKey);
@@ -122,30 +112,5 @@ public class ConfigUtils {
         break;
     }
     return jsonNode;
-  }
-
-  private static Set<String> getConfigProviders(JsonNode jsonNode, Set<String> inheritedConfigProviders) {
-    JsonNode configProvidersNode = jsonNode.get(CONFIG_PROVIDERS);
-    if (configProvidersNode == null || !configProvidersNode.isTextual()) {
-      return inheritedConfigProviders;
-    }
-
-    Set<String> configProviders = new HashSet<>(inheritedConfigProviders);
-    for (String configProvider : configProvidersNode.asText().split(",")) {
-      String trimmedConfigProvider = configProvider.trim();
-      if (!trimmedConfigProvider.isEmpty()) {
-        configProviders.add(trimmedConfigProvider);
-      }
-    }
-    return configProviders;
-  }
-
-  private static boolean isConfigProviderReference(String field, Set<String> configProviders) {
-    for (String configProvider : configProviders) {
-      if (field.startsWith("${" + configProvider + ":")) {
-        return true;
-      }
-    }
-    return false;
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/ConfigUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/ConfigUtilsTest.java
@@ -23,6 +23,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.spi.config.table.IndexingConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.StreamConfig;
@@ -54,6 +56,46 @@ public class ConfigUtilsTest {
     System.clearProperty("LOAD_MODE");
     System.clearProperty("AWS_ACCESS_KEY");
     System.clearProperty("AWS_SECRET_KEY");
+  }
+
+  @Test
+  public void testKafkaConfigProviderReferencesArePreserved() {
+    IndexingConfig indexingConfig = new IndexingConfig();
+    Map<String, String> streamConfigMap = new HashMap<>();
+    streamConfigMap.put("config.providers", "file");
+    streamConfigMap.put("ssl.keystore.password", "${file:/vault/secrets/kafka.properties:keystore.password}");
+    streamConfigMap.put("ssl.truststore.password", "${PINOT_KAFKA_TRUSTSTORE_PASSWORD:fallback}");
+    indexingConfig.setStreamConfigs(streamConfigMap);
+
+    IndexingConfig resolvedConfig =
+        ConfigUtils.applyConfigWithEnvVariablesAndSystemProperties(Map.of(), indexingConfig);
+
+    assertEquals(resolvedConfig.getStreamConfigs().get("ssl.keystore.password"),
+        "${file:/vault/secrets/kafka.properties:keystore.password}");
+    assertEquals(resolvedConfig.getStreamConfigs().get("ssl.truststore.password"), "fallback");
+  }
+
+  @Test
+  public void testConfigProviderReferencesAreScopedToDeclaringObject() {
+    Map<String, String> providerConfig = new HashMap<>();
+    providerConfig.put("config.providers", "file, vault");
+    providerConfig.put("ssl.keystore.password", "${file:/vault/secrets/kafka.properties:keystore.password}");
+    providerConfig.put("sasl.jaas.config", "${vault:secret/kafka:jaas}");
+    Map<String, String> regularConfig = Map.of("value", "${file:fallback}");
+
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setStreamIngestionConfig(
+        new StreamIngestionConfig(List.of(providerConfig, regularConfig)));
+
+    IngestionConfig resolvedConfig =
+        ConfigUtils.applyConfigWithEnvVariablesAndSystemProperties(Map.of(), ingestionConfig);
+    List<Map<String, String>> resolvedStreamConfigs =
+        resolvedConfig.getStreamIngestionConfig().getStreamConfigMaps();
+
+    assertEquals(resolvedStreamConfigs.get(0).get("ssl.keystore.password"),
+        "${file:/vault/secrets/kafka.properties:keystore.password}");
+    assertEquals(resolvedStreamConfigs.get(0).get("sasl.jaas.config"), "${vault:secret/kafka:jaas}");
+    assertEquals(resolvedStreamConfigs.get(1).get("value"), "fallback");
   }
 
   private void testIndexingWithConfig(Map<String, String> configOverride) {

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/ConfigUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/ConfigUtilsTest.java
@@ -23,8 +23,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.spi.config.table.IndexingConfig;
-import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
-import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.StreamConfig;
@@ -59,11 +57,10 @@ public class ConfigUtilsTest {
   }
 
   @Test
-  public void testKafkaConfigProviderReferencesArePreserved() {
+  public void testEscapedConfigReferenceIsPreserved() {
     IndexingConfig indexingConfig = new IndexingConfig();
     Map<String, String> streamConfigMap = new HashMap<>();
-    streamConfigMap.put("config.providers", "file");
-    streamConfigMap.put("ssl.keystore.password", "${file:/vault/secrets/kafka.properties:keystore.password}");
+    streamConfigMap.put("ssl.keystore.password", "$${file:/vault/secrets/kafka.properties:keystore.password}");
     streamConfigMap.put("ssl.truststore.password", "${PINOT_KAFKA_TRUSTSTORE_PASSWORD:fallback}");
     indexingConfig.setStreamConfigs(streamConfigMap);
 
@@ -76,26 +73,16 @@ public class ConfigUtilsTest {
   }
 
   @Test
-  public void testConfigProviderReferencesAreScopedToDeclaringObject() {
-    Map<String, String> providerConfig = new HashMap<>();
-    providerConfig.put("config.providers", "file, vault");
-    providerConfig.put("ssl.keystore.password", "${file:/vault/secrets/kafka.properties:keystore.password}");
-    providerConfig.put("sasl.jaas.config", "${vault:secret/kafka:jaas}");
-    Map<String, String> regularConfig = Map.of("value", "${file:fallback}");
+  public void testEscapedAndUnescapedConfigReferences() {
+    IndexingConfig indexingConfig = new IndexingConfig();
+    indexingConfig.setStreamConfigs(
+        Map.of("escaped", "$${file:fallback}", "unescaped", "${file:fallback}"));
 
-    IngestionConfig ingestionConfig = new IngestionConfig();
-    ingestionConfig.setStreamIngestionConfig(
-        new StreamIngestionConfig(List.of(providerConfig, regularConfig)));
+    IndexingConfig resolvedConfig =
+        ConfigUtils.applyConfigWithEnvVariablesAndSystemProperties(Map.of(), indexingConfig);
 
-    IngestionConfig resolvedConfig =
-        ConfigUtils.applyConfigWithEnvVariablesAndSystemProperties(Map.of(), ingestionConfig);
-    List<Map<String, String>> resolvedStreamConfigs =
-        resolvedConfig.getStreamIngestionConfig().getStreamConfigMaps();
-
-    assertEquals(resolvedStreamConfigs.get(0).get("ssl.keystore.password"),
-        "${file:/vault/secrets/kafka.properties:keystore.password}");
-    assertEquals(resolvedStreamConfigs.get(0).get("sasl.jaas.config"), "${vault:secret/kafka:jaas}");
-    assertEquals(resolvedStreamConfigs.get(1).get("value"), "fallback");
+    assertEquals(resolvedConfig.getStreamConfigs().get("escaped"), "${file:fallback}");
+    assertEquals(resolvedConfig.getStreamConfigs().get("unescaped"), "fallback");
   }
 
   private void testIndexingWithConfig(Map<String, String> configOverride) {


### PR DESCRIPTION
## Summary

- preserve Kafka ConfigProvider references while Pinot resolves environment variables and system properties in table configs
- pass `config.providers` and `config.providers.<alias>.*` through Kafka consumer and AdminClient property filtering
- apply the behavior to Kafka 3.x and Kafka 4.x, including the production shared AdminClient path
- cover legacy and multi-stream table configs, provider scoping, provider parameters, and actual Kafka client construction

## Why

Two independent transformations currently prevent Kafka ConfigProviders from working in realtime table configs:

1. Pinot interprets a value such as `${file:/vault/secrets/kafka.properties:keystore.password}` as its own `${name:default}` expression while reading the table config. Kafka never receives the reference.
2. Pinot filters Kafka client properties using `ConsumerConfig.configNames()` or `AdminClientConfig.configNames()`. Kafka's dynamic `config.providers.*` namespace is not part of those static name sets, so the provider configuration is removed before client construction.

This change preserves a `${provider:...}` reference only when that provider alias is declared by `config.providers` in the containing config object. Normal Pinot environment and system-property substitution remains unchanged, including across separate stream config maps.

The Kafka client filter continues to reject unrelated Pinot stream settings and admits only the target client's known properties plus Kafka's reserved config-provider namespace. The shared AdminClient path now applies the same filtering.

Provider values are resolved when a Kafka client is constructed. Recreating a consumer therefore rereads the mounted provider file; hot reloading an already-running Kafka client is outside this change.

Kafka client properties should use their unprefixed names in `streamConfigs`, for example `ssl.keystore.password`. The `stream.kafka.consumer.prop.*` prefix is not a generic Kafka property namespace.

## Testing

- `./mvnw -pl pinot-spi test` (787 tests passed)
- `./mvnw -pl pinot-spi -Dtest=ConfigUtilsTest test` (5 tests passed)
- `./mvnw -pl pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0,pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0 -am -Dtest=KafkaPartitionLevelConnectionHandlerTest -Dsurefire.failIfNoSpecifiedTests=false test` (3 tests passed for each connector)
- `./mvnw -pl pinot-spi,pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0,pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0 spotless:check checkstyle:check license:check`

The connector regression creates a temporary FileConfigProvider file, carries the unresolved password reference through Pinot table-config resolution and Kafka property filtering, forwards `allowed.paths`, verifies the resolved password, and constructs both a KafkaConsumer and the shared AdminClient. It runs against Kafka 3.9.2 and Kafka 4.2.0.

User documentation lives in `pinot-contrib/pinot-docs` and should be updated through its separate documentation workflow after this source change.

Addresses #19184