### PR TITLE
Fix FD_AWARE instance assignment when pool tags do not start at 0

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/FDAwareInstancePartitionSelector.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/FDAwareInstancePartitionSelector.java
@@ -286,7 +286,6 @@ public class FDAwareInstancePartitionSelector extends InstancePartitionSelector 
     int _mapDimInstancePerReplicaGroup;
     HashMap<String, Integer> _usedInstances = new HashMap<>();
     int _numFaultDomains;
-    int[][] _fdCounter;
 
     ReplicaGroupBasedAssignmentState(int numReplicaGroups, int numInstancesPerReplicaGroup,
         int numExistingReplicaGroups, int numExistingInstancesPerReplicaGroup, int numFaultDomains) {
@@ -300,7 +299,6 @@ public class FDAwareInstancePartitionSelector extends InstancePartitionSelector 
       _mapDimInstancePerReplicaGroup = Math.max(numExistingInstancesPerReplicaGroup, numInstancesPerReplicaGroup);
 
       _replicaGroupIdToInstancesMap = new Instance[_mapDimReplicaGroup][_mapDimInstancePerReplicaGroup];
-      _fdCounter = new int[_mapDimInstancePerReplicaGroup][_numFaultDomains];
     }
 
     ReplicaGroupBasedAssignmentState(int numReplicaGroups, int numInstancesPerReplicaGroup, int numFaultDomains) {
@@ -324,20 +322,16 @@ public class FDAwareInstancePartitionSelector extends InstancePartitionSelector 
       Preconditions.checkState(instance.getExistingReplicaGroupId() == Instance.NEW_INSTANCE);
       _replicaGroupIdToInstancesMap[replicaGroupId][instanceIndex] = instance;
       _usedInstances.put(instance.getInstanceName(), instance.getFaultDomainId());
-      _fdCounter[instanceIndex][instance.getFaultDomainId()] += 1;
     }
 
     private void setExistingInstance(int replicaGroupId, int instanceIndex, String instance, int fdId) {
       _replicaGroupIdToInstancesMap[replicaGroupId][instanceIndex] = new Instance(instance, fdId, replicaGroupId);
       _usedInstances.put(instance, fdId);
-      _fdCounter[instanceIndex][fdId] += 1;
     }
 
     private void unSetInstance(int replicaGroupId, int instanceIndex) {
-      int fdId = _replicaGroupIdToInstancesMap[replicaGroupId][instanceIndex].getFaultDomainId();
       _usedInstances.remove(_replicaGroupIdToInstancesMap[replicaGroupId][instanceIndex].getInstanceName());
       _replicaGroupIdToInstancesMap[replicaGroupId][instanceIndex] = null;
-      _fdCounter[instanceIndex][fdId] -= 1;
     }
 
     /// From an exising replica group, remove the instances that are gone and set them in \_replicaGroupIdToInstancesMap

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/instance/InstanceAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/instance/InstanceAssignmentTest.java
@@ -3393,6 +3393,107 @@ public class InstanceAssignmentTest {
       assertEquals(steadyStatePartitions.getInstances(0, rg), initialPartitions.getInstances(0, rg));
     }
   }
