### PR TITLE
Do not hold allIndexPreprocess throttler while processing startree index and multi-col text index

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
@@ -160,20 +160,11 @@ public class ImmutableSegmentLoader {
 
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(indexDir);
     if (segmentMetadata.getTotalDocs() > 0) {
-      if (segmentOperationsThrottlerSet != null) {
-        segmentOperationsThrottlerSet.getSegmentAllIndexPreprocessThrottler().acquire();
-      }
-      try {
-        convertSegmentFormat(indexDir, indexLoadingConfig, segmentMetadata);
-        // Preprocess requires table config and schema
-        if (indexLoadingConfig.getTableConfig() != null && indexLoadingConfig.getSchema() != null) {
-          preprocessSegment(indexDir, segmentMetadata.getName(), segmentMetadata.getCrc(), indexLoadingConfig,
-              segmentOperationsThrottlerSet, zkMetadata);
-        }
-      } finally {
-        if (segmentOperationsThrottlerSet != null) {
-          segmentOperationsThrottlerSet.getSegmentAllIndexPreprocessThrottler().release();
-        }
+      convertSegmentFormat(indexDir, indexLoadingConfig, segmentMetadata, segmentOperationsThrottlerSet);
+      // Preprocess requires table config and schema
+      if (indexLoadingConfig.getTableConfig() != null && indexLoadingConfig.getSchema() != null) {
+        preprocessSegment(indexDir, segmentMetadata.getName(), segmentMetadata.getCrc(), indexLoadingConfig,
+            segmentOperationsThrottlerSet, zkMetadata);
       }
     }
   }
@@ -291,8 +282,13 @@ public class ImmutableSegmentLoader {
     return segmentVersionToLoad != null && segmentVersionToLoad != segmentMetadata.getVersion();
   }
 
+  /// Up-converts the segment format if needed, e.g. from v1 to v3. The conversion rewrites every index of every
+  /// column into the new format, so it is guarded by the all-index preprocess throttler, the same throttler that
+  /// guards the index building step in [SegmentPreProcessor]. The permit is taken and released here, so a segment
+  /// needing both steps queues on the throttler twice rather than holding a permit across both.
   private static void convertSegmentFormat(File indexDir, IndexLoadingConfig indexLoadingConfig,
-      SegmentMetadataImpl localSegmentMetadata)
+      SegmentMetadataImpl localSegmentMetadata,
+      @Nullable SegmentOperationsThrottlerSet segmentOperationsThrottlerSet)
       throws Exception {
     SegmentVersion segmentVersionToLoad = indexLoadingConfig.getSegmentVersion();
     if (segmentVersionToLoad == null || SegmentDirectoryPaths.segmentDirectoryFor(indexDir, segmentVersionToLoad)
@@ -309,7 +305,16 @@ public class ImmutableSegmentLoader {
     SegmentFormatConverter converter =
         SegmentFormatConverterFactory.getConverter(segmentVersionOnDisk, segmentVersionToLoad);
     LOGGER.info("Using converter: {} to up-convert segment: {}", converter.getClass().getSimpleName(), segmentName);
-    converter.convert(indexDir);
+    if (segmentOperationsThrottlerSet != null) {
+      segmentOperationsThrottlerSet.getSegmentAllIndexPreprocessThrottler().acquire();
+    }
+    try {
+      converter.convert(indexDir);
+    } finally {
+      if (segmentOperationsThrottlerSet != null) {
+        segmentOperationsThrottlerSet.getSegmentAllIndexPreprocessThrottler().release();
+      }
+    }
     LOGGER.info("Successfully up-converted segment: {} from version: {} to {}", segmentName,
         segmentVersionOnDisk, segmentVersionToLoad);
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessor.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessor.java
@@ -109,6 +109,48 @@ public class SegmentPreProcessor implements AutoCloseable {
     // This fixes the issue of temporary files not getting deleted after creating new inverted indexes.
     removeInvertedIndexTempFiles(indexDir);
 
+    processColumnsAndIndexes(indexDir, segmentOperationsThrottlerSet);
+
+    // Startree creation will load the segment again, so we need to close and re-open the segment writer to make sure
+    // that the other required indices (e.g. forward index) are up-to-date.
+    try (SegmentDirectory.Writer segmentWriter = _segmentDirectory.createWriter()) {
+      if (processStarTrees(indexDir, segmentOperationsThrottlerSet)) {
+        _segmentDirectory.reloadMetadata();
+        segmentWriter.save();
+      }
+      // Create/modify/remove multi-col text index if required.
+      if (processMultiColTextIndex(indexDir, segmentWriter, segmentOperationsThrottlerSet)) {
+        // NOTE: When adding new steps after this, un-comment the next line.
+        //_segmentDirectory.reloadMetadata();
+        segmentWriter.save();
+      }
+    }
+  }
+
+  /// Updates the default columns according to the schema, then all the single-column indices (inverted, range, json,
+  /// text, ...), then the column min/max values.
+  ///
+  /// This is the only step guarded by the all-index preprocess throttler. Star-tree and multi-column text indexes
+  /// have their own throttlers, so the all-index permit is released before those builds start rather than being held
+  /// for their whole (potentially very long) duration.
+  private void processColumnsAndIndexes(File indexDir,
+      @Nullable SegmentOperationsThrottlerSet segmentOperationsThrottlerSet)
+      throws Exception {
+    if (segmentOperationsThrottlerSet != null) {
+      segmentOperationsThrottlerSet.getSegmentAllIndexPreprocessThrottler().acquire();
+    }
+    try {
+      updateColumnsAndIndexes(indexDir);
+    } finally {
+      if (segmentOperationsThrottlerSet != null) {
+        segmentOperationsThrottlerSet.getSegmentAllIndexPreprocessThrottler().release();
+      }
+    }
+  }
+
+  private void updateColumnsAndIndexes(File indexDir)
+      throws Exception {
+    SegmentMetadataImpl segmentMetadata = _segmentDirectory.getSegmentMetadata();
     try (SegmentDirectory.Writer segmentWriter = _segmentDirectory.createWriter()) {
       // Backward-compat shim: invalidate any legacy raw-value embedded-dictionary inverted indexes left over from
       // PR #17060 (reverted by PR #18410) so the standard handlers can rebuild them in the dict-id format. Must
@@ -173,21 +215,6 @@ public class SegmentPreProcessor implements AutoCloseable {
       }
 
       segmentWriter.save();
-    }
-
-    // Startree creation will load the segment again, so we need to close and re-open the segment writer to make sure
-    // that the other required indices (e.g. forward index) are up-to-date.
-    try (SegmentDirectory.Writer segmentWriter = _segmentDirectory.createWriter()) {
-      if (processStarTrees(indexDir, segmentOperationsThrottlerSet)) {
-        _segmentDirectory.reloadMetadata();
-        segmentWriter.save();
-      }
-      // Create/modify/remove multi-col text index if required.
-      if (processMultiColTextIndex(indexDir, segmentWriter, segmentOperationsThrottlerSet)) {
-        // NOTE: When adding new steps after this, un-comment the next line.
-        //_segmentDirectory.reloadMetadata();
-        segmentWriter.save();
-      }
     }
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/LoaderTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/LoaderTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
@@ -180,6 +181,44 @@ public class LoaderTest {
     try (SegmentDirectory segmentDirectory = new SegmentLocalFSDirectory(_indexDir, ReadMode.mmap)) {
       assertFalse(ImmutableSegmentLoader.needPreprocess(segmentDirectory, _v3IndexLoadingConfig));
     }
+  }
+
+  /// The segment format conversion is guarded by the all-index preprocess throttler, and so is the index building
+  /// step inside SegmentPreProcessor. Each step takes and releases its own permit, and a segment needing no
+  /// conversion never takes a permit for it.
+  @Test
+  public void testConvertAndPreprocessAcquireAllIndexPreprocessThrottler()
+      throws Exception {
+    constructV1Segment();
+    assertEquals(new SegmentMetadataImpl(_indexDir).getVersion(), SegmentVersion.v1);
+
+    AtomicInteger acquireCount = new AtomicInteger();
+    SegmentOperationsThrottler allIndexThrottler = new SegmentOperationsThrottler(1, 2, true) {
+      @Override
+      public void acquire()
+          throws InterruptedException {
+        acquireCount.incrementAndGet();
+        super.acquire();
+      }
+    };
+    SegmentOperationsThrottlerSet throttlerSet =
+        new SegmentOperationsThrottlerSet(allIndexThrottler, new SegmentOperationsThrottler(1, 2, true),
+            new SegmentOperationsThrottler(1, 2, true), new SegmentOperationsThrottler(1, 2, true));
+
+    // Loading a v1 segment with a v3 config both converts the format and runs the index handlers, taking the permit
+    // once for each step
+    IndexSegment indexSegment = ImmutableSegmentLoader.load(_indexDir, _v3IndexLoadingConfig, throttlerSet);
+    assertEquals(indexSegment.getSegmentMetadata().getVersion(), SegmentVersion.v3);
+    indexSegment.destroy();
+
+    assertEquals(acquireCount.get(), 2);
+    assertEquals(allIndexThrottler.availablePermits(), 1);
+
+    // A load with no conversion to do takes the permit only inside SegmentPreProcessor
+    indexSegment = ImmutableSegmentLoader.load(_indexDir, _v3IndexLoadingConfig, throttlerSet);
+    indexSegment.destroy();
+    assertEquals(acquireCount.get(), 3);
+    assertEquals(allIndexThrottler.availablePermits(), 1);
   }
 
   private void testConversion()

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
@@ -33,6 +33,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.ex.ConfigurationException;
@@ -71,6 +72,7 @@ import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.FieldConfig.CompressionCodec;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.JsonIndexConfig;
+import org.apache.pinot.spi.config.table.MultiColumnTextIndexConfig;
 import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -2022,6 +2024,70 @@ public class SegmentPreProcessorTest implements PinotBuffersAfterClassCheckRule 
             new IndexLoadingConfig(tableConfig, schema))) {
       assertTrue(processor.needProcess());
       processor.process(SEGMENT_OPERATIONS_THROTTLER);
+    }
+  }
+
+  /// The all-index preprocess throttler must only cover the single-column index steps. Star-tree and multi-column
+  /// text index builds have their own throttlers, and holding the all-index permit across them would block every
+  /// other segment preprocessing for the whole duration of those builds.
+  @Test
+  public void testAllIndexPreprocessThrottlerReleasedBeforeStarTreeAndMultiColTextIndex()
+      throws Exception {
+    // Build the sample segment
+    String[] stringValues = {"A", "C", "B", "C", "D", "E", "E", "E"};
+    long[] longValues = {2, 1, 2, 3, 4, 5, 3, 2};
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension("stringCol", FieldSpec.DataType.STRING)
+        .addMetric("longCol", DataType.LONG)
+        .build();
+    buildTestSegment(tableConfig, schema, stringValues, longValues);
+
+    // Add both a star-tree index and a multi-column text index so that both throttled steps actually run
+    IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
+    indexingConfig.setEnableDynamicStarTreeCreation(true);
+    indexingConfig.setStarTreeIndexConfigs(
+        List.of(new StarTreeIndexConfig(List.of("stringCol"), null, List.of("SUM__longCol"), null, 1000)));
+    indexingConfig.setMultiColumnTextIndexConfig(new MultiColumnTextIndexConfig(List.of("stringCol")));
+
+    SegmentOperationsThrottler allIndexThrottler = new SegmentOperationsThrottler(1, 1, true);
+    AtomicInteger permitsOnStarTreeAcquire = new AtomicInteger(-1);
+    AtomicInteger permitsOnMultiColTextAcquire = new AtomicInteger(-1);
+    SegmentOperationsThrottlerSet throttlerSet = new SegmentOperationsThrottlerSet(allIndexThrottler,
+        new PermitRecordingThrottler(allIndexThrottler, permitsOnStarTreeAcquire),
+        new SegmentOperationsThrottler(1, 1, true),
+        new PermitRecordingThrottler(allIndexThrottler, permitsOnMultiColTextAcquire));
+
+    try (SegmentDirectory segmentDirectory = new SegmentLocalFSDirectory(INDEX_DIR, ReadMode.mmap);
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfig, schema))) {
+      assertTrue(processor.needProcess());
+      processor.process(throttlerSet);
+    }
+
+    // Both steps must have run, and the all-index permit must have been released before either of them started
+    assertEquals(permitsOnStarTreeAcquire.get(), 1);
+    assertEquals(permitsOnMultiColTextAcquire.get(), 1);
+    // The all-index permit is released exactly once
+    assertEquals(allIndexThrottler.availablePermits(), 1);
+  }
+
+  /// Throttler that records the available permits of another throttler whenever it is acquired, so that tests can
+  /// assert which throttlers are held at the same time.
+  private static class PermitRecordingThrottler extends SegmentOperationsThrottler {
+    private final SegmentOperationsThrottler _observedThrottler;
+    private final AtomicInteger _observedPermitsOnAcquire;
+
+    PermitRecordingThrottler(SegmentOperationsThrottler observedThrottler, AtomicInteger observedPermitsOnAcquire) {
+      super(1, 1, true);
+      _observedThrottler = observedThrottler;
+      _observedPermitsOnAcquire = observedPermitsOnAcquire;
+    }
+
+    @Override
+    public void acquire()
+        throws InterruptedException {
+      _observedPermitsOnAcquire.set(_observedThrottler.availablePermits());
+      super.acquire();
     }
   }
 


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Throttler acquired/released per step: format conversion then column/index prep, then star\-tree/multi\-col text indexes\.

