### PR TITLE
Fix FULL-upsert vector candidate generation

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ExactVectorScanFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ExactVectorScanFilterOperator.java
@@ -36,6 +36,7 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.trace.FilterType;
 import org.apache.pinot.spi.trace.InvocationRecording;
 import org.apache.pinot.spi.trace.Tracing;
+import org.roaringbitmap.IntIterator;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.slf4j.Logger;
@@ -46,11 +47,11 @@ import org.slf4j.LoggerFactory;
 ///
 /// This operator is used when no ANN vector index exists on a segment for the target column
 /// (e.g., the segment was built before the vector index was added, or the index type is not
-/// supported). It reads all vectors from the forward index, computes exact distances to the
-/// query vector, and returns the top-K closest document IDs.
+/// supported). It reads vectors from the forward index, computes exact distances to the query vector, and returns the
+/// top-K closest document IDs. A mandatory candidate bitmap restricts the scan when present.
 ///
-/// The distance computation uses L2 (Euclidean) squared distance. For COSINE similarity,
-/// vectors should be pre-normalized. This matches the behavior of Lucene's HNSW implementation.
+/// Distance computation uses the function configured for the vector index, or Pinot's default when no index
+/// configuration is available.
 ///
 /// This operator is intentionally simple and correct rather than fast -- it is a safety net.
 /// A warning is logged when this operator is used because it scans all documents in the segment.
