### PR TITLE
Introduce reason codes for segment completion requests

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
@@ -153,16 +153,30 @@ public class SegmentCompletionProtocol {
   public static final String REASON_INDEX_CAPACITY_THRESHOLD_BREACHED = "indexCapacityThresholdBreached";
 
   public enum ReasonCode {
-    ROW_LIMIT(REASON_ROW_LIMIT),
-    TIME_LIMIT(REASON_TIME_LIMIT),
-    END_OF_PARTITION_GROUP(REASON_END_OF_PARTITION_GROUP),
-    FORCE_COMMIT_MESSAGE_RECEIVED(REASON_FORCE_COMMIT_MESSAGE_RECEIVED),
-    INDEX_CAPACITY_THRESHOLD_BREACHED(REASON_INDEX_CAPACITY_THRESHOLD_BREACHED);
+    ROW_LIMIT(100, REASON_ROW_LIMIT),
+    TIME_LIMIT(110, REASON_TIME_LIMIT),
+    END_OF_PARTITION_GROUP(120, REASON_END_OF_PARTITION_GROUP),
+    FORCE_COMMIT_MESSAGE_RECEIVED(130, REASON_FORCE_COMMIT_MESSAGE_RECEIVED),
+    INDEX_CAPACITY_THRESHOLD_BREACHED(140, REASON_INDEX_CAPACITY_THRESHOLD_BREACHED);
 
+    private static final Map<Integer, ReasonCode> BY_ID = new HashMap<>();
+
+    static {
+      for (ReasonCode value : values()) {
+        BY_ID.put(value.getId(), value);
+      }
+    }
+
+    private final int _id;
     private final String _reason;
 
-    ReasonCode(String reason) {
+    ReasonCode(int id, String reason) {
+      _id = id;
       _reason = reason;
+    }
+
+    public int getId() {
+      return _id;
     }
 
     public String getReason() {
@@ -178,12 +192,16 @@ public class SegmentCompletionProtocol {
       if (reasonCode == null) {
         return null;
       }
-      for (ReasonCode value : values()) {
-        if (value.name().equals(reasonCode) || value.getReason().equals(reasonCode)) {
-          return value;
-        }
+      try {
+        return fromCode(Integer.parseInt(reasonCode));
+      } catch (NumberFormatException e) {
+        return null;
       }
-      return null;
+    }
+
+    @Nullable
+    public static ReasonCode fromCode(int reasonCode) {
+      return BY_ID.get(reasonCode);
     }
 
     @Nullable
@@ -252,7 +270,7 @@ public class SegmentCompletionProtocol {
         params.put(PARAM_REASON, _params.getReason());
       }
       if (_params.getReasonCode() != null) {
-        params.put(PARAM_REASON_CODE, _params.getReasonCode().name());
+        params.put(PARAM_REASON_CODE, String.valueOf(_params.getReasonCode().getId()));
       }
       if (_params.getBuildTimeMillis() > 0) {
         params.put(PARAM_BUILD_TIME_MILLIS, String.valueOf(_params.getBuildTimeMillis()));
@@ -341,7 +359,7 @@ public class SegmentCompletionProtocol {
         return this;
       }
 
-      public Params withReasonCode(String reasonCode) {
+      public Params withReasonCode(@Nullable String reasonCode) {
         ReasonCode parsedReasonCode = ReasonCode.fromCode(reasonCode);
         if (parsedReasonCode != null) {
           return withReasonCode(parsedReasonCode);
@@ -349,7 +367,7 @@ public class SegmentCompletionProtocol {
         return this;
       }
 
-      public Params withReasonCode(ReasonCode reasonCode) {
+      public Params withReasonCode(@Nullable ReasonCode reasonCode) {
         _reasonCode = reasonCode;
         if (reasonCode != null && _reason == null) {
           _reason = reasonCode.getReason();

--- a/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
@@ -129,6 +129,7 @@ public class SegmentCompletionProtocol {
   public static final String PARAM_MEMORY_USED_BYTES = "memoryUsedBytes";
   public static final String PARAM_SEGMENT_SIZE_BYTES = "segmentSizeBytes";
   public static final String PARAM_REASON = "reason";
+  public static final String PARAM_REASON_CODE = "reasonCode";
   // Sent by servers to request additional time to build
   public static final String PARAM_EXTRA_TIME_SEC = "extraTimeSec";
   // Sent by servers to indicate the number of rows read so far
@@ -149,6 +150,52 @@ public class SegmentCompletionProtocol {
   // Stop reason sent by server as mutable index cannot consume more rows
   // (like size reaching close to its limit or number of col values for a col is about to overflow int max)
   public static final String REASON_INDEX_CAPACITY_THRESHOLD_BREACHED = "indexCapacityThresholdBreached";
+
+  public enum ReasonCode {
+    ROW_LIMIT(REASON_ROW_LIMIT),
+    TIME_LIMIT(REASON_TIME_LIMIT),
+    END_OF_PARTITION_GROUP(REASON_END_OF_PARTITION_GROUP),
+    FORCE_COMMIT_MESSAGE_RECEIVED(REASON_FORCE_COMMIT_MESSAGE_RECEIVED),
+    INDEX_CAPACITY_THRESHOLD_BREACHED(REASON_INDEX_CAPACITY_THRESHOLD_BREACHED);
+
+    private final String _reason;
+
+    ReasonCode(String reason) {
+      _reason = reason;
+    }
+
+    public String getReason() {
+      return _reason;
+    }
+
+    public boolean shouldPickWinnerImmediately() {
+      return this == ROW_LIMIT || this == END_OF_PARTITION_GROUP;
+    }
+
+    public static ReasonCode fromCode(String reasonCode) {
+      if (reasonCode == null) {
+        return null;
+      }
+      for (ReasonCode value : values()) {
+        if (value.name().equals(reasonCode) || value.getReason().equals(reasonCode)) {
+          return value;
+        }
+      }
+      return null;
+    }
+
+    public static ReasonCode fromReason(String reason) {
+      if (reason == null) {
+        return null;
+      }
+      for (ReasonCode value : values()) {
+        if (value.getReason().equals(reason)) {
+          return value;
+        }
+      }
+      return null;
+    }
+  }
 
   // Canned responses
   public static final Response RESP_NOT_LEADER =
@@ -201,6 +248,9 @@ public class SegmentCompletionProtocol {
       if (_params.getReason() != null) {
         params.put(PARAM_REASON, _params.getReason());
       }
+      if (_params.getReasonCode() != null) {
+        params.put(PARAM_REASON_CODE, _params.getReasonCode().name());
+      }
       if (_params.getBuildTimeMillis() > 0) {
         params.put(PARAM_BUILD_TIME_MILLIS, String.valueOf(_params.getBuildTimeMillis()));
       }
@@ -232,6 +282,7 @@ public class SegmentCompletionProtocol {
       private String _segmentName;
       private String _instanceId;
       private String _reason;
+      private ReasonCode _reasonCode;
       private int _numRows;
       private long _buildTimeMillis;
       private long _waitTimeMillis;
@@ -253,6 +304,7 @@ public class SegmentCompletionProtocol {
         _segmentSizeBytes = SEGMENT_SIZE_BYTES_DEFAULT;
         _streamPartitionMsgOffset = null;
         _reason = null;
+        _reasonCode = null;
       }
 
       public Params(Params params) {
@@ -267,6 +319,7 @@ public class SegmentCompletionProtocol {
         _segmentSizeBytes = params.getSegmentSizeBytes();
         _streamPartitionMsgOffset = params.getStreamPartitionMsgOffset();
         _reason = params.getReason();
+        _reasonCode = params.getReasonCode();
       }
 
       public Params withSegmentName(String segmentName) {
@@ -281,6 +334,23 @@ public class SegmentCompletionProtocol {
 
       public Params withReason(String reason) {
         _reason = reason;
+        _reasonCode = ReasonCode.fromReason(reason);
+        return this;
+      }
+
+      public Params withReasonCode(String reasonCode) {
+        ReasonCode parsedReasonCode = ReasonCode.fromCode(reasonCode);
+        if (parsedReasonCode != null) {
+          return withReasonCode(parsedReasonCode);
+        }
+        return this;
+      }
+
+      public Params withReasonCode(ReasonCode reasonCode) {
+        _reasonCode = reasonCode;
+        if (reasonCode != null && _reason == null) {
+          _reason = reasonCode.getReason();
+        }
         return this;
       }
 
@@ -332,6 +402,10 @@ public class SegmentCompletionProtocol {
         return _reason;
       }
 
+      public ReasonCode getReasonCode() {
+        return _reasonCode;
+      }
+
       public String getInstanceId() {
         return _instanceId;
       }
@@ -372,6 +446,7 @@ public class SegmentCompletionProtocol {
         return "Segment name: " + _segmentName
             + ",Instance Id: " + _instanceId
             + ",Reason: " + _reason
+            + ",ReasonCode: " + _reasonCode
             + ",NumRows: " + _numRows
             + ",BuildTimeMillis: " + _buildTimeMillis
             + ",WaitTimeMillis: " + _waitTimeMillis

--- a/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
@@ -152,6 +152,12 @@ public class SegmentCompletionProtocol {
   // (like size reaching close to its limit or number of col values for a col is about to overflow int max)
   public static final String REASON_INDEX_CAPACITY_THRESHOLD_BREACHED = "indexCapacityThresholdBreached";
 
+  /// Stable wire codes for server stop reasons.
+  ///
+  /// Numeric IDs are part of the segment-completion protocol and must remain unique, stable, and non-reusable.
+  /// Controllers ignore unknown numeric `reasonCode` values and fall back to the retained legacy `reason` value.
+  /// When both a known `reasonCode` and a legacy `reason` are present, the numeric code takes precedence and
+  /// normalizes the legacy reason string carried through the request params.
   public enum ReasonCode {
     ROW_LIMIT(100, REASON_ROW_LIMIT),
     TIME_LIMIT(110, REASON_TIME_LIMIT),
@@ -183,18 +189,14 @@ public class SegmentCompletionProtocol {
       return _reason;
     }
 
-    public boolean shouldPickWinnerImmediately() {
-      return this == ROW_LIMIT || this == END_OF_PARTITION_GROUP;
-    }
-
     @Nullable
-    public static ReasonCode fromCode(String reasonCode) {
+    public static ReasonCode fromReasonCodeParam(@Nullable String reasonCode) {
       if (reasonCode == null) {
         return null;
       }
       try {
         return fromCode(Integer.parseInt(reasonCode));
-      } catch (NumberFormatException e) {
+      } catch (NumberFormatException ignored) {
         return null;
       }
     }
@@ -205,7 +207,7 @@ public class SegmentCompletionProtocol {
     }
 
     @Nullable
-    public static ReasonCode fromReason(String reason) {
+    public static ReasonCode fromReason(@Nullable String reason) {
       if (reason == null) {
         return null;
       }
@@ -302,7 +304,9 @@ public class SegmentCompletionProtocol {
     public static class Params {
       private String _segmentName;
       private String _instanceId;
+      @Nullable
       private String _reason;
+      @Nullable
       private ReasonCode _reasonCode;
       private int _numRows;
       private long _buildTimeMillis;
@@ -353,23 +357,27 @@ public class SegmentCompletionProtocol {
         return this;
       }
 
-      public Params withReason(String reason) {
+      public Params withReason(@Nullable String reason) {
         _reason = reason;
         _reasonCode = ReasonCode.fromReason(reason);
         return this;
       }
 
-      public Params withReasonCode(@Nullable String reasonCode) {
-        ReasonCode parsedReasonCode = ReasonCode.fromCode(reasonCode);
+      /// Parses the raw `reasonCode` query parameter. Missing, malformed, or unknown values are ignored so the
+      /// retained legacy `reason` can continue to be used as fallback.
+      public Params withReasonCodeParam(@Nullable String reasonCode) {
+        ReasonCode parsedReasonCode = ReasonCode.fromReasonCodeParam(reasonCode);
         if (parsedReasonCode != null) {
           return withReasonCode(parsedReasonCode);
         }
         return this;
       }
 
+      /// Sets the typed stop reason. A known code also sets the legacy reason string so older controllers can ignore
+      /// `reasonCode` and still use `reason`. Passing `null` clears only the typed code.
       public Params withReasonCode(@Nullable ReasonCode reasonCode) {
         _reasonCode = reasonCode;
-        if (reasonCode != null && _reason == null) {
+        if (reasonCode != null) {
           _reason = reasonCode.getReason();
         }
         return this;
@@ -419,6 +427,7 @@ public class SegmentCompletionProtocol {
         return _segmentName;
       }
 
+      @Nullable
       public String getReason() {
         return _reason;
       }

--- a/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.spi.utils.JsonUtils;
 
@@ -172,6 +173,7 @@ public class SegmentCompletionProtocol {
       return this == ROW_LIMIT || this == END_OF_PARTITION_GROUP;
     }
 
+    @Nullable
     public static ReasonCode fromCode(String reasonCode) {
       if (reasonCode == null) {
         return null;
@@ -184,6 +186,7 @@ public class SegmentCompletionProtocol {
       return null;
     }
 
+    @Nullable
     public static ReasonCode fromReason(String reason) {
       if (reason == null) {
         return null;
@@ -402,6 +405,7 @@ public class SegmentCompletionProtocol {
         return _reason;
       }
 
+      @Nullable
       public ReasonCode getReasonCode() {
         return _reasonCode;
       }

--- a/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
@@ -373,6 +373,14 @@ public class SegmentCompletionProtocol {
         return this;
       }
 
+      public Params withReasonCodeParam(@Nullable Integer reasonCode) {
+        ReasonCode parsedReasonCode = reasonCode != null ? ReasonCode.fromCode(reasonCode) : null;
+        if (parsedReasonCode != null) {
+          return withReasonCode(parsedReasonCode);
+        }
+        return this;
+      }
+
       /// Sets the typed stop reason. A known code also sets the legacy reason string so older controllers can ignore
       /// `reasonCode` and still use `reason`. Passing `null` clears only the typed code.
       public Params withReasonCode(@Nullable ReasonCode reasonCode) {

--- a/pinot-common/src/test/java/org/apache/pinot/common/protocols/SegmentCompletionProtocolTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/protocols/SegmentCompletionProtocolTest.java
@@ -47,6 +47,7 @@ public class SegmentCompletionProtocolTest {
     Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_SEGMENT_NAME), "UNKNOWN_SEGMENT");
     Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_INSTANCE_ID), "UNKNOWN_INSTANCE");
     Assert.assertNull(paramsMap.get(SegmentCompletionProtocol.PARAM_REASON));
+    Assert.assertNull(paramsMap.get(SegmentCompletionProtocol.PARAM_REASON_CODE));
     Assert.assertNull(paramsMap.get(SegmentCompletionProtocol.PARAM_BUILD_TIME_MILLIS));
     Assert.assertNull(paramsMap.get(SegmentCompletionProtocol.PARAM_WAIT_TIME_MILLIS));
     Assert.assertNull(paramsMap.get(SegmentCompletionProtocol.PARAM_EXTRA_TIME_SEC));
@@ -69,6 +70,7 @@ public class SegmentCompletionProtocolTest {
     Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_SEGMENT_NAME), "foo__0__0__12345Z");
     Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_INSTANCE_ID), "Server_localhost_8099");
     Assert.assertNull(paramsMap.get(SegmentCompletionProtocol.PARAM_REASON));
+    Assert.assertNull(paramsMap.get(SegmentCompletionProtocol.PARAM_REASON_CODE));
     Assert.assertNull(paramsMap.get(SegmentCompletionProtocol.PARAM_BUILD_TIME_MILLIS));
     Assert.assertNull(paramsMap.get(SegmentCompletionProtocol.PARAM_WAIT_TIME_MILLIS));
     Assert.assertNull(paramsMap.get(SegmentCompletionProtocol.PARAM_EXTRA_TIME_SEC));
@@ -79,7 +81,8 @@ public class SegmentCompletionProtocolTest {
     Assert.assertNull(paramsMap.get(SegmentCompletionProtocol.PARAM_STREAM_PARTITION_MSG_OFFSET));
 
     params = new SegmentCompletionProtocol.Request.Params().withSegmentName("foo__0__0__12345Z")
-        .withInstanceId("Server_localhost_8099").withReason("ROW_LIMIT").withBuildTimeMillis(1000)
+        .withInstanceId("Server_localhost_8099").withReason(SegmentCompletionProtocol.REASON_ROW_LIMIT)
+        .withBuildTimeMillis(1000)
         .withWaitTimeMillis(2000).withExtraTimeSec(3000).withMemoryUsedBytes(4000).withSegmentSizeBytes(5000)
         .withNumRows(6000).withSegmentLocation("/tmp/segment").withStreamPartitionMsgOffset("7000");
     SegmentCompletionProtocol.SegmentCommitStartRequest commitStartRequestWithAllParams =
@@ -89,7 +92,10 @@ public class SegmentCompletionProtocolTest {
         Arrays.stream(uri.getQuery().split("&")).collect(Collectors.toMap(e -> e.split("=")[0], e -> e.split("=")[1]));
     Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_SEGMENT_NAME), "foo__0__0__12345Z");
     Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_INSTANCE_ID), "Server_localhost_8099");
-    Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_REASON), "ROW_LIMIT");
+    Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_REASON),
+        SegmentCompletionProtocol.REASON_ROW_LIMIT);
+    Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_REASON_CODE),
+        SegmentCompletionProtocol.ReasonCode.ROW_LIMIT.name());
     Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_BUILD_TIME_MILLIS), "1000");
     Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_WAIT_TIME_MILLIS), "2000");
     Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_EXTRA_TIME_SEC), "3000");
@@ -122,6 +128,7 @@ public class SegmentCompletionProtocolTest {
         URIUtils.encode("Server_localhost_8099"));
     Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_REASON),
         "%7B%22type%22%3A%22ROW_LIMIT%22%2C%20%22value%22%3A1000%7D");
+    Assert.assertNull(paramsMap.get(SegmentCompletionProtocol.PARAM_REASON_CODE));
     Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_BUILD_TIME_MILLIS), "1000");
     Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_WAIT_TIME_MILLIS), "2000");
     Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_EXTRA_TIME_SEC), "3000");
@@ -132,5 +139,27 @@ public class SegmentCompletionProtocolTest {
         URIUtils.encode("s3://my.bucket/segment"));
     Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_STREAM_PARTITION_MSG_OFFSET),
         URIUtils.encode("{\"shardId-000000000001\":\"49615238429973311938200772279310862572716999467690098706\"}"));
+  }
+
+  @Test
+  public void testReasonCodeCompatibility() {
+    SegmentCompletionProtocol.Request.Params params =
+        new SegmentCompletionProtocol.Request.Params().withReasonCode(SegmentCompletionProtocol.ReasonCode.TIME_LIMIT);
+    Assert.assertEquals(params.getReason(), SegmentCompletionProtocol.REASON_TIME_LIMIT);
+    Assert.assertEquals(params.getReasonCode(), SegmentCompletionProtocol.ReasonCode.TIME_LIMIT);
+
+    params = new SegmentCompletionProtocol.Request.Params().withReason("customReason")
+        .withReasonCode(SegmentCompletionProtocol.ReasonCode.ROW_LIMIT);
+    Assert.assertEquals(params.getReason(), "customReason");
+    Assert.assertEquals(params.getReasonCode(), SegmentCompletionProtocol.ReasonCode.ROW_LIMIT);
+
+    params = new SegmentCompletionProtocol.Request.Params().withReason(SegmentCompletionProtocol.REASON_ROW_LIMIT)
+        .withReasonCode("FUTURE_REASON_CODE");
+    Assert.assertEquals(params.getReason(), SegmentCompletionProtocol.REASON_ROW_LIMIT);
+    Assert.assertEquals(params.getReasonCode(), SegmentCompletionProtocol.ReasonCode.ROW_LIMIT);
+
+    params = new SegmentCompletionProtocol.Request.Params().withReasonCode("FUTURE_REASON_CODE");
+    Assert.assertNull(params.getReason());
+    Assert.assertNull(params.getReasonCode());
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/protocols/SegmentCompletionProtocolTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/protocols/SegmentCompletionProtocolTest.java
@@ -20,7 +20,9 @@ package org.apache.pinot.common.protocols;
 
 import java.net.URI;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.pinot.common.utils.URIUtils;
 import org.testng.Assert;
@@ -94,8 +96,7 @@ public class SegmentCompletionProtocolTest {
     Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_INSTANCE_ID), "Server_localhost_8099");
     Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_REASON),
         SegmentCompletionProtocol.REASON_ROW_LIMIT);
-    Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_REASON_CODE),
-        String.valueOf(SegmentCompletionProtocol.ReasonCode.ROW_LIMIT.getId()));
+    Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_REASON_CODE), "100");
     Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_BUILD_TIME_MILLIS), "1000");
     Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_WAIT_TIME_MILLIS), "2000");
     Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_EXTRA_TIME_SEC), "3000");
