### PR TITLE
Add DELTA and DELTADELTA transform codecs

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/BaseDeltaCodecDefinition.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/BaseDeltaCodecDefinition.java
@@ -1,0 +1,158 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.io.codec;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.List;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+
+
+/// Shared structure for [DeltaCodecDefinition] and [DeltaDeltaCodecDefinition].
+///
+/// Implementations are stateless and thread-safe: all per-call state lives on the stack, so a
+/// single singleton instance is shared across all columns and concurrent encode/decode calls.
+///
+/// **Typed-layout-preserving passthrough.** DELTA/DELTADELTA map an array of `count` column-typed values
+/// to an array of the same `count` values of the same width (no per-frame header). The element
+/// type comes from the [CodecContext] and `count` is derived from the buffer length, so the output
+/// is itself a contiguous typed value array that a following [CodecKind#TRANSFORM] stage (or the
+/// chunk reader) can consume directly. This is what makes chains like `DELTA,DELTADELTA,LZ4`
+/// work — see [#preservesTypedValueLayout()].
+///
+/// **Two's-complement wrap-around is intentional.** Deltas are computed using ordinary Java
+/// `-` on int/long, which silently wraps when the mathematical delta does not fit in the
+/// value's width (e.g. `Integer.MAX_VALUE - Integer.MIN_VALUE`). Decode applies the symmetric
+/// `+` so the original sequence is recovered bit-for-bit. Boundary tests in
+/// `DeltaCodecRoundTripTest` lock in this property — do not switch the encode/decode
+/// helpers to checked arithmetic (`Math.subtractExact`, `Math.addExact`) without also
+/// changing the on-disk format.
+abstract class BaseDeltaCodecDefinition<O extends CodecOptions> implements ChunkCodecHandler<O> {
+
+  @Override
+  public final CodecKind kind() {
+    return CodecKind.TRANSFORM;
+  }
+
+  @Override
+  public final boolean preservesTypedValueLayout() {
+    // Output is a same-width typed value array, so DELTA/DELTADELTA can be chained ahead of another
+    // transform (or each other).
+    return true;
+  }
+
+  @Override
+  public final void validateContext(O options, CodecContext ctx) {
+    DataType dt = ctx.getDataType();
+    if (dt != DataType.INT && dt != DataType.LONG) {
+      throw new IllegalArgumentException(
+          name() + " codec only supports INT and LONG columns, but column has type: " + dt);
+    }
+  }
+
+  @Override
+  public final int maxEncodedSize(O options, int inputSize) {
+    // Passthrough: output is exactly the same size as the input (no header).
+    return inputSize;
+  }
+
+  @Override
+  public final boolean requiresDirectDstBuffer() {
+    return false;
+  }
+
+  /// Subclasses must reject non-empty `args`.
+  @Override
+  public abstract O parseOptions(List<String> args);
+
+  @Override
+  public final ByteBuffer encode(O options, CodecContext ctx, ByteBuffer src) {
+    int elementSize = elementSize(ctx, src.remaining());
+    int count = src.remaining() / elementSize;
+    return elementSize == Long.BYTES ? encodeLong(src, count) : encodeInt(src, count);
+  }
+
+  @Override
+  public final ByteBuffer decode(O options, CodecContext ctx, ByteBuffer src) {
+    // The persisted transform layout is always big-endian, independent of the byte order on a
+    // caller-provided view. duplicate() also keeps the caller's position/limit untouched.
+    src = src.duplicate().order(ByteOrder.BIG_ENDIAN);
+    int elementSize = elementSize(ctx, src.remaining());
+    int count = src.remaining() / elementSize;
+    if (count == 0) {
+      return ByteBuffer.allocateDirect(0);
+    }
+    return elementSize == Long.BYTES ? decodeLong(src, count) : decodeInt(src, count);
+  }
+
+  @Override
+  public final void decodeInto(O options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) {
+    src = src.duplicate().order(ByteOrder.BIG_ENDIAN);
+    dst.clear();
+    int elementSize = elementSize(ctx, src.remaining());
+    int count = src.remaining() / elementSize;
+    long requiredCapacity = (long) count * elementSize;
+    if (requiredCapacity > dst.capacity()) {
+      throw new IllegalArgumentException(
+          name() + ": decoded size " + requiredCapacity + " exceeds dst capacity " + dst.capacity());
+    }
+    if (count > 0) {
+      if (elementSize == Long.BYTES) {
+        decodeLongInto(src, count, dst);
+      } else {
+        decodeIntInto(src, count, dst);
+      }
+    }
+    dst.flip();
+  }
+
+  /// Resolves the element size from the column context and validates that the buffer holds a whole
+  /// number of values. The element type (INT vs LONG) is carried by the pipeline context rather
+  /// than a per-frame flag, which is what allows these transforms to be chained.
+  private int elementSize(CodecContext ctx, int remaining) {
+    DataType dt = ctx.getDataType();
+    if (dt != DataType.INT && dt != DataType.LONG) {
+      throw new IllegalArgumentException(name() + " only supports INT and LONG columns, but column has type: " + dt);
+    }
+    int elementSize = dt.size();
+    if (remaining % elementSize != 0) {
+      throw new IllegalArgumentException(
+          name() + ": buffer size (" + remaining + ") is not a multiple of element size (" + elementSize
+              + ") for stored type " + dt);
+    }
+    return elementSize;
+  }
+
+  // -------------------------------------------------------------------------
+  // Arithmetic helpers — subclasses provide the encoding/decoding logic.
+  // All operate on a header-less, same-width array of `count` values.
+  // -------------------------------------------------------------------------
+
+  protected abstract ByteBuffer encodeInt(ByteBuffer src, int count);
+
+  protected abstract ByteBuffer encodeLong(ByteBuffer src, int count);
+
+  protected abstract ByteBuffer decodeInt(ByteBuffer src, int count);
+
+  protected abstract ByteBuffer decodeLong(ByteBuffer src, int count);
+
+  protected abstract void decodeIntInto(ByteBuffer src, int count, ByteBuffer dst);
+
+  protected abstract void decodeLongInto(ByteBuffer src, int count, ByteBuffer dst);
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/CodecRegistry.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/CodecRegistry.java
@@ -44,12 +44,14 @@ import org.apache.pinot.segment.spi.codec.CodecInvocation;
 /// Lookup is case-insensitive.
 final class CodecRegistry {
 
-  /// Default, immutable registry containing all built-in compression codecs.
+  /// Default, immutable registry containing all built-in transform and compression codecs.
   /// Safe for concurrent reads; does not allow [#register()].
   static final CodecRegistry DEFAULT;
 
   static {
     Map<String, ChunkCodecHandler<?>> m = new LinkedHashMap<>();
+    m.put(DeltaCodecDefinition.INSTANCE.name().toUpperCase(Locale.ROOT), DeltaCodecDefinition.INSTANCE);
+    m.put(DeltaDeltaCodecDefinition.INSTANCE.name().toUpperCase(Locale.ROOT), DeltaDeltaCodecDefinition.INSTANCE);
     m.put(ZstdCodecDefinition.INSTANCE.name().toUpperCase(Locale.ROOT), ZstdCodecDefinition.INSTANCE);
     // Accept the legacy enum spelling ZSTANDARD as an alias for ZSTD so users familiar with
     // FieldConfig.CompressionCodec.ZSTANDARD aren't blocked. Canonicalization still emits "ZSTD",

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/DeltaCodecDefinition.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/DeltaCodecDefinition.java
@@ -1,0 +1,164 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.io.codec;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+
+/// Transform codec that computes integer deltas between successive values before the
+/// compression stage (if any).
+///
+/// DSL form: `DELTA` (no arguments)
+///
+/// Supported stored types: `INT`, `LONG`.
+///
+/// Stateless and thread-safe; the [#INSTANCE] singleton is shared across all columns.
+///
+/// Wire format (header-less passthrough — the element type comes from the column context and the
+/// value count from the buffer length, so the output is itself a same-width typed value array that
+/// a following transform can consume):
+/// ```
+///   [element_size bytes: first value verbatim]
+///   [(count-1) * element_size bytes: successive deltas]
+/// ```
+final class DeltaCodecDefinition extends BaseDeltaCodecDefinition<DeltaCodecDefinition.Options> {
+
+  /// On-disk permanent name stored verbatim in segment file headers.
+  /// This string is a frozen on-disk API contract and must never be changed.
+  public static final String NAME = "DELTA";
+
+  public static final DeltaCodecDefinition INSTANCE = new DeltaCodecDefinition();
+
+  /// Singleton options — DELTA has no configurable parameters.
+  public static final Options OPTIONS = new Options();
+
+  private DeltaCodecDefinition() {
+  }
+
+  /// Typed options for [DeltaCodecDefinition]. DELTA has no configurable parameters.
+  public static final class Options implements CodecOptions {
+    private Options() {
+    }
+  }
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+
+  @Override
+  public Options parseOptions(List<String> args) {
+    if (!args.isEmpty()) {
+      throw new IllegalArgumentException("DELTA codec takes no arguments but got: " + args);
+    }
+    return OPTIONS;
+  }
+
+  @Override
+  public String canonicalize(Options options) {
+    return NAME;
+  }
+
+  @Override
+  protected ByteBuffer encodeInt(ByteBuffer src, int count) {
+    ByteBuffer out = ByteBuffer.allocateDirect(count * Integer.BYTES);
+    if (count == 0) {
+      out.flip();
+      return out;
+    }
+    int prev = src.getInt();
+    out.putInt(prev);
+    for (int i = 1; i < count; i++) {
+      int cur = src.getInt();
+      out.putInt(cur - prev);
+      prev = cur;
+    }
+    out.flip();
+    return out;
+  }
+
+  @Override
+  protected ByteBuffer encodeLong(ByteBuffer src, int count) {
+    ByteBuffer out = ByteBuffer.allocateDirect(count * Long.BYTES);
+    if (count == 0) {
+      out.flip();
+      return out;
+    }
+    long prev = src.getLong();
+    out.putLong(prev);
+    for (int i = 1; i < count; i++) {
+      long cur = src.getLong();
+      out.putLong(cur - prev);
+      prev = cur;
+    }
+    out.flip();
+    return out;
+  }
+
+  @Override
+  protected ByteBuffer decodeInt(ByteBuffer src, int count) {
+    ByteBuffer out = ByteBuffer.allocateDirect(count * Integer.BYTES);
+    int prev = src.getInt();
+    out.putInt(prev);
+    for (int i = 1; i < count; i++) {
+      int delta = src.getInt();
+      prev += delta;
+      out.putInt(prev);
+    }
+    out.flip();
+    return out;
+  }
+
+  @Override
+  protected ByteBuffer decodeLong(ByteBuffer src, int count) {
+    ByteBuffer out = ByteBuffer.allocateDirect(count * Long.BYTES);
+    long prev = src.getLong();
+    out.putLong(prev);
+    for (int i = 1; i < count; i++) {
+      long delta = src.getLong();
+      prev += delta;
+      out.putLong(prev);
+    }
+    out.flip();
+    return out;
+  }
+
+  @Override
+  protected void decodeIntInto(ByteBuffer src, int count, ByteBuffer dst) {
+    int prev = src.getInt();
+    dst.putInt(prev);
+    for (int i = 1; i < count; i++) {
+      int delta = src.getInt();
+      prev += delta;
+      dst.putInt(prev);
+    }
+  }
+
+  @Override
+  protected void decodeLongInto(ByteBuffer src, int count, ByteBuffer dst) {
+    long prev = src.getLong();
+    dst.putLong(prev);
+    for (int i = 1; i < count; i++) {
+      long delta = src.getLong();
+      prev += delta;
+      dst.putLong(prev);
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/DeltaDeltaCodecDefinition.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/DeltaDeltaCodecDefinition.java
@@ -1,0 +1,209 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.io.codec;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+
+/// Transform codec that computes delta-of-delta values between successive values before the
+/// compression stage (if any). Useful for data where the differences between consecutive values
+/// are approximately constant (e.g. timestamps with regular intervals).
+///
+/// DSL form: `DELTADELTA` (no arguments)
+///
+/// Supported stored types: `INT`, `LONG`.
+///
+/// Stateless and thread-safe; the [#INSTANCE] singleton is shared across all columns.
+///
+/// Wire format (header-less passthrough — element type from the column context, value count from
+/// the buffer length, so the output is a same-width typed value array a following transform can
+/// consume):
+/// ```
+///   [element_size bytes: first value verbatim]
+///   [element_size bytes: first delta (second - first), if count > 1]
+///   [(count-2) * element_size bytes: delta-of-deltas, if count > 2]
+/// ```
+final class DeltaDeltaCodecDefinition
+    extends BaseDeltaCodecDefinition<DeltaDeltaCodecDefinition.Options> {
+
+  /// On-disk permanent name stored verbatim in segment file headers.
+  /// This string is a frozen on-disk API contract and must never be changed.
+  public static final String NAME = "DELTADELTA";
+
+  public static final DeltaDeltaCodecDefinition INSTANCE = new DeltaDeltaCodecDefinition();
+
+  /// Singleton options — DELTADELTA has no configurable parameters.
+  public static final Options OPTIONS = new Options();
+
+  private DeltaDeltaCodecDefinition() {
+  }
+
+  /// Typed options for [DeltaDeltaCodecDefinition]. DELTADELTA has no configurable parameters.
+  public static final class Options implements CodecOptions {
+    private Options() {
+    }
+  }
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+
+  @Override
+  public Options parseOptions(List<String> args) {
+    if (!args.isEmpty()) {
+      throw new IllegalArgumentException("DELTADELTA codec takes no arguments but got: " + args);
+    }
+    return OPTIONS;
+  }
+
+  @Override
+  public String canonicalize(Options options) {
+    return NAME;
+  }
+
+  @Override
+  protected ByteBuffer encodeInt(ByteBuffer src, int count) {
+    ByteBuffer out = ByteBuffer.allocateDirect(count * Integer.BYTES);
+    if (count == 0) {
+      out.flip();
+      return out;
+    }
+    int prev = src.getInt();
+    out.putInt(prev);
+    if (count == 1) {
+      out.flip();
+      return out;
+    }
+    int prevDelta = src.getInt() - prev;
+    out.putInt(prevDelta);
+    prev += prevDelta;
+    for (int i = 2; i < count; i++) {
+      int cur = src.getInt();
+      int curDelta = cur - prev;
+      out.putInt(curDelta - prevDelta);
+      prev = cur;
+      prevDelta = curDelta;
+    }
+    out.flip();
+    return out;
+  }
+
+  @Override
+  protected ByteBuffer encodeLong(ByteBuffer src, int count) {
+    ByteBuffer out = ByteBuffer.allocateDirect(count * Long.BYTES);
+    if (count == 0) {
+      out.flip();
+      return out;
+    }
+    long prev = src.getLong();
+    out.putLong(prev);
+    if (count == 1) {
+      out.flip();
+      return out;
+    }
+    long prevDelta = src.getLong() - prev;
+    out.putLong(prevDelta);
+    prev += prevDelta;
+    for (int i = 2; i < count; i++) {
+      long cur = src.getLong();
+      long curDelta = cur - prev;
+      out.putLong(curDelta - prevDelta);
+      prev = cur;
+      prevDelta = curDelta;
+    }
+    out.flip();
+    return out;
+  }
+
+  @Override
+  protected ByteBuffer decodeInt(ByteBuffer src, int count) {
+    ByteBuffer out = ByteBuffer.allocateDirect(count * Integer.BYTES);
+    int prev = src.getInt();
+    out.putInt(prev);
+    if (count > 1) {
+      int prevDelta = src.getInt();
+      prev += prevDelta;
+      out.putInt(prev);
+      for (int i = 2; i < count; i++) {
+        int dod = src.getInt();
+        prevDelta += dod;
+        prev += prevDelta;
+        out.putInt(prev);
+      }
+    }
+    out.flip();
+    return out;
+  }
+
+  @Override
+  protected ByteBuffer decodeLong(ByteBuffer src, int count) {
+    ByteBuffer out = ByteBuffer.allocateDirect(count * Long.BYTES);
+    long prev = src.getLong();
+    out.putLong(prev);
+    if (count > 1) {
+      long prevDelta = src.getLong();
+      prev += prevDelta;
+      out.putLong(prev);
+      for (int i = 2; i < count; i++) {
+        long dod = src.getLong();
+        prevDelta += dod;
+        prev += prevDelta;
+        out.putLong(prev);
+      }
+    }
+    out.flip();
+    return out;
+  }
+
+  @Override
+  protected void decodeIntInto(ByteBuffer src, int count, ByteBuffer dst) {
+    int prev = src.getInt();
+    dst.putInt(prev);
+    if (count > 1) {
+      int prevDelta = src.getInt();
+      prev += prevDelta;
+      dst.putInt(prev);
+      for (int i = 2; i < count; i++) {
+        int dod = src.getInt();
+        prevDelta += dod;
+        prev += prevDelta;
+        dst.putInt(prev);
+      }
+    }
+  }
+
+  @Override
+  protected void decodeLongInto(ByteBuffer src, int count, ByteBuffer dst) {
+    long prev = src.getLong();
+    dst.putLong(prev);
+    if (count > 1) {
+      long prevDelta = src.getLong();
+      prev += prevDelta;
+      dst.putLong(prev);
+      for (int i = 2; i < count; i++) {
+        long dod = src.getLong();
+        prevDelta += dod;
+        prev += prevDelta;
+        dst.putLong(prev);
+      }
+    }
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/CodecPipelineValidatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/CodecPipelineValidatorTest.java
@@ -30,8 +30,9 @@ import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 
-/// Tests for [CodecPipelineValidator]. Synthetic transform handlers keep this layer independent
-/// from the concrete transform implementations introduced by later stacked pull requests.
+/// Tests for [CodecPipelineValidator]. Synthetic transform handlers keep the structural rules
+/// testable independently of the concrete transforms; the DELTA/DELTADELTA scenarios exercise the
+/// real typed-layout-preserving transforms against [CodecRegistry#DEFAULT].
 public class CodecPipelineValidatorTest {
   private static final TestCodecHandler TYPED_TRANSFORM =
       new TestCodecHandler("TYPED", CodecKind.TRANSFORM, true);
@@ -107,11 +108,78 @@ public class CodecPipelineValidatorTest {
     assertTrue(TYPED_TRANSFORM.preservesTypedValueLayout());
     assertFalse(PACKING_TRANSFORM.preservesTypedValueLayout());
     assertFalse(Lz4CodecDefinition.INSTANCE.preservesTypedValueLayout());
+    // DELTA/DELTADELTA output a same-width typed value array, so they may be chained ahead of
+    // another transform (or each other).
+    assertTrue(DeltaCodecDefinition.INSTANCE.preservesTypedValueLayout());
+    assertTrue(DeltaDeltaCodecDefinition.INSTANCE.preservesTypedValueLayout());
+  }
+
+  // -------------------------------------------------------------------------
+  // DELTA / DELTADELTA — the real typed-layout-preserving transforms, resolved
+  // through the production CodecRegistry.DEFAULT
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void testDeltaPipelinesAreValid() {
+    validateWithDefaultRegistry("DELTA", DataType.INT);
+    validateWithDefaultRegistry("DELTA", DataType.LONG);
+    validateWithDefaultRegistry("DELTADELTA", DataType.INT);
+    validateWithDefaultRegistry("DELTADELTA", DataType.LONG);
+    validateWithDefaultRegistry("DELTA,LZ4", DataType.INT);
+    validateWithDefaultRegistry("DELTA,ZSTD(3)", DataType.INT);
+    validateWithDefaultRegistry("DELTADELTA,SNAPPY", DataType.LONG);
+    validateWithDefaultRegistry("DELTADELTA,ZSTD(8)", DataType.LONG);
+  }
+
+  /// Typed-layout-preserving transforms may be chained in any order, including with themselves,
+  /// optionally followed by any number of compression stages.
+  @Test
+  public void testTypedLayoutTransformChainingAllowed() {
+    validateWithDefaultRegistry("DELTA,DELTADELTA,LZ4", DataType.INT);
+    validateWithDefaultRegistry("DELTA,DELTA,LZ4", DataType.INT);
+    validateWithDefaultRegistry("DELTA,DELTADELTA", DataType.INT);
+    validateWithDefaultRegistry("DELTADELTA,DELTA,ZSTD(3)", DataType.LONG);
+    validateWithDefaultRegistry("DELTA,LZ4,ZSTD(3)", DataType.INT);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class,
+      expectedExceptionsMessageRegExp = ".*must operate on column values.*")
+  public void testDeltaAfterCompressionRejected() {
+    // ZSTD before DELTA is wrong: DELTA cannot consume compressed bytes
+    validateWithDefaultRegistry("ZSTD(3),DELTA", DataType.INT);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class,
+      expectedExceptionsMessageRegExp = ".*DELTA codec only supports INT and LONG.*")
+  public void testDeltaOnStringColumn() {
+    validateWithDefaultRegistry("DELTA", DataType.STRING);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class,
+      expectedExceptionsMessageRegExp = ".*DELTA codec only supports INT and LONG.*")
+  public void testDeltaOnDoubleColumn() {
+    validateWithDefaultRegistry("DELTA", DataType.DOUBLE);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class,
+      expectedExceptionsMessageRegExp = ".*DELTADELTA codec only supports INT and LONG.*")
+  public void testDeltaDeltaOnStringColumn() {
+    validateWithDefaultRegistry("DELTADELTA", DataType.STRING);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testDeltaRejectsArguments() {
+    validateWithDefaultRegistry("DELTA(1)", DataType.INT);
   }
 
   private static void validate(String spec, DataType dataType) {
     CodecPipeline pipeline = CodecSpecParser.parse(spec);
     CodecPipelineValidator.validate(pipeline, REGISTRY, new CodecContext(dataType));
+  }
+
+  private static void validateWithDefaultRegistry(String spec, DataType dataType) {
+    CodecPipeline pipeline = CodecSpecParser.parse(spec);
+    CodecPipelineValidator.validate(pipeline, CodecRegistry.DEFAULT, new CodecContext(dataType));
   }
 
   private static final class TestCodecHandler implements ChunkCodecHandler<CodecOptions> {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/CodecRegistryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/CodecRegistryTest.java
@@ -36,13 +36,14 @@ import static org.testng.Assert.expectThrows;
 public class CodecRegistryTest {
 
   @Test
-  public void testDefaultRegistryContainsOnlyCompressionHandlersAndAlias() {
+  public void testDefaultRegistryContainsBuiltInHandlersAndAlias() {
     assertSame(CodecRegistry.DEFAULT.get("lz4"), Lz4CodecDefinition.INSTANCE);
     assertSame(CodecRegistry.DEFAULT.get("SNAPPY"), SnappyCodecDefinition.INSTANCE);
     assertSame(CodecRegistry.DEFAULT.get("gzip"), GzipCodecDefinition.INSTANCE);
     assertSame(CodecRegistry.DEFAULT.get("zstd"), ZstdCodecDefinition.INSTANCE);
     assertSame(CodecRegistry.DEFAULT.get("zstandard"), ZstdCodecDefinition.INSTANCE);
-    assertNull(CodecRegistry.DEFAULT.get("DELTA"));
+    assertSame(CodecRegistry.DEFAULT.get("delta"), DeltaCodecDefinition.INSTANCE);
+    assertSame(CodecRegistry.DEFAULT.get("DELTADELTA"), DeltaDeltaCodecDefinition.INSTANCE);
     assertNull(CodecRegistry.DEFAULT.get("T64"));
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/CompressionCodecCorruptInputTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/CompressionCodecCorruptInputTest.java
@@ -193,10 +193,9 @@ public class CompressionCodecCorruptInputTest {
 
   @Test
   public void testMultiStageDecodeBoundsInnerSnappyOutput() throws Exception {
-    // A valid Snappy frame that expands to 1 MiB is far larger than the LZ4-encoded intermediate
-    // for the four-byte final chunk declared by the outer format. The executor must use
-    // Snappy.decodeInto() with scratch derived from LZ4's bound instead of allocating from the
-    // inner Snappy header.
+    // A valid Snappy frame that expands to 1 MiB is far larger than the four-byte final INT
+    // chunk declared by the outer format. The executor must use Snappy.decodeInto() with a
+    // four-byte scratch bound instead of letting Snappy.decode() allocate from its inner header.
     byte[] compressed = Snappy.compress(new byte[1024 * 1024]);
     // Keep only a small prefix: it contains Snappy's claimed decoded length and stays below the
     // executor's outer encoded-size bound, so this specifically exercises the inner-frame guard.
@@ -204,7 +203,7 @@ public class CompressionCodecCorruptInputTest {
     encoded.put(compressed, 0, encoded.capacity()).flip();
     ByteBuffer decoded = ByteBuffer.allocateDirect(Integer.BYTES);
     CodecPipelineExecutor executor = CodecPipelineExecutor.create(
-        "LZ4,SNAPPY", CTX, CodecRegistry.DEFAULT);
+        "DELTA,SNAPPY", CTX, CodecRegistry.DEFAULT);
 
     IllegalArgumentException exception = expectThrows(IllegalArgumentException.class,
         () -> executor.decode(encoded, decoded, Integer.BYTES));

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/DeltaCodecRoundTripTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/DeltaCodecRoundTripTest.java
@@ -1,0 +1,244 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.io.codec;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+
+/// Round-trip coverage for the DELTA and DELTADELTA transform codecs driven through
+/// [CodecPipelineExecutor] encode/decode, over INT and LONG value arrays.
+///
+/// The V7 on-disk format does not exist yet at this point in the stack, so this test is the direct
+/// coverage of the delta arithmetic. It locks in the two's-complement wrap-around contract of
+/// [BaseDeltaCodecDefinition]: overflow-adjacent sequences (e.g. `MIN_VALUE` next to `MAX_VALUE`)
+/// must round-trip bit-for-bit through the wrapping `-`/`+` encode/decode helpers.
+public class DeltaCodecRoundTripTest {
+
+  private static final CodecContext INT_CTX = new CodecContext(DataType.INT);
+  private static final CodecContext LONG_CTX = new CodecContext(DataType.LONG);
+
+  /// Bare transforms exercise the single-stage decode path; the `,LZ4` chains exercise the
+  /// multi-stage path where the compression stage decodes into a bounded intermediate buffer.
+  private static final String[] SPECS = {"DELTA", "DELTADELTA", "DELTA,LZ4", "DELTADELTA,LZ4"};
+
+  private static final int[][] INT_DATASETS = {
+      // empty
+      {},
+      // single element
+      {42},
+      // two elements (DELTADELTA boundary: first delta present, delta-of-delta loop empty)
+      {3, -7},
+      // constant (all deltas and delta-of-deltas are zero)
+      {7, 7, 7, 7, 7},
+      // monotonic with regular then irregular strides
+      {1, 2, 3, 4, 5, 100, 1000, 1001},
+      // negative values and sign changes
+      {-5, -4, -10, 0, 3, -100, Integer.MIN_VALUE / 2},
+      // overflow-adjacent: deltas wrap around two's-complement and must still round-trip
+      {Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MIN_VALUE + 1, -1, 0, 1, Integer.MAX_VALUE - 1},
+  };
+
+  private static final long[][] LONG_DATASETS = {
+      // empty
+      {},
+      // single element
+      {42L},
+      // two elements (DELTADELTA boundary: first delta present, delta-of-delta loop empty)
+      {3L, -7L},
+      // constant (all deltas and delta-of-deltas are zero)
+      {7L, 7L, 7L, 7L, 7L},
+      // timestamp-like monotonic sequence with a jitter
+      {1700000000000L, 1700000000010L, 1700000000020L, 1700000000031L, 1700000000040L},
+      // negative values and sign changes
+      {-5L, -4L, -10L, 0L, 3L, -100L, Long.MIN_VALUE / 2},
+      // overflow-adjacent: deltas wrap around two's-complement and must still round-trip
+      {Long.MIN_VALUE, Long.MAX_VALUE, Long.MIN_VALUE + 1, -1L, 0L, 1L, Long.MAX_VALUE - 1},
+  };
+
+  @Test
+  public void testIntRoundTrip() throws IOException {
+    for (String spec : SPECS) {
+      for (int[] values : INT_DATASETS) {
+        assertIntRoundTrip(spec, values);
+      }
+    }
+  }
+
+  @Test
+  public void testLongRoundTrip() throws IOException {
+    for (String spec : SPECS) {
+      for (long[] values : LONG_DATASETS) {
+        assertLongRoundTrip(spec, values);
+      }
+    }
+  }
+
+  /// Decodes fixed byte sequences without consulting either encoder. These fixtures freeze the
+  /// persisted big-endian layout so an encoder/decoder pair cannot drift together unnoticed.
+  @Test
+  public void testStableDecodeFixtures() throws IOException {
+    assertIntDecodeFixture("DELTA", new byte[]{
+        0, 0, 0, 10,
+        0, 0, 0, 3,
+        -1, -1, -1, -5
+    }, new int[]{10, 13, 8});
+    assertLongDecodeFixture("DELTA", new byte[]{
+        0, 0, 0, 0, 0, 0, 0, 10,
+        0, 0, 0, 0, 0, 0, 0, 3,
+        -1, -1, -1, -1, -1, -1, -1, -5
+    }, new long[]{10, 13, 8});
+
+    assertIntDecodeFixture("DELTADELTA", new byte[]{
+        0, 0, 0, 10,
+        0, 0, 0, 3,
+        -1, -1, -1, -2
+    }, new int[]{10, 13, 14});
+    assertLongDecodeFixture("DELTADELTA", new byte[]{
+        0, 0, 0, 0, 0, 0, 0, 10,
+        0, 0, 0, 0, 0, 0, 0, 3,
+        -1, -1, -1, -1, -1, -1, -1, -2
+    }, new long[]{10, 13, 14});
+  }
+
+  /// A frame whose byte length is not a whole number of elements is corrupt and must fail closed
+  /// on both the encode and the bounded segment-reader decode path.
+  @Test
+  public void testMisalignedFrameRejected() {
+    CodecPipelineExecutor executor = CodecPipelineExecutor.create("DELTA", INT_CTX, CodecRegistry.DEFAULT);
+    ByteBuffer misaligned = ByteBuffer.allocateDirect(3);
+    misaligned.put((byte) 1).put((byte) 2).put((byte) 3).flip();
+
+    IllegalArgumentException encodeException = expectThrows(IllegalArgumentException.class,
+        () -> executor.encode(misaligned.duplicate()));
+    assertTrue(encodeException.getMessage().contains("not a multiple of element size"),
+        encodeException.getMessage());
+
+    ByteBuffer dst = ByteBuffer.allocateDirect(Integer.BYTES);
+    IllegalArgumentException decodeException = expectThrows(IllegalArgumentException.class,
+        () -> executor.decode(misaligned.duplicate(), dst, Integer.BYTES));
+    assertTrue(decodeException.getMessage().contains("not a multiple of element size"),
+        decodeException.getMessage());
+  }
+
+  private static void assertIntRoundTrip(String spec, int[] values) throws IOException {
+    CodecPipelineExecutor executor = CodecPipelineExecutor.create(spec, INT_CTX, CodecRegistry.DEFAULT);
+    int decodedSize = values.length * Integer.BYTES;
+    ByteBuffer src = ByteBuffer.allocateDirect(decodedSize);
+    for (int value : values) {
+      src.putInt(value);
+    }
+    src.flip();
+    ByteBuffer encoded = executor.encode(src.duplicate());
+
+    // Allocating decode path.
+    int[] decoded = readInts(executor.decode(encoded.duplicate()), values.length);
+    assertTrue(Arrays.equals(decoded, values),
+        describeMismatch(spec, Arrays.toString(values), Arrays.toString(decoded)));
+
+    // Bounded decode-into path (the segment-reader entry point).
+    ByteBuffer dst = ByteBuffer.allocateDirect(decodedSize);
+    executor.decode(encoded.duplicate(), dst, decodedSize);
+    int[] decodedInto = readInts(dst, values.length);
+    assertTrue(Arrays.equals(decodedInto, values),
+        describeMismatch(spec, Arrays.toString(values), Arrays.toString(decodedInto)));
+  }
+
+  private static void assertLongRoundTrip(String spec, long[] values) throws IOException {
+    CodecPipelineExecutor executor = CodecPipelineExecutor.create(spec, LONG_CTX, CodecRegistry.DEFAULT);
+    int decodedSize = values.length * Long.BYTES;
+    ByteBuffer src = ByteBuffer.allocateDirect(decodedSize);
+    for (long value : values) {
+      src.putLong(value);
+    }
+    src.flip();
+    ByteBuffer encoded = executor.encode(src.duplicate());
+
+    // Allocating decode path.
+    long[] decoded = readLongs(executor.decode(encoded.duplicate()), values.length);
+    assertTrue(Arrays.equals(decoded, values),
+        describeMismatch(spec, Arrays.toString(values), Arrays.toString(decoded)));
+
+    // Bounded decode-into path (the segment-reader entry point).
+    ByteBuffer dst = ByteBuffer.allocateDirect(decodedSize);
+    executor.decode(encoded.duplicate(), dst, decodedSize);
+    long[] decodedInto = readLongs(dst, values.length);
+    assertTrue(Arrays.equals(decodedInto, values),
+        describeMismatch(spec, Arrays.toString(values), Arrays.toString(decodedInto)));
+  }
+
+  private static void assertIntDecodeFixture(String spec, byte[] encoded, int[] expected) throws IOException {
+    CodecPipelineExecutor executor = CodecPipelineExecutor.create(spec, INT_CTX, CodecRegistry.DEFAULT);
+    int[] decoded = readInts(
+        executor.decode(ByteBuffer.wrap(encoded).order(ByteOrder.LITTLE_ENDIAN)), expected.length);
+    assertTrue(Arrays.equals(decoded, expected),
+        describeMismatch(spec, Arrays.toString(expected), Arrays.toString(decoded)));
+
+    ByteBuffer dst = ByteBuffer.allocateDirect(expected.length * Integer.BYTES);
+    executor.decode(ByteBuffer.wrap(encoded).order(ByteOrder.LITTLE_ENDIAN), dst, dst.capacity());
+    int[] decodedInto = readInts(dst, expected.length);
+    assertTrue(Arrays.equals(decodedInto, expected),
+        describeMismatch(spec, Arrays.toString(expected), Arrays.toString(decodedInto)));
+  }
+
+  private static void assertLongDecodeFixture(String spec, byte[] encoded, long[] expected) throws IOException {
+    CodecPipelineExecutor executor = CodecPipelineExecutor.create(spec, LONG_CTX, CodecRegistry.DEFAULT);
+    long[] decoded = readLongs(
+        executor.decode(ByteBuffer.wrap(encoded).order(ByteOrder.LITTLE_ENDIAN)), expected.length);
+    assertTrue(Arrays.equals(decoded, expected),
+        describeMismatch(spec, Arrays.toString(expected), Arrays.toString(decoded)));
+
+    ByteBuffer dst = ByteBuffer.allocateDirect(expected.length * Long.BYTES);
+    executor.decode(ByteBuffer.wrap(encoded).order(ByteOrder.LITTLE_ENDIAN), dst, dst.capacity());
+    long[] decodedInto = readLongs(dst, expected.length);
+    assertTrue(Arrays.equals(decodedInto, expected),
+        describeMismatch(spec, Arrays.toString(expected), Arrays.toString(decodedInto)));
+  }
+
+  private static int[] readInts(ByteBuffer buffer, int expectedCount) {
+    assertTrue(buffer.remaining() == expectedCount * Integer.BYTES,
+        "Decoded size " + buffer.remaining() + " != expected " + expectedCount * Integer.BYTES);
+    int[] values = new int[expectedCount];
+    for (int i = 0; i < expectedCount; i++) {
+      values[i] = buffer.getInt();
+    }
+    return values;
+  }
+
+  private static long[] readLongs(ByteBuffer buffer, int expectedCount) {
+    assertTrue(buffer.remaining() == expectedCount * Long.BYTES,
+        "Decoded size " + buffer.remaining() + " != expected " + expectedCount * Long.BYTES);
+    long[] values = new long[expectedCount];
+    for (int i = 0; i < expectedCount; i++) {
+      values[i] = buffer.getLong();
+    }
+    return values;
+  }
+
+  private static String describeMismatch(String spec, String expected, String actual) {
+    return "Round trip through '" + spec + "' failed: expected " + expected + " but got " + actual;
+  }
+}


### PR DESCRIPTION
## Context

Stacked on #19285 and part of the split of #18229.

## What changed

- Adds `DELTA` and `DELTADELTA` as typed-layout-preserving INT/LONG transforms.
- Keeps the output headerless and the same width/count as the input so transforms can be chained before packing or compression.
- Defines intentional two's-complement modular arithmetic for overflow-adjacent values.
- Registers both frozen codec names in the closed runtime registry.
- Makes persisted decoding explicitly big-endian, independent of a caller view's byte order.

## Safety and scope

Registering DELTA/DELTADELTA makes them available to the bounded runtime API, but production forward-index creation/loading is not wired until #19307. This slice changes no segment format or production I/O path.

## Verification

- INT/LONG round trips for empty, boundary, monotonic, negative, sign-changing, and overflow-adjacent data.
- Allocating and bounded `decodeInto` paths, transform chains, and malformed-width rejection.
- Stable hand-authored decode fixtures that pin DELTA and DELTADELTA wire bytes independently of the encoders.
- Little-endian caller-view regressions proving big-endian persisted decoding.
- Spotless, Checkstyle, license format, and license check for `pinot-segment-local`.

## Stack

#19284 → #19285 → **#19305 (this PR)** → #19306 → #19307 → #19308 → #19309

Review and merge parent-first.