+
+  /// FD_AWARE must accept Helix pool tags that do not start at 0 (e.g. 1/2/3).
+  /// Every other pool-based test uses {@code pool = i % numPools}, so this crash had no coverage.
+  /// See <a href="https://github.com/apache/pinot/issues/12239">#12239</a>.
+  @Test
+  public void testPoolBasedFDAwareNonZeroBasedPools() {
+    // Same first topology as testPoolBasedFDAware, but pool = (i % numPools) + 1 → {1,2,3,4,5}.
+    int numInstances = 21;
+    int numPools = 5;
+    int numReplicaGroups = 3;
+    int numInstancesPerReplicaGroup = numInstances / numReplicaGroups;
+    List<InstanceConfig> instanceConfigs =
+        newFDAwarePoolInstanceConfigs(numInstances, numPools);
+    InstanceTagPoolConfig tagPoolConfig = new InstanceTagPoolConfig(OFFLINE_TAG, true, numPools, null);
+    InstanceReplicaGroupPartitionConfig replicaPartitionConfig =
+        new InstanceReplicaGroupPartitionConfig(true, 0, numReplicaGroups, numInstancesPerReplicaGroup, 0, 0, false,
+            null);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
+        .setInstanceAssignmentConfigMap(Map.of(InstancePartitionsType.OFFLINE.toString(),
+            new InstanceAssignmentConfig(tagPoolConfig, null, replicaPartitionConfig,
+                InstanceAssignmentConfig.PartitionSelector.FD_AWARE_INSTANCE_PARTITION_SELECTOR.toString(), false)))
+        .build();
+    InstanceAssignmentDriver driver = new InstanceAssignmentDriver(tableConfig);
+    InstancePartitions instancePartitions =
+        driver.assignInstances(InstancePartitionsType.OFFLINE, instanceConfigs, null);
+    assertFilledUniqueAssignment(instancePartitions, instanceConfigs, numReplicaGroups,
+        numInstancesPerReplicaGroup);
+
+    // Incremental uplift with minimizeDataMovement hits setExistingInstance with the raw pool ids.
+    numInstances = 28;
+    numReplicaGroups = 4;
+    numInstancesPerReplicaGroup = numInstances / numReplicaGroups;
+    instanceConfigs = newFDAwarePoolInstanceConfigs(numInstances, numPools);
+    replicaPartitionConfig =
+        new InstanceReplicaGroupPartitionConfig(true, 0, numReplicaGroups, numInstancesPerReplicaGroup, 0, 0, true,
+            null);
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
+        .setInstanceAssignmentConfigMap(Map.of(InstancePartitionsType.OFFLINE.toString(),
+            new InstanceAssignmentConfig(tagPoolConfig, null, replicaPartitionConfig,
+                InstanceAssignmentConfig.PartitionSelector.FD_AWARE_INSTANCE_PARTITION_SELECTOR.toString(), true)))
+        .build();
+    driver = new InstanceAssignmentDriver(tableConfig);
+    instancePartitions = driver.assignInstances(InstancePartitionsType.OFFLINE, instanceConfigs, instancePartitions);
+    assertFilledUniqueAssignment(instancePartitions, instanceConfigs, numReplicaGroups,
+        numInstancesPerReplicaGroup);
+
+    // Reporter case: pools {1,2,3}.
+    numInstances = 6;
+    numPools = 3;
+    numReplicaGroups = 3;
+    numInstancesPerReplicaGroup = 2;
+    instanceConfigs = newFDAwarePoolInstanceConfigs(numInstances, numPools);
+    tagPoolConfig = new InstanceTagPoolConfig(OFFLINE_TAG, true, numPools, null);
+    replicaPartitionConfig =
+        new InstanceReplicaGroupPartitionConfig(true, 0, numReplicaGroups, numInstancesPerReplicaGroup, 0, 0, false,
+            null);
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
+        .setInstanceAssignmentConfigMap(Map.of(InstancePartitionsType.OFFLINE.toString(),
+            new InstanceAssignmentConfig(tagPoolConfig, null, replicaPartitionConfig,
+                InstanceAssignmentConfig.PartitionSelector.FD_AWARE_INSTANCE_PARTITION_SELECTOR.toString(), false)))
+        .build();
+    driver = new InstanceAssignmentDriver(tableConfig);
+    instancePartitions = driver.assignInstances(InstancePartitionsType.OFFLINE, instanceConfigs, null);
+    assertFilledUniqueAssignment(instancePartitions, instanceConfigs, numReplicaGroups,
+        numInstancesPerReplicaGroup);
+  }
+
+  /// Builds pool-tagged instance configs whose pool ids start at 1 rather than 0.
+  private static List<InstanceConfig> newFDAwarePoolInstanceConfigs(int numInstances, int numPools) {
+    List<InstanceConfig> instanceConfigs = new ArrayList<>(numInstances);
+    for (int i = 0; i < numInstances; i++) {
+      int pool = (i % numPools) + 1;
+      InstanceConfig instanceConfig =
+          new InstanceConfig(SERVER_INSTANCE_ID_PREFIX + i + SERVER_INSTANCE_POOL_PREFIX + pool);
+      instanceConfig.addTag(OFFLINE_TAG);
+      instanceConfig.getRecord().setMapField(InstanceUtils.POOL_KEY, Map.of(OFFLINE_TAG, Integer.toString(pool)));
+      instanceConfigs.add(instanceConfig);
+    }
+    return instanceConfigs;
+  }
+
+  private static void assertFilledUniqueAssignment(InstancePartitions instancePartitions,
+      List<InstanceConfig> instanceConfigs, int numReplicaGroups, int numInstancesPerReplicaGroup) {
+    assertEquals(instancePartitions.getNumReplicaGroups(), numReplicaGroups);
+    assertEquals(instancePartitions.getNumPartitions(), 1);
+    Set<String> candidates = new HashSet<>();
+    for (InstanceConfig instanceConfig : instanceConfigs) {
+      candidates.add(instanceConfig.getInstanceName());
+    }
+    Set<String> assigned = new HashSet<>();
+    for (int replicaGroupId = 0; replicaGroupId < numReplicaGroups; replicaGroupId++) {
+      List<String> instances = instancePartitions.getInstances(0, replicaGroupId);
+      assertEquals(instances.size(), numInstancesPerReplicaGroup);
+      for (String instance : instances) {
+        assertTrue(candidates.contains(instance), instance);
+        assertTrue(assigned.add(instance), instance);
+      }
+    }
+    assertEquals(assigned.size(), numReplicaGroups * numInstancesPerReplicaGroup);
+  }
+
   /// Verifies that subset-partition tables use the total Kafka partition count (not the subset size)
   /// for instance assignment, producing the same server spread as a normal full-partition table.
   ///


