### PR TITLE
Fix NPE when checking for legacy native text indexes without a local index dir

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/TextIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/TextIndexHandler.java
@@ -380,7 +380,15 @@ public class TextIndexHandler extends BaseIndexHandler {
   }
 
   private Set<String> getColumnsWithLegacyNativeTextIndex() {
+    // Legacy native text indexes are sidecar files that older segment formats wrote into the segment's local
+    // directory. A SegmentDirectory that is not backed by a local directory reports a null index dir and cannot
+    // hold such files, so there is nothing to look for. Returning early also keeps the version sub-directory
+    // resolution below from being handed a null parent, which yields a path relative to the working directory
+    // for v3 and another null for v1/v2.
     File indexDir = _segmentDirectory.getSegmentMetadata().getIndexDir();
+    if (indexDir == null) {
+      return Set.of();
+    }
     File segmentDirectory =
         SegmentDirectoryPaths.segmentDirectoryFor(indexDir, _segmentDirectory.getSegmentMetadata().getVersion());
     Collection<String> allColumns = _segmentDirectory.getSegmentMetadata().getAllColumns();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/TextIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/TextIndexUtils.java
@@ -151,9 +151,9 @@ public class TextIndexUtils {
   }
 
   /// Names of the entries directly inside `dir`, files and directories alike (a Lucene text index is
-  /// a directory), or empty when it cannot be listed.
-  private static Set<String> listEntryNames(File dir) {
-    String[] names = dir.list();
+  /// a directory), or empty when `dir` is null or cannot be listed.
+  private static Set<String> listEntryNames(@Nullable File dir) {
+    String[] names = dir == null ? null : dir.list();
     return names == null ? Set.of() : new HashSet<>(Arrays.asList(names));
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/TextIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/TextIndexUtils.java
@@ -120,7 +120,12 @@ public class TextIndexUtils {
   /// directory once rather than performing `columns × extensions` existence probes. Finding
   /// `<column><extension>` in the listing is equivalent to that path existing, so the answer is the
   /// same.
-  public static Set<String> getColumnsWithTextIndex(File segDir, Collection<String> columns) {
+  ///
+  /// A null `segDir` means the segment is not backed by a local directory and therefore not supports sidecar index.
+  public static Set<String> getColumnsWithTextIndex(@Nullable File segDir, Collection<String> columns) {
+    if (segDir == null) {
+      return Set.of();
+    }
     Set<String> entries = listEntryNames(segDir);
     Set<String> columnsWithIndex = new HashSet<>();
     for (String column : columns) {
@@ -139,7 +144,12 @@ public class TextIndexUtils {
   /// Listing-based for the same reason as [#getColumnsWithTextIndex]: the caller asks this for every
   /// column of a segment on every reload check, including the overwhelmingly common case where no
   /// column has ever had a native text index.
-  public static Set<String> getColumnsWithLegacyNativeTextIndex(File segDir, Collection<String> columns) {
+  ///
+  /// A null `segDir` means the segment is not backed by a local directory and therefore not supports sidecar index.
+  public static Set<String> getColumnsWithLegacyNativeTextIndex(@Nullable File segDir, Collection<String> columns) {
+    if (segDir == null) {
+      return Set.of();
+    }
     Set<String> entries = listEntryNames(segDir);
     Set<String> columnsWithIndex = new HashSet<>();
     for (String column : columns) {
@@ -151,9 +161,9 @@ public class TextIndexUtils {
   }
 
   /// Names of the entries directly inside `dir`, files and directories alike (a Lucene text index is
-  /// a directory), or empty when `dir` is null or cannot be listed.
-  private static Set<String> listEntryNames(@Nullable File dir) {
-    String[] names = dir == null ? null : dir.list();
+  /// a directory), or empty when it cannot be listed.
+  private static Set<String> listEntryNames(File dir) {
+    String[] names = dir.list();
     return names == null ? Set.of() : new HashSet<>(Arrays.asList(names));
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/VectorIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/VectorIndexUtils.java
@@ -110,7 +110,12 @@ public class VectorIndexUtils {
   /// directory once rather than performing `columns × extensions` existence probes. Finding
   /// `<column><extension>` in the listing is equivalent to that path existing, so the answer is the
   /// same.
-  public static Set<String> getColumnsWithVectorIndex(File segDir, Collection<String> columns) {
+  ///
+  /// A null `segDir` means the segment is not backed by a local directory and therefore not supports sidecar index.
+  public static Set<String> getColumnsWithVectorIndex(@Nullable File segDir, Collection<String> columns) {
+    if (segDir == null) {
+      return Set.of();
+    }
     Set<String> entries = listEntryNames(segDir);
     Set<String> columnsWithIndex = new HashSet<>();
     for (String column : columns) {
@@ -129,9 +134,9 @@ public class VectorIndexUtils {
   }
 
   /// Names of the entries directly inside `dir`, files and directories alike (an HNSW vector index is
-  /// a Lucene directory), or empty when `dir` is null or cannot be listed.
-  private static Set<String> listEntryNames(@Nullable File dir) {
-    String[] names = dir == null ? null : dir.list();
+  /// a Lucene directory), or empty when it cannot be listed.
+  private static Set<String> listEntryNames(File dir) {
+    String[] names = dir.list();
     return names == null ? Set.of() : new HashSet<>(Arrays.asList(names));
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/VectorIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/VectorIndexUtils.java
@@ -129,9 +129,9 @@ public class VectorIndexUtils {
   }
 
   /// Names of the entries directly inside `dir`, files and directories alike (an HNSW vector index is
-  /// a Lucene directory), or empty when it cannot be listed.
-  private static Set<String> listEntryNames(File dir) {
-    String[] names = dir.list();
+  /// a Lucene directory), or empty when `dir` is null or cannot be listed.
+  private static Set<String> listEntryNames(@Nullable File dir) {
+    String[] names = dir == null ? null : dir.list();
     return names == null ? Set.of() : new HashSet<>(Arrays.asList(names));
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/TextIndexHandlerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/TextIndexHandlerTest.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.loader.invertedindex;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import org.apache.pinot.segment.spi.creator.SegmentVersion;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
+import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+
+
+public class TextIndexHandlerTest {
+  private static final String COLUMN_NAME = "strCol";
+
+  @DataProvider(name = "segmentVersions")
+  public static Object[][] segmentVersions() {
+    return new Object[][]{{SegmentVersion.v1}, {SegmentVersion.v3}};
+  }
+
+  /// A segment served from a [SegmentDirectory] that is not backed by a local directory has no index dir. The
+  /// handler must not probe the file system for legacy native text index sidecar files in that case: those files
+  /// only exist inside an on-disk segment directory, so the answer is simply that there are none.
+  @Test(dataProvider = "segmentVersions")
+  public void testNeedUpdateIndicesWithoutLocalIndexDir(SegmentVersion segmentVersion) {
+    SegmentMetadataImpl segmentMetadata = mock(SegmentMetadataImpl.class);
+    when(segmentMetadata.getName()).thenReturn("testSegment");
+    when(segmentMetadata.getTotalDocs()).thenReturn(10);
+    when(segmentMetadata.getAllColumns()).thenReturn(new TreeSet<>(Set.of(COLUMN_NAME)));
+    when(segmentMetadata.getVersion()).thenReturn(segmentVersion);
+    // No local directory backing this segment
+    when(segmentMetadata.getIndexDir()).thenReturn(null);
+
+    SegmentDirectory segmentDirectory = mock(SegmentDirectory.class);
+    when(segmentDirectory.getSegmentMetadata()).thenReturn(segmentMetadata);
+    when(segmentDirectory.getColumnsWithIndex(StandardIndexes.text())).thenReturn(Set.of());
+
+    SegmentDirectory.Reader segmentReader = mock(SegmentDirectory.Reader.class);
+    when(segmentReader.toSegmentDirectory()).thenReturn(segmentDirectory);
+
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
+    Schema schema =
+        new Schema.SchemaBuilder().addSingleValueDimension(COLUMN_NAME, DataType.STRING).build();
+    TextIndexHandler handler = new TextIndexHandler(segmentDirectory, Map.of(), tableConfig, schema);
+
+    // No text index is configured and none exists, so there is nothing to update
+    assertFalse(handler.needUpdateIndices(segmentReader));
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/TextIndexUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/TextIndexUtilsTest.java
@@ -20,6 +20,8 @@ package org.apache.pinot.segment.local.segment.store;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.segment.index.text.TextIndexConfigBuilder;
 import org.apache.pinot.segment.spi.V1Constants;
@@ -48,5 +50,17 @@ public class TextIndexUtilsTest {
         new File(TEMP_DIR, V1Constants.Indexes.LUCENE_TEXT_INDEX_PROPERTIES_FILE),
         JsonUtils.stringToObject("{}", TextIndexConfig.class));
     assertEquals(readConfig, config);
+  }
+
+  /// A directory that cannot be listed, including one that does not exist or is not there at all, holds no index.
+  @Test
+  public void testUnlistableDirectoryHasNoColumnsWithIndex() {
+    List<String> columns = List.of("colA", "colB");
+    File missingDir = new File(TEMP_DIR, "doesNotExist");
+
+    assertEquals(TextIndexUtils.getColumnsWithTextIndex(missingDir, columns), Set.of());
+    assertEquals(TextIndexUtils.getColumnsWithLegacyNativeTextIndex(missingDir, columns), Set.of());
+    assertEquals(TextIndexUtils.getColumnsWithTextIndex(null, columns), Set.of());
+    assertEquals(TextIndexUtils.getColumnsWithLegacyNativeTextIndex(null, columns), Set.of());
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/VectorIndexUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/VectorIndexUtilsTest.java
@@ -22,6 +22,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.pinot.segment.spi.V1Constants.Indexes;
@@ -284,6 +286,16 @@ public class VectorIndexUtilsTest {
     Assert.assertEquals(VectorIndexUtils.storageFormatOf(VectorBackendType.IVF_FLAT), VectorBackendType.IVF_FLAT);
     Assert.assertEquals(VectorIndexUtils.storageFormatOf(VectorBackendType.IVF_PQ), VectorBackendType.IVF_PQ);
     Assert.assertEquals(VectorIndexUtils.storageFormatOf(VectorBackendType.HNSW), VectorBackendType.HNSW);
+  }
+
+  /// A directory that cannot be listed, including one that does not exist or is not there at all, holds no index.
+  @Test
+  public void testUnlistableDirectoryHasNoColumnsWithIndex() {
+    List<String> columns = List.of("colA", "colB");
+    File missingDir = new File(_tempDir, "doesNotExist");
+
+    Assert.assertEquals(VectorIndexUtils.getColumnsWithVectorIndex(missingDir, columns), Set.of());
+    Assert.assertEquals(VectorIndexUtils.getColumnsWithVectorIndex(null, columns), Set.of());
   }
 
   private static VectorBackendType sniff(byte[] payload)


### PR DESCRIPTION
## Description
#19212 replaced the per-column `File.exists()` probes in `TextIndexHandler#getColumnsWithLegacyNativeTextIndex` with a single directory listing. The old form was accidentally null-tolerant — `new File((File) null, name).exists()` resolves against the default directory and returns `false` — so a `SegmentDirectory` whose `SegmentMetadata` reports no local index dir simply returned an empty set. The listing form calls `File#list()` on that null:

```
java.lang.NullPointerException: Cannot invoke "java.io.File.list()" because "dir" is null
    at TextIndexUtils.listEntryNames(TextIndexUtils.java:156)
    at TextIndexUtils.getColumnsWithLegacyNativeTextIndex(TextIndexUtils.java:143)
    at TextIndexHandler.getColumnsWithLegacyNativeTextIndex(TextIndexHandler.java:387)
    at SegmentPreProcessor.needProcess(SegmentPreProcessor.java:219)
    at ImmutableSegmentLoader.needPreprocess(ImmutableSegmentLoader.java:285)
```

`SegmentDirectory` does not guarantee a local directory — implementations may serve segments from remote storage — and `needUpdateIndices` runs on every reload check, so affected segments fail to load entirely.

## Change 
**Fix:** guard at the caller. Legacy native text indexes are sidecar files of the on-disk segment formats, so a segment with no local directory has none by definition. Guarding there rather than only inside `listEntryNames` also avoids resolving the version sub-directory from a null parent, which yields a path relative to the working directory for v3 and another null for v1/v2 — the latter NPEs on `File#equals` before the listing is even reached.
