### PR TITLE
Skip missing consuming segment check for paused realtime tables

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -300,7 +300,8 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
       return false;
     }
 
-    if (PinotLLCRealtimeSegmentManager.isTablePaused(idealState)) {
+    boolean tablePaused = PinotLLCRealtimeSegmentManager.isTablePaused(idealState);
+    if (tablePaused) {
       context._pausedTables.add(tableNameWithType);
     }
 
@@ -585,9 +586,16 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
         numInvalidEndTime);
 
     if (tableType == TableType.REALTIME && tableConfig != null) {
-      List<StreamConfig> streamConfigs = IngestionConfigUtils.getStreamConfigs(tableConfig);
-      new MissingConsumingSegmentFinder(tableNameWithType, propertyStore, _controllerMetrics,
-          streamConfigs, idealState).findAndEmitMetrics(idealState);
+      if (tablePaused) {
+        // Ingestion is intentionally paused, so PinotLLCRealtimeSegmentManager deliberately does not create a new
+        // CONSUMING segment after the current one commits. MissingConsumingSegmentFinder would otherwise read that as
+        // a missing segment and alert for as long as the pause lasts.
+        MissingConsumingSegmentFinder.resetMetrics(tableNameWithType, _controllerMetrics);
+      } else {
+        List<StreamConfig> streamConfigs = IngestionConfigUtils.getStreamConfigs(tableConfig);
+        new MissingConsumingSegmentFinder(tableNameWithType, propertyStore, _controllerMetrics,
+            streamConfigs, idealState).findAndEmitMetrics(idealState);
+      }
     }
     return true;
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinder.java
@@ -107,6 +107,18 @@ public class MissingConsumingSegmentFinder {
     _streamPartitionMsgOffsetFactory = streamPartitionMsgOffsetFactory;
   }
 
