### PR TITLE
Skip stream consumer recreation when consumption is being stopped

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -462,13 +462,20 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
           _consecutiveErrorCount, e);
       throw e;
     } else {
-      if (_shouldStop && (e instanceof InterruptedException || e.getCause() instanceof InterruptedException)) {
-        _segmentLogger.debug("Interrupted to stop consumption", e);
-      } else {
+      if (!_shouldStop) {
         _segmentLogger.warn("Stream transient exception when fetching messages, retrying (count={})",
             _consecutiveErrorCount, e);
+        Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
       }
-      Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+      // Consumption being stopped is checked both before and after the uninterruptible retry backoff: the transient
+      // exception is usually the interrupt from the stop, and stop() can also interrupt the backoff itself. Either
+      // way the consume loop exits on the next check, so skip the stream consumer recreation. Closing the current
+      // consumer from the interrupted consumer thread would just fail with another interrupt; it is closed by the
+      // regular shutdown path instead.
+      if (_shouldStop) {
+        _segmentLogger.debug("Interrupted to stop consumption, skipping stream consumer recreation", e);
+        return;
+      }
       recreateStreamConsumer("Too many transient errors");
     }
   }


### PR DESCRIPTION
## Summary

When a consuming segment is stopped ([RealtimeSegmentDataManager#stop]), the consumer thread is interrupted (repeatedly, until it exits). If the thread is blocked in `fetchMessages` at that moment, the interrupt surfaces as a transient stream exception, and `handleTransientStreamErrors` — although it already recognizes the interrupted-to-stop case for logging — still sleeps 1 second uninterruptibly and recreates the stream consumer. That recreation is pure waste: the consume loop exits on the very next `_shouldStop` check, so the freshly created consumer is never used. Worse, closing the old Kafka consumer from the interrupted thread makes the Kafka client log a noisy error with a full stack trace on every such shutdown (from inside `KafkaConsumer#close`, so it cannot be suppressed on the Pinot side):

```
ERROR [ClassicKafkaConsumer] ... Failed to close fetcher with a timeout(ms)=30000
org.apache.kafka.common.errors.InterruptException: java.lang.InterruptedException
```

This shows up in bulk in integration test logs, since tests constantly stop tables with live consumers, and the interrupt lands inside `fetchMessages` most of the time.

Fix: when `_shouldStop` is set, `handleTransientStreamErrors` returns without the retry sleep and without recreating the consumer. The consume loop exits on the next check, and the current consumer is closed exactly once by the regular shutdown path (`closeStreamConsumer`, typically invoked from a non-interrupted thread). Besides removing the log noise, this also shaves the pointless 1s uninterruptible sleep plus a close/recreate cycle off every stop that races an in-flight fetch.
