### PR TITLE
Support PostgreSQL hex bytea literals

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
@@ -97,18 +97,56 @@ public class LiteralOnlyBrokerRequestTest {
     assertEquals((int[]) resultTable.getRows().get(0)[0], new int[]{1, 2});
     assertEquals((String[]) resultTable.getRows().get(0)[1], new String[]{"one", "two"});
 
-    brokerResponse = requestHandler.handleRequest("SELECT ARRAY[X'00', X'0102'] AS bytes");
-    resultTable = brokerResponse.getResultTable();
-    assertEquals(resultTable.getDataSchema().getColumnName(0), "bytes");
-    assertEquals(resultTable.getDataSchema().getColumnDataType(0), DataSchema.ColumnDataType.BYTES_ARRAY);
-    assertEquals(resultTable.getRows().size(), 1);
-    assertEquals(resultTable.getRows().get(0), new Object[]{new String[]{"00", "0102"}});
+    // The SQL-standard and PostgreSQL spellings must produce the same BYTES_ARRAY response.
+    for (String arrayLiteral : List.of("ARRAY[X'00', X'0102']", "ARRAY['\\x00'::bytea, '\\x0102'::bytea]",
+        "ARRAY[CAST('\\x00' AS BYTEA), CAST('\\x0102' AS BYTEA)]")) {
+      brokerResponse = requestHandler.handleRequest("SELECT " + arrayLiteral + " AS bytes");
+      resultTable = brokerResponse.getResultTable();
+      assertEquals(resultTable.getDataSchema().getColumnName(0), "bytes");
+      assertEquals(resultTable.getDataSchema().getColumnDataType(0), DataSchema.ColumnDataType.BYTES_ARRAY);
+      assertEquals(resultTable.getRows().size(), 1);
+      assertEquals(resultTable.getRows().get(0), new Object[]{new String[]{"00", "0102"}});
+    }
 
     brokerResponse = requestHandler.handleRequest(
         "SELECT ARRAYS_OVERLAP(ARRAY[X'00', X'0102'], ARRAY[X'03', X'0102']) AS overlaps");
     resultTable = brokerResponse.getResultTable();
     assertEquals(resultTable.getDataSchema().getColumnDataType(0), DataSchema.ColumnDataType.BOOLEAN);
     assertEquals(resultTable.getRows().get(0)[0], true);
+  }
+
+  /// A scalar bytea constant must be answered by the literal-only path exactly like `X'...'`, in both spellings.
+  @Test
+  public void testScalarBytesLiteralBrokerRequestFromSQL()
+      throws Exception {
+    SingleConnectionBrokerRequestHandler requestHandler =
+        new SingleConnectionBrokerRequestHandler(new PinotConfiguration(), "testBrokerId",
+            new BrokerRequestIdGenerator(), null, ACCESS_CONTROL_FACTORY, null, null, null, null,
+            mock(ServerRoutingStatsManager.class), mock(FailureDetector.class),
+            ThreadAccountantUtils.getNoOpAccountant(), null, null);
+
+    for (String literal : List.of("X'0102'", "'\\x0102'::bytea", "CAST('\\x0102' AS BYTEA)")) {
+      assertTrue(isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery("SELECT " + literal)));
+      BrokerResponse brokerResponse = requestHandler.handleRequest("SELECT " + literal + " AS b");
+      ResultTable resultTable = brokerResponse.getResultTable();
+      assertTrue(brokerResponse.getExceptions().isEmpty(), literal);
+      assertEquals(resultTable.getDataSchema().getColumnDataType(0), DataSchema.ColumnDataType.BYTES, literal);
+      assertEquals(resultTable.getRows().get(0)[0], "0102", literal);
+    }
+
+    // An empty bytea constant is legal in PostgreSQL and yields zero-length BYTES.
+    BrokerResponse brokerResponse = requestHandler.handleRequest("SELECT '\\x'::bytea AS b");
+    assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnDataType(0),
+        DataSchema.ColumnDataType.BYTES);
+    assertEquals(brokerResponse.getResultTable().getRows().get(0)[0], "");
+
+    // Constant folding over bytea elements still happens at parse time, so the query stays literal-only.
+    String folded = "SELECT ARRAY_LENGTH(ARRAY['\\x00'::bytea, '\\x0102'::bytea]) AS n";
+    assertTrue(isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery(folded)));
+    brokerResponse = requestHandler.handleRequest(folded);
+    assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnDataType(0),
+        DataSchema.ColumnDataType.INT);
+    assertEquals(brokerResponse.getResultTable().getRows().get(0)[0], 2);
   }
 
   @Test

--- a/pinot-common/src/main/codegen/config.fmpp
+++ b/pinot-common/src/main/codegen/config.fmpp
@@ -654,11 +654,13 @@ data: {
     # Binary operators tokens.
     # Example: "< INFIX_CAST: \"::\" >".
     binaryOperatorsTokens: [
+      "< INFIX_CAST: \"::\" >"
     ]
 
     # Binary operators initialization.
     # Example: "InfixCast".
     extraBinaryExpressions: [
+      "InfixCast"
       "SqlAtTimeZone"
     ]
 

--- a/pinot-common/src/main/codegen/includes/parserImpls.ftl
+++ b/pinot-common/src/main/codegen/includes/parserImpls.ftl
@@ -88,6 +88,25 @@ void SqlAtTimeZone(List<Object> list, ExprContext exprContext, Span s) :
     }
 }
 