@@ -142,7 +143,7 @@ public class SegmentCompletionProtocolTest {
   }
 
   @Test
-  public void testReasonCodeCompatibility() {
+  public void testReasonCodeCompatibilityAndPrecedence() {
     SegmentCompletionProtocol.Request.Params params =
         new SegmentCompletionProtocol.Request.Params().withReasonCode(SegmentCompletionProtocol.ReasonCode.TIME_LIMIT);
     Assert.assertEquals(params.getReason(), SegmentCompletionProtocol.REASON_TIME_LIMIT);
@@ -150,25 +151,75 @@ public class SegmentCompletionProtocolTest {
 
     params = new SegmentCompletionProtocol.Request.Params().withReason("customReason")
         .withReasonCode(SegmentCompletionProtocol.ReasonCode.ROW_LIMIT);
-    Assert.assertEquals(params.getReason(), "customReason");
+    Assert.assertEquals(params.getReason(), SegmentCompletionProtocol.REASON_ROW_LIMIT);
     Assert.assertEquals(params.getReasonCode(), SegmentCompletionProtocol.ReasonCode.ROW_LIMIT);
 
     params = new SegmentCompletionProtocol.Request.Params()
-        .withReasonCode(String.valueOf(SegmentCompletionProtocol.ReasonCode.TIME_LIMIT.getId()));
+        .withReasonCodeParam("110");
     Assert.assertEquals(params.getReason(), SegmentCompletionProtocol.REASON_TIME_LIMIT);
     Assert.assertEquals(params.getReasonCode(), SegmentCompletionProtocol.ReasonCode.TIME_LIMIT);
 
     params = new SegmentCompletionProtocol.Request.Params().withReason(SegmentCompletionProtocol.REASON_ROW_LIMIT)
-        .withReasonCode("999");
+        .withReasonCodeParam("999");
     Assert.assertEquals(params.getReason(), SegmentCompletionProtocol.REASON_ROW_LIMIT);
     Assert.assertEquals(params.getReasonCode(), SegmentCompletionProtocol.ReasonCode.ROW_LIMIT);
 
-    params = new SegmentCompletionProtocol.Request.Params().withReasonCode("999");
+    params = new SegmentCompletionProtocol.Request.Params().withReasonCodeParam("999");
     Assert.assertNull(params.getReason());
     Assert.assertNull(params.getReasonCode());
 
-    params = new SegmentCompletionProtocol.Request.Params().withReasonCode("FUTURE_REASON_CODE");
+    params = new SegmentCompletionProtocol.Request.Params().withReasonCodeParam("FUTURE_REASON_CODE");
     Assert.assertNull(params.getReason());
     Assert.assertNull(params.getReasonCode());
+  }
+
+  @Test
+  public void testReasonCodeValuesAreStableAndUnique() {
+    Object[][] expectedValues = {
+        {SegmentCompletionProtocol.ReasonCode.ROW_LIMIT, 100, SegmentCompletionProtocol.REASON_ROW_LIMIT},
+        {SegmentCompletionProtocol.ReasonCode.TIME_LIMIT, 110, SegmentCompletionProtocol.REASON_TIME_LIMIT},
+        {SegmentCompletionProtocol.ReasonCode.END_OF_PARTITION_GROUP, 120,
+            SegmentCompletionProtocol.REASON_END_OF_PARTITION_GROUP},
+        {SegmentCompletionProtocol.ReasonCode.FORCE_COMMIT_MESSAGE_RECEIVED, 130,
+            SegmentCompletionProtocol.REASON_FORCE_COMMIT_MESSAGE_RECEIVED},
+        {SegmentCompletionProtocol.ReasonCode.INDEX_CAPACITY_THRESHOLD_BREACHED, 140,
+            SegmentCompletionProtocol.REASON_INDEX_CAPACITY_THRESHOLD_BREACHED}
+    };
+
+    Set<Integer> ids = new HashSet<>();
+    for (Object[] expectedValue : expectedValues) {
+      SegmentCompletionProtocol.ReasonCode reasonCode =
+          (SegmentCompletionProtocol.ReasonCode) expectedValue[0];
+      int id = (int) expectedValue[1];
+      String reason = (String) expectedValue[2];
+
+      Assert.assertTrue(ids.add(id), "Reason code IDs must be unique");
+      Assert.assertEquals(reasonCode.getId(), id);
+      Assert.assertEquals(reasonCode.getReason(), reason);
+      Assert.assertEquals(SegmentCompletionProtocol.ReasonCode.fromCode(id), reasonCode);
+      Assert.assertEquals(SegmentCompletionProtocol.ReasonCode.fromReason(reason), reasonCode);
+    }
+
+    Assert.assertEquals(ids.size(), SegmentCompletionProtocol.ReasonCode.values().length);
+  }
+
+  @Test
+  public void testReasonCodeRequestRetainsLegacyReasonForOldController()
+      throws Exception {
+    SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params()
+        .withSegmentName("foo__0__0__12345Z")
+        .withInstanceId("Server_localhost_8099")
+        .withStreamPartitionMsgOffset("7000")
+        .withReasonCode(SegmentCompletionProtocol.ReasonCode.ROW_LIMIT);
+    SegmentCompletionProtocol.SegmentConsumedRequest request =
+        new SegmentCompletionProtocol.SegmentConsumedRequest(params);
+
+    URI uri = new URI(request.getUrl("localhost:8080", "http"));
+    Map<String, String> paramsMap =
+        Arrays.stream(uri.getQuery().split("&")).collect(Collectors.toMap(e -> e.split("=")[0], e -> e.split("=")[1]));
+
+    Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_REASON),
+        SegmentCompletionProtocol.REASON_ROW_LIMIT);
+    Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_REASON_CODE), "100");
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/protocols/SegmentCompletionProtocolTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/protocols/SegmentCompletionProtocolTest.java
@@ -95,7 +95,7 @@ public class SegmentCompletionProtocolTest {
     Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_REASON),
         SegmentCompletionProtocol.REASON_ROW_LIMIT);
     Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_REASON_CODE),
