### PR TITLE
Fix flaky TableMetadataReaderCompressionTest concurrency

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableMetadataReaderCompressionTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableMetadataReaderCompressionTest.java
@@ -431,11 +431,12 @@ public class TableMetadataReaderCompressionTest {
         List.of(segment("segment0", true, 100, 25)));
     AtomicInteger preferredRequests = new AtomicInteger();
     AtomicInteger fallbackRequests = new AtomicInteger();
-    CountDownLatch preferredStarted = new CountDownLatch(1);
+    CountDownLatch preferredStarted = new CountDownLatch(2);
     CountDownLatch releasePreferred = new CountDownLatch(1);
     CountDownLatch fallbackStarted = new CountDownLatch(1);
+    ExecutorService preferredExecutor = Executors.newFixedThreadPool(2);
     HttpServer preferred = startServer(createBlockingCompressionHandler(currentInfo(), preferredResponse,
-        preferredRequests, preferredStarted, releasePreferred));
+        preferredRequests, preferredStarted, releasePreferred), preferredExecutor);
     HttpServer fallback = startServer(createSignalingHandler(currentInfo(), fallbackResponse, fallbackRequests,
         fallbackStarted));
     ExecutorService caller = Executors.newSingleThreadExecutor();
@@ -464,6 +465,7 @@ public class TableMetadataReaderCompressionTest {
     } finally {
       releasePreferred.countDown();
       preferred.stop(0);
+      preferredExecutor.shutdownNow();
       fallback.stop(0);
       caller.shutdownNow();
     }


### PR DESCRIPTION
## Summary

- Run the preferred mock compression server with two handler threads.
- Wait for both independent preferred requests to enter their handlers.
- Shut down the dedicated test executor during cleanup.

## Root cause

The embedded `HttpServer` used its default executor, which serializes request handlers. This test sends final and retryable segment requests to the same preferred endpoint while deliberately blocking the handler. When the final request entered first, the retryable request could reach its half-deadline and be cancelled before its queued handler incremented the request counter. The test then reported `expected [2] but found [1]` even though the production deadline behavior was correct.

## How to reproduce

On an unfixed checkout, repeatedly run the failing method under JDK 25 with test retries disabled:

```bash
for attempt in {1..100}; do
  JAVA_HOME=/path/to/jdk-25 ./mvnw -q -pl pinot-controller \
    -Dtest=TableMetadataReaderCompressionTest#testFinalReplicaKeepsOverallDeadlineWhileAnotherSegmentFallsBack \
    -Dunit.test.rerun.count=0 surefire:test || break
done
```

The race is recorded in #19065 and in [GitHub Actions job 94326703474](https://github.com/apache/pinot/actions/runs/31661370206/job/94326703474), where the assertion failed after approximately the retryable half-deadline.

## Validation

- Focused JDK 25 build with retries disabled: passed.
- 20 independent focused Surefire executions: 20/20 passed.
- Full `TableMetadataReaderCompressionTest`: 24 tests passed, 0 failures/errors/skips.
- `spotless:apply`, `checkstyle:check`, `license:format`, and `license:check`: passed for `pinot-controller`.
- `git diff --check`: passed.

Closes #19065.
