### PR TITLE
Add T64 and GORILLA packing transform codecs

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/CodecRegistry.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/CodecRegistry.java
@@ -52,6 +52,8 @@ final class CodecRegistry {
     Map<String, ChunkCodecHandler<?>> m = new LinkedHashMap<>();
     m.put(DeltaCodecDefinition.INSTANCE.name().toUpperCase(Locale.ROOT), DeltaCodecDefinition.INSTANCE);
     m.put(DeltaDeltaCodecDefinition.INSTANCE.name().toUpperCase(Locale.ROOT), DeltaDeltaCodecDefinition.INSTANCE);
+    m.put(T64CodecDefinition.INSTANCE.name().toUpperCase(Locale.ROOT), T64CodecDefinition.INSTANCE);
+    m.put(GorillaCodecDefinition.INSTANCE.name().toUpperCase(Locale.ROOT), GorillaCodecDefinition.INSTANCE);
     m.put(ZstdCodecDefinition.INSTANCE.name().toUpperCase(Locale.ROOT), ZstdCodecDefinition.INSTANCE);
     // Accept the legacy enum spelling ZSTANDARD as an alias for ZSTD so users familiar with
     // FieldConfig.CompressionCodec.ZSTANDARD aren't blocked. Canonicalization still emits "ZSTD",

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/GorillaCodecDefinition.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/GorillaCodecDefinition.java
@@ -1,0 +1,450 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.io.codec;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.List;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+
+
+/// Gorilla-style XOR compression transform for SV INT/LONG, adapted from
+/// "Gorilla: A Fast, Scalable, In-Memory Time Series Database" (Facebook, VLDB 2015).
+///
+/// DSL form: `GORILLA` (no arguments)
+///
+/// Stateless and thread-safe; the [#INSTANCE] singleton is shared across all columns.
+///
+/// For each value v_i (i > 0):
+/// - Compute `x = v_i XOR v_{i-1}`.
+/// - If `x == 0`: write a single `0` bit.
+/// - Else: write `1` bit + meaningful-bit window metadata + the meaningful bits themselves.
+///   - If the new window is contained inside the previous window, write a `0` control bit followed
+///     by the bits selected with that previous window.
+///   - Otherwise, write a `1` control bit, the leading-zero count (5 bits for INT, 6 bits for
+///     LONG), the meaningful-bit count minus one (5/6 bits), and the meaningful bits.
+///
+/// Wire format:
+/// ```
+///   [flag : 1 byte]     // 0=INT (32-bit), 1=LONG (64-bit)
+///   [count: 4 bytes BE]          // total number of values
+///   [first: elementSize bytes BE] // verbatim first value (if count > 0)
+///   [bit_stream: N bytes]         // MSB-first per-value encoding (if count > 1)
+/// ```
+/// `count == 0` is the 5-byte header with no payload.
+///
+/// **Chainability.** Unlike the typed-layout-preserving DELTA/DELTADELTA transforms, Gorilla is a packing
+/// transform: it consumes column-typed input and produces a headered byte frame. It must be the
+/// last transform, but one or more byte-compression stages may follow (e.g. `GORILLA,LZ4`).
+final class GorillaCodecDefinition implements ChunkCodecHandler<GorillaCodecDefinition.Options> {
+
+  /// On-disk permanent name stored verbatim in segment file headers.
+  /// This string is a frozen on-disk API contract and must never be changed.
+  public static final String NAME = "GORILLA";
+
+  public static final GorillaCodecDefinition INSTANCE = new GorillaCodecDefinition();
+
+  /// Singleton options — GORILLA has no configurable parameters.
+  public static final Options OPTIONS = new Options();
+
+  private GorillaCodecDefinition() {
+  }
+
+  /// Typed options for [GorillaCodecDefinition]. GORILLA has no configurable parameters.
+  public static final class Options implements CodecOptions {
+    private Options() {
+    }
+  }
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+
+  @Override
+  public CodecKind kind() {
+    return CodecKind.TRANSFORM;
+  }
+
+  @Override
+  public Options parseOptions(List<String> args) {
+    if (!args.isEmpty()) {
+      throw new IllegalArgumentException("GORILLA codec takes no arguments but got: " + args);
+    }
+    return OPTIONS;
+  }
+
+  @Override
+  public void validateContext(Options options, CodecContext ctx) {
+    DataType dt = ctx.getDataType();
+    if (dt != DataType.INT && dt != DataType.LONG) {
+      throw new IllegalArgumentException(
+          "GORILLA codec only supports INT and LONG columns, but column has type: " + dt);
+    }
+  }
+
+  @Override
+  public String canonicalize(Options options) {
+    return NAME;
+  }
+
+  @Override
+  public boolean requiresDirectDstBuffer() {
+    return false;
+  }
+
+  @Override
+  public int maxEncodedSize(Options options, int inputSize) {
+    // Worst case: every value is incompressible XOR → control bits + leading + width + full bits.
+    // Approx 2*elementBits + 13 bits per value. Round up generously to elementBits * 2 + 16 bits.
+    // Cheap upper bound: header + 2 * inputSize bytes.
+    if (inputSize < 0) {
+      throw new IllegalArgumentException("GORILLA inputSize must be non-negative: " + inputSize);
+    }
+    long bound = 1L + Integer.BYTES + 2L * inputSize + 16;
+    if (bound > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException("GORILLA maximum encoded size exceeds Integer.MAX_VALUE: " + bound);
+    }
+    return (int) bound;
+  }
+
+  @Override
+  public ByteBuffer encode(Options options, CodecContext ctx, ByteBuffer src) {
+    int remaining = src.remaining();
+    DataType dt = ctx.getDataType();
+    if (dt != DataType.INT && dt != DataType.LONG) {
+      throw new IllegalArgumentException("GORILLA does not support stored type: " + dt);
+    }
+    int elementSize = dt.size();
+    if (remaining % elementSize != 0) {
+      throw new IllegalArgumentException(
+          "GORILLA: input buffer size (" + remaining + ") is not a multiple of element size ("
+              + elementSize + ")");
+    }
+    int count = remaining / elementSize;
+    boolean isLong = dt == DataType.LONG;
+    int elementBits = elementSize * 8;
+    int leadingBits = isLong ? 6 : 5;
+    int widthBits = isLong ? 6 : 5;
+
+    ByteBuffer out = ByteBuffer.allocateDirect(maxEncodedSize(options, remaining));
+    out.put((byte) (isLong ? 1 : 0));
+    out.putInt(count);
+    if (count == 0) {
+      out.flip();
+      return out;
+    }
+
+    // First value verbatim
+    long prev = isLong ? src.getLong() : (long) src.getInt();
+    if (isLong) {
+      out.putLong(prev);
+    } else {
+      out.putInt((int) prev);
+    }
+    if (count == 1) {
+      out.flip();
+      return out;
+    }
+
+    BitWriter writer = new BitWriter(out);
+    int prevLeading = -1; // sentinel: no previous window
+    int prevWidth = -1;
+
+    for (int i = 1; i < count; i++) {
+      long cur = isLong ? src.getLong() : (long) src.getInt();
+      long x = cur ^ prev;
+      if (x == 0) {
+        writer.writeBit(0);
+      } else {
+        writer.writeBit(1);
+        int leading;
+        int width;
+        int trailing;
+        // The `x == 0` branch above guarantees x has at least one set bit, so leading and
+        // trailing each return a value strictly less than the element width — no clamp needed.
+        if (isLong) {
+          leading = Long.numberOfLeadingZeros(x);
+          trailing = Long.numberOfTrailingZeros(x);
+          width = 64 - leading - trailing;
+        } else {
+          int xInt = (int) x;
+          leading = Integer.numberOfLeadingZeros(xInt);
+          trailing = Integer.numberOfTrailingZeros(xInt);
+          width = 32 - leading - trailing;
+        }
+        if (prevLeading >= 0 && leading >= prevLeading
+            && (leading + width) <= (prevLeading + prevWidth)) {
+          // Reuse previous window
+          writer.writeBit(0);
+          // Re-extract bits using previous (leading, width)
+          long prevMask = (prevWidth == 64) ? -1L : ((1L << prevWidth) - 1L);
+          long meaningful = (x >>> (elementBits - prevLeading - prevWidth)) & prevMask;
+          writer.writeBits(meaningful, prevWidth);
+        } else {
+          writer.writeBit(1);
+          writer.writeBits(leading, leadingBits);
+          // Width stored as (width - 1) using widthBits: values 1..(2^widthBits) map to 0..(2^widthBits - 1).
+          int widthEncoded = width - 1;
+          writer.writeBits(widthEncoded, widthBits);
+          long widthMask = (width == 64) ? -1L : ((1L << width) - 1L);
+          long meaningful = (x >>> (elementBits - leading - width)) & widthMask;
+          writer.writeBits(meaningful, width);
+          prevLeading = leading;
+          prevWidth = width;
+        }
+      }
+      prev = cur;
+    }
+
+    writer.flush();
+    out.flip();
+    return out;
+  }
+
+  @Override
+  public ByteBuffer decode(Options options, CodecContext ctx, ByteBuffer src) {
+    src = src.duplicate().order(ByteOrder.BIG_ENDIAN);
+    byte flag = src.get();
+    int count = src.getInt();
+    validateHeader(flag, count, ctx);
+    if (count == 0) {
+      ensureFullyConsumed(src);
+      return ByteBuffer.allocateDirect(0);
+    }
+    boolean isLong = flag == 1;
+    int elementSize = isLong ? Long.BYTES : Integer.BYTES;
+    ByteBuffer out = ByteBuffer.allocateDirect(decodedSize(count, elementSize));
+    decodeValues(src, count, isLong, out);
+    out.flip();
+    return out;
+  }
+
+  @Override
+  public void decodeInto(Options options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) {
+    src = src.duplicate().order(ByteOrder.BIG_ENDIAN);
+    dst.clear();
+    byte flag = src.get();
+    int count = src.getInt();
+    validateHeader(flag, count, ctx);
+    if (count == 0) {
+      ensureFullyConsumed(src);
+      dst.flip();
+      return;
+    }
+    boolean isLong = flag == 1;
+    int elementSize = isLong ? Long.BYTES : Integer.BYTES;
+    long requiredCapacity = (long) count * elementSize;
+    if (requiredCapacity > dst.capacity()) {
+      throw new IllegalArgumentException(
+          "GORILLA: decoded size " + requiredCapacity + " exceeds dst capacity " + dst.capacity());
+    }
+    decodeValues(src, count, isLong, dst);
+    dst.flip();
+  }
+
+  /// Validate the frame header: count must be ≥ 0 and flag must be a known type. Validating
+  /// **both** unconditionally (before any count-based short-circuit) means a corrupt segment
+  /// with `flag=42, count=0` is rejected rather than silently decoding to empty.
+  private static void validateHeader(byte flag, int count, CodecContext ctx) {
+    if (count < 0) {
+      throw new IllegalStateException(
+          "GORILLA: invalid count in header: " + count + ". Segment may be corrupt.");
+    }
+    if (flag != 0 && flag != 1) {
+      throw new IllegalStateException(
+          "Unknown GORILLA type flag: " + flag + ". Expected 0 (INT) or 1 (LONG). Segment may be corrupt.");
+    }
+    DataType dataType = ctx.getDataType();
+    if (dataType != DataType.INT && dataType != DataType.LONG) {
+      throw new IllegalStateException("GORILLA cannot decode column type " + dataType);
+    }
+    byte expectedFlag = dataType == DataType.LONG ? (byte) 1 : (byte) 0;
+    if (flag != expectedFlag) {
+      throw new IllegalStateException(
+          "GORILLA frame type " + (flag == 1 ? "LONG" : "INT") + " does not match column type "
+              + dataType + ". Segment may be corrupt.");
+    }
+  }
+
+  private static void decodeValues(ByteBuffer src, int count, boolean isLong, ByteBuffer dst) {
+    int elementBits = isLong ? 64 : 32;
+    int leadingBits = isLong ? 6 : 5;
+    int widthBits = isLong ? 6 : 5;
+
+    long prev = isLong ? src.getLong() : (long) src.getInt();
+    if (isLong) {
+      dst.putLong(prev);
+    } else {
+      dst.putInt((int) prev);
+    }
+    if (count == 1) {
+      ensureFullyConsumed(src);
+      return;
+    }
+
+    BitReader reader = new BitReader(src);
+    int prevLeading = -1;
+    int prevWidth = -1;
+    for (int i = 1; i < count; i++) {
+      int bit = reader.readBit();
+      if (bit == 0) {
+        if (isLong) {
+          dst.putLong(prev);
+        } else {
+          dst.putInt((int) prev);
+        }
+      } else {
+        int control = reader.readBit();
+        int leading;
+        int width;
+        if (control == 0) {
+          if (prevLeading < 0) {
+            throw new IllegalStateException(
+                "GORILLA: window-reuse before any explicit window. Segment may be corrupt.");
+          }
+          leading = prevLeading;
+          width = prevWidth;
+        } else {
+          leading = (int) reader.readBits(leadingBits);
+          width = (int) reader.readBits(widthBits) + 1;
+          prevLeading = leading;
+          prevWidth = width;
+        }
+        // Encode-side guarantees width ≥ 1 (explicit window stores width-1; reuse copies a
+        // previously-explicit width). Validate `leading + width` against elementBits to reject
+        // corrupt segments whose explicit-window header decodes to an out-of-range pair.
+        if (leading + width > elementBits) {
+          throw new IllegalStateException(
+              "GORILLA: invalid window leading=" + leading + " width=" + width + ". Segment may be corrupt.");
+        }
+        long meaningful = reader.readBits(width);
+        long x = meaningful << (elementBits - leading - width);
+        long cur = prev ^ x;
+        if (isLong) {
+          dst.putLong(cur);
+        } else {
+          dst.putInt((int) cur);
+        }
+        prev = cur;
+      }
+    }
+    reader.ensureFullyConsumed();
+  }
+
+  private static int decodedSize(int count, int elementSize) {
+    long decodedSize = (long) count * elementSize;
+    if (decodedSize > Integer.MAX_VALUE) {
+      throw new IllegalStateException(
+          "GORILLA: decoded size " + decodedSize + " exceeds Integer.MAX_VALUE. Segment may be corrupt.");
+    }
+    return (int) decodedSize;
+  }
+
+  private static void ensureFullyConsumed(ByteBuffer src) {
+    if (src.hasRemaining()) {
+      throw new IllegalStateException(
+          "GORILLA: trailing " + src.remaining() + " byte(s) after frame. Segment may be corrupt.");
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Bit-stream helpers (MSB-first within each byte)
+  // -------------------------------------------------------------------------
+
+  private static final class BitWriter {
+    private final ByteBuffer _out;
+    private int _byteAccumulator;
+    private int _bitsInAccumulator;
+
+    BitWriter(ByteBuffer out) {
+      _out = out;
+      _byteAccumulator = 0;
+      _bitsInAccumulator = 0;
+    }
+
+    void writeBit(int bit) {
+      _byteAccumulator = (_byteAccumulator << 1) | (bit & 1);
+      _bitsInAccumulator++;
+      if (_bitsInAccumulator == 8) {
+        _out.put((byte) _byteAccumulator);
+        _byteAccumulator = 0;
+        _bitsInAccumulator = 0;
+      }
+    }
+
+    void writeBits(long value, int numBits) {
+      // Write most-significant bits first.
+      for (int b = numBits - 1; b >= 0; b--) {
+        writeBit((int) ((value >>> b) & 1L));
+      }
+    }
+
+    /// Flush any remaining buffered bits, padding with zeros to the next byte boundary.
+    void flush() {
+      if (_bitsInAccumulator > 0) {
+        _byteAccumulator <<= (8 - _bitsInAccumulator);
+        _out.put((byte) _byteAccumulator);
+        _byteAccumulator = 0;
+        _bitsInAccumulator = 0;
+      }
+    }
+  }
+
+  private static final class BitReader {
+    private final ByteBuffer _in;
+    private int _byteAccumulator;
+    private int _bitsInAccumulator;
+
+    BitReader(ByteBuffer in) {
+      _in = in;
+      _byteAccumulator = 0;
+      _bitsInAccumulator = 0;
+    }
+
+    int readBit() {
+      if (_bitsInAccumulator == 0) {
+        _byteAccumulator = _in.get() & 0xFF;
+        _bitsInAccumulator = 8;
+      }
+      _bitsInAccumulator--;
+      return (_byteAccumulator >>> _bitsInAccumulator) & 1;
+    }
+
+    long readBits(int numBits) {
+      long result = 0L;
+      for (int b = numBits - 1; b >= 0; b--) {
+        result |= ((long) readBit()) << b;
+      }
+      return result;
+    }
+
+    void ensureFullyConsumed() {
+      if (_in.hasRemaining()) {
+        throw new IllegalStateException(
+            "GORILLA: trailing " + _in.remaining() + " byte(s) after bit stream. Segment may be corrupt.");
+      }
+      int paddingMask = (1 << _bitsInAccumulator) - 1;
+      if ((_byteAccumulator & paddingMask) != 0) {
+        throw new IllegalStateException(
+            "GORILLA: non-zero padding bits after bit stream. Segment may be corrupt.");
+      }
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/T64CodecDefinition.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/codec/T64CodecDefinition.java
@@ -1,0 +1,434 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.io.codec;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+
+
+/// Frame-of-reference (FOR) bit-packing transform on fixed-size 64-value blocks for SV INT/LONG.
+///
+/// DSL form: `T64` (no arguments)
+///
+/// Stateless and thread-safe; the [#INSTANCE] singleton is shared across all columns.
+///
+/// Each block of 64 values is encoded as:
+/// ```
+///   [baseline : elementSize bytes]   // min value in the block
+///   [bitWidth : 1 byte]              // 0..elementBits, bits needed for (value - baseline)
+///   [packed   : ceil(bitWidth * blockCount / 8) bytes]  // bit-packed deltas
+/// ```
+/// The final block may contain fewer than 64 values; its bit-packed payload still uses 64-value
+/// granularity (zeros for missing slots) so the on-disk size is `ceil(bitWidth * 64 / 8)`.
+///
+/// Wire format for the full encoded frame:
+/// ```
+///   [flag : 1 byte]      // 0=INT, 1=LONG
+///   [count: 4 bytes]     // total number of values
+///   [block_0]
+///   [block_1]
+///   ...
+///   [block_{N-1}]
+/// ```
+/// `count == 0` is encoded as the 5-byte header with no blocks.
+///
+/// **Chainability.** Unlike the typed-layout-preserving DELTA/DELTADELTA transforms, T64 is a packing
+/// transform: it consumes column-typed input and produces a headered byte frame. It must be the
+/// last transform, but one or more byte-compression stages may follow (e.g. `T64,LZ4`).
+final class T64CodecDefinition implements ChunkCodecHandler<T64CodecDefinition.Options> {
+
+  /// On-disk permanent name stored verbatim in segment file headers.
+  /// This string is a frozen on-disk API contract and must never be changed.
+  public static final String NAME = "T64";
+
+  public static final T64CodecDefinition INSTANCE = new T64CodecDefinition();
+
+  /// Singleton options — T64 has no configurable parameters.
+  public static final Options OPTIONS = new Options();
+
+  /// Block size in values. Frozen on-disk constant.
+  static final int BLOCK_SIZE = 64;
+
+  private T64CodecDefinition() {
+  }
+
+  /// Typed options for [T64CodecDefinition]. T64 has no configurable parameters.
+  public static final class Options implements CodecOptions {
+    private Options() {
+    }
+  }
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+
+  @Override
+  public CodecKind kind() {
+    return CodecKind.TRANSFORM;
+  }
+
+  @Override
+  public Options parseOptions(List<String> args) {
+    if (!args.isEmpty()) {
+      throw new IllegalArgumentException("T64 codec takes no arguments but got: " + args);
+    }
+    return OPTIONS;
+  }
+
+  @Override
+  public void validateContext(Options options, CodecContext ctx) {
+    DataType dt = ctx.getDataType();
+    if (dt != DataType.INT && dt != DataType.LONG) {
+      throw new IllegalArgumentException(
+          "T64 codec only supports INT and LONG columns, but column has type: " + dt);
+    }
+  }
+
+  @Override
+  public String canonicalize(Options options) {
+    return NAME;
+  }
+
+  @Override
+  public boolean requiresDirectDstBuffer() {
+    return false;
+  }
+
+  @Override
+  public int maxEncodedSize(Options options, int inputSize) {
+    // The on-disk size is 5-byte frame header + per-block (baseline + bitWidth + packed).
+    // A partial last block still writes a full `elementSize * BLOCK_SIZE` packed-payload of
+    // bit-packed slots (zero-filled at the tail), so payload size scales with **block count**,
+    // not with input value count.
+    //
+    // Element size isn't knowable from inputSize alone (the SPI passes only byte count), so we
+    // use the LONG worst case (elementSize = Long.BYTES) which is a valid upper bound for both
+    // INT and LONG inputs. Block count is bounded above using the smaller element size,
+    // Integer.BYTES, since inputSize / (Integer.BYTES * BLOCK_SIZE) ≥ inputSize / (Long.BYTES *
+    // BLOCK_SIZE) for any element size in {Integer.BYTES, Long.BYTES}.
+    if (inputSize < 0) {
+      throw new IllegalArgumentException("T64 inputSize must be non-negative: " + inputSize);
+    }
+    long approxBlocks = ((long) inputSize + BLOCK_SIZE * Integer.BYTES - 1)
+        / (BLOCK_SIZE * Integer.BYTES);
+    long bound = 1L + Integer.BYTES + approxBlocks * (Long.BYTES + 1L + Long.BYTES * BLOCK_SIZE);
+    if (bound > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException("T64 maximum encoded size exceeds Integer.MAX_VALUE: " + bound);
+    }
+    return (int) bound;
+  }
+
+  @Override
+  public ByteBuffer encode(Options options, CodecContext ctx, ByteBuffer src) {
+    int remaining = src.remaining();
+    DataType dt = ctx.getDataType();
+    if (dt != DataType.INT && dt != DataType.LONG) {
+      throw new IllegalArgumentException("T64 does not support stored type: " + dt);
+    }
+    int elementSize = dt.size();
+    if (remaining % elementSize != 0) {
+      throw new IllegalArgumentException(
+          "T64: input buffer size (" + remaining + ") is not a multiple of element size (" + elementSize + ")");
+    }
+    int count = remaining / elementSize;
+    boolean isLong = dt == DataType.LONG;
+
+    // Worst-case allocation upper bound — see maxEncodedSize.
+    int numBlocks = (count + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    int worstCase = 1 + Integer.BYTES + numBlocks * (elementSize + 1 + elementSize * BLOCK_SIZE);
+    ByteBuffer out = ByteBuffer.allocateDirect(worstCase);
+    out.put((byte) (isLong ? 1 : 0));
+    out.putInt(count);
+
+    // Reusable per-encode scratch buffer for packed-bytes; sized for the worst case
+    // `elementSize * BLOCK_SIZE` bytes (when bitWidth == elementBits) so it never needs to grow.
+    byte[] packedBuf = new byte[elementSize * BLOCK_SIZE];
+    // Decode and pack one block at a time. Retaining the whole chunk in a long[] would add up to
+    // 2 MiB of transient heap for a normal 1 MiB INT chunk, multiplied across concurrent writers.
+    long[] blockValues = new long[BLOCK_SIZE];
+
+    for (int blockStart = 0; blockStart < count; blockStart += BLOCK_SIZE) {
+      int blockCount = Math.min(BLOCK_SIZE, count - blockStart);
+      long min = Long.MAX_VALUE;
+      long max = Long.MIN_VALUE;
+      for (int i = 0; i < blockCount; i++) {
+        // Sign-extend INT to LONG so arithmetic uses two's-complement semantics for negative
+        // deltas.
+        long v = isLong ? src.getLong() : src.getInt();
+        blockValues[i] = v;
+        if (v < min) {
+          min = v;
+        }
+        if (v > max) {
+          max = v;
+        }
+      }
+      // Range is unsigned: max - min ≥ 0 for any two values in [Long.MIN_VALUE, Long.MAX_VALUE]
+      // and ≥ 0 in [Integer.MIN_VALUE, Integer.MAX_VALUE] after sign-extension. The bitWidth
+      // upper bound is elementBits (32 for INT, 64 for LONG); this is an invariant guaranteed
+      // by the source-type range and the encode loop.
+      long range = max - min;
+      int bitWidth = (range == 0) ? 0 : 64 - Long.numberOfLeadingZeros(range);
+      // Unconditional check — `assert` is off in production JVMs and a silent bitWidth overflow
+      // here would corrupt the encoded frame.
+      if (bitWidth > elementSize * 8) {
+        throw new IllegalStateException(
+            "T64 encode: bitWidth " + bitWidth + " exceeds elementBits " + (elementSize * 8));
+      }
+
+      // Baseline + bitWidth header.
+      if (isLong) {
+        out.putLong(min);
+      } else {
+        out.putInt((int) min);
+      }
+      out.put((byte) bitWidth);
+
+      if (bitWidth == 0) {
+        continue; // all values equal min; no packed bytes
+      }
+
+      // Pack BLOCK_SIZE values; missing tail slots get zero (i.e. baseline).
+      packBits(blockValues, blockCount, min, bitWidth, out, packedBuf);
+    }
+
+    out.flip();
+    return out;
+  }
+
+  @Override
+  public ByteBuffer decode(Options options, CodecContext ctx, ByteBuffer src) {
+    src = src.duplicate().order(ByteOrder.BIG_ENDIAN);
+    byte flag = src.get();
+    int count = src.getInt();
+    validateHeader(flag, count, ctx);
+    if (count == 0) {
+      ensureFullyConsumed(src);
+      return ByteBuffer.allocateDirect(0);
+    }
+    boolean isLong = flag == 1;
+    int elementSize = isLong ? Long.BYTES : Integer.BYTES;
+    ByteBuffer out = ByteBuffer.allocateDirect(decodedSize(count, elementSize));
+    decodeBlocks(src, count, isLong, out);
+    out.flip();
+    return out;
+  }
+
+  @Override
+  public void decodeInto(Options options, CodecContext ctx, ByteBuffer src, ByteBuffer dst) {
+    src = src.duplicate().order(ByteOrder.BIG_ENDIAN);
+    dst.clear();
+    byte flag = src.get();
+    int count = src.getInt();
+    validateHeader(flag, count, ctx);
+    if (count == 0) {
+      ensureFullyConsumed(src);
+      dst.flip();
+      return;
+    }
+    boolean isLong = flag == 1;
+    int elementSize = isLong ? Long.BYTES : Integer.BYTES;
+    long requiredCapacity = (long) count * elementSize;
+    if (requiredCapacity > dst.capacity()) {
+      throw new IllegalArgumentException(
+          "T64: decoded size " + requiredCapacity + " exceeds dst capacity " + dst.capacity());
+    }
+    decodeBlocks(src, count, isLong, dst);
+    dst.flip();
+  }
+
+  /// Validate the frame header: count must be ≥ 0 and flag must be a known type. Validating
+  /// **both** unconditionally (before any count-based short-circuit) means a corrupt segment
+  /// with `flag=42, count=0` is rejected rather than silently decoding to empty.
+  private static void validateHeader(byte flag, int count, CodecContext ctx) {
+    if (count < 0) {
+      throw new IllegalStateException(
+          "T64: invalid count in header: " + count + ". Segment may be corrupt.");
+    }
+    if (flag != 0 && flag != 1) {
+      throw new IllegalStateException(
+          "Unknown T64 type flag: " + flag + ". Expected 0 (INT) or 1 (LONG). Segment may be corrupt.");
+    }
+    DataType dataType = ctx.getDataType();
+    if (dataType != DataType.INT && dataType != DataType.LONG) {
+      throw new IllegalStateException("T64 cannot decode column type " + dataType);
+    }
+    byte expectedFlag = dataType == DataType.LONG ? (byte) 1 : (byte) 0;
+    if (flag != expectedFlag) {
+      throw new IllegalStateException(
+          "T64 frame type " + (flag == 1 ? "LONG" : "INT") + " does not match column type "
+              + dataType + ". Segment may be corrupt.");
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Bit-packing helpers
+  // -------------------------------------------------------------------------
+
+  /// Pack `blockCount` (≤ [#BLOCK_SIZE]) values, subtracting `baseline` from each, into
+  /// `bitWidth`-wide slots laid out in a fixed-size BLOCK_SIZE-slot frame. The output is written
+  /// at the current `out.position()` and uses `ceil(bitWidth * BLOCK_SIZE / 8)` bytes.
+  ///
+  /// `scratch` is a caller-supplied reusable buffer sized for the worst-case packed bytes
+  /// per block (i.e. `elementSize * BLOCK_SIZE`); only the first `ceil(bitWidth * BLOCK_SIZE / 8)`
+  /// bytes are read.
+  private static void packBits(long[] values, int blockCount, long baseline,
+      int bitWidth, ByteBuffer out, byte[] scratch) {
+    int packedBytes = (bitWidth * BLOCK_SIZE + 7) / 8;
+    // Zero out the bytes we'll write into (writeBits OR-merges into existing bits).
+    Arrays.fill(scratch, 0, packedBytes, (byte) 0);
+
+    long bitCursor = 0;
+    for (int i = 0; i < BLOCK_SIZE; i++) {
+      long value = (i < blockCount) ? (values[i] - baseline) : 0L;
+      writeBits(scratch, bitCursor, value, bitWidth);
+      bitCursor += bitWidth;
+    }
+    out.put(scratch, 0, packedBytes);
+  }
+
+  /// Decode one or more T64 blocks until `count` values have been read, appending the
+  /// resulting INT/LONG values to `dst`.
+  private static void decodeBlocks(ByteBuffer src, int count, boolean isLong, ByteBuffer dst) {
+    // Reusable per-decode scratch buffer; sized for the worst case (bitWidth = elementBits).
+    int elementSize = isLong ? Long.BYTES : Integer.BYTES;
+    byte[] packedBuf = new byte[elementSize * BLOCK_SIZE];
+    int remainingValues = count;
+    while (remainingValues > 0) {
+      long baseline = isLong ? src.getLong() : src.getInt();
+      // `& 0xFF` guarantees bitWidth ∈ [0, 255], so we only need to check the upper bound.
+      int bitWidth = src.get() & 0xFF;
+      if (bitWidth > 64 || (!isLong && bitWidth > 32)) {
+        throw new IllegalStateException(
+            "T64: invalid bit width " + bitWidth + ". Segment may be corrupt.");
+      }
+      int blockCount = Math.min(BLOCK_SIZE, remainingValues);
+      if (bitWidth == 0) {
+        // All values in this block equal baseline.
+        if (isLong) {
+          for (int i = 0; i < blockCount; i++) {
+            dst.putLong(baseline);
+          }
+        } else {
+          int baseInt = (int) baseline;
+          for (int i = 0; i < blockCount; i++) {
+            dst.putInt(baseInt);
+          }
+        }
+      } else {
+        int packedBytes = (bitWidth * BLOCK_SIZE + 7) / 8;
+        src.get(packedBuf, 0, packedBytes);
+        long bitCursor = 0;
+        if (isLong) {
+          for (int i = 0; i < blockCount; i++) {
+            long v = readBits(packedBuf, bitCursor, bitWidth) + baseline;
+            dst.putLong(v);
+            bitCursor += bitWidth;
+          }
+        } else {
+          for (int i = 0; i < blockCount; i++) {
+            int v = (int) (readBits(packedBuf, bitCursor, bitWidth) + baseline);
+            dst.putInt(v);
+            bitCursor += bitWidth;
+          }
+        }
+        // The encoder reserves fixed-width slots for the missing tail of a partial block and
+        // writes them as zero. Reject non-canonical non-zero tail slots rather than silently
+        // accepting alternate bytes for the same value sequence.
+        for (int i = blockCount; i < BLOCK_SIZE; i++) {
+          if (readBits(packedBuf, bitCursor, bitWidth) != 0) {
+            throw new IllegalStateException(
+                "T64: non-zero padding slot in final block. Segment may be corrupt.");
+          }
+          bitCursor += bitWidth;
+        }
+      }
+      remainingValues -= blockCount;
+    }
+    ensureFullyConsumed(src);
+  }
+
+  private static int decodedSize(int count, int elementSize) {
+    long decodedSize = (long) count * elementSize;
+    if (decodedSize > Integer.MAX_VALUE) {
+      throw new IllegalStateException(
+          "T64: decoded size " + decodedSize + " exceeds Integer.MAX_VALUE. Segment may be corrupt.");
+    }
+    return (int) decodedSize;
+  }
+
+  private static void ensureFullyConsumed(ByteBuffer src) {
+    if (src.hasRemaining()) {
+      throw new IllegalStateException(
+          "T64: trailing " + src.remaining() + " byte(s) after frame. Segment may be corrupt.");
+    }
+  }
+
+  /// Write `value` into `buf` at the given bit offset, packing
+  /// `bitWidth` bits (LSB-first within each byte). `value` must fit in
+  /// `bitWidth` bits; only the low `bitWidth` bits are used.
+  ///
+  /// Implementation extracts `take`-bit chunks **from the low end of `value`**
+  /// rather than left-shifting `value` into a 64-bit register, so it is safe for
+  /// `bitInByte + bitWidth > 64`.
+  private static void writeBits(byte[] buf, long bitOffset, long value, int bitWidth) {
+    long cursor = bitOffset;
+    int valueShift = 0;
+    int bitsRemaining = bitWidth;
+    while (bitsRemaining > 0) {
+      int byteIndex = (int) (cursor >>> 3);
+      int bitInByte = (int) (cursor & 7);
+      int take = Math.min(8 - bitInByte, bitsRemaining);
+      // `take` is in [1..8] (bounded by `8 - bitInByte`), so a byte-sized mask always suffices.
+      long takeMask = (1L << take) - 1L;
+      long chunk = (value >>> valueShift) & takeMask;
+      buf[byteIndex] |= (byte) (chunk << bitInByte);
+      cursor += take;
+      valueShift += take;
+      bitsRemaining -= take;
+    }
+  }
+
+  /// Read `bitWidth` bits from `buf` starting at `bitOffset`.
+  private static long readBits(byte[] buf, long bitOffset, int bitWidth) {
+    long byteIndex = bitOffset >>> 3;
+    int bitInByte = (int) (bitOffset & 7);
+    long out = 0L;
+    int shift = 0;
+    int bitsRemaining = bitWidth;
+    int idx = (int) byteIndex;
+    while (bitsRemaining > 0) {
+      long b = ((long) buf[idx]) & 0xFFL;
+      int available = 8 - bitInByte;
+      int take = Math.min(available, bitsRemaining);
+      // `take` is in [1..8] (bounded by `available`), so a byte-sized mask always suffices.
+      long mask = (1L << take) - 1L;
+      out |= ((b >>> bitInByte) & mask) << shift;
+      shift += take;
+      bitsRemaining -= take;
+      idx++;
+      bitInByte = 0;
+    }
+    return out;
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/CodecPipelineExecutorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/CodecPipelineExecutorTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.Arrays;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.testng.annotations.DataProvider;
@@ -111,6 +112,17 @@ public class CodecPipelineExecutorTest {
         "ZSTD(5),GZIP");
     assertEquals(CodecPipelineExecutor.create("lz4,snappy", DataType.INT).getCanonicalSpec(),
         "LZ4,SNAPPY");
+  }
+
+  @Test
+  public void testTypedTransformsIgnoreCallerByteOrder()
+      throws Exception {
+    for (String spec : new String[]{"DELTA", "DELTADELTA", "T64", "GORILLA"}) {
+      assertTypedTransformIgnoresCallerByteOrder(spec, DataType.INT,
+          new long[]{Integer.MIN_VALUE, -1, 0, 1, Integer.MAX_VALUE});
+      assertTypedTransformIgnoresCallerByteOrder(spec, DataType.LONG,
+          new long[]{Long.MIN_VALUE, -1L, 0L, 1L, Long.MAX_VALUE});
+    }
   }
 
   @Test
@@ -236,6 +248,58 @@ public class CodecPipelineExecutorTest {
   private static ByteBuffer inputBuffer(boolean direct) {
     ByteBuffer buffer = direct ? ByteBuffer.allocateDirect(INPUT.length) : ByteBuffer.allocate(INPUT.length);
     return buffer.put(INPUT).flip();
+  }
+
+  private static void assertTypedTransformIgnoresCallerByteOrder(String spec, DataType dataType, long[] values)
+      throws Exception {
+    int decodedSize = values.length * dataType.size();
+    ByteBuffer canonicalInput = ByteBuffer.allocateDirect(decodedSize).order(ByteOrder.BIG_ENDIAN);
+    for (long value : values) {
+      if (dataType == DataType.INT) {
+        canonicalInput.putInt((int) value);
+      } else {
+        canonicalInput.putLong(value);
+      }
+    }
+    canonicalInput.flip();
+
+    CodecPipelineExecutor executor = CodecPipelineExecutor.create(spec, dataType);
+    int maxIntermediateSize = Math.max(decodedSize, executor.maxEncodedSize(decodedSize));
+
+    // A LITTLE_ENDIAN input view must still be interpreted as persisted big-endian typed words.
+    ByteBuffer littleEndianInput = canonicalInput.duplicate().order(ByteOrder.LITTLE_ENDIAN);
+    ByteBuffer encodedFromLittleEndian = executor.encode(littleEndianInput);
+    assertEquals(littleEndianInput.position(), 0, "encode must not consume the caller's input view");
+    assertEquals(littleEndianInput.order(), ByteOrder.LITTLE_ENDIAN);
+    ByteBuffer bigEndianDestination = ByteBuffer.allocateDirect(decodedSize).order(ByteOrder.BIG_ENDIAN);
+    try (CodecPipelineExecutor.DecodeScratch scratch = new CodecPipelineExecutor.DecodeScratch()) {
+      executor.decode(encodedFromLittleEndian, bigEndianDestination, decodedSize, maxIntermediateSize,
+          Long.MAX_VALUE, scratch);
+    }
+    assertTypedValues(bigEndianDestination, dataType, values, spec + " LITTLE_ENDIAN encode view");
+
+    // A LITTLE_ENDIAN destination view must receive the same canonical big-endian bytes without
+    // changing the caller's configured order.
+    ByteBuffer encodedFromBigEndian = executor.encode(canonicalInput.duplicate());
+    ByteBuffer littleEndianDestination = ByteBuffer.allocateDirect(decodedSize).order(ByteOrder.LITTLE_ENDIAN);
+    try (CodecPipelineExecutor.DecodeScratch scratch = new CodecPipelineExecutor.DecodeScratch()) {
+      executor.decode(encodedFromBigEndian, littleEndianDestination, decodedSize, maxIntermediateSize,
+          Long.MAX_VALUE, scratch);
+    }
+    assertEquals(littleEndianDestination.order(), ByteOrder.LITTLE_ENDIAN);
+    assertTypedValues(littleEndianDestination, dataType, values, spec + " LITTLE_ENDIAN decode destination");
+  }
+
+  private static void assertTypedValues(ByteBuffer actual, DataType dataType, long[] expected, String message) {
+    ByteBuffer bigEndian = actual.duplicate().order(ByteOrder.BIG_ENDIAN);
+    assertEquals(bigEndian.remaining(), expected.length * dataType.size(), message);
+    for (long value : expected) {
+      if (dataType == DataType.INT) {
+        assertEquals(bigEndian.getInt(), (int) value, message);
+      } else {
+        assertEquals(bigEndian.getLong(), value, message);
+      }
+    }
   }
 
   private static void assertBytesEqual(ByteBuffer actual) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/CodecPipelineValidatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/CodecPipelineValidatorTest.java
@@ -112,6 +112,9 @@ public class CodecPipelineValidatorTest {
     // another transform (or each other).
     assertTrue(DeltaCodecDefinition.INSTANCE.preservesTypedValueLayout());
     assertTrue(DeltaDeltaCodecDefinition.INSTANCE.preservesTypedValueLayout());
+    // The packing transforms (T64/GORILLA) emit a headered byte frame, so they must return false.
+    assertFalse(T64CodecDefinition.INSTANCE.preservesTypedValueLayout());
+    assertFalse(GorillaCodecDefinition.INSTANCE.preservesTypedValueLayout());
   }
 
   // -------------------------------------------------------------------------
@@ -170,6 +173,61 @@ public class CodecPipelineValidatorTest {
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testDeltaRejectsArguments() {
     validateWithDefaultRegistry("DELTA(1)", DataType.INT);
+  }
+
+  // -------------------------------------------------------------------------
+  // T64 / GORILLA — the real packing transforms, resolved through the
+  // production CodecRegistry.DEFAULT
+  // -------------------------------------------------------------------------
+
+  /// A typed-layout-preserving transform may precede a packing transform, which may precede
+  /// compression(s).
+  @Test
+  public void testTypedLayoutThenPackingThenCompressionAllowed() {
+    validateWithDefaultRegistry("DELTA,T64,LZ4", DataType.INT);
+    validateWithDefaultRegistry("DELTADELTA,GORILLA,ZSTD(3)", DataType.LONG);
+    validateWithDefaultRegistry("DELTA,T64", DataType.LONG);
+  }
+
+  /// A packing transform may stand alone or be followed by any number of compression stages.
+  @Test
+  public void testCompressionAfterPackingAllowed() {
+    validateWithDefaultRegistry("T64", DataType.INT);
+    validateWithDefaultRegistry("GORILLA", DataType.LONG);
+    validateWithDefaultRegistry("T64,ZSTD(3)", DataType.LONG);
+    validateWithDefaultRegistry("GORILLA,SNAPPY", DataType.LONG);
+    validateWithDefaultRegistry("T64,LZ4,GZIP", DataType.INT);
+  }
+
+  /// A packing transform (T64/GORILLA) must be the last transform — another transform may not
+  /// follow it because its output is a bit-packed (non-typed) byte stream.
+  @Test(expectedExceptions = IllegalArgumentException.class,
+      expectedExceptionsMessageRegExp = ".*must operate on column values.*")
+  public void testTransformAfterT64Rejected() {
+    validateWithDefaultRegistry("T64,DELTA", DataType.INT);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class,
+      expectedExceptionsMessageRegExp = ".*must operate on column values.*")
+  public void testT64ThenGorillaRejected() {
+    validateWithDefaultRegistry("T64,GORILLA", DataType.LONG);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class,
+      expectedExceptionsMessageRegExp = ".*T64 codec only supports INT and LONG.*")
+  public void testT64OnStringColumn() {
+    validateWithDefaultRegistry("T64", DataType.STRING);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class,
+      expectedExceptionsMessageRegExp = ".*GORILLA codec only supports INT and LONG.*")
+  public void testGorillaOnDoubleColumn() {
+    validateWithDefaultRegistry("GORILLA", DataType.DOUBLE);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testT64RejectsArguments() {
+    validateWithDefaultRegistry("T64(1)", DataType.INT);
   }
 
   private static void validate(String spec, DataType dataType) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/CodecRegistryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/CodecRegistryTest.java
@@ -44,7 +44,9 @@ public class CodecRegistryTest {
     assertSame(CodecRegistry.DEFAULT.get("zstandard"), ZstdCodecDefinition.INSTANCE);
     assertSame(CodecRegistry.DEFAULT.get("delta"), DeltaCodecDefinition.INSTANCE);
     assertSame(CodecRegistry.DEFAULT.get("DELTADELTA"), DeltaDeltaCodecDefinition.INSTANCE);
-    assertNull(CodecRegistry.DEFAULT.get("T64"));
+    assertSame(CodecRegistry.DEFAULT.get("t64"), T64CodecDefinition.INSTANCE);
+    assertSame(CodecRegistry.DEFAULT.get("GORILLA"), GorillaCodecDefinition.INSTANCE);
+    assertNull(CodecRegistry.DEFAULT.get("NOSUCHCODEC"));
   }
 
   @Test

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/GorillaCodecDefinitionTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/GorillaCodecDefinitionTest.java
@@ -1,0 +1,380 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.io.codec;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+
+/// Focused boundary tests for [GorillaCodecDefinition].
+///
+/// The codec-pipeline on-disk format does not exist yet at this point in the stack, so this file
+/// is the direct coverage of the GORILLA bit-stream, targeting paths an on-disk writer/reader
+/// integration test would not exercise:
+///  - `count == 0`, `count == 1`
+///  - all-equal sequences (every value triggers the `x == 0` repeat branch)
+///  - window-reuse vs explicit-window switching across consecutive XOR deltas
+///  - INT_MIN/INT_MAX, LONG_MIN/LONG_MAX boundary values
+///  - first value verbatim with arbitrary sign-bit
+///  - corrupt-segment defenses (invalid flag, negative count, window-reuse before explicit)
+public class GorillaCodecDefinitionTest {
+
+  private static final GorillaCodecDefinition CODEC = GorillaCodecDefinition.INSTANCE;
+  private static final GorillaCodecDefinition.Options OPTS = GorillaCodecDefinition.OPTIONS;
+  private static final CodecContext INT_CTX = new CodecContext(DataType.INT);
+  private static final CodecContext LONG_CTX = new CodecContext(DataType.LONG);
+
+  // ---------- Round-trip helpers ----------
+
+  private static void roundTripInt(int[] values) {
+    ByteBuffer src = ByteBuffer.allocateDirect(values.length * Integer.BYTES);
+    for (int v : values) {
+      src.putInt(v);
+    }
+    src.flip();
+    ByteBuffer encoded = CODEC.encode(OPTS, INT_CTX, src);
+    assertDecodedInts(CODEC.decode(OPTS, INT_CTX, encoded.duplicate()), values);
+
+    ByteBuffer dst = ByteBuffer.allocateDirect(values.length * Integer.BYTES);
+    CODEC.decodeInto(OPTS, INT_CTX, encoded.duplicate(), dst);
+    assertDecodedInts(dst, values);
+  }
+
+  private static void assertDecodedInts(ByteBuffer decoded, int[] values) {
+    assertEquals(decoded.remaining(), values.length * Integer.BYTES,
+        "decoded byte length mismatch");
+    for (int i = 0; i < values.length; i++) {
+      assertEquals(decoded.getInt(), values[i], "INT mismatch at i=" + i);
+    }
+  }
+
+  private static void roundTripLong(long[] values) {
+    ByteBuffer src = ByteBuffer.allocateDirect(values.length * Long.BYTES);
+    for (long v : values) {
+      src.putLong(v);
+    }
+    src.flip();
+    ByteBuffer encoded = CODEC.encode(OPTS, LONG_CTX, src);
+    assertDecodedLongs(CODEC.decode(OPTS, LONG_CTX, encoded.duplicate()), values);
+
+    ByteBuffer dst = ByteBuffer.allocateDirect(values.length * Long.BYTES);
+    CODEC.decodeInto(OPTS, LONG_CTX, encoded.duplicate(), dst);
+    assertDecodedLongs(dst, values);
+  }
+
+  private static void assertDecodedLongs(ByteBuffer decoded, long[] values) {
+    assertEquals(decoded.remaining(), values.length * Long.BYTES,
+        "decoded byte length mismatch");
+    for (int i = 0; i < values.length; i++) {
+      assertEquals(decoded.getLong(), values[i], "LONG mismatch at i=" + i);
+    }
+  }
+
+  // ---------- Count edge cases ----------
+
+  @Test
+  public void testEmptyInt() {
+    roundTripInt(new int[0]);
+  }
+
+  @Test
+  public void testEmptyLong() {
+    roundTripLong(new long[0]);
+  }
+
+  @Test
+  public void testSingleValueInt() {
+    roundTripInt(new int[]{42});
+    roundTripInt(new int[]{Integer.MIN_VALUE});
+    roundTripInt(new int[]{Integer.MAX_VALUE});
+    roundTripInt(new int[]{0});
+  }
+
+  @Test
+  public void testSingleValueLong() {
+    roundTripLong(new long[]{1_700_000_000_000L});
+    roundTripLong(new long[]{Long.MIN_VALUE});
+    roundTripLong(new long[]{Long.MAX_VALUE});
+    roundTripLong(new long[]{0L});
+  }
+
+  // ---------- All-equal exercises the x==0 repeat path ----------
+
+  @Test
+  public void testAllEqualInt() {
+    int[] values = new int[200];
+    Arrays.fill(values, -42);
+    roundTripInt(values);
+  }
+
+  @Test
+  public void testAllEqualLong() {
+    long[] values = new long[200];
+    Arrays.fill(values, Long.MIN_VALUE + 1);
+    roundTripLong(values);
+  }
+
+  // ---------- Boundary values ----------
+
+  @Test
+  public void testIntBoundary() {
+    int[] values = new int[]{0, Integer.MIN_VALUE, Integer.MAX_VALUE, 0, -1, 1,
+        Integer.MIN_VALUE + 1, Integer.MAX_VALUE - 1, 0};
+    roundTripInt(values);
+  }
+
+  @Test
+  public void testLongBoundary() {
+    long[] values = new long[]{0L, Long.MIN_VALUE, Long.MAX_VALUE, 0L, -1L, 1L,
+        Long.MIN_VALUE + 1, Long.MAX_VALUE - 1, 0L};
+    roundTripLong(values);
+  }
+
+  // ---------- Window-reuse vs explicit transitions ----------
+
+  @Test
+  public void testTimestampLikeLong() {
+    // Small monotonic deltas — explicit window once, then many reuses
+    long[] values = new long[500];
+    long base = 1_700_000_000_000L;
+    for (int i = 0; i < 500; i++) {
+      values[i] = base + i * 1_000L;
+    }
+    roundTripLong(values);
+  }
+
+  @Test
+  public void testCounterLikeInt() {
+    int[] values = new int[500];
+    for (int i = 0; i < 500; i++) {
+      values[i] = i;
+    }
+    roundTripInt(values);
+  }
+
+  @Test
+  public void testAlternatingSignLong() {
+    long[] values = new long[300];
+    for (int i = 0; i < 300; i++) {
+      values[i] = (i % 2 == 0) ? (long) i : -((long) i);
+    }
+    roundTripLong(values);
+  }
+
+  @Test
+  public void testWidelyVaryingMagnitudesLong() {
+    // Each XOR delta forces a fresh explicit window
+    long[] values = new long[]{
+        0L,
+        0xFFFFL,
+        0xFFFF_FFFFL,
+        0xFFFF_FFFF_FFFFL,
+        0xFFFF_FFFF_FFFF_FFFFL,
+        0L,
+        1L
+    };
+    roundTripLong(values);
+  }
+
+  @Test
+  public void testRepeatedThenChanging() {
+    // Tests that prevLeading/prevWidth are preserved across `x == 0` repeats.
+    long[] values = new long[]{
+        1000L, 1000L, 1000L,
+        1001L,
+        1001L, 1001L,
+        1002L,
+        1002L
+    };
+    roundTripLong(values);
+  }
+
+  @Test
+  public void testMixedExecutorPipeline() throws IOException {
+    long[] values = new long[257];
+    for (int i = 0; i < values.length; i++) {
+      values[i] = 1_700_000_000_000L + (long) i * i * 13L;
+    }
+    ByteBuffer src = ByteBuffer.allocateDirect(values.length * Long.BYTES);
+    for (long value : values) {
+      src.putLong(value);
+    }
+    src.flip();
+
+    CodecPipelineExecutor executor = CodecPipelineExecutor.create(
+        "DELTADELTA,GORILLA,ZSTD(3)", LONG_CTX, CodecRegistry.DEFAULT);
+    ByteBuffer encoded = executor.encode(src.duplicate());
+    ByteBuffer decoded = ByteBuffer.allocateDirect(src.remaining());
+    executor.decode(encoded, decoded, src.remaining());
+    assertDecodedLongs(decoded, values);
+  }
+
+  // ---------- Corrupt-segment defenses ----------
+
+  @Test
+  public void testInvalidFlagThrows() {
+    ByteBuffer buf = ByteBuffer.allocateDirect(5);
+    buf.put((byte) 7);
+    buf.putInt(1);
+    buf.flip();
+    assertThrows(IllegalStateException.class, () -> CODEC.decode(OPTS, INT_CTX, buf));
+  }
+
+  @Test
+  public void testInvalidFlagWithZeroCountThrows() {
+    ByteBuffer buf = ByteBuffer.allocateDirect(5);
+    buf.put((byte) 7).putInt(0).flip();
+    assertThrows(IllegalStateException.class, () -> CODEC.decode(OPTS, INT_CTX, buf.duplicate()));
+    assertThrows(IllegalStateException.class,
+        () -> CODEC.decodeInto(OPTS, INT_CTX, buf.duplicate(), ByteBuffer.allocateDirect(0)));
+  }
+
+  @Test
+  public void testFrameTypeMustMatchContext() {
+    ByteBuffer longFrame = ByteBuffer.allocateDirect(5);
+    longFrame.put((byte) 1).putInt(0).flip();
+    assertThrows(IllegalStateException.class,
+        () -> CODEC.decode(OPTS, INT_CTX, longFrame.duplicate()));
+    assertThrows(IllegalStateException.class,
+        () -> CODEC.decodeInto(OPTS, INT_CTX, longFrame.duplicate(), ByteBuffer.allocateDirect(0)));
+  }
+
+  @Test
+  public void testNegativeCountThrows() {
+    ByteBuffer buf = ByteBuffer.allocateDirect(5);
+    buf.put((byte) 0);
+    buf.putInt(-1);
+    buf.flip();
+    assertThrows(IllegalStateException.class, () -> CODEC.decode(OPTS, INT_CTX, buf));
+  }
+
+  @Test
+  public void testWindowReuseBeforeExplicitThrows() {
+    // Hand-craft a corrupt stream: flag=INT, count=2, first=0, then bit-stream
+    // with bit=1 (nonzero XOR) followed by control=0 (reuse) but no prior explicit window.
+    ByteBuffer buf = ByteBuffer.allocateDirect(16);
+    buf.put((byte) 0); // INT flag
+    buf.putInt(2); // count
+    buf.putInt(0); // first value verbatim
+    // Bit stream: MSB-first within byte. Encode bits 1, 0, then garbage.
+    // 10000000 = 0x80
+    buf.put((byte) 0x80);
+    buf.flip();
+    assertThrows(IllegalStateException.class, () -> CODEC.decode(OPTS, INT_CTX, buf));
+  }
+
+  @Test
+  public void testTrailingBytesRejectedByCodecAndExecutor() {
+    for (int[] values : new int[][]{{}, {42}, {1, 2, 3}}) {
+      ByteBuffer src = ByteBuffer.allocateDirect(values.length * Integer.BYTES);
+      for (int value : values) {
+        src.putInt(value);
+      }
+      src.flip();
+      ByteBuffer withTrailingByte = appendByte(CODEC.encode(OPTS, INT_CTX, src));
+
+      assertThrows(IllegalStateException.class,
+          () -> CODEC.decode(OPTS, INT_CTX, withTrailingByte.duplicate()));
+      assertThrows(IllegalStateException.class,
+          () -> CODEC.decodeInto(OPTS, INT_CTX, withTrailingByte.duplicate(),
+              ByteBuffer.allocateDirect(values.length * Integer.BYTES)));
+
+      CodecPipelineExecutor executor = CodecPipelineExecutor.create("GORILLA", INT_CTX, CodecRegistry.DEFAULT);
+      assertThrows(RuntimeException.class,
+          () -> executor.decode(withTrailingByte.duplicate(),
+              ByteBuffer.allocateDirect(values.length * Integer.BYTES), values.length * Integer.BYTES));
+    }
+  }
+
+  @Test
+  public void testNonZeroPaddingBitsRejected() {
+    ByteBuffer src = ByteBuffer.allocateDirect(2 * Integer.BYTES);
+    src.putInt(7).putInt(7).flip();
+    ByteBuffer encoded = CODEC.encode(OPTS, INT_CTX, src);
+    encoded.put(encoded.limit() - 1, (byte) 1);
+
+    assertThrows(IllegalStateException.class,
+        () -> CODEC.decode(OPTS, INT_CTX, encoded.duplicate()));
+    CodecPipelineExecutor executor = CodecPipelineExecutor.create("GORILLA", INT_CTX, CodecRegistry.DEFAULT);
+    assertThrows(IllegalStateException.class,
+        () -> executor.decode(encoded.duplicate(), ByteBuffer.allocateDirect(2 * Integer.BYTES),
+            2 * Integer.BYTES));
+  }
+
+  /// Decodes fixed INT and LONG frames that are independent of the encoder under test. Both
+  /// represent `[0, 1]` with an explicit one-bit XOR window.
+  @Test
+  public void testKnownGoodDecodeBytes() {
+    byte[] encodedInt = {
+        0,
+        0, 0, 0, 2,
+        0, 0, 0, 0,
+        (byte) 0xFE, 0x08
+    };
+    assertDecodedInts(
+        CODEC.decode(OPTS, INT_CTX, ByteBuffer.wrap(encodedInt).order(ByteOrder.LITTLE_ENDIAN)), new int[]{0, 1});
+
+    byte[] encodedLong = {
+        1,
+        0, 0, 0, 2,
+        0, 0, 0, 0, 0, 0, 0, 0,
+        (byte) 0xFF, 0x02
+    };
+    long[] expectedLongs = {0L, 1L};
+    assertDecodedLongs(
+        CODEC.decode(OPTS, LONG_CTX, ByteBuffer.wrap(encodedLong).order(ByteOrder.LITTLE_ENDIAN)), expectedLongs);
+    ByteBuffer dst = ByteBuffer.allocateDirect(expectedLongs.length * Long.BYTES);
+    CODEC.decodeInto(OPTS, LONG_CTX, ByteBuffer.wrap(encodedLong).order(ByteOrder.LITTLE_ENDIAN), dst);
+    assertDecodedLongs(dst, expectedLongs);
+  }
+
+  @Test
+  public void testUnsupportedDataType() {
+    assertThrows(IllegalArgumentException.class,
+        () -> CODEC.validateContext(OPTS, new CodecContext(DataType.STRING)));
+    assertThrows(IllegalArgumentException.class,
+        () -> CODEC.validateContext(OPTS, new CodecContext(DataType.FLOAT)));
+  }
+
+  @Test
+  public void testRejectsArguments() {
+    assertThrows(IllegalArgumentException.class,
+        () -> CODEC.parseOptions(List.of("3")));
+  }
+
+  @Test
+  public void testMaxEncodedSizeRejectsOverflow() {
+    assertThrows(IllegalArgumentException.class,
+        () -> CODEC.maxEncodedSize(OPTS, Integer.MAX_VALUE));
+  }
+
+  private static ByteBuffer appendByte(ByteBuffer buffer) {
+    ByteBuffer withTrailingByte = ByteBuffer.allocateDirect(buffer.remaining() + 1);
+    withTrailingByte.put(buffer.duplicate()).put((byte) 1).flip();
+    return withTrailingByte;
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/T64CodecDefinitionTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/codec/T64CodecDefinitionTest.java
@@ -1,0 +1,532 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.io.codec;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+
+/// Focused boundary tests for [T64CodecDefinition].
+///
+/// The codec-pipeline on-disk format does not exist yet at this point in the stack, so this file
+/// is the direct coverage of the T64 transform, including code paths that monotonic test data
+/// would not reach:
+///  - `count == 0`, `count == 1`
+///  - bitWidth == 0 (all values in a block equal)
+///  - partial last block (count not a multiple of BLOCK_SIZE)
+///  - max-range INT and LONG inputs (forces bitWidth = 32 / 64)
+///  - alternating ± values, strictly decreasing
+///  - corrupt-segment defenses (invalid flag, invalid bitWidth, invalid count, mismatched size)
+public class T64CodecDefinitionTest {
+
+  private static final T64CodecDefinition CODEC = T64CodecDefinition.INSTANCE;
+  private static final T64CodecDefinition.Options OPTS = T64CodecDefinition.OPTIONS;
+  private static final CodecContext INT_CTX = new CodecContext(DataType.INT);
+  private static final CodecContext LONG_CTX = new CodecContext(DataType.LONG);
+
+  // ---------- Round-trip helpers ----------
+
+  private static void roundTripInt(int[] values) {
+    ByteBuffer src = ByteBuffer.allocateDirect(values.length * Integer.BYTES);
+    for (int v : values) {
+      src.putInt(v);
+    }
+    src.flip();
+    ByteBuffer encoded = CODEC.encode(OPTS, INT_CTX, src);
+    assertDecodedInts(CODEC.decode(OPTS, INT_CTX, encoded.duplicate()), values);
+
+    ByteBuffer dst = ByteBuffer.allocateDirect(values.length * Integer.BYTES);
+    CODEC.decodeInto(OPTS, INT_CTX, encoded.duplicate(), dst);
+    assertDecodedInts(dst, values);
+  }
+
+  private static void assertDecodedInts(ByteBuffer decoded, int[] values) {
+    assertEquals(decoded.remaining(), values.length * Integer.BYTES,
+        "decoded byte length mismatch");
+    for (int i = 0; i < values.length; i++) {
+      assertEquals(decoded.getInt(), values[i], "INT mismatch at i=" + i);
+    }
+  }
+
+  private static void roundTripLong(long[] values) {
+    ByteBuffer src = ByteBuffer.allocateDirect(values.length * Long.BYTES);
+    for (long v : values) {
+      src.putLong(v);
+    }
+    src.flip();
+    ByteBuffer encoded = CODEC.encode(OPTS, LONG_CTX, src);
+    assertDecodedLongs(CODEC.decode(OPTS, LONG_CTX, encoded.duplicate()), values);
+
+    ByteBuffer dst = ByteBuffer.allocateDirect(values.length * Long.BYTES);
+    CODEC.decodeInto(OPTS, LONG_CTX, encoded.duplicate(), dst);
+    assertDecodedLongs(dst, values);
+  }
+
+  private static void assertDecodedLongs(ByteBuffer decoded, long[] values) {
+    assertEquals(decoded.remaining(), values.length * Long.BYTES,
+        "decoded byte length mismatch");
+    for (int i = 0; i < values.length; i++) {
+      assertEquals(decoded.getLong(), values[i], "LONG mismatch at i=" + i);
+    }
+  }
+
+  // ---------- Count edge cases ----------
+
+  @Test
+  public void testEmptyInt() {
+    roundTripInt(new int[0]);
+  }
+
+  @Test
+  public void testEmptyLong() {
+    roundTripLong(new long[0]);
+  }
+
+  @Test
+  public void testSingleValueInt() {
+    roundTripInt(new int[]{42});
+  }
+
+  @Test
+  public void testSingleValueLong() {
+    roundTripLong(new long[]{1_700_000_000_000L});
+  }
+
+  @Test
+  public void testSingleValueIntMinMax() {
+    roundTripInt(new int[]{Integer.MIN_VALUE});
+    roundTripInt(new int[]{Integer.MAX_VALUE});
+  }
+
+  @Test
+  public void testSingleValueLongMinMax() {
+    roundTripLong(new long[]{Long.MIN_VALUE});
+    roundTripLong(new long[]{Long.MAX_VALUE});
+  }
+
+  // ---------- bitWidth == 0 (all equal) ----------
+
+  @Test
+  public void testAllEqualInt() {
+    int[] values = new int[128];
+    Arrays.fill(values, -7);
+    roundTripInt(values);
+  }
+
+  @Test
+  public void testAllEqualLong() {
+    long[] values = new long[128];
+    Arrays.fill(values, Long.MIN_VALUE);
+    roundTripLong(values);
+  }
+
+  // ---------- Partial last block ----------
+
+  @Test
+  public void testPartialLastBlock65Int() {
+    int[] values = new int[65];
+    for (int i = 0; i < 65; i++) {
+      values[i] = i * 3;
+    }
+    roundTripInt(values);
+  }
+
+  @Test
+  public void testPartialLastBlock127Long() {
+    long[] values = new long[127];
+    for (int i = 0; i < 127; i++) {
+      values[i] = (long) i * 1_000L;
+    }
+    roundTripLong(values);
+  }
+
+  @Test
+  public void testExactSingleBlockInt() {
+    int[] values = new int[64];
+    for (int i = 0; i < 64; i++) {
+      values[i] = i;
+    }
+    roundTripInt(values);
+  }
+
+  // ---------- Max-range values ----------
+
+  @Test
+  public void testIntMaxRange() {
+    int[] values = new int[]{Integer.MIN_VALUE, Integer.MAX_VALUE, 0, -1, 1,
+        Integer.MIN_VALUE + 1, Integer.MAX_VALUE - 1};
+    roundTripInt(values);
+  }
+
+  @Test
+  public void testLongMaxRange() {
+    long[] values = new long[]{Long.MIN_VALUE, Long.MAX_VALUE, 0L, -1L, 1L,
+        Long.MIN_VALUE + 1, Long.MAX_VALUE - 1};
+    roundTripLong(values);
+  }
+
+  @Test
+  public void testIntMaxRangeFullBlock() {
+    int[] values = new int[64];
+    values[0] = Integer.MIN_VALUE;
+    values[1] = Integer.MAX_VALUE;
+    for (int i = 2; i < 64; i++) {
+      values[i] = i;
+    }
+    roundTripInt(values);
+  }
+
+  @Test
+  public void testLongMaxRangeFullBlock() {
+    long[] values = new long[64];
+    values[0] = Long.MIN_VALUE;
+    values[1] = Long.MAX_VALUE;
+    for (int i = 2; i < 64; i++) {
+      values[i] = i;
+    }
+    roundTripLong(values);
+  }
+
+  @Test
+  public void testStrictlyDecreasingLong() {
+    long[] values = new long[300];
+    for (int i = 0; i < 300; i++) {
+      values[i] = -((long) i) * 1_000_000L;
+    }
+    roundTripLong(values);
+  }
+
+  @Test
+  public void testAlternatingSignInt() {
+    int[] values = new int[200];
+    for (int i = 0; i < 200; i++) {
+      values[i] = (i % 2 == 0) ? i : -i;
+    }
+    roundTripInt(values);
+  }
+
+  @Test
+  public void testMixedExecutorPipeline() throws IOException {
+    int[] values = new int[257];
+    for (int i = 0; i < values.length; i++) {
+      values[i] = i * i - 17 * i;
+    }
+    ByteBuffer src = ByteBuffer.allocateDirect(values.length * Integer.BYTES);
+    for (int value : values) {
+      src.putInt(value);
+    }
+    src.flip();
+
+    CodecPipelineExecutor executor = CodecPipelineExecutor.create("DELTA,T64,LZ4", INT_CTX,
+        CodecRegistry.DEFAULT);
+    ByteBuffer encoded = executor.encode(src.duplicate());
+    ByteBuffer decoded = ByteBuffer.allocateDirect(src.remaining());
+    executor.decode(encoded, decoded, src.remaining());
+    assertDecodedInts(decoded, values);
+  }
+
+  // ---------- Corrupt-segment defenses ----------
+
+  @Test
+  public void testInvalidFlagThrows() {
+    ByteBuffer buf = ByteBuffer.allocateDirect(5);
+    buf.put((byte) 7); // invalid flag
+    buf.putInt(1);
+    buf.flip();
+    assertThrows(IllegalStateException.class, () -> CODEC.decode(OPTS, INT_CTX, buf));
+  }
+
+  @Test
+  public void testInvalidFlagWithZeroCountThrows() {
+    // Flag validation must precede the count==0 short-circuit.
+    ByteBuffer buf = ByteBuffer.allocateDirect(5);
+    buf.put((byte) 42); // invalid flag
+    buf.putInt(0); // count = 0
+    buf.flip();
+    assertThrows(IllegalStateException.class, () -> CODEC.decode(OPTS, INT_CTX, buf));
+  }
+
+  @Test
+  public void testFrameTypeMustMatchContext() {
+    ByteBuffer longFrame = ByteBuffer.allocateDirect(5);
+    longFrame.put((byte) 1).putInt(0).flip();
+    assertThrows(IllegalStateException.class,
+        () -> CODEC.decode(OPTS, INT_CTX, longFrame.duplicate()));
+    assertThrows(IllegalStateException.class,
+        () -> CODEC.decodeInto(OPTS, INT_CTX, longFrame.duplicate(), ByteBuffer.allocateDirect(0)));
+  }
+
+  @Test
+  public void testNegativeCountThrows() {
+    ByteBuffer buf = ByteBuffer.allocateDirect(5);
+    buf.put((byte) 0);
+    buf.putInt(-1);
+    buf.flip();
+    assertThrows(IllegalStateException.class, () -> CODEC.decode(OPTS, INT_CTX, buf));
+  }
+
+  @Test
+  public void testInvalidBitWidthThrows() {
+    // INT with bitWidth=33 must be rejected
+    ByteBuffer buf = ByteBuffer.allocateDirect(64);
+    buf.put((byte) 0); // INT
+    buf.putInt(64);
+    buf.putInt(0); // baseline
+    buf.put((byte) 33); // invalid bitWidth for INT
+    buf.flip();
+    assertThrows(IllegalStateException.class, () -> CODEC.decode(OPTS, INT_CTX, buf));
+  }
+
+  @Test
+  public void testTrailingBytesRejectedByCodecAndExecutor() {
+    for (int[] values : new int[][]{{}, {42}, {1, 2, 3}}) {
+      ByteBuffer src = ByteBuffer.allocateDirect(values.length * Integer.BYTES);
+      for (int value : values) {
+        src.putInt(value);
+      }
+      src.flip();
+      ByteBuffer withTrailingByte = appendByte(CODEC.encode(OPTS, INT_CTX, src));
+
+      assertThrows(IllegalStateException.class,
+          () -> CODEC.decode(OPTS, INT_CTX, withTrailingByte.duplicate()));
+      assertThrows(IllegalStateException.class,
+          () -> CODEC.decodeInto(OPTS, INT_CTX, withTrailingByte.duplicate(),
+              ByteBuffer.allocateDirect(values.length * Integer.BYTES)));
+
+      CodecPipelineExecutor executor = CodecPipelineExecutor.create("T64", INT_CTX, CodecRegistry.DEFAULT);
+      assertThrows(RuntimeException.class,
+          () -> executor.decode(withTrailingByte.duplicate(),
+              ByteBuffer.allocateDirect(values.length * Integer.BYTES), values.length * Integer.BYTES));
+    }
+  }
+
+  @Test
+  public void testNonZeroPartialBlockPaddingRejected() {
+    ByteBuffer src = ByteBuffer.allocateDirect(4 * Integer.BYTES);
+    src.putInt(0).putInt(1).putInt(2).putInt(3).flip();
+    ByteBuffer encoded = CODEC.encode(OPTS, INT_CTX, src);
+    encoded.put(encoded.limit() - 1, (byte) 1);
+
+    assertThrows(IllegalStateException.class,
+        () -> CODEC.decode(OPTS, INT_CTX, encoded.duplicate()));
+    CodecPipelineExecutor executor = CodecPipelineExecutor.create("T64", INT_CTX, CodecRegistry.DEFAULT);
+    assertThrows(IllegalStateException.class,
+        () -> executor.decode(encoded.duplicate(), ByteBuffer.allocateDirect(4 * Integer.BYTES),
+            4 * Integer.BYTES));
+  }
+
+  @Test
+  public void testMisalignedInputSizeThrows() {
+    ByteBuffer buf = ByteBuffer.allocateDirect(7); // not a multiple of INT size
+    assertThrows(IllegalArgumentException.class, () -> CODEC.encode(OPTS, INT_CTX, buf));
+  }
+
+  @Test
+  public void testUnsupportedDataType() {
+    assertThrows(IllegalArgumentException.class,
+        () -> CODEC.validateContext(OPTS, new CodecContext(DataType.STRING)));
+    assertThrows(IllegalArgumentException.class,
+        () -> CODEC.validateContext(OPTS, new CodecContext(DataType.DOUBLE)));
+  }
+
+  @Test
+  public void testRejectsArguments() {
+    assertThrows(IllegalArgumentException.class,
+        () -> CODEC.parseOptions(List.of("3")));
+  }
+
+  // ---------- Encoded-size bound ----------
+
+  @DataProvider(name = "boundaryCounts")
+  public Object[][] boundaryCounts() {
+    return new Object[][]{
+        {0}, {1}, {63}, {64}, {65}, {127}, {128}, {129}, {256}, {1024}
+    };
+  }
+
+  @Test(dataProvider = "boundaryCounts")
+  public void testEncodedSizeWithinMaxEncodedSizeInt(int count) {
+    int[] values = new int[count];
+    // Force the worst case: alternate MIN_VALUE and MAX_VALUE so range == 2^32 - 1, bitWidth=32
+    for (int i = 0; i < count; i++) {
+      values[i] = (i % 2 == 0) ? Integer.MIN_VALUE : Integer.MAX_VALUE;
+    }
+    ByteBuffer src = ByteBuffer.allocateDirect(Math.max(1, count) * Integer.BYTES);
+    for (int v : values) {
+      src.putInt(v);
+    }
+    src.flip();
+    ByteBuffer encoded = CODEC.encode(OPTS, INT_CTX, src);
+    int max = CODEC.maxEncodedSize(OPTS, count * Integer.BYTES);
+    assertTrue(encoded.remaining() <= max,
+        "count=" + count + " encoded.remaining()=" + encoded.remaining()
+            + " exceeds maxEncodedSize=" + max);
+  }
+
+  @Test(dataProvider = "boundaryCounts")
+  public void testEncodedSizeWithinMaxEncodedSizeLong(int count) {
+    long[] values = new long[count];
+    for (int i = 0; i < count; i++) {
+      values[i] = (i % 2 == 0) ? Long.MIN_VALUE : Long.MAX_VALUE;
+    }
+    ByteBuffer src = ByteBuffer.allocateDirect(Math.max(1, count) * Long.BYTES);
+    for (long v : values) {
+      src.putLong(v);
+    }
+    src.flip();
+    ByteBuffer encoded = CODEC.encode(OPTS, LONG_CTX, src);
+    int max = CODEC.maxEncodedSize(OPTS, count * Long.BYTES);
+    assertTrue(encoded.remaining() <= max,
+        "count=" + count + " encoded.remaining()=" + encoded.remaining()
+            + " exceeds maxEncodedSize=" + max);
+  }
+
+  @Test
+  public void testMaxEncodedSizeRejectsOverflow() {
+    assertThrows(IllegalArgumentException.class,
+        () -> CODEC.maxEncodedSize(OPTS, Integer.MAX_VALUE));
+  }
+
+  // ---------- Wire-format byte-layout pin test ----------
+
+  /// Pins the on-disk bytes for a small canonical input. `NAME = "T64"` and the frame format are
+  /// documented as frozen on-disk contract — any unintended byte-layout regression must fail
+  /// this test.
+  @Test
+  public void testKnownGoodEncodedBytesInt() {
+    int[] values = new int[]{0, 1, 2, 3};
+    ByteBuffer src = ByteBuffer.allocateDirect(values.length * Integer.BYTES);
+    for (int v : values) {
+      src.putInt(v);
+    }
+    src.flip();
+    ByteBuffer encoded = CODEC.encode(OPTS, INT_CTX, src);
+
+    // Frame: flag=0 (INT), count=4, then one block:
+    //   baseline = 0 (int, 4 bytes big-endian — the ByteBuffer default)
+    //   bitWidth = 2  (range 0..3 needs 2 bits)
+    //   packed: 64 slots of 2 bits each = 16 bytes; slots 0..3 = (0, 1, 2, 3) lsb-first
+    //          slot 0 (bits 0-1): 00, slot 1 (bits 2-3): 01, slot 2 (bits 4-5): 10, slot 3 (bits 6-7): 11
+    //          → first byte = 0b11_10_01_00 = 0xE4; remaining 15 bytes zero.
+    byte[] expected = new byte[1 + 4 + 4 + 1 + 16];
+    expected[0] = 0; // flag = INT
+    // count = 4 (big-endian)
+    expected[1] = 0;
+    expected[2] = 0;
+    expected[3] = 0;
+    expected[4] = 4;
+    // baseline = 0 (big-endian)
+    expected[5] = 0;
+    expected[6] = 0;
+    expected[7] = 0;
+    expected[8] = 0;
+    expected[9] = 2; // bitWidth
+    expected[10] = (byte) 0xE4;
+    // Remaining 15 bytes default to zero.
+
+    byte[] actual = new byte[encoded.remaining()];
+    encoded.duplicate().get(actual);
+    assertEquals(actual.length, expected.length, "byte-length mismatch");
+    for (int i = 0; i < expected.length; i++) {
+      assertEquals(actual[i], expected[i],
+          "byte[" + i + "] mismatch: expected " + (expected[i] & 0xFF) + " got " + (actual[i] & 0xFF));
+    }
+  }
+
+  /// Independently freezes the LONG decoder layout. The bytes are not produced by the encoder
+  /// under test: flag=LONG, count=4, baseline=0, bitWidth=2, then the fixed 64-slot payload.
+  @Test
+  public void testKnownGoodDecodeBytesLong() {
+    byte[] encoded = new byte[1 + Integer.BYTES + Long.BYTES + 1 + 16];
+    encoded[0] = 1;
+    encoded[4] = 4;
+    encoded[13] = 2;
+    encoded[14] = (byte) 0xE4;
+    long[] expected = {0L, 1L, 2L, 3L};
+
+    assertDecodedLongs(
+        CODEC.decode(OPTS, LONG_CTX, ByteBuffer.wrap(encoded).order(ByteOrder.LITTLE_ENDIAN)), expected);
+    ByteBuffer dst = ByteBuffer.allocateDirect(expected.length * Long.BYTES);
+    CODEC.decodeInto(OPTS, LONG_CTX, ByteBuffer.wrap(encoded).order(ByteOrder.LITTLE_ENDIAN), dst);
+    assertDecodedLongs(dst, expected);
+  }
+
+  // ---------- Parameterized bit-width × position coverage ----------
+
+  /// For each pair (bitWidth, valuesPerBlock), construct a block that forces *exactly* bitWidth
+  /// bits of dynamic range so the encoder lays slots out at every bit-cursor position
+  /// {0, bitWidth, 2*bitWidth, ...} mod 8. A `writeBits` that left-shifts `value` into a 64-bit
+  /// register would silently truncate high bits whenever `bitInByte + bitWidth > 64`, which
+  /// manifests for any bitWidth ∈ {2..63} that produces a non-zero `bitInByte` at some slot.
+  @DataProvider(name = "bitWidthsLong")
+  public Object[][] bitWidthsLong() {
+    Object[][] cases = new Object[64][];
+    for (int bw = 1; bw <= 64; bw++) {
+      cases[bw - 1] = new Object[]{bw};
+    }
+    return cases;
+  }
+
+  @Test(dataProvider = "bitWidthsLong")
+  public void testRoundTripAllBitWidthsLong(int bitWidth) {
+    long range = (bitWidth == 64) ? -1L : ((1L << bitWidth) - 1L);
+    long[] values = new long[200];
+    for (int i = 0; i < 200; i++) {
+      // Alternate min and max-bit-set values so the encoder must emit full-width slots
+      // at every bit position 0..7. baseline is 0, so encoded slot value == values[i].
+      values[i] = (i % 2 == 0) ? 0L : range;
+    }
+    roundTripLong(values);
+  }
+
+  @DataProvider(name = "bitWidthsInt")
+  public Object[][] bitWidthsInt() {
+    Object[][] cases = new Object[32][];
+    for (int bw = 1; bw <= 32; bw++) {
+      cases[bw - 1] = new Object[]{bw};
+    }
+    return cases;
+  }
+
+  @Test(dataProvider = "bitWidthsInt")
+  public void testRoundTripAllBitWidthsInt(int bitWidth) {
+    int range = (bitWidth == 32) ? -1 : ((1 << bitWidth) - 1);
+    int[] values = new int[200];
+    for (int i = 0; i < 200; i++) {
+      values[i] = (i % 2 == 0) ? 0 : range;
+    }
+    roundTripInt(values);
+  }
+
+  private static ByteBuffer appendByte(ByteBuffer buffer) {
+    ByteBuffer withTrailingByte = ByteBuffer.allocateDirect(buffer.remaining() + 1);
+    withTrailingByte.put(buffer.duplicate()).put((byte) 1).flip();
+    return withTrailingByte;
+  }
+}


### PR DESCRIPTION
## Context

Stacked on #19305 and part of the split of #18229.

## What changed

- Adds `T64`, a frame-of-reference packing transform over fixed 64-value blocks.
- Adds `GORILLA`, an XOR/window packing transform with an MSB-first bitstream.
- Registers both frozen codec names and enforces that a packing transform is the last transform before any compression stages.
- Makes all fixed-width frame fields explicitly big-endian.
- Requires exact frame consumption: T64 rejects nonzero tail slots and trailing bytes; GORILLA rejects nonzero final padding and trailing bytes.
- Uses reusable 64-value block scratch for T64 instead of allocating a full chunk-sized `long[]`.
- Corrects the public wire documentation for contained-window reuse and width-minus-one encoding.

## Safety and scope

T64/GORILLA remain runtime-only in this slice; production forward-index creation/loading is first wired in #19307.

## Verification

- INT/LONG round trips across empty, singleton, partial-block, boundary, and every supported bit width.
- Happy-path bounded `decodeInto`, mixed executor chains, corruption/trailing/padding rejection, and encoded-size bounds.
- Independent known-byte fixtures for T64 INT/LONG and GORILLA.
- Little-endian caller-view regressions proving big-endian persisted decoding.
- Spotless, Checkstyle, license format, and license check for `pinot-segment-local`.

## Stack

#19284 → #19285 → #19305 → **#19306 (this PR)** → #19307 → #19308 → #19309

Review and merge parent-first.
