### PR TITLE
Shut down the task manager's cron scheduler when the controller stops

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -1191,6 +1191,11 @@ public abstract class BaseControllerStarter implements ServiceStartable {
       LOGGER.info("Stopping controller periodic tasks");
       _periodicTaskScheduler.stop();
 
+      // Also has to be done before stopping HelixResourceManager: the task manager runs its cron jobs on a
+      // scheduler of its own, which is separate from the periodic task scheduler stopped above.
+      LOGGER.info("Stopping task scheduler");
+      _taskManager.stopScheduler();
+
       LOGGER.info("Stopping lead controller manager");
       _leadControllerManager.stop();
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -1068,6 +1068,26 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
     }
   }
 
+  /// Shuts down the cron scheduler started by [#init()], its counterpart in the controller shutdown sequence.
+  ///
+  /// Must be called before the controller tears down Helix. The scheduler's worker threads are not daemons and keep
+  /// firing jobs until it is shut down, so otherwise the cron jobs keep running against a closed `ZkClient` and the
+  /// threads outlive the controller.
+  ///
+  /// Waits for the jobs already in flight, so a task generation in progress is not cut off midway. Safe to call more
+  /// than once, and a no-op when the scheduler is disabled.
+  public void stopScheduler() {
+    if (_scheduler == null) {
+      return;
+    }
+    try {
+      LOGGER.info("Shutting down the task scheduler");
+      _scheduler.shutdown(true);
+    } catch (SchedulerException e) {
+      LOGGER.error("Caught exception while shutting down the task scheduler", e);
+    }
+  }
+
   @Override
   protected void nonLeaderCleanup(List<String> tableNamesWithType) {
     LOGGER.info(

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerStatelessTest.java
@@ -83,6 +83,24 @@ public class PinotTaskManagerStatelessTest extends ControllerTest {
   }
 
   @Test
+  public void testSchedulerShutDownWithController()
+      throws Exception {
+    Map<String, Object> properties = getDefaultControllerConfiguration();
+    properties.put(ControllerConf.ControllerPeriodicTasksConf.PINOT_TASK_MANAGER_SCHEDULER_ENABLED, true);
+    startController(properties);
+    Scheduler scheduler = _controllerStarter.getTaskManager().getScheduler();
+    assertNotNull(scheduler);
+    assertTrue(scheduler.isStarted());
+    assertFalse(scheduler.isShutdown());
+
+    stopController();
+
+    // The scheduler's worker threads are not daemons, so one left running outlives the controller and keeps firing
+    // cron jobs against the ZkClient that the shutdown has already closed.
+    assertTrue(scheduler.isShutdown());
+  }
+
+  @Test
   public void testSkipLateCronSchedule()
       throws Exception {
     Map<String, Object> properties = getDefaultControllerConfiguration();


### PR DESCRIPTION
## Summary

`PinotTaskManager` runs its per-table cron jobs on a Quartz scheduler of its own, created in the constructor and
started in `init()`. Nothing ever shut it down.

This is easy to miss because there are two Quartz schedulers in play. `PeriodicTaskScheduler` owns one and shuts it
down correctly in its `stop()`. The one `PinotTaskManager` owns is separate, and `cleanUpTask()` — the only shutdown
hook it participates in — just cleans up the task generators. So it kept firing after `stopPinotController()` had
closed the ZkClient through `_helixResourceManager.stop()`:

```
ERROR [JobRunShell] Job ... threw an unhandled Exception:
java.lang.IllegalStateException: ZkClient already closed!
    at org.apache.helix.zookeeper.zkclient.ZkClient.retryUntilConnected(ZkClient.java:2166)
    ...
```

Quartz's `SimpleThreadPool` workers are not daemon threads either, so they outlived every controller stop. That
accumulates across controller restarts inside a single JVM, which is what integration tests do.

## Approach

`stopScheduler()` is added as the explicit counterpart to `init()`, and called from `stopPinotController()` right
after the periodic task scheduler stops — well before Helix is torn down.

It deliberately does *not* hang off `cleanUpTask()`, which would look like the natural hook. `cleanUpTask()` is also
used as a plain "reset the generators" operation on a live controller — see
`RealtimeToOfflineSegmentsMinionClusterIntegrationTest` — so attaching an irreversible scheduler shutdown to it would
be a trap for the next caller that does the same.

`shutdown(true)` waits for the jobs already in flight, so a task generation in progress is not cut off midway. This
matches what `PeriodicTaskScheduler` does for its own scheduler.

`stopScheduler()` is a no-op when the cron scheduler is disabled, which is the default
(`controller.task.scheduler.enabled`), so nothing changes for controllers that never start one.

## Coverage

`PinotTaskManagerStatelessTest#testSchedulerShutDownWithController` starts a controller with the scheduler enabled,
stops it, and asserts the scheduler is shut down. It fails on `master` and passes with this change.
