### PR TITLE
Fix BYTES primary key columns in dimension tables can never be looked up

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
@@ -241,7 +241,7 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
               }
 
               Object[] primaryKey = recordReader.getRecordValues(i, pkIndexes);
-                primaryKey = wrapPrimaryKey(primaryKey);
+              primaryKey = wrapPrimaryKey(primaryKey);
               Object[] values = recordReader.getRecordValues(i, valIndexes);
 
               Object[] previousValue = lookupTable.put(primaryKey, values);
@@ -320,7 +320,7 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
             }
 
             Object[] primaryKey = recordReader.getRecordValues(i, pkIndexes);
-              primaryKey = wrapPrimaryKey(primaryKey);
+            primaryKey = wrapPrimaryKey(primaryKey);
 
             long readerIdxAndDocId = (((long) readerIdx) << 32) | (i & 0xffffffffL);
             long previousValue = lookupTable.put(primaryKey, readerIdxAndDocId);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
@@ -47,6 +47,7 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.PrimaryKey;
+import org.apache.pinot.spi.utils.ByteArray;
 
 
 /// Dimension Table is a special type of OFFLINE table which is assigned to all servers
@@ -240,6 +241,7 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
               }
 
               Object[] primaryKey = recordReader.getRecordValues(i, pkIndexes);
+                primaryKey = wrapPrimaryKey(primaryKey);
               Object[] values = recordReader.getRecordValues(i, valIndexes);
 
               Object[] previousValue = lookupTable.put(primaryKey, values);
@@ -318,6 +320,7 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
             }
 
             Object[] primaryKey = recordReader.getRecordValues(i, pkIndexes);
+              primaryKey = wrapPrimaryKey(primaryKey);
 
             long readerIdxAndDocId = (((long) readerIdx) << 32) | (i & 0xffffffffL);
             long previousValue = lookupTable.put(primaryKey, readerIdxAndDocId);
@@ -335,6 +338,16 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
     }
     return new MemoryOptimizedDimensionTable(schema, primaryKeyColumns, lookupTable, segmentDataManagers, recordReaders,
         this);
+  }
+
+
+  private Object[] wrapPrimaryKey(Object[] primaryKey) {
+    for (int i = 0; i < primaryKey.length; i++) {
+      if (primaryKey[i] instanceof byte[]) {
+        primaryKey[i] = new ByteArray((byte[]) primaryKey[i]);
+      }
+    }
+    return primaryKey;
   }
 
   private void sortSegmentsForUpsert(List<SegmentDataManager> segmentDataManagers) {


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Convert byte\[\] primary key values to ByteArray for content\-based lookup in dimension tables\.

```mermaid
flowchart TD
  N0["Read primary key values #40;F1#41;"]:::stAdded
  N1["Wrap byte#91;#93; to ByteArray #40;F1#41;"]:::stAdded
  N2["Insert wrapped key into lookup table #40;F1#41;"]:::stAdded
  N0 -->|"data flow"| N1
  N1 -->|"data flow"| N2
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager\.java — [before](https://github.com/apache/pinot/blob/3ffb61485b8e9fd5dc1fe85dfcfed1a2f500b2f9/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java) · [after](https://github.com/apache/pinot/blob/6f00b3b625580f6c10207bc54dddb20f263f61a2/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjNmZmI2MTQ4NWI4ZTlmZDVkYzFmZTg1ZGZjZmVkMWEyZjUwMGIyZjkiLCJjb250ZXh0X2hhc2giOiIxZTIxZDRhYWVlOWViODRlYzllZDFlNGVlY2NlYWQ2OGUxOTdjYjEzY2Y3MWEwOTQzMzc1NDk2ZTAyMGEwZGIxIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MTk1MDI2LCJoZWFkX3NoYSI6IjZmMDBiM2I2MjU1ODBmNmMxMDIwN2JjNTRkZGRiMjBmMjYzZjYxYTIiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJjYjg5YzBlNGM1NjYwMDUwNTlkM2I2Yjk3YWQzMDZmMmUxNTlhZTk4IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 17a2420ae07dc150793b59ae112d5c1292e19b0112404953db1aca5c63cb0419 -->
<!-- pinot-pr-flow:end -->

Fix a bug where dimension tables with a `BYTES` primary key column can never be looked up.

**Root cause**: `DimensionTableDataManager` stores raw `byte[]` in the `Object[]` key array, but `byte[]` inherits identity-based `hashCode`/`equals` from `Object`. The probe side (`LookupTransformFunction`) correctly wraps the value in `ByteArray` (content-based), but it never matches the stored `byte[]`.

**Fix**: Wrap `byte[]` values as `ByteArray` in both `createFastLookupDimensionTable` and the memory-optimized path, so the stored key has content-based equality.

Fixes #19228