### PR TITLE
Fix LoggerUtilsTest flakiness caused by leaked LoggerConfig

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/SqlQueryOptionValidationTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/SqlQueryOptionValidationTest.java
@@ -209,6 +209,12 @@ public class SqlQueryOptionValidationTest {
     void detach() {
       _logger.removeAppender(this);
       stop();
+      // The captured logger is never declared in log4j2.xml, so attaching the appender implicitly registered a
+      // LoggerConfig for it. Remove it to leave the shared configuration as found — test classes share the JVM in
+      // this module, and other tests assert on the set of configured loggers.
+      LoggerContext context = _logger.getContext();
+      context.getConfiguration().removeLogger(_logger.getName());
+      context.updateLoggers();
     }
 
     List<String> messagesContaining(String substring) {


### PR DESCRIPTION
## Summary

`LoggerUtilsTest.testGetAllConfiguredLoggers` fails intermittently on CI with `expected [2] but found [3]` (most recently on master in "Pinot Unit Test Set 1"). Root cause chain:
- `SqlQueryOptionValidationTest`'s `CapturingAppender` attaches an appender to the `QueryOptionsUtils` logger, which has no explicit entry in the test `log4j2.xml`. In that case log4j's `AbstractConfiguration.addLoggerAppender` implicitly creates a `LoggerConfig` and registers it in the shared configuration.
- `detach()` removed the appender but not the implicitly created `LoggerConfig`, so the configuration permanently gained a third configured logger.
- `pinot-common` runs surefire with `reuseForks=true`, so test classes share JVMs, and with `unit.test.fork.count > 1` on CI the class-to-fork assignment varies run to run. Whenever `SqlQueryOptionValidationTest` lands before `LoggerUtilsTest` in the same fork, `getAllConfiguredLoggers()` returns 3 (`root`, `org.apache.pinot`, and the leaked `QueryOptionsUtils` config) and the exact-count assertion fails. The leaked config keeps the inherited level and additivity, so none of the other assertions in `LoggerUtilsTest` notice it — matching the observed single-method failure.

Fix: `detach()` now also removes the implicitly registered `LoggerConfig` and refreshes the loggers, leaving the shared configuration exactly as the config file defines it. Removal is unconditional because the captured logger is never declared in `log4j2.xml`; `LoggerUtilsTest`'s exact-count assertion keeps acting as the canary that no test leaks logger configuration.
