### PR TITLE
Make table deletion mutually exclusive with a deletion marker znode

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -86,6 +86,10 @@ public class ZKMetadataProvider {
   private static final String PROPERTYSTORE_MATERIALIZED_VIEW_RUNTIME_PREFIX = "/CONFIGS/MATERIALIZED_VIEW/RUNTIME";
   private static final String PROPERTYSTORE_QUERY_WORKLOAD_CONFIGS_PREFIX = "/CONFIGS/QUERYWORKLOAD";
   private static final String PROPERTYSTORE_TASK_LOCK_SUFFIX = "-Lock";
+  private static final String PROPERTYSTORE_TABLE_DELETION_IN_PROGRESS_PREFIX = "/TABLE_DELETION_IN_PROGRESS";
+  private static final String DELETION_MARKER_CONTROLLER_ID_KEY = "controllerId";
+  private static final String DELETION_MARKER_START_TIME_KEY = "startTimeMs";
+  private static final long DELETION_MARKER_EXPIRY_MS = 24 * 60 * 60 * 1000L; // 24 hours
 
   public static void setUserConfig(ZkHelixPropertyStore<ZNRecord> propertyStore, String username, ZNRecord znRecord) {
     propertyStore.set(constructPropertyStorePathForUserConfig(username), znRecord, AccessOption.PERSISTENT);
@@ -889,5 +893,110 @@ public class ZKMetadataProvider {
   public static boolean isTableConfigExists(ZkHelixPropertyStore<ZNRecord> propertyStore, String tableNameWithType) {
     return propertyStore.exists(constructPropertyStorePathForResourceConfig(tableNameWithType),
         AccessOption.PERSISTENT);
+  }
+
+  /// Creates a deletion marker for a table to indicate that deletion is in progress.
+  /// This marker is used to prevent concurrent deletions and prevent recreation of a table
+  /// while deletion is in progress.
+  ///
+  /// @param propertyStore The Helix property store
+  /// @param tableNameWithType The table name with type suffix (e.g., myTable_REALTIME)
+  /// @param controllerId The ID of the controller performing the deletion
+  /// @return true if the marker was created successfully, false if a marker already exists
+  public static boolean createTableDeletionMarker(ZkHelixPropertyStore<ZNRecord> propertyStore,
+      String tableNameWithType, String controllerId) {
+    String markerPath = constructPropertyStorePathForTableDeletionMarker(tableNameWithType);
+    ZNRecord markerRecord = new ZNRecord(tableNameWithType);
+    markerRecord.setSimpleField(DELETION_MARKER_CONTROLLER_ID_KEY, controllerId);
+    markerRecord.setLongField(DELETION_MARKER_START_TIME_KEY, System.currentTimeMillis());
+    return propertyStore.create(markerPath, markerRecord, AccessOption.PERSISTENT);
+  }
+
+  /// Checks if a deletion marker exists for the table and is still valid (not expired).
+  /// A marker is considered expired if it is older than DELETION_MARKER_EXPIRY_MS (24 hours).
+  ///
+  /// @param propertyStore The Helix property store
+  /// @param tableNameWithType The table name with type suffix (e.g., myTable_REALTIME)
+  /// @return true if a valid (non-expired) deletion marker exists, false otherwise
+  public static boolean isValidTableDeletionMarkerExists(ZkHelixPropertyStore<ZNRecord> propertyStore,
+      String tableNameWithType) {
+    String markerPath = constructPropertyStorePathForTableDeletionMarker(tableNameWithType);
+    if (!propertyStore.exists(markerPath, AccessOption.PERSISTENT)) {
+      return false;
+    }
+    ZNRecord markerRecord = propertyStore.get(markerPath, null, AccessOption.PERSISTENT);
+    if (markerRecord == null) {
+      return false;
+    }
+    Long startTimeMs = markerRecord.getLongField(DELETION_MARKER_START_TIME_KEY);
+    if (startTimeMs == null) {
+      // Marker exists but has no start time, consider it invalid
+      return false;
+    }
+    // Check if marker has expired
+    long ageMs = System.currentTimeMillis() - startTimeMs;
+    return ageMs < DELETION_MARKER_EXPIRY_MS;
+  }
+
+  /// Removes the deletion marker for a table.
+  /// This should be called after table deletion completes successfully.
+  ///
+  /// @param propertyStore The Helix property store
+  /// @param tableNameWithType The table name with type suffix (e.g., myTable_REALTIME)
+  public static void removeTableDeletionMarker(ZkHelixPropertyStore<ZNRecord> propertyStore,
+      String tableNameWithType) {
+    String markerPath = constructPropertyStorePathForTableDeletionMarker(tableNameWithType);
+    if (propertyStore.exists(markerPath, AccessOption.PERSISTENT)) {
+      propertyStore.remove(markerPath, AccessOption.PERSISTENT);
+    }
+  }
+
+  /// Allows taking over an expired deletion marker.
+  /// If the marker exists but is expired, it will be removed and a new marker will be created.
+  /// This handles the case where a controller crashes during deletion, leaving a stale marker.
+  ///
+  /// @param propertyStore The Helix property store
+  /// @param tableNameWithType The table name with type suffix (e.g., myTable_REALTIME)
+  /// @param controllerId The ID of the controller performing the deletion
+  /// @return true if the marker was created (either new or by taking over expired), false if a valid marker exists
+  public static boolean createOrTakeoverTableDeletionMarker(ZkHelixPropertyStore<ZNRecord> propertyStore,
+      String tableNameWithType, String controllerId) {
+    String markerPath = constructPropertyStorePathForTableDeletionMarker(tableNameWithType);
+    if (!propertyStore.exists(markerPath, AccessOption.PERSISTENT)) {
+      return createTableDeletionMarker(propertyStore, tableNameWithType, controllerId);
+    }
+    ZNRecord markerRecord = propertyStore.get(markerPath, null, AccessOption.PERSISTENT);
+    if (markerRecord == null) {
+      // Marker exists but is null, try to remove and recreate
+      propertyStore.remove(markerPath, AccessOption.PERSISTENT);
+      return createTableDeletionMarker(propertyStore, tableNameWithType, controllerId);
+    }
+    Long startTimeMs = markerRecord.getLongField(DELETION_MARKER_START_TIME_KEY);
+    if (startTimeMs == null) {
+      // Marker has no start time, consider it stale and remove
+      propertyStore.remove(markerPath, AccessOption.PERSISTENT);
+      return createTableDeletionMarker(propertyStore, tableNameWithType, controllerId);
+    }
+    long ageMs = System.currentTimeMillis() - startTimeMs;
+    if (ageMs >= DELETION_MARKER_EXPIRY_MS) {
+      // Marker has expired, remove it and create a new one
+      LOGGER.info("Taking over expired deletion marker for table: {} (age: {}ms)", tableNameWithType, ageMs);
+      propertyStore.remove(markerPath, AccessOption.PERSISTENT);
+      return createTableDeletionMarker(propertyStore, tableNameWithType, controllerId);
+    }
+    // Valid marker exists, cannot take over
+    return false;
+  }
+
+  private static String constructPropertyStorePathForTableDeletionMarker(String tableNameWithType) {
+    return PROPERTYSTORE_TABLE_DELETION_IN_PROGRESS_PREFIX + "/" + tableNameWithType;
+  }
+
+  /// Gets the property store prefix for table deletion in progress markers.
+  /// This is exposed for error messages to help users manually clean up stale markers.
+  ///
+  /// @return the property store prefix for table deletion in progress markers
+  public static String getPropertyStoreTableDeletionInProgressPrefix() {
+    return PROPERTYSTORE_TABLE_DELETION_IN_PROGRESS_PREFIX;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -906,10 +906,30 @@ public class ZKMetadataProvider {
   public static boolean createTableDeletionMarker(ZkHelixPropertyStore<ZNRecord> propertyStore,
       String tableNameWithType, String controllerId) {
     String markerPath = constructPropertyStorePathForTableDeletionMarker(tableNameWithType);
+    // create() is atomic: with concurrent callers only one succeeds, the rest get false.
+    return propertyStore.create(markerPath, buildTableDeletionMarkerRecord(tableNameWithType, controllerId),
+        AccessOption.PERSISTENT);
+  }
+
+  private static ZNRecord buildTableDeletionMarkerRecord(String tableNameWithType, String controllerId) {
     ZNRecord markerRecord = new ZNRecord(tableNameWithType);
     markerRecord.setSimpleField(DELETION_MARKER_CONTROLLER_ID_KEY, controllerId);
     markerRecord.setLongField(DELETION_MARKER_START_TIME_KEY, System.currentTimeMillis());
-    return propertyStore.create(markerPath, markerRecord, AccessOption.PERSISTENT);
+    return markerRecord;
+  }
+
+  /// Returns true when the marker record is present and has not passed [#DELETION_MARKER_EXPIRY_MS].
+  /// A marker with a missing or unparseable start time is treated as stale so that a malformed record can never
+  /// block deletion or re-creation forever.
+  private static boolean isTableDeletionMarkerValid(@Nullable ZNRecord markerRecord) {
+    if (markerRecord == null) {
+      return false;
+    }
+    long startTimeMs = markerRecord.getLongField(DELETION_MARKER_START_TIME_KEY, -1L);
+    if (startTimeMs < 0) {
+      return false;
+    }
+    return System.currentTimeMillis() - startTimeMs < DELETION_MARKER_EXPIRY_MS;
   }
 
   /// Checks if a deletion marker exists for the table and is still valid (not expired).
@@ -921,39 +941,36 @@ public class ZKMetadataProvider {
   public static boolean isValidTableDeletionMarkerExists(ZkHelixPropertyStore<ZNRecord> propertyStore,
       String tableNameWithType) {
     String markerPath = constructPropertyStorePathForTableDeletionMarker(tableNameWithType);
-    if (!propertyStore.exists(markerPath, AccessOption.PERSISTENT)) {
-      return false;
-    }
-    ZNRecord markerRecord = propertyStore.get(markerPath, null, AccessOption.PERSISTENT);
-    if (markerRecord == null) {
-      return false;
-    }
-    long startTimeMs = markerRecord.getLongField(DELETION_MARKER_START_TIME_KEY, -1L);
-    if (startTimeMs < 0) {
-      // Marker exists but has no (or an unparseable) start time, consider it invalid
-      return false;
-    }
-    // Check if marker has expired
-    long ageMs = System.currentTimeMillis() - startTimeMs;
-    return ageMs < DELETION_MARKER_EXPIRY_MS;
+    return isTableDeletionMarkerValid(propertyStore.get(markerPath, null, AccessOption.PERSISTENT));
   }
 
-  /// Removes the deletion marker for a table.
-  /// This should be called after table deletion completes successfully.
+  /// Removes the deletion marker for a table. Call this when a deletion finishes, successfully or not.
+  ///
+  /// Releasing is a no-op unless `controllerId` still owns the marker. If a deletion stalled past the expiry
+  /// window another controller may have taken the marker over and started its own deletion; the stalled
+  /// controller must not then release a lock it no longer holds.
   ///
   /// @param propertyStore The Helix property store
   /// @param tableNameWithType The table name with type suffix (e.g., myTable_REALTIME)
+  /// @param controllerId The ID of the controller that expects to own the marker
   public static void removeTableDeletionMarker(ZkHelixPropertyStore<ZNRecord> propertyStore,
-      String tableNameWithType) {
+      String tableNameWithType, String controllerId) {
     String markerPath = constructPropertyStorePathForTableDeletionMarker(tableNameWithType);
-    if (propertyStore.exists(markerPath, AccessOption.PERSISTENT)) {
-      propertyStore.remove(markerPath, AccessOption.PERSISTENT);
+    ZNRecord markerRecord = propertyStore.get(markerPath, null, AccessOption.PERSISTENT);
+    if (markerRecord == null) {
+      return;
     }
+    String ownerId = markerRecord.getSimpleField(DELETION_MARKER_CONTROLLER_ID_KEY);
+    if (!Objects.equals(ownerId, controllerId)) {
+      LOGGER.warn("Not releasing the deletion marker for table: {}: it is now owned by controller: {}, not: {}",
+          tableNameWithType, ownerId, controllerId);
+      return;
+    }
+    propertyStore.remove(markerPath, AccessOption.PERSISTENT);
   }
 
-  /// Allows taking over an expired deletion marker.
-  /// If the marker exists but is expired, it will be removed and a new marker will be created.
-  /// This handles the case where a controller crashes during deletion, leaving a stale marker.
+  /// Acquires the deletion marker, taking it over if the existing one is stale.
+  /// This handles the case where a controller crashes during deletion, leaving a stale marker behind.
   ///
   /// @param propertyStore The Helix property store
   /// @param tableNameWithType The table name with type suffix (e.g., myTable_REALTIME)
@@ -962,30 +979,33 @@ public class ZKMetadataProvider {
   public static boolean createOrTakeoverTableDeletionMarker(ZkHelixPropertyStore<ZNRecord> propertyStore,
       String tableNameWithType, String controllerId) {
     String markerPath = constructPropertyStorePathForTableDeletionMarker(tableNameWithType);
-    if (!propertyStore.exists(markerPath, AccessOption.PERSISTENT)) {
-      return createTableDeletionMarker(propertyStore, tableNameWithType, controllerId);
-    }
-    ZNRecord markerRecord = propertyStore.get(markerPath, null, AccessOption.PERSISTENT);
+    Stat stat = new Stat();
+    ZNRecord markerRecord = propertyStore.get(markerPath, stat, AccessOption.PERSISTENT);
     if (markerRecord == null) {
-      // Marker exists but is null, try to remove and recreate
-      propertyStore.remove(markerPath, AccessOption.PERSISTENT);
       return createTableDeletionMarker(propertyStore, tableNameWithType, controllerId);
     }
-    long startTimeMs = markerRecord.getLongField(DELETION_MARKER_START_TIME_KEY, -1L);
-    if (startTimeMs < 0) {
-      // Marker has no (or an unparseable) start time, consider it stale and remove
-      propertyStore.remove(markerPath, AccessOption.PERSISTENT);
-      return createTableDeletionMarker(propertyStore, tableNameWithType, controllerId);
+    if (isTableDeletionMarkerValid(markerRecord)) {
+      return false;
     }
-    long ageMs = System.currentTimeMillis() - startTimeMs;
-    if (ageMs >= DELETION_MARKER_EXPIRY_MS) {
-      // Marker has expired, remove it and create a new one
-      LOGGER.info("Taking over expired deletion marker for table: {} (age: {}ms)", tableNameWithType, ageMs);
-      propertyStore.remove(markerPath, AccessOption.PERSISTENT);
-      return createTableDeletionMarker(propertyStore, tableNameWithType, controllerId);
+    // The marker is stale. Overwrite it in place with a version checked write instead of remove-then-create:
+    // a remove-then-create would let two controllers both observe the same stale marker, and the second one's
+    // remove would then delete the first one's freshly created marker, leaving both of them believing they hold
+    // the lock. It would also briefly leave no marker at all, during which addTable() would wrongly allow a
+    // re-create. Helix throws ZkBadVersionException when the version no longer matches, so exactly one of the
+    // racing controllers wins the takeover.
+    try {
+      boolean tookOver = propertyStore.set(markerPath,
+          buildTableDeletionMarkerRecord(tableNameWithType, controllerId), stat.getVersion(),
+          AccessOption.PERSISTENT);
+      if (tookOver) {
+        LOGGER.info("Took over stale deletion marker for table: {} on behalf of controller: {}", tableNameWithType,
+            controllerId);
+      }
+      return tookOver;
+    } catch (ZkBadVersionException e) {
+      LOGGER.info("Lost the race to take over the stale deletion marker for table: {}", tableNameWithType);
+      return false;
     }
-    // Valid marker exists, cannot take over
-    return false;
   }
 
   private static String constructPropertyStorePathForTableDeletionMarker(String tableNameWithType) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -987,19 +987,39 @@ public class ZKMetadataProvider {
     if (isTableDeletionMarkerValid(markerRecord)) {
       return false;
     }
-    // The marker is stale. Overwrite it in place with a version checked write instead of remove-then-create:
-    // a remove-then-create would let two controllers both observe the same stale marker, and the second one's
-    // remove would then delete the first one's freshly created marker, leaving both of them believing they hold
-    // the lock. It would also briefly leave no marker at all, during which addTable() would wrongly allow a
-    // re-create. Helix throws ZkBadVersionException when the version no longer matches, so exactly one of the
-    // racing controllers wins the takeover.
+    // The marker is stale, so reclaim it. Pass the version we just observed so the write is rejected if another
+    // controller reclaimed it first.
+    return takeoverStaleTableDeletionMarker(propertyStore, tableNameWithType, controllerId, stat.getVersion());
+  }
+
+  /// Replaces a stale deletion marker in place, but only while it still has `expectedVersion`.
+  ///
+  /// The version check is what makes the takeover safe. A remove-then-create would let two controllers both
+  /// observe the same stale marker, and the second one's remove would then delete the first one's freshly created
+  /// marker, leaving both believing they hold the lock. It would also briefly leave no marker at all, during which
+  /// addTable() would wrongly allow the table to be re-created mid-deletion.
+  ///
+  /// Exposed for testing so a caller can supply a deliberately stale version; production callers should use
+  /// [#createOrTakeoverTableDeletionMarker].
+  ///
+  /// @return true only if this caller won the takeover
+  @VisibleForTesting
+  static boolean takeoverStaleTableDeletionMarker(ZkHelixPropertyStore<ZNRecord> propertyStore,
+      String tableNameWithType, String controllerId, int expectedVersion) {
+    String markerPath = constructPropertyStorePathForTableDeletionMarker(tableNameWithType);
     try {
+      // On a version mismatch ZkHelixPropertyStore returns false rather than throwing, so the false branch below
+      // is the path a losing controller actually takes. ZkBadVersionException is still caught because
+      // setSegmentZKMetadata above documents Helix throwing it for the same accessor type; treat both as a loss
+      // rather than assume only one can happen.
       boolean tookOver = propertyStore.set(markerPath,
-          buildTableDeletionMarkerRecord(tableNameWithType, controllerId), stat.getVersion(),
+          buildTableDeletionMarkerRecord(tableNameWithType, controllerId), expectedVersion,
           AccessOption.PERSISTENT);
       if (tookOver) {
         LOGGER.info("Took over stale deletion marker for table: {} on behalf of controller: {}", tableNameWithType,
             controllerId);
+      } else {
+        LOGGER.info("Lost the race to take over the stale deletion marker for table: {}", tableNameWithType);
       }
       return tookOver;
     } catch (ZkBadVersionException e) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -928,9 +928,9 @@ public class ZKMetadataProvider {
     if (markerRecord == null) {
       return false;
     }
-    Long startTimeMs = markerRecord.getLongField(DELETION_MARKER_START_TIME_KEY);
-    if (startTimeMs == null) {
-      // Marker exists but has no start time, consider it invalid
+    long startTimeMs = markerRecord.getLongField(DELETION_MARKER_START_TIME_KEY, -1L);
+    if (startTimeMs < 0) {
+      // Marker exists but has no (or an unparseable) start time, consider it invalid
       return false;
     }
     // Check if marker has expired
@@ -971,9 +971,9 @@ public class ZKMetadataProvider {
       propertyStore.remove(markerPath, AccessOption.PERSISTENT);
       return createTableDeletionMarker(propertyStore, tableNameWithType, controllerId);
     }
-    Long startTimeMs = markerRecord.getLongField(DELETION_MARKER_START_TIME_KEY);
-    if (startTimeMs == null) {
-      // Marker has no start time, consider it stale and remove
+    long startTimeMs = markerRecord.getLongField(DELETION_MARKER_START_TIME_KEY, -1L);
+    if (startTimeMs < 0) {
+      // Marker has no (or an unparseable) start time, consider it stale and remove
       propertyStore.remove(markerPath, AccessOption.PERSISTENT);
       return createTableDeletionMarker(propertyStore, tableNameWithType, controllerId);
     }

--- a/pinot-common/src/test/java/org/apache/pinot/common/metadata/TableDeletionMarkerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metadata/TableDeletionMarkerTest.java
@@ -1,0 +1,204 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.metadata;
+
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.impl.client.ZkClient;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+/// Unit tests for table deletion marker functionality in ZKMetadataProvider.
+/// Tests cover creation, validation, expiry, and cleanup of deletion markers.
+public class TableDeletionMarkerTest {
+
+  private ZkClient _zkClient;
+  private String _zkPath;
+  private ZkHelixPropertyStore<ZNRecord> _propertyStore;
+  private static final String TEST_TABLE_NAME = "testTable_REALTIME";
+  private static final String CONTROLLER_ID_1 = "controller_1";
+  private static final String CONTROLLER_ID_2 = "controller_2";
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    _zkPath = "/tmp/TableDeletionMarkerTest_" + System.currentTimeMillis();
+    _zkClient = new ZkClient("localhost:2181", 10000, 10000);
+    _propertyStore = new ZkHelixPropertyStore<>("localhost:2181", _zkPath, _zkClient);
+  }
+
+  @AfterClass
+  public void tearDown() {
+    try {
+      if (_propertyStore != null) {
+        _propertyStore.stop();
+      }
+      if (_zkClient != null) {
+        _zkClient.close();
+      }
+    } catch (Exception e) {
+      // Ignore cleanup errors
+    }
+  }
+
+  @Test
+  public void testCreateDeletionMarker() {
+    // Test successful creation of a deletion marker
+    boolean created = ZKMetadataProvider.createTableDeletionMarker(_propertyStore, TEST_TABLE_NAME, CONTROLLER_ID_1);
+    assertTrue(created, "Deletion marker should be created successfully");
+
+    // Verify the marker exists
+    boolean exists = ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TEST_TABLE_NAME);
+    assertTrue(exists, "Deletion marker should exist after creation");
+
+    // Cleanup
+    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, TEST_TABLE_NAME);
+  }
+
+  @Test
+  public void testCreateDuplicateDeletionMarker() {
+    // Create first marker
+    boolean firstCreated = ZKMetadataProvider.createTableDeletionMarker(_propertyStore, TEST_TABLE_NAME,
+        CONTROLLER_ID_1);
+    assertTrue(firstCreated, "First deletion marker should be created successfully");
+
+    // Try to create duplicate marker
+    boolean secondCreated = ZKMetadataProvider.createTableDeletionMarker(_propertyStore, TEST_TABLE_NAME,
+        CONTROLLER_ID_2);
+    assertFalse(secondCreated, "Duplicate deletion marker should not be created");
+
+    // Cleanup
+    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, TEST_TABLE_NAME);
+  }
+
+  @Test
+  public void testIsValidDeletionMarkerExists() {
+    // Test when marker does not exist
+    boolean exists = ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TEST_TABLE_NAME);
+    assertFalse(exists, "Deletion marker should not exist when not created");
+
+    // Create marker
+    ZKMetadataProvider.createTableDeletionMarker(_propertyStore, TEST_TABLE_NAME, CONTROLLER_ID_1);
+
+    // Test when marker exists and is valid
+    exists = ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TEST_TABLE_NAME);
+    assertTrue(exists, "Deletion marker should exist when created");
+
+    // Cleanup
+    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, TEST_TABLE_NAME);
+  }
+
+  @Test
+  public void testRemoveDeletionMarker() {
+    // Create marker
+    ZKMetadataProvider.createTableDeletionMarker(_propertyStore, TEST_TABLE_NAME, CONTROLLER_ID_1);
+
+    // Verify it exists
+    assertTrue(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TEST_TABLE_NAME));
+
+    // Remove marker
+    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, TEST_TABLE_NAME);
+
+    // Verify it's removed
+    assertFalse(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TEST_TABLE_NAME));
+  }
+
+  @Test
+  public void testRemoveNonExistentDeletionMarker() {
+    // Should not throw exception when removing non-existent marker
+    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, TEST_TABLE_NAME);
+    // Test passes if no exception is thrown
+  }
+
+  @Test
+  public void testCreateOrTakeoverDeletionMarkerNew() {
+    // Test takeover when no marker exists
+    boolean result = ZKMetadataProvider.createOrTakeoverTableDeletionMarker(_propertyStore, TEST_TABLE_NAME,
+        CONTROLLER_ID_1);
+    assertTrue(result, "Should create new marker when none exists");
+
+    // Cleanup
+    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, TEST_TABLE_NAME);
+  }
+
+  @Test
+  public void testCreateOrTakeoverDeletionMarkerExistingValid() {
+    // Create initial marker
+    ZKMetadataProvider.createTableDeletionMarker(_propertyStore, TEST_TABLE_NAME, CONTROLLER_ID_1);
+
+    // Try to takeover with different controller while marker is still valid
+    boolean result = ZKMetadataProvider.createOrTakeoverTableDeletionMarker(_propertyStore, TEST_TABLE_NAME,
+        CONTROLLER_ID_2);
+    assertFalse(result, "Should not takeover valid deletion marker");
+
+    // Cleanup
+    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, TEST_TABLE_NAME);
+  }
+
+  @Test
+  public void testGetPropertyStoreTableDeletionInProgressPrefix() {
+    String prefix = ZKMetadataProvider.getPropertyStoreTableDeletionInProgressPrefix();
+    assertNotNull(prefix, "Prefix should not be null");
+    assertEquals(prefix, "/TABLE_DELETION_IN_PROGRESS", "Prefix should match expected value");
+  }
+
+  @Test
+  public void testDeletionMarkerContent() {
+    // Create marker
+    ZKMetadataProvider.createTableDeletionMarker(_propertyStore, TEST_TABLE_NAME, CONTROLLER_ID_1);
+
+    // Verify marker content by checking it exists (detailed content verification would
+    // require internal access)
+    assertTrue(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TEST_TABLE_NAME));
+
+    // Cleanup
+    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, TEST_TABLE_NAME);
+  }
+
+  @Test
+  public void testMultipleTableMarkers() {
+    String table1 = "table1_REALTIME";
+    String table2 = "table2_OFFLINE";
+
+    // Create markers for different tables
+    boolean created1 = ZKMetadataProvider.createTableDeletionMarker(_propertyStore, table1, CONTROLLER_ID_1);
+    boolean created2 = ZKMetadataProvider.createTableDeletionMarker(_propertyStore, table2, CONTROLLER_ID_2);
+
+    assertTrue(created1, "Marker for table1 should be created");
+    assertTrue(created2, "Marker for table2 should be created");
+
+    // Verify both exist independently
+    assertTrue(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, table1));
+    assertTrue(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, table2));
+
+    // Remove one marker
+    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, table1);
+
+    // Verify only one remains
+    assertFalse(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, table1));
+    assertTrue(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, table2));
+
+    // Cleanup
+    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, table2);
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/metadata/TableDeletionMarkerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metadata/TableDeletionMarkerTest.java
@@ -18,6 +18,12 @@
  */
 package org.apache.pinot.common.metadata;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.apache.helix.AccessOption;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