### PR DESCRIPTION
## Problem

`FDAwareInstancePartitionSelector` sizes `_fdCounter` by the number of pools, then indexes it by the raw Helix pool tag. Deployments whose pool tags are `{1,2,3}` instead of `{0,1,2}` fail table creation:

    java.lang.ArrayIndexOutOfBoundsException: Index 3 out of bounds for length 3
        at ...FDAwareInstancePartitionSelector$...setNewInstance

`InstanceReplicaGroupPartitionSelector` is fine: it looks pool ids up as map keys, never as array indexes. Existing FD_AWARE tests only tagged pools `0..N-1`, so this never showed up.

## What I did

I deleted `_fdCounter` and the three writes that touched it (`setNewInstance`, `setExistingInstance`, `unSetInstance`).

`_fdCounter` is dead state. It is written in those three places and read nowhere. The only intended consumers, `normalize()` and `swapToInvariantState()`, are still unimplemented stubs. Its only runtime effect today is this crash.

## How I did it

Remove the unused array instead of adding a dense `poolId -> index` map. Net change is about −5 lines in `FDAwareInstancePartitionSelector`. No config, metric, HTTP, wire, or on-disk change. I did not rewrite `InstanceTagPoolSelector`, renumber Helix tags, or implement the `normalize` / `swapToInvariantState` TODOs.

`seekKey` on the minimize-data-movement path still mixes count-space and key-space. The miss is absorbed by `ceilingKey` / `firstKey` (no crash, wrong rotation start). I left that out of this PR on purpose.

If reviewers want the unfinished counter kept for later normalization work, the alternative is a dense map built from the already-sorted `faultDomainToInstanceConfigsMap.keySet()`. Happy to switch.

## Impact

`POST /tables` with `FD_AWARE` and non-zero-based pool tags (`{1,2,3}`, sparse `{5,9}`, single pool `7`, negative pool ids) no longer crashes. Zero-based `{0,1,2}` is unchanged. Replica-group assignment is unchanged.

## Testing

`InstanceAssignmentTest#testPoolBasedFDAwareNonZeroBasedPools` failed on current master with `Index 5 out of bounds for length 5`, then passed after the delete. It copies `testPoolBasedFDAware` but sets `pool = (i % numPools) + 1`, and also covers the reporter `{1,2,3}` case plus an incremental uplift that hits `setExistingInstance` with the raw pool ids.

```
./mvnw -pl pinot-controller -am -Dtest=InstanceAssignmentTest#testPoolBasedFDAwareNonZeroBasedPools,InstanceAssignmentTest#testPoolBasedFDAware test
./mvnw spotless:apply checkstyle:check license:format license:check -pl pinot-controller
```

Fixes #12239

Made with [Cursor](https://cursor.com)