### PR TITLE
Close Files.walk stream in LocalLogFileServer to prevent file descriptor leak

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/log/LocalLogFileServer.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/log/LocalLogFileServer.java
@@ -26,6 +26,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Stream;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
@@ -47,8 +48,12 @@ public class LocalLogFileServer implements LogFileServer {
   public Set<String> getAllLogFilePaths()
       throws IOException {
     Set<String> allFiles = new TreeSet<>();
-    Files.walk(_logRootDirPath).filter(Files::isRegularFile).forEach(
-        f -> allFiles.add(f.toAbsolutePath().toString().replace(_logRootDirPath.toAbsolutePath() + "/", "")));
+    // Files.walk holds one or more DirectoryStreams; close it eagerly so this method does not leak
+    // file descriptors when invoked repeatedly (e.g. once per downloadLogFile call).
+    try (Stream<Path> paths = Files.walk(_logRootDirPath)) {
+      paths.filter(Files::isRegularFile).forEach(
+          f -> allFiles.add(f.toAbsolutePath().toString().replace(_logRootDirPath.toAbsolutePath() + "/", "")));
+    }
     return allFiles;
   }
 

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/log/LocalLogFileServerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/log/LocalLogFileServerTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.common.utils.log;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.Set;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import org.apache.commons.io.FileUtils;
@@ -29,6 +30,7 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 
 public class LocalLogFileServerTest {
@@ -72,6 +74,37 @@ public class LocalLogFileServerTest {
       } catch (WebApplicationException e1) {
         assertEquals(e1.getResponse().getStatus(), Response.Status.FORBIDDEN.getStatusCode());
       }
+    } finally {
+      FileUtils.deleteQuietly(logRootDir);
+    }
+  }
+
+  /// Verifies that {@link LocalLogFileServer#getAllLogFilePaths()} enumerates files inside nested
+  /// subdirectories and returns paths that are relative to the log root. This is a regression test
+  /// for the {@code Files.walk} refactor that wraps the stream in a try-with-resources block; the
+  /// recursion behavior must be preserved so that downloads under nested directories continue to
+  /// work.
+  @Test
+  public void testGetAllLogFilePathsEnumeratesNestedDirectories()
+      throws IOException {
+    File logRootDir = new File(FileUtils.getTempDirectory(),
+        "testGetAllLogFilePathsEnumeratesNestedDirectories-" + System.currentTimeMillis());
+    try {
+      assertTrue(logRootDir.mkdirs());
+      File nested = new File(logRootDir, "sub/dir");
+      assertTrue(nested.mkdirs());
+      FileUtils.writeStringToFile(new File(logRootDir, "top.log"), "top", Charset.defaultCharset());
+      FileUtils.writeStringToFile(new File(nested, "nested.log"), "nested", Charset.defaultCharset());
+
+      LogFileServer logFileServer = new LocalLogFileServer(logRootDir.getAbsolutePath());
+      Set<String> paths = logFileServer.getAllLogFilePaths();
+
+      assertEquals(paths.size(), 2, "expected two enumerated files, got: " + paths);
+      assertTrue(paths.contains("top.log"), "missing top.log in " + paths);
+      assertTrue(paths.contains("sub/dir/nested.log"), "missing sub/dir/nested.log in " + paths);
+      // Both files must be downloadable via the relative paths returned above.
+      assertNotNull(logFileServer.downloadLogFile("top.log"));
+      assertNotNull(logFileServer.downloadLogFile("sub/dir/nested.log"));
     } finally {
       FileUtils.deleteQuietly(logRootDir);
     }


### PR DESCRIPTION
## Summary

`LocalLogFileServer.getAllLogFilePaths()` enumerated log files via `Files.walk(_logRootDirPath).filter(...).forEach(...)` without a `try-with-resources` block. Per the [JDK `Files.walk` javadoc](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/nio/file/Files.html#walk(java.nio.file.Path,java.nio.file.FileVisitOption...)):

> The returned stream encapsulates one or more `DirectoryStream`s. If timely disposal of file system resources is required, the try-with-resources construct should be used…

Because `downloadLogFile(String)` calls `getAllLogFilePaths()` on **every** download request (to authorize the requested path), the leak amplifies on hot paths — long-lived server and controller instances gradually accumulate `DirectoryStream` file descriptors until they approach the process `ulimit -n`.

This PR wraps the `Files.walk` stream in a `try-with-resources` block so the underlying `DirectoryStream`(s) are released as soon as enumeration completes. Sibling code in Pinot already uses the same pattern (e.g. `LocalPinotFS.listFiles`).

## Change

- `pinot-common/src/main/java/org/apache/pinot/common/utils/log/LocalLogFileServer.java` — wrap `Files.walk(_logRootDirPath)` in `try (Stream<Path> paths = Files.walk(...))`; enumeration logic is unchanged.

## Backwards compatibility

None affected. Public API, return values, and enumeration behavior are unchanged.

## Tests

- Added `LocalLogFileServerTest#testGetAllLogFilePathsEnumeratesNestedDirectories` — creates a nested `sub/dir/nested.log`, asserts both files are enumerated with paths relative to the log root, and asserts both are downloadable via `downloadLogFile(...)`. This guards the refactor against a regression that would break recursion into subdirectories.
- The pre-existing `testLoggerFileServer` continues to exercise the flat-directory happy path and the `FORBIDDEN` response for unknown paths.

Run locally:

```bash
./mvnw -pl pinot-common -am -Dtest=LocalLogFileServerTest test
```

## Risk

Very low. The change is a mechanical `try-with-resources` wrap around an existing `Files.walk` invocation; the traversal semantics are unchanged. The stream is fully consumed inside the block, so no lazy operations escape.