### PR TITLE
Do not count a deliberate consumer stop as a stream consumption error

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -50,10 +50,11 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   REALTIME_CLP_UNENCODABLE("rows", false),
   REALTIME_CLP_ENCODED_NON_STRINGS("rows", false),
   REALTIME_CONSUMPTION_EXCEPTIONS("exceptions", true),
-  // Number of times a consumer left its consume loop because it was interrupted to stop it, rather than because the
-  // stream failed. A rebalance, a server shutdown, a table disable or delete, and a CONSUMING -> ONLINE transition all
-  // stop consumers this way. Counted apart from realtimeConsumptionExceptions so that these deliberate teardowns stay
-  // visible without reading as stream faults.
+  // A consumer abandoned a segment after exhausting its transient-error retries. Unlike
+  // realtimeConsumptionExceptions, which moves on every attempt, this fires only once the retries stopped helping.
+  REALTIME_CONSUMPTION_RETRIES_EXHAUSTED("exceptions", true),
+  // A consumer left the consume loop because stop() interrupted it -- a rebalance, a shutdown, a table disable or
+  // delete, or a CONSUMING -> ONLINE transition -- rather than because the stream failed.
   REALTIME_CONSUMPTION_STOPPED_BY_INTERRUPT("stops", true),
   REALTIME_MERGED_TEXT_IDX_TRUNCATED_DOCUMENT_SIZE("bytes", false),
   REALTIME_OFFSET_COMMITS("commits", true),

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -50,9 +50,10 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   REALTIME_CLP_UNENCODABLE("rows", false),
   REALTIME_CLP_ENCODED_NON_STRINGS("rows", false),
   REALTIME_CONSUMPTION_EXCEPTIONS("exceptions", true),
-  // A consumer abandoned a segment after exhausting its transient-error retries. Unlike
-  // realtimeConsumptionExceptions, which moves on every attempt, this fires only once the retries stopped helping.
-  REALTIME_CONSUMPTION_RETRIES_EXHAUSTED("exceptions", true),
+  // A consumer abandoned a segment because the stream fetch failed: a permanent error, an Error, or transient errors
+  // that outlasted the retries. realtimeConsumptionExceptions moves on every attempt, including ones the next retry
+  // cleared, so this is the meter to alert on.
+  REALTIME_CONSUMPTION_STOPPED_BY_STREAM_ERROR("stops", true),
   // A consumer left the consume loop because stop() interrupted it -- a rebalance, a shutdown, a table disable or
   // delete, or a CONSUMING -> ONLINE transition -- rather than because the stream failed.
   REALTIME_CONSUMPTION_STOPPED_BY_INTERRUPT("stops", true),

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -50,6 +50,11 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   REALTIME_CLP_UNENCODABLE("rows", false),
   REALTIME_CLP_ENCODED_NON_STRINGS("rows", false),
   REALTIME_CONSUMPTION_EXCEPTIONS("exceptions", true),
+  // Number of times a consumer left its consume loop because it was interrupted to stop it, rather than because the
+  // stream failed. A rebalance, a server shutdown, a table disable or delete, and a CONSUMING -> ONLINE transition all
+  // stop consumers this way. Counted apart from realtimeConsumptionExceptions so that these deliberate teardowns stay
+  // visible without reading as stream faults.
+  REALTIME_CONSUMPTION_STOPPED_BY_INTERRUPT("stops", true),
   REALTIME_MERGED_TEXT_IDX_TRUNCATED_DOCUMENT_SIZE("bytes", false),
   REALTIME_OFFSET_COMMITS("commits", true),
   REALTIME_OFFSET_COMMIT_EXCEPTIONS("exceptions", false),

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -302,7 +302,6 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   private volatile boolean _shouldStop = false;
   /// Set when [#stop()] is invoked and never cleared, unlike [#_shouldStop] which
   /// [#catchupToFinalOffset(StreamPartitionMsgOffset, long)] resets so that the consume loop can run once more.
-  /// Records that this consumer is being torn down deliberately, for the whole remaining life of the consumer.
   private volatile boolean _stopping = false;
 
   // It takes 30s to locate controller leader, and more if there are multiple controller failures.
@@ -458,12 +457,10 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   /// Returns `true` if the consumer is being torn down by [#stop()] and the interrupt it delivered has landed on this
   /// thread.
   ///
-  /// The thread's interrupt status is the signal rather than the type of the exception the stream client raised,
-  /// because clients surface an interrupt in too many shapes to enumerate: Kafka wraps it in an unchecked
-  /// `InterruptException`, NIO channels throw `ClosedByInterruptException`, and the AWS SDK aborts the call with no
-  /// [InterruptedException] anywhere in the cause chain. All of them leave the interrupt status set, so checking the
-  /// status covers every client and, unlike inspecting the cause chain, does not mistake an [InterruptedException]
-  /// that was raised on some other thread and wrapped for us as an interrupt of our own.
+  /// The interrupt status is the signal rather than the type of the exception the client raised, because clients
+  /// surface an interrupt in too many shapes to enumerate: Kafka wraps it in an unchecked `InterruptException`, NIO
+  /// channels throw `ClosedByInterruptException`, and the AWS SDK aborts with no [InterruptedException] in the cause
+  /// chain at all. All of them leave the status set.
   ///
   /// This is checked against [#_stopping] rather than [#_shouldStop] because
   /// [#catchupToFinalOffset(StreamPartitionMsgOffset, long)] clears the latter before consuming once more.
@@ -471,16 +468,20 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     return _stopping && Thread.currentThread().isInterrupted();
   }
 
