### PR TITLE
[upsert] Support preload for OFFLINE table data managers

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -912,6 +912,18 @@ public abstract class BaseTableDataManager implements TableDataManager {
     return Map.of();
   }
 
+  /// Handles upsert preload if the upsert preload is enabled.
+  protected void handleUpsertPreload(SegmentZKMetadata zkMetadata, IndexLoadingConfig indexLoadingConfig) {
+    if (_tableUpsertMetadataManager == null || !_tableUpsertMetadataManager.getContext().isPreloadEnabled()) {
+      return;
+    }
+    Integer partitionId = SegmentUtils.getSegmentPartitionId(zkMetadata, null);
+    Preconditions.checkState(partitionId != null,
+        "Failed to get partition id for segment: %s in upsert-enabled table: %s", zkMetadata.getSegmentName(),
+        _tableNameWithType);
+    _tableUpsertMetadataManager.getOrCreatePartitionManager(partitionId).preloadSegments(indexLoadingConfig);
+  }
+
   protected void handleUpsert(ImmutableSegment immutableSegment, @Nullable SegmentZKMetadata zkMetadata) {
     String segmentName = immutableSegment.getSegmentName();
     _logger.info("Adding immutable segment: {} with upsert enabled", segmentName);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/OfflineTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/OfflineTableDataManager.java
@@ -73,6 +73,7 @@ public class OfflineTableDataManager extends BaseTableDataManager {
     SegmentZKMetadata zkMetadata = fetchZKMetadata(segmentName);
     IndexLoadingConfig indexLoadingConfig = fetchIndexLoadingConfig();
     indexLoadingConfig.setSegmentTier(zkMetadata.getTier());
+    handleUpsertPreload(zkMetadata, indexLoadingConfig);
     SegmentDataManager segmentDataManager = _segmentDataManagerMap.get(segmentName);
     if (segmentDataManager == null) {
       addNewOnlineSegment(zkMetadata, indexLoadingConfig);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -453,18 +453,6 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     handleDedupPreload(zkMetadata, indexLoadingConfig);
   }
 
-  /// Handles upsert preload if the upsert preload is enabled.
-  private void handleUpsertPreload(SegmentZKMetadata zkMetadata, IndexLoadingConfig indexLoadingConfig) {
-    if (_tableUpsertMetadataManager == null || !_tableUpsertMetadataManager.getContext().isPreloadEnabled()) {
-      return;
-    }
-    Integer partitionId = SegmentUtils.getSegmentPartitionId(zkMetadata, null);
-    Preconditions.checkState(partitionId != null,
-        "Failed to get partition id for segment: %s in upsert-enabled table: %s", zkMetadata.getSegmentName(),
-        _tableNameWithType);
-    _tableUpsertMetadataManager.getOrCreatePartitionManager(partitionId).preloadSegments(indexLoadingConfig);
-  }
-
   /// Handles dedup preload if the dedup preload is enabled.
   private void handleDedupPreload(SegmentZKMetadata zkMetadata, IndexLoadingConfig indexLoadingConfig) {
     if (_tableDedupMetadataManager == null || !_tableDedupMetadataManager.getContext().isPreloadEnabled()) {


### PR DESCRIPTION
### What

- Move the existing upsert preload handler from `RealtimeTableDataManager` into `BaseTableDataManager`.
- Invoke the shared handler before OFFLINE segment load and replacement.
- Keep the existing REALTIME preload behavior unchanged.

### Why

Upsert preload was tied to the REALTIME table lifecycle even though the preload operation is provided by the shared table and partition upsert metadata managers. As a result, `OfflineTableDataManager#doAddOnlineSegment` skipped preload and proceeded directly to segment load or replacement.

The root cause was the placement and invocation of the lifecycle hook, not the underlying partition preload implementation.

### Impact

OFFLINE upsert implementations can now restore their partition state before processing segments. The path remains a no-op when upsert is not configured or preload is disabled. There are no configuration or public API changes.

### Tests

No new tests. Per review feedback, the mock-only `OfflineTableDataManagerTest` was dropped since it exercised mock interactions through a test subclass rather than real preload behavior. Existing REALTIME preload coverage is unchanged, and the OFFLINE path reuses the same handler.

Spotless, Checkstyle, license checks, `git diff --check`, and `pinot-core` `test-compile` pass.