+  /// Zeroes out every gauge that [#findAndEmitMetrics] emits, for callers that intentionally skip the search (e.g. a
+  /// table whose ingestion is paused, where having no CONSUMING segment is expected rather than a defect). These
+  /// gauges are last-write-wins with no "unset" value, so a skipped table would otherwise keep reporting whatever was
+  /// last written before the skip began. Kept here so the class that owns these gauge names also owns their reset.
+  public static void resetMetrics(String realtimeTableName, ControllerMetrics controllerMetrics) {
+    controllerMetrics.setValueOfTableGauge(realtimeTableName, ControllerGauge.MISSING_CONSUMING_SEGMENT_TOTAL_COUNT, 0);
+    controllerMetrics.setValueOfTableGauge(realtimeTableName,
+        ControllerGauge.MISSING_CONSUMING_SEGMENT_NEW_PARTITION_COUNT, 0);
+    controllerMetrics.setValueOfTableGauge(realtimeTableName,
+        ControllerGauge.MISSING_CONSUMING_SEGMENT_MAX_DURATION_MINUTES, 0);
+  }
+
   public void findAndEmitMetrics(IdealState idealState) {
     MissingSegmentInfo info = findMissingSegments(idealState.getRecord().getMapFields(), Instant.now());
     _controllerMetrics.setValueOfTableGauge(_realtimeTableName, ControllerGauge.MISSING_CONSUMING_SEGMENT_TOTAL_COUNT,

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
@@ -48,7 +48,9 @@ import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.api.resources.SegmentStatusInfo;
 import org.apache.pinot.controller.api.resources.TableViews;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import org.apache.pinot.controller.util.TableSizeReader;
+import org.apache.pinot.spi.config.table.PauseState;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.TierConfig;
@@ -317,6 +319,90 @@ public class SegmentStatusCheckerTest {
     verifyControllerMetrics(REALTIME_TABLE_NAME, 3, 3, 3, 2, 66, 0, 100, 0, 0);
     assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, REALTIME_TABLE_NAME,
         ControllerGauge.MISSING_CONSUMING_SEGMENT_TOTAL_COUNT), 2);
+  }
+
+  /// When a table is paused via the pause/resume ingestion API, PinotLLCRealtimeSegmentManager deliberately does not
+  /// create a new CONSUMING segment after the current one commits. Without the pause gate,
+  /// MissingConsumingSegmentFinder would see the completed segments with no CONSUMING replacement and flag them as
+  /// missing for as long as the pause lasts.
+  ///
+  /// The fixture matches [#realtimeBasicTest], which reports a
+  /// [ControllerGauge#MISSING_CONSUMING_SEGMENT_TOTAL_COUNT] of 2. The checker is run twice against the same metrics
+  /// instance — once unpaused to establish that non-zero reading, then again after pausing — so this covers the
+  /// actual production scenario: these gauges are last-write-wins, so pausing must actively reset a previously
+  /// reported value rather than merely stop updating it.
+  @Test
+  public void realtimePausedTableHasNoMissingConsumingSegmentAlert() {
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setTimeColumnName("timeColumn")
+            .setNumReplicas(3).setStreamConfigs(getStreamConfigMap()).build();
+
+    String seg1 = new LLCSegmentName(RAW_TABLE_NAME, 1, 0, System.currentTimeMillis()).getSegmentName();
+    String seg2 = new LLCSegmentName(RAW_TABLE_NAME, 1, 1, System.currentTimeMillis()).getSegmentName();
+    String seg3 = new LLCSegmentName(RAW_TABLE_NAME, 2, 1, System.currentTimeMillis()).getSegmentName();
+    IdealState idealState = new IdealState(REALTIME_TABLE_NAME);
+    idealState.setPartitionState(seg1, "pinot1", "ONLINE");
+    idealState.setPartitionState(seg1, "pinot2", "ONLINE");
+    idealState.setPartitionState(seg1, "pinot3", "ONLINE");
+
+    idealState.setPartitionState(seg2, "pinot1", "ONLINE");
+    idealState.setPartitionState(seg2, "pinot2", "ONLINE");
+    idealState.setPartitionState(seg2, "pinot3", "ONLINE");
+
+    idealState.setPartitionState(seg3, "pinot1", "CONSUMING");
+    idealState.setPartitionState(seg3, "pinot2", "CONSUMING");
+    idealState.setPartitionState(seg3, "pinot3", "OFFLINE");
+    idealState.setReplicas("3");
+    idealState.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
+
+    ExternalView externalView = new ExternalView(REALTIME_TABLE_NAME);
+    externalView.setState(seg1, "pinot1", "ONLINE");
+    externalView.setState(seg1, "pinot2", "ONLINE");
+    externalView.setState(seg1, "pinot3", "ONLINE");
+
+    externalView.setState(seg2, "pinot1", "CONSUMING");
+    externalView.setState(seg2, "pinot2", "ONLINE");
+    externalView.setState(seg2, "pinot3", "CONSUMING");
+
+    externalView.setState(seg3, "pinot1", "CONSUMING");
+    externalView.setState(seg3, "pinot2", "CONSUMING");
+    externalView.setState(seg3, "pinot3", "OFFLINE");
+
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    when(resourceManager.getHelixInstanceConfig(any())).thenReturn(newQuerableInstanceConfig("any"));
+    when(resourceManager.getTableConfig(REALTIME_TABLE_NAME)).thenReturn(tableConfig);
+    when(resourceManager.getAllTables()).thenReturn(List.of(REALTIME_TABLE_NAME));
+    when(resourceManager.getTableIdealState(REALTIME_TABLE_NAME)).thenReturn(idealState);
+    when(resourceManager.getTableExternalView(REALTIME_TABLE_NAME)).thenReturn(externalView);
+    SegmentZKMetadata committedSegmentZKMetadata = mockCommittedSegmentZKMetadata();
+    SegmentZKMetadata consumingSegmentZKMetadata = mockConsumingSegmentZKMetadata(11111L);
+    mockSegmentsZKMetadata(resourceManager, REALTIME_TABLE_NAME,
+        Map.of(seg1, committedSegmentZKMetadata, seg2, committedSegmentZKMetadata, seg3, consumingSegmentZKMetadata));
+
+    // Stubbed exactly as in realtimeBasicTest so that MissingConsumingSegmentFinder computes a non-zero count.
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    when(resourceManager.getPropertyStore()).thenReturn(propertyStore);
+    ZNRecord znRecord = new ZNRecord("0");
+    znRecord.setSimpleField(CommonConstants.Segment.Realtime.END_OFFSET, "10000");
+    when(propertyStore.get(anyString(), any(), anyInt())).thenReturn(znRecord);
+
+    // Not yet paused: the finder runs and reports the missing consuming segments.
+    runSegmentStatusChecker(resourceManager, 0);
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, REALTIME_TABLE_NAME,
+        ControllerGauge.MISSING_CONSUMING_SEGMENT_TOTAL_COUNT), 2);
+
+    // Mirrors how PinotLLCRealtimeSegmentManager#updatePauseStateInIdealState records an administrative pause, and how
+    // #isTablePaused reads it back off the ideal state record.
+    idealState.getRecord().setSimpleField(PinotLLCRealtimeSegmentManager.PAUSE_STATE,
+        new PauseState(true, PauseState.ReasonCode.ADMINISTRATIVE, "paused for test", "0", null).toJsonString());
+
+    runSegmentStatusChecker(resourceManager, 0);
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, REALTIME_TABLE_NAME,
+        ControllerGauge.MISSING_CONSUMING_SEGMENT_TOTAL_COUNT), 0);
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, REALTIME_TABLE_NAME,
+        ControllerGauge.MISSING_CONSUMING_SEGMENT_NEW_PARTITION_COUNT), 0);
+    assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, REALTIME_TABLE_NAME,
+        ControllerGauge.MISSING_CONSUMING_SEGMENT_MAX_DURATION_MINUTES), 0);
   }
 
   @Test


