### PR TITLE
Throw IOException instead of NPE when listing an invalid path in LocalPinotFS

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
@@ -378,7 +378,7 @@ public class RetentionManager extends ControllerPeriodicTask<Void> {
       }
     } catch (IOException e) {
       LOGGER.warn("Unable to fetch segments from deep store that are beyond retention period for table: {}",
-          tableNameWithType);
+          tableNameWithType, e);
     }
 
     return segmentsToDelete;
@@ -405,6 +405,15 @@ public class RetentionManager extends ControllerPeriodicTask<Void> {
     String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
     URI tableDataUri = URIUtils.getUri(_pinotHelixResourceManager.getDataDir(), rawTableName);
     PinotFS pinotFS = PinotFSFactory.create(tableDataUri.getScheme());
+
+    // The data dir is created when the first segment is pushed, so it is legitimately absent for a table that has
+    // never had a segment in deep store. Such a table has no untracked segments to delete, and listing a
+    // non-existent directory fails on most file systems.
+    if (!pinotFS.exists(tableDataUri)) {
+      LOGGER.info("Skipping deep store scan for untracked segments for table: {} as data dir: {} does not exist",
+          tableNameWithType, tableDataUri);
+      return segmentsToDelete;
+    }
 
     long startTimeMs = System.currentTimeMillis();
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
@@ -967,6 +967,12 @@ public class RetentionManagerTest {
   public static class FakePinotFs extends LocalPinotFS {
 
     @Override
+    public boolean exists(URI fileUri) {
+      // The fake deep store is not backed by a real directory, but always has the segments listed below
+      return true;
+    }
+
+    @Override
     public List<FileMetadata> listFilesWithMetadata(URI fileUri, boolean recursive)
         throws IOException {
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
@@ -115,7 +115,8 @@ public class LocalPinotFS extends BasePinotFS {
       throws IOException {
     File file = toFile(fileUri);
     if (!recursive) {
-      return Arrays.stream(file.list()).map(s -> new File(file, s)).map(File::getAbsolutePath).toArray(String[]::new);
+      return Arrays.stream(listFileNames(file)).map(s -> new File(file, s)).map(File::getAbsolutePath)
+          .toArray(String[]::new);
     } else {
       try (Stream<Path> pathStream = Files.walk(Paths.get(fileUri))) {
         return pathStream.filter(s -> !s.equals(file.toPath())).map(Path::toString).toArray(String[]::new);
@@ -128,7 +129,8 @@ public class LocalPinotFS extends BasePinotFS {
       throws IOException {
     File file = toFile(fileUri);
     if (!recursive) {
-      return Arrays.stream(file.list()).map(s -> getFileMetadata(new File(file, s))).collect(Collectors.toList());
+      return Arrays.stream(listFileNames(file)).map(s -> getFileMetadata(new File(file, s)))
+          .collect(Collectors.toList());
     } else {
       try (Stream<Path> pathStream = Files.walk(Paths.get(fileUri))) {
         return pathStream.filter(s -> !s.equals(file.toPath()))
@@ -136,6 +138,20 @@ public class LocalPinotFS extends BasePinotFS {
             .collect(Collectors.toList());
       }
     }
+  }
+
+  /// Returns the names of the entries directly under the given directory.
+  ///
+  /// [File#list()] returns `null` instead of throwing when the path does not exist, is not a directory, or cannot be
+  /// read, so translate that into the `IOException` the listing methods are contracted to throw for an invalid path.
+  private static String[] listFileNames(File file)
+      throws IOException {
+    String[] fileNames = file.list();
+    if (fileNames == null) {
+      throw new IOException("Failed to list files under: " + file.getAbsolutePath()
+          + " because it does not exist, is not a directory, or cannot be read");
+    }
+    return fileNames;
   }
 
   private static FileMetadata getFileMetadata(File file) {

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/LocalPinotFSTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/LocalPinotFSTest.java
@@ -310,4 +310,25 @@ public class LocalPinotFSTest {
         expectedRecursive.containsAll(fileMetadata.stream().map(FileMetadata::getFilePath).collect(Collectors.toSet())),
         fileMetadata.toString());
   }
+
+  @Test
+  public void testListFilesOnPathThatIsNotADirectory()
+      throws IOException {
+    LocalPinotFS localPinotFS = new LocalPinotFS();
+    File tempDirPath = new File(_absoluteTmpDirPath, "test-list-files-invalid-path");
+    Assert.assertTrue(tempDirPath.mkdirs());
+
+    File nonExistentDir = new File(tempDirPath, "nonExistentDir");
+    URI nonExistentUri = nonExistentDir.toURI();
+    Assert.assertThrows(IOException.class, () -> localPinotFS.listFiles(nonExistentUri, false));
+    Assert.assertThrows(IOException.class, () -> localPinotFS.listFilesWithMetadata(nonExistentUri, false));
+    Assert.assertThrows(IOException.class, () -> localPinotFS.listFiles(nonExistentUri, true));
+    Assert.assertThrows(IOException.class, () -> localPinotFS.listFilesWithMetadata(nonExistentUri, true));
+
+    File testFile = new File(tempDirPath, "testFile");
+    Assert.assertTrue(testFile.createNewFile());
+    URI fileUri = testFile.toURI();
+    Assert.assertThrows(IOException.class, () -> localPinotFS.listFiles(fileUri, false));
+    Assert.assertThrows(IOException.class, () -> localPinotFS.listFilesWithMetadata(fileUri, false));
+  }
 }


### PR DESCRIPTION
## Summary

`File.list()` returns `null` — instead of throwing — when the path does not exist, is not a directory, or cannot be read. The non-recursive branches of `LocalPinotFS.listFiles()` and `LocalPinotFS.listFilesWithMetadata()` passed that result straight into `Arrays.stream(...)`, so an invalid path surfaced as a `NullPointerException` rather than the `IOException` the `PinotFS` listing contract specifies:

> Throws IOException if this abstract pathname is not valid, or if an I/O error occurs.

The recursive branches already behaved correctly — `Files.walk` throws `NoSuchFileException`.

This shows up in `RetentionManager`, which scans deep store for untracked segments. That call site handles `IOException`, but the NPE escaped the handler and was caught by the periodic-task loop instead:

```
ERROR [ControllerPeriodicTask] Caught exception while processing table: myTable_OFFLINE in task: RetentionManager
java.lang.NullPointerException: Cannot read the array length because "array" is null
	at java.base/java.util.Arrays.stream(Arrays.java:5464)
	at org.apache.pinot.spi.filesystem.LocalPinotFS.listFilesWithMetadata(LocalPinotFS.java:131)
	at org.apache.pinot.controller.helix.core.retention.RetentionManager.findUntrackedSegmentsToDeleteFromDeepstore(RetentionManager.java:411)
	...
```

It reproduces for any table whose data dir does not exist yet, since `<dataDir>/<rawTableName>` is only created once the first segment lands in deep store.

## Changes

- `LocalPinotFS`: route both non-recursive listing branches through a `listFileNames` helper that turns the `null` return into an `IOException` naming the path.
- `RetentionManager`: skip the deep-store scan when the table data dir does not exist. Such a table has no untracked segments, and without this the fixed `IOException` would produce a warning on every retention cycle for every table that has never had a segment pushed.
- `RetentionManager`: the existing `catch (IOException)` logged a message without the exception — pass it along so a genuine listing failure is diagnosable.
- `LocalPinotFSTest`: new `testListFilesOnPathThatIsNotADirectory`, covering a missing directory and a regular file for both listing methods. It fails with an NPE without the fix.
- `RetentionManagerTest`: `FakePinotFs` now overrides `exists()`, since it serves a `fake://` URI with no real directory behind it. Without the override the new early return would silently turn `testPerformanceWithLargeNumberOfSegments` into a no-op.