+  /// TODO: Key the table meter on `_clientId` instead of `_tableStreamName` so that it carries table, topic and
+  ///       partition labels, and keep the global meter for backward compatibility.
+  private void meterConsumptionException() {
+    _serverMetrics.addMeteredGlobalValue(ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS, 1L);
+    _serverMetrics.addMeteredTableValue(_tableStreamName, ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS, 1L);
+  }
+
   private void handleTransientStreamErrors(Exception e)
       throws Exception {
     _consecutiveErrorCount++;
-
-    // TODO: Alerting on every transient error is noisy. Consider counting them separately and only alerting once the
-    //       retries below are exhausted.
-    _serverMetrics.addMeteredGlobalValue(ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS, 1L);
-    _serverMetrics.addMeteredTableValue(_tableStreamName, ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS,
-        1L);
+    meterConsumptionException();
     if (_consecutiveErrorCount > MAX_CONSECUTIVE_ERROR_COUNT) {
+      _serverMetrics.addMeteredGlobalValue(ServerMeter.REALTIME_CONSUMPTION_RETRIES_EXHAUSTED, 1L);
+      _serverMetrics.addMeteredTableValue(_tableStreamName, ServerMeter.REALTIME_CONSUMPTION_RETRIES_EXHAUSTED, 1L);
       _segmentLogger.warn("Stream transient exception when fetching messages, stopping consumption after {} attempts",
           _consecutiveErrorCount, e);
       throw e;
@@ -538,20 +539,14 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         _endOfPartitionGroup = messageBatch.getMessageCount() == 0 && messageBatch.isEndOfPartitionGroup();
         _consecutiveErrorCount = 0;
       } catch (PermanentConsumerException e) {
-        // TODO: Key this meter on _clientId instead of _tableStreamName so that it carries table, topic and partition
-        //       labels, and keep the global meter for backward compatibility.
-        _serverMetrics.addMeteredGlobalValue(ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS, 1L);
-        _serverMetrics.addMeteredTableValue(_tableStreamName, ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS, 1L);
+        meterConsumptionException();
         _segmentLogger.warn("Permanent exception from stream when fetching messages, stopping consumption", e);
         throw e;
       } catch (Exception e) {
         if (isDeliberateStopInterrupt()) {
-          // stop() interrupts the consumer thread to tear it down, and the interrupt typically lands inside the
-          // fetch. That is a deliberate shutdown rather than a stream fault, so it must not be counted as a
-          // consumption error, slept on, or answered by building a replacement consumer for a segment that is
-          // going away. It is still counted on its own meter, so that a teardown remains visible and the two
-          // cases can be told apart when consumption stops unexpectedly. Exit the loop instead: on the offload
-          // path the thread winds down, and on the catch-up path the caller falls back to downloading the segment.
+          // A teardown rather than a stream fault, so it must not be slept on or answered by building a replacement
+          // consumer for a segment that is going away. Exit the loop instead: on the offload path the thread winds
+          // down, and on the catch-up path the caller falls back to downloading the segment.
           _serverMetrics.addMeteredGlobalValue(ServerMeter.REALTIME_CONSUMPTION_STOPPED_BY_INTERRUPT, 1L);
           _serverMetrics.addMeteredTableValue(_tableStreamName,
               ServerMeter.REALTIME_CONSUMPTION_STOPPED_BY_INTERRUPT, 1L);
@@ -567,7 +562,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         continue;
       } catch (Throwable t) {
         //track realtime rows fetched on a table level. This included valid + invalid rows
-        // TODO: This path is not counted by any meter today.
+        // An Error aborts consumption just as the cases above do, so it is counted the same way
+        meterConsumptionException();
         _segmentLogger.warn("Stream error when fetching messages, stopping consumption", t);
         throw t;
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -470,18 +470,17 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
 
   /// TODO: Key the table meter on `_clientId` instead of `_tableStreamName` so that it carries table, topic and
   ///       partition labels, and keep the global meter for backward compatibility.
-  private void meterConsumptionException() {
-    _serverMetrics.addMeteredGlobalValue(ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS, 1L);
-    _serverMetrics.addMeteredTableValue(_tableStreamName, ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS, 1L);
+  private void meterGlobalAndTable(ServerMeter meter) {
+    _serverMetrics.addMeteredGlobalValue(meter, 1L);
+    _serverMetrics.addMeteredTableValue(_tableStreamName, meter, 1L);
   }
 
   private void handleTransientStreamErrors(Exception e)
       throws Exception {
     _consecutiveErrorCount++;
-    meterConsumptionException();
+    meterGlobalAndTable(ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS);
     if (_consecutiveErrorCount > MAX_CONSECUTIVE_ERROR_COUNT) {
-      _serverMetrics.addMeteredGlobalValue(ServerMeter.REALTIME_CONSUMPTION_RETRIES_EXHAUSTED, 1L);
-      _serverMetrics.addMeteredTableValue(_tableStreamName, ServerMeter.REALTIME_CONSUMPTION_RETRIES_EXHAUSTED, 1L);
+      meterGlobalAndTable(ServerMeter.REALTIME_CONSUMPTION_STOPPED_BY_STREAM_ERROR);
       _segmentLogger.warn("Stream transient exception when fetching messages, stopping consumption after {} attempts",
           _consecutiveErrorCount, e);
       throw e;
@@ -539,7 +538,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         _endOfPartitionGroup = messageBatch.getMessageCount() == 0 && messageBatch.isEndOfPartitionGroup();
         _consecutiveErrorCount = 0;
       } catch (PermanentConsumerException e) {
-        meterConsumptionException();
+        meterGlobalAndTable(ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS);
+        meterGlobalAndTable(ServerMeter.REALTIME_CONSUMPTION_STOPPED_BY_STREAM_ERROR);
         _segmentLogger.warn("Permanent exception from stream when fetching messages, stopping consumption", e);
         throw e;
       } catch (Exception e) {
@@ -547,9 +547,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
           // A teardown rather than a stream fault, so it must not be slept on or answered by building a replacement
           // consumer for a segment that is going away. Exit the loop instead: on the offload path the thread winds
           // down, and on the catch-up path the caller falls back to downloading the segment.
-          _serverMetrics.addMeteredGlobalValue(ServerMeter.REALTIME_CONSUMPTION_STOPPED_BY_INTERRUPT, 1L);
-          _serverMetrics.addMeteredTableValue(_tableStreamName,
-              ServerMeter.REALTIME_CONSUMPTION_STOPPED_BY_INTERRUPT, 1L);
+          meterGlobalAndTable(ServerMeter.REALTIME_CONSUMPTION_STOPPED_BY_INTERRUPT);
           _segmentLogger.info("Consumption interrupted to stop the consumer, exiting the consume loop", e);
           break;
         }
@@ -563,7 +561,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       } catch (Throwable t) {
         //track realtime rows fetched on a table level. This included valid + invalid rows
         // An Error aborts consumption just as the cases above do, so it is counted the same way
-        meterConsumptionException();
+        meterGlobalAndTable(ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS);
+        meterGlobalAndTable(ServerMeter.REALTIME_CONSUMPTION_STOPPED_BY_STREAM_ERROR);
         _segmentLogger.warn("Stream error when fetching messages, stopping consumption", t);
         throw t;
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -25,7 +25,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.BufferOverflowException;
-import java.nio.channels.ClosedByInterruptException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -456,28 +455,28 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         || _forceCommitMessageReceived || !canAddMore();
   }
 
-  /// Returns `true` if the consumer is being torn down by [#stop()] and the given exception is the interrupt that
-  /// [#stop()] delivered. Stream clients surface an interrupt in different shapes: Kafka wraps it in an unchecked
-  /// `InterruptException`, and NIO-based clients throw [java.nio.channels.ClosedByInterruptException], so the whole
-  /// cause chain is inspected.
+  /// Returns `true` if the consumer is being torn down by [#stop()] and the interrupt it delivered has landed on this
+  /// thread.
+  ///
+  /// The thread's interrupt status is the signal rather than the type of the exception the stream client raised,
+  /// because clients surface an interrupt in too many shapes to enumerate: Kafka wraps it in an unchecked
+  /// `InterruptException`, NIO channels throw `ClosedByInterruptException`, and the AWS SDK aborts the call with no
+  /// [InterruptedException] anywhere in the cause chain. All of them leave the interrupt status set, so checking the
+  /// status covers every client and, unlike inspecting the cause chain, does not mistake an [InterruptedException]
+  /// that was raised on some other thread and wrapped for us as an interrupt of our own.
   ///
   /// This is checked against [#_stopping] rather than [#_shouldStop] because
   /// [#catchupToFinalOffset(StreamPartitionMsgOffset, long)] clears the latter before consuming once more.
-  private boolean isDeliberateStopInterrupt(Throwable t) {
-    if (!_stopping) {
-      return false;
-    }
-    for (Throwable cause = t; cause != null; cause = cause.getCause()) {
-      if (cause instanceof InterruptedException || cause instanceof ClosedByInterruptException) {
-        return true;
-      }
-    }
-    return false;
+  private boolean isDeliberateStopInterrupt() {
+    return _stopping && Thread.currentThread().isInterrupted();
   }
 
   private void handleTransientStreamErrors(Exception e)
       throws Exception {
     _consecutiveErrorCount++;
+
+    // TODO: Alerting on every transient error is noisy. Consider counting them separately and only alerting once the
+    //       retries below are exhausted.
     _serverMetrics.addMeteredGlobalValue(ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS, 1L);
     _serverMetrics.addMeteredTableValue(_tableStreamName, ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS,
         1L);
@@ -539,17 +538,23 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         _endOfPartitionGroup = messageBatch.getMessageCount() == 0 && messageBatch.isEndOfPartitionGroup();
         _consecutiveErrorCount = 0;
       } catch (PermanentConsumerException e) {
+        // TODO: Key this meter on _clientId instead of _tableStreamName so that it carries table, topic and partition
+        //       labels, and keep the global meter for backward compatibility.
         _serverMetrics.addMeteredGlobalValue(ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS, 1L);
         _serverMetrics.addMeteredTableValue(_tableStreamName, ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS, 1L);
         _segmentLogger.warn("Permanent exception from stream when fetching messages, stopping consumption", e);
         throw e;
       } catch (Exception e) {
-        if (isDeliberateStopInterrupt(e)) {
+        if (isDeliberateStopInterrupt()) {
           // stop() interrupts the consumer thread to tear it down, and the interrupt typically lands inside the
           // fetch. That is a deliberate shutdown rather than a stream fault, so it must not be counted as a
           // consumption error, slept on, or answered by building a replacement consumer for a segment that is
-          // going away. Exit the loop instead: on the offload path the thread winds down, and on the catch-up path
-          // the caller falls back to downloading the segment.
+          // going away. It is still counted on its own meter, so that a teardown remains visible and the two
+          // cases can be told apart when consumption stops unexpectedly. Exit the loop instead: on the offload
+          // path the thread winds down, and on the catch-up path the caller falls back to downloading the segment.
+          _serverMetrics.addMeteredGlobalValue(ServerMeter.REALTIME_CONSUMPTION_STOPPED_BY_INTERRUPT, 1L);
+          _serverMetrics.addMeteredTableValue(_tableStreamName,
+              ServerMeter.REALTIME_CONSUMPTION_STOPPED_BY_INTERRUPT, 1L);
           _segmentLogger.info("Consumption interrupted to stop the consumer, exiting the consume loop", e);
           break;
         }
@@ -562,6 +567,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         continue;
       } catch (Throwable t) {
         //track realtime rows fetched on a table level. This included valid + invalid rows
+        // TODO: This path is not counted by any meter today.
         _segmentLogger.warn("Stream error when fetching messages, stopping consumption", t);
         throw t;
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.BufferOverflowException;
+import java.nio.channels.ClosedByInterruptException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -300,6 +301,10 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   private volatile boolean _forceCommitMessageReceived = false;
   private volatile StreamPartitionMsgOffset _finalOffset; // Exclusive, used when we want to catch up to this one
   private volatile boolean _shouldStop = false;
+  /// Set when [#stop()] is invoked and never cleared, unlike [#_shouldStop] which
+  /// [#catchupToFinalOffset(StreamPartitionMsgOffset, long)] resets so that the consume loop can run once more.
+  /// Records that this consumer is being torn down deliberately, for the whole remaining life of the consumer.
+  private volatile boolean _stopping = false;
 
   // It takes 30s to locate controller leader, and more if there are multiple controller failures.
   // For now, we let 31s pass for this state transition.
@@ -451,6 +456,25 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         || _forceCommitMessageReceived || !canAddMore();
   }
 
+  /// Returns `true` if the consumer is being torn down by [#stop()] and the given exception is the interrupt that
+  /// [#stop()] delivered. Stream clients surface an interrupt in different shapes: Kafka wraps it in an unchecked
+  /// `InterruptException`, and NIO-based clients throw [java.nio.channels.ClosedByInterruptException], so the whole
+  /// cause chain is inspected.
+  ///
+  /// This is checked against [#_stopping] rather than [#_shouldStop] because
+  /// [#catchupToFinalOffset(StreamPartitionMsgOffset, long)] clears the latter before consuming once more.
+  private boolean isDeliberateStopInterrupt(Throwable t) {
+    if (!_stopping) {
+      return false;
+    }
+    for (Throwable cause = t; cause != null; cause = cause.getCause()) {
+      if (cause instanceof InterruptedException || cause instanceof ClosedByInterruptException) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   private void handleTransientStreamErrors(Exception e)
       throws Exception {
     _consecutiveErrorCount++;
@@ -461,16 +485,11 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       _segmentLogger.warn("Stream transient exception when fetching messages, stopping consumption after {} attempts",
           _consecutiveErrorCount, e);
       throw e;
-    } else {
-      if (_shouldStop && (e instanceof InterruptedException || e.getCause() instanceof InterruptedException)) {
-        _segmentLogger.debug("Interrupted to stop consumption", e);
-      } else {
-        _segmentLogger.warn("Stream transient exception when fetching messages, retrying (count={})",
-            _consecutiveErrorCount, e);
-      }
-      Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
-      recreateStreamConsumer("Too many transient errors");
     }
+    _segmentLogger.warn("Stream transient exception when fetching messages, retrying (count={})",
+        _consecutiveErrorCount, e);
+    Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+    recreateStreamConsumer("Too many transient errors");
   }
 
   protected boolean consumeLoop()
@@ -525,6 +544,15 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         _segmentLogger.warn("Permanent exception from stream when fetching messages, stopping consumption", e);
         throw e;
       } catch (Exception e) {
+        if (isDeliberateStopInterrupt(e)) {
+          // stop() interrupts the consumer thread to tear it down, and the interrupt typically lands inside the
+          // fetch. That is a deliberate shutdown rather than a stream fault, so it must not be counted as a
+          // consumption error, slept on, or answered by building a replacement consumer for a segment that is
+          // going away. Exit the loop instead: on the offload path the thread winds down, and on the catch-up path
+          // the caller falls back to downloading the segment.
+          _segmentLogger.info("Consumption interrupted to stop the consumer, exiting the consume loop", e);
+          break;
+        }
         //track realtime rows fetched on a table level. This included valid + invalid rows
         // all exceptions but PermanentConsumerException are handled the same way
         // can be a TimeoutException or TransientConsumerException routinely
@@ -1782,6 +1810,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   ///    interrupt the consumer thread because there is no need to build the segment.
   public void stop()
       throws InterruptedException {
+    _stopping = true;
     _shouldStop = true;
     if (Thread.currentThread() != _consumerThread && _consumerThread.isAlive()) {
       _segmentLogger.info("Interrupting the consumer thread and waiting for it to join");

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumerStopTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumerStopTest.java
@@ -116,12 +116,15 @@ public class RealtimeConsumerStopTest {
       startConsumingSegment(tableDataManager, serverMetrics);
       assertTrue(TestStreamConsumerFactory.awaitFetch(), "Consumer never reached the stream fetch");
       long consumptionExceptions = consumptionExceptions(serverMetrics);
+      long stoppedByInterrupt = stoppedByInterrupt(serverMetrics);
 
       // The call the Helix CONSUMING -> OFFLINE and CONSUMING -> DROPPED transitions make on the server
       tableDataManager.offloadSegment(SEGMENT_NAME_STR);
 
       assertEquals(consumptionExceptions(serverMetrics), consumptionExceptions,
           "Stopping a consumer must not be counted as a stream error");
+      assertEquals(stoppedByInterrupt(serverMetrics), stoppedByInterrupt + 1,
+          "Stopping a consumer must be counted on the deliberate stop meter");
       assertEquals(TestStreamConsumerFactory.CONSUMERS_CREATED.get(), 1,
           "No replacement consumer should be built for a segment being offloaded");
       assertEquals(TestStreamConsumerFactory.CONSUMERS_CLOSED.get(), 1, "The stream consumer should be closed");
@@ -145,6 +148,7 @@ public class RealtimeConsumerStopTest {
       RealtimeSegmentDataManager segmentDataManager = startConsumingSegment(tableDataManager, serverMetrics);
       assertTrue(TestStreamConsumerFactory.awaitFetch(), "Consumer never reached the stream fetch");
       long consumptionExceptions = consumptionExceptions(serverMetrics);
+      long stoppedByInterrupt = stoppedByInterrupt(serverMetrics);
       TestStreamConsumerFactory.fetchesBehaveAs(TestStreamConsumerFactory.FetchBehaviour.INTERRUPT);
       // Count only the fetches the catch-up loop makes, not the ones the consumer thread already made
       TestStreamConsumerFactory.FETCHES.set(0);
@@ -160,6 +164,9 @@ public class RealtimeConsumerStopTest {
 
       assertEquals(consumptionExceptions(serverMetrics), consumptionExceptions,
           "An interrupt on the catch-up path must not be counted as a stream error");
+      // Once for the consumer thread that stop() interrupted, once for the catch-up loop on this thread
+      assertEquals(stoppedByInterrupt(serverMetrics), stoppedByInterrupt + 2,
+          "Both the consumer thread and the catch-up loop should be counted on the deliberate stop meter");
       assertEquals(TestStreamConsumerFactory.FETCHES.get(), 1, "Catch-up should give up on the first interrupt");
       assertEquals(TestStreamConsumerFactory.CONSUMERS_CREATED.get(), 1,
           "No replacement consumer should be built while stopping");
@@ -168,9 +175,9 @@ public class RealtimeConsumerStopTest {
     }
   }
 
-  /// The counterpart of the case above, and the reason the distinction has to be drawn on the exception rather than
-  /// on the fact that a stop is in flight: a real fetch failure is still metered and still retried behind a fresh
-  /// consumer, even though it surfaces from the same catch block.
+  /// The counterpart of the cases above, and the reason the distinction has to be drawn on the thread's interrupt
+  /// status rather than on the fact that a stop is in flight: a real fetch failure is still metered and still retried
+  /// behind a fresh consumer, even though it surfaces from the same catch block.
   @Test
   public void testStreamFailureIsCountedAsAStreamError()
       throws Exception {
@@ -179,6 +186,7 @@ public class RealtimeConsumerStopTest {
     try {
       TestStreamConsumerFactory.fetchesBehaveAs(TestStreamConsumerFactory.FetchBehaviour.FAIL);
       long consumptionExceptions = consumptionExceptions(serverMetrics);
+      long stoppedByInterrupt = stoppedByInterrupt(serverMetrics);
       startConsumingSegment(tableDataManager, serverMetrics);
 
       // The transient handler sleeps and rebuilds the consumer, so a second consumer proves the retry happened
@@ -187,6 +195,8 @@ public class RealtimeConsumerStopTest {
 
       assertTrue(consumptionExceptions(serverMetrics) > consumptionExceptions,
           "A stream failure must be counted as a consumption exception");
+      assertEquals(stoppedByInterrupt(serverMetrics), stoppedByInterrupt,
+          "A stream failure must not be counted as a deliberate stop");
     } finally {
       tableDataManager.shutDown();
     }
@@ -194,6 +204,10 @@ public class RealtimeConsumerStopTest {
 
   private static long consumptionExceptions(ServerMetrics serverMetrics) {
     return serverMetrics.getMeteredValue(ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS).count();
+  }
+
+  private static long stoppedByInterrupt(ServerMetrics serverMetrics) {
+    return serverMetrics.getMeteredValue(ServerMeter.REALTIME_CONSUMPTION_STOPPED_BY_INTERRUPT).count();
   }
 
   private static InstanceDataManagerConfig createInstanceDataManagerConfig() {
@@ -298,6 +312,13 @@ public class RealtimeConsumerStopTest {
     }
 
     private static class TestConsumer implements PartitionGroupConsumer {
+      /// Never counted down. A [FetchBehaviour#BLOCK] fetch waits on this instead of sleeping for `timeoutMs`, so the
+      /// only way out of the fetch is the interrupt under test. An unbounded wait is what makes the timing
+      /// deterministic: a fetch that timed out on its own could return and start a second fetch while a test was
+      /// still arranging the stop, and that second fetch would then observe the arranged behaviour before `stop()`
+      /// had been called at all.
+      private static final CountDownLatch RECORDS_NEVER_ARRIVE = new CountDownLatch(1);
+
       @Override
       public MessageBatch fetchMessages(StreamPartitionMsgOffset startOffset, int timeoutMs) {
         FETCHES.incrementAndGet();
@@ -311,8 +332,8 @@ public class RealtimeConsumerStopTest {
             break;
         }
         try {
-          // A caught-up client parks here until records arrive or the poll times out
-          Thread.sleep(timeoutMs);
+          // A caught-up client parks here until records arrive
+          RECORDS_NEVER_ARRIVE.await();
         } catch (InterruptedException e) {
           throw interrupted();
         }
@@ -320,7 +341,8 @@ public class RealtimeConsumerStopTest {
       }
 
       /// Mirrors `org.apache.kafka.common.errors.InterruptException`: re-arm the thread interrupt flag and rethrow
-      /// the interrupt wrapped in an unchecked exception.
+      /// the interrupt wrapped in an unchecked exception. Re-arming is the part the consumer relies on to tell a
+      /// deliberate stop from a stream fault, and every client it supports does it.
       private static RuntimeException interrupted() {
         Thread.currentThread().interrupt();
         return new RuntimeException("Interrupted while polling the stream", new InterruptedException());

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumerStopTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumerStopTest.java
@@ -46,6 +46,7 @@ import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.MessageBatch;
 import org.apache.pinot.spi.stream.PartitionGroupConsumer;
 import org.apache.pinot.spi.stream.PartitionGroupConsumptionStatus;
+import org.apache.pinot.spi.stream.PermanentConsumerException;
 import org.apache.pinot.spi.stream.StreamConsumerFactory;
 import org.apache.pinot.spi.stream.StreamMessage;
 import org.apache.pinot.spi.stream.StreamMetadataProvider;
@@ -57,6 +58,7 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.mock;
@@ -181,7 +183,7 @@ public class RealtimeConsumerStopTest {
       TestStreamConsumerFactory.fetchesBehaveAs(TestStreamConsumerFactory.FetchBehaviour.FAIL);
       long consumptionExceptions = consumptionExceptions(serverMetrics);
       long stoppedByInterrupt = stoppedByInterrupt(serverMetrics);
-      long retriesExhausted = retriesExhausted(serverMetrics);
+      long stoppedByStreamError = stoppedByStreamError(serverMetrics);
       startConsumingSegment(tableDataManager, serverMetrics);
 
       // The transient handler sleeps and rebuilds the consumer, so a second consumer proves the retry happened
@@ -192,8 +194,8 @@ public class RealtimeConsumerStopTest {
           "A stream failure must be counted as a consumption exception");
       assertEquals(stoppedByInterrupt(serverMetrics), stoppedByInterrupt,
           "A stream failure must not be counted as a deliberate stop");
-      assertEquals(retriesExhausted(serverMetrics), retriesExhausted,
-          "A failure that still has retries left must not be counted as an exhausted retry budget");
+      assertEquals(stoppedByStreamError(serverMetrics), stoppedByStreamError,
+          "A failure with retries left has not stopped consumption yet");
     } finally {
       tableDataManager.shutDown();
     }
@@ -201,7 +203,7 @@ public class RealtimeConsumerStopTest {
 
   /// A stream that keeps failing eventually runs the retry budget out, which is the point at which the segment is
   /// abandoned. `realtimeConsumptionExceptions` moves on every attempt, including ones that would have self-healed,
-  /// so the exhaustion is what alerts hang on and it has to be counted exactly once per abandoned segment.
+  /// so the abandonment is what alerts hang on and it has to be counted exactly once per abandoned segment.
   @Test
   public void testExhaustingTheRetryBudgetIsCountedOnce()
       throws Exception {
@@ -210,15 +212,15 @@ public class RealtimeConsumerStopTest {
     try {
       TestStreamConsumerFactory.fetchesBehaveAs(TestStreamConsumerFactory.FetchBehaviour.FAIL);
       long consumptionExceptions = consumptionExceptions(serverMetrics);
-      long retriesExhausted = retriesExhausted(serverMetrics);
+      long stoppedByStreamError = stoppedByStreamError(serverMetrics);
       startConsumingSegment(tableDataManager, serverMetrics);
 
       // Each attempt backs off for a second before the next, so the budget takes a few seconds to run out
-      TestUtils.waitForCondition(aVoid -> retriesExhausted(serverMetrics) > retriesExhausted, 60_000L,
-          "Retry budget was never reported as exhausted");
+      TestUtils.waitForCondition(aVoid -> stoppedByStreamError(serverMetrics) > stoppedByStreamError, 60_000L,
+          "Consumption was never reported as stopped by a stream error");
 
-      assertEquals(retriesExhausted(serverMetrics), retriesExhausted + 1,
-          "Exhausting the retry budget should be counted once, not once per attempt");
+      assertEquals(stoppedByStreamError(serverMetrics), stoppedByStreamError + 1,
+          "Abandoning the segment should be counted once, not once per attempt");
       assertEquals(consumptionExceptions(serverMetrics), consumptionExceptions + ATTEMPTS_BEFORE_GIVING_UP,
           "Every failed attempt should be counted as a consumption exception");
     } finally {
@@ -226,12 +228,47 @@ public class RealtimeConsumerStopTest {
     }
   }
 
+  /// A permanent stream error and an [Error] both abandon the segment on the spot, with no retry to wait out. They
+  /// leave the consume loop through catch blocks of their own, so each has to reach the same meter as the exhausted
+  /// retry budget above — that meter is what says ingestion stopped, whatever the reason.
+  @Test(dataProvider = "failuresThatAbandonAtOnce")
+  public void testAFailureThatAbandonsTheSegmentAtOnceIsCountedOnce(
+      TestStreamConsumerFactory.FetchBehaviour fetchBehaviour)
+      throws Exception {
+    ServerMetrics serverMetrics = new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
+    RealtimeTableDataManager tableDataManager = createTableDataManager();
+    try {
+      TestStreamConsumerFactory.fetchesBehaveAs(fetchBehaviour);
+      long consumptionExceptions = consumptionExceptions(serverMetrics);
+      long stoppedByStreamError = stoppedByStreamError(serverMetrics);
+      startConsumingSegment(tableDataManager, serverMetrics);
+
+      TestUtils.waitForCondition(aVoid -> stoppedByStreamError(serverMetrics) > stoppedByStreamError, 30_000L,
+          "Consumption was never reported as stopped by a stream error");
+
+      assertEquals(stoppedByStreamError(serverMetrics), stoppedByStreamError + 1,
+          "Abandoning the segment should be counted once");
+      assertEquals(consumptionExceptions(serverMetrics), consumptionExceptions + 1,
+          "The failure should also be counted as a consumption exception");
+      assertEquals(TestStreamConsumerFactory.FETCHES.get(), 1, "Neither failure should be retried");
+    } finally {
+      tableDataManager.shutDown();
+    }
+  }
+
+  @DataProvider(name = "failuresThatAbandonAtOnce")
+  public Object[][] failuresThatAbandonAtOnce() {
+    return new Object[][]{
+        {TestStreamConsumerFactory.FetchBehaviour.PERMANENT}, {TestStreamConsumerFactory.FetchBehaviour.ERROR}
+    };
+  }
+
   private static long consumptionExceptions(ServerMetrics serverMetrics) {
     return serverMetrics.getMeteredValue(ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS).count();
   }
 
-  private static long retriesExhausted(ServerMetrics serverMetrics) {
-    return serverMetrics.getMeteredValue(ServerMeter.REALTIME_CONSUMPTION_RETRIES_EXHAUSTED).count();
+  private static long stoppedByStreamError(ServerMetrics serverMetrics) {
+    return serverMetrics.getMeteredValue(ServerMeter.REALTIME_CONSUMPTION_STOPPED_BY_STREAM_ERROR).count();
   }
 
   private static long stoppedByInterrupt(ServerMetrics serverMetrics) {
@@ -293,10 +330,10 @@ public class RealtimeConsumerStopTest {
   /// test. Registered through the table config, so the segment data manager builds it exactly as it builds a Kafka
   /// or Kinesis consumer.
   public static class TestStreamConsumerFactory extends StreamConsumerFactory {
-    /// Park like a caught-up client, fail like an unreachable broker, or fail the way a client does when the thread
-    /// calling it is interrupted.
+    /// Park like a caught-up client, fail like an unreachable broker, fail the way a client does when the thread
+    /// calling it is interrupted, fail in a way no retry can clear, or break below the [Exception] hierarchy.
     enum FetchBehaviour {
-      BLOCK, FAIL, INTERRUPT
+      BLOCK, FAIL, INTERRUPT, PERMANENT, ERROR
     }
 
     static final AtomicInteger CONSUMERS_CREATED = new AtomicInteger();
@@ -354,6 +391,10 @@ public class RealtimeConsumerStopTest {
             throw new RuntimeException("Stream is unreachable", new SocketTimeoutException());
           case INTERRUPT:
             throw interrupted();
+          case PERMANENT:
+            throw new PermanentConsumerException(new IllegalStateException("No such topic"));
+          case ERROR:
+            throw new StreamClientError();
           default:
             break;
         }
@@ -375,6 +416,14 @@ public class RealtimeConsumerStopTest {
       @Override
       public void close() {
         CONSUMERS_CLOSED.incrementAndGet();
+      }
+    }
+
+    /// Stands in for whatever a client can throw from below [Exception], such as a [LinkageError] from a broken
+    /// plugin classpath or an [OutOfMemoryError] while buffering a batch.
+    private static class StreamClientError extends Error {
+      StreamClientError() {
+        super("Stream client broke below the Exception hierarchy");
       }
     }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumerStopTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumerStopTest.java
@@ -65,20 +65,15 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 
-/// Verifies how a consuming segment reacts to being stopped while its consumer is blocked in the stream fetch.
+/// Verifies how a consuming segment reacts to being stopped while its consumer is blocked in the stream fetch. This
+/// is the shape of every deliberate teardown: Helix `CONSUMING -> OFFLINE` and `CONSUMING -> DROPPED` both land on
+/// `offloadSegment`, which interrupts the consumer thread while it is parked inside the stream client, so the
+/// interrupt surfaces as a fetch failure — and must not be mistaken for one.
 ///
-/// This is the shape of every deliberate teardown: Helix `CONSUMING -> OFFLINE` and `CONSUMING -> DROPPED` both land
-/// on `offloadSegment`, which reaches [RealtimeSegmentDataManager#doOffload()] and interrupts the consumer thread.
-/// The interrupt almost always arrives while that thread is parked inside the stream client, so it surfaces as a
-/// fetch failure — and must not be mistaken for one.
-///
-/// The table data manager, the consumer thread, the stop/interrupt/join handshake, the consume loop and its error
-/// handling are all real; the segment is offloaded through the same `offloadSegment` call the Helix state model
-/// makes. Only the stream is supplied by the test, through the [StreamConsumerFactory] extension point named in the
-/// table config, which is what makes the timing deterministic: the consumer is guaranteed to be inside
-/// `fetchMessages` when the interrupt lands. [TestStreamConsumerFactory] reproduces the Kafka client contract — a
-/// blocking fetch that, on interrupt, re-arms the thread interrupt flag and rethrows wrapped in an unchecked
-/// exception.
+/// The table data manager, the consumer thread, the stop/interrupt/join handshake, and the consume loop are all real.
+/// Only the stream is supplied by the test, through the [StreamConsumerFactory] extension point named in the table
+/// config, which is what makes the timing deterministic: the consumer is guaranteed to be inside `fetchMessages` when
+/// the interrupt lands.
 public class RealtimeConsumerStopTest {
   private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), "RealtimeConsumerStopTest");
   private static final String RAW_TABLE_NAME = "Coffee";
@@ -86,6 +81,8 @@ public class RealtimeConsumerStopTest {
   private static final LLCSegmentName SEGMENT_NAME = new LLCSegmentName(RAW_TABLE_NAME, 0, 0, 1600000000000L);
   private static final String SEGMENT_NAME_STR = SEGMENT_NAME.getSegmentName();
   private static final LongMsgOffset START_OFFSET = new LongMsgOffset(0L);
+  /// `MAX_CONSECUTIVE_ERROR_COUNT` retries, plus the attempt that takes the count past the limit.
+  private static final int ATTEMPTS_BEFORE_GIVING_UP = 6;
 
   @BeforeClass
   public void setUp() {
@@ -105,8 +102,7 @@ public class RealtimeConsumerStopTest {
   }
 
   /// Offloading a consuming segment interrupts its consumer mid-fetch. Nothing is wrong with the stream, so the
-  /// interrupt must not be metered as a consumption exception, and no replacement consumer may be built for a
-  /// segment that is going away.
+  /// interrupt must not be metered as a consumption exception, and no replacement consumer may be built.
   @Test
   public void testOffloadingAConsumingSegmentIsNotCountedAsAStreamError()
       throws Exception {
@@ -137,8 +133,6 @@ public class RealtimeConsumerStopTest {
   /// reach the committed end offset, clearing the stop flag so that loop is allowed to run. An interrupt arriving
   /// there — the state transition thread itself being interrupted, as happens when a server shuts down mid
   /// transition — is still part of the teardown, which is why the stop has to be remembered across that reset.
-  /// Catch-up then gives up at once and the replica falls back to downloading the segment, instead of booking a
-  /// stream error and rebuilding a consumer on each of five retries on the way out.
   @Test
   public void testInterruptWhileCatchingUpIsNotCountedAsAStreamError()
       throws Exception {
@@ -187,6 +181,7 @@ public class RealtimeConsumerStopTest {
       TestStreamConsumerFactory.fetchesBehaveAs(TestStreamConsumerFactory.FetchBehaviour.FAIL);
       long consumptionExceptions = consumptionExceptions(serverMetrics);
       long stoppedByInterrupt = stoppedByInterrupt(serverMetrics);
+      long retriesExhausted = retriesExhausted(serverMetrics);
       startConsumingSegment(tableDataManager, serverMetrics);
 
       // The transient handler sleeps and rebuilds the consumer, so a second consumer proves the retry happened
@@ -197,6 +192,35 @@ public class RealtimeConsumerStopTest {
           "A stream failure must be counted as a consumption exception");
       assertEquals(stoppedByInterrupt(serverMetrics), stoppedByInterrupt,
           "A stream failure must not be counted as a deliberate stop");
+      assertEquals(retriesExhausted(serverMetrics), retriesExhausted,
+          "A failure that still has retries left must not be counted as an exhausted retry budget");
+    } finally {
+      tableDataManager.shutDown();
+    }
+  }
+
+  /// A stream that keeps failing eventually runs the retry budget out, which is the point at which the segment is
+  /// abandoned. `realtimeConsumptionExceptions` moves on every attempt, including ones that would have self-healed,
+  /// so the exhaustion is what alerts hang on and it has to be counted exactly once per abandoned segment.
+  @Test
+  public void testExhaustingTheRetryBudgetIsCountedOnce()
+      throws Exception {
+    ServerMetrics serverMetrics = new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
+    RealtimeTableDataManager tableDataManager = createTableDataManager();
+    try {
+      TestStreamConsumerFactory.fetchesBehaveAs(TestStreamConsumerFactory.FetchBehaviour.FAIL);
+      long consumptionExceptions = consumptionExceptions(serverMetrics);
+      long retriesExhausted = retriesExhausted(serverMetrics);
+      startConsumingSegment(tableDataManager, serverMetrics);
+
+      // Each attempt backs off for a second before the next, so the budget takes a few seconds to run out
+      TestUtils.waitForCondition(aVoid -> retriesExhausted(serverMetrics) > retriesExhausted, 60_000L,
+          "Retry budget was never reported as exhausted");
+
+      assertEquals(retriesExhausted(serverMetrics), retriesExhausted + 1,
+          "Exhausting the retry budget should be counted once, not once per attempt");
+      assertEquals(consumptionExceptions(serverMetrics), consumptionExceptions + ATTEMPTS_BEFORE_GIVING_UP,
+          "Every failed attempt should be counted as a consumption exception");
     } finally {
       tableDataManager.shutDown();
     }
@@ -204,6 +228,10 @@ public class RealtimeConsumerStopTest {
 
   private static long consumptionExceptions(ServerMetrics serverMetrics) {
     return serverMetrics.getMeteredValue(ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS).count();
+  }
+
+  private static long retriesExhausted(ServerMetrics serverMetrics) {
+    return serverMetrics.getMeteredValue(ServerMeter.REALTIME_CONSUMPTION_RETRIES_EXHAUSTED).count();
   }
 
   private static long stoppedByInterrupt(ServerMetrics serverMetrics) {
@@ -265,8 +293,8 @@ public class RealtimeConsumerStopTest {
   /// test. Registered through the table config, so the segment data manager builds it exactly as it builds a Kafka
   /// or Kinesis consumer.
   public static class TestStreamConsumerFactory extends StreamConsumerFactory {
-    /// How the next fetch behaves: park like a caught-up client, fail like an unreachable broker, or fail the way a
-    /// client does when the thread calling it is interrupted.
+    /// Park like a caught-up client, fail like an unreachable broker, or fail the way a client does when the thread
+    /// calling it is interrupted.
     enum FetchBehaviour {
       BLOCK, FAIL, INTERRUPT
     }
@@ -312,11 +340,9 @@ public class RealtimeConsumerStopTest {
     }
 
     private static class TestConsumer implements PartitionGroupConsumer {
-      /// Never counted down. A [FetchBehaviour#BLOCK] fetch waits on this instead of sleeping for `timeoutMs`, so the
-      /// only way out of the fetch is the interrupt under test. An unbounded wait is what makes the timing
-      /// deterministic: a fetch that timed out on its own could return and start a second fetch while a test was
-      /// still arranging the stop, and that second fetch would then observe the arranged behaviour before `stop()`
-      /// had been called at all.
+      /// Never counted down, so the only way out of a [FetchBehaviour#BLOCK] fetch is the interrupt under test. A
+      /// fetch bounded by `timeoutMs` could instead return and start a second fetch while a test was still arranging
+      /// the stop, and that second fetch would observe the arranged behaviour before `stop()` had been called at all.
       private static final CountDownLatch RECORDS_NEVER_ARRIVE = new CountDownLatch(1);
 
       @Override
@@ -332,7 +358,6 @@ public class RealtimeConsumerStopTest {
             break;
         }
         try {
-          // A caught-up client parks here until records arrive
           RECORDS_NEVER_ARRIVE.await();
         } catch (InterruptedException e) {
           throw interrupted();
@@ -340,9 +365,8 @@ public class RealtimeConsumerStopTest {
         return new EmptyMessageBatch(startOffset);
       }
 
-      /// Mirrors `org.apache.kafka.common.errors.InterruptException`: re-arm the thread interrupt flag and rethrow
-      /// the interrupt wrapped in an unchecked exception. Re-arming is the part the consumer relies on to tell a
-      /// deliberate stop from a stream fault, and every client it supports does it.
+      /// Mirrors `org.apache.kafka.common.errors.InterruptException`: re-arm the thread interrupt flag and rethrow the
+      /// interrupt wrapped in an unchecked exception. The re-arm is what the consumer reads to recognize a stop.
       private static RuntimeException interrupted() {
         Thread.currentThread().interrupt();
         return new RuntimeException("Interrupted while polling the stream", new InterruptedException());
@@ -354,7 +378,7 @@ public class RealtimeConsumerStopTest {
       }
     }
 
-    /// What a caught-up client returns when the poll times out with no records.
+    /// What a caught-up client returns when a poll yields no records.
     private record EmptyMessageBatch(StreamPartitionMsgOffset _offsetOfNextBatch) implements MessageBatch<byte[]> {
       @Override
       public int getMessageCount() {

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumerStopTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumerStopTest.java
@@ -1,0 +1,358 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.manager.realtime;
+
+import java.io.File;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.commons.io.FileUtils;
+import org.apache.helix.HelixManager;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.metrics.ServerMeter;
+import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.core.data.manager.provider.DefaultTableDataManagerProvider;
+import org.apache.pinot.core.data.manager.provider.TableDataManagerProvider;
+import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamMessageDecoder;
+import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamMetadataProvider;
+import org.apache.pinot.segment.local.segment.creator.Fixtures;
+import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
+import org.apache.pinot.segment.local.utils.SegmentLocks;
+import org.apache.pinot.segment.local.utils.ServerReloadJobStatusCache;
+import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.metrics.PinotMetricUtils;
+import org.apache.pinot.spi.stream.LongMsgOffset;
+import org.apache.pinot.spi.stream.MessageBatch;
+import org.apache.pinot.spi.stream.PartitionGroupConsumer;
+import org.apache.pinot.spi.stream.PartitionGroupConsumptionStatus;
+import org.apache.pinot.spi.stream.StreamConsumerFactory;
+import org.apache.pinot.spi.stream.StreamMessage;
+import org.apache.pinot.spi.stream.StreamMetadataProvider;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.util.TestUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+/// Verifies how a consuming segment reacts to being stopped while its consumer is blocked in the stream fetch.
+///
+/// This is the shape of every deliberate teardown: Helix `CONSUMING -> OFFLINE` and `CONSUMING -> DROPPED` both land
+/// on `offloadSegment`, which reaches [RealtimeSegmentDataManager#doOffload()] and interrupts the consumer thread.
+/// The interrupt almost always arrives while that thread is parked inside the stream client, so it surfaces as a
+/// fetch failure — and must not be mistaken for one.
+///
+/// The table data manager, the consumer thread, the stop/interrupt/join handshake, the consume loop and its error
+/// handling are all real; the segment is offloaded through the same `offloadSegment` call the Helix state model
+/// makes. Only the stream is supplied by the test, through the [StreamConsumerFactory] extension point named in the
+/// table config, which is what makes the timing deterministic: the consumer is guaranteed to be inside
+/// `fetchMessages` when the interrupt lands. [TestStreamConsumerFactory] reproduces the Kafka client contract — a
+/// blocking fetch that, on interrupt, re-arms the thread interrupt flag and rethrows wrapped in an unchecked
+/// exception.
+public class RealtimeConsumerStopTest {
+  private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), "RealtimeConsumerStopTest");
+  private static final String RAW_TABLE_NAME = "Coffee";
+  private static final String REALTIME_TABLE_NAME = TableNameBuilder.REALTIME.tableNameWithType(RAW_TABLE_NAME);
+  private static final LLCSegmentName SEGMENT_NAME = new LLCSegmentName(RAW_TABLE_NAME, 0, 0, 1600000000000L);
+  private static final String SEGMENT_NAME_STR = SEGMENT_NAME.getSegmentName();
+  private static final LongMsgOffset START_OFFSET = new LongMsgOffset(0L);
+
+  @BeforeClass
+  public void setUp() {
+    FileUtils.deleteQuietly(TEMP_DIR);
+    SegmentBuildTimeLeaseExtender.initExecutor();
+  }
+
+  @AfterClass
+  public void tearDown() {
+    SegmentBuildTimeLeaseExtender.shutdownExecutor();
+    FileUtils.deleteQuietly(TEMP_DIR);
+  }
+
+  @AfterMethod
+  public void resetStream() {
+    TestStreamConsumerFactory.reset();
+  }
+
+  /// Offloading a consuming segment interrupts its consumer mid-fetch. Nothing is wrong with the stream, so the
+  /// interrupt must not be metered as a consumption exception, and no replacement consumer may be built for a
+  /// segment that is going away.
+  @Test
+  public void testOffloadingAConsumingSegmentIsNotCountedAsAStreamError()
+      throws Exception {
+    ServerMetrics serverMetrics = new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
+    RealtimeTableDataManager tableDataManager = createTableDataManager();
+    try {
+      startConsumingSegment(tableDataManager, serverMetrics);
+      assertTrue(TestStreamConsumerFactory.awaitFetch(), "Consumer never reached the stream fetch");
+      long consumptionExceptions = consumptionExceptions(serverMetrics);
+
+      // The call the Helix CONSUMING -> OFFLINE and CONSUMING -> DROPPED transitions make on the server
+      tableDataManager.offloadSegment(SEGMENT_NAME_STR);
+
+      assertEquals(consumptionExceptions(serverMetrics), consumptionExceptions,
+          "Stopping a consumer must not be counted as a stream error");
+      assertEquals(TestStreamConsumerFactory.CONSUMERS_CREATED.get(), 1,
+          "No replacement consumer should be built for a segment being offloaded");
+      assertEquals(TestStreamConsumerFactory.CONSUMERS_CLOSED.get(), 1, "The stream consumer should be closed");
+    } finally {
+      tableDataManager.shutDown();
+    }
+  }
+
+  /// `goOnlineFromConsuming` stops the consumer and then re-enters the consume loop on the caller's own thread to
+  /// reach the committed end offset, clearing the stop flag so that loop is allowed to run. An interrupt arriving
+  /// there — the state transition thread itself being interrupted, as happens when a server shuts down mid
+  /// transition — is still part of the teardown, which is why the stop has to be remembered across that reset.
+  /// Catch-up then gives up at once and the replica falls back to downloading the segment, instead of booking a
+  /// stream error and rebuilding a consumer on each of five retries on the way out.
+  @Test
+  public void testInterruptWhileCatchingUpIsNotCountedAsAStreamError()
+      throws Exception {
+    ServerMetrics serverMetrics = new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
+    RealtimeTableDataManager tableDataManager = createTableDataManager();
+    try {
+      RealtimeSegmentDataManager segmentDataManager = startConsumingSegment(tableDataManager, serverMetrics);
+      assertTrue(TestStreamConsumerFactory.awaitFetch(), "Consumer never reached the stream fetch");
+      long consumptionExceptions = consumptionExceptions(serverMetrics);
+      TestStreamConsumerFactory.fetchesBehaveAs(TestStreamConsumerFactory.FetchBehaviour.INTERRUPT);
+      // Count only the fetches the catch-up loop makes, not the ones the consumer thread already made
+      TestStreamConsumerFactory.FETCHES.set(0);
+
+      SegmentZKMetadata committedMetadata = new SegmentZKMetadata(SEGMENT_NAME_STR);
+      committedMetadata.setEndOffset(new LongMsgOffset(100L).toString());
+      committedMetadata.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
+      // Catch-up cannot reach the end offset, so the replica falls back to downloading the segment. There is no deep
+      // store behind this harness, so that download is what fails; the point of the test is what happened before it.
+      Assert.assertThrows(Exception.class, () -> segmentDataManager.goOnlineFromConsuming(committedMetadata));
+      // Catch-up ran on this thread, so clear the interrupt flag the stream re-armed on it
+      Thread.interrupted();
+
+      assertEquals(consumptionExceptions(serverMetrics), consumptionExceptions,
+          "An interrupt on the catch-up path must not be counted as a stream error");
+      assertEquals(TestStreamConsumerFactory.FETCHES.get(), 1, "Catch-up should give up on the first interrupt");
+      assertEquals(TestStreamConsumerFactory.CONSUMERS_CREATED.get(), 1,
+          "No replacement consumer should be built while stopping");
+    } finally {
+      tableDataManager.shutDown();
+    }
+  }
+
+  /// The counterpart of the case above, and the reason the distinction has to be drawn on the exception rather than
+  /// on the fact that a stop is in flight: a real fetch failure is still metered and still retried behind a fresh
+  /// consumer, even though it surfaces from the same catch block.
+  @Test
+  public void testStreamFailureIsCountedAsAStreamError()
+      throws Exception {
+    ServerMetrics serverMetrics = new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
+    RealtimeTableDataManager tableDataManager = createTableDataManager();
+    try {
+      TestStreamConsumerFactory.fetchesBehaveAs(TestStreamConsumerFactory.FetchBehaviour.FAIL);
+      long consumptionExceptions = consumptionExceptions(serverMetrics);
+      startConsumingSegment(tableDataManager, serverMetrics);
+
+      // The transient handler sleeps and rebuilds the consumer, so a second consumer proves the retry happened
+      TestUtils.waitForCondition(aVoid -> TestStreamConsumerFactory.CONSUMERS_CREATED.get() > 1, 30_000L,
+          "Consumer was not recreated after a stream failure");
+
+      assertTrue(consumptionExceptions(serverMetrics) > consumptionExceptions,
+          "A stream failure must be counted as a consumption exception");
+    } finally {
+      tableDataManager.shutDown();
+    }
+  }
+
+  private static long consumptionExceptions(ServerMetrics serverMetrics) {
+    return serverMetrics.getMeteredValue(ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS).count();
+  }
+
+  private static InstanceDataManagerConfig createInstanceDataManagerConfig() {
+    InstanceDataManagerConfig config = mock(InstanceDataManagerConfig.class);
+    when(config.getInstanceId()).thenReturn("server-1");
+    when(config.getInstanceDataDir()).thenReturn(TEMP_DIR.getAbsolutePath());
+    when(config.getConfig()).thenReturn(new PinotConfiguration());
+    when(config.getUpsertConfig()).thenReturn(new PinotConfiguration());
+    when(config.getDedupConfig()).thenReturn(new PinotConfiguration());
+    return config;
+  }
+
+  private static TableConfig createTableConfig()
+      throws Exception {
+    TableConfig tableConfig = Fixtures.createTableConfig(TestStreamConsumerFactory.class.getName(),
+        FakeStreamMessageDecoder.class.getName());
+    // Upsert would make consumption wait for every segment to load through Helix, which is out of scope here
+    tableConfig.setUpsertConfig(null);
+    return tableConfig;
+  }
+
+  /// Builds a fully initialized [RealtimeTableDataManager] through the production provider. The only stand-ins are
+  /// the instance config, the Helix manager and the reload-status cache, none of which take part in offloading.
+  private static RealtimeTableDataManager createTableDataManager()
+      throws Exception {
+    TableDataManagerProvider provider = new DefaultTableDataManagerProvider();
+    provider.init(createInstanceDataManagerConfig(), mock(HelixManager.class), new SegmentLocks(), null,
+        mock(ServerReloadJobStatusCache.class));
+    RealtimeTableDataManager tableDataManager =
+        (RealtimeTableDataManager) provider.getTableDataManager(createTableConfig(), Fixtures.createSchema());
+    tableDataManager.start();
+    return tableDataManager;
+  }
+
+  private static RealtimeSegmentDataManager startConsumingSegment(RealtimeTableDataManager tableDataManager,
+      ServerMetrics serverMetrics)
+      throws Exception {
+    TableConfig tableConfig = createTableConfig();
+    Schema schema = Fixtures.createSchema();
+    SegmentZKMetadata segmentZKMetadata = new SegmentZKMetadata(SEGMENT_NAME_STR);
+    segmentZKMetadata.setStartOffset(START_OFFSET.toString());
+    segmentZKMetadata.setCreationTime(System.currentTimeMillis());
+    segmentZKMetadata.setStatus(CommonConstants.Segment.Realtime.Status.IN_PROGRESS);
+    RealtimeSegmentDataManager segmentDataManager =
+        new RealtimeSegmentDataManager(segmentZKMetadata, tableConfig, tableDataManager,
+            new File(TEMP_DIR, REALTIME_TABLE_NAME).getAbsolutePath(),
+            new IndexLoadingConfig(createInstanceDataManagerConfig(), tableConfig), schema, SEGMENT_NAME,
+            new ConsumerCoordinator(false, tableDataManager), serverMetrics, null, null, () -> true);
+    tableDataManager.registerSegment(SEGMENT_NAME_STR, segmentDataManager);
+    segmentDataManager.startConsumption();
+    return segmentDataManager;
+  }
+
+  /// A stream whose fetch blocks like a caught-up client, or fails outright, depending on the mode selected by the
+  /// test. Registered through the table config, so the segment data manager builds it exactly as it builds a Kafka
+  /// or Kinesis consumer.
+  public static class TestStreamConsumerFactory extends StreamConsumerFactory {
+    /// How the next fetch behaves: park like a caught-up client, fail like an unreachable broker, or fail the way a
+    /// client does when the thread calling it is interrupted.
+    enum FetchBehaviour {
+      BLOCK, FAIL, INTERRUPT
+    }
+
+    static final AtomicInteger CONSUMERS_CREATED = new AtomicInteger();
+    static final AtomicInteger CONSUMERS_CLOSED = new AtomicInteger();
+    static final AtomicInteger FETCHES = new AtomicInteger();
+    private static volatile CountDownLatch _fetchEntered = new CountDownLatch(1);
+    private static volatile FetchBehaviour _fetchBehaviour = FetchBehaviour.BLOCK;
+
+    static void reset() {
+      CONSUMERS_CREATED.set(0);
+      CONSUMERS_CLOSED.set(0);
+      FETCHES.set(0);
+      _fetchEntered = new CountDownLatch(1);
+      _fetchBehaviour = FetchBehaviour.BLOCK;
+    }
+
+    static void fetchesBehaveAs(FetchBehaviour fetchBehaviour) {
+      _fetchBehaviour = fetchBehaviour;
+    }
+
+    static boolean awaitFetch()
+        throws InterruptedException {
+      return _fetchEntered.await(30, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public StreamMetadataProvider createPartitionMetadataProvider(String clientId, int partition) {
+      return new FakeStreamMetadataProvider(_streamConfig);
+    }
+
+    @Override
+    public StreamMetadataProvider createStreamMetadataProvider(String clientId) {
+      return new FakeStreamMetadataProvider(_streamConfig);
+    }
+
+    @Override
+    public PartitionGroupConsumer createPartitionGroupConsumer(String clientId,
+        PartitionGroupConsumptionStatus partitionGroupConsumptionStatus) {
+      CONSUMERS_CREATED.incrementAndGet();
+      return new TestConsumer();
+    }
+
+    private static class TestConsumer implements PartitionGroupConsumer {
+      @Override
+      public MessageBatch fetchMessages(StreamPartitionMsgOffset startOffset, int timeoutMs) {
+        FETCHES.incrementAndGet();
+        _fetchEntered.countDown();
+        switch (_fetchBehaviour) {
+          case FAIL:
+            throw new RuntimeException("Stream is unreachable", new SocketTimeoutException());
+          case INTERRUPT:
+            throw interrupted();
+          default:
+            break;
+        }
+        try {
+          // A caught-up client parks here until records arrive or the poll times out
+          Thread.sleep(timeoutMs);
+        } catch (InterruptedException e) {
+          throw interrupted();
+        }
+        return new EmptyMessageBatch(startOffset);
+      }
+
+      /// Mirrors `org.apache.kafka.common.errors.InterruptException`: re-arm the thread interrupt flag and rethrow
+      /// the interrupt wrapped in an unchecked exception.
+      private static RuntimeException interrupted() {
+        Thread.currentThread().interrupt();
+        return new RuntimeException("Interrupted while polling the stream", new InterruptedException());
+      }
+
+      @Override
+      public void close() {
+        CONSUMERS_CLOSED.incrementAndGet();
+      }
+    }
+
+    /// What a caught-up client returns when the poll times out with no records.
+    private record EmptyMessageBatch(StreamPartitionMsgOffset _offsetOfNextBatch) implements MessageBatch<byte[]> {
+      @Override
+      public int getMessageCount() {
+        return 0;
+      }
+
+      @Override
+      public StreamMessage<byte[]> getStreamMessage(int index) {
+        throw new IndexOutOfBoundsException("Empty batch has no message at index: " + index);
+      }
+
+      @Override
+      public StreamPartitionMsgOffset getOffsetOfNextBatch() {
+        return _offsetOfNextBatch;
+      }
+
+      @Override
+      public long getSizeInBytes() {
+        return 0;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem

`RealtimeSegmentDataManager.stop()` sets a stop flag and then interrupts the consumer thread. Helix reaches this method on two paths:

- `CONSUMING` to `OFFLINE` and `CONSUMING` to `DROPPED`, through `offloadSegment`. A rebalance, a server shutdown, a table disable, or a table delete causes these transitions.
- `CONSUMING` to `ONLINE`, while the replica still consumes.

A consumer waits inside the stream fetch for most of its life. The interrupt therefore arrives inside `fetchMessages`. Kafka wraps it in an unchecked `InterruptException` with an `InterruptedException` cause.

`consumeLoop` does not recognize this exception. The generic catch block sends it to `handleTransientStreamErrors`, which does three things:

1. It increments the `realtimeConsumptionExceptions` meter, both global and per table.
2. It sleeps for 1 second.
3. It builds a new stream consumer for the segment.

The loop then exits, because the stop flag is set. `doOffload` closes the consumer that step 3 built.

This has three results:

- Each stopped partition adds one count to an error meter, although nothing failed.
- Each stopped partition adds about 1 second, plus one client close and create, to the Helix transition thread.
- If the new consumer fails to build, `streamConsumerCreateExceptions` also increases.

An operation that moves or stops partitions across many tables produces a steady trickle of these counts. An alert on the meter reads that trickle as a stream fault.

apache/pinot#15660 already finds this case. It uses the result only to lower the log level from WARN to DEBUG. The meter increment, the sleep, and the consumer rebuild stay.

`catchupToFinalOffset` sets `_shouldStop` back to false before it consumes again. A condition on `_shouldStop` therefore cannot cover the catch-up path.

## Fix

A new field `_stopping` records the stop. `stop()` sets it, and nothing clears it. It survives the reset inside `catchupToFinalOffset`.

A new method `isDeliberateStopInterrupt` returns true when `_stopping` is set and the cause chain holds an `InterruptedException` or a `ClosedByInterruptException`. The second type covers NIO-based clients.

`consumeLoop` calls this method for each exception before it calls `handleTransientStreamErrors`. On a match it writes one log line and leaves the loop.

`handleTransientStreamErrors` now holds only the code for real errors. The old `_shouldStop` branch is unreachable after this change, so this change removes it.

## Behavior after the change

A deliberate stop adds no count, no sleep, and no new consumer.

- On the offload path, the consumer thread ends.
- On the catch-up path, `catchupToFinalOffset` returns false and the replica downloads the segment. This is the same result as before, without five retries first.

A real stream error keeps the old behavior. It still increments the meter, sleeps, and builds a new consumer.

One log line changes level. A transient error that is not an interrupt now writes WARN during a stop. It wrote DEBUG before.

## Tests

`RealtimeConsumerStopTest` is new. It uses a real table data manager, a real consumer thread, and the real `offloadSegment` call that the Helix state model makes. The test supplies the stream through the `StreamConsumerFactory` extension point. The consumer is then always inside `fetchMessages` when the interrupt arrives.

The class holds three tests:

- An offload of a consuming segment adds no count and builds no new consumer.
- An interrupt on the catch-up path adds no count and stops after one fetch.
- A real stream failure still adds a count and still builds a new consumer.

Without the fix, the first two tests fail. They record 1 and 6 unwanted counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
