### PR TITLE
Don't push non-deterministic or volatile filters below a join

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
@@ -39,6 +39,7 @@ import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.function.sql.PinotSqlFunction;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.spi.annotations.FunctionVolatility;
 import org.apache.pinot.spi.annotations.ScalarFunction;
 import org.apache.pinot.spi.utils.PinotReflectionUtils;
 import org.slf4j.Logger;
@@ -249,7 +250,8 @@ public class FunctionRegistry {
 
     @Override
     public PinotSqlFunction toPinotSqlFunction() {
-      return new PinotSqlFunction(_mainName, getReturnTypeInference(), getOperandTypeChecker(), isDeterministic());
+      return new PinotSqlFunction(_mainName, getReturnTypeInference(), getOperandTypeChecker(), isDeterministic(),
+          isVolatile());
     }
 
     private SqlReturnTypeInference getReturnTypeInference() {
@@ -326,6 +328,18 @@ public class FunctionRegistry {
         }
       }
       return true;
+    }
+
+    /// Conservatively reports the function as volatile if any registered overload is, matching [#isDeterministic()].
+    /// Both are operator-level properties, whereas the operand types that would select a single overload are only
+    /// known per call site.
+    private boolean isVolatile() {
+      for (FunctionInfo functionInfo : _functionInfoMap.values()) {
+        if (functionInfo.getVolatility() == FunctionVolatility.VOLATILE) {
+          return true;
+        }
+      }
+      return false;
     }
 
     @Override

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/sql/PinotSqlFunction.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/sql/PinotSqlFunction.java
@@ -28,12 +28,20 @@ import org.apache.calcite.sql.type.SqlReturnTypeInference;
 /// Pinot custom SqlFunction to be registered into SqlOperatorTable.
 public class PinotSqlFunction extends SqlFunction {
   private final boolean _deterministic;
+  private final boolean _volatile;
 
   public PinotSqlFunction(String name, SqlReturnTypeInference returnTypeInference,
-      SqlOperandTypeChecker operandTypeChecker, boolean deterministic) {
+      SqlOperandTypeChecker operandTypeChecker, boolean deterministic, boolean isVolatile) {
     super(name.toUpperCase(), SqlKind.OTHER_FUNCTION, returnTypeInference, null, operandTypeChecker,
         SqlFunctionCategory.USER_DEFINED_FUNCTION);
     _deterministic = deterministic;
+    _volatile = isVolatile;
+  }
+
+  /// A non-deterministic function is always volatile, mirroring `FunctionInfo#fromMethod`.
+  public PinotSqlFunction(String name, SqlReturnTypeInference returnTypeInference,
+      SqlOperandTypeChecker operandTypeChecker, boolean deterministic) {
+    this(name, returnTypeInference, operandTypeChecker, deterministic, !deterministic);
   }
 
   public PinotSqlFunction(String name, SqlReturnTypeInference returnTypeInference,
@@ -44,5 +52,16 @@ public class PinotSqlFunction extends SqlFunction {
   @Override
   public boolean isDeterministic() {
     return _deterministic;
+  }
+
+  /// Whether the function is `FunctionVolatility.VOLATILE`, i.e. its result can change on every invocation or it has
+  /// side effects.
+  ///
+  /// This is independent of [#isDeterministic()], which is Pinot's compile-time-evaluation hint: `now()` is
+  /// deterministic (so it can be constant-folded once at plan time) but volatile (so it must not be re-evaluated at a
+  /// different point in the plan). `FunctionVolatility.STABLE` is not reported here, since a stable function is
+  /// constant within a single query and is therefore safe to relocate.
+  public boolean isVolatile() {
+    return _volatile;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/sql/PinotSqlFunction.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/sql/PinotSqlFunction.java
@@ -28,14 +28,14 @@ import org.apache.calcite.sql.type.SqlReturnTypeInference;
 /// Pinot custom SqlFunction to be registered into SqlOperatorTable.
 public class PinotSqlFunction extends SqlFunction {
   private final boolean _deterministic;
-  private final boolean _volatile;
+  private final boolean _isVolatile;
 
   public PinotSqlFunction(String name, SqlReturnTypeInference returnTypeInference,
       SqlOperandTypeChecker operandTypeChecker, boolean deterministic, boolean isVolatile) {
     super(name.toUpperCase(), SqlKind.OTHER_FUNCTION, returnTypeInference, null, operandTypeChecker,
         SqlFunctionCategory.USER_DEFINED_FUNCTION);
     _deterministic = deterministic;
-    _volatile = isVolatile;
+    _isVolatile = isVolatile;
   }
 
   /// Derives volatility from determinism: a non-deterministic function is always volatile, and a deterministic one is
@@ -67,6 +67,6 @@ public class PinotSqlFunction extends SqlFunction {
   /// different point in the plan). `FunctionVolatility.STABLE` is not reported here, since a stable function is
   /// constant within a single query and is therefore safe to relocate.
   public boolean isVolatile() {
-    return _volatile;
+    return _isVolatile;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/sql/PinotSqlFunction.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/sql/PinotSqlFunction.java
@@ -38,7 +38,12 @@ public class PinotSqlFunction extends SqlFunction {
     _volatile = isVolatile;
   }
 
-  /// A non-deterministic function is always volatile, mirroring `FunctionInfo#fromMethod`.
+  /// Derives volatility from determinism: a non-deterministic function is always volatile, and a deterministic one is
+  /// assumed not to be.
+  ///
+  /// Only the second half is an assumption -- a deterministic function can still be
+  /// `FunctionVolatility.VOLATILE` (that is exactly what `now()` is). Use the constructor above to say so explicitly;
+  /// this overload is for operators that are plain immutable functions of their arguments.
   public PinotSqlFunction(String name, SqlReturnTypeInference returnTypeInference,
       SqlOperandTypeChecker operandTypeChecker, boolean deterministic) {
     this(name, returnTypeInference, operandTypeChecker, deterministic, !deterministic);

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/FunctionUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/FunctionUtilsTest.java
@@ -25,6 +25,7 @@ import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
+import org.apache.pinot.common.function.sql.PinotSqlFunction;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.spi.annotations.FunctionVolatility;
 import org.apache.pinot.spi.annotations.ScalarFunction;
@@ -123,6 +124,39 @@ public class FunctionUtilsTest {
     FunctionInfo workerId = FunctionRegistry.lookupFunctionInfo("workerid", 1);
     assertTrue(workerId.isDeterministic());
     assertEquals(workerId.getVolatility(), FunctionVolatility.VOLATILE);
+  }
+
+  /// The [FunctionInfo] volatility above is per-arity, but the [PinotSqlFunction] the planner sees is per-operator.
+  /// Both determinism and volatility are therefore aggregated conservatively across every registered overload.
+  @Test
+  public void testOperatorLevelVolatilityAggregatesAcrossOverloads() {
+    // rand() is VOLATILE and non-deterministic at 0 args, IMMUTABLE and deterministic at 1 arg. The single operator
+    // has to report the more restrictive of each.
+    PinotSqlFunction rand = toSqlFunction("rand");
+    assertFalse(rand.isDeterministic());
+    assertTrue(rand.isVolatile());
+
+    // now() stays deterministic so it can be constant-folded, but must still report volatile.
+    PinotSqlFunction now = toSqlFunction("now");
+    assertTrue(now.isDeterministic());
+    assertTrue(now.isVolatile());
+
+    // STABLE is constant within a query, so it must NOT be reported as volatile.
+    PinotSqlFunction reqId = toSqlFunction("reqid");
+    assertTrue(reqId.isDeterministic());
+    assertFalse(reqId.isVolatile());
+
+    PinotSqlFunction upper = toSqlFunction("upper");
+    assertTrue(upper.isDeterministic());
+    assertFalse(upper.isVolatile());
+  }
+
+  private static PinotSqlFunction toSqlFunction(String canonicalName) {
+    PinotScalarFunction scalarFunction = FunctionRegistry.getFunctions().get(canonicalName);
+    assertNotNull(scalarFunction, "Failed to find function: " + canonicalName);
+    PinotSqlFunction sqlFunction = scalarFunction.toPinotSqlFunction();
+    assertNotNull(sqlFunction, "Function is not registered as a PinotSqlFunction: " + canonicalName);
+    return sqlFunction;
   }
 
   @Test

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotFilterJoinRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotFilterJoinRule.java
@@ -48,9 +48,31 @@ public abstract class PinotFilterJoinRule<C extends FilterJoinRule.Config> exten
   }
 
   // Following code are copy-pasted from Calcite, and modified to not push down filter into right side of lookup join.
+  // SYNCED WITH Calcite 1.42.0 FilterJoinRule#perform -- re-diff this method body against upstream on every
+  // calcite.version bump; the only intended deviation is the canPushRight lookup-join restriction below. Known
+  // outstanding drift: upstream's RexUtil.containsCorrelation partitioning of aboveFilters and the variablesSet
+  // argument on the final RelBuilder#filter (CALCITE-7319) are not ported. Pinot decorrelates in
+  // QueryEnvironment#toRelation before these rules run, and the LogicalCorrelate shapes that do survive it
+  // (UNNEST / CROSS JOIN UNNEST) have an Uncollect right input, so a Filter carrying $cor never sits directly above a
+  // Join here. Revisit if Pinot ever retains a Correlate over a Join.
   //@formatter:off
   @Override
   protected void perform(RelOptRuleCall call, @Nullable Filter filter, Join join) {
+    // Upstream parity (CALCITE-7373): a non-deterministic conjunct such as rand() < 0.1 has an empty input bitmap, so
+    // classifyFilters would treat it as pushable and relocate it below the join, evaluating it per input row instead
+    // of per join-output row. Like upstream, this bails on the whole condition rather than per conjunct, so a
+    // deterministic conjunct sharing the WHERE clause also stays above the join.
+    // NOTE: this only covers @ScalarFunction(isDeterministic = false). Pinot's separate FunctionVolatility.VOLATILE
+    // axis (now(), ago(), stageId(), ...) is not consulted here, so such filters are still pushed below the join.
+    // Skip non-deterministic filter condition
+    if (filter != null && !RexUtil.isDeterministic(filter.getCondition())) {
+      return;
+    }
+    // Skip non-deterministic join condition
+    if (!RexUtil.isDeterministic(join.getCondition())) {
+      return;
+    }
+
     List<RexNode> joinFilters =
         RelOptUtil.conjunctions(join.getCondition());
     final List<RexNode> origJoinFilters = List.copyOf(joinFilters);

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotFilterJoinRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotFilterJoinRule.java
@@ -49,8 +49,10 @@ public abstract class PinotFilterJoinRule<C extends FilterJoinRule.Config> exten
 
   // Following code are copy-pasted from Calcite, and modified to not push down filter into right side of lookup join.
   // SYNCED WITH Calcite 1.42.0 FilterJoinRule#perform -- re-diff this method body against upstream on every
-  // calcite.version bump; the only intended deviation is the canPushRight lookup-join restriction below. Known
-  // outstanding drift: upstream's RexUtil.containsCorrelation partitioning of aboveFilters and the variablesSet
+  // calcite.version bump. The intended deviations are the canPushRight lookup-join restriction and the volatility half
+  // of the isStageInvariant guard, both marked PINOT MODIFICATION below.
+  //
+  // Known outstanding drift: upstream's RexUtil.containsCorrelation partitioning of aboveFilters and the variablesSet
   // argument on the final RelBuilder#filter (CALCITE-7319) are not ported. Pinot decorrelates in
   // QueryEnvironment#toRelation before these rules run, and the LogicalCorrelate shapes that do survive it
   // (UNNEST / CROSS JOIN UNNEST) have an Uncollect right input, so a Filter carrying $cor never sits directly above a
@@ -58,18 +60,20 @@ public abstract class PinotFilterJoinRule<C extends FilterJoinRule.Config> exten
   //@formatter:off
   @Override
   protected void perform(RelOptRuleCall call, @Nullable Filter filter, Join join) {
-    // Upstream parity (CALCITE-7373): a non-deterministic conjunct such as rand() < 0.1 has an empty input bitmap, so
+    // From CALCITE-7373: a non-deterministic conjunct such as rand() < 0.1 has an empty input bitmap, so
     // classifyFilters would treat it as pushable and relocate it below the join, evaluating it per input row instead
     // of per join-output row. Like upstream, this bails on the whole condition rather than per conjunct, so a
     // deterministic conjunct sharing the WHERE clause also stays above the join.
-    // NOTE: this only covers @ScalarFunction(isDeterministic = false). Pinot's separate FunctionVolatility.VOLATILE
-    // axis (now(), ago(), stageId(), ...) is not consulted here, so such filters are still pushed below the join.
-    // Skip non-deterministic filter condition
-    if (filter != null && !RexUtil.isDeterministic(filter.getCondition())) {
+    // PINOT MODIFICATION to also skip volatile conditions. Upstream uses RexUtil.isDeterministic, which only covers
+    // @ScalarFunction(isDeterministic = false). Pinot's separate FunctionVolatility.VOLATILE axis (now(), ago(),
+    // stageId(), ...) keeps isDeterministic() == true so PinotEvaluateLiteralRule can still fold it once at plan time,
+    // so it needs the wider PinotRuleUtils.isStageInvariant check here.
+    // Skip non-deterministic or volatile filter condition
+    if (filter != null && !PinotRuleUtils.isStageInvariant(filter.getCondition())) {
       return;
     }
-    // Skip non-deterministic join condition
-    if (!RexUtil.isDeterministic(join.getCondition())) {
+    // Skip non-deterministic or volatile join condition
+    if (!PinotRuleUtils.isStageInvariant(join.getCondition())) {
       return;
     }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotFilterJoinRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotFilterJoinRule.java
@@ -50,7 +50,7 @@ public abstract class PinotFilterJoinRule<C extends FilterJoinRule.Config> exten
   // Following code are copy-pasted from Calcite, and modified to not push down filter into right side of lookup join.
   // SYNCED WITH Calcite 1.42.0 FilterJoinRule#perform -- re-diff this method body against upstream on every
   // calcite.version bump. The intended deviations are the canPushRight lookup-join restriction and the volatility half
-  // of the isStageInvariant guard, both marked PINOT MODIFICATION below.
+  // of the isRelocatable guard, both marked PINOT MODIFICATION below.
   //
   // Known outstanding drift: upstream's RexUtil.containsCorrelation partitioning of aboveFilters and the variablesSet
   // argument on the final RelBuilder#filter (CALCITE-7319) are not ported. Pinot decorrelates in
@@ -67,13 +67,17 @@ public abstract class PinotFilterJoinRule<C extends FilterJoinRule.Config> exten
     // PINOT MODIFICATION to also skip volatile conditions. Upstream uses RexUtil.isDeterministic, which only covers
     // @ScalarFunction(isDeterministic = false). Pinot's separate FunctionVolatility.VOLATILE axis (now(), ago(),
     // stageId(), ...) keeps isDeterministic() == true so PinotEvaluateLiteralRule can still fold it once at plan time,
-    // so it needs the wider PinotRuleUtils.isStageInvariant check here.
+    // so it needs the wider PinotRuleUtils.isRelocatable check here.
     // Skip non-deterministic or volatile filter condition
-    if (filter != null && !PinotRuleUtils.isStageInvariant(filter.getCondition())) {
+    if (filter != null && !PinotRuleUtils.isRelocatable(filter.getCondition())) {
       return;
     }
-    // Skip non-deterministic or volatile join condition
-    if (!PinotRuleUtils.isStageInvariant(join.getCondition())) {
+    // Skip non-deterministic or volatile join condition.
+    // NOTE: for an INNER join this guard is largely moot for anything referencing a single side, because
+    // RelOptUtil.pushDownJoinConditions already hoisted such a call into that input's Project during sql-to-rel,
+    // before any rule ran; the condition seen here is then a bare RexInputRef. It is still load-bearing for outer
+    // joins, where the ON clause is preserved. See JoinPlans.json for both shapes.
+    if (!PinotRuleUtils.isRelocatable(join.getCondition())) {
       return;
     }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotRuleUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotRuleUtils.java
@@ -38,14 +38,18 @@ import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexVisitorImpl;
 import org.apache.calcite.rex.RexWindowBound;
 import org.apache.calcite.rex.RexWindowBounds;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.calcite.util.Util;
 import org.apache.pinot.calcite.rel.hint.PinotHintStrategyTable;
+import org.apache.pinot.common.function.sql.PinotSqlFunction;
 
 
 public class PinotRuleUtils {
@@ -130,6 +134,39 @@ public class PinotRuleUtils {
   public static String extractFunctionName(RexCall function) {
     SqlKind funcSqlKind = function.getOperator().getKind();
     return funcSqlKind == SqlKind.OTHER_FUNCTION ? function.getOperator().getName() : funcSqlKind.name();
+  }
+
+  /// Returns whether `node` evaluates to the same result no matter where in the plan it is placed, and can therefore
+  /// be relocated across a stage boundary (e.g. pushed below a join).
+  ///
+  /// Pinot tracks two independent axes of variability, and an expression must be clear of both:
+  ///
+  /// - [SqlOperator#isDeterministic()] -- `false` for `rand()`, `UUID_V4`, `UUID_V7` and Calcite's own `RAND` /
+  ///   `RAND_INTEGER`. This is what `RexUtil#isDeterministic` checks.
+  /// - [PinotSqlFunction#isVolatile()] -- `true` for `FunctionVolatility.VOLATILE` functions such as `now()`, `ago()`
+  ///   and `stageId()`. These stay `isDeterministic() == true` so that [PinotEvaluateLiteralRule] can still fold them
+  ///   once at plan time, so `RexUtil#isDeterministic` alone does not catch them.
+  ///
+  /// Relocating an expression that fails this check changes how many times, and in what context, it is evaluated --
+  /// which changes query results.
+  public static boolean isStageInvariant(RexNode node) {
+    try {
+      node.accept(new RexVisitorImpl<Void>(true) {
+        @Override
+        public Void visitCall(RexCall call) {
+          SqlOperator operator = call.getOperator();
+          if (!operator.isDeterministic()
+              || (operator instanceof PinotSqlFunction && ((PinotSqlFunction) operator).isVolatile())) {
+            throw Util.FoundOne.NULL;
+          }
+          return super.visitCall(call);
+        }
+      });
+      return true;
+    } catch (Util.FoundOne e) {
+      Util.swallow(e, null);
+      return false;
+    }
   }
 
   public static class WindowUtils {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotRuleUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotRuleUtils.java
@@ -38,6 +38,7 @@ import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.rex.RexVisitorImpl;
 import org.apache.calcite.rex.RexWindowBound;
 import org.apache.calcite.rex.RexWindowBounds;
@@ -136,26 +137,36 @@ public class PinotRuleUtils {
     return funcSqlKind == SqlKind.OTHER_FUNCTION ? function.getOperator().getName() : funcSqlKind.name();
   }
 
-  /// Returns whether `node` evaluates to the same result no matter where in the plan it is placed, and can therefore
-  /// be relocated across a stage boundary (e.g. pushed below a join).
+  /// Returns whether `node` evaluates to the same result no matter where in the plan it sits, and can therefore be
+  /// relocated -- pushed below a join, duplicated onto another input, and so on.
   ///
-  /// Pinot tracks two independent axes of variability, and an expression must be clear of both:
+  /// An expression must be clear of three axes of variability:
   ///
   /// - [SqlOperator#isDeterministic()] -- `false` for `rand()`, `UUID_V4`, `UUID_V7` and Calcite's own `RAND` /
-  ///   `RAND_INTEGER`. This is what `RexUtil#isDeterministic` checks.
-  /// - [PinotSqlFunction#isVolatile()] -- `true` for `FunctionVolatility.VOLATILE` functions such as `now()`, `ago()`
-  ///   and `stageId()`. These stay `isDeterministic() == true` so that [PinotEvaluateLiteralRule] can still fold them
-  ///   once at plan time, so `RexUtil#isDeterministic` alone does not catch them.
+  ///   `RAND_INTEGER`. Delegated to `RexUtil#isDeterministic` so this half tracks upstream automatically.
+  /// - [SqlOperator#isDynamicFunction()] -- Calcite's own "fold once per query, never re-evaluate" marker, used by
+  ///   `CURRENT_TIMESTAMP` and friends.
+  /// - [PinotSqlFunction#isVolatile()] -- Pinot's equivalent marker, `true` for `FunctionVolatility.VOLATILE`
+  ///   functions such as `now()`, `ago()` and `stageId()`. These deliberately stay `isDeterministic() == true` so that
+  ///   [PinotEvaluateLiteralRule] can still fold them once at plan time, which is precisely why
+  ///   `RexUtil#isDeterministic` alone does not catch them.
   ///
   /// Relocating an expression that fails this check changes how many times, and in what context, it is evaluated --
-  /// which changes query results.
-  public static boolean isStageInvariant(RexNode node) {
+  /// which changes query results. `FunctionVolatility.STABLE` deliberately passes: it is constant within a single
+  /// query, so moving it is safe.
+  ///
+  /// Note this is a predicate that callers must apply; it is not enforced globally. Only [PinotFilterJoinRule]
+  /// consults it today, so other rules that relocate expressions can still move volatile ones.
+  public static boolean isRelocatable(RexNode node) {
+    if (!RexUtil.isDeterministic(node)) {
+      return false;
+    }
     try {
       node.accept(new RexVisitorImpl<Void>(true) {
         @Override
         public Void visitCall(RexCall call) {
           SqlOperator operator = call.getOperator();
-          if (!operator.isDeterministic()
+          if (operator.isDynamicFunction()
               || (operator instanceof PinotSqlFunction && ((PinotSqlFunction) operator).isVolatile())) {
             throw Util.FoundOne.NULL;
           }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/fun/PinotOperatorTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/fun/PinotOperatorTable.java
@@ -324,7 +324,10 @@ public class PinotOperatorTable implements SqlOperatorTable {
           List.of(SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER, SqlTypeFamily.ANY),
           i -> i > 1)),
 
-      new PinotSqlFunction("NOW", ReturnTypes.TIMESTAMP, OperandTypes.NILADIC)
+      // Deterministic so PinotEvaluateLiteralRule folds it once at plan time, but volatile so it is never
+      // re-evaluated at a different point in the plan. This entry shadows the FunctionRegistry one (see
+      // registerScalarFunctions), so the volatility has to be repeated here.
+      new PinotSqlFunction("NOW", ReturnTypes.TIMESTAMP, OperandTypes.NILADIC, true, true)
   );
 
   private static final List<Pair<SqlOperator, List<String>>> PINOT_OPERATORS_WITH_ALIASES = List.of(

--- a/pinot-query-planner/src/test/java/org/apache/pinot/calcite/rel/rules/PinotRuleUtilsTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/calcite/rel/rules/PinotRuleUtilsTest.java
@@ -18,15 +18,21 @@
  */
 package org.apache.pinot.calcite.rel.rules;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.pinot.calcite.sql.fun.PinotOperatorTable;
 import org.apache.pinot.common.function.FunctionRegistry;
 import org.apache.pinot.common.function.PinotScalarFunction;
 import org.apache.pinot.common.function.sql.PinotSqlFunction;
@@ -37,20 +43,30 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 
-/// Tests [PinotRuleUtils#isStageInvariant], which decides whether an expression may be relocated across a stage
-/// boundary. It must reject both of Pinot's variability axes: `isDeterministic = false` and
-/// `FunctionVolatility.VOLATILE`.
+/// Tests [PinotRuleUtils#isRelocatable], which decides whether an expression may be moved to a different position in
+/// the plan. It must reject all three variability axes: `isDeterministic = false`, Calcite's `isDynamicFunction()`,
+/// and Pinot's `FunctionVolatility.VOLATILE`.
 public class PinotRuleUtilsTest {
 
   private final RelDataTypeFactory _typeFactory = new JavaTypeFactoryImpl();
   private final RexBuilder _rexBuilder = new RexBuilder(_typeFactory);
 
-  private PinotSqlFunction sqlFunction(String name) {
+  private PinotSqlFunction registryFunction(String name) {
     PinotScalarFunction scalarFunction = FunctionRegistry.getFunctions().get(FunctionRegistry.canonicalize(name));
     assertNotNull(scalarFunction, "Failed to find function: " + name);
     PinotSqlFunction sqlFunction = scalarFunction.toPinotSqlFunction();
     assertNotNull(sqlFunction, "Function is not registered as a PinotSqlFunction: " + name);
     return sqlFunction;
+  }
+
+  /// Resolves the operator a query would actually bind to, which is not always the [FunctionRegistry] entry --
+  /// `PinotOperatorTable#registerScalarFunctions` skips names already present in its hard-coded list.
+  private SqlOperator resolvedOperator(String name) {
+    List<SqlOperator> matches = new ArrayList<>();
+    PinotOperatorTable.instance(false).lookupOperatorOverloads(new SqlIdentifier(name, SqlParserPos.ZERO),
+        SqlFunctionCategory.USER_DEFINED_FUNCTION, SqlSyntax.FUNCTION, matches, null);
+    assertFalse(matches.isEmpty(), "Failed to resolve operator: " + name);
+    return matches.get(0);
   }
 
   private RexNode call(SqlOperator operator, RexNode... operands) {
@@ -63,60 +79,81 @@ public class PinotRuleUtilsTest {
   }
 
   @Test
-  public void testLiteralAndInputRefAreStageInvariant() {
-    assertTrue(PinotRuleUtils.isStageInvariant(literal(1)));
-    assertTrue(PinotRuleUtils.isStageInvariant(
+  public void testLiteralAndInputRefAreRelocatable() {
+    assertTrue(PinotRuleUtils.isRelocatable(literal(1)));
+    assertTrue(PinotRuleUtils.isRelocatable(
         _rexBuilder.makeInputRef(_typeFactory.createSqlType(SqlTypeName.INTEGER), 0)));
   }
 
   @Test
-  public void testDeterministicCallIsStageInvariant() {
-    assertTrue(PinotRuleUtils.isStageInvariant(call(SqlStdOperatorTable.PLUS, literal(1), literal(2))));
+  public void testDeterministicCallIsRelocatable() {
+    assertTrue(PinotRuleUtils.isRelocatable(call(SqlStdOperatorTable.PLUS, literal(1), literal(2))));
   }
 
   @Test
-  public void testNonDeterministicFunctionIsNotStageInvariant() {
+  public void testImmutableFunctionIsRelocatable() {
+    PinotSqlFunction upper = registryFunction("upper");
+    assertTrue(upper.isDeterministic());
+    assertFalse(upper.isVolatile());
+    assertTrue(PinotRuleUtils.isRelocatable(call(upper, _rexBuilder.makeLiteral("x"))));
+  }
+
+  @Test
+  public void testNonDeterministicFunctionIsNotRelocatable() {
     // rand() is @ScalarFunction(isDeterministic = false); the operator-level flag is shared with the seeded overload.
-    PinotSqlFunction rand = sqlFunction("rand");
+    PinotSqlFunction rand = registryFunction("rand");
     assertFalse(rand.isDeterministic());
-    assertFalse(PinotRuleUtils.isStageInvariant(call(rand)));
+    assertFalse(PinotRuleUtils.isRelocatable(call(rand)));
   }
 
   @Test
-  public void testVolatileFunctionIsNotStageInvariant() {
+  public void testVolatileFunctionIsNotRelocatable() {
     // stageId() stays deterministic so it can be constant-folded, but is VOLATILE, so it must not be relocated.
-    PinotSqlFunction stageId = sqlFunction("stageId");
+    PinotSqlFunction stageId = registryFunction("stageId");
     assertTrue(stageId.isDeterministic(), "stageId should stay deterministic for compile-time evaluation");
     assertTrue(stageId.isVolatile());
-    assertFalse(PinotRuleUtils.isStageInvariant(call(stageId, literal(0))));
+    assertFalse(PinotRuleUtils.isRelocatable(call(stageId, literal(0))));
   }
 
+  /// `FunctionVolatility.STABLE` is constant within a single query, so it is safe to relocate. `reqId` gets STABLE
+  /// from the class-level annotation on `InternalFunctions`, which also covers annotation inheritance.
   @Test
-  public void testNowIsVolatileButDeterministic() {
-    // The registry entry for now() must stay deterministic so PinotEvaluateLiteralRule can fold it once at plan time,
-    // while being volatile so it is never re-evaluated at a different point in the plan.
-    // Note: SQL NOW() resolves to the hard-coded PinotOperatorTable entry rather than this one (registerScalarFunctions
-    // skips names already present), and is niladic so it is always folded before the filter-join rules run. See
-    // QueryCompilationTest#testVolatileNowFilterIsStillPushedBelowJoin.
-    PinotSqlFunction now = sqlFunction("now");
-    assertTrue(now.isDeterministic());
-    assertTrue(now.isVolatile());
-    assertFalse(PinotRuleUtils.isStageInvariant(call(now)));
+  public void testStableFunctionIsRelocatable() {
+    PinotSqlFunction reqId = registryFunction("reqId");
+    assertTrue(reqId.isDeterministic());
+    assertFalse(reqId.isVolatile(), "STABLE must not be reported as volatile");
+    assertTrue(PinotRuleUtils.isRelocatable(call(reqId, literal(0))));
+  }
+
+  /// Calcite's own dynamic functions carry the same "fold once, never re-evaluate" contract via a different flag.
+  @Test
+  public void testCalciteDynamicFunctionIsNotRelocatable() {
+    assertTrue(SqlStdOperatorTable.CURRENT_TIMESTAMP.isDynamicFunction());
+    assertTrue(SqlStdOperatorTable.CURRENT_TIMESTAMP.isDeterministic(),
+        "guarding on isDeterministic alone would miss this");
+    assertFalse(PinotRuleUtils.isRelocatable(call(SqlStdOperatorTable.CURRENT_TIMESTAMP)));
+  }
+
+  /// Both the registry entry and the hard-coded [PinotOperatorTable] entry that shadows it must agree that `now()` is
+  /// volatile, otherwise the guard's answer depends on which one a query happens to bind to.
+  @Test
+  public void testNowIsVolatileOnBothRegistrations() {
+    PinotSqlFunction registryNow = registryFunction("now");
+    assertTrue(registryNow.isDeterministic(), "now() must stay deterministic so it is folded once at plan time");
+    assertTrue(registryNow.isVolatile());
+    assertFalse(PinotRuleUtils.isRelocatable(call(registryNow)));
+
+    SqlOperator resolvedNow = resolvedOperator("NOW");
+    assertTrue(resolvedNow instanceof PinotSqlFunction, "expected a PinotSqlFunction, got: " + resolvedNow.getClass());
+    assertTrue(((PinotSqlFunction) resolvedNow).isVolatile(),
+        "the operator NOW() actually binds to must also report volatile");
+    assertFalse(PinotRuleUtils.isRelocatable(call(resolvedNow)));
   }
 
   @Test
   public void testNestedVolatileOperandIsDetected() {
     // The visitor must recurse into operands, not just inspect the top-level operator.
-    RexNode nested = call(SqlStdOperatorTable.PLUS, literal(1), call(sqlFunction("stageId"), literal(0)));
-    assertFalse(PinotRuleUtils.isStageInvariant(nested));
-  }
-
-  @Test
-  public void testImmutableFunctionIsStageInvariant() {
-    PinotSqlFunction upper = sqlFunction("upper");
-    assertTrue(upper.isDeterministic());
-    assertFalse(upper.isVolatile());
-    assertTrue(PinotRuleUtils.isStageInvariant(
-        call(upper, _rexBuilder.makeLiteral("x"))));
+    RexNode nested = call(SqlStdOperatorTable.PLUS, literal(1), call(registryFunction("stageId"), literal(0)));
+    assertFalse(PinotRuleUtils.isRelocatable(nested));
   }
 }

--- a/pinot-query-planner/src/test/java/org/apache/pinot/calcite/rel/rules/PinotRuleUtilsTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/calcite/rel/rules/PinotRuleUtilsTest.java
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.calcite.rel.rules;
+
+import java.util.List;
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.pinot.common.function.FunctionRegistry;
+import org.apache.pinot.common.function.PinotScalarFunction;
+import org.apache.pinot.common.function.sql.PinotSqlFunction;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+/// Tests [PinotRuleUtils#isStageInvariant], which decides whether an expression may be relocated across a stage
+/// boundary. It must reject both of Pinot's variability axes: `isDeterministic = false` and
+/// `FunctionVolatility.VOLATILE`.
+public class PinotRuleUtilsTest {
+
+  private final RelDataTypeFactory _typeFactory = new JavaTypeFactoryImpl();
+  private final RexBuilder _rexBuilder = new RexBuilder(_typeFactory);
+
+  private PinotSqlFunction sqlFunction(String name) {
+    PinotScalarFunction scalarFunction = FunctionRegistry.getFunctions().get(FunctionRegistry.canonicalize(name));
+    assertNotNull(scalarFunction, "Failed to find function: " + name);
+    PinotSqlFunction sqlFunction = scalarFunction.toPinotSqlFunction();
+    assertNotNull(sqlFunction, "Function is not registered as a PinotSqlFunction: " + name);
+    return sqlFunction;
+  }
+
+  private RexNode call(SqlOperator operator, RexNode... operands) {
+    RelDataType returnType = _typeFactory.createSqlType(SqlTypeName.BIGINT);
+    return _rexBuilder.makeCall(returnType, operator, List.of(operands));
+  }
+
+  private RexNode literal(int value) {
+    return _rexBuilder.makeLiteral(value, _typeFactory.createSqlType(SqlTypeName.INTEGER));
+  }
+
+  @Test
+  public void testLiteralAndInputRefAreStageInvariant() {
+    assertTrue(PinotRuleUtils.isStageInvariant(literal(1)));
+    assertTrue(PinotRuleUtils.isStageInvariant(
+        _rexBuilder.makeInputRef(_typeFactory.createSqlType(SqlTypeName.INTEGER), 0)));
+  }
+
+  @Test
+  public void testDeterministicCallIsStageInvariant() {
+    assertTrue(PinotRuleUtils.isStageInvariant(call(SqlStdOperatorTable.PLUS, literal(1), literal(2))));
+  }
+
+  @Test
+  public void testNonDeterministicFunctionIsNotStageInvariant() {
+    // rand() is @ScalarFunction(isDeterministic = false); the operator-level flag is shared with the seeded overload.
+    PinotSqlFunction rand = sqlFunction("rand");
+    assertFalse(rand.isDeterministic());
+    assertFalse(PinotRuleUtils.isStageInvariant(call(rand)));
+  }
+
+  @Test
+  public void testVolatileFunctionIsNotStageInvariant() {
+    // stageId() stays deterministic so it can be constant-folded, but is VOLATILE, so it must not be relocated.
+    PinotSqlFunction stageId = sqlFunction("stageId");
+    assertTrue(stageId.isDeterministic(), "stageId should stay deterministic for compile-time evaluation");
+    assertTrue(stageId.isVolatile());
+    assertFalse(PinotRuleUtils.isStageInvariant(call(stageId, literal(0))));
+  }
+
+  @Test
+  public void testNowIsVolatileButDeterministic() {
+    // The registry entry for now() must stay deterministic so PinotEvaluateLiteralRule can fold it once at plan time,
+    // while being volatile so it is never re-evaluated at a different point in the plan.
+    // Note: SQL NOW() resolves to the hard-coded PinotOperatorTable entry rather than this one (registerScalarFunctions
+    // skips names already present), and is niladic so it is always folded before the filter-join rules run. See
+    // QueryCompilationTest#testVolatileNowFilterIsStillPushedBelowJoin.
+    PinotSqlFunction now = sqlFunction("now");
+    assertTrue(now.isDeterministic());
+    assertTrue(now.isVolatile());
+    assertFalse(PinotRuleUtils.isStageInvariant(call(now)));
+  }
+
+  @Test
+  public void testNestedVolatileOperandIsDetected() {
+    // The visitor must recurse into operands, not just inspect the top-level operator.
+    RexNode nested = call(SqlStdOperatorTable.PLUS, literal(1), call(sqlFunction("stageId"), literal(0)));
+    assertFalse(PinotRuleUtils.isStageInvariant(nested));
+  }
+
+  @Test
+  public void testImmutableFunctionIsStageInvariant() {
+    PinotSqlFunction upper = sqlFunction("upper");
+    assertTrue(upper.isDeterministic());
+    assertFalse(upper.isVolatile());
+    assertTrue(PinotRuleUtils.isStageInvariant(
+        call(upper, _rexBuilder.makeLiteral("x"))));
+  }
+}

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
@@ -434,6 +434,34 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
     }
   }
 
+  /// [org.apache.pinot.calcite.rel.rules.PinotFilterJoinRule] refuses to push a volatile filter below a join. `now()`
+  /// is volatile, but [org.apache.pinot.calcite.rel.rules.PinotEvaluateLiteralRule] folds it to a literal first, so
+  /// the common time-filter-over-a-join pattern must still reach the leaf scan.
+  ///
+  /// Asserted here rather than in JoinPlans.json because the folded epoch literal differs on every run.
+  @Test
+  public void testVolatileNowFilterIsStillPushedBelowJoin() {
+    String query =
+        "EXPLAIN PLAN FOR SELECT a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1 WHERE a.ts > now() - 86400000";
+
+    String explain = _queryEnvironment.explainQuery(query, RANDOM_REQUEST_ID_GEN.nextLong());
+    // now() folds to the current epoch millis, so mask the literal before comparing.
+    String normalized = explain.replaceAll("(?<=\\$7, )\\d+", "<EPOCH>");
+    //@formatter:off
+    assertEquals(normalized,
+        "Execution Plan\n"
+        + "LogicalProject(col1=[$0], col2=[$2])\n"
+        + "  LogicalJoin(condition=[=($0, $1)], joinType=[inner])\n"
+        + "    PinotLogicalExchange(distribution=[hash[0]])\n"
+        + "      LogicalProject(col1=[$0])\n"
+        + "        LogicalFilter(condition=[>($7, <EPOCH>)])\n"
+        + "          PinotLogicalTableScan(table=[[default, a]])\n"
+        + "    PinotLogicalExchange(distribution=[hash[0]])\n"
+        + "      LogicalProject(col1=[$0], col2=[$1])\n"
+        + "        PinotLogicalTableScan(table=[[default, b]])\n");
+    //@formatter:on
+  }
+
   @Test
   public void testAggregateCaseToFilter() {
     // Tests that queries like "SELECT SUM(CASE WHEN col1 = 'a' THEN 1 ELSE 0 END) FROM a" are rewritten to

--- a/pinot-query-planner/src/test/resources/queries/JoinPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/JoinPlans.json
@@ -664,6 +664,160 @@
           "\n                  PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
+      },
+      {
+        "description": "Non-deterministic WHERE filter is not pushed below the join",
+        "sql": "EXPLAIN PLAN FOR SELECT a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1 WHERE rand() < 0.1",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0], col2=[$2])",
+          "\n  LogicalFilter(condition=[<(RAND(), 0.1E0)])",
+          "\n    LogicalJoin(condition=[=($0, $1)], joinType=[inner])",
+          "\n      PinotLogicalExchange(distribution=[hash[0]])",
+          "\n        LogicalProject(col1=[$0])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalExchange(distribution=[hash[0]])",
+          "\n        LogicalProject(col1=[$0], col2=[$1])",
+          "\n          PinotLogicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Non-deterministic WHERE filter is not pushed below a left join",
+        "sql": "EXPLAIN PLAN FOR SELECT a.col1, b.col2 FROM a LEFT JOIN b ON a.col1 = b.col1 WHERE rand() < 0.1",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0], col2=[$2])",
+          "\n  LogicalFilter(condition=[<(RAND(), 0.1E0)])",
+          "\n    LogicalJoin(condition=[=($0, $1)], joinType=[left])",
+          "\n      PinotLogicalExchange(distribution=[hash[0]])",
+          "\n        LogicalProject(col1=[$0])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalExchange(distribution=[hash[0]])",
+          "\n        LogicalProject(col1=[$0], col2=[$1])",
+          "\n          PinotLogicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Non-deterministic WHERE filter on the null-generating side does not simplify the left join to inner",
+        "sql": "EXPLAIN PLAN FOR SELECT a.col1, b.col2 FROM a LEFT JOIN b ON a.col1 = b.col1 WHERE b.col3 > 100 * rand()",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0], col2=[$2])",
+          "\n  LogicalFilter(condition=[>(CAST($3):DOUBLE, *(100, RAND()))])",
+          "\n    LogicalJoin(condition=[=($0, $1)], joinType=[left])",
+          "\n      PinotLogicalExchange(distribution=[hash[0]])",
+          "\n        LogicalProject(col1=[$0])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalExchange(distribution=[hash[0]])",
+          "\n        LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
+          "\n          PinotLogicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Non-deterministic WHERE filter on the null-generating side does not simplify the full join",
+        "sql": "EXPLAIN PLAN FOR SELECT a.col1, b.col2 FROM a FULL JOIN b ON a.col1 = b.col1 WHERE b.col3 > 100 * rand()",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0], col2=[$2])",
+          "\n  LogicalFilter(condition=[>(CAST($3):DOUBLE, *(100, RAND()))])",
+          "\n    LogicalJoin(condition=[=($0, $1)], joinType=[full])",
+          "\n      PinotLogicalExchange(distribution=[hash[0]])",
+          "\n        LogicalProject(col1=[$0])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalExchange(distribution=[hash[0]])",
+          "\n        LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
+          "\n          PinotLogicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Non-deterministic ON condition is not pushed below the join",
+        "sql": "EXPLAIN PLAN FOR SELECT a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1 AND rand() < 0.1",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0], col2=[$2])",
+          "\n  LogicalJoin(condition=[AND(=($0, $1), <(RAND(), 0.1E0))], joinType=[inner])",
+          "\n    PinotLogicalExchange(distribution=[hash[0]])",
+          "\n      LogicalProject(col1=[$0])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
+          "\n    PinotLogicalExchange(distribution=[hash[0]])",
+          "\n      LogicalProject(col1=[$0], col2=[$1])",
+          "\n        PinotLogicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Non-deterministic UUID filter is not pushed below the join",
+        "sql": "EXPLAIN PLAN FOR SELECT a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1 WHERE uuid_v4() <> 'x'",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0], col2=[$2])",
+          "\n  LogicalFilter(condition=[<>(CAST(UUIDV4()):CHAR(1) CHARACTER SET \"UTF-8\" NOT NULL, _UTF-8'x')])",
+          "\n    LogicalJoin(condition=[=($0, $1)], joinType=[inner])",
+          "\n      PinotLogicalExchange(distribution=[hash[0]])",
+          "\n        LogicalProject(col1=[$0])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalExchange(distribution=[hash[0]])",
+          "\n        LogicalProject(col1=[$0], col2=[$1])",
+          "\n          PinotLogicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Non-deterministic filter blocks the semi join rewrite: the IN sub-query is planned as an inner join over a distinct aggregate, with the filter kept above the join",
+        "sql": "EXPLAIN PLAN FOR SELECT a.col1 FROM a WHERE a.col1 IN (SELECT b.col1 FROM b) AND rand() < 0.1",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0])",
+          "\n  LogicalFilter(condition=[<(RAND(), 0.1E0)])",
+          "\n    LogicalJoin(condition=[=($0, $1)], joinType=[inner])",
+          "\n      PinotLogicalExchange(distribution=[hash[0]])",
+          "\n        LogicalProject(col1=[$0])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalExchange(distribution=[hash[0]])",
+          "\n        PinotLogicalAggregate(group=[{0}], aggType=[FINAL])",
+          "\n          PinotLogicalExchange(distribution=[hash[0]])",
+          "\n            PinotLogicalAggregate(group=[{0}], aggType=[LEAF])",
+          "\n              PinotLogicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "A non-deterministic conjunct holds the whole WHERE filter above the join",
+        "sql": "EXPLAIN PLAN FOR SELECT a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1 WHERE a.col3 > 5 AND rand() < 0.1",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0], col2=[$3])",
+          "\n  LogicalFilter(condition=[AND(>($1, 5), <(RAND(), 0.1E0))])",
+          "\n    LogicalJoin(condition=[=($0, $2)], joinType=[inner])",
+          "\n      PinotLogicalExchange(distribution=[hash[0]])",
+          "\n        LogicalProject(col1=[$0], col3=[$2])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalExchange(distribution=[hash[0]])",
+          "\n        LogicalProject(col1=[$0], col2=[$1])",
+          "\n          PinotLogicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Deterministic WHERE filter is still pushed below the join",
+        "sql": "EXPLAIN PLAN FOR SELECT a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1 WHERE a.col3 > 5",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0], col2=[$2])",
+          "\n  LogicalJoin(condition=[=($0, $1)], joinType=[inner])",
+          "\n    PinotLogicalExchange(distribution=[hash[0]])",
+          "\n      LogicalProject(col1=[$0])",
+          "\n        LogicalFilter(condition=[>($2, 5)])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
+          "\n    PinotLogicalExchange(distribution=[hash[0]])",
+          "\n      LogicalProject(col1=[$0], col2=[$1])",
+          "\n        PinotLogicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
       }
     ]
   },
@@ -681,6 +835,22 @@
           "\n        PinotLogicalTableScan(table=[[default, a]])",
           "\n    LogicalProject(col1=[$0], col2=[$1])",
           "\n      PinotLogicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Non-deterministic WHERE filter is not pushed below a lookup join",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy = 'lookup') */ a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1 WHERE rand() < 0.1",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0], col2=[$2])",
+          "\n  LogicalFilter(condition=[<(RAND(), 0.1E0)])",
+          "\n    LogicalJoin(condition=[=($0, $1)], joinType=[inner])",
+          "\n      PinotLogicalExchange(distribution=[single])",
+          "\n        LogicalProject(col1=[$0])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
+          "\n      LogicalProject(col1=[$0], col2=[$1])",
+          "\n        PinotLogicalTableScan(table=[[default, b]])",
           "\n"
         ]
       },

--- a/pinot-query-planner/src/test/resources/queries/JoinPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/JoinPlans.json
@@ -803,6 +803,23 @@
         ]
       },
       {
+        "description": "Volatile WHERE filter is not pushed below the join, nor duplicated onto both inputs",
+        "sql": "EXPLAIN PLAN FOR SELECT a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1 WHERE stageId(a.col1) >= 0",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0], col2=[$2])",
+          "\n  LogicalFilter(condition=[>=(STAGEID($0), 0)])",
+          "\n    LogicalJoin(condition=[=($0, $1)], joinType=[inner])",
+          "\n      PinotLogicalExchange(distribution=[hash[0]])",
+          "\n        LogicalProject(col1=[$0])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
+          "\n      PinotLogicalExchange(distribution=[hash[0]])",
+          "\n        LogicalProject(col1=[$0], col2=[$1])",
+          "\n          PinotLogicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
         "description": "Deterministic WHERE filter is still pushed below the join",
         "sql": "EXPLAIN PLAN FOR SELECT a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1 WHERE a.col3 > 5",
         "output": [

--- a/pinot-query-planner/src/test/resources/queries/JoinPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/JoinPlans.json
@@ -820,6 +820,39 @@
         ]
       },
       {
+        "description": "Volatile ON condition is kept in the join condition for an outer join",
+        "sql": "EXPLAIN PLAN FOR SELECT a.col1, b.col2 FROM a LEFT JOIN b ON a.col1 = b.col1 AND stageId(b.col3) >= 0",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0], col2=[$2])",
+          "\n  LogicalJoin(condition=[AND(=($0, $1), >=(STAGEID($3), 0))], joinType=[left])",
+          "\n    PinotLogicalExchange(distribution=[hash[0]])",
+          "\n      LogicalProject(col1=[$0])",
+          "\n        PinotLogicalTableScan(table=[[default, a]])",
+          "\n    PinotLogicalExchange(distribution=[hash[0]])",
+          "\n      LogicalProject(col1=[$0], col2=[$1], EXPR$0=[CAST($2):VARCHAR CHARACTER SET \"UTF-8\" NOT NULL])",
+          "\n        PinotLogicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "KNOWN GAP: a volatile ON conjunct referencing one side of an INNER join is hoisted into that input by RelOptUtil.pushDownJoinConditions during sql-to-rel, before any rule runs, so the join-condition guard never sees it",
+        "sql": "EXPLAIN PLAN FOR SELECT a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1 AND stageId(a.col3) >= 0",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0], col2=[$2])",
+          "\n  LogicalJoin(condition=[=($0, $1)], joinType=[inner])",
+          "\n    PinotLogicalExchange(distribution=[hash[0]])",
+          "\n      LogicalProject(col1=[$0])",
+          "\n        LogicalFilter(condition=[>=(STAGEID(CAST($2):VARCHAR CHARACTER SET \"UTF-8\" NOT NULL), 0)])",
+          "\n          PinotLogicalTableScan(table=[[default, a]])",
+          "\n    PinotLogicalExchange(distribution=[hash[0]])",
+          "\n      LogicalProject(col1=[$0], col2=[$1])",
+          "\n        PinotLogicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
         "description": "Deterministic WHERE filter is still pushed below the join",
         "sql": "EXPLAIN PLAN FOR SELECT a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1 WHERE a.col3 > 5",
         "output": [


### PR DESCRIPTION
## Problem

`PinotFilterJoinRule` is a copy-paste fork of Calcite's `FilterJoinRule#perform` (it exists so filters aren't pushed into the right side of a lookup join). The fork predates [CALCITE-7373](https://issues.apache.org/jira/browse/CALCITE-7373), fixed in Calcite 1.42.0 — the version this repo already pins. Because the method is forked, the fix was never picked up.

A conjunct like `rand() < 0.1` references no input fields, so its `InputFinder` bitmap is empty. `RelOptUtil.classifyFilters` treats an empty bitmap as a subset of the left input's fields, classifies the predicate as pushable, and relocates it below the join, where it is evaluated **per left-input row instead of per join-output row**.

The same gap also fed `RelOptUtil.simplifyJoin`, which is the more damaging half. On master:

```
SELECT a.col1, b.col2 FROM a LEFT JOIN b ON a.col1 = b.col1 WHERE b.col3 > 100 * rand()
  ->  LogicalJoin(joinType=[inner])     -- was LEFT
```

The non-deterministic predicate was treated as null-rejecting, so the left join became an inner join and the null-padded outer rows were **dropped entirely**. `FULL JOIN` was likewise simplified to `RIGHT`. Wrong results, not just a different plan.

## Two variability axes, only one of which reaches Calcite

Porting the upstream guard verbatim fixes `rand()` / `UUID_V4` / `UUID_V7`, but not everything it should, because `@ScalarFunction` carries **two independent** notions:

| | propagates to Calcite? | examples |
|---|---|---|
| `isDeterministic = false` | yes, via `PinotSqlFunction#isDeterministic` → `RexUtil.isDeterministic` | `rand()`, `UUID_V4`, `UUID_V7` |
| `FunctionVolatility.VOLATILE` | **no** | `now()`, `ago()`, `sleep()`, `stageId()`, `workerId()`, `cid()`, `startTime()`, `endTime()` |

Volatile functions deliberately keep `isDeterministic = true` so `PinotEvaluateLiteralRule` can still fold them once at plan time. That means upstream's `RexUtil.isDeterministic` check does not see them. On master:

```
SELECT a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1 WHERE stageId(a.col1) >= 0
  ->  LogicalFilter(condition=[>=(STAGEID($0), 0)])   pushed into leaf a
  ->  LogicalFilter(condition=[>=(STAGEID($0), 0)])   AND duplicated into leaf b
```

`PinotJoinPushTransitivePredicatesRule` infers the predicate for the other side across the join equality, so a per-stage function ends up evaluated independently in two different leaf stages.

### Scope of the fix

This closes the case above — where the filter would have been pushed below the join in the first place. It does **not** make volatile expressions globally immovable, and two gaps are pinned by tests rather than fixed here:

- **Transitive duplication from an existing below-join filter.** `SELECT s.col1, b.col2 FROM (SELECT col1 FROM a WHERE stageId(col1) >= 0) s JOIN b ON s.col1 = b.col1` still duplicates the predicate onto both leaves, because it was never above the join for this rule to hold back.
- **Volatile conjunct in an INNER join `ON` clause.** `RelOptUtil.pushDownJoinConditions` hoists a one-sided call into that input's `Project` during sql-to-rel, before any rule runs, so the join-condition guard only ever sees a bare `RexInputRef`. It *is* load-bearing for outer joins, where the `ON` clause is preserved.

Both shapes now have plan tests, the inner-join one explicitly labelled `KNOWN GAP`. Follow-up work for the other relocation sites (`PinotJoinPushTransitivePredicatesRule`, `PinotProjectJoinTransposeRule`, and the stock `FilterSetOpTransposeRule` / `FilterAggregateTransposeRule` / `JoinPushExpressionsRule`) is tracked separately.

## Fix

- Port the upstream CALCITE-7373 guard (verified byte-for-byte against the Calcite 1.42.0 release artifact).
- Surface volatility on `PinotSqlFunction#isVolatile()`, plumbed from the existing `FunctionInfo` volatility that `FunctionRegistry` already computes. Also mark the hard-coded `PinotOperatorTable` `NOW` entry volatile — it shadows the registry entry, so the operator `NOW()` actually binds to was disagreeing with it.
- Add `PinotRuleUtils.isRelocatable(RexNode)` and use it in the rule, marked `PINOT MODIFICATION` so the next Calcite re-diff preserves it. It delegates the determinism half to `RexUtil.isDeterministic` (so that half tracks upstream automatically) and additionally rejects `SqlOperator#isDynamicFunction()` — Calcite's own "fold once, never re-evaluate" marker, which is deterministic and would otherwise slip through.

`STABLE` is intentionally not blocked — a stable function is constant within one query, so relocating it is safe.

### No regression for `now()`-based time filters

This was the main risk, since `WHERE ts > now() - <interval>` over a join is a very common Pinot pattern. It is unaffected, because `now()` / `ago()` are niladic or literal-argument and get constant-folded before these rules run:

```
WHERE a.ts > now() - 86400000
  ->  LogicalFilter(condition=[>($7, 1786399455434)])   still pushed to the leaf scan
```

Pinned by `QueryCompilationTest#testVolatileNowFilterIsStillPushedBelowJoin` (asserted in Java rather than as a plan snapshot, since the folded epoch literal differs every run).

## Trade-off (deliberate)

The guard bails on the **whole** condition rather than per conjunct, matching upstream. So a deterministic conjunct sharing a WHERE clause with a non-deterministic one also stays above the join:

```
WHERE a.col3 > 5 AND rand() < 0.1   ->  neither conjunct is pushed to the leaf
```

That costs leaf-stage filtering and shuffles more rows for those queries. Per-conjunct splitting would be finer-grained, but it would be a *new* deviation in a fork whose drift is the very bug being fixed, and it interacts with the `origAboveFilters` no-op detection that guards against repeated rule firing. Correctness first; a finer-grained version belongs upstream. Pinned by an explicit test so it can't change silently.

Related: keeping the filter above the join also blocks the semi-join rewrite for `IN (subquery) AND rand() < ...`, which then plans as an inner join over a distinct aggregate. Also covered by a test.

## Tests

`JoinPlans.json` — 11 in `join_planning_tests`, 1 in `lookup_join_planning_tests`:

- non-deterministic `WHERE` on inner / left join
- non-deterministic `WHERE` on the null-generating side of a **left** and a **full** join (join-type simplification suppressed)
- non-deterministic `ON` condition (the second guard, reached via `JoinConditionPushRule` with a null filter)
- `uuid_v4()`, to show the guard isn't `RAND`-specific
- **volatile** `stageId()` filter neither pushed below the join nor duplicated onto both inputs
- semi-join / `IN` subquery
- mixed deterministic + non-deterministic conjuncts, pinning the trade-off above
- lookup join, since that's why this fork exists
- volatile `ON` conjunct **kept** in the join condition for an outer join
- the INNER-join `ON` hoisting gap, labelled `KNOWN GAP` so it is visible rather than implied-fixed
- a **control** asserting a purely deterministic filter is still pushed to the leaf, so the guard can't silently over-block

Plus `PinotRuleUtilsTest` (9 cases) covering `isRelocatable` directly — all three axes, nested operands, `STABLE` staying relocatable, and both `NOW` registrations agreeing — the `now()` pushdown test above, and operator-level volatility aggregation across overloads in `pinot-common` (`rand` is the mixed case: `rand()` VOLATILE, `rand(long)` IMMUTABLE).

`pinot-common` 2125, `pinot-query-planner` 1434, `pinot-query-runtime` 4491 — all pass. No existing expected plan changed.

## Known remaining drift

The same forked method is also missing [CALCITE-7319](https://issues.apache.org/jira/browse/CALCITE-7319) (correlation-variable handling), also from 1.42.0. It appears inert — Pinot decorrelates before these rules run, and the `LogicalCorrelate` shapes that survive (`UNNEST`) have an `Uncollect` right input, so a `$cor`-bearing filter never sits directly above a join. Documented in a comment rather than fixed here, to keep this PR single-concern. The comment uses the repo's existing grep-able `SYNCED WITH Calcite <version>` marker (as in `PinotRelDecorrelator`) so the next Calcite bump re-diffs this method.