### PR DESCRIPTION
`bug` `metric`
## Summary

`missingConsumingSegmentTotalCount` and its two sibling gauges report a false positive for REALTIME tables whose ingestion is intentionally paused. This gates the check on the table's pause state and resets the gauges while paused.

## Problem

`SegmentStatusChecker.updateSegmentMetrics` invokes `MissingConsumingSegmentFinder` for every enabled REALTIME table, with no check for whether the table is paused via the pause/resume ingestion API.

When a table is paused, `PinotLLCRealtimeSegmentManager` deliberately does not create a replacement CONSUMING segment after the current one commits, leaving the partition with only a completed segment. `MissingConsumingSegmentFinder` treats exactly that shape — no consuming segment, a completed segment, and a stream offset that has advanced past it — as a missing consumer. Since the stream keeps advancing while paused, the condition never clears, so `MISSING_CONSUMING_SEGMENT_MAX_DURATION_MINUTES` grows for the duration of the pause. The result is indistinguishable from a genuine ingestion failure.

Disabled tables are unaffected: `updateSegmentMetrics` returns early on `!idealState.isEnabled()` and calls `removeMetricsForTable`. Paused tables had no equivalent guard.

The existing per-topic `PauseState.getIndexOfInactiveTopics()` exclusion inside the finder does not cover this. `updatePauseStateInIdealState` only carries forward a pre-existing inactive-topic list; a whole-table pause never populates it, so `isPaused() == true` leaves the finder's per-topic exclusion empty.

## Fix

Reuse the pause state already computed in `updateSegmentMetrics` for the `TABLE_CONSUMPTION_PAUSED` gauge, and skip the finder when the table is paused.

These gauges are last-write-wins with no "unset" value, so simply skipping the call would leave whatever value was written before the pause in place, alerting indefinitely. The paused branch therefore actively resets them through a new `MissingConsumingSegmentFinder.resetMetrics`, which keeps the set of gauge names in the class that emits them — otherwise a future gauge added to `findAndEmitMetrics` would silently go stale on the paused path, reintroducing this same bug.

No config, REST, metric-name, or wire-format changes. The only new surface is `MissingConsumingSegmentFinder.resetMetrics`, an internal helper on an existing controller-side class.

### Known gap / possible follow-up

This gates on whole-table pause (`isTablePaused`) only. Individually paused topics in a multi-topic stream config (`PauseState.getIndexOfInactiveTopics()`, added in #16692) are already handled for the ordinary case: `PartitionGroupMetadataFetcher.fetchMultipleStreams` skips paused topic indices, so those partitions never enter `_partitionGroupIdToLargestStreamOffsetMap` and the main detection loop never examines them.

There is a narrower gap, which I have left alone here. When that map ends up empty, `findMissingSegments` falls back to iterating `partitionGroupIdToLatestCompletedSegmentMap` and counts every partition without a consuming segment as missing, consulting neither pause state nor stream offsets. Pausing *every* topic of a multi-topic table individually reaches that fallback. The same fallback is also taken when the stream-metadata fetch throws, which is existing behaviour and a separate question.

That case seemed better handled on its own, since it is about the fallback path's semantics rather than the pause gate this PR adds. Happy to follow up separately, or to fold it in here if reviewers prefer.

## Test Plan

New `SegmentStatusCheckerTest.realtimePausedTableHasNoMissingConsumingSegmentAlert`, built on the existing `realtimeBasicTest` fixture and run in two phases against the same metrics instance:

1. unpaused — asserts `MISSING_CONSUMING_SEGMENT_TOTAL_COUNT == 2`, establishing a non-zero reading
2. paused — asserts all three `MISSING_CONSUMING_SEGMENT_*` gauges are `0`

The two-phase shape is deliberate: it covers the actual production scenario, where the gauge is already reporting non-zero from an earlier run and the pause must actively clear it, rather than merely never setting it.

Verified the test fails without the fix. With `SegmentStatusChecker.java` reverted to master, the run fails on the second phase with `expected [0] but found [2]`, and the surefire log contains no `Caught exception while updating segment status` — confirming the failure is a real computed value rather than a swallowed exception leaving the gauge at its default.

- `SegmentStatusCheckerTest`: 42/42 pass
- `MissingConsumingSegmentFinderTest`: 6/6 pass, no regression
- `spotless:apply`, `checkstyle:check`, `license:check` on `pinot-controller`: clean