@@ -55,13 +61,27 @@ public class TableDeletionMarkerTest {
   private ZkStarter.ZookeeperInstance _zk;
   private ZkClient _zkClient;
   private ZkHelixPropertyStore<ZNRecord> _propertyStore;
+  /// A second, independent property store over the same ZK, modelling a different controller process. A single
+  /// ZkHelixPropertyStore serializes its own operations, so two controllers cannot be simulated through one
+  /// instance.
+  private ZkClient _otherZkClient;
+  private ZkHelixPropertyStore<ZNRecord> _otherPropertyStore;
 
   @BeforeClass
   public void beforeClass() {
     _zk = ZkStarter.startLocalZkServer();
-    _zkClient = new ZkClient.Builder().setZkServer(_zk.getZkUrl()).setZkSerializer(new ZNRecordSerializer()).build();
-    assertTrue(_zkClient.waitUntilConnected(10_000, TimeUnit.MILLISECONDS));
+    _zkClient = newZkClient();
     _propertyStore = new ZkHelixPropertyStore<>(new ZkBaseDataAccessor<>(_zkClient), PROPERTY_STORE_ROOT, null);
+    _otherZkClient = newZkClient();
+    _otherPropertyStore =
+        new ZkHelixPropertyStore<>(new ZkBaseDataAccessor<>(_otherZkClient), PROPERTY_STORE_ROOT, null);
+  }
+
+  private ZkClient newZkClient() {
+    ZkClient client =
+        new ZkClient.Builder().setZkServer(_zk.getZkUrl()).setZkSerializer(new ZNRecordSerializer()).build();
+    assertTrue(client.waitUntilConnected(10_000, TimeUnit.MILLISECONDS));
+    return client;
   }
 
   @AfterClass
@@ -69,8 +89,14 @@ public class TableDeletionMarkerTest {
     if (_propertyStore != null) {
       _propertyStore.stop();
     }
+    if (_otherPropertyStore != null) {
+      _otherPropertyStore.stop();
+    }
     if (_zkClient != null) {
       _zkClient.close();
+    }
+    if (_otherZkClient != null) {
+      _otherZkClient.close();
     }
     if (_zk != null) {
       ZkStarter.stopLocalZkServer(_zk);
@@ -140,7 +166,7 @@ public class TableDeletionMarkerTest {
     assertTrue(ZKMetadataProvider.createTableDeletionMarker(_propertyStore, TABLE_NAME, CONTROLLER_1));
     assertTrue(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TABLE_NAME));
 
-    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, TABLE_NAME);
+    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, TABLE_NAME, CONTROLLER_1);
     assertFalse(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TABLE_NAME));
 
     // A fresh deletion of the same table must be possible once the marker is gone.
@@ -149,8 +175,23 @@ public class TableDeletionMarkerTest {
 
   @Test
   public void testRemoveNonExistentMarkerIsNoOp() {
-    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, TABLE_NAME);
+    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, TABLE_NAME, CONTROLLER_1);
     assertFalse(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TABLE_NAME));
+  }
+
+  /// A controller that stalled long enough to be taken over must not release the new owner's marker when it
+  /// eventually reaches its finally block, or both deletions would run unguarded.
+  @Test
+  public void testRemoveMarkerDoesNotReleaseAnotherControllersMarker() {
+    assertTrue(ZKMetadataProvider.createTableDeletionMarker(_propertyStore, TABLE_NAME, CONTROLLER_2));
+
+    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, TABLE_NAME, CONTROLLER_1);
+
+    assertTrue(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TABLE_NAME),
+        "Controller 1 must not be able to release a marker owned by controller 2");
+    ZNRecord record = _propertyStore.get(markerPath(TABLE_NAME), null, AccessOption.PERSISTENT);
+    assertNotNull(record);
+    assertEquals(record.getSimpleField(CONTROLLER_ID_KEY), CONTROLLER_2);
   }
 
   @Test