```mermaid
flowchart TD
  N0["ImmutableSegmentLoader#46;preprocess #40;F1#41;"]:::stModified
  N1["convertSegmentFormat #40;throttle acquire#47;release#41; #40;F1#41;"]:::stModified
  N2["preprocessSegment #40;calls SegmentPreProcessor#41; #40;F1#41;"]:::stUnchanged
  N3["SegmentPreProcessor#46;process #40;F2#41;"]:::stModified
  N4["processColumnsAndIndexes #40;throttle acquire#47;release#41; #40;F2#41;"]:::stAdded
  N5["updateColumnsAndIndexes #40;F2#41;"]:::stUnchanged
  N6["processStarTrees #40;F2#41;"]:::stUnchanged
  N7["processMultiColTextIndex #40;F2#41;"]:::stUnchanged
  N0 -->|"calls"| N1
  N1 -->|"next"| N2
  N2 -->|"calls"| N3
  N3 -->|"calls"| N4
  N4 -->|"calls"| N5
  N4 -->|"returns"| N3
  N3 -->|"calls"| N6
  N3 -->|"calls"| N7
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader\.java — [before](https://github.com/apache/pinot/blob/7fb11d92fbfdaf1d2b6a89e8da6a3503e06ea1f2/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java) · [after](https://github.com/apache/pinot/blob/b3e9cb30d2bded0fdc65b06a24d968d29b37f1ce/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java)
- F2: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessor\.java — [before](https://github.com/apache/pinot/blob/7fb11d92fbfdaf1d2b6a89e8da6a3503e06ea1f2/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessor.java) · [after](https://github.com/apache/pinot/blob/b3e9cb30d2bded0fdc65b06a24d968d29b37f1ce/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessor.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjdmYjExZDkyZmJmZGFmMWQyYjZhODllOGRhNmEzNTAzZTA2ZWExZjIiLCJjb250ZXh0X2hhc2giOiIzOTFkMTcyY2Q4YjQ0NTlmYmY4ODAzN2MzYTdmM2RhODJkMjhjMzFlMWFlYzRlYmE2NDFmNWVhOWUzMmM2MmQxIiwiZ2VuZXJhdGVkX2F0IjoxNzg5Mjg4NDUxLCJoZWFkX3NoYSI6ImIzZTljYjMwZDJiZGVkMGZkYzY1YjA2YTI0ZDk2OGQyOWIzN2YxY2UiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI3MzllNmE5MGQ3ODBjZjEwZDU4YzVhMmVmNWEzOWVjNGFjZGFlOTE3IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 3ee98dbb2dcc09c78509505e1231eba883cbda0053b799e0a49ccf5cf115d6c3 -->
<!-- pinot-pr-flow:end -->

