### PR TITLE
Advance consume offset past read_committed control-record tails

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -560,10 +560,10 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
               _currentOffset);
         }
         // We check this flag again further down
-      } else if (messageBatch.getUnfilteredMessageCount() > 0) {
+      } else if (messageBatch.getUnfilteredMessageCount() > 0
+          || messageBatch.getOffsetOfNextBatch().compareTo(_currentOffset) > 0) {
         _idleTimer.markEventConsumed();
-        // we consumed something from the stream but filtered all the content out,
-        // so we need to advance the offsets to avoid getting stuck
+        // Advance when next offset is ahead so filtered-all or empty tails cannot pin _currentOffset.
         StreamPartitionMsgOffset nextOffset = messageBatch.getOffsetOfNextBatch();
         if (_segmentLogger.isDebugEnabled()) {
           _segmentLogger.debug("Skipped empty batch. Advancing from {} to {}", _currentOffset, nextOffset);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
@@ -67,6 +67,8 @@ import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.metrics.PinotMetricUtils;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.LongMsgOffsetFactory;
+import org.apache.pinot.spi.stream.MessageBatch;
+import org.apache.pinot.spi.stream.PartitionGroupConsumer;
 import org.apache.pinot.spi.stream.PermanentConsumerException;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
@@ -78,6 +80,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
@@ -1174,6 +1177,54 @@ public class RealtimeSegmentDataManagerTest {
       Assert.assertEquals(((LongMsgOffset) segmentDataManager.getCurrentOffset()).getOffset(),
           START_OFFSET_VALUE + FakeStreamConfigUtils.SEGMENT_FLUSH_THRESHOLD_ROWS);
     }
+  }
+
+  @Test
+  public void testEmptyBatchWithAdvancedNextOffsetMovesCurrentOffset()
+      throws Exception {
+    try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager()) {
+      segmentDataManager._stubConsumeLoop = false;
+      long nextOffset = START_OFFSET_VALUE + 2;
+      injectPartitionGroupConsumer(segmentDataManager, emptyBatch(nextOffset));
+
+      Assert.assertEquals(((LongMsgOffset) segmentDataManager.getCurrentOffset()).getOffset(), START_OFFSET_VALUE);
+      segmentDataManager.consumeLoop();
+      Assert.assertEquals(((LongMsgOffset) segmentDataManager.getCurrentOffset()).getOffset(), nextOffset);
+    }
+  }
+
+  @Test
+  public void testEmptyBatchWithUnchangedNextOffsetDoesNotInventOffset()
+      throws Exception {
+    try (FakeRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager()) {
+      segmentDataManager._stubConsumeLoop = false;
+      injectPartitionGroupConsumer(segmentDataManager, emptyBatch(START_OFFSET_VALUE));
+
+      Assert.assertEquals(((LongMsgOffset) segmentDataManager.getCurrentOffset()).getOffset(), START_OFFSET_VALUE);
+      segmentDataManager.consumeLoop();
+      Assert.assertEquals(((LongMsgOffset) segmentDataManager.getCurrentOffset()).getOffset(), START_OFFSET_VALUE);
+    }
+  }
+
+  private static MessageBatch emptyBatch(long offsetOfNextBatch) {
+    MessageBatch messageBatch = mock(MessageBatch.class);
+    when(messageBatch.getMessageCount()).thenReturn(0);
+    when(messageBatch.getUnfilteredMessageCount()).thenReturn(0);
+    when(messageBatch.getOffsetOfNextBatch()).thenReturn(new LongMsgOffset(offsetOfNextBatch));
+    return messageBatch;
+  }
+
+  private static void injectPartitionGroupConsumer(FakeRealtimeSegmentDataManager segmentDataManager,
+      MessageBatch messageBatch)
+      throws Exception {
+    PartitionGroupConsumer partitionGroupConsumer = mock(PartitionGroupConsumer.class);
+    when(partitionGroupConsumer.fetchMessages(any(), anyInt())).thenAnswer(invocation -> {
+      segmentDataManager._shouldStop.set(segmentDataManager, true);
+      return messageBatch;
+    });
+    Field field = RealtimeSegmentDataManager.class.getDeclaredField("_partitionGroupConsumer");
+    field.setAccessible(true);
+    field.set(segmentDataManager, partitionGroupConsumer);
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ExactlyOnceKafkaRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ExactlyOnceKafkaRealtimeClusterIntegrationTest.java
@@ -42,6 +42,7 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.pinot.controller.util.ConsumingSegmentInfoReader;
 import org.apache.pinot.integration.tests.SharedKafkaRealtimeIntegrationTestSuite.ScenarioLease;
 import org.apache.pinot.plugin.inputformat.avro.AvroUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -86,6 +87,9 @@ public class ExactlyOnceKafkaRealtimeClusterIntegrationTest {
       long expectedRecords = RECORDS_PER_TRANSACTIONAL_PHASE;
       pushTransactionalData(owner, lease, avroFiles, expectedRecords);
       waitForPinotCount(owner, lease, expectedRecords, 1_200_000L);
+      // After the last commit marker, read_committed polls are empty but position() is at LSO.
+      // The consume loop must advance past that control-record tail so freshness/readiness pass.
+      waitForConsumingOffsetsToReachLatest(owner, lease, 120_000L);
     } catch (Throwable t) {
       primaryFailure = t;
       throw t;
@@ -378,6 +382,47 @@ public class ExactlyOnceKafkaRealtimeClusterIntegrationTest {
       List<PartitionInfo> partitions = consumer.partitionsFor(topic, Duration.ofSeconds(5));
       return partitions != null && partitions.size() >= expectedPartitions;
     } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private void waitForConsumingOffsetsToReachLatest(SharedKafkaRealtimeIntegrationTestSuite owner,
+      ScenarioLease lease, long timeoutMs) {
+    TestUtils.waitForCondition(aVoid -> consumingOffsetsHaveReachedLatest(owner, lease._tableName), 200L, timeoutMs,
+        "Consuming offsets did not reach latest after control-record tail for " + lease._tableName);
+  }
+
+  private boolean consumingOffsetsHaveReachedLatest(SharedKafkaRealtimeIntegrationTestSuite owner, String tableName) {
+    try {
+      ConsumingSegmentInfoReader.ConsumingSegmentsInfoMap info = owner.getOrCreateAdminClient().getTableClient()
+          .getConsumingSegmentsInfo(tableName, ConsumingSegmentInfoReader.ConsumingSegmentsInfoMap.class);
+      if (info._segmentToConsumingInfoMap == null || info._segmentToConsumingInfoMap.isEmpty()) {
+        return false;
+      }
+      boolean comparedAnyPartition = false;
+      for (List<ConsumingSegmentInfoReader.ConsumingSegmentInfo> infos : info._segmentToConsumingInfoMap.values()) {
+        // Empty list means IdealState CONSUMING but no server report (putIfAbsent(..., List.of())).
+        if (infos == null || infos.isEmpty()) {
+          return false;
+        }
+        for (ConsumingSegmentInfoReader.ConsumingSegmentInfo segmentInfo : infos) {
+          ConsumingSegmentInfoReader.PartitionOffsetInfo offsetInfo = segmentInfo._partitionOffsetInfo;
+          if (offsetInfo == null || offsetInfo._currentOffsetsMap == null || offsetInfo._currentOffsetsMap.isEmpty()
+              || offsetInfo._latestUpstreamOffsetMap == null) {
+            return false;
+          }
+          for (Map.Entry<String, String> entry : offsetInfo._currentOffsetsMap.entrySet()) {
+            String latest = offsetInfo._latestUpstreamOffsetMap.get(entry.getKey());
+            if (latest == null || Long.parseLong(entry.getValue()) < Long.parseLong(latest)) {
+              return false;
+            }
+            comparedAnyPartition = true;
+          }
+        }
+      }
+      return comparedAnyPartition;
+    } catch (Exception e) {
+      LOGGER.debug("Failed to read consuming segments info while waiting for offset catchup", e);
       return false;
     }
   }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/test/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConsumerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/test/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConsumerTest.java
@@ -66,6 +66,7 @@ import org.testng.annotations.Test;
 import static org.apache.kafka.clients.consumer.ConsumerRecord.NULL_CHECKSUM;
 import static org.apache.kafka.common.record.LegacyRecord.NO_TIMESTAMP;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -582,6 +583,44 @@ public class KafkaPartitionLevelConsumerTest {
         new FakeKafkaPartitionLevelConsumer("clientId-test", getStreamConfig("test-topic"), 0);
     KafkaMessageBatch kafkaMessageBatch = kafkaSimpleStreamConsumer.fetchMessages(new LongMsgOffset(12345L), 10000);
     Assert.assertEquals(kafkaMessageBatch.getSizeInBytes(), 14);
+  }
+
+  @Test
+  public void testReadCommittedEmptyPollSnapsOffsetOfNextBatchToPosition() {
+    TopicPartition topicPartition = new TopicPartition("test-topic", 0);
+    Consumer<Bytes, Bytes> mockConsumer = mock(Consumer.class);
+    ConsumerRecords<Bytes, Bytes> emptyRecords =
+        new ConsumerRecords<>(Map.of(topicPartition, List.of()));
+    when(mockConsumer.poll(any(Duration.class))).thenReturn(emptyRecords);
+    when(mockConsumer.position(eq(topicPartition), any(Duration.class))).thenReturn(12L);
+
+    class FakeKafkaPartitionLevelConsumer extends KafkaPartitionLevelConsumer {
+      FakeKafkaPartitionLevelConsumer(String clientId, StreamConfig streamConfig, int partition) {
+        super(clientId, streamConfig, partition);
+      }
+
+      @Override
+      protected Consumer<Bytes, Bytes> createConsumer(Properties consumerProp) {
+        return mockConsumer;
+      }
+    }
+
+    Map<String, String> streamConfigMap = new HashMap<>();
+    streamConfigMap.put("streamType", "kafka");
+    streamConfigMap.put("stream.kafka.topic.name", "test-topic");
+    streamConfigMap.put("stream.kafka.broker.list", _kafkaBrokerAddress);
+    streamConfigMap.put("stream.kafka.consumer.factory.class.name", getKafkaConsumerFactoryName());
+    streamConfigMap.put("stream.kafka.decoder.class.name", "decoderClass");
+    streamConfigMap.put("stream.kafka.isolation.level",
+        KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_ISOLATION_LEVEL_READ_COMMITTED);
+    StreamConfig streamConfig = new StreamConfig("tableName_REALTIME", streamConfigMap);
+
+    FakeKafkaPartitionLevelConsumer consumer =
+        new FakeKafkaPartitionLevelConsumer("clientId-empty-rc", streamConfig, 0);
+    MessageBatch messageBatch = consumer.fetchMessages(new LongMsgOffset(10L), 10000);
+    assertEquals(messageBatch.getMessageCount(), 0);
+    assertEquals(messageBatch.getUnfilteredMessageCount(), 0);
+    assertEquals(messageBatch.getOffsetOfNextBatch().toString(), "12");
   }
 
   @Test

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/test/java/org/apache/pinot/plugin/stream/kafka40/KafkaPartitionLevelConsumerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0/src/test/java/org/apache/pinot/plugin/stream/kafka40/KafkaPartitionLevelConsumerTest.java
@@ -66,6 +66,7 @@ import org.testng.annotations.Test;
 
 import static org.apache.kafka.common.record.RecordBatch.NO_TIMESTAMP;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -586,6 +587,44 @@ public class KafkaPartitionLevelConsumerTest {
         new FakeKafkaPartitionLevelConsumer("clientId-test", getStreamConfig("test-topic"), 0);
     KafkaMessageBatch kafkaMessageBatch = kafkaSimpleStreamConsumer.fetchMessages(new LongMsgOffset(12345L), 10000);
     Assert.assertEquals(kafkaMessageBatch.getSizeInBytes(), 14);
+  }
+
+  @Test
+  public void testReadCommittedEmptyPollSnapsOffsetOfNextBatchToPosition() {
+    TopicPartition topicPartition = new TopicPartition("test-topic", 0);
+    Consumer<Bytes, Bytes> mockConsumer = mock(Consumer.class);
+    ConsumerRecords<Bytes, Bytes> emptyRecords =
+        new ConsumerRecords<>(Map.of(topicPartition, List.of()));
+    when(mockConsumer.poll(any(Duration.class))).thenReturn(emptyRecords);
+    when(mockConsumer.position(eq(topicPartition), any(Duration.class))).thenReturn(12L);
+
+    class FakeKafkaPartitionLevelConsumer extends KafkaPartitionLevelConsumer {
+      FakeKafkaPartitionLevelConsumer(String clientId, StreamConfig streamConfig, int partition) {
+        super(clientId, streamConfig, partition);
+      }
+
+      @Override
+      protected Consumer<Bytes, Bytes> createConsumer(Properties consumerProp) {
+        return mockConsumer;
+      }
+    }
+
+    Map<String, String> streamConfigMap = new HashMap<>();
+    streamConfigMap.put("streamType", "kafka");
+    streamConfigMap.put("stream.kafka.topic.name", "test-topic");
+    streamConfigMap.put("stream.kafka.broker.list", _kafkaBrokerAddress);
+    streamConfigMap.put("stream.kafka.consumer.factory.class.name", getKafkaConsumerFactoryName());
+    streamConfigMap.put("stream.kafka.decoder.class.name", "decoderClass");
+    streamConfigMap.put("stream.kafka.isolation.level",
+        KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_ISOLATION_LEVEL_READ_COMMITTED);
+    StreamConfig streamConfig = new StreamConfig("tableName_REALTIME", streamConfigMap);
+
+    FakeKafkaPartitionLevelConsumer consumer =
+        new FakeKafkaPartitionLevelConsumer("clientId-empty-rc", streamConfig, 0);
+    MessageBatch messageBatch = consumer.fetchMessages(new LongMsgOffset(10L), 10000);
+    assertEquals(messageBatch.getMessageCount(), 0);
+    assertEquals(messageBatch.getUnfilteredMessageCount(), 0);
+    assertEquals(messageBatch.getOffsetOfNextBatch().toString(), "12");
   }
 
   @Test

--- a/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/FreshnessBasedConsumptionStatusCheckerTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/FreshnessBasedConsumptionStatusCheckerTest.java
@@ -137,6 +137,42 @@ public class FreshnessBasedConsumptionStatusCheckerTest {
     assertEquals(statusChecker.getNumConsumingSegmentsNotReachedIngestionCriteria(), 0);
   }
 
+  /// Behavior lock, not a regression test: this passes with or without the consume-loop fix, because the checker
+  /// only reads the offset the consume loop already produced. It exists so nobody "fixes" the stuck-freshness
+  /// report here by treating `latest - 1` as caught up, which would mark a genuinely lagging partition READY.
+  /// The consume-loop advance itself is covered by
+  /// `RealtimeSegmentDataManagerTest#testEmptyBatchWithAdvancedNextOffsetMovesCurrentOffset`.
+  @Test
+  public void controlRecordTailDoesNotTreatLatestMinusOneAsCaughtUp() {
+    String segA0 = "tableA__0__0__123Z";
+    Map<String, Set<String>> consumingSegments = new HashMap<>();
+    consumingSegments.put("tableA_REALTIME", ImmutableSet.of(segA0));
+    InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
+    FreshnessBasedConsumptionStatusChecker statusChecker =
+        new FreshnessBasedConsumptionStatusChecker(instanceDataManager, consumingSegments,
+            ConsumptionStatusCheckerTestUtils.getConsumingSegments(consumingSegments), 10000L, 0L);
+
+    RealtimeTableDataManager tableDataManagerA = mock(RealtimeTableDataManager.class);
+    when(instanceDataManager.getTableDataManager("tableA_REALTIME")).thenReturn(tableDataManagerA);
+    RealtimeSegmentDataManager segMngrA0 = mock(RealtimeSegmentDataManager.class);
+    when(tableDataManagerA.acquireSegment(segA0)).thenReturn(segMngrA0);
+    setupMinimumIngestionLag(segMngrA0, Long.MAX_VALUE);
+
+    StreamMetadataProvider segA0Provider = mock(StreamMetadataProvider.class);
+    when(tableDataManagerA.getStreamMetadataProvider(segMngrA0)).thenReturn(segA0Provider);
+    when(segMngrA0.getStreamPartitionId()).thenReturn(0);
+    when(segA0Provider.supportsOffsetLag()).thenReturn(true);
+
+    // current=10, latest=11: one visible message of lag. Must not treat latest-1 as ready.
+    when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(10));
+    when(segA0Provider.fetchLatestStreamOffset(anySet(), anyLong())).thenReturn(Map.of(0, new LongMsgOffset(11)));
+    assertEquals(statusChecker.getNumConsumingSegmentsNotReachedIngestionCriteria(), 1);
+
+    // current=11, latest=11: control-record tail already snapped; offset-caught-up.
+    when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(11));
+    assertEquals(statusChecker.getNumConsumingSegmentsNotReachedIngestionCriteria(), 0);
+  }
+
   @Test
   public void testWithDroppedTableAndSegment() {
     String segA0 = "tableA__0__0__123Z";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/MessageBatch.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/MessageBatch.java
@@ -42,6 +42,11 @@ public interface MessageBatch<T> {
   StreamMessage<T> getStreamMessage(int index);
 
   /// Returns the start offset of the next batch.
+  ///
+  /// Implementations must return the requested start offset unchanged when the partition had nothing to hand back,
+  /// and may only return a larger offset when the stream itself has moved past offsets this batch will never deliver
+  /// (for example Kafka transaction control records under `read_committed`). The consume loop advances the segment's
+  /// current offset to this value even for an empty batch, so returning a speculative larger offset skips data.
   StreamPartitionMsgOffset getOffsetOfNextBatch();
 
   /// Returns the offset of the first message (including tombstone) in the batch.


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Consume loop advances current offset when next batch offset is ahead, preventing stalling on empty batches under read\_committed isolation\.

```mermaid
flowchart TD
  N0["Check#58; unfiltered#62;0 OR nextOffset#62;currentOffset #40;F1#41;"]:::stModified
  N1["Mark idle timer consumed #40;F1#41;"]:::stModified
  N2["Set currentOffset #61; nextOffset #40;F1#41;"]:::stModified
  N3["Exit#58; no offset advance #40;F1#41;"]:::stModified
  N4["Test#58; setup batch with nextOffset ahead #40;F3#41;"]:::stAdded
  N5["Test#58; setup batch with nextOffset unchanged #40;F3#41;"]:::stAdded
  N6["Test#58; call consumeLoop#40;#41; #40;F3#41;"]:::stAdded
  N7["Test#58; assert currentOffset advanced #40;F3#41;"]:::stAdded
  N8["Test#58; assert currentOffset unchanged #40;F3#41;"]:::stAdded
  N4 --> N6
  N5 --> N6
  N6 --> N0
  N0 -->|"true"| N1
  N0 -->|"false"| N3
  N1 --> N2
  N2 --> N7
  N3 --> N8
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager\.java — [before](https://github.com/apache/pinot/blob/388bc64d5c89265ba0b0ab70c2b59af81d3a7862/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java) · [after](https://github.com/apache/pinot/blob/562d87f69397d3cfb22ed99add00ea6943a08933/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java)
- F3: pinot\-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest\.java — [before](https://github.com/apache/pinot/blob/388bc64d5c89265ba0b0ab70c2b59af81d3a7862/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java) · [after](https://github.com/apache/pinot/blob/562d87f69397d3cfb22ed99add00ea6943a08933/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjM4OGJjNjRkNWM4OTI2NWJhMGIwYWI3MGMyYjU5YWY4MWQzYTc4NjIiLCJjb250ZXh0X2hhc2giOiI1Mzc2NTAyZWQ2MWEyZjJlYzA3YjRiMTZmYmE5NGZjMWU0ZjJjYzY4YWRkNWMzOGQxNzhmMjA0MzcwMjZlMDc4IiwiZ2VuZXJhdGVkX2F0IjoxNzg5MDkwNTI1LCJoZWFkX3NoYSI6IjU2MmQ4N2Y2OTM5N2QzY2ZiMjJlZDk5YWRkMDBlYTY5NDNhMDg5MzMiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJjMjdlM2E3NzcwMTliODg1ZTYxZGVkOTZmYzUyZDMzYzQzNTc0NTQyIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 475d2ecd54e6666d34297e8a42b25c9f972970f8319add639a38ab1528815cc4 -->
<!-- pinot-pr-flow:end -->

## Problem

Under Kafka `isolation.level=read_committed`, a partition whose log tail is only transaction control records never advances `_currentOffset`. `FreshnessBasedConsumptionStatusChecker` then waits forever on a stable one-offset gap, and the server never reports GOOD. Rolling restarts of low-volume exactly-once tables loop.

The reporter case: last visible record at 18895, Pinot sitting at 18896, Kafka latest at 18897 (the commit marker). `isOffsetCaughtUp` requires `current >= latest`, so the partition never catches up.

`KafkaPartitionLevelConsumer` already has the right answer. On an empty `read_committed` poll it snaps `_nextReadOffset` to `KafkaConsumer.position()` and returns that as `offsetOfNextBatch`. `RealtimeSegmentDataManager` throws it away because the advance is gated on `getUnfilteredMessageCount() > 0`, and a control-record-only tail yields zero records.

## What I did

I widened that one guard so the consume loop also advances when the next-batch offset is already ahead of the current offset. I also documented the `MessageBatch.getOffsetOfNextBatch()` contract: return the requested start offset unchanged when the partition had nothing to hand back; only return a larger offset when the stream itself has moved past offsets this batch will never deliver.

## How I did it

In `RealtimeSegmentDataManager`:

```
} else if (messageBatch.getUnfilteredMessageCount() > 0
    || messageBatch.getOffsetOfNextBatch().compareTo(_currentOffset) > 0) {
```

`getOffsetOfNextBatch()` is generic SPI. Every other stream returns the start offset unchanged on a genuinely empty batch, so Kinesis and Pulsar behavior does not change. A partition that is genuinely lagging also returns the unchanged start offset and stays not-caught-up.

This is not a `latest - 1` heuristic. I did not change `DEFAULT_REALTIME_FRESHNESS_IDLE_TIMEOUT_MS`, `endOffsets` for `read_uncommitted`, or `KafkaStreamMetadataProvider.fetchLatestStreamOffset`.

## Impact

Idle EOS tables under `read_committed` can finish catch-up after a restart. Servers that hung in `RealtimeConsumptionCatchupServiceStatusCallback` can turn GOOD. Genuinely lagging partitions, `read_uncommitted`, Kinesis, and Pulsar are unchanged.

## Testing

`RealtimeSegmentDataManagerTest#testEmptyBatchWithAdvancedNextOffsetMovesCurrentOffset` fails before this change (stays at the old offset) and passes after. The sibling `testEmptyBatchWithUnchangedNextOffsetDoesNotInventOffset` asserts an empty batch whose next offset did not move invents no offset.

`KafkaPartitionLevelConsumerTest#testReadCommittedEmptyPollSnapsOffsetOfNextBatchToPosition` (kafka 3.0 and 4.0) pins the `position()` snap the guard depends on.

`ExactlyOnceKafkaRealtimeClusterIntegrationTest` now waits for consuming offsets to reach latest after the final commit marker.

`FreshnessBasedConsumptionStatusCheckerTest#controlRecordTailDoesNotTreatLatestMinusOneAsCaughtUp` is a behavior lock, not a regression test: it passes either way and exists so nobody "fixes" readiness with a `latest - 1` heuristic.

```
./mvnw -pl pinot-core -am -Dtest=RealtimeSegmentDataManagerTest#testEmptyBatchWithAdvancedNextOffsetMovesCurrentOffset,RealtimeSegmentDataManagerTest#testEmptyBatchWithUnchangedNextOffsetDoesNotInventOffset test
./mvnw -pl pinot-server -am -Dtest=FreshnessBasedConsumptionStatusCheckerTest#controlRecordTailDoesNotTreatLatestMinusOneAsCaughtUp test
./mvnw -pl pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0 -Dtest=KafkaPartitionLevelConsumerTest#testReadCommittedEmptyPollSnapsOffsetOfNextBatchToPosition test
./mvnw -pl pinot-plugins/pinot-stream-ingestion/pinot-kafka-4.0 -Dtest=KafkaPartitionLevelConsumerTest#testReadCommittedEmptyPollSnapsOffsetOfNextBatchToPosition test
./mvnw -pl pinot-integration-tests -am -Dtest=ExactlyOnceKafkaRealtimeClusterIntegrationTest -Dsurefire.failIfNoSpecifiedTests=false test
```

Fixes #17962

Made with [Cursor](https://cursor.com)