### PR TITLE
Apply ingestion Groovy policy consistently

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/evaluator/FunctionEvaluatorFactory.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/evaluator/FunctionEvaluatorFactory.java
@@ -18,11 +18,17 @@
  */
 package org.apache.pinot.common.evaluator;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.TimeFieldSpec;
 import org.apache.pinot.spi.data.TimeGranularitySpec;
+import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.function.FunctionEvaluator;
+import org.apache.pinot.spi.utils.CommonConstants;
 
 
 /// Factory class to create an [FunctionEvaluator] for the field spec based on the
@@ -30,6 +36,13 @@ import org.apache.pinot.spi.function.FunctionEvaluator;
 public class FunctionEvaluatorFactory {
   private static final String MAP_KEY_COLUMN_SUFFIX = "__KEYS";
   private static final String MAP_VALUE_COLUMN_SUFFIX = "__VALUES";
+  private static final String DISABLED_GROOVY_MESSAGE = String.format(
+      "Groovy ingestion functions are disabled. Set '%s=false' to enable them",
+      CommonConstants.Groovy.DISABLE_INGESTION_GROOVY);
+
+  // Standalone segment-generation jobs do not pass through service startup config, so allow only an explicit system
+  // property value of false to opt in. Missing or invalid values remain fail-closed.
+  private static volatile boolean _ingestionGroovyDisabled = readIngestionGroovyDisabledFromSystemProperty();
 
   private FunctionEvaluatorFactory() {
   }
@@ -40,13 +53,17 @@ public class FunctionEvaluatorFactory {
   /// 2. For TIME column, if conversion is needed, [TimeSpecFunctionEvaluator] for backward compatible handling
   /// of time spec. This
   /// is needed until we migrate to [org.apache.pinot.spi.data.DateTimeFieldSpec]
-  /// 3. For columns ending with \_\_KEYS or \_\_VALUES (used for interpreting Map column in Avro), create default
-  ///    groovy
-  /// functions for
-  /// handing the Map
+  /// 3. For columns ending with \_\_KEYS or \_\_VALUES (used for interpreting Map columns in Avro), create a
+  /// backward-compatible map evaluator
   /// 4. Return null, if none of the above
   @Nullable
   public static FunctionEvaluator getExpressionEvaluator(FieldSpec fieldSpec) {
+    return getExpressionEvaluator(fieldSpec, _ingestionGroovyDisabled);
+  }
+
+  /// Creates an ingestion evaluator using an explicit Groovy policy.
+  @Nullable
+  public static FunctionEvaluator getExpressionEvaluator(FieldSpec fieldSpec, boolean ingestionGroovyDisabled) {
     FunctionEvaluator functionEvaluator = null;
 
     String columnName = fieldSpec.getName();
@@ -58,7 +75,7 @@ public class FunctionEvaluatorFactory {
 
       // if transform function expression present, use it to generate function evaluator
       try {
-        functionEvaluator = getExpressionEvaluator(transformExpression);
+        functionEvaluator = getExpressionEvaluator(transformExpression, ingestionGroovyDisabled);
       } catch (Exception e) {
         throw new IllegalStateException(
             "Caught exception while constructing expression evaluator for transform expression: " + transformExpression
@@ -84,19 +101,23 @@ public class FunctionEvaluatorFactory {
 
       // for backward compatible handling of Map type (currently only in Avro)
       String sourceMapName = columnName.substring(0, columnName.length() - MAP_KEY_COLUMN_SUFFIX.length());
-      String defaultMapKeysTransformExpression = getDefaultMapKeysTransformExpression(sourceMapName);
-      functionEvaluator = getExpressionEvaluator(defaultMapKeysTransformExpression);
+      functionEvaluator = new MapFunctionEvaluator(sourceMapName, true);
     } else if (columnName.endsWith(MAP_VALUE_COLUMN_SUFFIX)) {
       // for backward compatible handling of Map type in avro (currently only in Avro)
       String sourceMapName =
           columnName.substring(0, columnName.length() - MAP_VALUE_COLUMN_SUFFIX.length());
-      String defaultMapValuesTransformExpression = getDefaultMapValuesTransformExpression(sourceMapName);
-      functionEvaluator = getExpressionEvaluator(defaultMapValuesTransformExpression);
+      functionEvaluator = new MapFunctionEvaluator(sourceMapName, false);
     }
     return functionEvaluator;
   }
 
   public static FunctionEvaluator getExpressionEvaluator(String transformExpression) {
+    return getExpressionEvaluator(transformExpression, _ingestionGroovyDisabled);
+  }
+
+  /// Creates an ingestion evaluator using an explicit Groovy policy.
+  public static FunctionEvaluator getExpressionEvaluator(String transformExpression, boolean ingestionGroovyDisabled) {
+    validateIngestionGroovyPolicy(transformExpression, ingestionGroovyDisabled);
     if (isGroovyExpression(transformExpression)) {
       return new GroovyFunctionEvaluator(transformExpression);
     } else {
@@ -104,16 +125,91 @@ public class FunctionEvaluatorFactory {
     }
   }
 
+  /// Sets whether Groovy-backed ingestion evaluators are disabled process-wide.
+  public static void setIngestionGroovyDisabled(boolean ingestionGroovyDisabled) {
+    _ingestionGroovyDisabled = ingestionGroovyDisabled;
+  }
+
+  /// Reads the ingestion Groovy policy from a configuration string. Only an explicit `false` enables Groovy.
+  public static boolean resolveIngestionGroovyDisabled(@Nullable String configuredValue) {
+    return CommonConstants.Groovy.isIngestionGroovyDisabled(configuredValue);
+  }
+
+  /// Returns whether Groovy-backed ingestion evaluators are disabled process-wide.
+  public static boolean isIngestionGroovyDisabled() {
+    return _ingestionGroovyDisabled;
+  }
+
+  // Visible for tests in the same package.
+  static void resetIngestionGroovyDisabledFromSystemProperty() {
+    _ingestionGroovyDisabled = readIngestionGroovyDisabledFromSystemProperty();
+  }
+
+  /// Rejects a Groovy ingestion expression when Groovy is disabled. Built-in expressions are always allowed.
+  public static void validateIngestionGroovyPolicy(String transformExpression) {
+    validateIngestionGroovyPolicy(transformExpression, _ingestionGroovyDisabled);
+  }
+
+  /// Rejects a Groovy ingestion expression under the given explicit policy.
+  public static void validateIngestionGroovyPolicy(String transformExpression, boolean ingestionGroovyDisabled) {
+    if (ingestionGroovyDisabled && isGroovyExpression(transformExpression)) {
+      throw new IllegalStateException(DISABLED_GROOVY_MESSAGE);
+    }
+  }
+
   /// @return true if the given transform function is a groovy expression, otherwise returns false
   public static boolean isGroovyExpression(String transformExpression) {
-    return transformExpression.startsWith(GroovyFunctionEvaluator.getGroovyExpressionPrefix());
+    String groovyPrefix = GroovyFunctionEvaluator.getGroovyExpressionPrefix();
+    return transformExpression.regionMatches(true, 0, groovyPrefix, 0, groovyPrefix.length());
   }
 
-  private static String getDefaultMapKeysTransformExpression(String mapColumnName) {
-    return String.format("Groovy({%s.sort()*.key}, %s)", mapColumnName, mapColumnName);
+  private static boolean readIngestionGroovyDisabledFromSystemProperty() {
+    String disableGroovy = System.getProperty(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY);
+    if (disableGroovy == null) {
+      return CommonConstants.Groovy.DEFAULT_DISABLE_INGESTION_GROOVY;
+    }
+    return resolveIngestionGroovyDisabled(disableGroovy);
   }
 
-  private static String getDefaultMapValuesTransformExpression(String mapColumnName) {
-    return String.format("Groovy({%s.sort()*.value}, %s)", mapColumnName, mapColumnName);
+  private static class MapFunctionEvaluator implements FunctionEvaluator {
+    private final String _mapColumnName;
+    private final List<String> _arguments;
+    private final boolean _extractKeys;
+
+    MapFunctionEvaluator(String mapColumnName, boolean extractKeys) {
+      _mapColumnName = mapColumnName;
+      _arguments = List.of(mapColumnName);
+      _extractKeys = extractKeys;
+    }
+
+    @Override
+    public List<String> getArguments() {
+      return _arguments;
+    }
+
+    @Override
+    public Object evaluate(GenericRow genericRow) {
+      return evaluateMap(genericRow.getValue(_mapColumnName));
+    }
+
+    @Override
+    public Object evaluate(Object[] values) {
+      return evaluateMap(values[0]);
+    }
+
+    @Nullable
+    private List<Object> evaluateMap(@Nullable Object value) {
+      if (value == null) {
+        return null;
+      }
+
+      Map<?, ?> map = (Map<?, ?>) value;
+      Map<?, ?> sortedMap = new TreeMap<>(map);
+      List<Object> result = new ArrayList<>(sortedMap.size());
+      for (Map.Entry<?, ?> entry : sortedMap.entrySet()) {
+        result.add(_extractKeys ? entry.getKey() : entry.getValue());
+      }
+      return result;
+    }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStartableUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStartableUtils.java
@@ -21,6 +21,7 @@ package org.apache.pinot.common.utils;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
@@ -53,6 +54,13 @@ public class ServiceStartableUtils {
   /// - pinot.all.\* will be replaced to role specific config, e.g. pinot.controller.\* for controllers
   public static void applyClusterConfig(PinotConfiguration instanceConfig, String zkAddress, String clusterName,
       ServiceRole serviceRole) {
+    applyClusterConfig(instanceConfig, zkAddress, clusterName, serviceRole, serviceRole != ServiceRole.BROKER);
+  }
+
+  /// Applies cluster config, optionally resolving the cluster-wide ingestion Groovy policy for this service.
+  /// Brokers and HELIX_ONLY controllers do not construct ingestion evaluators and should pass `false`.
+  public static void applyClusterConfig(PinotConfiguration instanceConfig, String zkAddress, String clusterName,
+      ServiceRole serviceRole, boolean applyIngestionGroovyPolicy) {
     int zkClientSessionConfig =
         instanceConfig.getProperty(CommonConstants.Helix.ZkClient.ZK_CLIENT_SESSION_TIMEOUT_MS_CONFIG,
             CommonConstants.Helix.ZkClient.DEFAULT_SESSION_TIMEOUT_MS);
@@ -72,6 +80,9 @@ public class ServiceStartableUtils {
           zkClient.readData(String.format(CLUSTER_CONFIG_ZK_PATH_TEMPLATE, clusterName, clusterName), true);
       if (clusterConfigZNRecord == null) {
         LOGGER.warn("Failed to find cluster config for cluster: {}, skipping applying cluster config", clusterName);
+        if (applyIngestionGroovyPolicy) {
+          applyIngestionGroovyPolicy(instanceConfig, null, serviceRole);
+        }
         setTimezone(instanceConfig);
         initForwardIndexConfig(instanceConfig);
         initFieldSpecConfig(instanceConfig);
@@ -79,11 +90,18 @@ public class ServiceStartableUtils {
       }
 
       Map<String, String> clusterConfigs = clusterConfigZNRecord.getSimpleFields();
+      if (applyIngestionGroovyPolicy) {
+        applyIngestionGroovyPolicy(instanceConfig,
+            clusterConfigs.get(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY), serviceRole);
+      }
       String instanceConfigKeyPrefix =
           String.format(PINOT_INSTANCE_CONFIG_KEY_PREFIX_TEMPLATE, serviceRole.name().toLowerCase());
       for (Map.Entry<String, String> entry : clusterConfigs.entrySet()) {
         String key = entry.getKey();
         String value = entry.getValue();
+        if (key.equals(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY)) {
+          continue;
+        }
         if (key.startsWith(PINOT_ALL_CONFIG_KEY_PREFIX)) {
           String instanceConfigKey = instanceConfigKeyPrefix + key.substring(PINOT_ALL_CONFIG_KEY_PREFIX.length());
           addConfigIfNotExists(instanceConfig, instanceConfigKey, value);
@@ -100,6 +118,45 @@ public class ServiceStartableUtils {
     initForwardIndexConfig(instanceConfig);
     initFieldSpecConfig(instanceConfig);
     initRequestUtilsConfig(instanceConfig);
+  }
+
+  static void applyIngestionGroovyPolicy(PinotConfiguration instanceConfig, @Nullable String clusterValue,
+      ServiceRole serviceRole) {
+    String key = CommonConstants.Groovy.DISABLE_INGESTION_GROOVY;
+    // During a rolling upgrade the cluster key can be absent. Preserve an explicit per-instance opt-in in that case,
+    // while keeping an unconfigured or invalid value fail-closed. Once present, the cluster value is authoritative.
+    if (clusterValue == null) {
+      boolean explicitlyConfigured = instanceConfig.containsKey(key);
+      boolean instanceDisablesGroovy = CommonConstants.Groovy.isIngestionGroovyDisabled(
+          explicitlyConfigured ? instanceConfig.getProperty(key) : null);
+      instanceConfig.setProperty(key, instanceDisablesGroovy);
+      if (!explicitlyConfigured && (serviceRole == ServiceRole.SERVER || serviceRole == ServiceRole.MINION)) {
+        LOGGER.warn("Cluster config '{}' is absent during startup; {} defaults to disabling ingestion Groovy. "
+                + "For an enabled cluster rolling upgrade, upgrade an API-serving controller first or explicitly "
+                + "configure '{}=false' on this instance until the cluster policy is published",
+            key, serviceRole.name().toLowerCase(), key);
+      }
+      return;
+    }
+    boolean clusterDisablesGroovy = CommonConstants.Groovy.isIngestionGroovyDisabled(clusterValue);
+    if (instanceConfig.containsKey(key)) {
+      boolean instanceDisablesGroovy =
+          CommonConstants.Groovy.isIngestionGroovyDisabled(instanceConfig.getProperty(key));
+      if (instanceDisablesGroovy != clusterDisablesGroovy) {
+        throw new IllegalStateException(String.format(
+            "Conflicting ingestion Groovy policy: cluster config '%s=%s' is authoritative, but the %s instance "
+                + "config resolves to %s",
+            key, clusterDisablesGroovy, serviceRole.name().toLowerCase(), instanceDisablesGroovy));
+      }
+    }
+    instanceConfig.setProperty(key, clusterDisablesGroovy);
+  }
+
+  /// Reapplies a previously resolved ingestion Groovy policy after custom configuration hooks have run.
+  /// This prevents an extension from weakening the authoritative cluster policy.
+  public static void enforceIngestionGroovyPolicy(PinotConfiguration instanceConfig, boolean disableGroovy,
+      ServiceRole serviceRole) {
+    applyIngestionGroovyPolicy(instanceConfig, Boolean.toString(disableGroovy), serviceRole);
   }
 
   private static void addConfigIfNotExists(PinotConfiguration instanceConfig, String key, String value) {

--- a/pinot-common/src/test/java/org/apache/pinot/common/evaluator/FunctionEvaluatorFactoryTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/evaluator/FunctionEvaluatorFactoryTest.java
@@ -1,0 +1,181 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.evaluator;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.function.FunctionEvaluator;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+
+public class FunctionEvaluatorFactoryTest {
+  private static final String GROOVY_EXPRESSION = "Groovy({value + 1}, value)";
+  private static final String DISABLED_GROOVY_MESSAGE = String.format(
+      "Groovy ingestion functions are disabled. Set '%s=false' to enable them",
+      CommonConstants.Groovy.DISABLE_INGESTION_GROOVY);
+
+  @BeforeMethod
+  public void setUp() {
+    FunctionEvaluatorFactory.setIngestionGroovyDisabled(true);
+  }
+
+  @AfterMethod(alwaysRun = true)
+  public void tearDown() {
+    FunctionEvaluatorFactory.setIngestionGroovyDisabled(true);
+  }
+
+  @Test
+  public void testGroovyDisabledByDefault() {
+    assertTrue(FunctionEvaluatorFactory.isIngestionGroovyDisabled());
+
+    IllegalStateException validationError = expectThrows(IllegalStateException.class,
+        () -> FunctionEvaluatorFactory.validateIngestionGroovyPolicy(GROOVY_EXPRESSION));
+    assertEquals(validationError.getMessage(), DISABLED_GROOVY_MESSAGE);
+
+    // Invalid Groovy must be rejected by policy before compilation is attempted.
+    IllegalStateException constructionError = expectThrows(IllegalStateException.class,
+        () -> FunctionEvaluatorFactory.getExpressionEvaluator("Groovy({not valid groovy!!!})"));
+    assertEquals(constructionError.getMessage(), DISABLED_GROOVY_MESSAGE);
+
+    IllegalStateException caseInsensitiveError = expectThrows(IllegalStateException.class,
+        () -> FunctionEvaluatorFactory.getExpressionEvaluator("groovy({1})"));
+    assertEquals(caseInsensitiveError.getMessage(), DISABLED_GROOVY_MESSAGE);
+  }
+
+  @Test
+  public void testExplicitGroovyOptIn() {
+    FunctionEvaluatorFactory.setIngestionGroovyDisabled(false);
+    assertFalse(FunctionEvaluatorFactory.isIngestionGroovyDisabled());
+    FunctionEvaluatorFactory.validateIngestionGroovyPolicy(GROOVY_EXPRESSION);
+
+    FunctionEvaluator evaluator = FunctionEvaluatorFactory.getExpressionEvaluator(GROOVY_EXPRESSION);
+    assertTrue(evaluator instanceof GroovyFunctionEvaluator);
+    assertEquals(evaluator.evaluate(new Object[]{1}), 2);
+  }
+
+  @Test
+  public void testExplicitPoliciesAreContextScoped() {
+    assertTrue(FunctionEvaluatorFactory.isIngestionGroovyDisabled());
+
+    FunctionEvaluator enabledEvaluator =
+        FunctionEvaluatorFactory.getExpressionEvaluator(GROOVY_EXPRESSION, false);
+    assertEquals(enabledEvaluator.evaluate(new Object[]{1}), 2);
+    IllegalStateException disabledError = expectThrows(IllegalStateException.class,
+        () -> FunctionEvaluatorFactory.getExpressionEvaluator(GROOVY_EXPRESSION, true));
+    assertEquals(disabledError.getMessage(), DISABLED_GROOVY_MESSAGE);
+    assertTrue(FunctionEvaluatorFactory.isIngestionGroovyDisabled());
+  }
+
+  @Test
+  public void testStandaloneSystemPropertyOptIn() {
+    assertTrue(FunctionEvaluatorFactory.resolveIngestionGroovyDisabled(null));
+    assertTrue(FunctionEvaluatorFactory.resolveIngestionGroovyDisabled("invalid"));
+    assertTrue(FunctionEvaluatorFactory.resolveIngestionGroovyDisabled("true"));
+    assertFalse(FunctionEvaluatorFactory.resolveIngestionGroovyDisabled(" false "));
+
+    String configKey = CommonConstants.Groovy.DISABLE_INGESTION_GROOVY;
+    String previousValue = System.getProperty(configKey);
+    try {
+      System.clearProperty(configKey);
+      FunctionEvaluatorFactory.resetIngestionGroovyDisabledFromSystemProperty();
+      assertTrue(FunctionEvaluatorFactory.isIngestionGroovyDisabled());
+
+      System.setProperty(configKey, "false");
+      FunctionEvaluatorFactory.resetIngestionGroovyDisabledFromSystemProperty();
+      assertFalse(FunctionEvaluatorFactory.isIngestionGroovyDisabled());
+
+      System.setProperty(configKey, "invalid");
+      FunctionEvaluatorFactory.resetIngestionGroovyDisabledFromSystemProperty();
+      assertTrue(FunctionEvaluatorFactory.isIngestionGroovyDisabled());
+    } finally {
+      if (previousValue == null) {
+        System.clearProperty(configKey);
+      } else {
+        System.setProperty(configKey, previousValue);
+      }
+      FunctionEvaluatorFactory.resetIngestionGroovyDisabledFromSystemProperty();
+    }
+  }
+
+  @Test
+  public void testBuiltInTransformUnaffected() {
+    FunctionEvaluatorFactory.validateIngestionGroovyPolicy("reverse(source)");
+    DimensionFieldSpec fieldSpec = new DimensionFieldSpec("destination", FieldSpec.DataType.STRING, true);
+    fieldSpec.setTransformFunction("reverse(source)");
+
+    FunctionEvaluator evaluator = FunctionEvaluatorFactory.getExpressionEvaluator(fieldSpec);
+    GenericRow row = new GenericRow();
+    row.putValue("source", "Pinot");
+    assertEquals(evaluator.evaluate(row), "toniP");
+  }
+
+  @Test
+  public void testImplicitMapTransformsUnaffected() {
+    DimensionFieldSpec keysFieldSpec =
+        new DimensionFieldSpec("attributes__KEYS", FieldSpec.DataType.STRING, false);
+    DimensionFieldSpec valuesFieldSpec =
+        new DimensionFieldSpec("attributes__VALUES", FieldSpec.DataType.INT, false);
+    FunctionEvaluator keysEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(keysFieldSpec);
+    FunctionEvaluator valuesEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(valuesFieldSpec);
+    assertFalse(keysEvaluator instanceof GroovyFunctionEvaluator);
+    assertFalse(valuesEvaluator instanceof GroovyFunctionEvaluator);
+    assertEquals(keysEvaluator.getArguments(), List.of("attributes"));
+    assertEquals(valuesEvaluator.getArguments(), List.of("attributes"));
+
+    Map<String, Integer> attributes = new LinkedHashMap<>();
+    attributes.put("z", 2);
+    attributes.put("a", 1);
+    GenericRow row = new GenericRow();
+    row.putValue("attributes", attributes);
+
+    Object keys = keysEvaluator.evaluate(row);
+    Object values = valuesEvaluator.evaluate(new Object[]{attributes});
+    assertTrue(keys instanceof ArrayList);
+    assertTrue(values instanceof ArrayList);
+    assertEquals(keys, List.of("a", "z"));
+    assertEquals(values, List.of(1, 2));
+    assertNull(keysEvaluator.evaluate(new Object[]{null}));
+
+    Map<String, Integer> reverseSortedAttributes = new TreeMap<>(java.util.Comparator.reverseOrder());
+    reverseSortedAttributes.putAll(attributes);
+    assertEquals(keysEvaluator.evaluate(new Object[]{reverseSortedAttributes}), List.of("a", "z"));
+    assertEquals(valuesEvaluator.evaluate(new Object[]{reverseSortedAttributes}), List.of(1, 2));
+  }
+
+  @Test
+  public void testDirectGroovyEvaluatorIsNotGovernedByIngestionPolicy() {
+    GroovyFunctionEvaluator evaluator = new GroovyFunctionEvaluator("Groovy({1})");
+    assertEquals(evaluator.evaluate(new Object[]{}), 1);
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/ServiceStartableUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/ServiceStartableUtilsTest.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils;
+
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.services.ServiceRole;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.expectThrows;
+
+
+public class ServiceStartableUtilsTest {
+  private static final String GROOVY_POLICY_KEY = CommonConstants.Groovy.DISABLE_INGESTION_GROOVY;
+
+  @Test
+  public void testMissingClusterPolicyPreservesExplicitOptIn() {
+    PinotConfiguration config = new PinotConfiguration();
+    config.setProperty(GROOVY_POLICY_KEY, "false");
+
+    ServiceStartableUtils.applyIngestionGroovyPolicy(config, null, ServiceRole.SERVER);
+
+    assertEquals(config.getProperty(GROOVY_POLICY_KEY), "false");
+  }
+
+  @Test
+  public void testMissingOrInvalidPolicyFailsClosed() {
+    PinotConfiguration missingConfig = new PinotConfiguration();
+    ServiceStartableUtils.applyIngestionGroovyPolicy(missingConfig, null, ServiceRole.MINION);
+    assertEquals(missingConfig.getProperty(GROOVY_POLICY_KEY), "true");
+
+    PinotConfiguration invalidConfig = new PinotConfiguration();
+    invalidConfig.setProperty(GROOVY_POLICY_KEY, "invalid");
+    ServiceStartableUtils.applyIngestionGroovyPolicy(invalidConfig, null, ServiceRole.SERVER);
+    assertEquals(invalidConfig.getProperty(GROOVY_POLICY_KEY), "true");
+  }
+
+  @Test
+  public void testClusterPolicyIsAuthoritative() {
+    PinotConfiguration config = new PinotConfiguration();
+    ServiceStartableUtils.applyIngestionGroovyPolicy(config, "false", ServiceRole.SERVER);
+    assertEquals(config.getProperty(GROOVY_POLICY_KEY), "false");
+
+    PinotConfiguration conflictingConfig = new PinotConfiguration();
+    conflictingConfig.setProperty(GROOVY_POLICY_KEY, "false");
+    IllegalStateException error = expectThrows(IllegalStateException.class,
+        () -> ServiceStartableUtils.applyIngestionGroovyPolicy(conflictingConfig, "true", ServiceRole.MINION));
+    assertEquals(error.getMessage(), String.format(
+        "Conflicting ingestion Groovy policy: cluster config '%s=true' is authoritative, but the minion instance "
+            + "config resolves to false", GROOVY_POLICY_KEY));
+  }
+
+  @Test
+  public void testResolvedPolicyCannotBeOverridden() {
+    PinotConfiguration config = new PinotConfiguration();
+    config.setProperty(GROOVY_POLICY_KEY, "false");
+
+    expectThrows(IllegalStateException.class,
+        () -> ServiceStartableUtils.enforceIngestionGroovyPolicy(config, true, ServiceRole.CONTROLLER));
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -201,6 +201,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
   protected String _helixParticipantInstanceId;
   protected boolean _isUpdateStateModel;
   protected ControllerConf.ControllerMode _controllerMode;
+  protected boolean _isIngestionGroovyPolicyExplicitlyConfigured;
   protected HelixManager _helixControllerManager;
   protected HelixManager _helixParticipantManager;
   protected PinotMetricsRegistry _metricsRegistry;
@@ -249,12 +250,22 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     _helixZkURL = HelixConfig.getAbsoluteZkPathForHelix(_config.getZkStr());
     _helixClusterName = _config.getHelixClusterName();
     _controllerMode = _config.getControllerMode();
+    _isIngestionGroovyPolicyExplicitlyConfigured = _config.containsKey(ControllerConf.DISABLE_GROOVY);
     if (_controllerMode == ControllerConf.ControllerMode.DUAL
         || _controllerMode == ControllerConf.ControllerMode.HELIX_ONLY) {
       HelixSetupUtils.setupHelixClusterWithDefaultConfigs(_helixZkURL, _helixClusterName, getDefaultClusterConfigs());
     }
-    ServiceStartableUtils.applyClusterConfig(_config, _helixZkURL, _helixClusterName, ServiceRole.CONTROLLER);
+    if (_controllerMode == ControllerConf.ControllerMode.DUAL) {
+      HelixSetupUtils.reconcileIngestionGroovyPolicy(_helixZkURL, _helixClusterName,
+          _isIngestionGroovyPolicyExplicitlyConfigured, _config.isDisableIngestionGroovy());
+    }
+    ServiceStartableUtils.applyClusterConfig(_config, _helixZkURL, _helixClusterName, ServiceRole.CONTROLLER,
+        _controllerMode != ControllerConf.ControllerMode.HELIX_ONLY);
+    boolean disableGroovy = _config.isDisableIngestionGroovy();
     applyCustomConfigs(_config);
+    if (_controllerMode != ControllerConf.ControllerMode.HELIX_ONLY) {
+      ServiceStartableUtils.enforceIngestionGroovyPolicy(_config, disableGroovy, ServiceRole.CONTROLLER);
+    }
 
     PinotInsecureMode.setPinotInInsecureMode(_config.getProperty(CommonConstants.CONFIG_OF_PINOT_INSECURE_MODE, false));
     PinotMd5Mode.setPinotMd5Disabled(_config.getProperty(CommonConstants.CONFIG_OF_PINOT_MD5_DISABLED,
@@ -305,7 +316,6 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     // Initialize the table config tuner registry.
     TableConfigTunerRegistry.init(_config.getTableConfigTunerPackages());
 
-    TableConfigUtils.setDisableGroovy(_config.isDisableIngestionGroovy());
     TableConfigUtils.setEnforcePoolBasedAssignment(_config.isEnforcePoolBasedAssignmentEnabled());
 
     ControllerJobTypes.init(_config);
@@ -480,6 +490,13 @@ public abstract class BaseControllerStarter implements ServiceStartable {
   @Override
   public void start()
       throws Exception {
+    if (_controllerMode == ControllerConf.ControllerMode.PINOT_ONLY) {
+      boolean configuredDisableGroovy = _isIngestionGroovyPolicyExplicitlyConfigured
+          ? _config.isDisableIngestionGroovy() : ControllerConf.DEFAULT_DISABLE_GROOVY;
+      boolean disableGroovy = HelixSetupUtils.reconcileIngestionGroovyPolicy(_helixZkURL, _helixClusterName,
+          _isIngestionGroovyPolicyExplicitlyConfigured, configuredDisableGroovy);
+      _config.setProperty(ControllerConf.DISABLE_GROOVY, disableGroovy);
+    }
     LOGGER.info("Starting Pinot controller in mode: {}. (Version: {})", _controllerMode.name(), PinotVersion.VERSION);
     LOGGER.info("Controller configs: {}", new PinotAppConfigs(getConfig()).toJSONString());
     long startTimeMs = System.currentTimeMillis();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -443,8 +443,8 @@ public class ControllerConf extends PinotConfiguration {
 
   public static final String DEFAULT_PINOT_FS_FACTORY_CLASS_LOCAL = LocalPinotFS.class.getName();
 
-  public static final String DISABLE_GROOVY = "controller.disable.ingestion.groovy";
-  public static final boolean DEFAULT_DISABLE_GROOVY = true;
+  public static final String DISABLE_GROOVY = CommonConstants.Groovy.DISABLE_INGESTION_GROOVY;
+  public static final boolean DEFAULT_DISABLE_GROOVY = CommonConstants.Groovy.DEFAULT_DISABLE_INGESTION_GROOVY;
 
   public static final String ENFORCE_POOL_BASED_ASSIGNMENT_KEY = "enforce.pool.based.assignment";
   public static final boolean DEFAULT_ENFORCE_POOL_BASED_ASSIGNMENT = false;
@@ -1527,7 +1527,7 @@ public class ControllerConf extends PinotConfiguration {
 
   /// @return true if Groovy functions are disabled in controller config, otherwise returns false.
   public boolean isDisableIngestionGroovy() {
-    return getProperty(DISABLE_GROOVY, DEFAULT_DISABLE_GROOVY);
+    return CommonConstants.Groovy.isIngestionGroovyDisabled(getProperty(DISABLE_GROOVY));
   }
 
   private long convertPeriodToUnit(String period, TimeUnit timeUnitToConvertTo) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
@@ -60,6 +60,7 @@ import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
@@ -230,7 +231,8 @@ public class PinotIngestionRestletResource {
     FileIngestionHelper fileIngestionHelper =
         new FileIngestionHelper(tableConfig, schema, batchConfigMap, getControllerUri(),
             new File(_controllerConf.getLocalTempDir(), INGESTION_DIR), authProvider,
-            _controllerConf.isIngestFromUriLocalFileSystemAllowed());
+            _controllerConf.isIngestFromUriLocalFileSystemAllowed(),
+            IngestionGroovyPolicy.fromDisabled(_controllerConf.isDisableIngestionGroovy()));
     return fileIngestionHelper.buildSegmentAndPush(payload);
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
@@ -61,6 +61,7 @@ import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.utils.DatabaseUtils;
+import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.access.AccessControlFactory;
 import org.apache.pinot.controller.api.access.AccessType;
 import org.apache.pinot.controller.api.access.Authenticate;
@@ -113,6 +114,9 @@ public class PinotSchemaRestletResource {
 
   @Inject
   AccessControlFactory _accessControlFactory;
+
+  @Inject
+  ControllerConf _controllerConf;
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
@@ -334,9 +338,9 @@ public class PinotSchemaRestletResource {
     validateSchemaName(schema);
     String schemaName = DatabaseUtils.translateTableName(schema.getSchemaName(), httpHeaders);
     schema.setSchemaName(schemaName);
-    validateSchemaInternal(schema);
     ResourceUtils.checkPermissionAndAccess(schemaName, request, httpHeaders,
         AccessType.READ, Actions.Table.VALIDATE_SCHEMA, _accessControlFactory, LOGGER);
+    validateSchemaInternal(schema);
     ObjectNode response = schema.toJsonObject();
     response.set("unrecognizedProperties", JsonUtils.objectToJsonNode(schemaAndUnrecognizedProps.getRight()));
     try {
@@ -365,9 +369,9 @@ public class PinotSchemaRestletResource {
     validateSchemaName(schema);
     String schemaName = DatabaseUtils.translateTableName(schema.getSchemaName(), httpHeaders);
     schema.setSchemaName(schemaName);
-    validateSchemaInternal(schema);
     ResourceUtils.checkPermissionAndAccess(schemaName, request, httpHeaders,
         AccessType.READ, Actions.Table.VALIDATE_SCHEMA, _accessControlFactory, LOGGER);
+    validateSchemaInternal(schema);
     ObjectNode response = schema.toJsonObject();
     response.set("unrecognizedProperties", JsonUtils.objectToJsonNode(schemaAndUnrecognizedProps.getRight()));
     try {
@@ -408,7 +412,8 @@ public class PinotSchemaRestletResource {
       List<TableConfig> tableConfigs = _pinotHelixResourceManager.getTableConfigsForSchema(schema.getSchemaName());
       boolean isIgnoreCase = _pinotHelixResourceManager.getTableCache().isIgnoreCase();
       Schema existingSchema = _pinotHelixResourceManager.getSchema(schema.getSchemaName());
-      SchemaUtils.validate(schema, tableConfigs, isIgnoreCase, existingSchema);
+      SchemaUtils.validate(schema, tableConfigs, isIgnoreCase, existingSchema,
+          _controllerConf.isDisableIngestionGroovy());
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER,
           "Invalid schema: " + schema.getSchemaName() + ". Reason: " + e.getMessage(), Response.Status.BAD_REQUEST, e);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -129,6 +129,7 @@ import org.apache.pinot.spi.controller.ControllerJobType;
 import org.apache.pinot.spi.data.LogicalTableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.exception.ConfigValidationException;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.PartitionGroupMetadata;
 import org.apache.pinot.spi.stream.StreamConfig;
@@ -466,7 +467,8 @@ public class PinotTableRestletResource {
   @ApiOperation(value = "Recommend config", notes = "Recommend a config with input json")
   public String recommendConfig(String inputStr) {
     try {
-      return RecommenderDriver.run(inputStr);
+      return RecommenderDriver.run(inputStr,
+          IngestionGroovyPolicy.fromDisabled(_controllerConf.isDisableIngestionGroovy()));
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST, e);
     }
@@ -861,7 +863,7 @@ public class PinotTableRestletResource {
         throw new SchemaNotFoundException("Failed to find schema for table: " + tableNameWithType);
       }
       TableConfigUtils.validate(tableConfig, schema, typesToSkip,
-          _pinotHelixResourceManager.getTableConfig(tableNameWithType));
+          _pinotHelixResourceManager.getTableConfig(tableNameWithType), _controllerConf.isDisableIngestionGroovy());
       TaskConfigUtils.validateTaskConfigs(tableConfig, schema, _pinotTaskManager, typesToSkip);
       TableConfigValidatorRegistry.validate(tableConfig, schema);
       ObjectNode tableConfigValidateStr = JsonUtils.newObjectNode();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigValidationUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigValidationUtils.java
@@ -63,7 +63,8 @@ public final class TableConfigValidationUtils {
       ControllerConf controllerConf, @Nullable PinotTaskManager taskManager,
       @Nullable TableConfig existingTableConfig) {
     validateEnvironmentVariables(tableConfig);
-    TableConfigUtils.validate(tableConfig, schema, typesToSkip, existingTableConfig);
+    TableConfigUtils.validate(tableConfig, schema, typesToSkip, existingTableConfig,
+        controllerConf.isDisableIngestionGroovy());
     TableConfigUtils.validateTableName(tableConfig);
     TableConfigUtils.ensureMinReplicas(tableConfig, controllerConf.getDefaultTableMinReplicas());
     TableConfigUtils.ensureStorageQuotaConstraints(tableConfig, controllerConf.getDimTableMaxSize());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -213,6 +213,14 @@ public class TableConfigsRestletResource {
           Response.Status.BAD_REQUEST);
     }
 
+    // Validate permission before semantic validation because validation can construct function evaluators.
+    String endpointUrl = request.getRequestURL().toString();
+    AccessControl accessControl = _accessControlFactory.create();
+    AccessControlUtils.validatePermission(rawTableName, AccessType.CREATE, httpHeaders, endpointUrl, accessControl);
+    if (!accessControl.hasAccess(httpHeaders, TargetType.TABLE, rawTableName, Actions.Table.CREATE_TABLE)) {
+      throw new ControllerApplicationException(LOGGER, "Permission denied", Response.Status.FORBIDDEN);
+    }
+
     validateConfig(tableConfigs, databaseName, typesToSkip);
     tableConfigs.setTableName(rawTableName);
 
@@ -221,15 +229,6 @@ public class TableConfigsRestletResource {
     Schema schema = tableConfigs.getSchema();
 
     try {
-      // validate permission
-      String endpointUrl = request.getRequestURL().toString();
-      AccessControl accessControl = _accessControlFactory.create();
-      AccessControlUtils.validatePermission(rawTableName, AccessType.CREATE, httpHeaders, endpointUrl,
-          accessControl);
-      if (!accessControl.hasAccess(httpHeaders, TargetType.TABLE, rawTableName, Actions.Table.CREATE_TABLE)) {
-        throw new ControllerApplicationException(LOGGER, "Permission denied", Response.Status.FORBIDDEN);
-      }
-
       if (offlineTableConfig != null) {
         applyTuning(offlineTableConfig, schema);
         if (!ignoreActiveTasks) {
@@ -494,8 +493,18 @@ public class TableConfigsRestletResource {
     }
     String databaseName = DatabaseUtils.extractDatabaseFromHttpHeaders(httpHeaders);
     TableConfigs tableConfigs = tableConfigsAndUnrecognizedProps.getLeft();
-    validateConfig(tableConfigs, databaseName, typesToSkip);
     String rawTableName = DatabaseUtils.translateTableName(tableConfigs.getTableName(), databaseName);
+
+    // Validate permission before semantic validation because validation can construct function evaluators.
+    String endpointUrl = request.getRequestURL().toString();
+    AccessControl accessControl = _accessControlFactory.create();
+    AccessControlUtils.validatePermission(rawTableName, AccessType.READ, httpHeaders, endpointUrl, accessControl);
+    if (!accessControl.hasAccess(httpHeaders, TargetType.TABLE, rawTableName,
+        Actions.Table.VALIDATE_TABLE_CONFIGS)) {
+      throw new ControllerApplicationException(LOGGER, "Permission denied", Response.Status.FORBIDDEN);
+    }
+
+    validateConfig(tableConfigs, databaseName, typesToSkip);
     tableConfigs.setTableName(rawTableName);
 
     // Cluster-aware validations are exclusive to the validate/tune pre-flight endpoints so that users get fail-fast
@@ -519,13 +528,6 @@ public class TableConfigsRestletResource {
           String.format("Invalid TableConfigs: %s. %s", rawTableName, e.getMessage()), Response.Status.BAD_REQUEST, e);
     }
 
-    // validate permission
-    String endpointUrl = request.getRequestURL().toString();
-    AccessControl accessControl = _accessControlFactory.create();
-    AccessControlUtils.validatePermission(rawTableName, AccessType.READ, httpHeaders, endpointUrl, accessControl);
-    if (!accessControl.hasAccess(httpHeaders, TargetType.TABLE, rawTableName, Actions.Table.VALIDATE_TABLE_CONFIGS)) {
-      throw new ControllerApplicationException(LOGGER, "Permission denied", Response.Status.FORBIDDEN);
-    }
     return tableConfigsAndUnrecognizedProps;
   }
 
@@ -566,7 +568,7 @@ public class TableConfigsRestletResource {
       Preconditions.checkState(rawTableName.equals(schemaName),
           "'tableName': %s must be equal to 'schemaName' from 'schema': %s", rawTableName, schema.getSchemaName());
       SchemaUtils.validateIngestionTransformVolatility(schema, _pinotHelixResourceManager.getSchema(schemaName));
-      SchemaUtils.validate(schema);
+      SchemaUtils.validate(schema, false, _controllerConf.isDisableIngestionGroovy());
       if (offlineTableConfig != null) {
         String offlineRawTableName = DatabaseUtils.translateTableName(
             TableNameBuilder.extractRawTableName(offlineTableConfig.getTableName()), database);
@@ -574,7 +576,8 @@ public class TableConfigsRestletResource {
             "Name in 'offline' table config: %s must be equal to 'tableName': %s", offlineRawTableName, rawTableName);
         TableConfigUtils.validateTableName(offlineTableConfig);
         TableConfigUtils.validate(offlineTableConfig, schema, typesToSkip,
-            _pinotHelixResourceManager.getTableConfig(TableNameBuilder.OFFLINE.tableNameWithType(rawTableName)));
+            _pinotHelixResourceManager.getTableConfig(TableNameBuilder.OFFLINE.tableNameWithType(rawTableName)),
+            _controllerConf.isDisableIngestionGroovy());
         TaskConfigUtils.validateTaskConfigs(tableConfigs.getOffline(), schema, _pinotTaskManager, typesToSkip);
         TableConfigValidatorRegistry.validate(offlineTableConfig, schema);
       }
@@ -585,7 +588,8 @@ public class TableConfigsRestletResource {
             "Name in 'realtime' table config: %s must be equal to 'tableName': %s", realtimeRawTableName, rawTableName);
         TableConfigUtils.validateTableName(realtimeTableConfig);
         TableConfigUtils.validate(realtimeTableConfig, schema, typesToSkip,
-            _pinotHelixResourceManager.getTableConfig(TableNameBuilder.REALTIME.tableNameWithType(rawTableName)));
+            _pinotHelixResourceManager.getTableConfig(TableNameBuilder.REALTIME.tableNameWithType(rawTableName)),
+            _controllerConf.isDisableIngestionGroovy());
         TaskConfigUtils.validateTaskConfigs(tableConfigs.getRealtime(), schema, _pinotTaskManager, typesToSkip);
         TableConfigValidatorRegistry.validate(realtimeTableConfig, schema);
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/HelixSetupUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/HelixSetupUtils.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.apache.helix.AccessOption;
 import org.apache.helix.ConfigAccessor;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
@@ -41,14 +42,17 @@ import org.apache.helix.model.StateModelDefinition;
 import org.apache.helix.model.builder.CustomModeISBuilder;
 import org.apache.helix.model.builder.FullAutoModeISBuilder;
 import org.apache.helix.model.builder.HelixConfigScopeBuilder;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
+import org.apache.helix.zookeeper.zkclient.exception.ZkBadVersionException;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.common.utils.helix.LeadControllerUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.helix.core.PinotHelixBrokerResourceOnlineOfflineStateModelGenerator;
 import org.apache.pinot.controller.helix.core.PinotHelixSegmentOnlineOfflineStateModelGenerator;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -116,6 +120,51 @@ public class HelixSetupUtils {
       }
     } finally {
       admin.close();
+    }
+  }
+
+  /// Reconciles the cluster-wide ingestion Groovy policy from the API-serving controller.
+  ///
+  /// The first API-serving controller atomically seeds a missing policy. Once the policy exists, it is authoritative;
+  /// an explicitly configured controller must match it. HELIX_ONLY controllers do not call this method, so they
+  /// cannot race the API-serving controller with their local default.
+  public static boolean reconcileIngestionGroovyPolicy(String zkAddress, String clusterName,
+      boolean explicitlyConfigured,
+      boolean disableGroovy) {
+    ZkBaseDataAccessor<ZNRecord> accessor = new ZkBaseDataAccessor<>(zkAddress, new ZNRecordSerializer());
+    try {
+      HelixConfigScope configScope =
+          new HelixConfigScopeBuilder(ConfigScopeProperty.CLUSTER).forCluster(clusterName).build();
+      String key = CommonConstants.Groovy.DISABLE_INGESTION_GROOVY;
+      String configuredValue = Boolean.toString(disableGroovy);
+      while (true) {
+        Stat stat = new Stat();
+        ZNRecord clusterConfig = accessor.get(configScope.getZkPath(), stat, AccessOption.PERSISTENT);
+        Preconditions.checkState(clusterConfig != null,
+            "Helix cluster does not exist for API-serving controller: %s", clusterName);
+        String existingValue = clusterConfig.getSimpleField(key);
+        if (existingValue != null) {
+          String resolvedExistingValue = Boolean.toString(
+              CommonConstants.Groovy.isIngestionGroovyDisabled(existingValue));
+          Preconditions.checkState(!explicitlyConfigured || configuredValue.equals(resolvedExistingValue),
+              "Conflicting ingestion Groovy policy: cluster config '%s=%s' is authoritative, but the controller "
+                  + "config resolves to %s. Update the cluster config before restarting controllers",
+              key, resolvedExistingValue, configuredValue);
+          return Boolean.parseBoolean(resolvedExistingValue);
+        }
+        ZNRecord updatedClusterConfig = new ZNRecord(clusterConfig);
+        updatedClusterConfig.setSimpleField(key, configuredValue);
+        try {
+          Preconditions.checkState(
+              accessor.set(configScope.getZkPath(), updatedClusterConfig, stat.getVersion(), AccessOption.PERSISTENT),
+              "Failed to persist ingestion Groovy policy for Helix cluster: %s", clusterName);
+          return disableGroovy;
+        } catch (ZkBadVersionException e) {
+          // Another API-serving controller won the compare-and-set. Re-read and adopt or reject its value.
+        }
+      }
+    } finally {
+      accessor.close();
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/RecommenderDriver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/RecommenderDriver.java
@@ -26,11 +26,13 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.controller.recommender.exceptions.InvalidInputException;
 import org.apache.pinot.controller.recommender.io.ConfigManager;
 import org.apache.pinot.controller.recommender.io.InputManager;
 import org.apache.pinot.controller.recommender.rules.AbstractRule;
 import org.apache.pinot.controller.recommender.rules.RulesToExecute;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +50,12 @@ public class RecommenderDriver {
 
   public static String run(String inputJson)
       throws InvalidInputException, IOException {
+    return run(inputJson,
+        IngestionGroovyPolicy.fromDisabled(FunctionEvaluatorFactory.isIngestionGroovyDisabled()));
+  }
+
+  public static String run(String inputJson, IngestionGroovyPolicy ingestionGroovyPolicy)
+      throws InvalidInputException, IOException {
 
     InputManager inputManager;
     ConfigManager outputManager;
@@ -56,7 +64,7 @@ public class RecommenderDriver {
     objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
 
     inputManager = objectMapper.readValue(inputJson, InputManager.class);
-    inputManager.init();
+    inputManager.init(ingestionGroovyPolicy);
     outputManager = inputManager.getOverWrittenConfigs();
 
     // silent rules will run, but their output will only be used in other rules and it will not be present to user

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/io/InputManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/io/InputManager.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.lang3.tuple.Triple;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.request.context.FilterContext;
@@ -57,6 +58,7 @@ import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
@@ -124,6 +126,8 @@ public class InputManager {
   Map<String, Integer> _colNameToIntMap = null;
   String[] _intToColNameMap = null;
   Map<String, Triple<Double, BrokerRequest, QueryContext>> _parsedQueries = new HashMap<>();
+  private IngestionGroovyPolicy _ingestionGroovyPolicy =
+      IngestionGroovyPolicy.fromDisabled(FunctionEvaluatorFactory.isIngestionGroovyDisabled());
 
   Map<FieldSpec.DataType, Integer> _dataTypeSizeMap = new HashMap<FieldSpec.DataType, Integer>() {{
       put(FieldSpec.DataType.INT, Integer.BYTES);
@@ -144,7 +148,14 @@ public class InputManager {
   /// This ensures we do not recommend indices on those dimensions
   public void init()
       throws InvalidInputException {
+    init(IngestionGroovyPolicy.fromDisabled(FunctionEvaluatorFactory.isIngestionGroovyDisabled()));
+  }
+
+  public void init(IngestionGroovyPolicy ingestionGroovyPolicy)
+      throws InvalidInputException {
     LOGGER.info("Preprocessing Input:");
+    _ingestionGroovyPolicy = ingestionGroovyPolicy;
+    SchemaUtils.validate(_schema, false, ingestionGroovyPolicy.isIngestionGroovyDisabled());
     reorderDimsAndBuildMap();
     registerColNameFieldType();
     validateQueries();
@@ -354,7 +365,6 @@ public class InputManager {
   public void setSchema(JsonNode jsonNode)
       throws IOException {
     _schema = JsonUtils.jsonNodeToObject(jsonNode, Schema.class);
-    SchemaUtils.validate(_schema);
     _schemaWithMetaData = JsonUtils.jsonNodeToObject(jsonNode, SchemaWithMetaData.class);
     _schemaWithMetaData.getDimensionFieldSpecs().forEach(fieldMetadata -> {
       _metaDataMap.put(fieldMetadata.getName(), fieldMetadata);
@@ -478,6 +488,11 @@ public class InputManager {
 
   public String getTableType() {
     return _tableType;
+  }
+
+  @JsonIgnore
+  public IngestionGroovyPolicy getIngestionGroovyPolicy() {
+    return _ingestionGroovyPolicy;
   }
 
   public long getNumMessagesPerSecInKafkaTopic() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/realtime/provisioning/MemoryEstimator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/realtime/provisioning/MemoryEstimator.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.controller.recommender.data.DataGenerationHelpers;
 import org.apache.pinot.controller.recommender.data.generator.DataGenerator;
@@ -60,6 +61,7 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.FileFormat;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.utils.DataSizeUtils;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.slf4j.Logger;
@@ -124,8 +126,18 @@ public class MemoryEstimator {
   public MemoryEstimator(TableConfig tableConfig, Schema schema, SchemaWithMetaData schemaWithMetadata,
       int numberOfRows, double ingestionRatePerPartition, long maxUsableHostMemory, int tableRetentionHours,
       File workingDir) {
+    this(tableConfig, schema, schemaWithMetadata, numberOfRows, ingestionRatePerPartition, maxUsableHostMemory,
+        tableRetentionHours, workingDir,
+        IngestionGroovyPolicy.fromDisabled(FunctionEvaluatorFactory.isIngestionGroovyDisabled()));
+  }
+
+  /// Constructor used for processing the given data characteristics with an explicit ingestion Groovy policy.
+  public MemoryEstimator(TableConfig tableConfig, Schema schema, SchemaWithMetaData schemaWithMetadata,
+      int numberOfRows, double ingestionRatePerPartition, long maxUsableHostMemory, int tableRetentionHours,
+      File workingDir, IngestionGroovyPolicy ingestionGroovyPolicy) {
     this(tableConfig, schema,
-        generateCompletedSegment(schemaWithMetadata, schema, tableConfig, numberOfRows, workingDir),
+        generateCompletedSegment(schemaWithMetadata, schema, tableConfig, numberOfRows, workingDir,
+            ingestionGroovyPolicy),
         ingestionRatePerPartition, maxUsableHostMemory, tableRetentionHours, workingDir);
   }
 
@@ -446,8 +458,9 @@ public class MemoryEstimator {
   }
 
   private static File generateCompletedSegment(SchemaWithMetaData schemaWithMetadata, Schema schema,
-      TableConfig tableConfig, int numberOfRows, File workingDir) {
-    return new SegmentGenerator(schemaWithMetadata, schema, tableConfig, numberOfRows, true, workingDir).generate();
+      TableConfig tableConfig, int numberOfRows, File workingDir, IngestionGroovyPolicy ingestionGroovyPolicy) {
+    return new SegmentGenerator(schemaWithMetadata, schema, tableConfig, numberOfRows, true, workingDir,
+        ingestionGroovyPolicy).generate();
   }
 
   /// This class is used in Memory Estimator to generate segment based on the given characteristics of data
@@ -460,15 +473,23 @@ public class MemoryEstimator {
     private int _numberOfRows;
     private boolean _deleteCsv;
     private File _workingDir;
+    private IngestionGroovyPolicy _ingestionGroovyPolicy;
 
     public SegmentGenerator(SchemaWithMetaData schemaWithMetadata, Schema schema, TableConfig tableConfig,
         int numberOfRows, boolean deleteCsv, File workingDir) {
+      this(schemaWithMetadata, schema, tableConfig, numberOfRows, deleteCsv, workingDir,
+          IngestionGroovyPolicy.fromDisabled(FunctionEvaluatorFactory.isIngestionGroovyDisabled()));
+    }
+
+    public SegmentGenerator(SchemaWithMetaData schemaWithMetadata, Schema schema, TableConfig tableConfig,
+        int numberOfRows, boolean deleteCsv, File workingDir, IngestionGroovyPolicy ingestionGroovyPolicy) {
       _schemaWithMetadata = schemaWithMetadata;
       _schema = schema;
       _tableConfig = tableConfig;
       _numberOfRows = numberOfRows;
       _deleteCsv = deleteCsv;
       _workingDir = workingDir;
+      _ingestionGroovyPolicy = ingestionGroovyPolicy;
     }
 
     public File generate() {
@@ -585,6 +606,7 @@ public class MemoryEstimator {
       segmentGeneratorConfig.setOutDir(outDir);
       segmentGeneratorConfig.setTableName(_tableConfig.getTableName());
       segmentGeneratorConfig.setSequenceId(0);
+      segmentGeneratorConfig.setIngestionGroovyDisabled(_ingestionGroovyPolicy.isIngestionGroovyDisabled());
 
       CSVRecordReaderConfig recordReaderConfig = new CSVRecordReaderConfig();
       recordReaderConfig.setEscapeCharacter('\\');

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/impl/RealtimeProvisioningRule.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/impl/RealtimeProvisioningRule.java
@@ -92,7 +92,7 @@ public class RealtimeProvisioningRule extends AbstractRule {
     MemoryEstimator memoryEstimator =
         new MemoryEstimator(tableConfig, _input.getSchema(), _input.getSchemaWithMetadata(),
             _params.getNumRowsInGeneratedSegment(), ingestionRatePerPartition, maxUsableHostMemoryByte, retentionHours,
-            workingDir);
+            workingDir, _input.getIngestionGroovyPolicy());
     try {
       // run memory estimator
       File statsFile = memoryEstimator.initializeStatsHistory();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/impl/SegmentSizeRule.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/impl/SegmentSizeRule.java
@@ -93,7 +93,7 @@ public class SegmentSizeRule extends AbstractRule {
         int numRowsInGeneratedSegment = segmentSizeRuleParams.getNumRowsInGeneratedSegment();
         File generatedSegmentDir =
             new MemoryEstimator.SegmentGenerator(_input._schemaWithMetaData, _input._schema, tableConfig,
-                numRowsInGeneratedSegment, true, workingDir).generate();
+                numRowsInGeneratedSegment, true, workingDir, _input.getIngestionGroovyPolicy()).generate();
         segmentSize = Math.round(FileUtils.sizeOfDirectory(generatedSegmentDir)
             * RecommenderConstants.SegmentSizeRule.INDEX_OVERHEAD_RATIO_FOR_SEGMENT_SIZE);
         numRows = numRowsInGeneratedSegment;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
@@ -32,6 +32,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.common.utils.TarCompressionUtils;
 import org.apache.pinot.controller.api.resources.SuccessResponse;
 import org.apache.pinot.segment.local.utils.IngestionUtils;
@@ -44,6 +45,7 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.filesystem.LocalPinotFS;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.ingestion.segment.uploader.SegmentUploader;
 import org.apache.pinot.spi.plugin.PluginManager;
@@ -77,9 +79,17 @@ public class FileIngestionHelper {
   private final File _ingestionDir;
   private final AuthProvider _authProvider;
   private final boolean _allowLocalFileSystemInUri;
+  private final IngestionGroovyPolicy _ingestionGroovyPolicy;
 
   public FileIngestionHelper(TableConfig tableConfig, Schema schema, Map<String, String> batchConfigMap,
       URI controllerUri, File ingestionDir, AuthProvider authProvider, boolean allowLocalFileSystemInUri) {
+    this(tableConfig, schema, batchConfigMap, controllerUri, ingestionDir, authProvider, allowLocalFileSystemInUri,
+        IngestionGroovyPolicy.fromDisabled(FunctionEvaluatorFactory.isIngestionGroovyDisabled()));
+  }
+
+  public FileIngestionHelper(TableConfig tableConfig, Schema schema, Map<String, String> batchConfigMap,
+      URI controllerUri, File ingestionDir, AuthProvider authProvider, boolean allowLocalFileSystemInUri,
+      IngestionGroovyPolicy ingestionGroovyPolicy) {
     _tableConfig = tableConfig;
     _schema = schema;
     _batchConfigMap = batchConfigMap;
@@ -87,6 +97,7 @@ public class FileIngestionHelper {
     _ingestionDir = ingestionDir;
     _authProvider = authProvider;
     _allowLocalFileSystemInUri = allowLocalFileSystemInUri;
+    _ingestionGroovyPolicy = ingestionGroovyPolicy;
   }
 
   /// Creates a segment using the provided data file/URI and uploads to Pinot
@@ -159,6 +170,7 @@ public class FileIngestionHelper {
       // Get SegmentGeneratorConfig
       SegmentGeneratorConfig segmentGeneratorConfig =
           IngestionUtils.generateSegmentGeneratorConfig(_tableConfig, _schema, batchIngestionConfigOverride);
+      segmentGeneratorConfig.setIngestionGroovyDisabled(_ingestionGroovyPolicy.isIngestionGroovyDisabled());
 
       // Build segment
       String segmentName = IngestionUtils.buildSegment(segmentGeneratorConfig);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerConfTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerConfTest.java
@@ -25,6 +25,7 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.common.restlet.resources.RebalanceConfig;
 import org.apache.pinot.spi.config.table.DisasterRecoveryMode;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.Enablement;
 import org.apache.pinot.spi.utils.TimeUtils;
 import org.testng.Assert;
@@ -51,6 +52,16 @@ public class ControllerConfTest {
   );
 
   private static final Random RAND = new Random();
+
+  @Test
+  public void testIngestionGroovyPolicyDefaultAndOptIn() {
+    Assert.assertEquals(ControllerConf.DISABLE_GROOVY, CommonConstants.Groovy.DISABLE_INGESTION_GROOVY);
+    Assert.assertEquals(ControllerConf.DEFAULT_DISABLE_GROOVY,
+        CommonConstants.Groovy.DEFAULT_DISABLE_INGESTION_GROOVY);
+    Assert.assertTrue(new ControllerConf(Map.of()).isDisableIngestionGroovy());
+    Assert.assertFalse(
+        new ControllerConf(Map.of(ControllerConf.DISABLE_GROOVY, false)).isDisableIngestionGroovy());
+  }
 
   /// When only new configs are supplied (deprecated configs have been removed), then the correct
   /// converted value is returned.

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSchemaRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSchemaRestletResourceTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.apache.pinot.client.admin.PinotAdminClient;
 import org.apache.pinot.client.admin.PinotAdminNotFoundException;
 import org.apache.pinot.client.admin.PinotAdminValidationException;
+import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
@@ -174,6 +175,53 @@ public class PinotSchemaRestletResourceTest {
     // Update non-existing schema
     expectNotFoundException(
         () -> adminClient.getSchemaClient().updateSchema(newSchemaName, schema.toSingleLineJsonString()));
+  }
+
+  @Test
+  public void testFieldSpecGroovyPolicyAcrossSchemaEndpoints()
+      throws Exception {
+    PinotAdminClient adminClient = TEST_INSTANCE.getOrCreateAdminClient();
+    String schemaName = "fieldSpecGroovyPolicy";
+    String enabledSchemaName = "fieldSpecGroovyPolicyEnabled";
+    String builtInSchemaName = "fieldSpecBuiltInPolicy";
+    Schema groovySchema = new Schema.SchemaBuilder().setSchemaName(schemaName)
+        .addSingleValueDimension("source", DataType.STRING)
+        .addSingleValueDimension("result", DataType.STRING).build();
+    groovySchema.getFieldSpecFor("result").setTransformFunction("Groovy({source.reverse()}, source)");
+    String disabledMessage = "controller.disable.ingestion.groovy=false";
+
+    TEST_INSTANCE.getControllerConfig().setProperty(ControllerConf.DISABLE_GROOVY, true);
+    try {
+      expectValidationExceptionWithMessage(
+          () -> adminClient.getSchemaClient().validateSchema(groovySchema.toSingleLineJsonString()), disabledMessage);
+      expectValidationExceptionWithMessage(
+          () -> adminClient.getSchemaClient().createSchema(groovySchema.toSingleLineJsonString()), disabledMessage);
+
+      // Seed metadata below REST validation to model a legacy schema persisted before the policy was enforced.
+      TEST_INSTANCE.getHelixResourceManager().addSchema(groovySchema, false, false);
+      expectValidationExceptionWithMessage(
+          () -> adminClient.getSchemaClient().updateSchema(schemaName, groovySchema.toSingleLineJsonString()),
+          disabledMessage);
+
+      Schema builtInSchema = new Schema.SchemaBuilder().setSchemaName(builtInSchemaName)
+          .addSingleValueDimension("source", DataType.STRING)
+          .addSingleValueDimension("result", DataType.STRING).build();
+      builtInSchema.getFieldSpecFor("result").setTransformFunction("reverse(source)");
+      adminClient.getSchemaClient().createSchema(builtInSchema.toSingleLineJsonString());
+
+      TEST_INSTANCE.getControllerConfig().setProperty(ControllerConf.DISABLE_GROOVY, false);
+      adminClient.getSchemaClient().validateSchema(groovySchema.toSingleLineJsonString());
+      adminClient.getSchemaClient().updateSchema(schemaName, groovySchema.toSingleLineJsonString());
+
+      groovySchema.setSchemaName(enabledSchemaName);
+      adminClient.getSchemaClient().createSchema(groovySchema.toSingleLineJsonString());
+    } finally {
+      // The shared controller fixture explicitly opts in to Groovy for its legacy tests.
+      TEST_INSTANCE.getControllerConfig().setProperty(ControllerConf.DISABLE_GROOVY, false);
+      TEST_INSTANCE.getHelixResourceManager().deleteSchema(schemaName);
+      TEST_INSTANCE.getHelixResourceManager().deleteSchema(enabledSchemaName);
+      TEST_INSTANCE.getHelixResourceManager().deleteSchema(builtInSchemaName);
+    }
   }
 
   @Test

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableConfigsRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableConfigsRestletResourceTest.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.client.admin.PinotAdminClient;
+import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConfigUtils;
 import org.apache.pinot.spi.config.TableConfigs;
@@ -607,6 +608,80 @@ public class TableConfigsRestletResourceTest extends ControllerTest {
         adminClient.getTableClient().deleteTableConfigs(tableName, null);
       } else if (DEFAULT_INSTANCE.getHelixResourceManager().getSchema(tableName) != null) {
         adminClient.getSchemaClient().deleteSchema(tableName);
+      }
+    }
+  }
+
+  @Test
+  public void testGroovyPolicyAcrossCombinedTableConfigsEndpoints()
+      throws Exception {
+    PinotAdminClient adminClient = getOrCreateAdminClient();
+    String tableName = "combinedGroovyPolicy";
+    String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
+    String enabledTableName = "combinedGroovyPolicyEnabled";
+    String enabledTableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(enabledTableName);
+    Schema schema = createDummySchema(tableName);
+    String schemaGroovy = "Groovy({metricB.intValue()}, metricB)";
+    String tableGroovy = "Groovy({dimB.reverse()}, dimB)";
+    schema.getFieldSpecFor("metricA").setTransformFunction(schemaGroovy);
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setTransformConfigs(List.of(new TransformConfig("dimA", tableGroovy)));
+    TableConfig offlineTableConfig = getBaseTableConfigBuilder(tableName, TableType.OFFLINE)
+        .setIngestionConfig(ingestionConfig).build();
+    TableConfigs tableConfigs = new TableConfigs(tableName, schema, offlineTableConfig, null);
+    String disabledMessage = "controller.disable.ingestion.groovy=false";
+
+    DEFAULT_INSTANCE.getControllerConfig().setProperty(ControllerConf.DISABLE_GROOVY, true);
+    try {
+      String schemaError = Assert.expectThrows(Exception.class,
+              () -> adminClient.getTableClient().validateTableConfigs(tableConfigs.toPrettyJsonString(), null))
+          .getMessage();
+      Assert.assertTrue(schemaError.contains(disabledMessage), schemaError);
+
+      schema.getFieldSpecFor("metricA").setTransformFunction(null);
+      String tableError = Assert.expectThrows(Exception.class,
+              () -> adminClient.getTableClient().validateTableConfigs(tableConfigs.toPrettyJsonString(), "ALL"))
+          .getMessage();
+      Assert.assertTrue(tableError.contains(disabledMessage), tableError);
+      String createError = Assert.expectThrows(Exception.class,
+              () -> adminClient.getTableClient().createTableConfigs(tableConfigs.toPrettyJsonString(), "ALL", null))
+          .getMessage();
+      Assert.assertTrue(createError.contains(disabledMessage), createError);
+
+      // Seed below REST validation to model persisted legacy table and schema metadata.
+      schema.getFieldSpecFor("metricA").setTransformFunction(schemaGroovy);
+      DEFAULT_INSTANCE.getHelixResourceManager().addSchema(schema, false, false);
+      DEFAULT_INSTANCE.getHelixResourceManager().addTable(offlineTableConfig);
+      String updateError = Assert.expectThrows(Exception.class,
+              () -> adminClient.getTableClient()
+                  .updateTableConfigs(tableName, tableConfigs.toPrettyJsonString(), "ALL", false, false))
+          .getMessage();
+      Assert.assertTrue(updateError.contains(disabledMessage), updateError);
+
+      DEFAULT_INSTANCE.getControllerConfig().setProperty(ControllerConf.DISABLE_GROOVY, false);
+      adminClient.getTableClient().validateTableConfigs(tableConfigs.toPrettyJsonString(), null);
+      adminClient.getTableClient()
+          .updateTableConfigs(tableName, tableConfigs.toPrettyJsonString(), null, false, false);
+
+      Schema enabledSchema = createDummySchema(enabledTableName);
+      enabledSchema.getFieldSpecFor("metricA").setTransformFunction(schemaGroovy);
+      TableConfig enabledTableConfig = getBaseTableConfigBuilder(enabledTableName, TableType.OFFLINE)
+          .setIngestionConfig(ingestionConfig).build();
+      TableConfigs enabledTableConfigs =
+          new TableConfigs(enabledTableName, enabledSchema, enabledTableConfig, null);
+      adminClient.getTableClient().createTableConfigs(enabledTableConfigs.toPrettyJsonString(), null, null);
+    } finally {
+      // The shared controller fixture explicitly opts in to Groovy for its legacy tests.
+      DEFAULT_INSTANCE.getControllerConfig().setProperty(ControllerConf.DISABLE_GROOVY, false);
+      if (DEFAULT_INSTANCE.getHelixResourceManager().hasTable(tableNameWithType)) {
+        adminClient.getTableClient().deleteTableConfigs(tableName, null);
+      } else if (DEFAULT_INSTANCE.getHelixResourceManager().getSchema(tableName) != null) {
+        adminClient.getSchemaClient().deleteSchema(tableName);
+      }
+      if (DEFAULT_INSTANCE.getHelixResourceManager().hasTable(enabledTableNameWithType)) {
+        adminClient.getTableClient().deleteTableConfigs(enabledTableName, null);
+      } else if (DEFAULT_INSTANCE.getHelixResourceManager().getSchema(enabledTableName) != null) {
+        adminClient.getSchemaClient().deleteSchema(enabledTableName);
       }
     }
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/ManualAuthorizationValidationOrderTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/ManualAuthorizationValidationOrderTest.java
@@ -1,0 +1,190 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.api.access.AccessControl;
+import org.apache.pinot.controller.api.access.AccessControlFactory;
+import org.apache.pinot.controller.api.access.AccessType;
+import org.apache.pinot.controller.api.exception.ControllerApplicationException;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.core.auth.Actions;
+import org.apache.pinot.core.auth.TargetType;
+import org.apache.pinot.spi.config.TableConfigs;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.glassfish.grizzly.http.server.Request;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.expectThrows;
+
+
+public class ManualAuthorizationValidationOrderTest {
+  private static final String TABLE_NAME = "unauthorizedGroovy";
+
+  @Test
+  public void schemaJsonValidationAuthorizesBeforeSemanticValidation() {
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    PinotSchemaRestletResource resource = new PinotSchemaRestletResource();
+    resource._pinotHelixResourceManager = resourceManager;
+    resource._controllerConf = groovyEnabledControllerConf();
+    resource._accessControlFactory = denyingAccess(AccessType.READ, Actions.Table.VALIDATE_SCHEMA);
+
+    ControllerApplicationException exception = expectThrows(ControllerApplicationException.class,
+        () -> resource.validateSchema(invalidGroovySchema().toSingleLineJsonString(), mock(HttpHeaders.class),
+            request("/schemas/validate")));
+
+    assertEquals(exception.getResponse().getStatus(), Response.Status.FORBIDDEN.getStatusCode());
+    verifyNoInteractions(resourceManager);
+  }
+
+  @Test
+  public void schemaMultipartValidationAuthorizesBeforeSemanticValidation() {
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    PinotSchemaRestletResource resource = new PinotSchemaRestletResource();
+    resource._pinotHelixResourceManager = resourceManager;
+    resource._controllerConf = groovyEnabledControllerConf();
+    resource._accessControlFactory = denyingAccess(AccessType.READ, Actions.Table.VALIDATE_SCHEMA);
+
+    FormDataBodyPart bodyPart = mock(FormDataBodyPart.class);
+    when(bodyPart.getValueAs(InputStream.class)).thenReturn(
+        new ByteArrayInputStream(invalidGroovySchema().toSingleLineJsonString().getBytes(StandardCharsets.UTF_8)));
+    FormDataMultiPart multiPart = mock(FormDataMultiPart.class);
+    when(multiPart.getFields()).thenReturn(Map.of("schema", List.of(bodyPart)));
+
+    ControllerApplicationException exception = expectThrows(ControllerApplicationException.class,
+        () -> resource.validateSchema(multiPart, mock(HttpHeaders.class), request("/schemas/validate")));
+
+    assertEquals(exception.getResponse().getStatus(), Response.Status.FORBIDDEN.getStatusCode());
+    verifyNoInteractions(resourceManager);
+  }
+
+  @Test
+  public void tableConfigsCreateAuthorizesBeforeSemanticValidation()
+      throws Exception {
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    TableConfigsRestletResource resource = new TableConfigsRestletResource();
+    resource._pinotHelixResourceManager = resourceManager;
+    resource._controllerConf = groovyEnabledControllerConf();
+    resource._accessControlFactory = denyingAccess(AccessType.CREATE, Actions.Table.CREATE_TABLE);
+
+    ControllerApplicationException exception = expectThrows(ControllerApplicationException.class,
+        () -> resource.addConfig(invalidGroovyTableConfigs().toJsonString(), null, false, mock(HttpHeaders.class),
+            request("/tableConfigs")));
+
+    assertEquals(exception.getResponse().getStatus(), Response.Status.FORBIDDEN.getStatusCode());
+    verify(resourceManager).hasOfflineTable(TABLE_NAME);
+    verify(resourceManager).hasRealtimeTable(TABLE_NAME);
+    verify(resourceManager).getSchema(TABLE_NAME);
+    verifyNoMoreInteractions(resourceManager);
+  }
+
+  @Test
+  public void tableConfigsValidationAuthorizesBeforeSemanticValidation() {
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    TableConfigsRestletResource resource = new TableConfigsRestletResource();
+    resource._pinotHelixResourceManager = resourceManager;
+    resource._controllerConf = groovyEnabledControllerConf();
+    resource._accessControlFactory = denyingAccess(AccessType.READ, Actions.Table.VALIDATE_TABLE_CONFIGS);
+
+    ControllerApplicationException exception = expectThrows(ControllerApplicationException.class,
+        () -> resource.validateConfig(invalidGroovyTableConfigs().toJsonString(), null, mock(HttpHeaders.class),
+            request("/tableConfigs/validate")));
+
+    assertEquals(exception.getResponse().getStatus(), Response.Status.FORBIDDEN.getStatusCode());
+    verifyNoInteractions(resourceManager);
+  }
+
+  @Test
+  public void tableConfigsTuneAuthorizesBeforeSemanticValidation() {
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    TableConfigsRestletResource resource = new TableConfigsRestletResource();
+    resource._pinotHelixResourceManager = resourceManager;
+    resource._controllerConf = groovyEnabledControllerConf();
+    resource._accessControlFactory = denyingAccess(AccessType.READ, Actions.Table.VALIDATE_TABLE_CONFIGS);
+
+    ControllerApplicationException exception = expectThrows(ControllerApplicationException.class,
+        () -> resource.tuneConfig(invalidGroovyTableConfigs().toJsonString(), null, mock(HttpHeaders.class),
+            request("/tableConfigs/tune")));
+
+    assertEquals(exception.getResponse().getStatus(), Response.Status.FORBIDDEN.getStatusCode());
+    verifyNoInteractions(resourceManager);
+  }
+
+  private static Schema invalidGroovySchema() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+        .addSingleValueDimension("source", DataType.STRING)
+        .addSingleValueDimension("derived", DataType.STRING)
+        .build();
+    schema.getFieldSpecFor("derived").setTransformFunction("Groovy({ def invalid = }, source)");
+    return schema;
+  }
+
+  private static TableConfigs invalidGroovyTableConfigs() {
+    TableConfig offlineTableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
+    return new TableConfigs(TABLE_NAME, invalidGroovySchema(), offlineTableConfig, null);
+  }
+
+  private static Request request(String path) {
+    Request request = mock(Request.class);
+    when(request.getRequestURL()).thenReturn(new StringBuilder("http://localhost" + path));
+    return request;
+  }
+
+  private static ControllerConf groovyEnabledControllerConf() {
+    return new ControllerConf(Map.of(ControllerConf.DISABLE_GROOVY, false));
+  }
+
+  private static AccessControlFactory denyingAccess(AccessType expectedAccessType, String expectedAction) {
+    return () -> new AccessControl() {
+      @Override
+      public boolean hasAccess(String tableName, AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
+        assertEquals(tableName, TABLE_NAME);
+        assertEquals(accessType, expectedAccessType);
+        return true;
+      }
+
+      @Override
+      public boolean hasAccess(HttpHeaders httpHeaders, TargetType targetType, String targetId, String action) {
+        assertEquals(targetType, TargetType.TABLE);
+        assertEquals(targetId, TABLE_NAME);
+        assertEquals(action, expectedAction);
+        return false;
+      }
+    };
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotControllerModeStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotControllerModeStatelessTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.helix;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.helix.HelixAdmin;
@@ -25,14 +26,17 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.model.ClusterConstraints;
 import org.apache.helix.model.ConstraintItem;
 import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.HelixConfigScope.ConfigScopeProperty;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.Message;
+import org.apache.helix.model.builder.HelixConfigScopeBuilder;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.apache.pinot.common.utils.helix.LeadControllerUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.ControllerStarter;
 import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.util.HelixSetupUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Helix;
@@ -272,6 +276,41 @@ public class PinotControllerModeStatelessTest extends ControllerTest {
     }, TIMEOUT_IN_MS, "Without live instance, there should be no partition in the external view");
 
     // Stop the Helix-only controller
+    helixOnlyController.stop();
+  }
+
+  @Test
+  public void testPinotOnlyControllerDoesNotRepublishInheritedGroovyOptIn()
+      throws Exception {
+    Map<String, Object> properties = getDefaultControllerConfiguration();
+    properties.put(ControllerConf.CONTROLLER_MODE, ControllerConf.ControllerMode.HELIX_ONLY);
+    ControllerStarter helixOnlyController = new ControllerStarter();
+    helixOnlyController.init(new PinotConfiguration(properties));
+    helixOnlyController.start();
+    HelixManager helixControllerManager = helixOnlyController.getHelixControllerManager();
+    TestUtils.waitForCondition(aVoid -> helixControllerManager.isConnected(), TIMEOUT_IN_MS,
+        "Failed to start the Helix-only controller");
+
+    HelixSetupUtils.reconcileIngestionGroovyPolicy(getZkUrl(), getHelixClusterName(), true, false);
+    properties = getDefaultControllerConfiguration();
+    properties.put(ControllerConf.CONTROLLER_MODE, ControllerConf.ControllerMode.PINOT_ONLY);
+    properties.remove(ControllerConf.DISABLE_GROOVY);
+    ControllerStarter pinotOnlyController = new ControllerStarter();
+    pinotOnlyController.init(new PinotConfiguration(properties));
+    Assert.assertFalse(pinotOnlyController.getConfig().isDisableIngestionGroovy());
+
+    HelixConfigScopeBuilder scopeBuilder =
+        new HelixConfigScopeBuilder(ConfigScopeProperty.CLUSTER).forCluster(getHelixClusterName());
+    HelixAdmin helixAdmin = helixControllerManager.getClusterManagmentTool();
+    helixAdmin.removeConfig(scopeBuilder.build(), List.of(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY));
+
+    pinotOnlyController.start();
+    Assert.assertEquals(
+        helixAdmin.getConfig(scopeBuilder.build(), List.of(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY))
+            .get(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY),
+        "true");
+
+    pinotOnlyController.stop();
     helixOnlyController.stop();
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/util/HelixSetupUtilsTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/util/HelixSetupUtilsTest.java
@@ -1,0 +1,175 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.manager.zk.ZKHelixAdmin;
+import org.apache.helix.model.HelixConfigScope;
+import org.apache.helix.model.HelixConfigScope.ConfigScopeProperty;
+import org.apache.helix.model.builder.HelixConfigScopeBuilder;
+import org.apache.pinot.common.utils.ServiceStartableUtils;
+import org.apache.pinot.common.utils.ZkStarter;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.services.ServiceRole;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.expectThrows;
+
+
+public class HelixSetupUtilsTest {
+  private static final String CLUSTER_NAME = "HelixSetupUtilsTest";
+  private static final String POLICY_KEY = CommonConstants.Groovy.DISABLE_INGESTION_GROOVY;
+
+  private ZkStarter.ZookeeperInstance _zookeeperInstance;
+  private HelixAdmin _helixAdmin;
+  private HelixConfigScope _clusterConfigScope;
+
+  @BeforeClass
+  public void setUp() {
+    _zookeeperInstance = ZkStarter.startLocalZkServer();
+    HelixSetupUtils.setupHelixClusterWithDefaultConfigs(_zookeeperInstance.getZkUrl(), CLUSTER_NAME,
+        Map.of("testConfig", "testValue"));
+    _helixAdmin = new ZKHelixAdmin.Builder().setZkAddress(_zookeeperInstance.getZkUrl()).build();
+    _clusterConfigScope =
+        new HelixConfigScopeBuilder(ConfigScopeProperty.CLUSTER).forCluster(CLUSTER_NAME).build();
+  }
+
+  @AfterClass
+  public void tearDown() {
+    if (_helixAdmin != null) {
+      _helixAdmin.close();
+    }
+    if (_zookeeperInstance != null) {
+      ZkStarter.stopLocalZkServer(_zookeeperInstance);
+    }
+  }
+
+  @BeforeMethod
+  public void clearPolicy() {
+    _helixAdmin.removeConfig(_clusterConfigScope, List.of(POLICY_KEY));
+  }
+
+  @Test
+  public void testFirstControllerSeedsPolicyAndLaterControllersAdoptIt() {
+    HelixSetupUtils.reconcileIngestionGroovyPolicy(_zookeeperInstance.getZkUrl(), CLUSTER_NAME, true, false);
+    HelixSetupUtils.reconcileIngestionGroovyPolicy(_zookeeperInstance.getZkUrl(), CLUSTER_NAME, false, true);
+
+    assertEquals(getPolicy(), "false");
+    PinotConfiguration serverConfig = new PinotConfiguration();
+    ServiceStartableUtils.applyClusterConfig(
+        serverConfig, _zookeeperInstance.getZkUrl(), CLUSTER_NAME, ServiceRole.SERVER);
+    assertEquals(serverConfig.getProperty(POLICY_KEY), "false");
+    PinotConfiguration minionConfig = new PinotConfiguration();
+    ServiceStartableUtils.applyClusterConfig(
+        minionConfig, _zookeeperInstance.getZkUrl(), CLUSTER_NAME, ServiceRole.MINION);
+    assertEquals(minionConfig.getProperty(POLICY_KEY), "false");
+  }
+
+  @Test
+  public void testExplicitPolicyMustMatchAuthoritativeClusterPolicy() {
+    HelixSetupUtils.reconcileIngestionGroovyPolicy(_zookeeperInstance.getZkUrl(), CLUSTER_NAME, true, false);
+
+    IllegalStateException error = expectThrows(IllegalStateException.class,
+        () -> HelixSetupUtils.reconcileIngestionGroovyPolicy(
+            _zookeeperInstance.getZkUrl(), CLUSTER_NAME, true, true));
+    assertEquals(error.getMessage(), String.format(
+        "Conflicting ingestion Groovy policy: cluster config '%s=false' is authoritative, but the controller config "
+            + "resolves to true. Update the cluster config before restarting controllers", POLICY_KEY));
+    assertEquals(getPolicy(), "false");
+  }
+
+  @Test
+  public void testConcurrentControllersCannotInitializeConflictingPolicies()
+      throws InterruptedException {
+    CountDownLatch startLatch = new CountDownLatch(1);
+    AtomicReference<Throwable> disabledControllerError = new AtomicReference<>();
+    AtomicReference<Throwable> enabledControllerError = new AtomicReference<>();
+    Thread disabledController = new Thread(
+        () -> reconcileAfterLatch(startLatch, true, disabledControllerError), "disabled-groovy-controller");
+    Thread enabledController = new Thread(
+        () -> reconcileAfterLatch(startLatch, false, enabledControllerError), "enabled-groovy-controller");
+
+    disabledController.start();
+    enabledController.start();
+    startLatch.countDown();
+    disabledController.join();
+    enabledController.join();
+
+    String policy = getPolicy();
+    if (Boolean.parseBoolean(policy)) {
+      assertNull(disabledControllerError.get());
+      assertNotNull(enabledControllerError.get());
+    } else {
+      assertNotNull(disabledControllerError.get());
+      assertNull(enabledControllerError.get());
+    }
+  }
+
+  @Test
+  public void testConcurrentControllersCanInitializeSamePolicy()
+      throws InterruptedException {
+    CountDownLatch startLatch = new CountDownLatch(1);
+    List<AtomicReference<Throwable>> errors = new ArrayList<>();
+    List<Thread> controllers = new ArrayList<>();
+    for (int i = 0; i < 8; i++) {
+      AtomicReference<Throwable> error = new AtomicReference<>();
+      errors.add(error);
+      controllers.add(new Thread(
+          () -> reconcileAfterLatch(startLatch, true, error), "disabled-groovy-controller-" + i));
+    }
+
+    controllers.forEach(Thread::start);
+    startLatch.countDown();
+    for (Thread controller : controllers) {
+      controller.join();
+    }
+
+    assertEquals(getPolicy(), "true");
+    for (AtomicReference<Throwable> error : errors) {
+      assertNull(error.get());
+    }
+  }
+
+  private void reconcileAfterLatch(CountDownLatch startLatch, boolean disableGroovy,
+      AtomicReference<Throwable> error) {
+    try {
+      startLatch.await();
+      HelixSetupUtils.reconcileIngestionGroovyPolicy(
+          _zookeeperInstance.getZkUrl(), CLUSTER_NAME, true, disableGroovy);
+    } catch (Throwable t) {
+      error.set(t);
+    }
+  }
+
+  private String getPolicy() {
+    return _helixAdmin.getConfig(_clusterConfigScope, List.of(POLICY_KEY)).get(POLICY_KEY);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -43,6 +43,7 @@ import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.Utils;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.metrics.ServerMeter;
@@ -89,6 +90,7 @@ import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.ParallelSegmentConsumptionPolicy;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.metrics.PinotMeter;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.stream.ConsumerPartitionState;
@@ -341,6 +343,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   /// Whether null handling is enabled by default. This value is only used if
   /// [Schema#isEnableColumnBasedNullHandling()] is false.
   private final boolean _defaultNullHandlingEnabled;
+  private final boolean _disableGroovy;
   private final SegmentCommitterFactory _segmentCommitterFactory;
   private final ConsumptionRateLimiter _partitionRateLimiter;
   private final ConsumptionRateLimiter _serverRateLimiter;
@@ -1240,7 +1243,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       RealtimeSegmentConverter converter =
           new RealtimeSegmentConverter(_realtimeSegment, segmentZKPropsConfig, tempSegmentFolder.getAbsolutePath(),
               _schema, _tableNameWithType, _tableConfig, _segmentZKMetadata.getSegmentName(),
-              _defaultNullHandlingEnabled);
+              _defaultNullHandlingEnabled, IngestionGroovyPolicy.fromDisabled(_disableGroovy));
       _segmentLogger.info("Trying to build segment");
       try {
         converter.build(_segmentVersion);
@@ -1941,7 +1944,10 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
             && ingestionConfig.getStreamIngestionConfig().isDropRecordOnPartitionMismatch());
 
     // Create message decoder
-    Set<String> fieldsToRead = IngestionUtils.getFieldsForRecordExtractor(_tableConfig, _schema);
+    boolean disableGroovy = FunctionEvaluatorFactory.resolveIngestionGroovyDisabled(instanceDataManagerConfig != null
+        ? instanceDataManagerConfig.getConfig().getProperty(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY) : null);
+    _disableGroovy = disableGroovy;
+    Set<String> fieldsToRead = IngestionUtils.getFieldsForRecordExtractor(_tableConfig, _schema, disableGroovy);
     RetryPolicy retryPolicy = RetryPolicies.exponentialBackoffRetryPolicy(5, 1000L, 1.2f);
     AtomicReference<StreamDataDecoder> localStreamDataDecoder = new AtomicReference<>();
     try {
@@ -1964,7 +1970,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     _streamDataDecoder = localStreamDataDecoder.get();
 
     try {
-      _transformPipeline = new TransformPipeline(tableConfig, schema);
+      _transformPipeline = new TransformPipeline(tableConfig, schema,
+          IngestionGroovyPolicy.fromDisabled(disableGroovy));
     } catch (Exception e) {
       _realtimeTableDataManager.addSegmentError(_segmentNameStr,
           new SegmentErrorInfo(now(), "Failed to initialize the TransformPipeline", e));

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -47,6 +47,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.Utils;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.metrics.ServerMetrics;
@@ -862,7 +863,8 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
           "Cannot configure multi-valued column %s as sorted column for table: %s", sortedColumn, _tableNameWithType);
     }
     // 2. Validate the schema itself
-    SchemaUtils.validate(schema);
+    SchemaUtils.validate(schema, false, FunctionEvaluatorFactory.resolveIngestionGroovyDisabled(
+        _instanceDataManagerConfig.getConfig().getProperty(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY)));
   }
 
   private boolean isEnforceConsumptionInOrder() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.readers.PinotSegmentRecordReader;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
@@ -36,6 +37,7 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,6 +55,7 @@ public class SegmentPurger {
   private final RecordPurger _recordPurger;
   private final RecordModifier _recordModifier;
   private final SegmentGeneratorCustomConfigs _segmentGeneratorCustomConfigs;
+  private final IngestionGroovyPolicy _ingestionGroovyPolicy;
   private SegmentGeneratorConfig _segmentGeneratorConfig;
   private int _numRecordsPurged;
   private int _numRecordsModified;
@@ -60,6 +63,14 @@ public class SegmentPurger {
   public SegmentPurger(File indexDir, File workingDir, TableConfig tableConfig, Schema schema,
       @Nullable RecordPurger recordPurger, @Nullable RecordModifier recordModifier,
       @Nullable SegmentGeneratorCustomConfigs segmentGeneratorCustomConfigs) {
+    this(indexDir, workingDir, tableConfig, schema, recordPurger, recordModifier, segmentGeneratorCustomConfigs,
+        IngestionGroovyPolicy.fromDisabled(FunctionEvaluatorFactory.isIngestionGroovyDisabled()));
+  }
+
+  public SegmentPurger(File indexDir, File workingDir, TableConfig tableConfig, Schema schema,
+      @Nullable RecordPurger recordPurger, @Nullable RecordModifier recordModifier,
+      @Nullable SegmentGeneratorCustomConfigs segmentGeneratorCustomConfigs,
+      IngestionGroovyPolicy ingestionGroovyPolicy) {
     Preconditions.checkArgument(recordPurger != null || recordModifier != null,
         "At least one of record purger and modifier should be non-null");
     _indexDir = indexDir;
@@ -69,6 +80,7 @@ public class SegmentPurger {
     _recordPurger = recordPurger;
     _recordModifier = recordModifier;
     _segmentGeneratorCustomConfigs = segmentGeneratorCustomConfigs;
+    _ingestionGroovyPolicy = ingestionGroovyPolicy;
   }
 
   public File purgeSegment()
@@ -120,6 +132,7 @@ public class SegmentPurger {
   @VisibleForTesting
   void initSegmentGeneratorConfig(String segmentName) {
     _segmentGeneratorConfig = new SegmentGeneratorConfig(_tableConfig, _schema);
+    _segmentGeneratorConfig.setIngestionGroovyDisabled(_ingestionGroovyPolicy.isIngestionGroovyDisabled());
     _segmentGeneratorConfig.setInstanceType(InstanceType.MINION);
     _segmentGeneratorConfig.setOutDir(_workingDir.getPath());
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorConfig.java
@@ -31,6 +31,8 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.creator.name.SegmentNameGenerator;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.TimestampIndexUtils;
 
 
@@ -49,13 +51,14 @@ public class SegmentProcessorConfig {
   private final Consumer<Object> _progressObserver;
   private final SegmentNameGenerator _segmentNameGenerator;
   private final Long _customCreationTime;
+  private final IngestionGroovyPolicy _ingestionGroovyPolicy;
 
   private SegmentProcessorConfig(TableConfig tableConfig, Schema schema, TimeHandlerConfig timeHandlerConfig,
       List<PartitionerConfig> partitionerConfigs, MergeType mergeType,
       Map<String, AggregationFunctionType> aggregationTypes,
       Map<String, Map<String, String>> aggregationFunctionParameters, SegmentConfig segmentConfig,
       Consumer<Object> progressObserver, @Nullable SegmentNameGenerator segmentNameGenerator,
-      @Nullable Long customCreationTime) {
+      @Nullable Long customCreationTime, IngestionGroovyPolicy ingestionGroovyPolicy) {
     TimestampIndexUtils.applyTimestampIndex(tableConfig, schema);
     _tableConfig = tableConfig;
     _schema = schema;
@@ -70,6 +73,7 @@ public class SegmentProcessorConfig {
     };
     _segmentNameGenerator = segmentNameGenerator;
     _customCreationTime = customCreationTime;
+    _ingestionGroovyPolicy = ingestionGroovyPolicy;
   }
 
   /// The Pinot table config
@@ -140,6 +144,10 @@ public class SegmentProcessorConfig {
     return _customCreationTime != null ? _customCreationTime : System.currentTimeMillis();
   }
 
+  public IngestionGroovyPolicy getIngestionGroovyPolicy() {
+    return _ingestionGroovyPolicy;
+  }
+
   @Override
   public String toString() {
     return "SegmentProcessorConfig{" + "_tableConfig=" + _tableConfig + ", _schema=" + _schema + ", _timeHandlerConfig="
@@ -161,6 +169,9 @@ public class SegmentProcessorConfig {
     private Consumer<Object> _progressObserver;
     private SegmentNameGenerator _segmentNameGenerator;
     private Long _customCreationTime;
+    private IngestionGroovyPolicy _ingestionGroovyPolicy = IngestionGroovyPolicy.fromDisabled(
+        CommonConstants.Groovy.isIngestionGroovyDisabled(
+            System.getProperty(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY)));
 
     public Builder setTableConfig(TableConfig tableConfig) {
       _tableConfig = tableConfig;
@@ -217,6 +228,11 @@ public class SegmentProcessorConfig {
       return this;
     }
 
+    public Builder setIngestionGroovyPolicy(IngestionGroovyPolicy ingestionGroovyPolicy) {
+      _ingestionGroovyPolicy = ingestionGroovyPolicy;
+      return this;
+    }
+
     public SegmentProcessorConfig build() {
       Preconditions.checkState(_tableConfig != null, "Must provide table config in SegmentProcessorConfig");
       Preconditions.checkState(_schema != null, "Must provide schema in SegmentProcessorConfig");
@@ -241,7 +257,7 @@ public class SegmentProcessorConfig {
       }
       return new SegmentProcessorConfig(_tableConfig, _schema, _timeHandlerConfig, _partitionerConfigs, _mergeType,
           _aggregationTypes, _aggregationFunctionParameters, _segmentConfig, _progressObserver,
-              _segmentNameGenerator, _customCreationTime);
+          _segmentNameGenerator, _customCreationTime, _ingestionGroovyPolicy);
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
@@ -296,6 +296,8 @@ public class SegmentProcessorFramework {
     String segmentNamePostfix = _segmentProcessorConfig.getSegmentConfig().getSegmentNamePostfix();
     String fixedSegmentName = _segmentProcessorConfig.getSegmentConfig().getFixedSegmentName();
     SegmentGeneratorConfig generatorConfig = new SegmentGeneratorConfig(tableConfig, schema);
+    generatorConfig.setIngestionGroovyDisabled(
+        _segmentProcessorConfig.getIngestionGroovyPolicy().isIngestionGroovyDisabled());
     generatorConfig.setInstanceType(InstanceType.MINION);
     generatorConfig.setOutDir(_segmentsOutputDir.getPath());
     Consumer<Object> observer = _segmentProcessorConfig.getProgressObserver();

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
@@ -50,6 +50,7 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordFetchException;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderFileConfig;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.recordtransformer.RecordTransformer;
 import org.apache.pinot.spi.tasks.MinionTaskBaseObserverStats;
 import org.apache.pinot.spi.utils.StringUtil;
@@ -87,13 +88,16 @@ public class SegmentMapper {
   public SegmentMapper(List<RecordReaderFileConfig> recordReaderFileConfigs,
       List<RecordTransformer> customRecordTransformers, SegmentProcessorConfig processorConfig, File mapperOutputDir) {
     this(recordReaderFileConfigs,
-        getTransformPipeline(processorConfig.getTableConfig(), processorConfig.getSchema(), customRecordTransformers),
+        getTransformPipeline(processorConfig.getTableConfig(), processorConfig.getSchema(), customRecordTransformers,
+            processorConfig.getIngestionGroovyPolicy()),
         processorConfig, mapperOutputDir);
   }
 
   private static TransformPipeline getTransformPipeline(TableConfig tableConfig, Schema schema,
-      @Nullable List<RecordTransformer> customRecordTransformers) {
-    List<RecordTransformer> recordTransformers = RecordTransformerUtils.getDefaultTransformers(tableConfig, schema);
+      @Nullable List<RecordTransformer> customRecordTransformers, IngestionGroovyPolicy ingestionGroovyPolicy) {
+    List<RecordTransformer> recordTransformers =
+        RecordTransformerUtils.getDefaultTransformers(tableConfig, schema,
+            ingestionGroovyPolicy.isIngestionGroovyDisabled());
     if (CollectionUtils.isNotEmpty(customRecordTransformers)) {
       recordTransformers.addAll(customRecordTransformers);
     }
@@ -117,7 +121,9 @@ public class SegmentMapper {
         schema.isEnableColumnBasedNullHandling() || tableConfig.getIndexingConfig().isNullHandlingEnabled();
     _transformPipeline = transformPipeline;
     _timeHandler = TimeHandlerFactory.getTimeHandler(processorConfig);
-    _partitioners = PartitionerFactory.getPartitioners(processorConfig.getPartitionerConfigs());
+    _partitioners =
+        PartitionerFactory.getPartitioners(processorConfig.getPartitionerConfigs(),
+            processorConfig.getIngestionGroovyPolicy());
     // Time partition + partition from partitioners
     _partitionsBuffer = new String[_partitioners.length + 1];
     _throttledLogger = new ThrottledLogger(LOGGER, tableConfig.getIngestionConfig());

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/PartitionerFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/PartitionerFactory.java
@@ -20,6 +20,8 @@ package org.apache.pinot.core.segment.processing.partitioner;
 
 import com.google.common.base.Preconditions;
 import java.util.List;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 
 
 /// Factory for Partitioner and PartitionFilter
@@ -41,6 +43,11 @@ public final class PartitionerFactory {
 
   /// Construct a Partitioner using the PartitioningConfig
   public static Partitioner getPartitioner(PartitionerConfig config) {
+    return getPartitioner(config,
+        IngestionGroovyPolicy.fromDisabled(FunctionEvaluatorFactory.isIngestionGroovyDisabled()));
+  }
+
+  public static Partitioner getPartitioner(PartitionerConfig config, IngestionGroovyPolicy ingestionGroovyPolicy) {
 
     Partitioner partitioner = null;
     switch (config.getPartitionerType()) {
@@ -60,7 +67,7 @@ public final class PartitionerFactory {
       case TRANSFORM_FUNCTION:
         Preconditions.checkState(config.getTransformFunction() != null,
             "Must provide transformFunction for TRANSFORM_FUNCTION partitioner");
-        partitioner = new TransformFunctionPartitioner(config.getTransformFunction());
+        partitioner = new TransformFunctionPartitioner(config.getTransformFunction(), ingestionGroovyPolicy);
         break;
       case TABLE_PARTITION_CONFIG:
         Preconditions.checkState(config.getColumnName() != null,
@@ -79,10 +86,16 @@ public final class PartitionerFactory {
   ///
   /// @return Array of partitioners
   public static Partitioner[] getPartitioners(List<PartitionerConfig> partitionerConfigs) {
+    return getPartitioners(partitionerConfigs,
+        IngestionGroovyPolicy.fromDisabled(FunctionEvaluatorFactory.isIngestionGroovyDisabled()));
+  }
+
+  public static Partitioner[] getPartitioners(List<PartitionerConfig> partitionerConfigs,
+      IngestionGroovyPolicy ingestionGroovyPolicy) {
     int numPartitioners = partitionerConfigs.size();
     Partitioner[] partitioners = new Partitioner[numPartitioners];
     for (int i = 0; i < numPartitioners; i++) {
-      partitioners[i] = PartitionerFactory.getPartitioner(partitionerConfigs.get(i));
+      partitioners[i] = PartitionerFactory.getPartitioner(partitionerConfigs.get(i), ingestionGroovyPolicy);
     }
     return partitioners;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/TransformFunctionPartitioner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/TransformFunctionPartitioner.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.segment.processing.partitioner;
 import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.function.FunctionEvaluator;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 
 
 /// Partitioner which evaluates a transform function using the row to get the partition value
@@ -29,7 +30,13 @@ public class TransformFunctionPartitioner implements Partitioner {
   private final FunctionEvaluator _functionEvaluator;
 
   public TransformFunctionPartitioner(String transformFunction) {
-    _functionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(transformFunction);
+    this(transformFunction,
+        IngestionGroovyPolicy.fromDisabled(FunctionEvaluatorFactory.isIngestionGroovyDisabled()));
+  }
+
+  public TransformFunctionPartitioner(String transformFunction, IngestionGroovyPolicy ingestionGroovyPolicy) {
+    _functionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(transformFunction,
+        ingestionGroovyPolicy.isIngestionGroovyDisabled());
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
@@ -168,6 +168,32 @@ public class RealtimeSegmentDataManagerTest {
   }
 
   @Test
+  public void testRealtimeInitializationRejectsLegacyFieldSpecGroovy()
+      throws Exception {
+    SegmentZKMetadata segmentZKMetadata = createZkMetadata();
+    TableConfig tableConfig = createTableConfig();
+    RealtimeTableDataManager tableDataManager = createTableDataManager(tableConfig);
+    LLCSegmentName llcSegmentName = new LLCSegmentName(SEGMENT_NAME_STR);
+    _partitionGroupIdToConsumerCoordinatorMap.putIfAbsent(PARTITION_GROUP_ID,
+        new ConsumerCoordinator(false, tableDataManager));
+    Schema legacySchema = Fixtures.createSchema();
+    legacySchema.getFieldSpecFor("d").setTransformFunction("Groovy({m.toString()}, m)");
+    ServerMetrics serverMetrics = new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
+
+    IllegalStateException exception = Assert.expectThrows(IllegalStateException.class,
+        () -> new FakeRealtimeSegmentDataManager(segmentZKMetadata, tableConfig, tableDataManager,
+            new File(TEMP_DIR, REALTIME_TABLE_NAME).getAbsolutePath(), legacySchema, llcSegmentName,
+            _partitionGroupIdToConsumerCoordinatorMap, serverMetrics, new TimeSupplier(), true));
+    Assert.assertTrue(exception.getMessage().contains("controller.disable.ingestion.groovy=false"));
+
+    try (FakeRealtimeSegmentDataManager ignored = new FakeRealtimeSegmentDataManager(segmentZKMetadata, tableConfig,
+        tableDataManager, new File(TEMP_DIR, REALTIME_TABLE_NAME).getAbsolutePath(), legacySchema, llcSegmentName,
+        _partitionGroupIdToConsumerCoordinatorMap, serverMetrics, new TimeSupplier(), false)) {
+      // Explicit server opt-in must preserve legacy Groovy ingestion behavior.
+    }
+  }
+
+  @Test
   public void testPostStopConsumedMsgDoesNotCheckRegisteredSegmentManager()
       throws Exception {
     try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager()) {
@@ -1379,13 +1405,15 @@ public class RealtimeSegmentDataManagerTest {
     private TimeSupplier _timeSupplier;
     private boolean _indexCapacityThresholdBreached;
 
-    private static InstanceDataManagerConfig makeInstanceDataManagerConfig() {
+    private static InstanceDataManagerConfig makeInstanceDataManagerConfig(boolean disableGroovy) {
       InstanceDataManagerConfig dataManagerConfig = mock(InstanceDataManagerConfig.class);
       when(dataManagerConfig.getReadMode()).thenReturn(null);
       when(dataManagerConfig.getAvgMultiValueCount()).thenReturn(null);
       when(dataManagerConfig.getSegmentFormatVersion()).thenReturn(null);
       when(dataManagerConfig.isRealtimeOffHeapAllocation()).thenReturn(false);
-      when(dataManagerConfig.getConfig()).thenReturn(new PinotConfiguration());
+      PinotConfiguration config = new PinotConfiguration();
+      config.setProperty(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY, disableGroovy);
+      when(dataManagerConfig.getConfig()).thenReturn(config);
       return dataManagerConfig;
     }
 
@@ -1394,10 +1422,18 @@ public class RealtimeSegmentDataManagerTest {
         LLCSegmentName llcSegmentName, Map<Integer, ConsumerCoordinator> consumerCoordinatorMap,
         ServerMetrics serverMetrics, TimeSupplier timeSupplier)
         throws Exception {
+      this(segmentZKMetadata, tableConfig, realtimeTableDataManager, resourceDataDir, schema, llcSegmentName,
+          consumerCoordinatorMap, serverMetrics, timeSupplier, true);
+    }
+
+    public FakeRealtimeSegmentDataManager(SegmentZKMetadata segmentZKMetadata, TableConfig tableConfig,
+        RealtimeTableDataManager realtimeTableDataManager, String resourceDataDir, Schema schema,
+        LLCSegmentName llcSegmentName, Map<Integer, ConsumerCoordinator> consumerCoordinatorMap,
+        ServerMetrics serverMetrics, TimeSupplier timeSupplier, boolean disableGroovy)
+        throws Exception {
       super(segmentZKMetadata, tableConfig, realtimeTableDataManager, resourceDataDir,
-          new IndexLoadingConfig(makeInstanceDataManagerConfig(), tableConfig), schema, llcSegmentName,
-          consumerCoordinatorMap.get(llcSegmentName.getPartitionGroupId()), serverMetrics, null, null,
-          () -> true);
+          new IndexLoadingConfig(makeInstanceDataManagerConfig(disableGroovy), tableConfig), schema, llcSegmentName,
+          consumerCoordinatorMap.get(llcSegmentName.getPartitionGroupId()), serverMetrics, null, null, () -> true);
       _tableDataManager = realtimeTableDataManager;
       _state = RealtimeSegmentDataManager.class.getDeclaredField("_state");
       _state.setAccessible(true);
@@ -1408,10 +1444,10 @@ public class RealtimeSegmentDataManagerTest {
       _segmentBuildFailedWithDeterministicError =
           RealtimeSegmentDataManager.class.getDeclaredField("_segmentBuildFailedWithDeterministicError");
       _segmentBuildFailedWithDeterministicError.setAccessible(true);
-      _consumerCoordinatorMap = consumerCoordinatorMap;
       _streamMsgOffsetFactory = RealtimeSegmentDataManager.class.getDeclaredField("_streamPartitionMsgOffsetFactory");
       _streamMsgOffsetFactory.setAccessible(true);
       _streamMsgOffsetFactory.set(this, new LongMsgOffsetFactory());
+      _consumerCoordinatorMap = consumerCoordinatorMap;
       _timeSupplier = timeSupplier;
     }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/PartitionerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/PartitionerTest.java
@@ -29,10 +29,13 @@ import org.apache.pinot.core.segment.processing.partitioner.TableConfigPartition
 import org.apache.pinot.core.segment.processing.partitioner.TransformFunctionPartitioner;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 import static org.testng.Assert.fail;
 
 
@@ -169,7 +172,7 @@ public class PartitionerTest {
     partitionerConfig =
         new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.TRANSFORM_FUNCTION)
             .setTransformFunction("toEpochDays(\"timestamp\")").build();
-    Partitioner partitioner = PartitionerFactory.getPartitioner(partitionerConfig);
+    Partitioner partitioner = PartitionerFactory.getPartitioner(partitionerConfig, IngestionGroovyPolicy.DISABLED);
     assertEquals(partitioner.getClass(), TransformFunctionPartitioner.class);
     GenericRow row = new GenericRow();
     row.putValue("timestamp", 1587410614000L);
@@ -178,7 +181,12 @@ public class PartitionerTest {
     partitionerConfig =
         new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.TRANSFORM_FUNCTION)
             .setTransformFunction("Groovy({a+b},a,b)").build();
-    partitioner = PartitionerFactory.getPartitioner(partitionerConfig);
+    PartitionerConfig groovyPartitionerConfig = partitionerConfig;
+    IllegalStateException exception = expectThrows(IllegalStateException.class,
+        () -> PartitionerFactory.getPartitioner(groovyPartitionerConfig, IngestionGroovyPolicy.DISABLED));
+    assertTrue(exception.getMessage().contains(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY));
+
+    partitioner = PartitionerFactory.getPartitioner(partitionerConfig, IngestionGroovyPolicy.ENABLED);
     row.putValue("a", 10);
     row.putValue("b", 20);
     assertEquals(partitioner.getPartition(row), "30");
@@ -187,7 +195,7 @@ public class PartitionerTest {
     partitionerConfig =
         new PartitionerConfig.Builder().setPartitionerType(PartitionerFactory.PartitionerType.TRANSFORM_FUNCTION)
             .setTransformFunction("Groovy({dMv[1]},dMv)").build();
-    partitioner = PartitionerFactory.getPartitioner(partitionerConfig);
+    partitioner = PartitionerFactory.getPartitioner(partitionerConfig, IngestionGroovyPolicy.ENABLED);
     row.putValue("dMv", new Object[]{1, 2, 3});
     assertEquals(partitioner.getPartition(row), "2");
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/SchemaUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/SchemaUtilsTest.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.segment.local.utils.SchemaUtils;
 import org.apache.pinot.segment.local.utils.TableConfigUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -41,6 +42,8 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertThrows;
@@ -50,6 +53,16 @@ import static org.testng.Assert.assertThrows;
 public class SchemaUtilsTest {
   private static final String TABLE_NAME = "testTable";
   private static final String TIME_COLUMN = "timeColumn";
+
+  @BeforeClass
+  public void enableGroovyForLegacyValidationTests() {
+    FunctionEvaluatorFactory.setIngestionGroovyDisabled(false);
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void restoreDefaultGroovyPolicy() {
+    FunctionEvaluatorFactory.setIngestionGroovyDisabled(true);
+  }
 
   @Test
   public void testCompatibilityWithTableConfig() {
@@ -475,6 +488,30 @@ public class SchemaUtilsTest {
     pinotSchema.getFieldSpecFor("m1").setTransformFunction("Groovy({function}, m2, m3)");
     pinotSchema.getFieldSpecFor("time").setTransformFunction("Groovy({function}, millis)");
     SchemaUtils.validate(pinotSchema);
+  }
+
+  @Test
+  public void testFieldSpecTransformGroovyPolicy() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+        .addSingleValueDimension("source", DataType.STRING)
+        .addSingleValueDimension("result", DataType.STRING).build();
+    schema.getFieldSpecFor("result").setTransformFunction("Groovy({source.reverse()}, source)");
+
+    FunctionEvaluatorFactory.setIngestionGroovyDisabled(true);
+    try {
+      IllegalStateException exception =
+          Assert.expectThrows(IllegalStateException.class, () -> SchemaUtils.validate(schema));
+      Assert.assertTrue(exception.getMessage().contains("controller.disable.ingestion.groovy=false"));
+
+      schema.getFieldSpecFor("result").setTransformFunction("reverse(source)");
+      SchemaUtils.validate(schema);
+
+      FunctionEvaluatorFactory.setIngestionGroovyDisabled(false);
+      schema.getFieldSpecFor("result").setTransformFunction("Groovy({source.reverse()}, source)");
+      SchemaUtils.validate(schema);
+    } finally {
+      FunctionEvaluatorFactory.setIngestionGroovyDisabled(false);
+    }
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/queries/TransformQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TransformQueriesTest.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.core.operator.query.AggregationOperator;
 import org.apache.pinot.core.operator.query.GroupByOperator;
 import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
@@ -97,6 +98,7 @@ public class TransformQueriesTest extends BaseQueriesTest {
   @BeforeClass
   public void setUp()
       throws Exception {
+    FunctionEvaluatorFactory.setIngestionGroovyDisabled(false);
     FileUtils.deleteQuietly(INDEX_DIR);
 
     buildSegment();
@@ -151,6 +153,7 @@ public class TransformQueriesTest extends BaseQueriesTest {
     config.setOutDir(INDEX_DIR.getPath());
     config.setTableName(TABLE_NAME);
     config.setSegmentName(SEGMENT_NAME);
+    config.setIngestionGroovyDisabled(false);
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
     try (RecordReader recordReader = new GenericRowRecordReader(rows)) {
@@ -159,10 +162,16 @@ public class TransformQueriesTest extends BaseQueriesTest {
     }
   }
 
-  @AfterClass
+  @AfterClass(alwaysRun = true)
   public void tearDown() {
-    _indexSegment.destroy();
-    FileUtils.deleteQuietly(INDEX_DIR);
+    try {
+      if (_indexSegment != null) {
+        _indexSegment.destroy();
+      }
+      FileUtils.deleteQuietly(INDEX_DIR);
+    } finally {
+      FunctionEvaluatorFactory.setIngestionGroovyDisabled(true);
+    }
   }
 
   @Test

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
@@ -78,6 +78,7 @@ import org.apache.pinot.segment.spi.creator.SegmentIndexCreationDriver;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.readers.FileFormat;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.stream.StreamDataProducer;
 import org.apache.pinot.spi.stream.StreamDataProvider;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -288,9 +289,26 @@ public class ClusterIntegrationTestUtils {
   public static void buildSegmentsFromAvro(List<File> avroFiles, TableConfig tableConfig,
       org.apache.pinot.spi.data.Schema schema, int baseSegmentIndex, File segmentDir, File tarDir)
       throws Exception {
+    buildSegmentsFromAvroInternal(avroFiles, tableConfig, schema, baseSegmentIndex, segmentDir, tarDir, null);
+  }
+
+  /// Builds Pinot segments with an explicit ingestion Groovy policy.
+  public static void buildSegmentsFromAvro(List<File> avroFiles, TableConfig tableConfig,
+      org.apache.pinot.spi.data.Schema schema, int baseSegmentIndex, File segmentDir, File tarDir,
+      IngestionGroovyPolicy ingestionGroovyPolicy)
+      throws Exception {
+    buildSegmentsFromAvroInternal(avroFiles, tableConfig, schema, baseSegmentIndex, segmentDir, tarDir,
+        ingestionGroovyPolicy);
+  }
+
+  private static void buildSegmentsFromAvroInternal(List<File> avroFiles, TableConfig tableConfig,
+      org.apache.pinot.spi.data.Schema schema, int baseSegmentIndex, File segmentDir, File tarDir,
+      @Nullable IngestionGroovyPolicy ingestionGroovyPolicy)
+      throws Exception {
     int numAvroFiles = avroFiles.size();
     if (numAvroFiles == 1) {
-      buildSegmentFromAvro(avroFiles.get(0), tableConfig, schema, baseSegmentIndex, segmentDir, tarDir);
+      buildSegmentFromAvro(avroFiles.get(0), tableConfig, schema, baseSegmentIndex, segmentDir, tarDir,
+          ingestionGroovyPolicy);
     } else {
       ExecutorService executorService =
           Executors.newFixedThreadPool(Math.min(numAvroFiles, Runtime.getRuntime().availableProcessors()));
@@ -299,7 +317,8 @@ public class ClusterIntegrationTestUtils {
         File avroFile = avroFiles.get(i);
         int segmentIndex = i + baseSegmentIndex;
         futures.add(executorService.submit(() -> {
-          buildSegmentFromAvro(avroFile, tableConfig, schema, segmentIndex, segmentDir, tarDir);
+          buildSegmentFromAvro(avroFile, tableConfig, schema, segmentIndex, segmentDir, tarDir,
+              ingestionGroovyPolicy);
           return null;
         }));
       }
@@ -325,6 +344,14 @@ public class ClusterIntegrationTestUtils {
     buildSegmentFromAvro(avroFile, tableConfig, schema, segmentIndex + " %", segmentDir, tarDir);
   }
 
+  private static void buildSegmentFromAvro(File avroFile, TableConfig tableConfig,
+      org.apache.pinot.spi.data.Schema schema, int segmentIndex, File segmentDir, File tarDir,
+      @Nullable IngestionGroovyPolicy ingestionGroovyPolicy)
+      throws Exception {
+    buildSegmentFromFile(avroFile, tableConfig, schema, segmentIndex + " %", segmentDir, tarDir, FileFormat.AVRO,
+        ingestionGroovyPolicy);
+  }
+
   /// Builds one Pinot segment from the given Avro file.
   ///
   /// @param avroFile Avro file
@@ -342,7 +369,17 @@ public class ClusterIntegrationTestUtils {
   public static void buildSegmentFromFile(File file, TableConfig tableConfig, org.apache.pinot.spi.data.Schema schema,
       String segmentNamePostfix, File segmentDir, File tarDir, FileFormat fileFormat)
       throws Exception {
+    buildSegmentFromFile(file, tableConfig, schema, segmentNamePostfix, segmentDir, tarDir, fileFormat, null);
+  }
+
+  private static void buildSegmentFromFile(File file, TableConfig tableConfig,
+      org.apache.pinot.spi.data.Schema schema, String segmentNamePostfix, File segmentDir, File tarDir,
+      FileFormat fileFormat, @Nullable IngestionGroovyPolicy ingestionGroovyPolicy)
+      throws Exception {
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
+    if (ingestionGroovyPolicy != null) {
+      segmentGeneratorConfig.setIngestionGroovyDisabled(ingestionGroovyPolicy.isIngestionGroovyDisabled());
+    }
     segmentGeneratorConfig.setFormat(fileFormat);
     segmentGeneratorConfig.setInputFilePath(file.getPath());
     segmentGeneratorConfig.setOutDir(segmentDir.getPath());

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SharedHybridClusterIntegrationTestSuite.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SharedHybridClusterIntegrationTestSuite.java
@@ -46,6 +46,7 @@ import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.InstanceTypeUtils;
@@ -318,7 +319,8 @@ public abstract class SharedHybridClusterIntegrationTestSuite extends BaseCluste
     TableConfig offlineTableConfig = createStandardOfflineTableConfig(lease);
     TableConfig realtimeTableConfig = createStandardRealtimeTableConfig(lease, realtimeAvroFiles.get(0));
     addScenarioTables(lease, offlineTableConfig, realtimeTableConfig);
-    buildAndUploadOfflineSegments(lease, offlineAvroFiles, offlineTableConfig, schema);
+    buildAndUploadOfflineSegments(lease, offlineAvroFiles, offlineTableConfig, schema,
+        IngestionGroovyPolicy.DISABLED);
     pushRealtimeRecords(lease, realtimeAvroFiles);
 
     lease._offlineInputCount = countRecords(offlineAvroFiles);
@@ -342,7 +344,7 @@ public abstract class SharedHybridClusterIntegrationTestSuite extends BaseCluste
         createIngestionConfigTableConfig(lease._tableName, TableType.REALTIME, streamConfig);
     installScenarioDecoder(lease, realtimeAvroFiles.get(0));
     addScenarioTables(lease, offlineTableConfig, realtimeTableConfig);
-    buildAndUploadOfflineSegments(lease, offlineAvroFiles, offlineTableConfig, schema);
+    buildAndUploadOfflineSegments(lease, offlineAvroFiles, offlineTableConfig, schema, IngestionGroovyPolicy.ENABLED);
     pushRealtimeRecords(lease, realtimeAvroFiles);
     waitForScenarioCount(lease._tableName, FILTERED_HYBRID_COUNT, 600_000L);
     return schema;
@@ -434,10 +436,10 @@ public abstract class SharedHybridClusterIntegrationTestSuite extends BaseCluste
   }
 
   private void buildAndUploadOfflineSegments(HybridScenarioLease lease, List<File> offlineAvroFiles,
-      TableConfig offlineTableConfig, Schema schema)
+      TableConfig offlineTableConfig, Schema schema, IngestionGroovyPolicy ingestionGroovyPolicy)
       throws Exception {
     ClusterIntegrationTestUtils.buildSegmentsFromAvro(offlineAvroFiles, offlineTableConfig, schema, 0,
-        lease._segmentDir, lease._tarDir);
+        lease._segmentDir, lease._tarDir, ingestionGroovyPolicy);
     uploadSegments(lease._tableName, lease._tarDir);
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/StaleSegmentCheckIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/StaleSegmentCheckIntegrationTest.java
@@ -36,6 +36,7 @@ import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
@@ -94,7 +95,8 @@ public class StaleSegmentCheckIntegrationTest extends BaseClusterIntegrationTest
     addTableConfig(_tableConfig);
 
     // Create and upload segments
-    ClusterIntegrationTestUtils.buildSegmentsFromAvro(_avroFiles, _tableConfig, _schema, 0, _segmentDir, _tarDir);
+    ClusterIntegrationTestUtils.buildSegmentsFromAvro(_avroFiles, _tableConfig, _schema, 0, _segmentDir, _tarDir,
+        IngestionGroovyPolicy.ENABLED);
     uploadSegments(getTableName(), _tarDir);
 
     // Wait for all documents loaded

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
@@ -108,7 +108,9 @@ public abstract class BaseMinionStarter implements ServiceStartable {
     String zkAddress = _config.getZkAddress();
     String helixClusterName = _config.getHelixClusterName();
     ServiceStartableUtils.applyClusterConfig(_config, zkAddress, helixClusterName, ServiceRole.MINION);
+    boolean disableGroovy = _config.isIngestionGroovyDisabled();
     applyCustomConfigs(_config);
+    ServiceStartableUtils.enforceIngestionGroovyPolicy(_config, disableGroovy, ServiceRole.MINION);
 
     PinotInsecureMode.setPinotInInsecureMode(_config.getProperty(CommonConstants.CONFIG_OF_PINOT_INSECURE_MODE, false));
     PinotMd5Mode.setPinotMd5Disabled(_config.getProperty(CommonConstants.CONFIG_OF_PINOT_MD5_DISABLED,

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionConf.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionConf.java
@@ -85,6 +85,11 @@ public class MinionConf extends PinotConfiguration {
     return getProperty(SEGMENT_DOWNLOAD_PARALLELISM, DEFAULT_SEGMENT_DOWNLOAD_PARALLELISM);
   }
 
+  public boolean isIngestionGroovyDisabled() {
+    return CommonConstants.Groovy.isIngestionGroovyDisabled(
+        getProperty(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY));
+  }
+
   public String getMetricsPrefix() {
     return Optional.ofNullable(getProperty(CommonConstants.Minion.CONFIG_OF_METRICS_PREFIX_KEY))
         .orElseGet(() -> getProperty(CommonConstants.Minion.DEPRECATED_CONFIG_OF_METRICS_PREFIX_KEY,

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationJobUtils.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationJobUtils.java
@@ -28,14 +28,20 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.common.segment.generation.SegmentGenerationUtils;
 import org.apache.pinot.common.utils.TarCompressionUtils;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.ingestion.batch.spec.ExecutionFrameworkSpec;
+import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentNameGeneratorSpec;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +59,31 @@ public class SegmentGenerationJobUtils implements Serializable {
   // Field names in the executionFrameworkSpec/extraConfigs section shared across ingestion frameworks
   public static final String DEPENDENCY_JAR_DIR = "dependencyJarDir";
   public static final String STAGING_DIR = "stagingDir";
+
+  /// Resolves the ingestion Groovy policy once in the job-launching JVM and persists it in the serialized job spec.
+  /// This keeps standalone and distributed workers on the same explicit policy.
+  public static boolean resolveAndPersistIngestionGroovyPolicy(SegmentGenerationJobSpec spec) {
+    ExecutionFrameworkSpec executionFrameworkSpec = spec.getExecutionFrameworkSpec();
+    if (executionFrameworkSpec == null) {
+      executionFrameworkSpec = new ExecutionFrameworkSpec();
+      spec.setExecutionFrameworkSpec(executionFrameworkSpec);
+    }
+    Map<String, String> extraConfigs = executionFrameworkSpec.getExtraConfigs() != null
+        ? new HashMap<>(executionFrameworkSpec.getExtraConfigs()) : new HashMap<>();
+    String configuredValue = extraConfigs.computeIfAbsent(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY,
+        ignored -> Boolean.toString(FunctionEvaluatorFactory.isIngestionGroovyDisabled()));
+    executionFrameworkSpec.setExtraConfigs(extraConfigs);
+    return FunctionEvaluatorFactory.resolveIngestionGroovyDisabled(configuredValue);
+  }
+
+  /// Reads the persisted ingestion Groovy policy. A legacy or incomplete worker spec fails closed.
+  public static boolean isIngestionGroovyDisabled(SegmentGenerationJobSpec spec) {
+    ExecutionFrameworkSpec executionFrameworkSpec = spec.getExecutionFrameworkSpec();
+    Map<String, String> extraConfigs = executionFrameworkSpec != null ? executionFrameworkSpec.getExtraConfigs() : null;
+    String configuredValue = extraConfigs != null
+        ? extraConfigs.get(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY) : null;
+    return FunctionEvaluatorFactory.resolveIngestionGroovyDisabled(configuredValue);
+  }
 
   /// Always use local directory sequence id unless explicitly config: "use.global.directory.sequence.id".
   public static boolean useGlobalDirectorySequenceId(SegmentNameGeneratorSpec spec) {

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
@@ -23,6 +23,8 @@ import com.google.common.base.Preconditions;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.creator.name.FixedSegmentNameGenerator;
@@ -38,6 +40,7 @@ import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationTaskSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentNameGeneratorSpec;
@@ -46,8 +49,8 @@ import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.JsonUtils;
 
 
-@SuppressWarnings("serial")
 public class SegmentGenerationTaskRunner implements Serializable {
+  private static final long serialVersionUID = -1755560917714370885L;
 
   // For FixedSegmentNameGenerator
   public static final String SEGMENT_NAME = "segment.name";
@@ -71,9 +74,17 @@ public class SegmentGenerationTaskRunner implements Serializable {
   public static final String EXCLUDE_TIME_IN_SEGMENT_NAME = BatchConfigProperties.EXCLUDE_TIME_IN_SEGMENT_NAME;
 
   private final SegmentGenerationTaskSpec _taskSpec;
+  @Nullable
+  private final IngestionGroovyPolicy _ingestionGroovyPolicy;
 
   public SegmentGenerationTaskRunner(SegmentGenerationTaskSpec taskSpec) {
+    this(taskSpec, IngestionGroovyPolicy.fromDisabled(FunctionEvaluatorFactory.isIngestionGroovyDisabled()));
+  }
+
+  public SegmentGenerationTaskRunner(SegmentGenerationTaskSpec taskSpec,
+      IngestionGroovyPolicy ingestionGroovyPolicy) {
     _taskSpec = taskSpec;
+    _ingestionGroovyPolicy = ingestionGroovyPolicy;
   }
 
   public String run()
@@ -107,6 +118,7 @@ public class SegmentGenerationTaskRunner implements Serializable {
     segmentGeneratorConfig.setInputFilePath(_taskSpec.getInputFilePath());
     segmentGeneratorConfig.setCustomProperties(_taskSpec.getCustomProperties());
     segmentGeneratorConfig.setFailOnEmptySegment(_taskSpec.isFailOnEmptySegment());
+    segmentGeneratorConfig.setIngestionGroovyDisabled(isIngestionGroovyDisabled());
 
     //init segmentName Generator
     SegmentNameGenerator segmentNameGenerator = getSegmentNameGenerator(segmentGeneratorConfig);
@@ -117,6 +129,11 @@ public class SegmentGenerationTaskRunner implements Serializable {
     segmentIndexCreationDriver.init(segmentGeneratorConfig);
     segmentIndexCreationDriver.build();
     return segmentIndexCreationDriver.getSegmentName();
+  }
+
+  boolean isIngestionGroovyDisabled() {
+    // Serialized runners created before this field was introduced have a null value and must fail closed.
+    return _ingestionGroovyPolicy == null || _ingestionGroovyPolicy.isIngestionGroovyDisabled();
   }
 
   private SegmentNameGenerator getSegmentNameGenerator(SegmentGeneratorConfig segmentGeneratorConfig) {

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/test/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationJobUtilsTest.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/test/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationJobUtilsTest.java
@@ -21,12 +21,48 @@ package org.apache.pinot.plugin.ingestion.batch.common;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
+import org.apache.pinot.spi.ingestion.batch.spec.ExecutionFrameworkSpec;
+import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentNameGeneratorSpec;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
 public class SegmentGenerationJobUtilsTest {
+
+  @Test
+  public void testResolveAndPersistIngestionGroovyPolicy() {
+    SegmentGenerationJobSpec spec = new SegmentGenerationJobSpec();
+    ExecutionFrameworkSpec executionFrameworkSpec = new ExecutionFrameworkSpec();
+    executionFrameworkSpec.setExtraConfigs(Map.of(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY, "false"));
+    spec.setExecutionFrameworkSpec(executionFrameworkSpec);
+
+    Assert.assertFalse(SegmentGenerationJobUtils.resolveAndPersistIngestionGroovyPolicy(spec));
+    Assert.assertFalse(SegmentGenerationJobUtils.isIngestionGroovyDisabled(spec));
+    Assert.assertEquals(spec.getExecutionFrameworkSpec().getExtraConfigs(),
+        Map.of(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY, "false"));
+  }
+
+  @Test
+  public void testMissingPolicyIsCapturedForLaunchAndFailsClosedOnLegacyWorker() {
+    SegmentGenerationJobSpec launchSpec = new SegmentGenerationJobSpec();
+    boolean expectedLaunchPolicy = FunctionEvaluatorFactory.isIngestionGroovyDisabled();
+
+    Assert.assertEquals(SegmentGenerationJobUtils.resolveAndPersistIngestionGroovyPolicy(launchSpec),
+        expectedLaunchPolicy);
+    Assert.assertEquals(launchSpec.getExecutionFrameworkSpec().getExtraConfigs().get(
+        CommonConstants.Groovy.DISABLE_INGESTION_GROOVY), Boolean.toString(expectedLaunchPolicy));
+
+    SegmentGenerationJobSpec legacyWorkerSpec = new SegmentGenerationJobSpec();
+    Assert.assertTrue(SegmentGenerationJobUtils.isIngestionGroovyDisabled(legacyWorkerSpec));
+    ExecutionFrameworkSpec invalidExecutionFrameworkSpec = new ExecutionFrameworkSpec();
+    invalidExecutionFrameworkSpec.setExtraConfigs(
+        Map.of(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY, "invalid"));
+    legacyWorkerSpec.setExecutionFrameworkSpec(invalidExecutionFrameworkSpec);
+    Assert.assertTrue(SegmentGenerationJobUtils.isIngestionGroovyDisabled(legacyWorkerSpec));
+  }
 
   @Test
   public void testUseGlobalDirectorySequenceId() {

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/test/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunnerTest.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/test/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunnerTest.java
@@ -1,0 +1,145 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.ingestion.batch.common;
+
+import java.io.File;
+import java.io.ObjectStreamClass;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.segment.readers.PinotSegmentRecordReader;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.data.readers.RecordReaderConfig;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
+import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
+import org.apache.pinot.spi.ingestion.batch.spec.RecordReaderSpec;
+import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationTaskSpec;
+import org.apache.pinot.spi.ingestion.batch.spec.SegmentNameGeneratorSpec;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+
+public class SegmentGenerationTaskRunnerTest {
+
+  @Test
+  public void testGroovyPolicySerializationCompatibility()
+      throws ReflectiveOperationException {
+    assertEquals(ObjectStreamClass.lookup(SegmentGenerationTaskRunner.class).getSerialVersionUID(),
+        -1755560917714370885L);
+
+    SegmentGenerationTaskRunner taskRunner =
+        new SegmentGenerationTaskRunner(new SegmentGenerationTaskSpec(), IngestionGroovyPolicy.ENABLED);
+    assertFalse(taskRunner.isIngestionGroovyDisabled());
+
+    // A runner serialized before the policy field was introduced deserializes with a null value and must fail closed.
+    Field ingestionGroovyPolicyField = SegmentGenerationTaskRunner.class.getDeclaredField("_ingestionGroovyPolicy");
+    ingestionGroovyPolicyField.setAccessible(true);
+    ingestionGroovyPolicyField.set(taskRunner, null);
+    assertTrue(taskRunner.isIngestionGroovyDisabled());
+  }
+
+  @Test
+  public void testRuntimeGroovyPolicy()
+      throws Exception {
+    File testDir = Files.createTempDirectory("segment-generation-groovy-policy").toFile();
+    try {
+      SegmentGenerationTaskSpec disabledTaskSpec = createTaskSpec(testDir);
+      IllegalStateException error = expectThrows(IllegalStateException.class,
+          () -> new SegmentGenerationTaskRunner(disabledTaskSpec, IngestionGroovyPolicy.DISABLED).run());
+      assertTrue(error.getMessage().contains("controller.disable.ingestion.groovy=false"));
+
+      SegmentGenerationTaskSpec enabledTaskSpec = createTaskSpec(testDir);
+      String segmentName = new SegmentGenerationTaskRunner(enabledTaskSpec, IngestionGroovyPolicy.ENABLED).run();
+      try (PinotSegmentRecordReader recordReader =
+          new PinotSegmentRecordReader(new File(enabledTaskSpec.getOutputDirectoryPath(), segmentName))) {
+        assertEquals(recordReader.next().getValue("derived"), "cba");
+      }
+    } finally {
+      FileUtils.deleteQuietly(testDir);
+    }
+  }
+
+  private static SegmentGenerationTaskSpec createTaskSpec(File testDir)
+      throws Exception {
+    File inputFile = new File(testDir, "input");
+    FileUtils.touch(inputFile);
+    File outputDir = new File(testDir, "output");
+    FileUtils.forceMkdir(outputDir);
+
+    Schema schema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("source", FieldSpec.DataType.STRING)
+        .addSingleValueDimension("derived", FieldSpec.DataType.STRING).build();
+    schema.getFieldSpecFor("derived").setTransformFunction("Groovy({source.reverse()}, source)");
+
+    RecordReaderSpec recordReaderSpec = new RecordReaderSpec();
+    recordReaderSpec.setClassName(OneRowRecordReader.class.getName());
+    SegmentNameGeneratorSpec segmentNameGeneratorSpec = new SegmentNameGeneratorSpec();
+    segmentNameGeneratorSpec.setType(BatchConfigProperties.SegmentNameGeneratorType.FIXED);
+    segmentNameGeneratorSpec.addConfig(SegmentGenerationTaskRunner.SEGMENT_NAME, "testSegment");
+
+    SegmentGenerationTaskSpec taskSpec = new SegmentGenerationTaskSpec();
+    taskSpec.setTableConfig(new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build());
+    taskSpec.setSchema(schema);
+    taskSpec.setRecordReaderSpec(recordReaderSpec);
+    taskSpec.setSegmentNameGeneratorSpec(segmentNameGeneratorSpec);
+    taskSpec.setInputFilePath(inputFile.getAbsolutePath());
+    taskSpec.setOutputDirectoryPath(outputDir.getAbsolutePath());
+    return taskSpec;
+  }
+
+  public static final class OneRowRecordReader implements RecordReader {
+    private boolean _read;
+
+    @Override
+    public void init(File dataFile, Set<String> fieldsToRead, @Nullable RecordReaderConfig recordReaderConfig) {
+    }
+
+    @Override
+    public boolean hasNext() {
+      return !_read;
+    }
+
+    @Override
+    public GenericRow next(GenericRow reuse) {
+      _read = true;
+      reuse.putValue("source", "abc");
+      return reuse;
+    }
+
+    @Override
+    public void rewind() {
+      _read = false;
+    }
+
+    @Override
+    public void close() {
+    }
+  }
+}

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentCreationMapper.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentCreationMapper.java
@@ -39,6 +39,7 @@ import org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationTaskRunne
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.ingestion.batch.spec.Constants;
 import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
@@ -153,6 +154,7 @@ public class HadoopSegmentCreationMapper extends Mapper<LongWritable, Text, Long
       taskSpec.setSequenceId(idx);
       taskSpec.setSegmentNameGeneratorSpec(_spec.getSegmentNameGeneratorSpec());
       taskSpec.setFailOnEmptySegment(_spec.isFailOnEmptySegment());
+      boolean isGroovyDisabled = SegmentGenerationJobUtils.isIngestionGroovyDisabled(_spec);
       taskSpec.setCustomProperty(BatchConfigProperties.INPUT_DATA_FILE_URI_KEY, inputFileURI.toString());
 
       // Start a thread that reports progress every minute during segment generation to prevent job getting killed
@@ -161,7 +163,8 @@ public class HadoopSegmentCreationMapper extends Mapper<LongWritable, Text, Long
       progressReporterThread.start();
       String segmentName;
       try {
-        SegmentGenerationTaskRunner taskRunner = new SegmentGenerationTaskRunner(taskSpec);
+        SegmentGenerationTaskRunner taskRunner = new SegmentGenerationTaskRunner(taskSpec,
+            IngestionGroovyPolicy.fromDisabled(isGroovyDisabled));
         segmentName = taskRunner.run();
       } catch (Exception e) {
         LOGGER.error("Caught exception while creating segment with input file: {}, sequence id: {}", path, idx, e);

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentGenerationJobRunner.java
@@ -122,9 +122,7 @@ public class HadoopSegmentGenerationJobRunner extends Configured implements Inge
           .generateTableConfigURI(pinotClusterSpec.getControllerURI(), _spec.getTableSpec().getTableName());
       _spec.getTableSpec().setTableConfigURI(tableConfigURI);
     }
-    if (_spec.getExecutionFrameworkSpec().getExtraConfigs() == null) {
-      _spec.getExecutionFrameworkSpec().setExtraConfigs(new HashMap<>());
-    }
+    SegmentGenerationJobUtils.resolveAndPersistIngestionGroovyPolicy(_spec);
   }
 
   @Override

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/test/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentGenerationJobRunnerTest.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/test/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentGenerationJobRunnerTest.java
@@ -42,6 +42,7 @@ import org.apache.pinot.spi.ingestion.batch.spec.RecordReaderSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.TableSpec;
 import org.apache.pinot.spi.plugin.PluginManager;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -72,7 +73,9 @@ public class HadoopSegmentGenerationJobRunnerTest {
         .setSchemaName(schemaName)
         .addSingleValueDimension("col1", DataType.STRING)
         .addMetric("col2", DataType.INT)
+        .addSingleValueDimension("derived", DataType.STRING)
         .build();
+    schema.getFieldSpecFor("derived").setTransformFunction("Groovy({col1.reverse()}, col1)");
     FileUtils.write(schemaFile, schema.toPrettyJsonString(), StandardCharsets.UTF_8);
 
     // Set up table config file.
@@ -130,6 +133,7 @@ public class HadoopSegmentGenerationJobRunnerTest {
     Map<String, String> extraConfigs = new HashMap<>();
     extraConfigs.put("stagingDir", stagingDir.toURI().toString());
     extraConfigs.put("dependencyJarDir", dependencyJarsDir.getAbsolutePath());
+    extraConfigs.put(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY, "false");
     efSpec.setExtraConfigs(extraConfigs);
     jobSpec.setExecutionFrameworkSpec(efSpec);
 

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunner.java
@@ -41,6 +41,7 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner;
 import org.apache.pinot.spi.ingestion.batch.spec.Constants;
@@ -113,9 +114,7 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
           _spec.getTableSpec().getTableName());
       _spec.getTableSpec().setTableConfigURI(tableConfigURI);
     }
-    if (_spec.getExecutionFrameworkSpec().getExtraConfigs() == null) {
-      _spec.getExecutionFrameworkSpec().setExtraConfigs(new HashMap<>());
-    }
+    SegmentGenerationJobUtils.resolveAndPersistIngestionGroovyPolicy(_spec);
   }
 
   @Override
@@ -286,9 +285,11 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
           taskSpec.setSequenceId(idx);
           taskSpec.setSegmentNameGeneratorSpec(_spec.getSegmentNameGeneratorSpec());
           taskSpec.setFailOnEmptySegment(_spec.isFailOnEmptySegment());
+          boolean isGroovyDisabled = SegmentGenerationJobUtils.isIngestionGroovyDisabled(_spec);
           taskSpec.setCustomProperty(BatchConfigProperties.INPUT_DATA_FILE_URI_KEY, inputFileURI.toString());
 
-          SegmentGenerationTaskRunner taskRunner = new SegmentGenerationTaskRunner(taskSpec);
+          SegmentGenerationTaskRunner taskRunner = new SegmentGenerationTaskRunner(taskSpec,
+              IngestionGroovyPolicy.fromDisabled(isGroovyDisabled));
           String segmentName = taskRunner.run();
 
           // Tar segment directory to compress file

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/test/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunnerTest.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/test/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunnerTest.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
@@ -42,6 +43,7 @@ import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.RecordReaderSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.TableSpec;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.spark.SparkContext;
 import org.testng.Assert;
@@ -73,7 +75,8 @@ public class SparkSegmentGenerationJobRunnerTest {
     final String schemaName = "myTable";
     File schemaFile = new File(testDir, "myTable.schema");
     Schema schema = new SchemaBuilder().setSchemaName(schemaName).addSingleValueDimension("col1", DataType.STRING)
-        .addMetric("col2", DataType.INT).build();
+        .addMetric("col2", DataType.INT).addSingleValueDimension("derived", DataType.STRING).build();
+    schema.getFieldSpecFor("derived").setTransformFunction("Groovy({col1.reverse()}, col1)");
     FileUtils.write(schemaFile, schema.toPrettyJsonString(), StandardCharsets.UTF_8);
 
     File tableConfigFile = new File(testDir, "myTable.table");
@@ -102,6 +105,7 @@ public class SparkSegmentGenerationJobRunnerTest {
     ExecutionFrameworkSpec efSpec = new ExecutionFrameworkSpec();
     efSpec.setName("standalone");
     efSpec.setSegmentGenerationJobRunnerClassName(SparkSegmentGenerationJobRunner.class.getName());
+    efSpec.setExtraConfigs(Map.of(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY, "false"));
     jobSpec.setExecutionFrameworkSpec(efSpec);
 
     PinotFSSpec pfsSpec = new PinotFSSpec();
@@ -127,7 +131,8 @@ public class SparkSegmentGenerationJobRunnerTest {
     final String schemaName = "myTable";
     File schemaFile = new File(testDir, "myTable.schema");
     Schema schema = new SchemaBuilder().setSchemaName(schemaName).addSingleValueDimension("col1", DataType.STRING)
-        .addMetric("col2", DataType.INT).build();
+        .addMetric("col2", DataType.INT).addSingleValueDimension("derived", DataType.STRING).build();
+    schema.getFieldSpecFor("derived").setTransformFunction("Groovy({col1.reverse()}, col1)");
     FileUtils.write(schemaFile, schema.toPrettyJsonString(), StandardCharsets.UTF_8);
 
     IngestionConfig ingestionConfig = new IngestionConfig();
@@ -158,6 +163,7 @@ public class SparkSegmentGenerationJobRunnerTest {
     ExecutionFrameworkSpec efSpec = new ExecutionFrameworkSpec();
     efSpec.setName("standalone");
     efSpec.setSegmentGenerationJobRunnerClassName(SparkSegmentGenerationJobRunner.class.getName());
+    efSpec.setExtraConfigs(Map.of(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY, "false"));
     jobSpec.setExecutionFrameworkSpec(efSpec);
 
     PinotFSSpec pfsSpec = new PinotFSSpec();

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
@@ -45,6 +45,7 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner;
 import org.apache.pinot.spi.ingestion.batch.spec.Constants;
@@ -83,6 +84,7 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
   @Override
   public void init(SegmentGenerationJobSpec spec) {
     _spec = spec;
+    SegmentGenerationJobUtils.resolveAndPersistIngestionGroovyPolicy(_spec);
 
     if (_spec.getInputDirURI() == null) {
       throw new RuntimeException("Missing property 'inputDirURI' in 'jobSpec' file");
@@ -245,6 +247,7 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
     taskSpec.setSequenceId(seqId);
     taskSpec.setFailOnEmptySegment(_spec.isFailOnEmptySegment());
     taskSpec.setCreateMetadataTarGz(_spec.isCreateMetadataTarGz());
+    boolean isGroovyDisabled = SegmentGenerationJobUtils.isIngestionGroovyDisabled(_spec);
     taskSpec.setCustomProperty(BatchConfigProperties.INPUT_DATA_FILE_URI_KEY, inputFileURI.toString());
 
     // If there's already been a failure, log and skip this file. Do this check right before the
@@ -261,7 +264,8 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
       File localSegmentTarFile = null;
       try {
         //invoke segmentGenerationTask
-        SegmentGenerationTaskRunner taskRunner = new SegmentGenerationTaskRunner(taskSpec);
+        SegmentGenerationTaskRunner taskRunner = new SegmentGenerationTaskRunner(taskSpec,
+            IngestionGroovyPolicy.fromDisabled(isGroovyDisabled));
         String segmentName = taskRunner.run();
         // Tar segment directory to compress file
         localSegmentDir = new File(localOutputTempDir, segmentName);

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/test/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunnerTest.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/test/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunnerTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationTaskRunner;
 import org.apache.pinot.plugin.inputformat.csv.CSVRecordReader;
@@ -44,6 +45,7 @@ import org.apache.pinot.spi.ingestion.batch.spec.RecordReaderSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentNameGeneratorSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.TableSpec;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -240,7 +242,9 @@ public class SegmentGenerationJobRunnerTest {
         .setSchemaName(schemaName)
         .addSingleValueDimension("col1", DataType.STRING)
         .addMetric("col2", DataType.INT)
+        .addSingleValueDimension("derived", DataType.STRING)
         .build();
+    schema.getFieldSpecFor("derived").setTransformFunction("Groovy({col1.reverse()}, col1)");
     FileUtils.write(schemaFile, schema.toPrettyJsonString(), StandardCharsets.UTF_8);
     return schemaFile;
   }
@@ -290,6 +294,7 @@ public class SegmentGenerationJobRunnerTest {
     ExecutionFrameworkSpec efSpec = new ExecutionFrameworkSpec();
     efSpec.setName("standalone");
     efSpec.setSegmentGenerationJobRunnerClassName(SegmentGenerationJobRunner.class.getName());
+    efSpec.setExtraConfigs(Map.of(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY, "false"));
     jobSpec.setExecutionFrameworkSpec(efSpec);
 
     PinotFSSpec pfsSpec = new PinotFSSpec();

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
@@ -89,6 +89,10 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
     _minionConf = minionConf;
   }
 
+  protected boolean isIngestionGroovyDisabled() {
+    return _minionConf == null || _minionConf.isIngestionGroovyDisabled();
+  }
+
   /// Converts the segment based on the given [PinotTaskConfig].
   ///
   /// @param pinotTaskConfig Task config

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseTaskExecutorFactory.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseTaskExecutorFactory.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.minion.tasks;
+
+import org.apache.pinot.minion.MinionConf;
+import org.apache.pinot.minion.executor.MinionTaskZkMetadataManager;
+import org.apache.pinot.minion.executor.PinotTaskExecutorFactory;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
+
+
+/// Base factory that retains initialized minion state for task-executor creation.
+///
+/// The framework calls [#init(MinionTaskZkMetadataManager, MinionConf)] exactly once before invoking `create()` on a
+/// factory. After initialization, subclasses may safely read the retained references from concurrent `create()` calls;
+/// neither this class nor subclasses should mutate or replace them.
+public abstract class BaseTaskExecutorFactory implements PinotTaskExecutorFactory {
+  protected MinionTaskZkMetadataManager _zkMetadataManager;
+  protected MinionConf _minionConf;
+
+  @Override
+  public final void init(MinionTaskZkMetadataManager zkMetadataManager, MinionConf minionConf) {
+    _zkMetadataManager = zkMetadataManager;
+    _minionConf = minionConf;
+  }
+
+  protected final IngestionGroovyPolicy getIngestionGroovyPolicy() {
+    return IngestionGroovyPolicy.fromDisabled(_minionConf == null || _minionConf.isIngestionGroovyDisabled());
+  }
+}

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/materializedview/MaterializedViewTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/materializedview/MaterializedViewTaskExecutor.java
@@ -726,6 +726,8 @@ public class MaterializedViewTaskExecutor extends BaseTaskExecutor {
     FileUtils.forceMkdir(segmentOutputDir);
 
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
+    segmentGeneratorConfig.setIngestionGroovyDisabled(
+        _minionConf == null || _minionConf.isIngestionGroovyDisabled());
     segmentGeneratorConfig.setTableName(tableName);
     segmentGeneratorConfig.setOutDir(segmentOutputDir.getAbsolutePath());
     segmentGeneratorConfig.setSegmentName(segmentName);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/materializedview/MaterializedViewTaskExecutorFactory.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/materializedview/MaterializedViewTaskExecutorFactory.java
@@ -22,11 +22,9 @@ import com.google.common.base.Preconditions;
 import org.apache.pinot.common.config.GrpcConfig;
 import org.apache.pinot.materializedview.executor.GrpcMaterializedViewQueryExecutor;
 import org.apache.pinot.materializedview.executor.MaterializedViewQueryExecutor;
-import org.apache.pinot.minion.MinionConf;
 import org.apache.pinot.minion.MinionContext;
-import org.apache.pinot.minion.executor.MinionTaskZkMetadataManager;
 import org.apache.pinot.minion.executor.PinotTaskExecutor;
-import org.apache.pinot.minion.executor.PinotTaskExecutorFactory;
+import org.apache.pinot.plugin.minion.tasks.BaseTaskExecutorFactory;
 import org.apache.pinot.spi.annotations.minion.TaskExecutorFactory;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
@@ -42,16 +40,8 @@ import org.apache.pinot.spi.utils.CommonConstants.MaterializedViewTask;
 /// The executor is then shared across all executor instances for connection
 /// reuse and load balancing.
 @TaskExecutorFactory
-public class MaterializedViewTaskExecutorFactory implements PinotTaskExecutorFactory {
-  private MinionTaskZkMetadataManager _zkMetadataManager;
-  private MinionConf _minionConf;
+public class MaterializedViewTaskExecutorFactory extends BaseTaskExecutorFactory {
   private volatile MaterializedViewQueryExecutor _queryExecutor;
-
-  @Override
-  public void init(MinionTaskZkMetadataManager zkMetadataManager, MinionConf minionConf) {
-    _zkMetadataManager = zkMetadataManager;
-    _minionConf = minionConf;
-  }
 
   @Override
   public String getTaskType() {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java
@@ -38,6 +38,7 @@ import org.apache.pinot.segment.local.segment.readers.PinotSegmentRecordReader;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.recordtransformer.RecordTransformer;
 import org.apache.pinot.spi.utils.Obfuscator;
 import org.slf4j.Logger;
@@ -76,7 +77,8 @@ public class MergeRollupTaskExecutor extends BaseMultipleSegmentsConversionExecu
     }
 
     SegmentProcessorConfig.Builder segmentProcessorConfigBuilder =
-        new SegmentProcessorConfig.Builder().setTableConfig(tableConfig).setSchema(schema);
+        new SegmentProcessorConfig.Builder().setTableConfig(tableConfig).setSchema(schema)
+            .setIngestionGroovyPolicy(IngestionGroovyPolicy.fromDisabled(isIngestionGroovyDisabled()));
 
     // Time handler config
     segmentProcessorConfigBuilder

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskExecutor.java
@@ -32,6 +32,7 @@ import org.apache.pinot.plugin.minion.tasks.SegmentConversionResult;
 import org.apache.pinot.spi.accounting.ThreadResourceUsageProvider;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 
 
@@ -41,6 +42,15 @@ public class PurgeTaskExecutor extends BaseSingleSegmentConversionExecutor {
   public static final String RECORD_MODIFIER_KEY = "recordModifier";
   public static final String NUM_RECORDS_PURGED_KEY = "numRecordsPurged";
   public static final String NUM_RECORDS_MODIFIED_KEY = "numRecordsModified";
+  private final IngestionGroovyPolicy _ingestionGroovyPolicy;
+
+  public PurgeTaskExecutor() {
+    this(IngestionGroovyPolicy.DISABLED);
+  }
+
+  public PurgeTaskExecutor(IngestionGroovyPolicy ingestionGroovyPolicy) {
+    _ingestionGroovyPolicy = ingestionGroovyPolicy;
+  }
 
   @Override
   protected SegmentConversionResult convert(PinotTaskConfig pinotTaskConfig, File indexDir, File workingDir)
@@ -61,7 +71,8 @@ public class PurgeTaskExecutor extends BaseSingleSegmentConversionExecutor {
 
     _eventObserver.notifyProgress(pinotTaskConfig, "Purging segment: " + indexDir);
     SegmentPurger segmentPurger =
-        new SegmentPurger(indexDir, workingDir, tableConfig, schema, recordPurger, recordModifier, null);
+        new SegmentPurger(indexDir, workingDir, tableConfig, schema, recordPurger, recordModifier, null,
+            _ingestionGroovyPolicy);
     long purgeTaskStartTimeNs = ThreadResourceUsageProvider.getCurrentThreadCpuTime();
     File purgedSegmentFile = segmentPurger.purgeSegment();
     long purgeTaskEndTimeNs = ThreadResourceUsageProvider.getCurrentThreadCpuTime();

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskExecutorFactory.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskExecutorFactory.java
@@ -19,20 +19,13 @@
 package org.apache.pinot.plugin.minion.tasks.purge;
 
 import org.apache.pinot.core.common.MinionConstants;
-import org.apache.pinot.minion.MinionConf;
-import org.apache.pinot.minion.executor.MinionTaskZkMetadataManager;
 import org.apache.pinot.minion.executor.PinotTaskExecutor;
-import org.apache.pinot.minion.executor.PinotTaskExecutorFactory;
+import org.apache.pinot.plugin.minion.tasks.BaseTaskExecutorFactory;
 import org.apache.pinot.spi.annotations.minion.TaskExecutorFactory;
 
 
 @TaskExecutorFactory
-public class PurgeTaskExecutorFactory implements PinotTaskExecutorFactory {
-
-  @Override
-  public void init(MinionTaskZkMetadataManager zkMetadataManager, MinionConf minionConf) {
-  }
-
+public class PurgeTaskExecutorFactory extends BaseTaskExecutorFactory {
   @Override
   public String getTaskType() {
     return MinionConstants.PurgeTask.TASK_TYPE;
@@ -40,6 +33,6 @@ public class PurgeTaskExecutorFactory implements PinotTaskExecutorFactory {
 
   @Override
   public PinotTaskExecutor create() {
-    return new PurgeTaskExecutor();
+    return new PurgeTaskExecutor(getIngestionGroovyPolicy());
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutor.java
@@ -42,6 +42,7 @@ import org.apache.pinot.segment.local.segment.readers.PinotSegmentRecordReader;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.utils.Obfuscator;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
@@ -124,7 +125,8 @@ public class RealtimeToOfflineSegmentsTaskExecutor extends BaseMultipleSegmentsC
     Schema schema = getSchema(offlineTableName);
 
     SegmentProcessorConfig.Builder segmentProcessorConfigBuilder =
-        new SegmentProcessorConfig.Builder().setTableConfig(tableConfig).setSchema(schema);
+        new SegmentProcessorConfig.Builder().setTableConfig(tableConfig).setSchema(schema)
+            .setIngestionGroovyPolicy(IngestionGroovyPolicy.fromDisabled(isIngestionGroovyDisabled()));
 
     // Time handler config
     segmentProcessorConfigBuilder

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutorFactory.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutorFactory.java
@@ -19,25 +19,14 @@
 package org.apache.pinot.plugin.minion.tasks.realtimetoofflinesegments;
 
 import org.apache.pinot.core.common.MinionConstants;
-import org.apache.pinot.minion.MinionConf;
-import org.apache.pinot.minion.executor.MinionTaskZkMetadataManager;
 import org.apache.pinot.minion.executor.PinotTaskExecutor;
-import org.apache.pinot.minion.executor.PinotTaskExecutorFactory;
+import org.apache.pinot.plugin.minion.tasks.BaseTaskExecutorFactory;
 import org.apache.pinot.spi.annotations.minion.TaskExecutorFactory;
 
 
 /// Factory for creating [RealtimeToOfflineSegmentsTaskExecutor] tasks
 @TaskExecutorFactory
-public class RealtimeToOfflineSegmentsTaskExecutorFactory implements PinotTaskExecutorFactory {
-  private MinionTaskZkMetadataManager _zkMetadataManager;
-  private MinionConf _minionConf;
-
-  @Override
-  public void init(MinionTaskZkMetadataManager zkMetadataManager, MinionConf minionConf) {
-    _zkMetadataManager = zkMetadataManager;
-    _minionConf = minionConf;
-  }
-
+public class RealtimeToOfflineSegmentsTaskExecutorFactory extends BaseTaskExecutorFactory {
   @Override
   public String getTaskType() {
     return MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE;

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/refreshsegment/RefreshSegmentTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/refreshsegment/RefreshSegmentTaskExecutor.java
@@ -43,6 +43,7 @@ import org.apache.pinot.spi.config.instance.InstanceType;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.utils.Obfuscator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,7 +52,16 @@ import org.slf4j.LoggerFactory;
 public class RefreshSegmentTaskExecutor extends BaseSingleSegmentConversionExecutor {
   private static final Logger LOGGER = LoggerFactory.getLogger(RefreshSegmentTaskExecutor.class);
 
+  private final IngestionGroovyPolicy _ingestionGroovyPolicy;
   private long _taskStartTime;
+
+  public RefreshSegmentTaskExecutor() {
+    this(IngestionGroovyPolicy.DISABLED);
+  }
+
+  public RefreshSegmentTaskExecutor(IngestionGroovyPolicy ingestionGroovyPolicy) {
+    _ingestionGroovyPolicy = ingestionGroovyPolicy;
+  }
 
   /// The code here currently covers segment refresh for the following cases:
   /// 1. Process newly added columns.
@@ -147,7 +157,7 @@ public class RefreshSegmentTaskExecutor extends BaseSingleSegmentConversionExecu
     try (PinotSegmentRecordReader recordReader = new PinotSegmentRecordReader()) {
       recordReader.init(segment);
       SegmentGeneratorConfig config = getSegmentGeneratorConfig(workingDir, tableConfig, segmentMetadata, segmentName,
-          getSchema(tableNameWithType));
+          getSchema(tableNameWithType), _ingestionGroovyPolicy.isIngestionGroovyDisabled());
       SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
       driver.init(config, recordReader);
       driver.build();
@@ -174,8 +184,9 @@ public class RefreshSegmentTaskExecutor extends BaseSingleSegmentConversionExecu
   }
 
   private static SegmentGeneratorConfig getSegmentGeneratorConfig(File workingDir, TableConfig tableConfig,
-      SegmentMetadataImpl segmentMetadata, String segmentName, Schema schema) {
+      SegmentMetadataImpl segmentMetadata, String segmentName, Schema schema, boolean disableGroovy) {
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+    config.setIngestionGroovyDisabled(disableGroovy);
     config.setInstanceType(InstanceType.MINION);
     config.setOutDir(workingDir.getPath());
     config.setSegmentName(segmentName);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/refreshsegment/RefreshSegmentTaskExecutorFactory.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/refreshsegment/RefreshSegmentTaskExecutorFactory.java
@@ -19,20 +19,13 @@
 package org.apache.pinot.plugin.minion.tasks.refreshsegment;
 
 import org.apache.pinot.core.common.MinionConstants;
-import org.apache.pinot.minion.MinionConf;
-import org.apache.pinot.minion.executor.MinionTaskZkMetadataManager;
 import org.apache.pinot.minion.executor.PinotTaskExecutor;
-import org.apache.pinot.minion.executor.PinotTaskExecutorFactory;
+import org.apache.pinot.plugin.minion.tasks.BaseTaskExecutorFactory;
 import org.apache.pinot.spi.annotations.minion.TaskExecutorFactory;
 
 
 @TaskExecutorFactory
-public class RefreshSegmentTaskExecutorFactory implements PinotTaskExecutorFactory {
-
-  @Override
-  public void init(MinionTaskZkMetadataManager zkMetadataManager, MinionConf minionConf) {
-  }
-
+public class RefreshSegmentTaskExecutorFactory extends BaseTaskExecutorFactory {
   @Override
   public String getTaskType() {
     return MinionConstants.RefreshSegmentTask.TASK_TYPE;
@@ -40,6 +33,6 @@ public class RefreshSegmentTaskExecutorFactory implements PinotTaskExecutorFacto
 
   @Override
   public PinotTaskExecutor create() {
-    return new RefreshSegmentTaskExecutor();
+    return new RefreshSegmentTaskExecutor(getIngestionGroovyPolicy());
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskExecutor.java
@@ -42,6 +42,7 @@ import org.apache.pinot.segment.local.utils.SegmentPushUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.ingestion.batch.spec.Constants;
 import org.apache.pinot.spi.ingestion.batch.spec.PinotClusterSpec;
@@ -102,6 +103,15 @@ public class SegmentGenerationAndPushTaskExecutor extends BaseTaskExecutor {
 
   private PinotTaskConfig _pinotTaskConfig;
   private MinionEventObserver _eventObserver;
+  private final IngestionGroovyPolicy _ingestionGroovyPolicy;
+
+  public SegmentGenerationAndPushTaskExecutor() {
+    this(IngestionGroovyPolicy.DISABLED);
+  }
+
+  public SegmentGenerationAndPushTaskExecutor(IngestionGroovyPolicy ingestionGroovyPolicy) {
+    _ingestionGroovyPolicy = ingestionGroovyPolicy;
+  }
 
   @Override
   protected SegmentZKMetadataCustomMapModifier getSegmentZKMetadataCustomMapModifier(PinotTaskConfig pinotTaskConfig,
@@ -138,7 +148,7 @@ public class SegmentGenerationAndPushTaskExecutor extends BaseTaskExecutor {
       throws Exception {
     // Generate Pinot Segment
     _eventObserver.notifyProgress(_pinotTaskConfig, "Generating segment");
-    SegmentGenerationTaskRunner taskRunner = new SegmentGenerationTaskRunner(taskSpec);
+    SegmentGenerationTaskRunner taskRunner = new SegmentGenerationTaskRunner(taskSpec, _ingestionGroovyPolicy);
     String segmentName = taskRunner.run();
 
     // Tar segment directory to compress file

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskExecutorFactory.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskExecutorFactory.java
@@ -19,20 +19,13 @@
 package org.apache.pinot.plugin.minion.tasks.segmentgenerationandpush;
 
 import org.apache.pinot.core.common.MinionConstants;
-import org.apache.pinot.minion.MinionConf;
-import org.apache.pinot.minion.executor.MinionTaskZkMetadataManager;
 import org.apache.pinot.minion.executor.PinotTaskExecutor;
-import org.apache.pinot.minion.executor.PinotTaskExecutorFactory;
+import org.apache.pinot.plugin.minion.tasks.BaseTaskExecutorFactory;
 import org.apache.pinot.spi.annotations.minion.TaskExecutorFactory;
 
 
 @TaskExecutorFactory
-public class SegmentGenerationAndPushTaskExecutorFactory implements PinotTaskExecutorFactory {
-
-  @Override
-  public void init(MinionTaskZkMetadataManager zkMetadataManager, MinionConf minionConf) {
-  }
-
+public class SegmentGenerationAndPushTaskExecutorFactory extends BaseTaskExecutorFactory {
   @Override
   public String getTaskType() {
     return MinionConstants.SegmentGenerationAndPushTask.TASK_TYPE;
@@ -40,6 +33,6 @@ public class SegmentGenerationAndPushTaskExecutorFactory implements PinotTaskExe
 
   @Override
   public PinotTaskExecutor create() {
-    return new SegmentGenerationAndPushTaskExecutor();
+    return new SegmentGenerationAndPushTaskExecutor(getIngestionGroovyPolicy());
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
@@ -36,6 +36,7 @@ import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.spi.config.instance.InstanceType;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.utils.Obfuscator;
 import org.roaringbitmap.RoaringBitmap;
 import org.slf4j.Logger;
@@ -44,6 +45,15 @@ import org.slf4j.LoggerFactory;
 
 public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExecutor {
   private static final Logger LOGGER = LoggerFactory.getLogger(UpsertCompactionTaskExecutor.class);
+  private final IngestionGroovyPolicy _ingestionGroovyPolicy;
+
+  public UpsertCompactionTaskExecutor() {
+    this(IngestionGroovyPolicy.DISABLED);
+  }
+
+  public UpsertCompactionTaskExecutor(IngestionGroovyPolicy ingestionGroovyPolicy) {
+    _ingestionGroovyPolicy = ingestionGroovyPolicy;
+  }
 
   @Override
   protected SegmentConversionResult convert(PinotTaskConfig pinotTaskConfig, File indexDir, File workingDir)
@@ -110,7 +120,7 @@ public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExe
     try (CompactedPinotSegmentRecordReader compactedRecordReader = new CompactedPinotSegmentRecordReader(validDocIds)) {
       compactedRecordReader.init(indexDir, null, null);
       SegmentGeneratorConfig config = getSegmentGeneratorConfig(workingDir, tableConfig, segmentMetadata, segmentName,
-          getSchema(tableNameWithType));
+          getSchema(tableNameWithType), _ingestionGroovyPolicy.isIngestionGroovyDisabled());
       SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
       driver.init(config, compactedRecordReader);
       driver.build();
@@ -138,8 +148,9 @@ public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExe
   }
 
   private static SegmentGeneratorConfig getSegmentGeneratorConfig(File workingDir, TableConfig tableConfig,
-      SegmentMetadataImpl segmentMetadata, String segmentName, Schema schema) {
+      SegmentMetadataImpl segmentMetadata, String segmentName, Schema schema, boolean disableGroovy) {
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+    config.setIngestionGroovyDisabled(disableGroovy);
     config.setInstanceType(InstanceType.MINION);
     config.setOutDir(workingDir.getPath());
     config.setSegmentName(segmentName);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutorFactory.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutorFactory.java
@@ -19,20 +19,13 @@
 package org.apache.pinot.plugin.minion.tasks.upsertcompaction;
 
 import org.apache.pinot.core.common.MinionConstants;
-import org.apache.pinot.minion.MinionConf;
-import org.apache.pinot.minion.executor.MinionTaskZkMetadataManager;
 import org.apache.pinot.minion.executor.PinotTaskExecutor;
-import org.apache.pinot.minion.executor.PinotTaskExecutorFactory;
+import org.apache.pinot.plugin.minion.tasks.BaseTaskExecutorFactory;
 import org.apache.pinot.spi.annotations.minion.TaskExecutorFactory;
 
 
 @TaskExecutorFactory
-public class UpsertCompactionTaskExecutorFactory implements PinotTaskExecutorFactory {
-
-  @Override
-  public void init(MinionTaskZkMetadataManager zkMetadataManager, MinionConf minionConf) {
-  }
-
+public class UpsertCompactionTaskExecutorFactory extends BaseTaskExecutorFactory {
   @Override
   public String getTaskType() {
     return MinionConstants.UpsertCompactionTask.TASK_TYPE;
@@ -40,6 +33,6 @@ public class UpsertCompactionTaskExecutorFactory implements PinotTaskExecutorFac
 
   @Override
   public PinotTaskExecutor create() {
-    return new UpsertCompactionTaskExecutor();
+    return new UpsertCompactionTaskExecutor(getIngestionGroovyPolicy());
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskExecutor.java
@@ -45,6 +45,7 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderFileConfig;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.utils.Obfuscator;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.roaringbitmap.RoaringBitmap;
@@ -81,7 +82,8 @@ public class UpsertCompactMergeTaskExecutor extends BaseMultipleSegmentsConversi
     Schema schema = getSchema(tableNameWithType);
 
     SegmentProcessorConfig.Builder segmentProcessorConfigBuilder =
-        new SegmentProcessorConfig.Builder().setTableConfig(tableConfig).setSchema(schema);
+        new SegmentProcessorConfig.Builder().setTableConfig(tableConfig).setSchema(schema)
+            .setIngestionGroovyPolicy(IngestionGroovyPolicy.fromDisabled(isIngestionGroovyDisabled()));
 
     // Progress observer
     segmentProcessorConfigBuilder.setProgressObserver(p -> _eventObserver.notifyProgress(_pinotTaskConfig, p));

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskExecutorFactory.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskExecutorFactory.java
@@ -19,23 +19,13 @@
 package org.apache.pinot.plugin.minion.tasks.upsertcompactmerge;
 
 import org.apache.pinot.core.common.MinionConstants;
-import org.apache.pinot.minion.MinionConf;
-import org.apache.pinot.minion.executor.MinionTaskZkMetadataManager;
 import org.apache.pinot.minion.executor.PinotTaskExecutor;
-import org.apache.pinot.minion.executor.PinotTaskExecutorFactory;
+import org.apache.pinot.plugin.minion.tasks.BaseTaskExecutorFactory;
 import org.apache.pinot.spi.annotations.minion.TaskExecutorFactory;
 
 
 @TaskExecutorFactory
-public class UpsertCompactMergeTaskExecutorFactory implements PinotTaskExecutorFactory {
-
-  private MinionConf _minionConf;
-
-  @Override
-  public void init(MinionTaskZkMetadataManager zkMetadataManager, MinionConf minionConf) {
-    _minionConf = minionConf;
-  }
-
+public class UpsertCompactMergeTaskExecutorFactory extends BaseTaskExecutorFactory {
   @Override
   public String getTaskType() {
     return MinionConstants.UpsertCompactMergeTask.TASK_TYPE;

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskExecutorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskExecutorTest.java
@@ -26,11 +26,14 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.pinot.minion.MinionConf;
 import org.apache.pinot.minion.event.DefaultMinionEventObserver;
 import org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationTaskRunner;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationTaskSpec;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -41,6 +44,15 @@ import static org.testng.Assert.assertTrue;
 
 /// Tests for [SegmentGenerationAndPushTaskExecutor]
 public class SegmentGenerationAndPushTaskExecutorTest {
+
+  @Test
+  public void testFactoryPropagatesExplicitGroovyOptIn()
+      throws IllegalAccessException {
+    SegmentGenerationAndPushTaskExecutorFactory factory = new SegmentGenerationAndPushTaskExecutorFactory();
+    factory.init(null, new MinionConf(Map.of(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY, false)));
+    SegmentGenerationAndPushTaskExecutor executor = (SegmentGenerationAndPushTaskExecutor) factory.create();
+    assertEquals(FieldUtils.readField(executor, "_ingestionGroovyPolicy", true), IngestionGroovyPolicy.ENABLED);
+  }
 
   @Test
   public void testGenerateTaskSpec()

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/GroovyFunctionEvaluator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/GroovyFunctionEvaluator.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.segment.local.function;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 
 
 /// Deprecated forwarding wrapper for the legacy Groovy evaluator type name.
@@ -33,7 +34,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 public class GroovyFunctionEvaluator extends org.apache.pinot.common.evaluator.GroovyFunctionEvaluator
     implements FunctionEvaluator {
   public GroovyFunctionEvaluator(String closure) {
-    super(closure);
+    super(validateIngestionPolicy(closure));
+  }
+
+  private static String validateIngestionPolicy(String closure) {
+    FunctionEvaluatorFactory.validateIngestionGroovyPolicy(closure);
+    return closure;
   }
 
   public static String getGroovyExpressionPrefix() {
@@ -41,6 +47,7 @@ public class GroovyFunctionEvaluator extends org.apache.pinot.common.evaluator.G
   }
 
   public static void parseGroovyScript(String script) {
+    FunctionEvaluatorFactory.validateIngestionGroovyPolicy(script);
     org.apache.pinot.common.evaluator.GroovyFunctionEvaluator.parseGroovyScript(script);
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
@@ -42,6 +43,7 @@ import org.apache.pinot.spi.config.table.SegmentZKPropsConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.roaringbitmap.RoaringBitmap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,10 +62,19 @@ public class RealtimeSegmentConverter {
   private final boolean _nullHandlingEnabled;
   private final boolean _enableColumnMajor;
   private final ServerMetrics _serverMetrics;
+  private final boolean _ingestionGroovyDisabled;
 
   public RealtimeSegmentConverter(MutableSegmentImpl realtimeSegment, SegmentZKPropsConfig segmentZKPropsConfig,
       String outputPath, Schema schema, String tableName, TableConfig tableConfig, String segmentName,
       boolean nullHandlingEnabled) {
+    this(realtimeSegment, segmentZKPropsConfig, outputPath, schema, tableName, tableConfig, segmentName,
+        nullHandlingEnabled,
+        IngestionGroovyPolicy.fromDisabled(FunctionEvaluatorFactory.isIngestionGroovyDisabled()));
+  }
+
+  public RealtimeSegmentConverter(MutableSegmentImpl realtimeSegment, SegmentZKPropsConfig segmentZKPropsConfig,
+      String outputPath, Schema schema, String tableName, TableConfig tableConfig, String segmentName,
+      boolean nullHandlingEnabled, IngestionGroovyPolicy ingestionGroovyPolicy) {
     _realtimeSegmentImpl = realtimeSegment;
     _segmentZKPropsConfig = segmentZKPropsConfig;
     _outputPath = outputPath;
@@ -72,6 +83,7 @@ public class RealtimeSegmentConverter {
     _tableConfig = tableConfig;
     _segmentName = segmentName;
     _nullHandlingEnabled = nullHandlingEnabled;
+    _ingestionGroovyDisabled = ingestionGroovyPolicy.isIngestionGroovyDisabled();
     if (_tableConfig.getIngestionConfig() != null
         && _tableConfig.getIngestionConfig().getStreamIngestionConfig() != null) {
       _enableColumnMajor =
@@ -87,6 +99,7 @@ public class RealtimeSegmentConverter {
     SegmentGeneratorConfig genConfig = new SegmentGeneratorConfig(_tableConfig, _dataSchema);
     genConfig.setInstanceType(InstanceType.SERVER);
     genConfig.setRealtimeConversion(true);
+    genConfig.setIngestionGroovyDisabled(_ingestionGroovyDisabled);
     genConfig.setConsumerDir(_realtimeSegmentImpl.getConsumerDir());
 
     // The segment generation code in SegmentColumnarIndexCreator will throw

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/writer/StatelessRealtimeSegmentWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/writer/StatelessRealtimeSegmentWriter.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.TarCompressionUtils;
@@ -52,6 +53,7 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.stream.MessageBatch;
 import org.apache.pinot.spi.stream.PartitionGroupConsumer;
@@ -68,6 +70,7 @@ import org.apache.pinot.spi.stream.StreamMessageMetadata;
 import org.apache.pinot.spi.stream.StreamMetadataProvider;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffsetFactory;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.spi.utils.retry.RetryPolicies;
@@ -112,6 +115,7 @@ public class StatelessRealtimeSegmentWriter implements Closeable {
   private volatile StreamPartitionMsgOffset _currentOffset;
   private final int _fetchTimeoutMs;
   private final TransformPipeline _transformPipeline;
+  private final boolean _disableGroovy;
   private volatile boolean _isSuccess = false;
   private volatile Throwable _consumptionException;
 
@@ -161,7 +165,12 @@ public class StatelessRealtimeSegmentWriter implements Closeable {
     _consumer = _consumerFactory.createPartitionGroupConsumer(clientId, partitionGroupConsumptionStatus);
 
     // Initialize decoder
-    Set<String> fieldsToRead = IngestionUtils.getFieldsForRecordExtractor(_tableConfig, _schema);
+    boolean disableGroovy = FunctionEvaluatorFactory.resolveIngestionGroovyDisabled(
+        indexLoadingConfig.getInstanceDataManagerConfig()
+        != null ? indexLoadingConfig.getInstanceDataManagerConfig().getConfig()
+        .getProperty(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY) : null);
+    _disableGroovy = disableGroovy;
+    Set<String> fieldsToRead = IngestionUtils.getFieldsForRecordExtractor(_tableConfig, _schema, disableGroovy);
     _decoder = createDecoder(fieldsToRead);
 
     // Fetch capacity from indexLoadingConfig or use default
@@ -200,7 +209,8 @@ public class StatelessRealtimeSegmentWriter implements Closeable {
 
     _realtimeSegment = new MutableSegmentImpl(realtimeSegmentConfigBuilder.build(), null);
 
-    _transformPipeline = new TransformPipeline(_tableConfig, _schema);
+    _transformPipeline = new TransformPipeline(_tableConfig, _schema,
+        IngestionGroovyPolicy.fromDisabled(disableGroovy));
 
     // Initialize fetch timeout
     _fetchTimeoutMs =
@@ -359,7 +369,8 @@ public class StatelessRealtimeSegmentWriter implements Closeable {
           new RealtimeSegmentConverter(_realtimeSegment, segmentZKPropsConfig, _resourceTmpDir.getAbsolutePath(),
               _schema,
               _tableNameWithType, _tableConfig, _segmentZKMetadata.getSegmentName(),
-              _tableConfig.getIndexingConfig().isNullHandlingEnabled());
+              _tableConfig.getIndexingConfig().isNullHandlingEnabled(),
+              IngestionGroovyPolicy.fromDisabled(_disableGroovy));
       try {
         converter.build(null);
       } catch (Exception e) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
@@ -39,6 +39,7 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.function.FunctionEvaluator;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.recordtransformer.RecordTransformer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,6 +71,13 @@ public class ExpressionTransformer implements RecordTransformer {
   private final ThrottledLogger _throttledLogger;
 
   public ExpressionTransformer(TableConfig tableConfig, Schema schema) {
+    this(tableConfig, schema,
+        IngestionGroovyPolicy.fromDisabled(FunctionEvaluatorFactory.isIngestionGroovyDisabled()));
+  }
+
+  public ExpressionTransformer(TableConfig tableConfig, Schema schema,
+      IngestionGroovyPolicy ingestionGroovyPolicy) {
+    boolean ingestionGroovyDisabled = ingestionGroovyPolicy.isIngestionGroovyDisabled();
     Map<String, FunctionEvaluator> expressionEvaluators = new HashMap<>();
     IngestionConfig ingestionConfig = tableConfig.getIngestionConfig();
     List<TransformConfig> transformConfigs =
@@ -77,7 +85,8 @@ public class ExpressionTransformer implements RecordTransformer {
     if (transformConfigs != null) {
       for (TransformConfig transformConfig : transformConfigs) {
         FunctionEvaluator previous = expressionEvaluators.put(transformConfig.getColumnName(),
-            FunctionEvaluatorFactory.getExpressionEvaluator(transformConfig.getTransformFunction()));
+            FunctionEvaluatorFactory.getExpressionEvaluator(transformConfig.getTransformFunction(),
+                ingestionGroovyDisabled));
         Preconditions.checkState(previous == null,
             "Cannot set more than one transform function on column: %s.", transformConfig.getColumnName());
       }
@@ -85,7 +94,8 @@ public class ExpressionTransformer implements RecordTransformer {
     for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
       String fieldName = fieldSpec.getName();
       if (!fieldSpec.isVirtualColumn() && !expressionEvaluators.containsKey(fieldName)) {
-        FunctionEvaluator functionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(fieldSpec);
+        FunctionEvaluator functionEvaluator =
+            FunctionEvaluatorFactory.getExpressionEvaluator(fieldSpec, ingestionGroovyDisabled);
         if (functionEvaluator != null) {
           expressionEvaluators.put(fieldName, functionEvaluator);
           if (isImplicitMapTransform(fieldSpec)) {
@@ -105,10 +115,18 @@ public class ExpressionTransformer implements RecordTransformer {
   /// transforms where derived columns should be recomputed on the merged row.
   public ExpressionTransformer(List<TransformConfig> transformConfigs, boolean overwriteExistingValues,
       boolean continueOnError) {
+    this(transformConfigs, overwriteExistingValues, continueOnError,
+        IngestionGroovyPolicy.fromDisabled(FunctionEvaluatorFactory.isIngestionGroovyDisabled()));
+  }
+
+  public ExpressionTransformer(List<TransformConfig> transformConfigs, boolean overwriteExistingValues,
+      boolean continueOnError, IngestionGroovyPolicy ingestionGroovyPolicy) {
+    boolean ingestionGroovyDisabled = ingestionGroovyPolicy.isIngestionGroovyDisabled();
     Map<String, FunctionEvaluator> expressionEvaluators = new HashMap<>();
     for (TransformConfig transformConfig : transformConfigs) {
       FunctionEvaluator previous = expressionEvaluators.put(transformConfig.getColumnName(),
-          FunctionEvaluatorFactory.getExpressionEvaluator(transformConfig.getTransformFunction()));
+          FunctionEvaluatorFactory.getExpressionEvaluator(transformConfig.getTransformFunction(),
+              ingestionGroovyDisabled));
       Preconditions.checkState(previous == null,
           "Cannot set more than one transform function on column: %s.", transformConfig.getColumnName());
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/FilterTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/FilterTransformer.java
@@ -26,6 +26,7 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.function.FunctionEvaluator;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.recordtransformer.RecordTransformer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,13 +45,19 @@ public class FilterTransformer implements RecordTransformer {
   private long _numRecordsFiltered;
 
   public FilterTransformer(TableConfig tableConfig) {
+    this(tableConfig, IngestionGroovyPolicy.fromDisabled(FunctionEvaluatorFactory.isIngestionGroovyDisabled()));
+  }
+
+  public FilterTransformer(TableConfig tableConfig, IngestionGroovyPolicy ingestionGroovyPolicy) {
     IngestionConfig ingestionConfig = tableConfig.getIngestionConfig();
     if (ingestionConfig != null && ingestionConfig.getFilterConfig() != null) {
       _filterFunction = ingestionConfig.getFilterConfig().getFilterFunction();
     } else {
       _filterFunction = null;
     }
-    _evaluator = _filterFunction != null ? FunctionEvaluatorFactory.getExpressionEvaluator(_filterFunction) : null;
+    _evaluator = _filterFunction != null
+        ? FunctionEvaluatorFactory.getExpressionEvaluator(_filterFunction,
+            ingestionGroovyPolicy.isIngestionGroovyDisabled()) : null;
     _continueOnError = ingestionConfig != null && ingestionConfig.isContinueOnError();
     _throttledLogger = new ThrottledLogger(LOGGER, ingestionConfig);
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerUtils.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.config.table.ingestion.EnrichmentConfig;
@@ -33,8 +34,10 @@ import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.SourceFieldConfig;
 import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.recordtransformer.RecordTransformer;
 import org.apache.pinot.spi.recordtransformer.enricher.RecordEnricher;
+import org.apache.pinot.spi.recordtransformer.enricher.RecordEnricherCreationContext;
 import org.apache.pinot.spi.recordtransformer.enricher.RecordEnricherRegistry;
 import org.apache.pinot.spi.utils.PinotDataType;
 
@@ -72,10 +75,18 @@ public class RecordTransformerUtils {
   public static List<RecordTransformer> getTransformers(TableConfig tableConfig, @Nullable Schema schema,
       boolean skipPreComplexTypeTransformers, boolean skipComplexTypeTransformer,
       boolean skipPostComplexTypeTransformers, boolean skipFilterTransformer) {
+    return getTransformers(tableConfig, schema, skipPreComplexTypeTransformers, skipComplexTypeTransformer,
+        skipPostComplexTypeTransformers, skipFilterTransformer,
+        FunctionEvaluatorFactory.isIngestionGroovyDisabled());
+  }
+
+  public static List<RecordTransformer> getTransformers(TableConfig tableConfig, @Nullable Schema schema,
+      boolean skipPreComplexTypeTransformers, boolean skipComplexTypeTransformer,
+      boolean skipPostComplexTypeTransformers, boolean skipFilterTransformer, boolean disableGroovy) {
     List<RecordTransformer> transformers = new ArrayList<>();
     if (!skipPreComplexTypeTransformers) {
       addSourceFieldDataTypeTransformer(tableConfig, transformers, true);
-      addRecordEnricherTransformers(tableConfig, transformers, true);
+      addRecordEnricherTransformers(tableConfig, transformers, true, disableGroovy);
     }
     if (!skipComplexTypeTransformer) {
       addIfNotNoOp(transformers, ComplexTypeTransformer.create(tableConfig));
@@ -86,10 +97,11 @@ public class RecordTransformerUtils {
     Preconditions.checkState(schema != null,
         "Schema must be provided when post complex type transformers are requested");
     addSourceFieldDataTypeTransformer(tableConfig, transformers, false);
-    addRecordEnricherTransformers(tableConfig, transformers, false);
-    addIfNotNoOp(transformers, new ExpressionTransformer(tableConfig, schema));
+    addRecordEnricherTransformers(tableConfig, transformers, false, disableGroovy);
+    IngestionGroovyPolicy ingestionGroovyPolicy = IngestionGroovyPolicy.fromDisabled(disableGroovy);
+    addIfNotNoOp(transformers, new ExpressionTransformer(tableConfig, schema, ingestionGroovyPolicy));
     if (!skipFilterTransformer) {
-      addIfNotNoOp(transformers, new FilterTransformer(tableConfig));
+      addIfNotNoOp(transformers, new FilterTransformer(tableConfig, ingestionGroovyPolicy));
     }
     addIfNotNoOp(transformers, SchemaConformingTransformer.create(tableConfig, schema));
     addIfNotNoOp(transformers, new DataTypeTransformer(tableConfig, schema));
@@ -104,6 +116,11 @@ public class RecordTransformerUtils {
     return getTransformers(tableConfig, schema, false, false, false, false);
   }
 
+  public static List<RecordTransformer> getDefaultTransformers(TableConfig tableConfig, Schema schema,
+      boolean disableGroovy) {
+    return getTransformers(tableConfig, schema, false, false, false, false, disableGroovy);
+  }
+
   /// Returns transformers to apply after a partial upsert merge. Only post-merge transform configs are honored to avoid
   /// re-running ingestion-time transforms. Derived columns must exist in the schema to be queryable.
   ///
@@ -112,6 +129,13 @@ public class RecordTransformerUtils {
   /// @return List of transformers to apply after merge, or `null` if none configured
   @Nullable
   public static List<RecordTransformer> getPostPartialUpsertTransformers(TableConfig tableConfig, Schema schema) {
+    return getPostPartialUpsertTransformers(tableConfig, schema,
+        FunctionEvaluatorFactory.isIngestionGroovyDisabled());
+  }
+
+  @Nullable
+  public static List<RecordTransformer> getPostPartialUpsertTransformers(TableConfig tableConfig, Schema schema,
+      boolean disableGroovy) {
     UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
     if (upsertConfig == null) {
       return null;
@@ -127,7 +151,7 @@ public class RecordTransformerUtils {
     boolean continueOnError = ingestionConfig != null && ingestionConfig.isContinueOnError();
     addIfNotNoOp(transformers,
         new ExpressionTransformer(postPartialUpsertTransformConfigs, true /* overwriteExistingValues */,
-            continueOnError));
+            continueOnError, IngestionGroovyPolicy.fromDisabled(disableGroovy)));
     addIfNotNoOp(transformers, new DataTypeTransformer(tableConfig, schema));
     addIfNotNoOp(transformers, new TimeValidationTransformer(tableConfig, schema));
     addIfNotNoOp(transformers, new SpecialValueTransformer(schema));
@@ -166,7 +190,7 @@ public class RecordTransformerUtils {
   }
 
   private static void addRecordEnricherTransformers(TableConfig tableConfig, List<RecordTransformer> transformers,
-      boolean preComplexTypeTransformers) {
+      boolean preComplexTypeTransformers, boolean disableGroovy) {
     IngestionConfig ingestionConfig = tableConfig.getIngestionConfig();
     if (ingestionConfig != null) {
       List<EnrichmentConfig> enrichmentConfigs = ingestionConfig.getEnrichmentConfigs();
@@ -179,7 +203,8 @@ public class RecordTransformerUtils {
           }
           RecordEnricher recordEnricher;
           try {
-            recordEnricher = RecordEnricherRegistry.createRecordEnricher(enrichmentConfig);
+            recordEnricher = RecordEnricherRegistry.createRecordEnricher(enrichmentConfig,
+                new RecordEnricherCreationContext(IngestionGroovyPolicy.fromDisabled(disableGroovy)));
           } catch (IOException e) {
             throw new RuntimeException("Failed to instantiate record enricher " + enrichmentConfig.getEnricherType(),
                 e);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/enricher/function/CustomFunctionEnricher.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/enricher/function/CustomFunctionEnricher.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.function.FunctionEvaluator;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.recordtransformer.enricher.RecordEnricher;
 import org.apache.pinot.spi.utils.JsonUtils;
 
@@ -40,13 +41,20 @@ public class CustomFunctionEnricher implements RecordEnricher {
 
   public CustomFunctionEnricher(JsonNode enricherProps)
       throws IOException {
+    this(enricherProps, IngestionGroovyPolicy.fromDisabled(
+        FunctionEvaluatorFactory.isIngestionGroovyDisabled()));
+  }
+
+  public CustomFunctionEnricher(JsonNode enricherProps, IngestionGroovyPolicy ingestionGroovyPolicy)
+      throws IOException {
     CustomFunctionEnricherConfig config = JsonUtils.jsonNodeToObject(enricherProps, CustomFunctionEnricherConfig.class);
     _fieldToFunctionEvaluator = new LinkedHashMap<>();
     _fieldsToExtract = new ArrayList<>();
     for (Map.Entry<String, String> entry : config.getFieldToFunctionMap().entrySet()) {
       String column = entry.getKey();
       String function = entry.getValue();
-      FunctionEvaluator functionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(function);
+      FunctionEvaluator functionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(function,
+          ingestionGroovyPolicy.isIngestionGroovyDisabled());
       _fieldToFunctionEvaluator.put(column, functionEvaluator);
       _fieldsToExtract.addAll(functionEvaluator.getArguments());
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/enricher/function/CustomFunctionEnricherFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/enricher/function/CustomFunctionEnricherFactory.java
@@ -23,6 +23,7 @@ import com.google.auto.service.AutoService;
 import java.io.IOException;
 import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.spi.recordtransformer.enricher.RecordEnricher;
+import org.apache.pinot.spi.recordtransformer.enricher.RecordEnricherCreationContext;
 import org.apache.pinot.spi.recordtransformer.enricher.RecordEnricherFactory;
 import org.apache.pinot.spi.recordtransformer.enricher.RecordEnricherValidationConfig;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -44,17 +45,35 @@ public class CustomFunctionEnricherFactory implements RecordEnricherFactory {
   }
 
   @Override
+  public RecordEnricher createEnricher(JsonNode enricherProps, RecordEnricherCreationContext creationContext)
+      throws IOException {
+    return new CustomFunctionEnricher(enricherProps, creationContext.getIngestionGroovyPolicy());
+  }
+
+  @Override
+  public void validateSecurityPolicy(JsonNode enricherProps, RecordEnricherValidationConfig validationConfig) {
+    if (enricherProps == null) {
+      return;
+    }
+    JsonNode fieldToFunctionMap = enricherProps.get("fieldToFunctionMap");
+    if (fieldToFunctionMap == null || !fieldToFunctionMap.isObject()) {
+      return;
+    }
+    for (JsonNode function : fieldToFunctionMap) {
+      if (function.isTextual()) {
+        FunctionEvaluatorFactory.validateIngestionGroovyPolicy(function.textValue(),
+            validationConfig.isGroovyDisabled());
+      }
+    }
+  }
+
+  @Override
   public void validateEnrichmentConfig(JsonNode enricherProps, RecordEnricherValidationConfig validationConfig) {
     CustomFunctionEnricherConfig config;
     try {
       config = JsonUtils.jsonNodeToObject(enricherProps, CustomFunctionEnricherConfig.class);
-      if (!validationConfig.isGroovyDisabled()) {
-        return;
-      }
       for (String function : config.getFieldToFunctionMap().values()) {
-        if (FunctionEvaluatorFactory.isGroovyExpression(function)) {
-          throw new IllegalArgumentException("Groovy expression is not allowed for enrichment");
-        }
+        FunctionEvaluatorFactory.validateIngestionGroovyPolicy(function, validationConfig.isGroovyDisabled());
       }
     } catch (IOException e) {
       throw new IllegalArgumentException("Failed to parse custom function enricher config", e);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/TransformPipeline.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/TransformPipeline.java
@@ -27,6 +27,7 @@ import org.apache.pinot.segment.local.recordtransformer.RecordTransformerUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.recordtransformer.RecordTransformer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,6 +68,12 @@ public class TransformPipeline {
 
   public TransformPipeline(TableConfig tableConfig, Schema schema) {
     this(tableConfig.getTableName(), RecordTransformerUtils.getDefaultTransformers(tableConfig, schema));
+  }
+
+  public TransformPipeline(TableConfig tableConfig, Schema schema, IngestionGroovyPolicy ingestionGroovyPolicy) {
+    this(tableConfig.getTableName(),
+        RecordTransformerUtils.getDefaultTransformers(tableConfig, schema,
+            ingestionGroovyPolicy.isIngestionGroovyDisabled()));
   }
 
   public static TransformPipeline getPassThroughPipeline(String tableNameWithType) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.common.metrics.MinionMeter;
 import org.apache.pinot.common.metrics.MinionMetrics;
 import org.apache.pinot.common.metrics.ServerMeter;
@@ -39,6 +40,7 @@ import org.apache.pinot.segment.local.segment.creator.TransformPipeline;
 import org.apache.pinot.segment.local.segment.readers.CompactedPinotSegmentRecordReader;
 import org.apache.pinot.segment.local.segment.readers.PinotSegmentRecordReader;
 import org.apache.pinot.segment.local.utils.IngestionUtils;
+import org.apache.pinot.segment.local.utils.TableConfigUtils;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.creator.ColumnStatistics;
 import org.apache.pinot.segment.spi.creator.SegmentCreationDataSource;
@@ -59,6 +61,7 @@ import org.apache.pinot.spi.data.readers.FileFormat;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderFactory;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.roaringbitmap.RoaringBitmap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,10 +101,10 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
   @Override
   public void init(SegmentGeneratorConfig config)
       throws Exception {
-    init(config, getRecordReader(config));
+    init(config, getRecordReader(config, isGroovyDisabled(config)));
   }
 
-  private RecordReader getRecordReader(SegmentGeneratorConfig segmentGeneratorConfig)
+  private RecordReader getRecordReader(SegmentGeneratorConfig segmentGeneratorConfig, boolean disableGroovy)
       throws Exception {
     File dataFile = new File(segmentGeneratorConfig.getInputFilePath());
     Preconditions.checkState(dataFile.exists(), "Input file: " + dataFile.getAbsolutePath() + " does not exist");
@@ -111,7 +114,7 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
     FileFormat fileFormat = segmentGeneratorConfig.getFormat();
     String recordReaderClassName = segmentGeneratorConfig.getRecordReaderPath();
     Set<String> sourceFields =
-        IngestionUtils.getFieldsForRecordExtractor(tableConfig, segmentGeneratorConfig.getSchema());
+        IngestionUtils.getFieldsForRecordExtractor(tableConfig, segmentGeneratorConfig.getSchema(), disableGroovy);
 
     // Allow for instantiation general record readers from a record reader path passed into segment generator config
     // If this is set, this will override the file format
@@ -142,7 +145,8 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
   public void init(SegmentGeneratorConfig config, RecordReader recordReader)
       throws Exception {
     init(config, new RecordReaderSegmentCreationDataSource(recordReader),
-        new TransformPipeline(config.getTableConfig(), config.getSchema()));
+        new TransformPipeline(config.getTableConfig(), config.getSchema(),
+            IngestionGroovyPolicy.fromDisabled(isGroovyDisabled(config))));
   }
 
   /// Initialize the driver for columnar segment building using a ColumnReaderFactory.
@@ -183,6 +187,7 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
     _schema = config.getSchema();
     _continueOnError = config.isContinueOnError();
     _instanceType = config.getInstanceType();
+    TableConfigUtils.validateGroovyPolicy(config.getTableConfig(), config.getSchema(), isGroovyDisabled(config));
 
     // Handle columnar data sources differently
     String readerClassName = null;
@@ -356,6 +361,10 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
         metrics.addMeteredTableValue(tableNameWithType, ServerMeter.CORRUPTED_RECORD_COUNT, _sanitizedRowsFound);
       }
     }
+  }
+
+  private static boolean isGroovyDisabled(SegmentGeneratorConfig config) {
+    return config.resolveIngestionGroovyDisabled(FunctionEvaluatorFactory.isIngestionGroovyDisabled());
   }
 
   public void buildByColumn(IndexSegment indexSegment, RoaringBitmap validDocIds)

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
@@ -83,6 +83,7 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.function.FunctionEvaluator;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.PinotDataType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -387,7 +388,12 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
       for (TransformConfig transformConfig : transformConfigs) {
         if (transformConfig.getColumnName().equals(column)) {
           String transformFunction = transformConfig.getTransformFunction();
-          FunctionEvaluator functionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(transformFunction);
+          boolean disableGroovy = FunctionEvaluatorFactory.resolveIngestionGroovyDisabled(
+              _indexLoadingConfig.getInstanceDataManagerConfig() != null
+                  ? _indexLoadingConfig.getInstanceDataManagerConfig().getConfig()
+                  .getProperty(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY) : null);
+          FunctionEvaluator functionEvaluator =
+              FunctionEvaluatorFactory.getExpressionEvaluator(transformFunction, disableGroovy);
 
           // Check if all arguments exist in the segment
           // TODO: Support chained derived column

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
@@ -24,12 +24,16 @@ import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.segment.local.utils.SegmentOperationsThrottlerSet;
+import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Server.Upsert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,8 +76,12 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
     Supplier<PartialUpsertHandler> partialUpsertHandlerSupplier = null;
     if (upsertConfig.getMode() == UpsertConfig.Mode.PARTIAL) {
       List<String> handlerComparisonColumns = comparisonColumns;
+      InstanceDataManagerConfig instanceDataManagerConfig = tableDataManager.getInstanceDataManagerConfig();
+      boolean disableGroovy = FunctionEvaluatorFactory.resolveIngestionGroovyDisabled(instanceDataManagerConfig != null
+          ? instanceDataManagerConfig.getConfig().getProperty(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY) : null);
       partialUpsertHandlerSupplier =
-          () -> new PartialUpsertHandler(tableConfig, schema, handlerComparisonColumns, upsertConfig);
+          () -> new PartialUpsertHandler(tableConfig, schema, handlerComparisonColumns, upsertConfig,
+              IngestionGroovyPolicy.fromDisabled(disableGroovy));
     }
 
     boolean enableSnapshot = upsertConfig.getSnapshot()

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.segment.local.recordtransformer.RecordTransformerUtils;
 import org.apache.pinot.segment.local.segment.readers.LazyRow;
 import org.apache.pinot.segment.local.upsert.merger.PartialUpsertMerger;
@@ -32,6 +33,7 @@ import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.recordtransformer.RecordTransformer;
 
 
@@ -58,11 +60,19 @@ public class PartialUpsertHandler {
 
   public PartialUpsertHandler(TableConfig tableConfig, Schema schema, List<String> comparisonColumns,
       UpsertConfig upsertConfig) {
+    this(tableConfig, schema, comparisonColumns, upsertConfig,
+        IngestionGroovyPolicy.fromDisabled(FunctionEvaluatorFactory.isIngestionGroovyDisabled()));
+  }
+
+  public PartialUpsertHandler(TableConfig tableConfig, Schema schema, List<String> comparisonColumns,
+      UpsertConfig upsertConfig, IngestionGroovyPolicy ingestionGroovyPolicy) {
     _primaryKeyColumns = schema.getPrimaryKeyColumns();
     _comparisonColumns = comparisonColumns;
     _partialUpsertMerger =
         PartialUpsertMergerFactory.getPartialUpsertMerger(_primaryKeyColumns, comparisonColumns, upsertConfig);
-    _postUpdateTransformers = RecordTransformerUtils.getPostPartialUpsertTransformers(tableConfig, schema);
+    _postUpdateTransformers =
+        RecordTransformerUtils.getPostPartialUpsertTransformers(tableConfig, schema,
+            ingestionGroovyPolicy.isIngestionGroovyDisabled());
     // cache default null values to handle null merger results
     for (Map.Entry<String, FieldSpec> entry : schema.getFieldSpecMap().entrySet()) {
       String column = entry.getKey();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.auth.AuthProviderUtils;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.apache.pinot.segment.local.recordtransformer.ComplexTypeTransformer;
@@ -55,6 +56,7 @@ import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.LocalPinotFS;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 import org.apache.pinot.spi.ingestion.batch.BatchConfig;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.ingestion.batch.spec.PinotClusterSpec;
@@ -299,6 +301,12 @@ public final class IngestionUtils {
   /// 2. The ingestion config in the table config. The ingestion config (e.g. filter, complexType) can have fields which
   /// are not in the schema.
   public static Set<String> getFieldsForRecordExtractor(TableConfig tableConfig, Schema schema) {
+    return getFieldsForRecordExtractor(tableConfig, schema,
+        FunctionEvaluatorFactory.isIngestionGroovyDisabled());
+  }
+
+  public static Set<String> getFieldsForRecordExtractor(TableConfig tableConfig, Schema schema,
+      boolean disableGroovy) {
     IngestionConfig ingestionConfig = tableConfig.getIngestionConfig();
     if (ingestionConfig != null && ingestionConfig.getSchemaConformingTransformerConfig() != null) {
       // The SchemaConformingTransformer requires that all fields are extracted, indicated by returning an empty set
@@ -317,7 +325,8 @@ public final class IngestionUtils {
         }
       }
     }
-    fields.addAll(new TransformPipeline(tableConfig, schema).getInputColumns());
+    fields.addAll(new TransformPipeline(tableConfig, schema, IngestionGroovyPolicy.fromDisabled(disableGroovy))
+        .getInputColumns());
     return getFieldsToReadWithComplexType(fields, ingestionConfig);
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
@@ -77,6 +77,12 @@ public class SchemaUtils {
 
   public static void validate(Schema schema, List<TableConfig> tableConfigs, boolean isIgnoreCase,
       @Nullable Schema existingSchema) {
+    validate(schema, tableConfigs, isIgnoreCase, existingSchema,
+        FunctionEvaluatorFactory.isIngestionGroovyDisabled());
+  }
+
+  public static void validate(Schema schema, List<TableConfig> tableConfigs, boolean isIgnoreCase,
+      @Nullable Schema existingSchema, boolean disableGroovy) {
     // The deprecation reject is intentionally placed only in this REST-driven overload (not in the single-arg
     // `validate(Schema)` that server-side table loading uses), so existing legacy schemas in ZK keep
     // loading. New / updated schemas submitted via the controller REST API are blocked.
@@ -84,9 +90,9 @@ public class SchemaUtils {
     rejectDeprecatedTimeFieldSpec(schema);
     validateIngestionTransformVolatility(schema, existingSchema);
     for (TableConfig tableConfig : tableConfigs) {
-      validateCompatibilityWithTableConfig(schema, tableConfig);
+      validateCompatibilityWithTableConfig(schema, tableConfig, disableGroovy);
     }
-    validate(schema, isIgnoreCase);
+    validate(schema, isIgnoreCase, disableGroovy);
   }
 
   /// Validates that new or changed legacy schema-level transform functions are immutable. An exact transform on the
@@ -140,10 +146,14 @@ public class SchemaUtils {
   /// 5) Checks valid dateTimeFieldSpecs - checks format and granularity string
   /// 6) Schema validations from [Schema#validate]
   public static void validate(Schema schema) {
-    validate(schema, false);
+    validate(schema, false, FunctionEvaluatorFactory.isIngestionGroovyDisabled());
   }
 
   public static void validate(Schema schema, boolean isIgnoreCase) {
+    validate(schema, isIgnoreCase, FunctionEvaluatorFactory.isIngestionGroovyDisabled());
+  }
+
+  public static void validate(Schema schema, boolean isIgnoreCase, boolean disableGroovy) {
     schema.validate();
 
     if (isIgnoreCase) {
@@ -173,8 +183,12 @@ public class SchemaUtils {
       }
       String transformFunction = fieldSpec.getTransformFunction();
       if (transformFunction != null) {
+        // Enforce the ingestion Groovy policy before constructing the evaluator. Besides preserving a clear
+        // configuration error, this guarantees schema validation cannot compile Groovy while it is disabled.
+        FunctionEvaluatorFactory.validateIngestionGroovyPolicy(transformFunction, disableGroovy);
         try {
-          List<String> arguments = FunctionEvaluatorFactory.getExpressionEvaluator(fieldSpec).getArguments();
+          List<String> arguments =
+              FunctionEvaluatorFactory.getExpressionEvaluator(fieldSpec, disableGroovy).getArguments();
           Preconditions.checkState(!arguments.contains(column),
               "The arguments of transform function %s should not contain the destination column %s",
               transformFunction, column);
@@ -231,12 +245,13 @@ public class SchemaUtils {
   }
 
   /// Validates that the schema is compatible with the given table config
-  private static void validateCompatibilityWithTableConfig(Schema schema, TableConfig tableConfig) {
+  private static void validateCompatibilityWithTableConfig(Schema schema, TableConfig tableConfig,
+      boolean disableGroovy) {
     try {
       // The associated table config already exists and is not being changed by schema validation. Pass it as the
       // existing config so unchanged legacy transforms remain grandfathered while all schema-dependent validation
       // still runs against the proposed schema.
-      TableConfigUtils.validate(tableConfig, schema, null, tableConfig);
+      TableConfigUtils.validate(tableConfig, schema, null, tableConfig, disableGroovy);
     } catch (Exception e) {
       throw new IllegalStateException(
           "Schema is incompatible with tableConfig with name: " + tableConfig.getTableName() + " and type: "

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -143,12 +143,10 @@ public final class TableConfigUtils {
       ImmutableSet.of(RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE,
           RoutingConfig.MULTI_STAGE_REPLICA_GROUP_SELECTOR_TYPE);
 
-  private static boolean _disableGroovy;
-
   private static boolean _enforcePoolBasedAssignment;
 
   public static void setDisableGroovy(boolean disableGroovy) {
-    _disableGroovy = disableGroovy;
+    FunctionEvaluatorFactory.setIngestionGroovyDisabled(disableGroovy);
   }
 
   public static void setEnforcePoolBasedAssignment(boolean enforcePoolBasedAssignment) {
@@ -175,15 +173,21 @@ public final class TableConfigUtils {
 
   public static void validate(TableConfig tableConfig, Schema schema, @Nullable String typesToSkip,
       @Nullable TableConfig existingTableConfig) {
+    validate(tableConfig, schema, typesToSkip, existingTableConfig,
+        FunctionEvaluatorFactory.isIngestionGroovyDisabled());
+  }
+
+  public static void validate(TableConfig tableConfig, Schema schema, @Nullable String typesToSkip,
+      @Nullable TableConfig existingTableConfig, boolean disableGroovy) {
     Preconditions.checkArgument(schema != null, "Schema should not be null for table: %s", tableConfig.getTableName());
     Set<ValidationType> skipTypes = parseTypesToSkipString(typesToSkip);
-    validateEffectiveTableConfig(tableConfig, schema, skipTypes, existingTableConfig);
+    validateEffectiveTableConfig(tableConfig, schema, skipTypes, existingTableConfig, disableGroovy);
     if (skipTypes.contains(ValidationType.ALL) || !hasConsumingSegmentTierOverwriteForRealtimeTable(tableConfig)) {
       return;
     }
     try {
       TableConfig consumingTableConfig = overwriteTableConfigForConsumingSegmentTier(tableConfig);
-      validateEffectiveTableConfig(consumingTableConfig, schema, skipTypes, existingTableConfig);
+      validateEffectiveTableConfig(consumingTableConfig, schema, skipTypes, existingTableConfig, disableGroovy);
     } catch (RuntimeException e) {
       throw new IllegalStateException(
           "tierOverwrites.consuming produces an invalid table config: " + e.getMessage(), e);
@@ -191,7 +195,9 @@ public final class TableConfigUtils {
   }
 
   private static void validateEffectiveTableConfig(TableConfig tableConfig, Schema schema,
-      Set<ValidationType> skipTypes, @Nullable TableConfig existingTableConfig) {
+      Set<ValidationType> skipTypes, @Nullable TableConfig existingTableConfig, boolean disableGroovy) {
+    validateGroovyPolicy(tableConfig, schema, disableGroovy);
+
     // Sanitize the table config before validation
     sanitize(tableConfig);
 
@@ -210,7 +216,7 @@ public final class TableConfigUtils {
 
     validateValidationConfig(tableConfig, schema);
     validateSegmentAssignmentConfig(tableConfig);
-    validateIngestionConfig(tableConfig, schema, existingTableConfig);
+    validateIngestionConfig(tableConfig, schema, existingTableConfig, disableGroovy);
     if (tableConfig.getTableType() == TableType.REALTIME) {
       validateStreamConfigMaps(tableConfig);
     }
@@ -221,7 +227,7 @@ public final class TableConfigUtils {
     validateInstanceAssignmentConfigs(tableConfig);
 
     if (!skipTypes.contains(ValidationType.UPSERT)) {
-      validateUpsertAndDedupConfig(tableConfig, schema, existingTableConfig);
+      validateUpsertAndDedupConfig(tableConfig, schema, existingTableConfig, disableGroovy);
     }
 
     validateTaskConfig(tableConfig);
@@ -229,6 +235,47 @@ public final class TableConfigUtils {
 
     if (_enforcePoolBasedAssignment) {
       validateInstancePoolsAndReplicaGroups(tableConfig);
+    }
+  }
+
+  public static void validateGroovyPolicy(TableConfig tableConfig, Schema schema, boolean disableGroovy) {
+    for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
+      validateGroovyPolicy(fieldSpec.getTransformFunction(), disableGroovy);
+    }
+
+    IngestionConfig ingestionConfig = tableConfig.getIngestionConfig();
+    if (ingestionConfig != null) {
+      FilterConfig filterConfig = ingestionConfig.getFilterConfig();
+      if (filterConfig != null) {
+        validateGroovyPolicy(filterConfig.getFilterFunction(), disableGroovy);
+      }
+      List<TransformConfig> transformConfigs = ingestionConfig.getTransformConfigs();
+      if (transformConfigs != null) {
+        for (TransformConfig transformConfig : transformConfigs) {
+          validateGroovyPolicy(transformConfig.getTransformFunction(), disableGroovy);
+        }
+      }
+      List<EnrichmentConfig> enrichmentConfigs = ingestionConfig.getEnrichmentConfigs();
+      if (enrichmentConfigs != null) {
+        for (EnrichmentConfig enrichmentConfig : enrichmentConfigs) {
+          RecordEnricherRegistry.validateSecurityPolicy(enrichmentConfig,
+              new RecordEnricherValidationConfig(disableGroovy));
+        }
+      }
+    }
+
+    List<TransformConfig> postPartialUpsertTransformConfigs =
+        getPostPartialUpsertTransformConfigs(tableConfig);
+    if (postPartialUpsertTransformConfigs != null) {
+      for (TransformConfig transformConfig : postPartialUpsertTransformConfigs) {
+        validateGroovyPolicy(transformConfig.getTransformFunction(), disableGroovy);
+      }
+    }
+  }
+
+  private static void validateGroovyPolicy(@Nullable String transformFunction, boolean disableGroovy) {
+    if (transformFunction != null) {
+      FunctionEvaluatorFactory.validateIngestionGroovyPolicy(transformFunction, disableGroovy);
     }
   }
 
@@ -463,12 +510,18 @@ public final class TableConfigUtils {
   /// - Schema-conforming transformer config.
   @VisibleForTesting
   public static void validateIngestionConfig(TableConfig tableConfig, Schema schema) {
-    validateIngestionConfig(tableConfig, schema, null);
+    validateIngestionConfig(tableConfig, schema, null, FunctionEvaluatorFactory.isIngestionGroovyDisabled());
   }
 
   @VisibleForTesting
   static void validateIngestionConfig(TableConfig tableConfig, Schema schema,
       @Nullable TableConfig existingTableConfig) {
+    validateIngestionConfig(tableConfig, schema, existingTableConfig,
+        FunctionEvaluatorFactory.isIngestionGroovyDisabled());
+  }
+
+  private static void validateIngestionConfig(TableConfig tableConfig, Schema schema,
+      @Nullable TableConfig existingTableConfig, boolean disableGroovy) {
     // All metrics-aggregation validation lives here; it returns the columns referenced as aggregation sources, which
     // a transform config is allowed to target as its destination (see the transform validation below).
     Set<String> aggregationSourceColumns = validateMetricsAggregation(tableConfig, schema);
@@ -534,12 +587,9 @@ public final class TableConfigUtils {
     if (filterConfig != null) {
       String filterFunction = filterConfig.getFilterFunction();
       if (filterFunction != null) {
-        if (_disableGroovy && FunctionEvaluatorFactory.isGroovyExpression(filterFunction)) {
-          throw new IllegalStateException(
-              "Groovy filter functions are disabled for table config. Found '" + filterFunction + "'");
-        }
         try {
-          FunctionEvaluatorFactory.getExpressionEvaluator(filterFunction);
+          FunctionEvaluatorFactory.validateIngestionGroovyPolicy(filterFunction, disableGroovy);
+          FunctionEvaluatorFactory.getExpressionEvaluator(filterFunction, disableGroovy);
         } catch (Exception e) {
           throw new IllegalStateException(
               "Invalid filter function '" + filterFunction + "', exception: " + e.getMessage(), e);
@@ -569,7 +619,7 @@ public final class TableConfigUtils {
     if (enrichmentConfigs != null) {
       for (EnrichmentConfig enrichmentConfig : enrichmentConfigs) {
         RecordEnricherRegistry.validateEnrichmentConfig(enrichmentConfig,
-            new RecordEnricherValidationConfig(_disableGroovy));
+            new RecordEnricherValidationConfig(disableGroovy));
       }
     }
 
@@ -590,11 +640,11 @@ public final class TableConfigUtils {
         // Skip Groovy expressions when Groovy is disabled: do not compile them just to collect arguments (the main
         // loop below rejects Groovy without compiling). Such a config is rejected anyway, so these columns are not
         // needed as valid intermediate targets.
-        if (transformFunction != null && !(_disableGroovy && FunctionEvaluatorFactory.isGroovyExpression(
-            transformFunction))) {
+        if (transformFunction != null
+            && !(disableGroovy && FunctionEvaluatorFactory.isGroovyExpression(transformFunction))) {
           try {
             transformInputColumns.addAll(
-                FunctionEvaluatorFactory.getExpressionEvaluator(transformFunction).getArguments());
+                FunctionEvaluatorFactory.getExpressionEvaluator(transformFunction, disableGroovy).getArguments());
           } catch (Exception ignore) {
             // Invalid functions are reported with a descriptive error in the main loop below.
           }
@@ -616,16 +666,12 @@ public final class TableConfigUtils {
             + "' of the transform function must be present in the schema, be consumed as the input of another "
             + "transform function, or be a source column for aggregations");
         FunctionEvaluator expressionEvaluator;
-        if (_disableGroovy && FunctionEvaluatorFactory.isGroovyExpression(transformFunction)) {
-          throw new IllegalStateException(
-              "Groovy transform functions are disabled for table config. Found '" + transformFunction + "' for column '"
-                  + columnName + "'");
-        }
         try {
+          FunctionEvaluatorFactory.validateIngestionGroovyPolicy(transformFunction, disableGroovy);
           if (tableConfig.getTableType() == TableType.REALTIME) {
             validateIngestionTransformFunctionVolatility(transformConfig, existingTransformConfigs);
           }
-          expressionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(transformFunction);
+          expressionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(transformFunction, disableGroovy);
         } catch (Exception e) {
           throw new IllegalStateException(
               "Invalid transform function '" + transformFunction + "' for column '" + columnName + "', exception: "
@@ -997,11 +1043,18 @@ public final class TableConfigUtils {
   /// - Dedup: delegates to [#validateTTLForDedupConfig]; rejects MD5 when disabled.
   @VisibleForTesting
   static void validateUpsertAndDedupConfig(TableConfig tableConfig, Schema schema) {
-    validateUpsertAndDedupConfig(tableConfig, schema, null);
+    validateUpsertAndDedupConfig(tableConfig, schema, null,
+        FunctionEvaluatorFactory.isIngestionGroovyDisabled());
   }
 
   static void validateUpsertAndDedupConfig(TableConfig tableConfig, Schema schema,
       @Nullable TableConfig existingTableConfig) {
+    validateUpsertAndDedupConfig(tableConfig, schema, existingTableConfig,
+        FunctionEvaluatorFactory.isIngestionGroovyDisabled());
+  }
+
+  private static void validateUpsertAndDedupConfig(TableConfig tableConfig, Schema schema,
+      @Nullable TableConfig existingTableConfig, boolean disableGroovy) {
     boolean upsertEnabled = tableConfig.isUpsertEnabled();
     boolean dedupEnabled = tableConfig.isDedupEnabled();
     if (!upsertEnabled && !dedupEnabled) {
@@ -1165,16 +1218,12 @@ public final class TableConfigUtils {
           Preconditions.checkState(schema.hasColumn(columnName),
               "The destination column '%s' of the post-partial-upsert transform function must be present in the "
                   + "schema", columnName);
-          if (_disableGroovy && FunctionEvaluatorFactory.isGroovyExpression(transformFunction)) {
-            throw new IllegalStateException(
-                "Groovy transform functions are disabled. Found '" + transformFunction + "' for column '"
-                    + columnName + "' in postPartialUpsertTransformConfigs");
-          }
           try {
+            FunctionEvaluatorFactory.validateIngestionGroovyPolicy(transformFunction, disableGroovy);
             validateIngestionTransformFunctionVolatility(transformConfig,
                 existingPostPartialUpsertTransformConfigs);
             FunctionEvaluator expressionEvaluator =
-                FunctionEvaluatorFactory.getExpressionEvaluator(transformFunction);
+                FunctionEvaluatorFactory.getExpressionEvaluator(transformFunction, disableGroovy);
             List<String> arguments = expressionEvaluator.getArguments();
             if (arguments.contains(columnName)) {
               throw new IllegalStateException(

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/function/FunctionPackageCompatibilityTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/function/FunctionPackageCompatibilityTest.java
@@ -24,6 +24,7 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 
@@ -48,13 +49,23 @@ public class FunctionPackageCompatibilityTest {
       throws Exception {
     GroovyStaticAnalyzerConfig config = GroovyStaticAnalyzerConfig.createDefault();
     GroovyFunctionEvaluator.setGroovyStaticAnalyzerConfig(config);
+    org.apache.pinot.common.evaluator.FunctionEvaluatorFactory.setIngestionGroovyDisabled(false);
     try {
       GroovyFunctionEvaluator.parseGroovyScript("Groovy({a + 1}, a)");
       FunctionEvaluator evaluator = FunctionEvaluatorFactory.getExpressionEvaluator("Groovy({a + 1}, a)");
       assertTrue(evaluator instanceof org.apache.pinot.common.evaluator.GroovyFunctionEvaluator);
       assertEquals(evaluator.evaluate(new Object[]{1}), 2);
+      assertEquals(new GroovyFunctionEvaluator("Groovy({a + 1}, a)").evaluate(new Object[]{1}), 2);
     } finally {
+      org.apache.pinot.common.evaluator.FunctionEvaluatorFactory.setIngestionGroovyDisabled(true);
       GroovyFunctionEvaluator.setGroovyStaticAnalyzerConfig(null);
     }
+  }
+
+  @Test
+  public void testLegacyGroovyConstructorHonorsIngestionPolicy() {
+    org.apache.pinot.common.evaluator.FunctionEvaluatorFactory.setIngestionGroovyDisabled(true);
+    assertThrows(IllegalStateException.class, () -> new GroovyFunctionEvaluator("Groovy({1})"));
+    assertThrows(IllegalStateException.class, () -> GroovyFunctionEvaluator.parseGroovyScript("Groovy({1})"));
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformerTest.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
@@ -36,11 +37,66 @@ import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 
 /// Tests the evaluation of transform expressions by the ExpressionTransformer
 public class ExpressionTransformerTest {
+
+  @BeforeClass
+  public void enableGroovyForLegacyTransformTests() {
+    FunctionEvaluatorFactory.setIngestionGroovyDisabled(false);
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void restoreDefaultGroovyPolicy() {
+    FunctionEvaluatorFactory.setIngestionGroovyDisabled(true);
+  }
+
+  @Test
+  public void testRuntimeGroovyPolicyForRealtimeAndOfflineTransforms() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("legacySchema")
+        .addSingleValueDimension("source", FieldSpec.DataType.STRING)
+        .addSingleValueDimension("result", FieldSpec.DataType.STRING).build();
+    TableConfig realtimeTableConfig =
+        new TableConfigBuilder(TableType.REALTIME).setTableName("legacySchema").build();
+    schema.getFieldSpecFor("result").setTransformFunction("Groovy({source.reverse()}, source)");
+
+    FunctionEvaluatorFactory.setIngestionGroovyDisabled(true);
+    try {
+      IllegalStateException schemaException = Assert.expectThrows(IllegalStateException.class,
+          () -> new ExpressionTransformer(realtimeTableConfig, schema));
+      Assert.assertTrue(schemaException.getMessage().contains("controller.disable.ingestion.groovy=false"));
+
+      schema.getFieldSpecFor("result").setTransformFunction("reverse(source)");
+      ExpressionTransformer builtInTransformer = new ExpressionTransformer(realtimeTableConfig, schema);
+      GenericRow builtInRow = new GenericRow();
+      builtInRow.putValue("source", "pinot");
+      builtInTransformer.transform(builtInRow);
+      Assert.assertEquals(builtInRow.getValue("result"), "tonip");
+
+      schema.getFieldSpecFor("result").setTransformFunction(null);
+      IngestionConfig ingestionConfig = new IngestionConfig();
+      ingestionConfig.setTransformConfigs(
+          List.of(new TransformConfig("result", "Groovy({source.reverse()}, source)")));
+      TableConfig offlineTableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("legacySchema")
+          .setIngestionConfig(ingestionConfig).build();
+      IllegalStateException tableException = Assert.expectThrows(IllegalStateException.class,
+          () -> new ExpressionTransformer(offlineTableConfig, schema));
+      Assert.assertTrue(tableException.getMessage().contains("controller.disable.ingestion.groovy=false"));
+
+      FunctionEvaluatorFactory.setIngestionGroovyDisabled(false);
+      ExpressionTransformer enabledTransformer = new ExpressionTransformer(offlineTableConfig, schema);
+      GenericRow enabledRow = new GenericRow();
+      enabledRow.putValue("source", "pinot");
+      enabledTransformer.transform(enabledRow);
+      Assert.assertEquals(enabledRow.getValue("result"), "tonip");
+    } finally {
+      FunctionEvaluatorFactory.setIngestionGroovyDisabled(false);
+    }
+  }
 
   @Test
   public void testTransformConfigsFromTableConfig() {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.common.utils.ServiceStartableUtils;
 import org.apache.pinot.segment.local.segment.creator.TransformPipeline;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -47,6 +48,8 @@ import org.apache.pinot.spi.recordtransformer.RecordTransformer;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.PinotDataType;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
@@ -59,6 +62,16 @@ public class RecordTransformerTest {
 
   // Transform multiple times should return the same result
   private static final int NUM_ROUNDS = 5;
+
+  @BeforeClass
+  public void enableGroovyForLegacyTransformerTests() {
+    FunctionEvaluatorFactory.setIngestionGroovyDisabled(false);
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void restoreDefaultGroovyPolicy() {
+    FunctionEvaluatorFactory.setIngestionGroovyDisabled(true);
+  }
 
   private static Schema createSchema() {
     Schema schema = new Schema.SchemaBuilder()

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/TransformPipelineTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/TransformPipelineTest.java
@@ -18,17 +18,23 @@
  */
 package org.apache.pinot.segment.local.segment.creator;
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.ingestion.EnrichmentConfig;
+import org.apache.pinot.spi.config.table.ingestion.FilterConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.FieldSpec.MaxLengthExceedStrategy;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.Test;
@@ -37,6 +43,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 
 public class TransformPipelineTest {
@@ -864,5 +871,69 @@ public class TransformPipelineTest {
     assertEquals(result.getIncompleteRowCount(), 1);
     assertEquals(result.getSanitizedRowCount(), 0);
     assertEquals(result.getSkippedRowCount(), 0);
+  }
+
+  @Test
+  public void testExplicitGroovyPolicyForFilter() {
+    Schema schema = new Schema.SchemaBuilder()
+        .setSchemaName("testTable")
+        .addSingleValueDimension("source", DataType.STRING)
+        .build();
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setFilterConfig(new FilterConfig("Groovy({source == 'drop'}, source)"));
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("testTable")
+        .setIngestionConfig(ingestionConfig)
+        .build();
+
+    IllegalStateException exception =
+        expectThrows(IllegalStateException.class,
+            () -> new TransformPipeline(tableConfig, schema, IngestionGroovyPolicy.DISABLED));
+    assertTrue(exception.getMessage().contains(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY));
+
+    TransformPipeline pipeline = new TransformPipeline(tableConfig, schema, IngestionGroovyPolicy.ENABLED);
+    GenericRow filteredRow = new GenericRow();
+    filteredRow.putValue("source", "drop");
+    TransformPipeline.Result filteredResult = pipeline.processRow(filteredRow);
+    assertTrue(filteredResult.getTransformedRows().isEmpty());
+    assertEquals(filteredResult.getSkippedRowCount(), 1);
+
+    GenericRow retainedRow = new GenericRow();
+    retainedRow.putValue("source", "keep");
+    TransformPipeline.Result retainedResult = pipeline.processRow(retainedRow);
+    assertEquals(retainedResult.getTransformedRows().size(), 1);
+    assertEquals(retainedResult.getTransformedRows().get(0).getValue("source"), "keep");
+  }
+
+  @Test
+  public void testExplicitGroovyPolicyForGenerateColumnEnricher() {
+    Schema schema = new Schema.SchemaBuilder()
+        .setSchemaName("testTable")
+        .addSingleValueDimension("source", DataType.STRING)
+        .addSingleValueDimension("destination", DataType.STRING)
+        .build();
+    ObjectNode fieldToFunctionMap = JsonNodeFactory.instance.objectNode();
+    fieldToFunctionMap.put("destination", "Groovy({source.reverse()}, source)");
+    ObjectNode enrichmentProperties = JsonNodeFactory.instance.objectNode();
+    enrichmentProperties.set("fieldToFunctionMap", fieldToFunctionMap);
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setEnrichmentConfigs(
+        List.of(new EnrichmentConfig("generateColumn", enrichmentProperties, false)));
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("testTable")
+        .setIngestionConfig(ingestionConfig)
+        .build();
+
+    IllegalStateException exception =
+        expectThrows(IllegalStateException.class,
+            () -> new TransformPipeline(tableConfig, schema, IngestionGroovyPolicy.DISABLED));
+    assertTrue(exception.getMessage().contains(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY));
+
+    TransformPipeline pipeline = new TransformPipeline(tableConfig, schema, IngestionGroovyPolicy.ENABLED);
+    GenericRow row = new GenericRow();
+    row.putValue("source", "abc");
+    TransformPipeline.Result result = pipeline.processRow(row);
+    assertEquals(result.getTransformedRows().size(), 1);
+    assertEquals(result.getTransformedRows().get(0).getValue("destination"), "cba");
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/SegmentGenerationWithFilterRecordsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/SegmentGenerationWithFilterRecordsTest.java
@@ -22,7 +22,9 @@ import com.google.common.collect.Lists;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.segment.local.PinotBuffersAfterMethodCheckRule;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
@@ -35,12 +37,17 @@ import org.apache.pinot.spi.config.table.ingestion.FilterConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.ColumnReaderFactory;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 
 /// Tests filtering of records during segment generation
@@ -64,6 +71,7 @@ public class SegmentGenerationWithFilterRecordsTest implements PinotBuffersAfter
 
   @BeforeClass
   public void setup() {
+    FunctionEvaluatorFactory.setIngestionGroovyDisabled(false);
     String filterFunction =
         "Groovy({((col2 < 1589007600000L) &&  (col3.max() < 4)) || col1 == \"B\"}, col1, col2, col3)";
     IngestionConfig ingestionConfig = new IngestionConfig();
@@ -73,6 +81,11 @@ public class SegmentGenerationWithFilterRecordsTest implements PinotBuffersAfter
     _schema = new Schema.SchemaBuilder().addSingleValueDimension(STRING_COLUMN, FieldSpec.DataType.STRING)
         .addMetric(LONG_COLUMN, FieldSpec.DataType.LONG).addMultiValueDimension(MV_INT_COLUMN, FieldSpec.DataType.INT)
         .build();
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void restoreDefaultGroovyPolicy() {
+    FunctionEvaluatorFactory.setIngestionGroovyDisabled(true);
   }
 
   @BeforeMethod
@@ -94,9 +107,58 @@ public class SegmentGenerationWithFilterRecordsTest implements PinotBuffersAfter
     }
   }
 
+  @Test
+  public void testOfflineSegmentGenerationEnforcesLegacyFieldSpecGroovyPolicy()
+      throws Exception {
+    Schema legacySchema = new Schema.SchemaBuilder()
+        .addSingleValueDimension(STRING_COLUMN, FieldSpec.DataType.STRING)
+        .addSingleValueDimension("derived", FieldSpec.DataType.STRING)
+        .addMetric(LONG_COLUMN, FieldSpec.DataType.LONG)
+        .addMultiValueDimension(MV_INT_COLUMN, FieldSpec.DataType.INT).build();
+    legacySchema.getFieldSpecFor("derived")
+        .setTransformFunction("Groovy({col1.reverse()}, col1)");
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
+
+    boolean originalDisableGroovy = FunctionEvaluatorFactory.isIngestionGroovyDisabled();
+    try {
+      FunctionEvaluatorFactory.setIngestionGroovyDisabled(true);
+      IllegalStateException exception =
+          Assert.expectThrows(IllegalStateException.class, () -> buildSegment(tableConfig, legacySchema));
+      Assert.assertTrue(exception.getMessage().contains("controller.disable.ingestion.groovy=false"));
+
+      FunctionEvaluatorFactory.setIngestionGroovyDisabled(false);
+      File segmentDir = buildSegment(tableConfig, legacySchema);
+      try (PinotSegmentRecordReader segmentRecordReader = new PinotSegmentRecordReader(segmentDir)) {
+        Assert.assertEquals(segmentRecordReader.next().getValue("derived"),
+            new StringBuilder(STRING_VALUES[0]).reverse().toString());
+      }
+    } finally {
+      FunctionEvaluatorFactory.setIngestionGroovyDisabled(originalDisableGroovy);
+    }
+  }
+
+  @Test
+  public void testColumnarSegmentGenerationRejectsLegacyFieldSpecGroovy()
+      throws Exception {
+    Schema legacySchema = new Schema.SchemaBuilder()
+        .addSingleValueDimension(STRING_COLUMN, FieldSpec.DataType.STRING)
+        .addSingleValueDimension("derived", FieldSpec.DataType.STRING).build();
+    legacySchema.getFieldSpecFor("derived").setTransformFunction("Groovy({col1.reverse()}, col1)");
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, legacySchema);
+    config.setIngestionGroovyDisabled(true);
+    ColumnReaderFactory columnReaderFactory = mock(ColumnReaderFactory.class);
+    when(columnReaderFactory.getAllColumnReaders()).thenReturn(Map.of());
+
+    IllegalStateException exception = Assert.expectThrows(IllegalStateException.class,
+        () -> new SegmentIndexCreationDriverImpl().init(config, columnReaderFactory));
+    Assert.assertTrue(exception.getMessage().contains("controller.disable.ingestion.groovy=false"));
+  }
+
   private File buildSegment(final TableConfig tableConfig, final Schema schema)
       throws Exception {
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+    config.setIngestionGroovyDisabled(FunctionEvaluatorFactory.isIngestionGroovyDisabled());
     config.setOutDir(SEGMENT_DIR_NAME);
     config.setSegmentName(SEGMENT_NAME);
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/IngestionUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/IngestionUtilsTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.ingestion.AggregationConfig;
@@ -40,11 +41,23 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 
 /// Tests fields extraction from Schema dna TableConfig for ingestion
 public class IngestionUtilsTest {
+
+  @BeforeClass
+  public void enableGroovyForLegacyIngestionTests() {
+    FunctionEvaluatorFactory.setIngestionGroovyDisabled(false);
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void restoreDefaultGroovyPolicy() {
+    FunctionEvaluatorFactory.setIngestionGroovyDisabled(true);
+  }
 
   /// Transform functions have moved to table config. This test remains for backward compatible handling testing
   @Test

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
+import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.common.tier.TierFactory;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.Constants;
@@ -61,6 +62,7 @@ import org.apache.pinot.spi.config.table.assignment.SegmentAssignmentConfig;
 import org.apache.pinot.spi.config.table.ingestion.AggregationConfig;
 import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.ComplexTypeConfig;
+import org.apache.pinot.spi.config.table.ingestion.EnrichmentConfig;
 import org.apache.pinot.spi.config.table.ingestion.FilterConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.SourceFieldConfig;
@@ -87,6 +89,8 @@ import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.PinotDataType;
 import org.apache.pinot.spi.utils.PinotMd5Mode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -103,6 +107,73 @@ public class TableConfigUtilsTest {
 
   private static final RoutingConfig STRICT_REPLICA_ROUTING_CONFIG =
       new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, false);
+
+  @BeforeMethod
+  public void enableGroovyForExistingValidationTests() {
+    FunctionEvaluatorFactory.setIngestionGroovyDisabled(false);
+  }
+
+  @AfterMethod(alwaysRun = true)
+  public void restoreDefaultGroovyPolicy() {
+    FunctionEvaluatorFactory.setIngestionGroovyDisabled(true);
+  }
+
+  @Test
+  public void testGroovyPolicyValidationCannotBeSkipped() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+        .addSingleValueDimension("source", DataType.STRING)
+        .addSingleValueDimension("destination", DataType.STRING)
+        .build();
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setIngestionConfig(ingestionConfig)
+        .build();
+    String groovyFunction = "Groovy({source.reverse()}, source)";
+    FunctionEvaluatorFactory.setIngestionGroovyDisabled(true);
+
+    schema.getFieldSpecFor("destination").setTransformFunction(groovyFunction);
+    assertGroovyPolicyRejected(tableConfig, schema);
+    schema.getFieldSpecFor("destination").setTransformFunction(null);
+
+    ingestionConfig.setFilterConfig(new FilterConfig(groovyFunction));
+    assertGroovyPolicyRejected(tableConfig, schema);
+    ingestionConfig.setFilterConfig(null);
+
+    ingestionConfig.setTransformConfigs(List.of(new TransformConfig("destination", groovyFunction)));
+    assertGroovyPolicyRejected(tableConfig, schema);
+    ingestionConfig.setTransformConfigs(null);
+
+    ObjectNode fieldToFunctionMap = JsonNodeFactory.instance.objectNode();
+    fieldToFunctionMap.put("destination", groovyFunction);
+    ObjectNode enrichmentProperties = JsonNodeFactory.instance.objectNode();
+    enrichmentProperties.set("fieldToFunctionMap", fieldToFunctionMap);
+    ingestionConfig.setEnrichmentConfigs(
+        List.of(new EnrichmentConfig("generateColumn", enrichmentProperties, false)));
+    assertGroovyPolicyRejected(tableConfig, schema);
+    ingestionConfig.setEnrichmentConfigs(null);
+
+    UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.PARTIAL);
+    upsertConfig.setPostPartialUpsertTransformConfigs(
+        List.of(new TransformConfig("destination", groovyFunction)));
+    tableConfig.setUpsertConfig(upsertConfig);
+    assertGroovyPolicyRejected(tableConfig, schema);
+
+    schema.getFieldSpecFor("destination").setTransformFunction("reverse(source)");
+    ingestionConfig.setFilterConfig(new FilterConfig("isNotNull(source)"));
+    ingestionConfig.setTransformConfigs(List.of(new TransformConfig("destination", "reverse(source)")));
+    fieldToFunctionMap.put("destination", "reverse(source)");
+    ingestionConfig.setEnrichmentConfigs(
+        List.of(new EnrichmentConfig("generateColumn", enrichmentProperties, false)));
+    upsertConfig.setPostPartialUpsertTransformConfigs(
+        List.of(new TransformConfig("destination", "reverse(source)")));
+    TableConfigUtils.validate(tableConfig, schema, "ALL");
+  }
+
+  private static void assertGroovyPolicyRejected(TableConfig tableConfig, Schema schema) {
+    IllegalStateException error = expectThrows(IllegalStateException.class,
+        () -> TableConfigUtils.validate(tableConfig, schema, "ALL"));
+    assertTrue(error.getMessage().contains(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY), error.getMessage());
+  }
 
   @Test
   public void validateTimeColumnValidationConfig() {
@@ -455,14 +526,16 @@ public class TableConfigUtilsTest {
     TableConfigUtils.validate(tableConfig, schema);
 
     // invalid transform config since Groovy is disabled
+    FunctionEvaluatorFactory.setIngestionGroovyDisabled(true);
     try {
-      TableConfigUtils.setDisableGroovy(true);
-      TableConfigUtils.validate(tableConfig, schema);
-      // Reset to false
-      TableConfigUtils.setDisableGroovy(false);
-      fail("Should fail when Groovy functions disabled but found in transform config");
-    } catch (IllegalStateException e) {
-      // expected
+      try {
+        TableConfigUtils.validate(tableConfig, schema);
+        fail("Should fail when Groovy functions disabled but found in transform config");
+      } catch (IllegalStateException e) {
+        // expected
+      }
+    } finally {
+      FunctionEvaluatorFactory.setIngestionGroovyDisabled(false);
     }
 
     // Using peer download scheme with replication of 1
@@ -491,14 +564,16 @@ public class TableConfigUtilsTest {
 
     // invalid filter config since Groovy is disabled
     ingestionConfig.setFilterConfig(new FilterConfig("Groovy({timestamp > 0}, timestamp)"));
+    FunctionEvaluatorFactory.setIngestionGroovyDisabled(true);
     try {
-      TableConfigUtils.setDisableGroovy(true);
-      TableConfigUtils.validate(tableConfig, schema);
-      // Reset to false
-      TableConfigUtils.setDisableGroovy(false);
-      fail("Should fail when Groovy functions disabled but found in filter config");
-    } catch (IllegalStateException e) {
-      // expected
+      try {
+        TableConfigUtils.validate(tableConfig, schema);
+        fail("Should fail when Groovy functions disabled but found in filter config");
+      } catch (IllegalStateException e) {
+        // expected
+      }
+    } finally {
+      FunctionEvaluatorFactory.setIngestionGroovyDisabled(false);
     }
 
     // null transform column name

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -53,6 +53,7 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.FileFormat;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.TimestampIndexUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
@@ -60,6 +61,11 @@ import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 
 /// Configuration properties used in the creation of index segments.
 public class SegmentGeneratorConfig implements Serializable {
+  // Preserve the pre-policy serial form. Older serialized configs contain neither policy field, so the default false
+  // value of _useDefaultIngestionGroovyPolicy plus the null _ingestionGroovyDisabled value is deliberately interpreted
+  // as disabled.
+  private static final long serialVersionUID = 4848997363993935176L;
+
   public enum TimeColumnType {
     EPOCH, SIMPLE_DATE
   }
@@ -125,6 +131,9 @@ public class SegmentGeneratorConfig implements Serializable {
   // Type of the instance (SERVER/MINION) that is trying to create the segment.
   private InstanceType _instanceType;
   private boolean _compressionStatsEnabled;
+  @Nullable
+  private Boolean _ingestionGroovyDisabled;
+  private boolean _useDefaultIngestionGroovyPolicy = true;
 
   /// Constructs the SegmentGeneratorConfig with table config and schema.
   /// NOTE: The passed in table config and schema might be changed.
@@ -686,5 +695,22 @@ public class SegmentGeneratorConfig implements Serializable {
   /// Sets whether this segment build records compression statistics.
   public void setCompressionStatsEnabled(boolean compressionStatsEnabled) {
     _compressionStatsEnabled = compressionStatsEnabled;
+  }
+
+  public boolean isIngestionGroovyDisabled() {
+    return resolveIngestionGroovyDisabled(CommonConstants.Groovy.isIngestionGroovyDisabled(
+        System.getProperty(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY)));
+  }
+
+  /// Resolves an unset policy from the caller's ingestion context. Explicit config values always take precedence;
+  /// configs serialized before the policy fields were introduced remain fail-closed.
+  public boolean resolveIngestionGroovyDisabled(boolean defaultIngestionGroovyDisabled) {
+    return _useDefaultIngestionGroovyPolicy ? defaultIngestionGroovyDisabled
+        : _ingestionGroovyDisabled == null || _ingestionGroovyDisabled;
+  }
+
+  public void setIngestionGroovyDisabled(boolean ingestionGroovyDisabled) {
+    _ingestionGroovyDisabled = ingestionGroovyDisabled;
+    _useDefaultIngestionGroovyPolicy = false;
   }
 }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfigTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.segment.spi.creator;
 
+import java.io.ObjectStreamClass;
+import java.lang.reflect.Field;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.segment.spi.creator.name.FixedSegmentNameGenerator;
 import org.apache.pinot.segment.spi.creator.name.NormalizedDateSegmentNameGenerator;
@@ -33,12 +35,36 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 
 // TODO: add more tests here.
 public class SegmentGeneratorConfigTest {
+
+  @Test
+  public void testGroovyPolicySerializationCompatibility()
+      throws ReflectiveOperationException {
+    assertEquals(ObjectStreamClass.lookup(SegmentGeneratorConfig.class).getSerialVersionUID(),
+        4848997363993935176L);
+
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("test").build();
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, new Schema.SchemaBuilder().build());
+    assertFalse(config.resolveIngestionGroovyDisabled(false));
+    assertTrue(config.resolveIngestionGroovyDisabled(true));
+
+    config.setIngestionGroovyDisabled(false);
+    assertFalse(config.isIngestionGroovyDisabled());
+    assertFalse(config.resolveIngestionGroovyDisabled(true));
+
+    // A config serialized before the policy field was introduced deserializes with a null value and must fail closed.
+    Field ingestionGroovyDisabledField = SegmentGeneratorConfig.class.getDeclaredField("_ingestionGroovyDisabled");
+    ingestionGroovyDisabledField.setAccessible(true);
+    ingestionGroovyDisabledField.set(config, null);
+    assertTrue(config.isIngestionGroovyDisabled());
+  }
 
   @Test
   public void testEpochTime() {

--- a/pinot-server/src/main/java/org/apache/pinot/server/conf/ServerConf.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/conf/ServerConf.java
@@ -37,7 +37,11 @@ public class ServerConf {
   }
 
   public PinotConfiguration getInstanceDataManagerConfig() {
-    return _serverConf.subset(INSTANCE_DATA_MANAGER_CONFIG_PREFIX);
+    PinotConfiguration config = _serverConf.subset(INSTANCE_DATA_MANAGER_CONFIG_PREFIX);
+    config.setProperty(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY,
+        CommonConstants.Groovy.isIngestionGroovyDisabled(
+            _serverConf.getProperty(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY)));
+    return config;
   }
 
   public PinotConfiguration getQueryExecutorConfig() {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -196,7 +196,10 @@ public abstract class BaseServerStarter implements ServiceStartable {
     _zkAddress = _serverConf.getProperty(CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER);
     _helixClusterName = _serverConf.getProperty(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME);
     ServiceStartableUtils.applyClusterConfig(_serverConf, _zkAddress, _helixClusterName, ServiceRole.SERVER);
+    boolean disableGroovy = CommonConstants.Groovy.isIngestionGroovyDisabled(
+        _serverConf.getProperty(CommonConstants.Groovy.DISABLE_INGESTION_GROOVY));
     applyCustomConfigs(_serverConf);
+    ServiceStartableUtils.enforceIngestionGroovyPolicy(_serverConf, disableGroovy, ServiceRole.SERVER);
     ServerContext.getInstance().setQueryOperatorFactoryProvider(createQueryOperatorFactoryProvider(_serverConf));
 
     PinotInsecureMode.setPinotInInsecureMode(

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/IngestionGroovyPolicy.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/IngestionGroovyPolicy.java
@@ -16,23 +16,29 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.plugin.minion.tasks.mergerollup;
-
-import org.apache.pinot.core.common.MinionConstants;
-import org.apache.pinot.minion.executor.PinotTaskExecutor;
-import org.apache.pinot.plugin.minion.tasks.BaseTaskExecutorFactory;
-import org.apache.pinot.spi.annotations.minion.TaskExecutorFactory;
+package org.apache.pinot.spi.ingestion;
 
 
-@TaskExecutorFactory
-public class MergeRollupTaskExecutorFactory extends BaseTaskExecutorFactory {
-  @Override
-  public String getTaskType() {
-    return MinionConstants.MergeRollupTask.TASK_TYPE;
+/// Immutable ingestion policy for Groovy-backed transform functions.
+///
+/// Enum instances are inherently thread-safe and can be shared across ingestion components.
+public enum IngestionGroovyPolicy {
+  ENABLED(false),
+  DISABLED(true);
+
+  private final boolean _ingestionGroovyDisabled;
+
+  IngestionGroovyPolicy(boolean ingestionGroovyDisabled) {
+    _ingestionGroovyDisabled = ingestionGroovyDisabled;
   }
 
-  @Override
-  public PinotTaskExecutor create() {
-    return new MergeRollupTaskExecutor(_minionConf);
+  /// Returns the policy corresponding to the given disabled flag.
+  public static IngestionGroovyPolicy fromDisabled(boolean ingestionGroovyDisabled) {
+    return ingestionGroovyDisabled ? DISABLED : ENABLED;
+  }
+
+  /// Returns whether Groovy-backed ingestion transforms are disabled.
+  public boolean isIngestionGroovyDisabled() {
+    return _ingestionGroovyDisabled;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/recordtransformer/enricher/RecordEnricherCreationContext.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/recordtransformer/enricher/RecordEnricherCreationContext.java
@@ -16,23 +16,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.plugin.minion.tasks.mergerollup;
+package org.apache.pinot.spi.recordtransformer.enricher;
 
-import org.apache.pinot.core.common.MinionConstants;
-import org.apache.pinot.minion.executor.PinotTaskExecutor;
-import org.apache.pinot.plugin.minion.tasks.BaseTaskExecutorFactory;
-import org.apache.pinot.spi.annotations.minion.TaskExecutorFactory;
+import java.util.Objects;
+import org.apache.pinot.spi.ingestion.IngestionGroovyPolicy;
 
 
-@TaskExecutorFactory
-public class MergeRollupTaskExecutorFactory extends BaseTaskExecutorFactory {
-  @Override
-  public String getTaskType() {
-    return MinionConstants.MergeRollupTask.TASK_TYPE;
+/// Immutable, thread-safe context supplied when creating a [RecordEnricher].
+///
+/// Factories must honor the contained ingestion policy when constructing policy-sensitive enrichers.
+public final class RecordEnricherCreationContext {
+  private final IngestionGroovyPolicy _ingestionGroovyPolicy;
+
+  public RecordEnricherCreationContext(IngestionGroovyPolicy ingestionGroovyPolicy) {
+    _ingestionGroovyPolicy = Objects.requireNonNull(ingestionGroovyPolicy, "ingestionGroovyPolicy must not be null");
   }
 
-  @Override
-  public PinotTaskExecutor create() {
-    return new MergeRollupTaskExecutor(_minionConf);
+  public IngestionGroovyPolicy getIngestionGroovyPolicy() {
+    return _ingestionGroovyPolicy;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/recordtransformer/enricher/RecordEnricherFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/recordtransformer/enricher/RecordEnricherFactory.java
@@ -32,6 +32,18 @@ public interface RecordEnricherFactory {
   RecordEnricher createEnricher(JsonNode enricherProps)
       throws IOException;
 
+  /// Creates an enricher using the given non-null runtime context.
+  ///
+  /// The default implementation preserves compatibility for factories that are not policy-sensitive.
+  default RecordEnricher createEnricher(JsonNode enricherProps, RecordEnricherCreationContext creationContext)
+      throws IOException {
+    return createEnricher(enricherProps);
+  }
+
+  /// Validates security policies that must not be skipped with the rest of table-config validation.
+  default void validateSecurityPolicy(JsonNode enricherProps, RecordEnricherValidationConfig validationConfig) {
+  }
+
   /// Validates the enrichment properties.
   void validateEnrichmentConfig(JsonNode enricherProps, RecordEnricherValidationConfig validationConfig);
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/recordtransformer/enricher/RecordEnricherRegistry.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/recordtransformer/enricher/RecordEnricherRegistry.java
@@ -50,11 +50,28 @@ public class RecordEnricherRegistry {
     factory.validateEnrichmentConfig(enrichmentConfig.getProperties(), validationConfig);
   }
 
+  public static void validateSecurityPolicy(EnrichmentConfig enrichmentConfig,
+      RecordEnricherValidationConfig validationConfig) {
+    RecordEnricherFactory factory = RECORD_ENRICHER_FACTORY_MAP.get(enrichmentConfig.getEnricherType());
+    if (factory != null) {
+      factory.validateSecurityPolicy(enrichmentConfig.getProperties(), validationConfig);
+    }
+  }
+
   public static RecordEnricher createRecordEnricher(EnrichmentConfig enrichmentConfig)
       throws IOException {
     String type = enrichmentConfig.getEnricherType();
     RecordEnricherFactory factory = RECORD_ENRICHER_FACTORY_MAP.get(type);
     Preconditions.checkArgument(factory != null, "No record enricher found for type: %s", type);
     return factory.createEnricher(enrichmentConfig.getProperties());
+  }
+
+  public static RecordEnricher createRecordEnricher(EnrichmentConfig enrichmentConfig,
+      RecordEnricherCreationContext creationContext)
+      throws IOException {
+    String type = enrichmentConfig.getEnricherType();
+    RecordEnricherFactory factory = RECORD_ENRICHER_FACTORY_MAP.get(type);
+    Preconditions.checkArgument(factory != null, "No record enricher found for type: %s", type);
+    return factory.createEnricher(enrichmentConfig.getProperties(), creationContext);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 
 
@@ -2885,6 +2886,14 @@ public class CommonConstants {
   /// User can config different configuration for query and ingestion (table creation and update) static analyzer.
   /// The all configuration is the default configuration for both query and ingestion static analyzer.
   public static class Groovy {
+    public static final String DISABLE_INGESTION_GROOVY = "controller.disable.ingestion.groovy";
+    public static final boolean DEFAULT_DISABLE_INGESTION_GROOVY = true;
+
+    /// Only an explicit `false` enables ingestion Groovy. Missing, blank, and invalid values fail closed.
+    public static boolean isIngestionGroovyDisabled(@Nullable String configuredValue) {
+      return configuredValue == null || !Boolean.FALSE.toString().equalsIgnoreCase(configuredValue.trim());
+    }
+
     public static final String GROOVY_ALL_STATIC_ANALYZER_CONFIG = "pinot.groovy.all.static.analyzer";
     public static final String GROOVY_QUERY_STATIC_ANALYZER_CONFIG = "pinot.groovy.query.static.analyzer";
     public static final String GROOVY_INGESTION_STATIC_ANALYZER_CONFIG = "pinot.groovy.ingestion.static.analyzer";


### PR DESCRIPTION
## Summary

- Centralize ingestion Groovy policy enforcement before evaluator construction.
- Apply the policy consistently to schema FieldSpec and table-config transforms during controller validation.
- Propagate the resolved policy through realtime server ingestion, minion tasks, and offline segment generation, including standalone, Spark, and Hadoop paths.
- Reject disabled Groovy transforms with a clear configuration error instead of compiling, executing, or silently ignoring them.
- Preserve explicitly enabled Groovy, non-Groovy built-in transforms, legacy map transforms, and query-time Groovy behavior.

## Root cause

The existing ingestion Groovy setting was enforced for table-config validation, but schema FieldSpec validation and several runtime evaluator-construction paths did not receive or apply the same policy. A schema persisted by an older deployment could therefore also reach ingestion-time evaluator construction without the controller-side check.

This change makes evaluator construction the common enforcement boundary and retains explicit checks at validation and runtime call sites as defense in depth.

## How to reproduce

1. Leave `controller.disable.ingestion.groovy` unset, which uses the disabled default.
2. Attempt a schema create, update, or validation operation, or a combined tableConfigs operation, whose schema contains a Groovy-backed FieldSpec transform.
3. Before this change, the transform could reach evaluator construction despite the disabled policy. A schema persisted by an older deployment could reach the same path during ingestion.
4. After this change, Pinot rejects the transform with a configuration error before Groovy compilation. Explicitly setting the policy to `false` preserves the existing opt-in behavior.

## Behavior

- Only an explicit `controller.disable.ingestion.groovy=false` enables ingestion Groovy.
- Missing, blank, or invalid values fail closed.
- Schema create, update, validation, and combined tableConfigs operations apply the same policy as table-config transforms.
- Authorization is checked before semantic validation on affected validation paths, so denied requests cannot trigger evaluator construction.
- Realtime ingestion and offline/minion segment-generation paths enforce the policy for persisted legacy schemas.
- Built-in transforms continue to work when Groovy is disabled.
- Conflicting controller, server, or minion settings fail with an actionable configuration error once the cluster policy is present.

## Rolling upgrade and rollback

Upgrade an API-serving controller before servers and minions. The first API-serving controller atomically publishes the resolved policy to the cluster config; once present, that cluster value is authoritative for controller, server, and minion processes.

For a legacy cluster where ingestion Groovy is intentionally enabled, configure API-serving controllers consistently with `controller.disable.ingestion.groovy=false` before upgrading them. If a new server or minion must start before an upgraded controller publishes the cluster value, temporarily configure the same explicit opt-in on that instance. An unconfigured new runtime process fails closed while the cluster value is absent.

Coordinate later policy changes through the cluster configuration before restarting services. Rolling back runtime roles removes the new defense-in-depth enforcement from those older processes, so keep the cluster policy consistent and verify persisted schemas before rollback.

## SPI compatibility

This change adds an immutable `IngestionGroovyPolicy` value and a `RecordEnricherCreationContext` for policy-aware enricher construction. `RecordEnricherFactory` retains the existing creation method; the new context-aware overload delegates to it by default, and the new security-policy hook is also a default method. Existing enricher implementations therefore require no source changes, while policy-sensitive implementations can opt into the new context and validation hook.

## Test coverage

Targeted tests cover:

- Default-disabled and explicit-opt-in evaluator behavior.
- Schema create, update, and validation operations.
- Combined tableConfigs create, update, and validation operations.
- Authorization-before-validation ordering.
- Table-config and FieldSpec transform policy consistency.
- Built-in transforms under the disabled policy.
- Realtime ingestion with persisted legacy schemas.
- Offline segment generation through common, standalone, Spark, Hadoop, and minion paths.
- Groovy filters, enrichers, and transform-function partitioners.
- Concurrent controller startup and authoritative cluster-policy propagation.
- Existing hybrid and stale-segment integration scenarios with explicit Groovy opt-in.

Affected-module formatting, checkstyle, license-format, and license checks pass. The JDK 25 warning-enabled affected-module compile passes with `-Xlint:all,-deprecation`.

The exact JDK 25 `-Xlint:all` invocation remains blocked on current master because `zstd-jni` references its provided JetBrains `@NotNull` dependency from the unchanged `ZstandardDecompressor` source.

## Scope

This change does not alter authorization actions or query-time Groovy policy. This PR is ready for coordinated review.

