### PR TITLE
Force-expire stranded segments in pauseless ingestion tests

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasePauselessRealtimeIngestionTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasePauselessRealtimeIngestionTest.java
@@ -56,7 +56,6 @@ public abstract class BasePauselessRealtimeIngestionTest extends BaseClusterInte
   protected static final int NUM_REALTIME_SEGMENTS = 48;
   protected static final long DEFAULT_COUNT_STAR_RESULT = 115545L;
   protected static final String DEFAULT_TABLE_NAME_2 = DEFAULT_TABLE_NAME + "_2";
-  private static final long MAX_SEGMENT_COMPLETION_TIME_MILLIS = 10_000;
 
   protected List<File> _avroFiles;
   protected boolean _failureEnabled = false;
@@ -106,7 +105,6 @@ public abstract class BasePauselessRealtimeIngestionTest extends BaseClusterInte
     startController();
     startBroker();
     startServer();
-    setMaxSegmentCompletionTimeMillis();
     setupNonPauselessTable();
     injectFailure();
     setupPauselessTable();
@@ -156,14 +154,6 @@ public abstract class BasePauselessRealtimeIngestionTest extends BaseClusterInte
     addTableConfig(tableConfig);
   }
 
-  protected void setMaxSegmentCompletionTimeMillis() {
-    PinotLLCRealtimeSegmentManager realtimeSegmentManager = _helixResourceManager.getRealtimeSegmentManager();
-    if (realtimeSegmentManager instanceof FailureInjectingPinotLLCRealtimeSegmentManager) {
-      ((FailureInjectingPinotLLCRealtimeSegmentManager) realtimeSegmentManager)
-          .setMaxSegmentCompletionTimeoutMs(MAX_SEGMENT_COMPLETION_TIME_MILLIS);
-    }
-  }
-
   protected void injectFailure() {
     PinotLLCRealtimeSegmentManager realtimeSegmentManager = _helixResourceManager.getRealtimeSegmentManager();
     if (realtimeSegmentManager instanceof FailureInjectingPinotLLCRealtimeSegmentManager) {
@@ -210,12 +200,21 @@ public abstract class BasePauselessRealtimeIngestionTest extends BaseClusterInte
       return segmentZKMetadataList.size() == getExpectedZKMetadataWithFailure();
     }, 1000, 100000, "New Segment ZK Metadata not created");
 
-    Thread.sleep(MAX_SEGMENT_COMPLETION_TIME_MILLIS);
     disableFailure();
 
-    Properties periodicTaskProperties = new Properties();
-    periodicTaskProperties.setProperty(ControllerPeriodicTask.RUN_SEGMENT_LEVEL_VALIDATION, Boolean.TRUE.toString());
-    _controllerStarter.getRealtimeSegmentValidationManager().run(periodicTaskProperties);
+    // Force-expire the segments stranded by the injected failure instead of waiting out the max segment completion
+    // time: they become immediately eligible for repair, and their in-flight commit attempts keep getting rejected,
+    // so the single validation run below stays the only recovery path under test. Segments created afterwards keep
+    // the production completion time and are never artificially rejected. Clear the expiry right after the run so
+    // that segments re-activated by the repair can commit normally.
+    PauselessRealtimeTestUtils.forceExpireSegments(_helixResourceManager, tableNameWithType);
+    try {
+      Properties periodicTaskProperties = new Properties();
+      periodicTaskProperties.setProperty(ControllerPeriodicTask.RUN_SEGMENT_LEVEL_VALIDATION, Boolean.TRUE.toString());
+      _controllerStarter.getRealtimeSegmentValidationManager().run(periodicTaskProperties);
+    } finally {
+      PauselessRealtimeTestUtils.clearForceExpiredSegments(_helixResourceManager);
+    }
 
     waitForAllDocsLoaded(600_000L);
     waitForAllDocsLoaded(tableNameWithType2, 600_000L);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionIntegrationTest.java
@@ -89,7 +89,6 @@ public class PauselessRealtimeIngestionIntegrationTest extends BasePauselessReal
     startController();
     startBroker();
     startServer();
-    setMaxSegmentCompletionTimeMillis();
     // setupNonPauselessTable() also unpacks and publishes the source records. All scenarios consume the immutable
     // topic from the smallest offset and compare their recovered metadata with this reference table.
     _scenario = Scenario.NO_FAILURE;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionSegmentCommitFailureTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionSegmentCommitFailureTest.java
@@ -31,9 +31,7 @@ import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.controller.BaseControllerStarter;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.helix.core.periodictask.ControllerPeriodicTask;
-import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import org.apache.pinot.integration.tests.realtime.utils.FailureInjectingControllerStarter;
-import org.apache.pinot.integration.tests.realtime.utils.FailureInjectingPinotLLCRealtimeSegmentManager;
 import org.apache.pinot.integration.tests.realtime.utils.FailureInjectingTableConfig;
 import org.apache.pinot.integration.tests.realtime.utils.FailureInjectingTableDataManagerProvider;
 import org.apache.pinot.server.starter.helix.HelixInstanceDataManagerConfig;