+/// Parses the PostgreSQL infix `::` cast operator. The operator and its target type are appended to the enclosing
+/// expression list so `SqlParserUtil.toTree` applies the standard precedence rules, exactly like `SqlAtTimeZone`
+/// above; collapsing the list here instead would make `::` bind the whole expression to its left. PostgreSQL BYTEA
+/// literals are normalized after parsing so both query engines receive the same binary literal representation as
+/// SQL `X'...'`.
+void InfixCast(List<Object> list, ExprContext exprContext, Span s) :
+{
+    final SqlDataTypeSpec dataType;
+}
+{
+    <INFIX_CAST> {
+        checkNonQueryExpression(exprContext);
+    }
+    dataType = DataType() {
+        list.add(new SqlParserUtil.ToTreeListItem(SqlLibraryOperators.INFIX_CAST, s.pos()));
+        list.add(dataType);
+    }
+}
+
 SqlNode SqlPhysicalExplain() :
 {
     SqlNode stmt;

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -129,6 +129,7 @@ public class CalciteSqlParser {
     try (StringReader inStream = new StringReader(sql)) {
       SqlParserImpl sqlParser = newSqlParser(inStream);
       SqlNodeList sqlNodeList = sqlParser.parseSqlStmtList();
+      sqlNodeList = (SqlNodeList) PostgreSqlCastRewriter.rewrite(sqlNodeList);
       // Extract OPTION statements from sql.
       SqlNodeAndOptions sqlNodeAndOptions = extractSqlNodeAndOptions(sqlNodeList);
       // add legacy OPTIONS keyword-based options
@@ -549,6 +550,7 @@ public class CalciteSqlParser {
     try (StringReader inStream = new StringReader(expression)) {
       SqlParserImpl sqlParser = newSqlParser(inStream);
       sqlNode = sqlParser.parseSqlExpressionEof();
+      sqlNode = PostgreSqlCastRewriter.rewrite(sqlNode);
     } catch (Throwable e) {
       throw new SqlCompilationException("Caught exception while parsing expression: " + expression, e);
     }

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/PostgreSqlCastRewriter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/PostgreSqlCastRewriter.java
@@ -1,0 +1,141 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers;
+
+import java.util.List;
+import org.apache.calcite.sql.SqlBinaryStringLiteral;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlCharStringLiteral;
+import org.apache.calcite.sql.SqlDataTypeSpec;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
+import org.apache.calcite.sql.util.SqlShuttle;
+
+
+/// Normalizes PostgreSQL hex-format BYTEA constants (`'\x0102'::bytea` and `CAST('\x0102' AS BYTEA)`) to Calcite
+/// binary literals, so both query engines see the same representation they would get from SQL `X'0102'`. Only quoted
+/// constants are normalized: a dynamic `STRING`-to-`BYTES` conversion would have to be implemented per row in each
+/// engine, and the two would be easy to drift apart.
+///
+/// Every other use of the PostgreSQL `::` operator is rejected here. That is a deliberate scope limit, not a
+/// technical one — `SqlLibraryOperators.INFIX_CAST` is an ordinary `SqlCastOperator` of kind
+/// [org.apache.calcite.sql.SqlKind#CAST], so `intCol::double` would in fact plan and run like `CAST(intCol AS
+/// DOUBLE)`. Supporting the full operator means committing to `::` type-name semantics across both engines and is
+/// left to a follow-up; until then the grammar accepts `::` only so that this rewriter can give a clear error
+/// instead of a parse failure.
+///
+/// Stateless and safe to share; `rewrite` uses a single immutable instance.
+final class PostgreSqlCastRewriter extends SqlShuttle {
+  private static final PostgreSqlCastRewriter INSTANCE = new PostgreSqlCastRewriter();
+  private static final String HEX_PREFIX = "\\x";
+  private static final String BYTEA_TYPE_NAME = "BYTEA";
+
+  private PostgreSqlCastRewriter() {
+  }
+
+  static SqlNode rewrite(SqlNode sqlNode) {
+    return sqlNode.accept(INSTANCE);
+  }
+
+  @Override
+  public SqlNode visit(SqlCall call) {
+    SqlNode visitedNode = super.visit(call);
+    if (!(visitedNode instanceof SqlCall)) {
+      return visitedNode;
+    }
+    SqlCall visitedCall = (SqlCall) visitedNode;
+    List<SqlNode> operands = visitedCall.getOperandList();
+    boolean infixCast = visitedCall.getOperator() == SqlLibraryOperators.INFIX_CAST;
+    if (visitedCall.getKind() != SqlKind.CAST || operands.size() != 2
+        || !(operands.get(1) instanceof SqlDataTypeSpec)) {
+      if (infixCast) {
+        // The target type did not survive as a type spec, e.g. `col::bytea[1]`, where the item accessor binds
+        // tighter than `::`. Reject it here rather than letting the malformed call reach the planner.
+        throw new SqlCompilationException("Unsupported PostgreSQL :: cast target in '" + visitedCall
+            + "'. Note that [] binds tighter than ::, so write CAST(<expr> AS <type>) instead");
+      }
+      return visitedCall;
+    }
+
+    SqlDataTypeSpec targetType = (SqlDataTypeSpec) operands.get(1);
+    boolean bytea = targetType.getTypeName().isSimple()
+        && targetType.getTypeName().getSimple().equalsIgnoreCase(BYTEA_TYPE_NAME);
+    if (!bytea) {
+      if (infixCast) {
+        throw new SqlCompilationException("PostgreSQL-style :: casts are supported only for BYTEA hex constants, "
+            + "not for target type '" + targetType.getTypeName() + "'. Use CAST(<expr> AS <type>) instead");
+      }
+      return visitedCall;
+    }
+
+    SqlNode source = operands.get(0);
+    if (source instanceof SqlBinaryStringLiteral) {
+      return source;
+    }
+    if (!(source instanceof SqlCharStringLiteral)) {
+      throw new SqlCompilationException("BYTEA casts are supported only for quoted hex constants such as "
+          + "'\\x0102', not for the expression '" + source + "'");
+    }
+    String value = ((SqlCharStringLiteral) source).getValueAs(String.class);
+    if (!value.startsWith(HEX_PREFIX)) {
+      throw invalidByteaLiteral(value);
+    }
+    return SqlBinaryStringLiteral.createBinaryString(normalizeHex(value), visitedCall.getParserPosition());
+  }
+
+  /// Decodes the digits after the leading `\x`. PostgreSQL allows whitespace between byte pairs but not inside one.
+  private static String normalizeHex(String literal) {
+    String value = literal.substring(HEX_PREFIX.length());
+    StringBuilder hex = new StringBuilder(value.length());
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (isAsciiWhitespace(c)) {
+        if ((hex.length() & 1) != 0) {
+          throw invalidByteaLiteral(literal);
+        }
+      } else if (isAsciiHexDigit(c)) {
+        hex.append(c);
+      } else {
+        throw invalidByteaLiteral(literal);
+      }
+    }
+    if ((hex.length() & 1) != 0) {
+      throw invalidByteaLiteral(literal);
+    }
+    return hex.toString();
+  }
+
+  /// Deliberately not `Character.digit(c, 16)`: that also accepts full-width and non-Latin digits such as `Ａ` and
+  /// `١`, which PostgreSQL rejects.
+  private static boolean isAsciiHexDigit(char c) {
+    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+  }
+
+  /// Deliberately not `Character.isWhitespace(c)`, for the same reason as [#isAsciiHexDigit]: PostgreSQL only skips
+  /// ASCII whitespace between byte pairs, so `'\x01 02'` is an error rather than `0x0102`.
+  private static boolean isAsciiWhitespace(char c) {
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == 0x0B;
+  }
+
+  private static SqlCompilationException invalidByteaLiteral(String value) {
+    return new SqlCompilationException("Invalid PostgreSQL BYTEA hex constant '" + value + "': it must begin with "
+        + "\\x and contain complete hexadecimal byte pairs, optionally separated by ASCII whitespace");
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/request/LiteralSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/request/LiteralSerDeTest.java
@@ -93,7 +93,9 @@ public class LiteralSerDeTest {
   public void testSingleStageQueryUsesNativeBytesArrayLiteral()
       throws TException {
     for (String sql : List.of("SELECT ARRAY[X'00', X'0102'] FROM myTable",
+        "SELECT ARRAY['\\x00'::bytea, CAST('\\x0102' AS BYTEA)] FROM myTable",
         "SELECT id FROM myTable WHERE ARRAYS_OVERLAP(bytesMV, ARRAY[X'01'])",
+        "SELECT id FROM myTable WHERE ARRAYS_OVERLAP(bytesMV, ARRAY['\\x01'::bytea])",
         "SELECT ARRAY[X'02'], COUNT(*) FROM myTable GROUP BY ARRAY[X'02']",
         "SELECT COUNT(*) FROM myTable HAVING ARRAYS_OVERLAP(ARRAYAGG(bytesColumn, 'BYTES'), ARRAY[X'03'])",
         "SELECT id FROM myTable "

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/request/RequestUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/request/RequestUtilsTest.java
@@ -127,6 +127,12 @@ public class RequestUtilsTest {
     assertEquals(RequestUtils.getBytesArrayValue(expression.getLiteral()), expected);
 
     expression = CalciteSqlParser.compileToPinotQuery(
+        "SELECT ARRAY['\\x00'::bytea, CAST('\\xDEADBEEF' AS BYTEA)] FROM myTable").getSelectList().get(0);
+    assertTrue(expression.isSetLiteral());
+    assertTrue(expression.getLiteral().isSetBytesArrayValue());
+    assertEquals(RequestUtils.getBytesArrayValue(expression.getLiteral()), expected);
+
+    expression = CalciteSqlParser.compileToPinotQuery(
         "SELECT ARRAYS_OVERLAP(ARRAY[X'00', X'0102'], ARRAY[X'03', X'0102'])").getSelectList().get(0);
     assertTrue(expression.isSetLiteral());
     assertTrue(expression.getLiteral().getBoolValue());

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlParserTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlParserTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.sql.parsers;
 
 import java.util.List;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.PinotQuery;
@@ -30,6 +31,8 @@ import org.testng.annotations.Test;
 import static org.apache.pinot.sql.parsers.CalciteSqlParser.CALCITE_SQL_PARSER_IDENTIFIER_MAX_LENGTH;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 
 /// Tests for CalciteSqlParser.
@@ -53,6 +56,108 @@ public class CalciteSqlParserTest {
   public void resetLegacyUnescaping() {
     // Reset to default (false) after each test
     RequestUtils.setUseLegacyLiteralUnescaping(true);
+  }
+
+  @Test
+  public void testPostgreSqlByteaHexLiterals() {
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("SELECT '\\x0102'::bytea");
+    assertEquals(pinotQuery.getSelectList().get(0).getLiteral().getBinaryValue(), new byte[]{1, 2});
+
+    pinotQuery = CalciteSqlParser.compileToPinotQuery("SELECT CAST('\\xDe Ad Be Ef' AS BYTEA)");
+    assertEquals(pinotQuery.getSelectList().get(0).getLiteral().getBinaryValue(),
+        new byte[]{(byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef});
+
+    pinotQuery = CalciteSqlParser.compileToPinotQuery("SELECT '\\x'::ByTeA");
+    assertEquals(pinotQuery.getSelectList().get(0).getLiteral().getBinaryValue(), new byte[0]);
+
+    Expression expression = CalciteSqlParser.compileToExpression("'\\x0102'::bytea");
+    assertEquals(expression.getLiteral().getBinaryValue(), new byte[]{1, 2});
+  }
+
+  /// `::` must bind only to the literal on its left, not to the whole expression accumulated so far, so that a bytea
+  /// constant can be used as the right operand of a comparison.
+  @Test(dataProvider = "binaryOperatorsTakingByteaLiterals")
+  public void testPostgreSqlByteaLiteralBindsTighterThanBinaryOperators(String predicate, String expectedOperator) {
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
+        "SELECT id FROM myTable WHERE bytesColumn " + predicate + " '\\x0102'::bytea");
+    Function filter = pinotQuery.getFilterExpression().getFunctionCall();
+    assertEquals(filter.getOperator(), expectedOperator);
+    assertEquals(filter.getOperands().get(0).getIdentifier().getName(), "bytesColumn");
+    assertEquals(filter.getOperands().get(1).getLiteral().getBinaryValue(), new byte[]{1, 2});
+  }
+
+  @DataProvider
+  public static Object[][] binaryOperatorsTakingByteaLiterals() {
+    return new Object[][]{
+        {"=", "EQUALS"},
+        {"<>", "NOT_EQUALS"},
+        {">", "GREATER_THAN"},
+        {"<=", "LESS_THAN_OR_EQUAL"}
+    };
+  }
+
+  @Test
+  public void testPostgreSqlByteaLiteralInCompoundPredicate() {
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
+        "SELECT id FROM myTable WHERE id = 1 AND bytesColumn = '\\x0102'::bytea");
+    Function and = pinotQuery.getFilterExpression().getFunctionCall();
+    assertEquals(and.getOperator(), "AND");
+    Function byteaEquals = and.getOperands().get(1).getFunctionCall();
+    assertEquals(byteaEquals.getOperands().get(0).getIdentifier().getName(), "bytesColumn");
+    assertEquals(byteaEquals.getOperands().get(1).getLiteral().getBinaryValue(), new byte[]{1, 2});
+  }
+
+  /// The infix and standard cast spellings must normalize to the same binary literal wherever they appear.
+  @Test
+  public void testPostgreSqlByteaLiteralMatchesStandardCastSpelling() {
+    for (String bytea : List.of("'\\x0102'::bytea", "'\\x0102' :: ByTeA", "CAST('\\x0102' AS BYTEA)",
+        "cast('\\x0102' as bytea)", "X'0102'")) {
+      PinotQuery pinotQuery =
+          CalciteSqlParser.compileToPinotQuery("SELECT id FROM myTable WHERE bytesColumn = " + bytea);
+      assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral()
+          .getBinaryValue(), new byte[]{1, 2}, bytea);
+      assertEquals(CalciteSqlParser.compileToExpression(bytea).getLiteral().getBinaryValue(), new byte[]{1, 2},
+          bytea);
+    }
+  }
+
+  @Test(dataProvider = "invalidPostgreSqlByteaLiterals")
+  public void testInvalidPostgreSqlByteaHexLiterals(String sql, String expectedMessageFragment) {
+    SqlCompilationException e =
+        expectThrows(SqlCompilationException.class, () -> CalciteSqlParser.compileToPinotQuery(sql));
+    assertTrue(ExceptionUtils.getStackTrace(e).contains(expectedMessageFragment),
+        "Expected <" + expectedMessageFragment + "> for " + sql + " but got: " + e.getMessage());
+  }
+
+  private static final String INVALID_CONSTANT = "Invalid PostgreSQL BYTEA hex constant";
+  private static final String NOT_A_CONSTANT = "BYTEA casts are supported only for quoted hex constants";
+
+  @DataProvider
+  public static Object[][] invalidPostgreSqlByteaLiterals() {
+    return new Object[][]{
+        // Malformed hex constants.
+        {"SELECT '\\x0'::bytea", INVALID_CONSTANT},
+        {"SELECT '\\x0g'::bytea", INVALID_CONSTANT},
+        {"SELECT '\\x0 1'::bytea", INVALID_CONSTANT},
+        {"SELECT '0102'::bytea", INVALID_CONSTANT},
+        // Full-width and non-Latin digits are hex digits to Character.digit but not to PostgreSQL.
+        {"SELECT '\\x\uFF21\uFF22'::bytea", INVALID_CONSTANT},
+        {"SELECT '\\x\u0660\u0661'::bytea", INVALID_CONSTANT},
+        // Non-ASCII whitespace is whitespace to Character.isWhitespace but not to PostgreSQL.
+        {"SELECT '\\x01\u205F02'::bytea", INVALID_CONSTANT},
+
+        // BYTEA casts of something that is not a constant.
+        {"SELECT bytesColumn::bytea FROM myTable", NOT_A_CONSTANT},
+        {"SELECT CAST(bytesColumn AS BYTEA) FROM myTable", NOT_A_CONSTANT},
+        {"SELECT id FROM myTable WHERE id = 1 AND bytesColumn::bytea = X'01'", NOT_A_CONSTANT},
+
+        // `::` to a target type other than BYTEA.
+        {"SELECT 1::int", "not for target type 'INTEGER'"},
+        {"SELECT bytesColumn::varchar FROM myTable", "not for target type 'VARCHAR'"},
+
+        // The item accessor binds tighter than `::`, so the target type does not survive as a type spec.
+        {"SELECT bytesColumn::bytea[1] FROM myTable", "Unsupported PostgreSQL :: cast target"}
+    };
   }
 
   @Test
@@ -100,6 +205,7 @@ public class CalciteSqlParserTest {
         new Object[]{"string"},
         new Object[]{"varchar"},
         new Object[]{"bytes"},
+        new Object[]{"bytea"},
         new Object[]{"binary"},
         new Object[]{"varbinary"},
         new Object[]{"variant"},

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/BytesMvTypeTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/BytesMvTypeTest.java
@@ -188,17 +188,19 @@ public class BytesMvTypeTest extends CustomDataQueryClusterIntegrationTest {
   public void testBytesArrayLiteral(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
-    String arrayLiteral = "ARRAY[X'07', X'0708', X'07090A']";
-    for (boolean withFrom : new boolean[]{true, false}) {
-      String query = withFrom ? String.format("SELECT %s FROM %s WHERE %s = 7 LIMIT 1", arrayLiteral,
-          getTableName(), ID_COLUMN) : "SELECT " + arrayLiteral;
-      JsonNode result = postQuery(query).get("resultTable");
-      assertEquals(result.get("dataSchema").get("columnDataTypes").get(0).asText(), "BYTES_ARRAY");
-      JsonNode values = result.get("rows").get(0).get(0);
-      assertEquals(values.size(), MV_LENGTH);
-      assertEquals(values.get(0).asText(), "07");
-      assertEquals(values.get(1).asText(), "0708");
-      assertEquals(values.get(2).asText(), "07090a");
+    for (String arrayLiteral : List.of("ARRAY[X'07', X'0708', X'07090A']",
+        "ARRAY['\\x07'::bytea, '\\x0708'::bytea, '\\x07090A'::bytea]")) {
+      for (boolean withFrom : new boolean[]{true, false}) {
+        String query = withFrom ? String.format("SELECT %s FROM %s WHERE %s = 7 LIMIT 1", arrayLiteral,
+            getTableName(), ID_COLUMN) : "SELECT " + arrayLiteral;
+        JsonNode result = postQuery(query).get("resultTable");
+        assertEquals(result.get("dataSchema").get("columnDataTypes").get(0).asText(), "BYTES_ARRAY");
+        JsonNode values = result.get("rows").get(0).get(0);
+        assertEquals(values.size(), MV_LENGTH);
+        assertEquals(values.get(0).asText(), "07");
+        assertEquals(values.get(1).asText(), "0708");
+        assertEquals(values.get(2).asText(), "07090a");
+      }
     }
   }
 
@@ -219,15 +221,18 @@ public class BytesMvTypeTest extends CustomDataQueryClusterIntegrationTest {
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
     for (String mvCol : MV_COLUMNS) {
-      String positiveQuery = String.format(
-          "SELECT COUNT(*) FROM %s WHERE ARRAYS_OVERLAP(%s, ARRAY[X'07'])", getTableName(), mvCol);
-      JsonNode rows = postQuery(positiveQuery).get("resultTable").get("rows");
-      assertEquals(rows.get(0).get(0).asLong(), 1L);
+      for (String[] literals : List.of(new String[]{"X'07'", "X'FF'"},
+          new String[]{"'\\x07'::bytea", "'\\xFF'::bytea"})) {
+        String positiveQuery = String.format(
+            "SELECT COUNT(*) FROM %s WHERE ARRAYS_OVERLAP(%s, ARRAY[%s])", getTableName(), mvCol, literals[0]);
+        JsonNode rows = postQuery(positiveQuery).get("resultTable").get("rows");
+        assertEquals(rows.get(0).get(0).asLong(), 1L);
 
-      String negativeQuery = String.format(
-          "SELECT COUNT(*) FROM %s WHERE ARRAYS_OVERLAP(%s, ARRAY[X'FF'])", getTableName(), mvCol);
-      rows = postQuery(negativeQuery).get("resultTable").get("rows");
-      assertEquals(rows.get(0).get(0).asLong(), 0L);
+        String negativeQuery = String.format(
+            "SELECT COUNT(*) FROM %s WHERE ARRAYS_OVERLAP(%s, ARRAY[%s])", getTableName(), mvCol, literals[1]);
+        rows = postQuery(negativeQuery).get("resultTable").get("rows");
+        assertEquals(rows.get(0).get(0).asLong(), 0L);
+      }
     }
   }
 
@@ -235,11 +240,14 @@ public class BytesMvTypeTest extends CustomDataQueryClusterIntegrationTest {
   public void testArraysOverlapWithLiterals(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
-    JsonNode result = postQuery(
-        "SELECT ARRAYS_OVERLAP(ARRAY[X'00', X'0102'], ARRAY[X'03', X'0102'])").get("resultTable");
-    assertTrue(result.get("rows").get(0).get(0).asBoolean());
+    for (String overlapping : List.of("ARRAYS_OVERLAP(ARRAY[X'00', X'0102'], ARRAY[X'03', X'0102'])",
+        "ARRAYS_OVERLAP(ARRAY[CAST('\\x00' AS BYTEA), CAST('\\x0102' AS BYTEA)], "
+            + "ARRAY['\\x03'::bytea, '\\x0102'::bytea])")) {
+      JsonNode result = postQuery("SELECT " + overlapping).get("resultTable");
+      assertTrue(result.get("rows").get(0).get(0).asBoolean());
+    }
 
-    result = postQuery(
+    JsonNode result = postQuery(
         "SELECT ARRAYS_OVERLAP(ARRAY[X'00', X'0102'], ARRAY[X'03', X'04'])").get("resultTable");
     assertFalse(result.get("rows").get(0).get(0).asBoolean());
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/BytesTypeTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/BytesTypeTest.java
@@ -307,4 +307,25 @@ public class BytesTypeTest extends CustomDataQueryClusterIntegrationTest {
       Assert.assertEquals(rows.get(i).get(0).asLong(), NUM_TOTAL_DOCS);
     }
   }
+
+  /// Regression coverage for the PostgreSQL `::` cast binding to the whole expression on its left instead of just
+  /// the literal, which made a bytea constant unusable as the right operand of a comparison.
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testPostgreSqlByteaLiteralAsPredicateOperand(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    for (String byteaLiteral : List.of("'\\x" + FIXED_HEX_STRING_VALUE + "'::bytea",
+        "CAST('\\x" + FIXED_HEX_STRING_VALUE + "' AS BYTEA)", "X'" + FIXED_HEX_STRING_VALUE + "'")) {
+      String query = String.format("SELECT count(*) FROM %s WHERE %s = %s", getTableName(), FIXED_BYTES,
+          byteaLiteral);
+      JsonNode rows = postQuery(query).get("resultTable").get("rows");
+      Assert.assertEquals(rows.get(0).get(0).asLong(), NUM_TOTAL_DOCS, query);
+
+      // Same literal on the right of a compound predicate, where the accumulated expression list is non-empty.
+      query = String.format("SELECT count(*) FROM %s WHERE %s IS NOT NULL AND %s = %s", getTableName(), FIXED_BYTES,
+          FIXED_BYTES, byteaLiteral);
+      rows = postQuery(query).get("resultTable").get("rows");
+      Assert.assertEquals(rows.get(0).get(0).asLong(), NUM_TOTAL_DOCS, query);
+    }
+  }
 }

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
@@ -143,6 +143,17 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
     }
   }
 
+  @Test
+  public void testPostgreSqlByteaLiteralTypeInference() {
+    RelDataType rowType = _queryEnvironment.compile(
+            "SELECT '\\x0102'::bytea, ARRAY['\\x00'::bytea, CAST('\\x0102' AS BYTEA)] FROM a")
+        .getRelRoot().validatedRowType;
+    assertEquals(rowType.getFieldList().get(0).getType().getSqlTypeName(), SqlTypeName.BINARY);
+    RelDataType arrayType = rowType.getFieldList().get(1).getType();
+    assertEquals(arrayType.getSqlTypeName(), SqlTypeName.ARRAY);
+    assertEquals(arrayType.getComponentType().getSqlTypeName(), SqlTypeName.VARBINARY);
+  }
+
   /// `jsonPath` must resolve to a literal, but the operand type checker deliberately does not demand a literal
   /// `SqlNode` in that position: operand checking runs before `PinotEvaluateLiteralRule` folds constant
   /// expressions, so an argument such as `CONCAT('$.', 'foo')` folds to a literal and plans and executes

--- a/pinot-query-runtime/src/test/resources/queries/BinaryTypes.json
+++ b/pinot-query-runtime/src/test/resources/queries/BinaryTypes.json
@@ -18,21 +18,28 @@
       },
       {
         "psql": "8.4.1",
-        "ignored": true,
-        "comments": [
-          "looks like we don't support constants, this is treated as a normal string",
-          "we also require using calcite syntax for byte strings to parse, which is x'deadbeef' instead",
-          "of postgres syntax which is '\\xdeadbeaf'"
-        ],
-        "description": "bytea hex constants",
-        "sql": "SELECT x'DEADBEEF', data from {bytea}"
+        "description": "PostgreSQL bytea hex constants",
+        "sql": "SELECT '\\xDEADBEEF'::bytea, data FROM {bytea}",
+        "h2Sql": "SELECT X'DEADBEEF', data FROM {bytea}"
+      },
+      {
+        "psql": "8.4.1",
+        "description": "PostgreSQL bytea hex constant as a comparison operand",
+        "sql": "SELECT data FROM {bytea} WHERE data = '\\xDEADBEEF'::bytea",
+        "h2Sql": "SELECT data FROM {bytea} WHERE data = X'DEADBEEF'"
+      },
+      {
+        "psql": "8.4.1",
+        "description": "PostgreSQL bytea hex constant in a compound predicate",
+        "sql": "SELECT data FROM {bytea} WHERE data <> '\\x00'::bytea AND data = CAST('\\xDEADBEEF' AS BYTEA)",
+        "h2Sql": "SELECT data FROM {bytea} WHERE data <> X'00' AND data = X'DEADBEEF'"
       },
       {
         "psql": "8.4.2",
         "ignored": true,
         "comments": [
-          "in order to specify bytea constants using escape syntax, we need type casting",
-          "which we don't support. also, calcite doesn't support the escape syntax for bytes"
+          "PostgreSQL's legacy octal bytea escape syntax remains unsupported",
+          "only PostgreSQL hex-format bytea literals are normalized to Pinot bytes"
         ],
         "description": "bytea escape constants",
         "sql": "SELECT CAST('\\046' AS BINARY), data from {bytea}"


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Parses PostgreSQL :: bytea casts, normalizes to binary literals, and flows them to broker, expression, planner, and integration paths\.

```mermaid
flowchart TD
  N0["Grammar extension for INFIX#95;CAST #58;#58; and extraBinaryExpressions #40;F1#44; F2#41;"]:::stAdded
  N1["Parsing yields SqlCall for #58;#58; or CAST #40;F2#41;"]:::stAdded
  N2["PostgreSqlCastRewriter rewrites BYTEA casts to SqlBinaryStringLiteral #40;F3#44; F4#41;"]:::stAdded
  N3["Literal#45;only broker path processes resulting BYTES literal #40;F5#41;"]:::stAdded
  N4["Expression compilation uses rewritten literal #40;F3#41;"]:::stAdded
  N5["Query planner#47;type inference validates binary literal type #40;F11#41;"]:::stAdded
  N6["Integration queries execute with bytea literals #40;F9#44; F10#44; F12#41;"]:::stAdded
  N0 -->|"enables"| N1
  N1 -->|"feeds"| N2
  N2 -->|"supplies"| N3
  N2 -->|"supplies"| N4
  N2 -->|"supplies"| N5
  N2 -->|"supplies"| N6
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-common/src/main/codegen/config\.fmpp — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-common/src/main/codegen/config.fmpp) · [after](https://github.com/apache/pinot/blob/4e70acf20da75a01476b90b4eae04d4823245b36/pinot-common/src/main/codegen/config.fmpp)
- F2: pinot\-common/src/main/codegen/includes/parserImpls\.ftl — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-common/src/main/codegen/includes/parserImpls.ftl) · [after](https://github.com/apache/pinot/blob/4e70acf20da75a01476b90b4eae04d4823245b36/pinot-common/src/main/codegen/includes/parserImpls.ftl)
- F3: pinot\-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java) · [after](https://github.com/apache/pinot/blob/4e70acf20da75a01476b90b4eae04d4823245b36/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java)
- F4: pinot\-common/src/main/java/org/apache/pinot/sql/parsers/PostgreSqlCastRewriter\.java — [after](https://github.com/apache/pinot/blob/4e70acf20da75a01476b90b4eae04d4823245b36/pinot-common/src/main/java/org/apache/pinot/sql/parsers/PostgreSqlCastRewriter.java)
- F5: pinot\-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java) · [after](https://github.com/apache/pinot/blob/4e70acf20da75a01476b90b4eae04d4823245b36/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java)
- F9: pinot\-integration\-tests/src/test/java/org/apache/pinot/integration/tests/custom/BytesMvTypeTest\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/BytesMvTypeTest.java) · [after](https://github.com/apache/pinot/blob/4e70acf20da75a01476b90b4eae04d4823245b36/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/BytesMvTypeTest.java)
- F10: pinot\-integration\-tests/src/test/java/org/apache/pinot/integration/tests/custom/BytesTypeTest\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/BytesTypeTest.java) · [after](https://github.com/apache/pinot/blob/4e70acf20da75a01476b90b4eae04d4823245b36/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/BytesTypeTest.java)
- F11: pinot\-query\-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java) · [after](https://github.com/apache/pinot/blob/4e70acf20da75a01476b90b4eae04d4823245b36/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java)
- F12: pinot\-query\-runtime/src/test/resources/queries/BinaryTypes\.json — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-query-runtime/src/test/resources/queries/BinaryTypes.json) · [after](https://github.com/apache/pinot/blob/4e70acf20da75a01476b90b4eae04d4823245b36/pinot-query-runtime/src/test/resources/queries/BinaryTypes.json)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImU2Nzg3ZTE3ODY0NWZkM2M1YTg4N2UyYWJhN2UwZGU4MzQzY2Q1MjQiLCJjb250ZXh0X2hhc2giOiJjZDMwMzZjM2ExZGU0ZjQ0ZDE0OWJhZmRhOWU2MTkwODA0NDkxYTk4NmI2YjAyNWZkZDIzYjJiYmQ1YmMwODJlIiwiZ2VuZXJhdGVkX2F0IjoxNzg4OTA3MTM1LCJoZWFkX3NoYSI6IjRlNzBhY2YyMGRhNzVhMDE0NzZiOTBiNGVhZTA0ZDQ4MjMyNDViMzYiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJlNjc4N2UxNzg2NDVmZDNjNWE4ODdlMmFiYTdlMGRlODM0M2NkNTI0IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 53313625ac441236c18d822e5dd0220e545af2a28edf48929760d00934fbc2fb -->
<!-- pinot-pr-flow:end -->

## Summary

Accept PostgreSQL hex-format `bytea` constants in both the infix `'\x0102'::bytea` form and the standard `CAST('\x0102' AS BYTEA)` spelling, and normalize them to Pinot's existing binary-literal representation before either the single-stage or multi-stage engine plans the query.

The SQL-standard `X'0102'` form is unchanged, and the two are fully interchangeable — including mixed within a single expression. The rewriter converts PostgreSQL constants to Calcite binary literals at parse time, so downstream there is no separate "PostgreSQL path": every spelling below produces the identical literal. Servers never see the new syntax, so there is no mixed-version exposure.

## Supported syntax

All of these produce the identical `BYTES` literal `0x0102`:

```sql
SELECT X'0102';                     -- SQL standard (unchanged)
SELECT x'0102';                     -- lowercase prefix
SELECT '\x0102'::bytea;             -- PostgreSQL infix cast (new)
SELECT '\x0102'::BYTEA;             -- type name is case-insensitive
SELECT CAST('\x0102' AS BYTEA);     -- standard CAST spelling (new)
SELECT CAST(X'0102' AS BYTEA);      -- spellings may be mixed
```

Constant formatting:

```sql
SELECT '\xdeadbeef'::bytea;         -- upper- or lowercase hex digits
SELECT '\xDE AD BE EF'::bytea;      -- ASCII whitespace between byte pairs
SELECT '\x'::bytea;                 -- empty -> zero-length BYTES
```

Arrays, including mixed spellings in one array:

```sql
SELECT ARRAY[X'00', X'0102'];
SELECT ARRAY['\x00'::bytea, '\x0102'::bytea];
SELECT ARRAY[X'00', '\x0102'::bytea];
SELECT ARRAY['\x00'::bytea, CAST('\x0102' AS BYTEA)];
```

Usable anywhere a binary literal is valid — predicates, `IN` lists, `CASE` branches, `GROUP BY`, and function arguments:

```sql
SELECT id FROM events WHERE payload = '\x0102'::bytea;
SELECT id FROM events WHERE payload IN ('\x01'::bytea, X'02');
SELECT CASE WHEN a = 1 THEN '\x01'::bytea ELSE X'02' END FROM events;
SELECT ARRAY['\x02'::bytea], COUNT(*) FROM events GROUP BY ARRAY['\x02'::bytea];

SELECT id, byte_values
FROM events
WHERE ARRAYS_OVERLAP(byte_values, ARRAY['\x0102'::bytea, '\xCAFE'::bytea]);
```

Result values remain hex strings, and an array result reports `BYTES_ARRAY` metadata.

## Not supported

| Rejected | Error | Use instead |
|---|---|---|
| `CAST(col AS BYTEA)` | BYTEA casts are supported only for quoted hex constants | `hexToBytes(col)` — plain hex digits, no `\x` prefix |
| `col::bytea` | BYTEA casts are supported only for quoted hex constants | `hexToBytes(col)` — plain hex digits, no `\x` prefix |
| `1::int` | `::` casts are supported only for BYTEA hex constants | `CAST(1 AS INT)` |
| `'0102'::bytea` | only the hex format is supported | — (PostgreSQL reads this as escape format: four bytes, `0x30 0x31 0x30 0x32`) |
| `'\046'::bytea` | only the hex format is supported (legacy escape format) | — |
| `'\X0102'::bytea` | the `\x` prefix is case-sensitive, as in PostgreSQL | `'\x0102'::bytea` |

Two boundaries are deliberately asymmetric:

- **`BYTEA` accepts only quoted constants**, while the existing `BYTES` type still accepts a dynamic per-row cast. A per-row `STRING`-to-`BYTES` conversion under `BYTEA` would have to be implemented separately in each engine and the two would be easy to drift apart, so it is not introduced here.
- **`::` is BYTEA-only.** This is a scope limit, not a technical one: `SqlLibraryOperators.INFIX_CAST` is an ordinary `SqlCastOperator` of kind `CAST`, and `intCol::double` does compile to the same `cast` function as `CAST(intCol AS DOUBLE)`. Supporting the full operator means committing to `::` type-name semantics across both engines (PostgreSQL names such as `int4`, `float8` and `text` are unknown to Calcite's `DataType()`), which is tracked in #19628. The grammar accepts `::` so this rewriter can report a clear error rather than a bare parse failure. Rejecting now keeps every option open: relaxing a rejection later is backward compatible, while narrowing a type the grammar already accepts would not be.

Only ASCII hex digits and ASCII whitespace are accepted. `Character.digit` and `Character.isWhitespace` also accept full-width and non-Latin forms, which PostgreSQL rejects.

Pre-existing conversions are unaffected: `CAST('0102' AS BYTES)`, `CAST(strCol AS BYTES)`, and `hexToBytes(...)` all behave as before.

## Parsing notes

`InfixCast` appends the operator and its target type to the enclosing expression list as a `SqlParserUtil.ToTreeListItem`, so precedence is resolved by `Expression2` — the same shape as the adjacent `SqlAtTimeZone` production and Calcite's own Babel `InfixCast`. This matters: collapsing the accumulated list eagerly makes `::` bind everything to its left, so `WHERE bytesCol = '\x01'::bytea` parses as `CAST(bytesCol = '\x01' AS BYTEA)` and fails to compile. The operator records the position of the `::` token itself, so the cast, and the literal it becomes, span exactly `'\x01'::bytea`.

**The rewrite is done in place.** A plain `SqlShuttle` is copy-on-write: it rebuilds every ancestor of a replaced node through `SqlOperator.createCall`, which does not preserve Pinot's own statement classes. With that approach, a bytea constant turned `EXPLAIN IMPLEMENTATION PLAN FOR` into a plain `SqlExplain` (silently returning the logical plan) and `CREATE MATERIALIZED VIEW` into a `SqlBasicCall` classified as DQL. The rewriter now replaces only the constant's direct parent, via `SqlCall.setOperand` or `SqlNodeList.set`, so every other node keeps its identity and class. Every node under which Pinot's grammar accepts an arbitrary expression supports this; a parent that cannot be updated in place is rejected with a clear error rather than rebuilt.

The `[]` and `.ident` postfix forms need no handling in this production; `Expression2` already owns those branches.

No Thrift or protobuf schema changes.

## Validation

Local runs on the final commit, built in a single Maven reactor (`-am`) so no module resolves a stale snapshot from `~/.m2`:

- All `pinot-common` parser, DDL and request suites (`org.apache.pinot.sql.parsers.**`, `org.apache.pinot.common.request.**`, `RequestUtilsTest`) — 523 passed, including `CalciteSqlParserTest` (59), `CalciteSqlCompilerTest` (95) and `PinotDdlParserTest` (60)
- `pinot-sql-ddl` `DdlCompilerMaterializedViewTest`, `DdlCompilerTest`, `RoundTripTest`, `CanonicalDdlEmitterMaterializedViewTest`, `MaterializedViewDdlHandlerTest` — 135 passed
- `QueryCompilationTest` — 242 passed
- `ResourceBasedQueriesTest` (includes `BinaryTypes.json` against H2, both optimizer variants) — 3697 passed
- `LiteralOnlyBrokerRequestTest` — 10 passed
- `BytesTypeTest`, `BytesMvTypeTest` (real Avro `array<bytes>` ingestion, both query engines) — 32 passed on the in-place rewrite; the final commit adds only the `::` position fix and the list guard on top, and CI covers it
- `spotless:apply`, `checkstyle:check`, `license:format`, `license:check` clean on all affected modules; no compiler warnings on added lines

Each regression test for the statement-node fix was checked against the previous copy-on-write rewriter and fails there: the parser tests see `SqlExplain` / `SqlBasicCall`, `testPostgreSqlByteaLiteralKeepsPhysicalExplain` gets the logical plan back instead of the physical one, and `definedSqlWithPostgreSqlByteaConstant` is rejected by the DDL compiler as an unsupported statement. `testPostgreSqlByteaLiteralKeepsItsSourcePosition` likewise fails against the previous grammar (column 17 instead of 27).
