### PR TITLE
Improve Controller ingestFromURI filesystem validation

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -354,6 +354,9 @@ public class ControllerConf extends PinotConfiguration {
   public static final String TABLE_MIN_REPLICAS = "table.minReplicas";
   public static final String JERSEY_ADMIN_API_PORT = "jersey.admin.api.port";
   public static final String JERSEY_ADMIN_IS_PRIMARY = "jersey.admin.isprimary";
+  /// Compatibility-only opt-in for local sources passed to `/ingestFromURI`. Enabling this allows callers with
+  /// access to the endpoint to read files visible to the controller process. Keep disabled unless callers and source
+  /// paths are fully trusted.
   public static final String INGEST_FROM_URI_ALLOW_LOCAL_FILE_SYSTEM =
       "controller.ingestFromURI.allowLocalFileSystem";
   public static final String ACCESS_CONTROL_FACTORY_CLASS = "controller.admin.access.control.factory.class";

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/exception/ControllerApplicationException.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/exception/ControllerApplicationException.java
@@ -26,6 +26,12 @@ import org.slf4j.Logger;
 
 public class ControllerApplicationException extends WebApplicationException {
 
+  /// Controls whether server logs include the supplied exception details or only its type.
+  public enum ExceptionLogMode {
+    FULL,
+    TYPE_ONLY
+  }
+
   public ControllerApplicationException(Logger logger, String message, Response.Status status) {
     this(logger, message, status.getStatusCode(), null);
   }
@@ -35,20 +41,34 @@ public class ControllerApplicationException extends WebApplicationException {
   }
 
   public ControllerApplicationException(Logger logger, String message, Response.Status status, @Nullable Throwable e) {
-    this(logger, message, status.getStatusCode(), e);
+    this(logger, message, status.getStatusCode(), e, ExceptionLogMode.FULL);
+  }
+
+  public ControllerApplicationException(Logger logger, String message, Response.Status status, @Nullable Throwable e,
+      ExceptionLogMode exceptionLogMode) {
+    this(logger, message, status.getStatusCode(), e, exceptionLogMode);
   }
 
   public ControllerApplicationException(Logger logger, String message, int status, @Nullable Throwable e) {
+    this(logger, message, status, e, ExceptionLogMode.FULL);
+  }
+
+  private ControllerApplicationException(Logger logger, String message, int status, @Nullable Throwable e,
+      ExceptionLogMode exceptionLogMode) {
     super(message, status);
     if (status >= 300 && status < 500) {
       if (e == null) {
         logger.info(message);
+      } else if (exceptionLogMode == ExceptionLogMode.TYPE_ONLY) {
+        logger.info("{} exception type: {}", message, e.getClass().getName());
       } else {
         logger.info("{} exception: {}", message, e.getMessage());
       }
     } else {
       if (e == null) {
         logger.error(message);
+      } else if (exceptionLogMode == ExceptionLogMode.TYPE_ONLY) {
+        logger.error("{} exception type: {}", message, e.getClass().getName());
       } else {
         logger.error(message, e);
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
@@ -49,6 +49,7 @@ import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.access.AccessType;
 import org.apache.pinot.controller.api.access.Authenticate;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
+import org.apache.pinot.controller.api.exception.ControllerApplicationException.ExceptionLogMode;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.util.FileIngestionHelper;
 import org.apache.pinot.controller.util.FileIngestionHelper.DataPayload;
@@ -180,7 +181,10 @@ public class PinotIngestionRestletResource {
   @ApiOperation(value = "Ingest from the given URI", notes =
       "Creates a segment using file at the given URI and pushes it to Pinot. "
           + "\n All steps happen on the controller. This API is NOT meant for production environments/large input "
-          + "files. " + "\nExample usage (query params need encoding):" + "\n```"
+          + "files. Local filesystem sources are disabled by default. The compatibility setting "
+          + "controller.ingestFromURI.allowLocalFileSystem permits callers with access to this endpoint to read "
+          + "files visible to the controller process and should only be enabled for trusted callers and paths. "
+          + "\nExample usage (query params need encoding):" + "\n```"
           + "\ncurl -X POST \"http://localhost:9000/ingestFromURI?tableNameWithType=foo_OFFLINE"
           + "\n&batchConfigMapStr={" + "\n  \"inputFormat\":\"json\","
           + "\n  \"input.fs.className\":\"org.apache.pinot.plugin.filesystem.S3PinotFS\","
@@ -197,14 +201,12 @@ public class PinotIngestionRestletResource {
     tableNameWithType = DatabaseUtils.translateTableName(tableNameWithType, headers);
     try {
       asyncResponse.resume(ingestData(tableNameWithType, batchConfigMapStr, new DataPayload(new URI(sourceURIStr))));
-    } catch (IllegalArgumentException e) {
-      asyncResponse.resume(new ControllerApplicationException(LOGGER, String
-          .format("Got illegal argument when ingesting file into table: %s. %s", tableNameWithType, e.getMessage()),
-          Response.Status.BAD_REQUEST, e));
-    } catch (Exception e) {
-      asyncResponse.resume(new ControllerApplicationException(LOGGER,
-          String.format("Caught exception when ingesting file into table: %s. %s", tableNameWithType, e.getMessage()),
-          Response.Status.INTERNAL_SERVER_ERROR, e));
+    } catch (IllegalArgumentException | URISyntaxException e) {
+      asyncResponse.resume(new ControllerApplicationException(LOGGER, "Invalid ingestFromURI request",
+          Response.Status.BAD_REQUEST, e, ExceptionLogMode.TYPE_ONLY));
+    } catch (Exception | LinkageError e) {
+      asyncResponse.resume(new ControllerApplicationException(LOGGER, "Failed to ingest from URI",
+          Response.Status.INTERNAL_SERVER_ERROR, e, ExceptionLogMode.TYPE_ONLY));
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
@@ -42,6 +42,7 @@ import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.filesystem.LocalPinotFS;
+import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.ingestion.segment.uploader.SegmentUploader;
@@ -59,6 +60,9 @@ import org.slf4j.LoggerFactory;
 public class FileIngestionHelper {
   private static final Logger LOGGER = LoggerFactory.getLogger(FileIngestionHelper.class);
   private static final String SEGMENT_UPLOADER_CLASS = "org.apache.pinot.plugin.segmentuploader.SegmentUploaderDefault";
+  private static final String LOCAL_FILE_SYSTEM_DISABLED_MESSAGE =
+      "Local filesystem sources are disabled for /ingestFromURI";
+  private static final String INVALID_FILE_SYSTEM_MESSAGE = "Invalid filesystem source for /ingestFromURI";
 
   private static final String WORKING_DIR_PREFIX = "working_dir";
   private static final String INPUT_DATA_DIR = "input_data_dir";
@@ -88,14 +92,30 @@ public class FileIngestionHelper {
   /// Creates a segment using the provided data file/URI and uploads to Pinot
   public SuccessResponse buildSegmentAndPush(DataPayload payload)
       throws Exception {
+    // Resolve and validate the source before creating working directories or parsing input data. Keep the resolved
+    // instance so a concurrent factory registration cannot replace it between validation and copying.
+    try (ResolvedFileSystem sourceFileSystem = payload._payloadType == PayloadType.URI
+        ? resolveSourceFileSystem(_batchConfigMap, payload._uri, _allowLocalFileSystemInUri) : null) {
+      return buildSegmentAndPush(payload, sourceFileSystem);
+    } catch (Exception | LinkageError e) {
+      if (payload._payloadType == PayloadType.URI) {
+        String tableNameWithType = _tableConfig != null ? _tableConfig.getTableName() : null;
+        LOGGER.error("Failed URI ingestion for table: {}, exception type: {}", tableNameWithType,
+            e.getClass().getName());
+      }
+      throw e;
+    }
+  }
+
+  private SuccessResponse buildSegmentAndPush(DataPayload payload, ResolvedFileSystem sourceFileSystem)
+      throws Exception {
     String tableNameWithType = _tableConfig.getTableName();
     // 1. append a timestamp for easy debugging
     // 2. append a random string to avoid using the same working directory when multiple tasks are running in parallel
     File workingDir = org.apache.pinot.common.utils.FileUtils.concatAndValidateFile(_ingestionDir,
         String.format("%s_%s_%d_%s", WORKING_DIR_PREFIX, tableNameWithType, System.currentTimeMillis(),
             RandomStringUtils.secure().next(10, true, false)), "Invalid table name: %S", tableNameWithType);
-    LOGGER.info("Starting ingestion of {} payload to table: {} using working dir: {}", payload._payloadType,
-        tableNameWithType, workingDir.getAbsolutePath());
+    LOGGER.info("Starting ingestion of {} payload to table: {}", payload._payloadType, tableNameWithType);
 
     // Setup working dir
     File inputDir = new File(workingDir, INPUT_DATA_DIR);
@@ -111,11 +131,11 @@ public class FileIngestionHelper {
       File inputFile = new File(inputDir, String.format(
           "%s.%s", DATA_FILE_PREFIX, _batchConfigMap.get(BatchConfigProperties.INPUT_FORMAT).toLowerCase()));
       if (payload._payloadType == PayloadType.URI) {
-        copyURIToLocal(_batchConfigMap, payload._uri, inputFile, _allowLocalFileSystemInUri);
-        LOGGER.info("Copied from URI: {} to local file: {}", payload._uri, inputFile.getAbsolutePath());
+        sourceFileSystem._fileSystem.copyToLocalFile(payload._uri, inputFile);
+        LOGGER.info("Copied URI source to a local staging file for table: {}", tableNameWithType);
       } else {
         copyMultipartToLocal(payload._multiPart, inputFile);
-        LOGGER.info("Copied multipart payload to local file: {}", inputDir.getAbsolutePath());
+        LOGGER.info("Copied multipart payload to a local staging file for table: {}", tableNameWithType);
       }
 
       // Update batch config map with values for file upload
@@ -158,61 +178,121 @@ public class FileIngestionHelper {
       SegmentUploader segmentUploader = PluginManager.get().createInstance(SEGMENT_UPLOADER_CLASS);
       segmentUploader.init(tableConfigOverride);
       segmentUploader.uploadSegment(segmentTarFile.toURI(), _authProvider);
-      LOGGER.info("Uploaded tar: {} to table: {}", segmentTarFile.getAbsolutePath(), tableNameWithType);
+      LOGGER.info("Uploaded generated segment to table: {}", tableNameWithType);
 
       return new SuccessResponse(
           "Successfully ingested file into table: " + tableNameWithType + " as segment: " + segmentName);
     } catch (Exception e) {
-      LOGGER.error("Caught exception when ingesting file to table: {}", tableNameWithType, e);
+      if (payload._payloadType == PayloadType.FILE) {
+        LOGGER.error("Caught exception when ingesting file to table: {}", tableNameWithType, e);
+      }
       throw e;
     } finally {
       FileUtils.deleteQuietly(workingDir);
     }
   }
 
-  /// Copy the file from given URI to local file
-  public static void copyURIToLocal(Map<String, String> batchConfigMap, URI sourceFileURI, File destFile)
-      throws Exception {
-    copyURIToLocal(batchConfigMap, sourceFileURI, destFile, true);
-  }
-
   public static void copyURIToLocal(Map<String, String> batchConfigMap, URI sourceFileURI, File destFile,
       boolean allowLocalFileSystem)
       throws Exception {
-    String sourceFileURIScheme = sourceFileURI.getScheme();
-    Preconditions.checkArgument(allowLocalFileSystem || StringUtils.isNotBlank(sourceFileURIScheme),
-        "Source URI must include a scheme: %s", sourceFileURI);
-    Preconditions.checkArgument(allowLocalFileSystem
-            || !PinotFSFactory.LOCAL_PINOT_FS_SCHEME.equalsIgnoreCase(sourceFileURIScheme),
-        "Local filesystem URIs are not allowed for /ingestFromURI: %s", sourceFileURI);
-    if (!PinotFSFactory.isSchemeSupported(sourceFileURIScheme)) {
-      String inputFsClassName = batchConfigMap.get(BatchConfigProperties.INPUT_FS_CLASS);
-      Preconditions.checkArgument(StringUtils.isNotBlank(inputFsClassName),
-          "Must provide %s for unsupported scheme: %s", BatchConfigProperties.INPUT_FS_CLASS, sourceFileURIScheme);
-      Preconditions.checkArgument(allowLocalFileSystem || !isLocalPinotFSClassName(inputFsClassName),
-          "Local filesystem implementation is not allowed for /ingestFromURI: %s", inputFsClassName);
-      try {
-        PinotFSFactory.register(sourceFileURIScheme, inputFsClassName,
-            IngestionConfigUtils.getInputFsProps(batchConfigMap));
-      } catch (RuntimeException e) {
-        throw new IllegalArgumentException(
-            String.format("Invalid %s for /ingestFromURI: %s", BatchConfigProperties.INPUT_FS_CLASS,
-                inputFsClassName), e);
-      }
+    try (ResolvedFileSystem sourceFileSystem =
+        resolveSourceFileSystem(batchConfigMap, sourceFileURI, allowLocalFileSystem)) {
+      sourceFileSystem._fileSystem.copyToLocalFile(sourceFileURI, destFile);
     }
-    Preconditions.checkArgument(allowLocalFileSystem
-            || !PinotFSFactory.isSchemeRegisteredWith(sourceFileURIScheme, LocalPinotFS.class),
-        "Local filesystem implementation is not allowed for /ingestFromURI: %s", sourceFileURIScheme);
-    PinotFSFactory.create(sourceFileURIScheme).copyToLocalFile(sourceFileURI, destFile);
   }
 
-  private static boolean isLocalPinotFSClassName(String className) {
-    String rawClassName = className;
-    int pluginSeparatorIndex = className.indexOf(':');
-    if (pluginSeparatorIndex >= 0) {
-      rawClassName = className.substring(pluginSeparatorIndex + 1);
+  private static ResolvedFileSystem resolveSourceFileSystem(Map<String, String> batchConfigMap, URI sourceFileURI,
+      boolean allowLocalFileSystem) {
+    String sourceFileURIScheme = sourceFileURI.getScheme();
+    Preconditions.checkArgument(allowLocalFileSystem || !isLocalSource(sourceFileURI),
+        LOCAL_FILE_SYSTEM_DISABLED_MESSAGE);
+    if (PinotFSFactory.isSchemeSupported(sourceFileURIScheme)) {
+      PinotFS sourceFileSystem;
+      try {
+        sourceFileSystem = PinotFSFactory.create(sourceFileURIScheme);
+      } catch (RuntimeException e) {
+        throw new IllegalArgumentException(INVALID_FILE_SYSTEM_MESSAGE, e);
+      }
+      validateFileSystemInstance(sourceFileSystem, allowLocalFileSystem);
+      return new ResolvedFileSystem(sourceFileSystem, null);
     }
-    return LocalPinotFS.class.getName().equals(PluginManager.loadClassWithBackwardCompatibleCheck(rawClassName));
+
+    String inputFsClassName = batchConfigMap.get(BatchConfigProperties.INPUT_FS_CLASS);
+    Preconditions.checkArgument(StringUtils.isNotBlank(inputFsClassName), INVALID_FILE_SYSTEM_MESSAGE);
+    Class<? extends PinotFS> fileSystemClass = loadFileSystemClass(inputFsClassName, allowLocalFileSystem);
+    PinotFS sourceFileSystem;
+    try {
+      sourceFileSystem = fileSystemClass.getConstructor().newInstance();
+    } catch (ReflectiveOperationException | RuntimeException | LinkageError e) {
+      throw new IllegalArgumentException(INVALID_FILE_SYSTEM_MESSAGE, e);
+    }
+    try {
+      validateFileSystemInstance(sourceFileSystem, allowLocalFileSystem);
+    } catch (RuntimeException | LinkageError e) {
+      closeRequestScopedFileSystem(sourceFileSystem);
+      throw e;
+    }
+    try {
+      sourceFileSystem.init(IngestionConfigUtils.getInputFsProps(batchConfigMap));
+    } catch (RuntimeException | LinkageError e) {
+      closeRequestScopedFileSystem(sourceFileSystem);
+      throw new IllegalArgumentException(INVALID_FILE_SYSTEM_MESSAGE, e);
+    }
+    return new ResolvedFileSystem(sourceFileSystem, sourceFileSystem);
+  }
+
+  private static boolean isLocalSource(URI sourceFileURI) {
+    String scheme = sourceFileURI.getScheme();
+    if (StringUtils.isBlank(scheme) || PinotFSFactory.LOCAL_PINOT_FS_SCHEME.equalsIgnoreCase(scheme)) {
+      return true;
+    }
+    // URI treats a Windows drive letter as a scheme (for example C:/data.csv).
+    return scheme.length() == 1 && sourceFileURI.getAuthority() == null
+        && (sourceFileURI.isOpaque() || sourceFileURI.getPath() != null && sourceFileURI.getPath().startsWith("/"));
+  }
+
+  private static Class<? extends PinotFS> loadFileSystemClass(String className, boolean allowLocalFileSystem) {
+    Class<?> fileSystemClass;
+    try {
+      fileSystemClass = PluginManager.get().loadClass(className);
+    } catch (Exception | LinkageError e) {
+      throw new IllegalArgumentException(INVALID_FILE_SYSTEM_MESSAGE, e);
+    }
+    Preconditions.checkArgument(PinotFS.class.isAssignableFrom(fileSystemClass), INVALID_FILE_SYSTEM_MESSAGE);
+    Preconditions.checkArgument(allowLocalFileSystem || !LocalPinotFS.class.isAssignableFrom(fileSystemClass),
+        LOCAL_FILE_SYSTEM_DISABLED_MESSAGE);
+    return fileSystemClass.asSubclass(PinotFS.class);
+  }
+
+  private static void validateFileSystemInstance(PinotFS fileSystem, boolean allowLocalFileSystem) {
+    Preconditions.checkArgument(allowLocalFileSystem
+            || !PinotFSFactory.isFileSystemInstanceOf(fileSystem, LocalPinotFS.class),
+        LOCAL_FILE_SYSTEM_DISABLED_MESSAGE);
+  }
+
+  private static void closeRequestScopedFileSystem(PinotFS fileSystem) {
+    try {
+      fileSystem.close();
+    } catch (Exception | LinkageError e) {
+      LOGGER.warn("Failed to close request-scoped filesystem, exception type: {}", e.getClass().getName());
+    }
+  }
+
+  private static class ResolvedFileSystem implements AutoCloseable {
+    private final PinotFS _fileSystem;
+    private final PinotFS _closeWhenDone;
+
+    private ResolvedFileSystem(PinotFS fileSystem, PinotFS closeWhenDone) {
+      _fileSystem = fileSystem;
+      _closeWhenDone = closeWhenDone;
+    }
+
+    @Override
+    public void close() {
+      if (_closeWhenDone != null) {
+        closeRequestScopedFileSystem(_closeWhenDone);
+      }
+    }
   }
 
   /// Copy the file from the uploaded multipart to a local file

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerConfTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerConfTest.java
@@ -243,4 +243,13 @@ public class ControllerConfTest {
     Assert.assertEquals(conf.getPinotTaskQueueCapacity(), 10000);
     Assert.assertEquals(conf.getPinotTaskQueueWarningThreshold(), 8000);
   }
+
+  @Test
+  public void testIngestFromUriLocalFileSystemCompatibilityOption() {
+    ControllerConf controllerConf = new ControllerConf();
+    Assert.assertFalse(controllerConf.isIngestFromUriLocalFileSystemAllowed());
+
+    controllerConf.setProperty(ControllerConf.INGEST_FROM_URI_ALLOW_LOCAL_FILE_SYSTEM, true);
+    Assert.assertTrue(controllerConf.isIngestFromUriLocalFileSystemAllowed());
+  }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotIngestionRestletResourceStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotIngestionRestletResourceStatelessTest.java
@@ -21,10 +21,20 @@ package org.apache.pinot.controller.api;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.entity.mime.FileBody;
+import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.pinot.client.admin.PinotAdminClient;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.helix.ControllerTest;
@@ -54,9 +64,7 @@ public class PinotIngestionRestletResourceStatelessTest extends ControllerTest {
   public void setUp()
       throws Exception {
     startZk();
-    Map<String, Object> controllerConfig = getDefaultControllerConfiguration();
-    controllerConfig.put(ControllerConf.INGEST_FROM_URI_ALLOW_LOCAL_FILE_SYSTEM, true);
-    startController(controllerConfig);
+    startController();
     addFakeBrokerInstancesToAutoJoinHelixCluster(1, true);
     addFakeServerInstancesToAutoJoinHelixCluster(1, true);
 
@@ -94,22 +102,64 @@ public class PinotIngestionRestletResourceStatelessTest extends ControllerTest {
     Map<String, String> batchConfigMap = new HashMap<>();
     batchConfigMap.put(BatchConfigProperties.INPUT_FORMAT, "csv");
     batchConfigMap.put(String.format("%s.delimiter", BatchConfigProperties.RECORD_READER_PROP_PREFIX), "|");
+
+    // Local URI validation happens before any working directory or segment is created, and the response does not
+    // expose the submitted path.
+    String sensitivePathToken = "controller-secret-ingest-source.csv";
+    String localUriResponse = sendHttpPost(adminClient.getFileIngestClient()
+        .buildIngestFromUriUrl(TABLE_NAME_WITH_TYPE, batchConfigMap, "file:///private/" + sensitivePathToken), 400);
+    assertFalse(localUriResponse.contains(sensitivePathToken));
+
+    String malformedUriToken = "malformed-controller-secret.csv";
+    String malformedUriResponse = sendHttpPost(adminClient.getFileIngestClient()
+        .buildIngestFromUriUrl(TABLE_NAME_WITH_TYPE, batchConfigMap, "file:///%" + malformedUriToken), 400);
+    assertFalse(malformedUriResponse.contains(malformedUriToken));
+    assertFalse(ingestionDir.exists());
+    segments = _helixResourceManager.getSegmentsFor(TABLE_NAME_WITH_TYPE, false);
+    assertEquals(segments.size(), 0);
+
     assertEquals(adminClient.getFileIngestClient().ingestFromFile(TABLE_NAME_WITH_TYPE, batchConfigMap, _inputFile),
         200);
     segments = _helixResourceManager.getSegmentsFor(TABLE_NAME_WITH_TYPE, false);
     assertEquals(segments.size(), 1);
 
-    // ingest from URI
-    assertEquals(adminClient.getFileIngestClient()
-            .ingestFromUri(TABLE_NAME_WITH_TYPE, batchConfigMap,
-                String.format("file://%s", _inputFile.getAbsolutePath()), _inputFile),
-        200);
-    segments = _helixResourceManager.getSegmentsFor(TABLE_NAME_WITH_TYPE, false);
-    assertEquals(segments.size(), 2);
+    // The compatibility option explicitly restores local URI ingestion.
+    _controllerConfig.setProperty(ControllerConf.INGEST_FROM_URI_ALLOW_LOCAL_FILE_SYSTEM, true);
+    try {
+      assertEquals(adminClient.getFileIngestClient()
+              .ingestFromUri(TABLE_NAME_WITH_TYPE, batchConfigMap,
+                  String.format("file://%s", _inputFile.getAbsolutePath()), _inputFile),
+          200);
+      segments = _helixResourceManager.getSegmentsFor(TABLE_NAME_WITH_TYPE, false);
+      assertEquals(segments.size(), 2);
+    } finally {
+      _controllerConfig.setProperty(ControllerConf.INGEST_FROM_URI_ALLOW_LOCAL_FILE_SYSTEM, false);
+    }
 
     // the ingestion dir exists after ingesting files. We check the existence to make sure this dir is created under
     // _controllerConfig.getLocalTempDir()
     assertTrue(ingestionDir.exists());
+  }
+
+  private String sendHttpPost(String uri, int expectedStatusCode)
+      throws IOException {
+    HttpPost httpPost = new HttpPost(uri);
+    HttpEntity reqEntity =
+        MultipartEntityBuilder.create().addPart("file", new FileBody(_inputFile.getAbsoluteFile())).build();
+    httpPost.setEntity(reqEntity);
+    try (CloseableHttpClient httpClient = HttpClientBuilder.create().build()) {
+      return httpClient.execute(httpPost, response -> {
+        String responseBody;
+        try {
+          responseBody = response.getEntity() != null
+              ? EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8) : "";
+        } catch (ParseException e) {
+          throw new IOException(e);
+        }
+        assertEquals(response.getCode(), expectedStatusCode, responseBody);
+        return responseBody;
+      });
+    }
   }
 
   @AfterClass

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/exception/ControllerApplicationExceptionTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/exception/ControllerApplicationExceptionTest.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.exception;
+
+import javax.ws.rs.core.Response;
+import org.apache.pinot.controller.api.exception.ControllerApplicationException.ExceptionLogMode;
+import org.slf4j.Logger;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.testng.Assert.assertEquals;
+
+
+/// Tests exception logging modes used by Controller API responses.
+public class ControllerApplicationExceptionTest {
+  private static final String PUBLIC_MESSAGE = "Request failed";
+  private static final String SENSITIVE_MESSAGE = "file:///private/controller-secret.csv?signature=secret";
+
+  @Test
+  public void testTypeOnlyClientErrorLoggingDoesNotExposeExceptionMessage() {
+    Logger logger = mock(Logger.class);
+    IllegalArgumentException cause = new IllegalArgumentException(SENSITIVE_MESSAGE);
+
+    ControllerApplicationException exception = new ControllerApplicationException(logger, PUBLIC_MESSAGE,
+        Response.Status.BAD_REQUEST, cause, ExceptionLogMode.TYPE_ONLY);
+
+    assertEquals(exception.getResponse().getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
+    assertEquals(exception.getMessage(), PUBLIC_MESSAGE);
+    verify(logger).info("{} exception type: {}", PUBLIC_MESSAGE, IllegalArgumentException.class.getName());
+    verifyNoMoreInteractions(logger);
+  }
+
+  @Test
+  public void testTypeOnlyServerErrorLoggingDoesNotExposeExceptionMessageOrThrowable() {
+    Logger logger = mock(Logger.class);
+    IllegalStateException cause = new IllegalStateException(SENSITIVE_MESSAGE);
+
+    ControllerApplicationException exception = new ControllerApplicationException(logger, PUBLIC_MESSAGE,
+        Response.Status.INTERNAL_SERVER_ERROR, cause, ExceptionLogMode.TYPE_ONLY);
+
+    assertEquals(exception.getResponse().getStatus(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+    assertEquals(exception.getMessage(), PUBLIC_MESSAGE);
+    verify(logger).error("{} exception type: {}", PUBLIC_MESSAGE, IllegalStateException.class.getName());
+    verifyNoMoreInteractions(logger);
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/util/FileIngestionHelperTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/util/FileIngestionHelperTest.java
@@ -19,30 +19,67 @@
 package org.apache.pinot.controller.util;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.filesystem.BasePinotFS;
 import org.apache.pinot.spi.filesystem.LocalPinotFS;
+import org.apache.pinot.spi.filesystem.NoClosePinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.expectThrows;
 
 
 @Test(groups = "stateless")
 public class FileIngestionHelperTest {
-  private static final File DEST_FILE = new File("unused");
+  private static final File DEST_FILE = new File(FileUtils.getTempDirectory(),
+      "pinot-ingest-uri-unused-" + UUID.randomUUID());
+  private static final String SENSITIVE_PATH_TOKEN = "controller-secret-7f4c.csv";
+  private static final String LOCAL_FILE_SYSTEM_DISABLED_MESSAGE =
+      "Local filesystem sources are disabled for /ingestFromURI";
+
+  @DataProvider(name = "localSources")
+  public static Object[][] localSources() {
+    return new Object[][]{
+        {URI.create("file:///private/" + SENSITIVE_PATH_TOKEN)},
+        {URI.create("file:/private/" + SENSITIVE_PATH_TOKEN)},
+        {URI.create("file:relative/" + SENSITIVE_PATH_TOKEN)},
+        {URI.create("FILE:///private/" + SENSITIVE_PATH_TOKEN)},
+        {URI.create("file://localhost/private/" + SENSITIVE_PATH_TOKEN)},
+        {URI.create("/private/" + SENSITIVE_PATH_TOKEN)},
+        {URI.create("relative/" + SENSITIVE_PATH_TOKEN)},
+        {URI.create("./relative/" + SENSITIVE_PATH_TOKEN)},
+        {URI.create("../relative/" + SENSITIVE_PATH_TOKEN)},
+        {URI.create("//localhost/share/" + SENSITIVE_PATH_TOKEN)},
+        {URI.create("C:/private/" + SENSITIVE_PATH_TOKEN)},
+        {URI.create("C:relative/" + SENSITIVE_PATH_TOKEN)}
+    };
+  }
+
+  @Test(dataProvider = "localSources")
+  public void testRejectsLocalSourcesByDefaultWithoutExposingPath(URI sourceURI) {
+    IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
+        () -> FileIngestionHelper.copyURIToLocal(Map.of(), sourceURI, DEST_FILE, false));
+
+    assertEquals(exception.getMessage(), LOCAL_FILE_SYSTEM_DISABLED_MESSAGE);
+    assertFalse(exception.getMessage().contains(SENSITIVE_PATH_TOKEN));
+    assertFalse(DEST_FILE.exists());
+  }
 
   @Test
-  public void testCopiesLocalFileUriWhenLocalFileSystemIsEnabled()
+  public void testCopiesLocalFileUriOnlyWhenCompatibilityOptionIsEnabled()
       throws Exception {
     Path tempDir = Files.createTempDirectory("pinot-ingest-uri-test");
     try {
@@ -50,7 +87,7 @@ public class FileIngestionHelperTest {
       Path destFile = tempDir.resolve("dest.csv");
       Files.writeString(inputFile, "col\nvalue\n", StandardCharsets.UTF_8);
 
-      FileIngestionHelper.copyURIToLocal(new HashMap<>(), inputFile.toUri(), destFile.toFile(), true);
+      FileIngestionHelper.copyURIToLocal(Map.of(), inputFile.toUri(), destFile.toFile(), true);
 
       assertEquals(Files.readString(destFile, StandardCharsets.UTF_8), "col\nvalue\n");
     } finally {
@@ -59,90 +96,436 @@ public class FileIngestionHelperTest {
   }
 
   @Test
-  public void testRejectsLocalFileUriWhenLocalFileSystemIsDisabled() {
-    IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
-        () -> FileIngestionHelper.copyURIToLocal(new HashMap<>(), URI.create("file:///tmp/input.csv"), DEST_FILE,
-            false));
+  public void testRejectsLocalSourceBeforeCreatingWorkingDirectory()
+      throws Exception {
+    Path tempDir = Files.createTempDirectory("pinot-ingest-uri-validation-test");
+    try {
+      File ingestionDir = tempDir.resolve("ingestion-dir").toFile();
+      FileIngestionHelper helper =
+          new FileIngestionHelper(null, null, Map.of(), null, ingestionDir, null, false);
 
-    assertTrue(exception.getMessage().contains("Local filesystem URIs are not allowed"));
+      expectThrows(IllegalArgumentException.class,
+          () -> helper.buildSegmentAndPush(new FileIngestionHelper.DataPayload(
+              URI.create("file:///private/" + SENSITIVE_PATH_TOKEN))));
+
+      assertFalse(ingestionDir.exists());
+    } finally {
+      FileUtils.deleteQuietly(tempDir.toFile());
+    }
   }
 
   @Test
-  public void testRejectsSchemeLessUriWhenLocalFileSystemIsDisabled() {
-    IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
-        () -> FileIngestionHelper.copyURIToLocal(new HashMap<>(), URI.create("/tmp/input.csv"), DEST_FILE, false));
+  public void testRejectsLocalFileSystemAliasesBeforeRegistration() {
+    String[] classNames = {
+        LocalPinotFS.class.getName(),
+        "org.apache.pinot.filesystem.LocalPinotFS",
+        "DEFAULT:" + LocalPinotFS.class.getName()
+    };
+    for (int i = 0; i < classNames.length; i++) {
+      String scheme = "localalias" + i;
+      Map<String, String> batchConfigMap = Map.of(BatchConfigProperties.INPUT_FS_CLASS, classNames[i]);
 
-    assertTrue(exception.getMessage().contains("Source URI must include a scheme"));
+      IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
+          () -> FileIngestionHelper.copyURIToLocal(batchConfigMap,
+              URI.create(scheme + ":///private/" + SENSITIVE_PATH_TOKEN), DEST_FILE, false));
+
+      assertEquals(exception.getMessage(), LOCAL_FILE_SYSTEM_DISABLED_MESSAGE);
+      assertFalse(exception.getMessage().contains(classNames[i]));
+      assertFalse(PinotFSFactory.isSchemeSupported(scheme));
+    }
   }
 
   @Test
-  public void testPreservesSchemeLessUriHandlingWhenLocalFileSystemIsEnabled() {
-    IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
-        () -> FileIngestionHelper.copyURIToLocal(new HashMap<>(), URI.create("/tmp/input.csv"), DEST_FILE, true));
-
-    assertTrue(exception.getMessage().contains("Must provide input.fs.className"));
-  }
-
-  @Test
-  public void testRejectsLocalFileSystemClassForCustomSchemeWhenLocalFileSystemIsDisabled() {
-    Map<String, String> batchConfigMap = new HashMap<>();
-    batchConfigMap.put(BatchConfigProperties.INPUT_FS_CLASS, LocalPinotFS.class.getName());
-
-    IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
-        () -> FileIngestionHelper.copyURIToLocal(batchConfigMap, URI.create("customlocalfstest:///tmp/input.csv"),
-            DEST_FILE, false));
-
-    assertTrue(exception.getMessage().contains("Local filesystem implementation is not allowed"));
-  }
-
-  @Test
-  public void testRejectsInvalidFileSystemClassForCustomScheme() {
-    Map<String, String> batchConfigMap = new HashMap<>();
-    batchConfigMap.put(BatchConfigProperties.INPUT_FS_CLASS,
-        "org.apache.pinot.spi.filesystem.DoesNotExistPinotFS");
-
-    IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
-        () -> FileIngestionHelper.copyURIToLocal(batchConfigMap, URI.create("invalidlocalfstest:///tmp/input.csv"),
-            DEST_FILE, false));
-
-    assertTrue(exception.getMessage().contains("Invalid input.fs.className for /ingestFromURI"));
-  }
-
-  @Test
-  public void testRejectsLegacyLocalFileSystemClassForCustomSchemeWhenLocalFileSystemIsDisabled() {
-    Map<String, String> batchConfigMap = new HashMap<>();
-    batchConfigMap.put(BatchConfigProperties.INPUT_FS_CLASS, "org.apache.pinot.filesystem.LocalPinotFS");
-
-    IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
-        () -> FileIngestionHelper.copyURIToLocal(batchConfigMap, URI.create("legacylocalfstest:///tmp/input.csv"),
-            DEST_FILE, false));
-
-    assertTrue(exception.getMessage().contains("Local filesystem implementation is not allowed"));
-  }
-
-  @Test
-  public void testRejectsRegisteredLocalFileSystemSchemeWhenLocalFileSystemIsDisabled() {
-    PinotFSFactory.register("registeredlocalfstest", LocalPinotFS.class.getName(), new PinotConfiguration());
-
-    IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
-        () -> FileIngestionHelper.copyURIToLocal(new HashMap<>(), URI.create("registeredlocalfstest:///tmp/input.csv"),
-            DEST_FILE, false));
-
-    assertTrue(exception.getMessage().contains("Local filesystem implementation is not allowed"));
-  }
-
-  @Test
-  public void testRejectsLocalFileSystemSubclassForCustomSchemeWhenLocalFileSystemIsDisabled() {
-    Map<String, String> batchConfigMap = new HashMap<>();
-    batchConfigMap.put(BatchConfigProperties.INPUT_FS_CLASS, TestLocalPinotFS.class.getName());
+  public void testRejectsLocalFileSystemSubclassBeforeConstructionOrRegistration() {
+    TestLocalPinotFS.reset();
+    String scheme = "localsubclass";
+    Map<String, String> batchConfigMap =
+        Map.of(BatchConfigProperties.INPUT_FS_CLASS, TestLocalPinotFS.class.getName());
 
     IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
         () -> FileIngestionHelper.copyURIToLocal(batchConfigMap,
-            URI.create("customlocalfssubclasstest:///tmp/input.csv"), DEST_FILE, false));
+            URI.create(scheme + ":///private/" + SENSITIVE_PATH_TOKEN), DEST_FILE, false));
 
-    assertTrue(exception.getMessage().contains("Local filesystem implementation is not allowed"));
+    assertEquals(exception.getMessage(), LOCAL_FILE_SYSTEM_DISABLED_MESSAGE);
+    assertEquals(TestLocalPinotFS._constructorCalls, 0);
+    assertEquals(TestLocalPinotFS._initCalls, 0);
+    assertEquals(TestLocalPinotFS._copyCalls, 0);
+    assertFalse(PinotFSFactory.isSchemeSupported(scheme));
+  }
+
+  @Test
+  public void testRejectsEndpointProvidedLocalDelegateBeforeInitializationOrRegistration() {
+    LocalDelegatePinotFS.reset();
+    String scheme = "localdelegate";
+    Map<String, String> batchConfigMap =
+        Map.of(BatchConfigProperties.INPUT_FS_CLASS, LocalDelegatePinotFS.class.getName());
+
+    IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
+        () -> FileIngestionHelper.copyURIToLocal(batchConfigMap,
+            URI.create(scheme + ":///private/" + SENSITIVE_PATH_TOKEN), DEST_FILE, false));
+
+    assertEquals(exception.getMessage(), LOCAL_FILE_SYSTEM_DISABLED_MESSAGE);
+    assertEquals(LocalDelegatePinotFS._constructorCalls, 1);
+    assertEquals(LocalDelegatePinotFS._initCalls, 0);
+    assertEquals(LocalDelegatePinotFS._copyCalls, 0);
+    assertEquals(LocalDelegatePinotFS._wrapperCloseCalls, 1);
+    assertEquals(LocalDelegatePinotFS._delegateCloseCalls, 0);
+    assertFalse(PinotFSFactory.isSchemeSupported(scheme));
+  }
+
+  @Test
+  public void testRejectsConfiguredNestedLocalDelegate() {
+    String scheme = "configuredlocaldelegate";
+    PinotFSFactory.register(scheme, LocalDelegatePinotFS.class.getName(), new PinotConfiguration());
+    LocalDelegatePinotFS._copyCalls = 0;
+
+    IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
+        () -> FileIngestionHelper.copyURIToLocal(Map.of(),
+            URI.create(scheme + ":///private/" + SENSITIVE_PATH_TOKEN), DEST_FILE, false));
+
+    assertEquals(exception.getMessage(), LOCAL_FILE_SYSTEM_DISABLED_MESSAGE);
+    assertEquals(LocalDelegatePinotFS._copyCalls, 0);
+  }
+
+  @Test
+  public void testCopiesFromRequestConfiguredRemoteFileSystem()
+      throws Exception {
+    TestRemotePinotFS.reset();
+    String scheme = "requestremote";
+    Map<String, String> batchConfigMap =
+        Map.of(BatchConfigProperties.INPUT_FS_CLASS, TestRemotePinotFS.class.getName());
+    Path destFile = Files.createTempFile("pinot-ingest-uri-remote", ".txt");
+    try {
+      FileIngestionHelper.copyURIToLocal(batchConfigMap, URI.create(scheme + "://bucket/object"),
+          destFile.toFile(), false);
+
+      assertEquals(TestRemotePinotFS._initCalls, 1);
+      assertEquals(TestRemotePinotFS._copyCalls, 1);
+      assertEquals(TestRemotePinotFS._closeCalls, 1);
+      assertEquals(Files.readString(destFile, StandardCharsets.UTF_8), TestRemotePinotFS.REMOTE_CONTENT);
+    } finally {
+      FileUtils.deleteQuietly(destFile.toFile());
+    }
+  }
+
+  @Test
+  public void testCopiesFromRequestConfiguredRemoteDelegate()
+      throws Exception {
+    TestRemotePinotFS.reset();
+    RemoteDelegatePinotFS.reset();
+    String scheme = "requestremotedelegate";
+    Map<String, String> batchConfigMap =
+        Map.of(BatchConfigProperties.INPUT_FS_CLASS, RemoteDelegatePinotFS.class.getName());
+    Path destFile = Files.createTempFile("pinot-ingest-uri-remote-delegate", ".txt");
+    try {
+      FileIngestionHelper.copyURIToLocal(batchConfigMap, URI.create(scheme + "://bucket/object"),
+          destFile.toFile(), false);
+
+      assertEquals(TestRemotePinotFS._initCalls, 1);
+      assertEquals(TestRemotePinotFS._copyCalls, 1);
+      assertEquals(TestRemotePinotFS._closeCalls, 0);
+      assertEquals(RemoteDelegatePinotFS._initCalls, 1);
+      assertEquals(RemoteDelegatePinotFS._copyCalls, 1);
+      assertEquals(RemoteDelegatePinotFS._closeCalls, 1);
+      assertEquals(Files.readString(destFile, StandardCharsets.UTF_8), TestRemotePinotFS.REMOTE_CONTENT);
+      assertFalse(PinotFSFactory.isSchemeSupported(scheme));
+    } finally {
+      FileUtils.deleteQuietly(destFile.toFile());
+    }
+  }
+
+  @Test
+  public void testCopiesFromControllerConfiguredRemoteFileSystem()
+      throws Exception {
+    TestRemotePinotFS.reset();
+    String scheme = "configuredremote";
+    PinotFSFactory.register(scheme, TestRemotePinotFS.class.getName(), new PinotConfiguration());
+    Path destFile = Files.createTempFile("pinot-ingest-uri-configured-remote", ".txt");
+    try {
+      FileIngestionHelper.copyURIToLocal(Map.of(), URI.create(scheme + "://bucket/object"), destFile.toFile(),
+          false);
+
+      assertEquals(TestRemotePinotFS._initCalls, 1);
+      assertEquals(TestRemotePinotFS._copyCalls, 1);
+      assertEquals(TestRemotePinotFS._closeCalls, 0);
+      assertEquals(Files.readString(destFile, StandardCharsets.UTF_8), TestRemotePinotFS.REMOTE_CONTENT);
+    } finally {
+      FileUtils.deleteQuietly(destFile.toFile());
+    }
+  }
+
+  @Test
+  public void testClosesRequestScopedFileSystemWhenInitializationFails() {
+    FailingInitRemotePinotFS.reset();
+    String scheme = "failinginitremote";
+    Map<String, String> batchConfigMap =
+        Map.of(BatchConfigProperties.INPUT_FS_CLASS, FailingInitRemotePinotFS.class.getName());
+
+    IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
+        () -> FileIngestionHelper.copyURIToLocal(batchConfigMap, URI.create(scheme + "://bucket/object"),
+            DEST_FILE, false));
+
+    assertEquals(exception.getMessage(), "Invalid filesystem source for /ingestFromURI");
+    assertEquals(FailingInitRemotePinotFS._closeCalls, 1);
+    assertFalse(PinotFSFactory.isSchemeSupported(scheme));
+  }
+
+  @Test
+  public void testSanitizesLinkageErrorDuringInitialization() {
+    LinkageErrorInitRemotePinotFS.reset();
+    Map<String, String> batchConfigMap =
+        Map.of(BatchConfigProperties.INPUT_FS_CLASS, LinkageErrorInitRemotePinotFS.class.getName());
+
+    IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
+        () -> FileIngestionHelper.copyURIToLocal(batchConfigMap, URI.create("linkageerror://bucket/object"),
+            DEST_FILE, false));
+
+    assertEquals(exception.getMessage(), "Invalid filesystem source for /ingestFromURI");
+    assertFalse(exception.getMessage().contains(SENSITIVE_PATH_TOKEN));
+    assertEquals(LinkageErrorInitRemotePinotFS._closeCalls, 1);
+  }
+
+  @Test
+  public void testRejectsInvalidFileSystemClassWithoutExposingClassName() {
+    String className = "org.apache.pinot.spi.filesystem.SensitiveMissingPinotFS";
+    Map<String, String> batchConfigMap = Map.of(BatchConfigProperties.INPUT_FS_CLASS, className);
+
+    IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
+        () -> FileIngestionHelper.copyURIToLocal(batchConfigMap, URI.create("invalidremote://bucket/object"),
+            DEST_FILE, false));
+
+    assertEquals(exception.getMessage(), "Invalid filesystem source for /ingestFromURI");
+    assertFalse(exception.getMessage().contains(className));
   }
 
   public static class TestLocalPinotFS extends LocalPinotFS {
+    private static int _constructorCalls;
+    private static int _initCalls;
+    private static int _copyCalls;
+
+    public TestLocalPinotFS() {
+      _constructorCalls++;
+    }
+
+    @Override
+    public void init(PinotConfiguration config) {
+      _initCalls++;
+    }
+
+    @Override
+    public void copyToLocalFile(URI srcUri, File dstFile)
+        throws Exception {
+      _copyCalls++;
+      super.copyToLocalFile(srcUri, dstFile);
+    }
+
+    private static void reset() {
+      _constructorCalls = 0;
+      _initCalls = 0;
+      _copyCalls = 0;
+    }
+  }
+
+  public static class LocalDelegatePinotFS extends NoClosePinotFS {
+    private static int _constructorCalls;
+    private static int _initCalls;
+    private static int _copyCalls;
+    private static int _wrapperCloseCalls;
+    private static int _delegateCloseCalls;
+
+    public LocalDelegatePinotFS() {
+      super(new LocalPinotFS() {
+        @Override
+        public void close() {
+          _delegateCloseCalls++;
+        }
+      });
+      _constructorCalls++;
+    }
+
+    @Override
+    public void init(PinotConfiguration config) {
+      _initCalls++;
+      super.init(config);
+    }
+
+    @Override
+    public void copyToLocalFile(URI srcUri, File dstFile)
+        throws Exception {
+      _copyCalls++;
+      super.copyToLocalFile(srcUri, dstFile);
+    }
+
+    @Override
+    public void close() {
+      _wrapperCloseCalls++;
+    }
+
+    private static void reset() {
+      _constructorCalls = 0;
+      _initCalls = 0;
+      _copyCalls = 0;
+      _wrapperCloseCalls = 0;
+      _delegateCloseCalls = 0;
+    }
+  }
+
+  public static class RemoteDelegatePinotFS extends NoClosePinotFS {
+    private static int _initCalls;
+    private static int _copyCalls;
+    private static int _closeCalls;
+
+    public RemoteDelegatePinotFS() {
+      super(new TestRemotePinotFS());
+    }
+
+    @Override
+    public void init(PinotConfiguration config) {
+      _initCalls++;
+      super.init(config);
+    }
+
+    @Override
+    public void copyToLocalFile(URI srcUri, File dstFile)
+        throws Exception {
+      _copyCalls++;
+      super.copyToLocalFile(srcUri, dstFile);
+    }
+
+    @Override
+    public void close() {
+      _closeCalls++;
+    }
+
+    private static void reset() {
+      _initCalls = 0;
+      _copyCalls = 0;
+      _closeCalls = 0;
+    }
+  }
+
+  public static class TestRemotePinotFS extends BasePinotFS {
+    private static final String REMOTE_CONTENT = "remote-content";
+    private static int _initCalls;
+    private static int _copyCalls;
+    private static int _closeCalls;
+
+    @Override
+    public void init(PinotConfiguration config) {
+      _initCalls++;
+    }
+
+    @Override
+    public boolean mkdir(URI uri) {
+      return true;
+    }
+
+    @Override
+    public boolean delete(URI segmentUri, boolean forceDelete) {
+      return true;
+    }
+
+    @Override
+    protected boolean doMove(URI srcUri, URI dstUri) {
+      return true;
+    }
+
+    @Override
+    public boolean copyDir(URI srcUri, URI dstUri) {
+      return true;
+    }
+
+    @Override
+    public boolean exists(URI fileUri) {
+      return true;
+    }
+
+    @Override
+    public long length(URI fileUri) {
+      return REMOTE_CONTENT.length();
+    }
+
+    @Override
+    public String[] listFiles(URI fileUri, boolean recursive) {
+      return new String[0];
+    }
+
+    @Override
+    public void copyToLocalFile(URI srcUri, File dstFile)
+        throws IOException {
+      _copyCalls++;
+      Files.writeString(dstFile.toPath(), REMOTE_CONTENT, StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public void copyFromLocalFile(File srcFile, URI dstUri) {
+    }
+
+    @Override
+    public boolean isDirectory(URI uri) {
+      return false;
+    }
+
+    @Override
+    public long lastModified(URI uri) {
+      return 0L;
+    }
+
+    @Override
+    public boolean touch(URI uri) {
+      return true;
+    }
+
+    @Override
+    public InputStream open(URI uri) {
+      return InputStream.nullInputStream();
+    }
+
+    @Override
+    public void close() {
+      _closeCalls++;
+    }
+
+    private static void reset() {
+      _initCalls = 0;
+      _copyCalls = 0;
+      _closeCalls = 0;
+    }
+  }
+
+  public static class FailingInitRemotePinotFS extends TestRemotePinotFS {
+    private static int _closeCalls;
+
+    @Override
+    public void init(PinotConfiguration config) {
+      throw new IllegalStateException("initialization failed");
+    }
+
+    @Override
+    public void close() {
+      _closeCalls++;
+    }
+
+    private static void reset() {
+      _closeCalls = 0;
+    }
+  }
+
+  public static class LinkageErrorInitRemotePinotFS extends TestRemotePinotFS {
+    private static int _closeCalls;
+
+    @Override
+    public void init(PinotConfiguration config) {
+      throw new NoClassDefFoundError(SENSITIVE_PATH_TOKEN);
+    }
+
+    @Override
+    public void close() {
+      _closeCalls++;
+    }
+
+    private static void reset() {
+      _closeCalls = 0;
+    }
   }
 }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentCreationMapper.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentCreationMapper.java
@@ -100,7 +100,8 @@ public class HadoopSegmentCreationMapper extends Mapper<LongWritable, Text, Long
     // Register file systems
     List<PinotFSSpec> pinotFSSpecs = _spec.getPinotFSSpecs();
     for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
-      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
+      PinotFSFactory.registerIfNeeded(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(),
+          new PinotConfiguration(pinotFSSpec));
     }
   }
 

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunner.java
@@ -225,7 +225,7 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
             throws Exception {
           PluginManager.get().init();
           for (PinotFSSpec pinotFSSpec : _spec.getPinotFSSpecs()) {
-            PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(),
+            PinotFSFactory.registerIfNeeded(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(),
                 new PinotConfiguration(pinotFSSpec));
           }
           PinotFS finalOutputDirFS = PinotFSFactory.create(finalOutputDirURI.getScheme());

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentMetadataPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentMetadataPushJobRunner.java
@@ -151,7 +151,7 @@ public class SparkSegmentMetadataPushJobRunner implements IngestionJobRunner, Se
       if (_spec.getPushJobSpec().isBatchSegmentUpload()) {
         // Process segments in batch mode using foreachPartition
         pathRDD.foreachPartition(segmentIterator -> {
-          setupFileSystems();
+          setupFileSystemsIfNeeded();
           List<String> segmentsInPartition = new ArrayList<>();
           segmentIterator.forEachRemaining(segmentsInPartition::add);
 
@@ -164,7 +164,7 @@ public class SparkSegmentMetadataPushJobRunner implements IngestionJobRunner, Se
       } else {
         // Process segments one by one using foreach
         pathRDD.foreach(segmentTarPath -> {
-          setupFileSystems();
+          setupFileSystemsIfNeeded();
           Map<String, String> segmentUriToTarPathMap =
               SegmentPushUtils.getSegmentUriToTarPathMap(outputDirURI, _spec.getPushJobSpec(),
                   new String[]{segmentTarPath});
@@ -198,7 +198,7 @@ public class SparkSegmentMetadataPushJobRunner implements IngestionJobRunner, Se
           @Override
           public void call(Iterator<String> segmentIterator) throws Exception {
             PluginManager.get().init();
-            setupFileSystems();
+            setupFileSystemsIfNeeded();
 
             List<String> segmentsInPartition = new ArrayList<>();
             segmentIterator.forEachRemaining(segmentsInPartition::add);
@@ -220,7 +220,7 @@ public class SparkSegmentMetadataPushJobRunner implements IngestionJobRunner, Se
           @Override
           public void call(String segmentTarPath) throws Exception {
             PluginManager.get().init();
-            setupFileSystems();
+            setupFileSystemsIfNeeded();
             try {
               Map<String, String> segmentUriToTarPathMap =
                   SegmentPushUtils.getSegmentUriToTarPathMap(outputDirURI, _spec.getPushJobSpec(),
@@ -246,6 +246,14 @@ public class SparkSegmentMetadataPushJobRunner implements IngestionJobRunner, Se
     List<PinotFSSpec> pinotFSSpecs = _spec.getPinotFSSpecs();
     for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
       PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
+    }
+  }
+
+  private void setupFileSystemsIfNeeded() {
+    List<PinotFSSpec> pinotFSSpecs = _spec.getPinotFSSpecs();
+    for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
+      PinotFSFactory.registerIfNeeded(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(),
+          new PinotConfiguration(pinotFSSpec));
     }
   }
 

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentTarPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentTarPushJobRunner.java
@@ -59,7 +59,7 @@ public class SparkSegmentTarPushJobRunner extends BaseSparkSegmentTarPushJobRunn
           throws Exception {
         PluginManager.get().init();
         for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
-          PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(),
+          PinotFSFactory.registerIfNeeded(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(),
               new PinotConfiguration(pinotFSSpec));
         }
         try {

--- a/pinot-plugins/pinot-file-system/pinot-hdfs/src/main/java/org/apache/pinot/plugin/filesystem/HadoopPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-hdfs/src/main/java/org/apache/pinot/plugin/filesystem/HadoopPinotFS.java
@@ -77,7 +77,9 @@ public class HadoopPinotFS extends BasePinotFS {
         UserGroupInformation.setLoginUser(ugi);
         LOGGER.info("Setting HDFS login user to: {}", globalHadoopUser);
       }
-      _hadoopFS = org.apache.hadoop.fs.FileSystem.get(_hadoopConf);
+      // Hadoop's FileSystem.get() returns a process-cached instance. HadoopPinotFS closes its filesystem, so it must
+      // own a distinct instance to avoid one PinotFS closing a client that is still in use elsewhere.
+      _hadoopFS = org.apache.hadoop.fs.FileSystem.newInstance(_hadoopConf);
       _hadoopFS.setWriteChecksum((config.getProperty(WRITE_CHECKSUM, false)));
       LOGGER.info("successfully initialized HadoopPinotFS");
     } catch (IOException e) {

--- a/pinot-plugins/pinot-file-system/pinot-hdfs/src/test/java/org/apache/pinot/plugin/filesystem/HadoopPinotFSTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-hdfs/src/test/java/org/apache/pinot/plugin/filesystem/HadoopPinotFSTest.java
@@ -22,12 +22,14 @@ package org.apache.pinot.plugin.filesystem;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.FileMetadata;
 import org.testng.Assert;
@@ -477,6 +479,64 @@ public class HadoopPinotFSTest {
       hadoopFS.init(config);
       String currentUser = org.apache.hadoop.security.UserGroupInformation.getLoginUser().getUserName();
       Assert.assertEquals(currentUser, testUser, "The Hadoop login user was not set correctly!");
+    }
+  }
+
+  @Test
+  public void testClosingOneInstanceLeavesAnotherUsable()
+      throws Exception {
+    File hadoopConfDir = new File(TMP_DIR, "close-aware-conf");
+    FileUtils.forceMkdir(hadoopConfDir);
+    String coreSiteXml = String.format("<configuration>"
+            + "<property><name>fs.defaultFS</name><value>closeaware:///</value></property>"
+            + "<property><name>fs.closeaware.impl</name><value>%s</value></property>"
+            + "</configuration>", CloseAwareFileSystem.class.getName());
+    FileUtils.writeStringToFile(new File(hadoopConfDir, "core-site.xml"), coreSiteXml, StandardCharsets.UTF_8);
+    PinotConfiguration config = new PinotConfiguration();
+    config.setProperty("hadoop.conf.path", hadoopConfDir.getAbsolutePath());
+
+    HadoopPinotFS first = new HadoopPinotFS();
+    boolean firstClosed = false;
+    try (HadoopPinotFS second = new HadoopPinotFS()) {
+      try {
+        first.init(config);
+        second.init(config);
+        first.close();
+        firstClosed = true;
+
+        Assert.assertTrue(second.exists(URI.create("closeaware:///probe")));
+      } finally {
+        if (!firstClosed) {
+          first.close();
+        }
+      }
+    }
+  }
+
+  /// Test filesystem that makes use-after-close observable without inspecting HadoopPinotFS internals.
+  public static class CloseAwareFileSystem extends RawLocalFileSystem {
+    private static final URI FILE_SYSTEM_URI = URI.create("closeaware:///");
+    private boolean _closed;
+
+    @Override
+    public URI getUri() {
+      return FILE_SYSTEM_URI;
+    }
+
+    @Override
+    public boolean exists(Path path)
+        throws IOException {
+      if (_closed) {
+        throw new IOException("Filesystem is closed");
+      }
+      return true;
+    }
+
+    @Override
+    public void close()
+        throws IOException {
+      _closed = true;
+      super.close();
     }
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java
@@ -247,7 +247,8 @@ public interface PinotFS extends Closeable, Serializable {
       throws IOException;
 
   /// For certain filesystems, we may need to close the filesystem and do relevant operations to prevent leaks.
-  /// By default, this method does nothing.
+  /// Implementations must only close resources owned by this instance, not clients shared with other PinotFS
+  /// instances. By default, this method does nothing.
   /// @throws IOException on IO failure
   default void close()
       throws IOException {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFSFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFSFactory.java
@@ -20,9 +20,13 @@ package org.apache.pinot.spi.filesystem;
 
 import com.google.common.base.Preconditions;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nullable;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.slf4j.Logger;
@@ -37,22 +41,52 @@ public class PinotFSFactory {
   public static final String LOCAL_PINOT_FS_SCHEME = "file";
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotFSFactory.class);
   private static final String CLASS = "class";
-  private static final Map<String, PinotFS> PINOT_FS_MAP = new HashMap<String, PinotFS>() {
-    {
-      put(LOCAL_PINOT_FS_SCHEME, new NoClosePinotFS(new LocalPinotFS()));
-    }
-  };
+  private static final Map<String, RegisteredFileSystem> PINOT_FS_MAP = new ConcurrentHashMap<>();
 
-  public static void register(String scheme, String fsClassName, PinotConfiguration fsConfiguration) {
+  static {
+    PINOT_FS_MAP.put(LOCAL_PINOT_FS_SCHEME,
+        new RegisteredFileSystem(new NoClosePinotFS(new LocalPinotFS()), LocalPinotFS.class.getName(), Map.of()));
+  }
+
+  /// Registers a filesystem, replacing any existing mapping. The replaced filesystem is not closed because callers
+  /// can retain the non-closing wrapper returned by [#create(String)] and still be using it.
+  public static void register(String scheme, String fsClassName, @Nullable PinotConfiguration fsConfiguration) {
+    PINOT_FS_MAP.put(scheme, createFileSystem(scheme, fsClassName, fsConfiguration, snapshot(fsConfiguration)));
+  }
+
+  /// Registers a filesystem unless the scheme is already initialized with the same class and configuration. This is
+  /// intended for repeated executor setup where every caller uses the same job configuration. A different explicit
+  /// configuration still replaces the existing mapping.
+  public static void registerIfNeeded(String scheme, String fsClassName, @Nullable PinotConfiguration fsConfiguration) {
+    Map<String, Object> configuration = snapshot(fsConfiguration);
+    PINOT_FS_MAP.compute(scheme, (ignored, current) -> current != null && current.matches(fsClassName, configuration)
+        ? current : createFileSystem(scheme, fsClassName, fsConfiguration, configuration));
+  }
+
+  private static RegisteredFileSystem createFileSystem(String scheme, String fsClassName,
+      @Nullable PinotConfiguration fsConfiguration, @Nullable Map<String, Object> configuration) {
+    PinotFS pinotFS = null;
     try {
       LOGGER.info("Initializing PinotFS for scheme {}, classname {}", scheme, fsClassName);
-      PinotFS pinotFS = PluginManager.get().createInstance(fsClassName);
+      pinotFS = PluginManager.get().createInstance(fsClassName);
       pinotFS.init(fsConfiguration);
-      PINOT_FS_MAP.put(scheme, new NoClosePinotFS(pinotFS));
+      return new RegisteredFileSystem(new NoClosePinotFS(pinotFS), fsClassName, configuration);
     } catch (Exception e) {
+      if (pinotFS != null) {
+        try {
+          pinotFS.close();
+        } catch (Exception closeException) {
+          e.addSuppressed(closeException);
+        }
+      }
       LOGGER.error("Could not instantiate file system for class {} with scheme {}", fsClassName, scheme, e);
       throw new RuntimeException(e);
     }
+  }
+
+  @Nullable
+  private static Map<String, Object> snapshot(@Nullable PinotConfiguration configuration) {
+    return configuration != null ? Collections.unmodifiableMap(new HashMap<>(configuration.toMap())) : null;
   }
 
   public static void init(PinotConfiguration fsFactoryConfig) {
@@ -72,9 +106,9 @@ public class PinotFSFactory {
   }
 
   public static PinotFS create(String scheme) {
-    PinotFS pinotFS = PINOT_FS_MAP.get(scheme);
-    Preconditions.checkState(pinotFS != null, "PinotFS for scheme: %s has not been initialized", scheme);
-    return pinotFS;
+    RegisteredFileSystem registeredFileSystem = PINOT_FS_MAP.get(scheme);
+    Preconditions.checkState(registeredFileSystem != null, "PinotFS for scheme: %s has not been initialized", scheme);
+    return registeredFileSystem._fileSystem;
   }
 
   public static boolean isSchemeSupported(String scheme) {
@@ -82,11 +116,17 @@ public class PinotFSFactory {
   }
 
   public static boolean isSchemeRegisteredWith(String scheme, Class<? extends PinotFS> pinotFSClass) {
-    PinotFS pinotFS = PINOT_FS_MAP.get(scheme);
-    if (pinotFS == null) {
+    RegisteredFileSystem registeredFileSystem = PINOT_FS_MAP.get(scheme);
+    if (registeredFileSystem == null) {
       return false;
     }
-    if (pinotFS instanceof NoClosePinotFS) {
+    return isFileSystemInstanceOf(registeredFileSystem._fileSystem, pinotFSClass);
+  }
+
+  /// Returns whether the filesystem resolves to the given type after recursively inspecting Pinot's non-closing
+  /// delegates.
+  public static boolean isFileSystemInstanceOf(PinotFS pinotFS, Class<? extends PinotFS> pinotFSClass) {
+    while (pinotFS instanceof NoClosePinotFS) {
       pinotFS = ((NoClosePinotFS) pinotFS)._delegate;
     }
     return pinotFSClass.isInstance(pinotFS);
@@ -94,8 +134,24 @@ public class PinotFSFactory {
 
   public static void shutdown()
       throws IOException {
-    for (PinotFS pinotFS : PINOT_FS_MAP.values()) {
-      ((NoClosePinotFS) pinotFS)._delegate.close();
+    for (RegisteredFileSystem registeredFileSystem : PINOT_FS_MAP.values()) {
+      ((NoClosePinotFS) registeredFileSystem._fileSystem)._delegate.close();
+    }
+  }
+
+  private static class RegisteredFileSystem {
+    private final PinotFS _fileSystem;
+    private final String _className;
+    private final @Nullable Map<String, Object> _configuration;
+
+    private RegisteredFileSystem(PinotFS fileSystem, String className, @Nullable Map<String, Object> configuration) {
+      _fileSystem = fileSystem;
+      _className = className;
+      _configuration = configuration;
+    }
+
+    private boolean matches(String className, @Nullable Map<String, Object> configuration) {
+      return _className.equals(className) && Objects.equals(_configuration, configuration);
     }
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/PinotFSFactoryTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/PinotFSFactoryTest.java
@@ -22,8 +22,16 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -39,6 +47,9 @@ public class PinotFSFactoryTest {
     Assert.assertTrue(PinotFSFactory.isSchemeRegisteredWith("file", LocalPinotFS.class));
     Assert.assertFalse(PinotFSFactory.isSchemeRegisteredWith("file", TestPinotFS.class));
     Assert.assertFalse(PinotFSFactory.isSchemeRegisteredWith("missing", LocalPinotFS.class));
+
+    PinotFS nestedLocalPinotFS = new NoClosePinotFS(new NoClosePinotFS(new LocalPinotFS()));
+    Assert.assertTrue(PinotFSFactory.isFileSystemInstanceOf(nestedLocalPinotFS, LocalPinotFS.class));
   }
 
   @Test
@@ -63,8 +74,95 @@ public class PinotFSFactoryTest {
     Assert.assertTrue(pinotFS._delegate instanceof LocalPinotFS);
   }
 
+  @Test
+  public void testRegisterIfNeededReusesEquivalentFileSystem() {
+    String scheme = "registerIfNeededEquivalent";
+    PinotConfiguration initialConfiguration = new PinotConfiguration(Map.of("accessKey", "initial"));
+    PinotFSFactory.registerIfNeeded(scheme, TestPinotFS.class.getName(), initialConfiguration);
+
+    NoClosePinotFS initialWrapper = (NoClosePinotFS) PinotFSFactory.create(scheme);
+    TestPinotFS initialFileSystem = (TestPinotFS) initialWrapper._delegate;
+    PinotFSFactory.registerIfNeeded(scheme, TestPinotFS.class.getName(),
+        new PinotConfiguration(Map.of("accessKey", "initial")));
+
+    Assert.assertSame(PinotFSFactory.create(scheme), initialWrapper);
+    Assert.assertEquals(initialFileSystem.getInitCalled(), 1);
+    Assert.assertEquals(initialFileSystem.getConfiguration().getProperty("accessKey"), "initial");
+    Assert.assertEquals(initialFileSystem.getCloseCalled(), 0);
+  }
+
+  @Test
+  public void testRegisterSupportsNullConfiguration() {
+    String scheme = "registerNullConfiguration";
+    PinotFSFactory.register(scheme, TestPinotFS.class.getName(), null);
+
+    TestPinotFS fileSystem = (TestPinotFS) ((NoClosePinotFS) PinotFSFactory.create(scheme))._delegate;
+    Assert.assertEquals(fileSystem.getInitCalled(), 1);
+    Assert.assertNull(fileSystem.getConfiguration());
+  }
+
+  @Test
+  public void testRegisterIfNeededReplacesDifferentFileSystemOrConfiguration() {
+    String scheme = "registerIfNeededDifferent";
+    PinotFSFactory.register(scheme, LocalPinotFS.class.getName(), new PinotConfiguration());
+    PinotFS previousWrapper = PinotFSFactory.create(scheme);
+
+    PinotFSFactory.registerIfNeeded(scheme, TestPinotFS.class.getName(),
+        new PinotConfiguration(Map.of("accessKey", "initial")));
+    NoClosePinotFS initialWrapper = (NoClosePinotFS) PinotFSFactory.create(scheme);
+    TestPinotFS initialFileSystem = (TestPinotFS) initialWrapper._delegate;
+    Assert.assertNotSame(initialWrapper, previousWrapper);
+
+    PinotFSFactory.registerIfNeeded(scheme, TestPinotFS.class.getName(),
+        new PinotConfiguration(Map.of("accessKey", "replacement")));
+    NoClosePinotFS replacementWrapper = (NoClosePinotFS) PinotFSFactory.create(scheme);
+    TestPinotFS replacementFileSystem = (TestPinotFS) replacementWrapper._delegate;
+
+    Assert.assertNotSame(replacementWrapper, initialWrapper);
+    Assert.assertEquals(replacementFileSystem.getConfiguration().getProperty("accessKey"), "replacement");
+    Assert.assertEquals(initialFileSystem.getCloseCalled(), 0);
+  }
+
+  @Test
+  public void testConcurrentRegisterIfNeededInitializesOnce()
+      throws Exception {
+    String scheme = "registerIfNeededConcurrent";
+    int numThreads = 8;
+    CountingPinotFS.reset();
+    ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+    CountDownLatch ready = new CountDownLatch(numThreads);
+    CountDownLatch start = new CountDownLatch(1);
+    List<Future<PinotFS>> futures = new ArrayList<>(numThreads);
+    try {
+      for (int i = 0; i < numThreads; i++) {
+        futures.add(executor.submit(() -> {
+          ready.countDown();
+          start.await();
+          PinotFSFactory.registerIfNeeded(scheme, CountingPinotFS.class.getName(),
+              new PinotConfiguration(Map.of("accessKey", "shared")));
+          return PinotFSFactory.create(scheme);
+        }));
+      }
+      Assert.assertTrue(ready.await(10, TimeUnit.SECONDS));
+      start.countDown();
+
+      PinotFS registeredFileSystem = futures.get(0).get(10, TimeUnit.SECONDS);
+      for (Future<PinotFS> future : futures) {
+        Assert.assertSame(future.get(10, TimeUnit.SECONDS), registeredFileSystem);
+      }
+    } finally {
+      start.countDown();
+      executor.shutdownNow();
+      Assert.assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+    }
+
+    Assert.assertEquals(CountingPinotFS.CONSTRUCTION_COUNT.get(), 1);
+    Assert.assertEquals(CountingPinotFS.INIT_COUNT.get(), 1);
+  }
+
   public static class TestPinotFS extends BasePinotFS {
     public int _initCalled = 0;
+    private int _closeCalled;
     private PinotConfiguration _configuration;
 
     public int getInitCalled() {
@@ -79,6 +177,15 @@ public class PinotFSFactoryTest {
 
     public PinotConfiguration getConfiguration() {
       return _configuration;
+    }
+
+    public int getCloseCalled() {
+      return _closeCalled;
+    }
+
+    @Override
+    public void close() {
+      _closeCalled++;
     }
 
     @Override
@@ -152,6 +259,26 @@ public class PinotFSFactoryTest {
     public InputStream open(URI uri)
         throws IOException {
       return null;
+    }
+  }
+
+  public static class CountingPinotFS extends TestPinotFS {
+    private static final AtomicInteger CONSTRUCTION_COUNT = new AtomicInteger();
+    private static final AtomicInteger INIT_COUNT = new AtomicInteger();
+
+    public CountingPinotFS() {
+      CONSTRUCTION_COUNT.incrementAndGet();
+    }
+
+    private static void reset() {
+      CONSTRUCTION_COUNT.set(0);
+      INIT_COUNT.set(0);
+    }
+
+    @Override
+    public void init(PinotConfiguration configuration) {
+      INIT_COUNT.incrementAndGet();
+      super.init(configuration);
     }
   }
 }


### PR DESCRIPTION
## Summary

- build on the existing default-off `ingestFromURI` local-filesystem policy by resolving and validating the exact filesystem before ingestion work starts
- reject local path, subclass, alias, and delegate forms while keeping configured and request-provided remote filesystems working
- keep request filesystem lifecycle ownership explicit, return generic API errors, and log only safe exception-type diagnostics
- ensure independently created Hadoop filesystem adapters own the clients they close, while repeated executor setup atomically reuses equivalent registrations

## Existing behavior on master

Master already contains `dd6520c7267` / #18660, which introduced the default-off setting and the initial direct URI and class checks. This change builds on that implementation to cover remaining delegate, lifecycle, ordering, and error-handling cases.

## How to reproduce the prior behavior

Run the focused regression tests introduced here against `dd6520c7267`. The nested-delegate, subclass side-effect, pre-working-directory, and request-scoped lifecycle cases fail on that baseline. In particular, filesystem selection can occur during copying, endpoint-provided implementations mutate shared factory state, and a rejected request can create Controller staging directories before source validation.

## Review focus

This PR has additive `pinot-spi` surface and filesystem lifecycle contract changes:

- `PinotFSFactory.isFileSystemInstanceOf(...)` recursively checks Pinot non-closing delegates without exposing the delegate
- `PinotFSFactory.registerIfNeeded(...)` atomically reuses equivalent executor registrations but preserves differing explicit class/configuration mappings
- `PinotFS.close()` documents that implementations close only resources owned by that instance
- `HadoopPinotFS` uses an independently owned Hadoop client because the adapter closes it
- URI failures retain exception-type diagnostics without logging submitted URI/path contents

Filesystem-plugin and Controller maintainers should review these ownership and compatibility details.

## Testing

- 66 focused tests across `PinotFSFactoryTest`, `ControllerConfTest`, `FileIngestionHelperTest`, `PinotIngestionRestletResourceStatelessTest`, `ControllerApplicationExceptionTest`, `HadoopPinotFSTest`, `SparkSegmentGenerationJobRunnerTest`, and `HadoopSegmentGenerationJobRunnerTest`
- Spotless, Checkstyle, license formatting, and license checks for `pinot-spi`, `pinot-controller`, `pinot-hdfs`, `pinot-batch-ingestion-spark-3`, and `pinot-batch-ingestion-hadoop`