-        SegmentCompletionProtocol.ReasonCode.ROW_LIMIT.name());
+        String.valueOf(SegmentCompletionProtocol.ReasonCode.ROW_LIMIT.getId()));
     Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_BUILD_TIME_MILLIS), "1000");
     Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_WAIT_TIME_MILLIS), "2000");
     Assert.assertEquals(paramsMap.get(SegmentCompletionProtocol.PARAM_EXTRA_TIME_SEC), "3000");
@@ -153,10 +153,19 @@ public class SegmentCompletionProtocolTest {
     Assert.assertEquals(params.getReason(), "customReason");
     Assert.assertEquals(params.getReasonCode(), SegmentCompletionProtocol.ReasonCode.ROW_LIMIT);
 
+    params = new SegmentCompletionProtocol.Request.Params()
+        .withReasonCode(String.valueOf(SegmentCompletionProtocol.ReasonCode.TIME_LIMIT.getId()));
+    Assert.assertEquals(params.getReason(), SegmentCompletionProtocol.REASON_TIME_LIMIT);
+    Assert.assertEquals(params.getReasonCode(), SegmentCompletionProtocol.ReasonCode.TIME_LIMIT);
+
     params = new SegmentCompletionProtocol.Request.Params().withReason(SegmentCompletionProtocol.REASON_ROW_LIMIT)
-        .withReasonCode("FUTURE_REASON_CODE");
+        .withReasonCode("999");
     Assert.assertEquals(params.getReason(), SegmentCompletionProtocol.REASON_ROW_LIMIT);
     Assert.assertEquals(params.getReasonCode(), SegmentCompletionProtocol.ReasonCode.ROW_LIMIT);
+
+    params = new SegmentCompletionProtocol.Request.Params().withReasonCode("999");
+    Assert.assertNull(params.getReason());
+    Assert.assertNull(params.getReasonCode());
 
     params = new SegmentCompletionProtocol.Request.Params().withReasonCode("FUTURE_REASON_CODE");
     Assert.assertNull(params.getReason());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
@@ -122,6 +122,7 @@ public class LLCSegmentCompletionHandlers {
       @QueryParam(SegmentCompletionProtocol.PARAM_SEGMENT_NAME) String segmentName,
       @QueryParam(SegmentCompletionProtocol.PARAM_STREAM_PARTITION_MSG_OFFSET) String streamPartitionMsgOffset,
       @QueryParam(SegmentCompletionProtocol.PARAM_REASON) String stopReason,
+      @QueryParam(SegmentCompletionProtocol.PARAM_REASON_CODE) String stopReasonCode,
       @QueryParam(SegmentCompletionProtocol.PARAM_MEMORY_USED_BYTES) long memoryUsedBytes,
       @QueryParam(SegmentCompletionProtocol.PARAM_ROW_COUNT) int numRows) {
     if (instanceId == null || segmentName == null || streamPartitionMsgOffset == null) {
@@ -135,6 +136,7 @@ public class LLCSegmentCompletionHandlers {
         .withSegmentName(segmentName)
         .withStreamPartitionMsgOffset(streamPartitionMsgOffset)
         .withReason(stopReason)
+        .withReasonCode(stopReasonCode)
         .withMemoryUsedBytes(memoryUsedBytes)
         .withNumRows(numRows);
     LOGGER.info("Processing segmentConsumed: {}", requestParams);
@@ -152,7 +154,8 @@ public class LLCSegmentCompletionHandlers {
   public String segmentStoppedConsuming(@QueryParam(SegmentCompletionProtocol.PARAM_INSTANCE_ID) String instanceId,
       @QueryParam(SegmentCompletionProtocol.PARAM_SEGMENT_NAME) String segmentName,
       @QueryParam(SegmentCompletionProtocol.PARAM_STREAM_PARTITION_MSG_OFFSET) String streamPartitionMsgOffset,
-      @QueryParam(SegmentCompletionProtocol.PARAM_REASON) String stopReason) {
+      @QueryParam(SegmentCompletionProtocol.PARAM_REASON) String stopReason,
+      @QueryParam(SegmentCompletionProtocol.PARAM_REASON_CODE) String stopReasonCode) {
     if (instanceId == null || segmentName == null || streamPartitionMsgOffset == null) {
       LOGGER.error("Invalid call: segmentName={}, instanceId={}, streamPartitionMsgOffset={}", segmentName, instanceId,
           streamPartitionMsgOffset);
@@ -163,7 +166,8 @@ public class LLCSegmentCompletionHandlers {
         .withInstanceId(instanceId)
         .withSegmentName(segmentName)
         .withStreamPartitionMsgOffset(streamPartitionMsgOffset)
-        .withReason(stopReason);
+        .withReason(stopReason)
+        .withReasonCode(stopReasonCode);
     LOGGER.info("Processing segmentStoppedConsuming: {}", requestParams);
 
     String response = _segmentCompletionManager.segmentStoppedConsuming(requestParams).toJsonString();
@@ -273,7 +277,9 @@ public class LLCSegmentCompletionHandlers {
       @QueryParam(SegmentCompletionProtocol.PARAM_WAIT_TIME_MILLIS) long waitTimeMillis,
       @QueryParam(SegmentCompletionProtocol.PARAM_ROW_COUNT) int numRows,
       @QueryParam(SegmentCompletionProtocol.PARAM_SEGMENT_SIZE_BYTES) long segmentSizeBytes,
-      @QueryParam(SegmentCompletionProtocol.PARAM_REASON) String stopReason, FormDataMultiPart metadataFiles) {
+      @QueryParam(SegmentCompletionProtocol.PARAM_REASON) String stopReason,
+      @QueryParam(SegmentCompletionProtocol.PARAM_REASON_CODE) String stopReasonCode,
+      FormDataMultiPart metadataFiles) {
     if (instanceId == null || segmentName == null || segmentLocation == null || metadataFiles == null
         || streamPartitionMsgOffset == null) {
       LOGGER.error("Invalid call: segmentName={}, instanceId={}, segmentLocation={}, streamPartitionMsgOffset={}",
@@ -292,7 +298,8 @@ public class LLCSegmentCompletionHandlers {
         .withWaitTimeMillis(waitTimeMillis)
         .withNumRows(numRows)
         .withMemoryUsedBytes(memoryUsedBytes)
-        .withReason(stopReason);
+        .withReason(stopReason)
+        .withReasonCode(stopReasonCode);
     LOGGER.info("Processing segmentCommitEndWithMetadata: {}", requestParams);
 
     SegmentMetadataImpl segmentMetadata;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
@@ -122,7 +122,7 @@ public class LLCSegmentCompletionHandlers {
       @QueryParam(SegmentCompletionProtocol.PARAM_SEGMENT_NAME) String segmentName,
       @QueryParam(SegmentCompletionProtocol.PARAM_STREAM_PARTITION_MSG_OFFSET) String streamPartitionMsgOffset,
       @QueryParam(SegmentCompletionProtocol.PARAM_REASON) String stopReason,
-      @QueryParam(SegmentCompletionProtocol.PARAM_REASON_CODE) String stopReasonCode,
+      @QueryParam(SegmentCompletionProtocol.PARAM_REASON_CODE) Integer stopReasonCode,
       @QueryParam(SegmentCompletionProtocol.PARAM_MEMORY_USED_BYTES) long memoryUsedBytes,
       @QueryParam(SegmentCompletionProtocol.PARAM_ROW_COUNT) int numRows) {
     if (instanceId == null || segmentName == null || streamPartitionMsgOffset == null) {
@@ -155,7 +155,7 @@ public class LLCSegmentCompletionHandlers {
       @QueryParam(SegmentCompletionProtocol.PARAM_SEGMENT_NAME) String segmentName,
       @QueryParam(SegmentCompletionProtocol.PARAM_STREAM_PARTITION_MSG_OFFSET) String streamPartitionMsgOffset,
       @QueryParam(SegmentCompletionProtocol.PARAM_REASON) String stopReason,
-      @QueryParam(SegmentCompletionProtocol.PARAM_REASON_CODE) String stopReasonCode) {
+      @QueryParam(SegmentCompletionProtocol.PARAM_REASON_CODE) Integer stopReasonCode) {
     if (instanceId == null || segmentName == null || streamPartitionMsgOffset == null) {
       LOGGER.error("Invalid call: segmentName={}, instanceId={}, streamPartitionMsgOffset={}", segmentName, instanceId,
           streamPartitionMsgOffset);
@@ -189,7 +189,7 @@ public class LLCSegmentCompletionHandlers {
       @QueryParam(SegmentCompletionProtocol.PARAM_ROW_COUNT) int numRows,
       @QueryParam(SegmentCompletionProtocol.PARAM_SEGMENT_SIZE_BYTES) long segmentSizeBytes,
       @QueryParam(SegmentCompletionProtocol.PARAM_REASON) String stopReason,
-      @QueryParam(SegmentCompletionProtocol.PARAM_REASON_CODE) String stopReasonCode) {
+      @QueryParam(SegmentCompletionProtocol.PARAM_REASON_CODE) Integer stopReasonCode) {
     if (instanceId == null || segmentName == null || streamPartitionMsgOffset == null) {
       LOGGER.error("Invalid call: segmentName={}, instanceId={}, streamPartitionMsgOffset={}", segmentName, instanceId,
           streamPartitionMsgOffset);
@@ -282,7 +282,7 @@ public class LLCSegmentCompletionHandlers {
       @QueryParam(SegmentCompletionProtocol.PARAM_ROW_COUNT) int numRows,
       @QueryParam(SegmentCompletionProtocol.PARAM_SEGMENT_SIZE_BYTES) long segmentSizeBytes,
       @QueryParam(SegmentCompletionProtocol.PARAM_REASON) String stopReason,
-      @QueryParam(SegmentCompletionProtocol.PARAM_REASON_CODE) String stopReasonCode,
+      @QueryParam(SegmentCompletionProtocol.PARAM_REASON_CODE) Integer stopReasonCode,
       FormDataMultiPart metadataFiles) {
     if (instanceId == null || segmentName == null || segmentLocation == null || metadataFiles == null
         || streamPartitionMsgOffset == null) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
@@ -136,7 +136,7 @@ public class LLCSegmentCompletionHandlers {
         .withSegmentName(segmentName)
         .withStreamPartitionMsgOffset(streamPartitionMsgOffset)
         .withReason(stopReason)
-        .withReasonCode(stopReasonCode)
+        .withReasonCodeParam(stopReasonCode)
         .withMemoryUsedBytes(memoryUsedBytes)
         .withNumRows(numRows);
     LOGGER.info("Processing segmentConsumed: {}", requestParams);
@@ -167,7 +167,7 @@ public class LLCSegmentCompletionHandlers {
         .withSegmentName(segmentName)
         .withStreamPartitionMsgOffset(streamPartitionMsgOffset)
         .withReason(stopReason)
-        .withReasonCode(stopReasonCode);
+        .withReasonCodeParam(stopReasonCode);
     LOGGER.info("Processing segmentStoppedConsuming: {}", requestParams);
 
     String response = _segmentCompletionManager.segmentStoppedConsuming(requestParams).toJsonString();
@@ -187,7 +187,9 @@ public class LLCSegmentCompletionHandlers {
       @QueryParam(SegmentCompletionProtocol.PARAM_BUILD_TIME_MILLIS) long buildTimeMillis,
       @QueryParam(SegmentCompletionProtocol.PARAM_WAIT_TIME_MILLIS) long waitTimeMillis,
       @QueryParam(SegmentCompletionProtocol.PARAM_ROW_COUNT) int numRows,
-      @QueryParam(SegmentCompletionProtocol.PARAM_SEGMENT_SIZE_BYTES) long segmentSizeBytes) {
+      @QueryParam(SegmentCompletionProtocol.PARAM_SEGMENT_SIZE_BYTES) long segmentSizeBytes,
+      @QueryParam(SegmentCompletionProtocol.PARAM_REASON) String stopReason,
+      @QueryParam(SegmentCompletionProtocol.PARAM_REASON_CODE) String stopReasonCode) {
     if (instanceId == null || segmentName == null || streamPartitionMsgOffset == null) {
       LOGGER.error("Invalid call: segmentName={}, instanceId={}, streamPartitionMsgOffset={}", segmentName, instanceId,
           streamPartitionMsgOffset);
@@ -202,7 +204,9 @@ public class LLCSegmentCompletionHandlers {
         .withBuildTimeMillis(buildTimeMillis)
         .withWaitTimeMillis(waitTimeMillis)
         .withNumRows(numRows)
-        .withSegmentSizeBytes(segmentSizeBytes);
+        .withSegmentSizeBytes(segmentSizeBytes)
+        .withReason(stopReason)
+        .withReasonCodeParam(stopReasonCode);
     LOGGER.info("Processing segmentCommitStart: {}", requestParams);
 
     String response = _segmentCompletionManager.segmentCommitStart(requestParams).toJsonString();
@@ -299,7 +303,7 @@ public class LLCSegmentCompletionHandlers {
         .withNumRows(numRows)
         .withMemoryUsedBytes(memoryUsedBytes)
         .withReason(stopReason)
-        .withReasonCode(stopReasonCode);
+        .withReasonCodeParam(stopReasonCode);
     LOGGER.info("Processing segmentCommitEndWithMetadata: {}", requestParams);
 
     SegmentMetadataImpl segmentMetadata;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/BlockingSegmentCompletionFSM.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/BlockingSegmentCompletionFSM.java
@@ -200,7 +200,7 @@ public class BlockingSegmentCompletionFSM implements SegmentCompletionFSM {
    */
   @Override
   public SegmentCompletionProtocol.Response segmentConsumed(String instanceId, StreamPartitionMsgOffset offset,
-      final String stopReason) {
+      final SegmentCompletionProtocol.ReasonCode stopReasonCode) {
     final long now = _segmentCompletionManager.getCurrentTimeMs();
     // We can synchronize the entire block for the SegmentConsumed message.
     synchronized (this) {
@@ -214,10 +214,10 @@ public class BlockingSegmentCompletionFSM implements SegmentCompletionFSM {
       _commitStateMap.put(instanceId, offset);
       switch (_state) {
         case PARTIAL_CONSUMING:
-          return partialConsumingConsumed(instanceId, offset, now, stopReason);
+          return partialConsumingConsumed(instanceId, offset, now, stopReasonCode);
 
         case HOLDING:
-          return holdingConsumed(instanceId, offset, now, stopReason);
+          return holdingConsumed(instanceId, offset, now, stopReasonCode);
 
         case COMMITTER_DECIDED: // This must be a retransmit
           return committerDecidedConsumed(instanceId, offset, now);
@@ -466,12 +466,12 @@ public class BlockingSegmentCompletionFSM implements SegmentCompletionFSM {
   }
 
   private SegmentCompletionProtocol.Response partialConsumingConsumed(String instanceId,
-      StreamPartitionMsgOffset offset, long now, final String stopReason) {
+      StreamPartitionMsgOffset offset, long now, final SegmentCompletionProtocol.ReasonCode stopReasonCode) {
     // This is the first time we are getting segmentConsumed() for this segment.
     // Some instance thinks we can close this segment, so go to HOLDING state, and process as normal.
     // We will just be looking for less replicas.
     _state = BlockingSegmentCompletionFSMState.HOLDING;
-    return holdingConsumed(instanceId, offset, now, stopReason);
+    return holdingConsumed(instanceId, offset, now, stopReasonCode);
   }
 
   /*
@@ -502,11 +502,11 @@ public class BlockingSegmentCompletionFSM implements SegmentCompletionFSM {
    * If we can go to COMMITTER_NOTIFIED then we respond with a COMMIT message, otherwise with a HOLD message.
    */
   private SegmentCompletionProtocol.Response holdingConsumed(String instanceId, StreamPartitionMsgOffset offset,
-      long now, final String stopReason) {
+      long now, final SegmentCompletionProtocol.ReasonCode stopReasonCode) {
     SegmentCompletionProtocol.Response response;
     // If we are past the max time to pick a winner, or we have heard from all replicas,
     // we are ready to pick a winner.
-    if (isWinnerPicked(instanceId, now, stopReason)) {
+    if (isWinnerPicked(instanceId, now, stopReasonCode)) {
       if (_winner.equals(instanceId)) {
         _logger.info("{}:Committer notified winner instance={} offset={}", _state, instanceId, offset);
         response = commit(instanceId, offset);
@@ -895,12 +895,11 @@ public class BlockingSegmentCompletionFSM implements SegmentCompletionFSM {
   ///
   /// @param preferredInstance The instance that is reporting in this thread.
   /// @param now current time
-  /// @param stopReason reason reported by instance for stopping consumption.
+  /// @param stopReasonCode reason code reported by instance for stopping consumption.
   /// @return true if winner picked, false otherwise.
-  private boolean isWinnerPicked(String preferredInstance, long now, final String stopReason) {
-    if ((SegmentCompletionProtocol.REASON_ROW_LIMIT.equals(stopReason)
-        || SegmentCompletionProtocol.REASON_END_OF_PARTITION_GROUP.equals(stopReason))
-        && _commitStateMap.size() == 1) {
+  private boolean isWinnerPicked(String preferredInstance, long now,
+      final SegmentCompletionProtocol.ReasonCode stopReasonCode) {
+    if (stopReasonCode != null && stopReasonCode.shouldPickWinnerImmediately() && _commitStateMap.size() == 1) {
       _winner = preferredInstance;
       _winningOffset = _commitStateMap.get(preferredInstance);
       return true;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/BlockingSegmentCompletionFSM.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/BlockingSegmentCompletionFSM.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
@@ -200,7 +201,7 @@ public class BlockingSegmentCompletionFSM implements SegmentCompletionFSM {
    */
   @Override
   public SegmentCompletionProtocol.Response segmentConsumed(String instanceId, StreamPartitionMsgOffset offset,
-      final SegmentCompletionProtocol.ReasonCode stopReasonCode) {
+      @Nullable final String stopReason) {
     final long now = _segmentCompletionManager.getCurrentTimeMs();
     // We can synchronize the entire block for the SegmentConsumed message.
     synchronized (this) {
@@ -214,10 +215,10 @@ public class BlockingSegmentCompletionFSM implements SegmentCompletionFSM {
       _commitStateMap.put(instanceId, offset);
       switch (_state) {
         case PARTIAL_CONSUMING:
-          return partialConsumingConsumed(instanceId, offset, now, stopReasonCode);
+          return partialConsumingConsumed(instanceId, offset, now, stopReason);
 
         case HOLDING:
-          return holdingConsumed(instanceId, offset, now, stopReasonCode);
+          return holdingConsumed(instanceId, offset, now, stopReason);
 
         case COMMITTER_DECIDED: // This must be a retransmit
           return committerDecidedConsumed(instanceId, offset, now);
@@ -466,12 +467,12 @@ public class BlockingSegmentCompletionFSM implements SegmentCompletionFSM {
   }
 
   private SegmentCompletionProtocol.Response partialConsumingConsumed(String instanceId,
-      StreamPartitionMsgOffset offset, long now, final SegmentCompletionProtocol.ReasonCode stopReasonCode) {
+      StreamPartitionMsgOffset offset, long now, @Nullable final String stopReason) {
     // This is the first time we are getting segmentConsumed() for this segment.
     // Some instance thinks we can close this segment, so go to HOLDING state, and process as normal.
     // We will just be looking for less replicas.
     _state = BlockingSegmentCompletionFSMState.HOLDING;
-    return holdingConsumed(instanceId, offset, now, stopReasonCode);
+    return holdingConsumed(instanceId, offset, now, stopReason);
   }
 
   /*
@@ -502,11 +503,11 @@ public class BlockingSegmentCompletionFSM implements SegmentCompletionFSM {
    * If we can go to COMMITTER_NOTIFIED then we respond with a COMMIT message, otherwise with a HOLD message.
    */
   private SegmentCompletionProtocol.Response holdingConsumed(String instanceId, StreamPartitionMsgOffset offset,
-      long now, final SegmentCompletionProtocol.ReasonCode stopReasonCode) {
+      long now, @Nullable final String stopReason) {
     SegmentCompletionProtocol.Response response;
     // If we are past the max time to pick a winner, or we have heard from all replicas,
     // we are ready to pick a winner.
-    if (isWinnerPicked(instanceId, now, stopReasonCode)) {
+    if (isWinnerPicked(instanceId, now, stopReason)) {
       if (_winner.equals(instanceId)) {
         _logger.info("{}:Committer notified winner instance={} offset={}", _state, instanceId, offset);
         response = commit(instanceId, offset);
@@ -895,11 +896,10 @@ public class BlockingSegmentCompletionFSM implements SegmentCompletionFSM {
   ///
   /// @param preferredInstance The instance that is reporting in this thread.
   /// @param now current time
-  /// @param stopReasonCode reason code reported by instance for stopping consumption.
+  /// @param stopReason reason reported by instance for stopping consumption.
   /// @return true if winner picked, false otherwise.
-  private boolean isWinnerPicked(String preferredInstance, long now,
-      final SegmentCompletionProtocol.ReasonCode stopReasonCode) {
-    if (stopReasonCode != null && stopReasonCode.shouldPickWinnerImmediately() && _commitStateMap.size() == 1) {
+  private boolean isWinnerPicked(String preferredInstance, long now, @Nullable final String stopReason) {
+    if (shouldPickWinnerImmediately(stopReason) && _commitStateMap.size() == 1) {
       _winner = preferredInstance;
       _winningOffset = _commitStateMap.get(preferredInstance);
       return true;
@@ -921,5 +921,10 @@ public class BlockingSegmentCompletionFSM implements SegmentCompletionFSM {
       return true;
     }
     return false;
+  }
+
+  private static boolean shouldPickWinnerImmediately(@Nullable String stopReason) {
+    return SegmentCompletionProtocol.REASON_ROW_LIMIT.equals(stopReason)
+        || SegmentCompletionProtocol.REASON_END_OF_PARTITION_GROUP.equals(stopReason);
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionFSM.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionFSM.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.helix.core.realtime;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 import org.apache.pinot.controller.helix.core.realtime.segment.CommittingSegmentDescriptor;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
@@ -68,10 +69,10 @@ public interface SegmentCompletionFSM {
   ///
   /// @param instanceId The ID of the server instance reporting consumption.
   /// @param offset The offset up to which the server has consumed.
-  /// @param stopReasonCode The reason code the server stopped consuming with (e.g., row limit or end of partition).
+  /// @param stopReason The reason the server stopped consuming with (e.g., row limit or end of partition).
   /// @return A response indicating the next action for the server (e.g., HOLD, CATCHUP, or COMMIT).
   SegmentCompletionProtocol.Response segmentConsumed(String instanceId, StreamPartitionMsgOffset offset,
-      SegmentCompletionProtocol.ReasonCode stopReasonCode);
+      @Nullable String stopReason);
 
   /// Processes the start of a segment commit from a server.
   ///

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionFSM.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionFSM.java
@@ -68,10 +68,10 @@ public interface SegmentCompletionFSM {
   ///
   /// @param instanceId The ID of the server instance reporting consumption.
   /// @param offset The offset up to which the server has consumed.
-  /// @param stopReason The reason the server stopped consuming (e.g., row limit or end of partition).
+  /// @param stopReasonCode The reason code the server stopped consuming with (e.g., row limit or end of partition).
   /// @return A response indicating the next action for the server (e.g., HOLD, CATCHUP, or COMMIT).
   SegmentCompletionProtocol.Response segmentConsumed(String instanceId, StreamPartitionMsgOffset offset,
-      String stopReason);
+      SegmentCompletionProtocol.ReasonCode stopReasonCode);
 
   /// Processes the start of a segment commit from a server.
   ///

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -157,7 +157,7 @@ public class SegmentCompletionManager {
       return SegmentCompletionProtocol.RESP_NOT_LEADER;
     }
     final String instanceId = reqParams.getInstanceId();
-    final String stopReason = reqParams.getReason();
+    final SegmentCompletionProtocol.ReasonCode stopReasonCode = reqParams.getReasonCode();
     final StreamPartitionMsgOffsetFactory factory = getStreamPartitionMsgOffsetFactory(segmentName);
     final StreamPartitionMsgOffset offset = factory.create(reqParams.getStreamPartitionMsgOffset());
 
@@ -165,7 +165,7 @@ public class SegmentCompletionManager {
     SegmentCompletionFSM fsm = null;
     try {
       fsm = lookupOrCreateFsm(segmentName, SegmentCompletionProtocol.MSG_TYPE_CONSUMED);
-      response = fsm.segmentConsumed(instanceId, offset, stopReason);
+      response = fsm.segmentConsumed(instanceId, offset, stopReasonCode);
     } catch (Exception e) {
       LOGGER.error("Caught exception in segmentConsumed for segment {}", segmentNameStr, e);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -157,7 +157,7 @@ public class SegmentCompletionManager {
       return SegmentCompletionProtocol.RESP_NOT_LEADER;
     }
     final String instanceId = reqParams.getInstanceId();
-    final SegmentCompletionProtocol.ReasonCode stopReasonCode = reqParams.getReasonCode();
+    final String stopReason = reqParams.getReason();
     final StreamPartitionMsgOffsetFactory factory = getStreamPartitionMsgOffsetFactory(segmentName);
     final StreamPartitionMsgOffset offset = factory.create(reqParams.getStreamPartitionMsgOffset());
 
@@ -165,7 +165,7 @@ public class SegmentCompletionManager {
     SegmentCompletionFSM fsm = null;
     try {
       fsm = lookupOrCreateFsm(segmentName, SegmentCompletionProtocol.MSG_TYPE_CONSUMED);
-      response = fsm.segmentConsumed(instanceId, offset, stopReasonCode);
+      response = fsm.segmentConsumed(instanceId, offset, stopReason);
     } catch (Exception e) {
       LOGGER.error("Caught exception in segmentConsumed for segment {}", segmentNameStr, e);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/CommittingSegmentDescriptor.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/CommittingSegmentDescriptor.java
@@ -32,6 +32,7 @@ public class CommittingSegmentDescriptor {
   private String _segmentLocation;
   private SegmentMetadataImpl _segmentMetadata;
   private String _stopReason;
+  private SegmentCompletionProtocol.ReasonCode _stopReasonCode;
   private int _preCommitRowCount;
 
   public static CommittingSegmentDescriptor fromSegmentCompletionReqParams(
@@ -41,6 +42,7 @@ public class CommittingSegmentDescriptor {
             reqParams.getSegmentSizeBytes());
     committingSegmentDescriptor.setSegmentLocation(reqParams.getSegmentLocation());
     committingSegmentDescriptor.setStopReason(reqParams.getReason());
+    committingSegmentDescriptor.setStopReasonCode(reqParams.getReasonCode());
     // Capture pre-commit row count from the request (for commit time compaction awareness)
     committingSegmentDescriptor.setPreCommitRowCount(reqParams.getNumRows());
 
@@ -103,6 +105,15 @@ public class CommittingSegmentDescriptor {
 
   public void setStopReason(String stopReason) {
     _stopReason = stopReason;
+  }
+
+  @Nullable
+  public SegmentCompletionProtocol.ReasonCode getStopReasonCode() {
+    return _stopReasonCode;
+  }
+
+  public void setStopReasonCode(SegmentCompletionProtocol.ReasonCode stopReasonCode) {
+    _stopReasonCode = stopReasonCode;
   }
 
   public int getPreCommitRowCount() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/CommittingSegmentDescriptor.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/CommittingSegmentDescriptor.java
@@ -31,7 +31,9 @@ public class CommittingSegmentDescriptor {
 
   private String _segmentLocation;
   private SegmentMetadataImpl _segmentMetadata;
+  @Nullable
   private String _stopReason;
+  @Nullable
   private SegmentCompletionProtocol.ReasonCode _stopReasonCode;
   private int _preCommitRowCount;
 
@@ -103,7 +105,7 @@ public class CommittingSegmentDescriptor {
     return _stopReason;
   }
 
-  public void setStopReason(String stopReason) {
+  public void setStopReason(@Nullable String stopReason) {
     _stopReason = stopReason;
   }
 
@@ -112,7 +114,7 @@ public class CommittingSegmentDescriptor {
     return _stopReasonCode;
   }
 
-  public void setStopReasonCode(SegmentCompletionProtocol.ReasonCode stopReasonCode) {
+  public void setStopReasonCode(@Nullable SegmentCompletionProtocol.ReasonCode stopReasonCode) {
     _stopReasonCode = stopReasonCode;
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/SizeBasedSegmentFlushThresholdComputer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/SizeBasedSegmentFlushThresholdComputer.java
@@ -90,9 +90,7 @@ class SizeBasedSegmentFlushThresholdComputer {
         calculateSizeForCalculation(usingPreCommitRows, preCommitRows, postCommitRows, postCommitSizeBytes);
 
     // Skip updating the ratio if the segment is empty, size is not available, or the segment is force-committed.
-    if (rowsForCalculation <= 0 || sizeForCalculation <= 0
-        || SegmentCompletionProtocol.REASON_FORCE_COMMIT_MESSAGE_RECEIVED.equals(
-        committingSegmentDescriptor.getStopReason())) {
+    if (rowsForCalculation <= 0 || sizeForCalculation <= 0 || isForceCommit(committingSegmentDescriptor)) {
       if (committingSegmentZKMetadata.getStatus() == Status.DONE) {
         // Do not log for COMMITTING segment, as it is expected to not have rowsConsumed and sizeInBytes set
         LOGGER.info(
@@ -220,6 +218,13 @@ class SizeBasedSegmentFlushThresholdComputer {
       return Integer.MAX_VALUE;
     }
     return Math.max((int) targetRows, MINIMUM_NUM_ROWS_THRESHOLD);
+  }
+
+  private static boolean isForceCommit(CommittingSegmentDescriptor committingSegmentDescriptor) {
+    SegmentCompletionProtocol.ReasonCode stopReasonCode = committingSegmentDescriptor.getStopReasonCode();
+    return SegmentCompletionProtocol.ReasonCode.FORCE_COMMIT_MESSAGE_RECEIVED == stopReasonCode
+        || (stopReasonCode == null && SegmentCompletionProtocol.REASON_FORCE_COMMIT_MESSAGE_RECEIVED.equals(
+            committingSegmentDescriptor.getStopReason()));
   }
 
   /// Calculates the size to use for segment size ratio calculations.

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlersTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlersTest.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
+import org.apache.pinot.controller.helix.core.realtime.SegmentCompletionManager;
+import org.mockito.ArgumentCaptor;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+public class LLCSegmentCompletionHandlersTest {
+  private static final String INSTANCE_ID = "Server_localhost_8099";
+  private static final String SEGMENT_NAME = "foo__0__0__12345Z";
+  private static final String OFFSET = "7000";
+
+  @Test
+  public void testSegmentCommitStartBindsReasonAndReasonCode() {
+    SegmentCompletionManager segmentCompletionManager = mock(SegmentCompletionManager.class);
+    when(segmentCompletionManager.segmentCommitStart(any())).thenReturn(SegmentCompletionProtocol.RESP_COMMIT_CONTINUE);
+    LLCSegmentCompletionHandlers handler = new LLCSegmentCompletionHandlers();
+    handler._segmentCompletionManager = segmentCompletionManager;
+
+    handler.segmentCommitStart(INSTANCE_ID, SEGMENT_NAME, OFFSET, 4000, 1000, 2000, 6000, 5000,
+        "legacyReason", "100");
+
+    SegmentCompletionProtocol.Request.Params params = captureSegmentCommitStartParams(segmentCompletionManager);
+    Assert.assertEquals(params.getReason(), SegmentCompletionProtocol.REASON_ROW_LIMIT);
+    Assert.assertEquals(params.getReasonCode(), SegmentCompletionProtocol.ReasonCode.ROW_LIMIT);
+  }
+
+  @Test
+  public void testSegmentCommitStartFallsBackToLegacyReasonForUnknownCode() {
+    SegmentCompletionManager segmentCompletionManager = mock(SegmentCompletionManager.class);
+    when(segmentCompletionManager.segmentCommitStart(any())).thenReturn(SegmentCompletionProtocol.RESP_COMMIT_CONTINUE);
+    LLCSegmentCompletionHandlers handler = new LLCSegmentCompletionHandlers();
+    handler._segmentCompletionManager = segmentCompletionManager;
+
+    handler.segmentCommitStart(INSTANCE_ID, SEGMENT_NAME, OFFSET, 4000, 1000, 2000, 6000, 5000,
+        SegmentCompletionProtocol.REASON_TIME_LIMIT, "999");
+
+    SegmentCompletionProtocol.Request.Params params = captureSegmentCommitStartParams(segmentCompletionManager);
+    Assert.assertEquals(params.getReason(), SegmentCompletionProtocol.REASON_TIME_LIMIT);
+    Assert.assertEquals(params.getReasonCode(), SegmentCompletionProtocol.ReasonCode.TIME_LIMIT);
+  }
+
+  @Test
+  public void testSegmentConsumedPrefersKnownReasonCodeOverLegacyReason() {
+    SegmentCompletionManager segmentCompletionManager = mock(SegmentCompletionManager.class);
+    when(segmentCompletionManager.segmentConsumed(any())).thenReturn(SegmentCompletionProtocol.RESP_FAILED);
+    LLCSegmentCompletionHandlers handler = new LLCSegmentCompletionHandlers();
+    handler._segmentCompletionManager = segmentCompletionManager;
+
+    handler.segmentConsumed(INSTANCE_ID, SEGMENT_NAME, OFFSET, "legacyReason", "100", 4000, 6000);
+
+    ArgumentCaptor<SegmentCompletionProtocol.Request.Params> paramsCaptor =
+        ArgumentCaptor.forClass(SegmentCompletionProtocol.Request.Params.class);
+    verify(segmentCompletionManager).segmentConsumed(paramsCaptor.capture());
+    SegmentCompletionProtocol.Request.Params params = paramsCaptor.getValue();
+    Assert.assertEquals(params.getReason(), SegmentCompletionProtocol.REASON_ROW_LIMIT);
+    Assert.assertEquals(params.getReasonCode(), SegmentCompletionProtocol.ReasonCode.ROW_LIMIT);
+  }
+
+  private static SegmentCompletionProtocol.Request.Params captureSegmentCommitStartParams(
+      SegmentCompletionManager segmentCompletionManager) {
+    ArgumentCaptor<SegmentCompletionProtocol.Request.Params> paramsCaptor =
+        ArgumentCaptor.forClass(SegmentCompletionProtocol.Request.Params.class);
+    verify(segmentCompletionManager).segmentCommitStart(paramsCaptor.capture());
+    return paramsCaptor.getValue();
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlersTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlersTest.java
@@ -21,15 +21,16 @@ package org.apache.pinot.controller.api.resources;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 import org.apache.pinot.controller.helix.core.realtime.SegmentCompletionManager;
 import org.mockito.ArgumentCaptor;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 
 
+/// Tests reason-code binding at the segment-completion REST resource boundary.
 public class LLCSegmentCompletionHandlersTest {
   private static final String INSTANCE_ID = "Server_localhost_8099";
   private static final String SEGMENT_NAME = "foo__0__0__12345Z";
@@ -42,12 +43,11 @@ public class LLCSegmentCompletionHandlersTest {
     LLCSegmentCompletionHandlers handler = new LLCSegmentCompletionHandlers();
     handler._segmentCompletionManager = segmentCompletionManager;
 
-    handler.segmentCommitStart(INSTANCE_ID, SEGMENT_NAME, OFFSET, 4000, 1000, 2000, 6000, 5000,
-        "legacyReason", "100");
+    handler.segmentCommitStart(INSTANCE_ID, SEGMENT_NAME, OFFSET, 4000, 1000, 2000, 6000, 5000, "legacyReason", 100);
 
     SegmentCompletionProtocol.Request.Params params = captureSegmentCommitStartParams(segmentCompletionManager);
-    Assert.assertEquals(params.getReason(), SegmentCompletionProtocol.REASON_ROW_LIMIT);
-    Assert.assertEquals(params.getReasonCode(), SegmentCompletionProtocol.ReasonCode.ROW_LIMIT);
+    assertEquals(params.getReason(), SegmentCompletionProtocol.REASON_ROW_LIMIT);
+    assertEquals(params.getReasonCode(), SegmentCompletionProtocol.ReasonCode.ROW_LIMIT);
   }
 
   @Test
@@ -58,11 +58,11 @@ public class LLCSegmentCompletionHandlersTest {
     handler._segmentCompletionManager = segmentCompletionManager;
 
     handler.segmentCommitStart(INSTANCE_ID, SEGMENT_NAME, OFFSET, 4000, 1000, 2000, 6000, 5000,
-        SegmentCompletionProtocol.REASON_TIME_LIMIT, "999");
+        SegmentCompletionProtocol.REASON_TIME_LIMIT, 999);
 
     SegmentCompletionProtocol.Request.Params params = captureSegmentCommitStartParams(segmentCompletionManager);
-    Assert.assertEquals(params.getReason(), SegmentCompletionProtocol.REASON_TIME_LIMIT);
-    Assert.assertEquals(params.getReasonCode(), SegmentCompletionProtocol.ReasonCode.TIME_LIMIT);
+    assertEquals(params.getReason(), SegmentCompletionProtocol.REASON_TIME_LIMIT);
+    assertEquals(params.getReasonCode(), SegmentCompletionProtocol.ReasonCode.TIME_LIMIT);
   }
 
   @Test
@@ -72,14 +72,14 @@ public class LLCSegmentCompletionHandlersTest {
     LLCSegmentCompletionHandlers handler = new LLCSegmentCompletionHandlers();
     handler._segmentCompletionManager = segmentCompletionManager;
 
-    handler.segmentConsumed(INSTANCE_ID, SEGMENT_NAME, OFFSET, "legacyReason", "100", 4000, 6000);
+    handler.segmentConsumed(INSTANCE_ID, SEGMENT_NAME, OFFSET, "legacyReason", 100, 4000, 6000);
 
     ArgumentCaptor<SegmentCompletionProtocol.Request.Params> paramsCaptor =
         ArgumentCaptor.forClass(SegmentCompletionProtocol.Request.Params.class);
     verify(segmentCompletionManager).segmentConsumed(paramsCaptor.capture());
     SegmentCompletionProtocol.Request.Params params = paramsCaptor.getValue();
-    Assert.assertEquals(params.getReason(), SegmentCompletionProtocol.REASON_ROW_LIMIT);
-    Assert.assertEquals(params.getReasonCode(), SegmentCompletionProtocol.ReasonCode.ROW_LIMIT);
+    assertEquals(params.getReason(), SegmentCompletionProtocol.REASON_ROW_LIMIT);
+    assertEquals(params.getReasonCode(), SegmentCompletionProtocol.ReasonCode.ROW_LIMIT);
   }
 
   private static SegmentCompletionProtocol.Request.Params captureSegmentCommitStartParams(

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
@@ -590,6 +590,44 @@ public class SegmentCompletionTest {
   }
 
   @Test
+  public void testWinnerOnRowLimitReasonCodeOverridesLegacyReason() {
+    SegmentCompletionProtocol.Response response;
+    Request.Params params;
+    _segmentCompletionMgr._seconds = 10L;
+    params = new Request.Params().withInstanceId(S_1).withStreamPartitionMsgOffset(_s1Offset.toString())
+        .withSegmentName(_segmentNameStr)
+        .withReason("unknownReason")
+        .withReasonCode(SegmentCompletionProtocol.ReasonCode.ROW_LIMIT);
+    response = _segmentCompletionMgr.segmentConsumed(params);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
+  }
+
+  @Test
+  public void testUnknownReasonCodeFallsBackToLegacyReason() {
+    SegmentCompletionProtocol.Response response;
+    Request.Params params;
+    _segmentCompletionMgr._seconds = 10L;
+    params = new Request.Params().withInstanceId(S_1).withStreamPartitionMsgOffset(_s1Offset.toString())
+        .withSegmentName(_segmentNameStr)
+        .withReason(SegmentCompletionProtocol.REASON_ROW_LIMIT)
+        .withReasonCode("FUTURE_REASON_CODE");
+    response = _segmentCompletionMgr.segmentConsumed(params);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
+  }
+
+  @Test
+  public void testUnknownReasonCodeWithoutLegacyReason() {
+    SegmentCompletionProtocol.Response response;
+    Request.Params params;
+    _segmentCompletionMgr._seconds = 10L;
+    params = new Request.Params().withInstanceId(S_1).withStreamPartitionMsgOffset(_s1Offset.toString())
+        .withSegmentName(_segmentNameStr)
+        .withReasonCode("FUTURE_REASON_CODE");
+    response = _segmentCompletionMgr.segmentConsumed(params);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.HOLD);
+  }
+
+  @Test
   public void testWinnerOnForceCommit() {
     SegmentCompletionProtocol.Response response;
     Request.Params params;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.controller.helix.core.realtime;
 
 import com.google.common.base.Preconditions;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.helix.HelixManager;
@@ -610,7 +611,7 @@ public class SegmentCompletionTest {
     params = new Request.Params().withInstanceId(S_1).withStreamPartitionMsgOffset(_s1Offset.toString())
         .withSegmentName(_segmentNameStr)
         .withReason(SegmentCompletionProtocol.REASON_ROW_LIMIT)
-        .withReasonCode("999");
+        .withReasonCodeParam("999");
     response = _segmentCompletionMgr.segmentConsumed(params);
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
   }
@@ -622,9 +623,19 @@ public class SegmentCompletionTest {
     _segmentCompletionMgr._seconds = 10L;
     params = new Request.Params().withInstanceId(S_1).withStreamPartitionMsgOffset(_s1Offset.toString())
         .withSegmentName(_segmentNameStr)
-        .withReasonCode("999");
+        .withReasonCodeParam("999");
     response = _segmentCompletionMgr.segmentConsumed(params);
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.HOLD);
+  }
+
+  @Test
+  public void testSegmentCompletionFsmKeepsLegacySegmentConsumedSignature()
+      throws Exception {
+    Method segmentConsumedMethod =
+        SegmentCompletionFSM.class.getMethod("segmentConsumed", String.class, StreamPartitionMsgOffset.class,
+            String.class);
+    Assert.assertEquals(segmentConsumedMethod.getParameterTypes()[2], String.class);
+    Assert.assertTrue(SegmentCompletionFSM.class.isAssignableFrom(LegacyStringSegmentCompletionFSM.class));
   }
 
   @Test
@@ -1349,6 +1360,51 @@ public class SegmentCompletionTest {
 
     // FSM should still be there for that segment
     Assert.assertTrue(_fsmMap.containsKey(_segmentNameStr));
+  }
+
+  private static class LegacyStringSegmentCompletionFSM implements SegmentCompletionFSM {
+    @Override
+    public void transitionToInitialState(String msgType) {
+    }
+
+    @Override
+    public boolean isDone() {
+      return false;
+    }
+
+    @Override
+    public boolean isImmutableSegmentCreated() {
+      return false;
+    }
+
+    @Override
+    public SegmentCompletionProtocol.Response segmentConsumed(String instanceId, StreamPartitionMsgOffset offset,
+        @Nullable String stopReason) {
+      return SegmentCompletionProtocol.RESP_FAILED;
+    }
+
+    @Override
+    public SegmentCompletionProtocol.Response segmentCommitStart(SegmentCompletionProtocol.Request.Params reqParams) {
+      return SegmentCompletionProtocol.RESP_FAILED;
+    }
+
+    @Override
+    public SegmentCompletionProtocol.Response stoppedConsuming(String instanceId, StreamPartitionMsgOffset offset,
+        String reason) {
+      return SegmentCompletionProtocol.RESP_FAILED;
+    }
+
+    @Override
+    public SegmentCompletionProtocol.Response extendBuildTime(String instanceId, StreamPartitionMsgOffset offset,
+        int extTimeSec) {
+      return SegmentCompletionProtocol.RESP_FAILED;
+    }
+
+    @Override
+    public SegmentCompletionProtocol.Response segmentCommitEnd(SegmentCompletionProtocol.Request.Params reqParams,
+        CommittingSegmentDescriptor committingSegmentDescriptor) {
+      return SegmentCompletionProtocol.RESP_FAILED;
+    }
   }
 
   private static HelixManager createMockHelixManager(boolean isLeader, boolean isConnected) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
@@ -610,7 +610,7 @@ public class SegmentCompletionTest {
     params = new Request.Params().withInstanceId(S_1).withStreamPartitionMsgOffset(_s1Offset.toString())
         .withSegmentName(_segmentNameStr)
         .withReason(SegmentCompletionProtocol.REASON_ROW_LIMIT)
-        .withReasonCode("FUTURE_REASON_CODE");
+        .withReasonCode("999");
     response = _segmentCompletionMgr.segmentConsumed(params);
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
   }
@@ -622,7 +622,7 @@ public class SegmentCompletionTest {
     _segmentCompletionMgr._seconds = 10L;
     params = new Request.Params().withInstanceId(S_1).withStreamPartitionMsgOffset(_s1Offset.toString())
         .withSegmentName(_segmentNameStr)
-        .withReasonCode("FUTURE_REASON_CODE");
+        .withReasonCode("999");
     response = _segmentCompletionMgr.segmentConsumed(params);
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.HOLD);
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/SizeBasedSegmentFlushThresholdComputerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/SizeBasedSegmentFlushThresholdComputerTest.java
@@ -23,6 +23,7 @@ import java.time.ZoneId;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.testng.annotations.Test;
 
@@ -113,6 +114,28 @@ public class SizeBasedSegmentFlushThresholdComputerTest {
     CommittingSegmentDescriptor committingSegmentDescriptor = mock(CommittingSegmentDescriptor.class);
     when(committingSegmentDescriptor.getSegmentSizeBytes()).thenReturn(committingSegmentSizeBytes);
     when(committingSegmentDescriptor.getStopReason()).thenReturn(REASON_FORCE_COMMIT_MESSAGE_RECEIVED);
+
+    SegmentZKMetadata committingSegmentZKMetadata = mock(SegmentZKMetadata.class);
+    when(committingSegmentZKMetadata.getSizeThresholdToFlushSegment()).thenReturn(committingSegmentSizeThreshold);
+
+    StreamConfig streamConfig = mock(StreamConfig.class);
+
+    computer.onSegmentCommit(committingSegmentDescriptor, committingSegmentZKMetadata);
+    int threshold = computer.computeThreshold(streamConfig, "newSegmentName");
+
+    assertEquals(threshold, committingSegmentSizeThreshold);
+  }
+
+  @Test
+  public void testUseLastSegmentsThresholdIfSegmentIsCommittingDueToForceCommitReasonCode() {
+    long committingSegmentSizeBytes = 500_000L;
+    int committingSegmentSizeThreshold = 25_000;
+    SizeBasedSegmentFlushThresholdComputer computer = new SizeBasedSegmentFlushThresholdComputer();
+
+    CommittingSegmentDescriptor committingSegmentDescriptor = mock(CommittingSegmentDescriptor.class);
+    when(committingSegmentDescriptor.getSegmentSizeBytes()).thenReturn(committingSegmentSizeBytes);
+    when(committingSegmentDescriptor.getStopReasonCode()).thenReturn(
+        SegmentCompletionProtocol.ReasonCode.FORCE_COMMIT_MESSAGE_RECEIVED);
 
     SegmentZKMetadata committingSegmentZKMetadata = mock(SegmentZKMetadata.class);
     when(committingSegmentZKMetadata.getSizeThresholdToFlushSegment()).thenReturn(committingSegmentSizeThreshold);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/SizeBasedSegmentFlushThresholdComputerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/SizeBasedSegmentFlushThresholdComputerTest.java
@@ -129,6 +129,7 @@ public class SizeBasedSegmentFlushThresholdComputerTest {
   @Test
   public void testUseLastSegmentsThresholdIfSegmentIsCommittingDueToForceCommitReasonCode() {
     long committingSegmentSizeBytes = 500_000L;
+    long committedRows = 100_000L;
     int committingSegmentSizeThreshold = 25_000;
     SizeBasedSegmentFlushThresholdComputer computer = new SizeBasedSegmentFlushThresholdComputer();
 
@@ -138,6 +139,7 @@ public class SizeBasedSegmentFlushThresholdComputerTest {
         SegmentCompletionProtocol.ReasonCode.FORCE_COMMIT_MESSAGE_RECEIVED);
 
     SegmentZKMetadata committingSegmentZKMetadata = mock(SegmentZKMetadata.class);
+    when(committingSegmentZKMetadata.getTotalDocs()).thenReturn(committedRows);
     when(committingSegmentZKMetadata.getSizeThresholdToFlushSegment()).thenReturn(committingSegmentSizeThreshold);
 
     StreamConfig streamConfig = mock(StreamConfig.class);
@@ -146,6 +148,30 @@ public class SizeBasedSegmentFlushThresholdComputerTest {
     int threshold = computer.computeThreshold(streamConfig, "newSegmentName");
 
     assertEquals(threshold, committingSegmentSizeThreshold);
+  }
+
+  @Test
+  public void testComputeThresholdIfSegmentIsNotCommittingDueToForceCommitReasonCode() {
+    long committingSegmentSizeBytes = 500_000L;
+    long committedRows = 100_000L;
+    int committingSegmentSizeThreshold = 25_000;
+    SizeBasedSegmentFlushThresholdComputer computer = new SizeBasedSegmentFlushThresholdComputer();
+
+    CommittingSegmentDescriptor committingSegmentDescriptor = mock(CommittingSegmentDescriptor.class);
+    when(committingSegmentDescriptor.getSegmentSizeBytes()).thenReturn(committingSegmentSizeBytes);
+    when(committingSegmentDescriptor.getStopReasonCode()).thenReturn(SegmentCompletionProtocol.ReasonCode.ROW_LIMIT);
+
+    SegmentZKMetadata committingSegmentZKMetadata = mock(SegmentZKMetadata.class);
+    when(committingSegmentZKMetadata.getTotalDocs()).thenReturn(committedRows);
+    when(committingSegmentZKMetadata.getSizeThresholdToFlushSegment()).thenReturn(committingSegmentSizeThreshold);
+
+    StreamConfig streamConfig = mock(StreamConfig.class);
+    when(streamConfig.getFlushThresholdSegmentSizeBytes()).thenReturn(2_000_000L);
+
+    computer.onSegmentCommit(committingSegmentDescriptor, committingSegmentZKMetadata);
+    int threshold = computer.computeThreshold(streamConfig, "newSegmentName");
+
+    assertEquals(threshold, 150_000);
   }
 
   @Test

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -335,7 +335,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   private long _consumeStartTime = -1;
   private long _lastLogTime = 0;
   private int _lastConsumedCount = 0;
-  private String _stopReason = null;
+  private SegmentCompletionProtocol.ReasonCode _stopReasonCode = null;
   private final Semaphore _segBuildSemaphore;
   private final boolean _isOffHeap;
   /// Whether null handling is enabled by default. This value is only used if
@@ -376,35 +376,35 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
                     _startTimeMs, now, _numRowsConsumed, _numRowsIndexed);
             _stopReasonPrinted = true;
           }
-          _stopReason = SegmentCompletionProtocol.REASON_TIME_LIMIT;
+          _stopReasonCode = SegmentCompletionProtocol.ReasonCode.TIME_LIMIT;
           return true;
         } else if (_numRowsIndexed >= _segmentMaxRowCount) {
           _segmentLogger.info("Stopping consumption due to row limit nRows={} numRowsIndexed={}, numRowsConsumed={}",
               _segmentMaxRowCount, _numRowsIndexed, _numRowsConsumed);
-          _stopReason = SegmentCompletionProtocol.REASON_ROW_LIMIT;
+          _stopReasonCode = SegmentCompletionProtocol.ReasonCode.ROW_LIMIT;
           return true;
         } else if (_endOfPartitionGroup) {
           _segmentLogger.info("Stopping consumption due to end of partitionGroup reached nRows={} numRowsIndexed={}, "
               + "numRowsConsumed={}", _segmentMaxRowCount, _numRowsIndexed, _numRowsConsumed);
-          _stopReason = SegmentCompletionProtocol.REASON_END_OF_PARTITION_GROUP;
+          _stopReasonCode = SegmentCompletionProtocol.ReasonCode.END_OF_PARTITION_GROUP;
           return true;
         } else if (_forceCommitMessageReceived) {
           _segmentLogger.info("Stopping consumption due to force commit - numRowsConsumed={} numRowsIndexed={}",
               _numRowsConsumed, _numRowsIndexed);
-          _stopReason = SegmentCompletionProtocol.REASON_FORCE_COMMIT_MESSAGE_RECEIVED;
+          _stopReasonCode = SegmentCompletionProtocol.ReasonCode.FORCE_COMMIT_MESSAGE_RECEIVED;
           return true;
         } else if (!canAddMore()) {
           _segmentLogger.info(
               "Stopping consumption as mutable index cannot consume more rows - numRowsConsumed={} "
                   + "numRowsIndexed={}",
               _numRowsConsumed, _numRowsIndexed);
-          _stopReason = SegmentCompletionProtocol.REASON_INDEX_CAPACITY_THRESHOLD_BREACHED;
+          _stopReasonCode = SegmentCompletionProtocol.ReasonCode.INDEX_CAPACITY_THRESHOLD_BREACHED;
           return true;
         }
         return false;
 
       case CATCHING_UP:
-        _stopReason = null;
+        _stopReasonCode = null;
         // We have posted segmentConsumed() at least once, and the controller is asking us to catch up to a certain
         // offset.
         // There is no time limit here, so just check to see that we are still within the offset we need to reach.
@@ -1071,7 +1071,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   private boolean startSegmentCommit() {
     SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
     params.withSegmentName(_segmentNameStr).withStreamPartitionMsgOffset(_currentOffset.toString())
-        .withNumRows(_numRowsIndexed).withInstanceId(_instanceId).withReason(_stopReason);
+        .withNumRows(_numRowsIndexed).withInstanceId(_instanceId).withReasonCode(_stopReasonCode);
     if (_isOffHeap) {
       params.withMemoryUsedBytes(_memoryManager.getTotalAllocatedBytes());
     }
@@ -1373,7 +1373,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
 
     params.withSegmentName(_segmentNameStr).withStreamPartitionMsgOffset(_currentOffset.toString())
-        .withNumRows(_numRowsIndexed).withInstanceId(_instanceId).withReason(_stopReason)
+        .withNumRows(_numRowsIndexed).withInstanceId(_instanceId).withReasonCode(_stopReasonCode)
         .withBuildTimeMillis(_segmentBuildDescriptor.getBuildTimeMillis())
         .withSegmentSizeBytes(_segmentBuildDescriptor.getSegmentSizeBytes())
         .withWaitTimeMillis(_segmentBuildDescriptor.getWaitTimeMillis());
@@ -1580,7 +1580,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     // Retry maybe once if leader is not found.
     SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
     params.withStreamPartitionMsgOffset(_currentOffset.toString()).withSegmentName(_segmentNameStr)
-        .withReason(_stopReason).withNumRows(_numRowsIndexed).withInstanceId(_instanceId);
+        .withReasonCode(_stopReasonCode).withNumRows(_numRowsIndexed).withInstanceId(_instanceId);
     if (_isOffHeap) {
       params.withMemoryUsedBytes(_memoryManager.getTotalAllocatedBytes());
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
@@ -1352,7 +1352,7 @@ public class RealtimeSegmentDataManagerTest {
 
     public Field _state;
     public Field _shouldStop;
-    public Field _stopReason;
+    public Field _stopReasonCode;
     public Field _segmentBuildFailedWithDeterministicError;
     public boolean _failSegmentBuildAndReplace = false;
     // When set, buildSegmentAndReplace runs the real implementation (including the upsert CRC guard) instead of being
@@ -1403,8 +1403,8 @@ public class RealtimeSegmentDataManagerTest {
       _state.setAccessible(true);
       _shouldStop = RealtimeSegmentDataManager.class.getDeclaredField("_shouldStop");
       _shouldStop.setAccessible(true);
-      _stopReason = RealtimeSegmentDataManager.class.getDeclaredField("_stopReason");
-      _stopReason.setAccessible(true);
+      _stopReasonCode = RealtimeSegmentDataManager.class.getDeclaredField("_stopReasonCode");
+      _stopReasonCode.setAccessible(true);
       _segmentBuildFailedWithDeterministicError =
           RealtimeSegmentDataManager.class.getDeclaredField("_segmentBuildFailedWithDeterministicError");
       _segmentBuildFailedWithDeterministicError.setAccessible(true);
@@ -1421,7 +1421,9 @@ public class RealtimeSegmentDataManagerTest {
 
     public String getStopReason() {
       try {
-        return (String) _stopReason.get(this);
+        SegmentCompletionProtocol.ReasonCode stopReasonCode =
+            (SegmentCompletionProtocol.ReasonCode) _stopReasonCode.get(this);
+        return stopReasonCode != null ? stopReasonCode.getReason() : null;
       } catch (Exception e) {
         Assert.fail();
       }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/mutable/provider/MutableIndexContext.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/mutable/provider/MutableIndexContext.java
@@ -39,6 +39,15 @@ public class MutableIndexContext {
   private final int _avgNumMultiValues;
   private final File _consumerDir;
 
+  /// @deprecated use the constructor that accepts maxNumMultiValues instead.
+  @Deprecated
+  public MutableIndexContext(FieldSpec fieldSpec, int fixedLengthBytes, boolean hasDictionary, String segmentName,
+      PinotDataBufferMemoryManager memoryManager, int capacity, boolean offHeap, int estimatedColSize,
+      int estimatedCardinality, int avgNumMultiValues, File consumerDir) {
+    this(fieldSpec, fixedLengthBytes, hasDictionary, segmentName, memoryManager, capacity, offHeap, estimatedColSize,
+        estimatedCardinality, ForwardIndexConfig.DEFAULT_MAX_NUM_MULTI_VALUES, avgNumMultiValues, consumerDir);
+  }
+
   public MutableIndexContext(FieldSpec fieldSpec, int fixedLengthBytes, boolean hasDictionary, String segmentName,
       PinotDataBufferMemoryManager memoryManager, int capacity, boolean offHeap, int estimatedColSize,
       int estimatedCardinality, int maxNumMultiValues, int avgNumMultiValues, File consumerDir) {


### PR DESCRIPTION
Fixes #12055

## Summary
- Add a typed `SegmentCompletionProtocol.ReasonCode` and send it as a `reasonCode` query parameter while preserving the existing `reason` parameter.
- Send reason codes from the realtime server for known stop reasons.
- Use reason codes in controller segment-completion decisions, with fallback to the legacy reason string for older servers and safe handling for unknown future codes.
- Add compatibility and controller behavior tests for known codes, unknown codes, legacy fallback, winner selection, and force-commit threshold handling.

## Testing
- `./mvnw -pl pinot-common -am -Dtest=SegmentCompletionProtocolTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false -Denforcer.skip=true -Djdk.version=21 test`
- `./mvnw -pl pinot-controller checkstyle:check -Denforcer.skip=true -Djdk.version=21`
- `./mvnw -pl pinot-core checkstyle:check -Denforcer.skip=true -Djdk.version=21`
- `git diff --check`

Note: Local machine has JDK 21, so these local runs skip the JDK enforcer. CI should run with Pinot's required JDK.

cc @Jackie-Jiang @krishan1390 @krishna-st for review.
