### PR TITLE
Throw stackless exceptions from test failure injection to reduce log noise

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/FailureInjectionUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/FailureInjectionUtils.java
@@ -32,7 +32,16 @@ public class FailureInjectionUtils {
   public static void injectFailure(String faultTypeKey, Map<String, String> managerConfigs) {
     String faultTypeConfig = managerConfigs.getOrDefault(faultTypeKey, "false");
     if (Boolean.parseBoolean(faultTypeConfig)) {
-      throw new RuntimeException("Injecting failure: " + faultTypeKey);
+      throw new InjectedFailureException("Injecting failure: " + faultTypeKey);
+    }
+  }
+
+  /// Thrown at a configured fault point. Carries no stack trace: these failures are thrown by design, often for
+  /// dozens of segments per test, and the catch sites log them in full — the fault point in the message is the only
+  /// meaningful context, so stack traces would just flood the test logs.
+  public static class InjectedFailureException extends RuntimeException {
+    public InjectedFailureException(String message) {
+      super(message, null, false, false);
     }
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/FailureInjectingRealtimeSegmentDataManager.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/FailureInjectingRealtimeSegmentDataManager.java
@@ -22,6 +22,7 @@ import java.util.function.BooleanSupplier;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.controller.helix.core.util.FailureInjectionUtils;
 import org.apache.pinot.core.data.manager.realtime.ConsumerCoordinator;
 import org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager;
@@ -53,7 +54,7 @@ public class FailureInjectingRealtimeSegmentDataManager extends RealtimeSegmentD
         llcSegmentName, consumerCoordinator, serverMetrics, null /* no PartitionUpsertMetadataManager */,
         partitionDedupMetadataManager, isTableReadyToConsumeData);
     if (failConsumingTransition) {
-      throw new RuntimeException("Forced to fail the consuming transition");
+      throw new FailureInjectionUtils.InjectedFailureException("Forced to fail the consuming transition");
     }
     _failCommit = failCommit;
   }
@@ -61,7 +62,7 @@ public class FailureInjectingRealtimeSegmentDataManager extends RealtimeSegmentD
   protected SegmentBuildDescriptor buildSegmentInternal(boolean forCommit)
       throws SegmentBuildFailureException {
     if (_failCommit) {
-      throw new RuntimeException("Forced failure in buildSegmentInternal");
+      throw new FailureInjectionUtils.InjectedFailureException("Forced failure in buildSegmentInternal");
     }
     return super.buildSegmentInternal(forCommit);
   }


### PR DESCRIPTION
## Summary

The pauseless recovery tests inject failures at commit fault points, and every injected throw gets logged by the production catch sites with a full stack trace (e.g. `PauselessSegmentCompletionFSM`'s "Caught exception while committing segment metadata" ERROR) — for the commit-end scenario that is ~46 segments' worth of ~30-frame stack dumps per run, flooding the test logs.

Make the injected exceptions stackless:
- `FailureInjectionUtils` gains a nested `InjectedFailureException` built with `RuntimeException(message, cause, enableSuppression, writableStackTrace)` and `writableStackTrace = false`, so it carries no stack frames. `injectFailure` throws it.
- The server-side injectors in `FailureInjectingRealtimeSegmentDataManager` (forced build failure, forced consuming-transition failure) throw the same type.

Every catch site still logs the failure — the injected-failure timeline stays visible and greppable, which matters when a test actually fails — but each occurrence is now a single line like `InjectedFailureException: Injecting failure: FaultBeforeCommitEndMetadata` instead of a stack dump. The fault point in the message is the only meaningful context anyway; the stack below the injection site is identical every time. Real failures keep their full stack traces, which is also why this is preferable to suppressing the noisy loggers in the test log config.
