### PR TITLE
[Vector Upsert 2/5] Harden vector search metric recording and backend param cleanup

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/VectorSimilarityFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/VectorSimilarityFilterOperator.java
@@ -305,8 +305,12 @@ public class VectorSimilarityFilterOperator extends BaseFilterOperator {
     String column = _predicate.getLhs().getIdentifier();
     float[] queryVector = _predicate.getValue();
     VectorExplainContext explainContext = _vectorExplainContext;
+    boolean backendParamsNeedCleanup = false;
+    boolean searchExecuted = false;
     try {
       // 1. Configure backend-specific parameters via interfaces
+      // Claim cleanup before the first setter because configuration can fail after partially updating reader state.
+      backendParamsNeedCleanup = true;
       configureBackendParams(column);
       refreshExplainContext(null);
       explainContext = _vectorExplainContext;
@@ -317,6 +321,7 @@ public class VectorSimilarityFilterOperator extends BaseFilterOperator {
       // 3. Execute ANN search (with pre-filter if available)
       ImmutableRoaringBitmap preFilter = _preFilterBitmap;
       ImmutableRoaringBitmap annResults;
+      searchExecuted = true;
       if (preFilter != null && _vectorIndexReader instanceof FilterAwareVectorIndexReader) {
         FilterAwareVectorIndexReader filterAwareReader = (FilterAwareVectorIndexReader) _vectorIndexReader;
         if (filterAwareReader.supportsPreFilter()) {
@@ -381,11 +386,17 @@ public class VectorSimilarityFilterOperator extends BaseFilterOperator {
 
       return annResults;
     } finally {
-      // Record search metrics for observability — always, regardless of which path was taken
-      VectorSearchMetrics.getInstance().recordSearch(_vectorSearchMode, _backendType);
-      // Refresh explain context with the final search mode decided during execution
-      refreshExplainContext(null);
-      clearBackendParams(column);
+      try {
+        if (searchExecuted) {
+          VectorSearchMetrics.getInstance().recordSearch(_vectorSearchMode, _backendType);
+        }
+        // Refresh explain context with the final search mode decided during execution
+        refreshExplainContext(null);
+      } finally {
+        if (backendParamsNeedCleanup) {
+          clearBackendParams(column);
+        }
+      }
     }
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/VectorSimilarityFilterOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/VectorSimilarityFilterOperatorTest.java
@@ -571,11 +571,38 @@ public class VectorSimilarityFilterOperatorTest {
     Assert.assertTrue(explain.contains("effectiveHnswUseBoundedQueue:false"), explain);
   }
 
+  @Test
+  public void testBackendParamsAreClearedWhenConfigurationFailsPartway() {
+    ConfigurableVectorReader mockReader = mock(ConfigurableVectorReader.class);
+    Mockito.doThrow(new IllegalStateException("efSearch configuration failed"))
+        .when(mockReader).setEfSearch(20);
+
+    VectorSimilarityPredicate predicate = new VectorSimilarityPredicate(
+        ExpressionContext.forIdentifier("embedding"), new float[]{1.0f, 2.0f}, 1);
+    VectorSearchParams params = new VectorSearchParams(8, false, null, null, 20, null, null);
+    VectorSimilarityFilterOperator operator = new VectorSimilarityFilterOperator(mockReader, predicate,
+        100, params, null,
+        createVectorIndexConfig("HNSW", VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN));
+
+    IllegalStateException exception = Assert.expectThrows(IllegalStateException.class, operator::getBitmaps);
+    Assert.assertEquals(exception.getMessage(), "efSearch configuration failed");
+    verify(mockReader).setNprobe(8);
+    verify(mockReader).setEfSearch(20);
+    verify(mockReader).clearNprobe();
+    verify(mockReader).clearEfSearch();
+    verify(mockReader).clearUseRelativeDistance();
+    verify(mockReader).clearUseBoundedQueue();
+    verify(mockReader, never()).getDocIds(Mockito.any(float[].class), Mockito.anyInt());
+  }
+
   /// Interface combining VectorIndexReader and NprobeAware for mocking IVF_FLAT readers.
   interface NprobeAwareVectorReader extends VectorIndexReader, NprobeAware {
   }
 
   interface EfSearchAwareVectorReader extends VectorIndexReader, EfSearchAware {
+  }
+
+  interface ConfigurableVectorReader extends VectorIndexReader, NprobeAware, EfSearchAware {
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})


### PR DESCRIPTION
Part 2/5 of the split of #19287 (Fix FULL-upsert vector candidate generation).

## Summary

Two robustness fixes in `VectorSimilarityFilterOperator.executeSearch`:

- Only record a vector search metric when a search actually executed. Previously a
  failure inside `configureBackendParams` still recorded a search that never ran.
- Guarantee backend search parameters are cleared even when configuration fails partway
  through the setters or the explain-context refresh throws, by claiming cleanup before
  the first setter and clearing in a nested finally. Backend search parameters
  (`nprobe`, `efSearch`) are ThreadLocal overrides on shared per-segment readers, so a
  skipped cleanup leaks a stale override onto a pooled query thread where it silently
  applies to a later query's search.

Part 4/5 relies on this hardening for its early-return exact-scan path.

## Validation

- `VectorSimilarityFilterOperatorTest`: 23 tests passed, including the new
  `testBackendParamsAreClearedWhenConfigurationFailsPartway`.

> Stacked on #19297 — this PR shows its commits until that merges; review only the last commit here.

## Stack

1. #19297 — exact-scan allowed-document filtering
2. #19298 — backend param cleanup hardening
3. #19299 — nested vector metadata guard
4. #19300 — apply the visible-document set before candidate generation (core fix)
5. #19301 — integration coverage