@@ -209,6 +250,46 @@ public class TableDeletionMarkerTest {
         "The refreshed marker should be valid again");
   }
 
+  /// Two controllers must never both hold the marker for one table. Uses two independent property stores because
+  /// a single ZkHelixPropertyStore serializes its own operations and so cannot model two controller processes.
+  ///
+  /// NOTE: this asserts the invariant but is not a regression test for the non-atomic takeover it replaced. The
+  /// vulnerable window in a remove-then-create takeover is sub-millisecond and could not be hit reliably from a
+  /// test. The takeover's correctness rests on the ZK version check in
+  /// [ZKMetadataProvider#createOrTakeoverTableDeletionMarker], not on this test.
+  @Test
+  public void testOnlyOneOfTwoControllersAcquiresTheMarker()
+      throws Exception {
+    CyclicBarrier startLine = new CyclicBarrier(2);
+    List<String> contenders = List.of(CONTROLLER_1, CONTROLLER_2);
+    List<ZkHelixPropertyStore<ZNRecord>> stores = List.of(_propertyStore, _otherPropertyStore);
+    List<Future<Boolean>> results = new ArrayList<>(2);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      for (int i = 0; i < contenders.size(); i++) {
+        String contender = contenders.get(i);
+        ZkHelixPropertyStore<ZNRecord> store = stores.get(i);
+        results.add(executor.submit(() -> {
+          startLine.await(10, TimeUnit.SECONDS);
+          return ZKMetadataProvider.createOrTakeoverTableDeletionMarker(store, TABLE_NAME, contender);
+        }));
+      }
+      int winners = 0;
+      for (Future<Boolean> result : results) {
+        if (result.get(20, TimeUnit.SECONDS)) {
+          winners++;
+        }
+      }
+      assertEquals(winners, 1, "Exactly one controller may acquire the deletion marker, but " + winners + " did");
+    } finally {
+      executor.shutdownNow();
+    }
+
+    ZNRecord record = _propertyStore.get(markerPath(TABLE_NAME), null, AccessOption.PERSISTENT);
+    assertNotNull(record);
+    assertTrue(contenders.contains(record.getSimpleField(CONTROLLER_ID_KEY)));
+  }
+
   @Test
   public void testMarkersForDifferentTablesAreIndependent() {
     String realtimeTable = "table1_REALTIME";
@@ -219,7 +300,7 @@ public class TableDeletionMarkerTest {
     assertTrue(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, realtimeTable));
     assertTrue(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, offlineTable));
 
-    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, realtimeTable);
+    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, realtimeTable, CONTROLLER_1);
 
     assertFalse(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, realtimeTable));
     assertTrue(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, offlineTable),

--- a/pinot-common/src/test/java/org/apache/pinot/common/metadata/TableDeletionMarkerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metadata/TableDeletionMarkerTest.java
@@ -18,187 +18,216 @@
  */
 package org.apache.pinot.common.metadata;
 
+import java.util.concurrent.TimeUnit;
+import org.apache.helix.AccessOption;
+import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
+import org.apache.pinot.common.utils.ZkStarter;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 
-/// Unit tests for table deletion marker functionality in ZKMetadataProvider.
-/// Tests cover creation, validation, expiry, and cleanup of deletion markers.
+/// Unit tests for the table deletion marker functionality in [ZKMetadataProvider].
+/// The marker provides mutual exclusion between concurrent table deletions and blocks table
+/// re-creation while a deletion is in flight, so these tests cover creation, duplicate
+/// rejection, removal, expiry and takeover.
 public class TableDeletionMarkerTest {
+  private static final String PROPERTY_STORE_ROOT = "/TableDeletionMarkerTest/PROPERTYSTORE";
+  private static final String MARKER_PREFIX = "/TABLE_DELETION_IN_PROGRESS";
+  private static final String START_TIME_KEY = "startTimeMs";
+  private static final String CONTROLLER_ID_KEY = "controllerId";
+  private static final long EXPIRY_MS = 24 * 60 * 60 * 1000L;
 
+  private static final String TABLE_NAME = "testTable_REALTIME";
+  private static final String CONTROLLER_1 = "Controller_localhost_9000";
+  private static final String CONTROLLER_2 = "Controller_localhost_9001";
+
+  private ZkStarter.ZookeeperInstance _zk;
   private ZkClient _zkClient;
-  private String _zkPath;
   private ZkHelixPropertyStore<ZNRecord> _propertyStore;
-  private static final String TEST_TABLE_NAME = "testTable_REALTIME";
-  private static final String CONTROLLER_ID_1 = "controller_1";
-  private static final String CONTROLLER_ID_2 = "controller_2";
 
   @BeforeClass
-  public void setUp()
-      throws Exception {
-    _zkPath = "/tmp/TableDeletionMarkerTest_" + System.currentTimeMillis();
-    _zkClient = new ZkClient("localhost:2181", 10000, 10000);
-    _propertyStore = new ZkHelixPropertyStore<>("localhost:2181", _zkPath, _zkClient);
+  public void beforeClass() {
+    _zk = ZkStarter.startLocalZkServer();
+    _zkClient = new ZkClient.Builder().setZkServer(_zk.getZkUrl()).setZkSerializer(new ZNRecordSerializer()).build();
+    assertTrue(_zkClient.waitUntilConnected(10_000, TimeUnit.MILLISECONDS));
+    _propertyStore = new ZkHelixPropertyStore<>(new ZkBaseDataAccessor<>(_zkClient), PROPERTY_STORE_ROOT, null);
   }
 
   @AfterClass
-  public void tearDown() {
-    try {
-      if (_propertyStore != null) {
-        _propertyStore.stop();
-      }
-      if (_zkClient != null) {
-        _zkClient.close();
-      }
-    } catch (Exception e) {
-      // Ignore cleanup errors
+  public void afterClass() {
+    if (_propertyStore != null) {
+      _propertyStore.stop();
+    }
+    if (_zkClient != null) {
+      _zkClient.close();
+    }
+    if (_zk != null) {
+      ZkStarter.stopLocalZkServer(_zk);
     }
   }
 
-  @Test
-  public void testCreateDeletionMarker() {
-    // Test successful creation of a deletion marker
-    boolean created = ZKMetadataProvider.createTableDeletionMarker(_propertyStore, TEST_TABLE_NAME, CONTROLLER_ID_1);
-    assertTrue(created, "Deletion marker should be created successfully");
+  /// Each test starts from a clean marker tree so the tests are order independent.
+  @BeforeMethod
+  public void cleanMarkers() {
+    if (_zkClient.exists(PROPERTY_STORE_ROOT + MARKER_PREFIX)) {
+      _zkClient.deleteRecursively(PROPERTY_STORE_ROOT + MARKER_PREFIX);
+    }
+  }
 
-    // Verify the marker exists
-    boolean exists = ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TEST_TABLE_NAME);
-    assertTrue(exists, "Deletion marker should exist after creation");
+  private static String markerPath(String tableNameWithType) {
+    return MARKER_PREFIX + "/" + tableNameWithType;
+  }
 
-    // Cleanup
-    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, TEST_TABLE_NAME);
+  /// Writes a marker whose start time is `ageMs` in the past, to simulate a marker left behind by
+  /// a controller that crashed mid-deletion.
+  private void writeMarkerWithAge(String tableNameWithType, String controllerId, long ageMs) {
+    ZNRecord record = new ZNRecord(tableNameWithType);
+    record.setSimpleField(CONTROLLER_ID_KEY, controllerId);
+    record.setLongField(START_TIME_KEY, System.currentTimeMillis() - ageMs);
+    assertTrue(_propertyStore.set(markerPath(tableNameWithType), record, AccessOption.PERSISTENT));
   }
 
   @Test
-  public void testCreateDuplicateDeletionMarker() {
-    // Create first marker
-    boolean firstCreated = ZKMetadataProvider.createTableDeletionMarker(_propertyStore, TEST_TABLE_NAME,
-        CONTROLLER_ID_1);
-    assertTrue(firstCreated, "First deletion marker should be created successfully");
-
-    // Try to create duplicate marker
-    boolean secondCreated = ZKMetadataProvider.createTableDeletionMarker(_propertyStore, TEST_TABLE_NAME,
-        CONTROLLER_ID_2);
-    assertFalse(secondCreated, "Duplicate deletion marker should not be created");
-
-    // Cleanup
-    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, TEST_TABLE_NAME);
+  public void testCreateMarker() {
+    assertTrue(ZKMetadataProvider.createTableDeletionMarker(_propertyStore, TABLE_NAME, CONTROLLER_1));
+    assertTrue(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TABLE_NAME));
   }
 
   @Test
-  public void testIsValidDeletionMarkerExists() {
-    // Test when marker does not exist
-    boolean exists = ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TEST_TABLE_NAME);
-    assertFalse(exists, "Deletion marker should not exist when not created");
+  public void testMarkerRecordsControllerIdAndStartTime() {
+    long before = System.currentTimeMillis();
+    assertTrue(ZKMetadataProvider.createTableDeletionMarker(_propertyStore, TABLE_NAME, CONTROLLER_1));
 
-    // Create marker
-    ZKMetadataProvider.createTableDeletionMarker(_propertyStore, TEST_TABLE_NAME, CONTROLLER_ID_1);
-
-    // Test when marker exists and is valid
-    exists = ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TEST_TABLE_NAME);
-    assertTrue(exists, "Deletion marker should exist when created");
-
-    // Cleanup
-    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, TEST_TABLE_NAME);
+    ZNRecord record = _propertyStore.get(markerPath(TABLE_NAME), null, AccessOption.PERSISTENT);
+    assertNotNull(record, "Marker znode should be readable after creation");
+    assertEquals(record.getSimpleField(CONTROLLER_ID_KEY), CONTROLLER_1,
+        "Marker must record the owning controller so a stale marker can be attributed");
+    long startTimeMs = record.getLongField(START_TIME_KEY, -1L);
+    assertTrue(startTimeMs >= before && startTimeMs <= System.currentTimeMillis(),
+        "Marker start time should be the wall clock time at creation, got: " + startTimeMs);
   }
 
   @Test
-  public void testRemoveDeletionMarker() {
-    // Create marker
-    ZKMetadataProvider.createTableDeletionMarker(_propertyStore, TEST_TABLE_NAME, CONTROLLER_ID_1);
+  public void testDuplicateMarkerIsRejected() {
+    assertTrue(ZKMetadataProvider.createTableDeletionMarker(_propertyStore, TABLE_NAME, CONTROLLER_1));
+    assertFalse(ZKMetadataProvider.createTableDeletionMarker(_propertyStore, TABLE_NAME, CONTROLLER_2),
+        "A second controller must not be able to create a marker for a table already being deleted");
 
-    // Verify it exists
-    assertTrue(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TEST_TABLE_NAME));
-
-    // Remove marker
-    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, TEST_TABLE_NAME);
-
-    // Verify it's removed
-    assertFalse(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TEST_TABLE_NAME));
+    // The original owner must be preserved.
+    ZNRecord record = _propertyStore.get(markerPath(TABLE_NAME), null, AccessOption.PERSISTENT);
+    assertNotNull(record);
+    assertEquals(record.getSimpleField(CONTROLLER_ID_KEY), CONTROLLER_1);
   }
 
   @Test
-  public void testRemoveNonExistentDeletionMarker() {
-    // Should not throw exception when removing non-existent marker
-    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, TEST_TABLE_NAME);
-    // Test passes if no exception is thrown
+  public void testNoMarkerWhenNotCreated() {
+    assertFalse(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TABLE_NAME));
   }
 
   @Test
-  public void testCreateOrTakeoverDeletionMarkerNew() {
-    // Test takeover when no marker exists
-    boolean result = ZKMetadataProvider.createOrTakeoverTableDeletionMarker(_propertyStore, TEST_TABLE_NAME,
-        CONTROLLER_ID_1);
-    assertTrue(result, "Should create new marker when none exists");
+  public void testRemoveMarker() {
+    assertTrue(ZKMetadataProvider.createTableDeletionMarker(_propertyStore, TABLE_NAME, CONTROLLER_1));
+    assertTrue(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TABLE_NAME));
 
-    // Cleanup
-    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, TEST_TABLE_NAME);
+    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, TABLE_NAME);
+    assertFalse(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TABLE_NAME));
+
+    // A fresh deletion of the same table must be possible once the marker is gone.
+    assertTrue(ZKMetadataProvider.createTableDeletionMarker(_propertyStore, TABLE_NAME, CONTROLLER_2));
   }
 
   @Test
-  public void testCreateOrTakeoverDeletionMarkerExistingValid() {
-    // Create initial marker
-    ZKMetadataProvider.createTableDeletionMarker(_propertyStore, TEST_TABLE_NAME, CONTROLLER_ID_1);
-
-    // Try to takeover with different controller while marker is still valid
-    boolean result = ZKMetadataProvider.createOrTakeoverTableDeletionMarker(_propertyStore, TEST_TABLE_NAME,
-        CONTROLLER_ID_2);
-    assertFalse(result, "Should not takeover valid deletion marker");
-
-    // Cleanup
-    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, TEST_TABLE_NAME);
+  public void testRemoveNonExistentMarkerIsNoOp() {
+    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, TABLE_NAME);
+    assertFalse(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TABLE_NAME));
   }
 
   @Test
-  public void testGetPropertyStoreTableDeletionInProgressPrefix() {
-    String prefix = ZKMetadataProvider.getPropertyStoreTableDeletionInProgressPrefix();
-    assertNotNull(prefix, "Prefix should not be null");
-    assertEquals(prefix, "/TABLE_DELETION_IN_PROGRESS", "Prefix should match expected value");
+  public void testExpiredMarkerIsNotValid() {
+    writeMarkerWithAge(TABLE_NAME, CONTROLLER_1, EXPIRY_MS + 60_000L);
+    assertFalse(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TABLE_NAME),
+        "A marker older than the expiry window must not block progress forever");
   }
 
   @Test
-  public void testDeletionMarkerContent() {
-    // Create marker
-    ZKMetadataProvider.createTableDeletionMarker(_propertyStore, TEST_TABLE_NAME, CONTROLLER_ID_1);
-
-    // Verify marker content by checking it exists (detailed content verification would
-    // require internal access)
-    assertTrue(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TEST_TABLE_NAME));
-
-    // Cleanup
-    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, TEST_TABLE_NAME);
+  public void testMarkerJustInsideExpiryWindowIsStillValid() {
+    writeMarkerWithAge(TABLE_NAME, CONTROLLER_1, EXPIRY_MS - 60_000L);
+    assertTrue(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TABLE_NAME),
+        "A marker inside the expiry window must still provide mutual exclusion");
   }
 
   @Test
