### PR TITLE
Fix two flaky unit tests exposed under parallel-fork CI load

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
@@ -300,15 +300,22 @@ public class SegmentDeletionManagerTest {
     TestUtils.waitForCondition((aVoid) -> dummyDir1.list().length == 1, 2000, 120000,
         "Unable to delete desired segments from dummyDir1");
 
-    // Check that empty directory has not been removed in the first run
-    TestUtils.waitForCondition((aVoid) -> dummyDir2.exists(), 2000, 120000,
-        "dummyDir2 does not exist");
+    // dummyDir2's files are all aged, so the first run deletes them (asynchronously, on the deletion
+    // manager's executor) but leaves the now-empty directory in place. Empty directories are only
+    // removed on a subsequent run. Wait until the directory is present AND empty before triggering
+    // that next run: this barrier both asserts the "directory survives the first run" behavior and,
+    // critically, guarantees the async file deletions have completed. Previously this only waited for
+    // dummyDir2.exists() (trivially true from the moment it is created), so the second run below could
+    // race ahead of the async deletions, still see files in dummyDir2, skip the empty-directory
+    // removal, and never delete the directory -- surfacing as a 120s "dummyDir2 still exists" timeout.
+    TestUtils.waitForCondition((aVoid) -> dummyDir2.exists() && dummyDir2.list().length == 0, 2000, 120000,
+        "dummyDir2 was not emptied by the first deletion run");
 
     // Check that deleted file without retention suffix is honoring cluster-wide retention period of 7 days.
     TestUtils.waitForCondition((aVoid) -> dummyDir3.list().length == 1, 2000, 120000,
         "Unable to delete desired segments from dummyDir3");
 
-    // Try to remove empty directory in the next run
+    // Try to remove the now-empty directory in the next run
     deletionManager.removeAgedDeletedSegments(leadControllerManager);
     TestUtils.waitForCondition((aVoid) -> !dummyDir2.exists(), 2000, 120000,
         "dummyDir2 still exists");

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManagerTest.java
@@ -65,6 +65,7 @@ import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -122,6 +123,23 @@ public class DimensionTableDataManagerTest {
     SegmentMetadata segmentMetadata = new SegmentMetadataImpl(_indexDir);
     _segmentZKMetadata = new SegmentZKMetadata(segmentName);
     _segmentZKMetadata.setCrc(Long.parseLong(segmentMetadata.getCrc()));
+  }
+
+  @AfterMethod(alwaysRun = true)
+  public void tearDownMethod() {
+    // DimensionTableDataManager is a process-wide singleton keyed by table name (see the static
+    // INSTANCES map in DimensionTableDataManager). Every test method loads the same
+    // dimBaseballTeams_OFFLINE table, so without an explicit teardown the singleton (and its
+    // property-store mock, loaded segments, and reload executor) leaks from one method into the
+    // next. A stale async reload from a prior method could then read a _propertyStore that a
+    // concurrent init() had swapped out, surfacing as an intermittent
+    // "Failed to find schema for table: dimBaseballTeams_OFFLINE". Shutting the singleton down
+    // removes it from INSTANCES so each method starts from a clean, freshly-initialized instance.
+    DimensionTableDataManager tableDataManager =
+        DimensionTableDataManager.getInstanceByTableName(OFFLINE_TABLE_NAME);
+    if (tableDataManager != null) {
+      tableDataManager.shutDown();
+    }
   }
 
   @AfterClass


### PR DESCRIPTION
## Summary

Fixes two flaky unit tests that intermittently failed on CI (surfacing under parallel-fork load). Both are **root-cause synchronization/isolation fixes** — no `Thread.sleep`/retry masking.

## 1. `SegmentDeletionManagerTest.testRemoveDeletedSegments` (pinot-controller)

**Symptom:** 120s timeout — `Failed to meet condition in 120000ms: dummyDir2 still exists`.

**Root cause:** `SegmentDeletionManager.removeAgedDeletedSegments` deletes aged files **asynchronously** (on its single-threaded executor), but removes an emptied deleted-segments directory **synchronously, only on a subsequent run** (when it scans the dir and finds it already empty). The barrier before the second `removeAgedDeletedSegments()` call only waited for `dummyDir2.exists()` — trivially true from the moment the directory is created. Under load, the second run could race ahead of the first run's async file deletions, still observe files in `dummyDir2`, skip the empty-directory removal path, and never delete the directory.

**Fix:** Strengthen the barrier to wait until `dummyDir2` **exists AND is empty** before triggering the next run, so the second run deterministically takes the empty-directory removal path. The `&&` short-circuit also keeps `list()` null-safe.

## 2. `DimensionTableDataManagerTest` (pinot-core)

**Symptom:** intermittent `IllegalStateException: Failed to find schema for table: dimBaseballTeams_OFFLINE` in `testReloadTable`.

**Root cause:** `DimensionTableDataManager` is a process-wide singleton keyed by table name (static `INSTANCES` map). Every test method loads the same `dimBaseballTeams_OFFLINE` table with **no per-method teardown**, so the singleton — with its property-store mock, loaded segments, and reload executor — leaked from one method into the next. A stale async reload from a prior method could read a `_propertyStore` that a concurrent `init()` had swapped out.

**Fix:** Add an `@AfterMethod` that shuts the singleton down (removing it from `INSTANCES`) so each method starts from a clean, freshly-initialized instance.

## Testing

Test-only changes. Pre-commit checks (spotless, checkstyle, license) pass on both modules. Rebased on current `master`.