### PR TITLE
Extract shared ServiceLoader plugin-discovery helper into PluginManager

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -25,11 +25,8 @@ import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.ServiceConfigurationError;
-import java.util.ServiceLoader;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.function.FunctionInfo;
@@ -325,8 +322,8 @@ public class TransformFunctionFactory {
   }
 
   /// Initializes the factory with the explicitly configured transform function classes (`pinot.server.transforms`)
-  /// and the [TransformFunction] service providers discovered via [ServiceLoader] (see the class documentation for
-  /// the provider contract).
+  /// and the [TransformFunction] service providers discovered via [PluginManager#loadServiceProviders(Class)] (see
+  /// the class documentation for the provider contract).
   ///
   /// Should be called during server startup, after all plugins have been loaded and before serving queries. The
   /// registry is built and validated locally and published atomically, so concurrent readers never observe a
@@ -347,15 +344,11 @@ public class TransformFunctionFactory {
     }
 
     // Discover service providers from the thread context classloader (the application classpath in a standard
-    // server deployment), then from every plugin classloader. Dedup by class name: the context classloader and a
-    // plugin classloader may both see the same META-INF/services file if their classpaths overlap (e.g. fat-jar +
-    // plugin realm).
-    Map<String, Class<? extends TransformFunction>> seenProviderClasses = new HashMap<>();
-    registerServiceProviders(ServiceLoader.load(TransformFunction.class), "thread context classloader", registry,
-        seenProviderClasses, explicitClassNames);
-    for (ClassLoader pluginClassLoader : PluginManager.get().getPluginClassLoaders()) {
-      registerServiceProviders(ServiceLoader.load(TransformFunction.class, pluginClassLoader),
-          "plugin classloader: " + pluginClassLoader, registry, seenProviderClasses, explicitClassNames);
+    // server deployment) and from every plugin classloader, de-duplicated by implementation class name (see
+    // PluginManager#loadServiceProviders)
+    for (PluginManager.ServiceProvider<TransformFunction> discovered : PluginManager.get()
+        .loadServiceProviders(TransformFunction.class)) {
+      registerServiceProvider(discovered.getProvider(), discovered.getSource(), registry, explicitClassNames);
     }
 
     // Register the explicitly configured classes last: explicit configuration keeps its historical override
@@ -385,81 +378,56 @@ public class TransformFunctionFactory {
     _transformFunctionMap = Collections.unmodifiableMap(registry);
   }
 
-  /// Registers the [TransformFunction] service providers visible through the given [ServiceLoader] into the local
-  /// registry being built. The provider instance is only used to obtain the implementation class and validate its
-  /// name; it is never initialized or evaluated. Fails fast (preserving the original cause) on malformed service
-  /// descriptors, providers that cannot be constructed, null/blank function names, and canonical name collisions.
-  private static void registerServiceProviders(ServiceLoader<TransformFunction> serviceLoader, String source,
-      Map<String, Class<? extends TransformFunction>> registry,
-      Map<String, Class<? extends TransformFunction>> seenProviderClasses, Set<String> explicitClassNames) {
-    Iterator<TransformFunction> iterator = serviceLoader.iterator();
-    while (true) {
-      TransformFunction provider;
-      try {
-        if (!iterator.hasNext()) {
-          return;
-        }
-        provider = iterator.next();
-      } catch (ServiceConfigurationError e) {
-        throw new IllegalStateException("Failed to load a TransformFunction service provider from: " + source, e);
-      }
-      Class<? extends TransformFunction> providerClass = provider.getClass();
-      String providerClassName = providerClass.getName();
-      if (explicitClassNames.contains(providerClassName)) {
-        LOGGER.info("Skipping service provider: {} (from: {}) which is also explicitly configured", providerClassName,
-            source);
-        continue;
-      }
-      Class<? extends TransformFunction> seenClass = seenProviderClasses.putIfAbsent(providerClassName, providerClass);
-      if (seenClass != null) {
-        // Same implementation already discovered through an overlapping classloader. A different Class object with
-        // the same name indicates version skew between classloaders; the first discovered copy wins.
-        if (seenClass != providerClass) {
-          LOGGER.warn("Ignoring duplicate service provider class: {} (classloader: {}, discovered from: {}); keeping "
-                  + "the copy from classloader: {}", providerClassName, providerClass.getClassLoader(), source,
-              seenClass.getClassLoader());
-        }
-        continue;
-      }
-      String name = provider.getName();
-      if (StringUtils.isBlank(name)) {
-        throw new IllegalStateException("TransformFunction service provider: " + providerClassName + " (classloader: "
-            + providerClass.getClassLoader() + ", discovered from: " + source + ") returned a "
-            + (name == null ? "null" : "blank") + " name from getName()");
-      }
-      String canonicalName = canonicalize(name);
-      Class<? extends TransformFunction> existing = registry.get(canonicalName);
-      if (existing != null) {
-        if (existing.getName().equals(providerClassName)) {
-          // Repeated registration of the identical implementation is a no-op. A different Class object with the same
-          // name indicates version skew between classloaders; the registered copy wins.
-          if (existing != providerClass) {
-            LOGGER.warn("Function: {} is already registered with class: {} from classloader: {}; ignoring the copy "
-                    + "from classloader: {} (discovered from: {})", canonicalName, existing.getName(),
-                existing.getClassLoader(), providerClass.getClassLoader(), source);
-          }
-          continue;
-        }
-        String existingDescription = BUILT_IN_TRANSFORM_FUNCTIONS.get(canonicalName) == existing
-            ? "built-in transform function class: " + existing.getName()
-            : "discovered transform function class: " + existing.getName();
-        throw new IllegalStateException(
-            "Transform function name collision on: " + canonicalName + ". Service provider class: "
-                + providerClassName + " (classloader: " + providerClass.getClassLoader() + ", discovered from: "
-                + source + ") collides with " + existingDescription + " (classloader: " + existing.getClassLoader()
-                + ")");
-      }
-      if (FunctionRegistry.contains(FunctionRegistry.canonicalize(name))) {
-        // Not a failure: providing a block-oriented implementation of an existing scalar function is the same
-        // pattern the built-ins use — but for an independently owned scalar function the semantics may diverge
-        // (e.g. literal-only invocations still constant-fold through the scalar implementation at compile time).
-        LOGGER.warn("Service-discovered transform function: {} with class: {} (from: {}) shadows a scalar function "
-            + "with the same name for single-stage server-side execution", canonicalName, providerClassName, source);
-      }
-      registry.put(canonicalName, providerClass);
-      LOGGER.info("Registering service-discovered function: {} with class: {} (from: {})", canonicalName,
-          providerClassName, source);
+  /// Registers a discovered [TransformFunction] service provider into the local registry being built. The provider
+  /// instance is only used to obtain the implementation class and validate its name; it is never initialized or
+  /// evaluated. Fails fast on null/blank function names and canonical name collisions.
+  private static void registerServiceProvider(TransformFunction provider, String source,
+      Map<String, Class<? extends TransformFunction>> registry, Set<String> explicitClassNames) {
+    Class<? extends TransformFunction> providerClass = provider.getClass();
+    String providerClassName = providerClass.getName();
+    if (explicitClassNames.contains(providerClassName)) {
+      LOGGER.info("Skipping service provider: {} (from: {}) which is also explicitly configured", providerClassName,
+          source);
+      return;
     }
+    String name = provider.getName();
+    if (StringUtils.isBlank(name)) {
+      throw new IllegalStateException("TransformFunction service provider: " + providerClassName + " (classloader: "
+          + providerClass.getClassLoader() + ", discovered from: " + source + ") returned a "
+          + (name == null ? "null" : "blank") + " name from getName()");
+    }
+    String canonicalName = canonicalize(name);
+    Class<? extends TransformFunction> existing = registry.get(canonicalName);
+    if (existing != null) {
+      if (existing.getName().equals(providerClassName)) {
+        // Repeated registration of the identical implementation is a no-op. A different Class object with the same
+        // name indicates version skew between classloaders; the registered copy wins.
+        if (existing != providerClass) {
+          LOGGER.warn("Function: {} is already registered with class: {} from classloader: {}; ignoring the copy "
+                  + "from classloader: {} (discovered from: {})", canonicalName, existing.getName(),
+              existing.getClassLoader(), providerClass.getClassLoader(), source);
+        }
+        return;
+      }
+      String existingDescription = BUILT_IN_TRANSFORM_FUNCTIONS.get(canonicalName) == existing
+          ? "built-in transform function class: " + existing.getName()
+          : "discovered transform function class: " + existing.getName();
+      throw new IllegalStateException(
+          "Transform function name collision on: " + canonicalName + ". Service provider class: "
+              + providerClassName + " (classloader: " + providerClass.getClassLoader() + ", discovered from: "
+              + source + ") collides with " + existingDescription + " (classloader: " + existing.getClassLoader()
+              + ")");
+    }
+    if (FunctionRegistry.contains(FunctionRegistry.canonicalize(name))) {
+      // Not a failure: providing a block-oriented implementation of an existing scalar function is the same
+      // pattern the built-ins use — but for an independently owned scalar function the semantics may diverge
+      // (e.g. literal-only invocations still constant-fold through the scalar implementation at compile time).
+      LOGGER.warn("Service-discovered transform function: {} with class: {} (from: {}) shadows a scalar function "
+          + "with the same name for single-stage server-side execution", canonicalName, providerClassName, source);
+    }
+    registry.put(canonicalName, providerClass);
+    LOGGER.info("Registering service-discovered function: {} with class: {} (from: {})", canonicalName,
+        providerClassName, source);
   }
 
   /// Returns an instance of transform function for the given expression.

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -24,8 +24,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.function.FunctionInfo;
@@ -90,18 +94,60 @@ import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
+import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
 /// Factory class for transformation functions.
+///
+/// The registry always contains the built-in transform functions. On top of those, [#init(Set)] registers external
+/// block-oriented [TransformFunction] implementations from two sources:
+///
+/// 1. **`ServiceLoader` discovery.** Any jar visible through the thread context classloader (the application
+///    classpath in a standard server deployment), or through any plugin classloader returned by
+///    [PluginManager#getPluginClassLoaders()], can register transform functions by shipping a standard service
+///    descriptor:
+///
+///    `META-INF/services/org.apache.pinot.core.operator.transform.function.TransformFunction`
+///
+///    listing one implementation class per line. A provider must be a public concrete class with a public
+///    no-argument constructor, and must return a non-null, non-blank name from [TransformFunction#getName()]. The
+///    instance created at discovery time is used only to read and validate its name; it is never initialized or
+///    evaluated — query execution always constructs a fresh instance through this factory. Names are canonicalized
+///    with [#canonicalize(String)]. The same implementation class visible through overlapping classloaders is
+///    de-duplicated, but a discovered class whose canonical name collides with a built-in or with a different
+///    discovered class fails initialization, as does any malformed descriptor or misbehaving provider.
+///
+/// 2. **Explicit configuration** (`pinot.server.transforms`). Explicitly configured classes are registered after
+///    discovered ones and keep their historical override semantics: they may replace built-in as well as discovered
+///    registrations. Discovery skips classes that are also explicitly configured, so shipping a service descriptor
+///    for an explicitly configured class never causes a collision failure.
+///
+/// Discovery only runs inside [#init(Set)], which the server calls once during startup after plugins are loaded;
+/// the query path ([#get]) performs plain map lookups against an immutable snapshot and never triggers
+/// `ServiceLoader` work. [#init(Set)] is synchronized and atomically publishes a fully validated snapshot, so
+/// concurrent readers never observe a partially initialized registry; calling it again with the same inputs is
+/// idempotent. Note that each function-expression lookup reads the current snapshot, so an expression compiled
+/// concurrently with a re-initialization may resolve different sub-expressions against different (complete)
+/// snapshots — irrelevant in practice because initialization happens before queries are served.
+///
+/// Note: this registers functions for server-side single-stage (leaf) execution only. It does not register them
+/// with the multi-stage engine's function catalog ([org.apache.pinot.common.function.FunctionRegistry] /
+/// PinotOperatorTable).
 public class TransformFunctionFactory {
   private TransformFunctionFactory() {
   }
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TransformFunctionFactory.class);
-  private static final Map<String, Class<? extends TransformFunction>> TRANSFORM_FUNCTION_MAP = createRegistry();
+  private static final Map<String, Class<? extends TransformFunction>> BUILT_IN_TRANSFORM_FUNCTIONS =
+      Collections.unmodifiableMap(createRegistry());
+
+  /// Immutable snapshot of the transform function registry, atomically replaced by [#init(Set)]. Starts as the
+  /// built-in registry so the factory is usable without an explicit init call.
+  private static volatile Map<String, Class<? extends TransformFunction>> _transformFunctionMap =
+      BUILT_IN_TRANSFORM_FUNCTIONS;
 
   private static Map<String, Class<? extends TransformFunction>> createRegistry() {
     Map<TransformFunctionType, Class<? extends TransformFunction>> typeToImplementation =
@@ -278,12 +324,42 @@ public class TransformFunctionFactory {
     return registry;
   }
 
-  /// Initializes the factory with a set of transform function classes.
+  /// Initializes the factory with the explicitly configured transform function classes (`pinot.server.transforms`)
+  /// and the [TransformFunction] service providers discovered via [ServiceLoader] (see the class documentation for
+  /// the provider contract).
   ///
-  /// Should be called only once before using the factory.
+  /// Should be called during server startup, after all plugins have been loaded and before serving queries. The
+  /// registry is built and validated locally and published atomically, so concurrent readers never observe a
+  /// partially initialized registry; repeated calls with the same inputs are idempotent. Any discovery or
+  /// validation failure aborts initialization (with the original cause preserved) and leaves the previously
+  /// published registry in place.
   ///
-  /// @param transformFunctionClasses Set of transform function classes
-  public static void init(Set<Class<TransformFunction>> transformFunctionClasses) {
+  /// @param transformFunctionClasses Set of explicitly configured transform function classes
+  public static synchronized void init(Set<Class<TransformFunction>> transformFunctionClasses) {
+    Map<String, Class<? extends TransformFunction>> registry = new HashMap<>(BUILT_IN_TRANSFORM_FUNCTIONS);
+
+    // Classes registered through explicit configuration are skipped during discovery: the explicit registration
+    // below handles them with its historical override semantics, so a service descriptor shipped for an explicitly
+    // configured class must not fail startup as a collision.
+    Set<String> explicitClassNames = new HashSet<>();
+    for (Class<TransformFunction> transformFunctionClass : transformFunctionClasses) {
+      explicitClassNames.add(transformFunctionClass.getName());
+    }
+
+    // Discover service providers from the thread context classloader (the application classpath in a standard
+    // server deployment), then from every plugin classloader. Dedup by class name: the context classloader and a
+    // plugin classloader may both see the same META-INF/services file if their classpaths overlap (e.g. fat-jar +
+    // plugin realm).
+    Map<String, Class<? extends TransformFunction>> seenProviderClasses = new HashMap<>();
+    registerServiceProviders(ServiceLoader.load(TransformFunction.class), "thread context classloader", registry,
+        seenProviderClasses, explicitClassNames);
+    for (ClassLoader pluginClassLoader : PluginManager.get().getPluginClassLoaders()) {
+      registerServiceProviders(ServiceLoader.load(TransformFunction.class, pluginClassLoader),
+          "plugin classloader: " + pluginClassLoader, registry, seenProviderClasses, explicitClassNames);
+    }
+
+    // Register the explicitly configured classes last: explicit configuration keeps its historical override
+    // semantics and may replace built-in as well as discovered registrations.
     for (Class<TransformFunction> transformFunctionClass : transformFunctionClasses) {
       TransformFunction transformFunction;
       try {
@@ -292,12 +368,97 @@ public class TransformFunctionFactory {
         throw new RuntimeException(
             "Caught exception while instantiating transform function from class: " + transformFunctionClass, e);
       }
-      String transformFunctionName = canonicalize(transformFunction.getName());
-      if (TRANSFORM_FUNCTION_MAP.put(transformFunctionName, transformFunctionClass) == null) {
+      String name = transformFunction.getName();
+      if (StringUtils.isBlank(name)) {
+        throw new IllegalStateException("Transform function class: " + transformFunctionClass.getName()
+            + " returned a " + (name == null ? "null" : "blank") + " name from getName()");
+      }
+      String transformFunctionName = canonicalize(name);
+      if (registry.put(transformFunctionName, transformFunctionClass) == null) {
         LOGGER.info("Registering function: {} with class: {}", transformFunctionName, transformFunctionClass);
       } else {
         LOGGER.info("Replacing function: {} with class: {}", transformFunctionName, transformFunctionClass);
       }
+    }
+
+    // Atomically publish the fully built and validated snapshot.
+    _transformFunctionMap = Collections.unmodifiableMap(registry);
+  }
+
+  /// Registers the [TransformFunction] service providers visible through the given [ServiceLoader] into the local
+  /// registry being built. The provider instance is only used to obtain the implementation class and validate its
+  /// name; it is never initialized or evaluated. Fails fast (preserving the original cause) on malformed service
+  /// descriptors, providers that cannot be constructed, null/blank function names, and canonical name collisions.
+  private static void registerServiceProviders(ServiceLoader<TransformFunction> serviceLoader, String source,
+      Map<String, Class<? extends TransformFunction>> registry,
+      Map<String, Class<? extends TransformFunction>> seenProviderClasses, Set<String> explicitClassNames) {
+    Iterator<TransformFunction> iterator = serviceLoader.iterator();
+    while (true) {
+      TransformFunction provider;
+      try {
+        if (!iterator.hasNext()) {
+          return;
+        }
+        provider = iterator.next();
+      } catch (ServiceConfigurationError e) {
+        throw new IllegalStateException("Failed to load a TransformFunction service provider from: " + source, e);
+      }
+      Class<? extends TransformFunction> providerClass = provider.getClass();
+      String providerClassName = providerClass.getName();
+      if (explicitClassNames.contains(providerClassName)) {
+        LOGGER.info("Skipping service provider: {} (from: {}) which is also explicitly configured", providerClassName,
+            source);
+        continue;
+      }
+      Class<? extends TransformFunction> seenClass = seenProviderClasses.putIfAbsent(providerClassName, providerClass);
+      if (seenClass != null) {
+        // Same implementation already discovered through an overlapping classloader. A different Class object with
+        // the same name indicates version skew between classloaders; the first discovered copy wins.
+        if (seenClass != providerClass) {
+          LOGGER.warn("Ignoring duplicate service provider class: {} (classloader: {}, discovered from: {}); keeping "
+                  + "the copy from classloader: {}", providerClassName, providerClass.getClassLoader(), source,
+              seenClass.getClassLoader());
+        }
+        continue;
+      }
+      String name = provider.getName();
+      if (StringUtils.isBlank(name)) {
+        throw new IllegalStateException("TransformFunction service provider: " + providerClassName + " (classloader: "
+            + providerClass.getClassLoader() + ", discovered from: " + source + ") returned a "
+            + (name == null ? "null" : "blank") + " name from getName()");
+      }
+      String canonicalName = canonicalize(name);
+      Class<? extends TransformFunction> existing = registry.get(canonicalName);
+      if (existing != null) {
+        if (existing.getName().equals(providerClassName)) {
+          // Repeated registration of the identical implementation is a no-op. A different Class object with the same
+          // name indicates version skew between classloaders; the registered copy wins.
+          if (existing != providerClass) {
+            LOGGER.warn("Function: {} is already registered with class: {} from classloader: {}; ignoring the copy "
+                    + "from classloader: {} (discovered from: {})", canonicalName, existing.getName(),
+                existing.getClassLoader(), providerClass.getClassLoader(), source);
+          }
+          continue;
+        }
+        String existingDescription = BUILT_IN_TRANSFORM_FUNCTIONS.get(canonicalName) == existing
+            ? "built-in transform function class: " + existing.getName()
+            : "discovered transform function class: " + existing.getName();
+        throw new IllegalStateException(
+            "Transform function name collision on: " + canonicalName + ". Service provider class: "
+                + providerClassName + " (classloader: " + providerClass.getClassLoader() + ", discovered from: "
+                + source + ") collides with " + existingDescription + " (classloader: " + existing.getClassLoader()
+                + ")");
+      }
+      if (FunctionRegistry.contains(FunctionRegistry.canonicalize(name))) {
+        // Not a failure: providing a block-oriented implementation of an existing scalar function is the same
+        // pattern the built-ins use — but for an independently owned scalar function the semantics may diverge
+        // (e.g. literal-only invocations still constant-fold through the scalar implementation at compile time).
+        LOGGER.warn("Service-discovered transform function: {} with class: {} (from: {}) shadows a scalar function "
+            + "with the same name for single-stage server-side execution", canonicalName, providerClassName, source);
+      }
+      registry.put(canonicalName, providerClass);
+      LOGGER.info("Registering service-discovered function: {} with class: {} (from: {})", canonicalName,
+          providerClassName, source);
     }
   }
 
@@ -337,7 +498,7 @@ public class TransformFunctionFactory {
         }
 
         TransformFunction transformFunction;
-        Class<? extends TransformFunction> transformFunctionClass = TRANSFORM_FUNCTION_MAP.get(functionName);
+        Class<? extends TransformFunction> transformFunctionClass = _transformFunctionMap.get(functionName);
         if (transformFunctionClass != null) {
           // Transform function
           try {
@@ -422,7 +583,9 @@ public class TransformFunctionFactory {
     return StringUtils.remove(functionName, '_').toLowerCase();
   }
 
+  /// Returns an immutable snapshot of the current registry (canonical name to implementation class). Registrations
+  /// from later [#init(Set)] calls are not reflected in previously returned maps.
   public static Map<String, Class<? extends TransformFunction>> getAllFunctions() {
-    return Collections.unmodifiableMap(TRANSFORM_FUNCTION_MAP);
+    return _transformFunctionMap;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactoryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactoryTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.core.operator.transform.function;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
@@ -47,6 +46,7 @@ import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.apache.pinot.core.operator.ColumnContext;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.spi.plugin.ChildFirstClassLoader;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -389,7 +389,7 @@ public class TransformFunctionFactoryTest extends BaseTransformFunctionTest {
       throws Exception {
     // The context classloader defines its own copy of PluginServiceTransformFunction (child-first) while the
     // plugin realm resolves the test-classpath copy through parent delegation: same class name, different Class
-    // objects. The first sighting (context classloader) must win and the skewed duplicate must be skipped
+    // objects. End to end, the duplicate registration must be skipped, keeping the first discovered copy
     initWithContextClassLoader(
         createChildFirstDescriptorClassLoader(PluginServiceTransformFunction.class.getName()), Set.of());
     Class<? extends TransformFunction> registered =
@@ -397,6 +397,17 @@ public class TransformFunctionFactoryTest extends BaseTransformFunctionTest {
     assertNotNull(registered);
     assertEquals(registered.getName(), PluginServiceTransformFunction.class.getName());
     assertNotSame(registered, PluginServiceTransformFunction.class);
+  }
+
+  @Test
+  public void testVersionSkewedCopyOfBuiltInIsIgnored()
+      throws Exception {
+    // A discovered provider that is a different-classloader copy of an already-registered built-in class (e.g. a
+    // fat plugin jar bundling pinot-core classes) must be skipped with a WARN — neither a collision failure nor an
+    // override — keeping the built-in registration
+    initWithContextClassLoader(
+        createChildFirstDescriptorClassLoader(AdditionTransformFunction.class.getName()), Set.of());
+    assertSame(TransformFunctionFactory.getAllFunctions().get("add"), AdditionTransformFunction.class);
   }
 
   @Test
@@ -482,8 +493,9 @@ public class TransformFunctionFactoryTest extends BaseTransformFunctionTest {
   }
 
   /// Like [#createDescriptorClassLoader(String...)], but the returned loader additionally defines its own copy of
-  /// the provider class from the test-classpath bytes instead of delegating to the parent, simulating a
-  /// classloader shipping its own (version-skewed) copy of the class.
+  /// the provider class from the test-classpath bytes instead of delegating to the parent (via the shared
+  /// [ChildFirstClassLoader] test utility), simulating a classloader shipping its own (version-skewed) copy of the
+  /// class.
   private static ClassLoader createChildFirstDescriptorClassLoader(String providerClassName)
       throws IOException {
     Path tempDir = Files.createTempDirectory("transform-function-descriptor");
@@ -495,41 +507,6 @@ public class TransformFunctionFactoryTest extends BaseTransformFunctionTest {
         TransformFunctionFactoryTest.class.getClassLoader(), providerClassName);
     DESCRIPTOR_CLASS_LOADERS.add(descriptorClassLoader);
     return descriptorClassLoader;
-  }
-
-  /// Classloader that defines its own copy of one class from the parent's class-file bytes instead of delegating,
-  /// producing a Class object with the same name but a different defining classloader. Everything else (including
-  /// the [TransformFunction] interface) is delegated to the parent so the copy remains a valid provider.
-  private static class ChildFirstClassLoader extends URLClassLoader {
-    private final String _childFirstClassName;
-
-    ChildFirstClassLoader(URL[] urls, ClassLoader parent, String childFirstClassName) {
-      super(urls, parent);
-      _childFirstClassName = childFirstClassName;
-    }
-
-    @Override
-    protected Class<?> loadClass(String name, boolean resolve)
-        throws ClassNotFoundException {
-      if (!name.equals(_childFirstClassName)) {
-        return super.loadClass(name, resolve);
-      }
-      synchronized (getClassLoadingLock(name)) {
-        Class<?> loaded = findLoadedClass(name);
-        if (loaded == null) {
-          try (InputStream inputStream = getParent().getResourceAsStream(name.replace('.', '/') + ".class")) {
-            byte[] classBytes = inputStream.readAllBytes();
-            loaded = defineClass(name, classBytes, 0, classBytes.length);
-          } catch (IOException e) {
-            throw new ClassNotFoundException(name, e);
-          }
-        }
-        if (resolve) {
-          resolveClass(loaded);
-        }
-        return loaded;
-      }
-    }
   }
 
   /// Runs [TransformFunctionFactory#init(Set)] with the given thread context classloader installed,

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactoryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactoryTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.operator.transform.function;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
@@ -40,6 +41,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.function.FunctionRegistry;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.apache.pinot.core.operator.ColumnContext;
@@ -52,6 +54,8 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
@@ -361,6 +365,41 @@ public class TransformFunctionFactoryTest extends BaseTransformFunctionTest {
   }
 
   @Test
+  public void testScalarFunctionNameShadowingAllowed()
+      throws Exception {
+    // Precondition: "reverse" is an existing scalar function
+    assertTrue(FunctionRegistry.contains(FunctionRegistry.canonicalize("reverse")));
+    // Shadowing a scalar function name is allowed (WARN only, not a collision): providing a block-oriented
+    // implementation of a scalar function is the same pattern the built-ins use
+    initWithContextClassLoader(createDescriptorClassLoader(ScalarShadowTransformFunction.class.getName()), Set.of());
+    assertSame(TransformFunctionFactory.getAllFunctions().get("reverse"), ScalarShadowTransformFunction.class);
+  }
+
+  @Test
+  public void testServiceRegisteredBuiltInClassIsNoOp()
+      throws Exception {
+    // A descriptor shipping a class that is already registered under the same canonical name (here: the built-in
+    // itself) is a no-op rather than a collision
+    initWithContextClassLoader(createDescriptorClassLoader(AdditionTransformFunction.class.getName()), Set.of());
+    assertSame(TransformFunctionFactory.getAllFunctions().get("add"), AdditionTransformFunction.class);
+  }
+
+  @Test
+  public void testVersionSkewedDuplicateKeepsFirstDiscoveredCopy()
+      throws Exception {
+    // The context classloader defines its own copy of PluginServiceTransformFunction (child-first) while the
+    // plugin realm resolves the test-classpath copy through parent delegation: same class name, different Class
+    // objects. The first sighting (context classloader) must win and the skewed duplicate must be skipped
+    initWithContextClassLoader(
+        createChildFirstDescriptorClassLoader(PluginServiceTransformFunction.class.getName()), Set.of());
+    Class<? extends TransformFunction> registered =
+        TransformFunctionFactory.getAllFunctions().get("pluginrealmservicetransform");
+    assertNotNull(registered);
+    assertEquals(registered.getName(), PluginServiceTransformFunction.class.getName());
+    assertNotSame(registered, PluginServiceTransformFunction.class);
+  }
+
+  @Test
   public void testRegistrationDoesNotInitOrEvaluateFunction()
       throws Exception {
     int constructionsBefore = DiscoveredServiceTransformFunction.CONSTRUCTION_COUNT.get();
@@ -440,6 +479,57 @@ public class TransformFunctionFactoryTest extends BaseTransformFunctionTest {
         TransformFunctionFactoryTest.class.getClassLoader());
     DESCRIPTOR_CLASS_LOADERS.add(descriptorClassLoader);
     return descriptorClassLoader;
+  }
+
+  /// Like [#createDescriptorClassLoader(String...)], but the returned loader additionally defines its own copy of
+  /// the provider class from the test-classpath bytes instead of delegating to the parent, simulating a
+  /// classloader shipping its own (version-skewed) copy of the class.
+  private static ClassLoader createChildFirstDescriptorClassLoader(String providerClassName)
+      throws IOException {
+    Path tempDir = Files.createTempDirectory("transform-function-descriptor");
+    TEMP_DIRS.add(tempDir);
+    Path descriptorFile = tempDir.resolve(SERVICE_DESCRIPTOR_PATH);
+    Files.createDirectories(descriptorFile.getParent());
+    Files.write(descriptorFile, List.of(providerClassName), StandardCharsets.UTF_8);
+    URLClassLoader descriptorClassLoader = new ChildFirstClassLoader(new URL[]{tempDir.toUri().toURL()},
+        TransformFunctionFactoryTest.class.getClassLoader(), providerClassName);
+    DESCRIPTOR_CLASS_LOADERS.add(descriptorClassLoader);
+    return descriptorClassLoader;
+  }
+
+  /// Classloader that defines its own copy of one class from the parent's class-file bytes instead of delegating,
+  /// producing a Class object with the same name but a different defining classloader. Everything else (including
+  /// the [TransformFunction] interface) is delegated to the parent so the copy remains a valid provider.
+  private static class ChildFirstClassLoader extends URLClassLoader {
+    private final String _childFirstClassName;
+
+    ChildFirstClassLoader(URL[] urls, ClassLoader parent, String childFirstClassName) {
+      super(urls, parent);
+      _childFirstClassName = childFirstClassName;
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve)
+        throws ClassNotFoundException {
+      if (!name.equals(_childFirstClassName)) {
+        return super.loadClass(name, resolve);
+      }
+      synchronized (getClassLoadingLock(name)) {
+        Class<?> loaded = findLoadedClass(name);
+        if (loaded == null) {
+          try (InputStream inputStream = getParent().getResourceAsStream(name.replace('.', '/') + ".class")) {
+            byte[] classBytes = inputStream.readAllBytes();
+            loaded = defineClass(name, classBytes, 0, classBytes.length);
+          } catch (IOException e) {
+            throw new ClassNotFoundException(name, e);
+          }
+        }
+        if (resolve) {
+          resolveClass(loaded);
+        }
+        return loaded;
+      }
+    }
   }
 
   /// Runs [TransformFunctionFactory#init(Set)] with the given thread context classloader installed,
@@ -654,6 +744,19 @@ public class TransformFunctionFactoryTest extends BaseTransformFunctionTest {
 
   /// Listed in a descriptor but does not implement [TransformFunction].
   public static class NotATransformFunction {
+  }
+
+  /// Provider whose name shadows the `reverse` scalar function.
+  public static class ScalarShadowTransformFunction extends BaseTransformFunction {
+    @Override
+    public String getName() {
+      return "reverse";
+    }
+
+    @Override
+    public TransformResultMetadata getResultMetadata() {
+      return INT_SV_NO_DICTIONARY_METADATA;
+    }
   }
 
   /// Listed in a descriptor but violates the concrete-class requirement of the provider contract.

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactoryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactoryTest.java
@@ -1,0 +1,671 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceConfigurationError;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.apache.pinot.core.operator.ColumnContext;
+import org.apache.pinot.core.operator.blocks.ValueBlock;
+import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.spi.plugin.PluginManager;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+
+/// Tests for [TransformFunctionFactory], with a focus on `ServiceLoader` discovery of external
+/// [TransformFunction] implementations.
+///
+/// Service descriptors are generated into temporary directories and exposed through isolated
+/// [URLClassLoader]s (installed as the thread context classloader) or through a [PluginManager]
+/// plugin realm, so no `META-INF/services` fixture leaks into the test classpath of this or any
+/// downstream module.
+public class TransformFunctionFactoryTest extends BaseTransformFunctionTest {
+  private static final String SERVICE_DESCRIPTOR_PATH = "META-INF/services/" + TransformFunction.class.getName();
+  private static final String PLUGIN_NAME = "transform-function-factory-test-plugin";
+  private static final List<Path> TEMP_DIRS = new ArrayList<>();
+  private static final List<URLClassLoader> DESCRIPTOR_CLASS_LOADERS = new ArrayList<>();
+
+  private Map<String, Class<? extends TransformFunction>> _builtInFunctions;
+
+  @BeforeClass
+  public void setUpServiceDiscoveryFixtures()
+      throws Exception {
+    // Captured before any init() call, so this is exactly the built-in registry
+    _builtInFunctions = Map.copyOf(TransformFunctionFactory.getAllFunctions());
+
+    // Register a new-style plugin realm holding only a service descriptor for
+    // PluginServiceTransformFunction. The realm delegates to the pinot realm for classes
+    // (parent.realmId=pinot), but the descriptor itself is only visible through the plugin
+    // classloader, so discovering the function proves the plugin classloaders are enumerated.
+    File pluginDir = Files.createTempDirectory(PLUGIN_NAME).toFile();
+    TEMP_DIRS.add(pluginDir.toPath());
+    Files.writeString(new File(pluginDir, "pinot-plugin.properties").toPath(), "parent.realmId=pinot\n");
+    try (JarOutputStream jarOutputStream = new JarOutputStream(
+        new FileOutputStream(new File(pluginDir, "transform-functions.jar")))) {
+      jarOutputStream.putNextEntry(new JarEntry(SERVICE_DESCRIPTOR_PATH));
+      jarOutputStream.write((PluginServiceTransformFunction.class.getName() + "\n").getBytes(StandardCharsets.UTF_8));
+      jarOutputStream.closeEntry();
+    }
+    PluginManager.get().load(PLUGIN_NAME, pluginDir);
+  }
+
+  @AfterMethod
+  public void resetRegistry() {
+    // Re-initializing without any context descriptor restores the built-ins (plus the plugin realm
+    // function) and drops any registration or override made by the previous test method
+    TransformFunctionFactory.init(Set.of());
+  }
+
+  @AfterClass
+  public void tearDownServiceDiscoveryFixtures()
+      throws IOException {
+    // Closing is safe: registered fixture classes were loaded by the parent (test) classloader, the isolated
+    // loaders only served descriptor resources
+    for (URLClassLoader descriptorClassLoader : DESCRIPTOR_CLASS_LOADERS) {
+      descriptorClassLoader.close();
+    }
+    for (Path tempDir : TEMP_DIRS) {
+      FileUtils.deleteQuietly(tempDir.toFile());
+    }
+  }
+
+  @Test
+  public void testApplicationClasspathDiscovery()
+      throws Exception {
+    initWithContextClassLoader(createDescriptorClassLoader(DiscoveredServiceTransformFunction.class.getName()),
+        Set.of());
+    assertSame(TransformFunctionFactory.getAllFunctions().get("discoveredservicetransform"),
+        DiscoveredServiceTransformFunction.class);
+  }
+
+  @Test
+  public void testDiscoveredFunctionResolutionAndEvaluation()
+      throws Exception {
+    initWithContextClassLoader(createDescriptorClassLoader(DiscoveredServiceTransformFunction.class.getName()),
+        Set.of());
+    ExpressionContext expression =
+        RequestContextUtils.getExpression(String.format("discovered_service_transform(%s)", INT_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof DiscoveredServiceTransformFunction);
+    int[] expectedValues = new int[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = _intSVValues[i] + 1;
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testCanonicalization()
+      throws Exception {
+    initWithContextClassLoader(createDescriptorClassLoader(DiscoveredServiceTransformFunction.class.getName()),
+        Set.of());
+    // getName() returns "Discovered_Service_Transform"; the registry key is the canonical form
+    assertTrue(TransformFunctionFactory.getAllFunctions().containsKey("discoveredservicetransform"));
+    // Any case/underscore variant of the name resolves through the factory
+    for (String variant : new String[]{
+        "DISCOVERED_SERVICE_TRANSFORM", "discoveredServiceTransform", "Discovered_Service_Transform"
+    }) {
+      ExpressionContext expression =
+          RequestContextUtils.getExpression(String.format("%s(%s)", variant, INT_SV_COLUMN));
+      assertTrue(TransformFunctionFactory.get(expression, _dataSourceMap) instanceof DiscoveredServiceTransformFunction,
+          "Failed to resolve variant: " + variant);
+    }
+  }
+
+  @Test
+  public void testPluginClassLoaderDiscovery() {
+    TransformFunctionFactory.init(Set.of());
+    assertSame(TransformFunctionFactory.getAllFunctions().get("pluginrealmservicetransform"),
+        PluginServiceTransformFunction.class);
+  }
+
+  @Test
+  public void testOverlappingClassLoaderDeduplication()
+      throws Exception {
+    // The same implementation class is visible both through the application classpath descriptor
+    // (context classloader) and through the plugin realm descriptor; it must be registered once
+    // without raising a collision
+    initWithContextClassLoader(createDescriptorClassLoader(PluginServiceTransformFunction.class.getName()), Set.of());
+    assertSame(TransformFunctionFactory.getAllFunctions().get("pluginrealmservicetransform"),
+        PluginServiceTransformFunction.class);
+  }
+
+  @Test
+  public void testRepeatedInitIdempotent()
+      throws Exception {
+    ClassLoader descriptorClassLoader =
+        createDescriptorClassLoader(DiscoveredServiceTransformFunction.class.getName());
+    initWithContextClassLoader(descriptorClassLoader, Set.of());
+    Map<String, Class<? extends TransformFunction>> firstSnapshot = TransformFunctionFactory.getAllFunctions();
+    initWithContextClassLoader(descriptorClassLoader, Set.of());
+    Map<String, Class<? extends TransformFunction>> secondSnapshot = TransformFunctionFactory.getAllFunctions();
+    assertEquals(secondSnapshot, firstSnapshot);
+    assertSame(secondSnapshot.get("discoveredservicetransform"), DiscoveredServiceTransformFunction.class);
+  }
+
+  @Test
+  public void testCollisionBetweenDiscoveredProviders()
+      throws Exception {
+    IllegalStateException exception = expectThrows(IllegalStateException.class,
+        () -> initWithContextClassLoader(
+            createDescriptorClassLoader(DuplicateNameServiceTransformFunctionA.class.getName(),
+                DuplicateNameServiceTransformFunctionB.class.getName()), Set.of()));
+    assertTrue(exception.getMessage().contains("duplicateservicename"), exception.getMessage());
+    assertTrue(exception.getMessage().contains(DuplicateNameServiceTransformFunctionA.class.getName()),
+        exception.getMessage());
+    assertTrue(exception.getMessage().contains(DuplicateNameServiceTransformFunctionB.class.getName()),
+        exception.getMessage());
+    assertTrue(exception.getMessage().contains("classloader"), exception.getMessage());
+    // The failed init must not have published a partial registry
+    assertNull(TransformFunctionFactory.getAllFunctions().get("duplicateservicename"));
+    assertSame(TransformFunctionFactory.getAllFunctions().get("add"), AdditionTransformFunction.class);
+  }
+
+  @Test
+  public void testCollisionWithBuiltIn()
+      throws Exception {
+    IllegalStateException exception = expectThrows(IllegalStateException.class,
+        () -> initWithContextClassLoader(
+            createDescriptorClassLoader(BuiltInNameServiceTransformFunction.class.getName()), Set.of()));
+    assertTrue(exception.getMessage().contains("add"), exception.getMessage());
+    assertTrue(exception.getMessage().contains("built-in"), exception.getMessage());
+    assertTrue(exception.getMessage().contains(BuiltInNameServiceTransformFunction.class.getName()),
+        exception.getMessage());
+    assertTrue(exception.getMessage().contains(AdditionTransformFunction.class.getName()), exception.getMessage());
+    // The built-in registration is untouched
+    assertSame(TransformFunctionFactory.getAllFunctions().get("add"), AdditionTransformFunction.class);
+  }
+
+  @Test
+  public void testMalformedDescriptorMissingClass()
+      throws Exception {
+    IllegalStateException exception = expectThrows(IllegalStateException.class,
+        () -> initWithContextClassLoader(createDescriptorClassLoader("com.example.DoesNotExist"), Set.of()));
+    assertTrue(exception.getCause() instanceof ServiceConfigurationError, String.valueOf(exception.getCause()));
+  }
+
+  @Test
+  public void testMalformedDescriptorInvalidSyntax()
+      throws Exception {
+    IllegalStateException exception = expectThrows(IllegalStateException.class,
+        () -> initWithContextClassLoader(createDescriptorClassLoader("not a valid class name"), Set.of()));
+    assertTrue(exception.getCause() instanceof ServiceConfigurationError, String.valueOf(exception.getCause()));
+  }
+
+  @Test
+  public void testDescriptorClassNotATransformFunction()
+      throws Exception {
+    IllegalStateException exception = expectThrows(IllegalStateException.class,
+        () -> initWithContextClassLoader(createDescriptorClassLoader(NotATransformFunction.class.getName()),
+            Set.of()));
+    assertTrue(exception.getCause() instanceof ServiceConfigurationError, String.valueOf(exception.getCause()));
+  }
+
+  @Test
+  public void testProviderConstructorFailure()
+      throws Exception {
+    IllegalStateException exception = expectThrows(IllegalStateException.class,
+        () -> initWithContextClassLoader(
+            createDescriptorClassLoader(ThrowingConstructorTransformFunction.class.getName()), Set.of()));
+    // The original cause must be preserved through the ServiceConfigurationError
+    Throwable cause = exception.getCause();
+    assertTrue(cause instanceof ServiceConfigurationError, String.valueOf(cause));
+    boolean foundOriginalCause = false;
+    for (Throwable t = cause; t != null; t = t.getCause()) {
+      if ("Intentional constructor failure".equals(t.getMessage())) {
+        foundOriginalCause = true;
+        break;
+      }
+    }
+    assertTrue(foundOriginalCause, "Original constructor failure not preserved in cause chain");
+  }
+
+  @Test
+  public void testProviderInaccessibleConstructor()
+      throws Exception {
+    IllegalStateException exception = expectThrows(IllegalStateException.class,
+        () -> initWithContextClassLoader(
+            createDescriptorClassLoader(PrivateConstructorTransformFunction.class.getName()), Set.of()));
+    assertTrue(exception.getCause() instanceof ServiceConfigurationError, String.valueOf(exception.getCause()));
+  }
+
+  @Test
+  public void testNullFunctionName()
+      throws Exception {
+    IllegalStateException exception = expectThrows(IllegalStateException.class,
+        () -> initWithContextClassLoader(createDescriptorClassLoader(NullNameServiceTransformFunction.class.getName()),
+            Set.of()));
+    assertTrue(exception.getMessage().contains(NullNameServiceTransformFunction.class.getName()),
+        exception.getMessage());
+    assertTrue(exception.getMessage().contains("null"), exception.getMessage());
+  }
+
+  @Test
+  public void testBlankFunctionName()
+      throws Exception {
+    IllegalStateException exception = expectThrows(IllegalStateException.class,
+        () -> initWithContextClassLoader(createDescriptorClassLoader(BlankNameServiceTransformFunction.class.getName()),
+            Set.of()));
+    assertTrue(exception.getMessage().contains(BlankNameServiceTransformFunction.class.getName()),
+        exception.getMessage());
+    assertTrue(exception.getMessage().contains("blank"), exception.getMessage());
+  }
+
+  @Test
+  public void testBuiltInsRemainAvailable()
+      throws Exception {
+    initWithContextClassLoader(createDescriptorClassLoader(DiscoveredServiceTransformFunction.class.getName()),
+        Set.of());
+    Map<String, Class<? extends TransformFunction>> registry = TransformFunctionFactory.getAllFunctions();
+    for (Map.Entry<String, Class<? extends TransformFunction>> builtIn : _builtInFunctions.entrySet()) {
+      assertSame(registry.get(builtIn.getKey()), builtIn.getValue(),
+          "Built-in function lost after discovery: " + builtIn.getKey());
+    }
+    // Built-ins remain resolvable and evaluable through the factory
+    ExpressionContext expression =
+        RequestContextUtils.getExpression(String.format("add(%s,%s)", INT_SV_COLUMN, INT_SV_COLUMN));
+    assertTrue(TransformFunctionFactory.get(expression, _dataSourceMap) instanceof AdditionTransformFunction);
+  }
+
+  @Test
+  public void testLegacyExplicitRegistrationAndOverride() {
+    // Legacy pinot.server.transforms style registration: no service descriptor involved
+    TransformFunctionFactory.init(Set.of(asTransformFunctionClass(LegacyConfiguredTransformFunction.class)));
+    assertSame(TransformFunctionFactory.getAllFunctions().get("legacyconfiguredtransform"),
+        LegacyConfiguredTransformFunction.class);
+
+    // Explicitly configured classes keep their historical ability to override built-ins
+    TransformFunctionFactory.init(Set.of(asTransformFunctionClass(AddOverrideTransformFunction.class)));
+    assertSame(TransformFunctionFactory.getAllFunctions().get("add"), AddOverrideTransformFunction.class);
+
+    // Re-initializing without the explicit class restores the built-in
+    TransformFunctionFactory.init(Set.of());
+    assertSame(TransformFunctionFactory.getAllFunctions().get("add"), AdditionTransformFunction.class);
+  }
+
+  @Test
+  public void testExplicitConfigurationOverridesDiscovered()
+      throws Exception {
+    // The explicitly configured class claims the same canonical name as the discovered provider and
+    // is applied after discovery, so it must win without raising a collision
+    initWithContextClassLoader(createDescriptorClassLoader(DiscoveredServiceTransformFunction.class.getName()),
+        Set.of(asTransformFunctionClass(ExplicitOverrideTransformFunction.class)));
+    assertSame(TransformFunctionFactory.getAllFunctions().get("discoveredservicetransform"),
+        ExplicitOverrideTransformFunction.class);
+  }
+
+  @Test
+  public void testExplicitlyConfiguredClassExemptFromDiscoveryCollision()
+      throws Exception {
+    // The same class is visible through a service descriptor AND explicitly configured to override a built-in.
+    // Discovery must skip it (instead of failing on the built-in collision) so the explicit registration keeps its
+    // historical override semantics
+    initWithContextClassLoader(createDescriptorClassLoader(AddOverrideTransformFunction.class.getName()),
+        Set.of(asTransformFunctionClass(AddOverrideTransformFunction.class)));
+    assertSame(TransformFunctionFactory.getAllFunctions().get("add"), AddOverrideTransformFunction.class);
+  }
+
+  @Test
+  public void testAbstractProviderClass()
+      throws Exception {
+    IllegalStateException exception = expectThrows(IllegalStateException.class,
+        () -> initWithContextClassLoader(
+            createDescriptorClassLoader(AbstractServiceTransformFunction.class.getName()), Set.of()));
+    assertTrue(exception.getCause() instanceof ServiceConfigurationError, String.valueOf(exception.getCause()));
+  }
+
+  @Test
+  public void testRegistrationDoesNotInitOrEvaluateFunction()
+      throws Exception {
+    int constructionsBefore = DiscoveredServiceTransformFunction.CONSTRUCTION_COUNT.get();
+    int initCallsBefore = DiscoveredServiceTransformFunction.INIT_COUNT.get();
+    int evalCallsBefore = DiscoveredServiceTransformFunction.EVAL_COUNT.get();
+    initWithContextClassLoader(createDescriptorClassLoader(DiscoveredServiceTransformFunction.class.getName()),
+        Set.of());
+    // Discovery constructs an instance to read its name, but never calls init() or evaluates it
+    assertTrue(DiscoveredServiceTransformFunction.CONSTRUCTION_COUNT.get() > constructionsBefore);
+    assertEquals(DiscoveredServiceTransformFunction.INIT_COUNT.get(), initCallsBefore);
+    assertEquals(DiscoveredServiceTransformFunction.EVAL_COUNT.get(), evalCallsBefore);
+
+    // Query execution constructs a fresh instance through the factory and initializes/evaluates it
+    ExpressionContext expression =
+        RequestContextUtils.getExpression(String.format("discovered_service_transform(%s)", INT_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    transformFunction.transformToIntValuesSV(_projectionBlock);
+    assertEquals(DiscoveredServiceTransformFunction.INIT_COUNT.get(), initCallsBefore + 1);
+    assertEquals(DiscoveredServiceTransformFunction.EVAL_COUNT.get(), evalCallsBefore + 1);
+  }
+
+  @Test
+  public void testNoPartialRegistryPublicationUnderConcurrentReads()
+      throws Exception {
+    Set<String> builtInNames = _builtInFunctions.keySet();
+    int numReaders = 4;
+    ExecutorService executorService = Executors.newFixedThreadPool(numReaders);
+    AtomicBoolean stopped = new AtomicBoolean();
+    try {
+      List<Future<?>> readers = new ArrayList<>(numReaders);
+      for (int i = 0; i < numReaders; i++) {
+        readers.add(executorService.submit(() -> {
+          while (!stopped.get()) {
+            Map<String, Class<? extends TransformFunction>> snapshot = TransformFunctionFactory.getAllFunctions();
+            assertTrue(snapshot.keySet().containsAll(builtInNames),
+                "Observed a registry snapshot missing built-in functions");
+            assertSame(snapshot.get("add"), AdditionTransformFunction.class);
+          }
+        }));
+      }
+      ClassLoader descriptorClassLoader =
+          createDescriptorClassLoader(DiscoveredServiceTransformFunction.class.getName());
+      for (int i = 0; i < 100; i++) {
+        initWithContextClassLoader(descriptorClassLoader, Set.of());
+        TransformFunctionFactory.init(Set.of());
+      }
+      stopped.set(true);
+      for (Future<?> reader : readers) {
+        // Propagates any assertion failure from the reader threads
+        reader.get(30, TimeUnit.SECONDS);
+      }
+    } finally {
+      stopped.set(true);
+      executorService.shutdownNow();
+    }
+  }
+
+  @Test
+  public void testGetAllFunctionsIsImmutable() {
+    TransformFunctionFactory.init(Set.of());
+    expectThrows(UnsupportedOperationException.class,
+        () -> TransformFunctionFactory.getAllFunctions().put("foo", AdditionTransformFunction.class));
+  }
+
+  /// Writes a `META-INF/services` descriptor for [TransformFunction] listing the given lines into a
+  /// fresh temporary directory, and returns an isolated [URLClassLoader] exposing it. The loader
+  /// delegates to the test classpath for classes, so fixture classes resolve while the descriptor
+  /// stays invisible to other tests and modules.
+  private static ClassLoader createDescriptorClassLoader(String... descriptorLines)
+      throws IOException {
+    Path tempDir = Files.createTempDirectory("transform-function-descriptor");
+    TEMP_DIRS.add(tempDir);
+    Path descriptorFile = tempDir.resolve(SERVICE_DESCRIPTOR_PATH);
+    Files.createDirectories(descriptorFile.getParent());
+    Files.write(descriptorFile, List.of(descriptorLines), StandardCharsets.UTF_8);
+    URLClassLoader descriptorClassLoader = new URLClassLoader(new URL[]{tempDir.toUri().toURL()},
+        TransformFunctionFactoryTest.class.getClassLoader());
+    DESCRIPTOR_CLASS_LOADERS.add(descriptorClassLoader);
+    return descriptorClassLoader;
+  }
+
+  /// Runs [TransformFunctionFactory#init(Set)] with the given thread context classloader installed,
+  /// exercising the production application-classpath discovery path (`ServiceLoader.load` uses the
+  /// context classloader), and restores the original context classloader afterwards.
+  private static void initWithContextClassLoader(ClassLoader classLoader,
+      Set<Class<TransformFunction>> transformFunctionClasses) {
+    Thread currentThread = Thread.currentThread();
+    ClassLoader originalClassLoader = currentThread.getContextClassLoader();
+    currentThread.setContextClassLoader(classLoader);
+    try {
+      TransformFunctionFactory.init(transformFunctionClasses);
+    } finally {
+      currentThread.setContextClassLoader(originalClassLoader);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Class<TransformFunction> asTransformFunctionClass(Class<? extends TransformFunction> clazz) {
+    return (Class<TransformFunction>) clazz;
+  }
+
+  // ------------------------------------------------------------------------------------------------------
+  // Service provider fixtures. These are regular test classes with no META-INF/services descriptor on the
+  // classpath; tests reference them from generated descriptors in isolated classloaders.
+  // ------------------------------------------------------------------------------------------------------
+
+  /// Valid provider used for happy-path discovery, canonicalization and evaluation tests. Returns the
+  /// int argument plus one.
+  public static class DiscoveredServiceTransformFunction extends BaseTransformFunction {
+    static final AtomicInteger CONSTRUCTION_COUNT = new AtomicInteger();
+    static final AtomicInteger INIT_COUNT = new AtomicInteger();
+    static final AtomicInteger EVAL_COUNT = new AtomicInteger();
+
+    public DiscoveredServiceTransformFunction() {
+      CONSTRUCTION_COUNT.incrementAndGet();
+    }
+
+    @Override
+    public String getName() {
+      return "Discovered_Service_Transform";
+    }
+
+    @Override
+    public void init(List<TransformFunction> arguments, Map<String, ColumnContext> columnContextMap) {
+      INIT_COUNT.incrementAndGet();
+      super.init(arguments, columnContextMap);
+    }
+
+    @Override
+    public TransformResultMetadata getResultMetadata() {
+      return INT_SV_NO_DICTIONARY_METADATA;
+    }
+
+    @Override
+    public int[] transformToIntValuesSV(ValueBlock valueBlock) {
+      EVAL_COUNT.incrementAndGet();
+      int length = valueBlock.getNumDocs();
+      initIntValuesSV(length);
+      int[] values = _arguments.get(0).transformToIntValuesSV(valueBlock);
+      for (int i = 0; i < length; i++) {
+        _intValuesSV[i] = values[i] + 1;
+      }
+      return _intValuesSV;
+    }
+  }
+
+  /// Valid provider registered through the plugin realm descriptor.
+  public static class PluginServiceTransformFunction extends BaseTransformFunction {
+    @Override
+    public String getName() {
+      return "Plugin_Realm_Service_Transform";
+    }
+
+    @Override
+    public TransformResultMetadata getResultMetadata() {
+      return INT_SV_NO_DICTIONARY_METADATA;
+    }
+  }
+
+  /// Explicitly configured provider claiming the same canonical name as
+  /// [DiscoveredServiceTransformFunction].
+  public static class ExplicitOverrideTransformFunction extends BaseTransformFunction {
+    @Override
+    public String getName() {
+      return "discoveredServiceTransform";
+    }
+
+    @Override
+    public TransformResultMetadata getResultMetadata() {
+      return INT_SV_NO_DICTIONARY_METADATA;
+    }
+  }
+
+  /// Legacy `pinot.server.transforms` style provider.
+  public static class LegacyConfiguredTransformFunction extends BaseTransformFunction {
+    @Override
+    public String getName() {
+      return "Legacy_Configured_Transform";
+    }
+
+    @Override
+    public TransformResultMetadata getResultMetadata() {
+      return INT_SV_NO_DICTIONARY_METADATA;
+    }
+  }
+
+  /// Explicitly configured provider overriding the built-in `add` function.
+  public static class AddOverrideTransformFunction extends BaseTransformFunction {
+    @Override
+    public String getName() {
+      return "add";
+    }
+
+    @Override
+    public TransformResultMetadata getResultMetadata() {
+      return INT_SV_NO_DICTIONARY_METADATA;
+    }
+  }
+
+  public static class DuplicateNameServiceTransformFunctionA extends BaseTransformFunction {
+    @Override
+    public String getName() {
+      return "Duplicate_Service_Name";
+    }
+
+    @Override
+    public TransformResultMetadata getResultMetadata() {
+      return INT_SV_NO_DICTIONARY_METADATA;
+    }
+  }
+
+  public static class DuplicateNameServiceTransformFunctionB extends BaseTransformFunction {
+    @Override
+    public String getName() {
+      return "duplicateServiceName";
+    }
+
+    @Override
+    public TransformResultMetadata getResultMetadata() {
+      return INT_SV_NO_DICTIONARY_METADATA;
+    }
+  }
+
+  /// Provider whose name collides with the built-in `add` function.
+  public static class BuiltInNameServiceTransformFunction extends BaseTransformFunction {
+    @Override
+    public String getName() {
+      return "ADD";
+    }
+
+    @Override
+    public TransformResultMetadata getResultMetadata() {
+      return INT_SV_NO_DICTIONARY_METADATA;
+    }
+  }
+
+  public static class NullNameServiceTransformFunction extends BaseTransformFunction {
+    @Override
+    public String getName() {
+      return null;
+    }
+
+    @Override
+    public TransformResultMetadata getResultMetadata() {
+      return INT_SV_NO_DICTIONARY_METADATA;
+    }
+  }
+
+  public static class BlankNameServiceTransformFunction extends BaseTransformFunction {
+    @Override
+    public String getName() {
+      return "   ";
+    }
+
+    @Override
+    public TransformResultMetadata getResultMetadata() {
+      return INT_SV_NO_DICTIONARY_METADATA;
+    }
+  }
+
+  public static class ThrowingConstructorTransformFunction extends BaseTransformFunction {
+    public ThrowingConstructorTransformFunction() {
+      throw new IllegalStateException("Intentional constructor failure");
+    }
+
+    @Override
+    public String getName() {
+      return "Throwing_Constructor_Transform";
+    }
+
+    @Override
+    public TransformResultMetadata getResultMetadata() {
+      return INT_SV_NO_DICTIONARY_METADATA;
+    }
+  }
+
+  public static class PrivateConstructorTransformFunction extends BaseTransformFunction {
+    private PrivateConstructorTransformFunction() {
+    }
+
+    @Override
+    public String getName() {
+      return "Private_Constructor_Transform";
+    }
+
+    @Override
+    public TransformResultMetadata getResultMetadata() {
+      return INT_SV_NO_DICTIONARY_METADATA;
+    }
+  }
+
+  /// Listed in a descriptor but does not implement [TransformFunction].
+  public static class NotATransformFunction {
+  }
+
+  /// Listed in a descriptor but violates the concrete-class requirement of the provider contract.
+  public abstract static class AbstractServiceTransformFunction extends BaseTransformFunction {
+    @Override
+    public String getName() {
+      return "Abstract_Service_Transform";
+    }
+
+    @Override
+    public TransformResultMetadata getResultMetadata() {
+      return INT_SV_NO_DICTIONARY_METADATA;
+    }
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/rules/PinotRuleSet.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/rules/PinotRuleSet.java
@@ -21,11 +21,8 @@ package org.apache.pinot.query.planner.rules;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.ServiceLoader;
-import java.util.Set;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.pinot.query.planner.spi.Phase;
 import org.apache.pinot.query.planner.spi.RuleSetCustomizer;
@@ -72,7 +69,7 @@ public final class PinotRuleSet {
     _rulesByPhase = Collections.unmodifiableMap(frozen);
   }
 
-  /// Discovers every [RuleSetCustomizer] via [ServiceLoader] and builds a
+  /// Discovers every [RuleSetCustomizer] via [PluginManager#loadServiceProviders(Class)] and builds a
   /// rule set from them. Used by [#defaultInstance()] and by callers that
   /// don't have an externally-managed customizer list.
   ///
@@ -83,24 +80,15 @@ public final class PinotRuleSet {
   ///    picks up customizers registered in plugin JARs via
   ///    `META-INF/services/org.apache.pinot.query.planner.spi.RuleSetCustomizer`.
   ///
+  /// Customizers visible through overlapping classloaders are de-duplicated by class name.
+  ///
   /// Call after all plugins have been loaded via [PluginManager]; plugins loaded
   /// after this method returns will not be included.
   public static PinotRuleSet loadFromServiceLoader() {
     List<RuleSetCustomizer> customizers = new ArrayList<>();
-    // Dedup by class name: the context classloader and a plugin classloader may both see the same
-    // META-INF/services file if their classpaths overlap (e.g. fat-jar + plugin realm).
-    Set<String> seen = new LinkedHashSet<>();
-    for (RuleSetCustomizer customizer : ServiceLoader.load(RuleSetCustomizer.class)) {
-      if (seen.add(customizer.getClass().getName())) {
-        customizers.add(customizer);
-      }
-    }
-    for (ClassLoader pluginClassLoader : PluginManager.get().getPluginClassLoaders()) {
-      for (RuleSetCustomizer customizer : ServiceLoader.load(RuleSetCustomizer.class, pluginClassLoader)) {
-        if (seen.add(customizer.getClass().getName())) {
-          customizers.add(customizer);
-        }
-      }
+    for (PluginManager.ServiceProvider<RuleSetCustomizer> discovered : PluginManager.get()
+        .loadServiceProviders(RuleSetCustomizer.class)) {
+      customizers.add(discovered.getProvider());
     }
     return new PinotRuleSet(customizers);
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorTypeRegistry.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorTypeRegistry.java
@@ -21,22 +21,20 @@ package org.apache.pinot.query.runtime.operator;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.ServiceLoader;
-import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.plugin.PluginManager;
 
 
 /// Registry of all known MSE [OperatorTypeDescriptor]s. Built-in types ([MultiStageOperator.Type] enum
-/// entries) are always present. Plugin-defined types are discovered at class-loading time via [ServiceLoader]:
-/// any jar that ships a
+/// entries) are always present. Plugin-defined types are discovered at class-loading time via
+/// [PluginManager#loadServiceProviders(Class)]: any jar that ships a
 /// `META-INF/services/org.apache.pinot.query.runtime.operator.OperatorTypeDescriptor` file will have its
 /// descriptors automatically registered without configuration. Discovery covers both the context classpath and the
-/// [PluginManager] plugin classloaders, so descriptors packaged in isolated plugin jars are found too — like
-/// `PinotRuleSet` does for `RuleSetCustomizer`. The registry is first used well after plugins are loaded
-/// (decoding/encoding stream-mode stats), so the plugin classloader snapshot is complete by then.
+/// [PluginManager] plugin classloaders (de-duplicated by descriptor class name), so descriptors packaged in
+/// isolated plugin jars are found too — like `PinotRuleSet` does for `RuleSetCustomizer`. The registry is first
+/// used well after plugins are loaded (decoding/encoding stream-mode stats), so the plugin classloader snapshot is
+/// complete by then.
 ///
 /// Thread-safe: the registry map is built once in a static initializer and never mutated afterward.
 public final class OperatorTypeRegistry {
@@ -48,36 +46,27 @@ public final class OperatorTypeRegistry {
     for (MultiStageOperator.Type builtIn : MultiStageOperator.Type.values()) {
       map.put(builtIn.getId(), builtIn);
     }
-    // Dedup by class name: the context classloader and a plugin classloader may both see the same
-    // META-INF/services file if their classpaths overlap (e.g. fat-jar + plugin realm).
-    Set<String> seen = new HashSet<>();
-    registerPlugins(ServiceLoader.load(OperatorTypeDescriptor.class), map, seen);
-    for (ClassLoader pluginClassLoader : PluginManager.get().getPluginClassLoaders()) {
-      registerPlugins(ServiceLoader.load(OperatorTypeDescriptor.class, pluginClassLoader), map, seen);
+    for (PluginManager.ServiceProvider<OperatorTypeDescriptor> discovered : PluginManager.get()
+        .loadServiceProviders(OperatorTypeDescriptor.class)) {
+      registerPlugin(discovered.getProvider(), map);
     }
     ID_TO_DESCRIPTOR = Collections.unmodifiableMap(map);
   }
 
-  private static void registerPlugins(ServiceLoader<OperatorTypeDescriptor> plugins,
-      Map<Integer, OperatorTypeDescriptor> map, Set<String> seen) {
-    for (OperatorTypeDescriptor plugin : plugins) {
-      if (!seen.add(plugin.getClass().getName())) {
-        continue;
-      }
-      // Enforce the documented id contract: ids below PLUGIN_ID_FLOOR are reserved for built-ins (current and
-      // future). Without this check a plugin could squat on a reserved id and work until a built-in claims it —
-      // and ids that fit in the legacy single-byte stat format would be silently emitted there, defeating the
-      // plugin-ids-are-stream-mode-only guarantee (see OperatorTypeDescriptor#getId).
-      if (plugin.getId() < OperatorTypeDescriptor.PLUGIN_ID_FLOOR) {
-        throw new IllegalStateException("Plugin operator type " + plugin.name() + " uses id " + plugin.getId()
-            + ", which is reserved for built-in types. Plugin ids must be >= "
-            + OperatorTypeDescriptor.PLUGIN_ID_FLOOR);
-      }
-      OperatorTypeDescriptor prev = map.put(plugin.getId(), plugin);
-      if (prev != null) {
-        throw new IllegalStateException(
-            "Duplicate operator type id " + plugin.getId() + ": " + prev.name() + " vs " + plugin.name());
-      }
+  private static void registerPlugin(OperatorTypeDescriptor plugin, Map<Integer, OperatorTypeDescriptor> map) {
+    // Enforce the documented id contract: ids below PLUGIN_ID_FLOOR are reserved for built-ins (current and
+    // future). Without this check a plugin could squat on a reserved id and work until a built-in claims it —
+    // and ids that fit in the legacy single-byte stat format would be silently emitted there, defeating the
+    // plugin-ids-are-stream-mode-only guarantee (see OperatorTypeDescriptor#getId).
+    if (plugin.getId() < OperatorTypeDescriptor.PLUGIN_ID_FLOOR) {
+      throw new IllegalStateException("Plugin operator type " + plugin.name() + " uses id " + plugin.getId()
+          + ", which is reserved for built-in types. Plugin ids must be >= "
+          + OperatorTypeDescriptor.PLUGIN_ID_FLOOR);
+    }
+    OperatorTypeDescriptor prev = map.put(plugin.getId(), plugin);
+    if (prev != null) {
+      throw new IllegalStateException(
+          "Duplicate operator type id " + plugin.getId() + ": " + prev.name() + " vs " + plugin.name());
     }
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorTypeRegistry.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorTypeRegistry.java
@@ -53,7 +53,8 @@ public final class OperatorTypeRegistry {
     ID_TO_DESCRIPTOR = Collections.unmodifiableMap(map);
   }
 
-  private static void registerPlugin(OperatorTypeDescriptor plugin, Map<Integer, OperatorTypeDescriptor> map) {
+  @VisibleForTesting
+  static void registerPlugin(OperatorTypeDescriptor plugin, Map<Integer, OperatorTypeDescriptor> map) {
     // Enforce the documented id contract: ids below PLUGIN_ID_FLOOR are reserved for built-ins (current and
     // future). Without this check a plugin could squat on a reserved id and work until a built-in claims it —
     // and ids that fit in the legacy single-byte stat format would be silently emitted there, defeating the

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorTypeRegistryTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorTypeRegistryTest.java
@@ -18,6 +18,10 @@
  */
 package org.apache.pinot.query.runtime.operator;
 
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.common.datatable.StatMap;
+import org.apache.pinot.common.response.broker.BrokerResponseNativeV2;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -56,5 +60,56 @@ public class OperatorTypeRegistryTest {
     Assert.assertEquals(descriptor.getId(), aggregate.getId());
     Assert.assertEquals(descriptor.name(), aggregate.name());
     Assert.assertEquals(descriptor.getStatKeyClass(), aggregate.getStatKeyClass());
+  }
+
+  @Test
+  public void testRegisterPluginRejectsReservedId() {
+    Map<Integer, OperatorTypeDescriptor> map = new HashMap<>();
+    IllegalStateException exception = Assert.expectThrows(IllegalStateException.class,
+        () -> OperatorTypeRegistry.registerPlugin(
+            descriptor(OperatorTypeDescriptor.PLUGIN_ID_FLOOR - 1, "reservedId"), map));
+    Assert.assertTrue(exception.getMessage().contains("reserved"), exception.getMessage());
+    Assert.assertTrue(map.isEmpty(), "Rejected descriptor must not be registered");
+  }
+
+  @Test
+  public void testRegisterPluginRejectsDuplicateId() {
+    Map<Integer, OperatorTypeDescriptor> map = new HashMap<>();
+    OperatorTypeRegistry.registerPlugin(descriptor(OperatorTypeDescriptor.PLUGIN_ID_FLOOR, "first"), map);
+    IllegalStateException exception = Assert.expectThrows(IllegalStateException.class,
+        () -> OperatorTypeRegistry.registerPlugin(descriptor(OperatorTypeDescriptor.PLUGIN_ID_FLOOR, "second"), map));
+    Assert.assertTrue(exception.getMessage().contains("Duplicate operator type id"), exception.getMessage());
+  }
+
+  @Test
+  public void testRegisterPluginAcceptsPluginId() {
+    Map<Integer, OperatorTypeDescriptor> map = new HashMap<>();
+    OperatorTypeDescriptor descriptor = descriptor(OperatorTypeDescriptor.PLUGIN_ID_FLOOR, "validPluginType");
+    OperatorTypeRegistry.registerPlugin(descriptor, map);
+    Assert.assertSame(map.get(OperatorTypeDescriptor.PLUGIN_ID_FLOOR), descriptor);
+  }
+
+  private static OperatorTypeDescriptor descriptor(int id, String name) {
+    return new OperatorTypeDescriptor() {
+      @Override
+      public int getId() {
+        return id;
+      }
+
+      @Override
+      public String name() {
+        return name;
+      }
+
+      @SuppressWarnings("rawtypes")
+      @Override
+      public Class getStatKeyClass() {
+        return MultiStageOperator.Type.AGGREGATE.getStatKeyClass();
+      }
+
+      @Override
+      public void mergeInto(BrokerResponseNativeV2 response, StatMap<?> map) {
+      }
+    };
   }
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.server.starter;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.netty.channel.ChannelHandler;
 import java.util.HashSet;
@@ -176,6 +177,17 @@ public class ServerInstance {
     }
     _instanceRequestHandler = instanceRequestHandler;
 
+    initTransformFunctions(serverConf);
+
+    LOGGER.info("Finish initializing server instance");
+  }
+
+  /// Initializes [TransformFunctionFactory] with the explicitly configured transform function classes
+  /// (`pinot.server.transforms`). The factory additionally discovers [TransformFunction] service providers from the
+  /// application classpath and the plugin classloaders via `ServiceLoader`, so external transform functions register
+  /// without any server configuration. Must run after all plugins have been loaded and before serving queries.
+  @VisibleForTesting
+  static void initTransformFunctions(ServerConf serverConf) {
     LOGGER.info("Initializing transform functions");
     Set<Class<TransformFunction>> transformFunctionClasses = new HashSet<>();
     for (String transformFunctionClassName : serverConf.getTransformFunctions()) {
@@ -187,8 +199,6 @@ public class ServerInstance {
       }
     }
     TransformFunctionFactory.init(transformFunctionClasses);
-
-    LOGGER.info("Finish initializing server instance");
   }
 
   public synchronized void startDataManager() {

--- a/pinot-server/src/test/java/org/apache/pinot/server/starter/ServerInstanceTransformFunctionTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/starter/ServerInstanceTransformFunctionTest.java
@@ -1,0 +1,158 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.server.starter;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.core.operator.transform.function.AdditionTransformFunction;
+import org.apache.pinot.core.operator.transform.function.BaseTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TransformFunction;
+import org.apache.pinot.core.operator.transform.function.TransformFunctionFactory;
+import org.apache.pinot.server.conf.ServerConf;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+
+/// Verifies the [ServerInstance] transform function initialization path: a [TransformFunction] service provider on
+/// the classpath registers through `ServiceLoader` discovery without `pinot.server.transforms`, while the legacy
+/// `pinot.server.transforms` configuration keeps working.
+///
+/// The service descriptor is generated into a temporary directory exposed through an isolated [URLClassLoader]
+/// (installed as the thread context classloader), so no `META-INF/services` fixture leaks into the test classpath.
+public class ServerInstanceTransformFunctionTest {
+  private static final String SERVICE_DESCRIPTOR_PATH = "META-INF/services/" + TransformFunction.class.getName();
+  private static final List<Path> TEMP_DIRS = new ArrayList<>();
+  private static final List<URLClassLoader> DESCRIPTOR_CLASS_LOADERS = new ArrayList<>();
+
+  @AfterMethod
+  public void resetRegistry() {
+    // Drop any registration made by the previous test method
+    TransformFunctionFactory.init(Set.of());
+  }
+
+  @AfterClass
+  public void tearDownDescriptorFixtures()
+      throws IOException {
+    for (URLClassLoader descriptorClassLoader : DESCRIPTOR_CLASS_LOADERS) {
+      descriptorClassLoader.close();
+    }
+    for (Path tempDir : TEMP_DIRS) {
+      FileUtils.deleteQuietly(tempDir.toFile());
+    }
+  }
+
+  @Test
+  public void testServiceProvidedTransformRegisteredWithoutConfig()
+      throws Exception {
+    ServerConf serverConf = new ServerConf(new PinotConfiguration());
+    assertTrue(serverConf.getTransformFunctions().isEmpty(), "pinot.server.transforms must not be set");
+
+    Thread currentThread = Thread.currentThread();
+    ClassLoader originalClassLoader = currentThread.getContextClassLoader();
+    currentThread.setContextClassLoader(
+        createDescriptorClassLoader(ServiceProvidedTransformFunction.class.getName()));
+    try {
+      ServerInstance.initTransformFunctions(serverConf);
+    } finally {
+      currentThread.setContextClassLoader(originalClassLoader);
+    }
+
+    assertSame(TransformFunctionFactory.getAllFunctions().get("serviceprovidedtransform"),
+        ServiceProvidedTransformFunction.class);
+    // Built-ins remain registered
+    assertSame(TransformFunctionFactory.getAllFunctions().get("add"), AdditionTransformFunction.class);
+  }
+
+  @Test
+  public void testLegacyTransformFunctionConfig() {
+    ServerConf serverConf = new ServerConf(new PinotConfiguration(
+        Map.of(CommonConstants.Server.CONFIG_OF_TRANSFORM_FUNCTIONS, ConfiguredTransformFunction.class.getName())));
+    ServerInstance.initTransformFunctions(serverConf);
+    assertSame(TransformFunctionFactory.getAllFunctions().get("configuredtransform"),
+        ConfiguredTransformFunction.class);
+  }
+
+  @Test
+  public void testMissingConfiguredTransformFunctionClassFails() {
+    ServerConf serverConf = new ServerConf(new PinotConfiguration(
+        Map.of(CommonConstants.Server.CONFIG_OF_TRANSFORM_FUNCTIONS, "com.example.DoesNotExist")));
+    Map<String, Class<? extends TransformFunction>> registryBefore = TransformFunctionFactory.getAllFunctions();
+    RuntimeException exception =
+        expectThrows(RuntimeException.class, () -> ServerInstance.initTransformFunctions(serverConf));
+    assertTrue(exception.getMessage().contains("com.example.DoesNotExist"), exception.getMessage());
+    // The failed init must leave the previously published registry snapshot untouched
+    assertSame(TransformFunctionFactory.getAllFunctions(), registryBefore);
+  }
+
+  private static ClassLoader createDescriptorClassLoader(String... descriptorLines)
+      throws IOException {
+    Path tempDir = Files.createTempDirectory("server-transform-function-descriptor");
+    TEMP_DIRS.add(tempDir);
+    Path descriptorFile = tempDir.resolve(SERVICE_DESCRIPTOR_PATH);
+    Files.createDirectories(descriptorFile.getParent());
+    Files.write(descriptorFile, List.of(descriptorLines), StandardCharsets.UTF_8);
+    URLClassLoader descriptorClassLoader = new URLClassLoader(new URL[]{tempDir.toUri().toURL()},
+        ServerInstanceTransformFunctionTest.class.getClassLoader());
+    DESCRIPTOR_CLASS_LOADERS.add(descriptorClassLoader);
+    return descriptorClassLoader;
+  }
+
+  /// Provider registered through the generated service descriptor.
+  public static class ServiceProvidedTransformFunction extends BaseTransformFunction {
+    @Override
+    public String getName() {
+      return "Service_Provided_Transform";
+    }
+
+    @Override
+    public TransformResultMetadata getResultMetadata() {
+      return INT_SV_NO_DICTIONARY_METADATA;
+    }
+  }
+
+  /// Provider registered through the legacy `pinot.server.transforms` configuration.
+  public static class ConfiguredTransformFunction extends BaseTransformFunction {
+    @Override
+    public String getName() {
+      return "Configured_Transform";
+    }
+
+    @Override
+    public TransformResultMetadata getResultMetadata() {
+      return INT_SV_NO_DICTIONARY_METADATA;
+    }
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginManager.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginManager.java
@@ -34,10 +34,13 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -482,13 +485,9 @@ public class PluginManager {
   /// and loaded into a dedicated [ClassRealm]. Legacy shaded plugins (loaded via
   /// [PluginClassLoader]) are excluded — new SPIs should only target new-style plugins.
   ///
-  /// Intended for `ServiceLoader` enumeration across plugin classloaders:
-  ///
-  /// ```java
-  /// for (ClassLoader cl : PluginManager.get().getPluginClassLoaders()) {
-  ///   for (MyService svc : ServiceLoader.load(MyService.class, cl)) { ... }
-  /// }
-  /// ```
+  /// Prefer [#loadServiceProviders(Class)] for `ServiceLoader` enumeration across the
+  /// context classloader and plugin classloaders; use this accessor directly only when a
+  /// caller needs the raw classloaders.
   ///
   /// Call after all plugins have been loaded; classloaders added after this
   /// call returns will not appear in the snapshot.
@@ -501,6 +500,93 @@ public class PluginManager {
       }
     }
     return Collections.unmodifiableSet(result);
+  }
+
+  /// Discovers service providers of the given service type via `ServiceLoader`, first from the thread context
+  /// classloader (the application classpath in a standard deployment), then from every plugin classloader (see
+  /// [#getPluginClassLoaders()]), in that order.
+  ///
+  /// Providers are de-duplicated by fully-qualified class name across classloaders: overlapping classpaths (e.g.
+  /// fat-jar + plugin realm) can surface the same provider through multiple loaders, and the first sighting wins.
+  /// A same-named provider whose `Class` object differs from the first sighting indicates version skew between
+  /// classloaders; it is logged at WARN and skipped.
+  ///
+  /// Each returned entry pairs the provider instance with a human-readable description of the classloader it was
+  /// discovered from, for use in call-site log and error messages. Enumeration failures
+  /// ([ServiceConfigurationError] — malformed descriptors, provider classes that cannot be found, are not subtypes
+  /// of the service type, or fail to construct) fail fast as [IllegalStateException] carrying the source
+  /// description, with the original error preserved as the cause. Per-provider validation and registration policy
+  /// stay with the caller.
+  ///
+  /// Returns an unmodifiable, freshly computed list — never null, empty when no providers are found. Thread-safe:
+  /// each call performs a fresh enumeration using only method-local state (the plugin classloader snapshot is taken
+  /// under the existing lock), and the result reflects the calling thread's context classloader.
+  ///
+  /// Call after all plugins have been loaded; plugin classloaders registered after this call returns are not
+  /// searched.
+  public <S> List<ServiceProvider<S>> loadServiceProviders(Class<S> serviceClass) {
+    List<ServiceProvider<S>> providers = new ArrayList<>();
+    Map<String, Class<?>> seenProviderClasses = new HashMap<>();
+    collectServiceProviders(ServiceLoader.load(serviceClass), serviceClass, "thread context classloader", providers,
+        seenProviderClasses);
+    for (ClassLoader pluginClassLoader : getPluginClassLoaders()) {
+      collectServiceProviders(ServiceLoader.load(serviceClass, pluginClassLoader), serviceClass,
+          "plugin classloader: " + pluginClassLoader, providers, seenProviderClasses);
+    }
+    return Collections.unmodifiableList(providers);
+  }
+
+  private static <S> void collectServiceProviders(ServiceLoader<S> serviceLoader, Class<S> serviceClass, String source,
+      List<ServiceProvider<S>> providers, Map<String, Class<?>> seenProviderClasses) {
+    Iterator<S> iterator = serviceLoader.iterator();
+    while (true) {
+      S provider;
+      try {
+        if (!iterator.hasNext()) {
+          return;
+        }
+        provider = iterator.next();
+      } catch (ServiceConfigurationError e) {
+        throw new IllegalStateException(
+            "Failed to load a " + serviceClass.getName() + " service provider from: " + source, e);
+      }
+      Class<?> providerClass = provider.getClass();
+      String providerClassName = providerClass.getName();
+      Class<?> seenClass = seenProviderClasses.putIfAbsent(providerClassName, providerClass);
+      if (seenClass != null) {
+        // Same provider already discovered through an overlapping classloader. A different Class object with the
+        // same name indicates version skew between classloaders; the first discovered copy wins.
+        if (seenClass != providerClass) {
+          LOGGER.warn("Ignoring duplicate service provider class: {} (classloader: {}, discovered from: {}); keeping "
+                  + "the copy from classloader: {}", providerClassName, providerClass.getClassLoader(), source,
+              seenClass.getClassLoader());
+        }
+        continue;
+      }
+      providers.add(new ServiceProvider<>(provider, source));
+    }
+  }
+
+  /// A service provider discovered by [#loadServiceProviders(Class)], paired with a human-readable description of
+  /// the classloader it was discovered from. Immutable and thread-safe.
+  public static final class ServiceProvider<S> {
+    private final S _provider;
+    private final String _source;
+
+    private ServiceProvider(S provider, String source) {
+      _provider = provider;
+      _source = source;
+    }
+
+    public S getProvider() {
+      return _provider;
+    }
+
+    /// Returns a human-readable description of the classloader the provider was discovered from, for use in log
+    /// and error messages.
+    public String getSource() {
+      return _source;
+    }
   }
 
   public static PluginManager get() {

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/plugin/ChildFirstClassLoader.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/plugin/ChildFirstClassLoader.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.plugin;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+
+/// Test utility classloader that defines its own copy of one class from the parent's class-file bytes instead of
+/// delegating, producing a `Class` object with the same name but a different defining classloader. Everything else
+/// (including the class's supertypes and any service interface) is delegated to the parent so the copy remains a
+/// valid service provider.
+///
+/// Used by `ServiceLoader` discovery tests (here and in downstream modules via the pinot-spi test-jar) to simulate
+/// a classloader shipping its own version-skewed copy of a provider class.
+public class ChildFirstClassLoader extends URLClassLoader {
+  private final String _childFirstClassName;
+
+  public ChildFirstClassLoader(URL[] urls, ClassLoader parent, String childFirstClassName) {
+    super(urls, parent);
+    _childFirstClassName = childFirstClassName;
+  }
+
+  @Override
+  protected Class<?> loadClass(String name, boolean resolve)
+      throws ClassNotFoundException {
+    if (!name.equals(_childFirstClassName)) {
+      return super.loadClass(name, resolve);
+    }
+    synchronized (getClassLoadingLock(name)) {
+      Class<?> loaded = findLoadedClass(name);
+      if (loaded == null) {
+        try (InputStream inputStream = getParent().getResourceAsStream(name.replace('.', '/') + ".class")) {
+          if (inputStream == null) {
+            throw new ClassNotFoundException(name);
+          }
+          byte[] classBytes = inputStream.readAllBytes();
+          loaded = defineClass(name, classBytes, 0, classBytes.length);
+        } catch (IOException e) {
+          throw new ClassNotFoundException(name, e);
+        }
+      }
+      if (resolve) {
+        resolveClass(loaded);
+      }
+      return loaded;
+    }
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/plugin/PluginManagerServiceProviderTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/plugin/PluginManagerServiceProviderTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.spi.plugin;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
@@ -37,6 +38,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
 
@@ -48,11 +50,6 @@ import static org.testng.Assert.expectThrows;
 /// Service descriptors are generated into temporary directories exposed through isolated [URLClassLoader]s
 /// (installed as the thread context classloader) or plugin realms of a fresh [PluginManager] instance, so no
 /// `META-INF/services` fixture leaks into the test classpath.
-///
-/// Note: the version-skew WARN branch (same provider class name resolving to different `Class` objects in
-/// different classloaders) is intentionally uncovered — it would require a self-first realm carrying its own copy
-/// of the provider's class bytes; the observable skip-duplicate outcome is asserted through the same-`Class`
-/// dedup test instead.
 public class PluginManagerServiceProviderTest {
   private static final String SERVICE_DESCRIPTOR_PATH = "META-INF/services/" + TestDiscoveryService.class.getName();
   private static final List<Path> TEMP_DIRS = new ArrayList<>();
@@ -122,6 +119,24 @@ public class PluginManagerServiceProviderTest {
   }
 
   @Test
+  public void testVersionSkewedDuplicateKeepsFirstDiscoveredCopy()
+      throws Exception {
+    // The context classloader defines its own copy of ImplA (child-first) while the plugin realm resolves the
+    // test-classpath copy through parent delegation: same class name, different Class objects. The first sighting
+    // (context classloader) must win and the skewed duplicate must be skipped with a WARN
+    PluginManager pluginManager = new PluginManager();
+    loadDescriptorOnlyPlugin(pluginManager, "spi-service-provider-skew-plugin", ImplA.class.getName());
+    List<PluginManager.ServiceProvider<TestDiscoveryService>> providers =
+        withContextClassLoader(createChildFirstDescriptorClassLoader(ImplA.class.getName()),
+            () -> pluginManager.loadServiceProviders(TestDiscoveryService.class));
+    assertEquals(providers.size(), 1);
+    Class<?> providerClass = providers.get(0).getProvider().getClass();
+    assertEquals(providerClass.getName(), ImplA.class.getName());
+    assertNotSame(providerClass, ImplA.class);
+    assertTrue(providers.get(0).getSource().contains("thread context classloader"), providers.get(0).getSource());
+  }
+
+  @Test
   public void testMalformedDescriptorFailsWithSourceAndCause()
       throws Exception {
     PluginManager pluginManager = new PluginManager();
@@ -178,6 +193,57 @@ public class PluginManagerServiceProviderTest {
         PluginManagerServiceProviderTest.class.getClassLoader());
     DESCRIPTOR_CLASS_LOADERS.add(descriptorClassLoader);
     return descriptorClassLoader;
+  }
+
+  /// Like [#createDescriptorClassLoader(String...)], but the returned loader additionally defines its own copy of
+  /// the provider class from the test-classpath bytes instead of delegating to the parent, simulating a
+  /// classloader shipping its own (version-skewed) copy of the class.
+  private static ClassLoader createChildFirstDescriptorClassLoader(String providerClassName)
+      throws IOException {
+    Path tempDir = Files.createTempDirectory("spi-service-provider-descriptor");
+    TEMP_DIRS.add(tempDir);
+    Path descriptorFile = tempDir.resolve(SERVICE_DESCRIPTOR_PATH);
+    Files.createDirectories(descriptorFile.getParent());
+    Files.write(descriptorFile, List.of(providerClassName), StandardCharsets.UTF_8);
+    URLClassLoader descriptorClassLoader = new ChildFirstClassLoader(new URL[]{tempDir.toUri().toURL()},
+        PluginManagerServiceProviderTest.class.getClassLoader(), providerClassName);
+    DESCRIPTOR_CLASS_LOADERS.add(descriptorClassLoader);
+    return descriptorClassLoader;
+  }
+
+  /// Classloader that defines its own copy of one class from the parent's class-file bytes instead of delegating,
+  /// producing a Class object with the same name but a different defining classloader. Everything else (including
+  /// the service interface) is delegated to the parent so the copy remains a valid provider.
+  private static class ChildFirstClassLoader extends URLClassLoader {
+    private final String _childFirstClassName;
+
+    ChildFirstClassLoader(URL[] urls, ClassLoader parent, String childFirstClassName) {
+      super(urls, parent);
+      _childFirstClassName = childFirstClassName;
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve)
+        throws ClassNotFoundException {
+      if (!name.equals(_childFirstClassName)) {
+        return super.loadClass(name, resolve);
+      }
+      synchronized (getClassLoadingLock(name)) {
+        Class<?> loaded = findLoadedClass(name);
+        if (loaded == null) {
+          try (InputStream inputStream = getParent().getResourceAsStream(name.replace('.', '/') + ".class")) {
+            byte[] classBytes = inputStream.readAllBytes();
+            loaded = defineClass(name, classBytes, 0, classBytes.length);
+          } catch (IOException e) {
+            throw new ClassNotFoundException(name, e);
+          }
+        }
+        if (resolve) {
+          resolveClass(loaded);
+        }
+        return loaded;
+      }
+    }
   }
 
   private static <T> T withContextClassLoader(ClassLoader classLoader, Callable<T> callable)

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/plugin/PluginManagerServiceProviderTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/plugin/PluginManagerServiceProviderTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.spi.plugin;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
@@ -196,8 +195,9 @@ public class PluginManagerServiceProviderTest {
   }
 
   /// Like [#createDescriptorClassLoader(String...)], but the returned loader additionally defines its own copy of
-  /// the provider class from the test-classpath bytes instead of delegating to the parent, simulating a
-  /// classloader shipping its own (version-skewed) copy of the class.
+  /// the provider class from the test-classpath bytes instead of delegating to the parent (via the shared
+  /// [ChildFirstClassLoader] test utility), simulating a classloader shipping its own (version-skewed) copy of the
+  /// class.
   private static ClassLoader createChildFirstDescriptorClassLoader(String providerClassName)
       throws IOException {
     Path tempDir = Files.createTempDirectory("spi-service-provider-descriptor");
@@ -209,41 +209,6 @@ public class PluginManagerServiceProviderTest {
         PluginManagerServiceProviderTest.class.getClassLoader(), providerClassName);
     DESCRIPTOR_CLASS_LOADERS.add(descriptorClassLoader);
     return descriptorClassLoader;
-  }
-
-  /// Classloader that defines its own copy of one class from the parent's class-file bytes instead of delegating,
-  /// producing a Class object with the same name but a different defining classloader. Everything else (including
-  /// the service interface) is delegated to the parent so the copy remains a valid provider.
-  private static class ChildFirstClassLoader extends URLClassLoader {
-    private final String _childFirstClassName;
-
-    ChildFirstClassLoader(URL[] urls, ClassLoader parent, String childFirstClassName) {
-      super(urls, parent);
-      _childFirstClassName = childFirstClassName;
-    }
-
-    @Override
-    protected Class<?> loadClass(String name, boolean resolve)
-        throws ClassNotFoundException {
-      if (!name.equals(_childFirstClassName)) {
-        return super.loadClass(name, resolve);
-      }
-      synchronized (getClassLoadingLock(name)) {
-        Class<?> loaded = findLoadedClass(name);
-        if (loaded == null) {
-          try (InputStream inputStream = getParent().getResourceAsStream(name.replace('.', '/') + ".class")) {
-            byte[] classBytes = inputStream.readAllBytes();
-            loaded = defineClass(name, classBytes, 0, classBytes.length);
-          } catch (IOException e) {
-            throw new ClassNotFoundException(name, e);
-          }
-        }
-        if (resolve) {
-          resolveClass(loaded);
-        }
-        return loaded;
-      }
-    }
   }
 
   private static <T> T withContextClassLoader(ClassLoader classLoader, Callable<T> callable)

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/plugin/PluginManagerServiceProviderTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/plugin/PluginManagerServiceProviderTest.java
@@ -1,0 +1,210 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.plugin;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceConfigurationError;
+import java.util.concurrent.Callable;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import org.apache.commons.io.FileUtils;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+
+/// Tests for [PluginManager#loadServiceProviders(Class)]: enumeration across the thread context classloader and
+/// plugin classloaders, de-duplication by provider class name, source descriptions, and fail-fast wrapping of
+/// [ServiceConfigurationError].
+///
+/// Service descriptors are generated into temporary directories exposed through isolated [URLClassLoader]s
+/// (installed as the thread context classloader) or plugin realms of a fresh [PluginManager] instance, so no
+/// `META-INF/services` fixture leaks into the test classpath.
+///
+/// Note: the version-skew WARN branch (same provider class name resolving to different `Class` objects in
+/// different classloaders) is intentionally uncovered — it would require a self-first realm carrying its own copy
+/// of the provider's class bytes; the observable skip-duplicate outcome is asserted through the same-`Class`
+/// dedup test instead.
+public class PluginManagerServiceProviderTest {
+  private static final String SERVICE_DESCRIPTOR_PATH = "META-INF/services/" + TestDiscoveryService.class.getName();
+  private static final List<Path> TEMP_DIRS = new ArrayList<>();
+  private static final List<URLClassLoader> DESCRIPTOR_CLASS_LOADERS = new ArrayList<>();
+
+  @AfterClass
+  public void tearDownDescriptorFixtures()
+      throws IOException {
+    for (URLClassLoader descriptorClassLoader : DESCRIPTOR_CLASS_LOADERS) {
+      descriptorClassLoader.close();
+    }
+    for (Path tempDir : TEMP_DIRS) {
+      FileUtils.deleteQuietly(tempDir.toFile());
+    }
+  }
+
+  @Test
+  public void testContextClassLoaderDiscovery()
+      throws Exception {
+    PluginManager pluginManager = new PluginManager();
+    List<PluginManager.ServiceProvider<TestDiscoveryService>> providers =
+        withContextClassLoader(createDescriptorClassLoader(ImplA.class.getName()),
+            () -> pluginManager.loadServiceProviders(TestDiscoveryService.class));
+    assertEquals(providers.size(), 1);
+    assertEquals(providers.get(0).getProvider().getClass(), ImplA.class);
+    assertTrue(providers.get(0).getSource().contains("thread context classloader"), providers.get(0).getSource());
+  }
+
+  @Test
+  public void testPluginClassLoaderDiscovery()
+      throws Exception {
+    PluginManager pluginManager = new PluginManager();
+    loadDescriptorOnlyPlugin(pluginManager, "spi-service-provider-test-plugin", ImplB.class.getName());
+    List<PluginManager.ServiceProvider<TestDiscoveryService>> providers =
+        pluginManager.loadServiceProviders(TestDiscoveryService.class);
+    assertEquals(providers.size(), 1);
+    assertEquals(providers.get(0).getProvider().getClass(), ImplB.class);
+    assertTrue(providers.get(0).getSource().contains("plugin classloader"), providers.get(0).getSource());
+  }
+
+  @Test
+  public void testDeduplicationAcrossOverlappingClassLoaders()
+      throws Exception {
+    // The same provider class is listed both in the context classloader descriptor and in the plugin realm
+    // descriptor; the first sighting (context classloader) wins and no duplicate is returned
+    PluginManager pluginManager = new PluginManager();
+    loadDescriptorOnlyPlugin(pluginManager, "spi-service-provider-dedup-plugin", ImplA.class.getName());
+    List<PluginManager.ServiceProvider<TestDiscoveryService>> providers =
+        withContextClassLoader(createDescriptorClassLoader(ImplA.class.getName()),
+            () -> pluginManager.loadServiceProviders(TestDiscoveryService.class));
+    assertEquals(providers.size(), 1);
+    assertEquals(providers.get(0).getProvider().getClass(), ImplA.class);
+    assertTrue(providers.get(0).getSource().contains("thread context classloader"), providers.get(0).getSource());
+  }
+
+  @Test
+  public void testDiscoveryOrderContextClassLoaderFirst()
+      throws Exception {
+    PluginManager pluginManager = new PluginManager();
+    loadDescriptorOnlyPlugin(pluginManager, "spi-service-provider-order-plugin", ImplB.class.getName());
+    List<PluginManager.ServiceProvider<TestDiscoveryService>> providers =
+        withContextClassLoader(createDescriptorClassLoader(ImplA.class.getName()),
+            () -> pluginManager.loadServiceProviders(TestDiscoveryService.class));
+    assertEquals(providers.size(), 2);
+    assertEquals(providers.get(0).getProvider().getClass(), ImplA.class);
+    assertEquals(providers.get(1).getProvider().getClass(), ImplB.class);
+  }
+
+  @Test
+  public void testMalformedDescriptorFailsWithSourceAndCause()
+      throws Exception {
+    PluginManager pluginManager = new PluginManager();
+    IllegalStateException exception = expectThrows(IllegalStateException.class,
+        () -> withContextClassLoader(createDescriptorClassLoader("com.example.DoesNotExist"),
+            () -> pluginManager.loadServiceProviders(TestDiscoveryService.class)));
+    assertTrue(exception.getMessage().contains(TestDiscoveryService.class.getName()), exception.getMessage());
+    assertTrue(exception.getMessage().contains("thread context classloader"), exception.getMessage());
+    assertTrue(exception.getCause() instanceof ServiceConfigurationError, String.valueOf(exception.getCause()));
+  }
+
+  @Test
+  public void testProviderConstructorFailureFailsWithCause()
+      throws Exception {
+    PluginManager pluginManager = new PluginManager();
+    IllegalStateException exception = expectThrows(IllegalStateException.class,
+        () -> withContextClassLoader(createDescriptorClassLoader(ThrowingImpl.class.getName()),
+            () -> pluginManager.loadServiceProviders(TestDiscoveryService.class)));
+    assertTrue(exception.getCause() instanceof ServiceConfigurationError, String.valueOf(exception.getCause()));
+  }
+
+  @Test
+  public void testNoDescriptorsYieldsEmptyList() {
+    PluginManager pluginManager = new PluginManager();
+    assertTrue(pluginManager.loadServiceProviders(TestDiscoveryService.class).isEmpty());
+  }
+
+  /// Registers a new-style plugin realm holding only a service descriptor. The realm delegates to the pinot realm
+  /// for classes (`parent.realmId=pinot`), but the descriptor itself is only visible through the plugin
+  /// classloader.
+  private static void loadDescriptorOnlyPlugin(PluginManager pluginManager, String pluginName,
+      String providerClassName)
+      throws IOException {
+    File pluginDir = Files.createTempDirectory(pluginName).toFile();
+    TEMP_DIRS.add(pluginDir.toPath());
+    Files.writeString(new File(pluginDir, "pinot-plugin.properties").toPath(), "parent.realmId=pinot\n");
+    try (JarOutputStream jarOutputStream = new JarOutputStream(
+        new FileOutputStream(new File(pluginDir, "service-descriptor.jar")))) {
+      jarOutputStream.putNextEntry(new JarEntry(SERVICE_DESCRIPTOR_PATH));
+      jarOutputStream.write((providerClassName + "\n").getBytes(StandardCharsets.UTF_8));
+      jarOutputStream.closeEntry();
+    }
+    pluginManager.load(pluginName, pluginDir);
+  }
+
+  private static ClassLoader createDescriptorClassLoader(String... descriptorLines)
+      throws IOException {
+    Path tempDir = Files.createTempDirectory("spi-service-provider-descriptor");
+    TEMP_DIRS.add(tempDir);
+    Path descriptorFile = tempDir.resolve(SERVICE_DESCRIPTOR_PATH);
+    Files.createDirectories(descriptorFile.getParent());
+    Files.write(descriptorFile, List.of(descriptorLines), StandardCharsets.UTF_8);
+    URLClassLoader descriptorClassLoader = new URLClassLoader(new URL[]{tempDir.toUri().toURL()},
+        PluginManagerServiceProviderTest.class.getClassLoader());
+    DESCRIPTOR_CLASS_LOADERS.add(descriptorClassLoader);
+    return descriptorClassLoader;
+  }
+
+  private static <T> T withContextClassLoader(ClassLoader classLoader, Callable<T> callable)
+      throws Exception {
+    Thread currentThread = Thread.currentThread();
+    ClassLoader originalClassLoader = currentThread.getContextClassLoader();
+    currentThread.setContextClassLoader(classLoader);
+    try {
+      return callable.call();
+    } finally {
+      currentThread.setContextClassLoader(originalClassLoader);
+    }
+  }
+
+  /// Service type used only by this test; no descriptor for it exists on the test classpath.
+  public interface TestDiscoveryService {
+  }
+
+  public static class ImplA implements TestDiscoveryService {
+  }
+
+  public static class ImplB implements TestDiscoveryService {
+  }
+
+  public static class ThrowingImpl implements TestDiscoveryService {
+    public ThrowingImpl() {
+      throw new IllegalStateException("Intentional constructor failure");
+    }
+  }
+}


### PR DESCRIPTION
> **Stacked on #19259** — this branch includes that PR's commit; only the second commit is new here. Will rebase once #19259 merges.

## Summary

Follow-up to #19259. Three call sites hand-rolled the same ServiceLoader enumeration pattern — load from the thread context classloader, then from every classloader returned by `PluginManager.get().getPluginClassLoaders()`, de-duplicating providers by fully-qualified class name:

- `PinotRuleSet.loadFromServiceLoader()` (pinot-query-planner)
- `OperatorTypeRegistry` static initializer (pinot-query-runtime)
- `TransformFunctionFactory.registerServiceProviders(...)` (pinot-core)

This PR extracts the shared mechanism into pinot-spi as `PluginManager#loadServiceProviders(Class)` and migrates all three call sites. Any future fix to the enumeration mechanism (dedup semantics, realm ordering, error context) now lands in one place.

## The helper

```java
List<PluginManager.ServiceProvider<MyService>> providers =
    PluginManager.get().loadServiceProviders(MyService.class);
```

- Enumerates the thread context classloader first (the application classpath in a standard deployment), then every plugin classloader, in load order.
- De-duplicates providers by fully-qualified class name across classloaders (overlapping classpaths — e.g. fat-jar + plugin realm — surface the same provider through multiple loaders; the first sighting wins). A same-named provider whose `Class` object differs from the first sighting indicates version skew between classloaders and is logged at WARN before being skipped.
- Each returned `ServiceProvider<S>` pairs the provider instance with a human-readable source description for call-site log/error messages.
- Enumeration failures (`ServiceConfigurationError` — malformed descriptors, missing/incompatible/unconstructable provider classes) fail fast as `IllegalStateException` carrying the source description with the original error preserved as the cause.
- Per-provider validation and registration policy stay with the caller (id-floor checks in `OperatorTypeRegistry`, name canonicalization/collision rules in `TransformFunctionFactory`, ordering in `PinotRuleSet`).

## New public SPI surface (reviewer attention)

This adds a permanent additive contract to pinot-spi that plugin authors can depend on: `PluginManager#loadServiceProviders(Class)` and the nested immutable `PluginManager.ServiceProvider<S>` pair type, with these semantics: context-classloader-first discovery order, first-sighting-wins dedup by class name, WARN-and-skip on classloader version skew, an unmodifiable freshly computed result list, and fail-fast `IllegalStateException` wrapping of `ServiceConfigurationError` with source context. No existing signature changed; `getPluginClassLoaders()` remains for callers needing the raw classloaders.

## Behavior notes

- `TransformFunctionFactory`: no behavior change — it previously used the exact logic now hosted in the helper.
- `PinotRuleSet` / `OperatorTypeRegistry` (deliberate unification onto the `TransformFunctionFactory` fail-fast contract): a malformed descriptor or failing provider constructor now surfaces as `IllegalStateException` with classloader-source context and the `ServiceConfigurationError` as cause, instead of the raw error propagating with no context (from `OperatorTypeRegistry`'s static initializer both variants surface as `ExceptionInInitializerError`). Both paths failed startup/class-init before and still do; the failure just carries more information. Their silent same-FQCN dedup now WARNs when the duplicate is a genuinely different class (version skew). Error precedence can also shift: providers are fully enumerated before caller-side validation runs, so an enumeration failure from a later classloader may now surface before a caller-side validation error that previously fired first — either way startup fails.
- All three modules already depended on pinot-spi; no layering change.

## Testing

- New `PluginManagerServiceProviderTest` (pinot-spi): context-classloader discovery, plugin-realm discovery, cross-classloader dedup, discovery order, malformed-descriptor and constructor-failure wrapping (source + cause asserted), empty result. Descriptors are generated into temp dirs behind isolated `URLClassLoader`s and fresh `PluginManager` instances, so no fixture leaks into the test classpath.
- Existing suites pass unchanged: `TransformFunctionFactoryTest` (23), `ServerInstanceTransformFunctionTest` (3), `PinotRuleSetTest`, `OperatorTypeRegistryTest`, `PluginRealmExportTest`.