-  public void testMultipleTableMarkers() {
-    String table1 = "table1_REALTIME";
-    String table2 = "table2_OFFLINE";
+  public void testMarkerWithoutStartTimeIsNotValid() {
+    ZNRecord record = new ZNRecord(TABLE_NAME);
+    record.setSimpleField(CONTROLLER_ID_KEY, CONTROLLER_1);
+    assertTrue(_propertyStore.set(markerPath(TABLE_NAME), record, AccessOption.PERSISTENT));
 
-    // Create markers for different tables
-    boolean created1 = ZKMetadataProvider.createTableDeletionMarker(_propertyStore, table1, CONTROLLER_ID_1);
-    boolean created2 = ZKMetadataProvider.createTableDeletionMarker(_propertyStore, table2, CONTROLLER_ID_2);
+    assertFalse(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TABLE_NAME),
+        "A malformed marker must not permanently block deletion or re-creation");
+  }
 
-    assertTrue(created1, "Marker for table1 should be created");
-    assertTrue(created2, "Marker for table2 should be created");
+  @Test
+  public void testTakeoverCreatesMarkerWhenNoneExists() {
+    assertTrue(ZKMetadataProvider.createOrTakeoverTableDeletionMarker(_propertyStore, TABLE_NAME, CONTROLLER_1));
+    assertTrue(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TABLE_NAME));
+  }
 
-    // Verify both exist independently
-    assertTrue(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, table1));
-    assertTrue(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, table2));
+  @Test
+  public void testTakeoverRejectedWhenValidMarkerExists() {
+    assertTrue(ZKMetadataProvider.createTableDeletionMarker(_propertyStore, TABLE_NAME, CONTROLLER_1));
+    assertFalse(ZKMetadataProvider.createOrTakeoverTableDeletionMarker(_propertyStore, TABLE_NAME, CONTROLLER_2),
+        "A live deletion must not be stolen by another controller");
 
-    // Remove one marker
-    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, table1);
+    ZNRecord record = _propertyStore.get(markerPath(TABLE_NAME), null, AccessOption.PERSISTENT);
+    assertNotNull(record);
+    assertEquals(record.getSimpleField(CONTROLLER_ID_KEY), CONTROLLER_1);
+  }
 
-    // Verify only one remains
-    assertFalse(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, table1));
-    assertTrue(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, table2));
+  @Test
+  public void testTakeoverOfExpiredMarkerSucceedsAndReassignsOwner() {
+    writeMarkerWithAge(TABLE_NAME, CONTROLLER_1, EXPIRY_MS + 60_000L);
 
-    // Cleanup
-    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, table2);
+    assertTrue(ZKMetadataProvider.createOrTakeoverTableDeletionMarker(_propertyStore, TABLE_NAME, CONTROLLER_2),
+        "An expired marker should be reclaimable so a crashed deletion can be retried");
+
+    ZNRecord record = _propertyStore.get(markerPath(TABLE_NAME), null, AccessOption.PERSISTENT);
+    assertNotNull(record);
+    assertEquals(record.getSimpleField(CONTROLLER_ID_KEY), CONTROLLER_2,
+        "Takeover must record the new owning controller");
+    assertTrue(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TABLE_NAME),
+        "The refreshed marker should be valid again");
+  }
+
+  @Test
+  public void testMarkersForDifferentTablesAreIndependent() {
+    String realtimeTable = "table1_REALTIME";
+    String offlineTable = "table2_OFFLINE";
+
+    assertTrue(ZKMetadataProvider.createTableDeletionMarker(_propertyStore, realtimeTable, CONTROLLER_1));
+    assertTrue(ZKMetadataProvider.createTableDeletionMarker(_propertyStore, offlineTable, CONTROLLER_2));
+    assertTrue(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, realtimeTable));
+    assertTrue(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, offlineTable));
+
+    ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, realtimeTable);
+
+    assertFalse(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, realtimeTable));
+    assertTrue(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, offlineTable),
+        "Deleting one table must not clear another table's marker");
+  }
+
+  @Test
+  public void testDeletionInProgressPrefixIsExposedForManualCleanup() {
+    assertEquals(ZKMetadataProvider.getPropertyStoreTableDeletionInProgressPrefix(), MARKER_PREFIX);
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/metadata/TableDeletionMarkerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metadata/TableDeletionMarkerTest.java
@@ -32,6 +32,7 @@ import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.apache.pinot.common.utils.ZkStarter;
+import org.apache.zookeeper.data.Stat;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -248,6 +249,49 @@ public class TableDeletionMarkerTest {
         "Takeover must record the new owning controller");
     assertTrue(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TABLE_NAME),
         "The refreshed marker should be valid again");
+  }
+
+  /// The version check is what makes the stale-marker takeover safe, so exercise it directly: a controller that
+  /// observed the marker at one version must lose the takeover if anyone else has written to it since.
+  ///
+  /// This is the deterministic form of the two-controller race. The real interleaving (both controllers reading
+  /// the same stale version, then both writing) cannot be forced from a test, so instead the stale version is
+  /// supplied explicitly, which is exactly the state the losing controller would be in.
+  @Test
+  public void testTakeoverWithAStaleVersionLosesTheRace() {
+    writeMarkerWithAge(TABLE_NAME, "Controller_crashed", EXPIRY_MS + 60_000L);
+    Stat observed = new Stat();
+    assertNotNull(_propertyStore.get(markerPath(TABLE_NAME), observed, AccessOption.PERSISTENT));
+    int staleVersion = observed.getVersion();
+
+    // Controller 1 reclaims it first, which bumps the version.
+    assertTrue(ZKMetadataProvider.createOrTakeoverTableDeletionMarker(_propertyStore, TABLE_NAME, CONTROLLER_1));
+
+    // Controller 2 is still holding the version it read before controller 1 won, and must be rejected.
+    assertFalse(
+        ZKMetadataProvider.takeoverStaleTableDeletionMarker(_propertyStore, TABLE_NAME, CONTROLLER_2, staleVersion),
+        "A takeover based on a superseded version must fail, otherwise two controllers would both delete the table");
+
+    ZNRecord record = _propertyStore.get(markerPath(TABLE_NAME), null, AccessOption.PERSISTENT);
+    assertNotNull(record, "The winner's marker must survive a losing takeover attempt");
+    assertEquals(record.getSimpleField(CONTROLLER_ID_KEY), CONTROLLER_1,
+        "The losing controller must not overwrite the winner's ownership");
+    assertTrue(ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, TABLE_NAME));
+  }
+
+  /// The matching success case: a takeover with the current version wins and reassigns ownership.
+  @Test
+  public void testTakeoverWithTheCurrentVersionWins() {
+    writeMarkerWithAge(TABLE_NAME, "Controller_crashed", EXPIRY_MS + 60_000L);
+    Stat observed = new Stat();
+    assertNotNull(_propertyStore.get(markerPath(TABLE_NAME), observed, AccessOption.PERSISTENT));
+
+    assertTrue(ZKMetadataProvider.takeoverStaleTableDeletionMarker(_propertyStore, TABLE_NAME, CONTROLLER_2,
+        observed.getVersion()));
+
+    ZNRecord record = _propertyStore.get(markerPath(TABLE_NAME), null, AccessOption.PERSISTENT);
+    assertNotNull(record);
+    assertEquals(record.getSimpleField(CONTROLLER_ID_KEY), CONTROLLER_2);
   }
 
   /// Two controllers must never both hold the marker for one table. Uses two independent property stores because

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -653,6 +653,10 @@ public class PinotTableRestletResource {
         tablesDeleted.forEach(deletedTableName -> LOGGER.info("Successfully deleted table: {}", deletedTableName));
         return new SuccessResponse("Tables: " + tablesDeleted + " deleted");
       }
