### PR TITLE
Validate Controller ingestFromURI filesystem sources

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -358,6 +358,13 @@ public class ControllerConf extends PinotConfiguration {
   public static final String TABLE_MIN_REPLICAS = "table.minReplicas";
   public static final String JERSEY_ADMIN_API_PORT = "jersey.admin.api.port";
   public static final String JERSEY_ADMIN_IS_PRIMARY = "jersey.admin.isprimary";
+  /**
+   * Compatibility-only opt-in for local sources passed to {@code /ingestFromURI}. Enabling this allows callers with
+   * access to the endpoint to read files visible to the controller process. Keep disabled unless callers and source
+   * paths are fully trusted.
+   */
+  public static final String INGEST_FROM_URI_ALLOW_LOCAL_FILE_SYSTEM =
+      "controller.ingestFromURI.allowLocalFileSystem";
   public static final String ACCESS_CONTROL_FACTORY_CLASS = "controller.admin.access.control.factory.class";
   public static final String ACCESS_CONTROL_USERNAME = "access.control.init.username";
   public static final String ACCESS_CONTROL_PASSWORD = "access.control.init.password";
@@ -399,6 +406,7 @@ public class ControllerConf extends PinotConfiguration {
   public static final int DEFAULT_DELETED_SEGMENTS_RETENTION_IN_DAYS = 7;
   public static final int DEFAULT_TABLE_MIN_REPLICAS = 1;
   public static final int DEFAULT_JERSEY_ADMIN_PORT = 21000;
+  public static final boolean DEFAULT_INGEST_FROM_URI_ALLOW_LOCAL_FILE_SYSTEM = false;
   public static final String DEFAULT_ACCESS_CONTROL_FACTORY_CLASS =
       "org.apache.pinot.controller.api.access.AllowAllAccessFactory";
   public static final String DEFAULT_ACCESS_CONTROL_USERNAME = "admin";
@@ -1060,6 +1068,10 @@ public class ControllerConf extends PinotConfiguration {
 
   public String getJerseyAdminApiPort() {
     return getProperty(JERSEY_ADMIN_API_PORT, String.valueOf(DEFAULT_JERSEY_ADMIN_PORT));
+  }
+
+  public boolean isIngestFromUriLocalFileSystemAllowed() {
+    return getProperty(INGEST_FROM_URI_ALLOW_LOCAL_FILE_SYSTEM, DEFAULT_INGEST_FROM_URI_ALLOW_LOCAL_FILE_SYSTEM);
   }
 
   public void setInitAccessControlUsername(String username) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
@@ -187,7 +187,10 @@ public class PinotIngestionRestletResource {
   @ApiOperation(value = "Ingest from the given URI", notes =
       "Creates a segment using file at the given URI and pushes it to Pinot. "
           + "\n All steps happen on the controller. This API is NOT meant for production environments/large input "
-          + "files. " + "\nExample usage (query params need encoding):" + "\n```"
+          + "files. Local filesystem sources are disabled by default. The compatibility setting "
+          + "controller.ingestFromURI.allowLocalFileSystem permits callers with access to this endpoint to read "
+          + "files visible to the controller process and should only be enabled for trusted callers and paths. "
+          + "\nExample usage (query params need encoding):" + "\n```"
           + "\ncurl -X POST \"http://localhost:9000/ingestFromURI?tableNameWithType=foo_OFFLINE"
           + "\n&batchConfigMapStr={" + "\n  \"inputFormat\":\"json\","
           + "\n  \"input.fs.className\":\"org.apache.pinot.plugin.filesystem.S3PinotFS\","
@@ -204,13 +207,11 @@ public class PinotIngestionRestletResource {
     tableNameWithType = DatabaseUtils.translateTableName(tableNameWithType, headers);
     try {
       asyncResponse.resume(ingestData(tableNameWithType, batchConfigMapStr, new DataPayload(new URI(sourceURIStr))));
-    } catch (IllegalArgumentException e) {
-      asyncResponse.resume(new ControllerApplicationException(LOGGER, String
-          .format("Got illegal argument when ingesting file into table: %s. %s", tableNameWithType, e.getMessage()),
+    } catch (IllegalArgumentException | URISyntaxException e) {
+      asyncResponse.resume(new ControllerApplicationException(LOGGER, "Invalid ingestFromURI request",
           Response.Status.BAD_REQUEST, e));
     } catch (Exception e) {
-      asyncResponse.resume(new ControllerApplicationException(LOGGER,
-          String.format("Caught exception when ingesting file into table: %s. %s", tableNameWithType, e.getMessage()),
+      asyncResponse.resume(new ControllerApplicationException(LOGGER, "Failed to ingest from URI",
           Response.Status.INTERNAL_SERVER_ERROR, e));
     }
   }
@@ -234,7 +235,8 @@ public class PinotIngestionRestletResource {
 
     FileIngestionHelper fileIngestionHelper =
         new FileIngestionHelper(tableConfig, schema, batchConfigMap, getControllerUri(),
-            new File(_controllerConf.getLocalTempDir(), INGESTION_DIR), authProvider);
+            new File(_controllerConf.getLocalTempDir(), INGESTION_DIR), authProvider,
+            _controllerConf.isIngestFromUriLocalFileSystemAllowed());
     return fileIngestionHelper.buildSegmentAndPush(payload);
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
@@ -41,6 +41,8 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.filesystem.LocalPinotFS;
+import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.ingestion.segment.uploader.SegmentUploader;
@@ -60,6 +62,9 @@ import org.slf4j.LoggerFactory;
 public class FileIngestionHelper {
   private static final Logger LOGGER = LoggerFactory.getLogger(FileIngestionHelper.class);
   private static final String SEGMENT_UPLOADER_CLASS = "org.apache.pinot.plugin.segmentuploader.SegmentUploaderDefault";
+  private static final String LOCAL_FILE_SYSTEM_DISABLED_MESSAGE =
+      "Local filesystem sources are disabled for /ingestFromURI";
+  private static final String INVALID_FILE_SYSTEM_MESSAGE = "Invalid filesystem source for /ingestFromURI";
 
   private static final String WORKING_DIR_PREFIX = "working_dir";
   private static final String INPUT_DATA_DIR = "input_data_dir";
@@ -73,21 +78,33 @@ public class FileIngestionHelper {
   private final URI _controllerUri;
   private final File _ingestionDir;
   private final AuthProvider _authProvider;
+  private final boolean _allowLocalFileSystemInUri;
 
   public FileIngestionHelper(TableConfig tableConfig, Schema schema, Map<String, String> batchConfigMap,
-      URI controllerUri, File ingestionDir, AuthProvider authProvider) {
+      URI controllerUri, File ingestionDir, AuthProvider authProvider, boolean allowLocalFileSystemInUri) {
     _tableConfig = tableConfig;
     _schema = schema;
     _batchConfigMap = batchConfigMap;
     _controllerUri = controllerUri;
     _ingestionDir = ingestionDir;
     _authProvider = authProvider;
+    _allowLocalFileSystemInUri = allowLocalFileSystemInUri;
   }
 
   /**
    * Creates a segment using the provided data file/URI and uploads to Pinot
    */
   public SuccessResponse buildSegmentAndPush(DataPayload payload)
+      throws Exception {
+    // Resolve and validate the source before creating working directories or parsing input data. Keep the resolved
+    // instance so a concurrent factory registration cannot replace it between validation and copying.
+    try (ResolvedFileSystem sourceFileSystem = payload._payloadType == PayloadType.URI
+        ? resolveSourceFileSystem(_batchConfigMap, payload._uri, _allowLocalFileSystemInUri) : null) {
+      return buildSegmentAndPush(payload, sourceFileSystem);
+    }
+  }
+
+  private SuccessResponse buildSegmentAndPush(DataPayload payload, ResolvedFileSystem sourceFileSystem)
       throws Exception {
     String tableNameWithType = _tableConfig.getTableName();
     // 1. append a timestamp for easy debugging
@@ -112,7 +129,7 @@ public class FileIngestionHelper {
       File inputFile = new File(inputDir, String.format(
           "%s.%s", DATA_FILE_PREFIX, _batchConfigMap.get(BatchConfigProperties.INPUT_FORMAT).toLowerCase()));
       if (payload._payloadType == PayloadType.URI) {
-        copyURIToLocal(_batchConfigMap, payload._uri, inputFile);
+        sourceFileSystem._fileSystem.copyToLocalFile(payload._uri, inputFile);
         LOGGER.info("Copied from URI: {} to local file: {}", payload._uri, inputFile.getAbsolutePath());
       } else {
         copyMultipartToLocal(payload._multiPart, inputFile);
@@ -176,12 +193,111 @@ public class FileIngestionHelper {
    */
   public static void copyURIToLocal(Map<String, String> batchConfigMap, URI sourceFileURI, File destFile)
       throws Exception {
-    String sourceFileURIScheme = sourceFileURI.getScheme();
-    if (!PinotFSFactory.isSchemeSupported(sourceFileURIScheme)) {
-      PinotFSFactory.register(sourceFileURIScheme, batchConfigMap.get(BatchConfigProperties.INPUT_FS_CLASS),
-          IngestionConfigUtils.getInputFsProps(batchConfigMap));
+    copyURIToLocal(batchConfigMap, sourceFileURI, destFile, true);
+  }
+
+  public static void copyURIToLocal(Map<String, String> batchConfigMap, URI sourceFileURI, File destFile,
+      boolean allowLocalFileSystem)
+      throws Exception {
+    try (ResolvedFileSystem sourceFileSystem =
+        resolveSourceFileSystem(batchConfigMap, sourceFileURI, allowLocalFileSystem)) {
+      sourceFileSystem._fileSystem.copyToLocalFile(sourceFileURI, destFile);
     }
-    PinotFSFactory.create(sourceFileURIScheme).copyToLocalFile(sourceFileURI, destFile);
+  }
+
+  private static ResolvedFileSystem resolveSourceFileSystem(Map<String, String> batchConfigMap, URI sourceFileURI,
+      boolean allowLocalFileSystem) {
+    String sourceFileURIScheme = sourceFileURI.getScheme();
+    Preconditions.checkArgument(allowLocalFileSystem || !isLocalSource(sourceFileURI),
+        LOCAL_FILE_SYSTEM_DISABLED_MESSAGE);
+    if (PinotFSFactory.isSchemeSupported(sourceFileURIScheme)) {
+      PinotFS sourceFileSystem;
+      try {
+        sourceFileSystem = PinotFSFactory.create(sourceFileURIScheme);
+      } catch (RuntimeException e) {
+        throw new IllegalArgumentException(INVALID_FILE_SYSTEM_MESSAGE, e);
+      }
+      validateFileSystemInstance(sourceFileSystem, allowLocalFileSystem);
+      return new ResolvedFileSystem(sourceFileSystem, null);
+    }
+
+    String inputFsClassName = batchConfigMap.get(BatchConfigProperties.INPUT_FS_CLASS);
+    Preconditions.checkArgument(StringUtils.isNotBlank(inputFsClassName), INVALID_FILE_SYSTEM_MESSAGE);
+    Class<? extends PinotFS> fileSystemClass = loadFileSystemClass(inputFsClassName, allowLocalFileSystem);
+    PinotFS sourceFileSystem;
+    try {
+      sourceFileSystem = fileSystemClass.getConstructor().newInstance();
+    } catch (ReflectiveOperationException | RuntimeException e) {
+      throw new IllegalArgumentException(INVALID_FILE_SYSTEM_MESSAGE, e);
+    }
+    PinotFS effectiveFileSystem = PinotFSFactory.getEffectiveFileSystem(sourceFileSystem);
+    try {
+      validateFileSystemInstance(sourceFileSystem, allowLocalFileSystem);
+    } catch (RuntimeException e) {
+      closeRequestScopedFileSystem(effectiveFileSystem);
+      throw e;
+    }
+    try {
+      sourceFileSystem.init(IngestionConfigUtils.getInputFsProps(batchConfigMap));
+    } catch (RuntimeException e) {
+      closeRequestScopedFileSystem(effectiveFileSystem);
+      throw new IllegalArgumentException(INVALID_FILE_SYSTEM_MESSAGE, e);
+    }
+    return new ResolvedFileSystem(sourceFileSystem, effectiveFileSystem);
+  }
+
+  private static boolean isLocalSource(URI sourceFileURI) {
+    String scheme = sourceFileURI.getScheme();
+    if (StringUtils.isBlank(scheme) || PinotFSFactory.LOCAL_PINOT_FS_SCHEME.equalsIgnoreCase(scheme)) {
+      return true;
+    }
+    // URI treats a Windows drive letter as a scheme (for example C:/data.csv).
+    return scheme.length() == 1 && sourceFileURI.getAuthority() == null && sourceFileURI.getPath() != null
+        && sourceFileURI.getPath().startsWith("/");
+  }
+
+  private static Class<? extends PinotFS> loadFileSystemClass(String className, boolean allowLocalFileSystem) {
+    Class<?> fileSystemClass;
+    try {
+      fileSystemClass = PluginManager.get().loadClass(className);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(INVALID_FILE_SYSTEM_MESSAGE, e);
+    }
+    Preconditions.checkArgument(PinotFS.class.isAssignableFrom(fileSystemClass), INVALID_FILE_SYSTEM_MESSAGE);
+    Preconditions.checkArgument(allowLocalFileSystem || !LocalPinotFS.class.isAssignableFrom(fileSystemClass),
+        LOCAL_FILE_SYSTEM_DISABLED_MESSAGE);
+    return fileSystemClass.asSubclass(PinotFS.class);
+  }
+
+  private static void validateFileSystemInstance(PinotFS fileSystem, boolean allowLocalFileSystem) {
+    PinotFS effectiveFileSystem = PinotFSFactory.getEffectiveFileSystem(fileSystem);
+    Preconditions.checkArgument(allowLocalFileSystem || !(effectiveFileSystem instanceof LocalPinotFS),
+        LOCAL_FILE_SYSTEM_DISABLED_MESSAGE);
+  }
+
+  private static void closeRequestScopedFileSystem(PinotFS fileSystem) {
+    try {
+      fileSystem.close();
+    } catch (IOException e) {
+      LOGGER.warn("Failed to close request-scoped filesystem", e);
+    }
+  }
+
+  private static class ResolvedFileSystem implements AutoCloseable {
+    private final PinotFS _fileSystem;
+    private final PinotFS _closeWhenDone;
+
+    private ResolvedFileSystem(PinotFS fileSystem, PinotFS closeWhenDone) {
+      _fileSystem = fileSystem;
+      _closeWhenDone = closeWhenDone;
+    }
+
+    @Override
+    public void close() {
+      if (_closeWhenDone != null) {
+        closeRequestScopedFileSystem(_closeWhenDone);
+      }
+    }
   }
 
   /**

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerConfTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerConfTest.java
@@ -320,4 +320,13 @@ public class ControllerConfTest {
     Assert.assertEquals(conf.getPinotTaskQueueCapacity(), 10000);
     Assert.assertEquals(conf.getPinotTaskQueueWarningThreshold(), 8000);
   }
+
+  @Test
+  public void testIngestFromUriLocalFileSystemCompatibilityOption() {
+    ControllerConf controllerConf = new ControllerConf();
+    Assert.assertFalse(controllerConf.isIngestFromUriLocalFileSystemAllowed());
+
+    controllerConf.setProperty(ControllerConf.INGEST_FROM_URI_ALLOW_LOCAL_FILE_SYSTEM, true);
+    Assert.assertTrue(controllerConf.isIngestFromUriLocalFileSystemAllowed());
+  }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotIngestionRestletResourceStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotIngestionRestletResourceStatelessTest.java
@@ -22,17 +22,20 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
-import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.entity.mime.FileBody;
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.core5.http.HttpEntity;
-import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -100,31 +103,57 @@ public class PinotIngestionRestletResourceStatelessTest extends ControllerTest {
     Map<String, String> batchConfigMap = new HashMap<>();
     batchConfigMap.put(BatchConfigProperties.INPUT_FORMAT, "csv");
     batchConfigMap.put(String.format("%s.delimiter", BatchConfigProperties.RECORD_READER_PROP_PREFIX), "|");
-    sendHttpPost(_controllerRequestURLBuilder.forIngestFromFile(TABLE_NAME_WITH_TYPE, batchConfigMap));
+
+    // Local URI validation happens before any working directory or segment is created, and the response does not
+    // expose the submitted path.
+    String sensitivePathToken = "controller-secret-ingest-source.csv";
+    String errorResponse = sendHttpPost(_controllerRequestURLBuilder.forIngestFromURI(TABLE_NAME_WITH_TYPE,
+        batchConfigMap, "file:///private/" + sensitivePathToken), 400);
+    assertFalse(errorResponse.contains(sensitivePathToken));
+    assertFalse(ingestionDir.exists());
+    segments = _helixResourceManager.getSegmentsFor(TABLE_NAME_WITH_TYPE, false);
+    assertEquals(segments.size(), 0);
+
+    sendHttpPost(_controllerRequestURLBuilder.forIngestFromFile(TABLE_NAME_WITH_TYPE, batchConfigMap), 200);
     segments = _helixResourceManager.getSegmentsFor(TABLE_NAME_WITH_TYPE, false);
     assertEquals(segments.size(), 1);
 
-    // ingest from URI
-    sendHttpPost(_controllerRequestURLBuilder.forIngestFromURI(TABLE_NAME_WITH_TYPE, batchConfigMap,
-        String.format("file://%s", _inputFile.getAbsolutePath())));
-    segments = _helixResourceManager.getSegmentsFor(TABLE_NAME_WITH_TYPE, false);
-    assertEquals(segments.size(), 2);
+    // The compatibility option explicitly restores local URI ingestion.
+    _controllerConfig.setProperty(ControllerConf.INGEST_FROM_URI_ALLOW_LOCAL_FILE_SYSTEM, true);
+    try {
+      sendHttpPost(_controllerRequestURLBuilder.forIngestFromURI(TABLE_NAME_WITH_TYPE, batchConfigMap,
+          String.format("file://%s", _inputFile.getAbsolutePath())), 200);
+      segments = _helixResourceManager.getSegmentsFor(TABLE_NAME_WITH_TYPE, false);
+      assertEquals(segments.size(), 2);
+    } finally {
+      _controllerConfig.setProperty(ControllerConf.INGEST_FROM_URI_ALLOW_LOCAL_FILE_SYSTEM, false);
+    }
 
     // the ingestion dir exists after ingesting files. We check the existence to make sure this dir is created under
     // _controllerConfig.getLocalTempDir()
     assertTrue(ingestionDir.exists());
   }
 
-  private void sendHttpPost(String uri)
+  private String sendHttpPost(String uri, int expectedStatusCode)
       throws IOException {
-    HttpClient httpClient = HttpClientBuilder.create().build();
     HttpPost httpPost = new HttpPost(uri);
     HttpEntity reqEntity =
         MultipartEntityBuilder.create().addPart("file", new FileBody(_inputFile.getAbsoluteFile())).build();
     httpPost.setEntity(reqEntity);
-    HttpResponse response = httpClient.execute(httpPost);
-    int statusCode = response.getCode();
-    assertEquals(statusCode, 200);
+    try (CloseableHttpClient httpClient = HttpClientBuilder.create().build()) {
+      return httpClient.execute(httpPost, response -> {
+        int statusCode = response.getCode();
+        String responseBody;
+        try {
+          responseBody = response.getEntity() != null
+              ? EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8) : "";
+        } catch (ParseException e) {
+          throw new IOException(e);
+        }
+        assertEquals(statusCode, expectedStatusCode, responseBody);
+        return responseBody;
+      });
+    }
   }
 
   @AfterClass

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/util/FileIngestionHelperTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/util/FileIngestionHelperTest.java
@@ -1,0 +1,481 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.filesystem.BasePinotFS;
+import org.apache.pinot.spi.filesystem.LocalPinotFS;
+import org.apache.pinot.spi.filesystem.NoClosePinotFS;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.expectThrows;
+
+
+@Test(groups = "stateless")
+public class FileIngestionHelperTest {
+  private static final File DEST_FILE = new File(FileUtils.getTempDirectory(),
+      "pinot-ingest-uri-unused-" + UUID.randomUUID());
+  private static final String SENSITIVE_PATH_TOKEN = "controller-secret-7f4c.csv";
+  private static final String LOCAL_FILE_SYSTEM_DISABLED_MESSAGE =
+      "Local filesystem sources are disabled for /ingestFromURI";
+
+  @DataProvider(name = "localSources")
+  public static Object[][] localSources() {
+    return new Object[][]{
+        {URI.create("file:///private/" + SENSITIVE_PATH_TOKEN)},
+        {URI.create("file:/private/" + SENSITIVE_PATH_TOKEN)},
+        {URI.create("file:relative/" + SENSITIVE_PATH_TOKEN)},
+        {URI.create("FILE:///private/" + SENSITIVE_PATH_TOKEN)},
+        {URI.create("file://localhost/private/" + SENSITIVE_PATH_TOKEN)},
+        {URI.create("/private/" + SENSITIVE_PATH_TOKEN)},
+        {URI.create("relative/" + SENSITIVE_PATH_TOKEN)},
+        {URI.create("./relative/" + SENSITIVE_PATH_TOKEN)},
+        {URI.create("../relative/" + SENSITIVE_PATH_TOKEN)},
+        {URI.create("//localhost/share/" + SENSITIVE_PATH_TOKEN)},
+        {URI.create("C:/private/" + SENSITIVE_PATH_TOKEN)}
+    };
+  }
+
+  @Test(dataProvider = "localSources")
+  public void testRejectsLocalSourcesByDefaultWithoutExposingPath(URI sourceURI) {
+    IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
+        () -> FileIngestionHelper.copyURIToLocal(Map.of(), sourceURI, DEST_FILE, false));
+
+    assertEquals(exception.getMessage(), LOCAL_FILE_SYSTEM_DISABLED_MESSAGE);
+    assertFalse(exception.getMessage().contains(SENSITIVE_PATH_TOKEN));
+    assertFalse(DEST_FILE.exists());
+  }
+
+  @Test
+  public void testCopiesLocalFileUriOnlyWhenCompatibilityOptionIsEnabled()
+      throws Exception {
+    Path tempDir = Files.createTempDirectory("pinot-ingest-uri-test");
+    try {
+      Path inputFile = tempDir.resolve("input.csv");
+      Path destFile = tempDir.resolve("dest.csv");
+      Files.writeString(inputFile, "col\nvalue\n", StandardCharsets.UTF_8);
+
+      FileIngestionHelper.copyURIToLocal(Map.of(), inputFile.toUri(), destFile.toFile(), true);
+
+      assertEquals(Files.readString(destFile, StandardCharsets.UTF_8), "col\nvalue\n");
+    } finally {
+      FileUtils.deleteQuietly(tempDir.toFile());
+    }
+  }
+
+  @Test
+  public void testRejectsLocalSourceBeforeCreatingWorkingDirectory()
+      throws Exception {
+    Path tempDir = Files.createTempDirectory("pinot-ingest-uri-validation-test");
+    try {
+      File ingestionDir = tempDir.resolve("ingestion-dir").toFile();
+      FileIngestionHelper helper =
+          new FileIngestionHelper(null, null, Map.of(), null, ingestionDir, null, false);
+
+      expectThrows(IllegalArgumentException.class,
+          () -> helper.buildSegmentAndPush(new FileIngestionHelper.DataPayload(
+              URI.create("file:///private/" + SENSITIVE_PATH_TOKEN))));
+
+      assertFalse(ingestionDir.exists());
+    } finally {
+      FileUtils.deleteQuietly(tempDir.toFile());
+    }
+  }
+
+  @Test
+  public void testRejectsLocalFileSystemAliasesBeforeRegistration() {
+    String[] classNames = {
+        LocalPinotFS.class.getName(),
+        "org.apache.pinot.filesystem.LocalPinotFS",
+        "DEFAULT:" + LocalPinotFS.class.getName()
+    };
+    for (int i = 0; i < classNames.length; i++) {
+      String scheme = "localalias" + i;
+      Map<String, String> batchConfigMap = Map.of(BatchConfigProperties.INPUT_FS_CLASS, classNames[i]);
+
+      IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
+          () -> FileIngestionHelper.copyURIToLocal(batchConfigMap,
+              URI.create(scheme + ":///private/" + SENSITIVE_PATH_TOKEN), DEST_FILE, false));
+
+      assertEquals(exception.getMessage(), LOCAL_FILE_SYSTEM_DISABLED_MESSAGE);
+      assertFalse(exception.getMessage().contains(classNames[i]));
+      assertFalse(PinotFSFactory.isSchemeSupported(scheme));
+    }
+  }
+
+  @Test
+  public void testRejectsLocalFileSystemSubclassBeforeConstructionOrRegistration() {
+    TestLocalPinotFS.reset();
+    String scheme = "localsubclass";
+    Map<String, String> batchConfigMap =
+        Map.of(BatchConfigProperties.INPUT_FS_CLASS, TestLocalPinotFS.class.getName());
+
+    IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
+        () -> FileIngestionHelper.copyURIToLocal(batchConfigMap,
+            URI.create(scheme + ":///private/" + SENSITIVE_PATH_TOKEN), DEST_FILE, false));
+
+    assertEquals(exception.getMessage(), LOCAL_FILE_SYSTEM_DISABLED_MESSAGE);
+    assertEquals(TestLocalPinotFS._constructorCalls, 0);
+    assertEquals(TestLocalPinotFS._initCalls, 0);
+    assertEquals(TestLocalPinotFS._copyCalls, 0);
+    assertFalse(PinotFSFactory.isSchemeSupported(scheme));
+  }
+
+  @Test
+  public void testRejectsEndpointProvidedLocalDelegateBeforeInitializationOrRegistration() {
+    LocalDelegatePinotFS.reset();
+    String scheme = "localdelegate";
+    Map<String, String> batchConfigMap =
+        Map.of(BatchConfigProperties.INPUT_FS_CLASS, LocalDelegatePinotFS.class.getName());
+
+    IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
+        () -> FileIngestionHelper.copyURIToLocal(batchConfigMap,
+            URI.create(scheme + ":///private/" + SENSITIVE_PATH_TOKEN), DEST_FILE, false));
+
+    assertEquals(exception.getMessage(), LOCAL_FILE_SYSTEM_DISABLED_MESSAGE);
+    assertEquals(LocalDelegatePinotFS._constructorCalls, 1);
+    assertEquals(LocalDelegatePinotFS._initCalls, 0);
+    assertEquals(LocalDelegatePinotFS._copyCalls, 0);
+    assertEquals(LocalDelegatePinotFS._closeCalls, 1);
+    assertFalse(PinotFSFactory.isSchemeSupported(scheme));
+  }
+
+  @Test
+  public void testRejectsConfiguredNestedLocalDelegate() {
+    String scheme = "configuredlocaldelegate";
+    PinotFSFactory.register(scheme, LocalDelegatePinotFS.class.getName(), new PinotConfiguration());
+    LocalDelegatePinotFS._copyCalls = 0;
+
+    IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
+        () -> FileIngestionHelper.copyURIToLocal(Map.of(),
+            URI.create(scheme + ":///private/" + SENSITIVE_PATH_TOKEN), DEST_FILE, false));
+
+    assertEquals(exception.getMessage(), LOCAL_FILE_SYSTEM_DISABLED_MESSAGE);
+    assertEquals(LocalDelegatePinotFS._copyCalls, 0);
+  }
+
+  @Test
+  public void testCopiesFromRequestConfiguredRemoteFileSystem()
+      throws Exception {
+    TestRemotePinotFS.reset();
+    String scheme = "requestremote";
+    Map<String, String> batchConfigMap =
+        Map.of(BatchConfigProperties.INPUT_FS_CLASS, TestRemotePinotFS.class.getName());
+    Path destFile = Files.createTempFile("pinot-ingest-uri-remote", ".txt");
+    try {
+      FileIngestionHelper.copyURIToLocal(batchConfigMap, URI.create(scheme + "://bucket/object"),
+          destFile.toFile(), false);
+
+      assertEquals(TestRemotePinotFS._initCalls, 1);
+      assertEquals(TestRemotePinotFS._copyCalls, 1);
+      assertEquals(TestRemotePinotFS._closeCalls, 1);
+      assertEquals(Files.readString(destFile, StandardCharsets.UTF_8), TestRemotePinotFS.REMOTE_CONTENT);
+    } finally {
+      FileUtils.deleteQuietly(destFile.toFile());
+    }
+  }
+
+  @Test
+  public void testCopiesFromRequestConfiguredRemoteDelegate()
+      throws Exception {
+    TestRemotePinotFS.reset();
+    RemoteDelegatePinotFS.reset();
+    String scheme = "requestremotedelegate";
+    Map<String, String> batchConfigMap =
+        Map.of(BatchConfigProperties.INPUT_FS_CLASS, RemoteDelegatePinotFS.class.getName());
+    Path destFile = Files.createTempFile("pinot-ingest-uri-remote-delegate", ".txt");
+    try {
+      FileIngestionHelper.copyURIToLocal(batchConfigMap, URI.create(scheme + "://bucket/object"),
+          destFile.toFile(), false);
+
+      assertEquals(TestRemotePinotFS._initCalls, 1);
+      assertEquals(TestRemotePinotFS._copyCalls, 1);
+      assertEquals(TestRemotePinotFS._closeCalls, 1);
+      assertEquals(RemoteDelegatePinotFS._initCalls, 1);
+      assertEquals(RemoteDelegatePinotFS._copyCalls, 1);
+      assertEquals(Files.readString(destFile, StandardCharsets.UTF_8), TestRemotePinotFS.REMOTE_CONTENT);
+      assertFalse(PinotFSFactory.isSchemeSupported(scheme));
+    } finally {
+      FileUtils.deleteQuietly(destFile.toFile());
+    }
+  }
+
+  @Test
+  public void testCopiesFromControllerConfiguredRemoteFileSystem()
+      throws Exception {
+    TestRemotePinotFS.reset();
+    String scheme = "configuredremote";
+    PinotFSFactory.register(scheme, TestRemotePinotFS.class.getName(), new PinotConfiguration());
+    Path destFile = Files.createTempFile("pinot-ingest-uri-configured-remote", ".txt");
+    try {
+      FileIngestionHelper.copyURIToLocal(Map.of(), URI.create(scheme + "://bucket/object"), destFile.toFile(),
+          false);
+
+      assertEquals(TestRemotePinotFS._initCalls, 1);
+      assertEquals(TestRemotePinotFS._copyCalls, 1);
+      assertEquals(TestRemotePinotFS._closeCalls, 0);
+      assertEquals(Files.readString(destFile, StandardCharsets.UTF_8), TestRemotePinotFS.REMOTE_CONTENT);
+    } finally {
+      FileUtils.deleteQuietly(destFile.toFile());
+    }
+  }
+
+  @Test
+  public void testClosesRequestScopedFileSystemWhenInitializationFails() {
+    FailingInitRemotePinotFS.reset();
+    String scheme = "failinginitremote";
+    Map<String, String> batchConfigMap =
+        Map.of(BatchConfigProperties.INPUT_FS_CLASS, FailingInitRemotePinotFS.class.getName());
+
+    IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
+        () -> FileIngestionHelper.copyURIToLocal(batchConfigMap, URI.create(scheme + "://bucket/object"),
+            DEST_FILE, false));
+
+    assertEquals(exception.getMessage(), "Invalid filesystem source for /ingestFromURI");
+    assertEquals(FailingInitRemotePinotFS._closeCalls, 1);
+    assertFalse(PinotFSFactory.isSchemeSupported(scheme));
+  }
+
+  @Test
+  public void testRejectsInvalidFileSystemClassWithoutExposingClassName() {
+    String className = "org.apache.pinot.spi.filesystem.SensitiveMissingPinotFS";
+    Map<String, String> batchConfigMap = Map.of(BatchConfigProperties.INPUT_FS_CLASS, className);
+
+    IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
+        () -> FileIngestionHelper.copyURIToLocal(batchConfigMap, URI.create("invalidremote://bucket/object"),
+            DEST_FILE, false));
+
+    assertEquals(exception.getMessage(), "Invalid filesystem source for /ingestFromURI");
+    assertFalse(exception.getMessage().contains(className));
+  }
+
+  public static class TestLocalPinotFS extends LocalPinotFS {
+    private static int _constructorCalls;
+    private static int _initCalls;
+    private static int _copyCalls;
+
+    public TestLocalPinotFS() {
+      _constructorCalls++;
+    }
+
+    @Override
+    public void init(PinotConfiguration config) {
+      _initCalls++;
+    }
+
+    @Override
+    public void copyToLocalFile(URI srcUri, File dstFile)
+        throws Exception {
+      _copyCalls++;
+      super.copyToLocalFile(srcUri, dstFile);
+    }
+
+    private static void reset() {
+      _constructorCalls = 0;
+      _initCalls = 0;
+      _copyCalls = 0;
+    }
+  }
+
+  public static class LocalDelegatePinotFS extends NoClosePinotFS {
+    private static int _constructorCalls;
+    private static int _initCalls;
+    private static int _copyCalls;
+    private static int _closeCalls;
+
+    public LocalDelegatePinotFS() {
+      super(new LocalPinotFS() {
+        @Override
+        public void close() {
+          _closeCalls++;
+        }
+      });
+      _constructorCalls++;
+    }
+
+    @Override
+    public void init(PinotConfiguration config) {
+      _initCalls++;
+      super.init(config);
+    }
+
+    @Override
+    public void copyToLocalFile(URI srcUri, File dstFile)
+        throws Exception {
+      _copyCalls++;
+      super.copyToLocalFile(srcUri, dstFile);
+    }
+
+    private static void reset() {
+      _constructorCalls = 0;
+      _initCalls = 0;
+      _copyCalls = 0;
+      _closeCalls = 0;
+    }
+  }
+
+  public static class RemoteDelegatePinotFS extends NoClosePinotFS {
+    private static int _initCalls;
+    private static int _copyCalls;
+
+    public RemoteDelegatePinotFS() {
+      super(new TestRemotePinotFS());
+    }
+
+    @Override
+    public void init(PinotConfiguration config) {
+      _initCalls++;
+      super.init(config);
+    }
+
+    @Override
+    public void copyToLocalFile(URI srcUri, File dstFile)
+        throws Exception {
+      _copyCalls++;
+      super.copyToLocalFile(srcUri, dstFile);
+    }
+
+    private static void reset() {
+      _initCalls = 0;
+      _copyCalls = 0;
+    }
+  }
+
+  public static class TestRemotePinotFS extends BasePinotFS {
+    private static final String REMOTE_CONTENT = "remote-content";
+    private static int _initCalls;
+    private static int _copyCalls;
+    private static int _closeCalls;
+
+    @Override
+    public void init(PinotConfiguration config) {
+      _initCalls++;
+    }
+
+    @Override
+    public boolean mkdir(URI uri) {
+      return true;
+    }
+
+    @Override
+    public boolean delete(URI segmentUri, boolean forceDelete) {
+      return true;
+    }
+
+    @Override
+    protected boolean doMove(URI srcUri, URI dstUri) {
+      return true;
+    }
+
+    @Override
+    public boolean copyDir(URI srcUri, URI dstUri) {
+      return true;
+    }
+
+    @Override
+    public boolean exists(URI fileUri) {
+      return true;
+    }
+
+    @Override
+    public long length(URI fileUri) {
+      return REMOTE_CONTENT.length();
+    }
+
+    @Override
+    public String[] listFiles(URI fileUri, boolean recursive) {
+      return new String[0];
+    }
+
+    @Override
+    public void copyToLocalFile(URI srcUri, File dstFile)
+        throws IOException {
+      _copyCalls++;
+      Files.writeString(dstFile.toPath(), REMOTE_CONTENT, StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public void copyFromLocalFile(File srcFile, URI dstUri) {
+    }
+
+    @Override
+    public boolean isDirectory(URI uri) {
+      return false;
+    }
+
+    @Override
+    public long lastModified(URI uri) {
+      return 0L;
+    }
+
+    @Override
+    public boolean touch(URI uri) {
+      return true;
+    }
+
+    @Override
+    public InputStream open(URI uri) {
+      return InputStream.nullInputStream();
+    }
+
+    @Override
+    public void close() {
+      _closeCalls++;
+    }
+
+    private static void reset() {
+      _initCalls = 0;
+      _copyCalls = 0;
+      _closeCalls = 0;
+    }
+  }
+
+  public static class FailingInitRemotePinotFS extends TestRemotePinotFS {
+    private static int _closeCalls;
+
+    @Override
+    public void init(PinotConfiguration config) {
+      throw new IllegalStateException("initialization failed");
+    }
+
+    @Override
+    public void close() {
+      _closeCalls++;
+    }
+
+    private static void reset() {
+      _closeCalls = 0;
+    }
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFSFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFSFactory.java
@@ -83,6 +83,16 @@ public class PinotFSFactory {
     return PINOT_FS_MAP.containsKey(scheme);
   }
 
+  /**
+   * Returns the effective filesystem after recursively unwrapping Pinot's non-closing delegates.
+   */
+  public static PinotFS getEffectiveFileSystem(PinotFS pinotFS) {
+    while (pinotFS instanceof NoClosePinotFS) {
+      pinotFS = ((NoClosePinotFS) pinotFS)._delegate;
+    }
+    return pinotFS;
+  }
+
   public static void shutdown()
       throws IOException {
     for (PinotFS pinotFS : PINOT_FS_MAP.values()) {

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/PinotFSFactoryTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/PinotFSFactoryTest.java
@@ -36,6 +36,9 @@ public class PinotFSFactoryTest {
     PinotFSFactory.init(new PinotConfiguration());
     NoClosePinotFS pinotFS = (NoClosePinotFS) PinotFSFactory.create("file");
     Assert.assertTrue(pinotFS._delegate instanceof LocalPinotFS);
+
+    PinotFS nestedLocalPinotFS = new NoClosePinotFS(new NoClosePinotFS(new LocalPinotFS()));
+    Assert.assertTrue(PinotFSFactory.getEffectiveFileSystem(nestedLocalPinotFS) instanceof LocalPinotFS);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Disable local filesystem sources for Controller `/ingestFromURI` by default.
- Validate the URI, loaded filesystem class, and effective delegated filesystem before parsing input or creating ingestion working state.
- Keep explicitly configured remote filesystems working, including request-scoped delegated implementations.
- Avoid global registration of request-provided filesystem classes and close request-scoped implementations after use.
- Return generic client errors without echoing submitted paths or filesystem class names.
- Add a compatibility-only opt-in, `controller.ingestFromURI.allowLocalFileSystem`, which remains disabled by default and documents the controller-local file access risk.

This adapts `dd6520c7267` for the 1.5.x release line and strengthens validation ordering and delegated-filesystem handling.

## Root cause

Filesystem selection previously happened at copy time. Unknown schemes could be registered globally before the resulting implementation was fully validated, while ingestion working directories and input metadata processing happened before URI policy validation. Validation also needed to inspect nested `NoClosePinotFS` delegates and subclasses rather than only the requested scheme or direct class name.

## User impact

Remote filesystem ingestion remains supported. Local URI ingestion now requires the explicit compatibility setting above; operators enabling it should only allow trusted callers and paths because the Controller process can read files visible to its local account.

## How to reproduce

1. Start a Controller with the default configuration and create an offline table named `foo_OFFLINE`.
2. Submit a local URI to the endpoint:

   ```bash
   curl -X POST -F 'file=@/dev/null' \
     'http://localhost:9000/ingestFromURI?tableNameWithType=foo_OFFLINE&batchConfigMapStr=%7B%22inputFormat%22%3A%22csv%22%7D&sourceURIStr=file%3A%2F%2F%2Ftmp%2Finput.csv'
   ```

3. Before this change, the request reaches local copy/ingestion setup. With this change it returns a generic HTTP 400 before a working directory or segment is created.
4. Set `controller.ingestFromURI.allowLocalFileSystem=true` only to verify the explicit compatibility behavior.

## Validation

- `./mvnw -pl pinot-controller -am -Dskip.npm=true -Dtest=PinotFSFactoryTest,ControllerConfTest,FileIngestionHelperTest,PinotIngestionRestletResourceStatelessTest -Dsurefire.failIfNoSpecifiedTests=false test`
  - 25 reactor modules passed
  - 37 selected tests passed: 2 SPI and 35 Controller
- `./mvnw spotless:apply -pl pinot-spi,pinot-controller -Dskip.npm=true`
- `./mvnw checkstyle:check -pl pinot-spi,pinot-controller -Dskip.npm=true`
- `./mvnw license:format -pl pinot-spi,pinot-controller -Dskip.npm=true`
- `./mvnw license:check -pl pinot-spi,pinot-controller -Dskip.npm=true`
- `./mvnw test-compile -pl pinot-spi,pinot-controller -Dskip.npm=true -Dmaven.compiler.showDeprecation=true -Dmaven.compiler.showWarnings=true '-Dmaven.compiler.compilerArgs=-Xlint:all'`
