### PR TITLE
Fix ColocatedJoinEmptyPartitionTest flake from deleting a table's uploaded segment tars

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/ColocatedJoinEmptyPartitionTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/ColocatedJoinEmptyPartitionTest.java
@@ -131,6 +131,20 @@ public class ColocatedJoinEmptyPartitionTest extends CustomDataQueryClusterInteg
       throws Exception {
     setUpTable(LEFT_TABLE_NAME, LEFT_POPULATED_PARTITIONS, LEFT_METRIC_MULTIPLIER);
     setUpTable(RIGHT_TABLE_NAME, RIGHT_POPULATED_PARTITIONS, RIGHT_METRIC_MULTIPLIER);
+    // Setting up the second table must not have removed the first one's tar files, see setUpTable(String, List, int).
+    assertTarFilesRetained(LEFT_TABLE_NAME, LEFT_POPULATED_PARTITIONS.size());
+    assertTarFilesRetained(RIGHT_TABLE_NAME, RIGHT_POPULATED_PARTITIONS.size());
+  }
+
+  /// Asserts that the segment tar files uploaded for the given table are still on disk. A metadata-only push, which
+  /// `ClusterTest#uploadSegments` selects at random, makes the tar file the only deep store copy, so deleting one
+  /// leaves its segment stuck in ERROR -- and only for a table whose segments no server had fetched yet, which is a
+  /// race that fails rarely and far from its cause.
+  private void assertTarFilesRetained(String tableName, int expectedNumSegments) {
+    File[] tarFiles = new File(_tarDir, tableName).listFiles();
+    assertNotNull(tarFiles, "Missing tar directory for table: " + tableName);
+    assertEquals(tarFiles.length, expectedNumSegments,
+        "Unexpected number of segment tar files for table: " + tableName);
   }
 
   @Override
@@ -358,17 +372,22 @@ public class ColocatedJoinEmptyPartitionTest extends CustomDataQueryClusterInteg
     TableConfig tableConfig = createTableConfigForTable(tableName);
     addTableConfig(tableConfig);
 
-    // The segment directories are shared across tables, and uploadSegments pushes everything it finds in the tar one.
-    TestUtils.ensureDirectoriesExistAndEmpty(_segmentDir, _tarDir);
+    // Give each table its own directories, and never empty a directory another table already uploaded from. A
+    // metadata-only push records a file:// download URI that points at the tar file, and the servers read it after the
+    // upload call has returned, so deleting that file makes the segment unloadable. Separate directories also keep
+    // uploadSegments, which pushes every tar it finds, from picking up the other table's segments.
+    File segmentDir = new File(_segmentDir, tableName);
+    File tarDir = new File(_tarDir, tableName);
+    TestUtils.ensureDirectoriesExistAndEmpty(segmentDir, tarDir);
     int segmentIndex = 0;
     for (int partition : populatedPartitions) {
       // One segment per partition, so that every segment holds exactly one partition id (a segment spanning several has
       // no usable partition metadata) and every partition has a fully replicated server.
       File avroFile = createAvroFile(tableName, partition, metricMultiplier);
-      ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFile, tableConfig, schema, segmentIndex++, _segmentDir,
-          _tarDir);
+      ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFile, tableConfig, schema, segmentIndex++, segmentDir,
+          tarDir);
     }
-    uploadSegments(tableName, _tarDir);
+    uploadSegments(tableName, tarDir);
   }
 
   private static Schema createSchemaForTable(String tableName) {


### PR DESCRIPTION
Follow-up to #19166. `ColocatedJoinEmptyPartitionTest`, added there, fails intermittently in `setUp` ([example run](https://github.com/apache/pinot/actions/runs/32197636088/job/95904769015?pr=19292)):

```
ColocatedJoinEmptyPartitionTest>CustomDataQueryClusterIntegrationTest.setUp:117->waitForAllDocsLoaded:140
Caught exception while checking the condition, error message:
Failed to load 6 documents into table: ColocatedJoinEmptyPartitionLeft
```

## Cause

The test deleted the segment tar files it had already uploaded.

`ClusterTest#uploadSegments` picks its push mode at random. Half the time it pushes only the metadata and records a `file://` download URI that points at the tar file itself:

```java
"file://" + segmentTarFile.getParentFile().getAbsolutePath() + "/" + URIUtils.encode(segmentTarFile.getName())
```

The tar file is then the only deep store copy, and the servers read it after the upload call has returned.

The test sets up two tables, and both used the same segment and tar directories. Each call emptied them first:

1. The left table uploads. Deep store now points into the shared tar directory.
2. The right table's setup empties that directory, which deletes the left table's only deep store copy.
3. The servers fetch, find nothing, and retry 3 times. The segments stay in `ERROR`.
4. The count query never reaches 6 rows.

Two things had to line up, which is why it failed rarely: the random push mode had to select metadata, and the servers had to still be fetching. A loaded machine makes the second one likely.

## Fix

Each table gets its own segment and tar directory, so no table empties a directory another one uploaded from. Separate directories also keep `uploadSegments`, which pushes every tar it finds, from reading the other table's segments. That was the only reason to empty the directory before.

A new assertion after both tables are set up makes sure that the tar files of both are still on disk. The original defect fails that assertion directly, instead of as a load timeout 60 seconds later.

## Verification

- The failure reproduces on the code before this change once the push mode is forced to metadata and the directory is emptied directly after the first upload, which is the timing a loaded CI machine produces. Same signature as CI: `AttemptsExceededException` out of `downloadSegmentFromDeepStore`, and load failures for the left table only.
- The new assertion fails on the code before this change with no forced push mode and no timing change.
- With the fix, the test passes with the push mode forced to metadata, and with the random mode.

## Not addressed here

The same shape exists in shared test infrastructure: `BaseClusterIntegrationTest#createAndUploadSegmentFromFile` empties the shared directories on every call, and `SSBQueryTest` empties them inside a per-table loop. Those survive because each waits for documents to load before the next upload, and their tables have one replica. This test had neither: it uploads two tables back to back with `numReplicas=2`. Making the shared upload path keep its own deep store copy would remove the hazard for every test, and belongs in its own change.
