### PR TITLE
Support STRING_ARRAY literal rendering

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
@@ -331,6 +331,8 @@ public class LiteralContext {
         return "'" + Arrays.toString((float[]) _value) + "'";
       case PRIMITIVE_DOUBLE_ARRAY:
         return "'" + Arrays.toString((double[]) _value) + "'";
+      case STRING_ARRAY:
+        return "'" + Arrays.toString((String[]) _value) + "'";
       default:
         throw new IllegalStateException("Unsupported PinotDataType: " + _pinotDataType);
     }

--- a/pinot-common/src/test/java/org/apache/pinot/common/request/context/LiteralContextTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/request/context/LiteralContextTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.common.request.context;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+import java.util.List;
 import java.util.UUID;
 import org.apache.pinot.common.request.Literal;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
@@ -208,6 +209,16 @@ public class LiteralContextTest {
 
     // Parse string as BYTES
     assertEquals(new LiteralContext(DataType.STRING, "deadbeef").getBytesValue(), BytesUtils.toBytes("deadbeef"));
+  }
+
+  @Test
+  public void testStringArrayLiteral() {
+    LiteralContext literalContext = new LiteralContext(Literal.stringArrayValue(List.of("foo", "bar")));
+
+    assertFalse(literalContext.isSingleValue());
+    assertEquals(literalContext.getType(), DataType.STRING);
+    assertEquals(literalContext.getValue(), new String[]{"foo", "bar"});
+    assertEquals(literalContext.toString(), "'[foo, bar]'");
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/ArrayTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/ArrayTest.java
@@ -527,6 +527,45 @@ public class ArrayTest extends CustomDataQueryClusterIntegrationTest {
   }
 
   @Test(dataProvider = "useBothQueryEngines")
+  public void testFoldedStringArrayLiteralWithIngestedColumn(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    // Selecting an ingested column sends the single-stage query to the servers, where the folded STRING_ARRAY literal
+    // is rendered. The returned column also verifies the Avro multi-value STRING data was ingested correctly.
+    String query = String.format("SELECT %s, %s, ARRAY['query-a','query-b'] FROM %s "
+            + "WHERE %s = 0 AND ARRAYS_OVERLAP(%s, ARRAY['/home','/not-present']) LIMIT 1",
+        INT_COLUMN, STRING_ARRAY_COLUMN, getTableName(), INT_COLUMN, STRING_ARRAY_COLUMN);
+    JsonNode result = postQuery(query).get("resultTable");
+    JsonNode columnDataTypes = result.get("dataSchema").get("columnDataTypes");
+    assertEquals(columnDataTypes.get(0).textValue(), "INT");
+    assertEquals(columnDataTypes.get(1).textValue(), "STRING_ARRAY");
+    assertEquals(columnDataTypes.get(2).textValue(), "STRING_ARRAY");
+
+    JsonNode rows = result.get("rows");
+    assertEquals(rows.size(), 1);
+    JsonNode row = rows.get(0);
+    assertEquals(row.size(), 3);
+    assertEquals(row.get(0).intValue(), 0);
+
+    JsonNode ingestedValues = row.get(1);
+    assertEquals(ingestedValues.size(), 4);
+    assertEquals(ingestedValues.get(0).textValue(), "/api/v1");
+    assertEquals(ingestedValues.get(1).textValue(), "/home");
+    assertEquals(ingestedValues.get(2).textValue(), "/api/v2");
+    assertEquals(ingestedValues.get(3).textValue(), "/metrics");
+
+    JsonNode literalValues = row.get(2);
+    assertEquals(literalValues.size(), 2);
+    assertEquals(literalValues.get(0).textValue(), "query-a");
+    assertEquals(literalValues.get(1).textValue(), "query-b");
+
+    String nonMatchingQuery = String.format(
+        "SELECT COUNT(*) FROM %s WHERE ARRAYS_OVERLAP(%s, ARRAY['/not-present','/also-not-present'])",
+        getTableName(), STRING_ARRAY_COLUMN);
+    assertEquals(postQuery(nonMatchingQuery).get("resultTable").get("rows").get(0).get(0).longValue(), 0L);
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
   public void testIntArrayLiteral(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);


### PR DESCRIPTION
## Summary

- render `STRING_ARRAY` values in `LiteralContext`
- add unit coverage for Thrift `STRING_ARRAY_VALUE` conversion and rendering
- add an `ArrayTest` integration test that validates ingested multi-value STRING data and composed string-array literals in projections and `ARRAYS_OVERLAP` filters with both query engines

## Reproduction

Before this change, a table-backed single-stage query such as:

```sql
SELECT intCol, stringArrayCol, ARRAY['query-a', 'query-b']
FROM ArrayTest
WHERE intCol = 0
```

folds the array constructor into a Thrift `STRING_ARRAY_VALUE`. When the server builds the selection result schema, `LiteralContext.toString()` throws:

```text
IllegalStateException: Unsupported PinotDataType: STRING_ARRAY
```

Literal-only queries avoid the server selection path, which is why the failure requires a table-backed projection.

## Validation

- `LiteralContextTest`: 11 tests passed
- `./mvnw -pl pinot-integration-tests -am -Dtest=ArrayTest#testFoldedStringArrayLiteralWithIngestedColumn -Dsurefire.failIfNoSpecifiedTests=false test`: 2 tests passed, covering both query engines
- `./mvnw spotless:apply -pl pinot-common,pinot-integration-tests`
- `./mvnw checkstyle:check -pl pinot-common,pinot-integration-tests`
- `./mvnw license:format -pl pinot-common,pinot-integration-tests`
- `./mvnw license:check -pl pinot-common,pinot-integration-tests`
