### PR TITLE
Preserve NotFoundException when fetching validDocIds bitmap from servers

### DIFF
--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+import javax.ws.rs.NotFoundException;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.HelixAdmin;
@@ -326,8 +327,18 @@ public class MinionTaskUtils {
     return defaultValue;
   }
 
-  /// Returns the validDocIds bitmap from server(s). `comparisonMode` is the task config value: UNSAFE,
-  /// EQUAL (default), or MOST_VALID_DOCS.
+  /// Returns the validDocIds bitmap for the segment resolved across the server(s) hosting it, per the consensus mode
+  /// (`comparisonModeStr` is the task config value):
+  /// - `UNSAFE`: the first usable server bitmap; servers that fail, mismatch the CRC, or are not READY are skipped.
+  /// - `EQUAL` (default): the bitmap every server agrees on.
+  /// - `MOST_VALID_DOCS`: the bitmap with the highest valid-doc count.
+  ///
+  /// Returns null when no server produced a usable bitmap (no server hosts the segment, or every server was skipped
+  /// in `UNSAFE` mode). In the non-`UNSAFE` modes any failure throws instead of being skipped:
+  /// - [NotFoundException] when a server has no validDocIds for the segment (e.g. the snapshot is not written yet, or
+  ///   the segment is not hosted) — a distinct condition that callers may handle with a documented fallback.
+  /// - [IllegalStateException] for any other fetch failure, a CRC mismatch (typically the server still reloading the
+  ///   segment), a server not in GOOD status, or an `EQUAL`-mode consensus failure.
   @Nullable
   public static RoaringBitmap getValidDocIdFromServerMatchingCrc(String tableNameWithType, String segmentName,
       String validDocIdsType, MinionContext minionContext, String expectedCrc, String comparisonModeStr) {
@@ -335,7 +346,9 @@ public class MinionTaskUtils {
         expectedCrc, null, comparisonModeStr);
   }
 