@@ -60,7 +58,7 @@ import static org.testng.Assert.assertNotNull;
 /// Verifies recovery from server-side segment commit and consuming-transition failures with one shared cluster.
 public class PauselessRealtimeIngestionSegmentCommitFailureTest extends BaseClusterIntegrationTest {
   private static final String REFERENCE_TABLE_NAME = DEFAULT_TABLE_NAME + "_reference";
-  private static final long MAX_SEGMENT_COMPLETION_TIME_MILLIS = 10_000L;
+  private static final long VALIDATION_RERUN_INTERVAL_MS = 10_000L;
 
   private FailureScenario _failureScenario;
   private File _sampleAvroFile;
@@ -112,7 +110,6 @@ public class PauselessRealtimeIngestionSegmentCommitFailureTest extends BaseClus
     List<File> avroFiles = unpackAvroData(_tempDir);
     _sampleAvroFile = avroFiles.get(0);
     pushAvroIntoKafka(avroFiles);
-    setMaxSegmentCompletionTimeMillis();
     setupReferenceTable();
   }
 
@@ -237,34 +234,44 @@ public class PauselessRealtimeIngestionSegmentCommitFailureTest extends BaseClus
     tableConfig.getValidationConfig().setRetentionTimeValue("100000");
   }
 
-  private void setMaxSegmentCompletionTimeMillis() {
-    PinotLLCRealtimeSegmentManager realtimeSegmentManager = _helixResourceManager.getRealtimeSegmentManager();
-    if (realtimeSegmentManager instanceof FailureInjectingPinotLLCRealtimeSegmentManager) {
-      ((FailureInjectingPinotLLCRealtimeSegmentManager) realtimeSegmentManager).setMaxSegmentCompletionTimeoutMs(
-          MAX_SEGMENT_COMPLETION_TIME_MILLIS);
-    }
-  }
-
-  private void verifyRecovery(FailureScenario failureScenario)
-      throws Exception {
+  private void verifyRecovery(FailureScenario failureScenario) {
     String pauselessTableName = TableNameBuilder.REALTIME.tableNameWithType(getPauselessTableName(failureScenario));
 
     List<String> erroredSegments = getSegmentsInEV(pauselessTableName, SegmentStateModel.ERROR);
     assertFalse(erroredSegments.isEmpty(), "No segments found in ERROR state, expected at least one.");
 
-    Thread.sleep(MAX_SEGMENT_COMPLETION_TIME_MILLIS);
-    Properties periodicTaskProperties = new Properties();
-    periodicTaskProperties.setProperty(ControllerPeriodicTask.RUN_SEGMENT_LEVEL_VALIDATION, Boolean.TRUE.toString());
-    _controllerStarter.getRealtimeSegmentValidationManager().run(periodicTaskProperties);
+    // Segments in ERROR state are repaired by the segment-level validation (re-ingestion for COMMITTING segments,
+    // reset for IN_PROGRESS segments), which runs periodically in production. Run it periodically here as well
+    // instead of asserting on a single pass: the failure injection keeps producing new ERROR states past any single
+    // pass — replicas hit the injected failures independently while the table is still consuming, and every reset of
+    // a consuming segment creates a new segment data manager that draws from the remaining failure budget. The
+    // re-runs are spaced out so that a pass does not re-trigger repairs (re-ingestion, reset) that are still in
+    // flight from the previous pass, while the ERROR-empty check itself polls at the usual 1s granularity.
+    long[] lastValidationRunMs = new long[1];
+    TestUtils.waitForCondition(aVoid -> {
+      if (getSegmentsInEV(pauselessTableName, SegmentStateModel.ERROR).isEmpty()) {
+        return true;
+      }
+      long nowMs = System.currentTimeMillis();
+      if (nowMs - lastValidationRunMs[0] >= VALIDATION_RERUN_INTERVAL_MS) {
+        lastValidationRunMs[0] = nowMs;
+        runSegmentLevelValidation();
+      }
+      return false;
+    }, 1000L, 600_000L, "Some segments are still in ERROR state after repeated validation runs");
 
-    TestUtils.waitForCondition(aVoid -> getSegmentsInEV(pauselessTableName, SegmentStateModel.ERROR).isEmpty(),
-        600_000L, "Some segments are still in ERROR state after resetSegments()");
     TestUtils.waitForCondition(aVoid -> getSegmentsInEV(pauselessTableName, SegmentStateModel.OFFLINE).isEmpty(),
         30_000L, "Some segments are in OFFLINE state after resetSegments()");
 
     compareZKMetadataForSegments(_helixResourceManager.getSegmentsZKMetadata(pauselessTableName),
         _helixResourceManager.getSegmentsZKMetadata(
             TableNameBuilder.REALTIME.tableNameWithType(getNonPauselessTableName())));
+  }
+
+  private void runSegmentLevelValidation() {
+    Properties periodicTaskProperties = new Properties();
+    periodicTaskProperties.setProperty(ControllerPeriodicTask.RUN_SEGMENT_LEVEL_VALIDATION, Boolean.TRUE.toString());
+    _controllerStarter.getRealtimeSegmentValidationManager().run(periodicTaskProperties);
   }
 
   private List<String> getSegmentsInEV(String realtimeTableName, String status) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TableRebalancePauselessIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TableRebalancePauselessIntegrationTest.java
@@ -82,7 +82,6 @@ public class TableRebalancePauselessIntegrationTest extends BasePauselessRealtim
     startServer();
     createServerTenant(getServerTenant(), 0, 1);
     createBrokerTenant(getBrokerTenant(), 1);
-    setMaxSegmentCompletionTimeMillis();
     setupNonPauselessTable();
     injectFailure();
     setupPauselessTable();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/FailureInjectingPinotLLCRealtimeSegmentManager.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/FailureInjectingPinotLLCRealtimeSegmentManager.java
@@ -19,23 +19,21 @@
 package org.apache.pinot.integration.tests.realtime.utils;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import org.apache.pinot.controller.helix.core.util.FailureInjectionUtils;
-import org.apache.zookeeper.data.Stat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class FailureInjectingPinotLLCRealtimeSegmentManager extends PinotLLCRealtimeSegmentManager {
   @VisibleForTesting
   private final Map<String, String> _failureConfig;
-  private long _maxSegmentCompletionTimeoutMs = 300000L;
-  private static final Logger LOGGER = LoggerFactory.getLogger(FailureInjectingPinotLLCRealtimeSegmentManager.class);
+  private final Set<String> _forceExpiredSegments = ConcurrentHashMap.newKeySet();
 
   public FailureInjectingPinotLLCRealtimeSegmentManager(PinotHelixResourceManager helixResourceManager,
       ControllerConf controllerConf, ControllerMetrics controllerMetrics) {
@@ -43,22 +41,22 @@ public class FailureInjectingPinotLLCRealtimeSegmentManager extends PinotLLCReal
     _failureConfig = new ConcurrentHashMap<>();
   }
 
+  /// Treats force-expired segments as exceeding the max segment completion time regardless of how recently their
+  /// segment ZK metadata was updated. This makes them immediately eligible for repair while keeping their in-flight
+  /// commit attempts rejected, without shortening the completion time for any other segment.
   @Override
   protected boolean isExceededMaxSegmentCompletionTime(String realtimeTableName, String segmentName,
       long currentTimeMs) {
-    Stat stat = new Stat();
-    getSegmentZKMetadata(realtimeTableName, segmentName, stat);
-    if (currentTimeMs > stat.getMtime() + _maxSegmentCompletionTimeoutMs) {
-      LOGGER.info("Segment: {} exceeds the max completion time: {}ms, metadata update time: {}, current time: {}",
-          segmentName, _maxSegmentCompletionTimeoutMs, stat.getMtime(), currentTimeMs);
-      return true;
-    } else {
-      return false;
-    }
+    return _forceExpiredSegments.contains(segmentName)
+        || super.isExceededMaxSegmentCompletionTime(realtimeTableName, segmentName, currentTimeMs);
   }
 
-  public void setMaxSegmentCompletionTimeoutMs(long maxSegmentCompletionTimeoutMs) {
-    _maxSegmentCompletionTimeoutMs = maxSegmentCompletionTimeoutMs;
+  public void forceExpireSegments(Collection<String> segmentNames) {
+    _forceExpiredSegments.addAll(segmentNames);
+  }
+
+  public void clearForceExpiredSegments() {
+    _forceExpiredSegments.clear();
   }
 
   @VisibleForTesting

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/PauselessRealtimeTestUtils.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/PauselessRealtimeTestUtils.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.integration.tests.realtime.utils;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +27,8 @@ import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.helix.HelixHelper;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import org.apache.pinot.spi.utils.CommonConstants;
 
 import static org.testng.Assert.assertEquals;
@@ -40,6 +43,29 @@ public class PauselessRealtimeTestUtils {
     IdealState idealState = HelixHelper.getTableIdealState(helixManager, tableName);
     Map<String, Map<String, String>> segmentAssignment = idealState.getRecord().getMapFields();
     assertEquals(segmentAssignment.size(), numSegmentsExpected);
+  }
+
+  /// Marks all current segments of the given table as exceeding the max segment completion time, making them
+  /// immediately eligible for repair by the next validation run while keeping their in-flight commit attempts
+  /// rejected. Segments created after this call are not affected. No-op when the cluster is not started with a
+  /// [FailureInjectingPinotLLCRealtimeSegmentManager].
+  public static void forceExpireSegments(PinotHelixResourceManager helixResourceManager, String tableNameWithType) {
+    PinotLLCRealtimeSegmentManager realtimeSegmentManager = helixResourceManager.getRealtimeSegmentManager();
+    if (realtimeSegmentManager instanceof FailureInjectingPinotLLCRealtimeSegmentManager) {
+      List<String> segmentNames = new ArrayList<>();
+      for (SegmentZKMetadata segmentZKMetadata : helixResourceManager.getSegmentsZKMetadata(tableNameWithType)) {
+        segmentNames.add(segmentZKMetadata.getSegmentName());
+      }
+      ((FailureInjectingPinotLLCRealtimeSegmentManager) realtimeSegmentManager).forceExpireSegments(segmentNames);
+    }
+  }
+
+  /// Clears the force-expired segments so that segments re-activated by the repair can complete normally.
+  public static void clearForceExpiredSegments(PinotHelixResourceManager helixResourceManager) {
+    PinotLLCRealtimeSegmentManager realtimeSegmentManager = helixResourceManager.getRealtimeSegmentManager();
+    if (realtimeSegmentManager instanceof FailureInjectingPinotLLCRealtimeSegmentManager) {
+      ((FailureInjectingPinotLLCRealtimeSegmentManager) realtimeSegmentManager).clearForceExpiredSegments();
+    }
   }
 
   public static boolean assertUrlPresent(List<SegmentZKMetadata> segmentZKMetadataList) {


### PR DESCRIPTION
## Summary

The pauseless recovery tests shorten the max segment completion time to 10 seconds so that segments stranded by an injected failure become eligible for repair after a short sleep. The shortened window applies to every segment though, so on a slow CI runner it also kills perfectly healthy commits: any segment whose commit-end arrives more than 10 seconds after its commit-start metadata update is permanently rejected with `Exceeded max segment completion time`, stays `COMMITTING` with no download URL, and — since recovery in these tests is a single manually triggered validation run — nothing ever repairs it. This matches the observed CI failure signature: `testSegmentAssignment` (which injects no failure and never runs the validator) timing out with "Some segments have status COMMITTING", and the failure scenarios timing out with "Some segments still have missing url".

Remove the shortened window (restoring the production 5-minute default) and make repair eligibility explicit instead of time-based:
- `FailureInjectingPinotLLCRealtimeSegmentManager` keeps a set of force-expired segment names; `isExceededMaxSegmentCompletionTime` returns true for those and otherwise defers to the production logic with the default 5-minute window. The `setMaxSegmentCompletionTimeoutMs` override is removed.
- `BasePauselessRealtimeIngestionTest#runValidationAndVerify` disables the injected failure, snapshots the table's current segments and force-expires them, triggers the single validation run, then clears the expiry. The expiry is needed there because the deep-store retry that repairs the stranded `COMMITTING` segments is gated by the completion time, and it is safe there because consumption is already quiesced when it runs (all segment ZK metadata created, or consumption stalled by the fault), so no in-flight commit can be caught by it.
- `PauselessRealtimeIngestionSegmentCommitFailureTest#verifyRecovery` drops the sleep and instead re-runs the segment-level validation periodically (every 10 seconds, bounded by the same overall timeout) while ERROR replicas remain, mirroring how the validation manager repairs ERROR segments periodically in production. A single pass is not a sound contract for this family: the dedup variant's entry gate fires on the first ERROR replica while the injected failures are still materializing on other replicas and partitions, in-order consumption staggers the error cascade, and every reset of a consuming segment creates a new segment data manager that draws from the remaining failure budget — so new ERROR states can appear after any given pass. No expiry is used here: ERROR-segment recovery (re-ingestion for `COMMITTING`, reset for `IN_PROGRESS`) is not gated by the completion time, and expiring segments while the table is still actively consuming would reject in-flight commits.

Effects:
- The 10-second `Thread.sleep` before each validation run is gone — repair eligibility is immediate where it is needed.
- Happy-path commits (the no-failure scenario, the reference tables, force-commits during rebalance, and all commits in the server-side failure tests) run under the production completion time and can no longer be stranded by a slow runner.
- The controller-failure recovery semantics stay strict: while the expiry is active, in-flight commit attempts for the stranded segments keep getting rejected, so the single validation run in `runValidationAndVerify` remains the only recovery path under test. Clearing the expiry right after the run lets segments re-activated by the repair (e.g. in the ideal-state-update-failure scenario) commit normally.