@@ -66,6 +67,8 @@ public class ExactVectorScanFilterOperator extends BaseFilterOperator {
   private final VectorExplainContext _vectorExplainContext;
   private final boolean _hasDistanceThreshold;
   private final float _distanceThreshold;
+  @Nullable
+  private final ImmutableRoaringBitmap _requiredUpsertCandidateBitmap;
   private ImmutableRoaringBitmap _matches;
 
   /// Creates an exact scan operator.
@@ -90,12 +93,21 @@ public class ExactVectorScanFilterOperator extends BaseFilterOperator {
   public ExactVectorScanFilterOperator(ForwardIndexReader<?> forwardIndexReader,
       VectorSimilarityPredicate predicate, String column, int numDocs, @Nullable VectorIndexConfig vectorIndexConfig,
       String fallbackReason, VectorSearchParams searchParams) {
+    this(forwardIndexReader, predicate, column, numDocs, vectorIndexConfig, fallbackReason, searchParams, null);
+  }
+
+  /// Creates an exact scan restricted to a mandatory query-owned candidate scope.
+  public ExactVectorScanFilterOperator(ForwardIndexReader<?> forwardIndexReader,
+      VectorSimilarityPredicate predicate, String column, int numDocs, @Nullable VectorIndexConfig vectorIndexConfig,
+      String fallbackReason, VectorSearchParams searchParams,
+      @Nullable VectorCandidateScope candidateScope) {
     super(numDocs, false);
     _forwardIndexReader = forwardIndexReader;
     _predicate = predicate;
     _column = column;
     _hasDistanceThreshold = searchParams.hasDistanceThreshold();
     _distanceThreshold = searchParams.getDistanceThreshold();
+    _requiredUpsertCandidateBitmap = candidateScope != null ? candidateScope.getRequiredDocIds() : null;
     float effectiveThreshold = _hasDistanceThreshold ? _distanceThreshold : -1f;
     _vectorExplainContext = new VectorExplainContext(VectorDistanceUtils.resolveBackendType(vectorIndexConfig),
         VectorDistanceUtils.resolveDistanceFunction(vectorIndexConfig), VectorExecutionMode.EXACT_SCAN,
@@ -149,6 +161,9 @@ public class ExactVectorScanFilterOperator extends BaseFilterOperator {
         + ", vector literal:" + Arrays.toString(_predicate.getValue())
         + ", topK to search:" + _predicate.getTopK()
         + ", fallbackReason:" + _vectorExplainContext.getFallbackReason()
+        + ", upsertCandidateFilterApplied:" + (_requiredUpsertCandidateBitmap != null)
+        + ", upsertCandidateFilterCardinality:" + getRequiredUpsertCandidateCardinality()
+        + ", effectiveAllowedDocIdsCardinality:" + getEffectiveAllowedDocIdsCardinality()
         + ')';
   }
 
@@ -169,55 +184,31 @@ public class ExactVectorScanFilterOperator extends BaseFilterOperator {
     attributeBuilder.putString("vectorLiteral", Arrays.toString(_predicate.getValue()));
     attributeBuilder.putString("fallbackReason", _vectorExplainContext.getFallbackReason());
     attributeBuilder.putLongIdempotent("topKtoSearch", _predicate.getTopK());
+    attributeBuilder.putBool("upsertCandidateFilterApplied", _requiredUpsertCandidateBitmap != null);
+    attributeBuilder.putLongIdempotent("upsertCandidateFilterCardinality", getRequiredUpsertCandidateCardinality());
+    attributeBuilder.putLongIdempotent("effectiveAllowedDocIdsCardinality",
+        getEffectiveAllowedDocIdsCardinality());
   }
 
   /// Performs brute-force exact search over all documents in the segment.
   /// When a distance threshold is set, returns all vectors within the threshold.
   /// Otherwise uses a max-heap to maintain the top-K closest vectors.
-  @SuppressWarnings("unchecked")
   private ImmutableRoaringBitmap computeExactTopK() {
+    ImmutableRoaringBitmap allowedDocIds = _requiredUpsertCandidateBitmap;
+    if (allowedDocIds != null && allowedDocIds.isEmpty()) {
+      return new MutableRoaringBitmap();
+    }
     LOGGER.warn("Performing exact vector scan fallback on column: {} for segment with {} docs. "
-            + "reason={}, distanceFunction={}, hasThreshold={}. "
+            + "reason={}, distanceFunction={}, hasThreshold={}, allowedDocs={}. "
             + "This is expensive -- consider adding a vector index.",
         _column, _numDocs, _vectorExplainContext.getFallbackReason(),
-        _vectorExplainContext.getDistanceFunction(), _hasDistanceThreshold);
+        _vectorExplainContext.getDistanceFunction(), _hasDistanceThreshold,
+        allowedDocIds != null ? allowedDocIds.getCardinality() : _numDocs);
 
     float[] queryVector = _predicate.getValue();
-
-    if (_hasDistanceThreshold) {
-      return computeExactThreshold(queryVector);
-    }
-
-    int topK = _predicate.getTopK();
-
-    // Max-heap: entry with largest distance is at the top so we can efficiently evict it
-    PriorityQueue<DocDistance> maxHeap = new PriorityQueue<>(topK + 1,
-        (a, b) -> Float.compare(b._distance, a._distance));
-
-    ForwardIndexReader rawReader = _forwardIndexReader;
-    try (ForwardIndexReaderContext context = rawReader.createContext()) {
-      for (int docId = 0; docId < _numDocs; docId++) {
-        float[] docVector = rawReader.getFloatMV(docId, context);
-        if (docVector == null || docVector.length == 0) {
-          continue;
-        }
-        float distance = VectorDistanceUtils.computeDistance(queryVector, docVector,
-            _vectorExplainContext.getDistanceFunction());
-        if (maxHeap.size() < topK) {
-          maxHeap.add(new DocDistance(docId, distance));
-        } else if (distance < maxHeap.peek()._distance) {
-          maxHeap.poll();
-          maxHeap.add(new DocDistance(docId, distance));
-        }
-      }
-    } catch (Exception e) {
-      throw new RuntimeException("Error during exact vector scan on column: " + _column, e);
-    }
-
-    MutableRoaringBitmap result = new MutableRoaringBitmap();
-    for (DocDistance dd : maxHeap) {
-      result.add(dd._docId);
-    }
+    Float threshold = _hasDistanceThreshold ? _distanceThreshold : null;
+    ImmutableRoaringBitmap result = computeExactMatches(_forwardIndexReader, queryVector, _predicate.getTopK(),
+        _numDocs, _vectorExplainContext.getDistanceFunction(), threshold, allowedDocIds, _column);
 
     LOGGER.debug("Exact vector scan on column: {} returned {} results from {} docs",
         _column, result.getCardinality(), _numDocs);
@@ -225,31 +216,81 @@ public class ExactVectorScanFilterOperator extends BaseFilterOperator {
     return result;
   }
 
-  /// Performs brute-force threshold scan: returns all vectors within the distance threshold.
-  @SuppressWarnings("unchecked")
-  private ImmutableRoaringBitmap computeExactThreshold(float[] queryVector) {
+  /// Performs an exact top-K or threshold search over all documents or the supplied allowed-document bitmap.
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  static ImmutableRoaringBitmap computeExactMatches(ForwardIndexReader<?> forwardIndexReader,
+      float[] queryVector, int topK, int numDocs,
+      VectorIndexConfig.VectorDistanceFunction distanceFunction, @Nullable Float distanceThreshold,
+      @Nullable ImmutableRoaringBitmap allowedDocIds, String column) {
+    if ((allowedDocIds != null && allowedDocIds.isEmpty()) || (distanceThreshold == null && topK <= 0)) {
+      return new MutableRoaringBitmap();
+    }
+
+    PriorityQueue<DocDistance> maxHeap = distanceThreshold == null
+        ? new PriorityQueue<>(topK + 1, (a, b) -> Float.compare(b._distance, a._distance)) : null;
     MutableRoaringBitmap result = new MutableRoaringBitmap();
-    ForwardIndexReader rawReader = _forwardIndexReader;
+    ForwardIndexReader rawReader = forwardIndexReader;
     try (ForwardIndexReaderContext context = rawReader.createContext()) {
-      for (int docId = 0; docId < _numDocs; docId++) {
-        float[] docVector = rawReader.getFloatMV(docId, context);
-        if (docVector == null || docVector.length == 0) {
-          continue;
+      if (allowedDocIds == null) {
+        for (int docId = 0; docId < numDocs; docId++) {
+          scoreDocument(rawReader, context, docId, queryVector, topK, distanceFunction, distanceThreshold,
+              maxHeap, result);
         }
-        float distance = VectorDistanceUtils.computeDistance(queryVector, docVector,
-            _vectorExplainContext.getDistanceFunction());
-        if (distance <= _distanceThreshold) {
-          result.add(docId);
+      } else {
+        IntIterator iterator = allowedDocIds.getIntIterator();
+        while (iterator.hasNext()) {
+          int docId = iterator.next();
+          // Query planning can race with later segment changes. Never read beyond the numDocs watermark captured by
+          // FilterPlanNode, even if a supplied bitmap contains larger document IDs.
+          if (docId < 0 || docId >= numDocs) {
+            break;
+          }
+          scoreDocument(rawReader, context, docId, queryVector, topK, distanceFunction, distanceThreshold,
+              maxHeap, result);
         }
       }
     } catch (Exception e) {
-      throw new RuntimeException("Error during exact threshold scan on column: " + _column, e);
+      throw new RuntimeException("Error during exact vector scan on column: " + column, e);
     }
 
-    LOGGER.debug("Exact threshold scan on column: {} returned {} results from {} docs (threshold={})",
-        _column, result.getCardinality(), _numDocs, _distanceThreshold);
-
+    if (maxHeap != null) {
+      for (DocDistance docDistance : maxHeap) {
+        result.add(docDistance._docId);
+      }
+    }
     return result.toImmutableRoaringBitmap();
+  }
+
+  private static void scoreDocument(ForwardIndexReader rawReader, ForwardIndexReaderContext context, int docId,
+      float[] queryVector, int topK, VectorIndexConfig.VectorDistanceFunction distanceFunction,
+      @Nullable Float distanceThreshold, @Nullable PriorityQueue<DocDistance> maxHeap,
+      MutableRoaringBitmap thresholdMatches) {
+    float[] docVector = rawReader.getFloatMV(docId, context);
+    if (docVector == null || docVector.length == 0) {
+      return;
+    }
+    float distance = VectorDistanceUtils.computeDistance(queryVector, docVector, distanceFunction);
+    if (distanceThreshold != null) {
+      if (distance <= distanceThreshold) {
+        thresholdMatches.add(docId);
+      }
+      return;
+    }
+
+    if (maxHeap.size() < topK) {
+      maxHeap.add(new DocDistance(docId, distance));
+    } else if (distance < maxHeap.peek()._distance) {
+      maxHeap.poll();
+      maxHeap.add(new DocDistance(docId, distance));
+    }
+  }
+
+  private int getRequiredUpsertCandidateCardinality() {
+    return _requiredUpsertCandidateBitmap != null ? _requiredUpsertCandidateBitmap.getCardinality() : -1;
+  }
+
+  private int getEffectiveAllowedDocIdsCardinality() {
+    return getRequiredUpsertCandidateCardinality();
   }
 
   /// Computes the squared L2 (Euclidean) distance between two vectors.

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/VectorCandidateScope.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/VectorCandidateScope.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.filter;
+
+import com.google.common.base.Preconditions;
+import java.nio.ByteBuffer;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+
+
+/// Immutable query-scoped constraint that must be applied before vector candidate selection.
+///
+/// The factory owns the single defensive copy of the supplied bitmap. Operators can safely share this scope and only
+/// allocate another bitmap when they need to intersect it with an independent optional filter.
+public final class VectorCandidateScope {
+  private final ImmutableRoaringBitmap _requiredDocIds;
+  private final String _fallbackReason;
+
+  private VectorCandidateScope(ImmutableRoaringBitmap requiredDocIds, String fallbackReason) {
+    byte[] serializedDocIds = new byte[requiredDocIds.serializedSizeInBytes()];
+    requiredDocIds.serialize(ByteBuffer.wrap(serializedDocIds));
+    _requiredDocIds = new ImmutableRoaringBitmap(ByteBuffer.wrap(serializedDocIds).asReadOnlyBuffer());
+    _fallbackReason = Preconditions.checkNotNull(fallbackReason, "Fallback reason must not be null");
+  }
+
+  /// Creates a mandatory candidate scope from a detached FULL-upsert valid-document snapshot.
+  public static VectorCandidateScope forUpsertSnapshot(ImmutableRoaringBitmap requiredDocIds,
+      String fallbackReason) {
+    return new VectorCandidateScope(Preconditions.checkNotNull(requiredDocIds, "Required doc IDs must not be null"),
+        fallbackReason);
+  }
+
+  public ImmutableRoaringBitmap getRequiredDocIds() {
+    return _requiredDocIds;
+  }
+
+  public String getFallbackReason() {
+    return _fallbackReason;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/VectorSimilarityFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/VectorSimilarityFilterOperator.java
@@ -58,9 +58,9 @@ import org.slf4j.LoggerFactory;
 ///      using exact distance from the forward index and re-sorted before final top-K selection.
 /// - **maxCandidates:** Controls how many ANN candidates are retrieved before rerank. Only
 ///      meaningful when rerank is enabled.
-/// - **Pre-filter:** For backends that implement FilterAwareVectorIndexReader, a pre-filter
-///      bitmap from sibling filter operators can be passed in to improve search quality under
-///      highly selective filters.
+/// - **Pre-filter:** For backends that implement FilterAwareVectorIndexReader, an optimizer-selected metadata bitmap
+///      can improve search quality under highly selective filters. FULL-upsert queries additionally apply their
+///      query-scoped valid-document snapshot before candidate selection.
 ///
 /// When no query options are specified, behavior is identical to the previous HNSW-only path
 /// (full backward compatibility).
@@ -84,13 +84,22 @@ public class VectorSimilarityFilterOperator extends BaseFilterOperator {
   private final boolean _hasThresholdPredicate;
   private final float _distanceThreshold;
   private final int _effectiveSearchCount;
+  @Nullable
+  private final ImmutableRoaringBitmap _requiredUpsertCandidateBitmap;
+  @Nullable
+  private final String _requiredCandidateFallbackReason;
   private volatile VectorExplainContext _vectorExplainContext;
   private volatile int _annCandidateCount;
   private volatile int _rerankedCandidateCount;
   private ImmutableRoaringBitmap _matches;
   @Nullable
-  private volatile ImmutableRoaringBitmap _preFilterBitmap;
+  private volatile ImmutableRoaringBitmap _optionalPreFilterBitmap;
+  @Nullable
+  private volatile ImmutableRoaringBitmap _effectiveAllowedDocIds;
   private volatile VectorSearchMode _vectorSearchMode;
+  @Nullable
+  private volatile String _runtimeFallbackReason;
+  private volatile boolean _candidateGenerationSkipped;
 
   /// Backward-compatible constructor that uses default search params and no forward index.
   /// Existing callers that do not pass query options continue to work unchanged.
@@ -129,6 +138,15 @@ public class VectorSimilarityFilterOperator extends BaseFilterOperator {
   public VectorSimilarityFilterOperator(VectorIndexReader vectorIndexReader, VectorSimilarityPredicate predicate,
       int numDocs, VectorSearchParams searchParams, @Nullable ForwardIndexReader<?> forwardIndexReader,
       @Nullable VectorIndexConfig vectorIndexConfig, boolean hasMetadataFilter) {
+    this(vectorIndexReader, predicate, numDocs, searchParams, forwardIndexReader, vectorIndexConfig,
+        hasMetadataFilter, null);
+  }
+
+  /// Full constructor with a mandatory query-owned scope and optional optimizer-selected metadata.
+  public VectorSimilarityFilterOperator(VectorIndexReader vectorIndexReader, VectorSimilarityPredicate predicate,
+      int numDocs, VectorSearchParams searchParams, @Nullable ForwardIndexReader<?> forwardIndexReader,
+      @Nullable VectorIndexConfig vectorIndexConfig, boolean hasMetadataFilter,
+      @Nullable VectorCandidateScope candidateScope) {
     super(numDocs, false);
     _vectorIndexReader = vectorIndexReader;
     _predicate = predicate;
@@ -142,9 +160,9 @@ public class VectorSimilarityFilterOperator extends BaseFilterOperator {
     _hasMetadataFilter = hasMetadataFilter;
     _hasThresholdPredicate = searchParams.hasDistanceThreshold();
     _distanceThreshold = searchParams.getDistanceThreshold();
-    // When metadata filter is present, over-fetch ANN candidates to compensate for filter loss.
-    // Default over-fetch factor is 2x topK for filtered queries without explicit maxCandidates.
-    // For threshold queries, use a larger candidate pool since we need distance refinement.
+    _requiredUpsertCandidateBitmap = candidateScope != null ? candidateScope.getRequiredDocIds() : null;
+    _requiredCandidateFallbackReason = candidateScope != null ? candidateScope.getFallbackReason() : null;
+    // Threshold and exact-rerank queries use a larger candidate pool for refinement.
     int baseSearchCount;
     if (_hasThresholdPredicate) {
       // Threshold queries need a larger candidate pool for exact distance refinement.
@@ -156,27 +174,45 @@ public class VectorSimilarityFilterOperator extends BaseFilterOperator {
       // For plain top-K and filtered queries (no rerank, no threshold), always ask
       // the ANN index for exactly topK candidates. Over-fetching would change the
       // predicate semantics: vectorSimilarity(col, q, 10) must return at most 10 docs.
-      // The metadata filter (bitmap AND) reduces this set further, which is correct.
+      // Adaptive metadata that remains post-filtered may reduce this set further. Required upsert candidates are
+      // instead applied before this top-K selection.
       baseSearchCount = predicate.getTopK();
     }
     _effectiveSearchCount = baseSearchCount;
-    refreshExplainContext(null);
     _annCandidateCount = -1;
     _rerankedCandidateCount = -1;
     _matches = null;
-    _preFilterBitmap = null;
-    _vectorSearchMode = VectorSearchMode.POST_FILTER_ANN;
+    _optionalPreFilterBitmap = null;
+    recomputeEffectiveAllowedDocIds();
+    if (!hasMandatoryCandidateScope()) {
+      _vectorSearchMode = VectorSearchMode.POST_FILTER_ANN;
+      _runtimeFallbackReason = null;
+    } else if (_effectiveAllowedDocIds.isEmpty()) {
+      _vectorSearchMode = VectorSearchMode.FILTER_THEN_ANN;
+      _runtimeFallbackReason = null;
+    } else if (readerSupportsPreFilter()) {
+      _vectorSearchMode = VectorSearchMode.FILTER_THEN_ANN;
+      _runtimeFallbackReason = null;
+    } else {
+      _vectorSearchMode = VectorSearchMode.EXACT_SCAN;
+      _runtimeFallbackReason = _requiredCandidateFallbackReason;
+    }
+    _candidateGenerationSkipped = hasMandatoryCandidateScope() && _effectiveAllowedDocIds.isEmpty();
+    refreshExplainContext();
   }
 
-  /// Sets a pre-filter bitmap to restrict the ANN search to a subset of documents.
-  /// When set, the operator will use FILTER_THEN_ANN mode if the underlying reader
-  /// supports [FilterAwareVectorIndexReader].
+  /// Sets an optimizer-selected optional metadata bitmap. When a mandatory upsert bitmap is also present, the
+  /// operator intersects private copies of the two bitmaps before candidate generation. When no mandatory bitmap is
+  /// present, readers that cannot pre-filter retain the existing unfiltered ANN behavior.
   ///
   /// This method must be called before any search execution (getTrues, getBitmaps, etc.).
   ///
   /// @param preFilterBitmap the bitmap of document IDs to restrict the search to
   public void setPreFilterBitmap(@Nullable ImmutableRoaringBitmap preFilterBitmap) {
-    _preFilterBitmap = preFilterBitmap;
+    _optionalPreFilterBitmap = copyBitmap(preFilterBitmap);
+    recomputeEffectiveAllowedDocIds();
+    _candidateGenerationSkipped = hasMandatoryCandidateScope() && _effectiveAllowedDocIds.isEmpty();
+    refreshExplainContext();
   }
 
   @Override
@@ -244,6 +280,16 @@ public class VectorSimilarityFilterOperator extends BaseFilterOperator {
     if (explainContext.getFilterSelectivity() >= 0) {
       sb.append(", filterSelectivity:").append(String.format("%.4f", explainContext.getFilterSelectivity()));
     }
+    sb.append(", upsertCandidateFilterApplied:").append(_requiredUpsertCandidateBitmap != null)
+        .append(", upsertCandidateFilterCardinality:").append(getRequiredUpsertCandidateCardinality())
+        .append(", effectiveAllowedDocIdsCardinality:").append(getEffectiveAllowedDocIdsCardinality())
+        .append(", candidateGenerationSkipped:").append(_candidateGenerationSkipped);
+    if (_candidateGenerationSkipped) {
+      sb.append(", candidateGenerationSkipReason:").append(getCandidateGenerationSkipReason());
+    }
+    if (_runtimeFallbackReason != null) {
+      sb.append(", fallbackReason:").append(_runtimeFallbackReason);
+    }
     sb.append(')');
     return sb.toString();
   }
@@ -292,12 +338,22 @@ public class VectorSimilarityFilterOperator extends BaseFilterOperator {
     if (explainContext.getFilterSelectivity() >= 0) {
       attributeBuilder.putString("filterSelectivity", String.format("%.4f", explainContext.getFilterSelectivity()));
     }
+    attributeBuilder.putBool("upsertCandidateFilterApplied", _requiredUpsertCandidateBitmap != null);
+    attributeBuilder.putLongIdempotent("upsertCandidateFilterCardinality", getRequiredUpsertCandidateCardinality());
+    attributeBuilder.putLongIdempotent("effectiveAllowedDocIdsCardinality",
+        getEffectiveAllowedDocIdsCardinality());
+    attributeBuilder.putBool("candidateGenerationSkipped", _candidateGenerationSkipped);
+    if (_candidateGenerationSkipped) {
+      attributeBuilder.putString("candidateGenerationSkipReason", getCandidateGenerationSkipReason());
+    }
+    if (_runtimeFallbackReason != null) {
+      attributeBuilder.putString("fallbackReason", _runtimeFallbackReason);
+    }
   }
 
   /// Returns true if the underlying vector index reader supports pre-filter ANN search.
   public boolean supportsPreFilter() {
-    return _vectorIndexReader instanceof FilterAwareVectorIndexReader
-        && ((FilterAwareVectorIndexReader) _vectorIndexReader).supportsPreFilter();
+    return readerSupportsPreFilter();
   }
 
   /// Executes the vector search with backend-specific parameter dispatch and optional rerank.
@@ -305,18 +361,53 @@ public class VectorSimilarityFilterOperator extends BaseFilterOperator {
     String column = _predicate.getLhs().getIdentifier();
     float[] queryVector = _predicate.getValue();
     VectorExplainContext explainContext = _vectorExplainContext;
+    boolean backendParamsNeedCleanup = false;
+    boolean searchExecuted = false;
     try {
+      ImmutableRoaringBitmap effectiveAllowedDocIds = _effectiveAllowedDocIds;
+      if (hasMandatoryCandidateScope() && effectiveAllowedDocIds.isEmpty()) {
+        _candidateGenerationSkipped = true;
+        _annCandidateCount = 0;
+        _rerankedCandidateCount = 0;
+        return new MutableRoaringBitmap();
+      }
+      _candidateGenerationSkipped = false;
+
+      if (hasMandatoryCandidateScope() && !readerSupportsPreFilter()) {
+        if (_forwardIndexReader == null) {
+          throw new IllegalStateException("Cannot honor mandatory vector candidate scope on vector column: "
+              + column + " -- vector index reader does not support filtered search and no forward index is available");
+        }
+        _vectorSearchMode = VectorSearchMode.EXACT_SCAN;
+        _runtimeFallbackReason = _requiredCandidateFallbackReason != null ? _requiredCandidateFallbackReason
+            : "vector_index_not_filter_aware_for_mandatory_scope";
+        VectorSearchMetrics.getInstance().recordFallback(_runtimeFallbackReason);
+        LOGGER.warn("Performing exact allowed-document vector scan on column: {} because {}. allowedDocs={}",
+            column, _runtimeFallbackReason, effectiveAllowedDocIds.getCardinality());
+        Float threshold = _hasThresholdPredicate ? _distanceThreshold : null;
+        searchExecuted = true;
+        ImmutableRoaringBitmap exactResults = ExactVectorScanFilterOperator.computeExactMatches(
+            _forwardIndexReader, queryVector, _predicate.getTopK(), _numDocs, _distanceFunction, threshold,
+            effectiveAllowedDocIds, column);
+        _annCandidateCount = -1;
+        _rerankedCandidateCount = exactResults.getCardinality();
+        return exactResults;
+      }
+
       // 1. Configure backend-specific parameters via interfaces
+      // Claim cleanup before the first setter because configuration can fail after partially updating reader state.
+      backendParamsNeedCleanup = true;
       configureBackendParams(column);
-      refreshExplainContext(null);
+      refreshExplainContext();
       explainContext = _vectorExplainContext;
 
       // 2. Determine effective search count (higher if rerank is enabled)
       int searchCount = explainContext.getEffectiveSearchCount();
 
       // 3. Execute ANN search (with pre-filter if available)
-      ImmutableRoaringBitmap preFilter = _preFilterBitmap;
+      ImmutableRoaringBitmap preFilter = effectiveAllowedDocIds;
       ImmutableRoaringBitmap annResults;
+      searchExecuted = true;
       if (preFilter != null && _vectorIndexReader instanceof FilterAwareVectorIndexReader) {
         FilterAwareVectorIndexReader filterAwareReader = (FilterAwareVectorIndexReader) _vectorIndexReader;
         if (filterAwareReader.supportsPreFilter()) {
@@ -326,6 +417,10 @@ public class VectorSimilarityFilterOperator extends BaseFilterOperator {
               column, preFilter.getCardinality(),
               _numDocs > 0 ? (double) preFilter.getCardinality() / _numDocs : 0.0);
         } else {
+          if (hasMandatoryCandidateScope()) {
+            throw new IllegalStateException("Cannot honor mandatory vector candidate scope on vector column: "
+                + column + " -- vector index reader stopped supporting filtered search");
+          }
           _vectorSearchMode = VectorSearchMode.POST_FILTER_ANN;
           annResults = _vectorIndexReader.getDocIds(queryVector, searchCount);
         }
@@ -381,11 +476,17 @@ public class VectorSimilarityFilterOperator extends BaseFilterOperator {
 
       return annResults;
     } finally {
-      // Record search metrics for observability — always, regardless of which path was taken
-      VectorSearchMetrics.getInstance().recordSearch(_vectorSearchMode, _backendType);
-      // Refresh explain context with the final search mode decided during execution
-      refreshExplainContext(null);
-      clearBackendParams(column);
+      try {
+        if (searchExecuted) {
+          VectorSearchMetrics.getInstance().recordSearch(_vectorSearchMode, _backendType);
+        }
+        // Refresh explain context with the final search mode decided during execution
+        refreshExplainContext();
+      } finally {
+        if (backendParamsNeedCleanup) {
+          clearBackendParams(column);
+        }
+      }
     }
   }
 
@@ -510,14 +611,21 @@ public class VectorSimilarityFilterOperator extends BaseFilterOperator {
     return _backendType.name();
   }
 
-  private void refreshExplainContext(@Nullable String fallbackReason) {
-    VectorExecutionMode executionMode = VectorQueryExecutionContext.selectExecutionMode(
-        true, _hasMetadataFilter, _hasThresholdPredicate, _effectiveExactRerank);
-    ImmutableRoaringBitmap preFilter = _preFilterBitmap;
+  private void refreshExplainContext() {
+    VectorExecutionMode executionMode;
+    if (_vectorSearchMode == VectorSearchMode.EXACT_SCAN) {
+      executionMode = VectorExecutionMode.EXACT_SCAN;
+    } else if (_vectorSearchMode == VectorSearchMode.FILTER_THEN_ANN) {
+      executionMode = VectorExecutionMode.FILTER_THEN_ANN;
+    } else {
+      executionMode = VectorQueryExecutionContext.selectExecutionMode(
+          true, _hasMetadataFilter, _hasThresholdPredicate, _effectiveExactRerank);
+    }
+    ImmutableRoaringBitmap preFilter = _effectiveAllowedDocIds;
     double filterSelectivity = (preFilter != null && _numDocs > 0)
         ? (double) preFilter.getCardinality() / _numDocs : -1.0;
-    Map<String, Object> indexDebugInfo =
-        _backendType.supportsNprobe() ? _vectorIndexReader.getIndexDebugInfo() : Map.of();
+    Map<String, Object> indexDebugInfo = !_candidateGenerationSkipped && _backendType.supportsNprobe()
+        ? _vectorIndexReader.getIndexDebugInfo() : Map.of();
     int effectiveEfSearch =
         resolveEffectiveEfSearch(_backendType, _searchParams);
     Boolean effectiveHnswUseRelativeDistance =
@@ -528,9 +636,55 @@ public class VectorSimilarityFilterOperator extends BaseFilterOperator {
     float effectiveThreshold = threshold != null ? threshold : -1f;
     _vectorExplainContext = new VectorExplainContext(_backendType, _distanceFunction, executionMode,
         resolveEffectiveNprobe(_backendType, _searchParams, indexDebugInfo),
-        _effectiveExactRerank, _effectiveSearchCount, fallbackReason, null,
+        _effectiveExactRerank, _effectiveSearchCount, _runtimeFallbackReason, null,
         effectiveEfSearch, effectiveThreshold, _vectorSearchMode, filterSelectivity,
         effectiveHnswUseRelativeDistance, effectiveHnswUseBoundedQueue);
+  }
+
+  private boolean readerSupportsPreFilter() {
+    return _vectorIndexReader instanceof FilterAwareVectorIndexReader
+        && ((FilterAwareVectorIndexReader) _vectorIndexReader).supportsPreFilter();
+  }
+
+  private boolean hasMandatoryCandidateScope() {
+    return _requiredUpsertCandidateBitmap != null;
+  }
+
+  private void recomputeEffectiveAllowedDocIds() {
+    if (_requiredUpsertCandidateBitmap == null) {
+      _effectiveAllowedDocIds = _optionalPreFilterBitmap;
+      return;
+    }
+    if (_optionalPreFilterBitmap == null) {
+      _effectiveAllowedDocIds = _requiredUpsertCandidateBitmap;
+      return;
+    }
+    MutableRoaringBitmap effective = _requiredUpsertCandidateBitmap.toMutableRoaringBitmap();
+    effective.and(_optionalPreFilterBitmap);
+    _effectiveAllowedDocIds = effective.toImmutableRoaringBitmap();
+  }
+
+  private int getRequiredUpsertCandidateCardinality() {
+    return _requiredUpsertCandidateBitmap != null ? _requiredUpsertCandidateBitmap.getCardinality() : -1;
+  }
+
+  private int getEffectiveAllowedDocIdsCardinality() {
+    return _effectiveAllowedDocIds != null ? _effectiveAllowedDocIds.getCardinality() : -1;
+  }
+
+  private String getCandidateGenerationSkipReason() {
+    if (_requiredUpsertCandidateBitmap != null && _requiredUpsertCandidateBitmap.isEmpty()) {
+      return "empty_upsert_candidate_filter";
+    }
+    return "empty_effective_candidate_filter";
+  }
+
+  @Nullable
+  private static ImmutableRoaringBitmap copyBitmap(@Nullable ImmutableRoaringBitmap bitmap) {
+    if (bitmap == null) {
+      return null;
+    }
+    return bitmap.toMutableRoaringBitmap().toImmutableRoaringBitmap();
   }
 
   private static int resolveEffectiveNprobe(VectorBackendType backendType, VectorSearchParams searchParams,

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -47,6 +47,7 @@ import org.apache.pinot.core.operator.filter.JsonMatchFilterOperator;
 import org.apache.pinot.core.operator.filter.MapFilterOperator;
 import org.apache.pinot.core.operator.filter.MatchAllFilterOperator;
 import org.apache.pinot.core.operator.filter.TextMatchFilterOperator;
+import org.apache.pinot.core.operator.filter.VectorCandidateScope;
 import org.apache.pinot.core.operator.filter.VectorDistanceUtils;
 import org.apache.pinot.core.operator.filter.VectorRadiusFilterOperator;
 import org.apache.pinot.core.operator.filter.VectorSearchMode;
@@ -65,6 +66,7 @@ import org.apache.pinot.segment.spi.index.IndexType;
 import org.apache.pinot.segment.spi.index.creator.VectorBackendType;
 import org.apache.pinot.segment.spi.index.creator.VectorIndexConfig;
 import org.apache.pinot.segment.spi.index.multicolumntext.MultiColumnTextMetadata;
+import org.apache.pinot.segment.spi.index.reader.FilterAwareVectorIndexReader;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.segment.spi.index.reader.JsonIndexReader;
 import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
@@ -72,6 +74,7 @@ import org.apache.pinot.segment.spi.index.reader.TextIndexReader;
 import org.apache.pinot.segment.spi.index.reader.VectorIndexReader;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 
@@ -80,6 +83,8 @@ public class FilterPlanNode implements PlanNode {
   private final SegmentContext _segmentContext;
   private final QueryContext _queryContext;
   private final FilterContext _filter;
+  @Nullable
+  private VectorCandidateScope _requiredVectorCandidateScope;
 
   // Cache the predicate evaluators
   private final List<Pair<Predicate, PredicateEvaluator>> _predicateEvaluators = new ArrayList<>(4);
@@ -97,20 +102,31 @@ public class FilterPlanNode implements PlanNode {
 
   @Override
   public BaseFilterOperator run() {
-    MutableRoaringBitmap docIdsSnapshot = _segmentContext.getDocIdsSnapshot();
     int numDocs = _indexSegment.getSegmentMetadata().getTotalDocs();
+    MutableRoaringBitmap docIdsSnapshot = _segmentContext.getDocIdsSnapshot();
+    boolean hasVectorPredicate = _filter != null && containsVectorPredicate(_filter);
+    if (hasVectorPredicate && docIdsSnapshot != null) {
+      _requiredVectorCandidateScope = VectorCandidateScope.forUpsertSnapshot(docIdsSnapshot,
+          getRequiredCandidateFallbackReason(_indexSegment.getSegmentMetadata().isMutableSegment()));
+    } else {
+      _requiredVectorCandidateScope = null;
+    }
+
+    ImmutableRoaringBitmap outerDocIdsSnapshot = _requiredVectorCandidateScope != null
+        ? _requiredVectorCandidateScope.getRequiredDocIds() : docIdsSnapshot;
 
     if (_filter != null) {
       BaseFilterOperator filterOperator = constructPhysicalOperator(_filter, numDocs);
-      if (docIdsSnapshot != null) {
-        BaseFilterOperator validDocFilter = new BitmapBasedFilterOperator(docIdsSnapshot, false, numDocs);
+      if (outerDocIdsSnapshot != null) {
+        BaseFilterOperator validDocFilter =
+            new BitmapBasedFilterOperator(outerDocIdsSnapshot, false, numDocs);
         return FilterOperatorUtils.getAndFilterOperator(_queryContext, Arrays.asList(filterOperator, validDocFilter),
             numDocs);
       } else {
         return filterOperator;
       }
-    } else if (docIdsSnapshot != null) {
-      return new BitmapBasedFilterOperator(docIdsSnapshot, false, numDocs);
+    } else if (outerDocIdsSnapshot != null) {
+      return new BitmapBasedFilterOperator(outerDocIdsSnapshot, false, numDocs);
     } else {
       return new MatchAllFilterOperator(numDocs);
     }
@@ -214,9 +230,10 @@ public class FilterPlanNode implements PlanNode {
       case AND:
         childFilters = filter.getChildren();
         childFilterOperators = new ArrayList<>(childFilters.size());
+        List<FilterContext> retainedChildFilters = new ArrayList<>(childFilters.size());
         for (FilterContext childFilter : childFilters) {
           BaseFilterOperator childFilterOperator;
-          if (isVectorSimilarityFilter(childFilter) && hasNonVectorSibling(childFilters)) {
+          if (isVectorSimilarityFilter(childFilter) && hasSafeMetadataSibling(childFilters)) {
             // Pass filtered context so vector operator reports correct execution mode
             childFilterOperator = constructFilteredVectorOperator(childFilter, numDocs);
           } else {
@@ -228,13 +245,14 @@ public class FilterPlanNode implements PlanNode {
           } else if (!childFilterOperator.isResultMatchingAll()) {
             // Remove child filter operators that match all records
             childFilterOperators.add(childFilterOperator);
+            retainedChildFilters.add(childFilter);
           }
         }
         // Wire pre-filter bitmaps for filter-aware ANN: if an AND contains a
         // VectorSimilarityFilterOperator alongside other filter children, evaluate the
         // non-vector filters first and pass the resulting bitmap to the vector operator
         // so it can restrict HNSW graph traversal to the pre-filtered document set.
-        wirePreFilterForVectorOperators(childFilterOperators, numDocs);
+        wirePreFilterForVectorOperators(retainedChildFilters, childFilterOperators, numDocs);
         return FilterOperatorUtils.getAndFilterOperator(_queryContext, childFilterOperators, numDocs);
       case OR:
         childFilters = filter.getChildren();
@@ -366,17 +384,28 @@ public class FilterPlanNode implements PlanNode {
     VectorSearchParams searchParams = VectorSearchParams.fromQueryOptions(_queryContext.getQueryOptions());
 
     if (vectorIndex != null) {
-      // ANN index path: pass forward index reader if rerank or threshold search requires exact distances
+      // ANN index path: pass the forward index when rerank/threshold needs exact distances, or when it is required as
+      // a correctness fallback for a reader that cannot honor the mandatory upsert candidate bitmap.
       ForwardIndexReader<?> forwardIndexReader = null;
       VectorBackendType backendType = VectorDistanceUtils.resolveBackendType(vectorIndexConfig);
-      if (searchParams.isExactRerank(backendType) || searchParams.hasDistanceThreshold()) {
+      boolean hasMandatoryCandidates = _requiredVectorCandidateScope != null
+          && !_requiredVectorCandidateScope.getRequiredDocIds().isEmpty();
+      boolean supportsMandatoryCandidateFilter = !hasMandatoryCandidates
+          || (vectorIndex instanceof FilterAwareVectorIndexReader
+          && ((FilterAwareVectorIndexReader) vectorIndex).supportsPreFilter());
+      if (searchParams.isExactRerank(backendType) || searchParams.hasDistanceThreshold()
+          || !supportsMandatoryCandidateFilter) {
         forwardIndexReader = dataSource.getForwardIndex();
         Preconditions.checkState(!searchParams.hasDistanceThreshold() || forwardIndexReader != null,
             "Cannot apply vectorDistanceThreshold on column: %s -- forward index required for threshold refinement",
             column);
       }
+      Preconditions.checkState(_requiredVectorCandidateScope == null || supportsMandatoryCandidateFilter
+              || forwardIndexReader != null,
+          "Cannot honor mandatory vector candidate scope on vector column: %s -- vector index reader does not "
+              + "support filtered search and no forward index is available", column);
       return new VectorSimilarityFilterOperator(vectorIndex, predicate, numDocs, searchParams, forwardIndexReader,
-          vectorIndexConfig, hasMetadataFilter);
+          vectorIndexConfig, hasMetadataFilter, _requiredVectorCandidateScope);
     }
 
     // Exact scan fallback: no vector index on this segment
@@ -384,7 +413,7 @@ public class FilterPlanNode implements PlanNode {
     Preconditions.checkState(forwardIndexReader != null,
         "Cannot apply VECTOR_SIMILARITY on column: %s -- no vector index and no forward index available", column);
     return new ExactVectorScanFilterOperator(forwardIndexReader, predicate, column, numDocs, vectorIndexConfig,
-        getVectorFallbackReason(vectorIndexConfig, isMutableSegment), searchParams);
+        getVectorFallbackReason(vectorIndexConfig, isMutableSegment), searchParams, _requiredVectorCandidateScope);
   }
 
   /// Constructs a vector operator for a VECTOR_SIMILARITY predicate that is part of an AND
@@ -398,11 +427,10 @@ public class FilterPlanNode implements PlanNode {
         numDocs, true);
   }
 
-  /// Returns true if the child list contains at least one non-VECTOR_SIMILARITY predicate
-  /// (i.e., a real metadata filter sibling).
-  private static boolean hasNonVectorSibling(List<FilterContext> childFilters) {
+  /// Returns true if the child list contains at least one sibling subtree with no vector predicate.
+  private static boolean hasSafeMetadataSibling(List<FilterContext> childFilters) {
     for (FilterContext child : childFilters) {
-      if (!isVectorSimilarityFilter(child)) {
+      if (!containsVectorPredicate(child)) {
         return true;
       }
     }
@@ -413,6 +441,24 @@ public class FilterPlanNode implements PlanNode {
   private static boolean isVectorSimilarityFilter(FilterContext filter) {
     return filter.getType() == FilterContext.Type.PREDICATE
         && filter.getPredicate().getType() == Predicate.Type.VECTOR_SIMILARITY;
+  }
+
+  /// Returns true when any node in the subtree is a vector top-K predicate. Such a subtree must never be
+  /// materialized as metadata for another vector predicate because doing so executes candidate generation out of its
+  /// original boolean context and can incorrectly push candidate results into a sibling.
+  private static boolean containsVectorPredicate(FilterContext filter) {
+    if (filter.getType() == FilterContext.Type.PREDICATE) {
+      return filter.getPredicate().getType() == Predicate.Type.VECTOR_SIMILARITY;
+    }
+    if (filter.getType() == FilterContext.Type.AND || filter.getType() == FilterContext.Type.OR
+        || filter.getType() == FilterContext.Type.NOT) {
+      for (FilterContext child : filter.getChildren()) {
+        if (containsVectorPredicate(child)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   /// Constructs the vector radius filter operator based on index availability.
@@ -430,38 +476,37 @@ public class FilterPlanNode implements PlanNode {
         vectorIndexConfig);
   }
 
-  /// Wires pre-filter bitmaps for filter-aware ANN search when an AND node contains both
-  /// vector similarity operators and non-vector filter operators.
+  /// Wires metadata bitmaps when an AND node contains both vector similarity operators and non-vector filters.
   ///
-  /// When the vector index reader supports pre-filtering (implements
-  /// [org.apache.pinot.segment.spi.index.reader.FilterAwareVectorIndexReader]), the non-vector
-  /// siblings are evaluated eagerly to produce a combined bitmap. This bitmap is passed to the
-  /// [VectorSimilarityFilterOperator] so that the HNSW graph traversal is restricted to
-  /// pre-filtered documents, improving recall for selective filters.
+  /// The existing adaptive behavior is preserved: only bitmap-producing filters are considered, and
+  /// [VectorSearchStrategy] decides whether the filter-aware reader should receive the bitmap.
   ///
   /// **Trade-off: eager filter evaluation.** The non-vector filter predicates are materialized
   /// into bitmaps before the vector search begins. This is intentional because the filter bitmap must
   /// be fully materialized before it can be passed to the vector index for pre-filtered ANN search.
-  /// The [VectorSearchStrategy] selectivity check below ensures we only pay this cost when the
-  /// estimated cardinality suggests pre-filtering is worthwhile.
+  /// The [VectorSearchStrategy] selectivity check below ensures queries only pay this cost when the estimated
+  /// cardinality suggests pre-filtering is worthwhile.
   ///
-  /// If no vector operators are found or the reader does not support pre-filtering,
-  /// this method is a no-op and the AND operator falls back to the default post-filter path.
+  /// If no vector operators are found, this method is a no-op. A non-upsert query whose reader does not support
+  /// pre-filtering retains the default post-filter path.
   ///
   /// @param childOperators the list of child filter operators under an AND node
   /// @param numDocs total documents in the segment
-  private void wirePreFilterForVectorOperators(List<BaseFilterOperator> childOperators, int numDocs) {
+  private void wirePreFilterForVectorOperators(List<FilterContext> childFilters,
+      List<BaseFilterOperator> childOperators, int numDocs) {
     if (childOperators.size() < 2) {
       return;
     }
 
-    // Find vector similarity operators that support pre-filtering
+    // Find indexed vector similarity operators and non-vector metadata siblings.
     List<VectorSimilarityFilterOperator> vectorOps = new ArrayList<>();
     List<BaseFilterOperator> nonVectorOps = new ArrayList<>();
-    for (BaseFilterOperator op : childOperators) {
-      if (op instanceof VectorSimilarityFilterOperator) {
+    for (int i = 0; i < childOperators.size(); i++) {
+      FilterContext childFilter = childFilters.get(i);
+      BaseFilterOperator op = childOperators.get(i);
+      if (isVectorSimilarityFilter(childFilter) && op instanceof VectorSimilarityFilterOperator) {
         vectorOps.add((VectorSimilarityFilterOperator) op);
-      } else {
+      } else if (!containsVectorPredicate(childFilter)) {
         nonVectorOps.add(op);
       }
     }
@@ -498,9 +543,7 @@ public class FilterPlanNode implements PlanNode {
     }
 
     // Combine non-vector filter bitmaps via AND.
-    // Note: this eagerly evaluates non-vector filters. BaseFilterOperator subclasses cache
-    // their results, so the subsequent evaluation by AndFilterOperator will reuse the cached
-    // bitmaps without double-evaluation.
+    // Bitmap-producing filters are cheap to evaluate again when the final AND executes.
     MutableRoaringBitmap combinedBitmap = null;
     for (BaseFilterOperator op : nonVectorOps) {
       BitmapCollection bitmapCollection = op.getBitmaps();
@@ -520,11 +563,6 @@ public class FilterPlanNode implements PlanNode {
     // the estimated selectivity. Only pass the bitmap if the strategy recommends
     // FILTER_THEN_ANN; otherwise fall back to the default post-filter path.
     int estimatedFilteredDocs = combinedBitmap.getCardinality();
-    // isMutableSegment=false is acceptable here because the supportsPreFilter() check above
-    // already ensures we only reach this point for immutable segments with
-    // FilterAwareVectorIndexReader. MutableVectorIndex does not implement
-    // FilterAwareVectorIndexReader, so mutable segments exit early via the
-    // anySupportsPreFilter guard.
     // backendType and searchParams are passed as null here because at the pre-filter wiring
     // stage we are deciding whether to activate pre-filtering at all, not per-backend tuning.
     // The strategy currently uses only selectivity (numDocs, estimatedFilteredDocs) for this
@@ -547,6 +585,11 @@ public class FilterPlanNode implements PlanNode {
         vectorOp.setPreFilterBitmap(combinedBitmap);
       }
     }
+  }
+
+  private static String getRequiredCandidateFallbackReason(boolean isMutableSegment) {
+    return isMutableSegment ? "mutable_vector_index_not_filter_aware_for_upsert"
+        : "vector_index_not_filter_aware_for_upsert";
   }
 
   private static String getVectorFallbackReason(@Nullable VectorIndexConfig vectorIndexConfig,

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/ExactVectorScanFilterOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/ExactVectorScanFilterOperatorTest.java
@@ -27,10 +27,14 @@ import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.mockito.Mockito;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 
@@ -88,6 +92,112 @@ public class ExactVectorScanFilterOperatorTest {
     Assert.assertTrue(result.contains(0));
     Assert.assertTrue(result.contains(1));
     Assert.assertTrue(result.contains(2));
+  }
+
+  @Test
+  public void testExactSearchOnlyScoresAllowedDocuments() {
+    float[][] vectors = {
+        {1.0f, 0.0f},
+        {1.0f, 0.0f},
+        {0.0f, 1.0f},
+        {0.0f, -1.0f}
+    };
+    ForwardIndexReader<?> mockReader = createMockForwardIndexReader(vectors);
+    VectorSimilarityPredicate predicate = new VectorSimilarityPredicate(
+        ExpressionContext.forIdentifier("embedding"), new float[]{1.0f, 0.0f}, 2);
+    ExactVectorScanFilterOperator operator = new ExactVectorScanFilterOperator(mockReader, predicate,
+        "embedding", 4, createVectorIndexConfig("HNSW", VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN),
+        "mutable_vector_index_not_filter_aware_for_upsert", VectorSearchParams.DEFAULT,
+        VectorCandidateScope.forUpsertSnapshot(bitmapOf(2, 3), "mutable_vector_index_not_filter_aware_for_upsert"));
+
+    Assert.assertEquals(operator.getBitmaps().reduce(), bitmapOf(2, 3));
+    ForwardIndexReader rawReader = mockReader;
+    verify(rawReader, never()).getFloatMV(Mockito.eq(0), Mockito.any());
+    verify(rawReader, never()).getFloatMV(Mockito.eq(1), Mockito.any());
+    verify(rawReader).getFloatMV(Mockito.eq(2), Mockito.any());
+    verify(rawReader).getFloatMV(Mockito.eq(3), Mockito.any());
+  }
+
+  @Test
+  public void testExactSearchWithEmptyAllowedDocumentsSkipsForwardIndex() {
+    ForwardIndexReader<?> mockReader = mock(ForwardIndexReader.class);
+    VectorSimilarityPredicate predicate = new VectorSimilarityPredicate(
+        ExpressionContext.forIdentifier("embedding"), new float[]{1.0f, 0.0f}, 2);
+    ExactVectorScanFilterOperator operator = new ExactVectorScanFilterOperator(mockReader, predicate,
+        "embedding", 4, null, "vector_index_missing", VectorSearchParams.DEFAULT,
+        VectorCandidateScope.forUpsertSnapshot(new MutableRoaringBitmap(),
+            "vector_index_not_filter_aware_for_upsert"));
+
+    Assert.assertTrue(operator.getBitmaps().reduce().isEmpty());
+    verifyNoInteractions(mockReader);
+  }
+
+  @Test
+  public void testExactSearchIgnoresAllowedDocumentsBeyondNumDocs() {
+    ForwardIndexReader<?> mockReader = createMockForwardIndexReader(new float[][]{
+        {1.0f, 0.0f}, {0.5f, 0.5f}, {0.0f, 1.0f}
+    });
+    VectorSimilarityPredicate predicate = new VectorSimilarityPredicate(
+        ExpressionContext.forIdentifier("embedding"), new float[]{1.0f, 0.0f}, 2);
+    ExactVectorScanFilterOperator operator = new ExactVectorScanFilterOperator(mockReader, predicate,
+        "embedding", 3, null, "mandatory_scope", VectorSearchParams.DEFAULT,
+        VectorCandidateScope.forUpsertSnapshot(bitmapOf(2, 99), "vector_index_not_filter_aware_for_upsert"));
+
+    Assert.assertEquals(operator.getBitmaps().reduce(), bitmapOf(2));
+    ForwardIndexReader rawReader = mockReader;
+    verify(rawReader).getFloatMV(Mockito.eq(2), Mockito.any());
+    verify(rawReader, never()).getFloatMV(Mockito.eq(99), Mockito.any());
+  }
+
+  @Test
+  public void testExactSearchWithNonPositiveTopKSkipsForwardIndex() {
+    ForwardIndexReader<?> mockReader = mock(ForwardIndexReader.class);
+
+    for (int topK : new int[]{0, -1}) {
+      ImmutableRoaringBitmap result = ExactVectorScanFilterOperator.computeExactMatches(mockReader,
+          new float[]{1.0f, 0.0f}, topK, 4, VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN, null, null,
+          "embedding");
+      Assert.assertTrue(result.isEmpty());
+    }
+    verifyNoInteractions(mockReader);
+  }
+
+  @Test
+  public void testExactSearchTopKLargerThanAllowedCardinality() {
+    ForwardIndexReader<?> mockReader = createMockForwardIndexReader(new float[][]{
+        {1.0f, 0.0f},
+        {0.5f, 0.5f},
+        {0.0f, 1.0f},
+        {0.0f, -1.0f}
+    });
+    VectorSimilarityPredicate predicate = new VectorSimilarityPredicate(
+        ExpressionContext.forIdentifier("embedding"), new float[]{1.0f, 0.0f}, 10);
+    ExactVectorScanFilterOperator operator = new ExactVectorScanFilterOperator(mockReader, predicate,
+        "embedding", 4, null, "vector_index_missing", VectorSearchParams.DEFAULT,
+        VectorCandidateScope.forUpsertSnapshot(bitmapOf(2, 3), "vector_index_not_filter_aware_for_upsert"));
+
+    Assert.assertEquals(operator.getBitmaps().reduce(), bitmapOf(2, 3));
+  }
+
+  @Test
+  public void testExactThresholdSearchOnlyScoresAllowedDocuments() {
+    ForwardIndexReader<?> mockReader = createMockForwardIndexReader(new float[][]{
+        {1.0f, 0.0f},
+        {0.9f, 0.1f},
+        {0.0f, 1.0f},
+        {-1.0f, 0.0f}
+    });
+    VectorSimilarityPredicate predicate = new VectorSimilarityPredicate(
+        ExpressionContext.forIdentifier("embedding"), new float[]{1.0f, 0.0f}, 10);
+    VectorSearchParams searchParams = new VectorSearchParams(null, null, null, 2.0f, null, null, null);
+    ExactVectorScanFilterOperator operator = new ExactVectorScanFilterOperator(mockReader, predicate,
+        "embedding", 4, null, "vector_index_missing", searchParams,
+        VectorCandidateScope.forUpsertSnapshot(bitmapOf(2, 3), "vector_index_not_filter_aware_for_upsert"));
+
+    Assert.assertEquals(operator.getBitmaps().reduce(), bitmapOf(2));
+    ForwardIndexReader rawReader = mockReader;
+    verify(rawReader, never()).getFloatMV(Mockito.eq(0), Mockito.any());
+    verify(rawReader, never()).getFloatMV(Mockito.eq(1), Mockito.any());
   }
 
   @Test
@@ -238,5 +348,11 @@ public class ExactVectorScanFilterOperatorTest {
       VectorIndexConfig.VectorDistanceFunction distanceFunction) {
     return new VectorIndexConfig(false, backendType, 2, 1, distanceFunction,
         Map.of("nlist", "4", "pqM", "2", "pqNbits", "8", "trainSampleSize", "16"));
+  }
+
+  private static MutableRoaringBitmap bitmapOf(int... docIds) {
+    MutableRoaringBitmap bitmap = new MutableRoaringBitmap();
+    bitmap.add(docIds);
+    return bitmap;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/FilterAwareVectorSearchTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/FilterAwareVectorSearchTest.java
@@ -22,7 +22,12 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.predicate.VectorSimilarityPredicate;
 import org.apache.pinot.segment.spi.index.creator.VectorIndexConfig;
 import org.apache.pinot.segment.spi.index.reader.FilterAwareVectorIndexReader;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
 import org.apache.pinot.segment.spi.index.reader.VectorIndexReader;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.testng.Assert;
@@ -34,6 +39,7 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 
@@ -249,6 +255,133 @@ public class FilterAwareVectorSearchTest {
   }
 
   @Test
+  public void testRequiredUpsertFilterAlwaysUsesFilteredReader() {
+    FilterAwareVectorIndexReader mockReader = mock(FilterAwareVectorIndexReader.class);
+    float[] queryVector = {1.0f, 0.0f};
+    MutableRoaringBitmap requiredSnapshot = bitmapOf(2, 3);
+    MutableRoaringBitmap expectedResult = bitmapOf(2, 3);
+    when(mockReader.supportsPreFilter()).thenReturn(true);
+    when(mockReader.getDocIds(eq(queryVector), eq(2), any(ImmutableRoaringBitmap.class)))
+        .thenReturn(expectedResult);
+
+    VectorSimilarityPredicate predicate = new VectorSimilarityPredicate(
+        ExpressionContext.forIdentifier("embedding"), queryVector, 2);
+    VectorCandidateScope candidateScope = VectorCandidateScope.forUpsertSnapshot(requiredSnapshot,
+        "vector_index_not_filter_aware_for_upsert");
+    VectorSimilarityFilterOperator operator = new VectorSimilarityFilterOperator(mockReader, predicate, 4,
+        VectorSearchParams.DEFAULT, null, null, false, candidateScope);
+
+    requiredSnapshot.clear();
+    Assert.assertFalse(candidateScope.getRequiredDocIds() instanceof MutableRoaringBitmap,
+        "The candidate scope must not expose a mutable bitmap implementation");
+    ImmutableRoaringBitmap result = operator.getBitmaps().reduce();
+    Assert.assertEquals(result, expectedResult);
+
+    ArgumentCaptor<ImmutableRoaringBitmap> filterCaptor = ArgumentCaptor.forClass(ImmutableRoaringBitmap.class);
+    verify(mockReader).getDocIds(eq(queryVector), eq(2), filterCaptor.capture());
+    Assert.assertEquals(filterCaptor.getValue(), bitmapOf(2, 3));
+    verify(mockReader, never()).getDocIds(queryVector, 2);
+    Assert.assertTrue(operator.toExplainString().contains("upsertCandidateFilterApplied:true"));
+    Assert.assertTrue(operator.toExplainString().contains("upsertCandidateFilterCardinality:2"));
+    Assert.assertTrue(operator.toExplainString().contains("searchMode:FILTER_THEN_ANN"));
+    Assert.assertTrue(operator.getExplainInfo().getAttributes().get("upsertCandidateFilterApplied").getBool());
+    Assert.assertEquals(
+        operator.getExplainInfo().getAttributes().get("upsertCandidateFilterCardinality").getLong(), 2L);
+    Assert.assertEquals(operator.getExplainInfo().getAttributes().get("searchMode").getString(),
+        "FILTER_THEN_ANN");
+  }
+
+  @Test
+  public void testEmptyRequiredUpsertFilterSkipsReader() {
+    FilterAwareVectorIndexReader mockReader = mock(FilterAwareVectorIndexReader.class);
+    float[] queryVector = {1.0f, 0.0f};
+    VectorSimilarityPredicate predicate = new VectorSimilarityPredicate(
+        ExpressionContext.forIdentifier("embedding"), queryVector, 2);
+    VectorSimilarityFilterOperator operator = new VectorSimilarityFilterOperator(mockReader, predicate, 4,
+        VectorSearchParams.DEFAULT, null, null, false, VectorCandidateScope.forUpsertSnapshot(
+            new MutableRoaringBitmap(), "vector_index_not_filter_aware_for_upsert"));
+
+    Assert.assertTrue(operator.getBitmaps().reduce().isEmpty());
+    verifyNoInteractions(mockReader);
+    Assert.assertTrue(operator.toExplainString().contains("candidateGenerationSkipped:true"));
+    Assert.assertEquals(operator.getExplainInfo().getAttributes().get("candidateGenerationSkipReason").getString(),
+        "empty_upsert_candidate_filter");
+  }
+
+  @Test
+  public void testRequiredAndOptionalFiltersAreIntersected() {
+    FilterAwareVectorIndexReader mockReader = mock(FilterAwareVectorIndexReader.class);
+    float[] queryVector = {1.0f, 0.0f};
+    MutableRoaringBitmap requiredSnapshot = bitmapOf(2, 3);
+    MutableRoaringBitmap optionalMetadata = bitmapOf(1, 3);
+    when(mockReader.supportsPreFilter()).thenReturn(true);
+    when(mockReader.getDocIds(eq(queryVector), eq(2), any(ImmutableRoaringBitmap.class)))
+        .thenReturn(bitmapOf(3));
+
+    VectorSimilarityPredicate predicate = new VectorSimilarityPredicate(
+        ExpressionContext.forIdentifier("embedding"), queryVector, 2);
+    VectorSimilarityFilterOperator operator = new VectorSimilarityFilterOperator(mockReader, predicate, 4,
+        VectorSearchParams.DEFAULT, null, null, true,
+        VectorCandidateScope.forUpsertSnapshot(requiredSnapshot, "vector_index_not_filter_aware_for_upsert"));
+    operator.setPreFilterBitmap(optionalMetadata);
+
+    optionalMetadata.add(2);
+    ImmutableRoaringBitmap result = operator.getBitmaps().reduce();
+    Assert.assertEquals(result, bitmapOf(3));
+    Assert.assertEquals(requiredSnapshot, bitmapOf(2, 3), "Required snapshot must not be mutated");
+
+    ArgumentCaptor<ImmutableRoaringBitmap> filterCaptor = ArgumentCaptor.forClass(ImmutableRoaringBitmap.class);
+    verify(mockReader).getDocIds(eq(queryVector), eq(2), filterCaptor.capture());
+    Assert.assertEquals(filterCaptor.getValue(), bitmapOf(3));
+    verify(mockReader, never()).getDocIds(queryVector, 2);
+  }
+
+  @Test
+  public void testRequiredFilterFallsBackToExactAllowedDocScan() {
+    VectorIndexReader mockReader = mock(VectorIndexReader.class);
+    float[] queryVector = {1.0f, 0.0f};
+    ForwardIndexReader<?> forwardIndexReader = createMockForwardIndexReader(new float[][]{
+        {1.0f, 0.0f},
+        {1.0f, 0.0f},
+        {0.0f, 1.0f},
+        {0.0f, -1.0f}
+    });
+    VectorSimilarityPredicate predicate = new VectorSimilarityPredicate(
+        ExpressionContext.forIdentifier("embedding"), queryVector, 2);
+    VectorSimilarityFilterOperator operator = new VectorSimilarityFilterOperator(mockReader, predicate, 4,
+        VectorSearchParams.DEFAULT, forwardIndexReader,
+        createVectorIndexConfig(VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN), false,
+        VectorCandidateScope.forUpsertSnapshot(bitmapOf(2, 3),
+            "mutable_vector_index_not_filter_aware_for_upsert"));
+
+    ImmutableRoaringBitmap result = operator.getBitmaps().reduce();
+    Assert.assertEquals(result, bitmapOf(2, 3));
+    verify(mockReader, never()).getDocIds(any(float[].class), anyInt());
+    verify((ForwardIndexReader<?>) forwardIndexReader, never()).getFloatMV(eq(0), any());
+    verify((ForwardIndexReader<?>) forwardIndexReader, never()).getFloatMV(eq(1), any());
+    verify((ForwardIndexReader<?>) forwardIndexReader).getFloatMV(eq(2), any());
+    verify((ForwardIndexReader<?>) forwardIndexReader).getFloatMV(eq(3), any());
+    String explain = operator.toExplainString();
+    Assert.assertTrue(explain.contains("executionMode:EXACT_SCAN"), explain);
+    Assert.assertTrue(explain.contains("searchMode:EXACT_SCAN"), explain);
+    Assert.assertTrue(explain.contains("fallbackReason:mutable_vector_index_not_filter_aware_for_upsert"), explain);
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class,
+      expectedExceptionsMessageRegExp = ".*mandatory vector candidate scope.*no forward index.*")
+  public void testRequiredFilterFailsClearlyWithoutExactFallback() {
+    VectorIndexReader mockReader = mock(VectorIndexReader.class);
+    float[] queryVector = {1.0f, 0.0f};
+    VectorSimilarityPredicate predicate = new VectorSimilarityPredicate(
+        ExpressionContext.forIdentifier("embedding"), queryVector, 2);
+    VectorSimilarityFilterOperator operator = new VectorSimilarityFilterOperator(mockReader, predicate, 4,
+        VectorSearchParams.DEFAULT, null, null, false,
+        VectorCandidateScope.forUpsertSnapshot(bitmapOf(2, 3), "vector_index_not_filter_aware_for_upsert"));
+
+    operator.getBitmaps();
+  }
+
+  @Test
   public void testExplainStringIncludesSearchMode() {
     FilterAwareVectorIndexReader mockReader = mock(FilterAwareVectorIndexReader.class);
     float[] queryVector = {1.0f, 2.0f};
@@ -288,5 +421,30 @@ public class FilterAwareVectorSearchTest {
 
     Assert.assertEquals(context.getVectorSearchMode(), VectorSearchMode.POST_FILTER_ANN);
     Assert.assertEquals(context.getFilterSelectivity(), -1.0, 0.001);
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private static ForwardIndexReader<?> createMockForwardIndexReader(float[][] vectors) {
+    ForwardIndexReader mockReader = mock(ForwardIndexReader.class);
+    ForwardIndexReaderContext mockContext = mock(ForwardIndexReaderContext.class);
+    when(mockReader.createContext()).thenReturn(mockContext);
+    when(mockReader.isSingleValue()).thenReturn(false);
+    when(mockReader.isDictionaryEncoded()).thenReturn(false);
+    when(mockReader.getStoredType()).thenReturn(DataType.FLOAT);
+    for (int i = 0; i < vectors.length; i++) {
+      when(mockReader.getFloatMV(Mockito.eq(i), Mockito.any())).thenReturn(vectors[i]);
+    }
+    return mockReader;
+  }
+
+  private static VectorIndexConfig createVectorIndexConfig(
+      VectorIndexConfig.VectorDistanceFunction distanceFunction) {
+    return new VectorIndexConfig(false, "HNSW", 2, 1, distanceFunction, java.util.Map.of());
+  }
+
+  private static MutableRoaringBitmap bitmapOf(int... docIds) {
+    MutableRoaringBitmap bitmap = new MutableRoaringBitmap();
+    bitmap.add(docIds);
+    return bitmap;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/VectorSimilarityFilterOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/VectorSimilarityFilterOperatorTest.java
@@ -571,11 +571,38 @@ public class VectorSimilarityFilterOperatorTest {
     Assert.assertTrue(explain.contains("effectiveHnswUseBoundedQueue:false"), explain);
   }
 
+  @Test
+  public void testBackendParamsAreClearedWhenConfigurationFailsPartway() {
+    ConfigurableVectorReader mockReader = mock(ConfigurableVectorReader.class);
+    Mockito.doThrow(new IllegalStateException("efSearch configuration failed"))
+        .when(mockReader).setEfSearch(20);
+
+    VectorSimilarityPredicate predicate = new VectorSimilarityPredicate(
+        ExpressionContext.forIdentifier("embedding"), new float[]{1.0f, 2.0f}, 1);
+    VectorSearchParams params = new VectorSearchParams(8, false, null, null, 20, null, null);
+    VectorSimilarityFilterOperator operator = new VectorSimilarityFilterOperator(mockReader, predicate,
+        100, params, null,
+        createVectorIndexConfig("HNSW", VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN));
+
+    IllegalStateException exception = Assert.expectThrows(IllegalStateException.class, operator::getBitmaps);
+    Assert.assertEquals(exception.getMessage(), "efSearch configuration failed");
+    verify(mockReader).setNprobe(8);
+    verify(mockReader).setEfSearch(20);
+    verify(mockReader).clearNprobe();
+    verify(mockReader).clearEfSearch();
+    verify(mockReader).clearUseRelativeDistance();
+    verify(mockReader).clearUseBoundedQueue();
+    verify(mockReader, never()).getDocIds(Mockito.any(float[].class), Mockito.anyInt());
+  }
+
   /// Interface combining VectorIndexReader and NprobeAware for mocking IVF_FLAT readers.
   interface NprobeAwareVectorReader extends VectorIndexReader, NprobeAware {
   }
 
   interface EfSearchAwareVectorReader extends VectorIndexReader, EfSearchAware {
+  }
+
+  interface ConfigurableVectorReader extends VectorIndexReader, NprobeAware, EfSearchAware {
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/FilterPlanNodeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/FilterPlanNodeTest.java
@@ -19,12 +19,15 @@
 package org.apache.pinot.core.plan;
 
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FilterContext;
+import org.apache.pinot.common.request.context.predicate.IsNullPredicate;
 import org.apache.pinot.common.request.context.predicate.Predicate;
 import org.apache.pinot.common.request.context.predicate.RegexpLikePredicate;
+import org.apache.pinot.common.request.context.predicate.VectorSimilarityPredicate;
 import org.apache.pinot.core.common.BlockDocIdIterator;
 import org.apache.pinot.core.common.BlockDocIdSet;
 import org.apache.pinot.core.operator.blocks.FilterBlock;
@@ -42,18 +45,31 @@ import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
 import org.apache.pinot.segment.spi.index.creator.VectorIndexConfig;
 import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.segment.spi.index.reader.FilterAwareVectorIndexReader;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
 import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
+import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
 import org.apache.pinot.segment.spi.index.reader.TextIndexReader;
+import org.apache.pinot.segment.spi.index.reader.VectorIndexReader;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -61,6 +77,333 @@ import static org.testng.Assert.assertTrue;
 
 
 public class FilterPlanNodeTest {
+
+  @DataProvider(name = "vectorFilterShapes")
+  public Object[][] vectorFilterShapes() {
+    FilterContext vectorFilter = FilterContext.forPredicate(new VectorSimilarityPredicate(
+        ExpressionContext.forIdentifier("embedding"), new float[]{1.0f, 0.0f}, 2));
+    return new Object[][]{
+        {vectorFilter},
+        {FilterContext.forAnd(List.of(vectorFilter, FilterContext.CONSTANT_TRUE))},
+        {FilterContext.forOr(List.of(vectorFilter, FilterContext.CONSTANT_FALSE))},
+        {FilterContext.forNot(FilterContext.forNot(vectorFilter))}
+    };
+  }
+
+  @DataProvider(name = "nestedVectorSubtreeShapes")
+  public Object[][] nestedVectorSubtreeShapes() {
+    return new Object[][]{{"AND"}, {"OR"}, {"NOT_OR"}};
+  }
+
+  @DataProvider(name = "nonVectorFilterShapes")
+  public Object[][] nonVectorFilterShapes() {
+    return new Object[][]{{FilterContext.CONSTANT_TRUE}, {null}};
+  }
+
+  @Test(dataProvider = "nonVectorFilterShapes")
+  public void testNonVectorPlansDoNotCopyCandidateSnapshot(FilterContext filter) {
+    IndexSegment segment = mock(IndexSegment.class);
+    SegmentMetadata metadata = mock(SegmentMetadata.class);
+    when(metadata.getTotalDocs()).thenReturn(4);
+    when(metadata.isMutableSegment()).thenReturn(true);
+    when(segment.getSegmentMetadata()).thenReturn(metadata);
+    QueryContext queryContext = mock(QueryContext.class);
+    when(queryContext.getFilter()).thenReturn(filter);
+    CopyCountingBitmap snapshot = new CopyCountingBitmap();
+    snapshot.add(1);
+    snapshot.add(3);
+    SegmentContext segmentContext = new SegmentContext(segment);
+    segmentContext.setDocIdsSnapshot(snapshot);
+
+    Assert.assertEquals(getFilteredDocIds(new FilterPlanNode(segmentContext, queryContext).run()), bitmapOf(1, 3));
+    Assert.assertEquals(snapshot.getNumCopies(), 0,
+        "Non-vector plans must preserve the original outer snapshot without a candidate-scope copy");
+    verify(metadata, never()).isMutableSegment();
+  }
+
+  @Test(dataProvider = "nestedVectorSubtreeShapes")
+  public void testNestedVectorSimilaritySubtreeIsNeverMaterializedAsMetadata(String shape) {
+    FilterAwareVectorIndexReader directVectorReader = mock(FilterAwareVectorIndexReader.class);
+    FilterAwareVectorIndexReader nestedVectorReader = mock(FilterAwareVectorIndexReader.class);
+    when(directVectorReader.supportsPreFilter()).thenReturn(true);
+    when(nestedVectorReader.supportsPreFilter()).thenReturn(true);
+    when(nestedVectorReader.getDocIds(Mockito.any(float[].class), Mockito.anyInt(),
+        any(ImmutableRoaringBitmap.class))).thenReturn(bitmapOf(1));
+    DataSource directVectorDataSource = mock(DataSource.class);
+    DataSource nestedVectorDataSource = mock(DataSource.class);
+    when(directVectorDataSource.getVectorIndex()).thenReturn(directVectorReader);
+    when(nestedVectorDataSource.getVectorIndex()).thenReturn(nestedVectorReader);
+    DataSource metadataDataSource = mock(DataSource.class);
+    NullValueVectorReader nullValueVectorReader = mock(NullValueVectorReader.class);
+    when(nullValueVectorReader.getNullBitmap()).thenReturn(bitmapOf(1));
+    when(metadataDataSource.getNullValueVector()).thenReturn(nullValueVectorReader);
+
+    IndexSegment segment = mock(IndexSegment.class);
+    SegmentMetadata metadata = mock(SegmentMetadata.class);
+    when(metadata.getTotalDocs()).thenReturn(1_000);
+    when(segment.getSegmentMetadata()).thenReturn(metadata);
+    when(segment.getDataSource("embeddingA", null)).thenReturn(directVectorDataSource);
+    when(segment.getDataSource("embeddingB", null)).thenReturn(nestedVectorDataSource);
+    when(segment.getDataSource("tenant", null)).thenReturn(metadataDataSource);
+
+    FilterContext directVector = FilterContext.forPredicate(new VectorSimilarityPredicate(
+        ExpressionContext.forIdentifier("embeddingA"), new float[]{1.0f, 0.0f}, 2));
+    FilterContext nestedVector = FilterContext.forPredicate(new VectorSimilarityPredicate(
+        ExpressionContext.forIdentifier("embeddingB"), new float[]{1.0f, 0.0f}, 2));
+    FilterContext metadataFilter = FilterContext.forPredicate(
+        new IsNullPredicate(ExpressionContext.forIdentifier("tenant")));
+    FilterContext nestedSubtree;
+    switch (shape) {
+      case "AND":
+        nestedSubtree = FilterContext.forAnd(List.of(nestedVector, metadataFilter));
+        break;
+      case "OR":
+        nestedSubtree = FilterContext.forOr(List.of(nestedVector, metadataFilter));
+        break;
+      case "NOT_OR":
+        nestedSubtree = FilterContext.forNot(FilterContext.forOr(List.of(nestedVector, metadataFilter)));
+        break;
+      default:
+        throw new IllegalStateException("Unexpected shape: " + shape);
+    }
+    QueryContext queryContext = mock(QueryContext.class);
+    when(queryContext.getFilter()).thenReturn(FilterContext.forAnd(List.of(directVector, nestedSubtree)));
+
+    SegmentContext segmentContext = new SegmentContext(segment);
+    segmentContext.setDocIdsSnapshot(bitmapOf(0, 1, 2, 3));
+    new FilterPlanNode(segmentContext, queryContext).run();
+
+    verify(nestedVectorReader, never()).getDocIds(Mockito.any(float[].class), Mockito.anyInt());
+    verify(nestedVectorReader, never()).getDocIds(Mockito.any(float[].class), Mockito.anyInt(),
+        any(ImmutableRoaringBitmap.class));
+    verify(directVectorReader, never()).getDocIds(Mockito.any(float[].class), Mockito.anyInt(),
+        any(ImmutableRoaringBitmap.class));
+  }
+
+  @Test
+  public void testNestedNotVectorIsNotPushedIntoSiblingCandidateScope() {
+    float[] directQuery = {1.0f, 0.0f};
+    float[] nestedQuery = {0.0f, 1.0f};
+    FilterAwareVectorIndexReader directVectorReader = mock(FilterAwareVectorIndexReader.class);
+    FilterAwareVectorIndexReader nestedVectorReader = mock(FilterAwareVectorIndexReader.class);
+    when(directVectorReader.supportsPreFilter()).thenReturn(true);
+    when(nestedVectorReader.supportsPreFilter()).thenReturn(true);
+    when(directVectorReader.getDocIds(eq(directQuery), eq(1), any(ImmutableRoaringBitmap.class)))
+        .thenReturn(bitmapOf(0));
+    when(nestedVectorReader.getDocIds(eq(nestedQuery), eq(1), any(ImmutableRoaringBitmap.class)))
+        .thenReturn(bitmapOf(0));
+    DataSource directDataSource = mock(DataSource.class);
+    DataSource nestedDataSource = mock(DataSource.class);
+    when(directDataSource.getVectorIndex()).thenReturn(directVectorReader);
+    when(nestedDataSource.getVectorIndex()).thenReturn(nestedVectorReader);
+    IndexSegment segment = mock(IndexSegment.class);
+    SegmentMetadata metadata = mock(SegmentMetadata.class);
+    when(metadata.getTotalDocs()).thenReturn(2);
+    when(segment.getSegmentMetadata()).thenReturn(metadata);
+    when(segment.getDataSource("embeddingA", null)).thenReturn(directDataSource);
+    when(segment.getDataSource("embeddingB", null)).thenReturn(nestedDataSource);
+    FilterContext directVector = FilterContext.forPredicate(new VectorSimilarityPredicate(
+        ExpressionContext.forIdentifier("embeddingA"), directQuery, 1));
+    FilterContext nestedVector = FilterContext.forPredicate(new VectorSimilarityPredicate(
+        ExpressionContext.forIdentifier("embeddingB"), nestedQuery, 1));
+    QueryContext queryContext = mock(QueryContext.class);
+    when(queryContext.getFilter()).thenReturn(
+        FilterContext.forAnd(List.of(directVector, FilterContext.forNot(nestedVector))));
+    SegmentContext segmentContext = new SegmentContext(segment);
+    segmentContext.setDocIdsSnapshot(bitmapOf(0, 1));
+
+    Assert.assertTrue(getFilteredDocIds(new FilterPlanNode(segmentContext, queryContext).run()).isEmpty());
+    ArgumentCaptor<ImmutableRoaringBitmap> directScope = ArgumentCaptor.forClass(ImmutableRoaringBitmap.class);
+    verify(directVectorReader).getDocIds(eq(directQuery), eq(1), directScope.capture());
+    Assert.assertEquals(directScope.getValue(), bitmapOf(0, 1),
+        "NOT(vector) is a result predicate, not metadata that may narrow its sibling's top-K corpus");
+  }
+
+  @Test(dataProvider = "vectorFilterShapes")
+  public void testRequiredUpsertSnapshotReachesVectorCandidatesForAllBooleanShapes(FilterContext filter) {
+    float[] queryVector = {1.0f, 0.0f};
+    FilterAwareVectorIndexReader vectorReader = mock(FilterAwareVectorIndexReader.class);
+    when(vectorReader.supportsPreFilter()).thenReturn(true);
+    when(vectorReader.getDocIds(queryVector, 2)).thenReturn(bitmapOf(0, 1));
+    when(vectorReader.getDocIds(eq(queryVector), eq(2), any(ImmutableRoaringBitmap.class)))
+        .thenReturn(bitmapOf(2, 3));
+
+    DataSource dataSource = mock(DataSource.class);
+    when(dataSource.getVectorIndex()).thenReturn(vectorReader);
+    IndexSegment segment = mock(IndexSegment.class);
+    SegmentMetadata metadata = mock(SegmentMetadata.class);
+    when(metadata.getTotalDocs()).thenReturn(4);
+    when(segment.getSegmentMetadata()).thenReturn(metadata);
+    when(segment.getDataSource("embedding", null)).thenReturn(dataSource);
+
+    QueryContext queryContext = mock(QueryContext.class);
+    when(queryContext.getFilter()).thenReturn(filter);
+    SegmentContext segmentContext = new SegmentContext(segment);
+    MutableRoaringBitmap snapshot = bitmapOf(2, 3);
+    segmentContext.setDocIdsSnapshot(snapshot);
+
+    BaseFilterOperator operator = new FilterPlanNode(segmentContext, queryContext).run();
+    snapshot.clear();
+    snapshot.add(0, 2);
+    Assert.assertEquals(getFilteredDocIds(operator), bitmapOf(2, 3));
+
+    ArgumentCaptor<ImmutableRoaringBitmap> filterCaptor = ArgumentCaptor.forClass(ImmutableRoaringBitmap.class);
+    verify(vectorReader).getDocIds(eq(queryVector), eq(2), filterCaptor.capture());
+    Assert.assertEquals(filterCaptor.getValue(), bitmapOf(2, 3));
+    verify(vectorReader, never()).getDocIds(queryVector, 2);
+  }
+
+  @Test
+  public void testEmptyUpsertSnapshotSkipsVectorReader() {
+    FilterAwareVectorIndexReader vectorReader = mock(FilterAwareVectorIndexReader.class);
+    DataSource dataSource = mock(DataSource.class);
+    when(dataSource.getVectorIndex()).thenReturn(vectorReader);
+    IndexSegment segment = mock(IndexSegment.class);
+    SegmentMetadata metadata = mock(SegmentMetadata.class);
+    when(metadata.getTotalDocs()).thenReturn(4);
+    when(segment.getSegmentMetadata()).thenReturn(metadata);
+    when(segment.getDataSource("embedding", null)).thenReturn(dataSource);
+
+    QueryContext queryContext = mock(QueryContext.class);
+    when(queryContext.getFilter()).thenReturn(FilterContext.forPredicate(new VectorSimilarityPredicate(
+        ExpressionContext.forIdentifier("embedding"), new float[]{1.0f, 0.0f}, 2)));
+    SegmentContext segmentContext = new SegmentContext(segment);
+    segmentContext.setDocIdsSnapshot(new MutableRoaringBitmap());
+
+    Assert.assertTrue(getFilteredDocIds(new FilterPlanNode(segmentContext, queryContext).run()).isEmpty());
+    verifyNoInteractions(vectorReader);
+  }
+
+  @Test
+  public void testNullUpsertSnapshotPreservesUnfilteredVectorSearch() {
+    float[] queryVector = {1.0f, 0.0f};
+    FilterAwareVectorIndexReader vectorReader = mock(FilterAwareVectorIndexReader.class);
+    when(vectorReader.getDocIds(queryVector, 2)).thenReturn(bitmapOf(0, 1));
+    DataSource dataSource = mock(DataSource.class);
+    when(dataSource.getVectorIndex()).thenReturn(vectorReader);
+    IndexSegment segment = mock(IndexSegment.class);
+    SegmentMetadata metadata = mock(SegmentMetadata.class);
+    when(metadata.getTotalDocs()).thenReturn(4);
+    when(segment.getSegmentMetadata()).thenReturn(metadata);
+    when(segment.getDataSource("embedding", null)).thenReturn(dataSource);
+
+    QueryContext queryContext = mock(QueryContext.class);
+    when(queryContext.getFilter()).thenReturn(FilterContext.forPredicate(new VectorSimilarityPredicate(
+        ExpressionContext.forIdentifier("embedding"), queryVector, 2)));
+
+    Assert.assertEquals(getFilteredDocIds(new FilterPlanNode(new SegmentContext(segment), queryContext).run()),
+        bitmapOf(0, 1));
+    verify(vectorReader).getDocIds(queryVector, 2);
+    verify(vectorReader, never()).getDocIds(eq(queryVector), eq(2), any(ImmutableRoaringBitmap.class));
+  }
+
+  @Test
+  public void testRequiredUpsertSnapshotPreservesNotSemantics() {
+    float[] queryVector = {1.0f, 0.0f};
+    FilterAwareVectorIndexReader vectorReader = mock(FilterAwareVectorIndexReader.class);
+    when(vectorReader.supportsPreFilter()).thenReturn(true);
+    when(vectorReader.getDocIds(eq(queryVector), eq(2), any(ImmutableRoaringBitmap.class)))
+        .thenReturn(bitmapOf(2));
+    DataSource dataSource = mock(DataSource.class);
+    when(dataSource.getVectorIndex()).thenReturn(vectorReader);
+    IndexSegment segment = mock(IndexSegment.class);
+    SegmentMetadata metadata = mock(SegmentMetadata.class);
+    when(metadata.getTotalDocs()).thenReturn(4);
+    when(segment.getSegmentMetadata()).thenReturn(metadata);
+    when(segment.getDataSource("embedding", null)).thenReturn(dataSource);
+    QueryContext queryContext = mock(QueryContext.class);
+    FilterContext vectorFilter = FilterContext.forPredicate(new VectorSimilarityPredicate(
+        ExpressionContext.forIdentifier("embedding"), queryVector, 2));
+    when(queryContext.getFilter()).thenReturn(FilterContext.forNot(vectorFilter));
+    SegmentContext segmentContext = new SegmentContext(segment);
+    segmentContext.setDocIdsSnapshot(bitmapOf(2, 3));
+
+    Assert.assertEquals(getFilteredDocIds(new FilterPlanNode(segmentContext, queryContext).run()), bitmapOf(3));
+    verify(vectorReader, never()).getDocIds(queryVector, 2);
+  }
+
+  @Test
+  public void testNonUpsertMetadataScopePreservesAdaptivePostFilterBehavior() {
+    float[] queryVector = {1.0f, 0.0f};
+    FilterAwareVectorIndexReader vectorReader = mock(FilterAwareVectorIndexReader.class);
+    when(vectorReader.supportsPreFilter()).thenReturn(true);
+    when(vectorReader.getDocIds(queryVector, 2)).thenReturn(bitmapOf(0, 1));
+
+    DataSource vectorDataSource = mock(DataSource.class);
+    when(vectorDataSource.getVectorIndex()).thenReturn(vectorReader);
+    DataSource metadataDataSource = mock(DataSource.class);
+    NullValueVectorReader nullValueVectorReader = mock(NullValueVectorReader.class);
+    when(nullValueVectorReader.getNullBitmap()).thenReturn(bitmapOf(2, 3));
+    when(metadataDataSource.getNullValueVector()).thenReturn(nullValueVectorReader);
+
+    IndexSegment segment = mock(IndexSegment.class);
+    SegmentMetadata metadata = mock(SegmentMetadata.class);
+    when(metadata.getTotalDocs()).thenReturn(4);
+    when(segment.getSegmentMetadata()).thenReturn(metadata);
+    when(segment.getDataSource("embedding", null)).thenReturn(vectorDataSource);
+    when(segment.getDataSource("tenant", null)).thenReturn(metadataDataSource);
+
+    FilterContext vectorFilter = FilterContext.forPredicate(new VectorSimilarityPredicate(
+        ExpressionContext.forIdentifier("embedding"), queryVector, 2));
+    FilterContext metadataFilter = FilterContext.forPredicate(
+        new IsNullPredicate(ExpressionContext.forIdentifier("tenant")));
+    QueryContext queryContext = mock(QueryContext.class);
+    when(queryContext.getFilter()).thenReturn(FilterContext.forAnd(List.of(vectorFilter, metadataFilter)));
+
+    Assert.assertTrue(getFilteredDocIds(new FilterPlanNode(new SegmentContext(segment), queryContext).run()).isEmpty());
+    verify(vectorReader).getDocIds(queryVector, 2);
+    verify(vectorReader, never()).getDocIds(eq(queryVector), eq(2), any(ImmutableRoaringBitmap.class));
+  }
+
+  @Test
+  public void testPlannerSelectsExactAllowedDocFallbackForNonFilterAwareReader() {
+    float[] queryVector = {1.0f, 0.0f};
+    VectorIndexReader vectorReader = mock(VectorIndexReader.class);
+    ForwardIndexReader<?> forwardIndexReader = createMockForwardIndexReader(new float[][]{
+        {1.0f, 0.0f}, {1.0f, 0.0f}, {0.0f, 1.0f}, {0.0f, -1.0f}
+    });
+    DataSource dataSource = mock(DataSource.class);
+    when(dataSource.getVectorIndex()).thenReturn(vectorReader);
+    Mockito.doReturn(forwardIndexReader).when(dataSource).getForwardIndex();
+    IndexSegment segment = mock(IndexSegment.class);
+    SegmentMetadata metadata = mock(SegmentMetadata.class);
+    when(metadata.getTotalDocs()).thenReturn(4);
+    when(metadata.isMutableSegment()).thenReturn(true);
+    when(segment.getSegmentMetadata()).thenReturn(metadata);
+    when(segment.getDataSource("embedding", null)).thenReturn(dataSource);
+    QueryContext queryContext = mock(QueryContext.class);
+    when(queryContext.getFilter()).thenReturn(FilterContext.forPredicate(new VectorSimilarityPredicate(
+        ExpressionContext.forIdentifier("embedding"), queryVector, 2)));
+    SegmentContext segmentContext = new SegmentContext(segment);
+    segmentContext.setDocIdsSnapshot(bitmapOf(2, 3));
+
+    Assert.assertEquals(getFilteredDocIds(new FilterPlanNode(segmentContext, queryContext).run()), bitmapOf(2, 3));
+    verify(vectorReader, never()).getDocIds(any(float[].class), eq(2));
+    verify(forwardIndexReader, never()).getFloatMV(eq(0), any());
+    verify(forwardIndexReader, never()).getFloatMV(eq(1), any());
+    verify(forwardIndexReader).getFloatMV(eq(2), any());
+    verify(forwardIndexReader).getFloatMV(eq(3), any());
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class,
+      expectedExceptionsMessageRegExp = ".*mandatory vector candidate scope.*no forward index.*")
+  public void testPlannerFailsWhenRequiredFilterCannotBeHonored() {
+    VectorIndexReader vectorReader = mock(VectorIndexReader.class);
+    DataSource dataSource = mock(DataSource.class);
+    when(dataSource.getVectorIndex()).thenReturn(vectorReader);
+    IndexSegment segment = mock(IndexSegment.class);
+    SegmentMetadata metadata = mock(SegmentMetadata.class);
+    when(metadata.getTotalDocs()).thenReturn(4);
+    when(segment.getSegmentMetadata()).thenReturn(metadata);
+    when(segment.getDataSource("embedding", null)).thenReturn(dataSource);
+    QueryContext queryContext = mock(QueryContext.class);
+    when(queryContext.getFilter()).thenReturn(FilterContext.forPredicate(new VectorSimilarityPredicate(
+        ExpressionContext.forIdentifier("embedding"), new float[]{1.0f, 0.0f}, 2)));
+    SegmentContext segmentContext = new SegmentContext(segment);
+    segmentContext.setDocIdsSnapshot(bitmapOf(2, 3));
+
+    new FilterPlanNode(segmentContext, queryContext).run();
+  }
 
   @Test
   public void testConsistentSnapshot()
@@ -152,6 +495,47 @@ public class FilterPlanNodeTest {
       numDocsFiltered++;
     }
     return numDocsFiltered;
+  }
+
+  private static MutableRoaringBitmap getFilteredDocIds(BaseFilterOperator operator) {
+    MutableRoaringBitmap docIds = new MutableRoaringBitmap();
+    BlockDocIdIterator iterator = operator.nextBlock().getBlockDocIdSet().iterator();
+    int docId;
+    while ((docId = iterator.next()) != Constants.EOF) {
+      docIds.add(docId);
+    }
+    return docIds;
+  }
+
+  private static MutableRoaringBitmap bitmapOf(int... docIds) {
+    MutableRoaringBitmap bitmap = new MutableRoaringBitmap();
+    bitmap.add(docIds);
+    return bitmap;
+  }
+
+  private static final class CopyCountingBitmap extends MutableRoaringBitmap {
+    private int _numCopies;
+
+    @Override
+    public MutableRoaringBitmap toMutableRoaringBitmap() {
+      _numCopies++;
+      return super.toMutableRoaringBitmap();
+    }
+
+    private int getNumCopies() {
+      return _numCopies;
+    }
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private static ForwardIndexReader<?> createMockForwardIndexReader(float[][] vectors) {
+    ForwardIndexReader mockReader = mock(ForwardIndexReader.class);
+    ForwardIndexReaderContext context = mock(ForwardIndexReaderContext.class);
+    when(mockReader.createContext()).thenReturn(context);
+    for (int i = 0; i < vectors.length; i++) {
+      when(mockReader.getFloatMV(Mockito.eq(i), Mockito.any())).thenReturn(vectors[i]);
+    }
+    return mockReader;
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/VectorUpsertTableTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/VectorUpsertTableTest.java
@@ -1,0 +1,523 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests.custom;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.pinot.client.ExecutionStats;
+import org.apache.pinot.client.ResultSetGroup;
+import org.apache.pinot.integration.tests.ClusterIntegrationTestUtils;
+import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
+import org.apache.pinot.segment.local.data.manager.TableDataManager;
+import org.apache.pinot.server.starter.helix.BaseServerStarter;
+import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.ReplicaGroupStrategyConfig;
+import org.apache.pinot.spi.config.table.RoutingConfig;
+import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.UpsertConfig;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.stream.StreamConfigProperties;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.util.TestUtils;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+/// Verifies that FULL-upsert visibility is applied before vector top-K candidate selection for both consuming and
+/// immutable realtime segments.
+@Test(suiteName = "CustomClusterIntegrationTest")
+public class VectorUpsertTableTest extends CustomDataQueryClusterIntegrationTest {
+  private static final String CONSUMING_TABLE_NAME = "VectorUpsertConsumingTest";
+  private static final String SEALED_TABLE_NAME = "VectorUpsertSealedTest";
+  private static final String CONSUMING_TOPIC = CONSUMING_TABLE_NAME + "-kafka";
+  private static final String SEALED_TOPIC = SEALED_TABLE_NAME + "-kafka";
+
+  private static final String ENTITY_ID_COLUMN = "entityId";
+  private static final String TIMESTAMP_COLUMN = "ts";
+  private static final String VECTOR_COLUMN = "embedding";
+  private static final int NUM_PARTITIONS = 1;
+  private static final int NUM_REPLICAS = 1;
+  private static final int NUM_CURRENT_RECORDS = 4;
+  private static final int NUM_PHYSICAL_RECORDS = 6;
+  private static final int TOP_K = 2;
+  private static final int REALTIME_TABLE_CONFIG_RETRY_COUNT = 5;
+  private static final long REALTIME_TABLE_CONFIG_RETRY_WAIT_MS = 1_000L;
+  private static final long KAFKA_TOPIC_METADATA_READY_TIMEOUT_MS = 30_000L;
+  private static final long STATE_TIMEOUT_MS = 120_000L;
+  private static final long OLD_TIMESTAMP = 1_700_000_000_000L;
+  private static final long NEW_TIMESTAMP = OLD_TIMESTAMP + 1_000L;
+
+  private static final TestRecord A1_V1 = new TestRecord("A1", OLD_TIMESTAMP, 1.0f, 0.0f);
+  private static final TestRecord A2_V1 = new TestRecord("A2", OLD_TIMESTAMP, 1.0f, 0.0f);
+  private static final TestRecord B1 = new TestRecord("B1", OLD_TIMESTAMP, 0.0f, 1.0f);
+  private static final TestRecord B2 = new TestRecord("B2", OLD_TIMESTAMP, 0.0f, -1.0f);
+  private static final TestRecord A1_V2 = new TestRecord("A1", NEW_TIMESTAMP, -1.0f, 0.0f);
+  private static final TestRecord A2_V2 = new TestRecord("A2", NEW_TIMESTAMP, -1.0f, 0.0f);
+  private static final List<TestRecord> OLD_A_AND_CURRENT_B = List.of(A1_V1, A2_V1, B1, B2);
+  private static final List<TestRecord> NEW_A = List.of(A1_V2, A2_V2);
+  private static final List<TestRecord> ALL_RECORDS = List.of(A1_V1, A2_V1, B1, B2, A1_V2, A2_V2);
+
+  private boolean _sealedTableCreated;
+
+  @Override
+  public String getTableName() {
+    return CONSUMING_TABLE_NAME;
+  }
+
+  @Override
+  public String getKafkaTopic() {
+    return CONSUMING_TOPIC;
+  }
+
+  @Override
+  public boolean isRealtimeTable() {
+    return true;
+  }
+
+  @Override
+  protected int getNumKafkaPartitions() {
+    return NUM_PARTITIONS;
+  }
+
+  @Override
+  protected int getRealtimeSegmentFlushSize() {
+    return 100;
+  }
+
+  @Override
+  protected String getPartitionColumn() {
+    return ENTITY_ID_COLUMN;
+  }
+
+  @Override
+  protected long getCountStarResult() {
+    return NUM_CURRENT_RECORDS;
+  }
+
+  @Override
+  public Schema createSchema() {
+    return createPinotSchema(CONSUMING_TABLE_NAME);
+  }
+
+  @Override
+  public List<File> createAvroFiles() {
+    // setUpTable() builds three purpose-specific Avro files instead of using the default fixture path.
+    return List.of();
+  }
+
+  @Override
+  protected void setUpTable()
+      throws Exception {
+    disableMultiStageQueryEngine();
+
+    File allRecordsFile = writeAvroFile("all-records.avro", ALL_RECORDS);
+    File oldAndCurrentRecordsFile = writeAvroFile("old-a-and-current-b.avro", OLD_A_AND_CURRENT_B);
+    File newARecordsFile = writeAvroFile("new-a.avro", NEW_A);
+
+    addSchema(createPinotSchema(CONSUMING_TABLE_NAME));
+    addSchema(createPinotSchema(SEALED_TABLE_NAME));
+    createSharedKafkaTopic(CONSUMING_TOPIC, NUM_PARTITIONS);
+    createSharedKafkaTopic(SEALED_TOPIC, NUM_PARTITIONS);
+    waitForKafkaTopicMetadataReadyForConsumer(CONSUMING_TOPIC);
+    waitForKafkaTopicMetadataReadyForConsumer(SEALED_TOPIC);
+
+    // Both tables use the same Avro field schema, so one sample file is sufficient for both decoder instances.
+    AvroFileSchemaKafkaAvroMessageDecoder._avroFile = allRecordsFile;
+    addRealtimeTableConfigWithRetry(createRealtimeUpsertTableConfig(CONSUMING_TABLE_NAME, CONSUMING_TOPIC),
+        CONSUMING_TOPIC);
+    addRealtimeTableConfigWithRetry(createRealtimeUpsertTableConfig(SEALED_TABLE_NAME, SEALED_TOPIC), SEALED_TOPIC);
+    _sealedTableCreated = true;
+
+    pushAvroFiles(CONSUMING_TOPIC, List.of(allRecordsFile));
+    pushAvroFiles(SEALED_TOPIC, List.of(oldAndCurrentRecordsFile));
+
+    // The old A versions and current B records must be fully queryable before sealing S0.
+    waitForTableState(SEALED_TABLE_NAME, OLD_A_AND_CURRENT_B.size(), OLD_A_AND_CURRENT_B.size(), 1, 1,
+        STATE_TIMEOUT_MS);
+    forceCommitAndWait(SEALED_TABLE_NAME);
+    pushAvroFiles(SEALED_TOPIC, List.of(newARecordsFile));
+  }
+
+  @Override
+  protected void waitForAllDocsLoaded(long timeoutMs) {
+    disableMultiStageQueryEngine();
+    long effectiveTimeoutMs = Math.max(timeoutMs, STATE_TIMEOUT_MS);
+    waitForTableState(CONSUMING_TABLE_NAME, NUM_PHYSICAL_RECORDS, NUM_CURRENT_RECORDS, 1, 1,
+        effectiveTimeoutMs);
+    waitForTableState(SEALED_TABLE_NAME, NUM_PHYSICAL_RECORDS, NUM_CURRENT_RECORDS, 2, 1, effectiveTimeoutMs);
+  }
+
+  @AfterClass
+  @Override
+  public void tearDown()
+      throws IOException {
+    try {
+      if (_sealedTableCreated) {
+        dropRealtimeTable(SEALED_TABLE_NAME);
+      }
+    } finally {
+      super.tearDown();
+    }
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testFullUpsertVectorCandidates(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    assertVectorResultMatchesCurrentCorpus(CONSUMING_TABLE_NAME, useMultiStageQueryEngine);
+    assertVectorResultMatchesCurrentCorpus(SEALED_TABLE_NAME, useMultiStageQueryEngine);
+  }
+
+  private void assertVectorResultMatchesCurrentCorpus(String tableName, boolean useMultiStageQueryEngine)
+      throws Exception {
+    String queryVector = "ARRAY[1.0, 0.0]";
+    String vectorQuery = String.format(
+        "SELECT %s, cosineDistance(%s, %s) AS distance FROM %s "
+            + "WHERE vectorSimilarity(%s, %s, %d) "
+            + "ORDER BY distance ASC, %s ASC LIMIT %d",
+        ENTITY_ID_COLUMN, VECTOR_COLUMN, queryVector, tableName,
+        VECTOR_COLUMN, queryVector, TOP_K, ENTITY_ID_COLUMN, TOP_K);
+    String exactQuery = String.format(
+        "SELECT %s, cosineDistance(%s, %s) AS distance FROM %s "
+            + "ORDER BY distance ASC, %s ASC LIMIT %d",
+        ENTITY_ID_COLUMN, VECTOR_COLUMN, queryVector, tableName, ENTITY_ID_COLUMN, TOP_K);
+    String physicalControlQuery = String.format(
+        "SELECT %s, %s, cosineDistance(%s, %s) AS distance FROM %s "
+            + "ORDER BY distance ASC, %s ASC LIMIT %d OPTION(skipUpsert=true)",
+        ENTITY_ID_COLUMN, TIMESTAMP_COLUMN, VECTOR_COLUMN, queryVector, tableName, ENTITY_ID_COLUMN, TOP_K);
+    String explainVectorQuery = tableName.equals(SEALED_TABLE_NAME) ? String.format(
+        "SELECT %s, cosineDistance(%s, %s) AS distance FROM %s "
+            + "WHERE vectorSimilarity(%s, %s, %d) AND %s = %d "
+            + "ORDER BY distance ASC, %s ASC LIMIT %d",
+        ENTITY_ID_COLUMN, VECTOR_COLUMN, queryVector, tableName,
+        VECTOR_COLUMN, queryVector, TOP_K, TIMESTAMP_COLUMN, OLD_TIMESTAMP, ENTITY_ID_COLUMN, TOP_K) : vectorQuery;
+
+    JsonNode vectorResponse = postQuery(vectorQuery);
+    JsonNode exactResponse = postQuery(exactQuery);
+    JsonNode physicalControlResponse = postQuery(physicalControlQuery);
+    JsonNode explainResponse = postQuery("SET explainAskingServers=true; EXPLAIN PLAN FOR " + explainVectorQuery);
+    assertNoError(vectorResponse);
+    assertNoError(exactResponse);
+    assertNoError(physicalControlResponse);
+    assertNoError(explainResponse);
+    List<String> vectorEntityIds = extractEntityIds(vectorResponse);
+    List<String> exactEntityIds = extractEntityIds(exactResponse);
+
+    String engine = useMultiStageQueryEngine ? "multi-stage" : "single-stage";
+    assertEquals(vectorEntityIds.size(), TOP_K,
+        "Vector query must return exactly K rows for " + tableName + " on the " + engine + " engine");
+    assertEquals(vectorEntityIds, List.of("B1", "B2"),
+        "Obsolete A versions must not consume vector candidates for " + tableName + " on the " + engine
+            + " engine");
+    assertEquals(vectorEntityIds, exactEntityIds,
+        "Vector and exact scalar ranking must agree for " + tableName + " on the " + engine + " engine");
+
+    JsonNode physicalRows = getRows(physicalControlResponse);
+    assertEquals(physicalRows.size(), TOP_K,
+        "skipUpsert control must return exactly K physical rows for " + tableName + " on the " + engine + " engine");
+    assertEquals(extractEntityIds(physicalControlResponse), List.of("A1", "A2"),
+        "The obsolete A versions should be the physically nearest rows for " + tableName + " on the " + engine
+            + " engine");
+    for (JsonNode row : physicalRows) {
+      assertEquals(row.get(1).asLong(), OLD_TIMESTAMP, "skipUpsert must expose the obsolete A version");
+      assertEquals(row.get(2).asDouble(), 0.0, 1e-6, "The obsolete A vector must be an exact query match");
+    }
+
+    String explain = GroupByOptionsTest.toExplainStr(explainResponse, useMultiStageQueryEngine);
+    assertExplainContains(explain, "upsertCandidateFilterApplied", true);
+    if (tableName.equals(CONSUMING_TABLE_NAME)) {
+      assertExplainContains(explain, "searchMode", "EXACT_SCAN");
+      assertExplainContains(explain, "fallbackReason", "mutable_vector_index_not_filter_aware_for_upsert");
+    } else {
+      assertTrue(explain.contains("VECTOR_SIMILARITY_INDEX") || explain.contains("VectorSimilarityIndex"),
+          "Sealed segments must use their vector index: " + explain);
+      assertExplainContains(explain, "searchMode", "FILTER_THEN_ANN");
+    }
+  }
+
+  private static void assertExplainContains(String explain, String key, Object value) {
+    String legacyStyle = key + ":" + value;
+    String multiStageStyle = key + "=[" + value + "]";
+    assertTrue(explain.contains(legacyStyle) || explain.contains(multiStageStyle),
+        "Explain should contain " + key + '=' + value + ": " + explain);
+  }
+
+  private TableConfig createRealtimeUpsertTableConfig(String tableName, String topicName) {
+    UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
+    upsertConfig.setComparisonColumns(List.of(TIMESTAMP_COLUMN));
+
+    Map<String, String> streamConfigs = getStreamConfigMap();
+    streamConfigs.put(StreamConfigProperties.constructStreamProperty("kafka",
+        StreamConfigProperties.STREAM_TOPIC_NAME), topicName);
+
+    FieldConfig vectorFieldConfig = new FieldConfig.Builder(VECTOR_COLUMN)
+        .withEncodingType(FieldConfig.EncodingType.RAW)
+        .withIndexTypes(List.of(FieldConfig.IndexType.VECTOR))
+        .withProperties(Map.of(
+            "vectorIndexType", "HNSW",
+            "vectorDimension", "2",
+            "vectorDistanceFunction", "COSINE",
+            "version", "1",
+            "commitDocs", "1"))
+        .build();
+
+    return new TableConfigBuilder(TableType.REALTIME)
+        .setTableName(tableName)
+        .setTimeColumnName(TIMESTAMP_COLUMN)
+        .setNumReplicas(NUM_REPLICAS)
+        .setFieldConfigList(List.of(vectorFieldConfig))
+        .setStreamConfigs(streamConfigs)
+        .setUpsertConfig(upsertConfig)
+        .setRoutingConfig(new RoutingConfig(null, null,
+            RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, false))
+        .setSegmentPartitionConfig(new SegmentPartitionConfig(
+            Map.of(ENTITY_ID_COLUMN, new ColumnPartitionConfig("Murmur", NUM_PARTITIONS))))
+        .setReplicaGroupStrategyConfig(new ReplicaGroupStrategyConfig(ENTITY_ID_COLUMN, 1))
+        .build();
+  }
+
+  private void addRealtimeTableConfigWithRetry(TableConfig tableConfig, String topicName)
+      throws Exception {
+    for (int attempt = 1; attempt <= REALTIME_TABLE_CONFIG_RETRY_COUNT; attempt++) {
+      try {
+        addTableConfig(tableConfig);
+        return;
+      } catch (IOException e) {
+        if (!isRetryableRealtimePartitionMetadataError(e, topicName)
+            || attempt == REALTIME_TABLE_CONFIG_RETRY_COUNT) {
+          throw e;
+        }
+        LOGGER.warn("Retrying realtime table creation for topic {} after metadata propagation failure "
+                + "(attempt {}/{})", topicName, attempt, REALTIME_TABLE_CONFIG_RETRY_COUNT, e);
+        waitForKafkaTopicMetadataReadyForConsumer(topicName);
+        Thread.sleep(REALTIME_TABLE_CONFIG_RETRY_WAIT_MS);
+      }
+    }
+    throw new IllegalStateException("Failed to create realtime table after retries for topic: " + topicName);
+  }
+
+  private static boolean isRetryableRealtimePartitionMetadataError(Throwable throwable, String topicName) {
+    String errorToken = "Failed to fetch partition information for topic: " + topicName;
+    Throwable current = throwable;
+    while (current != null) {
+      String message = current.getMessage();
+      if (message != null && message.contains(errorToken)) {
+        return true;
+      }
+      current = current.getCause();
+    }
+    return false;
+  }
+
+  private void waitForKafkaTopicMetadataReadyForConsumer(String topicName) {
+    TestUtils.waitForCondition(aVoid -> isKafkaTopicMetadataReadyForConsumer(topicName), 200L,
+        KAFKA_TOPIC_METADATA_READY_TIMEOUT_MS,
+        "Kafka topic '" + topicName + "' metadata is not visible to consumers in custom cluster suite");
+  }
+
+  private boolean isKafkaTopicMetadataReadyForConsumer(String topicName) {
+    Properties consumerProps = new Properties();
+    consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, getSharedKafkaBrokerList());
+    consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, "pinot-vector-upsert-topic-ready-" + UUID.randomUUID());
+    consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+    consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+    consumerProps.put(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG, "5000");
+    consumerProps.put(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, "5000");
+    try (KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(consumerProps)) {
+      List<PartitionInfo> partitionInfos = consumer.partitionsFor(topicName, Duration.ofSeconds(5));
+      return partitionInfos != null && partitionInfos.size() >= NUM_PARTITIONS;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private void pushAvroFiles(String topicName, List<File> avroFiles)
+      throws Exception {
+    ClusterIntegrationTestUtils.pushAvroIntoKafka(avroFiles, getSharedKafkaBrokerList(), topicName,
+        getMaxNumKafkaMessagesPerBatch(), getKafkaMessageHeader(), ENTITY_ID_COLUMN, false);
+  }
+
+  private void forceCommitAndWait(String tableName)
+      throws Exception {
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
+    String response = getOrCreateAdminClient().getTableClient().forceCommit(realtimeTableName);
+    String jobId = JsonUtils.stringToJsonNode(response).get("forceCommitJobId").asText();
+
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        String status = getOrCreateAdminClient().getTableClient().getForceCommitJobStatus(jobId);
+        return JsonUtils.stringToJsonNode(status)
+            .path(CommonConstants.ControllerJob.NUM_CONSUMING_SEGMENTS_YET_TO_BE_COMMITTED).asInt(-1) == 0;
+      } catch (Exception e) {
+        return false;
+      }
+    }, 200L, STATE_TIMEOUT_MS, "Timed out waiting for force-commit job: " + jobId);
+  }
+
+  private void waitForTableState(String tableName, int expectedPhysicalDocs, int expectedCurrentDocs,
+      int expectedSegments, int expectedConsumingSegments, long timeoutMs) {
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        if (!areReplicasReady(tableName, expectedSegments)) {
+          return false;
+        }
+        // Query repeatedly after verifying the table data manager so document counts and segment state must remain
+        // stable across broker requests.
+        for (int i = 0; i < 10; i++) {
+          ResultSetGroup physicalResult = getPinotConnection().execute(
+              "SELECT COUNT(*) FROM " + tableName + " OPTION(skipUpsert=true)");
+          ResultSetGroup currentResult = getPinotConnection().execute("SELECT COUNT(*) FROM " + tableName);
+          if (physicalResult.getResultSet(0).getLong(0) != expectedPhysicalDocs
+              || currentResult.getResultSet(0).getLong(0) != expectedCurrentDocs) {
+            return false;
+          }
+          ExecutionStats executionStats = physicalResult.getExecutionStats();
+          if (executionStats.getNumSegmentsQueried() != expectedSegments
+              || executionStats.getNumConsumingSegmentsQueried() != expectedConsumingSegments) {
+            return false;
+          }
+        }
+        return true;
+      } catch (Exception e) {
+        return false;
+      }
+    }, 200L, timeoutMs,
+        String.format("Timed out waiting for %s: physicalDocs=%d, currentDocs=%d, segments=%d, consumingSegments=%d",
+            tableName, expectedPhysicalDocs, expectedCurrentDocs, expectedSegments, expectedConsumingSegments));
+  }
+
+  private boolean areReplicasReady(String tableName, int expectedSegments) {
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
+    int readyReplicas = 0;
+    for (BaseServerStarter serverStarter : getSharedServerStarters()) {
+      TableDataManager tableDataManager = serverStarter.getServerInstance().getInstanceDataManager()
+          .getTableDataManager(realtimeTableName);
+      if (tableDataManager == null) {
+        continue;
+      }
+      List<SegmentDataManager> segmentDataManagers = tableDataManager.acquireAllSegments();
+      try {
+        if (segmentDataManagers.size() == expectedSegments) {
+          readyReplicas++;
+        }
+      } finally {
+        for (SegmentDataManager segmentDataManager : segmentDataManagers) {
+          tableDataManager.releaseSegment(segmentDataManager);
+        }
+      }
+    }
+    return readyReplicas == NUM_REPLICAS;
+  }
+
+  private File writeAvroFile(String fileName, List<TestRecord> records)
+      throws IOException {
+    org.apache.avro.Schema avroSchema = createAvroSchema();
+    File avroFile = new File(_tempDir, fileName);
+    try (DataFileWriter<GenericData.Record> writer =
+        new DataFileWriter<>(new GenericDatumWriter<>(avroSchema))) {
+      writer.create(avroSchema, avroFile);
+      for (TestRecord testRecord : records) {
+        GenericData.Record record = new GenericData.Record(avroSchema);
+        record.put(ENTITY_ID_COLUMN, testRecord._entityId);
+        record.put(TIMESTAMP_COLUMN, testRecord._timestamp);
+        record.put(VECTOR_COLUMN, List.of(testRecord._vectorX, testRecord._vectorY));
+        writer.append(record);
+      }
+    }
+    return avroFile;
+  }
+
+  private static Schema createPinotSchema(String tableName) {
+    return new Schema.SchemaBuilder()
+        .setSchemaName(tableName)
+        .addSingleValueDimension(ENTITY_ID_COLUMN, FieldSpec.DataType.STRING)
+        .addDateTime(TIMESTAMP_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
+        .addMultiValueDimension(VECTOR_COLUMN, FieldSpec.DataType.FLOAT)
+        .setPrimaryKeyColumns(List.of(ENTITY_ID_COLUMN))
+        .build();
+  }
+
+  private static org.apache.avro.Schema createAvroSchema() {
+    org.apache.avro.Schema avroSchema =
+        org.apache.avro.Schema.createRecord("VectorUpsertRecord", null, null, false);
+    avroSchema.setFields(List.of(
+        new org.apache.avro.Schema.Field(ENTITY_ID_COLUMN,
+            org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING), null, null),
+        new org.apache.avro.Schema.Field(TIMESTAMP_COLUMN,
+            org.apache.avro.Schema.create(org.apache.avro.Schema.Type.LONG), null, null),
+        new org.apache.avro.Schema.Field(VECTOR_COLUMN,
+            org.apache.avro.Schema.createArray(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.FLOAT)),
+            null, null)));
+    return avroSchema;
+  }
+
+  private static List<String> extractEntityIds(JsonNode response) {
+    JsonNode rows = getRows(response);
+    List<String> entityIds = new ArrayList<>(rows.size());
+    for (JsonNode row : rows) {
+      entityIds.add(row.get(0).asText());
+    }
+    return entityIds;
+  }
+
+  private static JsonNode getRows(JsonNode response) {
+    JsonNode resultTable = response.get("resultTable");
+    assertNotNull(resultTable, "Query failed: " + response.toPrettyString());
+    return resultTable.get("rows");
+  }
+
+  private static final class TestRecord {
+    private final String _entityId;
+    private final long _timestamp;
+    private final float _vectorX;
+    private final float _vectorY;
+
+    private TestRecord(String entityId, long timestamp, float vectorX, float vectorY) {
+      _entityId = entityId;
+      _timestamp = timestamp;
+      _vectorX = vectorX;
+      _vectorY = vectorY;
+    }
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/HnswVectorIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/HnswVectorIndexCreatorTest.java
@@ -26,6 +26,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.segment.creator.impl.vector.HnswVectorIndexCreator;
 import org.apache.pinot.segment.local.segment.index.readers.vector.HnswVectorIndexReader;
 import org.apache.pinot.segment.spi.index.creator.VectorIndexConfig;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -90,6 +91,21 @@ public class HnswVectorIndexCreatorTest {
       // Expect to get 1 matching docId since topK = 1 is used
       Assert.assertEquals(matchedDocIds.length, 1);
       Assert.assertEquals(matchedDocIds[0], 2);
+    }
+  }
+
+  @Test
+  public void testFilteredReaderReturnsKAllowedDocuments()
+      throws IOException {
+    MutableRoaringBitmap allowedDocIds = new MutableRoaringBitmap();
+    allowedDocIds.add(1);
+    allowedDocIds.add(3);
+    try (HnswVectorIndexReader reader = new HnswVectorIndexReader("foo", INDEX_DIR, 4, _config)) {
+      float[] queryVector = {5.0F, 42.0F, 54.33333F, 42.24F, 1001.045F};
+      Assert.assertEquals(reader.getDocIds(queryVector, 1).toArray(), new int[]{0},
+          "The nearest physical document should be outside the allowed set");
+      int[] matchedDocIds = reader.getDocIds(queryVector, 2, allowedDocIds).toArray();
+      Assert.assertEquals(matchedDocIds, new int[]{1, 3});
     }
   }
 


### PR DESCRIPTION
## Summary

Fix FULL-upsert vector queries so obsolete physical versions cannot consume the per-segment top-K candidate budget before Pinot applies the query-scoped upsert snapshot.

- Treat the upsert snapshot as a mandatory candidate-generation scope while retaining the final outer bitmap AND as defense in depth.
- Keep required upsert/publication scopes separate from optimizer-selected metadata filters.
- Use filtered ANN when the reader supports it; otherwise scan exact distances only over allowed document IDs and fail clearly when no safe path exists.
- Apply the same allowed-document contract to no-index exact search, threshold search, and vector radius predicates.
- Make mutable HNSW filter-aware with explicit Pinot document IDs, same-generation NRT lookup/filtering, immutable async inputs, and a captured publication boundary.
- Preserve adaptive metadata behavior for ordinary non-upsert queries and avoid vector bitmap allocation for non-vector plans.
- Add explain attributes for candidate-filter cardinality, execution mode, skipped generation, and fallback reason.

## Root cause

`FilterPlanNode` constructed and executed `VECTOR_SIMILARITY` before adding `SegmentContext.getDocIdsSnapshot()` as an outer AND. Obsolete versions could therefore occupy ANN top-K slots and be removed only afterward, producing fewer than K rows or omitting nearer current rows.

## Validation

All commands ran with JDK 25 and `GITHUB_ACTIONS=true`.

- Core vector/filter suite: 101 tests passed.
- Mutable and immutable HNSW suite: 16 tests passed.
- `VectorUpsertTableTest`: 2 query-engine invocations passed, covering both a single consuming segment and sealed-plus-consuming segments.
- Fresh affected-reactor `clean test-compile` with `-Xlint:all` passed.
- Spotless, Checkstyle, license format/check, and `git diff --check` passed.

The integration test verifies six physical records/four current records, exact K and entity membership, scalar-distance equivalence, both query engines, two replicas, and a `skipUpsert=true` control proving obsolete rows are physically nearest.

## Performance and compatibility

ANN approximation semantics are unchanged. Readers that cannot honor the mandatory bitmap use a correctness-first exact scan whose cost is proportional to the allowed-document count times vector dimension. Mutable HNSW currently opens an NRT reader per search; reusable reader management can be optimized separately.