+    } catch (ControllerApplicationException e) {
+      // Already carries a deliberate status (e.g. CONFLICT when a deletion is already in progress); do not
+      // downgrade it to a 500.
+      throw e;
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1948,13 +1948,15 @@ public class PinotHelixResourceManager {
     // This prevents recreation of a table while deletion is still in progress, which would
     // otherwise lead to a corrupted state where the new table gets deleted by the in-flight deletion
     if (ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, tableNameWithType)) {
-      throw new IllegalStateException(String.format(
+      // CONFLICT rather than a generic failure: this is an expected, retryable race against an in-flight delete,
+      // not a server fault, and callers should not see it as a 500.
+      throw new ControllerApplicationException(LOGGER, String.format(
           "Cannot create table '%s': a deletion is currently in progress. "
               + "Please wait for the deletion to complete before attempting to recreate the table. "
               + "If the deletion appears stuck, the deletion marker will expire after 24 hours, "
               + "or you can manually clean up the deletion marker from ZK at path: %s/%s",
-          tableNameWithType, ZKMetadataProvider.getPropertyStoreTableDeletionInProgressPrefix(),
-          tableNameWithType));
+          tableNameWithType, ZKMetadataProvider.getPropertyStoreTableDeletionInProgressPrefix(), tableNameWithType),
+          Response.Status.CONFLICT);
     }
 
     LOGGER.info("Adding table {}: Validate table configs", tableNameWithType);
@@ -2572,12 +2574,13 @@ public class PinotHelixResourceManager {
     // Acquire the deletion marker. It gives concurrent deletes mutual exclusion and makes addTable() refuse to
     // re-create the table while this deletion is still tearing its metadata down.
     if (!ZKMetadataProvider.createOrTakeoverTableDeletionMarker(_propertyStore, tableNameWithType, _controllerId)) {
-      throw new IllegalStateException(String.format(
+      // CONFLICT rather than a generic failure: a concurrent delete is an expected, retryable condition.
+      throw new ControllerApplicationException(LOGGER, String.format(
           "Cannot delete table '%s': a deletion is already in progress. "
               + "If the previous deletion failed, wait for the deletion marker to expire (24 hours) "
               + "or manually clean up the deletion marker from ZK at path: %s/%s",
-          tableNameWithType, ZKMetadataProvider.getPropertyStoreTableDeletionInProgressPrefix(),
-          tableNameWithType));
+          tableNameWithType, ZKMetadataProvider.getPropertyStoreTableDeletionInProgressPrefix(), tableNameWithType),
+          Response.Status.CONFLICT);
     }
     boolean deletionMarkerCreated = true;
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -308,7 +308,7 @@ public class PinotHelixResourceManager {
   /// reminder to clean up old Zk nodes when the controller starts up.
   public synchronized void start(HelixManager helixZkManager, @Nullable ControllerMetrics controllerMetrics) {
     _helixZkManager = helixZkManager;
-    _controllerId = _helixZkManager.getInstanceId();
+    _controllerId = _helixZkManager.getInstanceName();
     _helixAdmin = _helixZkManager.getClusterManagmentTool();
     _propertyStore = _helixZkManager.getHelixPropertyStore();
     _helixDataAccessor = _helixZkManager.getHelixDataAccessor();
@@ -2679,8 +2679,8 @@ public class PinotHelixResourceManager {
       ZKMetadataProvider.removeResourceConfigFromPropertyStore(_propertyStore, tableNameWithType);
       LOGGER.info("Deleting table {}: Removed table config", tableNameWithType);
 
-      // Validate that all table-related znodes have been successfully removed
-      validateTableDeletionCompleteness(tableNameWithType, tableType);
+      // Audit the property store for metadata that should now be gone, and warn about anything left behind
+      auditTableDeletionCompleteness(tableNameWithType, tableType);
 
       LOGGER.info("Deleting table {}: Finish", tableNameWithType);
     } finally {
@@ -2692,81 +2692,64 @@ public class PinotHelixResourceManager {
     }
   }
 
-  /// Validates that all table-related znodes have been successfully removed after deletion.
-  /// This ensures data consistency and helps detect partial deletions.
+  /// Audits the property store for table metadata that [#deleteTable] should have removed, and logs a warning
+  /// listing anything left behind so that an operator can clean it up.
+  ///
+  /// This deliberately only covers artifacts that `deleteTable` removes with a synchronous ZK write, so a
+  /// leftover here is a real leak rather than a timing artifact. In particular the ExternalView is NOT checked:
+  /// Helix removes it asynchronously via the controller pipeline after the IdealState is dropped, so it is
+  /// routinely still present at this point.
+  ///
+  /// This only warns and never throws. By the time it runs the table config is already gone, so the delete has
+  /// succeeded from the caller's point of view; failing the request here would report a misleading error for a
+  /// table that no longer exists, and would not make the leftovers go away.
+  ///
+  /// ponytail: tier instance partitions, minion task metadata and materialized view metadata are not audited.
+  /// Tier partitions are named per tier and minion metadata is keyed per task type, so covering them means
+  /// scanning every instance partitions / task znode in the cluster on every delete. If leaks are observed in
+  /// practice, add a targeted child listing for the specific parent path rather than a cluster-wide scan.
   ///
   /// @param tableNameWithType The table name with type suffix
   /// @param tableType The table type
-  private void validateTableDeletionCompleteness(String tableNameWithType, TableType tableType) {
+  private void auditTableDeletionCompleteness(String tableNameWithType, TableType tableType) {
     List<String> remainingArtifacts = new ArrayList<>();
 
-    // Check Helix resources
     if (_helixDataAccessor.getProperty(_keyBuilder.idealStates(tableNameWithType)) != null) {
       remainingArtifacts.add("IdealState");
     }
-    if (_helixDataAccessor.getProperty(_keyBuilder.externalView(tableNameWithType)) != null) {
-      remainingArtifacts.add("ExternalView");
-    }
-
-    // Check property store resources
-    // Note: ResourceConfig and TableConfig are stored at the same path in Pinot
     if (ZKMetadataProvider.isTableConfigExists(_propertyStore, tableNameWithType)) {
       remainingArtifacts.add("TableConfig");
     }
     List<String> segments = ZKMetadataProvider.getSegments(_propertyStore, tableNameWithType);
     if (segments != null && !segments.isEmpty()) {
-      remainingArtifacts.add("SegmentMetadata");
+      remainingArtifacts.add(segments.size() + " segment(s) of metadata");
     }
-
-    // Check instance partitions
-    if (tableType == TableType.OFFLINE) {
-      if (InstancePartitionsUtils.getInstancePartitions(_propertyStore, tableNameWithType) != null) {
-        remainingArtifacts.add("InstancePartitions");
-      }
-    } else {
-      String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
-      if (InstancePartitionsUtils.getInstancePartitions(_propertyStore,
-          InstancePartitionsType.CONSUMING.getInstancePartitionsName(rawTableName)) != null) {
-        remainingArtifacts.add("ConsumingInstancePartitions");
-      }
-      if (InstancePartitionsUtils.getInstancePartitions(_propertyStore,
-          InstancePartitionsType.COMPLETED.getInstancePartitionsName(rawTableName)) != null) {
-        remainingArtifacts.add("CompletedInstancePartitions");
-      }
-    }
-
-    // Check tier instance partitions
-    if (InstancePartitionsUtils.getTierInstancePartitions(_propertyStore, tableNameWithType) != null) {
-      remainingArtifacts.add("TierInstancePartitions");
-    }
-
-    // Check segment lineage
     if (SegmentLineageAccessHelper.getSegmentLineage(_propertyStore, tableNameWithType) != null) {
       remainingArtifacts.add("SegmentLineage");
     }
 
-    // Check minion task metadata
-    if (MinionTaskMetadataUtils.getTaskMetadata(_propertyStore, tableNameWithType) != null) {
-      remainingArtifacts.add("MinionTaskMetadata");
-    }
-
-    // Check materialized view metadata
-    if (MaterializedViewDefinitionMetadataUtils.get(_propertyStore, tableNameWithType) != null) {
-      remainingArtifacts.add("MVDefinitionMetadata");
-    }
-    if (MaterializedViewRuntimeMetadataUtils.get(_propertyStore, tableNameWithType) != null) {
-      remainingArtifacts.add("MVRuntimeMetadata");
-    }
-
-    if (!remainingArtifacts.isEmpty()) {
-      String errorMsg = String.format(
-          "Table deletion validation failed for '%s': %d artifact(s) still remain: %s. "
-              + "This may indicate a partial deletion or concurrent modification.",
-          tableNameWithType, remainingArtifacts.size(), remainingArtifacts);
-      LOGGER.error(errorMsg);
-      throw new IllegalStateException(errorMsg);
+    // Mirror the instance partitions names that deleteTable removes.
+    if (tableType == TableType.OFFLINE) {
+      if (InstancePartitionsUtils.fetchInstancePartitions(_propertyStore, tableNameWithType) != null) {
+        remainingArtifacts.add("InstancePartitions");
+      }
     } else {
-      LOGGER.info("Table deletion validation successful for '{}': all artifacts removed", tableNameWithType);
+      String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
+      for (InstancePartitionsType type : List.of(InstancePartitionsType.CONSUMING,
+          InstancePartitionsType.COMPLETED)) {
+        String instancePartitionsName = type.getInstancePartitionsName(rawTableName);
+        if (InstancePartitionsUtils.fetchInstancePartitions(_propertyStore, instancePartitionsName) != null) {
+          remainingArtifacts.add(instancePartitionsName);
+        }
+      }
+    }
+
+    if (remainingArtifacts.isEmpty()) {
+      LOGGER.info("Deleting table {}: Verified all audited metadata was removed", tableNameWithType);
+    } else {
+      LOGGER.warn("Deleting table {}: Finished but left {} metadata artifact(s) behind: {}. "
+              + "These need to be cleaned up manually before the table is re-created.", tableNameWithType,
+          remainingArtifacts.size(), remainingArtifacts);
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2582,8 +2582,6 @@ public class PinotHelixResourceManager {
           tableNameWithType, ZKMetadataProvider.getPropertyStoreTableDeletionInProgressPrefix(), tableNameWithType),
           Response.Status.CONFLICT);
     }
-    boolean deletionMarkerCreated = true;
-
     try {
       // Remove the table from brokerResource
       HelixHelper.removeResourceFromBrokerIdealState(_helixZkManager, tableNameWithType);
@@ -2668,29 +2666,34 @@ public class PinotHelixResourceManager {
       LOGGER.info("Deleting table {}: Removed table config", tableNameWithType);
 
       // Audit the property store for metadata that should now be gone, and warn about anything left behind
-      auditTableDeletionCompleteness(tableNameWithType, tableType);
+      List<String> leftoverMetadata = findLeftoverTableMetadata(tableNameWithType, tableType);
+      if (leftoverMetadata.isEmpty()) {
+        LOGGER.info("Deleting table {}: Verified all audited metadata was removed", tableNameWithType);
+      } else {
+        LOGGER.warn("Deleting table {}: Finished but left {} metadata artifact(s) behind: {}. "
+                + "These need to be cleaned up manually before the table is re-created.", tableNameWithType,
+            leftoverMetadata.size(), leftoverMetadata);
+      }
 
       LOGGER.info("Deleting table {}: Finish", tableNameWithType);
     } finally {
-      // Always remove the deletion marker, even if deletion failed
-      // This allows retry of deletion or recreation of the table
-      if (deletionMarkerCreated) {
-        ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, tableNameWithType, _controllerId);
-      }
+      // Always release the marker, even if the deletion failed, so the deletion can be retried or the table
+      // re-created. Releasing is a no-op if another controller has since taken the marker over.
+      ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, tableNameWithType, _controllerId);
     }
   }
 
-  /// Audits the property store for table metadata that [#deleteTable] should have removed, and logs a warning
-  /// listing anything left behind so that an operator can clean it up.
+  /// Returns the table metadata that [#deleteTable] should have removed but which is still present, so the
+  /// caller can warn an operator about it. An empty list means the audited metadata is all gone.
   ///
   /// This deliberately only covers artifacts that `deleteTable` removes with a synchronous ZK write, so a
   /// leftover here is a real leak rather than a timing artifact. In particular the ExternalView is NOT checked:
   /// Helix removes it asynchronously via the controller pipeline after the IdealState is dropped, so it is
   /// routinely still present at this point.
   ///
-  /// This only warns and never throws. By the time it runs the table config is already gone, so the delete has
-  /// succeeded from the caller's point of view; failing the request here would report a misleading error for a
-  /// table that no longer exists, and would not make the leftovers go away.
+  /// The caller only warns and never throws. By the time this runs the table config is already gone, so the
+  /// delete has succeeded from the caller's point of view; failing the request would report a misleading error
+  /// for a table that no longer exists, and would not make the leftovers go away.
   ///
   /// ponytail: tier instance partitions, minion task metadata and materialized view metadata are not audited.
   /// Tier partitions are named per tier and minion metadata is keyed per task type, so covering them means
@@ -2699,7 +2702,9 @@ public class PinotHelixResourceManager {
   ///
   /// @param tableNameWithType The table name with type suffix
   /// @param tableType The table type
-  private void auditTableDeletionCompleteness(String tableNameWithType, TableType tableType) {
+  /// @return the names of the metadata artifacts still present, empty when nothing was left behind
+  @VisibleForTesting
+  List<String> findLeftoverTableMetadata(String tableNameWithType, TableType tableType) {
     List<String> remainingArtifacts = new ArrayList<>();
 
     if (_helixDataAccessor.getProperty(_keyBuilder.idealStates(tableNameWithType)) != null) {
@@ -2732,13 +2737,7 @@ public class PinotHelixResourceManager {
       }
     }
 
-    if (remainingArtifacts.isEmpty()) {
-      LOGGER.info("Deleting table {}: Verified all audited metadata was removed", tableNameWithType);
-    } else {
-      LOGGER.warn("Deleting table {}: Finished but left {} metadata artifact(s) behind: {}. "
-              + "These need to be cleaned up manually before the table is re-created.", tableNameWithType,
-          remainingArtifacts.size(), remainingArtifacts);
-    }
+    return remainingArtifacts;
   }
 
   /// Deletes the logical table.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2547,8 +2547,30 @@ public class PinotHelixResourceManager {
     String tableNameWithType = TableNameBuilder.forType(tableType).tableNameWithType(tableName);
     LOGGER.info("Deleting table {}: Start", tableNameWithType);
 
-    // Create deletion marker to prevent concurrent deletions and prevent recreation during deletion
-    // This implements atomic deletion by using a ZK-based distributed lock mechanism
+    // Block the delete when materialized views depend on this base table. Orphaning an MV
+    // leaves its runtime znode pointing at a base that no longer exists; the MV's task
+    // generator would then fail forever on every cycle, and the broker rewrite engine (PR 2)
+    // would keep serving the now-orphaned MV partitions as if the base were intact — silent
+    // stale data. Force the operator to drop dependent MVs first.
+    // NOTE: This runs before the deletion marker is acquired so that a refused delete does not leave a marker
+    // that would make an unrelated addTable() report a deletion in progress.
+    MaterializedViewConsistencyManager mvMgr = _materializedViewConsistencyManager;
+    if (mvMgr != null) {
+      String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
+      List<String> dependentMVs = new ArrayList<>(mvMgr.getDependentMaterializedViews(rawTableName));
+      // Don't block when the table being dropped IS an MV (self-reference impossible, but the
+      // index entry exists for MVs over MVs — currently unsupported, but the guard is cheap).
+      dependentMVs.remove(tableNameWithType);
+      if (!dependentMVs.isEmpty()) {
+        throw new IllegalStateException(String.format(
+            "Cannot delete table '%s': %d materialized view(s) depend on it: %s. "
+                + "Drop the dependent materialized views first.",
+            tableNameWithType, dependentMVs.size(), dependentMVs));
+      }
+    }
+
+    // Acquire the deletion marker. It gives concurrent deletes mutual exclusion and makes addTable() refuse to
+    // re-create the table while this deletion is still tearing its metadata down.
     if (!ZKMetadataProvider.createOrTakeoverTableDeletionMarker(_propertyStore, tableNameWithType, _controllerId)) {
       throw new IllegalStateException(String.format(
           "Cannot delete table '%s': a deletion is already in progress. "
@@ -2560,26 +2582,6 @@ public class PinotHelixResourceManager {
     boolean deletionMarkerCreated = true;
 
     try {
-      // Block the delete when materialized views depend on this base table. Orphaning an MV
-      // leaves its runtime znode pointing at a base that no longer exists; the MV's task
-      // generator would then fail forever on every cycle, and the broker rewrite engine (PR 2)
-      // would keep serving the now-orphaned MV partitions as if the base were intact — silent
-      // stale data. Force the operator to drop dependent MVs first.
-      MaterializedViewConsistencyManager mvMgr = _materializedViewConsistencyManager;
-      if (mvMgr != null) {
-        String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
-        List<String> dependentMVs = new ArrayList<>(mvMgr.getDependentMaterializedViews(rawTableName));
-        // Don't block when the table being dropped IS an MV (self-reference impossible, but the
-        // index entry exists for MVs over MVs — currently unsupported, but the guard is cheap).
-        dependentMVs.remove(tableNameWithType);
-        if (!dependentMVs.isEmpty()) {
-          throw new IllegalStateException(String.format(
-              "Cannot delete table '%s': %d materialized view(s) depend on it: %s. "
-                  + "Drop the dependent materialized views first.",
-              tableNameWithType, dependentMVs.size(), dependentMVs));
-        }
-      }
-
       // Remove the table from brokerResource
       HelixHelper.removeResourceFromBrokerIdealState(_helixZkManager, tableNameWithType);
       LOGGER.info("Deleting table {}: Removed from broker resource", tableNameWithType);
@@ -2591,30 +2593,13 @@ public class PinotHelixResourceManager {
       _helixDataAccessor.removeProperty(_keyBuilder.idealStates(tableNameWithType));
       LOGGER.info("Deleting table {}: Removed ideal state", tableNameWithType);
 
-      // Remove all stored segments for the table
-      // Determine retention period with priority: query parameter > table config > cluster default
-      Long retentionPeriodMs;
-      if (retentionPeriod != null) {
-        // Query parameter takes highest priority
-        retentionPeriodMs = TimeUtils.convertPeriodToMillis(retentionPeriod);
-      } else {
-        // Check table config for deletedSegmentsRetentionPeriod
-        TableConfig tableConfig = getTableConfig(tableNameWithType);
-        if (tableConfig != null && tableConfig.getValidationConfig() != null) {
-          String tableRetentionPeriod = tableConfig.getValidationConfig().getDeletedSegmentsRetentionPeriod();
-          if (tableRetentionPeriod != null) {
-            retentionPeriodMs = TimeUtils.convertPeriodToMillis(tableRetentionPeriod);
-            LOGGER.info("Using table config retention period: {} for table {}", tableRetentionPeriod,
-                tableNameWithType);
-          } else {
-            // Fall back to null (will use cluster default in SegmentDeletionManager)
-            retentionPeriodMs = null;
-          }
-        } else {
-          // Fall back to null (will use cluster default in SegmentDeletionManager)
-          retentionPeriodMs = null;
-        }
-      }
+      // Remove all stored segments for the table.
+      // Retention precedence: the request's retention parameter, then the table config, then the cluster default
+      // that SegmentDeletionManager applies when this is null. Reuse SegmentDeletionManager's own extraction
+      // helper rather than re-reading the config here: it tolerates an empty or malformed period, which
+      // TimeUtils.convertPeriodToMillis would otherwise throw on and make the table undeletable.
+      Long retentionPeriodMs = retentionPeriod != null ? TimeUtils.convertPeriodToMillis(retentionPeriod)
+          : SegmentDeletionManager.getRetentionMsFromTableConfig(getTableConfig(tableNameWithType));
       _segmentDeletionManager.removeSegmentsFromStoreInBatch(tableNameWithType,
           getSegmentsFromPropertyStore(tableNameWithType),
           retentionPeriodMs);
@@ -2687,7 +2672,7 @@ public class PinotHelixResourceManager {
       // Always remove the deletion marker, even if deletion failed
       // This allows retry of deletion or recreation of the table
       if (deletionMarkerCreated) {
-        ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, tableNameWithType);
+        ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, tableNameWithType, _controllerId);
       }
     }
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -246,6 +246,7 @@ public class PinotHelixResourceManager {
   private final ControllerConf _controllerConf;
 
   private HelixManager _helixZkManager;
+  private String _controllerId;
   private HelixAdmin _helixAdmin;
   private ZkHelixPropertyStore<ZNRecord> _propertyStore;
   private HelixDataAccessor _helixDataAccessor;
@@ -307,6 +308,7 @@ public class PinotHelixResourceManager {
   /// reminder to clean up old Zk nodes when the controller starts up.
   public synchronized void start(HelixManager helixZkManager, @Nullable ControllerMetrics controllerMetrics) {
     _helixZkManager = helixZkManager;
+    _controllerId = _helixZkManager.getInstanceId();
     _helixAdmin = _helixZkManager.getClusterManagmentTool();
     _propertyStore = _helixZkManager.getHelixPropertyStore();
     _helixDataAccessor = _helixZkManager.getHelixDataAccessor();
@@ -1942,6 +1944,19 @@ public class PinotHelixResourceManager {
           + "external view");
     }
 
+    // Check if a deletion is in progress for this table
+    // This prevents recreation of a table while deletion is still in progress, which would
+    // otherwise lead to a corrupted state where the new table gets deleted by the in-flight deletion
+    if (ZKMetadataProvider.isValidTableDeletionMarkerExists(_propertyStore, tableNameWithType)) {
+      throw new IllegalStateException(String.format(
+          "Cannot create table '%s': a deletion is currently in progress. "
+              + "Please wait for the deletion to complete before attempting to recreate the table. "
+              + "If the deletion appears stuck, the deletion marker will expire after 24 hours, "
+              + "or you can manually clean up the deletion marker from ZK at path: %s/%s",
+          tableNameWithType, ZKMetadataProvider.getPropertyStoreTableDeletionInProgressPrefix(),
+          tableNameWithType));
+    }
+
     LOGGER.info("Adding table {}: Validate table configs", tableNameWithType);
     validateTableTenantConfig(tableConfig);
 
@@ -2532,104 +2547,227 @@ public class PinotHelixResourceManager {
     String tableNameWithType = TableNameBuilder.forType(tableType).tableNameWithType(tableName);
     LOGGER.info("Deleting table {}: Start", tableNameWithType);
 
-    // Block the delete when materialized views depend on this base table. Orphaning an MV
-    // leaves its runtime znode pointing at a base that no longer exists; the MV's task
-    // generator would then fail forever on every cycle, and the broker rewrite engine (PR 2)
-    // would keep serving the now-orphaned MV partitions as if the base were intact — silent
-    // stale data. Force the operator to drop dependent MVs first.
-    MaterializedViewConsistencyManager mvMgr = _materializedViewConsistencyManager;
-    if (mvMgr != null) {
-      String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
-      List<String> dependentMVs = new ArrayList<>(mvMgr.getDependentMaterializedViews(rawTableName));
-      // Don't block when the table being dropped IS an MV (self-reference impossible, but the
-      // index entry exists for MVs over MVs — currently unsupported, but the guard is cheap).
-      dependentMVs.remove(tableNameWithType);
-      if (!dependentMVs.isEmpty()) {
-        throw new IllegalStateException(String.format(
-            "Cannot delete table '%s': %d materialized view(s) depend on it: %s. "
-                + "Drop the dependent materialized views first.",
-            tableNameWithType, dependentMVs.size(), dependentMVs));
-      }
+    // Create deletion marker to prevent concurrent deletions and prevent recreation during deletion
+    // This implements atomic deletion by using a ZK-based distributed lock mechanism
+    if (!ZKMetadataProvider.createOrTakeoverTableDeletionMarker(_propertyStore, tableNameWithType, _controllerId)) {
+      throw new IllegalStateException(String.format(
+          "Cannot delete table '%s': a deletion is already in progress. "
+              + "If the previous deletion failed, wait for the deletion marker to expire (24 hours) "
+              + "or manually clean up the deletion marker from ZK at path: %s/%s",
+          tableNameWithType, ZKMetadataProvider.getPropertyStoreTableDeletionInProgressPrefix(),
+          tableNameWithType));
     }
+    boolean deletionMarkerCreated = true;
 
-    // Remove the table from brokerResource
-    HelixHelper.removeResourceFromBrokerIdealState(_helixZkManager, tableNameWithType);
-    LOGGER.info("Deleting table {}: Removed from broker resource", tableNameWithType);
+    try {
+      // Block the delete when materialized views depend on this base table. Orphaning an MV
+      // leaves its runtime znode pointing at a base that no longer exists; the MV's task
+      // generator would then fail forever on every cycle, and the broker rewrite engine (PR 2)
+      // would keep serving the now-orphaned MV partitions as if the base were intact — silent
+      // stale data. Force the operator to drop dependent MVs first.
+      MaterializedViewConsistencyManager mvMgr = _materializedViewConsistencyManager;
+      if (mvMgr != null) {
+        String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
+        List<String> dependentMVs = new ArrayList<>(mvMgr.getDependentMaterializedViews(rawTableName));
+        // Don't block when the table being dropped IS an MV (self-reference impossible, but the
+        // index entry exists for MVs over MVs — currently unsupported, but the guard is cheap).
+        dependentMVs.remove(tableNameWithType);
+        if (!dependentMVs.isEmpty()) {
+          throw new IllegalStateException(String.format(
+              "Cannot delete table '%s': %d materialized view(s) depend on it: %s. "
+                  + "Drop the dependent materialized views first.",
+              tableNameWithType, dependentMVs.size(), dependentMVs));
+        }
+      }
 
-    // Delete the table on servers
-    deleteTableOnServers(tableNameWithType);
+      // Remove the table from brokerResource
+      HelixHelper.removeResourceFromBrokerIdealState(_helixZkManager, tableNameWithType);
+      LOGGER.info("Deleting table {}: Removed from broker resource", tableNameWithType);
 
-    // Remove ideal state
-    _helixDataAccessor.removeProperty(_keyBuilder.idealStates(tableNameWithType));
-    LOGGER.info("Deleting table {}: Removed ideal state", tableNameWithType);
+      // Delete the table on servers
+      deleteTableOnServers(tableNameWithType);
 
-    // Remove all stored segments for the table
-    Long retentionPeriodMs = retentionPeriod != null ? TimeUtils.convertPeriodToMillis(retentionPeriod) : null;
-    _segmentDeletionManager.removeSegmentsFromStoreInBatch(tableNameWithType,
-        getSegmentsFromPropertyStore(tableNameWithType),
-        retentionPeriodMs);
-    LOGGER.info("Deleting table {}: Removed stored segments", tableNameWithType);
+      // Remove ideal state
+      _helixDataAccessor.removeProperty(_keyBuilder.idealStates(tableNameWithType));
+      LOGGER.info("Deleting table {}: Removed ideal state", tableNameWithType);
 
-    // Remove segment metadata
-    ZKMetadataProvider.removeResourceSegmentsFromPropertyStore(_propertyStore, tableNameWithType);
-    LOGGER.info("Deleting table {}: Removed segment metadata", tableNameWithType);
-
-    // Remove COMMITTING segment list
-    if (tableType == TableType.REALTIME) {
-      if (ZKMetadataProvider.removePauselessDebugMetadata(_propertyStore, tableNameWithType)) {
-        LOGGER.info("Deleting table {}: Removed pauseless debug metadata", tableNameWithType);
+      // Remove all stored segments for the table
+      // Determine retention period with priority: query parameter > table config > cluster default
+      Long retentionPeriodMs;
+      if (retentionPeriod != null) {
+        // Query parameter takes highest priority
+        retentionPeriodMs = TimeUtils.convertPeriodToMillis(retentionPeriod);
       } else {
-        LOGGER.info("Deleting table {}: Failed to remove pauseless debug metadata.", tableNameWithType);
+        // Check table config for deletedSegmentsRetentionPeriod
+        TableConfig tableConfig = getTableConfig(tableNameWithType);
+        if (tableConfig != null && tableConfig.getValidationConfig() != null) {
+          String tableRetentionPeriod = tableConfig.getValidationConfig().getDeletedSegmentsRetentionPeriod();
+          if (tableRetentionPeriod != null) {
+            retentionPeriodMs = TimeUtils.convertPeriodToMillis(tableRetentionPeriod);
+            LOGGER.info("Using table config retention period: {} for table {}", tableRetentionPeriod,
+                tableNameWithType);
+          } else {
+            // Fall back to null (will use cluster default in SegmentDeletionManager)
+            retentionPeriodMs = null;
+          }
+        } else {
+          // Fall back to null (will use cluster default in SegmentDeletionManager)
+          retentionPeriodMs = null;
+        }
+      }
+      _segmentDeletionManager.removeSegmentsFromStoreInBatch(tableNameWithType,
+          getSegmentsFromPropertyStore(tableNameWithType),
+          retentionPeriodMs);
+      LOGGER.info("Deleting table {}: Removed stored segments", tableNameWithType);
+
+      // Remove segment metadata
+      ZKMetadataProvider.removeResourceSegmentsFromPropertyStore(_propertyStore, tableNameWithType);
+      LOGGER.info("Deleting table {}: Removed segment metadata", tableNameWithType);
+
+      // Remove COMMITTING segment list
+      if (tableType == TableType.REALTIME) {
+        if (ZKMetadataProvider.removePauselessDebugMetadata(_propertyStore, tableNameWithType)) {
+          LOGGER.info("Deleting table {}: Removed pauseless debug metadata", tableNameWithType);
+        } else {
+          LOGGER.info("Deleting table {}: Failed to remove pauseless debug metadata.", tableNameWithType);
+        }
+      }
+
+      // Remove instance partitions
+      if (tableType == TableType.OFFLINE) {
+        InstancePartitionsUtils.removeInstancePartitions(_propertyStore, tableNameWithType);
+      } else {
+        String rawTableName = TableNameBuilder.extractRawTableName(tableName);
+        InstancePartitionsUtils.removeInstancePartitions(_propertyStore,
+            InstancePartitionsType.CONSUMING.getInstancePartitionsName(rawTableName));
+        InstancePartitionsUtils.removeInstancePartitions(_propertyStore,
+            InstancePartitionsType.COMPLETED.getInstancePartitionsName(rawTableName));
+      }
+      LOGGER.info("Deleting table {}: Removed instance partitions", tableNameWithType);
+
+      // Remove tier instance partitions
+      InstancePartitionsUtils.removeTierInstancePartitions(_propertyStore, tableNameWithType);
+      LOGGER.info("Deleting table {}: Removed tier instance partitions", tableNameWithType);
+
+      // Remove segment lineage
+      SegmentLineageAccessHelper.deleteSegmentLineage(_propertyStore, tableNameWithType);
+      LOGGER.info("Deleting table {}: Removed segment lineage", tableNameWithType);
+
+      // Remove task related metadata
+      MinionTaskMetadataUtils.deleteTaskMetadata(_propertyStore, tableNameWithType);
+      LOGGER.info("Deleting table {}: Removed all minion task metadata", tableNameWithType);
+
+      // Remove materialized view metadata (if any) and unregister from consistency manager
+      notifyMaterializedViewConsistencyManagerForTableDrop(tableNameWithType);
+      try {
+        MaterializedViewDefinitionMetadataUtils.delete(_propertyStore, tableNameWithType);
+        LOGGER.info("Deleting table {}: Removed MV definition metadata", tableNameWithType);
+      } catch (Exception e) {
+        LOGGER.debug("Deleting table {}: No MV definition metadata to remove or removal failed",
+            tableNameWithType, e);
+      }
+      try {
+        MaterializedViewRuntimeMetadataUtils.delete(_propertyStore, tableNameWithType);
+        LOGGER.info("Deleting table {}: Removed MV runtime metadata", tableNameWithType);
+      } catch (Exception e) {
+        LOGGER.debug("Deleting table {}: No MV runtime metadata to remove or removal failed",
+            tableNameWithType, e);
+      }
+
+      // Remove table config
+      // NOTE: This should always be the last step for deletion to avoid race condition in table re-create
+      ZKMetadataProvider.removeResourceConfigFromPropertyStore(_propertyStore, tableNameWithType);
+      LOGGER.info("Deleting table {}: Removed table config", tableNameWithType);
+
+      // Validate that all table-related znodes have been successfully removed
+      validateTableDeletionCompleteness(tableNameWithType, tableType);
+
+      LOGGER.info("Deleting table {}: Finish", tableNameWithType);
+    } finally {
+      // Always remove the deletion marker, even if deletion failed
+      // This allows retry of deletion or recreation of the table
+      if (deletionMarkerCreated) {
+        ZKMetadataProvider.removeTableDeletionMarker(_propertyStore, tableNameWithType);
+      }
+    }
+  }
+
+  /// Validates that all table-related znodes have been successfully removed after deletion.
+  /// This ensures data consistency and helps detect partial deletions.
+  ///
+  /// @param tableNameWithType The table name with type suffix
+  /// @param tableType The table type
+  private void validateTableDeletionCompleteness(String tableNameWithType, TableType tableType) {
+    List<String> remainingArtifacts = new ArrayList<>();
+
+    // Check Helix resources
+    if (_helixDataAccessor.getProperty(_keyBuilder.idealStates(tableNameWithType)) != null) {
+      remainingArtifacts.add("IdealState");
+    }
+    if (_helixDataAccessor.getProperty(_keyBuilder.externalView(tableNameWithType)) != null) {
+      remainingArtifacts.add("ExternalView");
+    }
+
+    // Check property store resources
+    // Note: ResourceConfig and TableConfig are stored at the same path in Pinot
+    if (ZKMetadataProvider.isTableConfigExists(_propertyStore, tableNameWithType)) {
+      remainingArtifacts.add("TableConfig");
+    }
+    List<String> segments = ZKMetadataProvider.getSegments(_propertyStore, tableNameWithType);
+    if (segments != null && !segments.isEmpty()) {
+      remainingArtifacts.add("SegmentMetadata");
+    }
+
+    // Check instance partitions
+    if (tableType == TableType.OFFLINE) {
+      if (InstancePartitionsUtils.getInstancePartitions(_propertyStore, tableNameWithType) != null) {
+        remainingArtifacts.add("InstancePartitions");
+      }
+    } else {
+      String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
+      if (InstancePartitionsUtils.getInstancePartitions(_propertyStore,
+          InstancePartitionsType.CONSUMING.getInstancePartitionsName(rawTableName)) != null) {
+        remainingArtifacts.add("ConsumingInstancePartitions");
+      }
+      if (InstancePartitionsUtils.getInstancePartitions(_propertyStore,
+          InstancePartitionsType.COMPLETED.getInstancePartitionsName(rawTableName)) != null) {
+        remainingArtifacts.add("CompletedInstancePartitions");
       }
     }
 
-    // Remove instance partitions
-    if (tableType == TableType.OFFLINE) {
-      InstancePartitionsUtils.removeInstancePartitions(_propertyStore, tableNameWithType);
+    // Check tier instance partitions
+    if (InstancePartitionsUtils.getTierInstancePartitions(_propertyStore, tableNameWithType) != null) {
+      remainingArtifacts.add("TierInstancePartitions");
+    }
+
+    // Check segment lineage
+    if (SegmentLineageAccessHelper.getSegmentLineage(_propertyStore, tableNameWithType) != null) {
+      remainingArtifacts.add("SegmentLineage");
+    }
+
+    // Check minion task metadata
+    if (MinionTaskMetadataUtils.getTaskMetadata(_propertyStore, tableNameWithType) != null) {
+      remainingArtifacts.add("MinionTaskMetadata");
+    }
+
+    // Check materialized view metadata
+    if (MaterializedViewDefinitionMetadataUtils.get(_propertyStore, tableNameWithType) != null) {
+      remainingArtifacts.add("MVDefinitionMetadata");
+    }
+    if (MaterializedViewRuntimeMetadataUtils.get(_propertyStore, tableNameWithType) != null) {
+      remainingArtifacts.add("MVRuntimeMetadata");
+    }
+
+    if (!remainingArtifacts.isEmpty()) {
+      String errorMsg = String.format(
+          "Table deletion validation failed for '%s': %d artifact(s) still remain: %s. "
+              + "This may indicate a partial deletion or concurrent modification.",
+          tableNameWithType, remainingArtifacts.size(), remainingArtifacts);
+      LOGGER.error(errorMsg);
+      throw new IllegalStateException(errorMsg);
     } else {
-      String rawTableName = TableNameBuilder.extractRawTableName(tableName);
-      InstancePartitionsUtils.removeInstancePartitions(_propertyStore,
-          InstancePartitionsType.CONSUMING.getInstancePartitionsName(rawTableName));
-      InstancePartitionsUtils.removeInstancePartitions(_propertyStore,
-          InstancePartitionsType.COMPLETED.getInstancePartitionsName(rawTableName));
+      LOGGER.info("Table deletion validation successful for '{}': all artifacts removed", tableNameWithType);
     }
-    LOGGER.info("Deleting table {}: Removed instance partitions", tableNameWithType);
-
-    // Remove tier instance partitions
-    InstancePartitionsUtils.removeTierInstancePartitions(_propertyStore, tableNameWithType);
-    LOGGER.info("Deleting table {}: Removed tier instance partitions", tableNameWithType);
-
-    // Remove segment lineage
-    SegmentLineageAccessHelper.deleteSegmentLineage(_propertyStore, tableNameWithType);
-    LOGGER.info("Deleting table {}: Removed segment lineage", tableNameWithType);
-
-    // Remove task related metadata
-    MinionTaskMetadataUtils.deleteTaskMetadata(_propertyStore, tableNameWithType);
-    LOGGER.info("Deleting table {}: Removed all minion task metadata", tableNameWithType);
-
-    // Remove materialized view metadata (if any) and unregister from consistency manager
-    notifyMaterializedViewConsistencyManagerForTableDrop(tableNameWithType);
-    try {
-      MaterializedViewDefinitionMetadataUtils.delete(_propertyStore, tableNameWithType);
-      LOGGER.info("Deleting table {}: Removed MV definition metadata", tableNameWithType);
-    } catch (Exception e) {
-      LOGGER.debug("Deleting table {}: No MV definition metadata to remove or removal failed",
-          tableNameWithType, e);
-    }
-    try {
-      MaterializedViewRuntimeMetadataUtils.delete(_propertyStore, tableNameWithType);
-      LOGGER.info("Deleting table {}: Removed MV runtime metadata", tableNameWithType);
-    } catch (Exception e) {
-      LOGGER.debug("Deleting table {}: No MV runtime metadata to remove or removal failed",
-          tableNameWithType, e);
-    }
-
-    // Remove table config
-    // NOTE: This should always be the last step for deletion to avoid race condition in table re-create
-    ZKMetadataProvider.removeResourceConfigFromPropertyStore(_propertyStore, tableNameWithType);
-    LOGGER.info("Deleting table {}: Removed table config", tableNameWithType);
-
-    LOGGER.info("Deleting table {}: Finish", tableNameWithType);
   }
 
   /// Deletes the logical table.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -342,44 +342,44 @@ public class SegmentDeletionManager {
         pinotFS.deleteBatch(filesToDelete, true);
       }
 
-      // Batch move segments with retention > 0
+      // Move the segments to the deleted directory and let the retention manager delete them later.
+      // PinotFS has no batch move, so this is still one move per segment; what this avoids relative to a
+      // per-segment helper is an exists() round trip per segment (move already reports a missing source) and
+      // one log line per segment, both of which dominate when dropping a table with many segments.
       if (!filesToMove.isEmpty()) {
-        LOGGER.info("Moving {} segment files to deleted directory", filesToMove.size());
-        int successCount = 0;
-        int failureCount = 0;
+        LOGGER.info("Moving {} segment files of table {} to the deleted directory", filesToMove.size(),
+            tableNameWithType);
+        int movedCount = 0;
+        List<URI> failedMoves = new ArrayList<>();
         for (int i = 0; i < filesToMove.size(); i++) {
           URI srcUri = filesToMove.get(i);
           URI destUri = moveDestinations.get(i);
           try {
-            // Perform move without individual exists() check for better performance
-            // The move operation will fail gracefully if the source file doesn't exist
+            // Overwrites the file if it already exists in the target directory.
             if (pinotFS.move(srcUri, destUri, true)) {
-              successCount++;
+              // Touch is needed so that removeAgedDeletedSegments() sees a fresh last-modified time.
+              // Only touch destinations we actually created: touching a path whose move failed can
+              // materialize an empty object on object stores and leave a phantom deleted segment behind.
+              if (!pinotFS.touch(destUri)) {
+                LOGGER.warn("Could not touch moved segment file at {}, it may be aged out on the wrong schedule",
+                    destUri);
+              }
+              movedCount++;
             } else {
-              failureCount++;
-              LOGGER.debug("Failed to move segment from {} to {}", srcUri, destUri);
+              failedMoves.add(srcUri);
             }
           } catch (IOException e) {
-            failureCount++;
+            failedMoves.add(srcUri);
             LOGGER.debug("Could not move segment from {} to {}", srcUri, destUri, e);
           }
         }
-        LOGGER.info("Moved {} segment files successfully, {} failed", successCount, failureCount);
-
-        // Batch touch operations on moved files to update timestamps for retention manager
-        LOGGER.info("Touching {} moved segment files", moveDestinations.size());
-        int touchSuccessCount = 0;
-        int touchFailureCount = 0;
-        for (URI destUri : moveDestinations) {
-          try {
-            pinotFS.touch(destUri);
-            touchSuccessCount++;
-          } catch (IOException e) {
-            touchFailureCount++;
-            LOGGER.debug("Could not touch moved segment file at {}", destUri, e);
-          }
+        if (failedMoves.isEmpty()) {
+          LOGGER.info("Moved {} segment files of table {} to the deleted directory", movedCount, tableNameWithType);
+        } else {
+          LOGGER.warn("Moved {} of {} segment files of table {} to the deleted directory; {} failed, first few: {}",
+              movedCount, filesToMove.size(), tableNameWithType, failedMoves.size(),
+              failedMoves.subList(0, Math.min(failedMoves.size(), 10)));
         }
-        LOGGER.info("Touched {} segment files successfully, {} failed", touchSuccessCount, touchFailureCount);
       }
 
       // Batch delete metadata files

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -306,6 +306,8 @@ public class SegmentDeletionManager {
 
     List<URI> filesToDelete = new ArrayList<>();
     List<URI> metadataFilesToDelete = new ArrayList<>();
+    List<URI> filesToMove = new ArrayList<>();
+    List<URI> moveDestinations = new ArrayList<>();
 
     PinotFS pinotFS = PinotFSFactory.create(URIUtils.getUri(_dataDir).getScheme());
 
@@ -324,52 +326,72 @@ public class SegmentDeletionManager {
       if (retentionMs <= 0) {
         filesToDelete.add(fileToDeleteURI);
       } else {
-        moveSegmentsToDeletedDir(segmentId, deletedSegmentsRetentionMs, rawTableName, pinotFS, fileToDeleteURI);
+        // Collect move operations for batched processing
+        String deletedFileName = deletedSegmentsRetentionMs == null ? URIUtils.encode(segmentId)
+            : getDeletedSegmentFileName(URIUtils.encode(segmentId), deletedSegmentsRetentionMs);
+        URI deletedSegmentMoveDestURI = URIUtils.getUri(_dataDir, DELETED_SEGMENTS, rawTableName, deletedFileName);
+        filesToMove.add(fileToDeleteURI);
+        moveDestinations.add(deletedSegmentMoveDestURI);
       }
     }
 
     try {
+      // Batch delete segments with retention <= 0
       if (!filesToDelete.isEmpty()) {
         LOGGER.info("Deleting {} segment files", filesToDelete.size());
         pinotFS.deleteBatch(filesToDelete, true);
       }
+
+      // Batch move segments with retention > 0
+      if (!filesToMove.isEmpty()) {
+        LOGGER.info("Moving {} segment files to deleted directory", filesToMove.size());
+        int successCount = 0;
+        int failureCount = 0;
+        for (int i = 0; i < filesToMove.size(); i++) {
+          URI srcUri = filesToMove.get(i);
+          URI destUri = moveDestinations.get(i);
+          try {
+            // Perform move without individual exists() check for better performance
+            // The move operation will fail gracefully if the source file doesn't exist
+            if (pinotFS.move(srcUri, destUri, true)) {
+              successCount++;
+            } else {
+              failureCount++;
+              LOGGER.debug("Failed to move segment from {} to {}", srcUri, destUri);
+            }
+          } catch (IOException e) {
+            failureCount++;
+            LOGGER.debug("Could not move segment from {} to {}", srcUri, destUri, e);
+          }
+        }
+        LOGGER.info("Moved {} segment files successfully, {} failed", successCount, failureCount);
+
+        // Batch touch operations on moved files to update timestamps for retention manager
+        LOGGER.info("Touching {} moved segment files", moveDestinations.size());
+        int touchSuccessCount = 0;
+        int touchFailureCount = 0;
+        for (URI destUri : moveDestinations) {
+          try {
+            pinotFS.touch(destUri);
+            touchSuccessCount++;
+          } catch (IOException e) {
+            touchFailureCount++;
+            LOGGER.debug("Could not touch moved segment file at {}", destUri, e);
+          }
+        }
+        LOGGER.info("Touched {} segment files successfully, {} failed", touchSuccessCount, touchFailureCount);
+      }
+
+      // Batch delete metadata files
       if (!metadataFilesToDelete.isEmpty()) {
         LOGGER.info("Deleting {} segment metadata files", metadataFilesToDelete.size());
         pinotFS.deleteBatch(metadataFilesToDelete, true);
       }
     } catch (IOException e) {
-      LOGGER.warn("Could not delete segment/metadata files", e);
+      LOGGER.warn("Could not delete/move segment/metadata files", e);
     }
   }
 
-  private void moveSegmentsToDeletedDir(String segmentId, Long deletedSegmentsRetentionMs, String rawTableName,
-      PinotFS pinotFS,
-      URI fileToDeleteURI) {
-    // move the segment file to deleted segments first and let retention manager handler the deletion
-    String deletedFileName = deletedSegmentsRetentionMs == null ? URIUtils.encode(segmentId)
-        : getDeletedSegmentFileName(URIUtils.encode(segmentId), deletedSegmentsRetentionMs);
-    URI deletedSegmentMoveDestURI = URIUtils.getUri(_dataDir, DELETED_SEGMENTS, rawTableName, deletedFileName);
-    try {
-      if (pinotFS.exists(fileToDeleteURI)) {
-        // Overwrites the file if it already exists in the target directory.
-        if (pinotFS.move(fileToDeleteURI, deletedSegmentMoveDestURI, true)) {
-          // Updates last modified.
-          // Touch is needed here so that removeAgedDeletedSegments() works correctly.
-          pinotFS.touch(deletedSegmentMoveDestURI);
-          LOGGER.info("Moved segment {} from {} to {}", segmentId, fileToDeleteURI.toString(),
-              deletedSegmentMoveDestURI.toString());
-        } else {
-          LOGGER.warn("Failed to move segment {} from {} to {}", segmentId, fileToDeleteURI.toString(),
-              deletedSegmentMoveDestURI.toString());
-        }
-      } else {
-        LOGGER.warn("Failed to find local segment file for segment {}", fileToDeleteURI.toString());
-      }
-    } catch (IOException e) {
-      LOGGER.warn("Could not move segment {} from {} to {}", segmentId, fileToDeleteURI.toString(),
-          deletedSegmentMoveDestURI.toString(), e);
-    }
-  }
 
 
   /// Retrieves the URI for segment deletion by checking two possible segment file variants in deep store.

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import javax.ws.rs.core.Response;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.controller.dataproviders.ResourceControllerDataProvider;
 import org.apache.helix.controller.rebalancer.strategy.CrushEdRebalanceStrategy;
@@ -56,6 +57,7 @@ import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.common.utils.helix.LeadControllerUtils;
 import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.api.exception.ControllerApplicationException;
 import org.apache.pinot.controller.api.exception.InvalidTableConfigException;
 import org.apache.pinot.controller.api.resources.InstanceInfo;
 import org.apache.pinot.controller.helix.ControllerTest;
@@ -1866,5 +1868,65 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
 
     _helixResourceManager.deleteRealtimeTable(rawTableName);
     deleteSchema(rawTableName);
+  }
+
+  /// The post-delete audit must actually detect leftover metadata, not just return empty. A live table is the
+  /// cleanest source of "leftovers": every artifact the audit looks for is present, so this exercises the
+  /// detection branches, and deleting the table then proves it reports nothing for a clean delete.
+  @Test
+  public void testFindLeftoverTableMetadataDetectsAndClears()
+      throws Exception {
+    addDummySchema(RAW_TABLE_NAME);
+    TableConfig offlineTableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setBrokerTenant(BROKER_TENANT_NAME)
+            .setServerTenant(SERVER_TENANT_NAME).build();
+    waitForEVToDisappear(offlineTableConfig.getTableName());
+    _helixResourceManager.addTable(offlineTableConfig);
+
+    List<String> leftovers =
+        _helixResourceManager.findLeftoverTableMetadata(OFFLINE_TABLE_NAME, TableType.OFFLINE);
+    assertTrue(leftovers.contains("IdealState"), "A live table's IdealState should be detected, got: " + leftovers);
+    assertTrue(leftovers.contains("TableConfig"), "A live table's config should be detected, got: " + leftovers);
+
+    _helixResourceManager.deleteOfflineTable(OFFLINE_TABLE_NAME);
+
+    assertTrue(_helixResourceManager.findLeftoverTableMetadata(OFFLINE_TABLE_NAME, TableType.OFFLINE).isEmpty(),
+        "A completed delete should leave no audited metadata behind");
+    // NOTE: the RAW_TABLE_NAME schema is created once in setUp() and shared by the rest of this class, so it must
+    // not be deleted here.
+  }
+
+  /// A deletion marker must block both a re-create and a second concurrent delete, and must report CONFLICT
+  /// rather than a generic server error, since both are expected retryable conditions.
+  @Test
+  public void testDeletionMarkerBlocksCreateAndConcurrentDelete()
+      throws Exception {
+    addDummySchema(RAW_TABLE_NAME);
+    TableConfig offlineTableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setBrokerTenant(BROKER_TENANT_NAME)
+            .setServerTenant(SERVER_TENANT_NAME).build();
+
+    // Simulate a delete that is in flight on some other controller.
+    assertTrue(ZKMetadataProvider.createTableDeletionMarker(_helixResourceManager.getPropertyStore(),
+        OFFLINE_TABLE_NAME, "Controller_other_9000"));
+    try {
+      ControllerApplicationException createFailure = expectThrows(ControllerApplicationException.class,
+          () -> _helixResourceManager.addTable(offlineTableConfig));
+      assertEquals(createFailure.getResponse().getStatus(), Response.Status.CONFLICT.getStatusCode(),
+          "Creating a table whose deletion is in flight should be a conflict, not a server error");
+
+      ControllerApplicationException deleteFailure = expectThrows(ControllerApplicationException.class,
+          () -> _helixResourceManager.deleteOfflineTable(OFFLINE_TABLE_NAME));
+      assertEquals(deleteFailure.getResponse().getStatus(), Response.Status.CONFLICT.getStatusCode(),
+          "A second concurrent delete should be a conflict, not a server error");
+    } finally {
+      ZKMetadataProvider.removeTableDeletionMarker(_helixResourceManager.getPropertyStore(), OFFLINE_TABLE_NAME,
+          "Controller_other_9000");
+    }
+
+    // With the marker gone the table can be created and deleted normally again.
+    _helixResourceManager.addTable(offlineTableConfig);
+    _helixResourceManager.deleteOfflineTable(OFFLINE_TABLE_NAME);
+    // NOTE: the RAW_TABLE_NAME schema is shared across this class; leave it in place.
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
@@ -737,4 +737,72 @@ public class SegmentDeletionManagerTest {
       }
     }
   }
+
+  /// A filesystem whose moves always fail, recording attempted moves and touches so a test can assert that we
+  /// never touch a destination we did not create.
+  public static class MoveFailingPinotFs extends LocalPinotFS {
+    static final List<URI> ATTEMPTED_MOVES = new ArrayList<>();
+    static final List<URI> TOUCHED_URIS = new ArrayList<>();
+
+    static synchronized void reset() {
+      ATTEMPTED_MOVES.clear();
+      TOUCHED_URIS.clear();
+    }
+
+    @Override
+    public synchronized boolean move(URI srcUri, URI dstUri, boolean overwrite) {
+      ATTEMPTED_MOVES.add(srcUri);
+      return false;
+    }
+
+    @Override
+    public synchronized boolean touch(URI uri) {
+      TOUCHED_URIS.add(uri);
+      return true;
+    }
+  }
+
+  /// Touching a destination whose move failed materializes an empty file in the deleted-segments directory on
+  /// object stores, leaving a phantom segment for the retention manager to track. Only successful moves may be
+  /// touched.
+  @Test
+  public void testFailedMoveDoesNotTouchDestination()
+      throws Exception {
+    MoveFailingPinotFs.reset();
+    // The data dir is a local path, so the deletion manager resolves the "file" scheme. Override that scheme and
+    // restore it afterwards so the rest of the suite keeps the real local filesystem.
+    PinotFSFactory.register(PinotFSFactory.LOCAL_PINOT_FS_SCHEME, MoveFailingPinotFs.class.getName(),
+        new PinotConfiguration());
+    try {
+      File tempDir = Files.createTempDirectory("pinot-test-").toFile();
+      tempDir.deleteOnExit();
+      SegmentDeletionManager deletionManager =
+          createDeletionManager(tempDir.getAbsolutePath(), makeHelixAdmin(), CLUSTER_NAME, makePropertyStore(), 7);
+
+      List<String> segments = segmentsThatShouldBeDeleted();
+      createTableAndSegmentFiles(tempDir, segments);
+
+      // Retention > 0 takes the move path rather than the immediate-delete path.
+      deletionManager.removeSegmentsFromStoreInBatch(TABLE_NAME, segments, TimeUnit.DAYS.toMillis(7));
+
+      synchronized (MoveFailingPinotFs.class) {
+        // Guard against the test silently passing because the move path was never reached at all.
+        Assert.assertEquals(MoveFailingPinotFs.ATTEMPTED_MOVES.size(), segments.size(),
+            "Expected one move attempt per segment on the retention > 0 path");
+        Assert.assertTrue(MoveFailingPinotFs.TOUCHED_URIS.isEmpty(),
+            "No destination should be touched when every move failed, but touched: "
+                + MoveFailingPinotFs.TOUCHED_URIS);
+      }
+
+      File deletedTableDir = new File(
+          tempDir.getAbsolutePath() + File.separator + SegmentDeletionManager.DELETED_SEGMENTS + File.separator
+              + TABLE_NAME);
+      File[] phantoms = deletedTableDir.listFiles();
+      Assert.assertTrue(phantoms == null || phantoms.length == 0,
+          "Failed moves must not leave phantom files in the deleted-segments directory");
+    } finally {
+      PinotFSFactory.register(PinotFSFactory.LOCAL_PINOT_FS_SCHEME, LocalPinotFS.class.getName(),
+          new PinotConfiguration());
+    }
+  }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
@@ -738,6 +738,82 @@ public class SegmentDeletionManagerTest {
     }
   }
 
+  /// A filesystem whose moves succeed but whose touch reports failure, to exercise the warning path.
+  public static class TouchFailingPinotFs extends LocalPinotFS {
+    @Override
+    public boolean touch(URI uri) {
+      return false;
+    }
+  }
+
+  /// A filesystem whose moves throw, to exercise the IOException path around the move.
+  public static class MoveThrowingPinotFs extends LocalPinotFS {
+    @Override
+    public boolean move(URI srcUri, URI dstUri, boolean overwrite)
+        throws IOException {
+      throw new IOException("simulated deep store failure");
+    }
+  }
+
+  /// A failed touch must not fail the deletion: the segment has already been moved, it just may age out on the
+  /// cluster default schedule instead of its own.
+  @Test
+  public void testFailedTouchStillCompletesTheMove()
+      throws Exception {
+    PinotFSFactory.register(PinotFSFactory.LOCAL_PINOT_FS_SCHEME, TouchFailingPinotFs.class.getName(),
+        new PinotConfiguration());
+    try {
+      File tempDir = Files.createTempDirectory("pinot-test-").toFile();
+      tempDir.deleteOnExit();
+      SegmentDeletionManager deletionManager =
+          createDeletionManager(tempDir.getAbsolutePath(), makeHelixAdmin(), CLUSTER_NAME, makePropertyStore(), 7);
+      List<String> segments = segmentsThatShouldBeDeleted();
+      createTableAndSegmentFiles(tempDir, segments);
+
+      deletionManager.removeSegmentsFromStoreInBatch(TABLE_NAME, segments, TimeUnit.DAYS.toMillis(7));
+
+      File deletedTableDir = new File(
+          tempDir.getAbsolutePath() + File.separator + SegmentDeletionManager.DELETED_SEGMENTS + File.separator
+              + TABLE_NAME);
+      File[] moved = deletedTableDir.listFiles();
+      Assert.assertNotNull(moved);
+      Assert.assertEquals(moved.length, segments.size(), "Segments should still be moved when touch fails");
+    } finally {
+      PinotFSFactory.register(PinotFSFactory.LOCAL_PINOT_FS_SCHEME, LocalPinotFS.class.getName(),
+          new PinotConfiguration());
+    }
+  }
+
+  /// A move that throws must be reported rather than aborting the whole batch, and must not leave a destination
+  /// behind.
+  @Test
+  public void testMoveThrowingIsContainedPerSegment()
+      throws Exception {
+    PinotFSFactory.register(PinotFSFactory.LOCAL_PINOT_FS_SCHEME, MoveThrowingPinotFs.class.getName(),
+        new PinotConfiguration());
+    try {
+      File tempDir = Files.createTempDirectory("pinot-test-").toFile();
+      tempDir.deleteOnExit();
+      SegmentDeletionManager deletionManager =
+          createDeletionManager(tempDir.getAbsolutePath(), makeHelixAdmin(), CLUSTER_NAME, makePropertyStore(), 7);
+      List<String> segments = segmentsThatShouldBeDeleted();
+      createTableAndSegmentFiles(tempDir, segments);
+
+      // Must not propagate: one bad segment should not abort the rest of the table's cleanup.
+      deletionManager.removeSegmentsFromStoreInBatch(TABLE_NAME, segments, TimeUnit.DAYS.toMillis(7));
+
+      File deletedTableDir = new File(
+          tempDir.getAbsolutePath() + File.separator + SegmentDeletionManager.DELETED_SEGMENTS + File.separator
+              + TABLE_NAME);
+      File[] phantoms = deletedTableDir.listFiles();
+      Assert.assertTrue(phantoms == null || phantoms.length == 0,
+          "A throwing move must not leave anything in the deleted-segments directory");
+    } finally {
+      PinotFSFactory.register(PinotFSFactory.LOCAL_PINOT_FS_SCHEME, LocalPinotFS.class.getName(),
+          new PinotConfiguration());
+    }
+  }
+
   /// A filesystem whose moves always fail, recording attempted moves and touches so a test can assert that we
   /// never touch a destination we did not create.
   public static class MoveFailingPinotFs extends LocalPinotFS {


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Table deletion acquires marker to block concurrent deletes and recreation; addTable checks marker to block during deletion\.

```mermaid
flowchart TD
  N0["deleteTable start #40;F2#41;"]:::stAdded
  N1["Check MV deps #40;F2#41;"]:::stAdded
  N2["Acquire del marker #40;F2#44; F1#41;"]:::stModified
  N3["Perform deletion #40;F2#41;"]:::stModified
  N4["Audit leftovers #40;F2#41;"]:::stAdded
  N5["Release marker #40;F2#44; F1#41;"]:::stModified
  N6["addTable start #40;F2#41;"]:::stAdded
  N7["Check del marker #40;F2#44; F1#41;"]:::stAdded
  N8["Proceed addTable #40;F2#41;"]:::stAdded
  N0 -->|"next"| N1
  N1 -->|"next"| N2
  N2 -->|"marker acquired"| N3
  N3 -->|"next"| N4
  N4 -->|"next"| N5
  N6 -->|"next"| N7
  N7 -->|"no existing marker"| N8
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider\.java — [before](https://github.com/apache/pinot/blob/ffa97d97d9004138173aa5c08f0ff4b7fd2d1771/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java) · [after](https://github.com/apache/pinot/blob/9f70e3ca6ff18cd275d684443e6ff42efc3fdfc0/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java)
- F2: pinot\-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager\.java — [before](https://github.com/apache/pinot/blob/ffa97d97d9004138173aa5c08f0ff4b7fd2d1771/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java) · [after](https://github.com/apache/pinot/blob/9f70e3ca6ff18cd275d684443e6ff42efc3fdfc0/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImZmYTk3ZDk3ZDkwMDQxMzgxNzNhYTVjMDhmMGZmNGI3ZmQyZDE3NzEiLCJjb250ZXh0X2hhc2giOiJkYzI1Y2Q2Mjk5ZDM5ZDViODRlMzNmYmJlZWE0Y2ZkODYwMzRjZGIwYjQ4MjEzNThmNjgxNTZjYzM5MzI1Y2MwIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MTk1MzQ3LCJoZWFkX3NoYSI6IjlmNzBlM2NhNmZmMThjZDI3NWQ2ODQ0NDNlNmZmNDJlZmMzZmRmYzAiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIyYWEzYWFkODE1ZDU4MTE0YmIxNzYxZjRhYjE0ZmIxMjI0ODMwZTBkIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature c0c005d78963a66d9b433ecb0644618bd9abae0dc2d0a7f14939f3e269caba00 -->
<!-- pinot-pr-flow:end -->

## Description

`DELETE /tables/{tableName}` has no mutual exclusion. The endpoint is not `@LeaderOnly`, so any controller can serve it, and `PinotHelixResourceManager.deleteTable()` is not synchronized (unlike `deleteSegment()` and `addInstance()`). Two concurrent deletes of the same table therefore interleave freely, and because the table config is removed last, a `POST /tables` can also re-create a table while an in-flight deletion is still tearing its metadata down — the new table then loses metadata to the older delete.

Note that `synchronized` alone cannot fix this: the request can land on any controller, so the exclusion has to be cluster-wide.

## What this changes

**Deletion marker znode (`/TABLE_DELETION_IN_PROGRESS/<tableNameWithType>`)**

- `deleteTable()` acquires a marker before touching any metadata and releases it in a `finally`. A second concurrent delete of the same table is rejected with `IllegalStateException`.
- `addTable()` refuses to create a table while a valid marker exists for it.
- The marker records the owning controller and a start timestamp, and is considered stale after 24 hours so a controller that crashes mid-deletion cannot block the table forever.
- Acquisition uses `propertyStore.create()` (atomic) for the common case, and a **version-checked `set()`** when reclaiming a stale marker, following the existing `ZkBadVersionException` idiom in `ZKMetadataProvider.setSegmentZKMetadata()`. A remove-then-create reclaim would be a non-atomic read-modify-write: two controllers could both observe the same stale marker and both believe they acquired it, and it would leave the path briefly empty, which would let `addTable()` through.
- Release is ownership-checked. A controller that stalled past the expiry window and was taken over must not delete the new owner's marker on its way out.

**Honour the table config's `deletedSegmentsRetentionPeriod` in `deleteTable()`**

`deleteTable()` called `removeSegmentsFromStoreInBatch()` with only the request's `retention` query parameter, so when that was absent the table's own `deletedSegmentsRetentionPeriod` was ignored and the cluster-wide default applied. It now falls back to `SegmentDeletionManager.getRetentionMsFromTableConfig()`, which is the existing helper used by the `deleteSegments(..., TableConfig)` path and which tolerates an empty or malformed period rather than throwing.

**Post-deletion metadata audit (warn only)**

After a delete completes, the property store is checked for artifacts that `deleteTable()` should have removed, and anything left behind is logged at `warn` for an operator to clean up.

This deliberately does not throw: by that point the table config is already gone, so the delete has succeeded from the caller's point of view, and failing the request would report a misleading error for a table that no longer exists. It also deliberately does not check the ExternalView, which Helix removes asynchronously after the IdealState drops and which is therefore routinely still present at that point. Tier instance partitions, minion task metadata and materialized view metadata are not audited, because covering them would mean scanning every instance-partitions / task znode in the cluster on every delete; this is called out in the javadoc.

**Status codes**

Both guards report **409 CONFLICT** rather than 500. A concurrent delete, or a create racing an in-flight delete, is expected and retryable, not a server fault, and a 500 would register as an outage in monitoring. `addTable()` already rethrows `ControllerApplicationException` untouched; the DELETE handler wrapped every exception into a 500, so it now rethrows a deliberate status rather than downgrading it. `PinotHelixResourceManager` already throws `ControllerApplicationException` elsewhere, so this follows the existing pattern.

**Ordering**

The materialized-view dependency check now runs before the marker is acquired, so a refused delete does not leave a marker that makes an unrelated `addTable()` report a deletion in progress.

**Minor: segment move loop in `SegmentDeletionManager`**

The `retention > 0` path previously called a per-segment helper that did an `exists()` check before each move and logged one line per segment. `getFileToDeleteURI()` already establishes that the file exists, so the inner check is redundant; removing it saves one round trip per segment and the logging is now aggregated. `PinotFS` has no batch move, so **this is still one `move()` per segment** — the saving is one `exists()` call and one log line per segment, not an order-of-magnitude change. Also fixed: `touch()` is now only called on destinations whose move actually succeeded, since touching a failed destination can materialize an empty object on object stores and leave a phantom entry for the retention manager to track.

## What this does NOT fix

- **The `addTable()` guard is still TOCTOU.** The marker check is a point-in-time read; a delete can begin immediately after it passes. This narrows the window substantially but does not close it. Closing it properly needs table epoch / creation-UUID fencing, which is not in this PR.
- **Removal of the final table config is still unconditional** (no compare-and-set on `removeResourceConfigFromPropertyStore`).
- **`DELETE` still proceeds when the table does not exist**, by design in `PinotTableRestletResource`. Unchanged here.
- A stale marker blocks re-creation of that table for up to 24 hours. The error messages name the znode path so an operator can clear it sooner. There is no automatic startup cleanup; metrics for active/expired markers would be a reasonable follow-up.

## Testing

- `TableDeletionMarkerTest` (new, 16 tests) against an embedded `ZkStarter` server: acquisition, duplicate rejection, marker contents, expiry boundaries, malformed markers, stale takeover, ownership-checked release, per-table independence, and two controllers racing to acquire the marker via two independent property stores.
- `SegmentDeletionManagerTest`: added a regression test for the touch-on-failed-move bug, verified to fail before the fix and pass after. Existing 8 tests still pass.
- `PinotTableRestletResourceTest` (27 existing tests) passes, covering the modified DELETE handler including the 404-when-the-table-does-not-exist path.
- Verified locally on JDK 25: `pinot-common` and `pinot-controller` compile, the above suites pass, `checkstyle` reports 0 violations, `license:check` clean, `spotless:apply` applied.

**Known gap in test coverage:** the single-winner test asserts the invariant but is not a regression test for the non-atomic takeover it replaced. That window is sub-millisecond and could not be hit reliably from a test, and a ZK data watch cannot distinguish remove-then-create from an in-place set because zkclient dispatches on the node's state at event-processing time. The takeover's correctness rests on the ZooKeeper version check itself rather than on a red-then-green test, and is worth reviewing on that basis.

## Backward compatibility / operational notes

- Adds one new top-level property store path, `/TABLE_DELETION_IN_PROGRESS`, matching the existing convention (`/SEGMENTS`, `/MINION_TASK_METADATA`, …). Nothing in the repo enumerates the property store root, so no existing tooling is affected.
- New user-visible failure modes: `POST /tables` and `DELETE /tables/{tableName}` can now fail with **HTTP 409 CONFLICT** and "a deletion is in progress" where they previously proceeded. This is the intended behaviour change and may warrant the `release-notes` label.
- No public API removals. `ZKMetadataProvider.removeTableDeletionMarker` takes an owner id (added in this PR, no external callers).

## Files changed

- `pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java`
- `pinot-common/src/test/java/org/apache/pinot/common/metadata/TableDeletionMarkerTest.java` (new)
- `pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java`
- `pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java`
- `pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java`
- `pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java`

Suggested labels: `bug`, `release-notes`
