### PR TITLE
[controller] Sanitize table configuration representations

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/TableAdminClient.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/TableAdminClient.java
@@ -48,6 +48,10 @@ import org.slf4j.LoggerFactory;
 /// Provides methods to create, update, delete, and manage Pinot tables.
 public class TableAdminClient extends BaseServiceAdminClient {
   private static final Logger LOGGER = LoggerFactory.getLogger(TableAdminClient.class);
+  private static final String RESPONSE_TYPE = "responseType";
+  private static final String CONFIGS = "configs";
+  private static final String REDACTED_TABLE_CONFIG_RESPONSE_TYPE = "redactedTableConfig";
+  private static final String REDACTED_TABLE_CONFIGS_RESPONSE_TYPE = "redactedTableConfigs";
 
   public TableAdminClient(PinotAdminTransport transport, String controllerAddress,
       Map<String, String> headers) {
@@ -125,7 +129,7 @@ public class TableAdminClient extends BaseServiceAdminClient {
   /// Gets the configuration for a specific table as a typed object.
   public TableConfig getTableConfigObject(String tableName)
       throws PinotAdminException, IOException {
-    return JsonUtils.stringToObject(getTableConfig(tableName), TableConfig.class);
+    return getTableConfigObject(tableName, null);
   }
 
   /// Gets the configuration for a specific raw table and type as a typed object.
@@ -133,14 +137,52 @@ public class TableAdminClient extends BaseServiceAdminClient {
       throws PinotAdminException, IOException {
     JsonNode response = _transport.executeGet(_controllerAddress, "/tables/" + tableName,
         tableType != null ? Map.of("type", tableType) : null, _headers);
-    JsonNode tableConfigNode = response;
-    if (tableType != null) {
-      JsonNode typedNode = response.get(tableType.toUpperCase(Locale.ROOT));
-      if (typedNode != null) {
-        tableConfigNode = typedNode;
+    JsonNode tableConfigNode = getTableConfigNode(response, tableName, tableType);
+    return JsonUtils.jsonNodeToObject(tableConfigNode, TableConfig.class);
+  }
+
+  private static JsonNode getTableConfigNode(JsonNode response, String tableName, @Nullable String tableType)
+      throws PinotAdminException {
+    boolean isEnvelope = REDACTED_TABLE_CONFIG_RESPONSE_TYPE.equals(response.path(RESPONSE_TYPE).asText());
+    JsonNode configsNode = isEnvelope ? getEnvelopeConfigs(response, REDACTED_TABLE_CONFIG_RESPONSE_TYPE) : response;
+    String selectedType = tableType;
+    if (selectedType == null) {
+      TableType tableTypeFromName = TableNameBuilder.getTableTypeFromTableName(tableName);
+      if (tableTypeFromName != null) {
+        selectedType = tableTypeFromName.name();
       }
     }
-    return JsonUtils.jsonNodeToObject(tableConfigNode, TableConfig.class);
+    if (selectedType != null) {
+      JsonNode typedNode = configsNode.get(selectedType.toUpperCase(Locale.ROOT));
+      if (typedNode != null) {
+        return typedNode;
+      }
+      if (isEnvelope || isTypedTableConfigMap(configsNode)) {
+        throw new PinotAdminException("Table config response does not contain type: " + selectedType);
+      }
+    }
+    if (isEnvelope || isTypedTableConfigMap(configsNode)) {
+      JsonNode offline = configsNode.get(TableType.OFFLINE.name());
+      JsonNode realtime = configsNode.get(TableType.REALTIME.name());
+      if ((offline == null) != (realtime == null)) {
+        return offline != null ? offline : realtime;
+      }
+      throw new PinotAdminException("Table config response contains multiple types; specify a table type");
+    }
+    return configsNode;
+  }
+
+  private static boolean isTypedTableConfigMap(JsonNode node) {
+    return node.isObject() && (node.has(TableType.OFFLINE.name()) || node.has(TableType.REALTIME.name()));
+  }
+
+  private static JsonNode getEnvelopeConfigs(JsonNode response, String responseType)
+      throws PinotAdminException {
+    JsonNode configsNode = response.get(CONFIGS);
+    if (configsNode == null || !configsNode.isObject()) {
+      throw new PinotAdminException("Invalid " + responseType + " response: missing configs object");
+    }
+    return configsNode;
   }
 
   /// Gets a specific table view (idealstate/externalview) for a table.
@@ -868,8 +910,10 @@ public class TableAdminClient extends BaseServiceAdminClient {
   public TableConfigs getTableConfigsObject(String tableName)
       throws PinotAdminException {
     JsonNode response = _transport.executeGet(_controllerAddress, "/tableConfigs/" + tableName, null, _headers);
+    JsonNode tableConfigsNode = REDACTED_TABLE_CONFIGS_RESPONSE_TYPE.equals(response.path(RESPONSE_TYPE).asText())
+        ? getEnvelopeConfigs(response, REDACTED_TABLE_CONFIGS_RESPONSE_TYPE) : response;
     try {
-      return JsonUtils.jsonNodeToObject(response, TableConfigs.class);
+      return JsonUtils.jsonNodeToObject(tableConfigsNode, TableConfigs.class);
     } catch (IOException e) {
       throw new PinotAdminException("Failed to deserialize table configs for table: " + tableName, e);
     }

--- a/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/admin/PinotAdminClientTest.java
+++ b/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/admin/PinotAdminClientTest.java
@@ -30,6 +30,7 @@ import org.apache.pinot.common.restlet.resources.PauseStatusDetails;
 import org.apache.pinot.common.restlet.resources.ServerRebalanceJobStatusResponse;
 import org.apache.pinot.common.restlet.resources.TableView;
 import org.apache.pinot.common.utils.PinotAppConfigs;
+import org.apache.pinot.spi.config.TableConfigs;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.Schema;
@@ -112,14 +113,50 @@ public class PinotAdminClientTest {
   @Test
   public void testGetTableConfig()
       throws Exception {
-    String jsonResponse = "{\"tableName\":\"tbl1_OFFLINE\"}";
+    TableConfig expectedTableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("tbl1").build();
+    String jsonResponse = redactedTableConfigEnvelope(expectedTableConfig);
     JsonNode mockResponse = new ObjectMapper().readTree(jsonResponse);
     lenient().when(_mockTransport.executeGet(anyString(), anyString(), any(), any()))
         .thenReturn(mockResponse);
 
     String cfg = _adminClient.getTableClient().getTableConfig("tbl1_OFFLINE");
     assertNotNull(cfg);
-    assertEquals(new ObjectMapper().readTree(cfg).get("tableName").asText(), "tbl1_OFFLINE");
+    JsonNode response = new ObjectMapper().readTree(cfg);
+    assertEquals(response.get("responseType").asText(), "redactedTableConfig");
+    assertEquals(response.get("tableName").get("raw").asText(), "tbl1");
+    assertEquals(response.get("configs").get("OFFLINE").get("tableName").asText(), "tbl1_OFFLINE");
+  }
+
+  @Test
+  public void testGetTableConfigObjectFromRedactedSingleEnvelope()
+      throws Exception {
+    TableConfig expectedTableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("tbl1").build();
+    JsonNode mockResponse = new ObjectMapper().readTree(redactedTableConfigEnvelope(expectedTableConfig));
+    lenient().when(_mockTransport.executeGet(anyString(), anyString(), any(), any()))
+        .thenReturn(mockResponse);
+
+    TableConfig tableConfig = _adminClient.getTableClient().getTableConfigObject("tbl1_OFFLINE");
+
+    assertEquals(tableConfig.getTableName(), "tbl1_OFFLINE");
+    assertEquals(tableConfig.getTableType(), TableType.OFFLINE);
+  }
+
+  @Test
+  public void testGetTableConfigObjectFromRedactedCombinedEnvelope()
+      throws Exception {
+    TableConfig offline = new TableConfigBuilder(TableType.OFFLINE).setTableName("tbl1").build();
+    TableConfig realtime = new TableConfigBuilder(TableType.REALTIME).setTableName("tbl1").build();
+    String jsonResponse = "{\"responseType\":\"redactedTableConfig\",\"responseVersion\":1,"
+        + "\"tableName\":{\"raw\":\"tbl1\"},\"baseVersions\":{\"OFFLINE\":3,\"REALTIME\":5},"
+        + "\"configs\":{\"OFFLINE\":" + JsonUtils.objectToString(offline) + ",\"REALTIME\":"
+        + JsonUtils.objectToString(realtime) + "}}";
+    lenient().when(_mockTransport.executeGet(anyString(), anyString(), any(), any()))
+        .thenReturn(new ObjectMapper().readTree(jsonResponse));
+
+    TableConfig tableConfig = _adminClient.getTableClient().getTableConfigObject("tbl1", "REALTIME");
+
+    assertEquals(tableConfig.getTableName(), "tbl1_REALTIME");
+    assertEquals(tableConfig.getTableType(), TableType.REALTIME);
   }
 
   @Test
@@ -154,6 +191,50 @@ public class PinotAdminClientTest {
     assertEquals(tableConfig.getTableType(), TableType.OFFLINE);
     verify(_mockTransport).executeGet(eq(CONTROLLER_ADDRESS), eq("/tables/tbl1"), eq(Map.of("type", "OFFLINE")),
         eq(HEADERS));
+  }
+
+  @Test
+  public void testGetTableConfigsPreservesEnvelopeAndTypedGetterUnwrapsIt()
+      throws Exception {
+    TableConfig offline = new TableConfigBuilder(TableType.OFFLINE).setTableName("tbl1").build();
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("tbl1").build();
+    TableConfigs expectedTableConfigs = new TableConfigs("tbl1", schema, offline, null);
+    String jsonResponse = "{\"responseType\":\"redactedTableConfigs\",\"responseVersion\":1,"
+        + "\"tableName\":{\"raw\":\"tbl1\"},\"baseVersions\":{\"offline\":3},\"configs\":"
+        + JsonUtils.objectToString(expectedTableConfigs) + "}";
+    lenient().when(_mockTransport.executeGet(anyString(), anyString(), any(), any()))
+        .thenReturn(new ObjectMapper().readTree(jsonResponse));
+
+    String rawResponse = _adminClient.getTableClient().getTableConfigs("tbl1");
+    TableConfigs tableConfigs = _adminClient.getTableClient().getTableConfigsObject("tbl1");
+
+    assertEquals(new ObjectMapper().readTree(rawResponse).get("responseType").asText(), "redactedTableConfigs");
+    assertEquals(tableConfigs.getTableName(), "tbl1");
+    assertEquals(tableConfigs.getSchema().getSchemaName(), "tbl1");
+    assertEquals(tableConfigs.getOffline().getTableName(), "tbl1_OFFLINE");
+  }
+
+  @Test
+  public void testGetTableConfigsObjectRetainsLegacyResponseSupport()
+      throws Exception {
+    TableConfig offline = new TableConfigBuilder(TableType.OFFLINE).setTableName("tbl1").build();
+    TableConfigs expectedTableConfigs =
+        new TableConfigs("tbl1", new Schema.SchemaBuilder().setSchemaName("tbl1").build(), offline, null);
+    lenient().when(_mockTransport.executeGet(anyString(), anyString(), any(), any()))
+        .thenReturn(new ObjectMapper().readTree(JsonUtils.objectToString(expectedTableConfigs)));
+
+    TableConfigs tableConfigs = _adminClient.getTableClient().getTableConfigsObject("tbl1");
+
+    assertEquals(tableConfigs.getTableName(), "tbl1");
+    assertEquals(tableConfigs.getOffline().getTableType(), TableType.OFFLINE);
+  }
+
+  private static String redactedTableConfigEnvelope(TableConfig tableConfig)
+      throws Exception {
+    String type = tableConfig.getTableType().name();
+    return "{\"responseType\":\"redactedTableConfig\",\"responseVersion\":1,"
+        + "\"tableName\":{\"raw\":\"tbl1\",\"type\":\"" + type + "\"},\"baseVersions\":{\"" + type
+        + "\":3},\"configs\":{\"" + type + "\":" + JsonUtils.objectToString(tableConfig) + "}}";
   }
 
   @Test

--- a/pinot-common/src/main/java/org/apache/pinot/common/exception/TableConfigVersionMismatchException.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/exception/TableConfigVersionMismatchException.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.exception;
+
+
+/// Thrown when a table config changes between a versioned read and update.
+public class TableConfigVersionMismatchException extends RuntimeException {
+
+  public TableConfigVersionMismatchException() {
+    super("Table config changed during update");
+  }
+
+  public TableConfigVersionMismatchException(Throwable cause) {
+    super("Table config changed during update", cause);
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -495,10 +495,23 @@ public class ZKMetadataProvider {
   @Nullable
   public static ImmutablePair<TableConfig, Integer> getTableConfigWithVersion(
       ZkHelixPropertyStore<ZNRecord> propertyStore, String tableNameWithType) {
+    return getTableConfigWithVersion(propertyStore, tableNameWithType, true, true);
+  }
+
+  /// Get the table config and ZK version from one read.
+  ///
+  /// @param tableNameWithType Table name with type
+  /// @param replaceVariables Whether to replace environment variables and system properties with their actual values
+  /// @param applyDecorator Whether to apply the table config decorator
+  /// @return a pair of table config and current version from the ZNRecord, or null if the table config does not exist
+  @Nullable
+  public static ImmutablePair<TableConfig, Integer> getTableConfigWithVersion(
+      ZkHelixPropertyStore<ZNRecord> propertyStore, String tableNameWithType, boolean replaceVariables,
+      boolean applyDecorator) {
     Stat tableConfigStat = new Stat();
-    TableConfig tableConfig = toTableConfig(
-        propertyStore.get(constructPropertyStorePathForResourceConfig(tableNameWithType), tableConfigStat,
-            AccessOption.PERSISTENT));
+    TableConfig tableConfig = toTableConfig(propertyStore.get(
+        constructPropertyStorePathForResourceConfig(tableNameWithType), tableConfigStat, AccessOption.PERSISTENT),
+        replaceVariables, applyDecorator);
     if (tableConfig == null) {
       return null;
     }
@@ -601,13 +614,24 @@ public class ZKMetadataProvider {
 
   @Nullable
   public static Schema getSchema(ZkHelixPropertyStore<ZNRecord> propertyStore, String schemaName) {
+    ImmutablePair<Schema, Integer> schemaWithVersion = getSchemaWithVersion(propertyStore, schemaName);
+    return schemaWithVersion != null ? schemaWithVersion.getLeft() : null;
+  }
+
+  /// Get the schema and ZK version from one read.
+  ///
+  /// @return a pair of schema and current version, or null if the schema does not exist
+  @Nullable
+  public static ImmutablePair<Schema, Integer> getSchemaWithVersion(ZkHelixPropertyStore<ZNRecord> propertyStore,
+      String schemaName) {
     try {
-      ZNRecord schemaZNRecord =
-          propertyStore.get(constructPropertyStorePathForSchema(schemaName), null, AccessOption.PERSISTENT);
+      Stat stat = new Stat();
+      ZNRecord schemaZNRecord = propertyStore.get(
+          constructPropertyStorePathForSchema(schemaName), stat, AccessOption.PERSISTENT);
       if (schemaZNRecord == null) {
         return null;
       }
-      return SchemaSerDeUtils.fromZNRecord(schemaZNRecord);
+      return ImmutablePair.of(SchemaSerDeUtils.fromZNRecord(schemaZNRecord), stat.getVersion());
     } catch (Exception e) {
       LOGGER.error("Caught exception while getting schema: {}", schemaName, e);
       return null;

--- a/pinot-common/src/main/java/org/apache/pinot/common/segment/generation/SegmentGenerationUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/segment/generation/SegmentGenerationUtils.java
@@ -56,6 +56,9 @@ public class SegmentGenerationUtils {
 
   private static final String OFFLINE = "OFFLINE";
   private static final String REALTIME = "REALTIME";
+  private static final String RESPONSE_TYPE = "responseType";
+  private static final String CONFIGS = "configs";
+  private static final String REDACTED_TABLE_CONFIG_RESPONSE_TYPE = "redactedTableConfig";
   public static final String PINOT_PLUGINS_TAR_GZ = "pinot-plugins.tar.gz";
   public static final String PINOT_PLUGINS_DIR = "pinot-plugins-dir";
 
@@ -122,7 +125,9 @@ public class SegmentGenerationUtils {
     try {
       tableConfigURI = new URI(tableConfigURIStr);
     } catch (URISyntaxException e) {
-      throw new RuntimeException("Table config URI is not valid - '" + tableConfigURIStr + "'", e);
+      // URI user-info and query parameters can contain credentials. Do not retain the input or the parser exception,
+      // whose message can echo the complete URI, in a diagnostic that callers commonly log.
+      throw new RuntimeException("Table config URI is not valid");
     }
     String scheme = tableConfigURI.getScheme();
     String tableConfigJson;
@@ -131,22 +136,33 @@ public class SegmentGenerationUtils {
       try (PinotFS pinotFS = PinotFSFactory.create(scheme);) {
         tableConfigJson = IOUtils.toString(pinotFS.open(tableConfigURI), StandardCharsets.UTF_8);
       } catch (IOException e) {
-        throw new RuntimeException("Failed to open table config file stream on Pinot fs - '" + tableConfigURI + "'", e);
+        throw new RuntimeException("Failed to open table config file stream on Pinot fs");
       }
     } else {
       try {
         tableConfigJson = fetchUrl(tableConfigURI.toURL(), authToken, tlsSpec);
       } catch (IOException e) {
-        throw new RuntimeException(
-            "Failed to read from table config file data stream on Pinot fs - '" + tableConfigURI + "'", e);
+        throw new RuntimeException("Failed to read from table config file data stream on Pinot fs");
       }
     }
+    return parseTableConfig(tableConfigJson);
+  }
+
+  static TableConfig parseTableConfig(String tableConfigJson) {
     // Controller API returns a wrapper of table config.
     JsonNode tableJsonNode;
     try {
       tableJsonNode = JsonUtils.stringToJsonNode(tableConfigJson);
     } catch (IOException e) {
-      throw new RuntimeException("Failed to decode table config into JSON from String - '" + tableConfigJson + "'", e);
+      // Both the input and Jackson's exception can include literal config values.
+      throw new RuntimeException("Failed to decode table config into JSON");
+    }
+    if (REDACTED_TABLE_CONFIG_RESPONSE_TYPE.equals(tableJsonNode.path(RESPONSE_TYPE).asText())) {
+      JsonNode configsNode = tableJsonNode.get(CONFIGS);
+      if (configsNode == null || !configsNode.isObject()) {
+        throw new RuntimeException("Failed to decode table config: invalid controller response envelope");
+      }
+      tableJsonNode = configsNode;
     }
     if (tableJsonNode.has(OFFLINE)) {
       tableJsonNode = tableJsonNode.get(OFFLINE);
@@ -156,7 +172,7 @@ public class SegmentGenerationUtils {
     try {
       return JsonUtils.jsonNodeToObject(tableJsonNode, TableConfig.class);
     } catch (IOException e) {
-      throw new RuntimeException("Failed to decode table config from JSON - '" + tableJsonNode + "'", e);
+      throw new RuntimeException("Failed to decode table config from JSON");
     }
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/AccessControlUserConfigUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/AccessControlUserConfigUtils.java
@@ -46,13 +46,15 @@ public class AccessControlUserConfigUtils {
 
     List<String> tableList = znRecord.getListField(UserConfig.TABLES_KEY);
     List<String> excludeTableList = znRecord.getListField(UserConfig.EXCLUDE_TABLES_KEY);
+    List<String> fineGrainedPermissionList = znRecord.getListField(UserConfig.FINE_GRAINED_PERMISSIONS_KEY);
 
     List<String> permissionListFromZNRecord = znRecord.getListField(UserConfig.PERMISSIONS_KEY);
     List<AccessType> permissionList = null;
     if (permissionListFromZNRecord != null) {
       permissionList = permissionListFromZNRecord.stream().map(x -> AccessType.valueOf(x)).collect(Collectors.toList());
     }
-    return new UserConfig(username, password, component, role, tableList, excludeTableList, permissionList);
+    return new UserConfig(username, password, component, role, tableList, excludeTableList, permissionList,
+        fineGrainedPermissionList);
   }
 
   public static ZNRecord toZNRecord(UserConfig userConfig)
@@ -81,6 +83,10 @@ public class AccessControlUserConfigUtils {
     if (permissionList != null) {
       listFields.put(UserConfig.PERMISSIONS_KEY,
           userConfig.getPermissions().stream().map(e -> e.toString()).collect(Collectors.toList()));
+    }
+    List<String> fineGrainedPermissionList = userConfig.getFineGrainedPermissions();
+    if (fineGrainedPermissionList != null) {
+      listFields.put(UserConfig.FINE_GRAINED_PERMISSIONS_KEY, fineGrainedPermissionList);
     }
 
     ZNRecord znRecord = new ZNRecord(userConfig.getUserName());

--- a/pinot-common/src/test/java/org/apache/pinot/common/segment/generation/SegmentGenerationUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/segment/generation/SegmentGenerationUtilsTest.java
@@ -28,13 +28,66 @@ import java.nio.file.Files;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.URIUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
 public class SegmentGenerationUtilsTest {
+
+  @Test
+  public void testParseTableConfigFromRedactedEnvelope()
+      throws Exception {
+    TableConfig offline = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").build();
+    TableConfig realtime = new TableConfigBuilder(TableType.REALTIME).setTableName("myTable").build();
+    String response = "{\"responseType\":\"redactedTableConfig\",\"responseVersion\":1,"
+        + "\"tableName\":{\"raw\":\"myTable\"},\"baseVersions\":{\"OFFLINE\":3,\"REALTIME\":5},"
+        + "\"configs\":{\"OFFLINE\":" + JsonUtils.objectToString(offline) + ",\"REALTIME\":"
+        + JsonUtils.objectToString(realtime) + "}}";
+
+    TableConfig parsed = SegmentGenerationUtils.parseTableConfig(response);
+
+    Assert.assertEquals(parsed.getTableName(), "myTable_OFFLINE");
+    Assert.assertEquals(parsed.getTableType(), TableType.OFFLINE);
+  }
+
+  @Test
+  public void testParseTableConfigRetainsLegacyResponseSupport()
+      throws Exception {
+    TableConfig realtime = new TableConfigBuilder(TableType.REALTIME).setTableName("myTable").build();
+    String wrappedResponse = "{\"REALTIME\":" + JsonUtils.objectToString(realtime) + "}";
+
+    Assert.assertEquals(SegmentGenerationUtils.parseTableConfig(wrappedResponse).getTableName(),
+        "myTable_REALTIME");
+    Assert.assertEquals(
+        SegmentGenerationUtils.parseTableConfig(JsonUtils.objectToString(realtime)).getTableName(),
+        "myTable_REALTIME");
+  }
+
+  @Test
+  public void testTableConfigDecodeErrorsDoNotExposeInput() {
+    String sentinel = "literal-table-config-secret";
+
+    RuntimeException malformedJson = Assert.expectThrows(RuntimeException.class,
+        () -> SegmentGenerationUtils.parseTableConfig("{malformed:" + sentinel));
+    Assert.assertFalse(malformedJson.getMessage().contains(sentinel), malformedJson.getMessage());
+    Assert.assertNull(malformedJson.getCause());
+
+    RuntimeException invalidConfig = Assert.expectThrows(RuntimeException.class,
+        () -> SegmentGenerationUtils.parseTableConfig("\"" + sentinel + "\""));
+    Assert.assertFalse(invalidConfig.getMessage().contains(sentinel), invalidConfig.getMessage());
+    Assert.assertNull(invalidConfig.getCause());
+
+    RuntimeException invalidUri = Assert.expectThrows(RuntimeException.class,
+        () -> SegmentGenerationUtils.getTableConfig("https://user:" + sentinel + "@[invalid", null));
+    Assert.assertFalse(invalidUri.getMessage().contains(sentinel), invalidUri.getMessage());
+    Assert.assertNull(invalidUri.getCause());
+  }
 
   @Test
   public void testExtractFileNameFromURI() {

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/AccessControlUserConfigUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/AccessControlUserConfigUtilsTest.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils.config;
+
+import java.util.List;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.spi.config.user.AccessType;
+import org.apache.pinot.spi.config.user.UserConfig;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class AccessControlUserConfigUtilsTest {
+
+  @Test
+  public void testFineGrainedPermissionsRoundTripInSeparateListField()
+      throws Exception {
+    UserConfig userConfig = new UserConfig("testUser", "testPassword", "CONTROLLER", "ADMIN",
+        List.of("table1"), List.of("excludedTable"), List.of(AccessType.READ), List.of("GetZnode"));
+
+    ZNRecord znRecord = AccessControlUserConfigUtils.toZNRecord(userConfig);
+    assertEquals(znRecord.getListField(UserConfig.PERMISSIONS_KEY), List.of("READ"));
+    assertEquals(znRecord.getListField(UserConfig.FINE_GRAINED_PERMISSIONS_KEY), List.of("GetZnode"));
+
+    UserConfig deserialized = AccessControlUserConfigUtils.fromZNRecord(znRecord);
+    assertEquals(deserialized.getPermissions(), List.of(AccessType.READ));
+    assertEquals(deserialized.getFineGrainedPermissions(), List.of("GetZnode"));
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
@@ -49,14 +49,15 @@ import org.apache.pinot.core.auth.TargetType;
 import org.glassfish.grizzly.http.server.Request;
 
 
-/// A container filter class responsible for automatic authentication of REST endpoints. Any rest endpoints annotated
-/// with [Authenticate] annotation, will go through authentication.
+/// A container filter class responsible for automatic authentication and authorization of REST endpoints. Any REST
+/// endpoint annotated with [Authenticate] or [Authorize] will go through the filter.
 @javax.ws.rs.ext.Provider
 public class AuthenticationFilter implements ContainerRequestFilter {
   private static final Set<String> UNPROTECTED_PATHS =
       new HashSet<>(Arrays.asList("", "help", "auth/info", "auth/verify", "auth/verify/v2", "health"));
   private static final String KEY_TABLE_NAME = "tableName";
   private static final String KEY_TABLE_NAME_WITH_TYPE = "tableNameWithType";
+  private static final String KEY_MATERIALIZED_VIEW_TABLE_NAME = "materializedViewTableName";
   private static final String KEY_SCHEMA_NAME = "schemaName";
 
   @Inject
@@ -86,8 +87,9 @@ public class AuthenticationFilter implements ContainerRequestFilter {
       return;
     }
 
-    // check if authentication is required implicitly
-    if (accessControl.protectAnnotatedOnly() && !endpointMethod.isAnnotationPresent(Authenticate.class)) {
+    // check if authentication or authorization is required implicitly
+    if (accessControl.protectAnnotatedOnly() && !endpointMethod.isAnnotationPresent(Authenticate.class)
+        && !endpointMethod.isAnnotationPresent(Authorize.class)) {
       return;
     }
 
@@ -99,8 +101,9 @@ public class AuthenticationFilter implements ContainerRequestFilter {
     // Note that table name is extracted from "path parameters" or "query parameters" if it's defined as one of the
     // followings:
     //     - "tableName",
-    //     - "tableNameWithType", or
-    //     - "schemaName"
+    //     - "tableNameWithType",
+    //     - "schemaName", or
+    //     - "materializedViewTableName"
     // A declared table target can identify a custom parameter name. For cluster-targeted annotations, retain the
     // parameter-name heuristics because several legacy table-scoped endpoints use cluster actions for fine-grained
     // authorization. If table name is not available, it means the endpoint is not a table-level endpoint.
@@ -166,6 +169,9 @@ public class AuthenticationFilter implements ContainerRequestFilter {
     }
     if (mmap.containsKey(KEY_TABLE_NAME_WITH_TYPE)) {
       return mmap.getFirst(KEY_TABLE_NAME_WITH_TYPE);
+    }
+    if (mmap.containsKey(KEY_MATERIALIZED_VIEW_TABLE_NAME)) {
+      return mmap.getFirst(KEY_MATERIALIZED_VIEW_TABLE_NAME);
     }
     if (mmap.containsKey(KEY_SCHEMA_NAME)) {
       return mmap.getFirst(KEY_SCHEMA_NAME);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/BaseBasicAuthAccessControl.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/BaseBasicAuthAccessControl.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.Optional;
 import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.core.HttpHeaders;
+import org.apache.pinot.core.auth.Actions;
 import org.apache.pinot.core.auth.BasicAuthPrincipal;
 import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
@@ -59,9 +60,13 @@ abstract class BaseBasicAuthAccessControl<P extends BasicAuthPrincipal> implemen
 
   @Override
   public final boolean hasAccess(HttpHeaders httpHeaders, TargetType targetType, String targetId, String action) {
+    Optional<P> principal = getPrincipal(httpHeaders);
+    if (Actions.Cluster.GET_ZNODE.equals(action)) {
+      return principal.filter(p -> p.hasExplicitPermission(Actions.Cluster.GET_ZNODE)).isPresent();
+    }
     // Basic auth permissions are CRUD access types, not action names. AuthenticationFilter enforces the resolved
     // AccessType before invoking this fine-grained check, so this overload must only prevent unauthenticated access.
-    return getPrincipal(httpHeaders).isPresent();
+    return principal.isPresent();
   }
 
   @Override

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/CopyTablePayload.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/CopyTablePayload.java
@@ -40,6 +40,10 @@ public class CopyTablePayload {
   /// The instanceAssignmentConfig's tagPoolConfig contains full tenant name. We will use this field to let user specify
   /// the replacement relation from source cluster's full tenant to target cluster's full tenant.
   private Map<String, String> _tagPoolReplacementMap;
+  /// Literal credentials for fields that the source cluster returns masked. Keys are RFC 6901 JSON Pointers into the
+  /// REALTIME table config (for example, `/ingestionConfig/streamIngestionConfig/streamConfigMaps/0/password`).
+  /// Overrides are accepted only where the source representation contains the redaction marker.
+  private Map<String, String> _credentialOverrides;
 
   @JsonCreator
   public CopyTablePayload(
@@ -47,12 +51,19 @@ public class CopyTablePayload {
       @JsonProperty("sourceClusterHeaders") Map<String, String> headers,
       @JsonProperty(value = "brokerTenant", required = true) String brokerTenant,
       @JsonProperty(value = "serverTenant", required = true) String serverTenant,
-      @JsonProperty("tagPoolReplacementMap") @Nullable Map<String, String> tagPoolReplacementMap) {
+      @JsonProperty("tagPoolReplacementMap") @Nullable Map<String, String> tagPoolReplacementMap,
+      @JsonProperty("credentialOverrides") @Nullable Map<String, String> credentialOverrides) {
     _sourceClusterUri = sourceClusterUri;
     _headers = headers;
     _brokerTenant = brokerTenant;
     _serverTenant = serverTenant;
     _tagPoolReplacementMap = tagPoolReplacementMap;
+    _credentialOverrides = credentialOverrides;
+  }
+
+  public CopyTablePayload(String sourceClusterUri, Map<String, String> headers, String brokerTenant,
+      String serverTenant, @Nullable Map<String, String> tagPoolReplacementMap) {
+    this(sourceClusterUri, headers, brokerTenant, serverTenant, tagPoolReplacementMap, null);
   }
 
   @JsonGetter("sourceClusterUri")
@@ -78,5 +89,11 @@ public class CopyTablePayload {
   @JsonGetter("tagPoolReplacementMap")
   public Map<String, String> getTagPoolReplacementMap() {
     return _tagPoolReplacementMap;
+  }
+
+  @JsonGetter("credentialOverrides")
+  @Nullable
+  public Map<String, String> getCredentialOverrides() {
+    return _credentialOverrides;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotDdlRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotDdlRestletResource.java
@@ -71,6 +71,7 @@ import org.apache.pinot.core.auth.Actions;
 import org.apache.pinot.core.auth.ManualAuthorization;
 import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableConfigRedactionUtils;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -132,6 +133,8 @@ public class PinotDdlRestletResource {
   /// in UTF-8 wire bytes can be accepted by Jackson before the length check rejects; operators
   /// sizing reverse-proxy body limits should plan accordingly.
   private static final int MAX_DDL_SQL_CHARS = 256 * 1024;
+  private static final String ACTIVE_TASKS_BLOCKED_MESSAGE =
+      "DROP TABLE blocked because active running tasks exist";
 
   @Inject
   PinotHelixResourceManager _pinotHelixResourceManager;
@@ -200,7 +203,7 @@ public class PinotDdlRestletResource {
     try {
       compiled = DdlCompiler.compile(request.getSql(), compileCtx);
     } catch (DdlCompilationException e) {
-      throw badRequest(e.getMessage());
+      throw badRequest("Invalid DDL statement");
     }
     // Any other RuntimeException is a programmer error or unexpected upstream failure;
     // let it propagate to the JAX-RS default handler as 500 so monitoring fires on it
@@ -344,6 +347,7 @@ public class PinotDdlRestletResource {
       throw new ControllerApplicationException(LOGGER,
           "Table " + tableNameWithType + " already exists.", Response.Status.CONFLICT);
     }
+    rejectRedactionMarkers(create.getTableConfig());
 
     // Look up the stored schema first. When the second physical variant of a hybrid pair is
     // created, the stored schema is the canonical source of metadata (primary keys, tags,
@@ -446,12 +450,10 @@ public class PinotDdlRestletResource {
       // Don't append a "remove via DELETE /schemas" hint here: arbitrary RuntimeException /
       // IOException from addTable can be a transient ZK or Helix blip, and pointing the
       // operator at a destructive schema-deletion command in response to a transient failure
-      // would encourage premature cleanup. The error message is logged with the original
-      // cause so an operator can investigate via log/metrics.
-      // ControllerApplicationException(LOGGER, ...) logs the exception, so don't double-log here.
-      throw new ControllerApplicationException(LOGGER,
-          "Failed to create table " + tableNameWithType + ": " + e.getMessage(),
-          Response.Status.INTERNAL_SERVER_ERROR, e);
+      // would encourage premature cleanup. Do not attach the original exception because it may
+      // have formatted values from the submitted table config.
+      throw new ControllerApplicationException(LOGGER, "Failed to create table " + tableNameWithType,
+          Response.Status.INTERNAL_SERVER_ERROR);
     }
   }
 
@@ -490,8 +492,8 @@ public class PinotDdlRestletResource {
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.CONFLICT, e);
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER,
-          "Failed to create table " + tableNameWithType + " after concurrent schema create: " + e.getMessage(),
-          Response.Status.INTERNAL_SERVER_ERROR, e);
+          "Failed to create table " + tableNameWithType + " after concurrent schema create",
+          Response.Status.INTERNAL_SERVER_ERROR);
     }
   }
 
@@ -607,15 +609,22 @@ public class PinotDdlRestletResource {
       // The Pinot validators consistently raise these for user-facing config errors
       // (upsert without primary keys, field configs referencing non-existent columns,
       // bad task configs, etc.). Surface as 400 — the caller can fix their DDL.
-      throw new ControllerApplicationException(LOGGER,
-          "Table config validation failed: " + e.getMessage(), Response.Status.BAD_REQUEST, e);
+      throw new ControllerApplicationException(LOGGER, "Table config validation failed", Response.Status.BAD_REQUEST);
     } catch (Exception e) {
       // Any other exception is unexpected — most likely a controller-side defect (e.g. NPE in
       // a registry validator, ZK connectivity blip during validateTableTenantConfig). 400 would
       // mislead the caller into "fix your DDL"; surface as 500 so monitoring picks it up.
+      throw new ControllerApplicationException(LOGGER, "Internal error during table config validation",
+          Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  private void rejectRedactionMarkers(TableConfig tableConfig) {
+    try {
+      TableConfigRedactionUtils.restoreRedactedValues(tableConfig, null);
+    } catch (IllegalArgumentException e) {
       throw new ControllerApplicationException(LOGGER,
-          "Internal error during table config validation: " + e.getMessage(),
-          Response.Status.INTERNAL_SERVER_ERROR, e);
+          "A redacted credential cannot be used when creating a table", Response.Status.BAD_REQUEST);
     }
   }
 
@@ -690,13 +699,13 @@ public class PinotDdlRestletResource {
     // preflight on the symmetric DROP side. IF NOT EXISTS does NOT suppress the type-mismatch
     // error: IF NOT EXISTS suppresses "object not found", not "wrong DDL verb for this object".
     String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
-    TableConfig existingOfflineConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
+    TableConfig existingOfflineConfig = getStoredOfflineTableConfig(tableNameWithType);
     if (existingOfflineConfig != null) {
       if (existingOfflineConfig.isMaterializedView()) {
         if (create.isIfNotExists()) {
           // Echo the persisted state, not the client-attempted body: an idempotent re-run
           // must not advertise the new (rejected) config as if it had been applied.
-          populateNoOpResponseFromPersisted(response, existingOfflineConfig, schemaName);
+          populateNoOpResponseFromPersisted(response, existingOfflineConfig, schemaName, headers, httpRequest);
           response.setMessage("Materialized view " + tableNameWithType
               + " already exists; CREATE IF NOT EXISTS is a no-op.");
           return Response.ok(response).build();
@@ -730,6 +739,7 @@ public class PinotDdlRestletResource {
               + "REALTIME table first.",
           Response.Status.BAD_REQUEST);
     }
+    rejectRedactionMarkers(create.getTableConfig());
 
     // A pre-existing schema can survive a prior failed CREATE (addSchema succeeded but
     // addTable failed). Accept it iff the column shape matches; otherwise 409 so the
@@ -778,7 +788,8 @@ public class PinotDdlRestletResource {
       }
       _pinotHelixResourceManager.addTable(create.getTableConfig());
     } catch (TableAlreadyExistsException e) {
-      Response noOp = mvIfNotExistsNoOpResponse(create.isIfNotExists(), tableNameWithType, schemaName, response);
+      Response noOp = mvIfNotExistsNoOpResponse(create.isIfNotExists(), tableNameWithType, schemaName, response,
+          headers, httpRequest);
       if (noOp != null) {
         return noOp;
       }
@@ -788,15 +799,14 @@ public class PinotDdlRestletResource {
       // schema, mirroring the CREATE TABLE recovery path so the two endpoints behave the same
       // under concurrent provisioning.
       return retryCreateMaterializedViewAfterSchemaRace(create, response, schemaName,
-          tableNameWithType, e);
+          tableNameWithType, e, headers, httpRequest);
     } catch (Exception e) {
       // Same intentional decision as CREATE TABLE: do not roll back the schema on a generic
       // addTable failure. A concurrent sibling CREATE may already be reusing the schema and
       // a non-atomic orphan-check + deleteSchema would race with it. Operators can DELETE
       // stale schemas explicitly via /schemas.
-      throw new ControllerApplicationException(LOGGER,
-          "Failed to create materialized view " + tableNameWithType + ": " + e.getMessage(),
-          Response.Status.INTERNAL_SERVER_ERROR, e);
+      throw new ControllerApplicationException(LOGGER, "Failed to create materialized view " + tableNameWithType,
+          Response.Status.INTERNAL_SERVER_ERROR);
     }
 
     response.setMessage("Successfully created materialized view " + tableNameWithType);
@@ -806,8 +816,9 @@ public class PinotDdlRestletResource {
 
   private Response retryCreateMaterializedViewAfterSchemaRace(CompiledCreateMaterializedView create,
       DdlExecutionResponse response, String schemaName, String tableNameWithType,
-      SchemaAlreadyExistsException schemaFailure) {
-    Response noOp = mvIfNotExistsNoOpResponse(create.isIfNotExists(), tableNameWithType, schemaName, response);
+      SchemaAlreadyExistsException schemaFailure, HttpHeaders headers, Request httpRequest) {
+    Response noOp = mvIfNotExistsNoOpResponse(create.isIfNotExists(), tableNameWithType, schemaName, response,
+        headers, httpRequest);
     if (noOp != null) {
       return noOp;
     }
@@ -829,16 +840,16 @@ public class PinotDdlRestletResource {
     try {
       _pinotHelixResourceManager.addTable(create.getTableConfig());
     } catch (TableAlreadyExistsException e) {
-      Response noOp2 = mvIfNotExistsNoOpResponse(create.isIfNotExists(), tableNameWithType, schemaName, response);
+      Response noOp2 = mvIfNotExistsNoOpResponse(create.isIfNotExists(), tableNameWithType, schemaName, response,
+          headers, httpRequest);
       if (noOp2 != null) {
         return noOp2;
       }
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.CONFLICT, e);
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER,
-          "Failed to create materialized view " + tableNameWithType
-              + " after concurrent schema create: " + e.getMessage(),
-          Response.Status.INTERNAL_SERVER_ERROR, e);
+          "Failed to create materialized view " + tableNameWithType + " after concurrent schema create",
+          Response.Status.INTERNAL_SERVER_ERROR);
     }
     response.setMessage("Successfully created materialized view " + tableNameWithType);
     LOGGER.info("DDL created materialized view {} after concurrent schema create", tableNameWithType);
@@ -846,30 +857,19 @@ public class PinotDdlRestletResource {
   }
 
   /// Overload: takes an already-fetched [TableConfig] (the fast-path pre-check has it in
-  /// hand) and only re-fetches the schema. Avoids a redundant ZK read while preserving the
-  /// "echo persisted, not client-attempted" contract documented on the other overload.
+  /// hand) and only re-fetches the schema. The persisted config is returned only after the normal
+  /// read authorization check and is redacted before it is added to the response.
   private void populateNoOpResponseFromPersisted(DdlExecutionResponse response,
-      TableConfig persistedTableConfig, String schemaName) {
+      TableConfig persistedTableConfig, String schemaName, HttpHeaders headers, Request httpRequest) {
     if (persistedTableConfig != null) {
-      response.setTableConfig(toJson(persistedTableConfig));
+      ResourceUtils.checkPermissionAndAccess(persistedTableConfig.getTableName(), httpRequest, headers,
+          AccessType.READ, Actions.Table.GET_TABLE_CONFIG, _accessControlFactory, LOGGER);
+      response.setTableConfig(toJson(TableConfigRedactionUtils.redact(persistedTableConfig)));
     }
     Schema persistedSchema = _pinotHelixResourceManager.getSchema(schemaName);
     if (persistedSchema != null) {
       response.setSchema(toJson(persistedSchema));
     }
-  }
-
-  /// Rewrites `response.tableConfig` and `response.schema` to reflect what is currently
-  /// persisted in Helix/ZK rather than what the client submitted. Without this rewrite, a
-  /// `CREATE MATERIALIZED VIEW IF NOT EXISTS` that lands on an existing MV returns 200 with
-  /// the client-attempted body echoed back — leading an operator running an idempotent
-  /// deployment script to believe their drifted body was applied when in fact the persisted
-  /// MV is unchanged. If either ZK read returns null (transient blip, raced DROP, etc.) the
-  /// corresponding response field is left as-is so the operator never sees an empty payload.
-  private void populateNoOpResponseFromPersisted(DdlExecutionResponse response,
-      String tableNameWithType, String schemaName) {
-    populateNoOpResponseFromPersisted(response,
-        _pinotHelixResourceManager.getTableConfig(tableNameWithType), schemaName);
   }
 
   /// CREATE MATERIALIZED VIEW IF NOT EXISTS no-op helper for `addTable` retry catches. Returns
@@ -880,18 +880,23 @@ public class PinotDdlRestletResource {
   /// (`executeCreateMaterializedView` main path, schema-race retry, and inner addTable retry).
   @Nullable
   private Response mvIfNotExistsNoOpResponse(boolean ifNotExists, String tableNameWithType,
-      String schemaName, DdlExecutionResponse response) {
+      String schemaName, DdlExecutionResponse response, HttpHeaders headers, Request httpRequest) {
     if (!ifNotExists) {
       return null;
     }
-    TableConfig raced = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
+    TableConfig raced = getStoredOfflineTableConfig(tableNameWithType);
     if (raced == null || !raced.isMaterializedView()) {
       return null;
     }
-    populateNoOpResponseFromPersisted(response, tableNameWithType, schemaName);
+    populateNoOpResponseFromPersisted(response, raced, schemaName, headers, httpRequest);
     response.setMessage("Materialized view " + tableNameWithType
         + " already exists; CREATE IF NOT EXISTS is a no-op.");
     return Response.ok(response).build();
+  }
+
+  private TableConfig getStoredOfflineTableConfig(String tableNameWithType) {
+    return _pinotHelixResourceManager.getOfflineTableConfig(
+        TableNameBuilder.extractRawTableName(tableNameWithType), false, false);
   }
 
   // -------------------------------------------------------------------------------------------
@@ -933,7 +938,7 @@ public class PinotDdlRestletResource {
     List<String> targets = new ArrayList<>(2);
     for (String candidate : candidates) {
       if (_pinotHelixResourceManager.hasTable(candidate)
-          || _pinotHelixResourceManager.getTableConfig(candidate) != null) {
+          || PinotTableRestletResource.getUnresolvedTableConfig(_pinotHelixResourceManager, candidate) != null) {
         targets.add(candidate);
       }
     }
@@ -974,7 +979,8 @@ public class PinotDdlRestletResource {
     // no-op for a missing target — `targets` is non-empty here, so we know at least one
     // candidate table really exists, and we can compare its shape against the requested form.
     for (String target : targets) {
-      TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(target);
+      TableConfig tableConfig =
+          PinotTableRestletResource.getUnresolvedTableConfig(_pinotHelixResourceManager, target);
       if (tableConfig != null && tableConfig.isMaterializedView()) {
         throw new ControllerApplicationException(LOGGER,
             "Table " + target + " is a materialized view. "
@@ -1013,13 +1019,13 @@ public class PinotDdlRestletResource {
         if (restorer != null && restorer.restore()) {
           tasksCleaned = false;
         }
-        LOGGER.warn("DROP TABLE on {} failed: {}", target, e.getMessage());
+        LOGGER.warn("DROP TABLE on {} failed with status {}", target, e.getResponse().getStatus());
         throw dropFailed(target, dropped, tasksCleaned, e.getResponse().getStatus(), e);
       } catch (Exception e) {
         if (restorer != null && restorer.restore()) {
           tasksCleaned = false;
         }
-        LOGGER.warn("DROP TABLE on {} failed unexpectedly: {}", target, e.toString());
+        LOGGER.warn("DROP TABLE on {} failed unexpectedly ({})", target, e.getClass().getName());
         throw dropFailed(target, dropped, tasksCleaned,
             Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), e);
       }
@@ -1072,8 +1078,9 @@ public class PinotDdlRestletResource {
     ResourceUtils.checkPermissionAndAccess(tableNameWithType, httpRequest, headers,
         AccessType.DELETE, Actions.Table.DELETE_TABLE, _accessControlFactory, LOGGER);
 
-    boolean exists = _pinotHelixResourceManager.hasTable(tableNameWithType)
-        || _pinotHelixResourceManager.getTableConfig(tableNameWithType) != null;
+    TableConfig tableConfig =
+        PinotTableRestletResource.getUnresolvedTableConfig(_pinotHelixResourceManager, tableNameWithType);
+    boolean exists = _pinotHelixResourceManager.hasTable(tableNameWithType) || tableConfig != null;
 
     DdlExecutionResponse response = new DdlExecutionResponse()
         .setOperation(DdlOperation.DROP_MATERIALIZED_VIEW)
@@ -1094,7 +1101,6 @@ public class PinotDdlRestletResource {
           Response.Status.NOT_FOUND);
     }
 
-    TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
     if (tableConfig == null) {
       // hasTable was true but the config disappeared between the two reads. Same diagnosis as
       // the SHOW CREATE path: ZK torn write or concurrent delete. Surface as 500 so monitoring
@@ -1145,7 +1151,7 @@ public class PinotDdlRestletResource {
       if (restorer != null && restorer.restore()) {
         tasksCleaned = false;
       }
-      LOGGER.warn("DROP MATERIALIZED VIEW on {} failed: {}", tableNameWithType, e.getMessage());
+      LOGGER.warn("DROP MATERIALIZED VIEW on {} failed ({})", tableNameWithType, e.getClass().getName());
       throw dropFailed(tableNameWithType, List.of(), tasksCleaned,
           e.getResponse().getStatus(), e);
     } catch (IllegalStateException e) {
@@ -1155,15 +1161,15 @@ public class PinotDdlRestletResource {
       if (restorer != null && restorer.restore()) {
         tasksCleaned = false;
       }
-      LOGGER.warn("DROP MATERIALIZED VIEW on {} blocked: {}", tableNameWithType, e.getMessage());
+      LOGGER.warn("DROP MATERIALIZED VIEW on {} blocked ({})", tableNameWithType, e.getClass().getName());
       throw dropFailed(tableNameWithType, List.of(), tasksCleaned,
           Response.Status.CONFLICT.getStatusCode(), e);
     } catch (Exception e) {
       if (restorer != null && restorer.restore()) {
         tasksCleaned = false;
       }
-      LOGGER.warn("DROP MATERIALIZED VIEW on {} failed unexpectedly: {}",
-          tableNameWithType, e.toString());
+      LOGGER.warn("DROP MATERIALIZED VIEW on {} failed unexpectedly ({})",
+          tableNameWithType, e.getClass().getName());
       throw dropFailed(tableNameWithType, List.of(), tasksCleaned,
           Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), e);
     }
@@ -1203,7 +1209,8 @@ public class PinotDdlRestletResource {
   private void assertNoActiveTasksBeforeDrop(List<String> targets) {
     List<String> pendingTasks = new ArrayList<>();
     for (String target : targets) {
-      TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(target);
+      TableConfig tableConfig =
+          PinotTableRestletResource.getUnresolvedTableConfig(_pinotHelixResourceManager, target);
       if (tableConfig == null || tableConfig.getTaskConfig() == null) {
         continue;
       }
@@ -1238,7 +1245,8 @@ public class PinotDdlRestletResource {
   @Nullable
   private TaskCleanupRestorer cleanupTableTasksBeforeDrop(String tableWithType)
       throws Exception {
-    TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableWithType);
+    TableConfig tableConfig =
+        PinotTableRestletResource.getUnresolvedTableConfig(_pinotHelixResourceManager, tableWithType);
     if (tableConfig == null || tableConfig.getTaskConfig() == null) {
       return null;
     }
@@ -1304,8 +1312,8 @@ public class PinotDdlRestletResource {
         restoreTaskSchedules(_tableWithType, _tableConfig, _removedSchedules);
         return true;
       } catch (ControllerApplicationException restoreFailure) {
-        LOGGER.warn("DROP TABLE on {} could not restore task schedules after deleteTable rejected the drop: {}",
-            _tableWithType, restoreFailure.getMessage());
+        LOGGER.warn("DROP TABLE on {} could not restore task schedules after deleteTable rejected the drop",
+            _tableWithType);
         return false;
       }
     }
@@ -1321,8 +1329,8 @@ public class PinotDdlRestletResource {
     } catch (Exception e) {
       restoreTaskSchedulesInMemory(tableConfig, removedSchedules);
       LOGGER.warn("Unable to remove task schedules before DROP TABLE on {}. "
-              + "Proceeding with table deletion because no active tasks were found. Reason: {}",
-          tableConfig.getTableName(), e.getMessage());
+              + "Proceeding with table deletion because no active tasks were found",
+          tableConfig.getTableName());
       return false;
     }
   }
@@ -1335,8 +1343,8 @@ public class PinotDdlRestletResource {
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER,
           "DROP TABLE detected active tasks after clearing task schedules for " + tableWithType
-              + " and failed to restore those schedules: " + e.getMessage(),
-          Response.Status.INTERNAL_SERVER_ERROR, e);
+              + " and failed to restore those schedules",
+          Response.Status.INTERNAL_SERVER_ERROR);
     }
   }
 
@@ -1374,7 +1382,7 @@ public class PinotDdlRestletResource {
 
   private ControllerApplicationException activeTasksBlocked(List<String> pendingTasks, String mutationContext) {
     return new ControllerApplicationException(LOGGER,
-        "DROP TABLE blocked because active running tasks exist: " + pendingTasks
+        ACTIVE_TASKS_BLOCKED_MESSAGE + ": " + pendingTasks
             + ". " + mutationContext + "; retry once the tasks finish.",
         Response.Status.BAD_REQUEST);
   }
@@ -1386,7 +1394,11 @@ public class PinotDdlRestletResource {
 
   private ControllerApplicationException dropFailed(String target, List<String> dropped,
       boolean taskSchedulesCleared, int statusCode, Exception cause) {
-    String causeDesc = cause.getMessage() != null ? cause.getMessage() : cause.getClass().getSimpleName();
+    // Preserve only the controller-owned active-task diagnosis. Other exception text can contain values formatted
+    // from a table config, so it is intentionally reduced to the exception type.
+    String causeDesc = cause instanceof ControllerApplicationException && cause.getMessage() != null
+        && cause.getMessage().startsWith(ACTIVE_TASKS_BLOCKED_MESSAGE)
+        ? "active running tasks exist" : cause.getClass().getSimpleName();
     String partialPrefix = dropped.isEmpty() ? "" : "Partial DROP TABLE: dropped " + dropped + ", ";
     String reCreateHint = dropped.isEmpty() ? ""
         : ". The successfully-dropped variant must be re-created if the original DROP was unintended.";
@@ -1397,7 +1409,7 @@ public class PinotDdlRestletResource {
         : "";
     return new ControllerApplicationException(LOGGER,
         partialPrefix + "failed to drop " + target + ": " + causeDesc + reCreateHint + taskScheduleHint,
-        statusCode, cause);
+        statusCode);
   }
 
   // -------------------------------------------------------------------------------------------
@@ -1473,7 +1485,9 @@ public class PinotDdlRestletResource {
       }
     }
 
-    TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
+    TableConfig tableConfig = resolvedType == TableType.OFFLINE
+        ? _pinotHelixResourceManager.getOfflineTableConfig(fullyQualifiedRaw, false, false)
+        : _pinotHelixResourceManager.getRealtimeTableConfig(fullyQualifiedRaw, false, false);
     if (tableConfig == null) {
       // hasTable returned true but getTableConfig returned null. This indicates ZK inconsistency
       // (torn write or concurrent delete between the two reads), not a missing table from the
@@ -1523,7 +1537,7 @@ public class PinotDdlRestletResource {
     // carries the correct qualifier even when the caller omits the db. prefix in the SQL.
     String ddl;
     try {
-      ddl = CanonicalDdlEmitter.emit(schema, tableConfig, database);
+      ddl = CanonicalDdlEmitter.emit(schema, TableConfigRedactionUtils.redact(tableConfig), database);
     } catch (IllegalArgumentException e) {
       // The emitter explicitly throws IllegalArgumentException to signal "this schema or config
       // cannot be expressed in the current DDL grammar":
@@ -1592,7 +1606,8 @@ public class PinotDdlRestletResource {
           Response.Status.NOT_FOUND);
     }
 
-    TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
+    TableConfig tableConfig =
+        _pinotHelixResourceManager.getOfflineTableConfig(fullyQualifiedRaw, false, false);
     if (tableConfig == null) {
       throw new ControllerApplicationException(LOGGER,
           "Table " + tableNameWithType + " has IdealState but no TableConfig in ZK; "
@@ -1628,7 +1643,7 @@ public class PinotDdlRestletResource {
 
     String ddl;
     try {
-      ddl = CanonicalDdlEmitter.emit(schema, tableConfig, database);
+      ddl = CanonicalDdlEmitter.emit(schema, TableConfigRedactionUtils.redact(tableConfig), database);
     } catch (IllegalArgumentException e) {
       // IllegalArgumentException from the MV branch of CanonicalDdlEmitter covers the
       // caller-actionable failure modes: non-round-trippable cron schedule (Q1=A —

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotMaterializedViewRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotMaterializedViewRestletResource.java
@@ -30,8 +30,10 @@ import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import javax.inject.Inject;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -51,14 +53,22 @@ import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.core.auth.Actions;
 import org.apache.pinot.core.auth.Authorize;
 import org.apache.pinot.core.auth.TargetType;
+import org.apache.pinot.materializedview.analysis.MaterializedViewAnalyzer;
 import org.apache.pinot.materializedview.metadata.MaterializedViewDefinitionMetadata;
+import org.apache.pinot.materializedview.metadata.MaterializedViewDefinitionMetadata.MaterializedViewSplitSpec;
 import org.apache.pinot.materializedview.metadata.MaterializedViewDefinitionMetadataUtils;
 import org.apache.pinot.materializedview.metadata.MaterializedViewRuntimeMetadata;
 import org.apache.pinot.materializedview.metadata.MaterializedViewRuntimeMetadataUtils;
 import org.apache.pinot.materializedview.metadata.PartitionInfo;
 import org.apache.pinot.materializedview.metadata.PartitionState;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableConfigRedactionUtils;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.DateTimeFieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.TimeUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,8 +78,9 @@ import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_K
 
 /// REST endpoints for the Materialized View UI: list, describe, drop.
 ///
-/// Read endpoints hydrate from the ZK definition + runtime znodes that the consistency manager
-/// and minion task executor maintain. The drop endpoint delegates to
+/// Read endpoints hydrate runtime state from the znodes that the consistency manager and minion
+/// task executor maintain. Every config-derived display field is rebuilt from current unresolved
+/// table configuration instead of executable definition metadata. The drop endpoint delegates to
 /// `PinotHelixResourceManager.deleteTable` so the same dependent-MV guards and segment-cleanup
 /// paths apply.
 ///
@@ -113,10 +124,10 @@ public class PinotMaterializedViewRestletResource {
         } catch (Exception e) {
           // One broken znode must not break the entire listing — surface it as a placeholder
           // entry that carries `error` so the UI can render it as a problem row.
-          LOGGER.warn("Failed to summarize MV {}: {}", viewTableName, e.getMessage());
+          LOGGER.warn("Failed to summarize MV {} ({})", viewTableName, e.getClass().getName());
           ObjectNode err = JsonUtils.newObjectNode();
           err.put("materializedViewTableName", viewTableName);
-          err.put("error", e.getMessage());
+          err.put("error", "Unable to summarize materialized view");
           mvs.add(err);
         }
       }
@@ -132,7 +143,7 @@ public class PinotMaterializedViewRestletResource {
   @Authorize(targetType = TargetType.TABLE, paramName = "materializedViewTableName",
       action = Actions.Table.GET_TABLE_CONFIG)
   @ApiOperation(value = "Get materialized view definition + runtime",
-      notes = "Returns the full ZK definition (definedSQL, base tables, split spec, partition expressions, "
+      notes = "Returns a display-safe definition (definedSQL, base tables, split spec, partition expressions, "
           + "stalenessThresholdMs) and runtime metadata (watermarkMs, per-bucket state map).")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success"),
@@ -140,22 +151,40 @@ public class PinotMaterializedViewRestletResource {
   public String getMaterializedView(
       @ApiParam(value = "MV table name (with type suffix, e.g. airlineStatsMv_OFFLINE)", required = true)
       @PathParam("materializedViewTableName") String viewTableName) {
-    ZkHelixPropertyStore<ZNRecord> propertyStore = _pinotHelixResourceManager.getPropertyStore();
-    MaterializedViewDefinitionMetadata definition =
-        MaterializedViewDefinitionMetadataUtils.fetch(propertyStore, viewTableName);
-    if (definition == null) {
-      throw new ControllerApplicationException(LOGGER,
-          "Materialized view not found: " + viewTableName, Response.Status.NOT_FOUND);
-    }
-    MaterializedViewRuntimeMetadata runtime = MaterializedViewRuntimeMetadataUtils.fetch(propertyStore, viewTableName);
+    try {
+      ZkHelixPropertyStore<ZNRecord> propertyStore = _pinotHelixResourceManager.getPropertyStore();
+      MaterializedViewDefinitionMetadata persistedDefinition =
+          MaterializedViewDefinitionMetadataUtils.fetch(propertyStore, viewTableName);
+      if (persistedDefinition == null) {
+        throw new ControllerApplicationException(LOGGER,
+            "Materialized view not found: " + viewTableName, Response.Status.NOT_FOUND);
+      }
+      MaterializedViewRuntimeMetadata runtime =
+          MaterializedViewRuntimeMetadataUtils.fetch(propertyStore, viewTableName);
 
-    ObjectNode result = JsonUtils.newObjectNode();
-    // Pass the already-fetched runtime so the partition-summary aggregates and the per-bucket
-    // table are computed from the SAME ZK snapshot.  Two reads would risk rendering
-    // VALID/STALE counts that disagree with the partition states on the same page.
-    result.set("definition", buildDefinitionNode(definition, runtime));
-    result.set("runtime", buildRuntimeNode(runtime));
-    return result.toString();
+      // The definition znode can be stale and older controllers may have populated it from an
+      // environment-resolved TableConfig. Read the current unresolved TableConfig instead so this
+      // ordinary table-read representation never returns a resolved value and preserves placeholders.
+      String rawTableName = TableNameBuilder.extractRawTableName(viewTableName);
+      TableConfig tableConfig = _pinotHelixResourceManager.getOfflineTableConfig(rawTableName, false, false);
+      MaterializedViewDefinitionMetadata displayDefinition =
+          buildDisplayDefinition(viewTableName, tableConfig);
+
+      ObjectNode result = JsonUtils.newObjectNode();
+      // Pass the already-fetched runtime so the partition-summary aggregates and the per-bucket
+      // table are computed from the SAME ZK snapshot.  Two reads would risk rendering
+      // VALID/STALE counts that disagree with the partition states on the same page.
+      result.set("definition", buildDefinitionNode(displayDefinition, runtime));
+      result.set("runtime", buildRuntimeNode(runtime));
+      return result.toString();
+    } catch (ControllerApplicationException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      // Do not attach the cause: metadata parse/redaction failures can contain persisted SQL.
+      throw new ControllerApplicationException(LOGGER,
+          "Failed to render materialized view details for " + viewTableName,
+          Response.Status.INTERNAL_SERVER_ERROR);
+    }
   }
 
   @DELETE
@@ -195,13 +224,14 @@ public class PinotMaterializedViewRestletResource {
       _pinotHelixResourceManager.deleteTable(viewTableName, tableType, null);
     } catch (IllegalStateException e) {
       // Thrown when a dependent MV blocks the delete.
-      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.CONFLICT, e);
+      throw new ControllerApplicationException(LOGGER,
+          "Materialized view cannot be dropped because another view depends on it", Response.Status.CONFLICT);
     } catch (WebApplicationException e) {
       throw e;
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER,
-          "Failed to drop materialized view " + viewTableName + ": " + e.getMessage(),
-          Response.Status.INTERNAL_SERVER_ERROR, e);
+          "Failed to drop materialized view " + viewTableName,
+          Response.Status.INTERNAL_SERVER_ERROR);
     }
     ObjectNode result = JsonUtils.newObjectNode();
     result.put("status", "Materialized view " + viewTableName + " dropped.");
@@ -259,25 +289,151 @@ public class PinotMaterializedViewRestletResource {
   private ObjectNode buildDefinitionNode(MaterializedViewDefinitionMetadata definition,
       MaterializedViewRuntimeMetadata runtime) {
     ObjectNode node = JsonUtils.newObjectNode();
-    node.put("materializedViewTableName", definition.getMaterializedViewTableNameWithType());
-    node.put("definedSQL", definition.getDefinedSql());
-    node.set("baseTables", JsonUtils.objectToJsonNode(definition.getBaseTables()));
-    node.set("partitionExprMaps", JsonUtils.objectToJsonNode(definition.getPartitionExprMaps()));
+    node.put("materializedViewTableName", TableConfigRedactionUtils.redactStructuredText(
+        definition.getMaterializedViewTableNameWithType()));
+    node.put("definedSQL", TableConfigRedactionUtils.redactStructuredText(definition.getDefinedSql()));
+    node.set("baseTables", JsonUtils.objectToJsonNode(
+        definition.getBaseTables().stream().map(TableConfigRedactionUtils::redactStructuredText).toList()));
+    node.set("partitionExprMaps", JsonUtils.objectToJsonNode(
+        redactPartitionExprMaps(definition.getPartitionExprMaps())));
     node.put("stalenessThresholdMs", definition.getStalenessThresholdMs());
     // Summary partition stats computed from the SAME runtime snapshot the partition table
     // below uses, so the two views can never disagree on a single page render.
     appendPartitionSummary(node, runtime);
     if (definition.getSplitSpec() != null) {
       ObjectNode split = JsonUtils.newObjectNode();
-      split.put("sourceTimeColumn", definition.getSplitSpec().getSourceTimeColumn());
-      split.put("sourceTimeFormat", definition.getSplitSpec().getSourceTimeFormat());
-      split.put("materializedViewTimeColumn", definition.getSplitSpec().getMaterializedViewTimeColumn());
+      split.put("sourceTimeColumn", TableConfigRedactionUtils.redactStructuredText(
+          definition.getSplitSpec().getSourceTimeColumn()));
+      split.put("sourceTimeFormat", TableConfigRedactionUtils.redactStructuredText(
+          definition.getSplitSpec().getSourceTimeFormat()));
+      split.put("materializedViewTimeColumn", TableConfigRedactionUtils.redactStructuredText(
+          definition.getSplitSpec().getMaterializedViewTimeColumn()));
       split.put("bucketMs", definition.getSplitSpec().getBucketMs());
       node.set("splitSpec", split);
     } else {
       node.putNull("splitSpec");
     }
     return node;
+  }
+
+  private MaterializedViewDefinitionMetadata buildDisplayDefinition(String viewTableName,
+      TableConfig tableConfig) {
+    if (tableConfig == null || !tableConfig.isMaterializedView()) {
+      throw new IllegalStateException("Current unresolved materialized-view TableConfig is unavailable");
+    }
+    if (tableConfig.getTaskConfig() == null || tableConfig.getTaskConfig().getTaskTypeConfigsMap() == null) {
+      throw new IllegalStateException("Current materialized-view task config is unavailable");
+    }
+
+    Map<String, String> displayTaskConfigs = null;
+    for (Map<String, String> taskConfigs : tableConfig.getTaskConfig().getTaskTypeConfigsMap().values()) {
+      if (taskConfigs == null) {
+        continue;
+      }
+      String candidate = taskConfigs.get(CommonConstants.MaterializedViewTask.DEFINED_SQL_KEY);
+      if (candidate == null || candidate.trim().isEmpty()) {
+        continue;
+      }
+      if (displayTaskConfigs != null) {
+        boolean sameDisplayInputs = Objects.equals(
+            displayTaskConfigs.get(CommonConstants.MaterializedViewTask.DEFINED_SQL_KEY), candidate)
+            && Objects.equals(
+                displayTaskConfigs.get(CommonConstants.MaterializedViewTask.BUCKET_TIME_PERIOD_KEY),
+                taskConfigs.get(CommonConstants.MaterializedViewTask.BUCKET_TIME_PERIOD_KEY))
+            && Objects.equals(
+                displayTaskConfigs.get(CommonConstants.MaterializedViewTask.STALENESS_THRESHOLD_MS_KEY),
+                taskConfigs.get(CommonConstants.MaterializedViewTask.STALENESS_THRESHOLD_MS_KEY));
+        if (!sameDisplayInputs) {
+          throw new IllegalStateException("Materialized-view task configs contain ambiguous display definitions");
+        }
+        continue;
+      }
+      displayTaskConfigs = taskConfigs;
+    }
+    if (displayTaskConfigs == null) {
+      throw new IllegalStateException("Current materialized-view SQL is unavailable");
+    }
+    String definedSql = displayTaskConfigs.get(CommonConstants.MaterializedViewTask.DEFINED_SQL_KEY);
+
+    // Rebuild every config-derived display field from unresolved state. The persisted
+    // definition remains the executable runtime contract and can contain values substituted by
+    // an environment provider, so none of its fields are eligible for an ordinary read response.
+    String sourceRawTableName = MaterializedViewAnalyzer.extractSourceTableName(definedSql);
+    String viewRawTableName = TableNameBuilder.extractRawTableName(viewTableName);
+    Schema viewSchema = _pinotHelixResourceManager.getSchema(viewRawTableName);
+    Schema sourceSchema = _pinotHelixResourceManager.getSchema(sourceRawTableName);
+    if (viewSchema == null || sourceSchema == null) {
+      throw new IllegalStateException("Current materialized-view schemas are unavailable");
+    }
+
+    TableConfig sourceTableConfig =
+        _pinotHelixResourceManager.getOfflineTableConfig(sourceRawTableName, false, false);
+    if (sourceTableConfig == null) {
+      sourceTableConfig = _pinotHelixResourceManager.getRealtimeTableConfig(sourceRawTableName, false, false);
+    }
+    if (sourceTableConfig == null || sourceTableConfig.getValidationConfig() == null
+        || tableConfig.getValidationConfig() == null) {
+      throw new IllegalStateException("Current unresolved materialized-view split configuration is unavailable");
+    }
+
+    String sourceTimeColumn = sourceTableConfig.getValidationConfig().getTimeColumnName();
+    String viewTimeColumn = tableConfig.getValidationConfig().getTimeColumnName();
+    DateTimeFieldSpec sourceTimeFieldSpec = sourceSchema.getSpecForTimeColumn(sourceTimeColumn);
+    DateTimeFieldSpec viewTimeFieldSpec = viewSchema.getSpecForTimeColumn(viewTimeColumn);
+    if (sourceTimeFieldSpec == null || viewTimeFieldSpec == null) {
+      throw new IllegalStateException("Current materialized-view time-column metadata is unavailable");
+    }
+
+    String bucketTimePeriod = displayTaskConfigs.get(CommonConstants.MaterializedViewTask.BUCKET_TIME_PERIOD_KEY);
+    if (bucketTimePeriod == null || bucketTimePeriod.isEmpty()) {
+      throw new IllegalStateException("Current materialized-view bucket period is unavailable");
+    }
+    long bucketMs = TimeUtils.convertPeriodToMillis(bucketTimePeriod);
+    if (bucketMs <= 0) {
+      throw new IllegalStateException("Current materialized-view bucket period is invalid");
+    }
+
+    long stalenessThresholdMs = CommonConstants.MaterializedViewTask.DEFAULT_STALENESS_THRESHOLD_MS;
+    String staleness = displayTaskConfigs.get(CommonConstants.MaterializedViewTask.STALENESS_THRESHOLD_MS_KEY);
+    if (staleness != null && !staleness.isEmpty()) {
+      try {
+        stalenessThresholdMs = Long.parseLong(staleness);
+      } catch (NumberFormatException e) {
+        throw new IllegalStateException("Current materialized-view staleness threshold is not displayable");
+      }
+      if (stalenessThresholdMs < 0) {
+        throw new IllegalStateException("Current materialized-view staleness threshold is invalid");
+      }
+    }
+
+    Map<String, String> partitionExprMaps =
+        MaterializedViewAnalyzer.extractPartitionExprMaps(definedSql, viewSchema);
+    MaterializedViewSplitSpec splitSpec = new MaterializedViewSplitSpec(
+        sourceTimeColumn, sourceTimeFieldSpec.getFormat(), viewTimeColumn, viewTimeFieldSpec.getFormat(), bucketMs);
+    return new MaterializedViewDefinitionMetadata(viewTableName, List.of(sourceRawTableName), definedSql,
+        partitionExprMaps, splitSpec, stalenessThresholdMs, true);
+  }
+
+  private static Map<String, String> redactPartitionExprMaps(Map<String, String> partitionExprMaps) {
+    Map<String, String> redacted = new LinkedHashMap<>();
+    if (partitionExprMaps == null) {
+      return redacted;
+    }
+    for (Map.Entry<String, String> entry : partitionExprMaps.entrySet()) {
+      if (entry.getKey() == null) {
+        throw new IllegalStateException("Materialized-view partition expression key is null");
+      }
+      String key = TableConfigRedactionUtils.redactStructuredText(entry.getKey());
+      String value = entry.getValue() != null
+          ? TableConfigRedactionUtils.redactStructuredText(entry.getValue()) : null;
+      // JSON object keys must remain unique. If masking makes two distinct expressions collide,
+      // returning either one would silently misrepresent persisted state, so fail closed.
+      if (redacted.containsKey(key)) {
+        throw new IllegalStateException("Redacted materialized-view partition expressions collide");
+      }
+      redacted.put(key, value);
+    }
+    return redacted;
   }
 
   /// Counts VALID / STALE / total partitions from the supplied runtime snapshot and attaches

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -17,8 +17,11 @@
  * under the License.
  */
 package org.apache.pinot.controller.api.resources;
+
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -42,6 +45,7 @@ import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -78,6 +82,7 @@ import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.exception.RebalanceInProgressException;
 import org.apache.pinot.common.exception.SchemaNotFoundException;
 import org.apache.pinot.common.exception.TableConfigBackwardIncompatibleException;
+import org.apache.pinot.common.exception.TableConfigVersionMismatchException;
 import org.apache.pinot.common.exception.TableNotFoundException;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metrics.ControllerMeter;
@@ -121,6 +126,7 @@ import org.apache.pinot.core.auth.ManualAuthorization;
 import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.segment.local.utils.TableConfigUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableConfigRedactionUtils;
 import org.apache.pinot.spi.config.table.TableConfigValidatorRegistry;
 import org.apache.pinot.spi.config.table.TableStatsHumanReadable;
 import org.apache.pinot.spi.config.table.TableStatus;
@@ -224,13 +230,14 @@ public class PinotTableRestletResource {
       throws IOException {
     // TODO introduce a table config ctor with json string.
     Pair<TableConfig, Map<String, Object>> tableConfigAndUnrecognizedProperties;
-    TableConfig tableConfig;
+    TableConfig tableConfig = null;
     String tableNameWithType;
     Schema schema;
     try {
       tableConfigAndUnrecognizedProperties =
           JsonUtils.stringToObjectAndUnrecognizedProperties(tableConfigStr, TableConfig.class);
       tableConfig = tableConfigAndUnrecognizedProperties.getLeft();
+      tableConfig = TableConfigRedactionUtils.restoreRedactedValues(tableConfig, null);
       tableNameWithType = DatabaseUtils.translateTableName(tableConfig.getTableName(), httpHeaders);
       tableConfig.setTableName(tableNameWithType);
 
@@ -252,10 +259,13 @@ public class PinotTableRestletResource {
 
       TableConfigValidationUtils.validateTableConfig(
           tableConfig, schema, typesToSkip, _pinotHelixResourceManager, _controllerConf, _pinotTaskManager);
+    } catch (IOException e) {
+      throw new ControllerApplicationException(LOGGER, "Invalid table config JSON", Response.Status.BAD_REQUEST);
     } catch (TableAlreadyExistsException e) {
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.CONFLICT, e);
     } catch (Exception e) {
-      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST, e);
+      throw new ControllerApplicationException(LOGGER, redactedConfigError("Invalid table config", e, tableConfig),
+          Response.Status.BAD_REQUEST);
     }
     try {
       if (!ignoreActiveTasks) {
@@ -265,27 +275,29 @@ public class PinotTableRestletResource {
       // TODO: validate that table was created successfully
       // (in realtime case, metadata might not have been created but would be created successfully in the next run of
       // the validation manager)
-      LOGGER.info("Successfully added table: {} with config: {}", tableNameWithType, tableConfig);
+      LOGGER.info("Successfully added table: {}", tableNameWithType);
       return new ConfigSuccessResponse("Table " + tableNameWithType + " successfully added",
           tableConfigAndUnrecognizedProperties.getRight());
     } catch (Exception e) {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_ADD_ERROR, 1L);
       if (e instanceof InvalidTableConfigException) {
-        String errStr = String.format("Invalid table config for table %s: %s", tableNameWithType, e.getMessage());
-        throw new ControllerApplicationException(LOGGER, errStr, Response.Status.BAD_REQUEST, e);
+        throw new ControllerApplicationException(LOGGER,
+            redactedConfigError("Invalid table config for table " + tableNameWithType, e, tableConfig),
+            Response.Status.BAD_REQUEST);
       } else if (e instanceof TableAlreadyExistsException) {
         throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.CONFLICT, e);
       } else if (e instanceof ControllerApplicationException) {
         throw e;
       } else {
-        throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
+        throw new ControllerApplicationException(LOGGER, "Failed to add table " + tableNameWithType,
+            Response.Status.INTERNAL_SERVER_ERROR);
       }
     }
   }
 
   @POST
   @Path("/tables/{tableName}/copy")
-  @Authorize(targetType = TargetType.TABLE, action = Actions.Table.CREATE_TABLE)
+  @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.CREATE_TABLE)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Copy a table's schema and config from another cluster", notes = "Non upsert table only")
   public CopyTableResponse copyTable(
@@ -295,11 +307,11 @@ public class PinotTableRestletResource {
       @ApiParam(value = "Dry run mode") @QueryParam("dryRun") @DefaultValue("true") boolean dryRun,
       @Context HttpHeaders headers) {
     try {
-      LOGGER.info("[copyTable] received request for table: {}, payload: {}", tableName, payload);
+      LOGGER.info("[copyTable] received request for table: {}", tableName);
       tableName = DatabaseUtils.translateTableName(tableName, headers);
 
-      if (_pinotHelixResourceManager.getTableConfig(TableNameBuilder.REALTIME.tableNameWithType(tableName)) != null
-          || _pinotHelixResourceManager.getTableConfig(TableNameBuilder.OFFLINE.tableNameWithType(tableName)) != null) {
+      if (_pinotHelixResourceManager.hasRealtimeTable(tableName)
+          || _pinotHelixResourceManager.hasOfflineTable(tableName)) {
         throw new TableAlreadyExistsException("Table config for " + tableName
             + " already exists. If this is unexpected, try deleting the table to remove all metadata associated"
             + " with it before attempting to recreate.");
@@ -309,7 +321,7 @@ public class PinotTableRestletResource {
       String sourceControllerUri = copyTablePayload.getSourceClusterUri();
       Map<String, String> requestHeaders = copyTablePayload.getHeaders();
 
-      LOGGER.info("[copyTable] Start copying table: {} from source: {}", tableName, sourceControllerUri);
+      LOGGER.info("[copyTable] Start copying table: {}", tableName);
 
       ControllerRequestURLBuilder urlBuilder = ControllerRequestURLBuilder.baseUrl(sourceControllerUri);
 
@@ -320,11 +332,15 @@ public class PinotTableRestletResource {
       Schema schema = Schema.fromString(schemaJson);
 
       URI tableConfigUri = new URI(urlBuilder.forTableGet(tableName));
+      Map<String, String> tableConfigRequestHeaders =
+          requestHeaders != null ? new HashMap<>(requestHeaders) : new HashMap<>();
+      tableConfigRequestHeaders.put(HttpHeaders.ACCEPT, RedactedTableConfigResponse.MEDIA_TYPE);
       SimpleHttpResponse tableConfigResponse = HttpClient.wrapAndThrowHttpException(
-          HttpClient.getInstance().sendGetRequest(tableConfigUri, requestHeaders));
+          HttpClient.getInstance().sendGetRequest(tableConfigUri, tableConfigRequestHeaders));
       String tableConfigJson = tableConfigResponse.getResponse();
       LOGGER.info("[copyTable] Fetched table config for table: {}", tableName);
-      JsonNode tableConfigNode = JsonUtils.stringToJsonNode(tableConfigJson);
+      JsonNode tableConfigResponseNode = JsonUtils.stringToJsonNode(tableConfigJson);
+      JsonNode tableConfigNode = unwrapTableConfigResponse(tableConfigResponseNode);
 
       URI watermarkUri = new URI(urlBuilder.forConsumerWatermarksGet(tableName));
       SimpleHttpResponse watermarkResponse = HttpClient.wrapAndThrowHttpException(
@@ -344,7 +360,9 @@ public class PinotTableRestletResource {
 
         ObjectNode realtimeTableConfigNode = (ObjectNode) tableConfigNode.get(TableType.REALTIME.name());
         tweakRealtimeTableConfig(realtimeTableConfigNode, copyTablePayload);
-        realtimeTableConfig = JsonUtils.jsonNodeToObject(realtimeTableConfigNode, TableConfig.class);
+        applyCredentialOverrides(realtimeTableConfigNode, copyTablePayload.getCredentialOverrides());
+        realtimeTableConfig = TableConfigRedactionUtils.restoreRedactedValues(
+            JsonUtils.jsonNodeToObject(realtimeTableConfigNode, TableConfig.class), null);
         if (realtimeTableConfig.getUpsertConfig() != null) {
           throw new IllegalStateException("upsert table copy not supported");
         }
@@ -353,12 +371,13 @@ public class PinotTableRestletResource {
         TableConfigValidationUtils.validateTableConfig(
             realtimeTableConfig, schema, null, _pinotHelixResourceManager, _controllerConf, _pinotTaskManager);
       } catch (ConfigValidationException | IllegalArgumentException | IllegalStateException e) {
-        throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST, e);
+        throw new ControllerApplicationException(LOGGER, "Invalid copied table config", Response.Status.BAD_REQUEST);
       }
       LOGGER.info("[copyTable] Successfully fetched and tweaked table config for table: {}", tableName);
 
       if (dryRun) {
-        return new CopyTableResponse("success", "Dry run", schema, realtimeTableConfig, watermarkInductionResult);
+        return new CopyTableResponse("success", "Dry run", schema,
+            TableConfigRedactionUtils.redact(realtimeTableConfig), watermarkInductionResult);
       }
 
       List<StreamConfig> streamConfigs = IngestionConfigUtils.getStreamConfigs(realtimeTableConfig);
@@ -376,17 +395,27 @@ public class PinotTableRestletResource {
       }
       if (verbose) {
         response.setSchema(schema);
-        response.setTableConfig(realtimeTableConfig);
+        response.setTableConfig(TableConfigRedactionUtils.redact(realtimeTableConfig));
         response.setWatermarkInductionResult(watermarkInductionResult);
       }
       return response;
     } catch (ControllerApplicationException e) {
       throw e;
     } catch (Exception e) {
-      LOGGER.error("[copyTable] Error copying table: {}", tableName, e);
-      throw new ControllerApplicationException(LOGGER, "Error copying table: " + e.getMessage(),
-          Response.Status.INTERNAL_SERVER_ERROR, e);
+      throw new ControllerApplicationException(LOGGER, "Error copying table: " + tableName,
+          Response.Status.INTERNAL_SERVER_ERROR);
     }
+  }
+
+  @VisibleForTesting
+  static JsonNode unwrapTableConfigResponse(JsonNode responseNode)
+      throws IOException {
+    if (!RedactedTableConfigResponse.isEnvelope(responseNode)) {
+      throw new IOException("Source controller did not return the requested table config representation");
+    }
+    RedactedTableConfigResponse response =
+        JsonUtils.jsonNodeToObject(responseNode, RedactedTableConfigResponse.class);
+    return JsonUtils.objectToJsonNode(response.getConfigs());
   }
 
   @VisibleForTesting
@@ -454,6 +483,42 @@ public class PinotTableRestletResource {
       String srcTag = tagPoolConfig.get("tag").asText();
       if (tagPoolReplacementMap.containsKey(srcTag)) {
         tagPoolConfig.put("tag", tagPoolReplacementMap.get(srcTag));
+      }
+    }
+  }
+
+  /// Replaces source-cluster redaction markers with caller-supplied credentials. Requiring an exact JSON Pointer to a
+  /// marker-bearing leaf preserves copy without adding a raw source-read path or allowing this field to mutate ordinary
+  /// configuration values.
+  @VisibleForTesting
+  static void applyCredentialOverrides(ObjectNode tableConfigNode, @Nullable Map<String, String> overrides) {
+    if (overrides == null || overrides.isEmpty()) {
+      return;
+    }
+    for (Map.Entry<String, String> override : overrides.entrySet()) {
+      JsonPointer pointer = JsonPointer.compile(override.getKey());
+      Preconditions.checkArgument(!pointer.matches(), "Credential override must identify a table config field");
+      JsonNode parent = tableConfigNode.at(pointer.head());
+      JsonPointer leaf = pointer.last();
+      JsonNode current;
+      if (parent.isObject() && leaf.mayMatchProperty()) {
+        current = parent.get(leaf.getMatchingProperty());
+      } else if (parent.isArray() && leaf.mayMatchElement()) {
+        current = parent.get(leaf.getMatchingIndex());
+      } else {
+        throw new IllegalArgumentException("Credential override does not identify a table config field");
+      }
+      String value = override.getValue();
+      Preconditions.checkArgument(value != null && !value.contains(TableConfigRedactionUtils.REDACTION_MARKER),
+          "Credential override must contain a literal replacement");
+      Preconditions.checkArgument(current != null && current.isTextual()
+              && TableConfigRedactionUtils.isValidCredentialOverride(
+                  tableConfigNode, override.getKey(), value),
+          "Credential override target is not a redacted credential");
+      if (parent.isObject()) {
+        ((ObjectNode) parent).put(leaf.getMatchingProperty(), value);
+      } else {
+        ((ArrayNode) parent).set(leaf.getMatchingIndex(), JsonUtils.objectToJsonNode(value));
       }
     }
   }
@@ -564,38 +629,49 @@ public class PinotTableRestletResource {
   @GET
   @Path("/tables/{tableName}")
   @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_TABLE_CONFIG)
-  @Produces(MediaType.APPLICATION_JSON)
-  @ApiOperation(value = "Lists the table configs")
+  @Produces({MediaType.APPLICATION_JSON, RedactedTableConfigResponse.MEDIA_TYPE})
+  @ApiOperation(value = "Lists the table configs",
+      notes = "Returns a versioned redacted response. Submit the complete response to PUT when retaining markers.")
   public String listTableConfigs(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "realtime|offline") @QueryParam("type") String tableTypeStr, @Context HttpHeaders headers) {
     try {
       tableName = DatabaseUtils.translateTableName(tableName, headers);
-      ObjectNode ret = JsonUtils.newObjectNode();
+      Map<String, TableConfig> configs = new LinkedHashMap<>();
+      Map<String, Integer> baseVersions = new LinkedHashMap<>();
 
       if ((tableTypeStr == null || TableType.OFFLINE.name().equalsIgnoreCase(tableTypeStr))
           && _pinotHelixResourceManager.hasOfflineTable(tableName)) {
-        TableConfig tableConfig = _pinotHelixResourceManager.getOfflineTableConfig(tableName, false, false);
-        Preconditions.checkNotNull(tableConfig);
-        ret.set(TableType.OFFLINE.name(), tableConfig.toJsonNode());
+        Pair<TableConfig, Integer> tableConfigWithVersion = getUnresolvedTableConfigWithVersion(
+            _pinotHelixResourceManager, TableNameBuilder.OFFLINE.tableNameWithType(tableName));
+        Preconditions.checkNotNull(tableConfigWithVersion);
+        configs.put(TableType.OFFLINE.name(), TableConfigRedactionUtils.redact(tableConfigWithVersion.getLeft()));
+        baseVersions.put(TableType.OFFLINE.name(), tableConfigWithVersion.getRight());
       }
 
       if ((tableTypeStr == null || TableType.REALTIME.name().equalsIgnoreCase(tableTypeStr))
           && _pinotHelixResourceManager.hasRealtimeTable(tableName)) {
-        TableConfig tableConfig = _pinotHelixResourceManager.getRealtimeTableConfig(tableName, false, false);
-        Preconditions.checkNotNull(tableConfig);
-        ret.set(TableType.REALTIME.name(), tableConfig.toJsonNode());
+        Pair<TableConfig, Integer> tableConfigWithVersion = getUnresolvedTableConfigWithVersion(
+            _pinotHelixResourceManager, TableNameBuilder.REALTIME.tableNameWithType(tableName));
+        Preconditions.checkNotNull(tableConfigWithVersion);
+        configs.put(TableType.REALTIME.name(), TableConfigRedactionUtils.redact(tableConfigWithVersion.getLeft()));
+        baseVersions.put(TableType.REALTIME.name(), tableConfigWithVersion.getRight());
       }
 
-      if (ret.isEmpty()) {
+      if (configs.isEmpty()) {
         String tableNameWithType = tableTypeStr != null ? tableName + "_" + tableTypeStr.toUpperCase() : tableName;
         throw new TableNotFoundException("Table " + tableNameWithType + " does not exist");
       }
-      return ret.toString();
+      Pair<Schema, Integer> schemaWithVersion = _pinotHelixResourceManager.getSchemaWithVersion(
+          TableNameBuilder.extractRawTableName(tableName));
+      Preconditions.checkNotNull(schemaWithVersion, "Failed to find schema for table: %s", tableName);
+      baseVersions.put(RedactedTableConfigResponse.SCHEMA_VERSION_KEY, schemaWithVersion.getRight());
+      return JsonUtils.objectToString(new RedactedTableConfigResponse(configs, baseVersions));
     } catch (TableNotFoundException e) {
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.NOT_FOUND, e);
     } catch (Exception e) {
-      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
+      throw new ControllerApplicationException(LOGGER, "Failed to retrieve table config",
+          Response.Status.INTERNAL_SERVER_ERROR);
     }
   }
 
@@ -680,7 +756,7 @@ public class PinotTableRestletResource {
   public static void tableTasksCleanup(String tableWithType, boolean ignoreActiveTasks,
       PinotHelixResourceManager pinotHelixResourceManager, PinotHelixTaskResourceManager pinotHelixTaskResourceManager)
       throws IOException {
-    TableConfig tableConfig = pinotHelixResourceManager.getTableConfig(tableWithType);
+    TableConfig tableConfig = getUnresolvedTableConfig(pinotHelixResourceManager, tableWithType);
     if (tableConfig == null || tableConfig.getTaskConfig() == null) {
       return;
     }
@@ -696,8 +772,7 @@ public class PinotTableRestletResource {
       try {
         pinotHelixResourceManager.updateTableConfig(tableConfig);
       } catch (Exception e) {
-        LOGGER.warn("Unable to remove the task schedules, going ahead with table deletion anyways. "
-            + "Reason for failure : {}", e.getMessage());
+        LOGGER.warn("Unable to remove task schedules before table deletion for {}", tableWithType);
       }
     }
     List<String> pendingTasks = new ArrayList<>();
@@ -723,6 +798,28 @@ public class PinotTableRestletResource {
           + ": " + pendingTasks + ". The task schedules have been cleared, so new tasks should not be generated. "
           + "Please try again once there are no more active tasks", Response.Status.BAD_REQUEST);
     }
+  }
+
+  @Nullable
+  static TableConfig getUnresolvedTableConfig(PinotHelixResourceManager resourceManager, String tableWithType) {
+    String rawTableName = TableNameBuilder.extractRawTableName(tableWithType);
+    TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableWithType);
+    if (tableType == TableType.REALTIME) {
+      return resourceManager.getRealtimeTableConfig(rawTableName, false, false);
+    }
+    if (tableType == TableType.OFFLINE) {
+      return resourceManager.getOfflineTableConfig(rawTableName, false, false);
+    }
+    return null;
+  }
+
+  @Nullable
+  static Pair<TableConfig, Integer> getUnresolvedTableConfigWithVersion(
+      PinotHelixResourceManager resourceManager, String tableWithType) {
+    if (TableNameBuilder.getTableTypeFromTableName(tableWithType) == null) {
+      return null;
+    }
+    return resourceManager.getTableConfigWithVersion(tableWithType, false, false);
   }
 
   //   Return true iff the table is of the expectedType based on the given tableName and tableType. The truth table:
@@ -768,55 +865,148 @@ public class PinotTableRestletResource {
       @Context HttpHeaders headers,
       String tableConfigString)
       throws Exception {
-    Pair<TableConfig, Map<String, Object>> tableConfigAndUnrecognizedProperties;
-    TableConfig tableConfig;
-    String tableNameWithType;
-    Schema schema;
+    ParsedTableConfigUpdate parsedUpdate;
+    Map<TableType, TableConfig> tableConfigs = new LinkedHashMap<>();
+    Map<TableType, TableConfig> storedTableConfigs = new LinkedHashMap<>();
+    Map<TableType, Integer> expectedVersions = new LinkedHashMap<>();
+    Pair<Schema, Integer> schemaWithVersion;
     try {
-      tableConfigAndUnrecognizedProperties =
-          JsonUtils.stringToObjectAndUnrecognizedProperties(tableConfigString, TableConfig.class);
-      tableConfig = tableConfigAndUnrecognizedProperties.getLeft();
-      tableNameWithType = DatabaseUtils.translateTableName(tableConfig.getTableName(), headers);
-      tableConfig.setTableName(tableNameWithType);
-      String tableNameFromPath = DatabaseUtils.translateTableName(
-          TableNameBuilder.forType(tableConfig.getTableType()).tableNameWithType(tableName), headers);
-      if (!tableNameFromPath.equals(tableNameWithType)) {
+      parsedUpdate = parseTableConfigUpdate(tableConfigString);
+      String rawTableName = DatabaseUtils.translateTableName(TableNameBuilder.extractRawTableName(tableName), headers);
+      schemaWithVersion = _pinotHelixResourceManager.getSchemaWithVersion(rawTableName);
+      Preconditions.checkNotNull(schemaWithVersion, "Failed to find schema for table: %s", rawTableName);
+      Integer schemaBaseVersion = parsedUpdate._baseVersions.get(RedactedTableConfigResponse.SCHEMA_VERSION_KEY);
+      if (schemaBaseVersion != null && !schemaBaseVersion.equals(schemaWithVersion.getRight())) {
         throw new ControllerApplicationException(LOGGER,
-            "Request table " + tableNameFromPath + " does not match table name in the body " + tableNameWithType,
-            Response.Status.BAD_REQUEST);
+            "Table schema changed after it was read; retrieve the table config again before updating",
+            Response.Status.CONFLICT);
       }
+      for (Map.Entry<TableType, TableConfig> entry : parsedUpdate._tableConfigs.entrySet()) {
+        TableType tableType = entry.getKey();
+        TableConfig tableConfig = entry.getValue();
+        String tableNameWithType = DatabaseUtils.translateTableName(tableConfig.getTableName(), headers);
+        tableConfig.setTableName(tableNameWithType);
+        String tableNameFromPath = DatabaseUtils.translateTableName(
+            TableNameBuilder.forType(tableType).tableNameWithType(tableName), headers);
+        if (!tableNameFromPath.equals(tableNameWithType)) {
+          throw new ControllerApplicationException(LOGGER,
+              "Request table " + tableNameFromPath + " does not match table name in the body " + tableNameWithType,
+              Response.Status.BAD_REQUEST);
+        }
 
-      schema = _pinotHelixResourceManager.getTableSchema(tableNameWithType);
-      Preconditions.checkState(schema != null, "Failed to find schema for table: %s", tableNameWithType);
-      TableConfigValidationUtils.validateTableConfig(
-          tableConfig, schema, typesToSkip, _pinotHelixResourceManager, _controllerConf, _pinotTaskManager,
-          _pinotHelixResourceManager.getTableConfig(tableNameWithType));
+        Pair<TableConfig, Integer> storedTableConfigWithVersion =
+            getUnresolvedTableConfigWithVersion(_pinotHelixResourceManager, tableNameWithType);
+        if (storedTableConfigWithVersion == null) {
+          throw new ControllerApplicationException(LOGGER, "Table " + tableNameWithType + " does not exist",
+              Response.Status.NOT_FOUND);
+        }
+        TableConfig storedTableConfig = storedTableConfigWithVersion.getLeft();
+        int currentVersion = storedTableConfigWithVersion.getRight();
+        Integer baseVersion = parsedUpdate._baseVersions.get(tableType.name());
+        if (baseVersion != null && baseVersion != currentVersion) {
+          throw new ControllerApplicationException(LOGGER,
+              "Table config changed after it was read; retrieve it again before updating", Response.Status.CONFLICT);
+        }
+        expectedVersions.put(tableType, baseVersion != null ? baseVersion : currentVersion);
+        tableConfig = TableConfigRedactionUtils.restoreRedactedValues(tableConfig, storedTableConfig);
+        storedTableConfigs.put(tableType, storedTableConfig);
+        tableConfigs.put(tableType, tableConfig);
+      }
+      boolean coordinatedHybridUpdate = tableConfigs.size() == 2;
+      for (Map.Entry<TableType, TableConfig> entry : tableConfigs.entrySet()) {
+        TableConfigValidationUtils.validateTableConfig(
+            entry.getValue(), schemaWithVersion.getLeft(), typesToSkip, _pinotHelixResourceManager, _controllerConf,
+            _pinotTaskManager, storedTableConfigs.get(entry.getKey()), !coordinatedHybridUpdate);
+      }
+      if (coordinatedHybridUpdate) {
+        TableConfigUtils.verifyHybridTableConfigs(rawTableName, tableConfigs.get(TableType.OFFLINE),
+            tableConfigs.get(TableType.REALTIME));
+      }
+    } catch (IOException e) {
+      throw new ControllerApplicationException(LOGGER, "Invalid table config JSON", Response.Status.BAD_REQUEST);
+    } catch (ControllerApplicationException e) {
+      throw e;
     } catch (Exception e) {
-      String msg = String.format("Invalid table config: %s with error: %s", tableName, e.getMessage());
-      throw new ControllerApplicationException(LOGGER, msg, Response.Status.BAD_REQUEST, e);
+      throw new ControllerApplicationException(LOGGER, "Invalid table config: " + tableName,
+          Response.Status.BAD_REQUEST);
     }
 
     try {
-      if (!_pinotHelixResourceManager.hasTable(tableNameWithType)) {
-        throw new ControllerApplicationException(LOGGER, "Table " + tableNameWithType + " does not exist",
-            Response.Status.NOT_FOUND);
+      for (TableConfig tableConfig : tableConfigs.values()) {
+        if (!_pinotHelixResourceManager.hasTable(tableConfig.getTableName())) {
+          throw new ControllerApplicationException(LOGGER, "Table " + tableConfig.getTableName() + " does not exist",
+              Response.Status.NOT_FOUND);
+        }
       }
-      _pinotHelixResourceManager.updateTableConfig(tableConfig, force);
+      if (parsedUpdate._envelope) {
+        _pinotHelixResourceManager.updateTableConfigsAtomicallyWithSchemaCheck(schemaWithVersion.getLeft(),
+            schemaWithVersion.getRight(), tableConfigs, expectedVersions, force);
+      } else {
+        TableConfig tableConfig = tableConfigs.values().iterator().next();
+        _pinotHelixResourceManager.updateTableConfig(
+            tableConfig, expectedVersions.get(tableConfig.getTableType()), force);
+      }
+    } catch (TableConfigVersionMismatchException e) {
+      _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_UPDATE_ERROR, 1L);
+      throw new ControllerApplicationException(LOGGER,
+          "Table config changed while the update was in progress; retry the request", Response.Status.CONFLICT);
     } catch (TableConfigBackwardIncompatibleException e) {
-      String errStr = String.format("Failed to update configuration for %s due to: %s", tableName, e.getMessage());
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_UPDATE_ERROR, 1L);
-      throw new ControllerApplicationException(LOGGER, errStr, Response.Status.BAD_REQUEST, e);
+      throw new ControllerApplicationException(LOGGER,
+          "Invalid update for table " + tableName, Response.Status.BAD_REQUEST);
     } catch (InvalidTableConfigException e) {
-      String errStr = String.format("Failed to update configuration for %s due to: %s", tableName, e.getMessage());
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_UPDATE_ERROR, 1L);
-      throw new ControllerApplicationException(LOGGER, errStr, Response.Status.BAD_REQUEST, e);
+      throw new ControllerApplicationException(LOGGER,
+          "Invalid table config for table " + tableName, Response.Status.BAD_REQUEST);
     } catch (Exception e) {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_UPDATE_ERROR, 1L);
-      throw e;
+      throw new ControllerApplicationException(LOGGER, "Failed to update table " + tableName,
+          Response.Status.INTERNAL_SERVER_ERROR);
     }
-    LOGGER.info("Successfully updated table: {} with new config: {}", tableNameWithType, tableConfig);
+    LOGGER.info("Successfully updated table configs: {}", tableConfigs.keySet());
     return new ConfigSuccessResponse("Table config updated for " + tableName,
+        parsedUpdate._unrecognizedProperties);
+  }
+
+  private static ParsedTableConfigUpdate parseTableConfigUpdate(String tableConfigString)
+      throws IOException {
+    JsonNode requestNode = JsonUtils.stringToJsonNode(tableConfigString);
+    if (RedactedTableConfigResponse.isEnvelope(requestNode)) {
+      Pair<RedactedTableConfigResponse, Map<String, Object>> responseAndUnrecognizedProperties =
+          JsonUtils.stringToObjectAndUnrecognizedProperties(tableConfigString, RedactedTableConfigResponse.class);
+      Map<TableType, TableConfig> configs = new LinkedHashMap<>();
+      responseAndUnrecognizedProperties.getLeft().getConfigs().forEach((typeName, tableConfig) -> {
+        TableType tableType = TableType.valueOf(typeName);
+        configs.put(tableType, tableConfig);
+      });
+      return new ParsedTableConfigUpdate(configs, responseAndUnrecognizedProperties.getLeft().getBaseVersions(), true,
+          responseAndUnrecognizedProperties.getRight());
+    }
+
+    Pair<TableConfig, Map<String, Object>> tableConfigAndUnrecognizedProperties =
+        JsonUtils.stringToObjectAndUnrecognizedProperties(tableConfigString, TableConfig.class);
+    // Bare requests remain supported for literal updates, but cannot carry a response marker. Requiring the complete
+    // envelope for markers prevents a nested redacted config from becoming a valid legacy update body.
+    TableConfig tableConfig =
+        TableConfigRedactionUtils.restoreRedactedValues(tableConfigAndUnrecognizedProperties.getLeft(), null);
+    return new ParsedTableConfigUpdate(Map.of(tableConfig.getTableType(), tableConfig), Map.of(), false,
         tableConfigAndUnrecognizedProperties.getRight());
+  }
+
+  private static final class ParsedTableConfigUpdate {
+    private final Map<TableType, TableConfig> _tableConfigs;
+    private final Map<String, Integer> _baseVersions;
+    private final boolean _envelope;
+    private final Map<String, Object> _unrecognizedProperties;
+
+    private ParsedTableConfigUpdate(Map<TableType, TableConfig> tableConfigs,
+        Map<String, Integer> baseVersions, boolean envelope,
+        Map<String, Object> unrecognizedProperties) {
+      _tableConfigs = tableConfigs;
+      _baseVersions = baseVersions;
+      _envelope = envelope;
+      _unrecognizedProperties = unrecognizedProperties;
+    }
   }
 
   @POST
@@ -835,8 +1025,7 @@ public class PinotTableRestletResource {
       tableConfigAndUnrecognizedProperties =
           JsonUtils.stringToObjectAndUnrecognizedProperties(tableConfigStr, TableConfig.class);
     } catch (IOException e) {
-      String msg = String.format("Invalid table config json string: %s. Reason: %s", tableConfigStr, e.getMessage());
-      throw new ControllerApplicationException(LOGGER, msg, Response.Status.BAD_REQUEST, e);
+      throw new ControllerApplicationException(LOGGER, "Invalid table config JSON", Response.Status.BAD_REQUEST);
     }
     TableConfig tableConfig = tableConfigAndUnrecognizedProperties.getLeft();
     String tableNameWithType = DatabaseUtils.translateTableName(tableConfig.getTableName(), httpHeaders);
@@ -861,7 +1050,7 @@ public class PinotTableRestletResource {
         throw new SchemaNotFoundException("Failed to find schema for table: " + tableNameWithType);
       }
       TableConfigUtils.validate(tableConfig, schema, typesToSkip,
-          _pinotHelixResourceManager.getTableConfig(tableNameWithType));
+          getUnresolvedTableConfig(_pinotHelixResourceManager, tableNameWithType));
       TaskConfigUtils.validateTaskConfigs(tableConfig, schema, _pinotTaskManager, typesToSkip);
       TableConfigValidatorRegistry.validate(tableConfig, schema);
       ObjectNode tableConfigValidateStr = JsonUtils.newObjectNode();
@@ -872,9 +1061,17 @@ public class PinotTableRestletResource {
       }
       return tableConfigValidateStr;
     } catch (Exception e) {
-      String msg = String.format("Invalid table config: %s. %s", tableNameWithType, e.getMessage());
-      throw new ControllerApplicationException(LOGGER, msg, Response.Status.BAD_REQUEST, e);
+      throw new ControllerApplicationException(LOGGER,
+          redactedConfigError("Invalid table config: " + tableNameWithType, e, tableConfig),
+          Response.Status.BAD_REQUEST);
     }
+  }
+
+  private static String redactedConfigError(String prefix, Exception exception, @Nullable TableConfig tableConfig) {
+    if (tableConfig == null) {
+      return prefix;
+    }
+    return prefix + ": " + TableConfigRedactionUtils.redactDiagnostic(exception.getMessage(), tableConfig);
   }
 
   @POST

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/RedactedTableConfigResponse.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/RedactedTableConfigResponse.java
@@ -1,0 +1,165 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Preconditions;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+
+
+/// Versioned response for the edit-capable `GET /tables/{tableName}` representation.
+///
+/// The table configs are deliberately nested below an envelope that is not a valid [TableConfig]. Clients retaining
+/// redaction markers must submit this complete response to the matching PUT endpoint; a bare table config containing a
+/// marker is rejected.
+@JsonPropertyOrder({RedactedTableConfigResponse.RESPONSE_TYPE_KEY,
+    RedactedTableConfigResponse.RESPONSE_VERSION_KEY, RedactedTableConfigResponse.TABLE_NAME_KEY,
+    RedactedTableConfigResponse.BASE_VERSIONS_KEY, RedactedTableConfigResponse.CONFIGS_KEY})
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class RedactedTableConfigResponse {
+  public static final String RESPONSE_TYPE_KEY = "responseType";
+  public static final String RESPONSE_VERSION_KEY = "responseVersion";
+  public static final String TABLE_NAME_KEY = "tableName";
+  public static final String BASE_VERSIONS_KEY = "baseVersions";
+  public static final String CONFIGS_KEY = "configs";
+  public static final String SCHEMA_VERSION_KEY = "schema";
+  public static final String RESPONSE_TYPE = "redactedTableConfig";
+  public static final int RESPONSE_VERSION = 1;
+  public static final String MEDIA_TYPE = "application/vnd.apache.pinot.redacted-table-config-v1+json";
+
+  private final TableIdentity _tableName;
+  private final Map<String, Integer> _baseVersions;
+  private final Map<String, TableConfig> _configs;
+
+  @JsonCreator
+  public RedactedTableConfigResponse(
+      @JsonProperty(value = RESPONSE_TYPE_KEY, required = true) String responseType,
+      @JsonProperty(value = RESPONSE_VERSION_KEY, required = true) int responseVersion,
+      @JsonProperty(value = TABLE_NAME_KEY, required = true) TableIdentity tableName,
+      @JsonProperty(value = BASE_VERSIONS_KEY, required = true) Map<String, Integer> baseVersions,
+      @JsonProperty(value = CONFIGS_KEY, required = true) Map<String, TableConfig> configs) {
+    Preconditions.checkArgument(RESPONSE_TYPE.equals(responseType), "Unsupported table config response type");
+    Preconditions.checkArgument(responseVersion == RESPONSE_VERSION, "Unsupported table config response version");
+    _tableName = Preconditions.checkNotNull(tableName, "Table name must not be null");
+    Preconditions.checkNotNull(configs, "Table configs must not be null");
+    Preconditions.checkArgument(!configs.isEmpty(), "Table configs must not be empty");
+    Preconditions.checkNotNull(baseVersions, "Table config base versions must not be null");
+    Map<String, Integer> configVersions = new LinkedHashMap<>(baseVersions);
+    Integer schemaVersion = configVersions.remove(SCHEMA_VERSION_KEY);
+    Preconditions.checkArgument(schemaVersion != null && schemaVersion >= 0,
+        "Table config schema base version must not be null or negative");
+    Preconditions.checkArgument(configVersions.keySet().equals(configs.keySet()),
+        "Table config base versions must exactly match the schema and config types");
+    for (Integer baseVersion : configVersions.values()) {
+      Preconditions.checkArgument(baseVersion != null && baseVersion >= 0,
+          "Table config base versions must not be null or negative");
+    }
+    for (Map.Entry<String, TableConfig> entry : configs.entrySet()) {
+      TableConfig config = Preconditions.checkNotNull(entry.getValue(), "Table config must not be null");
+      Preconditions.checkArgument(entry.getKey().equals(config.getTableType().name()),
+          "Table config key must match its table type");
+      Preconditions.checkArgument(
+          _tableName.getRaw().equals(TableNameBuilder.extractRawTableName(config.getTableName())),
+          "Table config must match the response table name");
+    }
+    if (_tableName.getType() != null) {
+      Preconditions.checkArgument(configs.size() == 1, "A typed response must contain exactly one table config");
+      Preconditions.checkArgument(configs.containsKey(_tableName.getType().name()),
+          "Table config must match the response table type");
+    }
+    _baseVersions = Collections.unmodifiableMap(new LinkedHashMap<>(baseVersions));
+    _configs = Collections.unmodifiableMap(new LinkedHashMap<>(configs));
+  }
+
+  public RedactedTableConfigResponse(Map<String, TableConfig> configs, Map<String, Integer> baseVersions) {
+    this(RESPONSE_TYPE, RESPONSE_VERSION, tableIdentity(configs), baseVersions, configs);
+  }
+
+  @JsonProperty(RESPONSE_TYPE_KEY)
+  public String getResponseType() {
+    return RESPONSE_TYPE;
+  }
+
+  @JsonProperty(RESPONSE_VERSION_KEY)
+  public int getResponseVersion() {
+    return RESPONSE_VERSION;
+  }
+
+  @JsonProperty(TABLE_NAME_KEY)
+  public TableIdentity getTableName() {
+    return _tableName;
+  }
+
+  @JsonProperty(BASE_VERSIONS_KEY)
+  public Map<String, Integer> getBaseVersions() {
+    return _baseVersions;
+  }
+
+  @JsonProperty(CONFIGS_KEY)
+  public Map<String, TableConfig> getConfigs() {
+    return _configs;
+  }
+
+  public static boolean isEnvelope(JsonNode node) {
+    return node.isObject() && node.has(RESPONSE_TYPE_KEY);
+  }
+
+  private static TableIdentity tableIdentity(Map<String, TableConfig> configs) {
+    Preconditions.checkNotNull(configs, "Table configs must not be null");
+    Preconditions.checkArgument(!configs.isEmpty(), "Table configs must not be empty");
+    TableConfig firstConfig = configs.values().iterator().next();
+    String rawTableName = TableNameBuilder.extractRawTableName(firstConfig.getTableName());
+    return new TableIdentity(rawTableName, configs.size() == 1 ? firstConfig.getTableType() : null);
+  }
+
+  /// Object-valued identity that makes this envelope incompatible with the legacy string-valued `tableName` field.
+  public static final class TableIdentity {
+    private final String _raw;
+    @Nullable
+    private final TableType _type;
+
+    @JsonCreator
+    public TableIdentity(@JsonProperty(value = "raw", required = true) String raw,
+        @JsonProperty("type") @Nullable TableType type) {
+      _raw = Preconditions.checkNotNull(raw, "Raw table name must not be null");
+      _type = type;
+    }
+
+    public String getRaw() {
+      return _raw;
+    }
+
+    @Nullable
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public TableType getType() {
+      return _type;
+    }
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/RedactedTableConfigsResponse.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/RedactedTableConfigsResponse.java
@@ -1,0 +1,145 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Preconditions;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.spi.config.TableConfigs;
+
+
+/// Versioned response for the edit-capable `GET /tableConfigs/{tableName}` representation.
+///
+/// The [TableConfigs] value is deliberately nested below an envelope that cannot be deserialized as a valid legacy
+/// [TableConfigs] request. Clients retaining redaction markers must submit the complete response to the matching PUT
+/// endpoint.
+@JsonPropertyOrder({RedactedTableConfigsResponse.RESPONSE_TYPE_KEY,
+    RedactedTableConfigsResponse.RESPONSE_VERSION_KEY, RedactedTableConfigsResponse.TABLE_NAME_KEY,
+    RedactedTableConfigsResponse.BASE_VERSIONS_KEY, RedactedTableConfigsResponse.CONFIGS_KEY})
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class RedactedTableConfigsResponse {
+  public static final String RESPONSE_TYPE_KEY = "responseType";
+  public static final String RESPONSE_VERSION_KEY = "responseVersion";
+  public static final String TABLE_NAME_KEY = "tableName";
+  public static final String BASE_VERSIONS_KEY = "baseVersions";
+  public static final String CONFIGS_KEY = "configs";
+  public static final String RESPONSE_TYPE = "redactedTableConfigs";
+  public static final int RESPONSE_VERSION = 1;
+  public static final int ABSENT_VERSION = -1;
+  public static final String SCHEMA_VERSION_KEY = "schema";
+  public static final String OFFLINE_VERSION_KEY = "offline";
+  public static final String REALTIME_VERSION_KEY = "realtime";
+  public static final String MEDIA_TYPE = "application/vnd.apache.pinot.redacted-table-configs-v1+json";
+
+  private final TableIdentity _tableName;
+  private final Map<String, Integer> _baseVersions;
+  private final TableConfigs _configs;
+
+  @JsonCreator
+  public RedactedTableConfigsResponse(
+      @JsonProperty(value = RESPONSE_TYPE_KEY, required = true) String responseType,
+      @JsonProperty(value = RESPONSE_VERSION_KEY, required = true) int responseVersion,
+      @JsonProperty(value = TABLE_NAME_KEY, required = true) TableIdentity tableName,
+      @JsonProperty(value = BASE_VERSIONS_KEY, required = true) Map<String, Integer> baseVersions,
+      @JsonProperty(value = CONFIGS_KEY, required = true) TableConfigs configs) {
+    Preconditions.checkArgument(RESPONSE_TYPE.equals(responseType), "Unsupported TableConfigs response type");
+    Preconditions.checkArgument(responseVersion == RESPONSE_VERSION, "Unsupported TableConfigs response version");
+    _tableName = Preconditions.checkNotNull(tableName, "Table name must not be null");
+    _configs = Preconditions.checkNotNull(configs, "TableConfigs must not be null");
+    Preconditions.checkArgument(_tableName.getRaw().equals(_configs.getTableName()),
+        "TableConfigs must match the response table name");
+    Set<String> expectedTypes = new LinkedHashSet<>();
+    expectedTypes.add(SCHEMA_VERSION_KEY);
+    expectedTypes.add(OFFLINE_VERSION_KEY);
+    expectedTypes.add(REALTIME_VERSION_KEY);
+    Preconditions.checkNotNull(baseVersions, "TableConfigs base versions must not be null");
+    Preconditions.checkArgument(baseVersions.keySet().equals(expectedTypes),
+        "TableConfigs base versions must cover schema, offline, and realtime state");
+    Integer schemaVersion = baseVersions.get(SCHEMA_VERSION_KEY);
+    Preconditions.checkArgument(schemaVersion != null && schemaVersion >= 0,
+        "TableConfigs schema base version must not be null or negative");
+    validateTableTypeVersion(OFFLINE_VERSION_KEY, baseVersions.get(OFFLINE_VERSION_KEY),
+        _configs.getOffline() != null);
+    validateTableTypeVersion(REALTIME_VERSION_KEY, baseVersions.get(REALTIME_VERSION_KEY),
+        _configs.getRealtime() != null);
+    _baseVersions = Collections.unmodifiableMap(new LinkedHashMap<>(baseVersions));
+  }
+
+  public RedactedTableConfigsResponse(TableConfigs configs, Map<String, Integer> baseVersions) {
+    this(RESPONSE_TYPE, RESPONSE_VERSION, new TableIdentity(configs.getTableName()), baseVersions, configs);
+  }
+
+  @JsonProperty(RESPONSE_TYPE_KEY)
+  public String getResponseType() {
+    return RESPONSE_TYPE;
+  }
+
+  @JsonProperty(RESPONSE_VERSION_KEY)
+  public int getResponseVersion() {
+    return RESPONSE_VERSION;
+  }
+
+  @JsonProperty(TABLE_NAME_KEY)
+  public TableIdentity getTableName() {
+    return _tableName;
+  }
+
+  @JsonProperty(BASE_VERSIONS_KEY)
+  public Map<String, Integer> getBaseVersions() {
+    return _baseVersions;
+  }
+
+  @JsonProperty(CONFIGS_KEY)
+  public TableConfigs getConfigs() {
+    return _configs;
+  }
+
+  public static boolean isEnvelope(JsonNode node) {
+    return node.isObject() && node.has(RESPONSE_TYPE_KEY);
+  }
+
+  private static void validateTableTypeVersion(String type, Integer version, boolean configIncluded) {
+    Preconditions.checkArgument(version != null && version >= ABSENT_VERSION,
+        "TableConfigs %s base version must be -1 or non-negative", type);
+    Preconditions.checkArgument(configIncluded || version == ABSENT_VERSION,
+        "TableConfigs %s config cannot be omitted when it existed in the read snapshot", type);
+  }
+
+  /// Object-valued identity that makes this envelope incompatible with the legacy string-valued `tableName` field.
+  public static final class TableIdentity {
+    private final String _raw;
+
+    @JsonCreator
+    public TableIdentity(@JsonProperty(value = "raw", required = true) String raw) {
+      _raw = Preconditions.checkNotNull(raw, "Raw table name must not be null");
+    }
+
+    public String getRaw() {
+      return _raw;
+    }
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigValidationUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigValidationUtils.java
@@ -62,12 +62,22 @@ public final class TableConfigValidationUtils {
       @Nullable String typesToSkip, PinotHelixResourceManager resourceManager,
       ControllerConf controllerConf, @Nullable PinotTaskManager taskManager,
       @Nullable TableConfig existingTableConfig) {
+    validateTableConfig(tableConfig, schema, typesToSkip, resourceManager, controllerConf, taskManager,
+        existingTableConfig, true);
+  }
+
+  static void validateTableConfig(TableConfig tableConfig, Schema schema,
+      @Nullable String typesToSkip, PinotHelixResourceManager resourceManager,
+      ControllerConf controllerConf, @Nullable PinotTaskManager taskManager,
+      @Nullable TableConfig existingTableConfig, boolean checkStoredHybridConfig) {
     validateEnvironmentVariables(tableConfig);
     TableConfigUtils.validate(tableConfig, schema, typesToSkip, existingTableConfig);
     TableConfigUtils.validateTableName(tableConfig);
     TableConfigUtils.ensureMinReplicas(tableConfig, controllerConf.getDefaultTableMinReplicas());
     TableConfigUtils.ensureStorageQuotaConstraints(tableConfig, controllerConf.getDimTableMaxSize());
-    checkHybridTableConfig(resourceManager, tableConfig);
+    if (checkStoredHybridConfig) {
+      checkHybridTableConfig(resourceManager, tableConfig);
+    }
     TaskConfigUtils.validateTaskConfigs(tableConfig, schema, taskManager, typesToSkip);
     validateInstanceAssignment(resourceManager, tableConfig);
     resourceManager.validateTableTenantConfig(tableConfig);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.api.resources;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
@@ -30,6 +31,7 @@ import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -51,6 +53,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.exception.TableConfigBackwardIncompatibleException;
+import org.apache.pinot.common.exception.TableConfigVersionMismatchException;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.metrics.ControllerMetrics;
@@ -78,7 +81,9 @@ import org.apache.pinot.segment.local.utils.SchemaUtils;
 import org.apache.pinot.segment.local.utils.TableConfigUtils;
 import org.apache.pinot.spi.config.TableConfigs;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableConfigRedactionUtils;
 import org.apache.pinot.spi.config.table.TableConfigValidatorRegistry;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.LogicalTableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -154,28 +159,55 @@ public class TableConfigsRestletResource {
   /// tableName_OFFLINE,
   /// realtime table config for tableName_REALTIME and schema for tableName
   @GET
-  @Produces(MediaType.APPLICATION_JSON)
+  @Produces({MediaType.APPLICATION_JSON, RedactedTableConfigsResponse.MEDIA_TYPE})
   @Path("/tableConfigs/{tableName}")
   @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_TABLE_CONFIGS)
   @Authenticate(AccessType.READ)
   @ApiOperation(value = "Get the TableConfigs for a given raw tableName",
-      notes = "Get the TableConfigs for a given raw tableName")
+      notes = "Returns a versioned redacted response. Submit the complete response to PUT when retaining markers.")
   public String getConfig(
       @ApiParam(value = "Raw table name", required = true) @PathParam("tableName") String tableName,
       @Context HttpHeaders headers) {
     try {
       tableName = DatabaseUtils.translateTableName(tableName, headers);
-      Schema schema = _pinotHelixResourceManager.getTableSchema(tableName);
-      if (schema == null) {
+      Pair<Schema, Integer> schemaWithVersion = _pinotHelixResourceManager.getSchemaWithVersion(tableName);
+      if (schemaWithVersion == null) {
         throw new NotFoundException(
             String.format("Schema does not exist for table %s Use POST to create it first.", tableName));
       }
-      TableConfig offlineTableConfig = _pinotHelixResourceManager.getOfflineTableConfig(tableName, false, false);
-      TableConfig realtimeTableConfig = _pinotHelixResourceManager.getRealtimeTableConfig(tableName, false, false);
-      TableConfigs config = new TableConfigs(tableName, schema, offlineTableConfig, realtimeTableConfig);
-      return config.toJsonString();
+      Schema schema = schemaWithVersion.getLeft();
+      Pair<TableConfig, Integer> offlineTableConfigWithVersion =
+          _pinotHelixResourceManager.getTableConfigWithVersion(
+              TableNameBuilder.OFFLINE.tableNameWithType(tableName), false, false);
+      Pair<TableConfig, Integer> realtimeTableConfigWithVersion =
+          _pinotHelixResourceManager.getTableConfigWithVersion(
+              TableNameBuilder.REALTIME.tableNameWithType(tableName), false, false);
+      TableConfig offlineTableConfig =
+          offlineTableConfigWithVersion != null ? offlineTableConfigWithVersion.getLeft() : null;
+      TableConfig realtimeTableConfig =
+          realtimeTableConfigWithVersion != null ? realtimeTableConfigWithVersion.getLeft() : null;
+      Map<String, Integer> baseVersions = new LinkedHashMap<>();
+      baseVersions.put(RedactedTableConfigsResponse.SCHEMA_VERSION_KEY, schemaWithVersion.getRight());
+      if (offlineTableConfigWithVersion != null) {
+        baseVersions.put(RedactedTableConfigsResponse.OFFLINE_VERSION_KEY, offlineTableConfigWithVersion.getRight());
+      } else {
+        baseVersions.put(RedactedTableConfigsResponse.OFFLINE_VERSION_KEY,
+            RedactedTableConfigsResponse.ABSENT_VERSION);
+      }
+      if (realtimeTableConfigWithVersion != null) {
+        baseVersions.put(RedactedTableConfigsResponse.REALTIME_VERSION_KEY,
+            realtimeTableConfigWithVersion.getRight());
+      } else {
+        baseVersions.put(RedactedTableConfigsResponse.REALTIME_VERSION_KEY,
+            RedactedTableConfigsResponse.ABSENT_VERSION);
+      }
+      TableConfigs config = new TableConfigs(tableName, schema,
+          offlineTableConfig != null ? TableConfigRedactionUtils.redact(offlineTableConfig) : null,
+          realtimeTableConfig != null ? TableConfigRedactionUtils.redact(realtimeTableConfig) : null);
+      return JsonUtils.objectToString(new RedactedTableConfigsResponse(config, baseVersions));
     } catch (Exception e) {
-      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
+      throw new ControllerApplicationException(LOGGER, "Failed to retrieve TableConfigs",
+          Response.Status.INTERNAL_SERVER_ERROR);
     }
   }
 
@@ -199,11 +231,24 @@ public class TableConfigsRestletResource {
     try {
       tableConfigsAndUnrecognizedProps =
           JsonUtils.stringToObjectAndUnrecognizedProperties(tableConfigsStr, TableConfigs.class);
-    } catch (Exception e) {
-      throw new ControllerApplicationException(LOGGER, String.format("Invalid TableConfigs. %s", e.getMessage()),
-          Response.Status.BAD_REQUEST, e);
+    } catch (IOException e) {
+      throw new ControllerApplicationException(LOGGER, "Invalid TableConfigs JSON", Response.Status.BAD_REQUEST);
     }
     TableConfigs tableConfigs = tableConfigsAndUnrecognizedProps.getLeft();
+    TableConfig offlineTableConfig = tableConfigs.getOffline();
+    TableConfig realtimeTableConfig = tableConfigs.getRealtime();
+    try {
+      if (offlineTableConfig != null) {
+        offlineTableConfig = TableConfigRedactionUtils.restoreRedactedValues(offlineTableConfig, null);
+      }
+      if (realtimeTableConfig != null) {
+        realtimeTableConfig = TableConfigRedactionUtils.restoreRedactedValues(realtimeTableConfig, null);
+      }
+    } catch (IllegalArgumentException e) {
+      throw new ControllerApplicationException(LOGGER, "Invalid TableConfigs", Response.Status.BAD_REQUEST);
+    }
+    tableConfigs = new TableConfigs(tableConfigs.getTableName(), tableConfigs.getSchema(), offlineTableConfig,
+        realtimeTableConfig);
     String databaseName = DatabaseUtils.extractDatabaseFromHttpHeaders(httpHeaders);
     String rawTableName = DatabaseUtils.translateTableName(tableConfigs.getTableName(), databaseName);
     if (_pinotHelixResourceManager.hasOfflineTable(rawTableName) || _pinotHelixResourceManager.hasRealtimeTable(
@@ -216,8 +261,8 @@ public class TableConfigsRestletResource {
     validateConfig(tableConfigs, databaseName, typesToSkip);
     tableConfigs.setTableName(rawTableName);
 
-    TableConfig offlineTableConfig = tableConfigs.getOffline();
-    TableConfig realtimeTableConfig = tableConfigs.getRealtime();
+    offlineTableConfig = tableConfigs.getOffline();
+    realtimeTableConfig = tableConfigs.getRealtime();
     Schema schema = tableConfigs.getSchema();
 
     try {
@@ -267,14 +312,16 @@ public class TableConfigsRestletResource {
     } catch (Exception e) {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_ADD_ERROR, 1L);
       if (e instanceof InvalidTableConfigException) {
-        throw new ControllerApplicationException(LOGGER, String.format("Invalid TableConfigs: %s. Reason: %s",
-            rawTableName, e.getMessage()), Response.Status.BAD_REQUEST, e);
+        throw new ControllerApplicationException(LOGGER,
+            redactedTableConfigsError("Invalid TableConfigs: " + rawTableName, e, tableConfigs),
+            Response.Status.BAD_REQUEST);
       } else if (e instanceof TableAlreadyExistsException) {
         throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.CONFLICT, e);
       } else if (e instanceof ControllerApplicationException) {
         throw e;
       } else {
-        throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
+        throw new ControllerApplicationException(LOGGER, "Failed to add TableConfigs: " + rawTableName,
+            Response.Status.INTERNAL_SERVER_ERROR);
       }
     }
   }
@@ -348,8 +395,7 @@ public class TableConfigsRestletResource {
   @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.UPDATE_TABLE_CONFIGS)
   @Authenticate(AccessType.UPDATE)
   @Produces(MediaType.APPLICATION_JSON)
-  @ApiOperation(value = "Update the TableConfigs provided by the tableConfigsStr json", notes = "Update the "
-      + "TableConfigs provided by the tableConfigsStr json")
+  @ApiOperation(value = "Update the TableConfigs provided by the tableConfigsStr json")
   public ConfigSuccessResponse updateConfig(
       @ApiParam(value = "TableConfigs name i.e. raw table name", required = true) @PathParam("tableName")
       String tableName,
@@ -362,20 +408,62 @@ public class TableConfigsRestletResource {
       throws Exception {
     String databaseName = DatabaseUtils.extractDatabaseFromHttpHeaders(headers);
     tableName = DatabaseUtils.translateTableName(tableName, databaseName);
-    Pair<TableConfigs, Map<String, Object>> tableConfigsAndUnrecognizedProps;
+    ParsedTableConfigsUpdate parsedUpdate;
     TableConfigs tableConfigs;
+    Pair<Schema, Integer> storedSchemaWithVersion;
+    Map<TableType, TableConfig> storedTableConfigs = new LinkedHashMap<>();
+    Map<TableType, Integer> expectedVersions = new LinkedHashMap<>();
+    TableType typeToCreate = null;
     try {
-      tableConfigsAndUnrecognizedProps =
-          JsonUtils.stringToObjectAndUnrecognizedProperties(tableConfigsStr, TableConfigs.class);
-      tableConfigs = tableConfigsAndUnrecognizedProps.getLeft();
-      validateConfig(tableConfigs, databaseName, typesToSkip);
+      parsedUpdate = parseTableConfigsUpdate(tableConfigsStr);
+      tableConfigs = parsedUpdate._tableConfigs;
       Preconditions.checkState(
           DatabaseUtils.translateTableName(tableConfigs.getTableName(), databaseName).equals(tableName),
           "'tableName' in TableConfigs: %s must match provided tableName: %s", tableConfigs.getTableName(), tableName);
       tableConfigs.setTableName(tableName);
+      TableConfig offlineTableConfig = tableConfigs.getOffline();
+      TableConfig realtimeTableConfig = tableConfigs.getRealtime();
+      storedSchemaWithVersion = _pinotHelixResourceManager.getSchemaWithVersion(tableName);
+      if (storedSchemaWithVersion == null) {
+        throw staleTableConfigsResponse();
+      }
+      if (parsedUpdate._envelope
+          && !parsedUpdate._baseVersions.get(RedactedTableConfigsResponse.SCHEMA_VERSION_KEY)
+          .equals(storedSchemaWithVersion.getRight())) {
+        throw staleTableConfigsResponse();
+      }
+
+      Pair<TableConfig, Integer> storedOfflineTableConfigWithVersion =
+          _pinotHelixResourceManager.getTableConfigWithVersion(
+              TableNameBuilder.OFFLINE.tableNameWithType(tableName), false, false);
+      Pair<TableConfig, Integer> storedRealtimeTableConfigWithVersion =
+          _pinotHelixResourceManager.getTableConfigWithVersion(
+              TableNameBuilder.REALTIME.tableNameWithType(tableName), false, false);
+      typeToCreate = compareTableTypeSnapshot(TableType.OFFLINE, offlineTableConfig,
+          storedOfflineTableConfigWithVersion, parsedUpdate, storedTableConfigs, expectedVersions, typeToCreate);
+      typeToCreate = compareTableTypeSnapshot(TableType.REALTIME, realtimeTableConfig,
+          storedRealtimeTableConfigWithVersion, parsedUpdate, storedTableConfigs, expectedVersions, typeToCreate);
+
+      TableConfig storedOfflineTableConfig = storedTableConfigs.get(TableType.OFFLINE);
+      TableConfig storedRealtimeTableConfig = storedTableConfigs.get(TableType.REALTIME);
+      if (offlineTableConfig != null) {
+        offlineTableConfig =
+            TableConfigRedactionUtils.restoreRedactedValues(offlineTableConfig, storedOfflineTableConfig);
+      }
+      if (realtimeTableConfig != null) {
+        realtimeTableConfig =
+            TableConfigRedactionUtils.restoreRedactedValues(realtimeTableConfig, storedRealtimeTableConfig);
+      }
+      tableConfigs = new TableConfigs(tableName, tableConfigs.getSchema(), offlineTableConfig, realtimeTableConfig);
+      validateConfig(tableConfigs, databaseName, typesToSkip,
+          new ExistingTableConfigs(storedOfflineTableConfig, storedRealtimeTableConfig));
+    } catch (IOException e) {
+      throw new ControllerApplicationException(LOGGER, "Invalid TableConfigs JSON", Response.Status.BAD_REQUEST);
+    } catch (ControllerApplicationException e) {
+      throw e;
     } catch (Exception e) {
-      throw new ControllerApplicationException(LOGGER, String.format("Invalid TableConfigs: %s. Reason: %s", tableName,
-          e.getMessage()), Response.Status.BAD_REQUEST, e);
+      throw new ControllerApplicationException(LOGGER, "Invalid TableConfigs: " + tableName,
+          Response.Status.BAD_REQUEST);
     }
 
     if (!_pinotHelixResourceManager.hasOfflineTable(tableName) && !_pinotHelixResourceManager.hasRealtimeTable(
@@ -390,46 +478,149 @@ public class TableConfigsRestletResource {
     Schema schema = tableConfigs.getSchema();
 
     try {
-      _pinotHelixResourceManager.updateSchema(schema, reload, forceTableSchemaUpdate);
-      LOGGER.info("Updated schema: {}", tableName);
-
+      Map<TableType, TableConfig> submittedTableConfigs = new LinkedHashMap<>();
       if (offlineTableConfig != null) {
-        applyTuning(offlineTableConfig, schema);
-        if (_pinotHelixResourceManager.hasOfflineTable(tableName)) {
-          _pinotHelixResourceManager.updateTableConfig(offlineTableConfig, forceTableSchemaUpdate);
-          LOGGER.info("Updated offline table config: {}", tableName);
-        } else {
-          _pinotHelixResourceManager.addTable(offlineTableConfig);
-          LOGGER.info("Created offline table config: {}", tableName);
-        }
+        submittedTableConfigs.put(TableType.OFFLINE, offlineTableConfig);
       }
       if (realtimeTableConfig != null) {
-        applyTuning(realtimeTableConfig, schema);
-        if (_pinotHelixResourceManager.hasRealtimeTable(tableName)) {
-          _pinotHelixResourceManager.updateTableConfig(realtimeTableConfig, forceTableSchemaUpdate);
-          LOGGER.info("Updated realtime table config: {}", tableName);
-        } else {
-          _pinotHelixResourceManager.addTable(realtimeTableConfig);
-          LOGGER.info("Created realtime table config: {}", tableName);
+        submittedTableConfigs.put(TableType.REALTIME, realtimeTableConfig);
+      }
+      if (typeToCreate != null && parsedUpdate._envelope) {
+        throw new ControllerApplicationException(LOGGER,
+            "A versioned TableConfigs edit cannot add a missing table type; use the table creation flow, then "
+                + "retrieve a fresh TableConfigs response before editing",
+            Response.Status.CONFLICT);
+      } else if (typeToCreate == null) {
+        for (TableConfig tableConfig : submittedTableConfigs.values()) {
+          applyTuning(tableConfig, schema);
+        }
+        _pinotHelixResourceManager.updateTableConfigsAtomically(schema, storedSchemaWithVersion.getRight(),
+            submittedTableConfigs, expectedVersions, reload, forceTableSchemaUpdate);
+        LOGGER.info("Atomically updated TableConfigs: {}", tableName);
+      } else {
+        // Keep the legacy literal-body behavior for adding a missing type. Versioned envelopes use the snapshot-gated
+        // path above so a marker-bearing edit can never race a schema or existing-type update.
+        _pinotHelixResourceManager.updateSchema(schema, reload, forceTableSchemaUpdate);
+        for (Map.Entry<TableType, TableConfig> entry : submittedTableConfigs.entrySet()) {
+          applyTuning(entry.getValue(), schema);
+          if (entry.getKey() == typeToCreate) {
+            _pinotHelixResourceManager.addTable(entry.getValue());
+          } else {
+            _pinotHelixResourceManager.updateTableConfig(
+                entry.getValue(), expectedVersions.get(entry.getKey()), forceTableSchemaUpdate);
+          }
         }
       }
+    } catch (ControllerApplicationException e) {
+      throw e;
+    } catch (TableConfigVersionMismatchException e) {
+      _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_UPDATE_ERROR, 1L);
+      throw new ControllerApplicationException(LOGGER,
+          "TableConfigs changed while the update was in progress; retry the request", Response.Status.CONFLICT);
     } catch (TableConfigBackwardIncompatibleException e) {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_UPDATE_ERROR, 1L);
       throw new ControllerApplicationException(LOGGER,
-          String.format("Invalid TableConfigs for: %s, %s", tableName, e.getMessage()), Response.Status.BAD_REQUEST, e);
+          redactedTableConfigsError("Invalid TableConfigs for: " + tableName, e, tableConfigs),
+          Response.Status.BAD_REQUEST);
     } catch (InvalidTableConfigException e) {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_UPDATE_ERROR, 1L);
       throw new ControllerApplicationException(LOGGER,
-          String.format("Invalid TableConfigs for: %s, %s", tableName, e.getMessage()), Response.Status.BAD_REQUEST, e);
+          redactedTableConfigsError("Invalid TableConfigs for: " + tableName, e, tableConfigs),
+          Response.Status.BAD_REQUEST);
     } catch (Exception e) {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_UPDATE_ERROR, 1L);
-      throw new ControllerApplicationException(LOGGER,
-          String.format("Failed to update TableConfigs for: %s, %s", tableName, e.getMessage()),
-          Response.Status.INTERNAL_SERVER_ERROR, e);
+      throw new ControllerApplicationException(LOGGER, "Failed to update TableConfigs for: " + tableName,
+          Response.Status.INTERNAL_SERVER_ERROR);
     }
 
     return new ConfigSuccessResponse("TableConfigs updated for " + tableName,
-        tableConfigsAndUnrecognizedProps.getRight());
+        parsedUpdate._unrecognizedProperties);
+  }
+
+  @Nullable
+  private static TableType compareTableTypeSnapshot(TableType tableType, @Nullable TableConfig submittedConfig,
+      @Nullable Pair<TableConfig, Integer> storedConfigWithVersion, ParsedTableConfigsUpdate parsedUpdate,
+      Map<TableType, TableConfig> storedConfigs, Map<TableType, Integer> expectedVersions,
+      @Nullable TableType typeToCreate) {
+    String versionKey = tableType == TableType.OFFLINE
+        ? RedactedTableConfigsResponse.OFFLINE_VERSION_KEY
+        : RedactedTableConfigsResponse.REALTIME_VERSION_KEY;
+    if (parsedUpdate._envelope) {
+      int baseVersion = parsedUpdate._baseVersions.get(versionKey);
+      if (baseVersion == RedactedTableConfigsResponse.ABSENT_VERSION) {
+        if (storedConfigWithVersion != null) {
+          throw staleTableConfigsResponse();
+        }
+        if (submittedConfig != null) {
+          Preconditions.checkState(typeToCreate == null,
+              "A TableConfigs update cannot create more than one table type");
+          return tableType;
+        }
+        return typeToCreate;
+      }
+      if (storedConfigWithVersion == null || baseVersion != storedConfigWithVersion.getRight()) {
+        throw staleTableConfigsResponse();
+      }
+      storedConfigs.put(tableType, storedConfigWithVersion.getLeft());
+      expectedVersions.put(tableType, baseVersion);
+      return typeToCreate;
+    }
+
+    if (submittedConfig == null) {
+      return typeToCreate;
+    }
+    if (storedConfigWithVersion == null) {
+      Preconditions.checkState(typeToCreate == null,
+          "A TableConfigs update cannot create more than one table type");
+      return tableType;
+    }
+    storedConfigs.put(tableType, storedConfigWithVersion.getLeft());
+    expectedVersions.put(tableType, storedConfigWithVersion.getRight());
+    return typeToCreate;
+  }
+
+  private static ParsedTableConfigsUpdate parseTableConfigsUpdate(String tableConfigsString)
+      throws IOException {
+    JsonNode requestNode = JsonUtils.stringToJsonNode(tableConfigsString);
+    if (RedactedTableConfigsResponse.isEnvelope(requestNode)) {
+      Pair<RedactedTableConfigsResponse, Map<String, Object>> responseAndUnrecognizedProperties =
+          JsonUtils.stringToObjectAndUnrecognizedProperties(
+              tableConfigsString, RedactedTableConfigsResponse.class);
+      return new ParsedTableConfigsUpdate(responseAndUnrecognizedProperties.getLeft().getConfigs(),
+          responseAndUnrecognizedProperties.getLeft().getBaseVersions(),
+          true, responseAndUnrecognizedProperties.getRight());
+    }
+
+    Pair<TableConfigs, Map<String, Object>> tableConfigsAndUnrecognizedProperties =
+        JsonUtils.stringToObjectAndUnrecognizedProperties(tableConfigsString, TableConfigs.class);
+    TableConfigs tableConfigs = tableConfigsAndUnrecognizedProperties.getLeft();
+    TableConfig offline = tableConfigs.getOffline() != null
+        ? TableConfigRedactionUtils.restoreRedactedValues(tableConfigs.getOffline(), null) : null;
+    TableConfig realtime = tableConfigs.getRealtime() != null
+        ? TableConfigRedactionUtils.restoreRedactedValues(tableConfigs.getRealtime(), null) : null;
+    return new ParsedTableConfigsUpdate(
+        new TableConfigs(tableConfigs.getTableName(), tableConfigs.getSchema(), offline, realtime), Map.of(),
+        false, tableConfigsAndUnrecognizedProperties.getRight());
+  }
+
+  private static ControllerApplicationException staleTableConfigsResponse() {
+    return new ControllerApplicationException(LOGGER,
+        "TableConfigs changed after they were read; retrieve them again before updating", Response.Status.CONFLICT);
+  }
+
+  private static final class ParsedTableConfigsUpdate {
+    private final TableConfigs _tableConfigs;
+    private final Map<String, Integer> _baseVersions;
+    private final boolean _envelope;
+    private final Map<String, Object> _unrecognizedProperties;
+
+    private ParsedTableConfigsUpdate(TableConfigs tableConfigs, Map<String, Integer> baseVersions, boolean envelope,
+        Map<String, Object> unrecognizedProperties) {
+      _tableConfigs = tableConfigs;
+      _baseVersions = baseVersions;
+      _envelope = envelope;
+      _unrecognizedProperties = unrecognizedProperties;
+    }
   }
 
   /// Validates the [TableConfigs] as provided in the tableConfigsStr json, by validating the schema,
@@ -488,9 +679,7 @@ public class TableConfigsRestletResource {
       tableConfigsAndUnrecognizedProps =
           JsonUtils.stringToObjectAndUnrecognizedProperties(tableConfigsStr, TableConfigs.class);
     } catch (IOException e) {
-      throw new ControllerApplicationException(LOGGER,
-          String.format("Invalid TableConfigs json string: %s. Reason: %s", tableConfigsStr, e.getMessage()),
-          Response.Status.BAD_REQUEST, e);
+      throw new ControllerApplicationException(LOGGER, "Invalid TableConfigs JSON", Response.Status.BAD_REQUEST);
     }
     String databaseName = DatabaseUtils.extractDatabaseFromHttpHeaders(httpHeaders);
     TableConfigs tableConfigs = tableConfigsAndUnrecognizedProps.getLeft();
@@ -516,7 +705,8 @@ public class TableConfigsRestletResource {
       throw e;
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER,
-          String.format("Invalid TableConfigs: %s. %s", rawTableName, e.getMessage()), Response.Status.BAD_REQUEST, e);
+          redactedTableConfigsError("Invalid TableConfigs: " + rawTableName, e, tableConfigs),
+          Response.Status.BAD_REQUEST);
     }
 
     // validate permission
@@ -547,10 +737,14 @@ public class TableConfigsRestletResource {
     TableConfigUtils.ensureStorageQuotaConstraints(tableConfig, _controllerConf.getDimTableMaxSize());
   }
 
-
   /// Validates the provided TableConfigs. Hybrid table validation is performed only on the provided
   /// configs and does not check for conflicts with existing tables in the cluster.
   private void validateConfig(TableConfigs tableConfigs, String database, @Nullable String typesToSkip) {
+    validateConfig(tableConfigs, database, typesToSkip, null);
+  }
+
+  private void validateConfig(TableConfigs tableConfigs, String database, @Nullable String typesToSkip,
+      @Nullable ExistingTableConfigs existingTableConfigs) {
     String rawTableName = DatabaseUtils.translateTableName(tableConfigs.getTableName(), database);
     TableConfig offlineTableConfig = tableConfigs.getOffline();
     TableConfig realtimeTableConfig = tableConfigs.getRealtime();
@@ -573,8 +767,11 @@ public class TableConfigsRestletResource {
         Preconditions.checkState(offlineRawTableName.equals(rawTableName),
             "Name in 'offline' table config: %s must be equal to 'tableName': %s", offlineRawTableName, rawTableName);
         TableConfigUtils.validateTableName(offlineTableConfig);
+        TableConfig existingOfflineTableConfig = existingTableConfigs != null
+            ? existingTableConfigs._offline : _pinotHelixResourceManager.getOfflineTableConfig(rawTableName, false,
+                false);
         TableConfigUtils.validate(offlineTableConfig, schema, typesToSkip,
-            _pinotHelixResourceManager.getTableConfig(TableNameBuilder.OFFLINE.tableNameWithType(rawTableName)));
+            existingOfflineTableConfig);
         TaskConfigUtils.validateTaskConfigs(tableConfigs.getOffline(), schema, _pinotTaskManager, typesToSkip);
         TableConfigValidatorRegistry.validate(offlineTableConfig, schema);
       }
@@ -584,8 +781,11 @@ public class TableConfigsRestletResource {
         Preconditions.checkState(realtimeRawTableName.equals(rawTableName),
             "Name in 'realtime' table config: %s must be equal to 'tableName': %s", realtimeRawTableName, rawTableName);
         TableConfigUtils.validateTableName(realtimeTableConfig);
+        TableConfig existingRealtimeTableConfig = existingTableConfigs != null
+            ? existingTableConfigs._realtime : _pinotHelixResourceManager.getRealtimeTableConfig(rawTableName, false,
+                false);
         TableConfigUtils.validate(realtimeTableConfig, schema, typesToSkip,
-            _pinotHelixResourceManager.getTableConfig(TableNameBuilder.REALTIME.tableNameWithType(rawTableName)));
+            existingRealtimeTableConfig);
         TaskConfigUtils.validateTaskConfigs(tableConfigs.getRealtime(), schema, _pinotTaskManager, typesToSkip);
         TableConfigValidatorRegistry.validate(realtimeTableConfig, schema);
       }
@@ -594,7 +794,29 @@ public class TableConfigsRestletResource {
       }
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER,
-          String.format("Invalid TableConfigs: %s. %s", rawTableName, e.getMessage()), Response.Status.BAD_REQUEST, e);
+          redactedTableConfigsError("Invalid TableConfigs: " + rawTableName, e, tableConfigs),
+          Response.Status.BAD_REQUEST);
     }
+  }
+
+  private static final class ExistingTableConfigs {
+    private final TableConfig _offline;
+    private final TableConfig _realtime;
+
+    private ExistingTableConfigs(@Nullable TableConfig offline, @Nullable TableConfig realtime) {
+      _offline = offline;
+      _realtime = realtime;
+    }
+  }
+
+  private static String redactedTableConfigsError(String prefix, Exception exception, TableConfigs tableConfigs) {
+    String diagnostic = exception.getMessage();
+    if (tableConfigs.getOffline() != null) {
+      diagnostic = TableConfigRedactionUtils.redactDiagnostic(diagnostic, tableConfigs.getOffline());
+    }
+    if (tableConfigs.getRealtime() != null) {
+      diagnostic = TableConfigRedactionUtils.redactDiagnostic(diagnostic, tableConfigs.getRealtime());
+    }
+    return prefix + ": " + (diagnostic != null ? diagnostic : "Invalid table config");
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -89,6 +89,7 @@ import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
+import org.apache.helix.zookeeper.zkclient.exception.ZkBadVersionException;
 import org.apache.pinot.common.assignment.InstanceAssignmentConfigUtils;
 import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.common.assignment.InstancePartitionsUtils;
@@ -100,6 +101,7 @@ import org.apache.pinot.common.exception.SchemaAlreadyExistsException;
 import org.apache.pinot.common.exception.SchemaBackwardIncompatibleException;
 import org.apache.pinot.common.exception.SchemaNotFoundException;
 import org.apache.pinot.common.exception.TableConfigBackwardIncompatibleException;
+import org.apache.pinot.common.exception.TableConfigVersionMismatchException;
 import org.apache.pinot.common.exception.TableNotFoundException;
 import org.apache.pinot.common.lineage.LineageEntry;
 import org.apache.pinot.common.lineage.LineageEntryState;
@@ -135,6 +137,8 @@ import org.apache.pinot.common.utils.LogicalTableConfigUtils;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.common.utils.config.AccessControlUserConfigUtils;
 import org.apache.pinot.common.utils.config.InstanceUtils;
+import org.apache.pinot.common.utils.config.SchemaSerDeUtils;
+import org.apache.pinot.common.utils.config.TableConfigSerDeUtils;
 import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.common.utils.config.TierConfigUtils;
 import org.apache.pinot.common.utils.helix.HelixHelper;
@@ -208,6 +212,7 @@ import org.apache.pinot.spi.utils.TimeUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.spi.utils.retry.RetryPolicies;
 import org.apache.pinot.spi.utils.retry.RetryPolicy;
+import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -904,11 +909,12 @@ public class PinotHelixResourceManager {
   /// tolerate a single broken znode without aborting.
   private boolean isMaterializedViewResource(String tableNameWithType) {
     try {
-      TableConfig tableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, tableNameWithType);
+      TableConfig tableConfig =
+          ZKMetadataProvider.getTableConfig(_propertyStore, tableNameWithType, false, false);
       return tableConfig != null && tableConfig.isMaterializedView();
     } catch (Exception e) {
-      LOGGER.warn("Failed to read TableConfig for {} while filtering MVs; treating as non-MV",
-          tableNameWithType, e);
+      LOGGER.warn("Failed to read TableConfig for {} while filtering MVs; treating as non-MV ({})",
+          tableNameWithType, e.getClass().getName());
       return false;
     }
   }
@@ -1656,7 +1662,7 @@ public class PinotHelixResourceManager {
     if (oldSchema != null) {
       // Update existing schema
       if (override) {
-        updateSchema(schema, oldSchema, force);
+        persistSchemaUpdate(schema, oldSchema, force);
       } else {
         throw new SchemaAlreadyExistsException("Schema: " + schemaName + " already exists");
       }
@@ -1688,7 +1694,12 @@ public class PinotHelixResourceManager {
       throw new SchemaNotFoundException("Schema: " + schemaName + " does not exist");
     }
 
-    updateSchema(schema, oldSchema, forceTableSchemaUpdate);
+    persistSchemaUpdate(schema, oldSchema, forceTableSchemaUpdate);
+    refreshSchema(schemaName, reload);
+  }
+
+  private void refreshSchema(String schemaName, boolean reload)
+      throws TableNotFoundException {
     if (ZKMetadataProvider.isLogicalTableExists(_propertyStore, schemaName)) {
       // For logical table schemas, we do not need to reload segments or send schema refresh messages
       LOGGER.info("Logical table schema: {} updated, no need to reload segments or send schema refresh messages",
@@ -1719,13 +1730,25 @@ public class PinotHelixResourceManager {
 
   /// Helper method to update the schema, or throw SchemaBackwardIncompatibleException when the new schema is not
   /// backward-compatible with the existing schema.
-  private void updateSchema(Schema schema, Schema oldSchema, boolean forceTableSchemaUpdate)
+  private void persistSchemaUpdate(Schema schema, Schema oldSchema, boolean forceTableSchemaUpdate)
+      throws SchemaBackwardIncompatibleException {
+    if (!prepareSchemaUpdate(schema, oldSchema, forceTableSchemaUpdate)) {
+      return;
+    }
+    ZKMetadataProvider.setSchema(_propertyStore, schema);
+    LOGGER.info("Updated schema: {}", schema.getSchemaName());
+  }
+
+  /// Applies compatibility-preserving normalization and validates an update without writing it.
+  ///
+  /// @return true when the schema differs from the stored schema and must be written
+  private boolean prepareSchemaUpdate(Schema schema, Schema oldSchema, boolean forceTableSchemaUpdate)
       throws SchemaBackwardIncompatibleException {
     String schemaName = schema.getSchemaName();
     schema.updateBooleanFieldsIfNeeded(oldSchema);
     if (schema.equals(oldSchema)) {
       LOGGER.info("New schema: {} is the same as the existing schema, not updating it", schemaName);
-      return;
+      return false;
     }
 
     boolean isBackwardCompatible = schema.isBackwardCompatibleWith(oldSchema);
@@ -1797,8 +1820,7 @@ public class PinotHelixResourceManager {
         throw new SchemaBackwardIncompatibleException(errorMsg.toString());
       }
     }
-    ZKMetadataProvider.setSchema(_propertyStore, schema);
-    LOGGER.info("Updated schema: {}", schemaName);
+    return true;
   }
 
   /// Deletes the given schema. Returns `true` when schema exists, `false` when schema does not exist.
@@ -1817,6 +1839,14 @@ public class PinotHelixResourceManager {
   @Nullable
   public Schema getSchema(String schemaName) {
     return ZKMetadataProvider.getSchema(_propertyStore, schemaName);
+  }
+
+  /// Get the schema and ZK version from one read.
+  ///
+  /// @return a pair of schema and current version, or null if the schema does not exist
+  @Nullable
+  public Pair<Schema, Integer> getSchemaWithVersion(String schemaName) {
+    return ZKMetadataProvider.getSchemaWithVersion(_propertyStore, schemaName);
   }
 
   @Nullable
@@ -1932,6 +1962,16 @@ public class PinotHelixResourceManager {
   /// @throws TableAlreadyExistsException if the table already exists
   public void addTable(TableConfig tableConfig, List<StreamMetadata> streamMetadataList)
       throws IOException {
+    validateTableAddition(tableConfig, streamMetadataList);
+    String tableNameWithType = tableConfig.getTableName();
+    LOGGER.info("Adding table {}: Creating table config in the property store", tableNameWithType);
+    if (!ZKMetadataProvider.createTableConfig(_propertyStore, tableConfig)) {
+      throw new RuntimeException("Failed to create table config for table: " + tableNameWithType);
+    }
+    finishAddingTable(tableConfig, streamMetadataList);
+  }
+
+  private void validateTableAddition(TableConfig tableConfig, List<StreamMetadata> streamMetadataList) {
     String tableNameWithType = tableConfig.getTableName();
     LOGGER.info("Adding table {}: Start", tableNameWithType);
     if (streamMetadataList != null && !streamMetadataList.isEmpty()) {
@@ -1964,8 +2004,6 @@ public class PinotHelixResourceManager {
 
     LOGGER.info("Adding table {}: Successfully validated added table", tableNameWithType);
 
-    IdealState idealState =
-        PinotTableIdealStateBuilder.buildEmptyIdealStateFor(tableNameWithType, tableConfig.getReplication());
     TableType tableType = tableConfig.getTableType();
     // Ensure that table is not created if schema is not present
     if (ZKMetadataProvider.getSchema(_propertyStore, rawTableName) == null) {
@@ -1973,13 +2011,14 @@ public class PinotHelixResourceManager {
     }
     Preconditions.checkState(tableType == TableType.OFFLINE || tableType == TableType.REALTIME,
         "Invalid table type: %s", tableType);
+  }
 
-    // Add table config
-    LOGGER.info("Adding table {}: Creating table config in the property store", tableNameWithType);
-    if (!ZKMetadataProvider.createTableConfig(_propertyStore, tableConfig)) {
-      throw new RuntimeException("Failed to create table config for table: " + tableNameWithType);
-    }
-
+  private void finishAddingTable(TableConfig tableConfig, List<StreamMetadata> streamMetadataList)
+      throws IOException {
+    String tableNameWithType = tableConfig.getTableName();
+    TableType tableType = tableConfig.getTableType();
+    IdealState idealState =
+        PinotTableIdealStateBuilder.buildEmptyIdealStateFor(tableNameWithType, tableConfig.getReplication());
     try {
       // Read table config from ZK to ensure we get consistent view across all APIs (e.g. environment variables applied,
       // unknown fields dropped)
@@ -2021,6 +2060,8 @@ public class PinotHelixResourceManager {
     // ZK glitch must not undo a successfully created table, and the notify fallback path
     // remains correct because every MV that reaches this method has already passed
     // `MaterializedViewAnalyzer.analyze` (single-FROM, simple-name source).
+    // Runtime MV metadata is consumed by broker rewriting and must describe the same resolved SQL used to populate
+    // the view. Display endpoints independently source and redact the unresolved TableConfig.
     persistMaterializedViewDefinitionMetadataBestEffort(tableConfig);
     notifyMaterializedViewConsistencyManagerForTableCreate(tableConfig);
     LOGGER.info("Adding table {}: Successfully added table", tableNameWithType);
@@ -2355,9 +2396,145 @@ public class PinotHelixResourceManager {
   /// @throws TableConfigBackwardIncompatibleException if config changes are backward incompatible and force is false
   public void updateTableConfig(TableConfig tableConfig, boolean force)
       throws IOException, TableConfigBackwardIncompatibleException {
+    updateTableConfig(tableConfig, -1, force);
+  }
+
+  /// Validate the table config and update it with the expected ZK version.
+  ///
+  /// @param tableConfig the table config to update
+  /// @param expectedVersion the expected version (-1 to ignore version check)
+  /// @param force if true, allows upsert/dedup config changes with a warning
+  /// @throws IOException
+  /// @throws TableConfigBackwardIncompatibleException if config changes are backward incompatible and force is false
+  /// @throws TableConfigVersionMismatchException if the table config changed after it was read
+  public void updateTableConfig(TableConfig tableConfig, int expectedVersion, boolean force)
+      throws IOException, TableConfigBackwardIncompatibleException {
     validateTableTenantConfig(tableConfig);
     validateTableTaskMinionInstanceTagConfig(tableConfig);
-    setExistingTableConfig(tableConfig, -1, force);
+    setExistingTableConfig(tableConfig, expectedVersion, force);
+  }
+
+  /// Atomically updates multiple existing table configs from one versioned read snapshot.
+  public void updateTableConfigsAtomically(Map<TableType, TableConfig> tableConfigs,
+      Map<TableType, Integer> expectedVersions, boolean force)
+      throws IOException, SchemaBackwardIncompatibleException, TableConfigBackwardIncompatibleException,
+      TableNotFoundException {
+    doUpdateTableConfigsAtomically(null, null, tableConfigs, expectedVersions, false, force, false);
+  }
+
+  /// Atomically updates table configs while checking that the schema used for validation is unchanged.
+  public void updateTableConfigsAtomicallyWithSchemaCheck(Schema schema, int expectedSchemaVersion,
+      Map<TableType, TableConfig> tableConfigs, Map<TableType, Integer> expectedVersions, boolean force)
+      throws IOException, SchemaBackwardIncompatibleException, TableConfigBackwardIncompatibleException,
+      TableNotFoundException {
+    doUpdateTableConfigsAtomically(schema, expectedSchemaVersion, tableConfigs, expectedVersions, false, force, true);
+  }
+
+  /// Atomically updates a schema and multiple existing table configs from one versioned read snapshot.
+  public void updateTableConfigsAtomically(Schema schema, int expectedSchemaVersion,
+      Map<TableType, TableConfig> tableConfigs, Map<TableType, Integer> expectedVersions, boolean reload,
+      boolean force)
+      throws IOException, SchemaBackwardIncompatibleException, TableConfigBackwardIncompatibleException,
+      TableNotFoundException {
+    doUpdateTableConfigsAtomically(schema, expectedSchemaVersion, tableConfigs, expectedVersions, reload, force,
+        false);
+  }
+
+  private void doUpdateTableConfigsAtomically(@Nullable Schema schema, @Nullable Integer expectedSchemaVersion,
+      Map<TableType, TableConfig> tableConfigs, Map<TableType, Integer> expectedVersions, boolean reload,
+      boolean force, boolean checkSchemaOnly)
+      throws IOException, SchemaBackwardIncompatibleException, TableConfigBackwardIncompatibleException,
+      TableNotFoundException {
+    Preconditions.checkArgument(!tableConfigs.isEmpty(), "At least one table config is required");
+    Preconditions.checkArgument(tableConfigs.keySet().equals(expectedVersions.keySet()),
+        "Expected versions must exactly match table config types");
+    for (Map.Entry<TableType, TableConfig> entry : tableConfigs.entrySet()) {
+      TableConfig tableConfig = Preconditions.checkNotNull(entry.getValue());
+      Preconditions.checkArgument(entry.getKey() == tableConfig.getTableType(),
+          "Table config key must match table type");
+      Preconditions.checkArgument(expectedVersions.get(entry.getKey()) >= 0,
+          "Existing table config updates require non-negative versions");
+      validateTableTenantConfig(tableConfig);
+      validateTableTaskMinionInstanceTagConfig(tableConfig);
+      Pair<TableConfig, Integer> storedTableConfigWithVersion = getTableConfigWithVersion(
+          tableConfig.getTableName(), false, false);
+      if (storedTableConfigWithVersion == null
+          || !expectedVersions.get(entry.getKey()).equals(storedTableConfigWithVersion.getRight())) {
+        throw new TableConfigVersionMismatchException();
+      }
+      validateExistingTableConfigUpdate(tableConfig, storedTableConfigWithVersion.getLeft(), force);
+    }
+
+    boolean schemaChanged = false;
+    if (schema != null) {
+      Preconditions.checkNotNull(expectedSchemaVersion);
+      Pair<Schema, Integer> storedSchemaWithVersion = getSchemaWithVersion(schema.getSchemaName());
+      if (storedSchemaWithVersion == null || !expectedSchemaVersion.equals(storedSchemaWithVersion.getRight())) {
+        throw new TableConfigVersionMismatchException();
+      }
+      if (checkSchemaOnly) {
+        Preconditions.checkArgument(schema.equals(storedSchemaWithVersion.getLeft()),
+            "Check-only schema must match the stored schema");
+      } else {
+        schemaChanged = prepareSchemaUpdate(schema, storedSchemaWithVersion.getLeft(), force);
+      }
+    }
+
+    ZkMultiWriteBuilder multiWrite = multiWriteZK();
+    if (schema != null) {
+      String schemaPath = ZKMetadataProvider.constructPropertyStorePathForSchema(schema.getSchemaName());
+      if (schemaChanged) {
+        multiWrite.set(schemaPath, SchemaSerDeUtils.toZNRecord(schema), expectedSchemaVersion);
+      } else {
+        multiWrite.check(schemaPath, expectedSchemaVersion);
+      }
+    }
+    for (TableType tableType : TableType.values()) {
+      TableConfig tableConfig = tableConfigs.get(tableType);
+      if (tableConfig != null) {
+        multiWrite.set(ZKMetadataProvider.constructPropertyStorePathForResourceConfig(tableConfig.getTableName()),
+            TableConfigSerDeUtils.toZNRecord(tableConfig), expectedVersions.get(tableType));
+      }
+    }
+    try {
+      multiWrite.execute();
+    } catch (KeeperException e) {
+      throw new TableConfigVersionMismatchException(e);
+    }
+
+    RuntimeException sideEffectFailure = null;
+    for (TableType tableType : TableType.values()) {
+      TableConfig tableConfig = tableConfigs.get(tableType);
+      if (tableConfig != null) {
+        try {
+          applyExistingTableConfigUpdate(tableConfig);
+        } catch (RuntimeException e) {
+          LOGGER.error("Table config was stored, but post-update actions failed for table: {} ({})",
+              tableConfig.getTableName(), e.getClass().getSimpleName());
+          if (sideEffectFailure == null) {
+            sideEffectFailure = e;
+          } else {
+            sideEffectFailure.addSuppressed(e);
+          }
+        }
+      }
+    }
+    if (schema != null && !checkSchemaOnly) {
+      try {
+        refreshSchema(schema.getSchemaName(), reload);
+      } catch (TableNotFoundException e) {
+        LOGGER.error("Schema was stored, but post-update actions failed for schema: {} ({})", schema.getSchemaName(),
+            e.getClass().getSimpleName());
+        if (sideEffectFailure == null) {
+          sideEffectFailure = new RuntimeException(e);
+        } else {
+          sideEffectFailure.addSuppressed(e);
+        }
+      }
+    }
+    if (sideEffectFailure != null) {
+      throw sideEffectFailure;
+    }
   }
 
   /// Sets the given table config into zookeeper bypassing validations in updateTableConfig
@@ -2473,7 +2650,32 @@ public class PinotHelixResourceManager {
   public void setExistingTableConfig(TableConfig tableConfig, int expectedVersion, boolean force)
       throws TableConfigBackwardIncompatibleException {
     String tableNameWithType = tableConfig.getTableName();
+    validateExistingTableConfigUpdate(tableConfig, force);
+
+    try {
+      if (!ZKMetadataProvider.setTableConfig(_propertyStore, tableConfig, expectedVersion)) {
+        if (expectedVersion >= 0) {
+          throw new TableConfigVersionMismatchException();
+        }
+        throw new RuntimeException("Failed to update table config in Zookeeper for table: " + tableNameWithType);
+      }
+    } catch (ZkBadVersionException e) {
+      throw new TableConfigVersionMismatchException(e);
+    }
+
+    applyExistingTableConfigUpdate(tableConfig);
+  }
+
+  private void validateExistingTableConfigUpdate(TableConfig tableConfig, boolean force)
+      throws TableConfigBackwardIncompatibleException {
+    String tableNameWithType = tableConfig.getTableName();
     TableConfig existingTableConfig = getTableConfig(tableNameWithType);
+    validateExistingTableConfigUpdate(tableConfig, existingTableConfig, force);
+  }
+
+  private void validateExistingTableConfigUpdate(TableConfig tableConfig, @Nullable TableConfig existingTableConfig,
+      boolean force)
+      throws TableConfigBackwardIncompatibleException {
     if (existingTableConfig != null) {
       List<String> violations = TableConfigUtils.validateBackwardCompatibility(tableConfig, existingTableConfig);
       if (!violations.isEmpty()) {
@@ -2490,13 +2692,10 @@ public class PinotHelixResourceManager {
         }
       }
     }
+  }
 
-    if (!ZKMetadataProvider.setTableConfig(_propertyStore, tableConfig, expectedVersion)) {
-      throw new RuntimeException(
-          "Failed to update table config in Zookeeper for table: " + tableNameWithType + " with" + " expected version: "
-              + expectedVersion);
-    }
-
+  private void applyExistingTableConfigUpdate(TableConfig tableConfig) {
+    String tableNameWithType = tableConfig.getTableName();
     // Update IdealState replication
     IdealState idealState = _helixAdmin.getResourceIdealState(_helixClusterName, tableNameWithType);
     Preconditions.checkArgument(idealState != null,
@@ -3803,6 +4002,19 @@ public class PinotHelixResourceManager {
   @Nullable
   public TableConfig getTableConfig(String tableNameWithType) {
     return ZKMetadataProvider.getTableConfig(_propertyStore, tableNameWithType);
+  }
+
+  /// Get the table config and ZK version from one read.
+  ///
+  /// @param tableNameWithType Table name with type suffix
+  /// @param replaceVariables Whether to replace environment variables and system properties with their actual values
+  /// @param applyDecorator Whether to apply the table config decorator
+  /// @return a pair of table config and current version, or null if the table config does not exist
+  @Nullable
+  public Pair<TableConfig, Integer> getTableConfigWithVersion(String tableNameWithType, boolean replaceVariables,
+      boolean applyDecorator) {
+    return ZKMetadataProvider.getTableConfigWithVersion(
+        _propertyStore, tableNameWithType, replaceVariables, applyDecorator);
   }
 
   /// Get all table configs.
@@ -5322,8 +5534,8 @@ public class PinotHelixResourceManager {
       }
     } catch (Exception e) {
       LOGGER.warn("Adding table {}: Best-effort MV definition metadata persist failed; "
-              + "consistency manager will fall back to extractSourceTableName",
-          tableNameWithType, e);
+              + "consistency manager will fall back to extractSourceTableName ({})",
+          tableNameWithType, e.getClass().getName());
     }
   }
 
@@ -5424,8 +5636,8 @@ public class PinotHelixResourceManager {
         mvsNeedingZnodePersist.add(cfg);
         registered++;
       } catch (Exception e) {
-        LOGGER.warn("MV reverse-index backfill: failed to register {} in memory; skipping",
-            tableNameWithType, e);
+        LOGGER.warn("MV reverse-index backfill: failed to register {} in memory; skipping ({})",
+            tableNameWithType, e.getClass().getName());
       }
     }
     LOGGER.info("MV reverse-index backfill phase 1: scanned {} MV(s), registered {} missing entries",
@@ -5446,8 +5658,8 @@ public class PinotHelixResourceManager {
         persistMaterializedViewDefinitionMetadataBestEffort(cfg);
         znodeAttempted++;
       } catch (Exception e) {
-        LOGGER.warn("MV reverse-index backfill: best-effort znode persist threw for {}; continuing",
-            cfg.getTableName(), e);
+        LOGGER.warn("MV reverse-index backfill: best-effort znode persist threw for {}; continuing ({})",
+            cfg.getTableName(), e.getClass().getName());
       }
     }
     LOGGER.info("MV reverse-index backfill phase 2: attempted znode persist for {} MV(s)",
@@ -5481,7 +5693,7 @@ public class PinotHelixResourceManager {
       return List.of(sourceTable);
     } catch (Exception e) {
       LOGGER.warn("MV reverse-index backfill: failed to extract source table from definedSQL "
-          + "for MV table {}; skipping", tableNameWithType, e);
+          + "for MV table {}; skipping ({})", tableNameWithType, e.getClass().getName());
       return null;
     }
   }
@@ -5519,7 +5731,8 @@ public class PinotHelixResourceManager {
       String sourceTable = MaterializedViewAnalyzer.extractSourceTableName(definedSQL);
       mgr.onMaterializedViewTableCreated(tableConfig.getTableName(), List.of(sourceTable));
     } catch (Exception e) {
-      LOGGER.warn("Failed to register MV table {} with consistency manager", tableConfig.getTableName(), e);
+      LOGGER.warn("Failed to register MV table {} with consistency manager ({})",
+          tableConfig.getTableName(), e.getClass().getName());
     }
   }
 
@@ -5529,7 +5742,8 @@ public class PinotHelixResourceManager {
       return;
     }
     try {
-      TableConfig tableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, tableNameWithType);
+      TableConfig tableConfig =
+          ZKMetadataProvider.getTableConfig(_propertyStore, tableNameWithType, false, false);
       if (tableConfig != null && !tableConfig.isMaterializedView()) {
         return;
       }
@@ -5565,7 +5779,8 @@ public class PinotHelixResourceManager {
             + "consistency reverse index may be stale", tableNameWithType);
       }
     } catch (Exception e) {
-      LOGGER.warn("Failed to unregister MV table {} from consistency manager", tableNameWithType, e);
+      LOGGER.warn("Failed to unregister MV table {} from consistency manager ({})",
+          tableNameWithType, e.getClass().getName());
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -20,8 +20,6 @@ package org.apache.pinot.controller.helix.core.minion;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -280,7 +278,8 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
           pinotTaskConfigs.forEach(pinotTaskConfig -> pinotTaskConfig.getConfigs()
               .computeIfAbsent(MinionConstants.TRIGGERED_BY, k -> triggeredBy));
           addDefaultsToTaskConfig(pinotTaskConfigs);
-          LOGGER.info("Submitting ad-hoc task for task type: {} with task configs: {}", taskType, pinotTaskConfigs);
+          LOGGER.info("Submitting {} ad-hoc task(s) for task type: {}, table: {}", pinotTaskConfigs.size(), taskType,
+              tableNameWithType);
           String minionInstanceTag =
               taskConfigs.getOrDefault(MINION_INSTANCE_TAG_CONFIG, CommonConstants.Helix.UNTAGGED_MINION_INSTANCE);
           _controllerMetrics.addMeteredTableValue(taskType, ControllerMeter.NUMBER_ADHOC_TASKS_SUBMITTED, 1);
@@ -327,7 +326,7 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
         pinotTaskConfigs.clear();
         // If the task is user-triggered, we throw an exception to notify the user
         // This is to ensure that the user is aware of the task generation limit
-        throw new RuntimeException(message);
+        throw new TooManyTasksException(message);
       }
       // For scheduled tasks, we log a warning and limit the number of tasks
       LOGGER.warn(message + "Only the first {} tasks will be scheduled", maxNumberOfSubTasks);
@@ -979,21 +978,18 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
           response.addGenerationError(message);
         }
       } catch (Exception e) {
-        StringWriter errors = new StringWriter();
-        try (PrintWriter pw = new PrintWriter(errors)) {
-          e.printStackTrace(pw);
-        }
+        String errors = safeTaskGenerationError(e);
         response.addGenerationError("Failed to generate tasks for task type " + taskType + " for table " + tableName
             + "\n Reason : " + errors);
         long failureRunTimestamp = System.currentTimeMillis();
         _taskManagerStatusCache.saveTaskGeneratorInfo(tableName, taskType,
             taskGeneratorMostRecentRunInfo -> taskGeneratorMostRecentRunInfo.addErrorRunMessage(failureRunTimestamp,
-                errors.toString()));
+                errors));
         // before the first task schedule, the follow gauge metric will be empty
         // TODO: find a better way to report task generation information
         _controllerMetrics.setOrUpdateTableGauge(tableName, taskType,
             ControllerGauge.LAST_MINION_TASK_GENERATION_ENCOUNTERS_ERROR, 1L);
-        LOGGER.error("Failed to generate tasks for task type {} for table {}", taskType, tableName, e);
+        LOGGER.error("Failed to generate tasks for task type {} for table {}: {}", taskType, tableName, errors);
       } finally {
         MDC.remove(GEN_ID_KEY);
       }
@@ -1009,21 +1005,21 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
       try {
         if (numTasks > 0) {
           if (_pinotHelixResourceManager.getInstancesWithTag(minionInstanceTag).isEmpty()) {
-            LOGGER.error("Skipping {} tasks for task type: {} with task configs: {} to invalid minionInstanceTag: {}",
-                numTasks, taskType, pinotTaskConfigs, minionInstanceTag);
+            LOGGER.error("Skipping {} tasks for task type: {} due to invalid minionInstanceTag: {}",
+                numTasks, taskType, minionInstanceTag);
             throw new IllegalArgumentException("No valid minion instance found for tag: " + minionInstanceTag);
           }
           addDefaultsToTaskConfig(pinotTaskConfigs);
-          // This might lead to lot of logs, maybe sum it up and move outside the loop
-          LOGGER.info("Submitting {} tasks for task type: {} to minionInstance: {} with task configs: {}", numTasks,
-              taskType, minionInstanceTag, pinotTaskConfigs);
+          LOGGER.info("Submitting {} tasks for task type: {} to minionInstance: {}", numTasks, taskType,
+              minionInstanceTag);
           submittedTaskNames.add(submitTasks(null, pinotTaskConfigs, taskGenerator, triggeredBy, minionInstanceTag));
         }
       } catch (Exception e) {
         numErrorTasksScheduled++;
-        LOGGER.error("Failed to schedule task type {} on minion instance {} with task configs: {}", taskType,
-            minionInstanceTag, pinotTaskConfigs, e);
-        response.addSchedulingError(e.getMessage());
+        LOGGER.error("Failed to schedule task type {} on minion instance {} ({})", taskType, minionInstanceTag,
+            e.getClass().getSimpleName());
+        response.addSchedulingError("Failed to schedule task type " + taskType + " on minion instance "
+            + minionInstanceTag + " (" + e.getClass().getSimpleName() + ")");
       }
     }
     if (numErrorTasksScheduled > 0) {
@@ -1044,6 +1040,23 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
 
   protected static String getGenerationId(String taskType, String tableName) {
     return taskType + "-" + tableName + "-" + System.currentTimeMillis();
+  }
+
+  @VisibleForTesting
+  static String safeTaskGenerationError(Exception exception) {
+    String message = exception.getMessage();
+    if (exception instanceof TooManyTasksException && message != null) {
+      return message;
+    }
+    return exception.getClass().getName();
+  }
+
+  private static final class TooManyTasksException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    private TooManyTasksException(String message) {
+      super(message);
+    }
   }
 
   protected String submitTasks(@Nullable String parentTaskName, List<PinotTaskConfig> pinotTaskConfigs,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/TableConfigTunerUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/TableConfigTunerUtils.java
@@ -55,7 +55,8 @@ public class TableConfigTunerUtils {
         TableConfigTuner tuner = TableConfigTunerRegistry.getTuner(tunerConfig.getName());
         tuner.apply(pinotHelixResourceManager, tableConfig, schema, extraProperties);
       } catch (Exception e) {
-        LOGGER.error(String.format("Exception occur when applying tuner: %s", tunerConfig.getName()), e);
+        LOGGER.error("Exception applying table config tuner {} ({})", tunerConfig.getName(),
+            e.getClass().getName());
       }
     }
   }

--- a/pinot-controller/src/main/resources/app/pages/TaskQueueTable.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TaskQueueTable.tsx
@@ -100,7 +100,7 @@ const TaskQueueTable = (props) => {
     const mostRecentErrorRunMessagesTS = get(taskGeneratorDebugData, 'data.0.mostRecentErrorRunMessages', {});
     const mostRecentErrorRunMessagesTSLastTime = last(keys(mostRecentErrorRunMessagesTS).sort());
     setMostRecentErrorRunMessage(get(mostRecentErrorRunMessagesTS, mostRecentErrorRunMessagesTSLastTime, ''));
-    setTableDetail(tableDetailRes);
+    setTableDetail(get(tableDetailRes, 'configs', tableDetailRes));
     setJobDetail(detail);
     setFetching(false);
   };

--- a/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
@@ -312,7 +312,8 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
           setTableNotFound(true);
           return;
         }
-        const tableObj:any = result.OFFLINE || result.REALTIME;
+        const tableConfigs = get(result, 'configs', result);
+        const tableObj:any = tableConfigs.OFFLINE || tableConfigs.REALTIME;
         setTableType(tableObj.tableType);
         setTableConfig(JSON.stringify(result, null, 2));
         return fetchTableState(tableObj.tableType);
@@ -372,7 +373,10 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
   const saveConfigAction = async () => {
     let configObj = JSON.parse(config);
     if(actionType === 'editTable'){
-      if(configObj.OFFLINE || configObj.REALTIME){
+      // Preserve the versioned response envelope so unchanged redacted values can
+      // be restored against the exact versions returned by GET. Older controllers
+      // return the table config map directly, which still needs to be unwrapped.
+      if(!configObj.configs && (configObj.OFFLINE || configObj.REALTIME)){
         configObj = configObj.OFFLINE || configObj.REALTIME;
       }
       const result = await PinotMethodUtils.updateTable(tableName, configObj);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
@@ -473,12 +473,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
 
   private TableConfig getTableConfig(String tableName, String tableType)
       throws Exception {
-    String tableConfigString = tableClient().getTableConfig(tableName, tableType);
-    JsonNode tableConfigNode = JsonUtils.stringToJsonNode(tableConfigString);
-    if (tableConfigNode.has(tableType)) {
-      tableConfigNode = tableConfigNode.get(tableType);
-    }
-    return JsonUtils.jsonNodeToObject(tableConfigNode, TableConfig.class);
+    return tableClient().getTableConfigObject(tableName, tableType);
   }
 
   @Test
@@ -549,7 +544,9 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     // Seed the config below the REST validation layer to model a table persisted before this validation existed.
     DEFAULT_INSTANCE.getHelixResourceManager().addTable(legacyTableConfig);
 
-    TableConfig update = getTableConfig(tableName, "REALTIME");
+    // Fetch the unresolved stored config because this test intentionally exercises the legacy bare-config update
+    // path. Redacted values must be submitted with the complete versioned response envelope instead.
+    TableConfig update = DEFAULT_INSTANCE.getHelixResourceManager().getRealtimeTableConfig(tableName, false, false);
     update.getValidationConfig().setRetentionTimeValue("10");
     JsonNode validationResponse = JsonUtils.stringToJsonNode(tableClient().validateTableConfig(update.toJsonString()));
     assertTrue(validationResponse.has("REALTIME"));
@@ -557,7 +554,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     JsonNode response = JsonUtils.stringToJsonNode(updateTable(tableName, update.toJsonString()));
     assertTrue(response.has("status"));
 
-    TableConfig stored = getTableConfig(tableName, "REALTIME");
+    TableConfig stored = DEFAULT_INSTANCE.getHelixResourceManager().getRealtimeTableConfig(tableName, false, false);
     assertEquals(stored.getValidationConfig().getRetentionTimeValue(), "10");
     assertEquals(stored.getIngestionConfig().getTransformConfigs().get(0).getTransformFunction(), "now()");
 
@@ -571,7 +568,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
 
     IOException updateError = expectThrows(IOException.class, () -> updateTable(tableName, update.toJsonString()));
     assertHasStatus(updateError, 400);
-    assertTrue(updateError.getMessage().contains("Function 'now' has VOLATILE volatility"), updateError.getMessage());
+    assertTrue(updateError.getMessage().contains("Invalid table config: " + tableName), updateError.getMessage());
   }
 
   @Test
@@ -1076,7 +1073,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
       updateTable(realtimeTableConfig.getTableName(), realtimeTableConfig.toJsonString());
       fail("Table update should fail due to invalid RG config");
     } catch (Exception e) {
-      assertTrue(e.getMessage().contains("Failed to calculate instance partitions for table: " + tableNameWithType));
+      assertHasStatus(e, 400);
     }
   }
 
@@ -1138,7 +1135,6 @@ public class PinotTableRestletResourceTest extends ControllerTest {
 
   /// Updating existing REALTIME table with invalid replication factor should throw exception.
   private void validateTableUpdateReplicationToInvalidValue(String rawTableName, TableType tableType) {
-    String tableNameWithType = TableNameBuilder.forType(tableType).tableNameWithType(rawTableName);
     TableConfig tableConfig = (tableType == TableType.REALTIME
         ? getRealtimeTableBuilder(rawTableName)
         : getOfflineTableBuilder(rawTableName))
@@ -1149,7 +1145,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
       updateTable(tableConfig.getTableName(), tableConfig.toJsonString());
       fail("Table update should fail due to invalid replication factor");
     } catch (Exception e) {
-      assertTrue(e.getMessage().contains("Failed to calculate instance partitions for table: " + tableNameWithType));
+      assertHasStatus(e, 400);
     }
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AuthenticationFilterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AuthenticationFilterTest.java
@@ -25,9 +25,14 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.controller.api.resources.LLCSegmentCompletionHandlers;
 import org.apache.pinot.controller.api.resources.PinotBrokerRestletResource;
@@ -36,12 +41,17 @@ import org.apache.pinot.controller.api.resources.PinotControllerPeriodicTaskRest
 import org.apache.pinot.controller.api.resources.PinotInstanceRestletResource;
 import org.apache.pinot.controller.api.resources.PinotQueryResource;
 import org.apache.pinot.controller.api.resources.PinotTableRestletResource;
+import org.apache.pinot.controller.api.resources.ZookeeperResource;
 import org.apache.pinot.core.auth.Actions;
 import org.apache.pinot.core.auth.Authorize;
 import org.apache.pinot.core.auth.TargetType;
+import org.glassfish.grizzly.http.server.Request;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
 
 
@@ -82,6 +92,15 @@ public class AuthenticationFilterTest {
     queryParams.putSingle("tableNameWithType", "E");
     queryParams.putSingle("schemaName", "F");
     assertEquals(AuthenticationFilter.extractTableName(pathParams, queryParams), "C");
+  }
+
+  @Test
+  public void testExtractTableNameWithMaterializedViewNameInPathParams() {
+    MultivaluedMap<String, String> pathParams = new MultivaluedHashMap<>();
+    MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+    pathParams.putSingle("materializedViewTableName", "mv_OFFLINE");
+
+    assertEquals(AuthenticationFilter.extractTableName(pathParams, queryParams), "mv_OFFLINE");
   }
 
   @Test
@@ -205,6 +224,45 @@ public class AuthenticationFilterTest {
       assertEquals(_authFilter.extractAccessType(method), AccessType.READ,
           resourceClass.getSimpleName() + "." + methodName);
     }
+  }
+
+  @Test
+  public void testAuthorizeAnnotationIsProtectedWhenProtectAnnotatedOnly()
+      throws Exception {
+    AuthenticationFilter authFilter = new AuthenticationFilter();
+    AccessControl accessControl = mock(AccessControl.class);
+    when(accessControl.protectAnnotatedOnly()).thenReturn(true);
+
+    AccessControlFactory accessControlFactory = mock(AccessControlFactory.class);
+    when(accessControlFactory.create()).thenReturn(accessControl);
+    authFilter._accessControlFactory = accessControlFactory;
+
+    Request request = mock(Request.class);
+    when(request.getRequestURI()).thenReturn("/zk/get");
+    when(request.getContextPath()).thenReturn("");
+    authFilter._requestProvider = () -> request;
+
+    ResourceInfo resourceInfo = mock(ResourceInfo.class);
+    when(resourceInfo.getResourceMethod()).thenReturn(ZookeeperResource.class.getMethod("getData", String.class));
+    authFilter._resourceInfo = resourceInfo;
+
+    HttpHeaders httpHeaders = mock(HttpHeaders.class);
+    authFilter._httpHeaders = httpHeaders;
+
+    UriInfo uriInfo = mock(UriInfo.class);
+    when(uriInfo.getPath()).thenReturn("zk/get");
+    when(uriInfo.getPathParameters()).thenReturn(new MultivaluedHashMap<>());
+    when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
+    ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
+    when(requestContext.getUriInfo()).thenReturn(uriInfo);
+
+    when(accessControl.hasAccess(AccessType.READ, httpHeaders, "/zk/get")).thenReturn(true);
+    when(accessControl.hasAccess(httpHeaders, TargetType.CLUSTER, null, Actions.Cluster.GET_ZNODE)).thenReturn(false);
+
+    WebApplicationException exception = expectThrows(WebApplicationException.class,
+        () -> authFilter.filter(requestContext));
+    assertEquals(exception.getResponse().getStatus(), Response.Status.FORBIDDEN.getStatusCode());
+    verify(accessControl).hasAccess(httpHeaders, TargetType.CLUSTER, null, Actions.Cluster.GET_ZNODE);
   }
 
   // DataProvider supplying test cases

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotDdlRestletResourceMaterializedViewUnitTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotDdlRestletResourceMaterializedViewUnitTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.controller.api.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.ws.rs.core.HttpHeaders;
@@ -29,13 +30,18 @@ import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.access.AccessControl;
 import org.apache.pinot.controller.api.access.AccessControlFactory;
+import org.apache.pinot.controller.api.access.AccessType;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
 import org.apache.pinot.controller.api.exception.TableAlreadyExistsException;
 import org.apache.pinot.controller.api.resources.ddl.DdlExecutionRequest;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.minion.PinotHelixTaskResourceManager;
 import org.apache.pinot.controller.helix.core.minion.PinotTaskManager;
+import org.apache.pinot.core.auth.Actions;
+import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableConfigRedactionUtils;
+import org.apache.pinot.spi.config.table.TableCustomConfig;
 import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -89,6 +95,18 @@ public class PinotDdlRestletResourceMaterializedViewUnitTest {
 
   private static final String MATERIALIZED_VIEW_RAW = "mv_orders";
   private static final String MATERIALIZED_VIEW_WITH_TYPE = MATERIALIZED_VIEW_RAW + "_OFFLINE";
+
+  @Test
+  public void createMaterializedViewRejectsRedactionMarkerBeforePersistence() {
+    PinotDdlRestletResource resource = newResource();
+    String ddl = "CREATE MATERIALIZED VIEW " + commonMaterializedViewBody(true)
+        .replace("'replication' = '1'", "'replication' = '1', 'provider.password' = '*****'");
+
+    ControllerApplicationException e = expectThrows(ControllerApplicationException.class,
+        () -> resource.executeDdl(new DdlExecutionRequest(ddl), false, mockHeaders(), mockRequest()));
+
+    assertEquals(e.getResponse().getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
+  }
   private static final String SOURCE = "orders";
 
   /// Happy path: REFRESH EVERY supplied → schedule key set on persisted TableConfig,
@@ -210,6 +228,23 @@ public class PinotDdlRestletResourceMaterializedViewUnitTest {
     }
   }
 
+  @Test
+  public void ifNotExistsAllowsMaskedMaterializedViewWriteFreeNoOp()
+      throws Exception {
+    PinotDdlRestletResource resource = newResource();
+    seedStoredMaterializedView(resource);
+    String ddl = "CREATE MATERIALIZED VIEW IF NOT EXISTS " + commonMaterializedViewBody(true)
+        .replace("'replication' = '1'", "'replication' = '1', 'provider.password' = '*****'");
+
+    try (QuietValidationMocks ignored = new QuietValidationMocks()) {
+      Response response = resource.executeDdl(
+          new DdlExecutionRequest(ddl), false, mockHeaders(), mockRequest());
+
+      assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+      verify(resource._pinotHelixResourceManager, never()).addTable(any(TableConfig.class));
+    }
+  }
+
   /// IF NOT EXISTS no-op response shape: the `tableConfig` and `schema` fields must echo
   /// what is *persisted* in ZK, not what the client submitted. Without this contract an
   /// operator running an idempotent deployment script who has since drifted the local DDL
@@ -225,7 +260,10 @@ public class PinotDdlRestletResourceMaterializedViewUnitTest {
     seedStoredMaterializedView(resource);
 
     TableConfig persisted = resource._pinotHelixResourceManager
-        .getTableConfig(MATERIALIZED_VIEW_WITH_TYPE);
+        .getOfflineTableConfig(MATERIALIZED_VIEW_RAW, false, false);
+    persisted.setCustomConfig(new TableCustomConfig(new LinkedHashMap<>(Map.of(
+        "provider.password", "persisted-password",
+        "provider.secondary.password", "${MV_PROVIDER_PASSWORD}"))));
     String persistedCron = persisted.getTaskConfig()
         .getConfigsForTaskType(MaterializedViewTask.TASK_TYPE)
         .get(PinotTaskManager.SCHEDULE_KEY);
@@ -256,6 +294,41 @@ public class PinotDdlRestletResourceMaterializedViewUnitTest {
       // persisted instance, so the schemaName field is a sufficient marker.
       assertEquals(body.path("schema").path("schemaName").asText(), MATERIALIZED_VIEW_RAW,
           "Response.schema must echo the persisted schema; got " + body.get("schema"));
+      String echoedConfig = body.path("tableConfig").toString();
+      assertFalse(echoedConfig.contains("persisted-password"), "No-op response returned a literal password");
+      assertTrue(echoedConfig.contains(TableConfigRedactionUtils.REDACTION_MARKER));
+      assertTrue(echoedConfig.contains("${MV_PROVIDER_PASSWORD}"));
+    }
+  }
+
+  @Test
+  public void ifNotExistsNoOpRequiresReadPermissionToReturnPersistedConfig()
+      throws Exception {
+    PinotDdlRestletResource resource = newResource();
+    seedStoredMaterializedView(resource);
+    when(resource._accessControlFactory.create()).thenReturn(new AccessControl() {
+      @Override
+      public boolean hasAccess(String tableName, AccessType accessType, HttpHeaders headers,
+          String endpointUrl) {
+        return accessType != AccessType.READ;
+      }
+
+      @Override
+      public boolean hasAccess(HttpHeaders headers, TargetType targetType, String targetId,
+          String action) {
+        return Actions.Table.CREATE_TABLE.equals(action);
+      }
+    });
+
+    try (QuietValidationMocks ignored = new QuietValidationMocks()) {
+      ControllerApplicationException e = expectThrows(ControllerApplicationException.class,
+          () -> resource.executeDdl(
+              new DdlExecutionRequest(
+                  "CREATE MATERIALIZED VIEW IF NOT EXISTS " + commonMaterializedViewBody(true)),
+              false, mockHeaders(), mockRequest()));
+
+      assertEquals(e.getResponse().getStatus(), Response.Status.FORBIDDEN.getStatusCode());
+      verify(resource._pinotHelixResourceManager, never()).addTable(any(TableConfig.class));
     }
   }
 
@@ -293,7 +366,7 @@ public class PinotDdlRestletResourceMaterializedViewUnitTest {
     TableConfig plainTable = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName(MATERIALIZED_VIEW_WITH_TYPE)
         .build();
-    when(resource._pinotHelixResourceManager.getTableConfig(MATERIALIZED_VIEW_WITH_TYPE))
+    when(resource._pinotHelixResourceManager.getOfflineTableConfig(MATERIALIZED_VIEW_RAW, false, false))
         .thenReturn(plainTable);
 
     try (QuietValidationMocks ignored = new QuietValidationMocks()) {
@@ -325,7 +398,7 @@ public class PinotDdlRestletResourceMaterializedViewUnitTest {
     TableConfig plainTable = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName(MATERIALIZED_VIEW_WITH_TYPE)
         .build();
-    when(resource._pinotHelixResourceManager.getTableConfig(MATERIALIZED_VIEW_WITH_TYPE))
+    when(resource._pinotHelixResourceManager.getOfflineTableConfig(MATERIALIZED_VIEW_RAW, false, false))
         .thenReturn(plainTable);
 
     try (QuietValidationMocks ignored = new QuietValidationMocks()) {
@@ -350,7 +423,7 @@ public class PinotDdlRestletResourceMaterializedViewUnitTest {
       throws Exception {
     PinotDdlRestletResource resource = newResource();
     String realtimeNameWithType = MATERIALIZED_VIEW_RAW + "_REALTIME";
-    when(resource._pinotHelixResourceManager.getTableConfig(MATERIALIZED_VIEW_WITH_TYPE))
+    when(resource._pinotHelixResourceManager.getOfflineTableConfig(MATERIALIZED_VIEW_RAW, false, false))
         .thenReturn(null);
     when(resource._pinotHelixResourceManager.hasTable(realtimeNameWithType)).thenReturn(true);
 
@@ -429,7 +502,7 @@ public class PinotDdlRestletResourceMaterializedViewUnitTest {
     TableConfig plainTable = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName(MATERIALIZED_VIEW_WITH_TYPE)
         .build();
-    when(resource._pinotHelixResourceManager.getTableConfig(MATERIALIZED_VIEW_WITH_TYPE))
+    when(resource._pinotHelixResourceManager.getOfflineTableConfig(MATERIALIZED_VIEW_RAW, false, false))
         .thenReturn(null)
         .thenReturn(plainTable);
     when(resource._pinotHelixResourceManager.hasTable(MATERIALIZED_VIEW_WITH_TYPE)).thenReturn(false);
@@ -535,6 +608,81 @@ public class PinotDdlRestletResourceMaterializedViewUnitTest {
         "MV DDL must carry the AS <query> clause; got:\n" + ddl);
   }
 
+  /// The MV representation must use exactly the same display policy as SHOW CREATE TABLE.
+  /// The stored config is deliberately fetched through the unresolved getter so an environment
+  /// placeholder cannot be replaced with controller-process state before redaction runs.
+  @Test
+  public void showCreateMaterializedViewRedactsStoredCredentialsAndPreservesPlaceholders() {
+    String plainPassword = "mv-plain-password-literal";
+    String jaasPassword = "mv-jaas-password-literal";
+    String accessKey = "mv-access-key-literal";
+    String uriUser = "mv-uri-user-literal";
+    String uriPassword = "mv-uri-password-literal";
+    String uriToken = "mv-uri-token-literal";
+    String passwordPlaceholder = "${MV_KAFKA_TRUSTSTORE_PASSWORD}";
+    String benignTopic = "mv-events-topic";
+
+    Map<String, String> streamConfigs = new LinkedHashMap<>();
+    streamConfigs.put("stream.kafka.consumer.prop.ssl.keystore.password", plainPassword);
+    streamConfigs.put("stream.kafka.consumer.prop.ssl.truststore.password", passwordPlaceholder);
+    streamConfigs.put("stream.kafka.consumer.prop.sasl.jaas.config",
+        "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"mv-jaas-user\" password=\""
+            + jaasPassword + "\";");
+    streamConfigs.put("stream.kinesis.accessKey", accessKey);
+    streamConfigs.put("stream.kafka.schema.registry.url",
+        "https://" + uriUser + ":" + uriPassword
+            + "@registry.example.test/schemas?access_token=" + uriToken + "&region=us-west-2");
+    streamConfigs.put("stream.kafka.topic.name", benignTopic);
+
+    CompiledCreateMaterializedView compiled = (CompiledCreateMaterializedView) DdlCompiler.compile(
+        "CREATE MATERIALIZED VIEW " + commonMaterializedViewBody(true));
+    TableConfig storedConfig = compiled.getTableConfig();
+    storedConfig.setTableName(MATERIALIZED_VIEW_WITH_TYPE);
+    storedConfig.getIndexingConfig().setStreamConfigs(streamConfigs);
+
+    PinotDdlRestletResource resource = newResource();
+    when(resource._accessControlFactory.create()).thenReturn(new AccessControl() {
+      @Override
+      public boolean hasAccess(String tableName, AccessType accessType, HttpHeaders headers,
+          String endpointUrl) {
+        return MATERIALIZED_VIEW_RAW.equals(tableName) && accessType == AccessType.READ;
+      }
+
+      @Override
+      public boolean hasAccess(HttpHeaders headers, TargetType targetType, String targetId,
+          String action) {
+        return targetType == TargetType.TABLE && MATERIALIZED_VIEW_WITH_TYPE.equals(targetId)
+            && Actions.Table.GET_TABLE_CONFIG.equals(action);
+      }
+    });
+    when(resource._pinotHelixResourceManager.hasTable(MATERIALIZED_VIEW_WITH_TYPE)).thenReturn(true);
+    when(resource._pinotHelixResourceManager.getOfflineTableConfig(MATERIALIZED_VIEW_RAW, false, false))
+        .thenReturn(storedConfig);
+    when(resource._pinotHelixResourceManager.getTableSchema(MATERIALIZED_VIEW_WITH_TYPE))
+        .thenReturn(compiled.getSchema());
+
+    Response response = resource.executeDdl(
+        new DdlExecutionRequest("SHOW CREATE MATERIALIZED VIEW " + MATERIALIZED_VIEW_RAW),
+        false, mockHeaders(), mockRequest());
+
+    assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+    String ddl = readBody(response).get("ddl").asText();
+    assertFalse(ddl.contains(plainPassword), "SHOW CREATE returned a literal password");
+    assertFalse(ddl.contains(jaasPassword), "SHOW CREATE returned a literal JAAS password");
+    assertFalse(ddl.contains(accessKey), "SHOW CREATE returned a literal access key");
+    assertFalse(ddl.contains(uriUser), "SHOW CREATE returned literal URI user-info");
+    assertFalse(ddl.contains(uriPassword), "SHOW CREATE returned a literal URI password");
+    assertFalse(ddl.contains(uriToken), "SHOW CREATE returned a literal URI token");
+    assertTrue(ddl.contains(TableConfigRedactionUtils.REDACTION_MARKER));
+    assertTrue(ddl.contains(passwordPlaceholder));
+    assertTrue(ddl.contains(benignTopic));
+    assertTrue(ddl.contains("registry.example.test/schemas"));
+    assertTrue(ddl.contains("region=us-west-2"));
+    verify(resource._pinotHelixResourceManager)
+        .getOfflineTableConfig(MATERIALIZED_VIEW_RAW, false, false);
+    verify(resource._pinotHelixResourceManager, never()).getTableConfig(MATERIALIZED_VIEW_WITH_TYPE);
+  }
+
   /// Without a stored table the endpoint must 404 — and the message must name the MV-specific
   /// form rather than the generic "Table not found" so tooling can distinguish missing-MV
   /// from missing-table errors when both DDLs run side by side.
@@ -569,6 +717,8 @@ public class PinotDdlRestletResourceMaterializedViewUnitTest {
         .build();
     when(resource._pinotHelixResourceManager.hasTable(MATERIALIZED_VIEW_WITH_TYPE)).thenReturn(true);
     when(resource._pinotHelixResourceManager.getTableConfig(MATERIALIZED_VIEW_WITH_TYPE))
+        .thenReturn(plainTable);
+    when(resource._pinotHelixResourceManager.getOfflineTableConfig(MATERIALIZED_VIEW_RAW, false, false))
         .thenReturn(plainTable);
     when(resource._pinotHelixResourceManager.getTableSchema(MATERIALIZED_VIEW_WITH_TYPE))
         .thenReturn(plainSchema);
@@ -661,7 +811,8 @@ public class PinotDdlRestletResourceMaterializedViewUnitTest {
       throws Exception {
     PinotDdlRestletResource resource = newResource();
     when(resource._pinotHelixResourceManager.hasTable(MATERIALIZED_VIEW_WITH_TYPE)).thenReturn(false);
-    when(resource._pinotHelixResourceManager.getTableConfig(MATERIALIZED_VIEW_WITH_TYPE)).thenReturn(null);
+    when(resource._pinotHelixResourceManager.getOfflineTableConfig(MATERIALIZED_VIEW_RAW, false, false))
+        .thenReturn(null);
 
     ControllerApplicationException e = expectThrows(ControllerApplicationException.class,
         () -> resource.executeDdl(
@@ -682,7 +833,8 @@ public class PinotDdlRestletResourceMaterializedViewUnitTest {
       throws Exception {
     PinotDdlRestletResource resource = newResource();
     when(resource._pinotHelixResourceManager.hasTable(MATERIALIZED_VIEW_WITH_TYPE)).thenReturn(false);
-    when(resource._pinotHelixResourceManager.getTableConfig(MATERIALIZED_VIEW_WITH_TYPE)).thenReturn(null);
+    when(resource._pinotHelixResourceManager.getOfflineTableConfig(MATERIALIZED_VIEW_RAW, false, false))
+        .thenReturn(null);
 
     Response response = resource.executeDdl(
         new DdlExecutionRequest("DROP MATERIALIZED VIEW IF EXISTS " + MATERIALIZED_VIEW_RAW),
@@ -712,7 +864,7 @@ public class PinotDdlRestletResourceMaterializedViewUnitTest {
         .setTableName(MATERIALIZED_VIEW_WITH_TYPE)
         .build();
     when(resource._pinotHelixResourceManager.hasTable(MATERIALIZED_VIEW_WITH_TYPE)).thenReturn(true);
-    when(resource._pinotHelixResourceManager.getTableConfig(MATERIALIZED_VIEW_WITH_TYPE))
+    when(resource._pinotHelixResourceManager.getOfflineTableConfig(MATERIALIZED_VIEW_RAW, false, false))
         .thenReturn(plainTable);
 
     ControllerApplicationException e = expectThrows(ControllerApplicationException.class,
@@ -975,6 +1127,8 @@ public class PinotDdlRestletResourceMaterializedViewUnitTest {
     Schema mvSchema = compiled.getSchema();
     when(resource._pinotHelixResourceManager.hasTable(MATERIALIZED_VIEW_WITH_TYPE)).thenReturn(true);
     when(resource._pinotHelixResourceManager.getTableConfig(MATERIALIZED_VIEW_WITH_TYPE))
+        .thenReturn(mvConfig);
+    when(resource._pinotHelixResourceManager.getOfflineTableConfig(MATERIALIZED_VIEW_RAW, false, false))
         .thenReturn(mvConfig);
     when(resource._pinotHelixResourceManager.getTableSchema(MATERIALIZED_VIEW_WITH_TYPE))
         .thenReturn(mvSchema);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotDdlRestletResourceUnitTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotDdlRestletResourceUnitTest.java
@@ -29,12 +29,17 @@ import org.apache.helix.task.TaskState;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.controller.api.access.AccessControl;
 import org.apache.pinot.controller.api.access.AccessControlFactory;
+import org.apache.pinot.controller.api.access.AccessType;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
 import org.apache.pinot.controller.api.resources.ddl.DdlExecutionRequest;
+import org.apache.pinot.controller.api.resources.ddl.DdlExecutionResponse;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.minion.PinotHelixTaskResourceManager;
 import org.apache.pinot.controller.helix.core.minion.PinotTaskManager;
+import org.apache.pinot.core.auth.Actions;
+import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableConfigRedactionUtils;
 import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
@@ -58,6 +63,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -70,6 +76,145 @@ import static org.testng.Assert.expectThrows;
 /// differences in schema-level metadata a DDL column list cannot express (primary keys, tags,
 /// null-handling) and reject differences in per-column attributes that the DDL does control.
 public class PinotDdlRestletResourceUnitTest {
+
+  @Test
+  public void createTableRejectsRedactionMarkerBeforePersistence() {
+    PinotDdlRestletResource resource = new PinotDdlRestletResource();
+    resource._pinotHelixResourceManager = mock(PinotHelixResourceManager.class);
+    resource._accessControlFactory = mock(AccessControlFactory.class);
+    when(resource._accessControlFactory.create()).thenReturn(new AccessControl() {
+    });
+    Request request = mock(Request.class);
+    when(request.getRequestURL()).thenReturn(new StringBuilder("http://localhost/sql/ddl"));
+    String ddl = "CREATE TABLE marker_create (id INT DIMENSION) TABLE_TYPE = OFFLINE "
+        + "PROPERTIES ('provider.password' = '*****')";
+
+    ControllerApplicationException e = expectThrows(ControllerApplicationException.class,
+        () -> resource.executeDdl(new DdlExecutionRequest(ddl), false, mock(HttpHeaders.class), request));
+
+    assertEquals(e.getResponse().getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
+  }
+
+  @Test
+  public void createTableIfNotExistsAllowsMaskedWriteFreeNoOp()
+      throws Exception {
+    PinotDdlRestletResource resource = new PinotDdlRestletResource();
+    resource._pinotHelixResourceManager = mock(PinotHelixResourceManager.class);
+    resource._accessControlFactory = mock(AccessControlFactory.class);
+    when(resource._accessControlFactory.create()).thenReturn(new AccessControl() {
+    });
+    when(resource._pinotHelixResourceManager.hasTable("marker_noop_OFFLINE")).thenReturn(true);
+    Request request = mock(Request.class);
+    when(request.getRequestURL()).thenReturn(new StringBuilder("http://localhost/sql/ddl"));
+    String ddl = "CREATE TABLE IF NOT EXISTS marker_noop (id INT DIMENSION) TABLE_TYPE = OFFLINE "
+        + "PROPERTIES ('provider.password' = '*****')";
+
+    Response response = resource.executeDdl(
+        new DdlExecutionRequest(ddl), false, mock(HttpHeaders.class), request);
+
+    assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+    verify(resource._pinotHelixResourceManager, never()).addTable(Mockito.any(TableConfig.class));
+  }
+
+  /// SHOW CREATE is a display surface, not a privileged configuration export. A caller granted
+  /// only ordinary table READ + GetTableConfig must receive the unresolved stored shape with
+  /// literal credentials masked. In particular, this test uses accessKey and JAAS/URI content
+  /// that cannot be covered by password-suffix matching alone.
+  @Test
+  public void showCreateTableRedactsStoredCredentialsAndPreservesPlaceholders() {
+    String rawTableName = "credential_display";
+    String tableNameWithType = rawTableName + "_REALTIME";
+    String plainPassword = "plain-password-literal";
+    String jaasPassword = "jaas-password-literal";
+    String accessKey = "access-key-literal";
+    String uriUser = "uri-user-literal";
+    String uriPassword = "uri-password-literal";
+    String uriToken = "uri-token-literal";
+    String placeholderName = "PINOT_SHOW_CREATE_REDACTION_TEST_PASSWORD";
+    String passwordPlaceholder = "${" + placeholderName + "}";
+    String resolvedPlaceholderValue = "resolved-placeholder-value";
+    String benignTopic = "events-topic";
+
+    Map<String, String> streamConfigs = new HashMap<>();
+    streamConfigs.put("stream.kafka.consumer.prop.ssl.keystore.password", plainPassword);
+    streamConfigs.put("stream.kafka.consumer.prop.ssl.truststore.password", passwordPlaceholder);
+    streamConfigs.put("stream.kafka.consumer.prop.sasl.jaas.config",
+        "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"jaas-user\" password=\""
+            + jaasPassword + "\";");
+    streamConfigs.put("stream.kinesis.accessKey", accessKey);
+    streamConfigs.put("stream.kafka.schema.registry.url",
+        "https://" + uriUser + ":" + uriPassword
+            + "@registry.example.test/schemas?access_token=" + uriToken + "&region=us-west-2");
+    streamConfigs.put("stream.kafka.topic.name", benignTopic);
+
+    TableConfig storedConfig = new TableConfigBuilder(TableType.REALTIME)
+        .setTableName(tableNameWithType)
+        .setStreamConfigs(streamConfigs)
+        .build();
+    Schema schema = new Schema.SchemaBuilder()
+        .setSchemaName(rawTableName)
+        .addSingleValueDimension("id", DataType.INT)
+        .build();
+
+    PinotDdlRestletResource resource = new PinotDdlRestletResource();
+    resource._pinotHelixResourceManager = mock(PinotHelixResourceManager.class);
+    resource._accessControlFactory = mock(AccessControlFactory.class);
+    when(resource._accessControlFactory.create()).thenReturn(new AccessControl() {
+      @Override
+      public boolean hasAccess(String tableName, AccessType accessType, HttpHeaders headers,
+          String endpointUrl) {
+        return rawTableName.equals(tableName) && accessType == AccessType.READ;
+      }
+
+      @Override
+      public boolean hasAccess(HttpHeaders headers, TargetType targetType, String targetId,
+          String action) {
+        return targetType == TargetType.TABLE && tableNameWithType.equals(targetId)
+            && Actions.Table.GET_TABLE_CONFIG.equals(action);
+      }
+    });
+    when(resource._pinotHelixResourceManager.hasTable(tableNameWithType)).thenReturn(true);
+    when(resource._pinotHelixResourceManager.getRealtimeTableConfig(rawTableName, false, false))
+        .thenReturn(storedConfig);
+    when(resource._pinotHelixResourceManager.getTableSchema(tableNameWithType)).thenReturn(schema);
+    Request request = mock(Request.class);
+    when(request.getRequestURL()).thenReturn(new StringBuilder("http://localhost/sql/ddl"));
+
+    String previousPlaceholderValue = System.getProperty(placeholderName);
+    Response response;
+    try {
+      System.setProperty(placeholderName, resolvedPlaceholderValue);
+      response = resource.executeDdl(
+          new DdlExecutionRequest("SHOW CREATE TABLE " + rawTableName + " TYPE REALTIME"),
+          false, mock(HttpHeaders.class), request);
+    } finally {
+      if (previousPlaceholderValue == null) {
+        System.clearProperty(placeholderName);
+      } else {
+        System.setProperty(placeholderName, previousPlaceholderValue);
+      }
+    }
+
+    assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+    DdlExecutionResponse body = (DdlExecutionResponse) response.getEntity();
+    String ddl = body.getDdl();
+    assertNotNull(ddl);
+    assertFalse(ddl.contains(plainPassword), "SHOW CREATE returned a literal password");
+    assertFalse(ddl.contains(jaasPassword), "SHOW CREATE returned a literal JAAS password");
+    assertFalse(ddl.contains(accessKey), "SHOW CREATE returned a literal access key");
+    assertFalse(ddl.contains(uriUser), "SHOW CREATE returned literal URI user-info");
+    assertFalse(ddl.contains(uriPassword), "SHOW CREATE returned a literal URI password");
+    assertFalse(ddl.contains(uriToken), "SHOW CREATE returned a literal URI token");
+    assertFalse(ddl.contains(resolvedPlaceholderValue), "SHOW CREATE resolved a credential placeholder");
+    assertTrue(ddl.contains(TableConfigRedactionUtils.REDACTION_MARKER));
+    assertTrue(ddl.contains(passwordPlaceholder));
+    assertTrue(ddl.contains(benignTopic));
+    assertTrue(ddl.contains("registry.example.test/schemas"));
+    assertTrue(ddl.contains("region=us-west-2"));
+    verify(resource._pinotHelixResourceManager)
+        .getRealtimeTableConfig(rawTableName, false, false);
+    verify(resource._pinotHelixResourceManager, never()).getTableConfig(tableNameWithType);
+  }
 
   /// A dry-run DROP must fail on the same non-mutating logical-table reference guard as a live
   /// DROP. Otherwise dry-run can promise a deletion that the real request will later reject.
@@ -124,7 +269,7 @@ public class PinotDdlRestletResourceUnitTest {
         .setTableName("events")
         .setTaskConfig(new TableTaskConfig(taskConfigs))
         .build();
-    when(resource._pinotHelixResourceManager.getTableConfig("events_OFFLINE")).thenReturn(tableConfig);
+    when(resource._pinotHelixResourceManager.getOfflineTableConfig("events", false, false)).thenReturn(tableConfig);
 
     PinotHelixTaskResourceManager.TaskCount taskCount = mock(PinotHelixTaskResourceManager.TaskCount.class);
     when(taskCount.getRunning()).thenReturn(1);
@@ -149,6 +294,7 @@ public class PinotDdlRestletResourceUnitTest {
 
     verify(resource._pinotHelixResourceManager, never()).updateTableConfig(tableConfig);
     verify(resource._pinotHelixResourceManager, never()).deleteTable("events", TableType.OFFLINE, null);
+    verify(resource._pinotHelixResourceManager, never()).getTableConfig("events_OFFLINE");
     assertEquals(tableConfig.getTaskConfig().getTaskTypeConfigsMap()
         .get("SegmentRefreshTask").get(PinotTaskManager.SCHEDULE_KEY), "0 0 * * * ?");
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotMaterializedViewRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotMaterializedViewRestletResourceTest.java
@@ -1,0 +1,235 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import org.apache.helix.AccessOption;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.controller.api.exception.ControllerApplicationException;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.core.auth.Authorize;
+import org.apache.pinot.materializedview.metadata.MaterializedViewDefinitionMetadata;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableConfigRedactionUtils;
+import org.apache.pinot.spi.config.table.TableTaskConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.zookeeper.data.Stat;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+
+/// Focused response-policy tests for materialized-view details backed by mocked ZK metadata.
+public class PinotMaterializedViewRestletResourceTest {
+  private static final String RAW_TABLE_NAME = "mv_events";
+  private static final String TABLE_NAME_WITH_TYPE = RAW_TABLE_NAME + "_OFFLINE";
+
+  @Test
+  public void testDetailsUseUnresolvedConfigAndRedactDefinitionStrings()
+      throws Exception {
+    String staleDefinitionSql = "SELECT * FROM events WHERE callback = "
+        + "'https://stale-user:stale-password@stale.example/path?token=stale-token'";
+    String currentSql = "SELECT eventTime, city, count(*) AS cnt FROM events "
+        + "WHERE callback = "
+        + "'https://${MV_URI_USER}:literal-password@registry.example/path?access_token=${MV_URI_TOKEN}&region=west' "
+        + "AND status = 'PAID' GROUP BY eventTime, city";
+    Map<String, String> partitionExprMaps = new LinkedHashMap<>();
+    partitionExprMaps.put(
+        "lookup('https://map-user:map-password@format.example/path?token=map-token&region=west')",
+        "https://value-user:value-password@value.example/path?access_token=value-token&region=east");
+    MaterializedViewDefinitionMetadata definition = new MaterializedViewDefinitionMetadata(
+        TABLE_NAME_WITH_TYPE, List.of("events_OFFLINE"), staleDefinitionSql, partitionExprMaps, null);
+    TableConfig unresolvedConfig = materializedViewConfig(currentSql);
+    PinotMaterializedViewRestletResource resource = resourceWith(definition, unresolvedConfig);
+
+    JsonNode response = JsonUtils.stringToJsonNode(resource.getMaterializedView(TABLE_NAME_WITH_TYPE));
+    JsonNode responseDefinition = response.path("definition");
+    String displayedSql = responseDefinition.path("definedSQL").asText();
+    String displayedExpressions = responseDefinition.path("partitionExprMaps").toString();
+
+    assertFalse(displayedSql.contains("stale-user"), displayedSql);
+    assertFalse(displayedSql.contains("stale-password"), displayedSql);
+    assertFalse(displayedSql.contains("stale-token"), displayedSql);
+    assertFalse(displayedSql.contains("literal-password"), displayedSql);
+    assertTrue(displayedSql.contains("${MV_URI_USER}"), displayedSql);
+    assertTrue(displayedSql.contains("${MV_URI_TOKEN}"), displayedSql);
+    assertTrue(displayedSql.contains("registry.example/path"), displayedSql);
+    assertTrue(displayedSql.contains("region=west"), displayedSql);
+    assertTrue(displayedSql.contains("status = 'PAID'"), displayedSql);
+    assertTrue(displayedSql.contains(TableConfigRedactionUtils.REDACTION_MARKER), displayedSql);
+
+    for (String credential : List.of("map-user", "map-password", "map-token",
+        "value-user", "value-password", "value-token", "format.example", "value.example")) {
+      assertFalse(displayedExpressions.contains(credential), displayedExpressions);
+    }
+    assertEquals(responseDefinition.path("partitionExprMaps").path("eventTime").asText(), "eventTime");
+    assertEquals(responseDefinition.path("baseTables").get(0).asText(), "events");
+    verify(resource._pinotHelixResourceManager)
+        .getOfflineTableConfig(RAW_TABLE_NAME, false, false);
+    verify(resource._pinotHelixResourceManager)
+        .getOfflineTableConfig("events", false, false);
+    verify(resource._pinotHelixResourceManager, never()).getTableConfig(TABLE_NAME_WITH_TYPE);
+  }
+
+  @Test
+  public void testDetailsRebuildPartitionExpressionsFromUnresolvedSql()
+      throws Exception {
+    String resolvedPartitionLiteral = "RESOLVED_BUCKET_UNIT_SENTINEL";
+    String unresolvedSql =
+        "SELECT dateTrunc('${MV_BUCKET_UNIT}', eventTime) AS eventTime, city FROM events";
+    Map<String, String> resolvedPartitionExprMaps = Map.of(
+        "dateTrunc('" + resolvedPartitionLiteral + "', eventTime)", "eventTime");
+    MaterializedViewDefinitionMetadata definition = new MaterializedViewDefinitionMetadata(
+        TABLE_NAME_WITH_TYPE, List.of("resolved_events"),
+        "SELECT dateTrunc('" + resolvedPartitionLiteral + "', eventTime) AS eventTime FROM resolved_events",
+        resolvedPartitionExprMaps, null);
+    PinotMaterializedViewRestletResource resource = resourceWith(
+        definition, materializedViewConfig(unresolvedSql));
+
+    JsonNode response = JsonUtils.stringToJsonNode(resource.getMaterializedView(TABLE_NAME_WITH_TYPE));
+    JsonNode responseDefinition = response.path("definition");
+    String displayedSql = responseDefinition.path("definedSQL").asText();
+    String displayedExpressions = responseDefinition.path("partitionExprMaps").toString();
+
+    assertTrue(displayedSql.contains("${MV_BUCKET_UNIT}"), displayedSql);
+    assertTrue(displayedExpressions.contains("${MV_BUCKET_UNIT}"), displayedExpressions);
+    assertFalse(displayedSql.contains(resolvedPartitionLiteral), displayedSql);
+    assertFalse(displayedExpressions.contains(resolvedPartitionLiteral), displayedExpressions);
+    assertEquals(responseDefinition.path("baseTables").get(0).asText(), "events");
+  }
+
+  @Test
+  public void testPartitionExpressionRedactionCollisionFailsClosed() {
+    MaterializedViewDefinitionMetadata definition = new MaterializedViewDefinitionMetadata(
+        TABLE_NAME_WITH_TYPE, List.of("events_OFFLINE"), "stale SQL", Map.of(), null);
+    String currentSql = "SELECT "
+        + "lookup('https://first-user:first-secret@same.example/path?token=first-token') AS eventTime, "
+        + "lookup('https://second-user:second-secret@same.example/path?token=second-token') AS otherTime "
+        + "FROM events";
+    PinotMaterializedViewRestletResource resource = resourceWith(
+        definition, materializedViewConfig(currentSql), viewSchemaWithOtherTime());
+
+    ControllerApplicationException error = expectThrows(ControllerApplicationException.class,
+        () -> resource.getMaterializedView(TABLE_NAME_WITH_TYPE));
+
+    assertEquals(error.getResponse().getStatus(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+    for (String credential : List.of("first-user", "first-secret", "first-token",
+        "second-user", "second-secret", "second-token")) {
+      assertFalse(error.getMessage().contains(credential), error.getMessage());
+    }
+  }
+
+  @Test
+  public void testDetailsEndpointUsesRecognizedTableNameAuthorizationParameter()
+      throws Exception {
+    Method method = PinotMaterializedViewRestletResource.class.getMethod("getMaterializedView", String.class);
+
+    assertEquals(method.getAnnotation(Path.class).value(), "/materializedViews/{materializedViewTableName}");
+    assertEquals(method.getAnnotation(Authorize.class).paramName(), "materializedViewTableName");
+  }
+
+  private static TableConfig materializedViewConfig(String definedSql) {
+    return new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(TABLE_NAME_WITH_TYPE)
+        .setIsMaterializedView(true)
+        .setTimeColumnName("eventTime")
+        .setTaskConfig(new TableTaskConfig(Map.of(
+            CommonConstants.MaterializedViewTask.TASK_TYPE,
+            Map.of(CommonConstants.MaterializedViewTask.DEFINED_SQL_KEY, definedSql,
+                CommonConstants.MaterializedViewTask.BUCKET_TIME_PERIOD_KEY, "1d"))))
+        .build();
+  }
+
+  private static PinotMaterializedViewRestletResource resourceWith(
+      MaterializedViewDefinitionMetadata definition, TableConfig unresolvedConfig) {
+    return resourceWith(definition, unresolvedConfig, viewSchema());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static PinotMaterializedViewRestletResource resourceWith(
+      MaterializedViewDefinitionMetadata definition, TableConfig unresolvedConfig, Schema viewSchema) {
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    String definitionPath =
+        ZKMetadataProvider.constructPropertyStorePathForMaterializedViewDefinition(TABLE_NAME_WITH_TYPE);
+    when(resourceManager.getPropertyStore()).thenReturn(propertyStore);
+    when(resourceManager.getOfflineTableConfig(RAW_TABLE_NAME, false, false)).thenReturn(unresolvedConfig);
+    when(resourceManager.getOfflineTableConfig("events", false, false)).thenReturn(sourceTableConfig());
+    when(resourceManager.getSchema(RAW_TABLE_NAME)).thenReturn(viewSchema);
+    when(resourceManager.getSchema("events")).thenReturn(sourceSchema());
+    when(propertyStore.get(eq(definitionPath), any(Stat.class), eq(AccessOption.PERSISTENT)))
+        .thenReturn(definition.toZNRecord());
+
+    PinotMaterializedViewRestletResource resource = new PinotMaterializedViewRestletResource();
+    resource._pinotHelixResourceManager = resourceManager;
+    return resource;
+  }
+
+  private static TableConfig sourceTableConfig() {
+    return new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("events_OFFLINE")
+        .setTimeColumnName("eventTime")
+        .build();
+  }
+
+  private static Schema viewSchema() {
+    return new Schema.SchemaBuilder()
+        .setSchemaName(RAW_TABLE_NAME)
+        .addDateTime("eventTime", DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:MILLISECONDS")
+        .addSingleValueDimension("city", DataType.STRING)
+        .build();
+  }
+
+  private static Schema viewSchemaWithOtherTime() {
+    return new Schema.SchemaBuilder()
+        .setSchemaName(RAW_TABLE_NAME)
+        .addDateTime("eventTime", DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:MILLISECONDS")
+        .addDateTime("otherTime", DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:MILLISECONDS")
+        .build();
+  }
+
+  private static Schema sourceSchema() {
+    return new Schema.SchemaBuilder()
+        .setSchemaName("events")
+        .addDateTime("eventTime", DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:MILLISECONDS")
+        .build();
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotReadOnlyTableConfigResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotReadOnlyTableConfigResourceTest.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.ws.rs.core.Response;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.controller.helix.ControllerTest;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableConfigRedactionUtils;
+import org.apache.pinot.spi.config.table.TableCustomConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+/// Exercises the table-config HTTP authorization boundary with a principal that has table READ permission only.
+public class PinotReadOnlyTableConfigResourceTest extends ControllerTest {
+  private static final String RAW_TABLE_NAME = "readOnlyConfig";
+  private static final String LITERAL_PASSWORD = "read-only-literal-password";
+  private static final String PASSWORD_PLACEHOLDER = "${READ_ONLY_PASSWORD}";
+  private static final Map<String, String> ADMIN_HEADERS =
+      Map.of("Authorization", "Basic YWRtaW46dmVyeXNlY3JldA==");
+  private static final Map<String, String> READ_ONLY_HEADERS =
+      Map.of("Authorization", "Basic dXNlcjpzZWNyZXQ=");
+  private static final Map<String, String> RAW_READER_HEADERS =
+      Map.of("Authorization", "Basic cmF3OnJhd3NlY3JldA==");
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    startZk();
+    Map<String, Object> configuration = getDefaultControllerConfiguration();
+    configuration.put("controller.admin.access.control.factory.class",
+        "org.apache.pinot.controller.api.access.BasicAuthAccessControlFactory");
+    configuration.put("controller.admin.access.control.principals", "admin,user,raw");
+    configuration.put("controller.admin.access.control.principals.admin.password", "verysecret");
+    configuration.put("controller.admin.access.control.principals.admin.permissions",
+        "create,read,update,delete,GetZnode");
+    configuration.put("controller.admin.access.control.principals.user.password", "secret");
+    configuration.put("controller.admin.access.control.principals.user.permissions", "read");
+    configuration.put("controller.admin.access.control.principals.raw.password", "rawsecret");
+    configuration.put("controller.admin.access.control.principals.raw.permissions", "GetZnode");
+    startController(configuration);
+    addFakeBrokerInstancesToAutoJoinHelixCluster(1, true);
+    addFakeServerInstancesToAutoJoinHelixCluster(1, true);
+
+    addDummySchema(RAW_TABLE_NAME);
+    TableConfig tableConfig = createDummyTableConfig(RAW_TABLE_NAME, TableType.OFFLINE);
+    addTableConfig(tableConfig);
+
+    Map<String, String> customConfigs = new HashMap<>();
+    customConfigs.put("provider.password", LITERAL_PASSWORD);
+    customConfigs.put("placeholder.password", PASSWORD_PLACEHOLDER);
+    customConfigs.put("client.id", "preserved-client");
+    tableConfig.setCustomConfig(new TableCustomConfig(customConfigs));
+    // Keep the placeholder unresolved in the stored representation. The ordinary create path performs runtime
+    // validation that can resolve environment-provider values, which would make this output-boundary test depend on
+    // the test process environment.
+    assertTrue(ZKMetadataProvider.setTableConfig(_propertyStore, tableConfig));
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void tearDown() {
+    cleanup();
+    stopFakeInstances();
+    stopController();
+    stopZk();
+  }
+
+  @Override
+  protected Map<String, String> getAdminClientHeaders() {
+    return ADMIN_HEADERS;
+  }
+
+  @Test
+  public void testReadOnlyPrincipalReceivesOnlyRedactedConfigs()
+      throws Exception {
+    String tableResponse = sendGetRequest(
+        controllerUrl("/tables/" + RAW_TABLE_NAME + "?type=OFFLINE"), READ_ONLY_HEADERS);
+    String combinedResponse = sendGetRequest(
+        controllerUrl("/tableConfigs/" + RAW_TABLE_NAME), READ_ONLY_HEADERS);
+
+    for (String response : new String[]{tableResponse, combinedResponse}) {
+      assertFalse(response.contains(LITERAL_PASSWORD), response);
+      assertTrue(response.contains(TableConfigRedactionUtils.REDACTION_MARKER), response);
+      assertTrue(response.contains(PASSWORD_PLACEHOLDER), response);
+      assertTrue(response.contains("preserved-client"), response);
+    }
+  }
+
+  @Test
+  public void testRawTableConfigZkReadRequiresGetZnodePermission()
+      throws Exception {
+    String tableConfigPath = "/" + getHelixClusterName() + "/PROPERTYSTORE"
+        + ZKMetadataProvider.constructPropertyStorePathForResourceConfig(RAW_TABLE_NAME + "_OFFLINE");
+    String rawTableConfigUrl = controllerUrl("/zk/get?path=" + tableConfigPath);
+
+    Pair<Integer, String> readOnlyResponse = sendGetRequestWithStatusCode(rawTableConfigUrl, READ_ONLY_HEADERS);
+    assertEquals(readOnlyResponse.getLeft().intValue(), Response.Status.FORBIDDEN.getStatusCode());
+
+    Pair<Integer, String> rawReaderResponse = sendGetRequestWithStatusCode(rawTableConfigUrl, RAW_READER_HEADERS);
+    assertEquals(rawReaderResponse.getLeft().intValue(), Response.Status.OK.getStatusCode());
+    assertTrue(rawReaderResponse.getRight().contains(LITERAL_PASSWORD),
+        "A principal with getznode permission should receive the stored ZK representation");
+
+    Pair<Integer, String> adminResponse = sendGetRequestWithStatusCode(rawTableConfigUrl, ADMIN_HEADERS);
+    assertEquals(adminResponse.getLeft().intValue(), Response.Status.OK.getStatusCode());
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotTableRestletResourceTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.controller.api.resources;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
@@ -47,6 +48,29 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
 
 public class PinotTableRestletResourceTest {
+
+  @Test
+  public void testCopyTablePayloadCredentialOverridesRoundTrip()
+      throws Exception {
+    String passwordPointer = "/ingestionConfig/streamIngestionConfig/streamConfigMaps/0/password~1value";
+    Map<String, String> overrides = new HashMap<>();
+    overrides.put(passwordPointer, "literal-password");
+    overrides.put("/ingestionConfig/streamIngestionConfig/streamConfigMaps/0/sasl.jaas.config",
+        "example.LoginModule required password=literal-jaas;");
+    CopyTablePayload payload = new CopyTablePayload("http://localhost:9000", Map.of("Authorization", "header"),
+        "brokerTenant", "serverTenant", Map.of("source_REALTIME", "target_REALTIME"), overrides);
+
+    CopyTablePayload roundTripped = JsonUtils.stringToObject(JsonUtils.objectToString(payload),
+        CopyTablePayload.class);
+
+    assertEquals(roundTripped.getSourceClusterUri(), payload.getSourceClusterUri());
+    assertEquals(roundTripped.getHeaders(), payload.getHeaders());
+    assertEquals(roundTripped.getBrokerTenant(), payload.getBrokerTenant());
+    assertEquals(roundTripped.getServerTenant(), payload.getServerTenant());
+    assertEquals(roundTripped.getTagPoolReplacementMap(), payload.getTagPoolReplacementMap());
+    assertEquals(roundTripped.getCredentialOverrides(), overrides);
+    assertEquals(roundTripped.getCredentialOverrides().get(passwordPointer), "literal-password");
+  }
 
   @Test
   public void testTweakRealtimeTableConfig() throws Exception {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/TableConfigRedactionResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/TableConfigRedactionResourceTest.java
@@ -1,0 +1,815 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pinot.common.exception.TableConfigVersionMismatchException;
+import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.api.exception.ControllerApplicationException;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.minion.PinotHelixTaskResourceManager;
+import org.apache.pinot.controller.helix.core.minion.PinotTaskManager;
+import org.apache.pinot.controller.tuner.TableConfigTunerUtils;
+import org.apache.pinot.controller.util.TaskConfigUtils;
+import org.apache.pinot.segment.local.utils.SchemaUtils;
+import org.apache.pinot.segment.local.utils.TableConfigUtils;
+import org.apache.pinot.spi.config.TableConfigs;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableConfigRedactionUtils;
+import org.apache.pinot.spi.config.table.TableConfigValidatorRegistry;
+import org.apache.pinot.spi.config.table.TableCustomConfig;
+import org.apache.pinot.spi.config.table.TableTaskConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.exception.ConfigValidationException;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.expectThrows;
+
+
+/// Verifies that table-config REST resources redact read responses and restore unchanged markers on update.
+public class TableConfigRedactionResourceTest {
+  private static final String RAW_TABLE_NAME = "credentialTable";
+  private static final String OFFLINE_TABLE_NAME = RAW_TABLE_NAME + "_OFFLINE";
+  private static final String REALTIME_TABLE_NAME = RAW_TABLE_NAME + "_REALTIME";
+  private static final String LITERAL_PASSWORD = "literal-password";
+  private static final String PASSWORD_PLACEHOLDER = "${PINOT_TEST_PASSWORD}";
+  private static final String ORIGINAL_CLIENT_ID = "original-client";
+  private static final String EDITED_CLIENT_ID = "edited-client";
+  private static final String LITERAL_PASSWORD_KEY = "literal.password";
+  private static final String PLACEHOLDER_PASSWORD_KEY = "placeholder.password";
+  private static final String CLIENT_ID_KEY = "client.id";
+  private static final int OFFLINE_CONFIG_VERSION = 7;
+  private static final int REALTIME_CONFIG_VERSION = 11;
+  private static final int SCHEMA_VERSION = 313;
+
+  @Test
+  public void testGetTableConfigRedactsLiteralAndPreservesPlaceholder()
+      throws Exception {
+    TableConfig stored = tableConfigWithCredentials();
+    PinotHelixResourceManager resourceManager = mockResourceManager(stored);
+    PinotTableRestletResource resource = new PinotTableRestletResource();
+    resource._pinotHelixResourceManager = resourceManager;
+
+    JsonNode response = JsonUtils.stringToJsonNode(resource.listTableConfigs(
+        RAW_TABLE_NAME, TableType.OFFLINE.name(), headersWithoutDatabase()));
+    JsonNode customConfigs = response.path(RedactedTableConfigResponse.CONFIGS_KEY).path(TableType.OFFLINE.name())
+        .path(TableConfig.CUSTOM_CONFIG_KEY).path("customConfigs");
+
+    assertEquals(customConfigs.path(LITERAL_PASSWORD_KEY).asText(),
+        TableConfigRedactionUtils.REDACTION_MARKER);
+    assertEquals(customConfigs.path(PLACEHOLDER_PASSWORD_KEY).asText(), PASSWORD_PLACEHOLDER);
+    assertEquals(customConfigs.path(CLIENT_ID_KEY).asText(), ORIGINAL_CLIENT_ID);
+    assertEquals(response.path(RedactedTableConfigResponse.BASE_VERSIONS_KEY)
+        .path(TableType.OFFLINE.name()).asInt(), OFFLINE_CONFIG_VERSION);
+    assertFalse(response.toString().contains(LITERAL_PASSWORD));
+    assertEquals(stored.getCustomConfig().getCustomConfigs().get(LITERAL_PASSWORD_KEY), LITERAL_PASSWORD,
+        "Redacting a response must not mutate the stored config instance");
+    verify(resourceManager).getTableConfigWithVersion(OFFLINE_TABLE_NAME, false, false);
+  }
+
+  @Test
+  public void testGetCombinedTableConfigsRedactsLiteralAndPreservesPlaceholder()
+      throws Exception {
+    TableConfig stored = tableConfigWithCredentials();
+    PinotHelixResourceManager resourceManager = mockResourceManager(stored);
+    TableConfigsRestletResource resource = new TableConfigsRestletResource();
+    resource._pinotHelixResourceManager = resourceManager;
+
+    JsonNode response = JsonUtils.stringToJsonNode(resource.getConfig(RAW_TABLE_NAME, headersWithoutDatabase()));
+    JsonNode customConfigs = response.path(RedactedTableConfigsResponse.CONFIGS_KEY).path("offline")
+        .path(TableConfig.CUSTOM_CONFIG_KEY).path("customConfigs");
+
+    assertEquals(customConfigs.path(LITERAL_PASSWORD_KEY).asText(),
+        TableConfigRedactionUtils.REDACTION_MARKER);
+    assertEquals(customConfigs.path(PLACEHOLDER_PASSWORD_KEY).asText(), PASSWORD_PLACEHOLDER);
+    assertEquals(customConfigs.path(CLIENT_ID_KEY).asText(), ORIGINAL_CLIENT_ID);
+    assertEquals(response.path(RedactedTableConfigsResponse.BASE_VERSIONS_KEY)
+        .path("offline").asInt(), OFFLINE_CONFIG_VERSION);
+    assertFalse(response.toString().contains(LITERAL_PASSWORD));
+    verify(resourceManager).getTableConfigWithVersion(OFFLINE_TABLE_NAME, false, false);
+  }
+
+  @Test
+  public void testResponseEnvelopesCannotBeDeserializedAsLegacyUpdateBodies()
+      throws Exception {
+    TableConfig stored = tableConfigWithCredentials();
+    PinotHelixResourceManager resourceManager = mockResourceManager(stored);
+
+    PinotTableRestletResource tableResource = new PinotTableRestletResource();
+    tableResource._pinotHelixResourceManager = resourceManager;
+    TableConfigsRestletResource combinedResource = new TableConfigsRestletResource();
+    combinedResource._pinotHelixResourceManager = resourceManager;
+
+    String tableResponse = tableResource.listTableConfigs(
+        RAW_TABLE_NAME, TableType.OFFLINE.name(), headersWithoutDatabase());
+    String combinedResponse = combinedResource.getConfig(RAW_TABLE_NAME, headersWithoutDatabase());
+
+    expectThrows(MismatchedInputException.class,
+        () -> JsonUtils.stringToObject(tableResponse, TableConfig.class));
+    expectThrows(MismatchedInputException.class,
+        () -> JsonUtils.stringToObject(combinedResponse, TableConfigs.class));
+
+    JsonNode responseNode = JsonUtils.stringToJsonNode(tableResponse);
+    JsonNode unwrapped = PinotTableRestletResource.unwrapTableConfigResponse(responseNode);
+    assertEquals(unwrapped.path(TableType.OFFLINE.name()),
+        responseNode.path(RedactedTableConfigResponse.CONFIGS_KEY).path(TableType.OFFLINE.name()));
+
+    ObjectNode legacyResponse = JsonUtils.newObjectNode();
+    legacyResponse.set(TableType.OFFLINE.name(), TableConfigRedactionUtils.redact(stored).toJsonNode());
+    expectThrows(IOException.class,
+        () -> PinotTableRestletResource.unwrapTableConfigResponse(legacyResponse));
+  }
+
+  @Test
+  public void testUpdateTableConfigRestoresMaskedStoredCredential()
+      throws Exception {
+    TableConfig stored = tableConfigWithCredentials();
+    PinotHelixResourceManager resourceManager = mockResourceManager(stored);
+    PinotTableRestletResource resource = new PinotTableRestletResource();
+    resource._pinotHelixResourceManager = resourceManager;
+    resource._controllerConf = mock(ControllerConf.class);
+    resource._pinotTaskManager = mock(PinotTaskManager.class);
+    String getResponse = resource.listTableConfigs(
+        RAW_TABLE_NAME, TableType.OFFLINE.name(), headersWithoutDatabase());
+    String editedResponse = editTableConfigResponse(getResponse, TableType.OFFLINE);
+
+    try (MockedStatic<TableConfigValidationUtils> ignored = Mockito.mockStatic(TableConfigValidationUtils.class)) {
+      resource.updateTableConfig(RAW_TABLE_NAME, null, false, headersWithoutDatabase(), editedResponse);
+    }
+
+    verify(resourceManager).updateTableConfigsAtomicallyWithSchemaCheck(Mockito.any(Schema.class), eq(SCHEMA_VERSION),
+        Mockito.argThat(configs -> {
+          assertRestoredCredentialAndEdit(configs.get(TableType.OFFLINE));
+          return configs.size() == 1;
+        }), eq(Map.of(TableType.OFFLINE, OFFLINE_CONFIG_VERSION)), eq(false));
+    verify(resourceManager, Mockito.times(2)).getTableConfigWithVersion(OFFLINE_TABLE_NAME, false, false);
+  }
+
+  @Test
+  public void testUpdateCombinedTableConfigsRestoresMaskedStoredCredential()
+      throws Exception {
+    TableConfig stored = tableConfigWithCredentials();
+    PinotHelixResourceManager resourceManager = mockResourceManager(stored);
+    TableConfigsRestletResource resource = new TableConfigsRestletResource();
+    resource._pinotHelixResourceManager = resourceManager;
+    resource._controllerConf = mock(ControllerConf.class);
+    resource._pinotTaskManager = mock(PinotTaskManager.class);
+    String getResponse = resource.getConfig(RAW_TABLE_NAME, headersWithoutDatabase());
+    String editedResponse = editTableConfigsResponse(getResponse, TableType.OFFLINE);
+
+    try (MockedStatic<SchemaUtils> ignoredSchema = Mockito.mockStatic(SchemaUtils.class);
+        MockedStatic<TableConfigUtils> ignoredConfig = Mockito.mockStatic(TableConfigUtils.class);
+        MockedStatic<TaskConfigUtils> ignoredTask = Mockito.mockStatic(TaskConfigUtils.class);
+        MockedStatic<TableConfigValidatorRegistry> ignoredRegistry =
+            Mockito.mockStatic(TableConfigValidatorRegistry.class);
+        MockedStatic<TableConfigTunerUtils> ignoredTuner = Mockito.mockStatic(TableConfigTunerUtils.class)) {
+      resource.updateConfig(
+          RAW_TABLE_NAME, null, false, false, editedResponse, headersWithoutDatabase());
+    }
+
+    verify(resourceManager).updateTableConfigsAtomically(Mockito.any(Schema.class), eq(SCHEMA_VERSION),
+        Mockito.argThat(configs -> {
+          assertRestoredCredentialAndEdit(configs.get(TableType.OFFLINE));
+          return configs.size() == 1;
+        }), eq(Map.of(TableType.OFFLINE, OFFLINE_CONFIG_VERSION)), eq(false), eq(false));
+    verify(resourceManager, Mockito.times(2)).getTableConfigWithVersion(OFFLINE_TABLE_NAME, false, false);
+  }
+
+  @Test
+  public void testBareExtractedMaskedBodiesAreRejected()
+      throws Exception {
+    TableConfig stored = tableConfigWithCredentials();
+    PinotHelixResourceManager resourceManager = mockResourceManager(stored);
+    PinotTableRestletResource tableResource = new PinotTableRestletResource();
+    tableResource._pinotHelixResourceManager = resourceManager;
+    String tableResponse = tableResource.listTableConfigs(
+        RAW_TABLE_NAME, TableType.OFFLINE.name(), headersWithoutDatabase());
+    String extractedTableConfig = JsonUtils.stringToJsonNode(tableResponse)
+        .path(RedactedTableConfigResponse.CONFIGS_KEY).path(TableType.OFFLINE.name()).toString();
+
+    ControllerApplicationException tableError = expectThrows(ControllerApplicationException.class,
+        () -> tableResource.updateTableConfig(
+            RAW_TABLE_NAME, null, false, headersWithoutDatabase(), extractedTableConfig));
+    assertEquals(tableError.getResponse().getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
+
+    TableConfigsRestletResource combinedResource = new TableConfigsRestletResource();
+    combinedResource._pinotHelixResourceManager = resourceManager;
+    String combinedResponse = combinedResource.getConfig(RAW_TABLE_NAME, headersWithoutDatabase());
+    String extractedTableConfigs = JsonUtils.stringToJsonNode(combinedResponse)
+        .path(RedactedTableConfigsResponse.CONFIGS_KEY).toString();
+    ControllerApplicationException combinedError = expectThrows(ControllerApplicationException.class,
+        () -> combinedResource.updateConfig(
+            RAW_TABLE_NAME, null, false, false, extractedTableConfigs, headersWithoutDatabase()));
+    assertEquals(combinedError.getResponse().getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
+    verify(resourceManager, never()).updateTableConfig(Mockito.any(TableConfig.class), Mockito.anyInt(), eq(false));
+  }
+
+  @Test
+  public void testLegacyLiteralUpdateBodiesRemainAccepted()
+      throws Exception {
+    TableConfig stored = tableConfigWithCredentials();
+    TableConfig literalUpdate = tableConfigWithCredentials();
+    literalUpdate.getCustomConfig().getCustomConfigs().put(CLIENT_ID_KEY, EDITED_CLIENT_ID);
+    PinotHelixResourceManager tableResourceManager = mockResourceManager(stored);
+    PinotTableRestletResource tableResource = new PinotTableRestletResource();
+    tableResource._pinotHelixResourceManager = tableResourceManager;
+    tableResource._controllerConf = mock(ControllerConf.class);
+    tableResource._pinotTaskManager = mock(PinotTaskManager.class);
+    try (MockedStatic<TableConfigValidationUtils> ignored = Mockito.mockStatic(TableConfigValidationUtils.class)) {
+      tableResource.updateTableConfig(
+          RAW_TABLE_NAME, null, false, headersWithoutDatabase(), literalUpdate.toJsonString());
+    }
+    verify(tableResourceManager).updateTableConfig(
+        Mockito.any(TableConfig.class), eq(OFFLINE_CONFIG_VERSION), eq(false));
+
+    PinotHelixResourceManager combinedResourceManager = mockResourceManager(stored);
+    TableConfigsRestletResource combinedResource = new TableConfigsRestletResource();
+    combinedResource._pinotHelixResourceManager = combinedResourceManager;
+    combinedResource._controllerConf = mock(ControllerConf.class);
+    combinedResource._pinotTaskManager = mock(PinotTaskManager.class);
+    TableConfigs literalTableConfigs = new TableConfigs(RAW_TABLE_NAME, schema(), literalUpdate, null);
+    try (MockedStatic<SchemaUtils> ignoredSchema = Mockito.mockStatic(SchemaUtils.class);
+        MockedStatic<TableConfigUtils> ignoredConfig = Mockito.mockStatic(TableConfigUtils.class);
+        MockedStatic<TaskConfigUtils> ignoredTask = Mockito.mockStatic(TaskConfigUtils.class);
+        MockedStatic<TableConfigValidatorRegistry> ignoredRegistry =
+            Mockito.mockStatic(TableConfigValidatorRegistry.class);
+        MockedStatic<TableConfigTunerUtils> ignoredTuner = Mockito.mockStatic(TableConfigTunerUtils.class)) {
+      combinedResource.updateConfig(RAW_TABLE_NAME, null, false, false, literalTableConfigs.toJsonString(),
+          headersWithoutDatabase());
+    }
+    verify(combinedResourceManager).updateTableConfigsAtomically(
+        Mockito.any(Schema.class), eq(SCHEMA_VERSION),
+        Mockito.argThat(configs -> configs.size() == 1 && configs.containsKey(TableType.OFFLINE)),
+        eq(Map.of(TableType.OFFLINE, OFFLINE_CONFIG_VERSION)), eq(false), eq(false));
+  }
+
+  @Test
+  public void testEnvelopeBaseVersionMustMatchGetSnapshot()
+      throws Exception {
+    TableConfig stored = tableConfigWithCredentials();
+    PinotHelixResourceManager resourceManager = mockResourceManager(stored);
+    PinotTableRestletResource resource = new PinotTableRestletResource();
+    resource._pinotHelixResourceManager = resourceManager;
+    resource._controllerConf = mock(ControllerConf.class);
+    resource._pinotTaskManager = mock(PinotTaskManager.class);
+
+    ControllerApplicationException error = expectThrows(ControllerApplicationException.class,
+        () -> resource.updateTableConfig(RAW_TABLE_NAME, null, false, headersWithoutDatabase(),
+            tableConfigEnvelope(maskedEditedConfig(stored), OFFLINE_CONFIG_VERSION - 1)));
+
+    assertEquals(error.getResponse().getStatus(), Response.Status.CONFLICT.getStatusCode());
+    verify(resourceManager, never()).updateTableConfig(Mockito.any(TableConfig.class), Mockito.anyInt(), eq(false));
+  }
+
+  @Test
+  public void testCombinedEnvelopeChecksSnapshotBeforeSchemaUpdate()
+      throws Exception {
+    TableConfig stored = tableConfigWithCredentials();
+    PinotHelixResourceManager resourceManager = mockResourceManager(stored);
+    TableConfigsRestletResource resource = new TableConfigsRestletResource();
+    resource._pinotHelixResourceManager = resourceManager;
+    TableConfigs submitted = new TableConfigs(RAW_TABLE_NAME, schema(), maskedEditedConfig(stored), null);
+
+    ControllerApplicationException error = expectThrows(ControllerApplicationException.class,
+        () -> resource.updateConfig(RAW_TABLE_NAME, null, false, false,
+            tableConfigsEnvelope(submitted, Map.of("offline", OFFLINE_CONFIG_VERSION - 1)),
+            headersWithoutDatabase()));
+
+    assertEquals(error.getResponse().getStatus(), Response.Status.CONFLICT.getStatusCode());
+    verify(resourceManager, never()).updateSchema(Mockito.any(Schema.class), eq(false), eq(false));
+    verify(resourceManager, never()).updateTableConfig(Mockito.any(TableConfig.class), Mockito.anyInt(), eq(false));
+  }
+
+  @Test
+  public void testEnvelopeRejectsMissingNegativeAndUnknownBaseVersions()
+      throws Exception {
+    TableConfig stored = tableConfigWithCredentials();
+    PinotHelixResourceManager resourceManager = mockResourceManager(stored);
+    PinotTableRestletResource resource = new PinotTableRestletResource();
+    resource._pinotHelixResourceManager = resourceManager;
+    ObjectNode response = (ObjectNode) JsonUtils.stringToJsonNode(resource.listTableConfigs(
+        RAW_TABLE_NAME, TableType.OFFLINE.name(), headersWithoutDatabase()));
+
+    ObjectNode missing = response.deepCopy();
+    missing.remove(RedactedTableConfigResponse.BASE_VERSIONS_KEY);
+    expectThrows(JsonMappingException.class,
+        () -> JsonUtils.stringToObject(missing.toString(), RedactedTableConfigResponse.class));
+
+    ObjectNode negative = response.deepCopy();
+    ((ObjectNode) negative.path(RedactedTableConfigResponse.BASE_VERSIONS_KEY))
+        .put(TableType.OFFLINE.name(), -1);
+    expectThrows(JsonMappingException.class,
+        () -> JsonUtils.stringToObject(negative.toString(), RedactedTableConfigResponse.class));
+
+    ObjectNode unknown = response.deepCopy();
+    ((ObjectNode) unknown.path(RedactedTableConfigResponse.BASE_VERSIONS_KEY))
+        .put(TableType.REALTIME.name(), REALTIME_CONFIG_VERSION);
+    expectThrows(JsonMappingException.class,
+        () -> JsonUtils.stringToObject(unknown.toString(), RedactedTableConfigResponse.class));
+  }
+
+  @Test
+  public void testRealtimeGetAndUpdateBranchesRedactAndRestore()
+      throws Exception {
+    TableConfig stored = tableConfigWithCredentials(TableType.REALTIME);
+    PinotHelixResourceManager resourceManager = mockRealtimeResourceManager(stored);
+    PinotTableRestletResource tableResource = new PinotTableRestletResource();
+    tableResource._pinotHelixResourceManager = resourceManager;
+    tableResource._controllerConf = mock(ControllerConf.class);
+    tableResource._pinotTaskManager = mock(PinotTaskManager.class);
+    TableConfigsRestletResource combinedResource = new TableConfigsRestletResource();
+    combinedResource._pinotHelixResourceManager = resourceManager;
+
+    String tableResponse = tableResource.listTableConfigs(
+        RAW_TABLE_NAME, TableType.REALTIME.name(), headersWithoutDatabase());
+    String combinedResponse = combinedResource.getConfig(RAW_TABLE_NAME, headersWithoutDatabase());
+    assertFalse(tableResponse.contains(LITERAL_PASSWORD));
+    assertFalse(combinedResponse.contains(LITERAL_PASSWORD));
+    assertEquals(JsonUtils.stringToJsonNode(tableResponse).path(RedactedTableConfigResponse.CONFIGS_KEY)
+        .path(TableType.REALTIME.name())
+        .path(TableConfig.CUSTOM_CONFIG_KEY).path("customConfigs").path(LITERAL_PASSWORD_KEY).asText(),
+        TableConfigRedactionUtils.REDACTION_MARKER);
+    assertEquals(JsonUtils.stringToJsonNode(combinedResponse).path(RedactedTableConfigsResponse.CONFIGS_KEY)
+        .path("realtime")
+        .path(TableConfig.CUSTOM_CONFIG_KEY).path("customConfigs").path(LITERAL_PASSWORD_KEY).asText(),
+        TableConfigRedactionUtils.REDACTION_MARKER);
+
+    try (MockedStatic<TableConfigValidationUtils> ignored = Mockito.mockStatic(TableConfigValidationUtils.class)) {
+      tableResource.updateTableConfig(RAW_TABLE_NAME, null, false, headersWithoutDatabase(),
+          editTableConfigResponse(tableResponse, TableType.REALTIME));
+    }
+
+    verify(resourceManager).updateTableConfigsAtomicallyWithSchemaCheck(Mockito.any(Schema.class), eq(SCHEMA_VERSION),
+        Mockito.argThat(configs -> {
+          assertRestoredCredentialAndEdit(configs.get(TableType.REALTIME));
+          return configs.size() == 1;
+        }), eq(Map.of(TableType.REALTIME, REALTIME_CONFIG_VERSION)), eq(false));
+    verify(resourceManager, Mockito.atLeastOnce()).getTableConfigWithVersion(REALTIME_TABLE_NAME, false, false);
+
+    combinedResource._controllerConf = mock(ControllerConf.class);
+    combinedResource._pinotTaskManager = mock(PinotTaskManager.class);
+    try (MockedStatic<SchemaUtils> ignoredSchema = Mockito.mockStatic(SchemaUtils.class);
+        MockedStatic<TableConfigUtils> ignoredConfig = Mockito.mockStatic(TableConfigUtils.class);
+        MockedStatic<TaskConfigUtils> ignoredTask = Mockito.mockStatic(TaskConfigUtils.class);
+        MockedStatic<TableConfigValidatorRegistry> ignoredRegistry =
+            Mockito.mockStatic(TableConfigValidatorRegistry.class);
+        MockedStatic<TableConfigTunerUtils> ignoredTuner = Mockito.mockStatic(TableConfigTunerUtils.class)) {
+      combinedResource.updateConfig(RAW_TABLE_NAME, null, false, false,
+          editTableConfigsResponse(combinedResponse, TableType.REALTIME),
+          headersWithoutDatabase());
+    }
+    verify(resourceManager).updateTableConfigsAtomically(Mockito.any(Schema.class), eq(SCHEMA_VERSION),
+        Mockito.argThat(configs -> {
+          assertRestoredCredentialAndEdit(configs.get(TableType.REALTIME));
+          return configs.size() == 1;
+        }), eq(Map.of(TableType.REALTIME, REALTIME_CONFIG_VERSION)), eq(false), eq(false));
+  }
+
+  @Test
+  public void testMaskedTableUpdateReturnsConflictForStaleVersion()
+      throws Exception {
+    TableConfig stored = tableConfigWithCredentials();
+    PinotHelixResourceManager resourceManager = mockResourceManager(stored);
+    Mockito.doThrow(new TableConfigVersionMismatchException()).when(resourceManager)
+        .updateTableConfigsAtomicallyWithSchemaCheck(Mockito.any(Schema.class), eq(SCHEMA_VERSION), Mockito.anyMap(),
+            Mockito.anyMap(), eq(false));
+    PinotTableRestletResource resource = new PinotTableRestletResource();
+    resource._pinotHelixResourceManager = resourceManager;
+    resource._controllerConf = mock(ControllerConf.class);
+    resource._pinotTaskManager = mock(PinotTaskManager.class);
+    resource._controllerMetrics = mock(ControllerMetrics.class);
+
+    ControllerApplicationException error;
+    try (MockedStatic<TableConfigValidationUtils> ignored = Mockito.mockStatic(TableConfigValidationUtils.class)) {
+      error = expectThrows(ControllerApplicationException.class,
+          () -> resource.updateTableConfig(RAW_TABLE_NAME, null, false, headersWithoutDatabase(),
+              tableConfigEnvelope(maskedEditedConfig(stored), OFFLINE_CONFIG_VERSION)));
+    }
+
+    assertEquals(error.getResponse().getStatus(), Response.Status.CONFLICT.getStatusCode());
+    assertFalse(error.getMessage().contains(LITERAL_PASSWORD));
+    verify(resourceManager).updateTableConfigsAtomicallyWithSchemaCheck(Mockito.any(Schema.class), eq(SCHEMA_VERSION),
+        Mockito.anyMap(), eq(Map.of(TableType.OFFLINE, OFFLINE_CONFIG_VERSION)), eq(false));
+    verify(resourceManager, never()).updateTableConfig(Mockito.any(TableConfig.class), eq(false));
+  }
+
+  @Test
+  public void testMaskedCombinedUpdateReturnsConflictForStaleVersion()
+      throws Exception {
+    TableConfig stored = tableConfigWithCredentials();
+    PinotHelixResourceManager resourceManager = mockResourceManager(stored);
+    Mockito.doThrow(new TableConfigVersionMismatchException()).when(resourceManager)
+        .updateTableConfigsAtomically(Mockito.any(Schema.class), eq(SCHEMA_VERSION), Mockito.anyMap(), Mockito.anyMap(),
+            eq(false), eq(false));
+    TableConfigsRestletResource resource = new TableConfigsRestletResource();
+    resource._pinotHelixResourceManager = resourceManager;
+    resource._controllerConf = mock(ControllerConf.class);
+    resource._pinotTaskManager = mock(PinotTaskManager.class);
+    resource._controllerMetrics = mock(ControllerMetrics.class);
+    TableConfigs submittedConfigs = new TableConfigs(RAW_TABLE_NAME, schema(), maskedEditedConfig(stored), null);
+
+    ControllerApplicationException error;
+    try (MockedStatic<SchemaUtils> ignoredSchema = Mockito.mockStatic(SchemaUtils.class);
+        MockedStatic<TableConfigUtils> ignoredConfig = Mockito.mockStatic(TableConfigUtils.class);
+        MockedStatic<TaskConfigUtils> ignoredTask = Mockito.mockStatic(TaskConfigUtils.class);
+        MockedStatic<TableConfigValidatorRegistry> ignoredRegistry =
+            Mockito.mockStatic(TableConfigValidatorRegistry.class);
+        MockedStatic<TableConfigTunerUtils> ignoredTuner = Mockito.mockStatic(TableConfigTunerUtils.class)) {
+      error = expectThrows(ControllerApplicationException.class,
+          () -> resource.updateConfig(RAW_TABLE_NAME, null, false, false,
+              tableConfigsEnvelope(submittedConfigs, Map.of("offline", OFFLINE_CONFIG_VERSION)),
+              headersWithoutDatabase()));
+    }
+
+    assertEquals(error.getResponse().getStatus(), Response.Status.CONFLICT.getStatusCode());
+    assertFalse(error.getMessage().contains(LITERAL_PASSWORD));
+    verify(resourceManager).updateTableConfigsAtomically(Mockito.any(Schema.class), eq(SCHEMA_VERSION),
+        Mockito.anyMap(), eq(Map.of(TableType.OFFLINE, OFFLINE_CONFIG_VERSION)), eq(false), eq(false));
+    verify(resourceManager, never()).updateTableConfig(Mockito.any(TableConfig.class), eq(false));
+  }
+
+  @Test
+  public void testHybridTableEnvelopeRoundTripRestoresBothCredentials()
+      throws Exception {
+    TableConfig storedOffline = tableConfigWithCredentials(TableType.OFFLINE);
+    TableConfig storedRealtime = tableConfigWithCredentials(TableType.REALTIME);
+    PinotHelixResourceManager resourceManager = mockHybridResourceManager(storedOffline, storedRealtime);
+    PinotTableRestletResource resource = new PinotTableRestletResource();
+    resource._pinotHelixResourceManager = resourceManager;
+    resource._controllerConf = mock(ControllerConf.class);
+    resource._pinotTaskManager = mock(PinotTaskManager.class);
+
+    String response = resource.listTableConfigs(RAW_TABLE_NAME, null, headersWithoutDatabase());
+    String editedResponse = editTableConfigResponse(
+        editTableConfigResponse(response, TableType.OFFLINE), TableType.REALTIME);
+    try (MockedStatic<TableConfigValidationUtils> ignored = Mockito.mockStatic(TableConfigValidationUtils.class);
+        MockedStatic<TableConfigUtils> ignoredConfig = Mockito.mockStatic(TableConfigUtils.class)) {
+      resource.updateTableConfig(RAW_TABLE_NAME, null, false, headersWithoutDatabase(), editedResponse);
+    }
+
+    verify(resourceManager).updateTableConfigsAtomicallyWithSchemaCheck(Mockito.any(Schema.class), eq(SCHEMA_VERSION),
+        Mockito.argThat(configs -> {
+          assertEquals(configs.size(), 2);
+          assertRestoredCredentialAndEdit(configs.get(TableType.OFFLINE));
+          assertRestoredCredentialAndEdit(configs.get(TableType.REALTIME));
+          return true;
+        }), eq(Map.of(TableType.OFFLINE, OFFLINE_CONFIG_VERSION,
+            TableType.REALTIME, REALTIME_CONFIG_VERSION)), eq(false));
+  }
+
+  @Test
+  public void testCombinedEnvelopeRejectsStaleSchemaWithoutMutation()
+      throws Exception {
+    TableConfig stored = tableConfigWithCredentials();
+    PinotHelixResourceManager resourceManager = mockResourceManager(stored);
+    TableConfigsRestletResource resource = new TableConfigsRestletResource();
+    resource._pinotHelixResourceManager = resourceManager;
+    ObjectNode response = (ObjectNode) JsonUtils.stringToJsonNode(
+        resource.getConfig(RAW_TABLE_NAME, headersWithoutDatabase()));
+    ((ObjectNode) response.path(RedactedTableConfigsResponse.BASE_VERSIONS_KEY))
+        .put(RedactedTableConfigsResponse.SCHEMA_VERSION_KEY, SCHEMA_VERSION - 1);
+
+    ControllerApplicationException error = expectThrows(ControllerApplicationException.class,
+        () -> resource.updateConfig(RAW_TABLE_NAME, null, false, false, response.toString(),
+            headersWithoutDatabase()));
+
+    assertEquals(error.getResponse().getStatus(), Response.Status.CONFLICT.getStatusCode());
+    verify(resourceManager, never()).updateTableConfigsAtomically(Mockito.any(Schema.class), Mockito.anyInt(),
+        Mockito.anyMap(), Mockito.anyMap(), eq(false), eq(false));
+    verify(resourceManager, never()).updateSchema(Mockito.any(Schema.class), eq(false), eq(false));
+  }
+
+  @Test
+  public void testVersionedEnvelopeRejectsMissingTypeAdditionWithoutMutation()
+      throws Exception {
+    TableConfig stored = tableConfigWithCredentials();
+    PinotHelixResourceManager resourceManager = mockResourceManager(stored);
+    TableConfigsRestletResource resource = new TableConfigsRestletResource();
+    resource._pinotHelixResourceManager = resourceManager;
+    resource._controllerConf = mock(ControllerConf.class);
+    resource._pinotTaskManager = mock(PinotTaskManager.class);
+    ObjectNode response = (ObjectNode) JsonUtils.stringToJsonNode(
+        resource.getConfig(RAW_TABLE_NAME, headersWithoutDatabase()));
+    ((ObjectNode) response.path(RedactedTableConfigsResponse.CONFIGS_KEY)).set("realtime",
+        tableConfigWithCredentials(TableType.REALTIME).toJsonNode());
+
+    ControllerApplicationException error;
+    try (MockedStatic<SchemaUtils> ignoredSchema = Mockito.mockStatic(SchemaUtils.class);
+        MockedStatic<TableConfigUtils> ignoredConfig = Mockito.mockStatic(TableConfigUtils.class);
+        MockedStatic<TaskConfigUtils> ignoredTask = Mockito.mockStatic(TaskConfigUtils.class);
+        MockedStatic<TableConfigValidatorRegistry> ignoredRegistry =
+            Mockito.mockStatic(TableConfigValidatorRegistry.class)) {
+      error = expectThrows(ControllerApplicationException.class,
+          () -> resource.updateConfig(RAW_TABLE_NAME, null, false, false, response.toString(),
+              headersWithoutDatabase()));
+    }
+
+    assertEquals(error.getResponse().getStatus(), Response.Status.CONFLICT.getStatusCode());
+    verify(resourceManager, never()).updateTableConfigsAtomically(Mockito.any(Schema.class), Mockito.anyInt(),
+        Mockito.anyMap(), Mockito.anyMap(), Mockito.anyBoolean(), Mockito.anyBoolean());
+    verify(resourceManager, never()).addTable(Mockito.any(TableConfig.class));
+  }
+
+  @Test
+  public void testCopyCredentialOverridesOnlyReplaceRedactedFields()
+      throws Exception {
+    ObjectNode tableConfig = (ObjectNode) JsonUtils.stringToJsonNode("""
+        {
+          "ingestionConfig": {
+            "streamIngestionConfig": {
+              "streamConfigMaps": [
+                {
+                  "stream.kafka.consumer.prop.password": "*****",
+                  "stream.kafka.topic.name": "*****",
+                  "sasl.jaas.config": "example.LoginModule required username=alice password=*****;",
+                  "schema.registry.url": "https://*****:*****@registry.example/path?token=*****&region=west"
+                }
+              ]
+            }
+          }
+        }
+        """);
+    String credentialPointer = "/ingestionConfig/streamIngestionConfig/streamConfigMaps/0/"
+        + "stream.kafka.consumer.prop.password";
+    String jaasPointer = "/ingestionConfig/streamIngestionConfig/streamConfigMaps/0/sasl.jaas.config";
+    String uriPointer = "/ingestionConfig/streamIngestionConfig/streamConfigMaps/0/schema.registry.url";
+    String literalJaas = "example.LoginModule required username=alice password=literal-password;";
+    String literalUri = "https://uri-user:uri-password@registry.example/path?token=literal-token&region=west";
+
+    PinotTableRestletResource.applyCredentialOverrides(tableConfig, Map.of(
+        credentialPointer, "replacement", jaasPointer, literalJaas, uriPointer, literalUri));
+
+    assertEquals(tableConfig.at(credentialPointer).asText(), "replacement");
+    assertEquals(tableConfig.at(jaasPointer).asText(), literalJaas);
+    assertEquals(tableConfig.at(uriPointer).asText(), literalUri);
+    expectThrows(IllegalArgumentException.class,
+        () -> PinotTableRestletResource.applyCredentialOverrides(tableConfig,
+            Map.of(credentialPointer, "second-replacement")));
+    expectThrows(IllegalArgumentException.class,
+        () -> PinotTableRestletResource.applyCredentialOverrides(tableConfig,
+            Map.of("/ingestionConfig/streamIngestionConfig/streamConfigMaps/0/stream.kafka.topic.name", "other")));
+  }
+
+  @Test
+  public void testAddTableRejectsCredentialMarkerBeforePersistence()
+      throws Exception {
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    PinotTableRestletResource resource = new PinotTableRestletResource();
+    resource._pinotHelixResourceManager = resourceManager;
+    TableConfig submitted = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(OFFLINE_TABLE_NAME)
+        .setCustomConfig(new TableCustomConfig(new HashMap<>(Map.of(LITERAL_PASSWORD_KEY,
+            TableConfigRedactionUtils.REDACTION_MARKER))))
+        .build();
+
+    ControllerApplicationException e = expectThrows(ControllerApplicationException.class,
+        () -> resource.addTable(submitted.toJsonString(), null, false, headersWithoutDatabase(), null));
+
+    assertEquals(e.getResponse().getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
+    verify(resourceManager, never()).addTable(org.mockito.ArgumentMatchers.any(TableConfig.class));
+  }
+
+  @Test
+  public void testAddCombinedTableConfigsRejectsCredentialMarkerBeforePersistence()
+      throws Exception {
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    TableConfigsRestletResource resource = new TableConfigsRestletResource();
+    resource._pinotHelixResourceManager = resourceManager;
+    TableConfig submitted = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(OFFLINE_TABLE_NAME)
+        .setCustomConfig(new TableCustomConfig(new HashMap<>(Map.of(LITERAL_PASSWORD_KEY,
+            TableConfigRedactionUtils.REDACTION_MARKER))))
+        .build();
+    TableConfigs submittedConfigs = new TableConfigs(RAW_TABLE_NAME, schema(), submitted, null);
+
+    ControllerApplicationException e = expectThrows(ControllerApplicationException.class,
+        () -> resource.addConfig(submittedConfigs.toJsonString(), null, false, headersWithoutDatabase(), null));
+
+    assertEquals(e.getResponse().getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
+    verify(resourceManager, never()).addTable(org.mockito.ArgumentMatchers.any(TableConfig.class));
+  }
+
+  @Test
+  public void testTaskCleanupPersistsUnresolvedCredentialPlaceholder()
+      throws Exception {
+    Map<String, String> customConfigs = new HashMap<>();
+    customConfigs.put(LITERAL_PASSWORD_KEY, PASSWORD_PLACEHOLDER);
+    TableConfig stored = new TableConfigBuilder(TableType.REALTIME)
+        .setTableName(REALTIME_TABLE_NAME)
+        .setCustomConfig(new TableCustomConfig(customConfigs))
+        .setTaskConfig(new TableTaskConfig(Map.of(
+            "TestTask", new HashMap<>(Map.of(PinotTaskManager.SCHEDULE_KEY, "0 0 * * * ?")))))
+        .build();
+    PinotHelixResourceManager resourceManager = mockRealtimeResourceManager(stored);
+    PinotHelixTaskResourceManager taskResourceManager = mock(PinotHelixTaskResourceManager.class);
+    when(taskResourceManager.getTaskStatesByTable("TestTask", REALTIME_TABLE_NAME)).thenReturn(Map.of());
+
+    PinotTableRestletResource.tableTasksCleanup(
+        REALTIME_TABLE_NAME, false, resourceManager, taskResourceManager);
+
+    ArgumentCaptor<TableConfig> updatedConfig = ArgumentCaptor.forClass(TableConfig.class);
+    verify(resourceManager).updateTableConfig(updatedConfig.capture());
+    verify(resourceManager).getRealtimeTableConfig(RAW_TABLE_NAME, false, false);
+    verify(resourceManager, never()).getTableConfig(REALTIME_TABLE_NAME);
+    assertEquals(updatedConfig.getValue().getCustomConfig().getCustomConfigs().get(LITERAL_PASSWORD_KEY),
+        PASSWORD_PLACEHOLDER);
+    assertFalse(updatedConfig.getValue().getTaskConfig().getConfigsForTaskType("TestTask")
+        .containsKey(PinotTaskManager.SCHEDULE_KEY));
+  }
+
+  @Test
+  public void testUpdateValidationDiagnosticDoesNotExposeCredential()
+      throws Exception {
+    String escapedCredential = "p\"ass\\word\nline";
+    TableConfig stored = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(OFFLINE_TABLE_NAME)
+        .setCustomConfig(new TableCustomConfig(new HashMap<>(Map.of("provider.password", escapedCredential))))
+        .build();
+    TableConfig submitted = TableConfigRedactionUtils.redact(stored);
+    PinotHelixResourceManager resourceManager = mockResourceManager(stored);
+    PinotTableRestletResource resource = new PinotTableRestletResource();
+    resource._pinotHelixResourceManager = resourceManager;
+    resource._controllerConf = mock(ControllerConf.class);
+    resource._pinotTaskManager = mock(PinotTaskManager.class);
+    ConfigValidationException validationException =
+        new ConfigValidationException("Invalid config " + stored.toJsonString());
+
+    ControllerApplicationException error;
+    try (MockedStatic<TableConfigValidationUtils> validation =
+        Mockito.mockStatic(TableConfigValidationUtils.class)) {
+      validation.when(() -> TableConfigValidationUtils.validateTableConfig(
+              Mockito.any(TableConfig.class), Mockito.any(Schema.class), Mockito.nullable(String.class),
+              Mockito.any(PinotHelixResourceManager.class), Mockito.any(ControllerConf.class),
+              Mockito.any(PinotTaskManager.class), Mockito.any(TableConfig.class), eq(true)))
+          .thenThrow(validationException);
+      error = expectThrows(ControllerApplicationException.class,
+          () -> resource.updateTableConfig(
+              RAW_TABLE_NAME, null, false, headersWithoutDatabase(),
+              tableConfigEnvelope(submitted, OFFLINE_CONFIG_VERSION)));
+    }
+
+    assertFalse(error.getMessage().contains(escapedCredential), error.getMessage());
+    assertFalse(error.getMessage().contains("p\\\"ass\\\\word\\nline"), error.getMessage());
+  }
+
+  private static PinotHelixResourceManager mockResourceManager(TableConfig stored) {
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    when(resourceManager.hasOfflineTable(RAW_TABLE_NAME)).thenReturn(true);
+    when(resourceManager.hasTable(OFFLINE_TABLE_NAME)).thenReturn(true);
+    when(resourceManager.getOfflineTableConfig(anyString(), eq(false), eq(false))).thenReturn(stored);
+    when(resourceManager.getTableConfigWithVersion(OFFLINE_TABLE_NAME, false, false))
+        .thenReturn(Pair.of(stored, OFFLINE_CONFIG_VERSION));
+    when(resourceManager.getTableConfig(OFFLINE_TABLE_NAME)).thenReturn(stored);
+    when(resourceManager.getTableSchema(anyString())).thenReturn(schema());
+    when(resourceManager.getSchema(RAW_TABLE_NAME)).thenReturn(schema());
+    when(resourceManager.getSchemaWithVersion(RAW_TABLE_NAME)).thenReturn(Pair.of(schema(), SCHEMA_VERSION));
+    return resourceManager;
+  }
+
+  private static PinotHelixResourceManager mockRealtimeResourceManager(TableConfig stored) {
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    when(resourceManager.hasRealtimeTable(RAW_TABLE_NAME)).thenReturn(true);
+    when(resourceManager.hasTable(REALTIME_TABLE_NAME)).thenReturn(true);
+    when(resourceManager.getRealtimeTableConfig(anyString(), eq(false), eq(false))).thenReturn(stored);
+    when(resourceManager.getTableConfigWithVersion(REALTIME_TABLE_NAME, false, false))
+        .thenReturn(Pair.of(stored, REALTIME_CONFIG_VERSION));
+    when(resourceManager.getTableSchema(anyString())).thenReturn(schema());
+    when(resourceManager.getSchema(RAW_TABLE_NAME)).thenReturn(schema());
+    when(resourceManager.getSchemaWithVersion(RAW_TABLE_NAME)).thenReturn(Pair.of(schema(), SCHEMA_VERSION));
+    return resourceManager;
+  }
+
+  private static PinotHelixResourceManager mockHybridResourceManager(TableConfig storedOffline,
+      TableConfig storedRealtime) {
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    when(resourceManager.hasOfflineTable(RAW_TABLE_NAME)).thenReturn(true);
+    when(resourceManager.hasRealtimeTable(RAW_TABLE_NAME)).thenReturn(true);
+    when(resourceManager.hasTable(OFFLINE_TABLE_NAME)).thenReturn(true);
+    when(resourceManager.hasTable(REALTIME_TABLE_NAME)).thenReturn(true);
+    when(resourceManager.getTableConfigWithVersion(OFFLINE_TABLE_NAME, false, false))
+        .thenReturn(Pair.of(storedOffline, OFFLINE_CONFIG_VERSION));
+    when(resourceManager.getTableConfigWithVersion(REALTIME_TABLE_NAME, false, false))
+        .thenReturn(Pair.of(storedRealtime, REALTIME_CONFIG_VERSION));
+    when(resourceManager.getSchemaWithVersion(RAW_TABLE_NAME)).thenReturn(Pair.of(schema(), SCHEMA_VERSION));
+    return resourceManager;
+  }
+
+  private static TableConfig tableConfigWithCredentials() {
+    return tableConfigWithCredentials(TableType.OFFLINE);
+  }
+
+  private static TableConfig tableConfigWithCredentials(TableType tableType) {
+    Map<String, String> customConfigs = new HashMap<>();
+    customConfigs.put(LITERAL_PASSWORD_KEY, LITERAL_PASSWORD);
+    customConfigs.put(PLACEHOLDER_PASSWORD_KEY, PASSWORD_PLACEHOLDER);
+    customConfigs.put(CLIENT_ID_KEY, ORIGINAL_CLIENT_ID);
+    return new TableConfigBuilder(tableType)
+        .setTableName(tableType == TableType.OFFLINE ? OFFLINE_TABLE_NAME : REALTIME_TABLE_NAME)
+        .setCustomConfig(new TableCustomConfig(customConfigs))
+        .build();
+  }
+
+  private static TableConfig maskedEditedConfig(TableConfig stored) {
+    TableConfig submitted = TableConfigRedactionUtils.redact(stored);
+    submitted.getCustomConfig().getCustomConfigs().put(CLIENT_ID_KEY, EDITED_CLIENT_ID);
+    return submitted;
+  }
+
+  private static String editTableConfigResponse(String response, TableType tableType)
+      throws Exception {
+    ObjectNode responseNode = (ObjectNode) JsonUtils.stringToJsonNode(response);
+    ObjectNode customConfigs = (ObjectNode) responseNode.path(RedactedTableConfigResponse.CONFIGS_KEY)
+        .path(tableType.name()).path(TableConfig.CUSTOM_CONFIG_KEY).path("customConfigs");
+    customConfigs.put(CLIENT_ID_KEY, EDITED_CLIENT_ID);
+    return responseNode.toString();
+  }
+
+  private static String editTableConfigsResponse(String response, TableType tableType)
+      throws Exception {
+    ObjectNode responseNode = (ObjectNode) JsonUtils.stringToJsonNode(response);
+    String configKey = tableType == TableType.OFFLINE ? "offline" : "realtime";
+    ObjectNode customConfigs = (ObjectNode) responseNode.path(RedactedTableConfigsResponse.CONFIGS_KEY)
+        .path(configKey).path(TableConfig.CUSTOM_CONFIG_KEY).path("customConfigs");
+    customConfigs.put(CLIENT_ID_KEY, EDITED_CLIENT_ID);
+    return responseNode.toString();
+  }
+
+  private static String tableConfigEnvelope(TableConfig tableConfig, int baseVersion)
+      throws Exception {
+    String tableType = tableConfig.getTableType().name();
+    Map<String, Integer> baseVersions = new HashMap<>();
+    baseVersions.put(RedactedTableConfigResponse.SCHEMA_VERSION_KEY, SCHEMA_VERSION);
+    baseVersions.put(tableType, baseVersion);
+    return JsonUtils.objectToString(
+        new RedactedTableConfigResponse(Map.of(tableType, tableConfig), baseVersions));
+  }
+
+  private static String tableConfigsEnvelope(TableConfigs tableConfigs, Map<String, Integer> baseVersions)
+      throws Exception {
+    Map<String, Integer> completeBaseVersions = new HashMap<>();
+    completeBaseVersions.put(RedactedTableConfigsResponse.SCHEMA_VERSION_KEY, SCHEMA_VERSION);
+    completeBaseVersions.put(RedactedTableConfigsResponse.OFFLINE_VERSION_KEY,
+        RedactedTableConfigsResponse.ABSENT_VERSION);
+    completeBaseVersions.put(RedactedTableConfigsResponse.REALTIME_VERSION_KEY,
+        RedactedTableConfigsResponse.ABSENT_VERSION);
+    completeBaseVersions.putAll(baseVersions);
+    return JsonUtils.objectToString(new RedactedTableConfigsResponse(tableConfigs, completeBaseVersions));
+  }
+
+  private static Schema schema() {
+    return new Schema.SchemaBuilder().setSchemaName(RAW_TABLE_NAME)
+        .addSingleValueDimension("id", FieldSpec.DataType.STRING).build();
+  }
+
+  private static HttpHeaders headersWithoutDatabase() {
+    return mock(HttpHeaders.class);
+  }
+
+  private static void assertRestoredCredentialAndEdit(TableConfig updatedConfig) {
+    Map<String, String> customConfigs = updatedConfig.getCustomConfig().getCustomConfigs();
+    assertEquals(customConfigs.get(LITERAL_PASSWORD_KEY), LITERAL_PASSWORD);
+    assertEquals(customConfigs.get(PLACEHOLDER_PASSWORD_KEY), PASSWORD_PLACEHOLDER);
+    assertEquals(customConfigs.get(CLIENT_ID_KEY), EDITED_CLIENT_ID);
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerMaterializedViewBackfillTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerMaterializedViewBackfillTest.java
@@ -104,6 +104,8 @@ public class PinotHelixResourceManagerMaterializedViewBackfillTest {
     try (MockedStatic<ZKMetadataProvider> zk = Mockito.mockStatic(ZKMetadataProvider.class);
          MockedStatic<MaterializedViewDefinitionMetadataUtils> def =
              Mockito.mockStatic(MaterializedViewDefinitionMetadataUtils.class)) {
+      zk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, mvWithType, false, false))
+          .thenReturn(mvConfig);
       zk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, mvWithType)).thenReturn(mvConfig);
       // Source TableConfig missing — phase 2's persistMaterializedViewDefinitionMetadataBestEffort
       // bails out internally with a logged WARN. Phase 1's in-memory registration is still
@@ -142,6 +144,8 @@ public class PinotHelixResourceManagerMaterializedViewBackfillTest {
     try (MockedStatic<ZKMetadataProvider> zk = Mockito.mockStatic(ZKMetadataProvider.class);
          MockedStatic<MaterializedViewDefinitionMetadataUtils> def =
              Mockito.mockStatic(MaterializedViewDefinitionMetadataUtils.class)) {
+      zk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, mvWithType, false, false))
+          .thenReturn(mvConfig);
       zk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, mvWithType)).thenReturn(mvConfig);
       def.when(() -> MaterializedViewDefinitionMetadataUtils.fetch(propertyStore, mvWithType))
           .thenReturn(existingDef);
@@ -177,6 +181,10 @@ public class PinotHelixResourceManagerMaterializedViewBackfillTest {
     try (MockedStatic<ZKMetadataProvider> zk = Mockito.mockStatic(ZKMetadataProvider.class);
          MockedStatic<MaterializedViewDefinitionMetadataUtils> def =
              Mockito.mockStatic(MaterializedViewDefinitionMetadataUtils.class)) {
+      zk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, healthyMv, false, false))
+          .thenReturn(healthyConfig);
+      zk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, brokenMv, false, false))
+          .thenReturn(brokenConfig);
       zk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, healthyMv)).thenReturn(healthyConfig);
       zk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, brokenMv)).thenReturn(brokenConfig);
       // Source TableConfig lookup for the healthy MV's source returns null so phase 2 bails
@@ -217,6 +225,8 @@ public class PinotHelixResourceManagerMaterializedViewBackfillTest {
     try (MockedStatic<ZKMetadataProvider> zk = Mockito.mockStatic(ZKMetadataProvider.class);
          MockedStatic<MaterializedViewDefinitionMetadataUtils> def =
              Mockito.mockStatic(MaterializedViewDefinitionMetadataUtils.class)) {
+      zk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, mvWithType, false, false))
+          .thenReturn(mvConfig);
       zk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, mvWithType)).thenReturn(mvConfig);
       def.when(() -> MaterializedViewDefinitionMetadataUtils.fetch(propertyStore, mvWithType))
           .thenReturn(null);
@@ -291,7 +301,8 @@ public class PinotHelixResourceManagerMaterializedViewBackfillTest {
     try (MockedStatic<ZKMetadataProvider> zk = Mockito.mockStatic(ZKMetadataProvider.class);
          MockedStatic<MaterializedViewDefinitionMetadataUtils> def =
              Mockito.mockStatic(MaterializedViewDefinitionMetadataUtils.class)) {
-      zk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, mvWithType)).thenReturn(mvConfig);
+      zk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, mvWithType, false, false))
+          .thenReturn(mvConfig);
       // Definition znode absent — the failure mode the new fallback covers.
       def.when(() -> MaterializedViewDefinitionMetadataUtils.fetch(propertyStore, mvWithType))
           .thenReturn(null);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerMaterializedViewListingTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerMaterializedViewListingTest.java
@@ -75,13 +75,13 @@ public class PinotHelixResourceManagerMaterializedViewListingTest {
         .build();
 
     try (MockedStatic<ZKMetadataProvider> staticZk = Mockito.mockStatic(ZKMetadataProvider.class)) {
-      staticZk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, "mv_orders_OFFLINE"))
+      staticZk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, "mv_orders_OFFLINE", false, false))
           .thenReturn(mvConfig);
-      staticZk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, "plain_orders_OFFLINE"))
+      staticZk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, "plain_orders_OFFLINE", false, false))
           .thenReturn(plainConfig);
       // `ghost_OFFLINE`: TableConfig fetch returns null (corruption). The helper must silently
       // drop it rather than throw — a single broken znode must not blank the entire listing.
-      staticZk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, "ghost_OFFLINE"))
+      staticZk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, "ghost_OFFLINE", false, false))
           .thenReturn(null);
 
       List<String> result = prm.getAllRawMaterializedViewNames(null);
@@ -92,7 +92,8 @@ public class PinotHelixResourceManagerMaterializedViewListingTest {
               + "result is reusable as input to SHOW CREATE / DROP MATERIALIZED VIEW.");
       // Critical: the REALTIME resource must NEVER trigger a TableConfig fetch — that would
       // be a wasted ZK round-trip on every realtime table in the cluster.
-      staticZk.verify(() -> ZKMetadataProvider.getTableConfig(propertyStore, "mv_orders_REALTIME"),
+      staticZk.verify(() -> ZKMetadataProvider.getTableConfig(
+              propertyStore, "mv_orders_REALTIME", false, false),
           Mockito.never());
     }
   }
@@ -116,8 +117,8 @@ public class PinotHelixResourceManagerMaterializedViewListingTest {
         .build();
 
     try (MockedStatic<ZKMetadataProvider> staticZk = Mockito.mockStatic(ZKMetadataProvider.class)) {
-      staticZk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore,
-          "analytics.mv_revenue_OFFLINE")).thenReturn(analyticsMv);
+      staticZk.when(() -> ZKMetadataProvider.getTableConfig(
+          propertyStore, "analytics.mv_revenue_OFFLINE", false, false)).thenReturn(analyticsMv);
       // marketing.mv_funnel is filtered by the database predicate BEFORE we hit ZK, so no stub
       // is needed; if the database filter regresses this test will fail with an
       // `UnnecessaryStubbingException`-equivalent (an unstubbed call returning null) which
@@ -136,10 +137,11 @@ public class PinotHelixResourceManagerMaterializedViewListingTest {
       // The default-database MV must NOT have been read either — a regression in the database
       // filter that lets default-db resources through would also let a header substitution
       // attack discover MVs the caller cannot read.
-      staticZk.verify(() -> ZKMetadataProvider.getTableConfig(propertyStore, "mv_global_OFFLINE"),
+      staticZk.verify(() -> ZKMetadataProvider.getTableConfig(
+              propertyStore, "mv_global_OFFLINE", false, false),
           Mockito.never());
-      staticZk.verify(() -> ZKMetadataProvider.getTableConfig(propertyStore,
-          "marketing.mv_funnel_OFFLINE"), Mockito.never());
+      staticZk.verify(() -> ZKMetadataProvider.getTableConfig(
+          propertyStore, "marketing.mv_funnel_OFFLINE", false, false), Mockito.never());
     }
   }
 
@@ -164,9 +166,9 @@ public class PinotHelixResourceManagerMaterializedViewListingTest {
         .build();
 
     try (MockedStatic<ZKMetadataProvider> staticZk = Mockito.mockStatic(ZKMetadataProvider.class)) {
-      staticZk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, "mv_healthy_OFFLINE"))
+      staticZk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, "mv_healthy_OFFLINE", false, false))
           .thenReturn(healthy);
-      staticZk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, "mv_broken_OFFLINE"))
+      staticZk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, "mv_broken_OFFLINE", false, false))
           .thenThrow(new RuntimeException("Simulated ZK read failure on broken znode"));
 
       List<String> result = prm.getAllRawMaterializedViewNames(null);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
@@ -41,6 +42,7 @@ import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.MasterSlaveSMD;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.exception.InvalidConfigException;
+import org.apache.pinot.common.exception.TableConfigVersionMismatchException;
 import org.apache.pinot.common.exception.TableNotFoundException;
 import org.apache.pinot.common.lineage.LineageEntryState;
 import org.apache.pinot.common.lineage.SegmentLineage;
@@ -79,6 +81,7 @@ import org.apache.pinot.spi.config.tenant.TenantRole;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.LogicalTableConfig;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.PartitionGroupConsumptionStatus;
 import org.apache.pinot.spi.stream.PartitionGroupMetadata;
@@ -101,6 +104,7 @@ import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -1127,6 +1131,143 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
       verify(resourceManager).sendTableConfigSchemaRefreshMessage(offlineTableName);
     } finally {
       _helixResourceManager.deleteOfflineTable(rawTableName);
+      deleteSchema(rawTableName);
+    }
+  }
+
+  @Test
+  public void testUpdateTableConfigRejectsStaleVersionAndPreservesInterveningConfig()
+      throws Exception {
+    String rawTableName = "tableConfigCompareAndSetTest";
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(rawTableName);
+    addDummySchema(rawTableName);
+
+    IngestionConfig initialIngestionConfig = new IngestionConfig();
+    initialIngestionConfig.setBatchIngestionConfig(new BatchIngestionConfig(
+        List.of(Map.of("input.fs.prop.secretKey", "initial-value")), "REFRESH", "DAILY"));
+    TableConfig initialTableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(rawTableName)
+        .setBrokerTenant(BROKER_TENANT_NAME)
+        .setServerTenant(SERVER_TENANT_NAME)
+        .setIngestionConfig(initialIngestionConfig)
+        .build();
+    waitForEVToDisappear(initialTableConfig.getTableName());
+    _helixResourceManager.addTable(initialTableConfig);
+
+    try {
+      Pair<TableConfig, Integer> staleRead =
+          _helixResourceManager.getTableConfigWithVersion(offlineTableName, false, false);
+      assertNotNull(staleRead);
+
+      IngestionConfig interveningIngestionConfig = new IngestionConfig();
+      interveningIngestionConfig.setBatchIngestionConfig(new BatchIngestionConfig(
+          List.of(Map.of("input.fs.prop.secretKey", "intervening-value")), "REFRESH", "DAILY"));
+      TableConfig interveningTableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(rawTableName)
+          .setBrokerTenant(BROKER_TENANT_NAME)
+          .setServerTenant(SERVER_TENANT_NAME)
+          .setIngestionConfig(interveningIngestionConfig)
+          .build();
+      _helixResourceManager.updateTableConfig(interveningTableConfig);
+
+      IngestionConfig staleIngestionConfig = new IngestionConfig();
+      staleIngestionConfig.setBatchIngestionConfig(new BatchIngestionConfig(
+          List.of(Map.of("input.fs.prop.secretKey", "stale-value")), "REFRESH", "DAILY"));
+      TableConfig staleTableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(rawTableName)
+          .setBrokerTenant(BROKER_TENANT_NAME)
+          .setServerTenant(SERVER_TENANT_NAME)
+          .setIngestionConfig(staleIngestionConfig)
+          .build();
+      assertThrows(TableConfigVersionMismatchException.class,
+          () -> _helixResourceManager.updateTableConfig(staleTableConfig, staleRead.getRight(), false));
+
+      TableConfig storedTableConfig =
+          _helixResourceManager.getTableConfigWithVersion(offlineTableName, false, false).getLeft();
+      assertEquals(storedTableConfig.getIngestionConfig().getBatchIngestionConfig().getBatchConfigMaps().get(0)
+          .get("input.fs.prop.secretKey"), "intervening-value");
+    } finally {
+      _helixResourceManager.deleteOfflineTable(rawTableName);
+      deleteSchema(rawTableName);
+    }
+  }
+
+  @Test
+  public void testAtomicSchemaAndHybridConfigUpdateRollsBackOnSecondConfigRace()
+      throws Exception {
+    String rawTableName = "atomicHybridConfigRaceTest";
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(rawTableName);
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(rawTableName);
+    addDummySchema(rawTableName);
+
+    try {
+      TableConfig initialOfflineConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(rawTableName)
+          .setBrokerTenant(BROKER_TENANT_NAME)
+          .setServerTenant(SERVER_TENANT_NAME)
+          .build();
+      waitForEVToDisappear(offlineTableName);
+      _helixResourceManager.addTable(initialOfflineConfig);
+      TableConfig initialRealtimeConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(rawTableName)
+          .setBrokerTenant(BROKER_TENANT_NAME)
+          .setServerTenant(SERVER_TENANT_NAME)
+          .setStreamConfigs(FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap())
+          .build();
+      waitForEVToDisappear(realtimeTableName);
+      _helixResourceManager.addTable(initialRealtimeConfig);
+
+      Pair<Schema, Integer> schemaSnapshot = _helixResourceManager.getSchemaWithVersion(rawTableName);
+      Pair<TableConfig, Integer> offlineSnapshot =
+          _helixResourceManager.getTableConfigWithVersion(offlineTableName, false, false);
+      Pair<TableConfig, Integer> realtimeSnapshot =
+          _helixResourceManager.getTableConfigWithVersion(realtimeTableName, false, false);
+      assertNotNull(schemaSnapshot);
+      assertNotNull(offlineSnapshot);
+      assertNotNull(realtimeSnapshot);
+
+      String originalSchemaDescription = schemaSnapshot.getLeft().getDescription();
+      Schema updatedSchema = schemaSnapshot.getLeft();
+      updatedSchema.setDescription("atomic update should roll back");
+      TableConfig updatedOfflineConfig = new TableConfig(offlineSnapshot.getLeft());
+      updatedOfflineConfig.setQueryConfig(new QueryConfig(11_000L, null, null, null, null, null));
+      TableConfig updatedRealtimeConfig = new TableConfig(realtimeSnapshot.getLeft());
+      updatedRealtimeConfig.setQueryConfig(new QueryConfig(22_000L, null, null, null, null, null));
+      TableConfig interveningRealtimeConfig = new TableConfig(realtimeSnapshot.getLeft());
+      interveningRealtimeConfig.setQueryConfig(new QueryConfig(33_000L, null, null, null, null, null));
+
+      PinotHelixResourceManager resourceManager = spy(_helixResourceManager);
+      doAnswer(invocation -> {
+        assertTrue(ZKMetadataProvider.setTableConfig(
+            _propertyStore, interveningRealtimeConfig, realtimeSnapshot.getRight()));
+        return _helixResourceManager.multiWriteZK();
+      }).when(resourceManager).multiWriteZK();
+
+      Map<TableType, TableConfig> updates = new LinkedHashMap<>();
+      updates.put(TableType.OFFLINE, updatedOfflineConfig);
+      updates.put(TableType.REALTIME, updatedRealtimeConfig);
+      Map<TableType, Integer> expectedVersions = new LinkedHashMap<>();
+      expectedVersions.put(TableType.OFFLINE, offlineSnapshot.getRight());
+      expectedVersions.put(TableType.REALTIME, realtimeSnapshot.getRight());
+
+      assertThrows(TableConfigVersionMismatchException.class,
+          () -> resourceManager.updateTableConfigsAtomically(
+              updatedSchema, schemaSnapshot.getRight(), updates, expectedVersions, false, false));
+      verify(resourceManager).multiWriteZK();
+
+      Pair<Schema, Integer> storedSchema = _helixResourceManager.getSchemaWithVersion(rawTableName);
+      Pair<TableConfig, Integer> storedOfflineConfig =
+          _helixResourceManager.getTableConfigWithVersion(offlineTableName, false, false);
+      Pair<TableConfig, Integer> storedRealtimeConfig =
+          _helixResourceManager.getTableConfigWithVersion(realtimeTableName, false, false);
+      assertEquals(storedSchema.getRight(), schemaSnapshot.getRight());
+      assertEquals(storedSchema.getLeft().getDescription(), originalSchemaDescription);
+      assertEquals(storedOfflineConfig.getRight(), offlineSnapshot.getRight());
+      assertNull(storedOfflineConfig.getLeft().getQueryConfig());
+      assertEquals(storedRealtimeConfig.getRight().intValue(), realtimeSnapshot.getRight() + 1);
+      assertEquals(storedRealtimeConfig.getLeft().getQueryConfig().getTimeoutMs(), Long.valueOf(33_000L));
+    } finally {
+      if (_helixResourceManager.hasOfflineTable(rawTableName)) {
+        _helixResourceManager.deleteOfflineTable(rawTableName);
+      }
+      if (_helixResourceManager.hasRealtimeTable(rawTableName)) {
+        _helixResourceManager.deleteRealtimeTable(rawTableName);
+      }
       deleteSchema(rawTableName);
     }
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerStatelessTest.java
@@ -61,6 +61,15 @@ import static org.testng.Assert.*;
 
 @Test(groups = "stateless")
 public class PinotTaskManagerStatelessTest extends ControllerTest {
+
+  @Test
+  public void testTaskGenerationDiagnosticsDoNotExposeExceptionMessage() {
+    String sentinel = "credential-sentinel";
+    String diagnostic = PinotTaskManager.safeTaskGenerationError(new IllegalStateException(sentinel));
+
+    assertEquals(diagnostic, IllegalStateException.class.getName());
+    assertFalse(diagnostic.contains(sentinel));
+  }
   private static final String RAW_TABLE_NAME = "myTable";
   public static final String TABLE_NAME_WITH_TYPE = "myTable_OFFLINE";
   private static final String OFFLINE_TABLE_NAME = TableNameBuilder.OFFLINE.tableNameWithType(RAW_TABLE_NAME);

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthPrincipal.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthPrincipal.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 
 /// Container object for basic auth principal
@@ -32,6 +33,7 @@ public class BasicAuthPrincipal {
   private final Set<String> _tables;
   private final Set<String> _excludeTables;
   private final Set<String> _permissions;
+  private final Set<String> _explicitPermissions;
   //key: table name, val: list of RLS filters applicable for that table.
   private final Map<String, List<String>> _rlsFilters;
 
@@ -42,11 +44,18 @@ public class BasicAuthPrincipal {
 
   public BasicAuthPrincipal(String name, String token, Set<String> tables, Set<String> excludeTables,
       Set<String> permissions, Map<String, List<String>> rlsFilters) {
+    this(name, token, tables, excludeTables, permissions, permissions, rlsFilters);
+  }
+
+  public BasicAuthPrincipal(String name, String token, Set<String> tables, Set<String> excludeTables,
+      Set<String> permissions, Set<String> explicitPermissions, Map<String, List<String>> rlsFilters) {
     _name = name;
     _token = token;
     _tables = tables;
     _excludeTables = excludeTables;
     _permissions = permissions.stream().map(s -> s.toLowerCase()).collect(Collectors.toSet());
+    _explicitPermissions = Stream.concat(_permissions.stream(), explicitPermissions.stream())
+        .map(s -> s.toLowerCase()).collect(Collectors.toSet());
     _rlsFilters = rlsFilters;
   }
 
@@ -74,9 +83,9 @@ public class BasicAuthPrincipal {
     return _permissions.isEmpty() || _permissions.contains(permission.toLowerCase());
   }
 
-  /// Returns whether this principal was explicitly granted the given permission.
+  /// Returns whether the permission was explicitly assigned, without applying the legacy empty-set wildcard.
   public boolean hasExplicitPermission(String permission) {
-    return _permissions.contains(permission.toLowerCase());
+    return _explicitPermissions.contains(permission.toLowerCase());
   }
 
   /// Gets the Row-Level Security (RLS) filter configured for the given table.

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthPrincipalUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthPrincipalUtils.java
@@ -118,12 +118,16 @@ public final class BasicAuthPrincipalUtils {
               .stream().collect(Collectors.toSet());
           Set<String> permissions = Optional.ofNullable(user.getPermissions())
               .orElseGet(() -> List.of())
-              .stream().map(x -> x.toString())
+              .stream().map(Object::toString)
+              .collect(Collectors.toSet());
+          Set<String> fineGrainedPermissions = Optional.ofNullable(user.getFineGrainedPermissions())
+              .orElseGet(() -> List.of())
+              .stream()
               .collect(Collectors.toSet());
           //todo: Handle RLS filters properly
           return new ZkBasicAuthPrincipal(name,
               BasicAuthTokenUtils.toBasicAuthToken(name, password), password, component, role,
-              tables, excludeTables, permissions, Map.of());
+              tables, excludeTables, permissions, fineGrainedPermissions, Map.of());
         }).collect(Collectors.toList());
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/FineGrainedAccessControl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/FineGrainedAccessControl.java
@@ -33,7 +33,9 @@ public interface FineGrainedAccessControl {
   /// @param action type to validate
   /// @return true if user is allowed to perform the action
   default boolean hasAccess(HttpHeaders httpHeaders, TargetType targetType, String targetId, String action) {
-    return true;
+    // Raw ZK reads can expose the persisted form of table configs, so implementations must grant this action
+    // explicitly. Keep the legacy allow-by-default behavior for all other fine-grained actions.
+    return !Actions.Cluster.GET_ZNODE.equals(action);
   }
 
   /// Checks whether the user has access to perform action on the particular resource type.

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/ZkBasicAuthPrincipal.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/ZkBasicAuthPrincipal.java
@@ -39,7 +39,13 @@ public class ZkBasicAuthPrincipal extends BasicAuthPrincipal {
   public ZkBasicAuthPrincipal(String name, String token, String password, String component, String role,
       Set<String> tables, Set<String> excludeTables, Set<String> permissions,
       Map<String, List<String>> tableRLSFilters) {
-    super(name, token, tables, excludeTables, permissions, tableRLSFilters);
+    this(name, token, password, component, role, tables, excludeTables, permissions, permissions, tableRLSFilters);
+  }
+
+  public ZkBasicAuthPrincipal(String name, String token, String password, String component, String role,
+      Set<String> tables, Set<String> excludeTables, Set<String> permissions, Set<String> fineGrainedPermissions,
+      Map<String, List<String>> tableRLSFilters) {
+    super(name, token, tables, excludeTables, permissions, fineGrainedPermissions, tableRLSFilters);
     _component = component;
     _role = role;
     _password = password;

--- a/pinot-core/src/test/java/org/apache/pinot/core/auth/BasicAuthTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/auth/BasicAuthTest.java
@@ -67,6 +67,11 @@ public class BasicAuthTest {
     Assert.assertFalse(new BasicAuthPrincipal("name", "token", ImmutableSet.of("myTable"), Set.of(),
         ImmutableSet.of("read"))
         .hasPermission("write"));
+    Assert.assertFalse(new BasicAuthPrincipal("name", "token", ImmutableSet.of("myTable"), Set.of(), Set.of())
+        .hasExplicitPermission(Actions.Cluster.GET_ZNODE));
+    Assert.assertTrue(new BasicAuthPrincipal("name", "token", ImmutableSet.of("myTable"), Set.of(),
+        ImmutableSet.of(Actions.Cluster.GET_ZNODE))
+        .hasExplicitPermission(Actions.Cluster.GET_ZNODE));
 
     Assert.assertEquals(new BasicAuthPrincipal("name", "token", ImmutableSet.of("myTable"), Set.of(),
         ImmutableSet.of("read"), Map.of("myTable", List.of("cityID > 100")))
@@ -79,6 +84,7 @@ public class BasicAuthTest {
     Map<String, Object> config = new HashMap<>();
     config.put("principals", "admin,user");
     config.put("principals.admin.password", "verysecret");
+    config.put("principals.admin.permissions", Actions.Cluster.GET_ZNODE);
     config.put("principals.user.password", "secret");
     config.put("principals.user.tables", "lessImportantStuff,lesserImportantStuff,leastImportantStuff");
     config.put("principals.user.excludeTables", "excludedTable");
@@ -99,6 +105,7 @@ public class BasicAuthTest {
         .orElse(null);
     Assert.assertNotNull(adminPrincipal);
     Assert.assertEquals(adminPrincipal.getName(), "admin");
+    Assert.assertTrue(adminPrincipal.hasExplicitPermission(Actions.Cluster.GET_ZNODE));
 
     // Verify user principal
     BasicAuthPrincipal userPrincipal = principals.stream()

--- a/pinot-core/src/test/java/org/apache/pinot/core/auth/FineGrainedAuthUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/auth/FineGrainedAuthUtilsTest.java
@@ -57,6 +57,15 @@ public class FineGrainedAuthUtilsTest {
   }
 
   @Test
+  public void testRawZnodeReadIsDeniedByDefault() {
+    FineGrainedAccessControl accessControl = new FineGrainedAccessControl() {
+    };
+
+    Assert.assertFalse(accessControl.hasAccess(null, TargetType.CLUSTER, null, Actions.Cluster.GET_ZNODE));
+    Assert.assertTrue(accessControl.hasAccess(null, TargetType.CLUSTER, null, Actions.Cluster.GET_CLUSTER_CONFIG));
+  }
+
+  @Test
   public void testValidateFineGrainedAuthAllowed() {
     FineGrainedAccessControl ac = Mockito.mock(FineGrainedAccessControl.class);
     Mockito.when(ac.hasAccess(Mockito.any(HttpHeaders.class), Mockito.any(), Mockito.any(), Mockito.any()))

--- a/pinot-core/src/test/java/org/apache/pinot/core/auth/ZkBasicAuthTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/auth/ZkBasicAuthTest.java
@@ -22,13 +22,34 @@ import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.pinot.spi.config.user.AccessType;
 import org.apache.pinot.spi.config.user.ComponentType;
 import org.apache.pinot.spi.config.user.RoleType;
+import org.apache.pinot.spi.config.user.UserConfig;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
 public class ZkBasicAuthTest {
+
+  @Test
+  public void testFineGrainedPermissionsAreAddedToZkPrincipal() {
+    UserConfig legacyUser = new UserConfig("legacy", "password", ComponentType.CONTROLLER.name(),
+        RoleType.ADMIN.name(), null, null, List.of(AccessType.READ));
+    ZkBasicAuthPrincipal legacyPrincipal = BasicAuthPrincipalUtils.extractBasicAuthPrincipals(List.of(legacyUser))
+        .get(0);
+    Assert.assertTrue(legacyPrincipal.hasPermission("read"));
+    Assert.assertTrue(legacyPrincipal.hasExplicitPermission("read"));
+    Assert.assertFalse(legacyPrincipal.hasExplicitPermission(Actions.Cluster.GET_ZNODE));
+
+    UserConfig fineGrainedUser = new UserConfig("fineGrained", "password", ComponentType.CONTROLLER.name(),
+        RoleType.ADMIN.name(), null, null, null, List.of(Actions.Cluster.GET_ZNODE));
+    ZkBasicAuthPrincipal fineGrainedPrincipal =
+        BasicAuthPrincipalUtils.extractBasicAuthPrincipals(List.of(fineGrainedUser)).get(0);
+    // The separate fine-grained permission must not turn the legacy empty-set wildcard into a table restriction.
+    Assert.assertTrue(fineGrainedPrincipal.hasPermission("read"));
+    Assert.assertTrue(fineGrainedPrincipal.hasExplicitPermission(Actions.Cluster.GET_ZNODE));
+  }
 
   @Test
   public void testBasicAuthPrincipal() {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -1959,6 +1959,7 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
       throws Exception {
     JsonNode tableConfigsNode =
         JsonUtils.stringToJsonNode(getOrCreateAdminClient().getTableClient().getTableConfig("mytable"));
+    tableConfigsNode = tableConfigsNode.has("configs") ? tableConfigsNode.get("configs") : tableConfigsNode;
     JsonNode schemaNode =
         JsonUtils.stringToJsonNode(getOrCreateAdminClient().getSchemaClient().getSchema("mytable"));
     List<String> successfulQueries = Arrays.asList("SELECT COUNT(*) FROM mytable",
@@ -2009,6 +2010,7 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
       throws Exception {
     JsonNode tableConfigsNode =
         JsonUtils.stringToJsonNode(getOrCreateAdminClient().getTableClient().getTableConfig("mytable"));
+    tableConfigsNode = tableConfigsNode.has("configs") ? tableConfigsNode.get("configs") : tableConfigsNode;
     JsonNode schemaNode =
         JsonUtils.stringToJsonNode(getOrCreateAdminClient().getSchemaClient().getSchema("mytable"));
     List<String> mixedQueries = Arrays.asList("SELECT COUNT(*) FROM mytable", "SELECT invalidColumn FROM mytable",
@@ -2057,6 +2059,7 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
       throws Exception {
     JsonNode tableConfigsNode =
         JsonUtils.stringToJsonNode(getOrCreateAdminClient().getTableClient().getTableConfig("mytable"));
+    tableConfigsNode = tableConfigsNode.has("configs") ? tableConfigsNode.get("configs") : tableConfigsNode;
     JsonNode schemaNode =
         JsonUtils.stringToJsonNode(getOrCreateAdminClient().getSchemaClient().getSchema("mytable"));
 
@@ -2228,6 +2231,7 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
       throws Exception {
     JsonNode tableConfigsNode =
         JsonUtils.stringToJsonNode(getOrCreateAdminClient().getTableClient().getTableConfig("mytable"));
+    tableConfigsNode = tableConfigsNode.has("configs") ? tableConfigsNode.get("configs") : tableConfigsNode;
     JsonNode schemaNode =
         JsonUtils.stringToJsonNode(getOrCreateAdminClient().getSchemaClient().getSchema("mytable"));
 

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/consistency/MaterializedViewConsistencyManager.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/consistency/MaterializedViewConsistencyManager.java
@@ -720,7 +720,7 @@ public class MaterializedViewConsistencyManager {
         // leave a stale definition znode here; re-registering it would resurrect a ghost
         // MV that source-table updates would chase. Skip the orphan and surface a WARN so
         // operators can clean up the stranded znode.
-        TableConfig viewConfig = ZKMetadataProvider.getTableConfig(_propertyStore, viewTableName);
+        TableConfig viewConfig = ZKMetadataProvider.getTableConfig(_propertyStore, viewTableName, false, false);
         if (viewConfig == null || !viewConfig.isMaterializedView()) {
           LOGGER.warn("Skipping orphan MV definition znode '{}': underlying TableConfig is "
               + "missing or no longer an MV. Operator should DELETE /materializedViewDefinitions "

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/executor/GrpcMaterializedViewQueryExecutor.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/executor/GrpcMaterializedViewQueryExecutor.java
@@ -83,34 +83,37 @@ public class GrpcMaterializedViewQueryExecutor implements MaterializedViewQueryE
     Pair<String, Integer> broker = selectBroker();
     LOGGER.info("Selected broker gRPC endpoint: {}:{}", broker.getLeft(), broker.getRight());
 
-    BrokerGrpcQueryClient client = getOrCreateClient(broker.getLeft(), broker.getRight());
+    try {
+      Broker.BrokerRequest brokerRequest = buildMaterializationRequest(sql, authHeaders);
+      BrokerGrpcQueryClient client = getOrCreateClient(broker.getLeft(), broker.getRight());
+      Iterator<Broker.BrokerResponse> responseIterator = client.submit(brokerRequest);
 
-    Broker.BrokerRequest brokerRequest = buildMaterializationRequest(sql, authHeaders);
-    Iterator<Broker.BrokerResponse> responseIterator = client.submit(brokerRequest);
+      Preconditions.checkState(responseIterator.hasNext(),
+          "gRPC broker %s:%d returned no response. Check broker health and gRPC connectivity.",
+          broker.getLeft(), broker.getRight());
+      Broker.BrokerResponse metadataResponse = responseIterator.next();
+      JsonNode metadataJson = JsonUtils.bytesToJsonNode(metadataResponse.getPayload().toByteArray());
+      if (metadataJson.has("exceptions") && !metadataJson.get("exceptions").isEmpty()) {
+        throw new IOException("Broker returned one or more query execution exceptions");
+      }
 
-    Preconditions.checkState(responseIterator.hasNext(),
-        "gRPC broker %s:%d returned no response for query: %s. Check broker health and gRPC connectivity.",
-        broker.getLeft(), broker.getRight(), sql);
-    Broker.BrokerResponse metadataResponse = responseIterator.next();
-    JsonNode metadataJson = JsonUtils.bytesToJsonNode(metadataResponse.getPayload().toByteArray());
-    if (metadataJson.has("exceptions") && !metadataJson.get("exceptions").isEmpty()) {
-      throw new IOException("Query execution failed with exceptions: " + metadataJson.get("exceptions"));
+      // The broker gRPC protocol always sends the schema frame after metadata, even for queries
+      // that match zero rows.  A missing schema therefore indicates a real protocol error
+      // (broker version mismatch, truncated stream, etc.) — fail loud with actionable diagnostics
+      // so the operator can identify and fix the underlying issue rather than silently advancing
+      // the watermark with no data.
+      Preconditions.checkState(responseIterator.hasNext(),
+          "gRPC broker %s:%d sent metadata but no schema frame. "
+              + "Indicates a broker protocol error (version mismatch or truncated stream). "
+              + "Empty result sets still include a schema frame.",
+          broker.getLeft(), broker.getRight());
+      Broker.BrokerResponse schemaResponse = responseIterator.next();
+      DataSchema dataSchema = DataSchema.fromBytes(schemaResponse.getPayload().asReadOnlyByteBuffer());
+
+      return new GrpcQueryHandle(broker, dataSchema, responseIterator);
+    } catch (Exception e) {
+      throw safeQueryExecutionFailure(e);
     }
-
-    // The broker gRPC protocol always sends the schema frame after metadata, even for queries
-    // that match zero rows.  A missing schema therefore indicates a real protocol error
-    // (broker version mismatch, truncated stream, etc.) — fail loud with actionable diagnostics
-    // so the operator can identify and fix the underlying issue rather than silently advancing
-    // the watermark with no data.
-    Preconditions.checkState(responseIterator.hasNext(),
-        "gRPC broker %s:%d sent metadata but no schema frame for query: %s. "
-            + "Indicates a broker protocol error (version mismatch or truncated stream). "
-            + "Empty result sets still include a schema frame.",
-        broker.getLeft(), broker.getRight(), sql);
-    Broker.BrokerResponse schemaResponse = responseIterator.next();
-    DataSchema dataSchema = DataSchema.fromBytes(schemaResponse.getPayload().asReadOnlyByteBuffer());
-
-    return new GrpcQueryHandle(broker, dataSchema, responseIterator);
   }
 
   /// Streaming handle that decodes one gRPC data frame at a time. Heap residency is bounded by
@@ -144,8 +147,12 @@ public class GrpcMaterializedViewQueryExecutor implements MaterializedViewQueryE
       // Drain any remaining gRPC frames so the underlying call's server-streaming RPC is
       // properly terminated. The Helix-managed channel is shared and cached; not draining
       // here would leak the stream until the channel closes.
-      while (_responseIterator.hasNext()) {
-        _responseIterator.next();
+      try {
+        while (_responseIterator.hasNext()) {
+          _responseIterator.next();
+        }
+      } catch (Exception e) {
+        throw safeQueryStreamFailure(e);
       }
     }
 
@@ -159,13 +166,17 @@ public class GrpcMaterializedViewQueryExecutor implements MaterializedViewQueryE
 
       @Override
       public boolean hasNext() {
-        while (_currentFrameRows == null || _cursor >= _currentFrameRows.size()) {
-          if (!_responseIterator.hasNext()) {
-            return false;
+        try {
+          while (_currentFrameRows == null || _cursor >= _currentFrameRows.size()) {
+            if (!_responseIterator.hasNext()) {
+              return false;
+            }
+            decodeNextFrame();
           }
-          decodeNextFrame();
+          return true;
+        } catch (Exception e) {
+          throw safeQueryStreamFailure(e);
         }
-        return true;
       }
 
       @Override
@@ -177,7 +188,8 @@ public class GrpcMaterializedViewQueryExecutor implements MaterializedViewQueryE
         return _currentFrameRows.get(_cursor++);
       }
 
-      private void decodeNextFrame() {
+      private void decodeNextFrame()
+          throws Exception {
         Broker.BrokerResponse dataResponse = _responseIterator.next();
         Map<String, String> responseMetadata = dataResponse.getMetadataMap();
         String compressionAlgorithm = responseMetadata.getOrDefault(
@@ -192,18 +204,8 @@ public class GrpcMaterializedViewQueryExecutor implements MaterializedViewQueryE
         Preconditions.checkNotNull(rowSizeStr,
             "gRPC response metadata missing required 'rowSize' field");
         int rowSize = Integer.parseInt(rowSizeStr);
-        byte[] uncompressedPayload;
-        try {
-          uncompressedPayload = compressor.decompress(respBytes);
-        } catch (Exception e) {
-          throw new RuntimeException("Failed to decompress gRPC response payload", e);
-        }
-        ResultTable resultTable;
-        try {
-          resultTable = responseEncoder.decodeResultTable(uncompressedPayload, rowSize, _dataSchema);
-        } catch (IOException e) {
-          throw new RuntimeException("Failed to decode gRPC response frame", e);
-        }
+        byte[] uncompressedPayload = compressor.decompress(respBytes);
+        ResultTable resultTable = responseEncoder.decodeResultTable(uncompressedPayload, rowSize, _dataSchema);
         _currentFrameRows = resultTable.getRows();
         _cursor = 0;
         _framesDecoded++;
@@ -213,6 +215,19 @@ public class GrpcMaterializedViewQueryExecutor implements MaterializedViewQueryE
         }
       }
     }
+  }
+
+  @VisibleForTesting
+  static IOException safeQueryExecutionFailure(Throwable throwable) {
+    // Broker and transport messages can echo the submitted SQL. Do not retain the message or cause because minion
+    // task result and progress diagnostics serialize the complete throwable chain.
+    return new IOException("gRPC query execution failed (exception type: " + throwable.getClass().getName() + ")");
+  }
+
+  @VisibleForTesting
+  static RuntimeException safeQueryStreamFailure(Throwable throwable) {
+    // Streaming failures have the same downstream throwable serialization path as initial execution failures.
+    return new RuntimeException("gRPC query stream failed (exception type: " + throwable.getClass().getName() + ")");
   }
 
   /// Builds the gRPC [Broker.BrokerRequest] for a materialization query, forcing materialized-view
@@ -313,7 +328,7 @@ public class GrpcMaterializedViewQueryExecutor implements MaterializedViewQueryE
       try {
         client.close();
       } catch (Exception e) {
-        LOGGER.warn("Error closing gRPC client", e);
+        LOGGER.warn("Error closing gRPC client (exception type: {})", e.getClass().getName());
       }
     }
     _clientCache.clear();

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/rewrite/MaterializedViewMetadataCache.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/rewrite/MaterializedViewMetadataCache.java
@@ -332,8 +332,8 @@ public class MaterializedViewMetadataCache {
         /// every match attempt returns null without logging. Operators must be alerted at
         /// ingestion time. The cache entry is still stored (with compiledQuery=null) so the
         /// controller-facing definition listing remains visible; only rewrite is disabled.
-        LOGGER.error("Failed to compile definedSql for MV {}; rewrite disabled until the SQL is "
-            + "fixed and the definition znode is updated. SQL: {}", viewTableNameWithType, definedSql, e);
+        LOGGER.error("Failed to compile definedSql for MV {}; rewrite disabled until the SQL is fixed and the "
+            + "definition znode is updated ({})", viewTableNameWithType, e.getClass().getSimpleName());
       }
     }
 

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/scheduler/MaterializedViewTaskScheduler.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/scheduler/MaterializedViewTaskScheduler.java
@@ -461,18 +461,20 @@ public class MaterializedViewTaskScheduler {
       // IllegalStateException) — surface with MV table context for operator triage.
       throw new IllegalStateException("Broker-bound SQL is unparseable for MV table: "
           + viewTableName + ". Check definedSQL for syntax issues (trailing comments, unbalanced "
-          + "quotes, etc). SQL: " + sqlWithTimeRange, e);
+          + "quotes, etc).", e);
     }
     String observedLimit = verifyLimit.map(String::valueOf).orElse("<absent>");
     Preconditions.checkState(
         verifyLimit.isPresent() && verifyLimit.get().intValue() == effectiveLimit,
         "LIMIT verification failed for MV table: %s. Re-parsed SQL has LIMIT=%s, expected %s. "
             + "definedSQL likely contains text (comments, literals) that interfered with SQL "
-            + "manipulation. SQL: %s",
-        viewTableName, observedLimit, effectiveLimit, sqlWithTimeRange);
+            + "manipulation.",
+        viewTableName, observedLimit, effectiveLimit);
 
     Map<String, String> configs = new HashMap<>();
     configs.put(MinionConstants.TABLE_NAME_KEY, viewTableName);
+    // The executor needs the broker-bound SQL, but this makes the task config credential-bearing. Callers must never
+    // log the full PinotTaskConfig; PinotTaskManager logs only task identifiers and counts.
     configs.put(MaterializedViewTask.DEFINED_SQL_KEY, sqlWithTimeRange);
     configs.put(MaterializedViewTask.WINDOW_START_MS_KEY, String.valueOf(windowStartMs));
     configs.put(MaterializedViewTask.WINDOW_END_MS_KEY, String.valueOf(windowEndMs));
@@ -897,9 +899,10 @@ public class MaterializedViewTaskScheduler {
       }
     }
 
-    // Initialize MaterializedViewDefinitionMetadata with base table info and partition expression maps
+    // Initialize executable MaterializedViewDefinitionMetadata from the same resolved SQL used to populate the view.
+    // Controller display endpoints independently source and redact the unresolved TableConfig.
     Schema viewSchema = _context.getTableSchema(viewTableWithType);
-    Map<String, String> partitionExprMaps = (viewSchema != null)
+    Map<String, String> partitionExprMaps = viewSchema != null
         ? MaterializedViewAnalyzer.extractPartitionExprMaps(definedSQL, viewSchema)
         : new HashMap<>();
 

--- a/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/executor/GrpcMaterializedViewQueryExecutorTest.java
+++ b/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/executor/GrpcMaterializedViewQueryExecutorTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.materializedview.executor;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -36,6 +37,8 @@ import org.testng.annotations.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -200,6 +203,23 @@ public class GrpcMaterializedViewQueryExecutorTest {
 
     /// Auth headers are preserved alongside the forced flag.
     assertEquals(request.getMetadataMap().get("Authorization"), "Bearer token", "Auth headers must be preserved");
+  }
+
+  @Test
+  public void testFailureDiagnosticsDoNotExposeExceptionMessages() {
+    String opaqueLiteral = "opaque-resolved-literal";
+
+    IOException executionFailure = GrpcMaterializedViewQueryExecutor.safeQueryExecutionFailure(
+        new IOException("Broker rejected SQL containing " + opaqueLiteral));
+    RuntimeException streamFailure = GrpcMaterializedViewQueryExecutor.safeQueryStreamFailure(
+        new IllegalStateException("Remote stream failed for " + opaqueLiteral));
+
+    assertTrue(executionFailure.getMessage().contains(IOException.class.getName()));
+    assertFalse(executionFailure.getMessage().contains(opaqueLiteral));
+    assertNull(executionFailure.getCause());
+    assertTrue(streamFailure.getMessage().contains(IllegalStateException.class.getName()));
+    assertFalse(streamFailure.getMessage().contains(opaqueLiteral));
+    assertNull(streamFailure.getCause());
   }
 
   private InstanceConfig buildBrokerConfig(String instanceName, String hostname, int grpcPort) {

--- a/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/scheduler/MaterializedViewTaskSchedulerTest.java
+++ b/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/scheduler/MaterializedViewTaskSchedulerTest.java
@@ -32,6 +32,7 @@ import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.materializedview.analysis.MaterializedViewAnalyzer;
 import org.apache.pinot.materializedview.context.MaterializedViewTaskGeneratorContext;
+import org.apache.pinot.materializedview.metadata.MaterializedViewDefinitionMetadata;
 import org.apache.pinot.materializedview.metadata.MaterializedViewRuntimeMetadata;
 import org.apache.pinot.materializedview.metadata.PartitionFingerprint;
 import org.apache.pinot.materializedview.metadata.PartitionInfo;
@@ -39,9 +40,12 @@ import org.apache.pinot.materializedview.metadata.PartitionState;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.CommonConstants.MaterializedViewTask;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.zookeeper.data.Stat;
+import org.mockito.ArgumentCaptor;
 import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -170,6 +174,56 @@ public class MaterializedViewTaskSchedulerTest {
     Optional<Integer> declared = MaterializedViewAnalyzer.tryExtractDeclaredLimit(sql);
     assertTrue(declared.isPresent());
     assertEquals(declared.get().intValue(), 5000);
+  }
+
+  @Test
+  public void testColdStartDefinitionPersistsResolvedExecutableSql() {
+    String viewTable = "mv";
+    String viewTableWithType = "mv_OFFLINE";
+    String sourceTable = "orders";
+    String sourceTableWithType = "orders_OFFLINE";
+    String resolvedSql = "SELECT ts, COUNT(*) AS cnt FROM orders WHERE endpoint = "
+        + "'https://service:runtime-value@example.test/data' GROUP BY ts";
+
+    HelixPropertyStore<ZNRecord> propertyStore = mockPropertyStore();
+    when(propertyStore.create(anyString(), any(ZNRecord.class), eq(AccessOption.PERSISTENT))).thenReturn(true);
+
+    MaterializedViewTaskGeneratorContext context = mock(MaterializedViewTaskGeneratorContext.class);
+    when(context.getPropertyStore()).thenReturn(propertyStore);
+    SegmentZKMetadata sourceSegment = segmentWithStartMs(0L);
+    when(context.getSegmentsZKMetadata(sourceTableWithType)).thenReturn(List.of(sourceSegment));
+
+    TableConfig sourceConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(sourceTable).setTimeColumnName("ts").build();
+    when(context.getTableConfig(sourceTableWithType)).thenReturn(sourceConfig);
+
+    TableConfig resolvedViewConfig = materializedViewConfig(viewTable, resolvedSql);
+    when(context.getTableConfig(viewTableWithType)).thenReturn(resolvedViewConfig);
+
+    Schema sourceSchema = new Schema.SchemaBuilder()
+        .setSchemaName(sourceTable)
+        .addDateTime("ts", FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:MILLISECONDS")
+        .addSingleValueDimension("endpoint", FieldSpec.DataType.STRING)
+        .build();
+    Schema viewSchema = new Schema.SchemaBuilder()
+        .setSchemaName(viewTable)
+        .addDateTime("ts", FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:MILLISECONDS")
+        .addMetric("cnt", FieldSpec.DataType.LONG)
+        .build();
+    when(context.getTableSchema(sourceTableWithType)).thenReturn(sourceSchema);
+    when(context.getTableSchema(viewTableWithType)).thenReturn(viewSchema);
+
+    new MaterializedViewTaskScheduler(context).getWatermarkMs(
+        viewTable, sourceTable, 86_400_000L, resolvedSql,
+        resolvedViewConfig.getTaskConfig().getConfigsForTaskType(MaterializedViewTask.TASK_TYPE));
+
+    ArgumentCaptor<ZNRecord> definitionCaptor = ArgumentCaptor.forClass(ZNRecord.class);
+    verify(propertyStore).create(
+        eq(ZKMetadataProvider.constructPropertyStorePathForMaterializedViewDefinition(viewTableWithType)),
+        definitionCaptor.capture(), eq(AccessOption.PERSISTENT));
+    MaterializedViewDefinitionMetadata persisted =
+        MaterializedViewDefinitionMetadata.fromZNRecord(definitionCaptor.getValue());
+    assertEquals(persisted.getDefinedSql(), resolvedSql);
   }
 
   // ---------------------------------------------------------------------------
@@ -303,6 +357,24 @@ public class MaterializedViewTaskSchedulerTest {
     SegmentZKMetadata seg = mock(SegmentZKMetadata.class);
     when(seg.getEndTimeMs()).thenReturn(endTimeMs);
     return seg;
+  }
+
+  private static SegmentZKMetadata segmentWithStartMs(long startTimeMs) {
+    SegmentZKMetadata segment = mock(SegmentZKMetadata.class);
+    when(segment.getStartTimeMs()).thenReturn(startTimeMs);
+    return segment;
+  }
+
+  private static TableConfig materializedViewConfig(String tableName, String definedSql) {
+    TableTaskConfig taskConfig = new TableTaskConfig(Map.of(MaterializedViewTask.TASK_TYPE, Map.of(
+        MaterializedViewTask.DEFINED_SQL_KEY, definedSql,
+        MaterializedViewTask.BUCKET_TIME_PERIOD_KEY, "1d")));
+    return new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(tableName)
+        .setTimeColumnName("ts")
+        .setIsMaterializedView(true)
+        .setTaskConfig(taskConfig)
+        .build();
   }
 
   // ---------------------------------------------------------------------------

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
@@ -43,7 +43,6 @@ import org.apache.pinot.minion.exception.TaskCancelledException;
 import org.apache.pinot.minion.executor.PinotTaskExecutor;
 import org.apache.pinot.minion.executor.PinotTaskExecutorFactory;
 import org.apache.pinot.minion.executor.TaskExecutorFactoryRegistry;
-import org.apache.pinot.spi.utils.Obfuscator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -136,9 +135,10 @@ public class TaskFactoryRegistry {
               String tableName = pinotTaskConfig.getTableName();
 
               _eventObserver.notifyTaskStart(pinotTaskConfig);
+              // Task configs can contain opaque values (for example SQL literals) that cannot be safely identified
+              // by key-name redaction. Log only stable task identity fields.
               if (LOGGER.isInfoEnabled()) {
-                LOGGER.info("Start running {}: {} with configs: {}", pinotTaskConfig.getTaskType(), _taskConfig.getId(),
-                    Obfuscator.DEFAULT.toJsonString(pinotTaskConfig.getConfigs()));
+                LOGGER.info("{}", safeTaskStartDiagnostic(pinotTaskConfig, _taskConfig.getId()));
               }
 
               try {
@@ -158,7 +158,8 @@ public class TaskFactoryRegistry {
                   _minionMetrics.addMeteredTableValue(tableName, taskType,
                       MinionMeter.NUMBER_TASKS_CANCELLED, 1L);
                 }
-                LOGGER.info("Task: {} got cancelled", _taskConfig.getId(), e);
+                LOGGER.info("Task: {} got cancelled (exception type: {})", _taskConfig.getId(),
+                    safeExceptionType(e));
                 return new TaskResult(TaskResult.Status.CANCELED, extractAndTrimRootCauseMessage(e));
               } catch (FatalException e) {
                 _eventObserver.notifyTaskError(pinotTaskConfig, e);
@@ -167,7 +168,8 @@ public class TaskFactoryRegistry {
                   _minionMetrics.addMeteredTableValue(tableName, taskType,
                       MinionMeter.NUMBER_TASKS_FATAL_FAILED, 1L);
                 }
-                LOGGER.error("Caught fatal exception while executing task: {}", _taskConfig.getId(), e);
+                LOGGER.error("Caught fatal exception while executing task: {} (exception type: {})",
+                    _taskConfig.getId(), safeExceptionType(e));
                 return new TaskResult(TaskResult.Status.FATAL_FAILED, extractAndTrimRootCauseMessage(e));
               } catch (Exception e) {
                 _eventObserver.notifyTaskError(pinotTaskConfig, e);
@@ -176,7 +178,8 @@ public class TaskFactoryRegistry {
                   _minionMetrics.addMeteredTableValue(tableName, taskType,
                       MinionMeter.NUMBER_TASKS_FAILED, 1L);
                 }
-                LOGGER.error("Caught exception while executing task: {}", _taskConfig.getId(), e);
+                LOGGER.error("Caught exception while executing task: {} (exception type: {})", _taskConfig.getId(),
+                    safeExceptionType(e));
                 return new TaskResult(TaskResult.Status.FAILED, extractAndTrimRootCauseMessage(e));
               } finally {
                 _minionMetrics.addMeteredValue(taskType, MinionMeter.NUMBER_TASKS_EXECUTED, 1L);
@@ -193,7 +196,7 @@ public class TaskFactoryRegistry {
             }
           };
         } catch (Exception e) {
-          LOGGER.error("Caught exception while creating new task", e);
+          LOGGER.error("Caught exception while creating new task (exception type: {})", safeExceptionType(e));
           throw new RuntimeException("Caught exception while creating new task", e);
         }
       };
@@ -207,6 +210,14 @@ public class TaskFactoryRegistry {
       return rootCauseMessage.substring(0, MAX_TASK_RESULT_INFO_LEN);
     }
     return rootCauseMessage;
+  }
+
+  static String safeExceptionType(Throwable throwable) {
+    return throwable.getClass().getName();
+  }
+
+  static String safeTaskStartDiagnostic(PinotTaskConfig pinotTaskConfig, String taskId) {
+    return "Start running " + pinotTaskConfig.getTaskType() + ": " + taskId;
   }
 
   /// Returns the task factory registry.

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistryTest.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistryTest.java
@@ -18,9 +18,8 @@
  */
 package org.apache.pinot.minion.taskfactory;
 
-import java.util.HashMap;
 import java.util.Map;
-import org.apache.pinot.spi.utils.Obfuscator;
+import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -28,48 +27,26 @@ import org.testng.annotations.Test;
 public class TaskFactoryRegistryTest {
 
   @Test
-  public void testObfuscatorMasksSensitiveConfigs() {
-    // Test that the Obfuscator properly masks sensitive configuration values
-    Map<String, String> configs = new HashMap<>();
-    configs.put("tableName", "myTable");
-    configs.put("authToken", "Basic YWRtaW46dmVyeXNlY3JldA");
-    configs.put("password", "verysecret");
-    configs.put("secretKey", "mySecretKey123");
-    configs.put("apiKey", "sk-1234567890abcdef");
-    configs.put("normalConfig", "normalValue");
+  public void testSafeExceptionTypeDoesNotIncludeMessage() {
+    String opaqueLiteral = "opaque-resolved-literal";
+    IllegalStateException exception = new IllegalStateException(opaqueLiteral);
 
-    String obfuscatedJson = Obfuscator.DEFAULT.toJsonString(configs);
+    String diagnostic = TaskFactoryRegistry.safeExceptionType(exception);
 
-    // Verify that sensitive values are masked
-    Assert.assertTrue(obfuscatedJson.contains("tableName"));
-    Assert.assertTrue(obfuscatedJson.contains("normalConfig"));
-    Assert.assertTrue(obfuscatedJson.contains("normalValue"));
-
-    // Verify that sensitive values are masked with "*****"
-    Assert.assertTrue(obfuscatedJson.contains("\"authToken\":\"*****\""));
-    Assert.assertTrue(obfuscatedJson.contains("\"password\":\"*****\""));
-    Assert.assertTrue(obfuscatedJson.contains("\"secretKey\":\"*****\""));
-    Assert.assertTrue(obfuscatedJson.contains("\"apiKey\":\"*****\""));
-
-    // Verify that the original sensitive values are not present
-    Assert.assertFalse(obfuscatedJson.contains("Basic YWRtaW46dmVyeXNlY3JldA"));
-    Assert.assertFalse(obfuscatedJson.contains("verysecret"));
-    Assert.assertFalse(obfuscatedJson.contains("mySecretKey123"));
-    Assert.assertFalse(obfuscatedJson.contains("sk-1234567890abcdef"));
+    Assert.assertEquals(diagnostic, IllegalStateException.class.getName());
+    Assert.assertFalse(diagnostic.contains(opaqueLiteral));
   }
 
   @Test
-  public void testObfuscatorHandlesNullAndEmptyValues() {
-    Map<String, String> configs = new HashMap<>();
-    configs.put("authToken", null);
-    configs.put("password", "");
-    configs.put("normalConfig", "value");
+  public void testTaskStartDiagnosticDoesNotIncludeConfigBody() {
+    String opaqueLiteral = "opaque-resolved-literal";
+    PinotTaskConfig taskConfig = new PinotTaskConfig("MaterializedViewTask",
+        Map.of("definedSQL", "SELECT * FROM source WHERE value = '" + opaqueLiteral + "'"));
 
-    String obfuscatedJson = Obfuscator.DEFAULT.toJsonString(configs);
+    String diagnostic = TaskFactoryRegistry.safeTaskStartDiagnostic(taskConfig, "task-id");
 
-    // Verify that null and empty values are handled properly
-    Assert.assertTrue(obfuscatedJson.contains("\"authToken\":\"*****\""));
-    Assert.assertTrue(obfuscatedJson.contains("\"password\":\"*****\""));
-    Assert.assertTrue(obfuscatedJson.contains("\"normalConfig\":\"value\""));
+    Assert.assertEquals(diagnostic, "Start running MaterializedViewTask: task-id");
+    Assert.assertFalse(diagnostic.contains(opaqueLiteral));
+    Assert.assertFalse(diagnostic.contains("definedSQL"));
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/materializedview/MaterializedViewTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/materializedview/MaterializedViewTaskExecutor.java
@@ -75,7 +75,6 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.CommonConstants.MaterializedViewTask;
-import org.apache.pinot.spi.utils.Obfuscator;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
@@ -171,9 +170,7 @@ public class MaterializedViewTaskExecutor extends BaseTaskExecutor {
 
     Map<String, String> configs = pinotTaskConfig.getConfigs();
     String taskType = pinotTaskConfig.getTaskType();
-    if (LOGGER.isInfoEnabled()) {
-      LOGGER.info("Starting task: {} with configs: {}", taskType, Obfuscator.DEFAULT.toJsonString(configs));
-    }
+    LOGGER.info("Starting task: {} with task id: {}", taskType, pinotTaskConfig.getTaskId());
 
     String tableName = configs.get(MinionConstants.TABLE_NAME_KEY);
     long windowStartMs = Long.parseLong(configs.get(MaterializedViewTask.WINDOW_START_MS_KEY));
@@ -191,8 +188,7 @@ public class MaterializedViewTaskExecutor extends BaseTaskExecutor {
     validateSourceFingerprintAtCommit(configs, tableName, windowStartMs, windowEndMs, taskFingerprint);
 
     String definedSQL = configs.get(MaterializedViewTask.DEFINED_SQL_KEY);
-    LOGGER.info("MaterializedViewTask for table: {}, window: [{}, {}), SQL: {}",
-        tableName, windowStartMs, windowEndMs, definedSQL);
+    LOGGER.info("MaterializedViewTask for table: {}, window: [{}, {})", tableName, windowStartMs, windowEndMs);
 
     TableConfig tableConfig = getTableConfig(tableName);
     Schema schema = getSchema(tableName);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/ConfigUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/ConfigUtils.java
@@ -64,10 +64,10 @@ public class ConfigUtils {
     }
     try {
       return (T) JsonUtils.jsonNodeToObject(jsonNode, configTemplate.getClass());
-    } catch (IOException e) {
+    } catch (IOException ignored) {
       throw new RuntimeException(String
-          .format("Unable to read JsonConfig to class [%s] after applying environment variables, jsonConfig is: '%s'.",
-              configTemplate.getClass().getName(), jsonNode.toString()), e);
+          .format("Unable to read JsonConfig to class [%s] after applying environment variables.",
+              configTemplate.getClass().getName()));
     }
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfigRedactionUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfigRedactionUtils.java
@@ -1,0 +1,1791 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.table;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.utils.JsonUtils;
+
+
+/// Produces the display-safe form of a table config and merges that form back into the stored config on update.
+///
+/// Redaction is recursive so plugin-owned stream, batch, filesystem, decoder, provider, task, and custom property maps
+/// receive the same treatment as first-class table config fields. Literal values under credential-bearing keys are
+/// masked, as are JAAS/connection-string assignments and credentials embedded in URI user-info or query parameters.
+/// Whole-value environment and system-property placeholders are preserved and are never resolved by this class.
+///
+/// The redaction marker is reserved in credential-bearing positions. During an update, an unchanged marker restores
+/// the corresponding value from the unresolved stored config. Marker-bearing array elements are matched to their
+/// exact redacted stored form instead of by array position, which supports reordering without moving one source's
+/// credentials to another. Ambiguous or edited marker-bearing elements are rejected.
+///
+/// This class is stateless and thread-safe.
+public final class TableConfigRedactionUtils {
+  public static final String REDACTION_MARKER = "*****";
+
+  private static final Pattern URI_REFERENCE_PATTERN = Pattern.compile("(?i)(?:[a-z][a-z0-9+.-]*:)?//");
+  private static final Pattern CREDENTIAL_ASSIGNMENT_PATTERN = Pattern.compile(
+      "(?i)(\\b([a-z][a-z0-9._-]*)\\s*=\\s*)"
+          + "(\\\"(?:\\\\.|[^\\\"\\\\]++)*+\\\"|'(?:\\\\.|[^'\\\\]++)*+'|"
+          + "\\\"(?:\\\\.|[^\\\"\\\\]++)*+(?=;|\\r|\\n|$)|"
+          + "'(?:\\\\.|[^'\\\\]++)*+(?=;|\\r|\\n|$)|"
+          + "(?:(?![&,][a-z][a-z0-9._-]*\\s*=)(?!\\s+[a-z][a-z0-9._-]*\\s*=(?!=))"
+          + "[^;\\r\\n'\"])+)");
+  private static final Pattern JAAS_MODULE_PATTERN = Pattern.compile(
+      "(?i)([a-z_$][a-z0-9_.$-]*)\\s+(?:required|requisite|sufficient|optional)\\b");
+
+  private TableConfigRedactionUtils() {
+  }
+
+  /// Returns a deep-copied table config with displayable credentials replaced by [#REDACTION_MARKER].
+  public static TableConfig redact(TableConfig tableConfig) {
+    Objects.requireNonNull(tableConfig, "tableConfig must not be null");
+    JsonNode redacted = redactNode(tableConfig.toJsonNode(), null, false);
+    return toTableConfig(redacted, "Unable to create redacted table config");
+  }
+
+  /// Redacts credential-bearing assignments and URI components from an arbitrary display string.
+  ///
+  /// This is the same leaf-value policy used by [#redact(TableConfig)]. Whole placeholders and ordinary text are
+  /// preserved. JSON-encoded object and array values are traversed recursively so plugin option blobs receive the
+  /// same key policy as native property maps.
+  public static String redactStructuredText(String value) {
+    Objects.requireNonNull(value, "value must not be null");
+    if (isPlaceholder(value)) {
+      return value;
+    }
+    return redactStructuredCredentials(value);
+  }
+
+  /// Returns whether a property name is classified as credential-bearing by the shared display policy.
+  public static boolean isSensitivePropertyName(String propertyName) {
+    return propertyName != null && isSensitiveKey(propertyName);
+  }
+
+  /// Returns whether the whole value is an unresolved environment or system-property placeholder.
+  public static boolean isUnresolvedPlaceholder(String value) {
+    return value != null && isPlaceholder(value);
+  }
+
+  /// Returns a deep-copied submitted config with unchanged redaction markers restored from the unresolved stored
+  /// config. New literal values are retained as intentional credential replacements.
+  ///
+  /// @throws IllegalArgumentException if a marker has no unambiguous stored credential to restore
+  public static TableConfig restoreRedactedValues(TableConfig submitted, @Nullable TableConfig stored) {
+    Objects.requireNonNull(submitted, "submitted table config must not be null");
+    JsonNode submittedNode = submitted.toJsonNode();
+    JsonNode storedNode = stored != null ? stored.toJsonNode() : null;
+    JsonNode restored = restoreNode(submittedNode, storedNode, null, false);
+    return toTableConfig(restored, "Unable to restore redacted table config");
+  }
+
+  /// Redacts credentials from a diagnostic that was produced while handling the supplied table config. This preserves
+  /// useful validation context without allowing literal config credentials to reach an error response or log record.
+  public static String redactDiagnostic(@Nullable String diagnostic, TableConfig tableConfig) {
+    Objects.requireNonNull(tableConfig, "tableConfig must not be null");
+    if (diagnostic == null || diagnostic.isEmpty()) {
+      return "Invalid table config";
+    }
+    // A diagnostic can contain the resolved value of a placeholder even though the unresolved config never contains
+    // that literal. There is no sound string-level way to discover and remove such a value, so fail closed.
+    if (containsPlaceholder(tableConfig.toJsonNode())) {
+      return "Invalid table config";
+    }
+    String redacted = redactStructuredCredentials(diagnostic);
+    List<String> literalCredentials = new ArrayList<>();
+    collectLiteralCredentials(tableConfig.toJsonNode(), null, false, literalCredentials);
+    literalCredentials.sort(Comparator.comparingInt(String::length).reversed());
+    for (String credential : literalCredentials) {
+      if (!credential.isEmpty() && !isPlaceholder(credential)) {
+        redacted = redacted.replace(credential, REDACTION_MARKER);
+        redacted = redacted.replace(jsonEscaped(credential), REDACTION_MARKER);
+      }
+    }
+    return redacted;
+  }
+
+  private static String jsonEscaped(String value) {
+    try {
+      String json = JsonUtils.objectToString(value);
+      return json.substring(1, json.length() - 1);
+    } catch (IOException e) {
+      return value;
+    }
+  }
+
+  /// Returns whether replacing the JSON Pointer target with the supplied literal would reproduce its current masked
+  /// representation under this policy. This permits whole-leaf JAAS and URI replacements without allowing an override
+  /// to change non-credential content such as a URI host or JAAS principal.
+  public static boolean isValidCredentialOverride(JsonNode tableConfigNode, String jsonPointer, String replacement) {
+    Objects.requireNonNull(tableConfigNode, "tableConfigNode must not be null");
+    Objects.requireNonNull(jsonPointer, "jsonPointer must not be null");
+    Objects.requireNonNull(replacement, "replacement must not be null");
+    String[] segments = jsonPointer.split("/", -1);
+    if (segments.length <= 1 || !segments[0].isEmpty()) {
+      return false;
+    }
+    JsonNode node = tableConfigNode;
+    boolean parentSensitive = false;
+    String fieldName = null;
+    for (int i = 1; i < segments.length; i++) {
+      String segment = decodeJsonPointerSegment(segments[i]);
+      if (node.isObject()) {
+        fieldName = segment;
+        parentSensitive |= isSensitiveKey(fieldName);
+        node = node.get(fieldName);
+      } else if (node.isArray()) {
+        int index;
+        try {
+          index = Integer.parseInt(segment);
+        } catch (NumberFormatException e) {
+          return false;
+        }
+        node = index >= 0 && index < node.size() ? node.get(index) : null;
+      } else {
+        return false;
+      }
+      if (node == null) {
+        return false;
+      }
+    }
+    if (!node.isTextual() || isPlaceholder(node.textValue())) {
+      return false;
+    }
+    boolean hasPolicyMarker = parentSensitive && REDACTION_MARKER.equals(node.textValue())
+        || containsCredentialMarker(node.textValue());
+    return hasPolicyMarker && redactText(fieldName, replacement, parentSensitive).equals(node.textValue());
+  }
+
+  private static String decodeJsonPointerSegment(String segment) {
+    return segment.replace("~1", "/").replace("~0", "~");
+  }
+
+  private static boolean containsPlaceholder(JsonNode node) {
+    if (node.isObject()) {
+      for (JsonNode value : node) {
+        if (containsPlaceholder(value)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    if (node.isArray()) {
+      for (JsonNode value : node) {
+        if (containsPlaceholder(value)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    return node.isTextual() && node.textValue().contains("${");
+  }
+
+  private static void collectLiteralCredentials(JsonNode node, @Nullable String fieldName, boolean parentSensitive,
+      List<String> credentials) {
+    boolean sensitive = parentSensitive || isSensitiveKey(fieldName);
+    if (node.isObject()) {
+      for (Map.Entry<String, JsonNode> field : node.properties()) {
+        collectLiteralCredentials(field.getValue(), field.getKey(), sensitive, credentials);
+      }
+      return;
+    }
+    if (node.isArray()) {
+      for (JsonNode element : node) {
+        collectLiteralCredentials(element, fieldName, sensitive, credentials);
+      }
+      return;
+    }
+    if (!node.isValueNode()) {
+      return;
+    }
+    if (sensitive) {
+      if (!node.isTextual() || !isPlaceholder(node.textValue())) {
+        credentials.add(node.asText());
+      }
+    } else if (node.isTextual() && !isPlaceholder(node.textValue())) {
+      collectStructuredLiteralCredentials(node.textValue(), credentials);
+    }
+  }
+
+  private static void collectStructuredLiteralCredentials(String value, List<String> credentials) {
+    JsonNode structuredJson = tryParseStructuredJson(value);
+    if (structuredJson != null) {
+      collectLiteralCredentials(structuredJson, null, false, credentials);
+      return;
+    }
+    List<UriSpan> uriSpans = findUriSpans(value);
+    int offset = 0;
+    for (UriSpan span : uriSpans) {
+      collectAssignmentLiteralCredentials(value.substring(offset, span._start), credentials);
+      collectUriLiteralCredentials(value.substring(span._start, span._end), credentials);
+      offset = span._end;
+    }
+    collectAssignmentLiteralCredentials(value.substring(offset), credentials);
+  }
+
+  private static void collectAssignmentLiteralCredentials(String value, List<String> credentials) {
+    Matcher matcher = CREDENTIAL_ASSIGNMENT_PATTERN.matcher(value);
+    while (matcher.find()) {
+      String credential = unquote(matcher.group(3));
+      if (isSensitiveKey(matcher.group(2)) && !isPlaceholder(credential)) {
+        credentials.add(credential);
+      }
+    }
+  }
+
+  private static void collectUriLiteralCredentials(String uri, List<String> credentials) {
+    UriParts parts = new UriParts(uri);
+    if (parts._userInfo != null) {
+      for (String credential : splitOutsidePlaceholders(parts._userInfo, ':')) {
+        if (!credential.isEmpty() && !isPlaceholder(credential)) {
+          credentials.add(credential);
+        }
+      }
+    }
+    collectUriParameterLiteralCredentials(parts._query, credentials);
+    collectUriParameterLiteralCredentials(parameterLikeFragment(parts._fragment), credentials);
+  }
+
+  private static void collectUriParameterLiteralCredentials(@Nullable String parameters,
+      List<String> credentials) {
+    if (parameters == null) {
+      return;
+    }
+    for (String parameter : splitQuery(parameters)) {
+      int equalsIndex = parameter.indexOf('=');
+      if (equalsIndex < 0) {
+        continue;
+      }
+      String key = stripQueryPrefix(parameter.substring(0, equalsIndex));
+      String value = parameter.substring(equalsIndex + 1);
+      if (isSensitiveQueryKey(key) && !isPlaceholder(value)) {
+        credentials.add(value);
+        String decoded = decodeQueryValue(value);
+        if (decoded != null && !decoded.equals(value)) {
+          credentials.add(decoded);
+        }
+      } else if (!isPlaceholder(value)) {
+        collectStructuredLiteralCredentials(value, credentials);
+        String decoded = decodeQueryValue(value);
+        if (decoded != null && !decoded.equals(value)) {
+          collectStructuredLiteralCredentials(decoded, credentials);
+        }
+      }
+    }
+  }
+
+  private static JsonNode redactNode(JsonNode node, @Nullable String fieldName, boolean parentSensitive) {
+    boolean sensitive = parentSensitive || isSensitiveKey(fieldName);
+    if (node.isObject()) {
+      ObjectNode copy = (ObjectNode) node.deepCopy();
+      for (Map.Entry<String, JsonNode> field : copy.properties()) {
+        copy.set(field.getKey(), redactNode(field.getValue(), field.getKey(), sensitive));
+      }
+      return copy;
+    }
+    if (node.isArray()) {
+      ArrayNode copy = (ArrayNode) node.deepCopy();
+      for (int i = 0; i < copy.size(); i++) {
+        copy.set(i, redactNode(copy.get(i), fieldName, sensitive));
+      }
+      return copy;
+    }
+    if (node.isTextual()) {
+      return JsonUtils.objectToJsonNode(redactText(fieldName, node.textValue(), sensitive));
+    }
+    if (sensitive && node.isValueNode() && !node.isNull()) {
+      return JsonUtils.objectToJsonNode(REDACTION_MARKER);
+    }
+    return node.deepCopy();
+  }
+
+  private static JsonNode restoreNode(JsonNode submitted, @Nullable JsonNode stored, @Nullable String fieldName,
+      boolean parentSensitive) {
+    boolean sensitive = parentSensitive || isSensitiveKey(fieldName);
+    if (submitted.isObject()) {
+      validateObjectSecurityIdentity((ObjectNode) submitted, stored, fieldName, sensitive);
+      ObjectNode copy = (ObjectNode) submitted.deepCopy();
+      for (Map.Entry<String, JsonNode> field : copy.properties()) {
+        JsonNode storedChild = stored != null && stored.isObject() ? stored.get(field.getKey()) : null;
+        copy.set(field.getKey(), restoreNode(field.getValue(), storedChild, field.getKey(), sensitive));
+      }
+      return copy;
+    }
+    if (submitted.isArray()) {
+      return restoreArray((ArrayNode) submitted, stored, fieldName, sensitive);
+    }
+    if (sensitive && submitted.isTextual() && REDACTION_MARKER.equals(submitted.textValue())) {
+      if (stored == null || stored.isContainerNode()) {
+        throw unresolvedMarker();
+      }
+      return stored.deepCopy();
+    }
+    if (!submitted.isTextual()) {
+      return submitted.deepCopy();
+    }
+
+    String submittedValue = submitted.textValue();
+    String storedValue = stored != null && stored.isTextual() ? stored.textValue() : null;
+    if (isPlaceholder(submittedValue)) {
+      return submitted.deepCopy();
+    }
+    if (sensitive) {
+      if (submittedValue.contains(REDACTION_MARKER)) {
+        throw unresolvedMarker();
+      }
+      return submitted.deepCopy();
+    }
+
+    if (storedValue != null) {
+      String redactedStoredValue = redactText(fieldName, storedValue, false);
+      if (!storedValue.equals(redactedStoredValue) && submittedValue.equals(redactedStoredValue)) {
+        return JsonUtils.objectToJsonNode(storedValue);
+      }
+    }
+    if (containsCredentialMarker(submittedValue)) {
+      if (storedValue == null) {
+        throw unresolvedMarker();
+      }
+      return JsonUtils.objectToJsonNode(restoreStructuredCredentials(submittedValue, storedValue));
+    }
+    return submitted.deepCopy();
+  }
+
+  private static JsonNode restoreArray(ArrayNode submitted, @Nullable JsonNode stored, @Nullable String fieldName,
+      boolean sensitive) {
+    ArrayNode copy = (ArrayNode) submitted.deepCopy();
+    if (stored != null && stored.isArray() && submitted.equals(redactNode(stored, fieldName, sensitive))) {
+      for (int i = 0; i < copy.size(); i++) {
+        copy.set(i, restoreNode(copy.get(i), stored.get(i), fieldName, sensitive));
+      }
+      return copy;
+    }
+    if (canRestoreArrayByPosition(submitted, stored, fieldName, sensitive)) {
+      for (int i = 0; i < copy.size(); i++) {
+        copy.set(i, restoreNode(copy.get(i), stored.get(i), fieldName, sensitive));
+      }
+      return copy;
+    }
+    boolean[] usedStoredElements = stored != null && stored.isArray() ? new boolean[stored.size()] : new boolean[0];
+    for (int i = 0; i < copy.size(); i++) {
+      JsonNode submittedElement = copy.get(i);
+      int match = -1;
+      if (containsRestorableMarker(submittedElement, fieldName, sensitive)) {
+        match = findExactStoredArrayElement(submittedElement, stored, fieldName, sensitive, usedStoredElements);
+        if (match >= 0) {
+          usedStoredElements[match] = true;
+        }
+      }
+      if (match < 0 && containsRestorableMarker(submittedElement, fieldName, sensitive)) {
+        throw unresolvedMarker();
+      }
+      JsonNode storedElement = match >= 0 ? stored.get(match) : null;
+      copy.set(i, restoreNode(submittedElement, storedElement, fieldName, sensitive));
+    }
+    return copy;
+  }
+
+  private static boolean canRestoreArrayByPosition(ArrayNode submitted, @Nullable JsonNode stored,
+      @Nullable String fieldName, boolean sensitive) {
+    if (stored == null || !stored.isArray() || submitted.size() != stored.size()) {
+      return false;
+    }
+    if (submitted.size() <= 1) {
+      if (submitted.isEmpty() || !containsRestorableMarker(submitted.get(0), fieldName, sensitive)) {
+        return true;
+      }
+      Map<String, String> submittedIdentity = new HashMap<>();
+      collectStableArrayIdentity(submitted.get(0), "", fieldName, sensitive, submittedIdentity);
+      if (submittedIdentity.isEmpty()) {
+        return false;
+      }
+      Map<String, String> storedIdentity = new HashMap<>();
+      collectStableArrayIdentity(redactNode(stored.get(0), fieldName, sensitive), "", fieldName, sensitive,
+          storedIdentity);
+      return submittedIdentity.equals(storedIdentity);
+    }
+    Set<Map<String, String>> submittedIdentities = new HashSet<>();
+    for (int i = 0; i < submitted.size(); i++) {
+      if (!containsRestorableMarker(submitted.get(i), fieldName, sensitive)) {
+        continue;
+      }
+      Map<String, String> submittedIdentity = new HashMap<>();
+      collectStableArrayIdentity(submitted.get(i), "", fieldName, sensitive, submittedIdentity);
+      if (submittedIdentity.isEmpty()) {
+        return false;
+      }
+      Map<String, String> storedIdentity = new HashMap<>();
+      collectStableArrayIdentity(redactNode(stored.get(i), fieldName, sensitive), "", fieldName, sensitive,
+          storedIdentity);
+      if (!submittedIdentity.equals(storedIdentity) || !submittedIdentities.add(submittedIdentity)) {
+        return false;
+      }
+    }
+    Set<Map<String, String>> storedIdentities = new HashSet<>();
+    for (int i = 0; i < stored.size(); i++) {
+      JsonNode redactedStored = redactNode(stored.get(i), fieldName, sensitive);
+      if (!containsRestorableMarker(redactedStored, fieldName, sensitive)) {
+        continue;
+      }
+      Map<String, String> identity = new HashMap<>();
+      collectStableArrayIdentity(redactedStored, "", fieldName, sensitive, identity);
+      if (identity.isEmpty()) {
+        return false;
+      }
+      if (!storedIdentities.add(identity)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static int findExactStoredArrayElement(JsonNode submittedElement, @Nullable JsonNode stored,
+      @Nullable String fieldName, boolean sensitive, boolean[] usedStoredElements) {
+    if (stored == null || !stored.isArray()) {
+      return -1;
+    }
+    int candidate = -1;
+    int candidateCount = 0;
+    for (int i = 0; i < stored.size(); i++) {
+      if (usedStoredElements[i]) {
+        continue;
+      }
+      if (!submittedElement.equals(redactNode(stored.get(i), fieldName, sensitive))) {
+        continue;
+      }
+      candidate = i;
+      candidateCount++;
+    }
+    return candidateCount == 1 ? candidate : -1;
+  }
+
+  private static void collectStableArrayIdentity(JsonNode node, String path, @Nullable String fieldName,
+      boolean parentSensitive, Map<String, String> identity) {
+    boolean sensitive = parentSensitive || isSensitiveKey(fieldName);
+    if (node.isObject()) {
+      for (Map.Entry<String, JsonNode> field : node.properties()) {
+        String childPath = path.isEmpty() ? field.getKey() : path + "." + field.getKey();
+        collectStableArrayIdentity(field.getValue(), childPath, field.getKey(), sensitive, identity);
+      }
+      return;
+    }
+    if (node.isArray()) {
+      for (int i = 0; i < node.size(); i++) {
+        collectStableArrayIdentity(node.get(i), path + "[" + i + "]", fieldName, sensitive, identity);
+      }
+      return;
+    }
+    if (!sensitive && isStableArrayIdentityKey(fieldName) && !containsRestorableMarker(node, fieldName, false)) {
+      identity.put(path, stableIdentityValue(node));
+    }
+  }
+
+  private static boolean isStableArrayIdentityKey(@Nullable String fieldName) {
+    if (fieldName == null) {
+      return false;
+    }
+    String normalized = normalizeKey(fieldName);
+    return normalized.equals("name") || normalized.equals("id") || normalized.equals("type")
+        || normalized.endsWith("tablename") || normalized.endsWith("tasktype")
+        || normalized.endsWith("streamtype") || normalized.endsWith("topic")
+        || normalized.endsWith("topicname") || normalized.endsWith("endpoint")
+        || normalized.endsWith("host") || normalized.endsWith("server") || normalized.endsWith("url")
+        || normalized.endsWith("uri") || normalized.endsWith("path") || normalized.endsWith("bootstrapservers")
+        || isExecutableClassSelectorKey(normalized);
+  }
+
+  private static void validateObjectSecurityIdentity(ObjectNode submitted, @Nullable JsonNode stored,
+      @Nullable String fieldName, boolean parentSensitive) {
+    if (stored == null || !stored.isObject()
+        || !containsRestorableMarker(submitted, fieldName, parentSensitive)) {
+      return;
+    }
+    ObjectNode redactedStored = (ObjectNode) redactNode(stored, fieldName, parentSensitive);
+    rejectNormalizedKeyAliases(submitted);
+    Map<String, String> submittedIdentity = new HashMap<>();
+    collectObjectSecurityIdentity(submitted, "", fieldName, parentSensitive, submittedIdentity);
+    Map<String, String> storedIdentity = new HashMap<>();
+    collectObjectSecurityIdentity(redactedStored, "", fieldName, parentSensitive, storedIdentity);
+    if (!submittedIdentity.equals(storedIdentity)) {
+      throw unresolvedMarker();
+    }
+    validateCredentialPairs(submitted, redactedStored);
+    validateCredentialEndpointBindings(submitted, redactedStored);
+  }
+
+  private static void rejectNormalizedKeyAliases(JsonNode node) {
+    if (node.isObject()) {
+      Map<String, String> normalizedToRaw = new HashMap<>();
+      for (Map.Entry<String, JsonNode> field : node.properties()) {
+        String normalized = normalizeKey(field.getKey());
+        String previous = normalizedToRaw.putIfAbsent(normalized, field.getKey());
+        if (previous != null && !previous.equals(field.getKey())) {
+          throw unresolvedMarker();
+        }
+        rejectNormalizedKeyAliases(field.getValue());
+      }
+    } else if (node.isArray()) {
+      for (JsonNode element : node) {
+        rejectNormalizedKeyAliases(element);
+      }
+    }
+  }
+
+  private static void collectObjectSecurityIdentity(JsonNode node, String path, @Nullable String fieldName,
+      boolean parentSensitive, Map<String, String> identity) {
+    if (node.isObject()) {
+      for (Map.Entry<String, JsonNode> field : node.properties()) {
+        String childPath = path.isEmpty() ? field.getKey() : path + "." + field.getKey();
+        JsonNode value = field.getValue();
+        if (isObjectOwnerIdentityField(field.getKey()) && value.isValueNode()
+            && !containsRestorableMarker(value, field.getKey(), parentSensitive)) {
+          identity.put(childPath, stableIdentityValue(value));
+        }
+        collectObjectSecurityIdentity(value, childPath, field.getKey(), parentSensitive, identity);
+      }
+      return;
+    }
+    if (node.isArray()) {
+      for (int i = 0; i < node.size(); i++) {
+        collectObjectSecurityIdentity(node.get(i), path + "[" + i + "]", fieldName, parentSensitive, identity);
+      }
+    }
+  }
+
+  private static boolean isObjectOwnerIdentityField(@Nullable String fieldName) {
+    if (fieldName == null) {
+      return false;
+    }
+    String normalized = normalizeKey(fieldName);
+    return normalized.equals("user") || normalized.equals("username") || normalized.equals("principal")
+        || normalized.equals("accountname")
+        || isExecutableClassSelectorKey(normalized)
+        || normalized.endsWith("clientemail");
+  }
+
+  private static boolean isExecutableClassSelectorKey(String normalizedKey) {
+    return normalizedKey.equals("class") || normalizedKey.endsWith("interceptorclasses")
+        || normalizedKey.endsWith("metricreporters") || normalizedKey.endsWith("partitionassignmentstrategy")
+        || normalizedKey.endsWith("deserializer") || normalizedKey.endsWith("serializer")
+        || normalizedKey.endsWith("partitionerclass") || normalizedKey.endsWith("oauthprovidertype")
+        || normalizedKey.contains("fsazureaccountoauthprovidertype")
+        || normalizedKey.endsWith("securityproviders")
+        || normalizedKey.endsWith("classname")
+        || normalizedKey.endsWith("factoryclass") || normalizedKey.endsWith("providerclass")
+        || normalizedKey.endsWith("decoderclass") || normalizedKey.endsWith("callbackhandlerclass")
+        || normalizedKey.endsWith("loginmoduleclass") || normalizedKey.endsWith("loginclass")
+        || normalizedKey.endsWith("credentialsprovider")
+        || normalizedKey.endsWith("credentialprovider");
+  }
+
+  private static void validateCredentialPairs(ObjectNode submitted, ObjectNode redactedStored) {
+    Map<String, JsonNode> submittedFields = normalizedFields(submitted);
+    Map<String, JsonNode> storedFields = normalizedFields(redactedStored);
+    validateCredentialPair(submittedFields, storedFields,
+        List.of("accesskey", "accesskeyid", "awsaccesskeyid"), List.of("secretkey", "secretaccesskey"));
+    validateCredentialPair(submittedFields, storedFields,
+        List.of("clientid", "applicationid"), List.of("clientsecret"));
+    validateCredentialPair(submittedFields, storedFields,
+        List.of("sharedaccesskeyname", "sharedaccesspolicyname"), List.of("sharedaccesskey"));
+    validateCredentialPair(submittedFields, storedFields,
+        List.of("username", "user", "principal", "accountname"),
+        List.of("passwords", "password", "passwd", "pwd", "passphrases", "passphrase"));
+    for (Map.Entry<String, JsonNode> field : submitted.properties()) {
+      JsonNode storedChild = redactedStored.get(field.getKey());
+      if (field.getValue().isObject() && storedChild != null && storedChild.isObject()) {
+        validateCredentialPairs((ObjectNode) field.getValue(), (ObjectNode) storedChild);
+      }
+    }
+  }
+
+  private static void validateCredentialEndpointBindings(ObjectNode submitted, ObjectNode redactedStored) {
+    Map<String, String> submittedEndpoints = collectEndpointBindings(submitted);
+    Map<String, String> storedEndpoints = collectEndpointBindings(redactedStored);
+    for (Map.Entry<String, JsonNode> field : submitted.properties()) {
+      String normalizedKey = normalizeKey(field.getKey());
+      String credentialSuffix = sensitiveBindingSuffix(normalizedKey);
+      if (credentialSuffix == null || !containsRestorableMarker(field.getValue(), field.getKey(), false)) {
+        continue;
+      }
+      String prefix = normalizedKey.substring(0, normalizedKey.length() - credentialSuffix.length());
+      if (!endpointBindingsForPrefix(submittedEndpoints, prefix)
+          .equals(endpointBindingsForPrefix(storedEndpoints, prefix))) {
+        throw unresolvedMarker();
+      }
+    }
+  }
+
+  private static Map<String, String> collectEndpointBindings(ObjectNode node) {
+    Map<String, String> endpoints = new HashMap<>();
+    for (Map.Entry<String, JsonNode> field : node.properties()) {
+      String normalizedKey = normalizeKey(field.getKey());
+      String endpointSuffix = endpointBindingSuffix(normalizedKey);
+      JsonNode value = field.getValue();
+      if (endpointSuffix != null && value.isValueNode()
+          && !containsRestorableMarker(value, field.getKey(), false)) {
+        String prefix = normalizedKey.substring(0, normalizedKey.length() - endpointSuffix.length());
+        endpoints.put(prefix + ':' + normalizedKey, stableIdentityValue(value));
+      }
+    }
+    return endpoints;
+  }
+
+  private static Map<String, String> endpointBindingsForPrefix(Map<String, String> bindings, String prefix) {
+    Map<String, String> result = new HashMap<>();
+    String mapPrefix = prefix + ':';
+    for (Map.Entry<String, String> binding : bindings.entrySet()) {
+      if (binding.getKey().startsWith(mapPrefix)) {
+        result.put(binding.getKey(), binding.getValue());
+      }
+    }
+    return result;
+  }
+
+  @Nullable
+  private static String endpointBindingSuffix(String normalizedKey) {
+    return matchingSuffix(normalizedKey,
+        List.of("bootstrapservers", "serviceurl", "baseurl", "endpoint", "server", "host", "url", "uri"));
+  }
+
+  @Nullable
+  private static String sensitiveBindingSuffix(String normalizedKey) {
+    return matchingSuffix(normalizedKey, List.of(
+        "secretaccesskey", "sharedaccesskey", "accesskeyid", "accesskey", "secretkey", "privatekey",
+        "accountkey", "storagekey", "clientkey", "hmackey", "encryptionkey", "signingkey", "apikey",
+        "passphrases", "passphrase", "passwords", "password", "credentials", "credential", "secrets",
+        "secret", "tokens", "token", "passwd", "pwd", "signature", "authorization", "authheader", "auth"));
+  }
+
+  private static Map<String, JsonNode> normalizedFields(ObjectNode node) {
+    Map<String, JsonNode> fields = new HashMap<>();
+    for (Map.Entry<String, JsonNode> field : node.properties()) {
+      fields.put(normalizeKey(field.getKey()), field.getValue());
+    }
+    return fields;
+  }
+
+  private static void validateCredentialPair(Map<String, JsonNode> submitted, Map<String, JsonNode> stored,
+      List<String> identityKeys, List<String> secretKeys) {
+    for (Map.Entry<String, JsonNode> secret : submitted.entrySet()) {
+      String secretSuffix = matchingSuffix(secret.getKey(), secretKeys);
+      if (secretSuffix == null || !containsRestorableMarker(secret.getValue(), null, true)) {
+        continue;
+      }
+      String prefix = secret.getKey().substring(0, secret.getKey().length() - secretSuffix.length());
+      JsonNode submittedIdentity = firstFieldWithPrefix(submitted, identityKeys, prefix);
+      JsonNode storedIdentity = firstFieldWithPrefix(stored, identityKeys, prefix);
+      if (!Objects.equals(submittedIdentity, storedIdentity)) {
+        throw unresolvedMarker();
+      }
+    }
+  }
+
+  @Nullable
+  private static JsonNode firstFieldWithPrefix(Map<String, JsonNode> fields, List<String> keys, String prefix) {
+    for (Map.Entry<String, JsonNode> field : fields.entrySet()) {
+      String suffix = matchingSuffix(field.getKey(), keys);
+      if (suffix != null && field.getKey().substring(0, field.getKey().length() - suffix.length()).equals(prefix)) {
+        return field.getValue();
+      }
+    }
+    return null;
+  }
+
+  @Nullable
+  private static String matchingSuffix(String normalizedKey, List<String> suffixes) {
+    for (String suffix : suffixes) {
+      if (normalizedKey.equals(suffix) || normalizedKey.endsWith(suffix)) {
+        return suffix;
+      }
+    }
+    return null;
+  }
+
+  private static String stableIdentityValue(JsonNode node) {
+    if (node.isTextual() && URI_REFERENCE_PATTERN.matcher(node.textValue()).lookingAt()) {
+      return uriIdentity(node.textValue());
+    }
+    return node.toString();
+  }
+
+  private static boolean containsRestorableMarker(JsonNode node, @Nullable String fieldName,
+      boolean parentSensitive) {
+    boolean sensitive = parentSensitive || isSensitiveKey(fieldName);
+    if (node.isObject()) {
+      for (Map.Entry<String, JsonNode> field : node.properties()) {
+        if (containsRestorableMarker(field.getValue(), field.getKey(), sensitive)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    if (node.isArray()) {
+      for (JsonNode element : node) {
+        if (containsRestorableMarker(element, fieldName, sensitive)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    if (!node.isTextual() || isPlaceholder(node.textValue()) || !node.textValue().contains(REDACTION_MARKER)) {
+      return false;
+    }
+    return sensitive || containsCredentialMarker(node.textValue());
+  }
+
+  private static IllegalArgumentException unresolvedMarker() {
+    return new IllegalArgumentException("Redacted credential has no unambiguous unchanged stored value");
+  }
+
+  private static String redactText(@Nullable String fieldName, String value, boolean sensitive) {
+    if (isPlaceholder(value)) {
+      return value;
+    }
+    if (sensitive || isSensitiveKey(fieldName)) {
+      return REDACTION_MARKER;
+    }
+    return redactStructuredCredentials(value);
+  }
+
+  private static boolean isPlaceholder(String value) {
+    if (value.length() < 4 || !value.startsWith("${")) {
+      return false;
+    }
+
+    int keyEnd = value.indexOf(':', 2);
+    if (keyEnd < 0) {
+      keyEnd = value.length() - 1;
+    }
+    if (keyEnd == 2) {
+      return false;
+    }
+    for (int i = 2; i < keyEnd; i++) {
+      char current = value.charAt(i);
+      if (Character.isWhitespace(current) || current == '{' || current == '}') {
+        return false;
+      }
+    }
+    return value.endsWith("}");
+  }
+
+  private static boolean isSensitiveKey(@Nullable String fieldName) {
+    if (fieldName == null) {
+      return false;
+    }
+    String normalized = normalizeKey(fieldName);
+    if (normalized.isEmpty() || normalized.equals("usekeytab")) {
+      return false;
+    }
+    return normalized.endsWith("password") || normalized.endsWith("passwords")
+        || normalized.endsWith("passwd") || normalized.endsWith("pwd")
+        || normalized.endsWith("passphrase") || normalized.endsWith("passphrases")
+        || normalized.endsWith("secret") || normalized.endsWith("secrets")
+        || normalized.endsWith("token") || normalized.endsWith("tokens")
+        || normalized.endsWith("credential") || normalized.endsWith("credentials")
+        || normalized.endsWith("accesskey") || normalized.endsWith("accesskeyid")
+        || normalized.endsWith("apikey") || normalized.endsWith("secretkey")
+        || normalized.endsWith("privatekey") || normalized.endsWith("accountkey")
+        || normalized.endsWith("storagekey") || normalized.endsWith("sharedkey")
+        || normalized.endsWith("masterkey") || normalized.endsWith("clientkey")
+        || normalized.endsWith("hmackey") || normalized.endsWith("encryptionkey")
+        || normalized.endsWith("signingkey") || normalized.endsWith("keytab")
+        || normalized.equals("sig") || normalized.endsWith("signature")
+        || normalized.equals("auth")
+        || normalized.endsWith("authorization") || normalized.endsWith("authheader")
+        || normalized.endsWith("serviceaccountjson") || normalized.endsWith("credentialjson")
+        || normalized.equals("gcpkey") || normalized.equals("jsonkey")
+        || normalized.endsWith("sslkeypem") || normalized.endsWith("sslkeystorekey")
+        || normalized.contains("basicauthuserinfo")
+        || normalized.contains("fsazureaccountkey")
+        || normalized.contains("fsazureaccountoauth2clientsecret")
+        || normalized.contains("fsazuresas");
+  }
+
+  private static boolean isSensitiveQueryKey(String key) {
+    String decoded = decodeQueryKey(key);
+    return decoded == null || isSensitiveQueryKeyLiteral(key)
+        || !decoded.equals(key) && isSensitiveQueryKeyLiteral(decoded);
+  }
+
+  private static boolean isSensitiveQueryKeyLiteral(String key) {
+    String normalized = normalizeKey(key);
+    return isSensitiveKey(key) || normalized.equals("xamzcredential") || normalized.equals("xgoogcredential")
+        || normalized.equals("auth") || normalized.equals("code") || normalized.equals("key")
+        || normalized.equals("assertion") || normalized.equals("clientassertion") || normalized.equals("jwt")
+        || normalized.equals("ticket") || normalized.equals("samlresponse") || normalized.equals("session")
+        || normalized.equals("sessionid") || normalized.equals("sessionkey") || normalized.equals("sid");
+  }
+
+  @Nullable
+  private static String decodeQueryKey(String key) {
+    try {
+      return URLDecoder.decode(key, StandardCharsets.UTF_8);
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  private static String normalizeQueryKey(String key) {
+    String decoded = decodeQueryKey(key);
+    return normalizeKey(decoded != null ? decoded : key);
+  }
+
+  private static String normalizeKey(String key) {
+    return key.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]", "");
+  }
+
+  private static String redactStructuredCredentials(String value) {
+    JsonNode structuredJson = tryParseStructuredJson(value);
+    if (structuredJson != null) {
+      JsonNode redactedJson = redactNode(structuredJson, null, false);
+      return redactedJson.equals(structuredJson) ? value : redactedJson.toString();
+    }
+    List<UriSpan> uriSpans = findUriSpans(value);
+    StringBuilder result = new StringBuilder(value.length());
+    int offset = 0;
+    for (UriSpan span : uriSpans) {
+      result.append(redactCredentialAssignments(value.substring(offset, span._start)));
+      result.append(redactUri(value.substring(span._start, span._end)));
+      offset = span._end;
+    }
+    result.append(redactCredentialAssignments(value.substring(offset)));
+    return result.toString();
+  }
+
+  private static String redactCredentialAssignments(String value) {
+    Matcher matcher = CREDENTIAL_ASSIGNMENT_PATTERN.matcher(value);
+    StringBuffer result = new StringBuffer();
+    while (matcher.find()) {
+      if (!isSensitiveKey(matcher.group(2))) {
+        continue;
+      }
+      String assignmentValue = matcher.group(3);
+      String unquotedValue = unquote(assignmentValue);
+      if (isPlaceholder(unquotedValue)) {
+        continue;
+      }
+      String replacementValue = quoteLike(assignmentValue, REDACTION_MARKER);
+      matcher.appendReplacement(result, Matcher.quoteReplacement(matcher.group(1) + replacementValue));
+    }
+    matcher.appendTail(result);
+    return result.toString();
+  }
+
+  private static boolean containsCredentialMarker(String value) {
+    if (!value.contains(REDACTION_MARKER)) {
+      return false;
+    }
+    JsonNode structuredJson = tryParseStructuredJson(value);
+    if (structuredJson != null) {
+      return containsRestorableMarker(structuredJson, null, false);
+    }
+    List<UriSpan> uriSpans = findUriSpans(value);
+    int offset = 0;
+    for (UriSpan span : uriSpans) {
+      if (assignmentSegmentContainsCredentialMarker(value.substring(offset, span._start))
+          || uriContainsCredentialMarker(value.substring(span._start, span._end))) {
+        return true;
+      }
+      offset = span._end;
+    }
+    return assignmentSegmentContainsCredentialMarker(value.substring(offset));
+  }
+
+  private static boolean assignmentSegmentContainsCredentialMarker(String value) {
+    Matcher matcher = CREDENTIAL_ASSIGNMENT_PATTERN.matcher(value);
+    while (matcher.find()) {
+      String assignmentValue = unquote(matcher.group(3));
+      if (isSensitiveKey(matcher.group(2)) && !isPlaceholder(assignmentValue)
+          && assignmentValue.contains(REDACTION_MARKER)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String restoreStructuredCredentials(String submitted, String stored) {
+    JsonNode submittedJson = tryParseStructuredJson(submitted);
+    JsonNode storedJson = tryParseStructuredJson(stored);
+    if (submittedJson != null || storedJson != null) {
+      if (submittedJson == null || storedJson == null || submittedJson.isObject() != storedJson.isObject()) {
+        throw unresolvedMarker();
+      }
+      return restoreNode(submittedJson, storedJson, null, false).toString();
+    }
+    String redactedStored = redactStructuredCredentials(stored);
+    if (!structuredSecurityIdentity(submitted).equals(structuredSecurityIdentity(redactedStored))) {
+      throw unresolvedMarker();
+    }
+    validateStructuredCredentialPairs(submitted, redactedStored);
+    String restoredUris = restoreUriCredentials(submitted, stored);
+    return restoreCredentialAssignments(restoredUris, stored);
+  }
+
+  private static String structuredSecurityIdentity(String value) {
+    StringBuilder identity = new StringBuilder();
+    Matcher moduleMatcher = JAAS_MODULE_PATTERN.matcher(value);
+    while (moduleMatcher.find()) {
+      identity.append("module:").append(moduleMatcher.group(1)).append(';');
+    }
+    Matcher assignmentMatcher = CREDENTIAL_ASSIGNMENT_PATTERN.matcher(value);
+    while (assignmentMatcher.find()) {
+      String key = assignmentMatcher.group(2);
+      if (!isSecurityIdentityAssignmentKey(key)) {
+        continue;
+      }
+      String assignmentValue = unquote(assignmentMatcher.group(3));
+      identity.append(normalizeKey(key)).append(':').append(securityIdentityValue(assignmentValue)).append(';');
+    }
+    return identity.toString();
+  }
+
+  private static boolean isSecurityIdentityAssignmentKey(String key) {
+    String normalized = normalizeKey(key);
+    return normalized.equals("user") || normalized.equals("username") || normalized.equals("principal")
+        || normalized.equals("accountname") || normalized.endsWith("clientid") || normalized.endsWith("applicationid")
+        || normalized.endsWith("accesskeyid") || normalized.endsWith("sharedaccesskeyname")
+        || normalized.endsWith("sharedaccesspolicyname") || normalized.endsWith("accesskeyname")
+        || normalized.endsWith("endpoint") || normalized.endsWith("host") || normalized.endsWith("server")
+        || normalized.endsWith("url") || normalized.endsWith("uri")
+        || isExecutableClassSelectorKey(normalized);
+  }
+
+  private static void validateStructuredCredentialPairs(String submitted, String redactedStored) {
+    Map<String, List<String>> submittedValues = collectAssignmentValues(submitted);
+    Map<String, List<String>> storedValues = collectAssignmentValues(redactedStored);
+    validateStructuredCredentialPair(submittedValues, storedValues,
+        List.of("username", "user", "principal", "accountname"),
+        List.of("passwords", "password", "passwd", "pwd", "passphrases", "passphrase"));
+  }
+
+  private static Map<String, List<String>> collectAssignmentValues(String value) {
+    Map<String, List<String>> result = new HashMap<>();
+    List<UriSpan> uriSpans = findUriSpans(value);
+    int offset = 0;
+    for (UriSpan span : uriSpans) {
+      collectAllAssignmentValues(value.substring(offset, span._start), result);
+      offset = span._end;
+    }
+    collectAllAssignmentValues(value.substring(offset), result);
+    return result;
+  }
+
+  private static void collectAllAssignmentValues(String segment, Map<String, List<String>> values) {
+    Matcher matcher = CREDENTIAL_ASSIGNMENT_PATTERN.matcher(segment);
+    while (matcher.find()) {
+      values.computeIfAbsent(normalizeKey(matcher.group(2)), ignored -> new ArrayList<>())
+          .add(unquote(matcher.group(3)));
+    }
+  }
+
+  private static void validateStructuredCredentialPair(Map<String, List<String>> submitted,
+      Map<String, List<String>> stored, List<String> identityKeys, List<String> secretKeys) {
+    for (Map.Entry<String, List<String>> secret : submitted.entrySet()) {
+      String secretSuffix = matchingSuffix(secret.getKey(), secretKeys);
+      if (secretSuffix == null || secret.getValue().stream().noneMatch(TableConfigRedactionUtils::markerValue)) {
+        continue;
+      }
+      String prefix = secret.getKey().substring(0, secret.getKey().length() - secretSuffix.length());
+      if (!Objects.equals(uniqueAssignmentIdentity(submitted, identityKeys, prefix),
+          uniqueAssignmentIdentity(stored, identityKeys, prefix))) {
+        throw unresolvedMarker();
+      }
+    }
+  }
+
+  private static boolean markerValue(String value) {
+    return !isPlaceholder(value) && value.contains(REDACTION_MARKER);
+  }
+
+  @Nullable
+  private static String uniqueAssignmentIdentity(Map<String, List<String>> values, List<String> keys,
+      String prefix) {
+    String identity = null;
+    for (Map.Entry<String, List<String>> field : values.entrySet()) {
+      String suffix = matchingSuffix(field.getKey(), keys);
+      if (suffix == null
+          || !field.getKey().substring(0, field.getKey().length() - suffix.length()).equals(prefix)) {
+        continue;
+      }
+      for (String value : field.getValue()) {
+        if (identity != null && !identity.equals(value)) {
+          throw unresolvedMarker();
+        }
+        identity = value;
+      }
+    }
+    return identity;
+  }
+
+  private static String securityIdentityValue(String value) {
+    Matcher uriMatcher = URI_REFERENCE_PATTERN.matcher(value);
+    return uriMatcher.lookingAt() ? uriIdentity(value) : value;
+  }
+
+  private static String restoreUriCredentials(String submitted, String stored) {
+    List<UriSpan> submittedSpans = findUriSpans(submitted);
+    List<UriSpan> storedSpans = findUriSpans(stored);
+    boolean[] usedStoredUris = new boolean[storedSpans.size()];
+    StringBuilder result = new StringBuilder(submitted.length());
+    int offset = 0;
+    for (UriSpan submittedSpan : submittedSpans) {
+      String submittedUri = submitted.substring(submittedSpan._start, submittedSpan._end);
+      result.append(submitted, offset, submittedSpan._start);
+      if (!uriContainsCredentialMarker(submittedUri)) {
+        result.append(submittedUri);
+      } else {
+        int match = findStoredUri(submittedUri, stored, storedSpans, usedStoredUris);
+        if (match < 0) {
+          throw unresolvedMarker();
+        }
+        UriSpan storedSpan = storedSpans.get(match);
+        String storedUri = stored.substring(storedSpan._start, storedSpan._end);
+        result.append(restoreUri(submittedUri, storedUri));
+        usedStoredUris[match] = true;
+      }
+      offset = submittedSpan._end;
+    }
+    result.append(submitted, offset, submitted.length());
+    return result.toString();
+  }
+
+  private static int findStoredUri(String submittedUri, String stored, List<UriSpan> storedSpans,
+      boolean[] usedStoredUris) {
+    String submittedIdentity = uriIdentity(submittedUri);
+    int match = -1;
+    for (int i = 0; i < storedSpans.size(); i++) {
+      if (usedStoredUris[i]) {
+        continue;
+      }
+      UriSpan span = storedSpans.get(i);
+      String candidate = stored.substring(span._start, span._end);
+      if (submittedIdentity.equals(uriIdentity(redactUri(candidate)))) {
+        if (match >= 0) {
+          return -1;
+        }
+        match = i;
+      }
+    }
+    return match;
+  }
+
+  private static String restoreCredentialAssignments(String submitted, String stored) {
+    Map<String, List<String>> storedValues = collectCredentialAssignmentValues(stored);
+    List<UriSpan> uriSpans = findUriSpans(submitted);
+    StringBuilder result = new StringBuilder(submitted.length());
+    int offset = 0;
+    for (UriSpan span : uriSpans) {
+      result.append(restoreCredentialAssignmentsInSegment(submitted.substring(offset, span._start), storedValues));
+      result.append(submitted, span._start, span._end);
+      offset = span._end;
+    }
+    result.append(restoreCredentialAssignmentsInSegment(submitted.substring(offset), storedValues));
+    return result.toString();
+  }
+
+  private static Map<String, List<String>> collectCredentialAssignmentValues(String value) {
+    Map<String, List<String>> result = new HashMap<>();
+    List<UriSpan> uriSpans = findUriSpans(value);
+    int offset = 0;
+    for (UriSpan span : uriSpans) {
+      collectCredentialAssignmentValuesFromSegment(value.substring(offset, span._start), result);
+      offset = span._end;
+    }
+    collectCredentialAssignmentValuesFromSegment(value.substring(offset), result);
+    return result;
+  }
+
+  private static void collectCredentialAssignmentValuesFromSegment(String segment,
+      Map<String, List<String>> values) {
+    Matcher matcher = CREDENTIAL_ASSIGNMENT_PATTERN.matcher(segment);
+    while (matcher.find()) {
+      if (isSensitiveKey(matcher.group(2))) {
+        values.computeIfAbsent(normalizeKey(matcher.group(2)), ignored -> new ArrayList<>()).add(matcher.group(3));
+      }
+    }
+  }
+
+  private static String restoreCredentialAssignmentsInSegment(String segment,
+      Map<String, List<String>> storedValues) {
+    Matcher matcher = CREDENTIAL_ASSIGNMENT_PATTERN.matcher(segment);
+    StringBuffer result = new StringBuffer();
+    while (matcher.find()) {
+      if (!isSensitiveKey(matcher.group(2))) {
+        continue;
+      }
+      String submittedValue = unquote(matcher.group(3));
+      if (isPlaceholder(submittedValue)) {
+        continue;
+      }
+      if (REDACTION_MARKER.equals(submittedValue)) {
+        String storedValue = uniqueStoredValue(storedValues.get(normalizeKey(matcher.group(2))));
+        matcher.appendReplacement(result, Matcher.quoteReplacement(matcher.group(1) + storedValue));
+      } else if (submittedValue.contains(REDACTION_MARKER)) {
+        throw unresolvedMarker();
+      }
+    }
+    matcher.appendTail(result);
+    return result.toString();
+  }
+
+  private static String uniqueStoredValue(@Nullable List<String> storedValues) {
+    if (storedValues == null || storedValues.isEmpty()) {
+      throw unresolvedMarker();
+    }
+    String value = storedValues.get(0);
+    for (int i = 1; i < storedValues.size(); i++) {
+      if (!value.equals(storedValues.get(i))) {
+        throw unresolvedMarker();
+      }
+    }
+    return value;
+  }
+
+  private static String unquote(String value) {
+    if (value.length() >= 2) {
+      char first = value.charAt(0);
+      if ((first == '\'' || first == '"') && value.charAt(value.length() - 1) == first) {
+        return value.substring(1, value.length() - 1);
+      }
+    }
+    return value;
+  }
+
+  private static String quoteLike(String original, String replacement) {
+    if (original.length() >= 2) {
+      char first = original.charAt(0);
+      if ((first == '\'' || first == '"') && original.charAt(original.length() - 1) == first) {
+        return first + replacement + first;
+      }
+    }
+    return replacement;
+  }
+
+  private static List<UriSpan> findUriSpans(String value) {
+    List<UriSpan> spans = new ArrayList<>();
+    Matcher matcher = URI_REFERENCE_PATTERN.matcher(value);
+    int searchFrom = 0;
+    while (searchFrom < value.length() && matcher.find(searchFrom)) {
+      int start = matcher.start();
+      int end = findUriEnd(value, matcher.end());
+      spans.add(new UriSpan(start, end));
+      searchFrom = Math.max(end, matcher.end());
+    }
+    return spans;
+  }
+
+  private static int findUriEnd(String value, int from) {
+    int placeholderDepth = 0;
+    boolean inAuthority = true;
+    for (int i = from; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (startsPlaceholder(value, i)) {
+        placeholderDepth++;
+        continue;
+      }
+      if (placeholderDepth > 0) {
+        if (c == '{' && value.charAt(i - 1) != '$') {
+          placeholderDepth++;
+        } else if (c == '}') {
+          placeholderDepth--;
+        }
+        continue;
+      }
+      if (startsWithUriReference(value, i)) {
+        return i;
+      }
+      if (Character.isWhitespace(c) || ((c == '\'' || c == '"') && !isEscaped(value, i))) {
+        return i;
+      }
+      if (c == '/' || c == '?' || c == '#') {
+        inAuthority = false;
+      }
+      if ((c == ',' || c == ';')
+          && !(inAuthority && hasUserInfoTerminatorAhead(value, i + 1))
+          && (startsWithUriScheme(value, i + 1) || startsWithAssignment(value, i + 1))) {
+        return i;
+      }
+    }
+    return value.length();
+  }
+
+  private static boolean hasUserInfoTerminatorAhead(String value, int from) {
+    int placeholderDepth = 0;
+    for (int i = from; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (startsPlaceholder(value, i)) {
+        placeholderDepth++;
+        continue;
+      }
+      if (placeholderDepth > 0) {
+        if (c == '{' && value.charAt(i - 1) != '$') {
+          placeholderDepth++;
+        } else if (c == '}') {
+          placeholderDepth--;
+        }
+        continue;
+      }
+      if (c == '@') {
+        return true;
+      }
+      if (c == '/' || c == '?' || c == '#' || Character.isWhitespace(c)
+          || (c == '\'' || c == '"') && !isEscaped(value, i)) {
+        return false;
+      }
+    }
+    return false;
+  }
+
+  private static boolean startsWithUriScheme(String value, int from) {
+    int index = from;
+    while (index < value.length() && Character.isWhitespace(value.charAt(index))) {
+      index++;
+    }
+    Matcher matcher = URI_REFERENCE_PATTERN.matcher(value);
+    matcher.region(index, value.length());
+    return matcher.lookingAt();
+  }
+
+  private static boolean startsWithUriReference(String value, int from) {
+    Matcher matcher = URI_REFERENCE_PATTERN.matcher(value);
+    matcher.region(from, value.length());
+    return matcher.lookingAt();
+  }
+
+  private static boolean startsWithAssignment(String value, int from) {
+    int index = from;
+    while (index < value.length() && Character.isWhitespace(value.charAt(index))) {
+      index++;
+    }
+    Matcher matcher = CREDENTIAL_ASSIGNMENT_PATTERN.matcher(value);
+    matcher.region(index, value.length());
+    return matcher.lookingAt();
+  }
+
+  private static boolean startsPlaceholder(String value, int index) {
+    return value.charAt(index) == '$' && index + 1 < value.length() && value.charAt(index + 1) == '{';
+  }
+
+  private static boolean isEscaped(String value, int index) {
+    int slashCount = 0;
+    for (int i = index - 1; i >= 0 && value.charAt(i) == '\\'; i--) {
+      slashCount++;
+    }
+    return slashCount % 2 != 0;
+  }
+
+  private static String redactUri(String uri) {
+    UriParts parts = new UriParts(uri);
+    return parts.rebuild(redactUserInfo(parts._userInfo), redactQuery(parts._query), redactFragment(parts._fragment));
+  }
+
+  private static String restoreUri(String submitted, String stored) {
+    UriParts submittedParts = new UriParts(submitted);
+    UriParts storedParts = new UriParts(stored);
+    String userInfo = restoreUserInfo(submittedParts._userInfo, storedParts._userInfo);
+    String query = restoreQuery(submittedParts._query, storedParts._query);
+    String fragment = restoreFragment(submittedParts._fragment, storedParts._fragment);
+    return submittedParts.rebuild(userInfo, query, fragment);
+  }
+
+  private static String uriIdentity(String uri) {
+    UriParts parts = new UriParts(uri);
+    return parts._prefix + nonCredentialUserInfo(parts._userInfo) + parts._resource
+        + nonCredentialQuery(parts._query) + nonCredentialFragment(parts._fragment);
+  }
+
+  private static String nonCredentialUserInfo(@Nullable String userInfo) {
+    if (userInfo == null) {
+      return "";
+    }
+    List<String> parts = splitOutsidePlaceholders(userInfo, ':');
+    for (int i = 0; i < parts.size(); i++) {
+      String part = parts.get(i);
+      if (!REDACTION_MARKER.equals(part)) {
+        return "userinfo=" + part + "@";
+      }
+    }
+    return "";
+  }
+
+  private static String nonCredentialQuery(@Nullable String query) {
+    if (query == null) {
+      return "";
+    }
+    StringBuilder identity = new StringBuilder();
+    for (String parameter : splitQuery(query)) {
+      int equalsIndex = parameter.indexOf('=');
+      String key = equalsIndex >= 0 ? stripQueryPrefix(parameter.substring(0, equalsIndex)) : parameter;
+      String value = equalsIndex >= 0 ? parameter.substring(equalsIndex + 1) : "";
+      String decodedKey = decodeQueryKey(key);
+      String identityKey = decodedKey != null ? decodedKey : key;
+      String normalizedIdentityKey = normalizeKey(identityKey);
+      if (isSecurityIdentityAssignmentKey(identityKey)
+          && (!isSensitiveQueryKey(key) || normalizedIdentityKey.endsWith("accesskeyid"))
+          && !queryValueContainsCredentialMarker(value)) {
+        identity.append('&').append(normalizedIdentityKey).append('=').append(value);
+      }
+    }
+    return identity.toString();
+  }
+
+  private static boolean uriContainsCredentialMarker(String uri) {
+    UriParts parts = new UriParts(uri);
+    if (parts._userInfo != null) {
+      for (String part : splitOutsidePlaceholders(parts._userInfo, ':')) {
+        if (!isPlaceholder(part) && part.contains(REDACTION_MARKER)) {
+          return true;
+        }
+      }
+    }
+    return queryContainsCredentialMarker(parts._query)
+        || queryContainsCredentialMarker(parameterLikeFragment(parts._fragment));
+  }
+
+  private static String redactFragment(String fragment) {
+    String parameters = parameterLikeFragment(fragment);
+    return parameters != null ? transformQuery(parameters, null) : fragment;
+  }
+
+  private static String restoreFragment(String submitted, String stored) {
+    String submittedParameters = parameterLikeFragment(submitted);
+    if (submittedParameters == null || !queryContainsCredentialMarker(submittedParameters)) {
+      return submitted;
+    }
+    String storedParameters = parameterLikeFragment(stored);
+    return transformQuery(submittedParameters, collectQueryValues(storedParameters));
+  }
+
+  private static String nonCredentialFragment(String fragment) {
+    String parameters = parameterLikeFragment(fragment);
+    return parameters != null ? nonCredentialQuery(parameters) : fragment;
+  }
+
+  @Nullable
+  private static String parameterLikeFragment(String fragment) {
+    return fragment.indexOf('=') >= 0 ? fragment : null;
+  }
+
+  @Nullable
+  private static String redactUserInfo(@Nullable String userInfo) {
+    if (userInfo == null) {
+      return null;
+    }
+    List<String> parts = splitOutsidePlaceholders(userInfo, ':');
+    for (int i = 0; i < parts.size(); i++) {
+      String part = parts.get(i);
+      if (!part.isEmpty() && !isPlaceholder(part)) {
+        parts.set(i, REDACTION_MARKER);
+      }
+    }
+    return String.join(":", parts);
+  }
+
+  @Nullable
+  private static String restoreUserInfo(@Nullable String submitted, @Nullable String stored) {
+    if (submitted == null || !submitted.contains(REDACTION_MARKER)) {
+      return submitted;
+    }
+    if (stored == null) {
+      throw unresolvedMarker();
+    }
+    List<String> submittedParts = splitOutsidePlaceholders(submitted, ':');
+    List<String> storedParts = splitOutsidePlaceholders(stored, ':');
+    if (submittedParts.size() != storedParts.size()) {
+      throw unresolvedMarker();
+    }
+    for (int i = 0; i < submittedParts.size(); i++) {
+      String part = submittedParts.get(i);
+      if (isPlaceholder(part)) {
+        continue;
+      } else if (REDACTION_MARKER.equals(part)) {
+        submittedParts.set(i, storedParts.get(i));
+      } else if (part.contains(REDACTION_MARKER)) {
+        throw unresolvedMarker();
+      }
+    }
+    return String.join(":", submittedParts);
+  }
+
+  @Nullable
+  private static String redactQuery(@Nullable String query) {
+    if (query == null || query.length() <= 1) {
+      return query;
+    }
+    return transformQuery(query, null);
+  }
+
+  @Nullable
+  private static String restoreQuery(@Nullable String submitted, @Nullable String stored) {
+    if (submitted == null || !submitted.contains(REDACTION_MARKER)) {
+      return submitted;
+    }
+    Map<String, List<String>> storedValues = collectQueryValues(stored);
+    return transformQuery(submitted, storedValues);
+  }
+
+  private static String transformQuery(String query, @Nullable Map<String, List<String>> storedValues) {
+    StringBuilder result = new StringBuilder(query.length());
+    int start = 0;
+    int placeholderDepth = 0;
+    for (int i = 0; i <= query.length(); i++) {
+      if (i < query.length()) {
+        char c = query.charAt(i);
+        if (startsPlaceholder(query, i)) {
+          placeholderDepth++;
+          continue;
+        }
+        if (placeholderDepth > 0) {
+          if (c == '{' && query.charAt(i - 1) != '$') {
+            placeholderDepth++;
+          } else if (c == '}') {
+            placeholderDepth--;
+          }
+          continue;
+        }
+        if (c != '&' && c != ';') {
+          continue;
+        }
+      }
+      result.append(transformQueryParameter(query.substring(start, i), storedValues));
+      if (i < query.length()) {
+        result.append(query.charAt(i));
+      }
+      start = i + 1;
+    }
+    return result.toString();
+  }
+
+  private static String transformQueryParameter(String parameter,
+      @Nullable Map<String, List<String>> storedValues) {
+    int equalsIndex = parameter.indexOf('=');
+    if (equalsIndex < 0) {
+      return parameter;
+    }
+    String key = stripQueryPrefix(parameter.substring(0, equalsIndex));
+    String keyPrefix = parameter.substring(0, equalsIndex + 1);
+    String value = parameter.substring(equalsIndex + 1);
+    if (isSensitiveQueryKey(key)) {
+      if (storedValues == null) {
+        return keyPrefix + (isPlaceholder(value) ? value : REDACTION_MARKER);
+      }
+      if (isPlaceholder(value)) {
+        return parameter;
+      }
+      if (REDACTION_MARKER.equals(value)) {
+        return keyPrefix + uniqueStoredValue(storedValues.get(normalizeQueryKey(key)));
+      }
+      if (value.contains(REDACTION_MARKER)) {
+        throw unresolvedMarker();
+      }
+      return parameter;
+    }
+    if (storedValues == null) {
+      return keyPrefix + redactQueryValue(value);
+    }
+    if (queryValueContainsCredentialMarker(value)) {
+      String storedValue = uniqueStoredValue(storedValues.get(normalizeQueryKey(key)));
+      return keyPrefix + restoreQueryValue(value, storedValue);
+    }
+    return parameter;
+  }
+
+  private static String redactQueryValue(String value) {
+    String redacted = redactStructuredCredentials(value);
+    if (!redacted.equals(value)) {
+      return redacted;
+    }
+    String decoded = decodeQueryValue(value);
+    if (decoded == null || decoded.equals(value)) {
+      return value;
+    }
+    String redactedDecoded = redactStructuredCredentials(decoded);
+    return redactedDecoded.equals(decoded) ? value : encodeQueryValue(redactedDecoded);
+  }
+
+  private static String restoreQueryValue(String submitted, String stored) {
+    if (containsCredentialMarker(submitted)) {
+      return restoreStructuredCredentials(submitted, stored);
+    }
+    String decodedSubmitted = decodeQueryValue(submitted);
+    String decodedStored = decodeQueryValue(stored);
+    if (decodedSubmitted == null || decodedStored == null || !containsCredentialMarker(decodedSubmitted)) {
+      throw unresolvedMarker();
+    }
+    return encodeQueryValue(restoreStructuredCredentials(decodedSubmitted, decodedStored));
+  }
+
+  private static boolean queryValueContainsCredentialMarker(String value) {
+    if (isPlaceholder(value)) {
+      return false;
+    }
+    if (containsCredentialMarker(value)) {
+      return true;
+    }
+    String decoded = decodeQueryValue(value);
+    return decoded != null && !decoded.equals(value) && containsCredentialMarker(decoded);
+  }
+
+  @Nullable
+  private static String decodeQueryValue(String value) {
+    try {
+      return URLDecoder.decode(value, StandardCharsets.UTF_8);
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  private static String encodeQueryValue(String value) {
+    String encodedMarker = URLEncoder.encode(REDACTION_MARKER, StandardCharsets.UTF_8);
+    return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20")
+        .replace(encodedMarker, REDACTION_MARKER);
+  }
+
+  private static String stripQueryPrefix(String key) {
+    return key.startsWith("?") ? key.substring(1) : key;
+  }
+
+  private static Map<String, List<String>> collectQueryValues(@Nullable String query) {
+    Map<String, List<String>> result = new HashMap<>();
+    if (query == null) {
+      return result;
+    }
+    for (String parameter : splitQuery(query)) {
+      int equalsIndex = parameter.indexOf('=');
+      if (equalsIndex < 0) {
+        continue;
+      }
+      String key = stripQueryPrefix(parameter.substring(0, equalsIndex));
+      result.computeIfAbsent(normalizeQueryKey(key), ignored -> new ArrayList<>())
+          .add(parameter.substring(equalsIndex + 1));
+    }
+    return result;
+  }
+
+  private static boolean queryContainsCredentialMarker(@Nullable String query) {
+    if (query == null || !query.contains(REDACTION_MARKER)) {
+      return false;
+    }
+    for (String parameter : splitQuery(query)) {
+      int equalsIndex = parameter.indexOf('=');
+      if (equalsIndex < 0) {
+        continue;
+      }
+      String key = stripQueryPrefix(parameter.substring(0, equalsIndex));
+      String value = parameter.substring(equalsIndex + 1);
+      if ((isSensitiveQueryKey(key) && !isPlaceholder(value) && value.contains(REDACTION_MARKER))
+          || !isSensitiveQueryKey(key) && queryValueContainsCredentialMarker(value)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static List<String> splitQuery(String query) {
+    List<String> result = new ArrayList<>();
+    int start = 0;
+    int placeholderDepth = 0;
+    for (int i = 0; i <= query.length(); i++) {
+      if (i < query.length()) {
+        char c = query.charAt(i);
+        if (startsPlaceholder(query, i)) {
+          placeholderDepth++;
+          continue;
+        }
+        if (placeholderDepth > 0) {
+          if (c == '{' && query.charAt(i - 1) != '$') {
+            placeholderDepth++;
+          } else if (c == '}') {
+            placeholderDepth--;
+          }
+          continue;
+        }
+        if (c != '&' && c != ';') {
+          continue;
+        }
+      }
+      result.add(query.substring(start, i));
+      start = i + 1;
+    }
+    return result;
+  }
+
+  private static List<String> splitOutsidePlaceholders(String value, char delimiter) {
+    List<String> result = new ArrayList<>();
+    int start = 0;
+    int placeholderDepth = 0;
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (startsPlaceholder(value, i)) {
+        placeholderDepth++;
+        continue;
+      }
+      if (placeholderDepth > 0) {
+        if (c == '{' && value.charAt(i - 1) != '$') {
+          placeholderDepth++;
+        } else if (c == '}') {
+          placeholderDepth--;
+        }
+      } else if (c == delimiter) {
+        result.add(value.substring(start, i));
+        start = i + 1;
+      }
+    }
+    result.add(value.substring(start));
+    return result;
+  }
+
+  private static int findOutsidePlaceholder(String value, char target, int from, int to) {
+    int placeholderDepth = 0;
+    for (int i = from; i < to; i++) {
+      char c = value.charAt(i);
+      if (startsPlaceholder(value, i)) {
+        placeholderDepth++;
+        continue;
+      }
+      if (placeholderDepth > 0) {
+        if (c == '{' && value.charAt(i - 1) != '$') {
+          placeholderDepth++;
+        } else if (c == '}') {
+          placeholderDepth--;
+        }
+      } else if (c == target) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  private static int findLastOutsidePlaceholder(String value, char target, int from, int to) {
+    int result = -1;
+    int placeholderDepth = 0;
+    for (int i = from; i < to; i++) {
+      char c = value.charAt(i);
+      if (startsPlaceholder(value, i)) {
+        placeholderDepth++;
+        continue;
+      }
+      if (placeholderDepth > 0) {
+        if (c == '{' && value.charAt(i - 1) != '$') {
+          placeholderDepth++;
+        } else if (c == '}') {
+          placeholderDepth--;
+        }
+      } else if (c == target) {
+        result = i;
+      }
+    }
+    return result;
+  }
+
+  @Nullable
+  private static JsonNode tryParseStructuredJson(String value) {
+    String trimmed = value.trim();
+    if (trimmed.length() < 2
+        || !(trimmed.startsWith("{") && trimmed.endsWith("}")
+        || trimmed.startsWith("[") && trimmed.endsWith("]"))) {
+      return null;
+    }
+    try {
+      JsonNode node = JsonUtils.stringToJsonNode(trimmed);
+      return node != null && (node.isObject() || node.isArray()) ? node : null;
+    } catch (IOException e) {
+      return null;
+    }
+  }
+
+  private static TableConfig toTableConfig(JsonNode node, String errorMessage) {
+    try {
+      return JsonUtils.jsonNodeToObject(node, TableConfig.class);
+    } catch (IOException | RuntimeException e) {
+      throw new IllegalArgumentException(errorMessage, e);
+    }
+  }
+
+  private static final class UriSpan {
+    private final int _start;
+    private final int _end;
+
+    private UriSpan(int start, int end) {
+      _start = start;
+      _end = end;
+    }
+  }
+
+  private static final class UriParts {
+    private final String _prefix;
+    private final String _resource;
+    private final String _fragment;
+    @Nullable
+    private final String _userInfo;
+    @Nullable
+    private final String _query;
+
+    private UriParts(String uri) {
+      int schemeEnd = uri.indexOf("://") + 3;
+      int queryStart = findOutsidePlaceholder(uri, '?', schemeEnd, uri.length());
+      int fragmentStart = findOutsidePlaceholder(uri, '#', schemeEnd, uri.length());
+      if (queryStart >= 0 && fragmentStart >= 0 && queryStart > fragmentStart) {
+        queryStart = -1;
+      }
+      int resourceEnd = uri.length();
+      if (queryStart >= 0) {
+        resourceEnd = queryStart;
+      }
+      if (fragmentStart >= 0 && fragmentStart < resourceEnd) {
+        resourceEnd = fragmentStart;
+      }
+      int authorityEnd = findOutsidePlaceholder(uri, '/', schemeEnd, resourceEnd);
+      if (authorityEnd < 0) {
+        authorityEnd = resourceEnd;
+      }
+      int userInfoEnd = findLastOutsidePlaceholder(uri, '@', schemeEnd, authorityEnd);
+      int resourceStart = userInfoEnd >= 0 ? userInfoEnd + 1 : schemeEnd;
+
+      _prefix = uri.substring(0, schemeEnd);
+      _userInfo = userInfoEnd >= 0 ? uri.substring(schemeEnd, userInfoEnd) : null;
+      _resource = uri.substring(resourceStart, resourceEnd);
+      int queryEnd = fragmentStart >= 0 ? fragmentStart : uri.length();
+      _query = queryStart >= 0 ? uri.substring(queryStart, queryEnd) : null;
+      _fragment = fragmentStart >= 0 ? uri.substring(fragmentStart) : "";
+    }
+
+    private String rebuild(@Nullable String userInfo, @Nullable String query, String fragment) {
+      return _prefix + (userInfo != null ? userInfo + "@" : "") + _resource
+          + (query != null ? query : "") + fragment;
+    }
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/user/UserConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/user/UserConfig.java
@@ -38,6 +38,7 @@ public class UserConfig extends BaseJsonConfig {
   public static final String TABLES_KEY = "tables";
   public static final String EXCLUDE_TABLES_KEY = "excludeTables";
   public static final String PERMISSIONS_KEY = "permissions";
+  public static final String FINE_GRAINED_PERMISSIONS_KEY = "fineGrainedPermissions";
 
   @JsonPropertyDescription("The name of User")
   private String _username;
@@ -60,7 +61,9 @@ public class UserConfig extends BaseJsonConfig {
   @JsonPropertyDescription("The table permission of User")
   private List<AccessType> _permissions;
 
-  @JsonCreator
+  @JsonPropertyDescription("The fine-grained permission of User")
+  private List<String> _fineGrainedPermissions;
+
   public UserConfig(@JsonProperty(value = USERNAME_KEY, required = true) String username,
       @JsonProperty(value = PASSWORD_KEY, required = true) String password,
       @JsonProperty(value = COMPONET_KEY, required = true) String component,
@@ -68,6 +71,18 @@ public class UserConfig extends BaseJsonConfig {
       @JsonProperty(value = TABLES_KEY) @Nullable List<String> tableList,
       @JsonProperty(value = EXCLUDE_TABLES_KEY) @Nullable List<String> excludeTableList,
       @JsonProperty(value = PERMISSIONS_KEY) @Nullable List<AccessType> permissionList) {
+    this(username, password, component, role, tableList, excludeTableList, permissionList, null);
+  }
+
+  @JsonCreator
+  public UserConfig(@JsonProperty(value = USERNAME_KEY, required = true) String username,
+      @JsonProperty(value = PASSWORD_KEY, required = true) String password,
+      @JsonProperty(value = COMPONET_KEY, required = true) String component,
+      @JsonProperty(value = ROLE_KEY, required = true) String role,
+      @JsonProperty(value = TABLES_KEY) @Nullable List<String> tableList,
+      @JsonProperty(value = EXCLUDE_TABLES_KEY) @Nullable List<String> excludeTableList,
+      @JsonProperty(value = PERMISSIONS_KEY) @Nullable List<AccessType> permissionList,
+      @JsonProperty(value = FINE_GRAINED_PERMISSIONS_KEY) @Nullable List<String> fineGrainedPermissionList) {
     Preconditions.checkArgument(username != null, "'username' must be configured");
     Preconditions.checkArgument(password != null, "'password' must be configured");
 
@@ -79,6 +94,7 @@ public class UserConfig extends BaseJsonConfig {
     _tables = tableList;
     _excludeTables = excludeTableList;
     _permissions = permissionList;
+    _fineGrainedPermissions = fineGrainedPermissionList;
   }
 
   @JsonProperty(USERNAME_KEY)
@@ -113,6 +129,12 @@ public class UserConfig extends BaseJsonConfig {
   @JsonProperty(PERMISSIONS_KEY)
   public List<AccessType> getPermissions() {
     return _permissions;
+  }
+
+  @JsonProperty(FINE_GRAINED_PERMISSIONS_KEY)
+  @Nullable
+  public List<String> getFineGrainedPermissions() {
+    return _fineGrainedPermissions;
   }
 
   /// @deprecated Use [#getPermissions()] instead. This method has a typo in its name.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/Obfuscator.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/Obfuscator.java
@@ -21,12 +21,14 @@ package org.apache.pinot.spi.utils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import java.io.IOException;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.apache.pinot.spi.config.table.TableConfigRedactionUtils;
 
 
 /// Simple obfuscator for object trees and configuration containers with key-value pairs. Matches a configurable set of
@@ -66,11 +68,15 @@ public final class Obfuscator {
 
   private final String _maskedValue;
   private final List<Pattern> _patterns;
+  private final boolean _useDefaultCredentialPolicy;
 
-  /// Obfuscator with default behavior matching (ignore case) "secret", "password", and "token" suffixes. Masks any
-  /// values with '\*\*\*\*\*'
+  /// Obfuscator using the shared credential policy. It masks sensitive property names and credential-shaped content
+  /// in textual values, including assignments and URI user-info or query parameters, while preserving whole unresolved
+  /// placeholders. Masked values use '\*\*\*\*\*'.
   public Obfuscator() {
-    this(DEFAULT_MASKED_VALUE, DEFAULT_PATTERNS);
+    _maskedValue = DEFAULT_MASKED_VALUE;
+    _patterns = DEFAULT_PATTERNS;
+    _useDefaultCredentialPolicy = true;
   }
 
   /// Obfuscator with customized masking behavior. Defaults do not apply! Please ensure case-insensitive regex matching.
@@ -80,6 +86,7 @@ public final class Obfuscator {
   public Obfuscator(String maskedValue, List<Pattern> patterns) {
     _maskedValue = maskedValue;
     _patterns = patterns;
+    _useDefaultCredentialPolicy = false;
   }
 
   /// Serialize an object tree to JSON and obfuscate matching keys. This method handles special cases for JsonNode and
@@ -119,14 +126,21 @@ public final class Obfuscator {
   private JsonNode toJsonRecursive(JsonNode node) {
     if (node.isObject()) {
       node.fieldNames().forEachRemaining(field -> {
-        if (_patterns.stream().anyMatch(pattern -> pattern.matcher(field).matches())) {
+        JsonNode fieldValue = node.get(field);
+        boolean preservePlaceholder = _useDefaultCredentialPolicy && fieldValue.isTextual()
+            && TableConfigRedactionUtils.isUnresolvedPlaceholder(fieldValue.textValue());
+        boolean sensitive = _patterns.stream().anyMatch(pattern -> pattern.matcher(field).matches())
+            || (_useDefaultCredentialPolicy && TableConfigRedactionUtils.isSensitivePropertyName(field));
+        if (sensitive && !preservePlaceholder) {
           ((ObjectNode) node).put(field, _maskedValue);
         } else {
-          ((ObjectNode) node).set(field, toJsonRecursive(node.get(field)));
+          ((ObjectNode) node).set(field, toJsonRecursive(fieldValue));
         }
       });
     } else if (node.isArray()) {
       IntStream.range(0, node.size()).forEach(i -> ((ArrayNode) node).set(i, toJsonRecursive(node.get(i))));
+    } else if (_useDefaultCredentialPolicy && node.isTextual()) {
+      return TextNode.valueOf(TableConfigRedactionUtils.redactStructuredText(node.textValue()));
     }
 
     return node;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/UserConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/UserConfigBuilder.java
@@ -33,6 +33,7 @@ public class UserConfigBuilder {
   private List<String> _tableList;
   private List<String> _excludeTableList;
   private List<AccessType> _permissionList;
+  private List<String> _fineGrainedPermissionList;
 
   public UserConfigBuilder setComponentType(ComponentType componentType) {
     _componentType = componentType;
@@ -69,8 +70,13 @@ public class UserConfigBuilder {
     return this;
   }
 
+  public UserConfigBuilder setFineGrainedPermissionList(List<String> fineGrainedPermissionList) {
+    _fineGrainedPermissionList = fineGrainedPermissionList;
+    return this;
+  }
+
   public UserConfig build() {
     return new UserConfig(_username, _password, _componentType.toString(), _roleType.toString(), _tableList,
-        _excludeTableList, _permissionList);
+        _excludeTableList, _permissionList, _fineGrainedPermissionList);
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/ConfigUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/ConfigUtilsTest.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.spi.config;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -27,14 +30,30 @@ import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 
 public class ConfigUtilsTest {
+
+  @Test
+  public void testConversionFailureDoesNotIncludeResolvedConfigValues() {
+    String rejectedSecret = "resolved-secret-sentinel";
+    RuntimeException error = expectThrows(RuntimeException.class,
+        () -> ConfigUtils.applyConfigWithEnvVariablesAndSystemProperties(
+            Map.of("INVALID_NUMBER", rejectedSecret), new MalformedConfig()));
+    StringWriter stack = new StringWriter();
+    error.printStackTrace(new PrintWriter(stack));
+
+    assertNull(error.getCause());
+    assertFalse(stack.toString().contains(rejectedSecret), stack.toString());
+  }
 
   @Test
   public void testIndexing() {
@@ -42,6 +61,24 @@ public class ConfigUtilsTest {
         Map.of("LOAD_MODE", "MMAP", "AWS_ACCESS_KEY", "default_aws_access_key", "AWS_SECRET_KEY",
             "default_aws_secret_key");
     testIndexingWithConfig(environment);
+  }
+
+  private static final class MalformedConfig extends BaseJsonConfig {
+    private int _number;
+
+    @Override
+    public JsonNode toJsonNode() {
+      return JsonUtils.newObjectNode()
+          .put("number", "$" + "{INVALID_NUMBER}");
+    }
+
+    public int getNumber() {
+      return _number;
+    }
+
+    public void setNumber(int number) {
+      _number = number;
+    }
   }
 
   @Test

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/TableConfigRedactionUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/TableConfigRedactionUtilsTest.java
@@ -1,0 +1,896 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.table;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+
+public class TableConfigRedactionUtilsTest {
+  private static final String MARKER = TableConfigRedactionUtils.REDACTION_MARKER;
+  private static final String STREAM_PASSWORD_KEY = "stream.kafka.consumer.prop.ssl.keystore.password";
+  private static final String STREAM_PLACEHOLDER_KEY = "stream.kafka.consumer.prop.ssl.truststore.password";
+  private static final String JAAS_KEY = "stream.kafka.consumer.prop.sasl.jaas.config";
+  private static final String URI_KEY = "stream.kafka.schema.registry.url";
+  private static final String CLIENT_ID_KEY = "client.id";
+  private static final String PLACEHOLDER = "${STREAM_TRUSTSTORE_PASSWORD}";
+  private static final String URI = "https://uri-user:uri-password@registry.example.test/schemas"
+      + "?access_token=uri-token&X-Amz-Signature=uri-signature&region=us-west-2";
+  private static final String PLACEHOLDER_URI =
+      "https://${URI_USER:default-user}:${URI_PASSWORD:default-pass}@registry.example.test/schemas"
+          + "?token=${URI_TOKEN:default-token}&region=us-west-2";
+
+  private static final List<String> LITERAL_SECRETS = List.of(
+      "stream-password", "jaas-password", "stream-access-key", "decoder-api-key", "uri-user", "uri-password",
+      "uri-token", "uri-signature", "batch-access-key", "batch-secret-key", "batch-credential",
+      "reader-password", "tier-account-key", "connection-account-key", "custom-password", "task-auth-token",
+      "task-secret-key", "schema-user", "schema-password", "dynamic-azure-key", "first-user", "first-pass",
+      "second-user", "second-pass", "first-query", "second-query", "endpoint-account-key");
+
+  @Test
+  public void testRedactsCredentialsAcrossTableConfigSurfaces() {
+    TableConfig stored = tableConfigWithCredentials();
+
+    TableConfig redacted = TableConfigRedactionUtils.redact(stored);
+    String redactedJson = redacted.toJsonString();
+
+    for (String secret : LITERAL_SECRETS) {
+      assertFalse(redactedJson.contains(secret), "Literal credential was not redacted: " + secret);
+    }
+    Map<String, String> stream = redacted.getIndexingConfig().getStreamConfigs();
+    assertEquals(stream.get(STREAM_PASSWORD_KEY), MARKER);
+    assertEquals(stream.get(STREAM_PLACEHOLDER_KEY), PLACEHOLDER);
+    assertEquals(stream.get("stream.kafka.topic.name"), "events-topic");
+    assertEquals(stream.get("stream.kafka.decoder.class.name"), "example.Decoder");
+    assertEquals(stream.get("stream.kinesis.credentialsProvider"), "example.CredentialsProvider");
+
+    String jaas = stream.get(JAAS_KEY);
+    assertTrue(jaas.contains("username=\"jaas-user\""), jaas);
+    assertTrue(jaas.contains("password=\"" + MARKER + "\""), jaas);
+    assertTrue(jaas.contains("token=\"${JAAS_TOKEN}\""), jaas);
+    assertTrue(jaas.contains("useKeyTab=true"), jaas);
+
+    String uri = stream.get(URI_KEY);
+    assertTrue(uri.contains("https://" + MARKER + ":" + MARKER + "@registry.example.test/schemas"), uri);
+    assertTrue(uri.contains("access_token=" + MARKER), uri);
+    assertTrue(uri.contains("X-Amz-Signature=" + MARKER), uri);
+    assertTrue(uri.contains("region=us-west-2"), uri);
+    assertEquals(stream.get("stream.kafka.placeholder.uri"), PLACEHOLDER_URI);
+    assertEquals(stream.get("stream.kafka.decoder.prop.schema.registry.basic.auth.user.info"), MARKER);
+    String uriList = stream.get("stream.kafka.credential.urls");
+    assertTrue(uriList.contains("https://" + MARKER + ":" + MARKER + "@one.example.test"), uriList);
+    assertTrue(uriList.contains("https://" + MARKER + ":" + MARKER + "@two.example.test"), uriList);
+    assertTrue(uriList.contains("password=" + MARKER + "&region=west"), uriList);
+    assertTrue(uriList.contains("token=" + MARKER + "&region=east"), uriList);
+    String unquotedJaas = stream.get("stream.kafka.other.jaas.config");
+    assertFalse(unquotedJaas.contains("p@ss"), unquotedJaas);
+    assertFalse(unquotedJaas.contains("&word"), unquotedJaas);
+
+    Map<String, String> batch = redacted.getIngestionConfig().getBatchIngestionConfig().getBatchConfigMaps().get(0);
+    assertEquals(batch.get("input.fs.prop.accessKey"), MARKER);
+    assertEquals(batch.get("input.fs.prop.secretKey"), MARKER);
+    assertEquals(batch.get("recordReader.prop.password"), MARKER);
+    assertEquals(batch.get("recordReader.className"), "example.Reader");
+    assertTrue(batch.get("input.dir.uri").contains("X-Amz-Credential=" + MARKER));
+    assertEquals(batch.get("input.fs.prop.fs.azure.account.key.account.dfs.core.windows.net"), MARKER);
+
+    Map<String, String> tier = redacted.getTierConfigsList().get(0).getTierBackendProperties();
+    assertEquals(tier.get("azure.storage.accountKey"), MARKER);
+    assertEquals(tier.get("endpoint"), "https://storage.example.test/container?region=west");
+    assertEquals(tier.get("connection.string"),
+        "DefaultEndpointsProtocol=https;AccountName=storage-user;AccountKey=" + MARKER + ";EndpointSuffix=core.test");
+    assertEquals(tier.get("uri.connection.string"),
+        "Endpoint=https://storage.example.test/container;AccountKey=" + MARKER + ";Region=west");
+    assertEquals(redacted.getCustomConfig().getCustomConfigs().get("provider.custom.password"), MARKER);
+    assertEquals(redacted.getCustomConfig().getCustomConfigs().get("placeholder.secretKey"),
+        "${CUSTOM_SECRET_KEY:default-key}");
+    assertEquals(redacted.getCustomConfig().getCustomConfigs().get("serviceAccountJson"),
+        "${SERVICE_ACCOUNT_JSON:{\"type\":\"service_account\",\"message\":\"use } literally\"}}");
+    assertEquals(redacted.getTaskConfig().getConfigsForTaskType("SegmentGenerationAndPushTask").get("authToken"),
+        MARKER);
+
+    assertEquals(stored.getIndexingConfig().getStreamConfigs().get(STREAM_PASSWORD_KEY), "stream-password");
+    assertEquals(stored.getIndexingConfig().getStreamConfigs().get(URI_KEY), URI);
+    assertNotSame(redacted, stored);
+    assertNotSame(redacted.getIndexingConfig().getStreamConfigs(), stored.getIndexingConfig().getStreamConfigs());
+  }
+
+  @Test
+  public void testRestoreRetainsCredentialsAndAppliesNonSensitiveEdit() {
+    TableConfig stored = tableConfigWithCredentials();
+    TableConfig submitted = TableConfigRedactionUtils.redact(stored);
+    submitted.getCustomConfig().getCustomConfigs().put(CLIENT_ID_KEY, "edited-client");
+
+    TableConfig restored = TableConfigRedactionUtils.restoreRedactedValues(submitted, stored);
+
+    assertEquals(restored.getIndexingConfig().getStreamConfigs().get(STREAM_PASSWORD_KEY), "stream-password");
+    assertEquals(restored.getIndexingConfig().getStreamConfigs().get(JAAS_KEY),
+        stored.getIndexingConfig().getStreamConfigs().get(JAAS_KEY));
+    assertEquals(restored.getIndexingConfig().getStreamConfigs().get(URI_KEY), URI);
+    assertEquals(restored.getIngestionConfig().getBatchIngestionConfig().getBatchConfigMaps().get(0)
+        .get("input.fs.prop.secretKey"), "batch-secret-key");
+    assertEquals(restored.getCustomConfig().getCustomConfigs().get(CLIENT_ID_KEY), "edited-client");
+    assertEquals(stored.getCustomConfig().getCustomConfigs().get(CLIENT_ID_KEY), "original-client");
+    assertNotSame(restored, submitted);
+    assertNotSame(restored.getCustomConfig().getCustomConfigs(), submitted.getCustomConfig().getCustomConfigs());
+  }
+
+  @Test
+  public void testRestoreUnchangedDuplicateArrayElementsByPosition() {
+    Map<String, String> first = new LinkedHashMap<>();
+    first.put("streamType", "kafka");
+    first.put("stream.kafka.topic.name", "same-topic");
+    first.put("password", "first-password");
+    Map<String, String> second = new LinkedHashMap<>();
+    second.put("streamType", "kafka");
+    second.put("stream.kafka.topic.name", "same-topic");
+    second.put("password", "second-password");
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setStreamIngestionConfig(new StreamIngestionConfig(List.of(first, second)));
+    TableConfig stored = new TableConfigBuilder(TableType.REALTIME)
+        .setTableName("duplicateStreams_REALTIME")
+        .setIngestionConfig(ingestionConfig)
+        .build();
+
+    TableConfig restored = TableConfigRedactionUtils.restoreRedactedValues(
+        TableConfigRedactionUtils.redact(stored), stored);
+
+    List<Map<String, String>> streams = restored.getIngestionConfig().getStreamIngestionConfig().getStreamConfigMaps();
+    assertEquals(streams.get(0).get("password"), "first-password");
+    assertEquals(streams.get(1).get("password"), "second-password");
+  }
+
+  @Test
+  public void testRestoreAcceptsIntentionalLiteralCredentialReplacement() {
+    TableConfig stored = tableConfigWithCredentials();
+    TableConfig submitted = TableConfigRedactionUtils.redact(stored);
+    submitted.getIndexingConfig().getStreamConfigs().put(STREAM_PASSWORD_KEY, "replacement-password");
+
+    TableConfig restored = TableConfigRedactionUtils.restoreRedactedValues(submitted, stored);
+
+    assertEquals(restored.getIndexingConfig().getStreamConfigs().get(STREAM_PASSWORD_KEY), "replacement-password");
+    assertEquals(stored.getIndexingConfig().getStreamConfigs().get(STREAM_PASSWORD_KEY), "stream-password");
+  }
+
+  @Test
+  public void testRestoreRejectsMarkersThatCannotBeSafelyMerged() {
+    TableConfig stored = tableConfigWithCredentials();
+    TableConfig editedUri = TableConfigRedactionUtils.redact(stored);
+    editedUri.getIndexingConfig().getStreamConfigs().compute(URI_KEY,
+        (key, value) -> value.replace("registry.example.test", "other.example.test"));
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(editedUri, stored));
+
+    TableConfig missingStoredCredential = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("missingStored_OFFLINE")
+        .setCustomConfig(new TableCustomConfig(new HashMap<>(Map.of("new.password", MARKER))))
+        .build();
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(missingStoredCredential, null));
+  }
+
+  @Test
+  public void testRestoreStructuredCredentialsWhileApplyingBenignEdits() {
+    TableConfig stored = tableConfigWithCredentials();
+    TableConfig submitted = TableConfigRedactionUtils.redact(stored);
+    Map<String, String> stream = submitted.getIndexingConfig().getStreamConfigs();
+    stream.compute(URI_KEY, (key, value) -> value.replace("region=us-west-2", "region=us-east-1"));
+    stream.compute(JAAS_KEY, (key, value) -> value.replace("useKeyTab=true", "useKeyTab=false"));
+    submitted.getTierConfigsList().get(0).getTierBackendProperties().compute("connection.string",
+        (key, value) -> value.replace("EndpointSuffix=core.test", "EndpointSuffix=edited.test"));
+
+    TableConfig restored = TableConfigRedactionUtils.restoreRedactedValues(submitted, stored);
+
+    String uri = restored.getIndexingConfig().getStreamConfigs().get(URI_KEY);
+    assertTrue(uri.contains("uri-user:uri-password"), uri);
+    assertTrue(uri.contains("access_token=uri-token"), uri);
+    assertTrue(uri.contains("region=us-east-1"), uri);
+    String jaas = restored.getIndexingConfig().getStreamConfigs().get(JAAS_KEY);
+    assertTrue(jaas.contains("password=\"jaas-password\""), jaas);
+    assertTrue(jaas.contains("useKeyTab=false"), jaas);
+    String connection = restored.getTierConfigsList().get(0).getTierBackendProperties().get("connection.string");
+    assertTrue(connection.contains("AccountKey=connection-account-key"), connection);
+    assertTrue(connection.contains("EndpointSuffix=edited.test"), connection);
+  }
+
+  @Test
+  public void testRestoreMatchesReorderedArrayElementsWithoutMovingCredentials() {
+    Map<String, String> first = new LinkedHashMap<>();
+    first.put("streamType", "kafka");
+    first.put("stream.kafka.topic.name", "first-topic");
+    first.put("stream.kafka.consumer.prop.password", "first-password");
+    Map<String, String> second = new LinkedHashMap<>();
+    second.put("streamType", "kafka");
+    second.put("stream.kafka.topic.name", "second-topic");
+    second.put("stream.kafka.consumer.prop.password", "second-password");
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setStreamIngestionConfig(new StreamIngestionConfig(List.of(first, second)));
+    TableConfig stored = new TableConfigBuilder(TableType.REALTIME)
+        .setTableName("twoStreams_REALTIME")
+        .setIngestionConfig(ingestionConfig)
+        .build();
+    TableConfig submitted = TableConfigRedactionUtils.redact(stored);
+    List<Map<String, String>> submittedStreams = submitted.getIngestionConfig().getStreamIngestionConfig()
+        .getStreamConfigMaps();
+    Map<String, String> firstSubmitted = submittedStreams.remove(0);
+    submittedStreams.add(firstSubmitted);
+
+    TableConfig restored = TableConfigRedactionUtils.restoreRedactedValues(submitted, stored);
+
+    List<Map<String, String>> restoredStreams = restored.getIngestionConfig().getStreamIngestionConfig()
+        .getStreamConfigMaps();
+    assertEquals(restoredStreams.get(0).get("stream.kafka.topic.name"), "second-topic");
+    assertEquals(restoredStreams.get(0).get("stream.kafka.consumer.prop.password"), "second-password");
+    assertEquals(restoredStreams.get(1).get("stream.kafka.topic.name"), "first-topic");
+    assertEquals(restoredStreams.get(1).get("stream.kafka.consumer.prop.password"), "first-password");
+
+    TableConfig editedAndReordered = TableConfigRedactionUtils.redact(stored);
+    List<Map<String, String>> editedStreams = editedAndReordered.getIngestionConfig().getStreamIngestionConfig()
+        .getStreamConfigMaps();
+    Map<String, String> editedFirst = editedStreams.remove(0);
+    editedStreams.add(editedFirst);
+    editedStreams.get(0).put("stream.kafka.topic.name", "edited-second-topic");
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(editedAndReordered, stored));
+  }
+
+  @Test
+  public void testRestoreDoesNotUsePositionForDuplicateArrayIdentities() {
+    Map<String, String> first = new LinkedHashMap<>();
+    first.put("streamType", "kafka");
+    first.put("stream.kafka.topic.name", "shared-topic");
+    first.put("plugin.tenant", "first-tenant");
+    first.put("password", "first-password");
+    Map<String, String> second = new LinkedHashMap<>();
+    second.put("streamType", "kafka");
+    second.put("stream.kafka.topic.name", "shared-topic");
+    second.put("plugin.tenant", "second-tenant");
+    second.put("password", "second-password");
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setStreamIngestionConfig(new StreamIngestionConfig(List.of(first, second)));
+    TableConfig stored = new TableConfigBuilder(TableType.REALTIME)
+        .setTableName("duplicateIdentity_REALTIME")
+        .setIngestionConfig(ingestionConfig)
+        .build();
+    TableConfig submitted = TableConfigRedactionUtils.redact(stored);
+    List<Map<String, String>> streams = submitted.getIngestionConfig().getStreamIngestionConfig()
+        .getStreamConfigMaps();
+    streams.add(streams.remove(0));
+
+    TableConfig restored = TableConfigRedactionUtils.restoreRedactedValues(submitted, stored);
+
+    List<Map<String, String>> restoredStreams = restored.getIngestionConfig().getStreamIngestionConfig()
+        .getStreamConfigMaps();
+    assertEquals(restoredStreams.get(0).get("plugin.tenant"), "second-tenant");
+    assertEquals(restoredStreams.get(0).get("password"), "second-password");
+    assertEquals(restoredStreams.get(1).get("plugin.tenant"), "first-tenant");
+    assertEquals(restoredStreams.get(1).get("password"), "first-password");
+  }
+
+  @Test
+  public void testRestoreSamePositionMultiElementArrayWithBenignEdit() {
+    Map<String, String> first = new LinkedHashMap<>();
+    first.put("streamType", "kafka");
+    first.put("stream.kafka.topic.name", "first-topic");
+    first.put("stream.kafka.decoder.class.name", "FirstDecoder");
+    first.put("stream.kafka.consumer.prop.fetch.min.bytes", "1");
+    first.put("password", "first-password");
+    Map<String, String> second = new LinkedHashMap<>();
+    second.put("streamType", "kafka");
+    second.put("stream.kafka.topic.name", "second-topic");
+    second.put("stream.kafka.decoder.class.name", "SecondDecoder");
+    second.put("stream.kafka.consumer.prop.fetch.min.bytes", "1");
+    second.put("password", "second-password");
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setStreamIngestionConfig(new StreamIngestionConfig(List.of(first, second)));
+    TableConfig stored = new TableConfigBuilder(TableType.REALTIME)
+        .setTableName("editedStreams_REALTIME")
+        .setIngestionConfig(ingestionConfig)
+        .build();
+    TableConfig submitted = TableConfigRedactionUtils.redact(stored);
+    submitted.getIngestionConfig().getStreamIngestionConfig().getStreamConfigMaps().get(1)
+        .put("stream.kafka.consumer.prop.fetch.min.bytes", "2");
+
+    TableConfig restored = TableConfigRedactionUtils.restoreRedactedValues(submitted, stored);
+
+    List<Map<String, String>> streams = restored.getIngestionConfig().getStreamIngestionConfig()
+        .getStreamConfigMaps();
+    assertEquals(streams.get(0).get("password"), "first-password");
+    assertEquals(streams.get(1).get("password"), "second-password");
+    assertEquals(streams.get(1).get("stream.kafka.consumer.prop.fetch.min.bytes"), "2");
+  }
+
+  @Test
+  public void testExistingCredentialEqualToMarkerStillRoundTrips() {
+    TableConfig stored = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("markerCredential_OFFLINE")
+        .setCustomConfig(new TableCustomConfig(new HashMap<>(Map.of("provider.password", MARKER))))
+        .build();
+
+    TableConfig restored = TableConfigRedactionUtils.restoreRedactedValues(
+        TableConfigRedactionUtils.redact(stored), stored);
+
+    assertEquals(restored.getCustomConfig().getCustomConfigs().get("provider.password"), MARKER);
+  }
+
+  @Test
+  public void testRestoreAllowsMarkerInBenignValue() {
+    TableConfig submitted = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("benignMarker_OFFLINE")
+        .setCustomConfig(new TableCustomConfig(new HashMap<>(Map.of("display.value", MARKER))))
+        .build();
+
+    TableConfig restored = TableConfigRedactionUtils.restoreRedactedValues(submitted, null);
+
+    assertEquals(restored.getCustomConfig().getCustomConfigs().get("display.value"), MARKER);
+  }
+
+  @Test
+  public void testMixedPlaceholdersDoNotHideLiteralUriCredentials() {
+    assertTrue(TableConfigRedactionUtils.isUnresolvedPlaceholder("${PASSWORD}"));
+    assertTrue(TableConfigRedactionUtils.isUnresolvedPlaceholder("${PASSWORD:default-value}"));
+    assertTrue(TableConfigRedactionUtils.isUnresolvedPlaceholder(
+        "${SERVICE_ACCOUNT_JSON:{\"message\":\"use } literally\"}}"));
+    assertFalse(TableConfigRedactionUtils.isUnresolvedPlaceholder("${PASSWORD}${TOKEN}"));
+    assertFalse(TableConfigRedactionUtils.isUnresolvedPlaceholder(
+        "${IGNORED} https://user:password@host.example/path}"));
+
+    Map<String, String> custom = new HashMap<>();
+    custom.put("mixed.userinfo", "https://${URI_USER}:literal-password@host.example/path");
+    custom.put("mixed.query", "https://host.example/path?region=${REGION}&password=literal-query-secret");
+    custom.put("placeholder.marker", "${PASSWORD:*****}");
+    custom.put("assignment.placeholder", "LoginModule required password=\"${PASSWORD:*****}\";");
+    TableConfig stored = tableWithCustomConfigs(custom);
+
+    TableConfig redacted = TableConfigRedactionUtils.redact(stored);
+
+    assertEquals(redacted.getCustomConfig().getCustomConfigs().get("mixed.userinfo"),
+        "https://${URI_USER}:" + MARKER + "@host.example/path");
+    assertEquals(redacted.getCustomConfig().getCustomConfigs().get("mixed.query"),
+        "https://host.example/path?region=${REGION}&password=" + MARKER);
+    assertEquals(redacted.getCustomConfig().getCustomConfigs().get("placeholder.marker"), "${PASSWORD:*****}");
+    assertEquals(redacted.getCustomConfig().getCustomConfigs().get("assignment.placeholder"),
+        "LoginModule required password=\"${PASSWORD:*****}\";");
+    assertEquals(TableConfigRedactionUtils.restoreRedactedValues(redacted, stored).toJsonNode(), stored.toJsonNode());
+  }
+
+  @Test
+  public void testRedactsEncodedAndNestedUriCredentialsAndKnownPrivateKeys() {
+    Map<String, String> custom = new HashMap<>();
+    custom.put("encoded.query", "https://host.example/path?access%5Ftoken=encoded-secret&region=west");
+    custom.put("oauth.assertion", "https://idp.example/token?client_assertion=literal-client-assertion&region=west");
+    custom.put("nested.uri", "https://gateway.example/path?target=https://user:pass@store.example/bucket");
+    custom.put("encoded.nested.uri", "https://gateway.example/path?target="
+        + "https%3A%2F%2Fencoded-user%3Aencoded-pass%40store.example%2Fbucket");
+    custom.put("connection.signature", "SharedAccessSignature=sv=1&sig=shared-signature");
+    custom.put("connection.whitespace",
+        "DefaultEndpointsProtocol=https;AccountName=a;AccountKey=abc def==;EndpointSuffix=core.windows.net");
+    custom.put("standalone.parameters", "region=west&password=standalone-secret");
+    custom.put("fs.azure.sas.container.account.blob.core.windows.net", "sp=r&sv=1&sig=literal-sas");
+    custom.put("privateKeyPassphrase", "literal-passphrase");
+    custom.put("provider.urls", "https://u1:p1@one.example|https://u2:p2@two.example");
+    custom.put("proxy.uri", "https://proxy.example/fetch/https://nested-user:nested-pass@store.example");
+    custom.put("network.path", "//relative-user:relative-pass@store.example/path");
+    custom.put("semicolon.userinfo", "https://semicolon-user:p;foo=bar@store.example/path");
+    custom.put("comma.userinfo", "https://comma-user:p,foo=bar@store.example/path");
+    custom.put("oauth.fragment",
+        "https://callback.example/path#access_token=fragment-secret&state=opaque");
+    custom.put("placeholder.fragment",
+        "https://callback.example/path#access_token=${FRAGMENT_TOKEN}&state=opaque");
+    custom.put("plain.fragment", "https://callback.example/path#section-two");
+    custom.put("auth", "Bearer literal-auth-token");
+    custom.put("comma.parameters", "username=alice,password=comma-secret");
+    custom.put("stream.kafka.consumer.prop.ssl.key.pem",
+        "-----BEGIN PRIVATE KEY-----\npem-private-material\n-----END PRIVATE KEY-----");
+    custom.put("stream.kafka.consumer.prop.ssl.keystore.key", "keystore-private-key");
+    TableConfig stored = tableWithCustomConfigs(custom);
+
+    TableConfig redacted = TableConfigRedactionUtils.redact(stored);
+    String json = redacted.toJsonString();
+
+    for (String secret : List.of("encoded-secret", "literal-client-assertion", "encoded-user", "encoded-pass",
+        "shared-signature", "abc def==", "standalone-secret", "literal-sas", "literal-passphrase", "u1:", ":p1@", "u2:",
+        ":p2@",
+        "nested-user", "nested-pass", "relative-user", "relative-pass", "semicolon-user", "comma-user",
+        "p;foo=bar", "p,foo=bar", "literal-auth-token", "comma-secret",
+        "fragment-secret", "pem-private-material",
+        "keystore-private-key")) {
+      assertFalse(json.contains(secret), secret);
+    }
+    assertTrue(json.contains("region=west"), json);
+    assertTrue(json.contains("client_assertion=" + MARKER + "&region=west"), json);
+    assertTrue(json.contains("#access_token=" + MARKER + "&state=opaque"), json);
+    assertTrue(json.contains("#access_token=${FRAGMENT_TOKEN}&state=opaque"), json);
+    assertTrue(json.contains("#section-two"), json);
+    assertTrue(json.contains("target=https://" + MARKER + ":" + MARKER + "@store.example/bucket"), json);
+    assertEquals(TableConfigRedactionUtils.restoreRedactedValues(redacted, stored).toJsonNode(), stored.toJsonNode());
+  }
+
+  @Test
+  public void testRestoreRejectsChangedStructuredSecurityIdentity() {
+    Map<String, String> custom = new HashMap<>();
+    custom.put("jaas", "TrustedLoginModule required password=trusted-password;");
+    custom.put("connection", "Endpoint=https://trusted.example;Password=connection-password");
+    custom.put("client", "clientId=trusted-client clientSecret=client-secret");
+    custom.put("servicebus",
+        "Endpoint=sb://trusted.example/;SharedAccessKeyName=trusted-policy;SharedAccessKey=shared-secret");
+    custom.put("aws", "AccessKeyId=AKIAOLD;SecretAccessKey=aws-secret");
+    custom.put("uri", "https://trusted-user:uri-password@trusted.example/path?client_id=trusted&token=query-token");
+    custom.put("placeholder.uri", "https://" + "$" + "{URI_USER}:placeholder-uri-secret@trusted.example/path");
+    custom.put("encoded.uri",
+        "https://trusted.example/path?client%5Fid=trusted&client_secret=encoded-client-secret");
+    custom.put("aws.uri", "https://s3.example/b?AWSAccessKeyId=OLD&Signature=old-signature");
+    custom.put("fragment.uri", "https://trusted.example/callback#access_token=fragment-secret&state=opaque");
+    custom.put("provider.assignment", "providerClass=TrustedProvider;password=provider-secret");
+    custom.put("prefixed.assignment", "db.username=trusted;db.password=database-secret");
+    TableConfig stored = tableWithCustomConfigs(custom);
+    TableConfig changedModule = TableConfigRedactionUtils.redact(stored);
+    changedModule.getCustomConfig().getCustomConfigs().compute("jaas",
+        (key, value) -> value.replace("TrustedLoginModule", "AttackerLoginModule"));
+    TableConfig changedEndpoint = TableConfigRedactionUtils.redact(stored);
+    changedEndpoint.getCustomConfig().getCustomConfigs().compute("connection",
+        (key, value) -> value.replace("trusted.example", "attacker.example"));
+    TableConfig changedClient = TableConfigRedactionUtils.redact(stored);
+    changedClient.getCustomConfig().getCustomConfigs().compute("client",
+        (key, value) -> value.replace("trusted-client", "attacker-client"));
+    TableConfig changedPolicy = TableConfigRedactionUtils.redact(stored);
+    changedPolicy.getCustomConfig().getCustomConfigs().compute("servicebus",
+        (key, value) -> value.replace("trusted-policy", "attacker-policy"));
+    TableConfig changedAccessKey = TableConfigRedactionUtils.redact(stored);
+    changedAccessKey.getCustomConfig().getCustomConfigs().compute("aws",
+        (key, value) -> value.replace(MARKER + ";SecretAccessKey", "AKIANEW;SecretAccessKey"));
+    TableConfig changedUriUser = TableConfigRedactionUtils.redact(stored);
+    changedUriUser.getCustomConfig().getCustomConfigs().compute("uri",
+        (key, value) -> value.replace(MARKER + ":", "attacker-user:"));
+    TableConfig changedUriQueryIdentity = TableConfigRedactionUtils.redact(stored);
+    changedUriQueryIdentity.getCustomConfig().getCustomConfigs().compute("uri",
+        (key, value) -> value.replace("client_id=trusted", "client_id=attacker"));
+    TableConfig changedPlaceholderUser = TableConfigRedactionUtils.redact(stored);
+    changedPlaceholderUser.getCustomConfig().getCustomConfigs().compute("placeholder.uri",
+        (key, value) -> value.replace("$" + "{URI_USER}", "$" + "{OTHER_USER}"));
+    TableConfig changedEncodedClient = TableConfigRedactionUtils.redact(stored);
+    changedEncodedClient.getCustomConfig().getCustomConfigs().compute("encoded.uri",
+        (key, value) -> value.replace("client%5Fid=trusted", "client%5Fid=attacker"));
+    TableConfig changedAwsAccessKey = TableConfigRedactionUtils.redact(stored);
+    changedAwsAccessKey.getCustomConfig().getCustomConfigs().compute("aws.uri",
+        (key, value) -> value.replace("AWSAccessKeyId=" + MARKER, "AWSAccessKeyId=NEW"));
+    TableConfig changedFragmentHost = TableConfigRedactionUtils.redact(stored);
+    changedFragmentHost.getCustomConfig().getCustomConfigs().compute("fragment.uri",
+        (key, value) -> value.replace("trusted.example", "attacker.example"));
+    TableConfig changedProviderClass = TableConfigRedactionUtils.redact(stored);
+    changedProviderClass.getCustomConfig().getCustomConfigs().compute("provider.assignment",
+        (key, value) -> value.replace("TrustedProvider", "AttackerProvider"));
+    TableConfig changedPrefixedUser = TableConfigRedactionUtils.redact(stored);
+    changedPrefixedUser.getCustomConfig().getCustomConfigs().compute("prefixed.assignment",
+        (key, value) -> value.replace("db.username=trusted", "db.username=attacker"));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(changedModule, stored));
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(changedEndpoint, stored));
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(changedClient, stored));
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(changedPolicy, stored));
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(changedAccessKey, stored));
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(changedUriUser, stored));
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(changedUriQueryIdentity, stored));
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(changedPlaceholderUser, stored));
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(changedEncodedClient, stored));
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(changedAwsAccessKey, stored));
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(changedFragmentHost, stored));
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(changedProviderClass, stored));
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(changedPrefixedUser, stored));
+  }
+
+  @Test
+  public void testRestoreRejectsChangedSingletonArrayIdentity() {
+    Map<String, String> stream = new LinkedHashMap<>();
+    stream.put("streamType", "kafka");
+    stream.put("stream.kafka.topic.name", "trusted-topic");
+    stream.put("password", "trusted-password");
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setStreamIngestionConfig(new StreamIngestionConfig(List.of(stream)));
+    TableConfig stored = new TableConfigBuilder(TableType.REALTIME)
+        .setTableName("singleStream_REALTIME")
+        .setIngestionConfig(ingestionConfig)
+        .build();
+    TableConfig submitted = TableConfigRedactionUtils.redact(stored);
+    submitted.getIngestionConfig().getStreamIngestionConfig().getStreamConfigMaps().get(0)
+        .put("stream.kafka.topic.name", "attacker-topic");
+
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(submitted, stored));
+  }
+
+  @Test
+  public void testRedactsAndRestoresJsonEncodedProviderOptions() {
+    String options = "{\"username\":\"alice\",\"password\":\"json-secret\",\"region\":\"west\","
+        + "\"nested\":{\"endpoint\":\"https://json-user:json-pass@store.example/path?token=json-token\"}}";
+    TableConfig stored = tableWithCustomConfigs(new HashMap<>(Map.of("provider.options", options)));
+
+    TableConfig redacted = TableConfigRedactionUtils.redact(stored);
+    String redactedOptions = redacted.getCustomConfig().getCustomConfigs().get("provider.options");
+
+    for (String secret : List.of("json-secret", "json-user", "json-pass", "json-token")) {
+      assertFalse(redactedOptions.contains(secret), redactedOptions);
+    }
+    assertTrue(redactedOptions.contains("\"username\":\"alice\""), redactedOptions);
+    assertTrue(redactedOptions.contains("\"region\":\"west\""), redactedOptions);
+    redacted.getCustomConfig().getCustomConfigs().put("provider.options",
+        redactedOptions.replace("\"region\":\"west\"", "\"region\":\"east\""));
+
+    String restored = TableConfigRedactionUtils.restoreRedactedValues(redacted, stored)
+        .getCustomConfig().getCustomConfigs().get("provider.options");
+    assertTrue(restored.contains("\"password\":\"json-secret\""), restored);
+    assertTrue(restored.contains("https://json-user:json-pass@store.example/path?token=json-token"), restored);
+    assertTrue(restored.contains("\"region\":\"east\""), restored);
+  }
+
+  @Test
+  public void testRedactsNumericJsonCredentialAndRejectsJsonOwnerChange() {
+    String options = "{\"clientId\":\"trusted\",\"clientSecret\":\"json-secret\","
+        + "\"password\":123456,\"providerClass\":\"TrustedProvider\"}";
+    TableConfig stored = tableWithCustomConfigs(new HashMap<>(Map.of("provider.options", options)));
+    TableConfig redacted = TableConfigRedactionUtils.redact(stored);
+    String redactedOptions = redacted.getCustomConfig().getCustomConfigs().get("provider.options");
+
+    assertFalse(redactedOptions.contains("123456"), redactedOptions);
+    assertFalse(redactedOptions.contains("json-secret"), redactedOptions);
+    TableConfig changedClient = TableConfigRedactionUtils.redact(stored);
+    changedClient.getCustomConfig().getCustomConfigs().compute("provider.options",
+        (key, value) -> value.replace("\"clientId\":\"trusted\"", "\"clientId\":\"attacker\""));
+    TableConfig changedProvider = TableConfigRedactionUtils.redact(stored);
+    changedProvider.getCustomConfig().getCustomConfigs().compute("provider.options",
+        (key, value) -> value.replace("TrustedProvider", "AttackerProvider"));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(changedClient, stored));
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(changedProvider, stored));
+    assertEquals(TableConfigRedactionUtils.restoreRedactedValues(redacted, stored).toJsonNode(), stored.toJsonNode());
+  }
+
+  @Test
+  public void testRestoreRejectsNestedJsonProviderReassociation() {
+    String options = "{\"provider\":{\"providerClass\":\"TrustedProvider\"},"
+        + "\"options\":{\"password\":\"json-secret\"}}";
+    TableConfig stored = tableWithCustomConfigs(new HashMap<>(Map.of("provider.options", options)));
+    TableConfig submitted = TableConfigRedactionUtils.redact(stored);
+    submitted.getCustomConfig().getCustomConfigs().compute("provider.options",
+        (key, value) -> value.replace("TrustedProvider", "AttackerProvider"));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(submitted, stored));
+  }
+
+  @Test
+  public void testRestoreRejectsChangedAccessKeyForMaskedSecretKey() {
+    Map<String, String> batch = new LinkedHashMap<>();
+    batch.put("input.fs.prop.accessKey", "INPUT_ID");
+    batch.put("input.fs.prop.secretKey", "INPUT_SECRET");
+    batch.put("output.fs.prop.accessKey", "OUTPUT_ID");
+    batch.put("output.fs.prop.secretKey", "OUTPUT_SECRET");
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setBatchIngestionConfig(new BatchIngestionConfig(List.of(batch), "APPEND", "DAILY"));
+    TableConfig stored = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("credentialPair_OFFLINE")
+        .setIngestionConfig(ingestionConfig)
+        .build();
+    TableConfig submitted = TableConfigRedactionUtils.redact(stored);
+    submitted.getIngestionConfig().getBatchIngestionConfig().getBatchConfigMaps().get(0)
+        .put("input.fs.prop.accessKey", "CHANGED_ID");
+
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(submitted, stored));
+  }
+
+  @Test
+  public void testStructuredTextPolicyPreservesSqlShapeAndPlaceholders() {
+    String sql = "SELECT count(*) FROM source WHERE status = 'PAID' "
+        + "AND endpoint = 'https://sql-user:sql-pass@store.example/path?token=sql-token&region=west' "
+        + "AND configured = '" + "$" + "{ENDPOINT}'";
+
+    String redacted = TableConfigRedactionUtils.redactStructuredText(sql);
+
+    for (String secret : List.of("sql-user", "sql-pass", "sql-token")) {
+      assertFalse(redacted.contains(secret), redacted);
+    }
+    assertTrue(redacted.contains("status = 'PAID'"), redacted);
+    assertTrue(redacted.contains("store.example/path"), redacted);
+    assertTrue(redacted.contains("region=west"), redacted);
+    assertTrue(redacted.contains("'" + "$" + "{ENDPOINT}'"), redacted);
+    assertTrue(redacted.endsWith("'"), redacted);
+  }
+
+  @Test
+  public void testStructuredTextRedactionHandlesLongUnterminatedQuotesWithoutRecursion() {
+    String backslashes = "\\".repeat(50_000);
+
+    assertEquals(TableConfigRedactionUtils.redactStructuredText("password=\"" + backslashes),
+        "password=" + MARKER);
+    assertEquals(TableConfigRedactionUtils.redactStructuredText("token='" + backslashes),
+        "token=" + MARKER);
+  }
+
+  @Test
+  public void testStructuredTextRedactsWhitespaceInConnectionStringCredential() {
+    String connectionString = "DefaultEndpointsProtocol=https;AccountName=a;AccountKey=abc def==;"
+        + "EndpointSuffix=core.windows.net";
+
+    String redacted = TableConfigRedactionUtils.redactStructuredText(connectionString);
+
+    assertFalse(redacted.contains("abc"), redacted);
+    assertFalse(redacted.contains("def=="), redacted);
+    assertTrue(redacted.contains("AccountKey=" + MARKER), redacted);
+    assertTrue(redacted.contains("EndpointSuffix=core.windows.net"), redacted);
+  }
+
+  @Test
+  public void testRestoreRejectsDecoderReassociation() {
+    Map<String, String> stream = new LinkedHashMap<>();
+    stream.put("streamType", "kafka");
+    stream.put("stream.kafka.topic.name", "trusted-topic");
+    stream.put("stream.kafka.decoder.class.name", "TrustedDecoder");
+    stream.put("stream.kafka.consumer.prop.sasl.login.callback.handler.class", "TrustedHandler");
+    stream.put("stream.kafka.consumer.prop.sasl.login.class", "TrustedLogin");
+    stream.put("stream.kafka.consumer.prop.interceptor.classes", "TrustedInterceptor");
+    stream.put("stream.kafka.consumer.prop.key.deserializer", "TrustedKeyDeserializer");
+    stream.put("stream.kafka.consumer.prop.value.serializer", "TrustedValueSerializer");
+    stream.put("stream.kafka.consumer.prop.partitioner.class", "TrustedPartitioner");
+    stream.put("fs.azure.account.oauth.provider.type.account.dfs.core.windows.net", "TrustedAzureTokenProvider");
+    stream.put("fs.azure.account.oauth2.client.secret.account.dfs.core.windows.net", "azure-client-secret");
+    stream.put("stream.kafka.decoder.prop.password", "decoder-secret");
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setStreamIngestionConfig(new StreamIngestionConfig(List.of(stream)));
+    TableConfig stored = new TableConfigBuilder(TableType.REALTIME)
+        .setTableName("decoderIdentity_REALTIME")
+        .setIngestionConfig(ingestionConfig)
+        .build();
+    for (String selector : List.of("stream.kafka.consumer.prop.interceptor.classes",
+        "stream.kafka.consumer.prop.key.deserializer", "stream.kafka.consumer.prop.value.serializer",
+        "stream.kafka.consumer.prop.partitioner.class",
+        "fs.azure.account.oauth.provider.type.account.dfs.core.windows.net")) {
+      TableConfig submitted = TableConfigRedactionUtils.redact(stored);
+      submitted.getIngestionConfig().getStreamIngestionConfig().getStreamConfigMaps().get(0)
+          .put(selector, "AttackerImplementation");
+
+      assertThrows(selector, IllegalArgumentException.class,
+          () -> TableConfigRedactionUtils.restoreRedactedValues(submitted, stored));
+    }
+  }
+
+  @Test
+  public void testRestoreRejectsLegacyDecoderReassociationButAllowsUnrelatedUriEdit() {
+    Map<String, String> legacyStream = new LinkedHashMap<>();
+    legacyStream.put("streamType", "kafka");
+    legacyStream.put("stream.kafka.topic.name", "trusted-topic");
+    legacyStream.put("stream.kafka.decoder.class.name", "TrustedDecoder");
+    legacyStream.put("stream.kafka.consumer.prop.sasl.login.callback.handler.class", "TrustedHandler");
+    legacyStream.put("stream.kafka.decoder.prop.password", "decoder-secret");
+    TableConfig stored = new TableConfigBuilder(TableType.REALTIME)
+        .setTableName("legacyDecoderIdentity_REALTIME")
+        .setStreamConfigs(legacyStream)
+        .setCustomConfig(new TableCustomConfig(new HashMap<>(Map.of(
+            "provider.password", "provider-secret", "callbackUrl", "https://old.example/callback"))))
+        .build();
+    TableConfig changedDecoder = TableConfigRedactionUtils.redact(stored);
+    changedDecoder.getIndexingConfig().getStreamConfigs()
+        .put("stream.kafka.consumer.prop.sasl.login.callback.handler.class", "AttackerHandler");
+    TableConfig changedCallback = TableConfigRedactionUtils.redact(stored);
+    changedCallback.getCustomConfig().getCustomConfigs().put("callbackUrl", "https://new.example/callback");
+
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(changedDecoder, stored));
+    TableConfig restored = TableConfigRedactionUtils.restoreRedactedValues(changedCallback, stored);
+    assertEquals(restored.getCustomConfig().getCustomConfigs().get("callbackUrl"), "https://new.example/callback");
+    assertEquals(restored.getCustomConfig().getCustomConfigs().get("provider.password"), "provider-secret");
+  }
+
+  @Test
+  public void testRestoreRejectsLegacyEndpointAndUserReassociation() {
+    Map<String, String> legacyStream = new LinkedHashMap<>();
+    legacyStream.put("streamType", "kinesis");
+    legacyStream.put("stream.kinesis.topic.name", "trusted-stream");
+    legacyStream.put("stream.kinesis.endpoint", "https://trusted.example/path?region=west");
+    legacyStream.put("stream.kinesis.accessKey", "OLD_ID");
+    legacyStream.put("stream.kinesis.secretKey", "OLD_SECRET");
+    legacyStream.put("stream.kinesis.username", "trusted-user");
+    legacyStream.put("stream.kinesis.password", "old-password");
+    TableConfig stored = new TableConfigBuilder(TableType.REALTIME)
+        .setTableName("legacyCredentialIdentity_REALTIME")
+        .setStreamConfigs(legacyStream)
+        .build();
+    TableConfig changedEndpoint = TableConfigRedactionUtils.redact(stored);
+    changedEndpoint.getIndexingConfig().getStreamConfigs().put(
+        "stream.kinesis.endpoint", "https://attacker.example/path?region=west");
+    TableConfig changedUsername = TableConfigRedactionUtils.redact(stored);
+    changedUsername.getIndexingConfig().getStreamConfigs().put("stream.kinesis.username", "attacker-user");
+
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(changedEndpoint, stored));
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(changedUsername, stored));
+    assertEquals(TableConfigRedactionUtils.restoreRedactedValues(
+        TableConfigRedactionUtils.redact(stored), stored).toJsonNode(), stored.toJsonNode());
+
+    TableConfig aliasedUser = TableConfigRedactionUtils.redact(stored);
+    aliasedUser.getIndexingConfig().getStreamConfigs().put("stream.kinesis.username", "attacker-user");
+    aliasedUser.getIndexingConfig().getStreamConfigs().put("stream_kinesis_username", "trusted-user");
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(aliasedUser, stored));
+  }
+
+  @Test
+  public void testRestoreRejectsAmbiguousEditedArrayIdentity() {
+    Map<String, String> first = new LinkedHashMap<>();
+    first.put("streamType", "kafka");
+    first.put("stream.kafka.topic.name", "first-topic");
+    first.put("stream.kafka.decoder.class.name", "FirstDecoder");
+    first.put("password", "first-password");
+    Map<String, String> second = new LinkedHashMap<>();
+    second.put("streamType", "kafka");
+    second.put("stream.kafka.topic.name", "second-topic");
+    second.put("stream.kafka.decoder.class.name", "SecondDecoder");
+    second.put("password", "second-password");
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setStreamIngestionConfig(new StreamIngestionConfig(List.of(first, second)));
+    TableConfig stored = new TableConfigBuilder(TableType.REALTIME)
+        .setTableName("ambiguousStreams_REALTIME")
+        .setIngestionConfig(ingestionConfig)
+        .build();
+    TableConfig submitted = TableConfigRedactionUtils.redact(stored);
+    List<Map<String, String>> streams = submitted.getIngestionConfig().getStreamIngestionConfig()
+        .getStreamConfigMaps();
+    streams.remove(0);
+    streams.get(0).put("stream.kafka.topic.name", "first-topic");
+
+    assertThrows(IllegalArgumentException.class,
+        () -> TableConfigRedactionUtils.restoreRedactedValues(submitted, stored));
+  }
+
+  @Test
+  public void testRedactDiagnosticPreservesContextWithoutCredentialValues() {
+    TableConfig tableConfig = tableWithCustomConfigs(new HashMap<>(Map.of(
+        "provider.password", "stream-password", "provider.token", "uri-token", "sasl.jaas.config",
+        "example.LoginModule required password=jaas-password;")));
+    String diagnostic = "Invalid replication for credentialTable_REALTIME; password=stream-password; "
+        + "JAAS value contains jaas-password; URI token uri-token is invalid";
+
+    String redacted = TableConfigRedactionUtils.redactDiagnostic(diagnostic, tableConfig);
+
+    assertTrue(redacted.contains("Invalid replication for credentialTable_REALTIME"), redacted);
+    assertFalse(redacted.contains("stream-password"), redacted);
+    assertFalse(redacted.contains("jaas-password"), redacted);
+    assertFalse(redacted.contains("uri-token"), redacted);
+
+    String escapedCredential = "p\"ass\\word\nline";
+    TableConfig escapedConfig = tableWithCustomConfigs(
+        new HashMap<>(Map.of("provider.password", escapedCredential)));
+    String escapedDiagnostic = "Invalid config " + escapedConfig.toJsonString();
+    String redactedEscaped = TableConfigRedactionUtils.redactDiagnostic(escapedDiagnostic, escapedConfig);
+    assertFalse(redactedEscaped.contains(escapedCredential), redactedEscaped);
+    assertFalse(redactedEscaped.contains("p\\\"ass\\\\word\\nline"), redactedEscaped);
+
+    TableConfig placeholderConfig = tableWithCustomConfigs(
+        new HashMap<>(Map.of("provider.password", "${PROVIDER_PASSWORD}")));
+    String placeholderDiagnostic = TableConfigRedactionUtils.redactDiagnostic(
+        "Resolved provider password was resolved-literal", placeholderConfig);
+    assertEquals(placeholderDiagnostic, "Invalid table config");
+    assertFalse(placeholderDiagnostic.contains("resolved-literal"));
+  }
+
+  private static TableConfig tableWithCustomConfigs(Map<String, String> customConfigs) {
+    return new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("customConfig_OFFLINE")
+        .setCustomConfig(new TableCustomConfig(customConfigs))
+        .build();
+  }
+
+  private static TableConfig tableConfigWithCredentials() {
+    Map<String, String> legacyStream = new LinkedHashMap<>();
+    legacyStream.put("streamType", "kafka");
+    legacyStream.put("stream.kafka.topic.name", "events-topic");
+    legacyStream.put("stream.kafka.decoder.class.name", "example.Decoder");
+    legacyStream.put("stream.kinesis.credentialsProvider", "example.CredentialsProvider");
+    legacyStream.put(STREAM_PASSWORD_KEY, "stream-password");
+    legacyStream.put(STREAM_PLACEHOLDER_KEY, PLACEHOLDER);
+    legacyStream.put(JAAS_KEY, "example.LoginModule required username=\"jaas-user\" password=\"jaas-password\" "
+        + "token=\"${JAAS_TOKEN}\" useKeyTab=true;");
+    legacyStream.put("stream.kinesis.accessKey", "stream-access-key");
+    legacyStream.put("stream.kafka.decoder.prop.apiKey", "decoder-api-key");
+    legacyStream.put(URI_KEY, URI);
+    legacyStream.put("stream.kafka.placeholder.uri", PLACEHOLDER_URI);
+    legacyStream.put("stream.kafka.decoder.prop.schema.registry.basic.auth.user.info",
+        "schema-user:schema-password");
+    legacyStream.put("stream.kafka.credential.urls",
+        "https://first-user:first-pass@one.example.test/a?password=first-query&region=west,"
+            + "https://second-user:second-pass@two.example.test/b?token=second-query&region=east");
+    legacyStream.put("stream.kafka.other.jaas.config", "example.LoginModule required password=p@ss&word;");
+
+    Map<String, String> stream = new LinkedHashMap<>();
+    stream.put("streamType", "kafka");
+    stream.put("stream.kafka.topic.name", "secondary-topic");
+    stream.put("stream.kafka.consumer.prop.password", "stream-password");
+    Map<String, String> batch = new LinkedHashMap<>();
+    batch.put("input.fs.prop.accessKey", "batch-access-key");
+    batch.put("input.fs.prop.secretKey", "batch-secret-key");
+    batch.put("input.dir.uri", "s3://bucket/path?X-Amz-Credential=batch-credential&region=us-west-2");
+    batch.put("recordReader.prop.password", "reader-password");
+    batch.put("recordReader.className", "example.Reader");
+    batch.put("input.fs.prop.fs.azure.account.key.account.dfs.core.windows.net", "dynamic-azure-key");
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setStreamIngestionConfig(new StreamIngestionConfig(List.of(stream)));
+    ingestionConfig.setBatchIngestionConfig(new BatchIngestionConfig(List.of(batch), "APPEND", "DAILY"));
+
+    Map<String, String> tierProperties = new LinkedHashMap<>();
+    tierProperties.put("azure.storage.accountKey", "tier-account-key");
+    tierProperties.put("endpoint", "https://storage.example.test/container?region=west");
+    tierProperties.put("connection.string",
+        "DefaultEndpointsProtocol=https;AccountName=storage-user;AccountKey=connection-account-key;"
+            + "EndpointSuffix=core.test");
+    tierProperties.put("uri.connection.string",
+        "Endpoint=https://storage.example.test/container;AccountKey=endpoint-account-key;Region=west");
+    TierConfig tierConfig = new TierConfig("TIER1", "TIME", "7d", null, "PINOT_SERVER", null, "s3",
+        tierProperties);
+
+    Map<String, String> custom = new HashMap<>();
+    custom.put("provider.custom.password", "custom-password");
+    custom.put(CLIENT_ID_KEY, "original-client");
+    custom.put("placeholder.secretKey", "${CUSTOM_SECRET_KEY:default-key}");
+    custom.put("serviceAccountJson",
+        "${SERVICE_ACCOUNT_JSON:{\"type\":\"service_account\",\"message\":\"use } literally\"}}");
+
+    Map<String, String> task = new LinkedHashMap<>();
+    task.put("authToken", "task-auth-token");
+    task.put("output.fs.prop.secretKey", "task-secret-key");
+    task.put("provider.class", "example.Provider");
+
+    return new TableConfigBuilder(TableType.REALTIME)
+        .setTableName("credentialTable_REALTIME")
+        .setStreamConfigs(legacyStream)
+        .setIngestionConfig(ingestionConfig)
+        .setTierConfigList(List.of(tierConfig))
+        .setCustomConfig(new TableCustomConfig(custom))
+        .setTaskConfig(new TableTaskConfig(Map.of("SegmentGenerationAndPushTask", task)))
+        .build();
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/user/UserConfigTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/user/UserConfigTest.java
@@ -135,7 +135,33 @@ public class UserConfigTest {
     assertNull(userConfig.getTables());
     assertNull(userConfig.getExcludeTables());
     assertNull(userConfig.getPermissions());
+    assertNull(userConfig.getFineGrainedPermissions());
     assertNull(userConfig.getPermissios()); // Deprecated method should also return null
+  }
+
+  @Test
+  public void testFineGrainedPermissionsJsonRoundTrip()
+      throws IOException {
+    UserConfig original = new UserConfig("testUser", "testPassword", "CONTROLLER", "ADMIN",
+        List.of("table1"), List.of(), List.of(AccessType.READ), List.of("GetZnode"));
+
+    String jsonString = original.toJsonString();
+    JsonNode jsonNode = JsonUtils.stringToJsonNode(jsonString);
+    assertEquals(jsonNode.get(UserConfig.PERMISSIONS_KEY).get(0).asText(), "READ");
+    assertEquals(jsonNode.get(UserConfig.FINE_GRAINED_PERMISSIONS_KEY).get(0).asText(), "GetZnode");
+
+    UserConfig deserialized = JsonUtils.stringToObject(jsonString, UserConfig.class);
+    assertEquals(deserialized.getPermissions(), List.of(AccessType.READ));
+    assertEquals(deserialized.getFineGrainedPermissions(), List.of("GetZnode"));
+  }
+
+  @Test
+  public void testLegacyPermissionsExcludeFineGrainedActions() {
+    assertFalse(Arrays.stream(AccessType.values()).map(AccessType::name).anyMatch("GET_ZNODE"::equals));
+
+    UserConfig legacyConfig = new UserConfig("testUser", "testPassword", "CONTROLLER", "ADMIN",
+        null, null, List.of(AccessType.READ));
+    assertNull(legacyConfig.getFineGrainedPermissions());
   }
 
   @Test

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/ObfuscatorTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/ObfuscatorTest.java
@@ -206,6 +206,30 @@ public class ObfuscatorTest {
     Assert.assertFalse(output.contains(SECRET));
   }
 
+  @Test
+  public void testDefaultUsesStructuredCredentialPolicy() {
+    Map<String, Object> config = new HashMap<>();
+    config.put("endpoint", "https://uri-user:uri-password@store.example/path?access_token=uri-token&region=west");
+    config.put("input.fs.prop.fs.azure.account.key.account.dfs.core.windows.net", "azure-account-key");
+    config.put("placeholder.password", "${PASSWORD}");
+    config.put("mixedEndpoint", "${IGNORED} https://mixed-user:mixed-password@mixed.example.test/path"
+        + "?token=mixed-token}");
+    config.put("ordinary", "preserved");
+
+    String output = Obfuscator.DEFAULT.toJsonString(config);
+
+    for (String credential : List.of("uri-user", "uri-password", "uri-token", "azure-account-key", "mixed-user",
+        "mixed-password", "mixed-token")) {
+      Assert.assertFalse(output.contains(credential), output);
+    }
+    Assert.assertTrue(output.contains("store.example/path"), output);
+    Assert.assertTrue(output.contains("region=west"), output);
+    Assert.assertTrue(output.contains("${PASSWORD}"), output);
+    Assert.assertTrue(output.contains("${IGNORED}"), output);
+    Assert.assertTrue(output.contains("mixed.example.test/path"), output);
+    Assert.assertTrue(output.contains("preserved"), output);
+  }
+
   private static Map<String, Object> createEntry(String key, String value) {
     Map<String, Object> map = new HashMap<>();
     map.put(key, value);

--- a/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/reverse/PropertyExtractor.java
+++ b/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/reverse/PropertyExtractor.java
@@ -391,7 +391,7 @@ public final class PropertyExtractor {
     for (String value : list) {
       if (value != null && value.contains(",")) {
         throw new IllegalArgumentException("SHOW CREATE TABLE cannot emit property '" + key
-            + "' as comma-separated DDL because value '" + value + "' contains a comma; "
+            + "' as comma-separated DDL because one of its values contains a comma; "
             + "replaying the emitted DDL would split it into multiple values. Use the JSON "
             + "table config API for this table until the DDL grammar supports escaped CSV values.");
       }

--- a/pinot-sql-ddl/src/test/java/org/apache/pinot/sql/ddl/reverse/CanonicalDdlEmitterTest.java
+++ b/pinot-sql-ddl/src/test/java/org/apache/pinot/sql/ddl/reverse/CanonicalDdlEmitterTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.sql.ddl.reverse;
 
 import java.math.BigDecimal;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableCustomConfig;
@@ -419,6 +420,27 @@ public class CanonicalDdlEmitterTest {
       org.testng.Assert.fail("Expected IllegalArgumentException for shadowing streamType key");
     } catch (IllegalArgumentException expected) {
       assertTrue(expected.getMessage().contains("streamType"), expected.getMessage());
+    }
+  }
+
+  @Test
+  public void commaBearingValueIsNotIncludedInErrorMessage() {
+    String valueContainingSecret = "team,do-not-log-this-value";
+    Schema schema = new Schema.SchemaBuilder()
+        .setSchemaName("t")
+        .addSingleValueDimension("id", DataType.INT)
+        .build();
+    TableConfig config = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("t")
+        .setTags(List.of(valueContainingSecret))
+        .build();
+
+    try {
+      CanonicalDdlEmitter.emit(schema, config);
+      org.testng.Assert.fail("Expected IllegalArgumentException for comma-bearing tag");
+    } catch (IllegalArgumentException expected) {
+      assertFalse(expected.getMessage().contains(valueContainingSecret), "Error message contained the property value");
+      assertTrue(expected.getMessage().contains("tags"));
     }
   }
 


### PR DESCRIPTION
## Summary

- Return redacted, unresolved table-configuration representations from the table GET APIs by default.
- Apply the same representation policy to `SHOW CREATE TABLE`, `SHOW CREATE MATERIALIZED VIEW`, and materialized-view details.
- Cover credential-bearing ingestion, filesystem, decoder/provider/custom properties, structured login strings, and URI components while preserving ordinary values and `${...}` placeholders.
- Require an explicit `get_znode` permission for raw ZooKeeper reads.
- Remove configuration bodies and SQL text from related failure diagnostics.

## Update semantics

The GET APIs return a versioned envelope containing the redacted configs and the ZooKeeper generations used to produce them. Clients editing a masked response must retain and submit the complete envelope.

- An unchanged `*****` value restores the stored value only when it remains unambiguously bound to the same property and consumer identity.
- Literal replacements are applied as intentional updates.
- New, moved, stale, ambiguous, or reassociated markers are rejected instead of being persisted.
- Schema and existing OFFLINE/REALTIME configs are generation-checked and committed in one ZooKeeper multi-operation.
- Hybrid responses can be edited and submitted together.
- A versioned edit cannot add a missing table type; use the normal table-creation flow and fetch a fresh envelope before editing.
- Legacy literal PUT bodies remain accepted when they do not contain a redaction marker.

## Compatibility

This changes the default response shape for the two table-configuration GET APIs. The response now has an object-valued table identity, format version, base versions, and nested configs. The Java admin client, controller UI, segment-generation reader, copy flow, and affected integration-test consumers are updated accordingly.

The envelope is intentionally not deserializable as the previous top-level `TableConfig` or `TableConfigs` body, so replaying a complete masked response through an older controller fails before mutation. Mixed-version clients must preserve the envelope and send it to a controller that supports the new format. Copy requires the matching versioned response media type.

## How to reproduce

1. Create a test table with representative credential properties, a credential-bearing URI, and an unresolved `${...}` placeholder.
2. Fetch it through `/tables/{name}` and `/tableConfigs/{name}` as a table READ principal, and inspect both SHOW CREATE forms.
3. Verify literal credentials are shown as `*****`, the placeholder remains unchanged, and ordinary settings are preserved.
4. Edit an ordinary setting in the complete response envelope and submit it with PUT.
5. Fetch the stored config through an explicitly permitted administrative path and verify the original credential remains unchanged.
6. Repeat with a stale envelope and verify the update returns a conflict without a partial schema or hybrid-config write.
7. Attempt the raw ZooKeeper read as the READ-only principal and verify it is denied.

## Validation

- Targeted redaction, placeholder, URI, structured-property, marker-restoration, and identity-binding tests pass in `pinot-spi`.
- Both controller GET/PUT resources, READ-only HTTP access, raw-ZooKeeper authorization, SHOW CREATE, materialized-view details, client parsing, copy handling, and diagnostic paths have focused passing tests.
- Real-ZooKeeper tests cover stale single-config CAS and atomic rollback when the second config changes during a schema plus hybrid-config update.
- The controller UI production build completed successfully (7,177 modules transformed).
- Direct JDK 25 `test-compile` with `-Xlint:all` passed for all ten affected Maven modules.
- `spotless:apply`, `license:format`, `checkstyle:check`, and `license:check` passed for all affected modules; `git diff --check` is clean.

## Existing reactor compile issue

The equivalent affected-module `test-compile` command with `-am` stops in unchanged `pinot-segment-local` code at `ZstandardDecompressor.java:51` because the current `zstd-jni` class metadata references `org.jetbrains.annotations.NotNull`, which is not on that module's compile classpath. Direct compilation of every modified module passes.
