### PR TITLE
Make segment-replace timeouts and endReplaceSegments convergence wait configurable

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
@@ -278,8 +278,16 @@ public class HttpClient implements AutoCloseable {
   public SimpleHttpResponse sendRequest(ClassicHttpRequest request, long socketTimeoutMs)
       throws IOException {
 
+    // Besides the per-request response (socket) timeout, explicitly bound the connection-request
+    // (pool checkout) wait instead of silently inheriting the Apache HttpClient default, so a
+    // saturated connection pool cannot block a replace/upload request unboundedly. The TCP connect
+    // timeout is applied at the connection-manager level and is tunable via
+    // http.client.connectionTimeoutMs (see HttpClientConfig).
     RequestConfig requestConfig =
-        RequestConfig.custom().setResponseTimeout(Timeout.ofMilliseconds(socketTimeoutMs)).build();
+        RequestConfig.custom()
+            .setResponseTimeout(Timeout.ofMilliseconds(socketTimeoutMs))
+            .setConnectionRequestTimeout(Timeout.ofMilliseconds(DEFAULT_CONNECTION_REQUEST_TIMEOUT_MS))
+            .build();
     HttpClientContext clientContext = HttpClientContext.create();
     clientContext.setRequestConfig(requestConfig);
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -35,6 +35,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.controller.rebalancer.strategy.AutoRebalanceStrategy;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 import org.apache.pinot.common.restlet.resources.RebalanceConfig;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.spi.config.table.DisasterRecoveryMode;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.LocalPinotFS;
@@ -458,6 +459,18 @@ public class ControllerConf extends PinotConfiguration {
   public static final String CONFIG_OF_MAX_TENANT_REBALANCE_JOBS_IN_ZK = "controller.tenant.rebalance.maxJobsInZK";
   public static final String CONFIG_OF_MAX_RELOAD_SEGMENT_JOBS_IN_ZK = "controller.reload.segment.maxJobsInZK";
   public static final String CONFIG_OF_MAX_FORCE_COMMIT_JOBS_IN_ZK = "controller.force.commit.maxJobsInZK";
+
+  // Knobs governing how long endReplaceSegments blocks while waiting for the new segments to become
+  // ONLINE in the ExternalView (IdealState -> ExternalView convergence). The per-attempt wait is
+  // retried up to the configured number of attempts, so the worst-case block is
+  // maxWaitMs * maxRetryAttempts. Defaults preserve the historical hard-coded values.
+  public static final String CONFIG_OF_SEGMENT_REPLACE_EXTERNAL_VIEW_MAX_WAIT_MS =
+      "controller.segment.replace.externalViewMaxWaitMs";
+  public static final String CONFIG_OF_SEGMENT_REPLACE_EXTERNAL_VIEW_CHECK_INTERVAL_MS =
+      "controller.segment.replace.externalViewCheckIntervalMs";
+  public static final String CONFIG_OF_SEGMENT_REPLACE_MAX_RETRY_ATTEMPTS =
+      "controller.segment.replace.maxRetryAttempts";
+  public static final int DEFAULT_SEGMENT_REPLACE_MAX_RETRY_ATTEMPTS = 5;
 
   private final Map<String, String> _invalidConfigs = new ConcurrentHashMap<>();
 
@@ -1598,6 +1611,20 @@ public class ControllerConf extends PinotConfiguration {
 
   public int getMaxForceCommitZkJobs() {
     return getProperty(CONFIG_OF_MAX_FORCE_COMMIT_JOBS_IN_ZK, ControllerJob.DEFAULT_MAXIMUM_CONTROLLER_JOBS_IN_ZK);
+  }
+
+  public long getSegmentReplaceExternalViewMaxWaitMs() {
+    return getProperty(CONFIG_OF_SEGMENT_REPLACE_EXTERNAL_VIEW_MAX_WAIT_MS,
+        PinotHelixResourceManager.EXTERNAL_VIEW_ONLINE_SEGMENTS_MAX_WAIT_MS);
+  }
+
+  public long getSegmentReplaceExternalViewCheckIntervalMs() {
+    return getProperty(CONFIG_OF_SEGMENT_REPLACE_EXTERNAL_VIEW_CHECK_INTERVAL_MS,
+        PinotHelixResourceManager.EXTERNAL_VIEW_CHECK_INTERVAL_MS);
+  }
+
+  public int getSegmentReplaceMaxRetryAttempts() {
+    return getProperty(CONFIG_OF_SEGMENT_REPLACE_MAX_RETRY_ATTEMPTS, DEFAULT_SEGMENT_REPLACE_MAX_RETRY_ATTEMPTS);
   }
 
   /// Get the configured timeseries languages from controller configuration.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -226,7 +226,9 @@ public class PinotHelixResourceManager {
     START, END, REVERT
   }
 
-  // TODO: make this configurable
+  // Default values for the endReplaceSegments IdealState -> ExternalView convergence wait,
+  // overridable via controller config (see ControllerConf#getSegmentReplaceExternalView*). The
+  // resolved values live in the _segmentReplace* / _endReplaceSegmentsRetryPolicy fields.
   public static final long EXTERNAL_VIEW_ONLINE_SEGMENTS_MAX_WAIT_MS = 10 * 60_000L; // 10 minutes
   public static final long EXTERNAL_VIEW_CHECK_INTERVAL_MS = 1_000L; // 1 second
 
@@ -247,6 +249,11 @@ public class PinotHelixResourceManager {
   @Nullable
   private final ControllerConf _controllerConf;
   private final AuthProvider _serverAdminAuthProvider;
+  // endReplaceSegments IdealState -> ExternalView convergence knobs, resolved once from controller
+  // config (or the static defaults when no config is supplied).
+  private final long _segmentReplaceExternalViewMaxWaitMs;
+  private final long _segmentReplaceExternalViewCheckIntervalMs;
+  private final RetryPolicy _endReplaceSegmentsRetryPolicy;
 
   private HelixManager _helixZkManager;
   private HelixAdmin _helixAdmin;
@@ -279,6 +286,16 @@ public class PinotHelixResourceManager {
     _controllerConf = controllerConf;
     _serverAdminAuthProvider =
         AuthProviderUtils.extractAuthProvider(controllerConf, ControllerConf.CONTROLLER_SERVER_ADMIN_AUTH_PREFIX);
+    if (controllerConf != null) {
+      _segmentReplaceExternalViewMaxWaitMs = controllerConf.getSegmentReplaceExternalViewMaxWaitMs();
+      _segmentReplaceExternalViewCheckIntervalMs = controllerConf.getSegmentReplaceExternalViewCheckIntervalMs();
+      _endReplaceSegmentsRetryPolicy =
+          RetryPolicies.exponentialBackoffRetryPolicy(controllerConf.getSegmentReplaceMaxRetryAttempts(), 1000L, 2.0f);
+    } else {
+      _segmentReplaceExternalViewMaxWaitMs = EXTERNAL_VIEW_ONLINE_SEGMENTS_MAX_WAIT_MS;
+      _segmentReplaceExternalViewCheckIntervalMs = EXTERNAL_VIEW_CHECK_INTERVAL_MS;
+      _endReplaceSegmentsRetryPolicy = DEFAULT_RETRY_POLICY;
+    }
     _instanceAdminEndpointCache =
         CacheBuilder.newBuilder().expireAfterWrite(CACHE_ENTRY_EXPIRE_TIME_HOURS, TimeUnit.HOURS)
             .build(new CacheLoader<>() {
@@ -4548,7 +4565,7 @@ public class PinotHelixResourceManager {
     long endReplaceSegmentsTs = System.currentTimeMillis();
     int attemptCount;
     try {
-      attemptCount = DEFAULT_RETRY_POLICY.attempt(() -> {
+      attemptCount = _endReplaceSegmentsRetryPolicy.attempt(() -> {
         long endReplaceSegmentsTsForAttempt = System.currentTimeMillis();
         // Fetch the segment lineage and look up the lineage entry based on the entry id.
         SegmentLineage segmentLineage = SegmentLineageAccessHelper.getSegmentLineage(_propertyStore, tableNameWithType);
@@ -4847,7 +4864,7 @@ public class PinotHelixResourceManager {
 
   private boolean waitForSegmentsBecomeOnline(String tableNameWithType, List<String> segmentsToCheck)
       throws InterruptedException {
-    long endTimeMs = System.currentTimeMillis() + EXTERNAL_VIEW_ONLINE_SEGMENTS_MAX_WAIT_MS;
+    long endTimeMs = System.currentTimeMillis() + _segmentReplaceExternalViewMaxWaitMs;
     String segmentNotOnline;
     do {
       segmentNotOnline = null;
@@ -4861,7 +4878,7 @@ public class PinotHelixResourceManager {
       if (segmentNotOnline == null) {
         return true;
       }
-      Thread.sleep(EXTERNAL_VIEW_CHECK_INTERVAL_MS);
+      Thread.sleep(_segmentReplaceExternalViewCheckIntervalMs);
     } while (System.currentTimeMillis() < endTimeMs);
     LOGGER.warn("Timed out while waiting for segment: {} to become ONLINE for table: {}", segmentNotOnline,
         tableNameWithType);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerConfTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerConfTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.common.restlet.resources.RebalanceConfig;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.spi.config.table.DisasterRecoveryMode;
 import org.apache.pinot.spi.utils.Enablement;
 import org.apache.pinot.spi.utils.TimeUtils;
@@ -251,5 +252,28 @@ public class ControllerConfTest {
 
     controllerConf.setProperty(ControllerConf.INGEST_FROM_URI_ALLOW_LOCAL_FILE_SYSTEM, true);
     Assert.assertTrue(controllerConf.isIngestFromUriLocalFileSystemAllowed());
+  }
+
+  @Test
+  public void testSegmentReplaceConvergenceDefaults() {
+    ControllerConf conf = new ControllerConf();
+    Assert.assertEquals(conf.getSegmentReplaceExternalViewMaxWaitMs(),
+        PinotHelixResourceManager.EXTERNAL_VIEW_ONLINE_SEGMENTS_MAX_WAIT_MS);
+    Assert.assertEquals(conf.getSegmentReplaceExternalViewCheckIntervalMs(),
+        PinotHelixResourceManager.EXTERNAL_VIEW_CHECK_INTERVAL_MS);
+    Assert.assertEquals(conf.getSegmentReplaceMaxRetryAttempts(),
+        ControllerConf.DEFAULT_SEGMENT_REPLACE_MAX_RETRY_ATTEMPTS);
+  }
+
+  @Test
+  public void testSegmentReplaceConvergenceCustomValues() {
+    ControllerConf conf = new ControllerConf();
+    conf.setProperty(ControllerConf.CONFIG_OF_SEGMENT_REPLACE_EXTERNAL_VIEW_MAX_WAIT_MS, 45 * 60_000L);
+    conf.setProperty(ControllerConf.CONFIG_OF_SEGMENT_REPLACE_EXTERNAL_VIEW_CHECK_INTERVAL_MS, 500L);
+    conf.setProperty(ControllerConf.CONFIG_OF_SEGMENT_REPLACE_MAX_RETRY_ATTEMPTS, 2);
+
+    Assert.assertEquals(conf.getSegmentReplaceExternalViewMaxWaitMs(), 45 * 60_000L);
+    Assert.assertEquals(conf.getSegmentReplaceExternalViewCheckIntervalMs(), 500L);
+    Assert.assertEquals(conf.getSegmentReplaceMaxRetryAttempts(), 2);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -53,6 +53,10 @@ public class MinionConstants {
   public static final String INITIAL_RETRY_DELAY_MS_KEY = "initialRetryDelayMs";
   public static final String RETRY_SCALE_FACTOR_KEY = "retryScaleFactor";
 
+  /// Per-task socket timeout (ms) for the minion -> controller segment upload request. Defaults to
+  /// [org.apache.pinot.common.utils.http.HttpClient#DEFAULT_SOCKET_TIMEOUT_MS] when unset.
+  public static final String SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS_KEY = "segmentUploadRequestTimeoutMs";
+
   /// Cluster level configs
   public static final String TIMEOUT_MS_KEY_SUFFIX = ".timeoutMs";
   public static final String NUM_CONCURRENT_TASKS_PER_INSTANCE_KEY_SUFFIX = ".numConcurrentTasksPerInstance";

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionConf.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionConf.java
@@ -28,8 +28,10 @@ import org.apache.pinot.spi.utils.NetUtils;
 
 public class MinionConf extends PinotConfiguration {
   public static final String END_REPLACE_SEGMENTS_TIMEOUT_MS_KEY = "pinot.minion.endReplaceSegments.timeoutMs";
+  public static final String START_REPLACE_SEGMENTS_TIMEOUT_MS_KEY = "pinot.minion.startReplaceSegments.timeoutMs";
   public static final String MINION_TASK_PROGRESS_MANAGER_CLASS = "pinot.minion.taskProgressManager.class";
   public static final int DEFAULT_END_REPLACE_SEGMENTS_SOCKET_TIMEOUT_MS = 10 * 60 * 1000; // 10 mins
+  public static final int DEFAULT_START_REPLACE_SEGMENTS_SOCKET_TIMEOUT_MS = 10 * 60 * 1000; // 10 mins
 
   /// The number of threads to use for downloading segments from the deepstore.
   /// This is a global setting that applies to all tasks of BaseMultipleSegmentsConversionExecutor class.
@@ -70,6 +72,10 @@ public class MinionConf extends PinotConfiguration {
 
   public int getEndReplaceSegmentsTimeoutMs() {
     return getProperty(END_REPLACE_SEGMENTS_TIMEOUT_MS_KEY, DEFAULT_END_REPLACE_SEGMENTS_SOCKET_TIMEOUT_MS);
+  }
+
+  public int getStartReplaceSegmentsTimeoutMs() {
+    return getProperty(START_REPLACE_SEGMENTS_TIMEOUT_MS_KEY, DEFAULT_START_REPLACE_SEGMENTS_SOCKET_TIMEOUT_MS);
   }
 
   public boolean isAllowDownloadFromServer() {

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/MinionConfTest.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/MinionConfTest.java
@@ -72,4 +72,18 @@ public class MinionConfTest {
     Assert.assertEquals(subcfg.subset("class").getProperty("nooppinotcrypter"),
         "org.apache.pinot.core.crypt.NoOpPinotCrypter");
   }
+
+  @Test
+  public void testReplaceSegmentsTimeoutDefaultsAndOverrides() {
+    MinionConf conf = new MinionConf();
+    Assert.assertEquals(conf.getStartReplaceSegmentsTimeoutMs(),
+        MinionConf.DEFAULT_START_REPLACE_SEGMENTS_SOCKET_TIMEOUT_MS);
+    Assert.assertEquals(conf.getEndReplaceSegmentsTimeoutMs(),
+        MinionConf.DEFAULT_END_REPLACE_SEGMENTS_SOCKET_TIMEOUT_MS);
+
+    conf.setProperty(MinionConf.START_REPLACE_SEGMENTS_TIMEOUT_MS_KEY, 30 * 60 * 1000);
+    conf.setProperty(MinionConf.END_REPLACE_SEGMENTS_TIMEOUT_MS_KEY, 45 * 60 * 1000);
+    Assert.assertEquals(conf.getStartReplaceSegmentsTimeoutMs(), 30 * 60 * 1000);
+    Assert.assertEquals(conf.getEndReplaceSegmentsTimeoutMs(), 45 * 60 * 1000);
+  }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
@@ -141,7 +141,8 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
               .collect(Collectors.toList());
       String lineageEntryId =
           SegmentConversionUtils.startSegmentReplace(context.getTableNameWithType(), context.getUploadURL(),
-              new StartReplaceSegmentsRequest(segmentsFrom, segmentsTo), context.getAuthProvider());
+              new StartReplaceSegmentsRequest(segmentsFrom, segmentsTo), context.getAuthProvider(), true,
+              _minionConf.getStartReplaceSegmentsTimeoutMs());
       context.setCustomContext(CUSTOM_SEGMENT_UPLOAD_CONTEXT_LINEAGE_ENTRY_ID, lineageEntryId);
     }
   }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/SegmentConversionUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/SegmentConversionUtils.java
@@ -126,6 +126,10 @@ public class SegmentConversionUtils {
         retryScaleFactorConfig != null ? Double.parseDouble(retryScaleFactorConfig) : DEFAULT_RETRY_SCALE_FACTOR;
     RetryPolicy retryPolicy =
         RetryPolicies.exponentialBackoffRetryPolicy(maxNumAttempts, initialRetryDelayMs, retryScaleFactor);
+    String socketTimeoutMsConfig = configs.get(MinionConstants.SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS_KEY);
+    int socketTimeoutMs =
+        socketTimeoutMsConfig != null ? Integer.parseInt(socketTimeoutMsConfig)
+            : HttpClient.DEFAULT_SOCKET_TIMEOUT_MS;
 
     // Upload the segment with retry policy
     SSLContext sslContext = MinionContext.getInstance().getSSLContext();
@@ -143,7 +147,7 @@ public class SegmentConversionUtils {
         try {
           SimpleHttpResponse response =
               fileUploadDownloadClient.uploadSegment(uri, segmentName, fileToUpload, httpHeaders, parameters,
-                  HttpClient.DEFAULT_SOCKET_TIMEOUT_MS);
+                  socketTimeoutMs);
           LOGGER.info("Got response {}: {} while uploading table: {}, segment: {} with uploadURL: {}",
               response.getStatusCode(), response.getResponse(), tableNameWithType, segmentName, uploadURL);
           return true;
@@ -178,6 +182,14 @@ public class SegmentConversionUtils {
       StartReplaceSegmentsRequest startReplaceSegmentsRequest, @Nullable AuthProvider authProvider,
       boolean forceCleanup)
       throws Exception {
+    return startSegmentReplace(tableNameWithType, uploadURL, startReplaceSegmentsRequest, authProvider, forceCleanup,
+        HttpClient.DEFAULT_SOCKET_TIMEOUT_MS);
+  }
+
+  public static String startSegmentReplace(String tableNameWithType, String uploadURL,
+      StartReplaceSegmentsRequest startReplaceSegmentsRequest, @Nullable AuthProvider authProvider,
+      boolean forceCleanup, int socketTimeoutMs)
+      throws Exception {
     String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
     TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
     SSLContext sslContext = MinionContext.getInstance().getSSLContext();
@@ -185,7 +197,8 @@ public class SegmentConversionUtils {
       URI uri = FileUploadDownloadClient.getStartReplaceSegmentsURI(new URI(uploadURL), rawTableName, tableType.name(),
           forceCleanup);
       SimpleHttpResponse response =
-          fileUploadDownloadClient.startReplaceSegments(uri, startReplaceSegmentsRequest, authProvider);
+          fileUploadDownloadClient.startReplaceSegments(uri, startReplaceSegmentsRequest, authProvider,
+              socketTimeoutMs);
       String responseString = response.getResponse();
       LOGGER.info(
           "Got response {}: {} while sending start replace segment request for table: {}, uploadURL: {}, request: {}",


### PR DESCRIPTION
## Summary

Minion → controller segment-replace requests (`startReplaceSegments` / `endReplaceSegments` / segment upload) can run for a long time. In particular, the controller handles `endReplaceSegments` **synchronously**, blocking on IdealState → ExternalView convergence, which for large tables can take many minutes. Several of the governing timeouts were hard-coded, so the client socket timeout and the controller-side work time could not be aligned per deployment.

This change exposes those knobs as configuration, all with backward-compatible defaults (no behavior change unless configured).

### Controller convergence wait (`PinotHelixResourceManager.endReplaceSegments`)
Previously hard-coded (`// TODO: make this configurable`). Now read from controller config:

| Config key | Default |
|---|---|
| `controller.segment.replace.externalViewMaxWaitMs` | 600000 (10 min) |
| `controller.segment.replace.externalViewCheckIntervalMs` | 1000 (1 s) |
| `controller.segment.replace.maxRetryAttempts` | 5 |

The values are resolved once from `ControllerConf` (falling back to the existing static constants), and the retry policy wrapping `endReplaceSegments` is built from the configured attempt count.

### Minion client socket timeouts
- `pinot.minion.startReplaceSegments.timeoutMs` (new, default 10 min) — wired through `SegmentConversionUtils.startSegmentReplace` (new `socketTimeoutMs` overload) and `BaseMultipleSegmentsConversionExecutor`.
- `segmentUploadRequestTimeoutMs` task config (new, default 10 min) — read inside `SegmentConversionUtils.uploadSegment`, alongside the existing retry knobs.
- `endReplaceSegments` timeout was already configurable (`pinot.minion.endReplaceSegments.timeoutMs`).

### HttpClient
`HttpClient.sendRequest` now sets an explicit connection-request (pool checkout) timeout instead of silently inheriting the Apache HttpClient default, so a saturated pool cannot block a replace/upload request unboundedly. The TCP connect timeout remains tunable via the existing `http.client.connectionTimeoutMs`.

## Testing
- `ControllerConfTest` — defaults and overrides for the three new controller keys.
- `MinionConfTest` — defaults/overrides for the start/end replace-segments timeouts.
- `mvn spotless:apply checkstyle:check license:check` clean on all touched modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