-  /// Variant that also matches on the expected data CRC; see [#crcMatches].
+  /// Variant that also matches on the expected data CRC (see [#crcMatches]), with the same return and exception
+  /// contract as [#getValidDocIdFromServerMatchingCrc(String, String, String, MinionContext, String, String)].
+  @Nullable
   public static RoaringBitmap getValidDocIdFromServerMatchingCrc(String tableNameWithType, String segmentName,
       String validDocIdsType, MinionContext minionContext, String expectedCrc, @Nullable String expectedDataCrc,
       String comparisonModeStr) {
@@ -356,14 +369,18 @@ public class MinionTaskUtils {
             serverSegmentMetadataReader.getValidDocIdsBitmapFromServer(tableNameWithType, segmentName, endpoint,
                 validDocIdsType, 60_000);
       } catch (Exception e) {
+        String errorMessage =
+            "Unable to retrieve validDocIds bitmap for segment: " + segmentName + " from endpoint: " + endpoint;
         if (consensusMode == MinionConstants.ValidDocIdsConsensusMode.UNSAFE) {
-          LOGGER.warn(
-              "Unable to retrieve validDocIds bitmap for segment: " + segmentName + " from endpoint: " + endpoint, e);
+          LOGGER.warn(errorMessage, e);
           continue;
-        } else {
-          throw new IllegalStateException(
-              "Unable to retrieve validDocIds bitmap for segment: " + segmentName + " from endpoint: " + endpoint, e);
         }
+        if (e instanceof NotFoundException) {
+          // Preserve the type: a 404 means the server has no validDocIds for the segment (e.g. a not-yet-written
+          // snapshot), which callers may handle with a documented fallback, unlike infrastructure failures.
+          throw new NotFoundException(errorMessage, e);
+        }
+        throw new IllegalStateException(errorMessage, e);
       }
 
       String crcFromValidDocIdsBitmap = validDocIdsBitmapResponse.getSegmentCrc();

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtilsTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtilsTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.ws.rs.NotFoundException;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
 import org.apache.helix.model.ExternalView;
@@ -394,6 +395,38 @@ public class MinionTaskUtilsTest {
     RoaringBitmap result = getValidDocIdFromServerMatchingCrcWithMockedReader("myTable_REALTIME", "seg1", "1000",
         "5000", "UNSAFE", responses, new String[]{"server1"}, this);
     assertNull(result);
+  }
+
+  @Test
+  public void testFetchFailurePreservesNotFoundException() {
+    List<Object> responses = List.of(new NotFoundException("HTTP 404 Not Found"));
+    NotFoundException e = expectThrows(NotFoundException.class,
+        () -> getValidDocIdFromServerMatchingCrcWithMockedReader("myTable_REALTIME", "seg1", "1000", "EQUAL",
+            responses, new String[]{"server1"}, this));
+    assertTrue(e.getMessage().contains("seg1"), e.getMessage());
+    assertTrue(e.getMessage().contains("localhost"), e.getMessage());
+    assertTrue(e.getCause() instanceof NotFoundException);
+  }
+
+  @Test
+  public void testFetchFailureWrapsOtherExceptions() {
+    List<Object> responses = List.of(new RuntimeException("connection reset"));
+    IllegalStateException e = expectThrows(IllegalStateException.class,
+        () -> getValidDocIdFromServerMatchingCrcWithMockedReader("myTable_REALTIME", "seg1", "1000", "EQUAL",
+            responses, new String[]{"server1"}, this));
+    assertTrue(e.getMessage().contains("seg1"), e.getMessage());
+    assertEquals(e.getCause().getMessage(), "connection reset");
+  }
+
+  @Test
+  public void testUnsafeModeSkipsFetchFailure() {
+    List<Object> responses = List.of(
+        new NotFoundException("HTTP 404 Not Found"),
+        makeResponse("seg1", "1000", "server2", makeBitmap(3)));
+    RoaringBitmap result = getValidDocIdFromServerMatchingCrcWithMockedReader("myTable_REALTIME", "seg1", "1000",
+        "UNSAFE", responses, new String[]{"server1", "server2"}, this);
+    assertNotNull(result);
+    assertEquals(result.getCardinality(), 3);
   }
 
   private static RoaringBitmap makeBitmap(int numDocs) {


### PR DESCRIPTION
## Summary

#17696 introduced the validDocIds consensus modes and, in the non-`UNSAFE` modes, wraps every fetch failure from `getValidDocIdsBitmapFromServer` in `IllegalStateException`. This erased a meaningful type: the server's 404 (`javax.ws.rs.NotFoundException`) means "no validDocIds available for this segment" — a missing/not-yet-persisted snapshot or a segment that is not hosted — which is a distinct, actionable condition that callers handle with documented fallbacks (e.g. treat the segment as all-valid until the snapshot is written), unlike the consensus-fatal failures (CRC mismatch, server not READY, replica disagreement). After the wrapping, a `catch (NotFoundException)` around this method silently became dead code, and the fallback path was replaced by a permanently failing task retry loop until the snapshot appears.

This PR:
- Rethrows a `NotFoundException` carrying the same contextual message (segment + endpoint) and the original exception as cause, so callers keep both the type and the diagnostics. All other fetch failures still become `IllegalStateException`, and the `UNSAFE` warn-and-skip behavior is unchanged — the failures #17696 deliberately made fatal stay fatal.
- Documents the full contract on `getValidDocIdFromServerMatchingCrc`: per-mode return semantics, when null is returned, and the meaning of each exception type.
- Adds the missing `@Nullable` on the second overload (it could always return null but was never annotated).
- Adds unit tests on the existing mocked-reader harness: 404 → `NotFoundException` with context and cause (fails without this change), non-404 → `IllegalStateException` with cause, and `UNSAFE` skipping a failing server and returning the healthy replica's bitmap.
