### PR TITLE
Disable IN clause threshold with query parameter so we can prune at broker for large IN clauses

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -147,10 +147,11 @@ public class QueryOptionsUtils {
     return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.SKIP_UPSERT));
   }
 
-  /// Returns whether the column-value and bloom-filter segment pruners should always attempt to prune segments
-  /// for IN predicates, regardless of the number of values in the IN clause. Defaults to `false`.
-  public static boolean isForceInPredicatePruning(Map<String, String> queryOptions) {
-    return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.FORCE_IN_PREDICATE_PRUNING));
+  /// Query-level IN-pruning threshold override. Negative means always prune.
+  @Nullable
+  public static Integer getInPredicatePruningThreshold(Map<String, String> queryOptions) {
+    return uncheckedParseInt(QueryOptionKey.IN_PREDICATE_PRUNING_THRESHOLD,
+        queryOptions.get(QueryOptionKey.IN_PREDICATE_PRUNING_THRESHOLD));
   }
 
   /// Returns whether materialized-view rewrite is allowed for this query. Defaults to `true`

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -147,6 +147,12 @@ public class QueryOptionsUtils {
     return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.SKIP_UPSERT));
   }
 
+  /// Returns whether the column-value and bloom-filter segment pruners should always attempt to prune segments
+  /// for IN predicates, regardless of the number of values in the IN clause. Defaults to `false`.
+  public static boolean isForceInPredicatePruning(Map<String, String> queryOptions) {
+    return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.FORCE_IN_PREDICATE_PRUNING));
+  }
+
   /// Returns whether materialized-view rewrite is allowed for this query. Defaults to `true`
   /// (absence ⇒ rewrite allowed) for backward compatibility with the pre-option behavior; the
   /// MV minion executor sets it to `false` so a materialization query is never rewritten back

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/QueryOptionsUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/QueryOptionsUtilsTest.java
@@ -110,14 +110,16 @@ public class QueryOptionsUtilsTest {
   }
 
   @Test
-  public void shouldReadForceInPredicatePruningOption() {
-    Map<String, String> optsTrue = Map.of(FORCE_IN_PREDICATE_PRUNING, "true");
-    Map<String, String> optsFalse = Map.of(FORCE_IN_PREDICATE_PRUNING, "false");
-    Map<String, String> optsMissing = Map.of();
+  public void shouldReadInPredicatePruningThresholdOption() {
+    // Any integer is accepted; a negative value means always attempt IN-predicate pruning
+    assertEquals(QueryOptionsUtils.getInPredicatePruningThreshold(Map.of(IN_PREDICATE_PRUNING_THRESHOLD, "20")), 20);
+    assertEquals(QueryOptionsUtils.getInPredicatePruningThreshold(Map.of(IN_PREDICATE_PRUNING_THRESHOLD, "-1")), -1);
+    assertNull(QueryOptionsUtils.getInPredicatePruningThreshold(Map.of()));
+  }
 
-    assertTrue(QueryOptionsUtils.isForceInPredicatePruning(optsTrue));
-    assertFalse(QueryOptionsUtils.isForceInPredicatePruning(optsFalse));
-    assertFalse(QueryOptionsUtils.isForceInPredicatePruning(optsMissing));
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void shouldRejectInvalidInPredicatePruningThreshold() {
+    QueryOptionsUtils.getInPredicatePruningThreshold(Map.of(IN_PREDICATE_PRUNING_THRESHOLD, "invalid"));
   }
 
   @Test

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/QueryOptionsUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/QueryOptionsUtilsTest.java
@@ -110,6 +110,17 @@ public class QueryOptionsUtilsTest {
   }
 
   @Test
+  public void shouldReadForceInPredicatePruningOption() {
+    Map<String, String> optsTrue = Map.of(FORCE_IN_PREDICATE_PRUNING, "true");
+    Map<String, String> optsFalse = Map.of(FORCE_IN_PREDICATE_PRUNING, "false");
+    Map<String, String> optsMissing = Map.of();
+
+    assertTrue(QueryOptionsUtils.isForceInPredicatePruning(optsTrue));
+    assertFalse(QueryOptionsUtils.isForceInPredicatePruning(optsFalse));
+    assertFalse(QueryOptionsUtils.isForceInPredicatePruning(optsMissing));
+  }
+
+  @Test
   public void testSkipIndexesParsing() {
     String skipIndexesStr = "col1=inverted,range&col2=sorted";
     Map<String, String> queryOptions = Map.of(SKIP_INDEXES, skipIndexesStr);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/BloomFilterSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/BloomFilterSegmentPruner.java
@@ -229,7 +229,6 @@ public class BloomFilterSegmentPruner extends ValueBasedSegmentPruner {
   }
 
   /// For IN predicate, prune the segments based on column bloom filter.
-  /// NOTE: Negative threshold means always attempt pruning.
   private boolean pruneInPredicate(IndexSegment segment, InPredicate inPredicate,
       Map<String, DataSource> dataSourceCache, ValueCache valueCache, QueryContext query) {
     List<String> values = inPredicate.getValues();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/BloomFilterSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/BloomFilterSegmentPruner.java
@@ -62,7 +62,7 @@ public class BloomFilterSegmentPruner extends ValueBasedSegmentPruner {
   }
 
   @Override
-  protected boolean isApplicableToPredicate(Predicate predicate, boolean forceInPredicatePruning) {
+  protected boolean isApplicableToPredicate(Predicate predicate, Map<String, String> queryOptions) {
     // Only prune columns
     if (predicate.getLhs().getType() != ExpressionContext.Type.IDENTIFIER) {
       return false;
@@ -73,9 +73,8 @@ public class BloomFilterSegmentPruner extends ValueBasedSegmentPruner {
     }
     if (predicateType == Predicate.Type.IN) {
       List<String> values = ((InPredicate) predicate).getValues();
-      // Skip pruning when there are too many values in the IN predicate, unless pruning is forced for this query
       //noinspection RedundantIfStatement
-      if (shouldPruneInPredicate(values.size(), forceInPredicatePruning)) {
+      if (shouldPruneInPredicate(values.size(), queryOptions)) {
         return true;
       }
     }
@@ -230,13 +229,11 @@ public class BloomFilterSegmentPruner extends ValueBasedSegmentPruner {
   }
 
   /// For IN predicate, prune the segments based on column bloom filter.
-  /// NOTE: segments will not be pruned if the number of values is greater than the threshold, unless pruning is
-  /// forced for this query.
+  /// NOTE: Negative threshold means always attempt pruning.
   private boolean pruneInPredicate(IndexSegment segment, InPredicate inPredicate,
       Map<String, DataSource> dataSourceCache, ValueCache valueCache, QueryContext query) {
     List<String> values = inPredicate.getValues();
-    // Skip pruning when there are too many values in the IN predicate, unless pruning is forced for this query
-    if (!shouldPruneInPredicate(values.size(), isInPredicatePruningForced(query))) {
+    if (!shouldPruneInPredicate(values.size(), query.getQueryOptions())) {
       return false;
     }
     String column = inPredicate.getLhs().getIdentifier();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/BloomFilterSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/BloomFilterSegmentPruner.java
@@ -62,7 +62,7 @@ public class BloomFilterSegmentPruner extends ValueBasedSegmentPruner {
   }
 
   @Override
-  protected boolean isApplicableToPredicate(Predicate predicate) {
+  protected boolean isApplicableToPredicate(Predicate predicate, boolean forceInPredicatePruning) {
     // Only prune columns
     if (predicate.getLhs().getType() != ExpressionContext.Type.IDENTIFIER) {
       return false;
@@ -73,9 +73,9 @@ public class BloomFilterSegmentPruner extends ValueBasedSegmentPruner {
     }
     if (predicateType == Predicate.Type.IN) {
       List<String> values = ((InPredicate) predicate).getValues();
-      // Skip pruning when there are too many values in the IN predicate
+      // Skip pruning when there are too many values in the IN predicate, unless pruning is forced for this query
       //noinspection RedundantIfStatement
-      if (values.size() <= _inPredicateThreshold) {
+      if (shouldPruneInPredicate(values.size(), forceInPredicatePruning)) {
         return true;
       }
     }
@@ -206,7 +206,7 @@ public class BloomFilterSegmentPruner extends ValueBasedSegmentPruner {
     if (predicateType == Predicate.Type.EQ) {
       return pruneEqPredicate(segment, (EqPredicate) predicate, dataSourceCache, cachedValues);
     } else if (predicateType == Predicate.Type.IN) {
-      return pruneInPredicate(segment, (InPredicate) predicate, dataSourceCache, cachedValues);
+      return pruneInPredicate(segment, (InPredicate) predicate, dataSourceCache, cachedValues, query);
     } else {
       return false;
     }
@@ -230,12 +230,13 @@ public class BloomFilterSegmentPruner extends ValueBasedSegmentPruner {
   }
 
   /// For IN predicate, prune the segments based on column bloom filter.
-  /// NOTE: segments will not be pruned if the number of values is greater than the threshold.
+  /// NOTE: segments will not be pruned if the number of values is greater than the threshold, unless pruning is
+  /// forced for this query.
   private boolean pruneInPredicate(IndexSegment segment, InPredicate inPredicate,
-      Map<String, DataSource> dataSourceCache, ValueCache valueCache) {
+      Map<String, DataSource> dataSourceCache, ValueCache valueCache, QueryContext query) {
     List<String> values = inPredicate.getValues();
-    // Skip pruning when there are too many values in the IN predicate
-    if (values.size() > _inPredicateThreshold) {
+    // Skip pruning when there are too many values in the IN predicate, unless pruning is forced for this query
+    if (!shouldPruneInPredicate(values.size(), isInPredicatePruningForced(query))) {
       return false;
     }
     String column = inPredicate.getLhs().getIdentifier();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
@@ -48,7 +48,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 @SuppressWarnings({"rawtypes", "unchecked", "RedundantIfStatement"})
 public class ColumnValueSegmentPruner extends ValueBasedSegmentPruner {
   @Override
-  protected boolean isApplicableToPredicate(Predicate predicate, boolean forceInPredicatePruning) {
+  protected boolean isApplicableToPredicate(Predicate predicate, Map<String, String> queryOptions) {
     // Only prune columns
     if (predicate.getLhs().getType() != ExpressionContext.Type.IDENTIFIER) {
       return false;
@@ -59,8 +59,7 @@ public class ColumnValueSegmentPruner extends ValueBasedSegmentPruner {
     }
     if (predicateType == Predicate.Type.IN) {
       List<String> values = ((InPredicate) predicate).getValues();
-      // Skip pruning when there are too many values in the IN predicate, unless pruning is forced for this query
-      if (shouldPruneInPredicate(values.size(), forceInPredicatePruning)) {
+      if (shouldPruneInPredicate(values.size(), queryOptions)) {
         return true;
       }
     }
@@ -114,12 +113,11 @@ public class ColumnValueSegmentPruner extends ValueBasedSegmentPruner {
   ///
   /// - Column min/max value
   ///
-  /// NOTE: segments will not be pruned if the number of values is greater than the threshold.
+  /// NOTE: Negative threshold means always attempt pruning.
   private boolean pruneInPredicate(IndexSegment segment, InPredicate inPredicate,
       Map<String, DataSource> dataSourceCache, ValueCache valueCache, QueryContext query) {
     List<String> values = inPredicate.getValues();
-    // Skip pruning when there are too many values in the IN predicate, unless pruning is forced for this query
-    if (!shouldPruneInPredicate(values.size(), isInPredicatePruningForced(query))) {
+    if (!shouldPruneInPredicate(values.size(), query.getQueryOptions())) {
       return false;
     }
     String column = inPredicate.getLhs().getIdentifier();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
@@ -48,7 +48,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 @SuppressWarnings({"rawtypes", "unchecked", "RedundantIfStatement"})
 public class ColumnValueSegmentPruner extends ValueBasedSegmentPruner {
   @Override
-  protected boolean isApplicableToPredicate(Predicate predicate) {
+  protected boolean isApplicableToPredicate(Predicate predicate, boolean forceInPredicatePruning) {
     // Only prune columns
     if (predicate.getLhs().getType() != ExpressionContext.Type.IDENTIFIER) {
       return false;
@@ -59,8 +59,8 @@ public class ColumnValueSegmentPruner extends ValueBasedSegmentPruner {
     }
     if (predicateType == Predicate.Type.IN) {
       List<String> values = ((InPredicate) predicate).getValues();
-      // Skip pruning when there are too many values in the IN predicate
-      if (values.size() <= _inPredicateThreshold) {
+      // Skip pruning when there are too many values in the IN predicate, unless pruning is forced for this query
+      if (shouldPruneInPredicate(values.size(), forceInPredicatePruning)) {
         return true;
       }
     }
@@ -118,8 +118,8 @@ public class ColumnValueSegmentPruner extends ValueBasedSegmentPruner {
   private boolean pruneInPredicate(IndexSegment segment, InPredicate inPredicate,
       Map<String, DataSource> dataSourceCache, ValueCache valueCache, QueryContext query) {
     List<String> values = inPredicate.getValues();
-    // Skip pruning when there are too many values in the IN predicate
-    if (values.size() > _inPredicateThreshold) {
+    // Skip pruning when there are too many values in the IN predicate, unless pruning is forced for this query
+    if (!shouldPruneInPredicate(values.size(), isInPredicatePruningForced(query))) {
       return false;
     }
     String column = inPredicate.getLhs().getIdentifier();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
@@ -113,7 +113,6 @@ public class ColumnValueSegmentPruner extends ValueBasedSegmentPruner {
   ///
   /// - Column min/max value
   ///
-  /// NOTE: Negative threshold means always attempt pruning.
   private boolean pruneInPredicate(IndexSegment segment, InPredicate inPredicate,
       Map<String, DataSource> dataSourceCache, ValueCache valueCache, QueryContext query) {
     List<String> values = inPredicate.getValues();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ValueBasedSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ValueBasedSegmentPruner.java
@@ -58,7 +58,7 @@ abstract public class ValueBasedSegmentPruner implements SegmentPruner {
     if (query.getFilter() == null) {
       return false;
     }
-    return isApplicableToFilter(query.getFilter(), isInPredicatePruningForced(query));
+    return isApplicableToFilter(query.getFilter(), query.getQueryOptions());
   }
 
   /// 1. NOT is not applicable for segment pruning;
@@ -66,12 +66,12 @@ abstract public class ValueBasedSegmentPruner implements SegmentPruner {
   /// 3. For AND, if one of the child filter is applicable for pruning, the parent filter is applicable, but it
   ///    doesn't mean this child filter can prune the segment.
   /// 4. The specific pruners decide their own applicable predicate types.
-  private boolean isApplicableToFilter(FilterContext filter, boolean forceInPredicatePruning) {
+  private boolean isApplicableToFilter(FilterContext filter, Map<String, String> queryOptions) {
     switch (filter.getType()) {
       case AND:
         assert filter.getChildren() != null;
         for (FilterContext child : filter.getChildren()) {
-          if (isApplicableToFilter(child, forceInPredicatePruning)) {
+          if (isApplicableToFilter(child, queryOptions)) {
             return true;
           }
         }
@@ -79,7 +79,7 @@ abstract public class ValueBasedSegmentPruner implements SegmentPruner {
       case OR:
         assert filter.getChildren() != null;
         for (FilterContext child : filter.getChildren()) {
-          if (!isApplicableToFilter(child, forceInPredicatePruning)) {
+          if (!isApplicableToFilter(child, queryOptions)) {
             return false;
           }
         }
@@ -88,26 +88,25 @@ abstract public class ValueBasedSegmentPruner implements SegmentPruner {
         // Do not prune NOT filter
         return false;
       case PREDICATE:
-        return isApplicableToPredicate(filter.getPredicate(), forceInPredicatePruning);
+        return isApplicableToPredicate(filter.getPredicate(), queryOptions);
       default:
         throw new IllegalStateException();
     }
   }
 
-  /// Returns whether IN-predicate pruning should be attempted for a clause with the given number of values.
-  /// Pruning is attempted when it is forced for this query, or the clause has at most the configured
-  /// number of values.
-  protected boolean shouldPruneInPredicate(int numValues, boolean forceInPredicatePruning) {
-    return forceInPredicatePruning || numValues <= _inPredicateThreshold;
+  /// Returns whether IN-pruning should run. Negative threshold means always prune.
+  protected boolean shouldPruneInPredicate(int numValues, Map<String, String> queryOptions) {
+    int threshold = getEffectiveInPredicateThreshold(queryOptions);
+    return threshold < 0 || numValues <= threshold;
   }
 
-  /// Returns whether IN-predicate pruning should be attempted regardless of the IN clause size for this query.
-  /// The flag is read from the query options, so the shared pruner instance can serve concurrent queries safely.
-  protected boolean isInPredicatePruningForced(QueryContext query) {
-    return QueryOptionsUtils.isForceInPredicatePruning(query.getQueryOptions());
+  /// Returns the query override when set, otherwise the server threshold.
+  protected int getEffectiveInPredicateThreshold(Map<String, String> queryOptions) {
+    Integer threshold = QueryOptionsUtils.getInPredicatePruningThreshold(queryOptions);
+    return threshold != null ? threshold : _inPredicateThreshold;
   }
 
-  abstract boolean isApplicableToPredicate(Predicate predicate, boolean forceInPredicatePruning);
+  abstract boolean isApplicableToPredicate(Predicate predicate, Map<String, String> queryOptions);
 
   @Override
   public List<IndexSegment> prune(List<IndexSegment> segments, QueryContext query) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ValueBasedSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ValueBasedSegmentPruner.java
@@ -29,6 +29,7 @@ import org.apache.pinot.common.request.context.FilterContext;
 import org.apache.pinot.common.request.context.predicate.EqPredicate;
 import org.apache.pinot.common.request.context.predicate.InPredicate;
 import org.apache.pinot.common.request.context.predicate.Predicate;
+import org.apache.pinot.common.utils.config.QueryOptionsUtils;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.local.segment.index.readers.bloom.GuavaBloomFilterReaderUtils;
 import org.apache.pinot.segment.spi.IndexSegment;
@@ -57,7 +58,7 @@ abstract public class ValueBasedSegmentPruner implements SegmentPruner {
     if (query.getFilter() == null) {
       return false;
     }
-    return isApplicableToFilter(query.getFilter());
+    return isApplicableToFilter(query.getFilter(), isInPredicatePruningForced(query));
   }
 
   /// 1. NOT is not applicable for segment pruning;
@@ -65,12 +66,12 @@ abstract public class ValueBasedSegmentPruner implements SegmentPruner {
   /// 3. For AND, if one of the child filter is applicable for pruning, the parent filter is applicable, but it
   ///    doesn't mean this child filter can prune the segment.
   /// 4. The specific pruners decide their own applicable predicate types.
-  private boolean isApplicableToFilter(FilterContext filter) {
+  private boolean isApplicableToFilter(FilterContext filter, boolean forceInPredicatePruning) {
     switch (filter.getType()) {
       case AND:
         assert filter.getChildren() != null;
         for (FilterContext child : filter.getChildren()) {
-          if (isApplicableToFilter(child)) {
+          if (isApplicableToFilter(child, forceInPredicatePruning)) {
             return true;
           }
         }
@@ -78,7 +79,7 @@ abstract public class ValueBasedSegmentPruner implements SegmentPruner {
       case OR:
         assert filter.getChildren() != null;
         for (FilterContext child : filter.getChildren()) {
-          if (!isApplicableToFilter(child)) {
+          if (!isApplicableToFilter(child, forceInPredicatePruning)) {
             return false;
           }
         }
@@ -87,13 +88,26 @@ abstract public class ValueBasedSegmentPruner implements SegmentPruner {
         // Do not prune NOT filter
         return false;
       case PREDICATE:
-        return isApplicableToPredicate(filter.getPredicate());
+        return isApplicableToPredicate(filter.getPredicate(), forceInPredicatePruning);
       default:
         throw new IllegalStateException();
     }
   }
 
-  abstract boolean isApplicableToPredicate(Predicate predicate);
+  /// Returns whether IN-predicate pruning should be attempted for a clause with the given number of values.
+  /// Pruning is attempted when it is forced for this query, or the clause has at most the configured
+  /// number of values.
+  protected boolean shouldPruneInPredicate(int numValues, boolean forceInPredicatePruning) {
+    return forceInPredicatePruning || numValues <= _inPredicateThreshold;
+  }
+
+  /// Returns whether IN-predicate pruning should be attempted regardless of the IN clause size for this query.
+  /// The flag is read from the query options, so the shared pruner instance can serve concurrent queries safely.
+  protected boolean isInPredicatePruningForced(QueryContext query) {
+    return QueryOptionsUtils.isForceInPredicatePruning(query.getQueryOptions());
+  }
+
+  abstract boolean isApplicableToPredicate(Predicate predicate, boolean forceInPredicatePruning);
 
   @Override
   public List<IndexSegment> prune(List<IndexSegment> segments, QueryContext query) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/BloomFilterSegmentPrunerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/BloomFilterSegmentPrunerTest.java
@@ -258,9 +258,9 @@ public class BloomFilterSegmentPrunerTest {
     queryContext = QueryContextConverterUtils.getQueryContext(
         "SELECT COUNT(*) FROM testTable WHERE column IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)");
     assertFalse(PRUNER.isApplicableTo(queryContext));
-    // ... but applicable when pruning is forced for the query
+    // ... but applicable when the query threshold is negative
     queryContext = QueryContextConverterUtils.getQueryContext(
-        "SET forceInPredicatePruning=true; SELECT COUNT(*) FROM testTable WHERE column IN "
+        "SET inPredicatePruningThreshold=-1; SELECT COUNT(*) FROM testTable WHERE column IN "
             + "(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)");
     assertTrue(PRUNER.isApplicableTo(queryContext));
     // Other predicate types are not applicable
@@ -284,7 +284,7 @@ public class BloomFilterSegmentPrunerTest {
   }
 
   @Test
-  public void testForcedInPredicatePruning()
+  public void testInPredicatePruningThresholdOverride()
       throws IOException {
     IndexSegment indexSegment = mockIndexSegment(new String[]{"1.0", "2.0", "3.0", "5.0", "7.0", "21.0"});
 
@@ -293,9 +293,27 @@ public class BloomFilterSegmentPrunerTest {
     assertFalse(runPruner(indexSegment,
         "SELECT COUNT(*) FROM testTable WHERE column IN "
             + "(30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0, 37.0, 38.0, 39.0, 40.0)"));
-    // With the option, the same IN list is pruned as all values are absent from the bloom filter
+    // A negative query threshold always prunes, regardless of the IN clause size
     assertTrue(runPruner(indexSegment,
-        "SET forceInPredicatePruning=true; SELECT COUNT(*) FROM testTable WHERE column IN "
+        "SET inPredicatePruningThreshold=-1; SELECT COUNT(*) FROM testTable WHERE column IN "
+            + "(30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0, 37.0, 38.0, 39.0, 40.0)"));
+    // A positive query threshold above the clause size also prunes
+    assertTrue(runPruner(indexSegment,
+        "SET inPredicatePruningThreshold=20; SELECT COUNT(*) FROM testTable WHERE column IN "
+            + "(30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0, 37.0, 38.0, 39.0, 40.0)"));
+  }
+
+  @Test
+  public void testNegativeServerThresholdAlwaysPrunes()
+      throws IOException {
+    // The server config follows the same convention: a negative `inpredicate.threshold` always prunes
+    BloomFilterSegmentPruner pruner = new BloomFilterSegmentPruner();
+    pruner.init(new PinotConfiguration(Map.of(ColumnValueSegmentPruner.IN_PREDICATE_THRESHOLD, -1)));
+
+    IndexSegment indexSegment = mockIndexSegment(new String[]{"1.0", "2.0", "3.0", "5.0", "7.0", "21.0"});
+    // 11 values, all absent from the bloom filter, pruned without any query option
+    assertTrue(runPruner(pruner, indexSegment,
+        "SELECT COUNT(*) FROM testTable WHERE column IN "
             + "(30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0, 37.0, 38.0, 39.0, 40.0)"));
   }
 
@@ -324,6 +342,12 @@ public class BloomFilterSegmentPrunerTest {
 
   private boolean runPruner(IndexSegment segment, String query) {
     return runPruner(List.of(segment), query, 5000).isEmpty();
+  }
+
+  private boolean runPruner(BloomFilterSegmentPruner pruner, IndexSegment segment, String query) {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
+    queryContext.setEndTimeMs(System.currentTimeMillis() + 5000);
+    return pruner.prune(List.of(segment), queryContext, Executors.newCachedThreadPool()).isEmpty();
   }
 
   private List<IndexSegment> runPruner(List<IndexSegment> segments, String query, long queryTimeout) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/BloomFilterSegmentPrunerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/BloomFilterSegmentPrunerTest.java
@@ -256,8 +256,13 @@ public class BloomFilterSegmentPrunerTest {
     assertFalse(PRUNER.isApplicableTo(queryContext));
     // Too many values for IN clause
     queryContext = QueryContextConverterUtils.getQueryContext(
-        "SELECT COUNT(*) FROM testTable WHERE column IN (1, 2, 3, 4, 5, 6, 7)");
+        "SELECT COUNT(*) FROM testTable WHERE column IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)");
     assertFalse(PRUNER.isApplicableTo(queryContext));
+    // ... but applicable when pruning is forced for the query
+    queryContext = QueryContextConverterUtils.getQueryContext(
+        "SET forceInPredicatePruning=true; SELECT COUNT(*) FROM testTable WHERE column IN "
+            + "(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)");
+    assertTrue(PRUNER.isApplicableTo(queryContext));
     // Other predicate types are not applicable
     queryContext = QueryContextConverterUtils.getQueryContext("SELECT COUNT(*) FROM testTable WHERE column LIKE 5");
     assertFalse(PRUNER.isApplicableTo(queryContext));
@@ -276,6 +281,22 @@ public class BloomFilterSegmentPrunerTest {
     queryContext = QueryContextConverterUtils.getQueryContext(
         "SELECT COUNT(*) FROM testTable WHERE column = 3 OR (column NOT IN (1, 2) AND column = 4)");
     assertTrue(PRUNER.isApplicableTo(queryContext));
+  }
+
+  @Test
+  public void testForcedInPredicatePruning()
+      throws IOException {
+    IndexSegment indexSegment = mockIndexSegment(new String[]{"1.0", "2.0", "3.0", "5.0", "7.0", "21.0"});
+
+    // Without the option, a large IN list (more than the default threshold of 10) is not pruned even though all
+    // values are absent from the bloom filter
+    assertFalse(runPruner(indexSegment,
+        "SELECT COUNT(*) FROM testTable WHERE column IN "
+            + "(30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0, 37.0, 38.0, 39.0, 40.0)"));
+    // With the option, the same IN list is pruned as all values are absent from the bloom filter
+    assertTrue(runPruner(indexSegment,
+        "SET forceInPredicatePruning=true; SELECT COUNT(*) FROM testTable WHERE column IN "
+            + "(30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0, 37.0, 38.0, 39.0, 40.0)"));
   }
 
   private IndexSegment mockIndexSegment(String[] values)

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPrunerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPrunerTest.java
@@ -113,7 +113,7 @@ public class ColumnValueSegmentPrunerTest {
   }
 
   @Test
-  public void testForcedInPredicatePruning() {
+  public void testInPredicatePruningThresholdOverride() {
     IndexSegment indexSegment = mockIndexSegment();
 
     DataSource dataSource = mock(DataSource.class);
@@ -128,10 +128,35 @@ public class ColumnValueSegmentPrunerTest {
     // values are out of min/max range
     assertFalse(runPruner(indexSegment,
         "SELECT COUNT(*) FROM testTable WHERE column IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 21)"));
-    // With the option, the same IN list is pruned as all values are out of min/max range
+    // A negative query threshold always prunes, regardless of the IN clause size
     assertTrue(runPruner(indexSegment,
-        "SET forceInPredicatePruning=true; "
+        "SET inPredicatePruningThreshold=-1; "
             + "SELECT COUNT(*) FROM testTable WHERE column IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 21)"));
+    // A positive query threshold above the clause size also prunes
+    assertTrue(runPruner(indexSegment,
+        "SET inPredicatePruningThreshold=20; "
+            + "SELECT COUNT(*) FROM testTable WHERE column IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 21)"));
+  }
+
+  @Test
+  public void testNegativeServerThresholdAlwaysPrunes() {
+    // The server config follows the same convention: a negative `inpredicate.threshold` always prunes
+    ColumnValueSegmentPruner pruner = new ColumnValueSegmentPruner();
+    pruner.init(new PinotConfiguration(Map.of(ColumnValueSegmentPruner.IN_PREDICATE_THRESHOLD, -1)));
+
+    IndexSegment indexSegment = mockIndexSegment();
+
+    DataSource dataSource = mock(DataSource.class);
+    when(indexSegment.getDataSource(eq("column"), any(Schema.class))).thenReturn(dataSource);
+    DataSourceMetadata dataSourceMetadata = mock(DataSourceMetadata.class);
+    when(dataSourceMetadata.getDataType()).thenReturn(DataType.INT);
+    when(dataSourceMetadata.getMinValue()).thenReturn(10);
+    when(dataSourceMetadata.getMaxValue()).thenReturn(20);
+    when(dataSource.getDataSourceMetadata()).thenReturn(dataSourceMetadata);
+
+    // 11 values, all out of min/max range, pruned without any query option
+    assertTrue(runPruner(pruner, indexSegment,
+        "SELECT COUNT(*) FROM testTable WHERE column IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 21)"));
   }
 
   @Test
@@ -183,9 +208,9 @@ public class ColumnValueSegmentPrunerTest {
     queryContext = QueryContextConverterUtils.getQueryContext(
         "SELECT COUNT(*) FROM testTable WHERE column IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)");
     assertFalse(PRUNER.isApplicableTo(queryContext));
-    // ... but applicable when pruning is forced for the query
+    // ... but applicable when the query threshold is negative
     queryContext = QueryContextConverterUtils.getQueryContext(
-        "SET forceInPredicatePruning=true; SELECT COUNT(*) FROM testTable WHERE column IN "
+        "SET inPredicatePruningThreshold=-1; SELECT COUNT(*) FROM testTable WHERE column IN "
             + "(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)");
     assertTrue(PRUNER.isApplicableTo(queryContext));
     // Other predicate types are not applicable
@@ -218,8 +243,12 @@ public class ColumnValueSegmentPrunerTest {
   }
 
   private boolean runPruner(IndexSegment indexSegment, String query) {
+    return runPruner(PRUNER, indexSegment, query);
+  }
+
+  private boolean runPruner(ColumnValueSegmentPruner pruner, IndexSegment indexSegment, String query) {
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
     queryContext.setSchema(mock(Schema.class));
-    return PRUNER.prune(Arrays.asList(indexSegment), queryContext).isEmpty();
+    return pruner.prune(Arrays.asList(indexSegment), queryContext).isEmpty();
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPrunerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPrunerTest.java
@@ -113,6 +113,28 @@ public class ColumnValueSegmentPrunerTest {
   }
 
   @Test
+  public void testForcedInPredicatePruning() {
+    IndexSegment indexSegment = mockIndexSegment();
+
+    DataSource dataSource = mock(DataSource.class);
+    when(indexSegment.getDataSource(eq("column"), any(Schema.class))).thenReturn(dataSource);
+    DataSourceMetadata dataSourceMetadata = mock(DataSourceMetadata.class);
+    when(dataSourceMetadata.getDataType()).thenReturn(DataType.INT);
+    when(dataSourceMetadata.getMinValue()).thenReturn(10);
+    when(dataSourceMetadata.getMaxValue()).thenReturn(20);
+    when(dataSource.getDataSourceMetadata()).thenReturn(dataSourceMetadata);
+
+    // Without the option, a large IN list (more than the default threshold of 10) is not pruned even though all
+    // values are out of min/max range
+    assertFalse(runPruner(indexSegment,
+        "SELECT COUNT(*) FROM testTable WHERE column IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 21)"));
+    // With the option, the same IN list is pruned as all values are out of min/max range
+    assertTrue(runPruner(indexSegment,
+        "SET forceInPredicatePruning=true; "
+            + "SELECT COUNT(*) FROM testTable WHERE column IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 21)"));
+  }
+
+  @Test
   public void testPartitionPruning() {
     IndexSegment indexSegment = mockIndexSegment();
 
@@ -159,8 +181,13 @@ public class ColumnValueSegmentPrunerTest {
     assertFalse(PRUNER.isApplicableTo(queryContext));
     // Too many values for IN clause
     queryContext = QueryContextConverterUtils.getQueryContext(
-        "SELECT COUNT(*) FROM testTable WHERE column IN (1, 2, 3, 4, 5, 6, 7)");
+        "SELECT COUNT(*) FROM testTable WHERE column IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)");
     assertFalse(PRUNER.isApplicableTo(queryContext));
+    // ... but applicable when pruning is forced for the query
+    queryContext = QueryContextConverterUtils.getQueryContext(
+        "SET forceInPredicatePruning=true; SELECT COUNT(*) FROM testTable WHERE column IN "
+            + "(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)");
+    assertTrue(PRUNER.isApplicableTo(queryContext));
     // Other predicate types are not applicable
     queryContext = QueryContextConverterUtils.getQueryContext("SELECT COUNT(*) FROM testTable WHERE column LIKE 5");
     assertFalse(PRUNER.isApplicableTo(queryContext));

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -860,10 +860,8 @@ public class CommonConstants {
 
         public static final String IN_PREDICATE_PRE_SORTED = "inPredicatePreSorted";
         public static final String IN_PREDICATE_LOOKUP_ALGORITHM = "inPredicateLookupAlgorithm";
-        /// When true, the column-value and bloom-filter segment pruners always attempt to prune segments for
-        /// IN predicates, regardless of the number of values in the IN clause (i.e. the server-configured
-        /// `inpredicate.threshold` is ignored for this query). Defaults to false.
-        public static final String FORCE_IN_PREDICATE_PRUNING = "forceInPredicatePruning";
+        /// Query-level override for `inpredicate.threshold`. Negative means always prune.
+        public static final String IN_PREDICATE_PRUNING_THRESHOLD = "inPredicatePruningThreshold";
 
         // When evaluating REGEXP_LIKE predicate on a dictionary encoded column:
         // - If dictionary size is smaller than this threshold, scan the dictionary to get the matching dictionary ids
@@ -1505,6 +1503,8 @@ public class CommonConstants {
     public static final String PREFIX_OF_CONFIG_OF_PINOT_CRYPTER = "pinot.server.crypter";
     public static final String CONFIG_OF_VALUE_PRUNER_IN_PREDICATE_THRESHOLD =
         "pinot.server.query.executor.pruner.columnvaluesegmentpruner.inpredicate.threshold";
+    /// Default IN-pruning threshold. Negative means always prune.
+    /// Can be overridden per query via [Request.QueryOptionKey#IN_PREDICATE_PRUNING_THRESHOLD].
     public static final int DEFAULT_VALUE_PRUNER_IN_PREDICATE_THRESHOLD = 10;
 
     /// Service token for accessing protected controller APIs.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -860,6 +860,10 @@ public class CommonConstants {
 
         public static final String IN_PREDICATE_PRE_SORTED = "inPredicatePreSorted";
         public static final String IN_PREDICATE_LOOKUP_ALGORITHM = "inPredicateLookupAlgorithm";
+        /// When true, the column-value and bloom-filter segment pruners always attempt to prune segments for
+        /// IN predicates, regardless of the number of values in the IN clause (i.e. the server-configured
+        /// `inpredicate.threshold` is ignored for this query). Defaults to false.
+        public static final String FORCE_IN_PREDICATE_PRUNING = "forceInPredicatePruning";
 
         // When evaluating REGEXP_LIKE predicate on a dictionary encoded column:
         // - If dictionary size is smaller than this threshold, scan the dictionary to get the matching dictionary ids


### PR DESCRIPTION
Per https://github.com/apache/pinot/issues/19279, it would be convenient to have a query parameter that disables the IN clause pruning threshold.

-------
## Summary

* Add the inPredicatePruningThreshold query option to override the server inpredicate.threshold (default 10) on a per-query basis. A negative value disables the threshold entirely, so IN-predicate segment pruning is always attempted regardless of IN-clause size.

## Usage

Added a per-query integer query option `inPredicatePruningThreshold`:

 ```sql
   -- Raise the threshold for this query
   SET inPredicatePruningThreshold=501;
   SELECT ... WHERE id IN (a, b, ..., 500 values)

   -- Or disable the threshold entirely (negative value = always
 prune)
   SET inPredicatePruningThreshold=-1;
   SELECT ... WHERE id IN (a, b, ..., 500 values)
 ```

A negative value means the pruners always attempt to prune segments for IN predicates, regardless of the clause size. When unset, the server-configured inpredicate.threshold (default 10) applies, preserving existing behavior.

Pruning is per-segment and all-or-nothing. The pruner either skips a whole segment (none of the IN values exist in it) or keeps it. On a single-segment table there is nothing to skip, so no pruning is observed (my local test cluster setup); in a larger cluster, segments that contain none of the IN values are pruned.

 ## Testing

 Unit tests cover:
 - `QueryOptionsUtils` getter
 - End-to-end pruning of a >10-value IN list in both `ColumnValueSegmentPrunerTest` and `BloomFilterSegmentPrunerTest`, with negative and positive overrides
 - Negative server config (inpredicate.threshold = -1) prunes without any query option

_Also tested in my local Pinot cluster setup and ran a few queries to validate query plans and behavior (both SSE and MSE)._