### PR TITLE
Null handling for the sketch-backed distinct counts, plus a filtered DISTINCTCOUNTTHETASKETCH group-by MV fix

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -396,25 +396,25 @@ public class AggregationFunctionFactory {
           case DISTINCTCOUNTOFFHEAP:
             return new DistinctCountOffHeapAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTCOUNTBITMAP:
-            return new DistinctCountBitmapAggregationFunction(arguments);
+            return new DistinctCountBitmapAggregationFunction(arguments, nullHandlingEnabled);
           case SEGMENTPARTITIONEDDISTINCTCOUNT:
-            return new SegmentPartitionedDistinctCountAggregationFunction(arguments);
+            return new SegmentPartitionedDistinctCountAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTCOUNTHLL:
-            return new DistinctCountHLLAggregationFunction(arguments);
+            return new DistinctCountHLLAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTCOUNTRAWHLL:
-            return new DistinctCountRawHLLAggregationFunction(arguments);
+            return new DistinctCountRawHLLAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTCOUNTSMARTHLL:
-            return new DistinctCountSmartHLLAggregationFunction(arguments);
+            return new DistinctCountSmartHLLAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTCOUNTSMARTHLLPLUS:
-            return new DistinctCountSmartHLLPlusAggregationFunction(arguments);
+            return new DistinctCountSmartHLLPlusAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTCOUNTSMARTULL:
-            return new DistinctCountSmartULLAggregationFunction(arguments);
+            return new DistinctCountSmartULLAggregationFunction(arguments, nullHandlingEnabled);
           case FASTHLL:
-            return new FastHLLAggregationFunction(arguments);
+            return new FastHLLAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTCOUNTTHETASKETCH:
-            return new DistinctCountThetaSketchAggregationFunction(arguments);
+            return new DistinctCountThetaSketchAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTCOUNTRAWTHETASKETCH:
-            return new DistinctCountRawThetaSketchAggregationFunction(arguments);
+            return new DistinctCountRawThetaSketchAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTSUM:
             return new DistinctSumAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTAVG:
@@ -436,19 +436,19 @@ public class AggregationFunctionFactory {
           case DISTINCTCOUNTMV:
             return new DistinctCountMVAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTCOUNTBITMAPMV:
-            return new DistinctCountBitmapMVAggregationFunction(arguments);
+            return new DistinctCountBitmapMVAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTCOUNTHLLMV:
-            return new DistinctCountHLLMVAggregationFunction(arguments);
+            return new DistinctCountHLLMVAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTCOUNTRAWHLLMV:
-            return new DistinctCountRawHLLMVAggregationFunction(arguments);
+            return new DistinctCountRawHLLMVAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTCOUNTHLLPLUS:
-            return new DistinctCountHLLPlusAggregationFunction(arguments);
+            return new DistinctCountHLLPlusAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTCOUNTRAWHLLPLUS:
-            return new DistinctCountRawHLLPlusAggregationFunction(arguments);
+            return new DistinctCountRawHLLPlusAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTCOUNTHLLPLUSMV:
-            return new DistinctCountHLLPlusMVAggregationFunction(arguments);
+            return new DistinctCountHLLPlusMVAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTCOUNTRAWHLLPLUSMV:
-            return new DistinctCountRawHLLPlusMVAggregationFunction(arguments);
+            return new DistinctCountRawHLLPlusMVAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTSUMMV:
             return new DistinctSumMVAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTAVGMV:
@@ -520,13 +520,13 @@ public class AggregationFunctionFactory {
           case FREQUENTLONGSSKETCH:
             return new FrequentLongsSketchAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTCOUNTCPCSKETCH:
-            return new DistinctCountCPCSketchAggregationFunction(arguments);
+            return new DistinctCountCPCSketchAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTCOUNTRAWCPCSKETCH:
-            return new DistinctCountRawCPCSketchAggregationFunction(arguments);
+            return new DistinctCountRawCPCSketchAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTCOUNTULL:
-            return new DistinctCountULLAggregationFunction(arguments);
+            return new DistinctCountULLAggregationFunction(arguments, nullHandlingEnabled);
           case DISTINCTCOUNTRAWULL:
-            return new DistinctCountRawULLAggregationFunction(arguments);
+            return new DistinctCountRawULLAggregationFunction(arguments, nullHandlingEnabled);
           case TIMESERIESAGGREGATE:
             return new TimeSeriesAggregationFunction(arguments);
           default:

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctCountSmartSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctCountSmartSketchAggregationFunction.java
@@ -48,12 +48,13 @@ import org.roaringbitmap.RoaringBitmap;
 /// Subclasses provide the sketch-specific behavior (conversion and dictionary handling).
 @SuppressWarnings({"rawtypes", "unchecked"})
 abstract class BaseDistinctCountSmartSketchAggregationFunction
-    extends BaseSingleInputAggregationFunction<Object, Integer> {
+    extends NullableSingleInputAggregationFunction<Object, Integer> {
   // Use empty IntOpenHashSet as a placeholder for empty result
   protected static final IntSet EMPTY_PLACEHOLDER = new IntOpenHashSet();
 
-  protected BaseDistinctCountSmartSketchAggregationFunction(ExpressionContext expression) {
-    super(expression);
+  protected BaseDistinctCountSmartSketchAggregationFunction(ExpressionContext expression,
+      boolean nullHandlingEnabled) {
+    super(expression, nullHandlingEnabled);
   }
 
   protected abstract int getThreshold();
@@ -93,47 +94,58 @@ abstract class BaseDistinctCountSmartSketchAggregationFunction
         case INT: {
           IntOpenHashSet intSet = (IntOpenHashSet) valueSet;
           int[] intValues = blockValSet.getIntValuesSV();
-          for (int i = 0; i < length; i++) {
-            intSet.add(intValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              intSet.add(intValues[i]);
+            }
+          });
           break;
         }
         case LONG: {
           LongOpenHashSet longSet = (LongOpenHashSet) valueSet;
           long[] longValues = blockValSet.getLongValuesSV();
-          for (int i = 0; i < length; i++) {
-            longSet.add(longValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              longSet.add(longValues[i]);
+            }
+          });
           break;
         }
         case FLOAT: {
           FloatOpenHashSet floatSet = (FloatOpenHashSet) valueSet;
           float[] floatValues = blockValSet.getFloatValuesSV();
-          for (int i = 0; i < length; i++) {
-            floatSet.add(floatValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              floatSet.add(floatValues[i]);
+            }
+          });
           break;
         }
         case DOUBLE: {
           DoubleOpenHashSet doubleSet = (DoubleOpenHashSet) valueSet;
           double[] doubleValues = blockValSet.getDoubleValuesSV();
-          for (int i = 0; i < length; i++) {
-            doubleSet.add(doubleValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              doubleSet.add(doubleValues[i]);
+            }
+          });
           break;
         }
         case STRING: {
           ObjectOpenHashSet<String> stringSet = (ObjectOpenHashSet<String>) valueSet;
           String[] stringValues = blockValSet.getStringValuesSV();
-          stringSet.addAll(Arrays.asList(stringValues).subList(0, length));
+          forEachNotNull(length, blockValSet,
+              (from, to) -> stringSet.addAll(Arrays.asList(stringValues).subList(from, to)));
           break;
         }
         case BYTES: {
           ObjectOpenHashSet<ByteArray> bytesSet = (ObjectOpenHashSet<ByteArray>) valueSet;
           byte[][] bytesValues = blockValSet.getBytesValuesSV();
-          for (int i = 0; i < length; i++) {
-            bytesSet.add(new ByteArray(bytesValues[i]));
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              bytesSet.add(new ByteArray(bytesValues[i]));
+            }
+          });
           break;
         }
         default:
@@ -144,49 +156,59 @@ abstract class BaseDistinctCountSmartSketchAggregationFunction
         case INT: {
           IntOpenHashSet intSet = (IntOpenHashSet) valueSet;
           int[][] intValues = blockValSet.getIntValuesMV();
-          for (int i = 0; i < length; i++) {
-            for (int value : intValues[i]) {
-              intSet.add(value);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (int value : intValues[i]) {
+                intSet.add(value);
+              }
             }
-          }
+          });
           break;
         }
         case LONG: {
           LongOpenHashSet longSet = (LongOpenHashSet) valueSet;
           long[][] longValues = blockValSet.getLongValuesMV();
-          for (int i = 0; i < length; i++) {
-            for (long value : longValues[i]) {
-              longSet.add(value);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (long value : longValues[i]) {
+                longSet.add(value);
+              }
             }
-          }
+          });
           break;
         }
         case FLOAT: {
           FloatOpenHashSet floatSet = (FloatOpenHashSet) valueSet;
           float[][] floatValues = blockValSet.getFloatValuesMV();
-          for (int i = 0; i < length; i++) {
-            for (float value : floatValues[i]) {
-              floatSet.add(value);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (float value : floatValues[i]) {
+                floatSet.add(value);
+              }
             }
-          }
+          });
           break;
         }
         case DOUBLE: {
           DoubleOpenHashSet doubleSet = (DoubleOpenHashSet) valueSet;
           double[][] doubleValues = blockValSet.getDoubleValuesMV();
-          for (int i = 0; i < length; i++) {
-            for (double value : doubleValues[i]) {
-              doubleSet.add(value);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (double value : doubleValues[i]) {
+                doubleSet.add(value);
+              }
             }
-          }
+          });
           break;
         }
         case STRING: {
           ObjectOpenHashSet<String> stringSet = (ObjectOpenHashSet<String>) valueSet;
           String[][] stringValues = blockValSet.getStringValuesMV();
-          for (int i = 0; i < length; i++) {
-            Collections.addAll(stringSet, stringValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              Collections.addAll(stringSet, stringValues[i]);
+            }
+          });
           break;
         }
         default:
@@ -210,14 +232,18 @@ abstract class BaseDistinctCountSmartSketchAggregationFunction
       IntSet modifiedGroups = new IntOpenHashSet();
       if (blockValSet.isSingleValue()) {
         int[] dictIds = blockValSet.getDictionaryIdsSV();
-        for (int i = 0; i < length; i++) {
-          aggregateDictIdForGroup(groupByResultHolder, groupKeyArray[i], dictionary, dictIds[i], modifiedGroups);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            aggregateDictIdForGroup(groupByResultHolder, groupKeyArray[i], dictionary, dictIds[i], modifiedGroups);
+          }
+        });
       } else {
         int[][] dictIds = blockValSet.getDictionaryIdsMV();
-        for (int i = 0; i < length; i++) {
-          aggregateDictIdsForGroup(groupByResultHolder, groupKeyArray[i], dictionary, dictIds[i], modifiedGroups);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            aggregateDictIdsForGroup(groupByResultHolder, groupKeyArray[i], dictionary, dictIds[i], modifiedGroups);
+          }
+        });
       }
       // Check cardinality only once per modified group after all additions
       checkAndConvertToSketchForGroups(groupByResultHolder, modifiedGroups);
@@ -230,47 +256,60 @@ abstract class BaseDistinctCountSmartSketchAggregationFunction
       switch (storedType) {
         case INT: {
           int[] intValues = blockValSet.getIntValuesSV();
-          for (int i = 0; i < length; i++) {
-            ((IntOpenHashSet) getValueSet(groupByResultHolder, groupKeyArray[i], DataType.INT)).add(intValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              ((IntOpenHashSet) getValueSet(groupByResultHolder, groupKeyArray[i], DataType.INT)).add(intValues[i]);
+            }
+          });
           break;
         }
         case LONG: {
           long[] longValues = blockValSet.getLongValuesSV();
-          for (int i = 0; i < length; i++) {
-            ((LongOpenHashSet) getValueSet(groupByResultHolder, groupKeyArray[i], DataType.LONG)).add(longValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              ((LongOpenHashSet) getValueSet(groupByResultHolder, groupKeyArray[i], DataType.LONG)).add(longValues[i]);
+            }
+          });
           break;
         }
         case FLOAT: {
           float[] floatValues = blockValSet.getFloatValuesSV();
-          for (int i = 0; i < length; i++) {
-            ((FloatOpenHashSet) getValueSet(groupByResultHolder, groupKeyArray[i], DataType.FLOAT)).add(floatValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              ((FloatOpenHashSet) getValueSet(groupByResultHolder, groupKeyArray[i], DataType.FLOAT))
+                  .add(floatValues[i]);
+            }
+          });
           break;
         }
         case DOUBLE: {
           double[] doubleValues = blockValSet.getDoubleValuesSV();
-          for (int i = 0; i < length; i++) {
-            ((DoubleOpenHashSet) getValueSet(groupByResultHolder, groupKeyArray[i], DataType.DOUBLE)).add(
-                doubleValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              ((DoubleOpenHashSet) getValueSet(groupByResultHolder, groupKeyArray[i], DataType.DOUBLE)).add(
+                  doubleValues[i]);
+            }
+          });
           break;
         }
         case STRING: {
           String[] stringValues = blockValSet.getStringValuesSV();
-          for (int i = 0; i < length; i++) {
-            ((ObjectOpenHashSet<String>) getValueSet(groupByResultHolder, groupKeyArray[i], DataType.STRING)).add(
-                stringValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              ((ObjectOpenHashSet<String>) getValueSet(groupByResultHolder, groupKeyArray[i], DataType.STRING)).add(
+                  stringValues[i]);
+            }
+          });
           break;
         }
         case BYTES: {
           byte[][] bytesValues = blockValSet.getBytesValuesSV();
-          for (int i = 0; i < length; i++) {
-            ((ObjectOpenHashSet<ByteArray>) getValueSet(groupByResultHolder, groupKeyArray[i], DataType.BYTES)).add(
-                new ByteArray(bytesValues[i]));
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              ((ObjectOpenHashSet<ByteArray>) getValueSet(groupByResultHolder, groupKeyArray[i], DataType.BYTES)).add(
+                  new ByteArray(bytesValues[i]));
+            }
+          });
           break;
         }
         default:
@@ -280,54 +319,64 @@ abstract class BaseDistinctCountSmartSketchAggregationFunction
       switch (storedType) {
         case INT: {
           int[][] intValues = blockValSet.getIntValuesMV();
-          for (int i = 0; i < length; i++) {
-            IntOpenHashSet intSet = (IntOpenHashSet) getValueSet(groupByResultHolder, groupKeyArray[i], DataType.INT);
-            for (int value : intValues[i]) {
-              intSet.add(value);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              IntOpenHashSet intSet = (IntOpenHashSet) getValueSet(groupByResultHolder, groupKeyArray[i], DataType.INT);
+              for (int value : intValues[i]) {
+                intSet.add(value);
+              }
             }
-          }
+          });
           break;
         }
         case LONG: {
           long[][] longValues = blockValSet.getLongValuesMV();
-          for (int i = 0; i < length; i++) {
-            LongOpenHashSet longSet =
-                (LongOpenHashSet) getValueSet(groupByResultHolder, groupKeyArray[i], DataType.LONG);
-            for (long value : longValues[i]) {
-              longSet.add(value);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              LongOpenHashSet longSet =
+                  (LongOpenHashSet) getValueSet(groupByResultHolder, groupKeyArray[i], DataType.LONG);
+              for (long value : longValues[i]) {
+                longSet.add(value);
+              }
             }
-          }
+          });
           break;
         }
         case FLOAT: {
           float[][] floatValues = blockValSet.getFloatValuesMV();
-          for (int i = 0; i < length; i++) {
-            FloatOpenHashSet floatSet =
-                (FloatOpenHashSet) getValueSet(groupByResultHolder, groupKeyArray[i], DataType.FLOAT);
-            for (float value : floatValues[i]) {
-              floatSet.add(value);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              FloatOpenHashSet floatSet =
+                  (FloatOpenHashSet) getValueSet(groupByResultHolder, groupKeyArray[i], DataType.FLOAT);
+              for (float value : floatValues[i]) {
+                floatSet.add(value);
+              }
             }
-          }
+          });
           break;
         }
         case DOUBLE: {
           double[][] doubleValues = blockValSet.getDoubleValuesMV();
-          for (int i = 0; i < length; i++) {
-            DoubleOpenHashSet doubleSet =
-                (DoubleOpenHashSet) getValueSet(groupByResultHolder, groupKeyArray[i], DataType.DOUBLE);
-            for (double value : doubleValues[i]) {
-              doubleSet.add(value);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              DoubleOpenHashSet doubleSet =
+                  (DoubleOpenHashSet) getValueSet(groupByResultHolder, groupKeyArray[i], DataType.DOUBLE);
+              for (double value : doubleValues[i]) {
+                doubleSet.add(value);
+              }
             }
-          }
+          });
           break;
         }
         case STRING: {
           String[][] stringValues = blockValSet.getStringValuesMV();
-          for (int i = 0; i < length; i++) {
-            ObjectOpenHashSet<String> stringSet =
-                (ObjectOpenHashSet<String>) getValueSet(groupByResultHolder, groupKeyArray[i], DataType.STRING);
-            Collections.addAll(stringSet, stringValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              ObjectOpenHashSet<String> stringSet =
+                  (ObjectOpenHashSet<String>) getValueSet(groupByResultHolder, groupKeyArray[i], DataType.STRING);
+              Collections.addAll(stringSet, stringValues[i]);
+            }
+          });
           break;
         }
         default:
@@ -347,18 +396,22 @@ abstract class BaseDistinctCountSmartSketchAggregationFunction
       IntSet modifiedGroups = new IntOpenHashSet();
       if (blockValSet.isSingleValue()) {
         int[] dictIds = blockValSet.getDictionaryIdsSV();
-        for (int i = 0; i < length; i++) {
-          for (int groupKey : groupKeysArray[i]) {
-            aggregateDictIdForGroup(groupByResultHolder, groupKey, dictionary, dictIds[i], modifiedGroups);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              aggregateDictIdForGroup(groupByResultHolder, groupKey, dictionary, dictIds[i], modifiedGroups);
+            }
           }
-        }
+        });
       } else {
         int[][] dictIds = blockValSet.getDictionaryIdsMV();
-        for (int i = 0; i < length; i++) {
-          for (int groupKey : groupKeysArray[i]) {
-            aggregateDictIdsForGroup(groupByResultHolder, groupKey, dictionary, dictIds[i], modifiedGroups);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              aggregateDictIdsForGroup(groupByResultHolder, groupKey, dictionary, dictIds[i], modifiedGroups);
+            }
           }
-        }
+        });
       }
       // Check cardinality only once per modified group after all additions
       checkAndConvertToSketchForGroups(groupByResultHolder, modifiedGroups);
@@ -371,44 +424,56 @@ abstract class BaseDistinctCountSmartSketchAggregationFunction
       switch (storedType) {
         case INT: {
           int[] intValues = blockValSet.getIntValuesSV();
-          for (int i = 0; i < length; i++) {
-            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], intValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], intValues[i]);
+            }
+          });
           break;
         }
         case LONG: {
           long[] longValues = blockValSet.getLongValuesSV();
-          for (int i = 0; i < length; i++) {
-            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], longValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], longValues[i]);
+            }
+          });
           break;
         }
         case FLOAT: {
           float[] floatValues = blockValSet.getFloatValuesSV();
-          for (int i = 0; i < length; i++) {
-            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], floatValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], floatValues[i]);
+            }
+          });
           break;
         }
         case DOUBLE: {
           double[] doubleValues = blockValSet.getDoubleValuesSV();
-          for (int i = 0; i < length; i++) {
-            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], doubleValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], doubleValues[i]);
+            }
+          });
           break;
         }
         case STRING: {
           String[] stringValues = blockValSet.getStringValuesSV();
-          for (int i = 0; i < length; i++) {
-            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], stringValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], stringValues[i]);
+            }
+          });
           break;
         }
         case BYTES: {
           byte[][] bytesValues = blockValSet.getBytesValuesSV();
-          for (int i = 0; i < length; i++) {
-            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], new ByteArray(bytesValues[i]));
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], new ByteArray(bytesValues[i]));
+            }
+          });
           break;
         }
         default:
@@ -418,62 +483,73 @@ abstract class BaseDistinctCountSmartSketchAggregationFunction
       switch (storedType) {
         case INT: {
           int[][] intValues = blockValSet.getIntValuesMV();
-          for (int i = 0; i < length; i++) {
-            for (int groupKey : groupKeysArray[i]) {
-              IntOpenHashSet intSet = (IntOpenHashSet) getValueSet(groupByResultHolder, groupKey, DataType.INT);
-              for (int value : intValues[i]) {
-                intSet.add(value);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (int groupKey : groupKeysArray[i]) {
+                IntOpenHashSet intSet = (IntOpenHashSet) getValueSet(groupByResultHolder, groupKey, DataType.INT);
+                for (int value : intValues[i]) {
+                  intSet.add(value);
+                }
               }
             }
-          }
+          });
           break;
         }
         case LONG: {
           long[][] longValues = blockValSet.getLongValuesMV();
-          for (int i = 0; i < length; i++) {
-            for (int groupKey : groupKeysArray[i]) {
-              LongOpenHashSet longSet = (LongOpenHashSet) getValueSet(groupByResultHolder, groupKey, DataType.LONG);
-              for (long value : longValues[i]) {
-                longSet.add(value);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (int groupKey : groupKeysArray[i]) {
+                LongOpenHashSet longSet = (LongOpenHashSet) getValueSet(groupByResultHolder, groupKey, DataType.LONG);
+                for (long value : longValues[i]) {
+                  longSet.add(value);
+                }
               }
             }
-          }
+          });
           break;
         }
         case FLOAT: {
           float[][] floatValues = blockValSet.getFloatValuesMV();
-          for (int i = 0; i < length; i++) {
-            for (int groupKey : groupKeysArray[i]) {
-              FloatOpenHashSet floatSet = (FloatOpenHashSet) getValueSet(groupByResultHolder, groupKey, DataType.FLOAT);
-              for (float value : floatValues[i]) {
-                floatSet.add(value);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (int groupKey : groupKeysArray[i]) {
+                FloatOpenHashSet floatSet =
+                    (FloatOpenHashSet) getValueSet(groupByResultHolder, groupKey, DataType.FLOAT);
+                for (float value : floatValues[i]) {
+                  floatSet.add(value);
+                }
               }
             }
-          }
+          });
           break;
         }
         case DOUBLE: {
           double[][] doubleValues = blockValSet.getDoubleValuesMV();
-          for (int i = 0; i < length; i++) {
-            for (int groupKey : groupKeysArray[i]) {
-              DoubleOpenHashSet doubleSet =
-                  (DoubleOpenHashSet) getValueSet(groupByResultHolder, groupKey, DataType.DOUBLE);
-              for (double value : doubleValues[i]) {
-                doubleSet.add(value);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (int groupKey : groupKeysArray[i]) {
+                DoubleOpenHashSet doubleSet =
+                    (DoubleOpenHashSet) getValueSet(groupByResultHolder, groupKey, DataType.DOUBLE);
+                for (double value : doubleValues[i]) {
+                  doubleSet.add(value);
+                }
               }
             }
-          }
+          });
           break;
         }
         case STRING: {
           String[][] stringValues = blockValSet.getStringValuesMV();
-          for (int i = 0; i < length; i++) {
-            for (int groupKey : groupKeysArray[i]) {
-              ObjectOpenHashSet<String> stringSet =
-                  (ObjectOpenHashSet<String>) getValueSet(groupByResultHolder, groupKey, DataType.STRING);
-              Collections.addAll(stringSet, stringValues[i]);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (int groupKey : groupKeysArray[i]) {
+                ObjectOpenHashSet<String> stringSet =
+                    (ObjectOpenHashSet<String>) getValueSet(groupByResultHolder, groupKey, DataType.STRING);
+                Collections.addAll(stringSet, stringValues[i]);
+              }
             }
-          }
+          });
           break;
         }
         default:

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountBitmapAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountBitmapAggregationFunction.java
@@ -42,14 +42,15 @@ import org.roaringbitmap.RoaringBitmap;
 /// The `DistinctCountBitmapAggregationFunction` calculates the number of distinct values for a given single-value or
 /// multi-value expression using RoaringBitmap. The bitmap stores the actual values for `INT` expression, or hash code
 /// of the values for other data types (values with the same hash code will only be counted once).
-public class DistinctCountBitmapAggregationFunction extends BaseSingleInputAggregationFunction<RoaringBitmap, Integer> {
+public class DistinctCountBitmapAggregationFunction
+    extends NullableSingleInputAggregationFunction<RoaringBitmap, Integer> {
 
-  public DistinctCountBitmapAggregationFunction(List<ExpressionContext> arguments) {
-    this(verifySingleArgument(arguments, "DISTINCT_COUNT_BITMAP"));
+  public DistinctCountBitmapAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    this(verifySingleArgument(arguments, "DISTINCT_COUNT_BITMAP"), nullHandlingEnabled);
   }
 
-  protected DistinctCountBitmapAggregationFunction(ExpressionContext expression) {
-    super(expression);
+  protected DistinctCountBitmapAggregationFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
+    super(expression, nullHandlingEnabled);
   }
 
   @Override
@@ -73,27 +74,30 @@ public class DistinctCountBitmapAggregationFunction extends BaseSingleInputAggre
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
     DataType dataType = blockValSet.getValueType();
-    if (dataType == DataType.BYTES) {
+    boolean singleValue = blockValSet.isSingleValue();
+    if (dataType == DataType.BYTES && singleValue) {
       // Logical BYTES is a serialized RoaringBitmap and always uses the single-value representation.
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
-      RoaringBitmap valueBitmap = aggregationResultHolder.getResult();
-      if (valueBitmap != null) {
-        for (int i = 0; i < length; i++) {
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        int i = from;
+        RoaringBitmap valueBitmap = aggregationResultHolder.getResult();
+        if (valueBitmap == null) {
+          if (i == to) {
+            return;
+          }
+          // The first bitmap read becomes the accumulator instead of being merged into a fresh one
+          valueBitmap = RoaringBitmapUtils.deserialize(bytesValues[i++]);
+          aggregationResultHolder.setValue(valueBitmap);
+        }
+        for (; i < to; i++) {
           valueBitmap.or(RoaringBitmapUtils.deserialize(bytesValues[i]));
         }
-      } else {
-        valueBitmap = RoaringBitmapUtils.deserialize(bytesValues[0]);
-        aggregationResultHolder.setValue(valueBitmap);
-        for (int i = 1; i < length; i++) {
-          valueBitmap.or(RoaringBitmapUtils.deserialize(bytesValues[i]));
-        }
-      }
+      });
       return;
     }
 
     DataType storedType = dataType.getStoredType();
-
-    if (blockValSet.isSingleValue()) {
+    if (singleValue) {
       aggregateSV(length, aggregationResultHolder, blockValSet, storedType);
     } else {
       aggregateMV(length, aggregationResultHolder, blockValSet, storedType);
@@ -106,46 +110,62 @@ public class DistinctCountBitmapAggregationFunction extends BaseSingleInputAggre
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[] dictIds = blockValSet.getDictionaryIdsSV();
-      getDictIdBitmap(aggregationResultHolder, dictionary).addN(dictIds, 0, length);
+      forEachNotNull(length, blockValSet,
+          (from, to) -> getDictIdBitmap(aggregationResultHolder, dictionary).addN(dictIds, from, to - from));
       return;
     }
 
     // For non-dictionary-encoded expression, store hash code of the values into the bitmap
-    RoaringBitmap valueBitmap = getValueBitmap(aggregationResultHolder);
     switch (storedType) {
       case INT:
         int[] intValues = blockValSet.getIntValuesSV();
-        valueBitmap.addN(intValues, 0, length);
+        forEachNotNull(length, blockValSet,
+            (from, to) -> getValueBitmap(aggregationResultHolder).addN(intValues, from, to - from));
         break;
       case LONG:
         long[] longValues = blockValSet.getLongValuesSV();
-        for (int i = 0; i < length; i++) {
-          valueBitmap.add(Long.hashCode(longValues[i]));
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          RoaringBitmap valueBitmap = getValueBitmap(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            valueBitmap.add(Long.hashCode(longValues[i]));
+          }
+        });
         break;
       case FLOAT:
         float[] floatValues = blockValSet.getFloatValuesSV();
-        for (int i = 0; i < length; i++) {
-          valueBitmap.add(Float.hashCode(floatValues[i]));
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          RoaringBitmap valueBitmap = getValueBitmap(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            valueBitmap.add(Float.hashCode(floatValues[i]));
+          }
+        });
         break;
       case DOUBLE:
         double[] doubleValues = blockValSet.getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
-          valueBitmap.add(Double.hashCode(doubleValues[i]));
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          RoaringBitmap valueBitmap = getValueBitmap(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            valueBitmap.add(Double.hashCode(doubleValues[i]));
+          }
+        });
         break;
       case STRING:
         String[] stringValues = blockValSet.getStringValuesSV();
-        for (int i = 0; i < length; i++) {
-          valueBitmap.add(stringValues[i].hashCode());
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          RoaringBitmap valueBitmap = getValueBitmap(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            valueBitmap.add(stringValues[i].hashCode());
+          }
+        });
         break;
       case BYTES:
         byte[][] bytesValues = blockValSet.getBytesValuesSV();
-        for (int i = 0; i < length; i++) {
-          valueBitmap.add(Arrays.hashCode(bytesValues[i]));
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          RoaringBitmap valueBitmap = getValueBitmap(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            valueBitmap.add(Arrays.hashCode(bytesValues[i]));
+          }
+        });
         break;
       default:
         throw new IllegalStateException(
@@ -158,62 +178,81 @@ public class DistinctCountBitmapAggregationFunction extends BaseSingleInputAggre
     // For dictionary-encoded expression, store dictionary ids into the bitmap
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
-      RoaringBitmap dictIdBitmap = getDictIdBitmap(aggregationResultHolder, dictionary);
       int[][] dictIds = blockValSet.getDictionaryIdsMV();
-      for (int i = 0; i < length; i++) {
-        dictIdBitmap.add(dictIds[i]);
-      }
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        RoaringBitmap dictIdBitmap = getDictIdBitmap(aggregationResultHolder, dictionary);
+        for (int i = from; i < to; i++) {
+          dictIdBitmap.add(dictIds[i]);
+        }
+      });
       return;
     }
 
     // For non-dictionary-encoded expression, store hash code of the values into the bitmap
-    RoaringBitmap valueBitmap = getValueBitmap(aggregationResultHolder);
     switch (storedType) {
       case INT:
         int[][] intValues = blockValSet.getIntValuesMV();
-        for (int i = 0; i < length; i++) {
-          valueBitmap.add(intValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          RoaringBitmap valueBitmap = getValueBitmap(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            valueBitmap.add(intValues[i]);
+          }
+        });
         break;
       case LONG:
         long[][] longValues = blockValSet.getLongValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (long value : longValues[i]) {
-            valueBitmap.add(Long.hashCode(value));
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          RoaringBitmap valueBitmap = getValueBitmap(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            for (long value : longValues[i]) {
+              valueBitmap.add(Long.hashCode(value));
+            }
           }
-        }
+        });
         break;
       case FLOAT:
         float[][] floatValues = blockValSet.getFloatValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (float value : floatValues[i]) {
-            valueBitmap.add(Float.hashCode(value));
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          RoaringBitmap valueBitmap = getValueBitmap(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            for (float value : floatValues[i]) {
+              valueBitmap.add(Float.hashCode(value));
+            }
           }
-        }
+        });
         break;
       case DOUBLE:
         double[][] doubleValues = blockValSet.getDoubleValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (double value : doubleValues[i]) {
-            valueBitmap.add(Double.hashCode(value));
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          RoaringBitmap valueBitmap = getValueBitmap(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            for (double value : doubleValues[i]) {
+              valueBitmap.add(Double.hashCode(value));
+            }
           }
-        }
+        });
         break;
       case STRING:
         String[][] stringValues = blockValSet.getStringValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (String value : stringValues[i]) {
-            valueBitmap.add(value.hashCode());
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          RoaringBitmap valueBitmap = getValueBitmap(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            for (String value : stringValues[i]) {
+              valueBitmap.add(value.hashCode());
+            }
           }
-        }
+        });
         break;
       case BYTES:
         byte[][][] bytesValues = blockValSet.getBytesValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (byte[] value : bytesValues[i]) {
-            valueBitmap.add(Arrays.hashCode(value));
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          RoaringBitmap valueBitmap = getValueBitmap(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            for (byte[] value : bytesValues[i]) {
+              valueBitmap.add(Arrays.hashCode(value));
+            }
           }
-        }
+        });
         break;
       default:
         throw new IllegalStateException(
@@ -227,25 +266,27 @@ public class DistinctCountBitmapAggregationFunction extends BaseSingleInputAggre
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
     DataType dataType = blockValSet.getValueType();
-    if (dataType == DataType.BYTES) {
+    boolean singleValue = blockValSet.isSingleValue();
+    if (dataType == DataType.BYTES && singleValue) {
       // Logical BYTES is a serialized RoaringBitmap and always uses the single-value representation.
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
-      for (int i = 0; i < length; i++) {
-        RoaringBitmap value = RoaringBitmapUtils.deserialize(bytesValues[i]);
-        int groupKey = groupKeyArray[i];
-        RoaringBitmap valueBitmap = groupByResultHolder.getResult(groupKey);
-        if (valueBitmap != null) {
-          valueBitmap.or(value);
-        } else {
-          groupByResultHolder.setValueForKey(groupKey, value);
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          RoaringBitmap value = RoaringBitmapUtils.deserialize(bytesValues[i]);
+          int groupKey = groupKeyArray[i];
+          RoaringBitmap valueBitmap = groupByResultHolder.getResult(groupKey);
+          if (valueBitmap != null) {
+            valueBitmap.or(value);
+          } else {
+            groupByResultHolder.setValueForKey(groupKey, value);
+          }
         }
-      }
+      });
       return;
     }
 
     DataType storedType = dataType.getStoredType();
-
-    if (blockValSet.isSingleValue()) {
+    if (singleValue) {
       aggregateSVGroupBySV(length, groupKeyArray, groupByResultHolder, blockValSet, storedType);
     } else {
       aggregateMVGroupBySV(length, groupKeyArray, groupByResultHolder, blockValSet, storedType);
@@ -258,9 +299,11 @@ public class DistinctCountBitmapAggregationFunction extends BaseSingleInputAggre
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[] dictIds = blockValSet.getDictionaryIdsSV();
-      for (int i = 0; i < length; i++) {
-        getDictIdBitmap(groupByResultHolder, groupKeyArray[i], dictionary).add(dictIds[i]);
-      }
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          getDictIdBitmap(groupByResultHolder, groupKeyArray[i], dictionary).add(dictIds[i]);
+        }
+      });
       return;
     }
 
@@ -268,39 +311,51 @@ public class DistinctCountBitmapAggregationFunction extends BaseSingleInputAggre
     switch (storedType) {
       case INT:
         int[] intValues = blockValSet.getIntValuesSV();
-        for (int i = 0; i < length; i++) {
-          getValueBitmap(groupByResultHolder, groupKeyArray[i]).add(intValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            getValueBitmap(groupByResultHolder, groupKeyArray[i]).add(intValues[i]);
+          }
+        });
         break;
       case LONG:
         long[] longValues = blockValSet.getLongValuesSV();
-        for (int i = 0; i < length; i++) {
-          getValueBitmap(groupByResultHolder, groupKeyArray[i]).add(Long.hashCode(longValues[i]));
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            getValueBitmap(groupByResultHolder, groupKeyArray[i]).add(Long.hashCode(longValues[i]));
+          }
+        });
         break;
       case FLOAT:
         float[] floatValues = blockValSet.getFloatValuesSV();
-        for (int i = 0; i < length; i++) {
-          getValueBitmap(groupByResultHolder, groupKeyArray[i]).add(Float.hashCode(floatValues[i]));
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            getValueBitmap(groupByResultHolder, groupKeyArray[i]).add(Float.hashCode(floatValues[i]));
+          }
+        });
         break;
       case DOUBLE:
         double[] doubleValues = blockValSet.getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
-          getValueBitmap(groupByResultHolder, groupKeyArray[i]).add(Double.hashCode(doubleValues[i]));
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            getValueBitmap(groupByResultHolder, groupKeyArray[i]).add(Double.hashCode(doubleValues[i]));
+          }
+        });
         break;
       case STRING:
         String[] stringValues = blockValSet.getStringValuesSV();
-        for (int i = 0; i < length; i++) {
-          getValueBitmap(groupByResultHolder, groupKeyArray[i]).add(stringValues[i].hashCode());
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            getValueBitmap(groupByResultHolder, groupKeyArray[i]).add(stringValues[i].hashCode());
+          }
+        });
         break;
       case BYTES:
         byte[][] bytesValues = blockValSet.getBytesValuesSV();
-        for (int i = 0; i < length; i++) {
-          getValueBitmap(groupByResultHolder, groupKeyArray[i]).add(Arrays.hashCode(bytesValues[i]));
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            getValueBitmap(groupByResultHolder, groupKeyArray[i]).add(Arrays.hashCode(bytesValues[i]));
+          }
+        });
         break;
       default:
         throw new IllegalStateException(
@@ -314,9 +369,11 @@ public class DistinctCountBitmapAggregationFunction extends BaseSingleInputAggre
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[][] dictIds = blockValSet.getDictionaryIdsMV();
-      for (int i = 0; i < length; i++) {
-        getDictIdBitmap(groupByResultHolder, groupKeyArray[i], dictionary).add(dictIds[i]);
-      }
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          getDictIdBitmap(groupByResultHolder, groupKeyArray[i], dictionary).add(dictIds[i]);
+        }
+      });
       return;
     }
 
@@ -324,54 +381,66 @@ public class DistinctCountBitmapAggregationFunction extends BaseSingleInputAggre
     switch (storedType) {
       case INT:
         int[][] intValues = blockValSet.getIntValuesMV();
-        for (int i = 0; i < length; i++) {
-          getValueBitmap(groupByResultHolder, groupKeyArray[i]).add(intValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            getValueBitmap(groupByResultHolder, groupKeyArray[i]).add(intValues[i]);
+          }
+        });
         break;
       case LONG:
         long[][] longValues = blockValSet.getLongValuesMV();
-        for (int i = 0; i < length; i++) {
-          RoaringBitmap bitmap = getValueBitmap(groupByResultHolder, groupKeyArray[i]);
-          for (long value : longValues[i]) {
-            bitmap.add(Long.hashCode(value));
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            RoaringBitmap bitmap = getValueBitmap(groupByResultHolder, groupKeyArray[i]);
+            for (long value : longValues[i]) {
+              bitmap.add(Long.hashCode(value));
+            }
           }
-        }
+        });
         break;
       case FLOAT:
         float[][] floatValues = blockValSet.getFloatValuesMV();
-        for (int i = 0; i < length; i++) {
-          RoaringBitmap bitmap = getValueBitmap(groupByResultHolder, groupKeyArray[i]);
-          for (float value : floatValues[i]) {
-            bitmap.add(Float.hashCode(value));
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            RoaringBitmap bitmap = getValueBitmap(groupByResultHolder, groupKeyArray[i]);
+            for (float value : floatValues[i]) {
+              bitmap.add(Float.hashCode(value));
+            }
           }
-        }
+        });
         break;
       case DOUBLE:
         double[][] doubleValues = blockValSet.getDoubleValuesMV();
-        for (int i = 0; i < length; i++) {
-          RoaringBitmap bitmap = getValueBitmap(groupByResultHolder, groupKeyArray[i]);
-          for (double value : doubleValues[i]) {
-            bitmap.add(Double.hashCode(value));
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            RoaringBitmap bitmap = getValueBitmap(groupByResultHolder, groupKeyArray[i]);
+            for (double value : doubleValues[i]) {
+              bitmap.add(Double.hashCode(value));
+            }
           }
-        }
+        });
         break;
       case STRING:
         String[][] stringValues = blockValSet.getStringValuesMV();
-        for (int i = 0; i < length; i++) {
-          RoaringBitmap bitmap = getValueBitmap(groupByResultHolder, groupKeyArray[i]);
-          for (String value : stringValues[i]) {
-            bitmap.add(value.hashCode());
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            RoaringBitmap bitmap = getValueBitmap(groupByResultHolder, groupKeyArray[i]);
+            for (String value : stringValues[i]) {
+              bitmap.add(value.hashCode());
+            }
           }
-        }
+        });
         break;
       case BYTES:
         byte[][][] bytesValues = blockValSet.getBytesValuesMV();
-        for (int i = 0; i < length; i++) {
-          RoaringBitmap bitmap = getValueBitmap(groupByResultHolder, groupKeyArray[i]);
-          for (byte[] value : bytesValues[i]) {
-            bitmap.add(Arrays.hashCode(value));
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            RoaringBitmap bitmap = getValueBitmap(groupByResultHolder, groupKeyArray[i]);
+            for (byte[] value : bytesValues[i]) {
+              bitmap.add(Arrays.hashCode(value));
+            }
           }
-        }
+        });
         break;
       default:
         throw new IllegalStateException(
@@ -385,27 +454,29 @@ public class DistinctCountBitmapAggregationFunction extends BaseSingleInputAggre
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
     DataType dataType = blockValSet.getValueType();
-    if (dataType == DataType.BYTES) {
+    boolean singleValue = blockValSet.isSingleValue();
+    if (dataType == DataType.BYTES && singleValue) {
       // Logical BYTES is a serialized RoaringBitmap and always uses the single-value representation.
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
-      for (int i = 0; i < length; i++) {
-        RoaringBitmap value = RoaringBitmapUtils.deserialize(bytesValues[i]);
-        for (int groupKey : groupKeysArray[i]) {
-          RoaringBitmap bitmap = groupByResultHolder.getResult(groupKey);
-          if (bitmap != null) {
-            bitmap.or(value);
-          } else {
-            // Clone a bitmap for the group
-            groupByResultHolder.setValueForKey(groupKey, value.clone());
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          RoaringBitmap value = RoaringBitmapUtils.deserialize(bytesValues[i]);
+          for (int groupKey : groupKeysArray[i]) {
+            RoaringBitmap bitmap = groupByResultHolder.getResult(groupKey);
+            if (bitmap != null) {
+              bitmap.or(value);
+            } else {
+              // Clone a bitmap for the group
+              groupByResultHolder.setValueForKey(groupKey, value.clone());
+            }
           }
         }
-      }
+      });
       return;
     }
 
     DataType storedType = dataType.getStoredType();
-
-    if (blockValSet.isSingleValue()) {
+    if (singleValue) {
       aggregateSVGroupByMV(length, groupKeysArray, groupByResultHolder, blockValSet, storedType);
     } else {
       aggregateMVGroupByMV(length, groupKeysArray, groupByResultHolder, blockValSet, storedType);
@@ -418,9 +489,11 @@ public class DistinctCountBitmapAggregationFunction extends BaseSingleInputAggre
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[] dictIds = blockValSet.getDictionaryIdsSV();
-      for (int i = 0; i < length; i++) {
-        setDictIdForGroupKeys(groupByResultHolder, groupKeysArray[i], dictionary, dictIds[i]);
-      }
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          setDictIdForGroupKeys(groupByResultHolder, groupKeysArray[i], dictionary, dictIds[i]);
+        }
+      });
       return;
     }
 
@@ -428,39 +501,51 @@ public class DistinctCountBitmapAggregationFunction extends BaseSingleInputAggre
     switch (storedType) {
       case INT:
         int[] intValues = blockValSet.getIntValuesSV();
-        for (int i = 0; i < length; i++) {
-          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], intValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], intValues[i]);
+          }
+        });
         break;
       case LONG:
         long[] longValues = blockValSet.getLongValuesSV();
-        for (int i = 0; i < length; i++) {
-          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], Long.hashCode(longValues[i]));
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], Long.hashCode(longValues[i]));
+          }
+        });
         break;
       case FLOAT:
         float[] floatValues = blockValSet.getFloatValuesSV();
-        for (int i = 0; i < length; i++) {
-          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], Float.hashCode(floatValues[i]));
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], Float.hashCode(floatValues[i]));
+          }
+        });
         break;
       case DOUBLE:
         double[] doubleValues = blockValSet.getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
-          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], Double.hashCode(doubleValues[i]));
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], Double.hashCode(doubleValues[i]));
+          }
+        });
         break;
       case STRING:
         String[] stringValues = blockValSet.getStringValuesSV();
-        for (int i = 0; i < length; i++) {
-          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], stringValues[i].hashCode());
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], stringValues[i].hashCode());
+          }
+        });
         break;
       case BYTES:
         byte[][] bytesValues = blockValSet.getBytesValuesSV();
-        for (int i = 0; i < length; i++) {
-          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], Arrays.hashCode(bytesValues[i]));
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], Arrays.hashCode(bytesValues[i]));
+          }
+        });
         break;
       default:
         throw new IllegalStateException(
@@ -474,11 +559,13 @@ public class DistinctCountBitmapAggregationFunction extends BaseSingleInputAggre
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[][] dictIds = blockValSet.getDictionaryIdsMV();
-      for (int i = 0; i < length; i++) {
-        for (int groupKey : groupKeysArray[i]) {
-          getDictIdBitmap(groupByResultHolder, groupKey, dictionary).add(dictIds[i]);
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          for (int groupKey : groupKeysArray[i]) {
+            getDictIdBitmap(groupByResultHolder, groupKey, dictionary).add(dictIds[i]);
+          }
         }
-      }
+      });
       return;
     }
 
@@ -486,66 +573,78 @@ public class DistinctCountBitmapAggregationFunction extends BaseSingleInputAggre
     switch (storedType) {
       case INT:
         int[][] intValues = blockValSet.getIntValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (int groupKey : groupKeysArray[i]) {
-            getValueBitmap(groupByResultHolder, groupKey).add(intValues[i]);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              getValueBitmap(groupByResultHolder, groupKey).add(intValues[i]);
+            }
           }
-        }
+        });
         break;
       case LONG:
         long[][] longValues = blockValSet.getLongValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (int groupKey : groupKeysArray[i]) {
-            RoaringBitmap bitmap = getValueBitmap(groupByResultHolder, groupKey);
-            for (long value : longValues[i]) {
-              bitmap.add(Long.hashCode(value));
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              RoaringBitmap bitmap = getValueBitmap(groupByResultHolder, groupKey);
+              for (long value : longValues[i]) {
+                bitmap.add(Long.hashCode(value));
+              }
             }
           }
-        }
+        });
         break;
       case FLOAT:
         float[][] floatValues = blockValSet.getFloatValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (int groupKey : groupKeysArray[i]) {
-            RoaringBitmap bitmap = getValueBitmap(groupByResultHolder, groupKey);
-            for (float value : floatValues[i]) {
-              bitmap.add(Float.hashCode(value));
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              RoaringBitmap bitmap = getValueBitmap(groupByResultHolder, groupKey);
+              for (float value : floatValues[i]) {
+                bitmap.add(Float.hashCode(value));
+              }
             }
           }
-        }
+        });
         break;
       case DOUBLE:
         double[][] doubleValues = blockValSet.getDoubleValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (int groupKey : groupKeysArray[i]) {
-            RoaringBitmap bitmap = getValueBitmap(groupByResultHolder, groupKey);
-            for (double value : doubleValues[i]) {
-              bitmap.add(Double.hashCode(value));
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              RoaringBitmap bitmap = getValueBitmap(groupByResultHolder, groupKey);
+              for (double value : doubleValues[i]) {
+                bitmap.add(Double.hashCode(value));
+              }
             }
           }
-        }
+        });
         break;
       case STRING:
         String[][] stringValues = blockValSet.getStringValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (int groupKey : groupKeysArray[i]) {
-            RoaringBitmap bitmap = getValueBitmap(groupByResultHolder, groupKey);
-            for (String value : stringValues[i]) {
-              bitmap.add(value.hashCode());
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              RoaringBitmap bitmap = getValueBitmap(groupByResultHolder, groupKey);
+              for (String value : stringValues[i]) {
+                bitmap.add(value.hashCode());
+              }
             }
           }
-        }
+        });
         break;
       case BYTES:
         byte[][][] bytesValues = blockValSet.getBytesValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (int groupKey : groupKeysArray[i]) {
-            RoaringBitmap bitmap = getValueBitmap(groupByResultHolder, groupKey);
-            for (byte[] value : bytesValues[i]) {
-              bitmap.add(Arrays.hashCode(value));
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              RoaringBitmap bitmap = getValueBitmap(groupByResultHolder, groupKey);
+              for (byte[] value : bytesValues[i]) {
+                bitmap.add(Arrays.hashCode(value));
+              }
             }
           }
-        }
+        });
         break;
       default:
         throw new IllegalStateException(

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountBitmapMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountBitmapMVAggregationFunction.java
@@ -25,8 +25,8 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 public class DistinctCountBitmapMVAggregationFunction extends DistinctCountBitmapAggregationFunction {
 
-  public DistinctCountBitmapMVAggregationFunction(List<ExpressionContext> arguments) {
-    super(verifySingleArgument(arguments, "DISTINCT_COUNT_BITMAP_MV"));
+  public DistinctCountBitmapMVAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    super(verifySingleArgument(arguments, "DISTINCT_COUNT_BITMAP_MV"), nullHandlingEnabled);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountCPCSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountCPCSketchAggregationFunction.java
@@ -82,13 +82,14 @@ import org.roaringbitmap.RoaringBitmap;
 ///     )
 @SuppressWarnings({"rawtypes"})
 public class DistinctCountCPCSketchAggregationFunction
-    extends BaseSingleInputAggregationFunction<CpcSketchAccumulator, Comparable> {
+    extends NullableSingleInputAggregationFunction<CpcSketchAccumulator, Comparable> {
   private static final int DEFAULT_ACCUMULATOR_THRESHOLD = 2;
   protected int _accumulatorThreshold = DEFAULT_ACCUMULATOR_THRESHOLD;
   protected int _lgNominalEntries;
 
-  public DistinctCountCPCSketchAggregationFunction(List<ExpressionContext> arguments) {
-    super(arguments.get(0));
+  public DistinctCountCPCSketchAggregationFunction(List<ExpressionContext> arguments,
+      boolean nullHandlingEnabled) {
+    super(arguments.get(0), nullHandlingEnabled);
     int numExpressions = arguments.size();
     // This function expects 1 or 2 arguments - it is a code smell to extend the base for single
     // input aggregation functions.  Nevertheless, there are other functions in the base class that
@@ -136,17 +137,21 @@ public class DistinctCountCPCSketchAggregationFunction
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
     DataType dataType = blockValSet.getValueType();
-    if (dataType == DataType.BYTES) {
+    boolean singleValue = blockValSet.isSingleValue();
+    if (dataType == DataType.BYTES && singleValue) {
       // Logical BYTES stores serialized CpcSketch objects in the single-value representation.
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
       try {
         CpcSketchAccumulator cpcSketchAccumulator = getAccumulator(aggregationResultHolder);
-        CpcSketch[] sketches = deserializeSketches(bytesValues, length);
-        for (CpcSketch sketch : sketches) {
-          if (sketch != null) {
-            cpcSketchAccumulator.apply(sketch);
+        CpcSketch[] sketches = deserializeSketches(bytesValues, length, blockValSet);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            CpcSketch sketch = sketches[i];
+            if (sketch != null) {
+              cpcSketchAccumulator.apply(sketch);
+            }
           }
-        }
+        });
       } catch (Exception e) {
         throw new RuntimeException("Caught exception while merging CPC sketches", e);
       }
@@ -154,7 +159,7 @@ public class DistinctCountCPCSketchAggregationFunction
     }
 
     DataType storedType = dataType.getStoredType();
-    if (blockValSet.isSingleValue()) {
+    if (singleValue) {
       aggregateSV(length, aggregationResultHolder, blockValSet, storedType);
     } else {
       aggregateMV(length, aggregationResultHolder, blockValSet, storedType);
@@ -167,7 +172,8 @@ public class DistinctCountCPCSketchAggregationFunction
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[] dictIds = blockValSet.getDictionaryIdsSV();
-      getDictIdBitmap(aggregationResultHolder, dictionary).addN(dictIds, 0, length);
+      forEachNotNull(length, blockValSet,
+          (from, to) -> getDictIdBitmap(aggregationResultHolder, dictionary).addN(dictIds, from, to - from));
       return;
     }
 
@@ -176,39 +182,51 @@ public class DistinctCountCPCSketchAggregationFunction
     switch (storedType) {
       case INT:
         int[] intValues = blockValSet.getIntValuesSV();
-        for (int i = 0; i < length; i++) {
-          cpcSketch.update(intValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            cpcSketch.update(intValues[i]);
+          }
+        });
         break;
       case LONG:
         long[] longValues = blockValSet.getLongValuesSV();
-        for (int i = 0; i < length; i++) {
-          cpcSketch.update(longValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            cpcSketch.update(longValues[i]);
+          }
+        });
         break;
       case FLOAT:
         float[] floatValues = blockValSet.getFloatValuesSV();
-        for (int i = 0; i < length; i++) {
-          cpcSketch.update(floatValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            cpcSketch.update(floatValues[i]);
+          }
+        });
         break;
       case DOUBLE:
         double[] doubleValues = blockValSet.getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
-          cpcSketch.update(doubleValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            cpcSketch.update(doubleValues[i]);
+          }
+        });
         break;
       case STRING:
         String[] stringValues = blockValSet.getStringValuesSV();
-        for (int i = 0; i < length; i++) {
-          cpcSketch.update(stringValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            cpcSketch.update(stringValues[i]);
+          }
+        });
         break;
       case BYTES:
         byte[][] bytesValues = blockValSet.getBytesValuesSV();
-        for (int i = 0; i < length; i++) {
-          cpcSketch.update(bytesValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            cpcSketch.update(bytesValues[i]);
+          }
+        });
         break;
       default:
         throw new IllegalStateException("Illegal data type for DISTINCT_COUNT_CPC aggregation function: " + storedType);
@@ -222,9 +240,11 @@ public class DistinctCountCPCSketchAggregationFunction
     if (dictionary != null) {
       int[][] dictIds = blockValSet.getDictionaryIdsMV();
       RoaringBitmap dictIdBitmap = getDictIdBitmap(aggregationResultHolder, dictionary);
-      for (int i = 0; i < length; i++) {
-        dictIdBitmap.add(dictIds[i]);
-      }
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          dictIdBitmap.add(dictIds[i]);
+        }
+      });
       return;
     }
 
@@ -233,11 +253,13 @@ public class DistinctCountCPCSketchAggregationFunction
       case BYTES:
         byte[][][] bytesValues = blockValSet.getBytesValuesMV();
         CpcSketch cpcSketch = getCpcSketch(aggregationResultHolder);
-        for (int i = 0; i < length; i++) {
-          for (byte[] value : bytesValues[i]) {
-            cpcSketch.update(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (byte[] value : bytesValues[i]) {
+              cpcSketch.update(value);
+            }
           }
-        }
+        });
         break;
       default:
         throw new IllegalStateException("Illegal data type for DISTINCT_COUNT_CPC aggregation function: " + storedType);
@@ -250,18 +272,21 @@ public class DistinctCountCPCSketchAggregationFunction
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
     DataType dataType = blockValSet.getValueType();
-    if (dataType == DataType.BYTES) {
+    boolean singleValue = blockValSet.isSingleValue();
+    if (dataType == DataType.BYTES && singleValue) {
       // Logical BYTES stores serialized CpcSketch objects in the single-value representation.
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
       try {
-        CpcSketch[] sketches = deserializeSketches(bytesValues, length);
-        for (int i = 0; i < length; i++) {
-          CpcSketch sketch = sketches[i];
-          if (sketch != null) {
-            CpcSketchAccumulator cpcSketchAccumulator = getAccumulator(groupByResultHolder, groupKeyArray[i]);
-            cpcSketchAccumulator.apply(sketch);
+        CpcSketch[] sketches = deserializeSketches(bytesValues, length, blockValSet);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            CpcSketch sketch = sketches[i];
+            if (sketch != null) {
+              CpcSketchAccumulator cpcSketchAccumulator = getAccumulator(groupByResultHolder, groupKeyArray[i]);
+              cpcSketchAccumulator.apply(sketch);
+            }
           }
-        }
+        });
       } catch (Exception e) {
         throw new RuntimeException("Caught exception while aggregating CPC Sketches", e);
       }
@@ -269,7 +294,7 @@ public class DistinctCountCPCSketchAggregationFunction
     }
 
     DataType storedType = dataType.getStoredType();
-    if (blockValSet.isSingleValue()) {
+    if (singleValue) {
       aggregateSVGroupBySV(length, groupKeyArray, groupByResultHolder, blockValSet, storedType);
     } else {
       aggregateMVGroupBySV(length, groupKeyArray, groupByResultHolder, blockValSet, storedType);
@@ -282,9 +307,11 @@ public class DistinctCountCPCSketchAggregationFunction
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[] dictIds = blockValSet.getDictionaryIdsSV();
-      for (int i = 0; i < length; i++) {
-        getDictIdBitmap(groupByResultHolder, groupKeyArray[i], dictionary).add(dictIds[i]);
-      }
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          getDictIdBitmap(groupByResultHolder, groupKeyArray[i], dictionary).add(dictIds[i]);
+        }
+      });
       return;
     }
 
@@ -292,39 +319,51 @@ public class DistinctCountCPCSketchAggregationFunction
     switch (storedType) {
       case INT:
         int[] intValues = blockValSet.getIntValuesSV();
-        for (int i = 0; i < length; i++) {
-          getCpcSketch(groupByResultHolder, groupKeyArray[i]).update(intValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            getCpcSketch(groupByResultHolder, groupKeyArray[i]).update(intValues[i]);
+          }
+        });
         break;
       case LONG:
         long[] longValues = blockValSet.getLongValuesSV();
-        for (int i = 0; i < length; i++) {
-          getCpcSketch(groupByResultHolder, groupKeyArray[i]).update(longValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            getCpcSketch(groupByResultHolder, groupKeyArray[i]).update(longValues[i]);
+          }
+        });
         break;
       case FLOAT:
         float[] floatValues = blockValSet.getFloatValuesSV();
-        for (int i = 0; i < length; i++) {
-          getCpcSketch(groupByResultHolder, groupKeyArray[i]).update(floatValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            getCpcSketch(groupByResultHolder, groupKeyArray[i]).update(floatValues[i]);
+          }
+        });
         break;
       case DOUBLE:
         double[] doubleValues = blockValSet.getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
-          getCpcSketch(groupByResultHolder, groupKeyArray[i]).update(doubleValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            getCpcSketch(groupByResultHolder, groupKeyArray[i]).update(doubleValues[i]);
+          }
+        });
         break;
       case STRING:
         String[] stringValues = blockValSet.getStringValuesSV();
-        for (int i = 0; i < length; i++) {
-          getCpcSketch(groupByResultHolder, groupKeyArray[i]).update(stringValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            getCpcSketch(groupByResultHolder, groupKeyArray[i]).update(stringValues[i]);
+          }
+        });
         break;
       case BYTES:
         byte[][] bytesValues = blockValSet.getBytesValuesSV();
-        for (int i = 0; i < length; i++) {
-          getCpcSketch(groupByResultHolder, groupKeyArray[i]).update(bytesValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            getCpcSketch(groupByResultHolder, groupKeyArray[i]).update(bytesValues[i]);
+          }
+        });
         break;
       default:
         throw new IllegalStateException("Illegal data type for DISTINCT_COUNT_CPC aggregation function: " + storedType);
@@ -337,9 +376,11 @@ public class DistinctCountCPCSketchAggregationFunction
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[][] dictIds = blockValSet.getDictionaryIdsMV();
-      for (int i = 0; i < length; i++) {
-        getDictIdBitmap(groupByResultHolder, groupKeyArray[i], dictionary).add(dictIds[i]);
-      }
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          getDictIdBitmap(groupByResultHolder, groupKeyArray[i], dictionary).add(dictIds[i]);
+        }
+      });
       return;
     }
 
@@ -347,12 +388,14 @@ public class DistinctCountCPCSketchAggregationFunction
     switch (storedType) {
       case BYTES:
         byte[][][] bytesValues = blockValSet.getBytesValuesMV();
-        for (int i = 0; i < length; i++) {
-          CpcSketch cpcSketch = getCpcSketch(groupByResultHolder, groupKeyArray[i]);
-          for (byte[] value : bytesValues[i]) {
-            cpcSketch.update(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            CpcSketch cpcSketch = getCpcSketch(groupByResultHolder, groupKeyArray[i]);
+            for (byte[] value : bytesValues[i]) {
+              cpcSketch.update(value);
+            }
           }
-        }
+        });
         break;
       default:
         throw new IllegalStateException("Illegal data type for DISTINCT_COUNT_CPC aggregation function: " + storedType);
@@ -365,18 +408,21 @@ public class DistinctCountCPCSketchAggregationFunction
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
     DataType dataType = blockValSet.getValueType();
-    if (dataType == DataType.BYTES) {
+    boolean singleValue = blockValSet.isSingleValue();
+    if (dataType == DataType.BYTES && singleValue) {
       // Logical BYTES stores serialized CpcSketch objects in the single-value representation.
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
       try {
-        CpcSketch[] sketches = deserializeSketches(bytesValues, length);
-        for (int i = 0; i < length; i++) {
-          if (sketches[i] != null) {
-            for (int groupKey : groupKeysArray[i]) {
-              getAccumulator(groupByResultHolder, groupKey).apply(sketches[i]);
+        CpcSketch[] sketches = deserializeSketches(bytesValues, length, blockValSet);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            if (sketches[i] != null) {
+              for (int groupKey : groupKeysArray[i]) {
+                getAccumulator(groupByResultHolder, groupKey).apply(sketches[i]);
+              }
             }
           }
-        }
+        });
       } catch (Exception e) {
         throw new RuntimeException("Caught exception while aggregating CPC sketches", e);
       }
@@ -384,7 +430,7 @@ public class DistinctCountCPCSketchAggregationFunction
     }
 
     DataType storedType = dataType.getStoredType();
-    if (blockValSet.isSingleValue()) {
+    if (singleValue) {
       aggregateSVGroupByMV(length, groupKeysArray, groupByResultHolder, blockValSet, storedType);
     } else {
       aggregateMVGroupByMV(length, groupKeysArray, groupByResultHolder, blockValSet, storedType);
@@ -397,9 +443,11 @@ public class DistinctCountCPCSketchAggregationFunction
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[] dictIds = blockValSet.getDictionaryIdsSV();
-      for (int i = 0; i < length; i++) {
-        setDictIdForGroupKeys(groupByResultHolder, groupKeysArray[i], dictionary, dictIds[i]);
-      }
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          setDictIdForGroupKeys(groupByResultHolder, groupKeysArray[i], dictionary, dictIds[i]);
+        }
+      });
       return;
     }
 
@@ -407,51 +455,63 @@ public class DistinctCountCPCSketchAggregationFunction
     switch (storedType) {
       case INT:
         int[] intValues = blockValSet.getIntValuesSV();
-        for (int i = 0; i < length; i++) {
-          for (int groupKey : groupKeysArray[i]) {
-            getCpcSketch(groupByResultHolder, groupKey).update(intValues[i]);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              getCpcSketch(groupByResultHolder, groupKey).update(intValues[i]);
+            }
           }
-        }
+        });
         break;
       case LONG:
         long[] longValues = blockValSet.getLongValuesSV();
-        for (int i = 0; i < length; i++) {
-          for (int groupKey : groupKeysArray[i]) {
-            getCpcSketch(groupByResultHolder, groupKey).update(longValues[i]);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              getCpcSketch(groupByResultHolder, groupKey).update(longValues[i]);
+            }
           }
-        }
+        });
         break;
       case FLOAT:
         float[] floatValues = blockValSet.getFloatValuesSV();
-        for (int i = 0; i < length; i++) {
-          for (int groupKey : groupKeysArray[i]) {
-            getCpcSketch(groupByResultHolder, groupKey).update(floatValues[i]);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              getCpcSketch(groupByResultHolder, groupKey).update(floatValues[i]);
+            }
           }
-        }
+        });
         break;
       case DOUBLE:
         double[] doubleValues = blockValSet.getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
-          for (int groupKey : groupKeysArray[i]) {
-            getCpcSketch(groupByResultHolder, groupKey).update(doubleValues[i]);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              getCpcSketch(groupByResultHolder, groupKey).update(doubleValues[i]);
+            }
           }
-        }
+        });
         break;
       case STRING:
         String[] stringValues = blockValSet.getStringValuesSV();
-        for (int i = 0; i < length; i++) {
-          for (int groupKey : groupKeysArray[i]) {
-            getCpcSketch(groupByResultHolder, groupKey).update(stringValues[i]);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              getCpcSketch(groupByResultHolder, groupKey).update(stringValues[i]);
+            }
           }
-        }
+        });
         break;
       case BYTES:
         byte[][] bytesValues = blockValSet.getBytesValuesSV();
-        for (int i = 0; i < length; i++) {
-          for (int groupKey : groupKeysArray[i]) {
-            getCpcSketch(groupByResultHolder, groupKey).update(bytesValues[i]);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              getCpcSketch(groupByResultHolder, groupKey).update(bytesValues[i]);
+            }
           }
-        }
+        });
         break;
       default:
         throw new IllegalStateException("Illegal data type for DISTINCT_COUNT_CPC aggregation function: " + storedType);
@@ -464,12 +524,14 @@ public class DistinctCountCPCSketchAggregationFunction
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[][] dictIds = blockValSet.getDictionaryIdsMV();
-      for (int i = 0; i < length; i++) {
-        int[] rowDictIds = dictIds[i];
-        for (int groupKey : groupKeysArray[i]) {
-          getDictIdBitmap(groupByResultHolder, groupKey, dictionary).add(rowDictIds);
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          int[] rowDictIds = dictIds[i];
+          for (int groupKey : groupKeysArray[i]) {
+            getDictIdBitmap(groupByResultHolder, groupKey, dictionary).add(rowDictIds);
+          }
         }
-      }
+      });
       return;
     }
 
@@ -477,14 +539,16 @@ public class DistinctCountCPCSketchAggregationFunction
     switch (storedType) {
       case BYTES:
         byte[][][] bytesValues = blockValSet.getBytesValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (int groupKey : groupKeysArray[i]) {
-            CpcSketch cpcSketch = getCpcSketch(groupByResultHolder, groupKey);
-            for (byte[] value : bytesValues[i]) {
-              cpcSketch.update(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              CpcSketch cpcSketch = getCpcSketch(groupByResultHolder, groupKey);
+              for (byte[] value : bytesValues[i]) {
+                cpcSketch.update(value);
+              }
             }
           }
-        }
+        });
         break;
       default:
         throw new IllegalStateException("Illegal data type for DISTINCT_COUNT_CPC aggregation function: " + storedType);
@@ -725,15 +789,20 @@ public class DistinctCountCPCSketchAggregationFunction
     return accumulator;
   }
 
-  /// Deserializes the sketches from the bytes.  Returns null for empty byte arrays which represent
-  /// the default null value for BYTES columns in Pinot.  Callers must handle null entries.
+  /// Deserializes the sketch carried by each row, leaving `null` where there is none.
+  ///
+  /// A null row is skipped rather than deserialized, so a column whose `defaultNullValue` is a real serialized sketch
+  /// does not contribute one. An empty payload also deserializes to `null`, and a row that is not null can carry one,
+  /// so callers must handle `null` entries even inside a non-null range.
   @SuppressWarnings({"unchecked"})
-  private CpcSketch[] deserializeSketches(byte[][] serializedSketches, int length) {
+  private CpcSketch[] deserializeSketches(byte[][] serializedSketches, int length, BlockValSet blockValSet) {
     CpcSketch[] sketches = new CpcSketch[length];
-    for (int i = 0; i < length; i++) {
-      byte[] bytes = serializedSketches[i];
-      sketches[i] = bytes.length > 0 ? CpcSketch.heapify(MemorySegment.ofArray(bytes)) : null;
-    }
+    forEachNotNull(length, blockValSet, (from, to) -> {
+      for (int i = from; i < to; i++) {
+        byte[] bytes = serializedSketches[i];
+        sketches[i] = bytes.length > 0 ? CpcSketch.heapify(MemorySegment.ofArray(bytes)) : null;
+      }
+    });
     return sketches;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
@@ -41,11 +41,11 @@ import org.apache.pinot.spi.utils.CommonConstants;
 import org.roaringbitmap.RoaringBitmap;
 
 
-public class DistinctCountHLLAggregationFunction extends BaseSingleInputAggregationFunction<HyperLogLog, Long> {
+public class DistinctCountHLLAggregationFunction extends NullableSingleInputAggregationFunction<HyperLogLog, Long> {
   protected final int _log2m;
 
-  public DistinctCountHLLAggregationFunction(List<ExpressionContext> arguments) {
-    super(arguments.get(0));
+  public DistinctCountHLLAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    super(arguments.get(0), nullHandlingEnabled);
     int numExpressions = arguments.size();
     // This function expects 1 or 2 arguments.
     Preconditions.checkArgument(numExpressions <= 2, "DistinctCountHLL expects 1 or 2 arguments, got: %s",
@@ -82,31 +82,34 @@ public class DistinctCountHLLAggregationFunction extends BaseSingleInputAggregat
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
     DataType dataType = blockValSet.getValueType();
-    if (dataType == DataType.BYTES) {
+    boolean singleValue = blockValSet.isSingleValue();
+    if (dataType == DataType.BYTES && singleValue) {
       // Logical BYTES is a serialized HyperLogLog and always uses the single-value representation.
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
-      try {
-        HyperLogLog hyperLogLog = aggregationResultHolder.getResult();
-        if (hyperLogLog != null) {
-          for (int i = 0; i < length; i++) {
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        try {
+          int i = from;
+          HyperLogLog hyperLogLog = aggregationResultHolder.getResult();
+          if (hyperLogLog == null) {
+            if (i == to) {
+              return;
+            }
+            // The first HyperLogLog read becomes the accumulator instead of being merged into a fresh one
+            hyperLogLog = ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize(bytesValues[i++]);
+            aggregationResultHolder.setValue(hyperLogLog);
+          }
+          for (; i < to; i++) {
             hyperLogLog.addAll(ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize(bytesValues[i]));
           }
-        } else {
-          hyperLogLog = ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize(bytesValues[0]);
-          aggregationResultHolder.setValue(hyperLogLog);
-          for (int i = 1; i < length; i++) {
-            hyperLogLog.addAll(ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize(bytesValues[i]));
-          }
+        } catch (Exception e) {
+          throw new RuntimeException("Caught exception while merging HyperLogLogs", e);
         }
-      } catch (Exception e) {
-        throw new RuntimeException("Caught exception while merging HyperLogLogs", e);
-      }
+      });
       return;
     }
 
     DataType storedType = dataType.getStoredType();
-
-    if (blockValSet.isSingleValue()) {
+    if (singleValue) {
       aggregateSV(length, aggregationResultHolder, blockValSet, storedType);
     } else {
       aggregateMV(length, aggregationResultHolder, blockValSet, storedType);
@@ -121,51 +124,70 @@ public class DistinctCountHLLAggregationFunction extends BaseSingleInputAggregat
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[] dictIds = blockValSet.getDictionaryIdsSV();
-      BitSet bitSet = getDictIdBitSet(aggregationResultHolder, dictionary);
-      for (int i = 0; i < length; i++) {
-        bitSet.set(dictIds[i]);
-      }
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        BitSet bitSet = getDictIdBitSet(aggregationResultHolder, dictionary);
+        for (int i = from; i < to; i++) {
+          bitSet.set(dictIds[i]);
+        }
+      });
       return;
     }
 
     // For non-dictionary-encoded expression, store values into the HyperLogLog
-    HyperLogLog hyperLogLog = getHyperLogLog(aggregationResultHolder);
     switch (storedType) {
       case INT:
         int[] intValues = blockValSet.getIntValuesSV();
-        for (int i = 0; i < length; i++) {
-          hyperLogLog.offer(intValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          HyperLogLog hyperLogLog = getHyperLogLog(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            hyperLogLog.offer(intValues[i]);
+          }
+        });
         break;
       case LONG:
         long[] longValues = blockValSet.getLongValuesSV();
-        for (int i = 0; i < length; i++) {
-          hyperLogLog.offer(longValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          HyperLogLog hyperLogLog = getHyperLogLog(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            hyperLogLog.offer(longValues[i]);
+          }
+        });
         break;
       case FLOAT:
         float[] floatValues = blockValSet.getFloatValuesSV();
-        for (int i = 0; i < length; i++) {
-          hyperLogLog.offer(floatValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          HyperLogLog hyperLogLog = getHyperLogLog(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            hyperLogLog.offer(floatValues[i]);
+          }
+        });
         break;
       case DOUBLE:
         double[] doubleValues = blockValSet.getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
-          hyperLogLog.offer(doubleValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          HyperLogLog hyperLogLog = getHyperLogLog(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            hyperLogLog.offer(doubleValues[i]);
+          }
+        });
         break;
       case STRING:
         String[] stringValues = blockValSet.getStringValuesSV();
-        for (int i = 0; i < length; i++) {
-          hyperLogLog.offer(stringValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          HyperLogLog hyperLogLog = getHyperLogLog(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            hyperLogLog.offer(stringValues[i]);
+          }
+        });
         break;
       case BYTES:
         byte[][] bytesValues = blockValSet.getBytesValuesSV();
-        for (int i = 0; i < length; i++) {
-          hyperLogLog.offer(bytesValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          HyperLogLog hyperLogLog = getHyperLogLog(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            hyperLogLog.offer(bytesValues[i]);
+          }
+        });
         break;
       default:
         throw new IllegalStateException("Illegal data type for DISTINCT_COUNT_HLL aggregation function: " + storedType);
@@ -178,65 +200,84 @@ public class DistinctCountHLLAggregationFunction extends BaseSingleInputAggregat
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[][] dictIds = blockValSet.getDictionaryIdsMV();
-      BitSet bitSet = getDictIdBitSet(aggregationResultHolder, dictionary);
-      for (int i = 0; i < length; i++) {
-        for (int dictId : dictIds[i]) {
-          bitSet.set(dictId);
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        BitSet bitSet = getDictIdBitSet(aggregationResultHolder, dictionary);
+        for (int i = from; i < to; i++) {
+          for (int dictId : dictIds[i]) {
+            bitSet.set(dictId);
+          }
         }
-      }
+      });
       return;
     }
 
     // For non-dictionary-encoded expression, store values into the HyperLogLog
-    HyperLogLog hyperLogLog = getHyperLogLog(aggregationResultHolder);
     switch (storedType) {
       case INT:
         int[][] intValuesArray = blockValSet.getIntValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (int value : intValuesArray[i]) {
-            hyperLogLog.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          HyperLogLog hyperLogLog = getHyperLogLog(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            for (int value : intValuesArray[i]) {
+              hyperLogLog.offer(value);
+            }
           }
-        }
+        });
         break;
       case LONG:
         long[][] longValuesArray = blockValSet.getLongValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (long value : longValuesArray[i]) {
-            hyperLogLog.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          HyperLogLog hyperLogLog = getHyperLogLog(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            for (long value : longValuesArray[i]) {
+              hyperLogLog.offer(value);
+            }
           }
-        }
+        });
         break;
       case FLOAT:
         float[][] floatValuesArray = blockValSet.getFloatValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (float value : floatValuesArray[i]) {
-            hyperLogLog.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          HyperLogLog hyperLogLog = getHyperLogLog(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            for (float value : floatValuesArray[i]) {
+              hyperLogLog.offer(value);
+            }
           }
-        }
+        });
         break;
       case DOUBLE:
         double[][] doubleValuesArray = blockValSet.getDoubleValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (double value : doubleValuesArray[i]) {
-            hyperLogLog.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          HyperLogLog hyperLogLog = getHyperLogLog(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            for (double value : doubleValuesArray[i]) {
+              hyperLogLog.offer(value);
+            }
           }
-        }
+        });
         break;
       case STRING:
         String[][] stringValuesArray = blockValSet.getStringValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (String value : stringValuesArray[i]) {
-            hyperLogLog.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          HyperLogLog hyperLogLog = getHyperLogLog(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            for (String value : stringValuesArray[i]) {
+              hyperLogLog.offer(value);
+            }
           }
-        }
+        });
         break;
       case BYTES:
         byte[][][] bytesValuesArray = blockValSet.getBytesValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (byte[] value : bytesValuesArray[i]) {
-            hyperLogLog.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          HyperLogLog hyperLogLog = getHyperLogLog(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            for (byte[] value : bytesValuesArray[i]) {
+              hyperLogLog.offer(value);
+            }
           }
-        }
+        });
         break;
       default:
         throw new IllegalStateException("Illegal data type for DISTINCT_COUNT_HLL aggregation function: " + storedType);
@@ -249,29 +290,31 @@ public class DistinctCountHLLAggregationFunction extends BaseSingleInputAggregat
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
     DataType dataType = blockValSet.getValueType();
-    if (dataType == DataType.BYTES) {
+    boolean singleValue = blockValSet.isSingleValue();
+    if (dataType == DataType.BYTES && singleValue) {
       // Logical BYTES is a serialized HyperLogLog and always uses the single-value representation.
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
-      try {
-        for (int i = 0; i < length; i++) {
-          HyperLogLog value = ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize(bytesValues[i]);
-          int groupKey = groupKeyArray[i];
-          HyperLogLog hyperLogLog = groupByResultHolder.getResult(groupKey);
-          if (hyperLogLog != null) {
-            hyperLogLog.addAll(value);
-          } else {
-            groupByResultHolder.setValueForKey(groupKey, value);
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        try {
+          for (int i = from; i < to; i++) {
+            HyperLogLog value = ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize(bytesValues[i]);
+            int groupKey = groupKeyArray[i];
+            HyperLogLog hyperLogLog = groupByResultHolder.getResult(groupKey);
+            if (hyperLogLog != null) {
+              hyperLogLog.addAll(value);
+            } else {
+              groupByResultHolder.setValueForKey(groupKey, value);
+            }
           }
+        } catch (Exception e) {
+          throw new RuntimeException("Caught exception while merging HyperLogLogs", e);
         }
-      } catch (Exception e) {
-        throw new RuntimeException("Caught exception while merging HyperLogLogs", e);
-      }
+      });
       return;
     }
 
     DataType storedType = dataType.getStoredType();
-
-    if (blockValSet.isSingleValue()) {
+    if (singleValue) {
       aggregateSVGroupBySV(length, groupKeyArray, groupByResultHolder, blockValSet, storedType);
     } else {
       aggregateMVGroupBySV(length, groupKeyArray, groupByResultHolder, blockValSet, storedType);
@@ -287,9 +330,11 @@ public class DistinctCountHLLAggregationFunction extends BaseSingleInputAggregat
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[] dictIds = blockValSet.getDictionaryIdsSV();
-      for (int i = 0; i < length; i++) {
-        getDictIdBitmap(groupByResultHolder, groupKeyArray[i], dictionary).add(dictIds[i]);
-      }
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          getDictIdBitmap(groupByResultHolder, groupKeyArray[i], dictionary).add(dictIds[i]);
+        }
+      });
       return;
     }
 
@@ -297,39 +342,51 @@ public class DistinctCountHLLAggregationFunction extends BaseSingleInputAggregat
     switch (storedType) {
       case INT:
         int[] intValues = blockValSet.getIntValuesSV();
-        for (int i = 0; i < length; i++) {
-          getHyperLogLog(groupByResultHolder, groupKeyArray[i]).offer(intValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            getHyperLogLog(groupByResultHolder, groupKeyArray[i]).offer(intValues[i]);
+          }
+        });
         break;
       case LONG:
         long[] longValues = blockValSet.getLongValuesSV();
-        for (int i = 0; i < length; i++) {
-          getHyperLogLog(groupByResultHolder, groupKeyArray[i]).offer(longValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            getHyperLogLog(groupByResultHolder, groupKeyArray[i]).offer(longValues[i]);
+          }
+        });
         break;
       case FLOAT:
         float[] floatValues = blockValSet.getFloatValuesSV();
-        for (int i = 0; i < length; i++) {
-          getHyperLogLog(groupByResultHolder, groupKeyArray[i]).offer(floatValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            getHyperLogLog(groupByResultHolder, groupKeyArray[i]).offer(floatValues[i]);
+          }
+        });
         break;
       case DOUBLE:
         double[] doubleValues = blockValSet.getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
-          getHyperLogLog(groupByResultHolder, groupKeyArray[i]).offer(doubleValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            getHyperLogLog(groupByResultHolder, groupKeyArray[i]).offer(doubleValues[i]);
+          }
+        });
         break;
       case STRING:
         String[] stringValues = blockValSet.getStringValuesSV();
-        for (int i = 0; i < length; i++) {
-          getHyperLogLog(groupByResultHolder, groupKeyArray[i]).offer(stringValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            getHyperLogLog(groupByResultHolder, groupKeyArray[i]).offer(stringValues[i]);
+          }
+        });
         break;
       case BYTES:
         byte[][] bytesValues = blockValSet.getBytesValuesSV();
-        for (int i = 0; i < length; i++) {
-          getHyperLogLog(groupByResultHolder, groupKeyArray[i]).offer(bytesValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            getHyperLogLog(groupByResultHolder, groupKeyArray[i]).offer(bytesValues[i]);
+          }
+        });
         break;
       default:
         throw new IllegalStateException("Illegal data type for DISTINCT_COUNT_HLL aggregation function: " + storedType);
@@ -342,9 +399,11 @@ public class DistinctCountHLLAggregationFunction extends BaseSingleInputAggregat
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[][] dictIds = blockValSet.getDictionaryIdsMV();
-      for (int i = 0; i < length; i++) {
-        getDictIdBitmap(groupByResultHolder, groupKeyArray[i], dictionary).add(dictIds[i]);
-      }
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          getDictIdBitmap(groupByResultHolder, groupKeyArray[i], dictionary).add(dictIds[i]);
+        }
+      });
       return;
     }
 
@@ -352,57 +411,69 @@ public class DistinctCountHLLAggregationFunction extends BaseSingleInputAggregat
     switch (storedType) {
       case INT:
         int[][] intValuesArray = blockValSet.getIntValuesMV();
-        for (int i = 0; i < length; i++) {
-          HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKeyArray[i]);
-          for (int value : intValuesArray[i]) {
-            hyperLogLog.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKeyArray[i]);
+            for (int value : intValuesArray[i]) {
+              hyperLogLog.offer(value);
+            }
           }
-        }
+        });
         break;
       case LONG:
         long[][] longValuesArray = blockValSet.getLongValuesMV();
-        for (int i = 0; i < length; i++) {
-          HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKeyArray[i]);
-          for (long value : longValuesArray[i]) {
-            hyperLogLog.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKeyArray[i]);
+            for (long value : longValuesArray[i]) {
+              hyperLogLog.offer(value);
+            }
           }
-        }
+        });
         break;
       case FLOAT:
         float[][] floatValuesArray = blockValSet.getFloatValuesMV();
-        for (int i = 0; i < length; i++) {
-          HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKeyArray[i]);
-          for (float value : floatValuesArray[i]) {
-            hyperLogLog.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKeyArray[i]);
+            for (float value : floatValuesArray[i]) {
+              hyperLogLog.offer(value);
+            }
           }
-        }
+        });
         break;
       case DOUBLE:
         double[][] doubleValuesArray = blockValSet.getDoubleValuesMV();
-        for (int i = 0; i < length; i++) {
-          HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKeyArray[i]);
-          for (double value : doubleValuesArray[i]) {
-            hyperLogLog.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKeyArray[i]);
+            for (double value : doubleValuesArray[i]) {
+              hyperLogLog.offer(value);
+            }
           }
-        }
+        });
         break;
       case STRING:
         String[][] stringValuesArray = blockValSet.getStringValuesMV();
-        for (int i = 0; i < length; i++) {
-          HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKeyArray[i]);
-          for (String value : stringValuesArray[i]) {
-            hyperLogLog.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKeyArray[i]);
+            for (String value : stringValuesArray[i]) {
+              hyperLogLog.offer(value);
+            }
           }
-        }
+        });
         break;
       case BYTES:
         byte[][][] bytesValuesArray = blockValSet.getBytesValuesMV();
-        for (int i = 0; i < length; i++) {
-          HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKeyArray[i]);
-          for (byte[] value : bytesValuesArray[i]) {
-            hyperLogLog.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKeyArray[i]);
+            for (byte[] value : bytesValuesArray[i]) {
+              hyperLogLog.offer(value);
+            }
           }
-        }
+        });
         break;
       default:
         throw new IllegalStateException("Illegal data type for DISTINCT_COUNT_HLL aggregation function: " + storedType);
@@ -415,32 +486,34 @@ public class DistinctCountHLLAggregationFunction extends BaseSingleInputAggregat
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
     DataType dataType = blockValSet.getValueType();
-    if (dataType == DataType.BYTES) {
+    boolean singleValue = blockValSet.isSingleValue();
+    if (dataType == DataType.BYTES && singleValue) {
       // Logical BYTES is a serialized HyperLogLog and always uses the single-value representation.
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
-      try {
-        for (int i = 0; i < length; i++) {
-          HyperLogLog value = ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize(bytesValues[i]);
-          for (int groupKey : groupKeysArray[i]) {
-            HyperLogLog hyperLogLog = groupByResultHolder.getResult(groupKey);
-            if (hyperLogLog != null) {
-              hyperLogLog.addAll(value);
-            } else {
-              // Create a new HyperLogLog for the group
-              groupByResultHolder.setValueForKey(groupKey,
-                  ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize(bytesValues[i]));
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        try {
+          for (int i = from; i < to; i++) {
+            HyperLogLog value = ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize(bytesValues[i]);
+            for (int groupKey : groupKeysArray[i]) {
+              HyperLogLog hyperLogLog = groupByResultHolder.getResult(groupKey);
+              if (hyperLogLog != null) {
+                hyperLogLog.addAll(value);
+              } else {
+                // Create a new HyperLogLog for the group
+                groupByResultHolder.setValueForKey(groupKey,
+                    ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize(bytesValues[i]));
+              }
             }
           }
+        } catch (Exception e) {
+          throw new RuntimeException("Caught exception while merging HyperLogLogs", e);
         }
-      } catch (Exception e) {
-        throw new RuntimeException("Caught exception while merging HyperLogLogs", e);
-      }
+      });
       return;
     }
 
     DataType storedType = dataType.getStoredType();
-
-    if (blockValSet.isSingleValue()) {
+    if (singleValue) {
       aggregateSVGroupByMV(length, groupKeysArray, groupByResultHolder, blockValSet, storedType);
     } else {
       aggregateMVGroupByMV(length, groupKeysArray, groupByResultHolder, blockValSet, storedType);
@@ -453,12 +526,14 @@ public class DistinctCountHLLAggregationFunction extends BaseSingleInputAggregat
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[] dictIds = blockValSet.getDictionaryIdsSV();
-      for (int i = 0; i < length; i++) {
-        int dictId = dictIds[i];
-        for (int groupKey : groupKeysArray[i]) {
-          getDictIdBitmap(groupByResultHolder, groupKey, dictionary).add(dictId);
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          int dictId = dictIds[i];
+          for (int groupKey : groupKeysArray[i]) {
+            getDictIdBitmap(groupByResultHolder, groupKey, dictionary).add(dictId);
+          }
         }
-      }
+      });
       return;
     }
 
@@ -466,39 +541,51 @@ public class DistinctCountHLLAggregationFunction extends BaseSingleInputAggregat
     switch (storedType) {
       case INT:
         int[] intValues = blockValSet.getIntValuesSV();
-        for (int i = 0; i < length; i++) {
-          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], intValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], intValues[i]);
+          }
+        });
         break;
       case LONG:
         long[] longValues = blockValSet.getLongValuesSV();
-        for (int i = 0; i < length; i++) {
-          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], longValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], longValues[i]);
+          }
+        });
         break;
       case FLOAT:
         float[] floatValues = blockValSet.getFloatValuesSV();
-        for (int i = 0; i < length; i++) {
-          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], floatValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], floatValues[i]);
+          }
+        });
         break;
       case DOUBLE:
         double[] doubleValues = blockValSet.getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
-          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], doubleValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], doubleValues[i]);
+          }
+        });
         break;
       case STRING:
         String[] stringValues = blockValSet.getStringValuesSV();
-        for (int i = 0; i < length; i++) {
-          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], stringValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], stringValues[i]);
+          }
+        });
         break;
       case BYTES:
         byte[][] bytesValues = blockValSet.getBytesValuesSV();
-        for (int i = 0; i < length; i++) {
-          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], bytesValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], bytesValues[i]);
+          }
+        });
         break;
       default:
         throw new IllegalStateException("Illegal data type for DISTINCT_COUNT_HLL aggregation function: " + storedType);
@@ -511,12 +598,14 @@ public class DistinctCountHLLAggregationFunction extends BaseSingleInputAggregat
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[][] dictIds = blockValSet.getDictionaryIdsMV();
-      for (int i = 0; i < length; i++) {
-        int[] rowDictIds = dictIds[i];
-        for (int groupKey : groupKeysArray[i]) {
-          getDictIdBitmap(groupByResultHolder, groupKey, dictionary).add(rowDictIds);
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          int[] rowDictIds = dictIds[i];
+          for (int groupKey : groupKeysArray[i]) {
+            getDictIdBitmap(groupByResultHolder, groupKey, dictionary).add(rowDictIds);
+          }
         }
-      }
+      });
       return;
     }
 
@@ -524,75 +613,87 @@ public class DistinctCountHLLAggregationFunction extends BaseSingleInputAggregat
     switch (storedType) {
       case INT:
         int[][] intValuesArray = blockValSet.getIntValuesMV();
-        for (int i = 0; i < length; i++) {
-          int[] intValues = intValuesArray[i];
-          for (int groupKey : groupKeysArray[i]) {
-            HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKey);
-            for (int value : intValues) {
-              hyperLogLog.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            int[] intValues = intValuesArray[i];
+            for (int groupKey : groupKeysArray[i]) {
+              HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKey);
+              for (int value : intValues) {
+                hyperLogLog.offer(value);
+              }
             }
           }
-        }
+        });
         break;
       case LONG:
         long[][] longValuesArray = blockValSet.getLongValuesMV();
-        for (int i = 0; i < length; i++) {
-          long[] longValues = longValuesArray[i];
-          for (int groupKey : groupKeysArray[i]) {
-            HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKey);
-            for (long value : longValues) {
-              hyperLogLog.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            long[] longValues = longValuesArray[i];
+            for (int groupKey : groupKeysArray[i]) {
+              HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKey);
+              for (long value : longValues) {
+                hyperLogLog.offer(value);
+              }
             }
           }
-        }
+        });
         break;
       case FLOAT:
         float[][] floatValuesArray = blockValSet.getFloatValuesMV();
-        for (int i = 0; i < length; i++) {
-          float[] floatValues = floatValuesArray[i];
-          for (int groupKey : groupKeysArray[i]) {
-            HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKey);
-            for (float value : floatValues) {
-              hyperLogLog.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            float[] floatValues = floatValuesArray[i];
+            for (int groupKey : groupKeysArray[i]) {
+              HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKey);
+              for (float value : floatValues) {
+                hyperLogLog.offer(value);
+              }
             }
           }
-        }
+        });
         break;
       case DOUBLE:
         double[][] doubleValuesArray = blockValSet.getDoubleValuesMV();
-        for (int i = 0; i < length; i++) {
-          double[] doubleValues = doubleValuesArray[i];
-          for (int groupKey : groupKeysArray[i]) {
-            HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKey);
-            for (double value : doubleValues) {
-              hyperLogLog.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            double[] doubleValues = doubleValuesArray[i];
+            for (int groupKey : groupKeysArray[i]) {
+              HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKey);
+              for (double value : doubleValues) {
+                hyperLogLog.offer(value);
+              }
             }
           }
-        }
+        });
         break;
       case STRING:
         String[][] stringValuesArray = blockValSet.getStringValuesMV();
-        for (int i = 0; i < length; i++) {
-          String[] stringValues = stringValuesArray[i];
-          for (int groupKey : groupKeysArray[i]) {
-            HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKey);
-            for (String value : stringValues) {
-              hyperLogLog.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            String[] stringValues = stringValuesArray[i];
+            for (int groupKey : groupKeysArray[i]) {
+              HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKey);
+              for (String value : stringValues) {
+                hyperLogLog.offer(value);
+              }
             }
           }
-        }
+        });
         break;
       case BYTES:
         byte[][][] bytesValuesArray = blockValSet.getBytesValuesMV();
-        for (int i = 0; i < length; i++) {
-          byte[][] bytesValues = bytesValuesArray[i];
-          for (int groupKey : groupKeysArray[i]) {
-            HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKey);
-            for (byte[] value : bytesValues) {
-              hyperLogLog.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            byte[][] bytesValues = bytesValuesArray[i];
+            for (int groupKey : groupKeysArray[i]) {
+              HyperLogLog hyperLogLog = getHyperLogLog(groupByResultHolder, groupKey);
+              for (byte[] value : bytesValues) {
+                hyperLogLog.offer(value);
+              }
             }
           }
-        }
+        });
         break;
       default:
         throw new IllegalStateException("Illegal data type for DISTINCT_COUNT_HLL aggregation function: " + storedType);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLMVAggregationFunction.java
@@ -25,8 +25,8 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggregationFunction {
 
-  public DistinctCountHLLMVAggregationFunction(List<ExpressionContext> arguments) {
-    super(arguments);
+  public DistinctCountHLLMVAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    super(arguments, nullHandlingEnabled);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLPlusAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLPlusAggregationFunction.java
@@ -41,14 +41,15 @@ import org.roaringbitmap.PeekableIntIterator;
 import org.roaringbitmap.RoaringBitmap;
 
 
-public class DistinctCountHLLPlusAggregationFunction extends BaseSingleInputAggregationFunction<HyperLogLogPlus, Long> {
+public class DistinctCountHLLPlusAggregationFunction
+    extends NullableSingleInputAggregationFunction<HyperLogLogPlus, Long> {
   // The parameter "p" determines the precision of the sparse list in HyperLogLogPlus.
   protected final int _p;
   // The "sp" parameter specifies the number of standard deviations that the sparse list's precision should be set to.
   protected final int _sp;
 
-  public DistinctCountHLLPlusAggregationFunction(List<ExpressionContext> arguments) {
-    super(arguments.get(0));
+  public DistinctCountHLLPlusAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    super(arguments.get(0), nullHandlingEnabled);
     int numExpressions = arguments.size();
     // This function expects 1 or 2 or 3 arguments.
     Preconditions.checkArgument(numExpressions <= 3, "DistinctCountHLLPlus expects 2 or 3 arguments, got: %s",
@@ -94,29 +95,34 @@ public class DistinctCountHLLPlusAggregationFunction extends BaseSingleInputAggr
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
     DataType dataType = blockValSet.getValueType();
-    if (dataType == DataType.BYTES) {
+    boolean singleValue = blockValSet.isSingleValue();
+    if (dataType == DataType.BYTES && singleValue) {
       // Logical BYTES is a serialized HyperLogLogPlus and always uses the single-value representation.
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
-      try {
-        HyperLogLogPlus hyperLogLogPlus = aggregationResultHolder.getResult();
-        if (hyperLogLogPlus == null) {
-          hyperLogLogPlus = ObjectSerDeUtils.HYPER_LOG_LOG_PLUS_SER_DE.deserialize(bytesValues[0]);
-          aggregationResultHolder.setValue(hyperLogLogPlus);
-        } else {
-          hyperLogLogPlus.addAll(ObjectSerDeUtils.HYPER_LOG_LOG_PLUS_SER_DE.deserialize(bytesValues[0]));
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        try {
+          int i = from;
+          HyperLogLogPlus hyperLogLogPlus = aggregationResultHolder.getResult();
+          if (hyperLogLogPlus == null) {
+            if (i == to) {
+              return;
+            }
+            // The first HyperLogLogPlus read becomes the accumulator instead of being merged into a fresh one
+            hyperLogLogPlus = ObjectSerDeUtils.HYPER_LOG_LOG_PLUS_SER_DE.deserialize(bytesValues[i++]);
+            aggregationResultHolder.setValue(hyperLogLogPlus);
+          }
+          for (; i < to; i++) {
+            hyperLogLogPlus.addAll(ObjectSerDeUtils.HYPER_LOG_LOG_PLUS_SER_DE.deserialize(bytesValues[i]));
+          }
+        } catch (Exception e) {
+          throw new RuntimeException("Caught exception while merging HyperLogLogPlus", e);
         }
-        for (int i = 1; i < length; i++) {
-          hyperLogLogPlus.addAll(ObjectSerDeUtils.HYPER_LOG_LOG_PLUS_SER_DE.deserialize(bytesValues[i]));
-        }
-      } catch (Exception e) {
-        throw new RuntimeException("Caught exception while merging HyperLogLogPlus", e);
-      }
+      });
       return;
     }
 
     DataType storedType = dataType.getStoredType();
-
-    if (blockValSet.isSingleValue()) {
+    if (singleValue) {
       aggregateSV(length, aggregationResultHolder, blockValSet, storedType);
     } else {
       aggregateMV(length, aggregationResultHolder, blockValSet, storedType);
@@ -129,48 +135,66 @@ public class DistinctCountHLLPlusAggregationFunction extends BaseSingleInputAggr
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[] dictIds = blockValSet.getDictionaryIdsSV();
-      getDictIdBitmap(aggregationResultHolder, dictionary).addN(dictIds, 0, length);
+      forEachNotNull(length, blockValSet,
+          (from, to) -> getDictIdBitmap(aggregationResultHolder, dictionary).addN(dictIds, from, to - from));
       return;
     }
 
     // For non-dictionary-encoded expression, store values into the HyperLogLogPlus
-    HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(aggregationResultHolder);
     switch (storedType) {
       case INT:
         int[] intValues = blockValSet.getIntValuesSV();
-        for (int i = 0; i < length; i++) {
-          hyperLogLogPlus.offer(intValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            hyperLogLogPlus.offer(intValues[i]);
+          }
+        });
         break;
       case LONG:
         long[] longValues = blockValSet.getLongValuesSV();
-        for (int i = 0; i < length; i++) {
-          hyperLogLogPlus.offer(longValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            hyperLogLogPlus.offer(longValues[i]);
+          }
+        });
         break;
       case FLOAT:
         float[] floatValues = blockValSet.getFloatValuesSV();
-        for (int i = 0; i < length; i++) {
-          hyperLogLogPlus.offer(floatValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            hyperLogLogPlus.offer(floatValues[i]);
+          }
+        });
         break;
       case DOUBLE:
         double[] doubleValues = blockValSet.getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
-          hyperLogLogPlus.offer(doubleValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            hyperLogLogPlus.offer(doubleValues[i]);
+          }
+        });
         break;
       case STRING:
         String[] stringValues = blockValSet.getStringValuesSV();
-        for (int i = 0; i < length; i++) {
-          hyperLogLogPlus.offer(stringValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            hyperLogLogPlus.offer(stringValues[i]);
+          }
+        });
         break;
       case BYTES:
         byte[][] bytesValues = blockValSet.getBytesValuesSV();
-        for (int i = 0; i < length; i++) {
-          hyperLogLogPlus.offer(bytesValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            hyperLogLogPlus.offer(bytesValues[i]);
+          }
+        });
         break;
       default:
         throw new IllegalStateException(
@@ -183,64 +207,83 @@ public class DistinctCountHLLPlusAggregationFunction extends BaseSingleInputAggr
     // For dictionary-encoded expression, store dictionary ids into the bitmap
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
-      RoaringBitmap dictIdBitmap = getDictIdBitmap(aggregationResultHolder, dictionary);
       int[][] dictIds = blockValSet.getDictionaryIdsMV();
-      for (int i = 0; i < length; i++) {
-        dictIdBitmap.add(dictIds[i]);
-      }
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        RoaringBitmap dictIdBitmap = getDictIdBitmap(aggregationResultHolder, dictionary);
+        for (int i = from; i < to; i++) {
+          dictIdBitmap.add(dictIds[i]);
+        }
+      });
       return;
     }
 
     // For non-dictionary-encoded expression, store values into the HyperLogLogPlus
-    HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(aggregationResultHolder);
     switch (storedType) {
       case INT:
         int[][] intValuesArray = blockValSet.getIntValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (int value : intValuesArray[i]) {
-            hyperLogLogPlus.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            for (int value : intValuesArray[i]) {
+              hyperLogLogPlus.offer(value);
+            }
           }
-        }
+        });
         break;
       case LONG:
         long[][] longValuesArray = blockValSet.getLongValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (long value : longValuesArray[i]) {
-            hyperLogLogPlus.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            for (long value : longValuesArray[i]) {
+              hyperLogLogPlus.offer(value);
+            }
           }
-        }
+        });
         break;
       case FLOAT:
         float[][] floatValuesArray = blockValSet.getFloatValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (float value : floatValuesArray[i]) {
-            hyperLogLogPlus.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            for (float value : floatValuesArray[i]) {
+              hyperLogLogPlus.offer(value);
+            }
           }
-        }
+        });
         break;
       case DOUBLE:
         double[][] doubleValuesArray = blockValSet.getDoubleValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (double value : doubleValuesArray[i]) {
-            hyperLogLogPlus.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            for (double value : doubleValuesArray[i]) {
+              hyperLogLogPlus.offer(value);
+            }
           }
-        }
+        });
         break;
       case STRING:
         String[][] stringValuesArray = blockValSet.getStringValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (String value : stringValuesArray[i]) {
-            hyperLogLogPlus.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            for (String value : stringValuesArray[i]) {
+              hyperLogLogPlus.offer(value);
+            }
           }
-        }
+        });
         break;
       case BYTES:
         byte[][][] bytesValuesArray = blockValSet.getBytesValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (byte[] value : bytesValuesArray[i]) {
-            hyperLogLogPlus.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            for (byte[] value : bytesValuesArray[i]) {
+              hyperLogLogPlus.offer(value);
+            }
           }
-        }
+        });
         break;
       default:
         throw new IllegalStateException(
@@ -254,29 +297,31 @@ public class DistinctCountHLLPlusAggregationFunction extends BaseSingleInputAggr
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
     DataType dataType = blockValSet.getValueType();
-    if (dataType == DataType.BYTES) {
+    boolean singleValue = blockValSet.isSingleValue();
+    if (dataType == DataType.BYTES && singleValue) {
       // Logical BYTES is a serialized HyperLogLogPlus and always uses the single-value representation.
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
-      try {
-        for (int i = 0; i < length; i++) {
-          HyperLogLogPlus value = ObjectSerDeUtils.HYPER_LOG_LOG_PLUS_SER_DE.deserialize(bytesValues[i]);
-          int groupKey = groupKeyArray[i];
-          HyperLogLogPlus hyperLogLogPlus = groupByResultHolder.getResult(groupKey);
-          if (hyperLogLogPlus != null) {
-            hyperLogLogPlus.addAll(value);
-          } else {
-            groupByResultHolder.setValueForKey(groupKey, value);
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        try {
+          for (int i = from; i < to; i++) {
+            HyperLogLogPlus value = ObjectSerDeUtils.HYPER_LOG_LOG_PLUS_SER_DE.deserialize(bytesValues[i]);
+            int groupKey = groupKeyArray[i];
+            HyperLogLogPlus hyperLogLogPlus = groupByResultHolder.getResult(groupKey);
+            if (hyperLogLogPlus != null) {
+              hyperLogLogPlus.addAll(value);
+            } else {
+              groupByResultHolder.setValueForKey(groupKey, value);
+            }
           }
+        } catch (Exception e) {
+          throw new RuntimeException("Caught exception while merging HyperLogLogPlus", e);
         }
-      } catch (Exception e) {
-        throw new RuntimeException("Caught exception while merging HyperLogLogPlus", e);
-      }
+      });
       return;
     }
 
     DataType storedType = dataType.getStoredType();
-
-    if (blockValSet.isSingleValue()) {
+    if (singleValue) {
       aggregateSVGroupBySV(length, groupKeyArray, groupByResultHolder, blockValSet, storedType);
     } else {
       aggregateMVGroupBySV(length, groupKeyArray, groupByResultHolder, blockValSet, storedType);
@@ -289,9 +334,11 @@ public class DistinctCountHLLPlusAggregationFunction extends BaseSingleInputAggr
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[] dictIds = blockValSet.getDictionaryIdsSV();
-      for (int i = 0; i < length; i++) {
-        getDictIdBitmap(groupByResultHolder, groupKeyArray[i], dictionary).add(dictIds[i]);
-      }
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          getDictIdBitmap(groupByResultHolder, groupKeyArray[i], dictionary).add(dictIds[i]);
+        }
+      });
       return;
     }
 
@@ -299,39 +346,51 @@ public class DistinctCountHLLPlusAggregationFunction extends BaseSingleInputAggr
     switch (storedType) {
       case INT:
         int[] intValues = blockValSet.getIntValuesSV();
-        for (int i = 0; i < length; i++) {
-          getHyperLogLogPlus(groupByResultHolder, groupKeyArray[i]).offer(intValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            getHyperLogLogPlus(groupByResultHolder, groupKeyArray[i]).offer(intValues[i]);
+          }
+        });
         break;
       case LONG:
         long[] longValues = blockValSet.getLongValuesSV();
-        for (int i = 0; i < length; i++) {
-          getHyperLogLogPlus(groupByResultHolder, groupKeyArray[i]).offer(longValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            getHyperLogLogPlus(groupByResultHolder, groupKeyArray[i]).offer(longValues[i]);
+          }
+        });
         break;
       case FLOAT:
         float[] floatValues = blockValSet.getFloatValuesSV();
-        for (int i = 0; i < length; i++) {
-          getHyperLogLogPlus(groupByResultHolder, groupKeyArray[i]).offer(floatValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            getHyperLogLogPlus(groupByResultHolder, groupKeyArray[i]).offer(floatValues[i]);
+          }
+        });
         break;
       case DOUBLE:
         double[] doubleValues = blockValSet.getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
-          getHyperLogLogPlus(groupByResultHolder, groupKeyArray[i]).offer(doubleValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            getHyperLogLogPlus(groupByResultHolder, groupKeyArray[i]).offer(doubleValues[i]);
+          }
+        });
         break;
       case STRING:
         String[] stringValues = blockValSet.getStringValuesSV();
-        for (int i = 0; i < length; i++) {
-          getHyperLogLogPlus(groupByResultHolder, groupKeyArray[i]).offer(stringValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            getHyperLogLogPlus(groupByResultHolder, groupKeyArray[i]).offer(stringValues[i]);
+          }
+        });
         break;
       case BYTES:
         byte[][] bytesValues = blockValSet.getBytesValuesSV();
-        for (int i = 0; i < length; i++) {
-          getHyperLogLogPlus(groupByResultHolder, groupKeyArray[i]).offer(bytesValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            getHyperLogLogPlus(groupByResultHolder, groupKeyArray[i]).offer(bytesValues[i]);
+          }
+        });
         break;
       default:
         throw new IllegalStateException(
@@ -345,9 +404,11 @@ public class DistinctCountHLLPlusAggregationFunction extends BaseSingleInputAggr
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[][] dictIds = blockValSet.getDictionaryIdsMV();
-      for (int i = 0; i < length; i++) {
-        getDictIdBitmap(groupByResultHolder, groupKeyArray[i], dictionary).add(dictIds[i]);
-      }
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          getDictIdBitmap(groupByResultHolder, groupKeyArray[i], dictionary).add(dictIds[i]);
+        }
+      });
       return;
     }
 
@@ -355,57 +416,69 @@ public class DistinctCountHLLPlusAggregationFunction extends BaseSingleInputAggr
     switch (storedType) {
       case INT:
         int[][] intValuesArray = blockValSet.getIntValuesMV();
-        for (int i = 0; i < length; i++) {
-          HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(groupByResultHolder, groupKeyArray[i]);
-          for (int value : intValuesArray[i]) {
-            hyperLogLogPlus.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(groupByResultHolder, groupKeyArray[i]);
+            for (int value : intValuesArray[i]) {
+              hyperLogLogPlus.offer(value);
+            }
           }
-        }
+        });
         break;
       case LONG:
         long[][] longValuesArray = blockValSet.getLongValuesMV();
-        for (int i = 0; i < length; i++) {
-          HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(groupByResultHolder, groupKeyArray[i]);
-          for (long value : longValuesArray[i]) {
-            hyperLogLogPlus.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(groupByResultHolder, groupKeyArray[i]);
+            for (long value : longValuesArray[i]) {
+              hyperLogLogPlus.offer(value);
+            }
           }
-        }
+        });
         break;
       case FLOAT:
         float[][] floatValuesArray = blockValSet.getFloatValuesMV();
-        for (int i = 0; i < length; i++) {
-          HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(groupByResultHolder, groupKeyArray[i]);
-          for (float value : floatValuesArray[i]) {
-            hyperLogLogPlus.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(groupByResultHolder, groupKeyArray[i]);
+            for (float value : floatValuesArray[i]) {
+              hyperLogLogPlus.offer(value);
+            }
           }
-        }
+        });
         break;
       case DOUBLE:
         double[][] doubleValuesArray = blockValSet.getDoubleValuesMV();
-        for (int i = 0; i < length; i++) {
-          HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(groupByResultHolder, groupKeyArray[i]);
-          for (double value : doubleValuesArray[i]) {
-            hyperLogLogPlus.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(groupByResultHolder, groupKeyArray[i]);
+            for (double value : doubleValuesArray[i]) {
+              hyperLogLogPlus.offer(value);
+            }
           }
-        }
+        });
         break;
       case STRING:
         String[][] stringValuesArray = blockValSet.getStringValuesMV();
-        for (int i = 0; i < length; i++) {
-          HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(groupByResultHolder, groupKeyArray[i]);
-          for (String value : stringValuesArray[i]) {
-            hyperLogLogPlus.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(groupByResultHolder, groupKeyArray[i]);
+            for (String value : stringValuesArray[i]) {
+              hyperLogLogPlus.offer(value);
+            }
           }
-        }
+        });
         break;
       case BYTES:
         byte[][][] bytesValuesArray = blockValSet.getBytesValuesMV();
-        for (int i = 0; i < length; i++) {
-          HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(groupByResultHolder, groupKeyArray[i]);
-          for (byte[] value : bytesValuesArray[i]) {
-            hyperLogLogPlus.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(groupByResultHolder, groupKeyArray[i]);
+            for (byte[] value : bytesValuesArray[i]) {
+              hyperLogLogPlus.offer(value);
+            }
           }
-        }
+        });
         break;
       default:
         throw new IllegalStateException(
@@ -419,32 +492,34 @@ public class DistinctCountHLLPlusAggregationFunction extends BaseSingleInputAggr
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
     DataType dataType = blockValSet.getValueType();
-    if (dataType == DataType.BYTES) {
+    boolean singleValue = blockValSet.isSingleValue();
+    if (dataType == DataType.BYTES && singleValue) {
       // Logical BYTES is a serialized HyperLogLogPlus and always uses the single-value representation.
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
-      try {
-        for (int i = 0; i < length; i++) {
-          HyperLogLogPlus value = ObjectSerDeUtils.HYPER_LOG_LOG_PLUS_SER_DE.deserialize(bytesValues[i]);
-          for (int groupKey : groupKeysArray[i]) {
-            HyperLogLogPlus hyperLogLogPlus = groupByResultHolder.getResult(groupKey);
-            if (hyperLogLogPlus != null) {
-              hyperLogLogPlus.addAll(value);
-            } else {
-              // Create a new HyperLogLogPlus for the group
-              groupByResultHolder.setValueForKey(groupKey,
-                  ObjectSerDeUtils.HYPER_LOG_LOG_PLUS_SER_DE.deserialize(bytesValues[i]));
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        try {
+          for (int i = from; i < to; i++) {
+            HyperLogLogPlus value = ObjectSerDeUtils.HYPER_LOG_LOG_PLUS_SER_DE.deserialize(bytesValues[i]);
+            for (int groupKey : groupKeysArray[i]) {
+              HyperLogLogPlus hyperLogLogPlus = groupByResultHolder.getResult(groupKey);
+              if (hyperLogLogPlus != null) {
+                hyperLogLogPlus.addAll(value);
+              } else {
+                // Create a new HyperLogLogPlus for the group
+                groupByResultHolder.setValueForKey(groupKey,
+                    ObjectSerDeUtils.HYPER_LOG_LOG_PLUS_SER_DE.deserialize(bytesValues[i]));
+              }
             }
           }
+        } catch (Exception e) {
+          throw new RuntimeException("Caught exception while merging HyperLogLogPlus", e);
         }
-      } catch (Exception e) {
-        throw new RuntimeException("Caught exception while merging HyperLogLogPlus", e);
-      }
+      });
       return;
     }
 
     DataType storedType = dataType.getStoredType();
-
-    if (blockValSet.isSingleValue()) {
+    if (singleValue) {
       aggregateSVGroupByMV(length, groupKeysArray, groupByResultHolder, blockValSet, storedType);
     } else {
       aggregateMVGroupByMV(length, groupKeysArray, groupByResultHolder, blockValSet, storedType);
@@ -457,9 +532,11 @@ public class DistinctCountHLLPlusAggregationFunction extends BaseSingleInputAggr
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[] dictIds = blockValSet.getDictionaryIdsSV();
-      for (int i = 0; i < length; i++) {
-        setDictIdForGroupKeys(groupByResultHolder, groupKeysArray[i], dictionary, dictIds[i]);
-      }
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          setDictIdForGroupKeys(groupByResultHolder, groupKeysArray[i], dictionary, dictIds[i]);
+        }
+      });
       return;
     }
 
@@ -467,39 +544,51 @@ public class DistinctCountHLLPlusAggregationFunction extends BaseSingleInputAggr
     switch (storedType) {
       case INT:
         int[] intValues = blockValSet.getIntValuesSV();
-        for (int i = 0; i < length; i++) {
-          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], intValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], intValues[i]);
+          }
+        });
         break;
       case LONG:
         long[] longValues = blockValSet.getLongValuesSV();
-        for (int i = 0; i < length; i++) {
-          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], longValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], longValues[i]);
+          }
+        });
         break;
       case FLOAT:
         float[] floatValues = blockValSet.getFloatValuesSV();
-        for (int i = 0; i < length; i++) {
-          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], floatValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], floatValues[i]);
+          }
+        });
         break;
       case DOUBLE:
         double[] doubleValues = blockValSet.getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
-          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], doubleValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], doubleValues[i]);
+          }
+        });
         break;
       case STRING:
         String[] stringValues = blockValSet.getStringValuesSV();
-        for (int i = 0; i < length; i++) {
-          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], stringValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], stringValues[i]);
+          }
+        });
         break;
       case BYTES:
         byte[][] bytesValues = blockValSet.getBytesValuesSV();
-        for (int i = 0; i < length; i++) {
-          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], bytesValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], bytesValues[i]);
+          }
+        });
         break;
       default:
         throw new IllegalStateException(
@@ -513,11 +602,13 @@ public class DistinctCountHLLPlusAggregationFunction extends BaseSingleInputAggr
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[][] dictIds = blockValSet.getDictionaryIdsMV();
-      for (int i = 0; i < length; i++) {
-        for (int groupKey : groupKeysArray[i]) {
-          getDictIdBitmap(groupByResultHolder, groupKey, dictionary).add(dictIds[i]);
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          for (int groupKey : groupKeysArray[i]) {
+            getDictIdBitmap(groupByResultHolder, groupKey, dictionary).add(dictIds[i]);
+          }
         }
-      }
+      });
       return;
     }
 
@@ -525,75 +616,87 @@ public class DistinctCountHLLPlusAggregationFunction extends BaseSingleInputAggr
     switch (storedType) {
       case INT:
         int[][] intValuesArray = blockValSet.getIntValuesMV();
-        for (int i = 0; i < length; i++) {
-          int[] intValues = intValuesArray[i];
-          for (int groupKey : groupKeysArray[i]) {
-            HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(groupByResultHolder, groupKey);
-            for (int value : intValues) {
-              hyperLogLogPlus.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            int[] intValues = intValuesArray[i];
+            for (int groupKey : groupKeysArray[i]) {
+              HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(groupByResultHolder, groupKey);
+              for (int value : intValues) {
+                hyperLogLogPlus.offer(value);
+              }
             }
           }
-        }
+        });
         break;
       case LONG:
         long[][] longValuesArray = blockValSet.getLongValuesMV();
-        for (int i = 0; i < length; i++) {
-          long[] longValues = longValuesArray[i];
-          for (int groupKey : groupKeysArray[i]) {
-            HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(groupByResultHolder, groupKey);
-            for (long value : longValues) {
-              hyperLogLogPlus.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            long[] longValues = longValuesArray[i];
+            for (int groupKey : groupKeysArray[i]) {
+              HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(groupByResultHolder, groupKey);
+              for (long value : longValues) {
+                hyperLogLogPlus.offer(value);
+              }
             }
           }
-        }
+        });
         break;
       case FLOAT:
         float[][] floatValuesArray = blockValSet.getFloatValuesMV();
-        for (int i = 0; i < length; i++) {
-          float[] floatValues = floatValuesArray[i];
-          for (int groupKey : groupKeysArray[i]) {
-            HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(groupByResultHolder, groupKey);
-            for (float value : floatValues) {
-              hyperLogLogPlus.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            float[] floatValues = floatValuesArray[i];
+            for (int groupKey : groupKeysArray[i]) {
+              HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(groupByResultHolder, groupKey);
+              for (float value : floatValues) {
+                hyperLogLogPlus.offer(value);
+              }
             }
           }
-        }
+        });
         break;
       case DOUBLE:
         double[][] doubleValuesArray = blockValSet.getDoubleValuesMV();
-        for (int i = 0; i < length; i++) {
-          double[] doubleValues = doubleValuesArray[i];
-          for (int groupKey : groupKeysArray[i]) {
-            HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(groupByResultHolder, groupKey);
-            for (double value : doubleValues) {
-              hyperLogLogPlus.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            double[] doubleValues = doubleValuesArray[i];
+            for (int groupKey : groupKeysArray[i]) {
+              HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(groupByResultHolder, groupKey);
+              for (double value : doubleValues) {
+                hyperLogLogPlus.offer(value);
+              }
             }
           }
-        }
+        });
         break;
       case STRING:
         String[][] stringValuesArray = blockValSet.getStringValuesMV();
-        for (int i = 0; i < length; i++) {
-          String[] stringValues = stringValuesArray[i];
-          for (int groupKey : groupKeysArray[i]) {
-            HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(groupByResultHolder, groupKey);
-            for (String value : stringValues) {
-              hyperLogLogPlus.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            String[] stringValues = stringValuesArray[i];
+            for (int groupKey : groupKeysArray[i]) {
+              HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(groupByResultHolder, groupKey);
+              for (String value : stringValues) {
+                hyperLogLogPlus.offer(value);
+              }
             }
           }
-        }
+        });
         break;
       case BYTES:
         byte[][][] bytesValuesArray = blockValSet.getBytesValuesMV();
-        for (int i = 0; i < length; i++) {
-          byte[][] bytesValues = bytesValuesArray[i];
-          for (int groupKey : groupKeysArray[i]) {
-            HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(groupByResultHolder, groupKey);
-            for (byte[] value : bytesValues) {
-              hyperLogLogPlus.offer(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            byte[][] bytesValues = bytesValuesArray[i];
+            for (int groupKey : groupKeysArray[i]) {
+              HyperLogLogPlus hyperLogLogPlus = getHyperLogLogPlus(groupByResultHolder, groupKey);
+              for (byte[] value : bytesValues) {
+                hyperLogLogPlus.offer(value);
+              }
             }
           }
-        }
+        });
         break;
       default:
         throw new IllegalStateException(

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLPlusMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLPlusMVAggregationFunction.java
@@ -25,8 +25,8 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 public class DistinctCountHLLPlusMVAggregationFunction extends DistinctCountHLLPlusAggregationFunction {
 
-  public DistinctCountHLLPlusMVAggregationFunction(List<ExpressionContext> arguments) {
-    super(arguments);
+  public DistinctCountHLLPlusMVAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    super(arguments, nullHandlingEnabled);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawCPCSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawCPCSketchAggregationFunction.java
@@ -31,8 +31,9 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 /// [DistinctCountCPCSketchAggregationFunction], and returns the sketch as a base64 encoded string.
 public class DistinctCountRawCPCSketchAggregationFunction extends DistinctCountCPCSketchAggregationFunction {
 
-  public DistinctCountRawCPCSketchAggregationFunction(List<ExpressionContext> arguments) {
-    super(arguments);
+  public DistinctCountRawCPCSketchAggregationFunction(List<ExpressionContext> arguments,
+      boolean nullHandlingEnabled) {
+    super(arguments, nullHandlingEnabled);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLAggregationFunction.java
@@ -33,16 +33,17 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
 public class DistinctCountRawHLLAggregationFunction
-    extends BaseSingleInputAggregationFunction<HyperLogLog, SerializedHLL> {
+    extends NullableSingleInputAggregationFunction<HyperLogLog, SerializedHLL> {
   private final DistinctCountHLLAggregationFunction _distinctCountHLLAggregationFunction;
 
-  public DistinctCountRawHLLAggregationFunction(List<ExpressionContext> arguments) {
-    this(arguments.get(0), new DistinctCountHLLAggregationFunction(arguments));
+  public DistinctCountRawHLLAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    this(arguments.get(0), new DistinctCountHLLAggregationFunction(arguments, nullHandlingEnabled),
+        nullHandlingEnabled);
   }
 
   DistinctCountRawHLLAggregationFunction(ExpressionContext expression,
-      DistinctCountHLLAggregationFunction distinctCountHLLAggregationFunction) {
-    super(expression);
+      DistinctCountHLLAggregationFunction distinctCountHLLAggregationFunction, boolean nullHandlingEnabled) {
+    super(expression, nullHandlingEnabled);
     _distinctCountHLLAggregationFunction = distinctCountHLLAggregationFunction;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLMVAggregationFunction.java
@@ -25,8 +25,9 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 public class DistinctCountRawHLLMVAggregationFunction extends DistinctCountRawHLLAggregationFunction {
 
-  public DistinctCountRawHLLMVAggregationFunction(List<ExpressionContext> arguments) {
-    super(arguments.get(0), new DistinctCountHLLMVAggregationFunction(arguments));
+  public DistinctCountRawHLLMVAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    super(arguments.get(0), new DistinctCountHLLMVAggregationFunction(arguments, nullHandlingEnabled),
+        nullHandlingEnabled);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLPlusAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLPlusAggregationFunction.java
@@ -33,16 +33,17 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
 public class DistinctCountRawHLLPlusAggregationFunction
-    extends BaseSingleInputAggregationFunction<HyperLogLogPlus, SerializedHLLPlus> {
+    extends NullableSingleInputAggregationFunction<HyperLogLogPlus, SerializedHLLPlus> {
   private final DistinctCountHLLPlusAggregationFunction _distinctCountHLLPlusAggregationFunction;
 
-  public DistinctCountRawHLLPlusAggregationFunction(List<ExpressionContext> arguments) {
-    this(arguments.get(0), new DistinctCountHLLPlusAggregationFunction(arguments));
+  public DistinctCountRawHLLPlusAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    this(arguments.get(0), new DistinctCountHLLPlusAggregationFunction(arguments, nullHandlingEnabled),
+        nullHandlingEnabled);
   }
 
   DistinctCountRawHLLPlusAggregationFunction(ExpressionContext expression,
-      DistinctCountHLLPlusAggregationFunction distinctCountHLLPlusAggregationFunction) {
-    super(expression);
+      DistinctCountHLLPlusAggregationFunction distinctCountHLLPlusAggregationFunction, boolean nullHandlingEnabled) {
+    super(expression, nullHandlingEnabled);
     _distinctCountHLLPlusAggregationFunction = distinctCountHLLPlusAggregationFunction;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLPlusMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawHLLPlusMVAggregationFunction.java
@@ -25,8 +25,9 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 public class DistinctCountRawHLLPlusMVAggregationFunction extends DistinctCountRawHLLPlusAggregationFunction {
 
-  public DistinctCountRawHLLPlusMVAggregationFunction(List<ExpressionContext> arguments) {
-    super(arguments.get(0), new DistinctCountHLLPlusMVAggregationFunction(arguments));
+  public DistinctCountRawHLLPlusMVAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    super(arguments.get(0), new DistinctCountHLLPlusMVAggregationFunction(arguments, nullHandlingEnabled),
+        nullHandlingEnabled);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawThetaSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawThetaSketchAggregationFunction.java
@@ -33,8 +33,9 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 /// [DistinctCountThetaSketchAggregationFunction], and returns the sketch as a base64 encoded string.
 public class DistinctCountRawThetaSketchAggregationFunction extends DistinctCountThetaSketchAggregationFunction {
 
-  public DistinctCountRawThetaSketchAggregationFunction(List<ExpressionContext> arguments) {
-    super(arguments);
+  public DistinctCountRawThetaSketchAggregationFunction(List<ExpressionContext> arguments,
+      boolean nullHandlingEnabled) {
+    super(arguments, nullHandlingEnabled);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawULLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawULLAggregationFunction.java
@@ -28,8 +28,8 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
 public class DistinctCountRawULLAggregationFunction extends DistinctCountULLAggregationFunction {
-  public DistinctCountRawULLAggregationFunction(List<ExpressionContext> arguments) {
-    super(arguments);
+  public DistinctCountRawULLAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    super(arguments, nullHandlingEnabled);
   }
 
   @Nullable

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartHLLAggregationFunction.java
@@ -62,8 +62,8 @@ public class DistinctCountSmartHLLAggregationFunction extends BaseDistinctCountS
   private final int _log2m;
   private final int _dictIdCardinalityThreshold;
 
-  public DistinctCountSmartHLLAggregationFunction(List<ExpressionContext> arguments) {
-    super(arguments.get(0));
+  public DistinctCountSmartHLLAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    super(arguments.get(0), nullHandlingEnabled);
 
     if (arguments.size() > 1) {
       Parameters parameters = new Parameters(arguments.get(1).getLiteral().getStringValue());
@@ -126,16 +126,20 @@ public class DistinctCountSmartHLLAggregationFunction extends BaseDistinctCountS
                                        int length) {
     if (blockValSet.isSingleValue()) {
       int[] dictIds = blockValSet.getDictionaryIdsSV();
-      for (int i = 0; i < length; i++) {
-        hyperLogLog.offer(dictionary.get(dictIds[i]));
-      }
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          hyperLogLog.offer(dictionary.get(dictIds[i]));
+        }
+      });
     } else {
       int[][] dictIds = blockValSet.getDictionaryIdsMV();
-      for (int i = 0; i < length; i++) {
-        for (int dictId : dictIds[i]) {
-          hyperLogLog.offer(dictionary.get(dictId));
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          for (int dictId : dictIds[i]) {
+            hyperLogLog.offer(dictionary.get(dictId));
+          }
         }
-      }
+      });
     }
   }
 
@@ -143,12 +147,14 @@ public class DistinctCountSmartHLLAggregationFunction extends BaseDistinctCountS
   private void aggregateDictIdsIntoBitmap(RoaringBitmap dictIdBitmap, BlockValSet blockValSet, int length) {
     if (blockValSet.isSingleValue()) {
       int[] dictIds = blockValSet.getDictionaryIdsSV();
-      dictIdBitmap.addN(dictIds, 0, length);
+      forEachNotNull(length, blockValSet, (from, to) -> dictIdBitmap.addN(dictIds, from, to - from));
     } else {
       int[][] dictIds = blockValSet.getDictionaryIdsMV();
-      for (int i = 0; i < length; i++) {
-        dictIdBitmap.add(dictIds[i]);
-      }
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          dictIdBitmap.add(dictIds[i]);
+        }
+      });
     }
   }
 
@@ -167,39 +173,51 @@ public class DistinctCountSmartHLLAggregationFunction extends BaseDistinctCountS
       switch (storedType) {
         case INT:
           int[] intValues = blockValSet.getIntValuesSV();
-          for (int i = 0; i < length; i++) {
-            hll.offer(intValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              hll.offer(intValues[i]);
+            }
+          });
           break;
         case LONG:
           long[] longValues = blockValSet.getLongValuesSV();
-          for (int i = 0; i < length; i++) {
-            hll.offer(longValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              hll.offer(longValues[i]);
+            }
+          });
           break;
         case FLOAT:
           float[] floatValues = blockValSet.getFloatValuesSV();
-          for (int i = 0; i < length; i++) {
-            hll.offer(floatValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              hll.offer(floatValues[i]);
+            }
+          });
           break;
         case DOUBLE:
           double[] doubleValues = blockValSet.getDoubleValuesSV();
-          for (int i = 0; i < length; i++) {
-            hll.offer(doubleValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              hll.offer(doubleValues[i]);
+            }
+          });
           break;
         case STRING:
           String[] stringValues = blockValSet.getStringValuesSV();
-          for (int i = 0; i < length; i++) {
-            hll.offer(stringValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              hll.offer(stringValues[i]);
+            }
+          });
           break;
         case BYTES:
           byte[][] bytesValues = blockValSet.getBytesValuesSV();
-          for (int i = 0; i < length; i++) {
-            hll.offer(bytesValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              hll.offer(bytesValues[i]);
+            }
+          });
           break;
         default:
           throw getIllegalDataTypeException(valueType, true);
@@ -208,43 +226,53 @@ public class DistinctCountSmartHLLAggregationFunction extends BaseDistinctCountS
       switch (storedType) {
         case INT:
           int[][] intValues = blockValSet.getIntValuesMV();
-          for (int i = 0; i < length; i++) {
-            for (int value : intValues[i]) {
-              hll.offer(value);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (int value : intValues[i]) {
+                hll.offer(value);
+              }
             }
-          }
+          });
           break;
         case LONG:
           long[][] longValues = blockValSet.getLongValuesMV();
-          for (int i = 0; i < length; i++) {
-            for (long value : longValues[i]) {
-              hll.offer(value);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (long value : longValues[i]) {
+                hll.offer(value);
+              }
             }
-          }
+          });
           break;
         case FLOAT:
           float[][] floatValues = blockValSet.getFloatValuesMV();
-          for (int i = 0; i < length; i++) {
-            for (float value : floatValues[i]) {
-              hll.offer(value);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (float value : floatValues[i]) {
+                hll.offer(value);
+              }
             }
-          }
+          });
           break;
         case DOUBLE:
           double[][] doubleValues = blockValSet.getDoubleValuesMV();
-          for (int i = 0; i < length; i++) {
-            for (double value : doubleValues[i]) {
-              hll.offer(value);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (double value : doubleValues[i]) {
+                hll.offer(value);
+              }
             }
-          }
+          });
           break;
         case STRING:
           String[][] stringValues = blockValSet.getStringValuesMV();
-          for (int i = 0; i < length; i++) {
-            for (String value : stringValues[i]) {
-              hll.offer(value);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (String value : stringValues[i]) {
+                hll.offer(value);
+              }
             }
-          }
+          });
           break;
         default:
           throw getIllegalDataTypeException(valueType, false);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartHLLPlusAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartHLLPlusAggregationFunction.java
@@ -60,8 +60,8 @@ public class DistinctCountSmartHLLPlusAggregationFunction extends BaseDistinctCo
   private final int _p;
   private final int _sp;
 
-  public DistinctCountSmartHLLPlusAggregationFunction(List<ExpressionContext> arguments) {
-    super(arguments.get(0));
+  public DistinctCountSmartHLLPlusAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    super(arguments.get(0), nullHandlingEnabled);
 
     if (arguments.size() > 1) {
       Parameters parameters = new Parameters(arguments.get(1).getLiteral().getStringValue());
@@ -103,12 +103,14 @@ public class DistinctCountSmartHLLPlusAggregationFunction extends BaseDistinctCo
       RoaringBitmap dictIdBitmap = getDictIdBitmap(aggregationResultHolder, dictionary);
       if (blockValSet.isSingleValue()) {
         int[] dictIds = blockValSet.getDictionaryIdsSV();
-        dictIdBitmap.addN(dictIds, 0, length);
+        forEachNotNull(length, blockValSet, (from, to) -> dictIdBitmap.addN(dictIds, from, to - from));
       } else {
         int[][] dictIds = blockValSet.getDictionaryIdsMV();
-        for (int i = 0; i < length; i++) {
-          dictIdBitmap.add(dictIds[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            dictIdBitmap.add(dictIds[i]);
+          }
+        });
       }
       return;
     }
@@ -130,39 +132,51 @@ public class DistinctCountSmartHLLPlusAggregationFunction extends BaseDistinctCo
       switch (storedType) {
         case INT:
           int[] intValues = blockValSet.getIntValuesSV();
-          for (int i = 0; i < length; i++) {
-            hllPlus.offer(intValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              hllPlus.offer(intValues[i]);
+            }
+          });
           break;
         case LONG:
           long[] longValues = blockValSet.getLongValuesSV();
-          for (int i = 0; i < length; i++) {
-            hllPlus.offer(longValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              hllPlus.offer(longValues[i]);
+            }
+          });
           break;
         case FLOAT:
           float[] floatValues = blockValSet.getFloatValuesSV();
-          for (int i = 0; i < length; i++) {
-            hllPlus.offer(floatValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              hllPlus.offer(floatValues[i]);
+            }
+          });
           break;
         case DOUBLE:
           double[] doubleValues = blockValSet.getDoubleValuesSV();
-          for (int i = 0; i < length; i++) {
-            hllPlus.offer(doubleValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              hllPlus.offer(doubleValues[i]);
+            }
+          });
           break;
         case STRING:
           String[] stringValues = blockValSet.getStringValuesSV();
-          for (int i = 0; i < length; i++) {
-            hllPlus.offer(stringValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              hllPlus.offer(stringValues[i]);
+            }
+          });
           break;
         case BYTES:
           byte[][] bytesValues = blockValSet.getBytesValuesSV();
-          for (int i = 0; i < length; i++) {
-            hllPlus.offer(bytesValues[i]);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              hllPlus.offer(bytesValues[i]);
+            }
+          });
           break;
         default:
           throw getIllegalDataTypeException(valueType, true);
@@ -171,43 +185,53 @@ public class DistinctCountSmartHLLPlusAggregationFunction extends BaseDistinctCo
       switch (storedType) {
         case INT:
           int[][] intValues = blockValSet.getIntValuesMV();
-          for (int i = 0; i < length; i++) {
-            for (int value : intValues[i]) {
-              hllPlus.offer(value);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (int value : intValues[i]) {
+                hllPlus.offer(value);
+              }
             }
-          }
+          });
           break;
         case LONG:
           long[][] longValues = blockValSet.getLongValuesMV();
-          for (int i = 0; i < length; i++) {
-            for (long value : longValues[i]) {
-              hllPlus.offer(value);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (long value : longValues[i]) {
+                hllPlus.offer(value);
+              }
             }
-          }
+          });
           break;
         case FLOAT:
           float[][] floatValues = blockValSet.getFloatValuesMV();
-          for (int i = 0; i < length; i++) {
-            for (float value : floatValues[i]) {
-              hllPlus.offer(value);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (float value : floatValues[i]) {
+                hllPlus.offer(value);
+              }
             }
-          }
+          });
           break;
         case DOUBLE:
           double[][] doubleValues = blockValSet.getDoubleValuesMV();
-          for (int i = 0; i < length; i++) {
-            for (double value : doubleValues[i]) {
-              hllPlus.offer(value);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (double value : doubleValues[i]) {
+                hllPlus.offer(value);
+              }
             }
-          }
+          });
           break;
         case STRING:
           String[][] stringValues = blockValSet.getStringValuesMV();
-          for (int i = 0; i < length; i++) {
-            for (String value : stringValues[i]) {
-              hllPlus.offer(value);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (String value : stringValues[i]) {
+                hllPlus.offer(value);
+              }
             }
-          }
+          });
           break;
         default:
           throw getIllegalDataTypeException(valueType, false);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartULLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartULLAggregationFunction.java
@@ -59,8 +59,8 @@ public class DistinctCountSmartULLAggregationFunction extends BaseDistinctCountS
   private final int _threshold;
   private final int _p;
 
-  public DistinctCountSmartULLAggregationFunction(List<ExpressionContext> arguments) {
-    super(arguments.get(0));
+  public DistinctCountSmartULLAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    super(arguments.get(0), nullHandlingEnabled);
     int numExpressions = arguments.size();
     // This function expects 1 or 2 arguments.
     Preconditions.checkArgument(numExpressions <= 2, "DistinctCountSmartULL expects 1 or 2 arguments, got: %s",
@@ -101,12 +101,14 @@ public class DistinctCountSmartULLAggregationFunction extends BaseDistinctCountS
       RoaringBitmap dictIdBitmap = getDictIdBitmap(aggregationResultHolder, dictionary);
       if (blockValSet.isSingleValue()) {
         int[] dictIds = blockValSet.getDictionaryIdsSV();
-        dictIdBitmap.addN(dictIds, 0, length);
+        forEachNotNull(length, blockValSet, (from, to) -> dictIdBitmap.addN(dictIds, from, to - from));
       } else {
         int[][] dictIds = blockValSet.getDictionaryIdsMV();
-        for (int i = 0; i < length; i++) {
-          dictIdBitmap.add(dictIds[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            dictIdBitmap.add(dictIds[i]);
+          }
+        });
       }
       return;
     }
@@ -127,44 +129,56 @@ public class DistinctCountSmartULLAggregationFunction extends BaseDistinctCountS
       switch (storedType) {
         case INT: {
           int[] intValues = blockValSet.getIntValuesSV();
-          for (int i = 0; i < length; i++) {
-            UltraLogLogUtils.hashObject(intValues[i]).ifPresent(ull::add);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              UltraLogLogUtils.hashObject(intValues[i]).ifPresent(ull::add);
+            }
+          });
           break;
         }
         case LONG: {
           long[] longValues = blockValSet.getLongValuesSV();
-          for (int i = 0; i < length; i++) {
-            UltraLogLogUtils.hashObject(longValues[i]).ifPresent(ull::add);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              UltraLogLogUtils.hashObject(longValues[i]).ifPresent(ull::add);
+            }
+          });
           break;
         }
         case FLOAT: {
           float[] floatValues = blockValSet.getFloatValuesSV();
-          for (int i = 0; i < length; i++) {
-            UltraLogLogUtils.hashObject(floatValues[i]).ifPresent(ull::add);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              UltraLogLogUtils.hashObject(floatValues[i]).ifPresent(ull::add);
+            }
+          });
           break;
         }
         case DOUBLE: {
           double[] doubleValues = blockValSet.getDoubleValuesSV();
-          for (int i = 0; i < length; i++) {
-            UltraLogLogUtils.hashObject(doubleValues[i]).ifPresent(ull::add);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              UltraLogLogUtils.hashObject(doubleValues[i]).ifPresent(ull::add);
+            }
+          });
           break;
         }
         case STRING: {
           String[] stringValues = blockValSet.getStringValuesSV();
-          for (int i = 0; i < length; i++) {
-            UltraLogLogUtils.hashObject(stringValues[i]).ifPresent(ull::add);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              UltraLogLogUtils.hashObject(stringValues[i]).ifPresent(ull::add);
+            }
+          });
           break;
         }
         case BYTES: {
           byte[][] bytesValues = blockValSet.getBytesValuesSV();
-          for (int i = 0; i < length; i++) {
-            UltraLogLogUtils.hashObject(bytesValues[i]).ifPresent(ull::add);
-          }
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              UltraLogLogUtils.hashObject(bytesValues[i]).ifPresent(ull::add);
+            }
+          });
           break;
         }
         default:
@@ -174,56 +188,68 @@ public class DistinctCountSmartULLAggregationFunction extends BaseDistinctCountS
       switch (storedType) {
         case INT: {
           int[][] intValues = blockValSet.getIntValuesMV();
-          for (int i = 0; i < length; i++) {
-            for (int value : intValues[i]) {
-              UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (int value : intValues[i]) {
+                UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+              }
             }
-          }
+          });
           break;
         }
         case LONG: {
           long[][] longValues = blockValSet.getLongValuesMV();
-          for (int i = 0; i < length; i++) {
-            for (long value : longValues[i]) {
-              UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (long value : longValues[i]) {
+                UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+              }
             }
-          }
+          });
           break;
         }
         case FLOAT: {
           float[][] floatValues = blockValSet.getFloatValuesMV();
-          for (int i = 0; i < length; i++) {
-            for (float value : floatValues[i]) {
-              UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (float value : floatValues[i]) {
+                UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+              }
             }
-          }
+          });
           break;
         }
         case DOUBLE: {
           double[][] doubleValues = blockValSet.getDoubleValuesMV();
-          for (int i = 0; i < length; i++) {
-            for (double value : doubleValues[i]) {
-              UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (double value : doubleValues[i]) {
+                UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+              }
             }
-          }
+          });
           break;
         }
         case STRING: {
           String[][] stringValues = blockValSet.getStringValuesMV();
-          for (int i = 0; i < length; i++) {
-            for (String value : stringValues[i]) {
-              UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (String value : stringValues[i]) {
+                UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+              }
             }
-          }
+          });
           break;
         }
         case BYTES: {
           byte[][][] bytesValues = blockValSet.getBytesValuesMV();
-          for (int i = 0; i < length; i++) {
-            for (byte[] value : bytesValues[i]) {
-              UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+          forEachNotNull(length, blockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (byte[] value : bytesValues[i]) {
+                UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+              }
             }
-          }
+          });
           break;
         }
         default:

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
@@ -80,7 +80,7 @@ import org.apache.pinot.sql.parsers.CalciteSqlParser;
 /// E.g. DISTINCT_COUNT_THETA_SKETCH(col, 'nominalEntries=8192')
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class DistinctCountThetaSketchAggregationFunction
-    extends BaseSingleInputAggregationFunction<List<ThetaSketchAccumulator>, Comparable> {
+    extends NullableSingleInputAggregationFunction<List<ThetaSketchAccumulator>, Comparable> {
   private static final String SET_UNION = "setunion";
   private static final String SET_INTERSECT = "setintersect";
   private static final String SET_DIFF = "setdiff";
@@ -95,8 +95,9 @@ public class DistinctCountThetaSketchAggregationFunction
   protected final ThetaSetOperationBuilder _setOperationBuilder = new ThetaSetOperationBuilder();
   protected int _accumulatorThreshold = DEFAULT_ACCUMULATOR_THRESHOLD;
 
-  public DistinctCountThetaSketchAggregationFunction(List<ExpressionContext> arguments) {
-    super(arguments.get(0));
+  public DistinctCountThetaSketchAggregationFunction(List<ExpressionContext> arguments,
+      boolean nullHandlingEnabled) {
+    super(arguments.get(0), nullHandlingEnabled);
 
     // Initialize the UpdatableThetaSketchBuilder and ThetaSetOperationBuilder with the parameters
     int numArguments = arguments.size();
@@ -185,877 +186,1072 @@ public class DistinctCountThetaSketchAggregationFunction
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet mainBlockValSet = blockValSetMap.get(_expression);
     int numExpressions = _inputExpressions.size();
     boolean[] singleValues = new boolean[numExpressions];
     DataType[] valueTypes = new DataType[numExpressions];
     Object[] valueArrays = new Object[numExpressions];
     extractValues(blockValSetMap, singleValues, valueTypes, valueArrays);
-    int numFilters = _filterEvaluators.size();
 
     // Main expression is always index 0
-    if (valueTypes[0] != DataType.BYTES) {
-      List<UpdatableThetaSketch> updateSketches = getUpdateSketches(aggregationResultHolder);
-      if (singleValues[0]) {
-        switch (valueTypes[0].getStoredType()) {
-          case INT:
-            int[] intValues = (int[]) valueArrays[0];
-            if (_includeDefaultSketch) {
-              UpdatableThetaSketch defaultSketch = updateSketches.get(0);
-              for (int i = 0; i < length; i++) {
-                defaultSketch.update(intValues[i]);
-              }
-            }
-            for (int i = 0; i < numFilters; i++) {
-              FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
-              UpdatableThetaSketch updateSketch = updateSketches.get(i + 1);
-              for (int j = 0; j < length; j++) {
-                if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-                  updateSketch.update(intValues[j]);
-                }
-              }
-            }
-            break;
-          case LONG:
-            long[] longValues = (long[]) valueArrays[0];
-            if (_includeDefaultSketch) {
-              UpdatableThetaSketch defaultSketch = updateSketches.get(0);
-              for (int i = 0; i < length; i++) {
-                defaultSketch.update(longValues[i]);
-              }
-            }
-            for (int i = 0; i < numFilters; i++) {
-              FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
-              UpdatableThetaSketch updateSketch = updateSketches.get(i + 1);
-              for (int j = 0; j < length; j++) {
-                if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-                  updateSketch.update(longValues[j]);
-                }
-              }
-            }
-            break;
-          case FLOAT:
-            float[] floatValues = (float[]) valueArrays[0];
-            if (_includeDefaultSketch) {
-              UpdatableThetaSketch defaultSketch = updateSketches.get(0);
-              for (int i = 0; i < length; i++) {
-                defaultSketch.update(floatValues[i]);
-              }
-            }
-            for (int i = 0; i < numFilters; i++) {
-              FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
-              UpdatableThetaSketch updateSketch = updateSketches.get(i + 1);
-              for (int j = 0; j < length; j++) {
-                if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-                  updateSketch.update(floatValues[j]);
-                }
-              }
-            }
-            break;
-          case DOUBLE:
-            double[] doubleValues = (double[]) valueArrays[0];
-            if (_includeDefaultSketch) {
-              UpdatableThetaSketch defaultSketch = updateSketches.get(0);
-              for (int i = 0; i < length; i++) {
-                defaultSketch.update(doubleValues[i]);
-              }
-            }
-            for (int i = 0; i < numFilters; i++) {
-              FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
-              UpdatableThetaSketch updateSketch = updateSketches.get(i + 1);
-              for (int j = 0; j < length; j++) {
-                if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-                  updateSketch.update(doubleValues[j]);
-                }
-              }
-            }
-            break;
-          case STRING:
-            String[] stringValues = (String[]) valueArrays[0];
-            if (_includeDefaultSketch) {
-              UpdatableThetaSketch defaultSketch = updateSketches.get(0);
-              for (int i = 0; i < length; i++) {
-                defaultSketch.update(stringValues[i]);
-              }
-            }
-            for (int i = 0; i < numFilters; i++) {
-              FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
-              UpdatableThetaSketch updateSketch = updateSketches.get(i + 1);
-              for (int j = 0; j < length; j++) {
-                if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-                  updateSketch.update(stringValues[j]);
-                }
-              }
-            }
-            break;
-          case BYTES:
-            byte[][] bytesValues = (byte[][]) valueArrays[0];
-            if (_includeDefaultSketch) {
-              UpdatableThetaSketch defaultSketch = updateSketches.get(0);
-              for (int i = 0; i < length; i++) {
-                defaultSketch.update(bytesValues[i]);
-              }
-            }
-            for (int i = 0; i < numFilters; i++) {
-              FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
-              UpdatableThetaSketch updateSketch = updateSketches.get(i + 1);
-              for (int j = 0; j < length; j++) {
-                if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-                  updateSketch.update(bytesValues[j]);
-                }
-              }
-            }
-            break;
-          default:
-            throw new IllegalStateException(
-                "Illegal single-value data type for DISTINCT_COUNT_THETA_SKETCH aggregation function: "
-                    + valueTypes[0]);
-        }
-      } else {
-        switch (valueTypes[0].getStoredType()) {
-          case INT:
-            int[][] intValues = (int[][]) valueArrays[0];
-            if (_includeDefaultSketch) {
-              UpdatableThetaSketch defaultSketch = updateSketches.get(0);
-              for (int i = 0; i < length; i++) {
-                for (int value : intValues[i]) {
-                  defaultSketch.update(value);
-                }
-              }
-            }
-            for (int i = 0; i < numFilters; i++) {
-              FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
-              UpdatableThetaSketch updateSketch = updateSketches.get(i + 1);
-              for (int j = 0; j < length; j++) {
-                if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-                  for (int value : intValues[j]) {
-                    updateSketch.update(value);
-                  }
-                }
-              }
-            }
-            break;
-          case LONG:
-            long[][] longValues = (long[][]) valueArrays[0];
-            if (_includeDefaultSketch) {
-              UpdatableThetaSketch defaultSketch = updateSketches.get(0);
-              for (int i = 0; i < length; i++) {
-                for (long value : longValues[i]) {
-                  defaultSketch.update(value);
-                }
-              }
-            }
-            for (int i = 0; i < numFilters; i++) {
-              FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
-              UpdatableThetaSketch updateSketch = updateSketches.get(i + 1);
-              for (int j = 0; j < length; j++) {
-                if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-                  for (long value : longValues[j]) {
-                    updateSketch.update(value);
-                  }
-                }
-              }
-            }
-            break;
-          case FLOAT:
-            float[][] floatValues = (float[][]) valueArrays[0];
-            if (_includeDefaultSketch) {
-              UpdatableThetaSketch defaultSketch = updateSketches.get(0);
-              for (int i = 0; i < length; i++) {
-                for (float value : floatValues[i]) {
-                  defaultSketch.update(value);
-                }
-              }
-            }
-            for (int i = 0; i < numFilters; i++) {
-              FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
-              UpdatableThetaSketch updateSketch = updateSketches.get(i + 1);
-              for (int j = 0; j < length; j++) {
-                if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-                  for (float value : floatValues[j]) {
-                    updateSketch.update(value);
-                  }
-                }
-              }
-            }
-            break;
-          case DOUBLE:
-            double[][] doubleValues = (double[][]) valueArrays[0];
-            if (_includeDefaultSketch) {
-              UpdatableThetaSketch defaultSketch = updateSketches.get(0);
-              for (int i = 0; i < length; i++) {
-                for (double value : doubleValues[i]) {
-                  defaultSketch.update(value);
-                }
-              }
-            }
-            for (int i = 0; i < numFilters; i++) {
-              FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
-              UpdatableThetaSketch updateSketch = updateSketches.get(i + 1);
-              for (int j = 0; j < length; j++) {
-                if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-                  for (double value : doubleValues[j]) {
-                    updateSketch.update(value);
-                  }
-                }
-              }
-            }
-            break;
-          case STRING:
-            String[][] stringValues = (String[][]) valueArrays[0];
-            if (_includeDefaultSketch) {
-              UpdatableThetaSketch defaultSketch = updateSketches.get(0);
-              for (int i = 0; i < length; i++) {
-                for (String value : stringValues[i]) {
-                  defaultSketch.update(value);
-                }
-              }
-            }
-            for (int i = 0; i < numFilters; i++) {
-              FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
-              UpdatableThetaSketch updateSketch = updateSketches.get(i + 1);
-              for (int j = 0; j < length; j++) {
-                if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-                  for (String value : stringValues[j]) {
-                    updateSketch.update(value);
-                  }
-                }
-              }
-            }
-            break;
-          case BYTES:
-            byte[][][] bytesValues = (byte[][][]) valueArrays[0];
-            if (_includeDefaultSketch) {
-              UpdatableThetaSketch defaultSketch = updateSketches.get(0);
-              for (int i = 0; i < length; i++) {
-                for (byte[] value : bytesValues[i]) {
-                  defaultSketch.update(value);
-                }
-              }
-            }
-            for (int i = 0; i < numFilters; i++) {
-              FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
-              UpdatableThetaSketch updateSketch = updateSketches.get(i + 1);
-              for (int j = 0; j < length; j++) {
-                if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-                  for (byte[] value : bytesValues[j]) {
-                    updateSketch.update(value);
-                  }
-                }
-              }
-            }
-            break;
-          default:
-            throw new IllegalStateException(
-                "Illegal multi-value data type for DISTINCT_COUNT_THETA_SKETCH aggregation function: " + valueTypes[0]);
-        }
-      }
-    } else {
+    if (valueTypes[0] == DataType.BYTES && singleValues[0]) {
       // Logical BYTES stores serialized ThetaSketch objects in the single-value representation.
       List<ThetaSketchAccumulator> thetaSketchAccumulators = getUnions(aggregationResultHolder);
-      ThetaSketch[] sketches = deserializeSketches((byte[][]) valueArrays[0], length);
+      ThetaSketch[] sketches = deserializeSketches((byte[][]) valueArrays[0], length, mainBlockValSet);
       if (_includeDefaultSketch) {
         ThetaSketchAccumulator defaultThetaAccumulator = thetaSketchAccumulators.get(0);
-        for (ThetaSketch sketch : sketches) {
-          defaultThetaAccumulator.apply(sketch);
-        }
+        forEachNotNull(length, mainBlockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            defaultThetaAccumulator.apply(sketches[i]);
+          }
+        });
       }
+      int numFilters = _filterEvaluators.size();
       for (int i = 0; i < numFilters; i++) {
         FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
         ThetaSketchAccumulator thetaSketchAccumulator = thetaSketchAccumulators.get(i + 1);
-        for (int j = 0; j < length; j++) {
-          if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-            thetaSketchAccumulator.apply(sketches[j]);
+        forEachNotNull(length, mainBlockValSet, (from, to) -> {
+          for (int j = from; j < to; j++) {
+            if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+              thetaSketchAccumulator.apply(sketches[j]);
+            }
           }
-        }
+        });
       }
+      return;
+    }
+
+    if (singleValues[0]) {
+      aggregateSV(length, aggregationResultHolder, mainBlockValSet, singleValues, valueTypes, valueArrays);
+    } else {
+      aggregateMV(length, aggregationResultHolder, mainBlockValSet, singleValues, valueTypes, valueArrays);
+    }
+  }
+
+  protected void aggregateSV(int length, AggregationResultHolder aggregationResultHolder,
+      BlockValSet mainBlockValSet, boolean[] singleValues, DataType[] valueTypes, Object[] valueArrays) {
+    int numFilters = _filterEvaluators.size();
+    List<UpdatableThetaSketch> updateSketches = getUpdateSketches(aggregationResultHolder);
+    switch (valueTypes[0].getStoredType()) {
+      case INT:
+        int[] intValues = (int[]) valueArrays[0];
+        if (_includeDefaultSketch) {
+          UpdatableThetaSketch defaultSketch = updateSketches.get(0);
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              defaultSketch.update(intValues[i]);
+            }
+          });
+        }
+        for (int i = 0; i < numFilters; i++) {
+          FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
+          UpdatableThetaSketch updateSketch = updateSketches.get(i + 1);
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int j = from; j < to; j++) {
+              if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+                updateSketch.update(intValues[j]);
+              }
+            }
+          });
+        }
+        break;
+      case LONG:
+        long[] longValues = (long[]) valueArrays[0];
+        if (_includeDefaultSketch) {
+          UpdatableThetaSketch defaultSketch = updateSketches.get(0);
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              defaultSketch.update(longValues[i]);
+            }
+          });
+        }
+        for (int i = 0; i < numFilters; i++) {
+          FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
+          UpdatableThetaSketch updateSketch = updateSketches.get(i + 1);
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int j = from; j < to; j++) {
+              if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+                updateSketch.update(longValues[j]);
+              }
+            }
+          });
+        }
+        break;
+      case FLOAT:
+        float[] floatValues = (float[]) valueArrays[0];
+        if (_includeDefaultSketch) {
+          UpdatableThetaSketch defaultSketch = updateSketches.get(0);
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              defaultSketch.update(floatValues[i]);
+            }
+          });
+        }
+        for (int i = 0; i < numFilters; i++) {
+          FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
+          UpdatableThetaSketch updateSketch = updateSketches.get(i + 1);
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int j = from; j < to; j++) {
+              if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+                updateSketch.update(floatValues[j]);
+              }
+            }
+          });
+        }
+        break;
+      case DOUBLE:
+        double[] doubleValues = (double[]) valueArrays[0];
+        if (_includeDefaultSketch) {
+          UpdatableThetaSketch defaultSketch = updateSketches.get(0);
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              defaultSketch.update(doubleValues[i]);
+            }
+          });
+        }
+        for (int i = 0; i < numFilters; i++) {
+          FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
+          UpdatableThetaSketch updateSketch = updateSketches.get(i + 1);
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int j = from; j < to; j++) {
+              if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+                updateSketch.update(doubleValues[j]);
+              }
+            }
+          });
+        }
+        break;
+      case STRING:
+        String[] stringValues = (String[]) valueArrays[0];
+        if (_includeDefaultSketch) {
+          UpdatableThetaSketch defaultSketch = updateSketches.get(0);
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              defaultSketch.update(stringValues[i]);
+            }
+          });
+        }
+        for (int i = 0; i < numFilters; i++) {
+          FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
+          UpdatableThetaSketch updateSketch = updateSketches.get(i + 1);
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int j = from; j < to; j++) {
+              if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+                updateSketch.update(stringValues[j]);
+              }
+            }
+          });
+        }
+        break;
+      case BYTES:
+        byte[][] bytesValues = (byte[][]) valueArrays[0];
+        if (_includeDefaultSketch) {
+          UpdatableThetaSketch defaultSketch = updateSketches.get(0);
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              defaultSketch.update(bytesValues[i]);
+            }
+          });
+        }
+        for (int i = 0; i < numFilters; i++) {
+          FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
+          UpdatableThetaSketch updateSketch = updateSketches.get(i + 1);
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int j = from; j < to; j++) {
+              if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+                updateSketch.update(bytesValues[j]);
+              }
+            }
+          });
+        }
+        break;
+      default:
+        throw new IllegalStateException(
+            "Illegal single-value data type for DISTINCT_COUNT_THETA_SKETCH aggregation function: "
+                + valueTypes[0]);
+    }
+  }
+
+  protected void aggregateMV(int length, AggregationResultHolder aggregationResultHolder,
+      BlockValSet mainBlockValSet, boolean[] singleValues, DataType[] valueTypes, Object[] valueArrays) {
+    int numFilters = _filterEvaluators.size();
+    List<UpdatableThetaSketch> updateSketches = getUpdateSketches(aggregationResultHolder);
+    switch (valueTypes[0].getStoredType()) {
+      case INT:
+        int[][] intValues = (int[][]) valueArrays[0];
+        if (_includeDefaultSketch) {
+          UpdatableThetaSketch defaultSketch = updateSketches.get(0);
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (int value : intValues[i]) {
+                defaultSketch.update(value);
+              }
+            }
+          });
+        }
+        for (int i = 0; i < numFilters; i++) {
+          FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
+          UpdatableThetaSketch updateSketch = updateSketches.get(i + 1);
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int j = from; j < to; j++) {
+              if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+                for (int value : intValues[j]) {
+                  updateSketch.update(value);
+                }
+              }
+            }
+          });
+        }
+        break;
+      case LONG:
+        long[][] longValues = (long[][]) valueArrays[0];
+        if (_includeDefaultSketch) {
+          UpdatableThetaSketch defaultSketch = updateSketches.get(0);
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (long value : longValues[i]) {
+                defaultSketch.update(value);
+              }
+            }
+          });
+        }
+        for (int i = 0; i < numFilters; i++) {
+          FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
+          UpdatableThetaSketch updateSketch = updateSketches.get(i + 1);
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int j = from; j < to; j++) {
+              if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+                for (long value : longValues[j]) {
+                  updateSketch.update(value);
+                }
+              }
+            }
+          });
+        }
+        break;
+      case FLOAT:
+        float[][] floatValues = (float[][]) valueArrays[0];
+        if (_includeDefaultSketch) {
+          UpdatableThetaSketch defaultSketch = updateSketches.get(0);
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (float value : floatValues[i]) {
+                defaultSketch.update(value);
+              }
+            }
+          });
+        }
+        for (int i = 0; i < numFilters; i++) {
+          FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
+          UpdatableThetaSketch updateSketch = updateSketches.get(i + 1);
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int j = from; j < to; j++) {
+              if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+                for (float value : floatValues[j]) {
+                  updateSketch.update(value);
+                }
+              }
+            }
+          });
+        }
+        break;
+      case DOUBLE:
+        double[][] doubleValues = (double[][]) valueArrays[0];
+        if (_includeDefaultSketch) {
+          UpdatableThetaSketch defaultSketch = updateSketches.get(0);
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (double value : doubleValues[i]) {
+                defaultSketch.update(value);
+              }
+            }
+          });
+        }
+        for (int i = 0; i < numFilters; i++) {
+          FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
+          UpdatableThetaSketch updateSketch = updateSketches.get(i + 1);
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int j = from; j < to; j++) {
+              if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+                for (double value : doubleValues[j]) {
+                  updateSketch.update(value);
+                }
+              }
+            }
+          });
+        }
+        break;
+      case STRING:
+        String[][] stringValues = (String[][]) valueArrays[0];
+        if (_includeDefaultSketch) {
+          UpdatableThetaSketch defaultSketch = updateSketches.get(0);
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (String value : stringValues[i]) {
+                defaultSketch.update(value);
+              }
+            }
+          });
+        }
+        for (int i = 0; i < numFilters; i++) {
+          FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
+          UpdatableThetaSketch updateSketch = updateSketches.get(i + 1);
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int j = from; j < to; j++) {
+              if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+                for (String value : stringValues[j]) {
+                  updateSketch.update(value);
+                }
+              }
+            }
+          });
+        }
+        break;
+      case BYTES:
+        byte[][][] bytesValues = (byte[][][]) valueArrays[0];
+        if (_includeDefaultSketch) {
+          UpdatableThetaSketch defaultSketch = updateSketches.get(0);
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (byte[] value : bytesValues[i]) {
+                defaultSketch.update(value);
+              }
+            }
+          });
+        }
+        for (int i = 0; i < numFilters; i++) {
+          FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
+          UpdatableThetaSketch updateSketch = updateSketches.get(i + 1);
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int j = from; j < to; j++) {
+              if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+                for (byte[] value : bytesValues[j]) {
+                  updateSketch.update(value);
+                }
+              }
+            }
+          });
+        }
+        break;
+      default:
+        throw new IllegalStateException(
+            "Illegal multi-value data type for DISTINCT_COUNT_THETA_SKETCH aggregation function: " + valueTypes[0]);
     }
   }
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet mainBlockValSet = blockValSetMap.get(_expression);
     int numExpressions = _inputExpressions.size();
     boolean[] singleValues = new boolean[numExpressions];
     DataType[] valueTypes = new DataType[numExpressions];
     Object[] valueArrays = new Object[numExpressions];
     extractValues(blockValSetMap, singleValues, valueTypes, valueArrays);
-    int numFilters = _filterEvaluators.size();
 
     // Main expression is always index 0
-    if (valueTypes[0] != DataType.BYTES) {
-      if (singleValues[0]) {
-        switch (valueTypes[0].getStoredType()) {
-          case INT:
-            int[] intValues = (int[]) valueArrays[0];
-            for (int i = 0; i < length; i++) {
-              List<UpdatableThetaSketch> updateSketches = getUpdateSketches(groupByResultHolder, groupKeyArray[i]);
-              int value = intValues[i];
-              if (_includeDefaultSketch) {
-                updateSketches.get(0).update(value);
-              }
-              for (int j = 0; j < numFilters; j++) {
-                if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
-                  updateSketches.get(j + 1).update(value);
-                }
-              }
-            }
-            break;
-          case LONG:
-            long[] longValues = (long[]) valueArrays[0];
-            for (int i = 0; i < length; i++) {
-              List<UpdatableThetaSketch> updateSketches = getUpdateSketches(groupByResultHolder, groupKeyArray[i]);
-              long value = longValues[i];
-              if (_includeDefaultSketch) {
-                updateSketches.get(0).update(value);
-              }
-              for (int j = 0; j < numFilters; j++) {
-                if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
-                  updateSketches.get(j + 1).update(value);
-                }
-              }
-            }
-            break;
-          case FLOAT:
-            float[] floatValues = (float[]) valueArrays[0];
-            for (int i = 0; i < length; i++) {
-              List<UpdatableThetaSketch> updateSketches = getUpdateSketches(groupByResultHolder, groupKeyArray[i]);
-              float value = floatValues[i];
-              if (_includeDefaultSketch) {
-                updateSketches.get(0).update(value);
-              }
-              for (int j = 0; j < numFilters; j++) {
-                if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
-                  updateSketches.get(j + 1).update(value);
-                }
-              }
-            }
-            break;
-          case DOUBLE:
-            double[] doubleValues = (double[]) valueArrays[0];
-            for (int i = 0; i < length; i++) {
-              List<UpdatableThetaSketch> updateSketches = getUpdateSketches(groupByResultHolder, groupKeyArray[i]);
-              double value = doubleValues[i];
-              if (_includeDefaultSketch) {
-                updateSketches.get(0).update(value);
-              }
-              for (int j = 0; j < numFilters; j++) {
-                if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
-                  updateSketches.get(j + 1).update(value);
-                }
-              }
-            }
-            break;
-          case STRING:
-            String[] stringValues = (String[]) valueArrays[0];
-            for (int i = 0; i < length; i++) {
-              List<UpdatableThetaSketch> updateSketches = getUpdateSketches(groupByResultHolder, groupKeyArray[i]);
-              String value = stringValues[i];
-              if (_includeDefaultSketch) {
-                updateSketches.get(0).update(value);
-              }
-              for (int j = 0; j < numFilters; j++) {
-                if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
-                  updateSketches.get(j + 1).update(value);
-                }
-              }
-            }
-            break;
-          case BYTES:
-            byte[][] bytesValues = (byte[][]) valueArrays[0];
-            for (int i = 0; i < length; i++) {
-              List<UpdatableThetaSketch> updateSketches =
-                  getUpdateSketches(groupByResultHolder, groupKeyArray[i]);
-              byte[] value = bytesValues[i];
-              if (_includeDefaultSketch) {
-                updateSketches.get(0).update(value);
-              }
-              for (int j = 0; j < numFilters; j++) {
-                if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
-                  updateSketches.get(j + 1).update(value);
-                }
-              }
-            }
-            break;
-          default:
-            throw new IllegalStateException(
-                "Illegal single-value data type for DISTINCT_COUNT_THETA_SKETCH aggregation function: "
-                    + valueTypes[0]);
-        }
-      } else {
-        switch (valueTypes[0].getStoredType()) {
-          case INT:
-            int[][] intValues = (int[][]) valueArrays[0];
-            for (int i = 0; i < length; i++) {
-              List<UpdatableThetaSketch> updateSketches = getUpdateSketches(groupByResultHolder, groupKeyArray[i]);
-              int[] values = intValues[i];
-              if (_includeDefaultSketch) {
-                UpdatableThetaSketch defaultSketch = updateSketches.get(0);
-                for (int value : values) {
-                  defaultSketch.update(value);
-                }
-              }
-              for (int j = 0; j < numFilters; j++) {
-                if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
-                  UpdatableThetaSketch updateSketch = updateSketches.get(j + 1);
-                  for (int value : values) {
-                    updateSketch.update(value);
-                  }
-                }
-              }
-            }
-            break;
-          case LONG:
-            long[][] longValues = (long[][]) valueArrays[0];
-            for (int i = 0; i < length; i++) {
-              List<UpdatableThetaSketch> updateSketches = getUpdateSketches(groupByResultHolder, groupKeyArray[i]);
-              long[] values = longValues[i];
-              if (_includeDefaultSketch) {
-                UpdatableThetaSketch defaultSketch = updateSketches.get(0);
-                for (long value : values) {
-                  defaultSketch.update(value);
-                }
-              }
-              for (int j = 0; j < numFilters; j++) {
-                if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
-                  UpdatableThetaSketch updateSketch = updateSketches.get(j + 1);
-                  for (long value : values) {
-                    updateSketch.update(value);
-                  }
-                }
-              }
-            }
-            break;
-          case FLOAT:
-            float[][] floatValues = (float[][]) valueArrays[0];
-            for (int i = 0; i < length; i++) {
-              List<UpdatableThetaSketch> updateSketches = getUpdateSketches(groupByResultHolder, groupKeyArray[i]);
-              float[] values = floatValues[i];
-              if (_includeDefaultSketch) {
-                UpdatableThetaSketch defaultSketch = updateSketches.get(0);
-                for (float value : values) {
-                  defaultSketch.update(value);
-                }
-              }
-              for (int j = 0; j < numFilters; j++) {
-                if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
-                  UpdatableThetaSketch updateSketch = updateSketches.get(j + 1);
-                  for (float value : values) {
-                    updateSketch.update(value);
-                  }
-                }
-              }
-            }
-            break;
-          case DOUBLE:
-            double[][] doubleValues = (double[][]) valueArrays[0];
-            for (int i = 0; i < length; i++) {
-              List<UpdatableThetaSketch> updateSketches = getUpdateSketches(groupByResultHolder, groupKeyArray[i]);
-              double[] values = doubleValues[i];
-              if (_includeDefaultSketch) {
-                UpdatableThetaSketch defaultSketch = updateSketches.get(0);
-                for (double value : values) {
-                  defaultSketch.update(value);
-                }
-              }
-              for (int j = 0; j < numFilters; j++) {
-                if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
-                  UpdatableThetaSketch updateSketch = updateSketches.get(j + 1);
-                  for (double value : values) {
-                    updateSketch.update(value);
-                  }
-                }
-              }
-            }
-            break;
-          case STRING:
-            String[][] stringValues = (String[][]) valueArrays[0];
-            for (int i = 0; i < length; i++) {
-              List<UpdatableThetaSketch> updateSketches = getUpdateSketches(groupByResultHolder, groupKeyArray[i]);
-              String[] values = stringValues[i];
-              if (_includeDefaultSketch) {
-                UpdatableThetaSketch defaultSketch = updateSketches.get(0);
-                for (String value : values) {
-                  defaultSketch.update(value);
-                }
-              }
-              for (int j = 0; j < numFilters; j++) {
-                if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
-                  UpdatableThetaSketch updateSketch = updateSketches.get(j + 1);
-                  for (String value : values) {
-                    updateSketch.update(value);
-                  }
-                }
-              }
-            }
-            break;
-          case BYTES:
-            byte[][][] bytesValues = (byte[][][]) valueArrays[0];
-            for (int i = 0; i < length; i++) {
-              List<UpdatableThetaSketch> updateSketches =
-                  getUpdateSketches(groupByResultHolder, groupKeyArray[i]);
-              byte[][] values = bytesValues[i];
-              if (_includeDefaultSketch) {
-                UpdatableThetaSketch defaultSketch = updateSketches.get(0);
-                for (byte[] value : values) {
-                  defaultSketch.update(value);
-                }
-              }
-              for (int j = 0; j < numFilters; j++) {
-                if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
-                  UpdatableThetaSketch updateSketch = updateSketches.get(j + 1);
-                  for (byte[] value : values) {
-                    updateSketch.update(value);
-                  }
-                }
-              }
-            }
-            break;
-          default:
-            throw new IllegalStateException(
-                "Illegal multi-value data type for DISTINCT_COUNT_THETA_SKETCH aggregation function: " + valueTypes[0]);
-        }
-      }
-    } else {
+    if (valueTypes[0] == DataType.BYTES && singleValues[0]) {
       // Logical BYTES stores serialized ThetaSketch objects in the single-value representation.
-      ThetaSketch[] sketches = deserializeSketches((byte[][]) valueArrays[0], length);
-      for (int i = 0; i < length; i++) {
-        List<ThetaSketchAccumulator> thetaSketchAccumulators = getUnions(groupByResultHolder, groupKeyArray[i]);
-        ThetaSketch sketch = sketches[i];
-        if (_includeDefaultSketch) {
-          thetaSketchAccumulators.get(0).apply(sketch);
-        }
-        for (int j = 0; j < numFilters; j++) {
-          if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
-            thetaSketchAccumulators.get(j + 1).apply(sketch);
+      ThetaSketch[] sketches = deserializeSketches((byte[][]) valueArrays[0], length, mainBlockValSet);
+      forEachNotNull(length, mainBlockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          List<ThetaSketchAccumulator> thetaSketchAccumulators = getUnions(groupByResultHolder, groupKeyArray[i]);
+          ThetaSketch sketch = sketches[i];
+          if (_includeDefaultSketch) {
+            thetaSketchAccumulators.get(0).apply(sketch);
+          }
+          int numFilters = _filterEvaluators.size();
+          for (int j = 0; j < numFilters; j++) {
+            if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
+              thetaSketchAccumulators.get(j + 1).apply(sketch);
+            }
           }
         }
-      }
+      });
+      return;
+    }
+
+    if (singleValues[0]) {
+      aggregateSVGroupBySV(length, groupKeyArray, groupByResultHolder, mainBlockValSet, singleValues,
+          valueTypes, valueArrays);
+    } else {
+      aggregateMVGroupBySV(length, groupKeyArray, groupByResultHolder, mainBlockValSet, singleValues,
+          valueTypes, valueArrays);
+    }
+  }
+
+  protected void aggregateSVGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
+      BlockValSet mainBlockValSet, boolean[] singleValues, DataType[] valueTypes, Object[] valueArrays) {
+    int numFilters = _filterEvaluators.size();
+    switch (valueTypes[0].getStoredType()) {
+      case INT:
+        int[] intValues = (int[]) valueArrays[0];
+        forEachNotNull(length, mainBlockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            List<UpdatableThetaSketch> updateSketches = getUpdateSketches(groupByResultHolder, groupKeyArray[i]);
+            int value = intValues[i];
+            if (_includeDefaultSketch) {
+              updateSketches.get(0).update(value);
+            }
+            for (int j = 0; j < numFilters; j++) {
+              if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
+                updateSketches.get(j + 1).update(value);
+              }
+            }
+          }
+        });
+        break;
+      case LONG:
+        long[] longValues = (long[]) valueArrays[0];
+        forEachNotNull(length, mainBlockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            List<UpdatableThetaSketch> updateSketches = getUpdateSketches(groupByResultHolder, groupKeyArray[i]);
+            long value = longValues[i];
+            if (_includeDefaultSketch) {
+              updateSketches.get(0).update(value);
+            }
+            for (int j = 0; j < numFilters; j++) {
+              if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
+                updateSketches.get(j + 1).update(value);
+              }
+            }
+          }
+        });
+        break;
+      case FLOAT:
+        float[] floatValues = (float[]) valueArrays[0];
+        forEachNotNull(length, mainBlockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            List<UpdatableThetaSketch> updateSketches = getUpdateSketches(groupByResultHolder, groupKeyArray[i]);
+            float value = floatValues[i];
+            if (_includeDefaultSketch) {
+              updateSketches.get(0).update(value);
+            }
+            for (int j = 0; j < numFilters; j++) {
+              if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
+                updateSketches.get(j + 1).update(value);
+              }
+            }
+          }
+        });
+        break;
+      case DOUBLE:
+        double[] doubleValues = (double[]) valueArrays[0];
+        forEachNotNull(length, mainBlockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            List<UpdatableThetaSketch> updateSketches = getUpdateSketches(groupByResultHolder, groupKeyArray[i]);
+            double value = doubleValues[i];
+            if (_includeDefaultSketch) {
+              updateSketches.get(0).update(value);
+            }
+            for (int j = 0; j < numFilters; j++) {
+              if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
+                updateSketches.get(j + 1).update(value);
+              }
+            }
+          }
+        });
+        break;
+      case STRING:
+        String[] stringValues = (String[]) valueArrays[0];
+        forEachNotNull(length, mainBlockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            List<UpdatableThetaSketch> updateSketches = getUpdateSketches(groupByResultHolder, groupKeyArray[i]);
+            String value = stringValues[i];
+            if (_includeDefaultSketch) {
+              updateSketches.get(0).update(value);
+            }
+            for (int j = 0; j < numFilters; j++) {
+              if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
+                updateSketches.get(j + 1).update(value);
+              }
+            }
+          }
+        });
+        break;
+      case BYTES:
+        byte[][] bytesValues = (byte[][]) valueArrays[0];
+        forEachNotNull(length, mainBlockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            List<UpdatableThetaSketch> updateSketches =
+                getUpdateSketches(groupByResultHolder, groupKeyArray[i]);
+            byte[] value = bytesValues[i];
+            if (_includeDefaultSketch) {
+              updateSketches.get(0).update(value);
+            }
+            for (int j = 0; j < numFilters; j++) {
+              if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
+                updateSketches.get(j + 1).update(value);
+              }
+            }
+          }
+        });
+        break;
+      default:
+        throw new IllegalStateException(
+            "Illegal single-value data type for DISTINCT_COUNT_THETA_SKETCH aggregation function: "
+                + valueTypes[0]);
+    }
+  }
+
+  protected void aggregateMVGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
+      BlockValSet mainBlockValSet, boolean[] singleValues, DataType[] valueTypes, Object[] valueArrays) {
+    int numFilters = _filterEvaluators.size();
+    switch (valueTypes[0].getStoredType()) {
+      case INT:
+        int[][] intValues = (int[][]) valueArrays[0];
+        forEachNotNull(length, mainBlockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            List<UpdatableThetaSketch> updateSketches = getUpdateSketches(groupByResultHolder, groupKeyArray[i]);
+            int[] values = intValues[i];
+            if (_includeDefaultSketch) {
+              UpdatableThetaSketch defaultSketch = updateSketches.get(0);
+              for (int value : values) {
+                defaultSketch.update(value);
+              }
+            }
+            for (int j = 0; j < numFilters; j++) {
+              if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
+                UpdatableThetaSketch updateSketch = updateSketches.get(j + 1);
+                for (int value : values) {
+                  updateSketch.update(value);
+                }
+              }
+            }
+          }
+        });
+        break;
+      case LONG:
+        long[][] longValues = (long[][]) valueArrays[0];
+        forEachNotNull(length, mainBlockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            List<UpdatableThetaSketch> updateSketches = getUpdateSketches(groupByResultHolder, groupKeyArray[i]);
+            long[] values = longValues[i];
+            if (_includeDefaultSketch) {
+              UpdatableThetaSketch defaultSketch = updateSketches.get(0);
+              for (long value : values) {
+                defaultSketch.update(value);
+              }
+            }
+            for (int j = 0; j < numFilters; j++) {
+              if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
+                UpdatableThetaSketch updateSketch = updateSketches.get(j + 1);
+                for (long value : values) {
+                  updateSketch.update(value);
+                }
+              }
+            }
+          }
+        });
+        break;
+      case FLOAT:
+        float[][] floatValues = (float[][]) valueArrays[0];
+        forEachNotNull(length, mainBlockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            List<UpdatableThetaSketch> updateSketches = getUpdateSketches(groupByResultHolder, groupKeyArray[i]);
+            float[] values = floatValues[i];
+            if (_includeDefaultSketch) {
+              UpdatableThetaSketch defaultSketch = updateSketches.get(0);
+              for (float value : values) {
+                defaultSketch.update(value);
+              }
+            }
+            for (int j = 0; j < numFilters; j++) {
+              if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
+                UpdatableThetaSketch updateSketch = updateSketches.get(j + 1);
+                for (float value : values) {
+                  updateSketch.update(value);
+                }
+              }
+            }
+          }
+        });
+        break;
+      case DOUBLE:
+        double[][] doubleValues = (double[][]) valueArrays[0];
+        forEachNotNull(length, mainBlockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            List<UpdatableThetaSketch> updateSketches = getUpdateSketches(groupByResultHolder, groupKeyArray[i]);
+            double[] values = doubleValues[i];
+            if (_includeDefaultSketch) {
+              UpdatableThetaSketch defaultSketch = updateSketches.get(0);
+              for (double value : values) {
+                defaultSketch.update(value);
+              }
+            }
+            for (int j = 0; j < numFilters; j++) {
+              if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
+                UpdatableThetaSketch updateSketch = updateSketches.get(j + 1);
+                for (double value : values) {
+                  updateSketch.update(value);
+                }
+              }
+            }
+          }
+        });
+        break;
+      case STRING:
+        String[][] stringValues = (String[][]) valueArrays[0];
+        forEachNotNull(length, mainBlockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            List<UpdatableThetaSketch> updateSketches = getUpdateSketches(groupByResultHolder, groupKeyArray[i]);
+            String[] values = stringValues[i];
+            if (_includeDefaultSketch) {
+              UpdatableThetaSketch defaultSketch = updateSketches.get(0);
+              for (String value : values) {
+                defaultSketch.update(value);
+              }
+            }
+            for (int j = 0; j < numFilters; j++) {
+              if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
+                UpdatableThetaSketch updateSketch = updateSketches.get(j + 1);
+                for (String value : values) {
+                  updateSketch.update(value);
+                }
+              }
+            }
+          }
+        });
+        break;
+      case BYTES:
+        byte[][][] bytesValues = (byte[][][]) valueArrays[0];
+        forEachNotNull(length, mainBlockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            List<UpdatableThetaSketch> updateSketches =
+                getUpdateSketches(groupByResultHolder, groupKeyArray[i]);
+            byte[][] values = bytesValues[i];
+            if (_includeDefaultSketch) {
+              UpdatableThetaSketch defaultSketch = updateSketches.get(0);
+              for (byte[] value : values) {
+                defaultSketch.update(value);
+              }
+            }
+            for (int j = 0; j < numFilters; j++) {
+              if (_filterEvaluators.get(j).evaluate(singleValues, valueTypes, valueArrays, i)) {
+                UpdatableThetaSketch updateSketch = updateSketches.get(j + 1);
+                for (byte[] value : values) {
+                  updateSketch.update(value);
+                }
+              }
+            }
+          }
+        });
+        break;
+      default:
+        throw new IllegalStateException(
+            "Illegal multi-value data type for DISTINCT_COUNT_THETA_SKETCH aggregation function: " + valueTypes[0]);
     }
   }
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet mainBlockValSet = blockValSetMap.get(_expression);
     int numExpressions = _inputExpressions.size();
     boolean[] singleValues = new boolean[numExpressions];
     DataType[] valueTypes = new DataType[numExpressions];
     Object[] valueArrays = new Object[numExpressions];
     extractValues(blockValSetMap, singleValues, valueTypes, valueArrays);
-    int numFilters = _filterEvaluators.size();
 
     // Main expression is always index 0
-    if (valueTypes[0] != DataType.BYTES) {
-      if (singleValues[0]) {
-        switch (valueTypes[0].getStoredType()) {
-          case INT:
-            int[] intValues = (int[]) valueArrays[0];
-            if (_includeDefaultSketch) {
-              for (int i = 0; i < length; i++) {
-                for (int groupKey : groupKeysArray[i]) {
-                  getUpdateSketches(groupByResultHolder, groupKey).get(0).update(intValues[i]);
-                }
-              }
-            }
-            for (int i = 0; i < numFilters; i++) {
-              FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
-              for (int j = 0; j < length; j++) {
-                if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-                  for (int groupKey : groupKeysArray[i]) {
-                    getUpdateSketches(groupByResultHolder, groupKey).get(i + 1).update(intValues[j]);
-                  }
-                }
-              }
-            }
-            break;
-          case LONG:
-            long[] longValues = (long[]) valueArrays[0];
-            if (_includeDefaultSketch) {
-              for (int i = 0; i < length; i++) {
-                for (int groupKey : groupKeysArray[i]) {
-                  getUpdateSketches(groupByResultHolder, groupKey).get(0).update(longValues[i]);
-                }
-              }
-            }
-            for (int i = 0; i < numFilters; i++) {
-              FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
-              for (int j = 0; j < length; j++) {
-                if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-                  for (int groupKey : groupKeysArray[i]) {
-                    getUpdateSketches(groupByResultHolder, groupKey).get(i + 1).update(longValues[j]);
-                  }
-                }
-              }
-            }
-            break;
-          case FLOAT:
-            float[] floatValues = (float[]) valueArrays[0];
-            if (_includeDefaultSketch) {
-              for (int i = 0; i < length; i++) {
-                for (int groupKey : groupKeysArray[i]) {
-                  getUpdateSketches(groupByResultHolder, groupKey).get(0).update(floatValues[i]);
-                }
-              }
-            }
-            for (int i = 0; i < numFilters; i++) {
-              FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
-              for (int j = 0; j < length; j++) {
-                if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-                  for (int groupKey : groupKeysArray[i]) {
-                    getUpdateSketches(groupByResultHolder, groupKey).get(i + 1).update(floatValues[j]);
-                  }
-                }
-              }
-            }
-            break;
-          case DOUBLE:
-            double[] doubleValues = (double[]) valueArrays[0];
-            if (_includeDefaultSketch) {
-              for (int i = 0; i < length; i++) {
-                for (int groupKey : groupKeysArray[i]) {
-                  getUpdateSketches(groupByResultHolder, groupKey).get(0).update(doubleValues[i]);
-                }
-              }
-            }
-            for (int i = 0; i < numFilters; i++) {
-              FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
-              for (int j = 0; j < length; j++) {
-                if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-                  for (int groupKey : groupKeysArray[i]) {
-                    getUpdateSketches(groupByResultHolder, groupKey).get(i + 1).update(doubleValues[j]);
-                  }
-                }
-              }
-            }
-            break;
-          case STRING:
-            String[] stringValues = (String[]) valueArrays[0];
-            if (_includeDefaultSketch) {
-              for (int i = 0; i < length; i++) {
-                for (int groupKey : groupKeysArray[i]) {
-                  getUpdateSketches(groupByResultHolder, groupKey).get(0).update(stringValues[i]);
-                }
-              }
-            }
-            for (int i = 0; i < numFilters; i++) {
-              FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
-              for (int j = 0; j < length; j++) {
-                if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-                  for (int groupKey : groupKeysArray[i]) {
-                    getUpdateSketches(groupByResultHolder, groupKey).get(i + 1).update(stringValues[j]);
-                  }
-                }
-              }
-            }
-            break;
-          case BYTES:
-            byte[][] bytesValues = (byte[][]) valueArrays[0];
-            if (_includeDefaultSketch) {
-              for (int i = 0; i < length; i++) {
-                for (int groupKey : groupKeysArray[i]) {
-                  getUpdateSketches(groupByResultHolder, groupKey).get(0).update(bytesValues[i]);
-                }
-              }
-            }
-            for (int i = 0; i < numFilters; i++) {
-              FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
-              for (int j = 0; j < length; j++) {
-                if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-                  for (int groupKey : groupKeysArray[j]) {
-                    getUpdateSketches(groupByResultHolder, groupKey).get(i + 1).update(bytesValues[j]);
-                  }
-                }
-              }
-            }
-            break;
-          default:
-            throw new IllegalStateException(
-                "Illegal single-value data type for DISTINCT_COUNT_THETA_SKETCH aggregation function: "
-                    + valueTypes[0]);
-        }
-      } else {
-        switch (valueTypes[0].getStoredType()) {
-          case INT:
-            int[][] intValues = (int[][]) valueArrays[0];
-            if (_includeDefaultSketch) {
-              for (int i = 0; i < length; i++) {
-                for (int groupKey : groupKeysArray[i]) {
-                  UpdatableThetaSketch defaultSketch = getUpdateSketches(groupByResultHolder, groupKey).get(0);
-                  for (int value : intValues[i]) {
-                    defaultSketch.update(value);
-                  }
-                }
-              }
-            }
-            for (int i = 0; i < numFilters; i++) {
-              FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
-              for (int j = 0; j < length; j++) {
-                if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-                  for (int groupKey : groupKeysArray[i]) {
-                    UpdatableThetaSketch updateSketch = getUpdateSketches(groupByResultHolder, groupKey).get(i + 1);
-                    for (int value : intValues[i]) {
-                      updateSketch.update(value);
-                    }
-                  }
-                }
-              }
-            }
-            break;
-          case LONG:
-            long[][] longValues = (long[][]) valueArrays[0];
-            if (_includeDefaultSketch) {
-              for (int i = 0; i < length; i++) {
-                for (int groupKey : groupKeysArray[i]) {
-                  UpdatableThetaSketch defaultSketch = getUpdateSketches(groupByResultHolder, groupKey).get(0);
-                  for (long value : longValues[i]) {
-                    defaultSketch.update(value);
-                  }
-                }
-              }
-            }
-            for (int i = 0; i < numFilters; i++) {
-              FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
-              for (int j = 0; j < length; j++) {
-                if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-                  for (int groupKey : groupKeysArray[i]) {
-                    UpdatableThetaSketch updateSketch = getUpdateSketches(groupByResultHolder, groupKey).get(i + 1);
-                    for (long value : longValues[i]) {
-                      updateSketch.update(value);
-                    }
-                  }
-                }
-              }
-            }
-            break;
-          case FLOAT:
-            float[][] floatValues = (float[][]) valueArrays[0];
-            if (_includeDefaultSketch) {
-              for (int i = 0; i < length; i++) {
-                for (int groupKey : groupKeysArray[i]) {
-                  UpdatableThetaSketch defaultSketch = getUpdateSketches(groupByResultHolder, groupKey).get(0);
-                  for (float value : floatValues[i]) {
-                    defaultSketch.update(value);
-                  }
-                }
-              }
-            }
-            for (int i = 0; i < numFilters; i++) {
-              FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
-              for (int j = 0; j < length; j++) {
-                if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-                  for (int groupKey : groupKeysArray[i]) {
-                    UpdatableThetaSketch updateSketch = getUpdateSketches(groupByResultHolder, groupKey).get(i + 1);
-                    for (float value : floatValues[i]) {
-                      updateSketch.update(value);
-                    }
-                  }
-                }
-              }
-            }
-            break;
-          case DOUBLE:
-            double[][] doubleValues = (double[][]) valueArrays[0];
-            if (_includeDefaultSketch) {
-              for (int i = 0; i < length; i++) {
-                for (int groupKey : groupKeysArray[i]) {
-                  UpdatableThetaSketch defaultSketch = getUpdateSketches(groupByResultHolder, groupKey).get(0);
-                  for (double value : doubleValues[i]) {
-                    defaultSketch.update(value);
-                  }
-                }
-              }
-            }
-            for (int i = 0; i < numFilters; i++) {
-              FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
-              for (int j = 0; j < length; j++) {
-                if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-                  for (int groupKey : groupKeysArray[i]) {
-                    UpdatableThetaSketch updateSketch = getUpdateSketches(groupByResultHolder, groupKey).get(i + 1);
-                    for (double value : doubleValues[i]) {
-                      updateSketch.update(value);
-                    }
-                  }
-                }
-              }
-            }
-            break;
-          case STRING:
-            String[][] stringValues = (String[][]) valueArrays[0];
-            if (_includeDefaultSketch) {
-              for (int i = 0; i < length; i++) {
-                for (int groupKey : groupKeysArray[i]) {
-                  UpdatableThetaSketch defaultSketch = getUpdateSketches(groupByResultHolder, groupKey).get(0);
-                  for (String value : stringValues[i]) {
-                    defaultSketch.update(value);
-                  }
-                }
-              }
-            }
-            for (int i = 0; i < numFilters; i++) {
-              FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
-              for (int j = 0; j < length; j++) {
-                if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-                  for (int groupKey : groupKeysArray[i]) {
-                    UpdatableThetaSketch updateSketch = getUpdateSketches(groupByResultHolder, groupKey).get(i + 1);
-                    for (String value : stringValues[i]) {
-                      updateSketch.update(value);
-                    }
-                  }
-                }
-              }
-            }
-            break;
-          case BYTES:
-            byte[][][] bytesValues = (byte[][][]) valueArrays[0];
-            if (_includeDefaultSketch) {
-              for (int i = 0; i < length; i++) {
-                for (int groupKey : groupKeysArray[i]) {
-                  UpdatableThetaSketch defaultSketch = getUpdateSketches(groupByResultHolder, groupKey).get(0);
-                  for (byte[] value : bytesValues[i]) {
-                    defaultSketch.update(value);
-                  }
-                }
-              }
-            }
-            for (int i = 0; i < numFilters; i++) {
-              FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
-              for (int j = 0; j < length; j++) {
-                if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-                  for (int groupKey : groupKeysArray[j]) {
-                    UpdatableThetaSketch updateSketch =
-                        getUpdateSketches(groupByResultHolder, groupKey).get(i + 1);
-                    for (byte[] value : bytesValues[j]) {
-                      updateSketch.update(value);
-                    }
-                  }
-                }
-              }
-            }
-            break;
-          default:
-            throw new IllegalStateException(
-                "Illegal multi-value data type for DISTINCT_COUNT_THETA_SKETCH aggregation function: " + valueTypes[0]);
-        }
-      }
-    } else {
+    if (valueTypes[0] == DataType.BYTES && singleValues[0]) {
       // Logical BYTES stores serialized ThetaSketch objects in the single-value representation.
-      ThetaSketch[] sketches = deserializeSketches((byte[][]) valueArrays[0], length);
+      ThetaSketch[] sketches = deserializeSketches((byte[][]) valueArrays[0], length, mainBlockValSet);
       if (_includeDefaultSketch) {
-        for (int i = 0; i < length; i++) {
-          for (int groupKey : groupKeysArray[i]) {
-            getUnions(groupByResultHolder, groupKey).get(0).apply(sketches[i]);
+        forEachNotNull(length, mainBlockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              getUnions(groupByResultHolder, groupKey).get(0).apply(sketches[i]);
+            }
           }
-        }
+        });
       }
+      int numFilters = _filterEvaluators.size();
       for (int i = 0; i < numFilters; i++) {
         FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
-        for (int j = 0; j < length; j++) {
-          if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
-            for (int groupKey : groupKeysArray[i]) {
-              getUnions(groupByResultHolder, groupKey).get(i + 1).apply(sketches[i]);
+        int filterIndex = i;
+        forEachNotNull(length, mainBlockValSet, (from, to) -> {
+          for (int j = from; j < to; j++) {
+            if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+              for (int groupKey : groupKeysArray[j]) {
+                getUnions(groupByResultHolder, groupKey).get(filterIndex + 1).apply(sketches[j]);
+              }
             }
           }
-        }
+        });
       }
+      return;
+    }
+
+    if (singleValues[0]) {
+      aggregateSVGroupByMV(length, groupKeysArray, groupByResultHolder, mainBlockValSet, singleValues,
+          valueTypes, valueArrays);
+    } else {
+      aggregateMVGroupByMV(length, groupKeysArray, groupByResultHolder, mainBlockValSet, singleValues,
+          valueTypes, valueArrays);
+    }
+  }
+
+  protected void aggregateSVGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
+      BlockValSet mainBlockValSet, boolean[] singleValues, DataType[] valueTypes, Object[] valueArrays) {
+    int numFilters = _filterEvaluators.size();
+    switch (valueTypes[0].getStoredType()) {
+      case INT:
+        int[] intValues = (int[]) valueArrays[0];
+        if (_includeDefaultSketch) {
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (int groupKey : groupKeysArray[i]) {
+                getUpdateSketches(groupByResultHolder, groupKey).get(0).update(intValues[i]);
+              }
+            }
+          });
+        }
+        for (int i = 0; i < numFilters; i++) {
+          FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
+          int filterIndex = i;
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int j = from; j < to; j++) {
+              if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+                for (int groupKey : groupKeysArray[j]) {
+                  getUpdateSketches(groupByResultHolder, groupKey).get(filterIndex + 1).update(intValues[j]);
+                }
+              }
+            }
+          });
+        }
+        break;
+      case LONG:
+        long[] longValues = (long[]) valueArrays[0];
+        if (_includeDefaultSketch) {
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (int groupKey : groupKeysArray[i]) {
+                getUpdateSketches(groupByResultHolder, groupKey).get(0).update(longValues[i]);
+              }
+            }
+          });
+        }
+        for (int i = 0; i < numFilters; i++) {
+          FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
+          int filterIndex = i;
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int j = from; j < to; j++) {
+              if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+                for (int groupKey : groupKeysArray[j]) {
+                  getUpdateSketches(groupByResultHolder, groupKey).get(filterIndex + 1).update(longValues[j]);
+                }
+              }
+            }
+          });
+        }
+        break;
+      case FLOAT:
+        float[] floatValues = (float[]) valueArrays[0];
+        if (_includeDefaultSketch) {
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (int groupKey : groupKeysArray[i]) {
+                getUpdateSketches(groupByResultHolder, groupKey).get(0).update(floatValues[i]);
+              }
+            }
+          });
+        }
+        for (int i = 0; i < numFilters; i++) {
+          FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
+          int filterIndex = i;
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int j = from; j < to; j++) {
+              if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+                for (int groupKey : groupKeysArray[j]) {
+                  getUpdateSketches(groupByResultHolder, groupKey).get(filterIndex + 1).update(floatValues[j]);
+                }
+              }
+            }
+          });
+        }
+        break;
+      case DOUBLE:
+        double[] doubleValues = (double[]) valueArrays[0];
+        if (_includeDefaultSketch) {
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (int groupKey : groupKeysArray[i]) {
+                getUpdateSketches(groupByResultHolder, groupKey).get(0).update(doubleValues[i]);
+              }
+            }
+          });
+        }
+        for (int i = 0; i < numFilters; i++) {
+          FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
+          int filterIndex = i;
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int j = from; j < to; j++) {
+              if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+                for (int groupKey : groupKeysArray[j]) {
+                  getUpdateSketches(groupByResultHolder, groupKey).get(filterIndex + 1).update(doubleValues[j]);
+                }
+              }
+            }
+          });
+        }
+        break;
+      case STRING:
+        String[] stringValues = (String[]) valueArrays[0];
+        if (_includeDefaultSketch) {
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (int groupKey : groupKeysArray[i]) {
+                getUpdateSketches(groupByResultHolder, groupKey).get(0).update(stringValues[i]);
+              }
+            }
+          });
+        }
+        for (int i = 0; i < numFilters; i++) {
+          FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
+          int filterIndex = i;
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int j = from; j < to; j++) {
+              if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+                for (int groupKey : groupKeysArray[j]) {
+                  getUpdateSketches(groupByResultHolder, groupKey).get(filterIndex + 1).update(stringValues[j]);
+                }
+              }
+            }
+          });
+        }
+        break;
+      case BYTES:
+        byte[][] bytesValues = (byte[][]) valueArrays[0];
+        if (_includeDefaultSketch) {
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (int groupKey : groupKeysArray[i]) {
+                getUpdateSketches(groupByResultHolder, groupKey).get(0).update(bytesValues[i]);
+              }
+            }
+          });
+        }
+        for (int i = 0; i < numFilters; i++) {
+          FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
+          int filterIndex = i;
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int j = from; j < to; j++) {
+              if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+                for (int groupKey : groupKeysArray[j]) {
+                  getUpdateSketches(groupByResultHolder, groupKey).get(filterIndex + 1).update(bytesValues[j]);
+                }
+              }
+            }
+          });
+        }
+        break;
+      default:
+        throw new IllegalStateException(
+            "Illegal single-value data type for DISTINCT_COUNT_THETA_SKETCH aggregation function: "
+                + valueTypes[0]);
+    }
+  }
+
+  protected void aggregateMVGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
+      BlockValSet mainBlockValSet, boolean[] singleValues, DataType[] valueTypes, Object[] valueArrays) {
+    int numFilters = _filterEvaluators.size();
+    switch (valueTypes[0].getStoredType()) {
+      case INT:
+        int[][] intValues = (int[][]) valueArrays[0];
+        if (_includeDefaultSketch) {
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (int groupKey : groupKeysArray[i]) {
+                UpdatableThetaSketch defaultSketch = getUpdateSketches(groupByResultHolder, groupKey).get(0);
+                for (int value : intValues[i]) {
+                  defaultSketch.update(value);
+                }
+              }
+            }
+          });
+        }
+        for (int i = 0; i < numFilters; i++) {
+          FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
+          int filterIndex = i;
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int j = from; j < to; j++) {
+              if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+                for (int groupKey : groupKeysArray[j]) {
+                  UpdatableThetaSketch updateSketch =
+                      getUpdateSketches(groupByResultHolder, groupKey).get(filterIndex + 1);
+                  for (int value : intValues[j]) {
+                    updateSketch.update(value);
+                  }
+                }
+              }
+            }
+          });
+        }
+        break;
+      case LONG:
+        long[][] longValues = (long[][]) valueArrays[0];
+        if (_includeDefaultSketch) {
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (int groupKey : groupKeysArray[i]) {
+                UpdatableThetaSketch defaultSketch = getUpdateSketches(groupByResultHolder, groupKey).get(0);
+                for (long value : longValues[i]) {
+                  defaultSketch.update(value);
+                }
+              }
+            }
+          });
+        }
+        for (int i = 0; i < numFilters; i++) {
+          FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
+          int filterIndex = i;
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int j = from; j < to; j++) {
+              if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+                for (int groupKey : groupKeysArray[j]) {
+                  UpdatableThetaSketch updateSketch =
+                      getUpdateSketches(groupByResultHolder, groupKey).get(filterIndex + 1);
+                  for (long value : longValues[j]) {
+                    updateSketch.update(value);
+                  }
+                }
+              }
+            }
+          });
+        }
+        break;
+      case FLOAT:
+        float[][] floatValues = (float[][]) valueArrays[0];
+        if (_includeDefaultSketch) {
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (int groupKey : groupKeysArray[i]) {
+                UpdatableThetaSketch defaultSketch = getUpdateSketches(groupByResultHolder, groupKey).get(0);
+                for (float value : floatValues[i]) {
+                  defaultSketch.update(value);
+                }
+              }
+            }
+          });
+        }
+        for (int i = 0; i < numFilters; i++) {
+          FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
+          int filterIndex = i;
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int j = from; j < to; j++) {
+              if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+                for (int groupKey : groupKeysArray[j]) {
+                  UpdatableThetaSketch updateSketch =
+                      getUpdateSketches(groupByResultHolder, groupKey).get(filterIndex + 1);
+                  for (float value : floatValues[j]) {
+                    updateSketch.update(value);
+                  }
+                }
+              }
+            }
+          });
+        }
+        break;
+      case DOUBLE:
+        double[][] doubleValues = (double[][]) valueArrays[0];
+        if (_includeDefaultSketch) {
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (int groupKey : groupKeysArray[i]) {
+                UpdatableThetaSketch defaultSketch = getUpdateSketches(groupByResultHolder, groupKey).get(0);
+                for (double value : doubleValues[i]) {
+                  defaultSketch.update(value);
+                }
+              }
+            }
+          });
+        }
+        for (int i = 0; i < numFilters; i++) {
+          FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
+          int filterIndex = i;
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int j = from; j < to; j++) {
+              if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+                for (int groupKey : groupKeysArray[j]) {
+                  UpdatableThetaSketch updateSketch =
+                      getUpdateSketches(groupByResultHolder, groupKey).get(filterIndex + 1);
+                  for (double value : doubleValues[j]) {
+                    updateSketch.update(value);
+                  }
+                }
+              }
+            }
+          });
+        }
+        break;
+      case STRING:
+        String[][] stringValues = (String[][]) valueArrays[0];
+        if (_includeDefaultSketch) {
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (int groupKey : groupKeysArray[i]) {
+                UpdatableThetaSketch defaultSketch = getUpdateSketches(groupByResultHolder, groupKey).get(0);
+                for (String value : stringValues[i]) {
+                  defaultSketch.update(value);
+                }
+              }
+            }
+          });
+        }
+        for (int i = 0; i < numFilters; i++) {
+          FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
+          int filterIndex = i;
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int j = from; j < to; j++) {
+              if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+                for (int groupKey : groupKeysArray[j]) {
+                  UpdatableThetaSketch updateSketch =
+                      getUpdateSketches(groupByResultHolder, groupKey).get(filterIndex + 1);
+                  for (String value : stringValues[j]) {
+                    updateSketch.update(value);
+                  }
+                }
+              }
+            }
+          });
+        }
+        break;
+      case BYTES:
+        byte[][][] bytesValues = (byte[][][]) valueArrays[0];
+        if (_includeDefaultSketch) {
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int i = from; i < to; i++) {
+              for (int groupKey : groupKeysArray[i]) {
+                UpdatableThetaSketch defaultSketch = getUpdateSketches(groupByResultHolder, groupKey).get(0);
+                for (byte[] value : bytesValues[i]) {
+                  defaultSketch.update(value);
+                }
+              }
+            }
+          });
+        }
+        for (int i = 0; i < numFilters; i++) {
+          FilterEvaluator filterEvaluator = _filterEvaluators.get(i);
+          int filterIndex = i;
+          forEachNotNull(length, mainBlockValSet, (from, to) -> {
+            for (int j = from; j < to; j++) {
+              if (filterEvaluator.evaluate(singleValues, valueTypes, valueArrays, j)) {
+                for (int groupKey : groupKeysArray[j]) {
+                  UpdatableThetaSketch updateSketch =
+                      getUpdateSketches(groupByResultHolder, groupKey).get(filterIndex + 1);
+                  for (byte[] value : bytesValues[j]) {
+                    updateSketch.update(value);
+                  }
+                }
+              }
+            }
+          });
+        }
+        break;
+      default:
+        throw new IllegalStateException(
+            "Illegal multi-value data type for DISTINCT_COUNT_THETA_SKETCH aggregation function: " + valueTypes[0]);
     }
   }
 
@@ -1473,12 +1669,18 @@ public class DistinctCountThetaSketchAggregationFunction
     return unions;
   }
 
-  /// Deserializes the sketches from the bytes.
-  private ThetaSketch[] deserializeSketches(byte[][] serializedSketches, int length) {
+  /// Deserializes the sketch carried by each row, leaving `null` for the rows that carry none.
+  ///
+  /// A null row is skipped rather than wrapped. That matters here beyond the wasted work: the default for a `BYTES`
+  /// column is an empty array, which is not a serialized sketch. Every caller reads this array only within a non-null
+  /// range, so the gaps are never read.
+  private ThetaSketch[] deserializeSketches(byte[][] serializedSketches, int length, BlockValSet blockValSet) {
     ThetaSketch[] sketches = new ThetaSketch[length];
-    for (int i = 0; i < length; i++) {
-      sketches[i] = ThetaSketch.wrap(MemorySegment.ofArray(serializedSketches[i]).asReadOnly());
-    }
+    forEachNotNull(length, blockValSet, (from, to) -> {
+      for (int i = from; i < to; i++) {
+        sketches[i] = ThetaSketch.wrap(MemorySegment.ofArray(serializedSketches[i]).asReadOnly());
+      }
+    });
     return sketches;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountULLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountULLAggregationFunction.java
@@ -42,11 +42,12 @@ import org.roaringbitmap.PeekableIntIterator;
 import org.roaringbitmap.RoaringBitmap;
 
 
-public class DistinctCountULLAggregationFunction extends BaseSingleInputAggregationFunction<UltraLogLog, Comparable> {
+public class DistinctCountULLAggregationFunction extends NullableSingleInputAggregationFunction<UltraLogLog,
+    Comparable> {
   protected final int _p;
 
-  public DistinctCountULLAggregationFunction(List<ExpressionContext> arguments) {
-    super(arguments.get(0));
+  public DistinctCountULLAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    super(arguments.get(0), nullHandlingEnabled);
     int numExpressions = arguments.size();
     // This function expects 1 or 2 arguments.
     Preconditions.checkArgument(numExpressions <= 2, "DistinctCountULL expects 1 or 2 arguments, got: %s",
@@ -83,29 +84,34 @@ public class DistinctCountULLAggregationFunction extends BaseSingleInputAggregat
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
     DataType dataType = blockValSet.getValueType();
-    if (dataType == DataType.BYTES) {
+    boolean singleValue = blockValSet.isSingleValue();
+    if (dataType == DataType.BYTES && singleValue) {
       // Logical BYTES is a serialized UltraLogLog and always uses the single-value representation.
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
-      try {
-        UltraLogLog ull = aggregationResultHolder.getResult();
-        if (ull == null) {
-          ull = ObjectSerDeUtils.ULTRA_LOG_LOG_OBJECT_SER_DE.deserialize(bytesValues[0]);
-          aggregationResultHolder.setValue(ull);
-        } else {
-          ull.add(ObjectSerDeUtils.ULTRA_LOG_LOG_OBJECT_SER_DE.deserialize(bytesValues[0]));
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        try {
+          int i = from;
+          UltraLogLog ull = aggregationResultHolder.getResult();
+          if (ull == null) {
+            if (i == to) {
+              return;
+            }
+            // The first UltraLogLog read becomes the accumulator instead of being merged into a fresh one
+            ull = ObjectSerDeUtils.ULTRA_LOG_LOG_OBJECT_SER_DE.deserialize(bytesValues[i++]);
+            aggregationResultHolder.setValue(ull);
+          }
+          for (; i < to; i++) {
+            ull.add(ObjectSerDeUtils.ULTRA_LOG_LOG_OBJECT_SER_DE.deserialize(bytesValues[i]));
+          }
+        } catch (Exception e) {
+          throw new RuntimeException("Caught exception while merging UltraLogLogs", e);
         }
-        for (int i = 1; i < length; i++) {
-          ull.add(ObjectSerDeUtils.ULTRA_LOG_LOG_OBJECT_SER_DE.deserialize(bytesValues[i]));
-        }
-      } catch (Exception e) {
-        throw new RuntimeException("Caught exception while merging UltraLogLogs", e);
-      }
+      });
       return;
     }
 
     DataType storedType = dataType.getStoredType();
-
-    if (blockValSet.isSingleValue()) {
+    if (singleValue) {
       aggregateSV(length, aggregationResultHolder, blockValSet, storedType);
     } else {
       aggregateMV(length, aggregationResultHolder, blockValSet, storedType);
@@ -118,48 +124,66 @@ public class DistinctCountULLAggregationFunction extends BaseSingleInputAggregat
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[] dictIds = blockValSet.getDictionaryIdsSV();
-      getDictIdBitmap(aggregationResultHolder, dictionary).addN(dictIds, 0, length);
+      forEachNotNull(length, blockValSet,
+          (from, to) -> getDictIdBitmap(aggregationResultHolder, dictionary).addN(dictIds, from, to - from));
       return;
     }
 
     // For non-dictionary-encoded expression, store values into the UltraLogLog
-    UltraLogLog ull = getULL(aggregationResultHolder);
     switch (storedType) {
       case INT:
         int[] intValues = blockValSet.getIntValuesSV();
-        for (int i = 0; i < length; i++) {
-          UltraLogLogUtils.hashObject(intValues[i]).ifPresent(ull::add);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          UltraLogLog ull = getULL(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            UltraLogLogUtils.hashObject(intValues[i]).ifPresent(ull::add);
+          }
+        });
         break;
       case LONG:
         long[] longValues = blockValSet.getLongValuesSV();
-        for (int i = 0; i < length; i++) {
-          UltraLogLogUtils.hashObject(longValues[i]).ifPresent(ull::add);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          UltraLogLog ull = getULL(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            UltraLogLogUtils.hashObject(longValues[i]).ifPresent(ull::add);
+          }
+        });
         break;
       case FLOAT:
         float[] floatValues = blockValSet.getFloatValuesSV();
-        for (int i = 0; i < length; i++) {
-          UltraLogLogUtils.hashObject(floatValues[i]).ifPresent(ull::add);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          UltraLogLog ull = getULL(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            UltraLogLogUtils.hashObject(floatValues[i]).ifPresent(ull::add);
+          }
+        });
         break;
       case DOUBLE:
         double[] doubleValues = blockValSet.getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
-          UltraLogLogUtils.hashObject(doubleValues[i]).ifPresent(ull::add);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          UltraLogLog ull = getULL(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            UltraLogLogUtils.hashObject(doubleValues[i]).ifPresent(ull::add);
+          }
+        });
         break;
       case STRING:
         String[] stringValues = blockValSet.getStringValuesSV();
-        for (int i = 0; i < length; i++) {
-          UltraLogLogUtils.hashObject(stringValues[i]).ifPresent(ull::add);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          UltraLogLog ull = getULL(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            UltraLogLogUtils.hashObject(stringValues[i]).ifPresent(ull::add);
+          }
+        });
         break;
       case BYTES:
         byte[][] bytesValues = blockValSet.getBytesValuesSV();
-        for (int i = 0; i < length; i++) {
-          UltraLogLogUtils.hashObject(bytesValues[i]).ifPresent(ull::add);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          UltraLogLog ull = getULL(aggregationResultHolder);
+          for (int i = from; i < to; i++) {
+            UltraLogLogUtils.hashObject(bytesValues[i]).ifPresent(ull::add);
+          }
+        });
         break;
       default:
         throw new IllegalStateException(
@@ -174,9 +198,11 @@ public class DistinctCountULLAggregationFunction extends BaseSingleInputAggregat
     if (dictionary != null) {
       RoaringBitmap dictIdBitmap = getDictIdBitmap(aggregationResultHolder, dictionary);
       int[][] dictIds = blockValSet.getDictionaryIdsMV();
-      for (int i = 0; i < length; i++) {
-        dictIdBitmap.add(dictIds[i]);
-      }
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          dictIdBitmap.add(dictIds[i]);
+        }
+      });
       return;
     }
 
@@ -185,51 +211,63 @@ public class DistinctCountULLAggregationFunction extends BaseSingleInputAggregat
     switch (storedType) {
       case INT:
         int[][] intValues = blockValSet.getIntValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (int value : intValues[i]) {
-            UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int value : intValues[i]) {
+              UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+            }
           }
-        }
+        });
         break;
       case LONG:
         long[][] longValues = blockValSet.getLongValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (long value : longValues[i]) {
-            UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (long value : longValues[i]) {
+              UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+            }
           }
-        }
+        });
         break;
       case FLOAT:
         float[][] floatValues = blockValSet.getFloatValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (float value : floatValues[i]) {
-            UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (float value : floatValues[i]) {
+              UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+            }
           }
-        }
+        });
         break;
       case DOUBLE:
         double[][] doubleValues = blockValSet.getDoubleValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (double value : doubleValues[i]) {
-            UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (double value : doubleValues[i]) {
+              UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+            }
           }
-        }
+        });
         break;
       case STRING:
         String[][] stringValues = blockValSet.getStringValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (String value : stringValues[i]) {
-            UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (String value : stringValues[i]) {
+              UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+            }
           }
-        }
+        });
         break;
       case BYTES:
         byte[][][] bytesValues = blockValSet.getBytesValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (byte[] value : bytesValues[i]) {
-            UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (byte[] value : bytesValues[i]) {
+              UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+            }
           }
-        }
+        });
         break;
       default:
         throw new IllegalStateException(
@@ -243,29 +281,31 @@ public class DistinctCountULLAggregationFunction extends BaseSingleInputAggregat
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
     DataType dataType = blockValSet.getValueType();
-    if (dataType == DataType.BYTES) {
+    boolean singleValue = blockValSet.isSingleValue();
+    if (dataType == DataType.BYTES && singleValue) {
       // Logical BYTES is a serialized UltraLogLog and always uses the single-value representation.
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
-      try {
-        for (int i = 0; i < length; i++) {
-          UltraLogLog value = ObjectSerDeUtils.ULTRA_LOG_LOG_OBJECT_SER_DE.deserialize(bytesValues[i]);
-          int groupKey = groupKeyArray[i];
-          UltraLogLog ull = groupByResultHolder.getResult(groupKey);
-          if (ull != null) {
-            ull.add(value);
-          } else {
-            groupByResultHolder.setValueForKey(groupKey, value);
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        try {
+          for (int i = from; i < to; i++) {
+            UltraLogLog value = ObjectSerDeUtils.ULTRA_LOG_LOG_OBJECT_SER_DE.deserialize(bytesValues[i]);
+            int groupKey = groupKeyArray[i];
+            UltraLogLog ull = groupByResultHolder.getResult(groupKey);
+            if (ull != null) {
+              ull.add(value);
+            } else {
+              groupByResultHolder.setValueForKey(groupKey, value);
+            }
           }
+        } catch (Exception e) {
+          throw new RuntimeException("Caught exception while merging UltraLogLog", e);
         }
-      } catch (Exception e) {
-        throw new RuntimeException("Caught exception while merging UltraLogLog", e);
-      }
+      });
       return;
     }
 
     DataType storedType = dataType.getStoredType();
-
-    if (blockValSet.isSingleValue()) {
+    if (singleValue) {
       aggregateSVGroupBySV(length, groupKeyArray, groupByResultHolder, blockValSet, storedType);
     } else {
       aggregateMVGroupBySV(length, groupKeyArray, groupByResultHolder, blockValSet, storedType);
@@ -278,9 +318,11 @@ public class DistinctCountULLAggregationFunction extends BaseSingleInputAggregat
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[] dictIds = blockValSet.getDictionaryIdsSV();
-      for (int i = 0; i < length; i++) {
-        getDictIdBitmap(groupByResultHolder, groupKeyArray[i], dictionary).add(dictIds[i]);
-      }
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          getDictIdBitmap(groupByResultHolder, groupKeyArray[i], dictionary).add(dictIds[i]);
+        }
+      });
       return;
     }
 
@@ -288,45 +330,57 @@ public class DistinctCountULLAggregationFunction extends BaseSingleInputAggregat
     switch (storedType) {
       case INT:
         int[] intValues = blockValSet.getIntValuesSV();
-        for (int i = 0; i < length; i++) {
-          UltraLogLogUtils.hashObject(intValues[i])
-              .ifPresent(getULL(groupByResultHolder, groupKeyArray[i])::add);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            UltraLogLogUtils.hashObject(intValues[i])
+                .ifPresent(getULL(groupByResultHolder, groupKeyArray[i])::add);
+          }
+        });
         break;
       case LONG:
         long[] longValues = blockValSet.getLongValuesSV();
-        for (int i = 0; i < length; i++) {
-          UltraLogLogUtils.hashObject(longValues[i])
-              .ifPresent(getULL(groupByResultHolder, groupKeyArray[i])::add);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            UltraLogLogUtils.hashObject(longValues[i])
+                .ifPresent(getULL(groupByResultHolder, groupKeyArray[i])::add);
+          }
+        });
         break;
       case FLOAT:
         float[] floatValues = blockValSet.getFloatValuesSV();
-        for (int i = 0; i < length; i++) {
-          UltraLogLogUtils.hashObject(floatValues[i])
-              .ifPresent(getULL(groupByResultHolder, groupKeyArray[i])::add);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            UltraLogLogUtils.hashObject(floatValues[i])
+                .ifPresent(getULL(groupByResultHolder, groupKeyArray[i])::add);
+          }
+        });
         break;
       case DOUBLE:
         double[] doubleValues = blockValSet.getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
-          UltraLogLogUtils.hashObject(doubleValues[i])
-              .ifPresent(getULL(groupByResultHolder, groupKeyArray[i])::add);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            UltraLogLogUtils.hashObject(doubleValues[i])
+                .ifPresent(getULL(groupByResultHolder, groupKeyArray[i])::add);
+          }
+        });
         break;
       case STRING:
         String[] stringValues = blockValSet.getStringValuesSV();
-        for (int i = 0; i < length; i++) {
-          UltraLogLogUtils.hashObject(stringValues[i])
-              .ifPresent(getULL(groupByResultHolder, groupKeyArray[i])::add);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            UltraLogLogUtils.hashObject(stringValues[i])
+                .ifPresent(getULL(groupByResultHolder, groupKeyArray[i])::add);
+          }
+        });
         break;
       case BYTES:
         byte[][] bytesValues = blockValSet.getBytesValuesSV();
-        for (int i = 0; i < length; i++) {
-          UltraLogLogUtils.hashObject(bytesValues[i])
-              .ifPresent(getULL(groupByResultHolder, groupKeyArray[i])::add);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            UltraLogLogUtils.hashObject(bytesValues[i])
+                .ifPresent(getULL(groupByResultHolder, groupKeyArray[i])::add);
+          }
+        });
         break;
       default:
         throw new IllegalStateException(
@@ -340,9 +394,11 @@ public class DistinctCountULLAggregationFunction extends BaseSingleInputAggregat
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[][] dictIds = blockValSet.getDictionaryIdsMV();
-      for (int i = 0; i < length; i++) {
-        getDictIdBitmap(groupByResultHolder, groupKeyArray[i], dictionary).add(dictIds[i]);
-      }
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          getDictIdBitmap(groupByResultHolder, groupKeyArray[i], dictionary).add(dictIds[i]);
+        }
+      });
       return;
     }
 
@@ -350,57 +406,69 @@ public class DistinctCountULLAggregationFunction extends BaseSingleInputAggregat
     switch (storedType) {
       case INT:
         int[][] intValues = blockValSet.getIntValuesMV();
-        for (int i = 0; i < length; i++) {
-          UltraLogLog ull = getULL(groupByResultHolder, groupKeyArray[i]);
-          for (int value : intValues[i]) {
-            UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            UltraLogLog ull = getULL(groupByResultHolder, groupKeyArray[i]);
+            for (int value : intValues[i]) {
+              UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+            }
           }
-        }
+        });
         break;
       case LONG:
         long[][] longValues = blockValSet.getLongValuesMV();
-        for (int i = 0; i < length; i++) {
-          UltraLogLog ull = getULL(groupByResultHolder, groupKeyArray[i]);
-          for (long value : longValues[i]) {
-            UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            UltraLogLog ull = getULL(groupByResultHolder, groupKeyArray[i]);
+            for (long value : longValues[i]) {
+              UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+            }
           }
-        }
+        });
         break;
       case FLOAT:
         float[][] floatValues = blockValSet.getFloatValuesMV();
-        for (int i = 0; i < length; i++) {
-          UltraLogLog ull = getULL(groupByResultHolder, groupKeyArray[i]);
-          for (float value : floatValues[i]) {
-            UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            UltraLogLog ull = getULL(groupByResultHolder, groupKeyArray[i]);
+            for (float value : floatValues[i]) {
+              UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+            }
           }
-        }
+        });
         break;
       case DOUBLE:
         double[][] doubleValues = blockValSet.getDoubleValuesMV();
-        for (int i = 0; i < length; i++) {
-          UltraLogLog ull = getULL(groupByResultHolder, groupKeyArray[i]);
-          for (double value : doubleValues[i]) {
-            UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            UltraLogLog ull = getULL(groupByResultHolder, groupKeyArray[i]);
+            for (double value : doubleValues[i]) {
+              UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+            }
           }
-        }
+        });
         break;
       case STRING:
         String[][] stringValues = blockValSet.getStringValuesMV();
-        for (int i = 0; i < length; i++) {
-          UltraLogLog ull = getULL(groupByResultHolder, groupKeyArray[i]);
-          for (String value : stringValues[i]) {
-            UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            UltraLogLog ull = getULL(groupByResultHolder, groupKeyArray[i]);
+            for (String value : stringValues[i]) {
+              UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+            }
           }
-        }
+        });
         break;
       case BYTES:
         byte[][][] bytesValues = blockValSet.getBytesValuesMV();
-        for (int i = 0; i < length; i++) {
-          UltraLogLog ull = getULL(groupByResultHolder, groupKeyArray[i]);
-          for (byte[] value : bytesValues[i]) {
-            UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            UltraLogLog ull = getULL(groupByResultHolder, groupKeyArray[i]);
+            for (byte[] value : bytesValues[i]) {
+              UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+            }
           }
-        }
+        });
         break;
       default:
         throw new IllegalStateException(
@@ -414,31 +482,33 @@ public class DistinctCountULLAggregationFunction extends BaseSingleInputAggregat
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
     DataType dataType = blockValSet.getValueType();
-    if (dataType == DataType.BYTES) {
+    boolean singleValue = blockValSet.isSingleValue();
+    if (dataType == DataType.BYTES && singleValue) {
       // Logical BYTES is a serialized UltraLogLog and always uses the single-value representation.
       byte[][] bytesValues = blockValSet.getBytesValuesSV();
-      try {
-        for (int i = 0; i < length; i++) {
-          UltraLogLog value = ObjectSerDeUtils.ULTRA_LOG_LOG_OBJECT_SER_DE.deserialize(bytesValues[i]);
-          for (int groupKey : groupKeysArray[i]) {
-            UltraLogLog ull = groupByResultHolder.getResult(groupKey);
-            if (ull != null) {
-              ull.add(value);
-            } else {
-              groupByResultHolder.setValueForKey(groupKey,
-                  ObjectSerDeUtils.ULTRA_LOG_LOG_OBJECT_SER_DE.deserialize(bytesValues[i]));
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        try {
+          for (int i = from; i < to; i++) {
+            UltraLogLog value = ObjectSerDeUtils.ULTRA_LOG_LOG_OBJECT_SER_DE.deserialize(bytesValues[i]);
+            for (int groupKey : groupKeysArray[i]) {
+              UltraLogLog ull = groupByResultHolder.getResult(groupKey);
+              if (ull != null) {
+                ull.add(value);
+              } else {
+                groupByResultHolder.setValueForKey(groupKey,
+                    ObjectSerDeUtils.ULTRA_LOG_LOG_OBJECT_SER_DE.deserialize(bytesValues[i]));
+              }
             }
           }
+        } catch (Exception e) {
+          throw new RuntimeException("Caught exception while merging UltraLogLog", e);
         }
-      } catch (Exception e) {
-        throw new RuntimeException("Caught exception while merging UltraLogLog", e);
-      }
+      });
       return;
     }
 
     DataType storedType = dataType.getStoredType();
-
-    if (blockValSet.isSingleValue()) {
+    if (singleValue) {
       aggregateSVGroupByMV(length, groupKeysArray, groupByResultHolder, blockValSet, storedType);
     } else {
       aggregateMVGroupByMV(length, groupKeysArray, groupByResultHolder, blockValSet, storedType);
@@ -451,9 +521,11 @@ public class DistinctCountULLAggregationFunction extends BaseSingleInputAggregat
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[] dictIds = blockValSet.getDictionaryIdsSV();
-      for (int i = 0; i < length; i++) {
-        setDictIdForGroupKeys(groupByResultHolder, groupKeysArray[i], dictionary, dictIds[i]);
-      }
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          setDictIdForGroupKeys(groupByResultHolder, groupKeysArray[i], dictionary, dictIds[i]);
+        }
+      });
       return;
     }
 
@@ -461,39 +533,51 @@ public class DistinctCountULLAggregationFunction extends BaseSingleInputAggregat
     switch (storedType) {
       case INT:
         int[] intValues = blockValSet.getIntValuesSV();
-        for (int i = 0; i < length; i++) {
-          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], intValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], intValues[i]);
+          }
+        });
         break;
       case LONG:
         long[] longValues = blockValSet.getLongValuesSV();
-        for (int i = 0; i < length; i++) {
-          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], longValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], longValues[i]);
+          }
+        });
         break;
       case FLOAT:
         float[] floatValues = blockValSet.getFloatValuesSV();
-        for (int i = 0; i < length; i++) {
-          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], floatValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], floatValues[i]);
+          }
+        });
         break;
       case DOUBLE:
         double[] doubleValues = blockValSet.getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
-          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], doubleValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], doubleValues[i]);
+          }
+        });
         break;
       case STRING:
         String[] stringValues = blockValSet.getStringValuesSV();
-        for (int i = 0; i < length; i++) {
-          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], stringValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], stringValues[i]);
+          }
+        });
         break;
       case BYTES:
         byte[][] bytesValues = blockValSet.getBytesValuesSV();
-        for (int i = 0; i < length; i++) {
-          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], bytesValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], bytesValues[i]);
+          }
+        });
         break;
       default:
         throw new IllegalStateException(
@@ -507,11 +591,13 @@ public class DistinctCountULLAggregationFunction extends BaseSingleInputAggregat
     Dictionary dictionary = blockValSet.isDictionaryEncoded() ? blockValSet.getDictionary() : null;
     if (dictionary != null) {
       int[][] dictIds = blockValSet.getDictionaryIdsMV();
-      for (int i = 0; i < length; i++) {
-        for (int groupKey : groupKeysArray[i]) {
-          getDictIdBitmap(groupByResultHolder, groupKey, dictionary).add(dictIds[i]);
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          for (int groupKey : groupKeysArray[i]) {
+            getDictIdBitmap(groupByResultHolder, groupKey, dictionary).add(dictIds[i]);
+          }
         }
-      }
+      });
       return;
     }
 
@@ -519,75 +605,87 @@ public class DistinctCountULLAggregationFunction extends BaseSingleInputAggregat
     switch (storedType) {
       case INT:
         int[][] intValues = blockValSet.getIntValuesMV();
-        for (int i = 0; i < length; i++) {
-          int[] intRow = intValues[i];
-          for (int groupKey : groupKeysArray[i]) {
-            UltraLogLog ull = getULL(groupByResultHolder, groupKey);
-            for (int value : intRow) {
-              UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            int[] intRow = intValues[i];
+            for (int groupKey : groupKeysArray[i]) {
+              UltraLogLog ull = getULL(groupByResultHolder, groupKey);
+              for (int value : intRow) {
+                UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+              }
             }
           }
-        }
+        });
         break;
       case LONG:
         long[][] longValues = blockValSet.getLongValuesMV();
-        for (int i = 0; i < length; i++) {
-          long[] longRow = longValues[i];
-          for (int groupKey : groupKeysArray[i]) {
-            UltraLogLog ull = getULL(groupByResultHolder, groupKey);
-            for (long value : longRow) {
-              UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            long[] longRow = longValues[i];
+            for (int groupKey : groupKeysArray[i]) {
+              UltraLogLog ull = getULL(groupByResultHolder, groupKey);
+              for (long value : longRow) {
+                UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+              }
             }
           }
-        }
+        });
         break;
       case FLOAT:
         float[][] floatValues = blockValSet.getFloatValuesMV();
-        for (int i = 0; i < length; i++) {
-          float[] floatRow = floatValues[i];
-          for (int groupKey : groupKeysArray[i]) {
-            UltraLogLog ull = getULL(groupByResultHolder, groupKey);
-            for (float value : floatRow) {
-              UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            float[] floatRow = floatValues[i];
+            for (int groupKey : groupKeysArray[i]) {
+              UltraLogLog ull = getULL(groupByResultHolder, groupKey);
+              for (float value : floatRow) {
+                UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+              }
             }
           }
-        }
+        });
         break;
       case DOUBLE:
         double[][] doubleValues = blockValSet.getDoubleValuesMV();
-        for (int i = 0; i < length; i++) {
-          double[] doubleRow = doubleValues[i];
-          for (int groupKey : groupKeysArray[i]) {
-            UltraLogLog ull = getULL(groupByResultHolder, groupKey);
-            for (double value : doubleRow) {
-              UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            double[] doubleRow = doubleValues[i];
+            for (int groupKey : groupKeysArray[i]) {
+              UltraLogLog ull = getULL(groupByResultHolder, groupKey);
+              for (double value : doubleRow) {
+                UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+              }
             }
           }
-        }
+        });
         break;
       case STRING:
         String[][] stringValues = blockValSet.getStringValuesMV();
-        for (int i = 0; i < length; i++) {
-          String[] stringRow = stringValues[i];
-          for (int groupKey : groupKeysArray[i]) {
-            UltraLogLog ull = getULL(groupByResultHolder, groupKey);
-            for (String value : stringRow) {
-              UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            String[] stringRow = stringValues[i];
+            for (int groupKey : groupKeysArray[i]) {
+              UltraLogLog ull = getULL(groupByResultHolder, groupKey);
+              for (String value : stringRow) {
+                UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+              }
             }
           }
-        }
+        });
         break;
       case BYTES:
         byte[][][] bytesValues = blockValSet.getBytesValuesMV();
-        for (int i = 0; i < length; i++) {
-          byte[][] bytesRow = bytesValues[i];
-          for (int groupKey : groupKeysArray[i]) {
-            UltraLogLog ull = getULL(groupByResultHolder, groupKey);
-            for (byte[] value : bytesRow) {
-              UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            byte[][] bytesRow = bytesValues[i];
+            for (int groupKey : groupKeysArray[i]) {
+              UltraLogLog ull = getULL(groupByResultHolder, groupKey);
+              for (byte[] value : bytesRow) {
+                UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+              }
             }
           }
-        }
+        });
         break;
       default:
         throw new IllegalStateException(

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
@@ -37,12 +37,12 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 /// Use [DistinctCountHLLAggregationFunction] on byte\[\] for serialized HyperLogLog.
 @Deprecated
-public class FastHLLAggregationFunction extends BaseSingleInputAggregationFunction<HyperLogLog, Long> {
+public class FastHLLAggregationFunction extends NullableSingleInputAggregationFunction<HyperLogLog, Long> {
   public static final int DEFAULT_LOG2M = 8;
   private static final int BYTE_TO_CHAR_OFFSET = 129;
 
-  public FastHLLAggregationFunction(List<ExpressionContext> arguments) {
-    super(verifySingleArgument(arguments, "FAST_HLL"));
+  public FastHLLAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    super(verifySingleArgument(arguments, "FAST_HLL"), nullHandlingEnabled);
   }
 
   @Override
@@ -63,65 +63,75 @@ public class FastHLLAggregationFunction extends BaseSingleInputAggregationFuncti
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    String[] values = blockValSetMap.get(_expression).getStringValuesSV();
-    try {
-      HyperLogLog hyperLogLog = aggregationResultHolder.getResult();
-      if (hyperLogLog != null) {
-        for (int i = 0; i < length; i++) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    String[] values = blockValSet.getStringValuesSV();
+    forEachNotNull(length, blockValSet, (from, to) -> {
+      try {
+        int i = from;
+        HyperLogLog hyperLogLog = aggregationResultHolder.getResult();
+        if (hyperLogLog == null) {
+          if (i == to) {
+            return;
+          }
+          // The first HyperLogLog read becomes the accumulator instead of being merged into a fresh one
+          hyperLogLog = convertStringToHLL(values[i++]);
+          aggregationResultHolder.setValue(hyperLogLog);
+        }
+        for (; i < to; i++) {
           hyperLogLog.addAll(convertStringToHLL(values[i]));
         }
-      } else {
-        hyperLogLog = convertStringToHLL(values[0]);
-        aggregationResultHolder.setValue(hyperLogLog);
-        for (int i = 1; i < length; i++) {
-          hyperLogLog.addAll(convertStringToHLL(values[i]));
-        }
+      } catch (Exception e) {
+        throw new RuntimeException("Caught exception while merging HyperLogLogs", e);
       }
-    } catch (Exception e) {
-      throw new RuntimeException("Caught exception while merging HyperLogLogs", e);
-    }
+    });
   }
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    String[] values = blockValSetMap.get(_expression).getStringValuesSV();
-    try {
-      for (int i = 0; i < length; i++) {
-        HyperLogLog value = convertStringToHLL(values[i]);
-        int groupKey = groupKeyArray[i];
-        HyperLogLog hyperLogLog = groupByResultHolder.getResult(groupKey);
-        if (hyperLogLog != null) {
-          hyperLogLog.addAll(value);
-        } else {
-          groupByResultHolder.setValueForKey(groupKey, value);
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    String[] values = blockValSet.getStringValuesSV();
+    forEachNotNull(length, blockValSet, (from, to) -> {
+      try {
+        for (int i = from; i < to; i++) {
+          HyperLogLog value = convertStringToHLL(values[i]);
+          int groupKey = groupKeyArray[i];
+          HyperLogLog hyperLogLog = groupByResultHolder.getResult(groupKey);
+          if (hyperLogLog != null) {
+            hyperLogLog.addAll(value);
+          } else {
+            groupByResultHolder.setValueForKey(groupKey, value);
+          }
         }
+      } catch (Exception e) {
+        throw new RuntimeException("Caught exception while merging HyperLogLogs", e);
       }
-    } catch (Exception e) {
-      throw new RuntimeException("Caught exception while merging HyperLogLogs", e);
-    }
+    });
   }
 
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    String[] values = blockValSetMap.get(_expression).getStringValuesSV();
-    try {
-      for (int i = 0; i < length; i++) {
-        HyperLogLog value = convertStringToHLL(values[i]);
-        for (int groupKey : groupKeysArray[i]) {
-          HyperLogLog hyperLogLog = groupByResultHolder.getResult(groupKey);
-          if (hyperLogLog != null) {
-            hyperLogLog.addAll(value);
-          } else {
-            // Create a new HyperLogLog for the group
-            groupByResultHolder.setValueForKey(groupKey, convertStringToHLL(values[i]));
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    String[] values = blockValSet.getStringValuesSV();
+    forEachNotNull(length, blockValSet, (from, to) -> {
+      try {
+        for (int i = from; i < to; i++) {
+          HyperLogLog value = convertStringToHLL(values[i]);
+          for (int groupKey : groupKeysArray[i]) {
+            HyperLogLog hyperLogLog = groupByResultHolder.getResult(groupKey);
+            if (hyperLogLog != null) {
+              hyperLogLog.addAll(value);
+            } else {
+              // Create a new HyperLogLog for the group
+              groupByResultHolder.setValueForKey(groupKey, convertStringToHLL(values[i]));
+            }
           }
         }
+      } catch (Exception e) {
+        throw new RuntimeException("Caught exception while merging HyperLogLogs", e);
       }
-    } catch (Exception e) {
-      throw new RuntimeException("Caught exception while merging HyperLogLogs", e);
-    }
+    });
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FrequentLongsSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FrequentLongsSketchAggregationFunction.java
@@ -36,7 +36,7 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
 import org.apache.pinot.segment.local.customobject.SerializedFrequentLongsSketch;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 ///  `FrequentLongsSketchAggregationFunction` provides an approximate FrequentItems aggregation function based on
@@ -93,39 +93,52 @@ public class FrequentLongsSketchAggregationFunction
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet valueSet = blockValSetMap.get(_expression);
-    FieldSpec.DataType valueType = valueSet.getValueType();
+    DataType dataType = valueSet.getValueType();
+    boolean singleValue = valueSet.isSingleValue();
+    if (dataType == DataType.BYTES && singleValue) {
+      // Assuming the column contains serialized data sketch
+      byte[][] bytesValues = valueSet.getBytesValuesSV();
+      // The sketch is created inside the range, so a block with no non-null row leaves the holder untouched and
+      // extractFinalResult sees the null that means nothing was aggregated
+      forEachNotNull(length, valueSet, (from, to) -> {
+        if (to == from) {
+          return;
+        }
+        FrequentLongsSketch sketch = getOrCreateSketch(aggregationResultHolder);
+        for (int i = from; i < to; i++) {
+          sketch.merge(deserializeSketch(bytesValues[i]));
+        }
+      });
+      return;
+    }
 
-    switch (valueType) {
-      case BYTES:
-        // Assuming the column contains serialized data sketch
-        byte[][] bytesValues = valueSet.getBytesValuesSV();
-        // The sketch is created inside the range, so a block with no non-null row leaves the holder untouched and
-        // extractFinalResult sees the null that means nothing was aggregated
-        forEachNotNull(length, valueSet, (from, to) -> {
-          if (to == from) {
-            return;
+    DataType storedType = dataType.getStoredType();
+    Preconditions.checkState(storedType == DataType.INT || storedType == DataType.LONG,
+        "FREQUENT_LONGS_SKETCH only supports INT/LONG column");
+    if (singleValue) {
+      long[] longValues = valueSet.getLongValuesSV();
+      forEachNotNull(length, valueSet, (from, to) -> {
+        if (to == from) {
+          return;
+        }
+        FrequentLongsSketch sketch = getOrCreateSketch(aggregationResultHolder);
+        for (int i = from; i < to; i++) {
+          sketch.update(longValues[i]);
+        }
+      });
+    } else {
+      long[][] longValues = valueSet.getLongValuesMV();
+      forEachNotNull(length, valueSet, (from, to) -> {
+        if (to == from) {
+          return;
+        }
+        FrequentLongsSketch sketch = getOrCreateSketch(aggregationResultHolder);
+        for (int i = from; i < to; i++) {
+          for (long value : longValues[i]) {
+            sketch.update(value);
           }
-          FrequentLongsSketch sketch = getOrCreateSketch(aggregationResultHolder);
-          for (int i = from; i < to; i++) {
-            sketch.merge(deserializeSketch(bytesValues[i]));
-          }
-        });
-        break;
-      case INT:
-      case LONG:
-        long[] longValues = valueSet.getLongValuesSV();
-        forEachNotNull(length, valueSet, (from, to) -> {
-          if (to == from) {
-            return;
-          }
-          FrequentLongsSketch sketch = getOrCreateSketch(aggregationResultHolder);
-          for (int i = from; i < to; i++) {
-            sketch.update(longValues[i]);
-          }
-        });
-        break;
-      default:
-        throw new UnsupportedOperationException("Cannot aggregate on non int/long types");
+        }
+      });
     }
   }
 
@@ -133,29 +146,39 @@ public class FrequentLongsSketchAggregationFunction
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet valueSet = blockValSetMap.get(_expression);
-    FieldSpec.DataType valueType = valueSet.getValueType();
+    DataType dataType = valueSet.getValueType();
+    boolean singleValue = valueSet.isSingleValue();
+    if (dataType == DataType.BYTES && singleValue) {
+      // Assuming the column contains serialized data sketch
+      byte[][] bytesValues = valueSet.getBytesValuesSV();
+      forEachNotNull(length, valueSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          getOrCreateSketch(groupByResultHolder, groupKeyArray[i]).merge(deserializeSketch(bytesValues[i]));
+        }
+      });
+      return;
+    }
 
-    switch (valueType) {
-      case BYTES:
-        // serialized sketch
-        byte[][] bytesValues = valueSet.getBytesValuesSV();
-        forEachNotNull(length, valueSet, (from, to) -> {
-          for (int i = from; i < to; i++) {
-            getOrCreateSketch(groupByResultHolder, groupKeyArray[i]).merge(deserializeSketch(bytesValues[i]));
+    DataType storedType = dataType.getStoredType();
+    Preconditions.checkState(storedType == DataType.INT || storedType == DataType.LONG,
+        "FREQUENT_LONGS_SKETCH only supports INT/LONG column");
+    if (singleValue) {
+      long[] values = valueSet.getLongValuesSV();
+      forEachNotNull(length, valueSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          getOrCreateSketch(groupByResultHolder, groupKeyArray[i]).update(values[i]);
+        }
+      });
+    } else {
+      long[][] values = valueSet.getLongValuesMV();
+      forEachNotNull(length, valueSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          FrequentLongsSketch sketch = getOrCreateSketch(groupByResultHolder, groupKeyArray[i]);
+          for (long value : values[i]) {
+            sketch.update(value);
           }
-        });
-        break;
-      case INT:
-      case LONG:
-        long[] values = valueSet.getLongValuesSV();
-        forEachNotNull(length, valueSet, (from, to) -> {
-          for (int i = from; i < to; i++) {
-            getOrCreateSketch(groupByResultHolder, groupKeyArray[i]).update(values[i]);
-          }
-        });
-        break;
-      default:
-        throw new UnsupportedOperationException("Cannot aggregate on non int/long types");
+        }
+      });
     }
   }
 
@@ -163,35 +186,48 @@ public class FrequentLongsSketchAggregationFunction
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet valueSet = blockValSetMap.get(_expression);
-    FieldSpec.DataType valueType = valueSet.getValueType();
+    DataType dataType = valueSet.getValueType();
+    boolean singleValue = valueSet.isSingleValue();
+    if (dataType == DataType.BYTES && singleValue) {
+      // Assuming the column contains serialized data sketch
+      byte[][] bytesValues = valueSet.getBytesValuesSV();
+      forEachNotNull(length, valueSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          // Deserialized once per row, not once per group key the row belongs to
+          FrequentLongsSketch rowSketch = deserializeSketch(bytesValues[i]);
+          for (int groupKey : groupKeysArray[i]) {
+            getOrCreateSketch(groupByResultHolder, groupKey).merge(rowSketch);
+          }
+        }
+      });
+      return;
+    }
 
-    switch (valueType) {
-      case BYTES:
-        // serialized sketch
-        byte[][] bytesValues = valueSet.getBytesValuesSV();
-        forEachNotNull(length, valueSet, (from, to) -> {
-          for (int i = from; i < to; i++) {
-            // Deserialized once per row, not once per group key the row belongs to
-            FrequentLongsSketch rowSketch = deserializeSketch(bytesValues[i]);
-            for (int groupKey : groupKeysArray[i]) {
-              getOrCreateSketch(groupByResultHolder, groupKey).merge(rowSketch);
+    DataType storedType = dataType.getStoredType();
+    Preconditions.checkState(storedType == DataType.INT || storedType == DataType.LONG,
+        "FREQUENT_LONGS_SKETCH only supports INT/LONG column");
+    if (singleValue) {
+      long[] values = valueSet.getLongValuesSV();
+      forEachNotNull(length, valueSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          for (int groupKey : groupKeysArray[i]) {
+            getOrCreateSketch(groupByResultHolder, groupKey).update(values[i]);
+          }
+        }
+      });
+    } else {
+      long[][] values = valueSet.getLongValuesMV();
+      forEachNotNull(length, valueSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          long[] rowValues = values[i];
+          for (int groupKey : groupKeysArray[i]) {
+            FrequentLongsSketch sketch = getOrCreateSketch(groupByResultHolder, groupKey);
+            for (long value : rowValues) {
+              sketch.update(value);
             }
           }
-        });
-        break;
-      case INT:
-      case LONG:
-        long[] values = valueSet.getLongValuesSV();
-        forEachNotNull(length, valueSet, (from, to) -> {
-          for (int i = from; i < to; i++) {
-            for (int groupKey : groupKeysArray[i]) {
-              getOrCreateSketch(groupByResultHolder, groupKey).update(values[i]);
-            }
-          }
-        });
-        break;
-      default:
-        throw new UnsupportedOperationException("Cannot aggregate on non int/long types");
+        }
+      });
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FrequentStringsSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FrequentStringsSketchAggregationFunction.java
@@ -37,7 +37,7 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
 import org.apache.pinot.segment.local.customobject.SerializedFrequentStringsSketch;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 ///  `FrequentStringsSketchAggregationFunction` provides an approximate FrequentItems aggregation function based
@@ -95,9 +95,9 @@ public class FrequentStringsSketchAggregationFunction
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet valueSet = blockValSetMap.get(_expression);
-    FieldSpec.DataType valueType = valueSet.getValueType();
-
-    if (valueType == FieldSpec.DataType.BYTES) {
+    DataType dataType = valueSet.getValueType();
+    boolean singleValue = valueSet.isSingleValue();
+    if (dataType == DataType.BYTES && singleValue) {
       // Assuming the column contains serialized data sketch
       byte[][] bytesValues = valueSet.getBytesValuesSV();
       // The sketch is created inside the range, so a block with no non-null row leaves the holder untouched and
@@ -111,7 +111,10 @@ public class FrequentStringsSketchAggregationFunction
           sketch.merge(deserializeSketch(bytesValues[i]));
         }
       });
-    } else {
+      return;
+    }
+
+    if (singleValue) {
       String[] values = valueSet.getStringValuesSV();
       forEachNotNull(length, valueSet, (from, to) -> {
         if (to == from) {
@@ -122,6 +125,19 @@ public class FrequentStringsSketchAggregationFunction
           sketch.update(values[i]);
         }
       });
+    } else {
+      String[][] values = valueSet.getStringValuesMV();
+      forEachNotNull(length, valueSet, (from, to) -> {
+        if (to == from) {
+          return;
+        }
+        FrequentItemsSketch<String> sketch = getOrCreateSketch(aggregationResultHolder);
+        for (int i = from; i < to; i++) {
+          for (String value : values[i]) {
+            sketch.update(value);
+          }
+        }
+      });
     }
   }
 
@@ -129,9 +145,9 @@ public class FrequentStringsSketchAggregationFunction
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet valueSet = blockValSetMap.get(_expression);
-    FieldSpec.DataType valueType = valueSet.getValueType();
-
-    if (valueType == FieldSpec.DataType.BYTES) {
+    DataType dataType = valueSet.getValueType();
+    boolean singleValue = valueSet.isSingleValue();
+    if (dataType == DataType.BYTES && singleValue) {
       // serialized sketch
       byte[][] bytesValues = valueSet.getBytesValuesSV();
       forEachNotNull(length, valueSet, (from, to) -> {
@@ -139,11 +155,24 @@ public class FrequentStringsSketchAggregationFunction
           getOrCreateSketch(groupByResultHolder, groupKeyArray[i]).merge(deserializeSketch(bytesValues[i]));
         }
       });
-    } else {
+      return;
+    }
+
+    if (singleValue) {
       String[] values = valueSet.getStringValuesSV();
       forEachNotNull(length, valueSet, (from, to) -> {
         for (int i = from; i < to; i++) {
           getOrCreateSketch(groupByResultHolder, groupKeyArray[i]).update(values[i]);
+        }
+      });
+    } else {
+      String[][] values = valueSet.getStringValuesMV();
+      forEachNotNull(length, valueSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          FrequentItemsSketch<String> sketch = getOrCreateSketch(groupByResultHolder, groupKeyArray[i]);
+          for (String value : values[i]) {
+            sketch.update(value);
+          }
         }
       });
     }
@@ -153,9 +182,9 @@ public class FrequentStringsSketchAggregationFunction
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet valueSet = blockValSetMap.get(_expression);
-    FieldSpec.DataType valueType = valueSet.getValueType();
-
-    if (valueType == FieldSpec.DataType.BYTES) {
+    DataType dataType = valueSet.getValueType();
+    boolean singleValue = valueSet.isSingleValue();
+    if (dataType == DataType.BYTES && singleValue) {
       // serialized sketch
       byte[][] bytesValues = valueSet.getBytesValuesSV();
       forEachNotNull(length, valueSet, (from, to) -> {
@@ -167,12 +196,28 @@ public class FrequentStringsSketchAggregationFunction
           }
         }
       });
-    } else {
+      return;
+    }
+
+    if (singleValue) {
       String[] values = valueSet.getStringValuesSV();
       forEachNotNull(length, valueSet, (from, to) -> {
         for (int i = from; i < to; i++) {
           for (int groupKey : groupKeysArray[i]) {
             getOrCreateSketch(groupByResultHolder, groupKey).update(values[i]);
+          }
+        }
+      });
+    } else {
+      String[][] values = valueSet.getStringValuesMV();
+      forEachNotNull(length, valueSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          String[] rowValues = values[i];
+          for (int groupKey : groupKeysArray[i]) {
+            FrequentItemsSketch<String> sketch = getOrCreateSketch(groupByResultHolder, groupKey);
+            for (String value : rowValues) {
+              sketch.update(value);
+            }
           }
         }
       });

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
@@ -41,7 +41,7 @@ import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder
 import org.apache.pinot.segment.local.customobject.TupleIntSketchAccumulator;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.Constants;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.CommonConstants;
 
 
@@ -117,7 +117,7 @@ public class IntegerTupleSketchAggregationFunction
           "Tuple Sketch Aggregation Function expects the second argument to be a literal (parameters)," + " but got: ",
           secondArgument.getType());
 
-      if (secondArgument.getLiteral().getType() == FieldSpec.DataType.STRING) {
+      if (secondArgument.getLiteral().getType() == DataType.STRING) {
         Parameters parameters = new Parameters(secondArgument.getLiteral().getStringValue());
         // Allows the user to trade-off memory usage for merge CPU; higher values use more memory
         _accumulatorThreshold = parameters.getAccumulatorThreshold();
@@ -152,56 +152,41 @@ public class IntegerTupleSketchAggregationFunction
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
-    // Treat BYTES value as serialized Integer Tuple Sketch
-    FieldSpec.DataType storedType = blockValSet.getValueType().getStoredType();
-    if (storedType == FieldSpec.DataType.BYTES) {
-      byte[][] bytesValues = blockValSet.getBytesValuesSV();
-      try {
-        // The accumulator is created inside the range, so an all-null block leaves the holder untouched and
-        // extractFinalResult sees the null that means nothing was aggregated
-        forEachNotNull(length, blockValSet, (from, to) -> {
-          // An empty range still reaches here, for a zero-length block. Creating the accumulator for it would mark
-          // the holder as aggregated and lose the signal this whole arrangement exists to carry.
-          if (to == from) {
-            return;
-          }
-          TupleIntSketchAccumulator tupleIntSketchAccumulator = getAccumulator(aggregationResultHolder);
-          for (int i = from; i < to; i++) {
-            tupleIntSketchAccumulator.apply(deserializeSketch(bytesValues[i]));
-          }
-        });
-      } catch (Exception e) {
-        throw new RuntimeException("Caught exception while aggregating Tuple Sketches", e);
+    DataType dataType = blockValSet.getValueType();
+    boolean singleValue = blockValSet.isSingleValue();
+    Preconditions.checkState(dataType == DataType.BYTES && singleValue,
+        "INTEGER_TUPLE_SKETCH only supports SV BYTES column");
+    byte[][] bytesValues = blockValSet.getBytesValuesSV();
+    // The accumulator is created inside the range, so an all-null block leaves the holder untouched and
+    // extractFinalResult sees the null that means nothing was aggregated
+    forEachNotNull(length, blockValSet, (from, to) -> {
+      // An empty range still reaches here, for a zero-length block. Creating the accumulator for it would mark
+      // the holder as aggregated and lose the signal this whole arrangement exists to carry.
+      if (to == from) {
+        return;
       }
-    } else {
-      throw new IllegalStateException("Illegal data type for " + getType() + " aggregation function: " + storedType);
-    }
+      TupleIntSketchAccumulator tupleIntSketchAccumulator = getAccumulator(aggregationResultHolder);
+      for (int i = from; i < to; i++) {
+        tupleIntSketchAccumulator.apply(deserializeSketch(bytesValues[i]));
+      }
+    });
   }
 
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
-    // Treat BYTES value as serialized Integer Tuple Sketch
-    FieldSpec.DataType storedType = blockValSet.getValueType().getStoredType();
-
-    if (storedType == FieldSpec.DataType.BYTES) {
-      byte[][] bytesValues = blockValSet.getBytesValuesSV();
-      try {
-        forEachNotNull(length, blockValSet, (from, to) -> {
-          for (int i = from; i < to; i++) {
-            getAccumulator(groupByResultHolder, groupKeyArray[i]).apply(deserializeSketch(bytesValues[i]));
-          }
-        });
-      } catch (Exception e) {
-        throw new RuntimeException("Caught exception while aggregating Tuple Sketches", e);
+    DataType dataType = blockValSet.getValueType();
+    boolean singleValue = blockValSet.isSingleValue();
+    Preconditions.checkState(dataType == DataType.BYTES && singleValue,
+        "INTEGER_TUPLE_SKETCH only supports SV BYTES column");
+    byte[][] bytesValues = blockValSet.getBytesValuesSV();
+    forEachNotNull(length, blockValSet, (from, to) -> {
+      for (int i = from; i < to; i++) {
+        getAccumulator(groupByResultHolder, groupKeyArray[i]).apply(deserializeSketch(bytesValues[i]));
       }
-    } else {
-      throw new IllegalStateException(
-          "Illegal data type for INTEGER_TUPLE_SKETCH_UNION aggregation function: " + storedType);
-    }
+    });
   }
 
   @Override
@@ -209,29 +194,20 @@ public class IntegerTupleSketchAggregationFunction
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
 
-    // Treat BYTES value as serialized Integer Tuple Sketch
-    FieldSpec.DataType storedType = blockValSet.getValueType().getStoredType();
+    DataType dataType = blockValSet.getValueType();
     boolean singleValue = blockValSet.isSingleValue();
-
-    if (singleValue && storedType == FieldSpec.DataType.BYTES) {
-      byte[][] bytesValues = blockValSetMap.get(_expression).getBytesValuesSV();
-      try {
-        forEachNotNull(length, blockValSet, (from, to) -> {
-          for (int i = from; i < to; i++) {
-            // Deserialized once per row, not once per group key the row belongs to
-            TupleSketch<IntegerSummary> sketch = deserializeSketch(bytesValues[i]);
-            for (int groupKey : groupKeysArray[i]) {
-              getAccumulator(groupByResultHolder, groupKey).apply(sketch);
-            }
-          }
-        });
-      } catch (Exception e) {
-        throw new RuntimeException("Caught exception while aggregating Tuple Sketches", e);
+    Preconditions.checkState(dataType == DataType.BYTES && singleValue,
+        "INTEGER_TUPLE_SKETCH only supports SV BYTES column");
+    byte[][] bytesValues = blockValSet.getBytesValuesSV();
+    forEachNotNull(length, blockValSet, (from, to) -> {
+      for (int i = from; i < to; i++) {
+        // Deserialized once per row, not once per group key the row belongs to
+        TupleSketch<IntegerSummary> sketch = deserializeSketch(bytesValues[i]);
+        for (int groupKey : groupKeysArray[i]) {
+          getAccumulator(groupByResultHolder, groupKey).apply(sketch);
+        }
       }
-    } else {
-      throw new IllegalStateException(
-          "Illegal data type for INTEGER_TUPLE_SKETCH_UNION aggregation function: " + storedType);
-    }
+    });
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileKLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileKLLAggregationFunction.java
@@ -98,11 +98,11 @@ public class PercentileKLLAggregationFunction
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet valueSet = blockValSetMap.get(_expression);
-    DataType valueType = valueSet.getValueType();
     KllDoublesSketch sketch = getOrCreateSketch(aggregationResultHolder);
 
-    if (valueType == DataType.BYTES) {
-      // Assuming the column contains serialized data sketch
+    DataType dataType = valueSet.getValueType();
+    boolean singleValue = valueSet.isSingleValue();
+    if (dataType == DataType.BYTES && singleValue) {
       KllDoublesSketch[] deserializedSketches = deserializeSketches(blockValSetMap.get(_expression).getBytesValuesSV());
       forEachNotNull(length, valueSet, (from, to) -> {
         for (int i = from; i < to; i++) {
@@ -112,15 +112,14 @@ public class PercentileKLLAggregationFunction
       return;
     }
 
-    if (valueSet.isSingleValue()) {
-      aggregateSV(length, aggregationResultHolder, valueSet, sketch);
+    if (singleValue) {
+      aggregateSV(length, valueSet, sketch);
     } else {
-      aggregateMV(length, aggregationResultHolder, valueSet, sketch);
+      aggregateMV(length, valueSet, sketch);
     }
   }
 
-  protected void aggregateSV(int length, AggregationResultHolder aggregationResultHolder, BlockValSet valueSet,
-      KllDoublesSketch sketch) {
+  protected void aggregateSV(int length, BlockValSet valueSet, KllDoublesSketch sketch) {
     double[] values = valueSet.getDoubleValuesSV();
     forEachNotNull(length, valueSet, (from, to) -> {
       for (int i = from; i < to; i++) {
@@ -129,8 +128,7 @@ public class PercentileKLLAggregationFunction
     });
   }
 
-  protected void aggregateMV(int length, AggregationResultHolder aggregationResultHolder, BlockValSet valueSet,
-      KllDoublesSketch sketch) {
+  protected void aggregateMV(int length, BlockValSet valueSet, KllDoublesSketch sketch) {
     double[][] values = valueSet.getDoubleValuesMV();
     forEachNotNull(length, valueSet, (from, to) -> {
       for (int i = from; i < to; i++) {
@@ -145,10 +143,10 @@ public class PercentileKLLAggregationFunction
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet valueSet = blockValSetMap.get(_expression);
-    DataType valueType = valueSet.getValueType();
 
-    if (valueType == DataType.BYTES) {
-      // serialized sketch
+    DataType dataType = valueSet.getValueType();
+    boolean singleValue = valueSet.isSingleValue();
+    if (dataType == DataType.BYTES && singleValue) {
       KllDoublesSketch[] deserializedSketches = deserializeSketches(blockValSetMap.get(_expression).getBytesValuesSV());
       forEachNotNull(length, valueSet, (from, to) -> {
         for (int i = from; i < to; i++) {
@@ -159,7 +157,7 @@ public class PercentileKLLAggregationFunction
       return;
     }
 
-    if (valueSet.isSingleValue()) {
+    if (singleValue) {
       aggregateSVGroupBySV(length, groupKeyArray, groupByResultHolder, valueSet);
     } else {
       aggregateMVGroupBySV(length, groupKeyArray, groupByResultHolder, valueSet);
@@ -194,10 +192,10 @@ public class PercentileKLLAggregationFunction
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet valueSet = blockValSetMap.get(_expression);
-    DataType valueType = valueSet.getValueType();
 
-    if (valueType == DataType.BYTES) {
-      // serialized sketch
+    DataType dataType = valueSet.getValueType();
+    boolean singleValue = valueSet.isSingleValue();
+    if (dataType == DataType.BYTES && singleValue) {
       KllDoublesSketch[] deserializedSketches = deserializeSketches(blockValSetMap.get(_expression).getBytesValuesSV());
       forEachNotNull(length, valueSet, (from, to) -> {
         for (int i = from; i < to; i++) {
@@ -210,7 +208,7 @@ public class PercentileKLLAggregationFunction
       return;
     }
 
-    if (valueSet.isSingleValue()) {
+    if (singleValue) {
       aggregateSVGroupByMV(length, groupKeysArray, groupByResultHolder, valueSet);
     } else {
       aggregateMVGroupByMV(length, groupKeysArray, groupByResultHolder, valueSet);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SegmentPartitionedDistinctCountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SegmentPartitionedDistinctCountAggregationFunction.java
@@ -47,10 +47,12 @@ import org.roaringbitmap.RoaringBitmap;
 ///
 /// This function calculates the exact number of distinct values within the segment, then simply sums up the results
 /// from different segments to get the final result.
-public class SegmentPartitionedDistinctCountAggregationFunction extends BaseSingleInputAggregationFunction<Long, Long> {
+public class SegmentPartitionedDistinctCountAggregationFunction extends NullableSingleInputAggregationFunction<Long,
+    Long> {
 
-  public SegmentPartitionedDistinctCountAggregationFunction(List<ExpressionContext> arguments) {
-    super(verifySingleArgument(arguments, "SEGMENT_PARTITIONED_DISTINCT_COUNT"));
+  public SegmentPartitionedDistinctCountAggregationFunction(List<ExpressionContext> arguments,
+      boolean nullHandlingEnabled) {
+    super(verifySingleArgument(arguments, "SEGMENT_PARTITIONED_DISTINCT_COUNT"), nullHandlingEnabled);
   }
 
   @Override
@@ -83,12 +85,14 @@ public class SegmentPartitionedDistinctCountAggregationFunction extends BaseSing
     // For dictionary-encoded expression, store dictionary ids into a RoaringBitmap
     if (blockValSet.isDictionaryEncoded()) {
       int[] dictIds = blockValSet.getDictionaryIdsSV();
-      RoaringBitmap bitmap = aggregationResultHolder.getResult();
-      if (bitmap == null) {
-        bitmap = new RoaringBitmap();
-        aggregationResultHolder.setValue(bitmap);
-      }
-      bitmap.addN(dictIds, 0, length);
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        RoaringBitmap bitmap = aggregationResultHolder.getResult();
+        if (bitmap == null) {
+          bitmap = new RoaringBitmap();
+          aggregationResultHolder.setValue(bitmap);
+        }
+        bitmap.addN(dictIds, from, to - from);
+      });
       return;
     }
 
@@ -97,68 +101,79 @@ public class SegmentPartitionedDistinctCountAggregationFunction extends BaseSing
     switch (storedType) {
       case INT:
         int[] intValues = blockValSet.getIntValuesSV();
-        RoaringBitmap bitmap = aggregationResultHolder.getResult();
-        if (bitmap == null) {
-          bitmap = new RoaringBitmap();
-          aggregationResultHolder.setValue(bitmap);
-        }
-        bitmap.addN(intValues, 0, length);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          RoaringBitmap bitmap = aggregationResultHolder.getResult();
+          if (bitmap == null) {
+            bitmap = new RoaringBitmap();
+            aggregationResultHolder.setValue(bitmap);
+          }
+          bitmap.addN(intValues, from, to - from);
+        });
         break;
       case LONG:
         long[] longValues = blockValSet.getLongValuesSV();
-        LongOpenHashSet longSet = aggregationResultHolder.getResult();
-        if (longSet == null) {
-          longSet = new LongOpenHashSet();
-          aggregationResultHolder.setValue(longSet);
-        }
-        for (int i = 0; i < length; i++) {
-          longSet.add(longValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          LongOpenHashSet longSet = aggregationResultHolder.getResult();
+          if (longSet == null) {
+            longSet = new LongOpenHashSet();
+            aggregationResultHolder.setValue(longSet);
+          }
+          for (int i = from; i < to; i++) {
+            longSet.add(longValues[i]);
+          }
+        });
         break;
       case FLOAT:
         float[] floatValues = blockValSet.getFloatValuesSV();
-        FloatOpenHashSet floatSet = aggregationResultHolder.getResult();
-        if (floatSet == null) {
-          floatSet = new FloatOpenHashSet();
-          aggregationResultHolder.setValue(floatSet);
-        }
-        for (int i = 0; i < length; i++) {
-          floatSet.add(floatValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          FloatOpenHashSet floatSet = aggregationResultHolder.getResult();
+          if (floatSet == null) {
+            floatSet = new FloatOpenHashSet();
+            aggregationResultHolder.setValue(floatSet);
+          }
+          for (int i = from; i < to; i++) {
+            floatSet.add(floatValues[i]);
+          }
+        });
         break;
       case DOUBLE:
         double[] doubleValues = blockValSet.getDoubleValuesSV();
-        DoubleOpenHashSet doubleSet = aggregationResultHolder.getResult();
-        if (doubleSet == null) {
-          doubleSet = new DoubleOpenHashSet();
-          aggregationResultHolder.setValue(doubleSet);
-        }
-        for (int i = 0; i < length; i++) {
-          doubleSet.add(doubleValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          DoubleOpenHashSet doubleSet = aggregationResultHolder.getResult();
+          if (doubleSet == null) {
+            doubleSet = new DoubleOpenHashSet();
+            aggregationResultHolder.setValue(doubleSet);
+          }
+          for (int i = from; i < to; i++) {
+            doubleSet.add(doubleValues[i]);
+          }
+        });
         break;
       case STRING:
         String[] stringValues = blockValSet.getStringValuesSV();
-        ObjectOpenHashSet<String> stringSet = aggregationResultHolder.getResult();
-        if (stringSet == null) {
-          stringSet = new ObjectOpenHashSet<>();
-          aggregationResultHolder.setValue(stringSet);
-        }
-        //noinspection ManualArrayToCollectionCopy
-        for (int i = 0; i < length; i++) {
-          stringSet.add(stringValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          ObjectOpenHashSet<String> stringSet = aggregationResultHolder.getResult();
+          if (stringSet == null) {
+            stringSet = new ObjectOpenHashSet<>();
+            aggregationResultHolder.setValue(stringSet);
+          }
+          for (int i = from; i < to; i++) {
+            stringSet.add(stringValues[i]);
+          }
+        });
         break;
       case BYTES:
         byte[][] bytesValues = blockValSet.getBytesValuesSV();
-        ObjectOpenHashSet<ByteArray> bytesSet = aggregationResultHolder.getResult();
-        if (bytesSet == null) {
-          bytesSet = new ObjectOpenHashSet<>();
-          aggregationResultHolder.setValue(bytesSet);
-        }
-        for (int i = 0; i < length; i++) {
-          bytesSet.add(new ByteArray(bytesValues[i]));
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          ObjectOpenHashSet<ByteArray> bytesSet = aggregationResultHolder.getResult();
+          if (bytesSet == null) {
+            bytesSet = new ObjectOpenHashSet<>();
+            aggregationResultHolder.setValue(bytesSet);
+          }
+          for (int i = from; i < to; i++) {
+            bytesSet.add(new ByteArray(bytesValues[i]));
+          }
+        });
         break;
       default:
         throw new IllegalStateException(
@@ -170,14 +185,16 @@ public class SegmentPartitionedDistinctCountAggregationFunction extends BaseSing
     // For dictionary-encoded expression, store dictionary ids into a RoaringBitmap
     if (blockValSet.isDictionaryEncoded()) {
       int[][] dictIds = blockValSet.getDictionaryIdsMV();
-      RoaringBitmap bitmap = aggregationResultHolder.getResult();
-      if (bitmap == null) {
-        bitmap = new RoaringBitmap();
-        aggregationResultHolder.setValue(bitmap);
-      }
-      for (int i = 0; i < length; i++) {
-        bitmap.add(dictIds[i]);
-      }
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        RoaringBitmap bitmap = aggregationResultHolder.getResult();
+        if (bitmap == null) {
+          bitmap = new RoaringBitmap();
+          aggregationResultHolder.setValue(bitmap);
+        }
+        for (int i = from; i < to; i++) {
+          bitmap.add(dictIds[i]);
+        }
+      });
       return;
     }
 
@@ -186,79 +203,91 @@ public class SegmentPartitionedDistinctCountAggregationFunction extends BaseSing
     switch (storedType) {
       case INT:
         int[][] intValues = blockValSet.getIntValuesMV();
-        RoaringBitmap bitmap = aggregationResultHolder.getResult();
-        if (bitmap == null) {
-          bitmap = new RoaringBitmap();
-          aggregationResultHolder.setValue(bitmap);
-        }
-        for (int i = 0; i < length; i++) {
-          bitmap.add(intValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          RoaringBitmap bitmap = aggregationResultHolder.getResult();
+          if (bitmap == null) {
+            bitmap = new RoaringBitmap();
+            aggregationResultHolder.setValue(bitmap);
+          }
+          for (int i = from; i < to; i++) {
+            bitmap.add(intValues[i]);
+          }
+        });
         break;
       case LONG:
         long[][] longValues = blockValSet.getLongValuesMV();
-        LongOpenHashSet longSet = aggregationResultHolder.getResult();
-        if (longSet == null) {
-          longSet = new LongOpenHashSet();
-          aggregationResultHolder.setValue(longSet);
-        }
-        for (int i = 0; i < length; i++) {
-          for (long value : longValues[i]) {
-            longSet.add(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          LongOpenHashSet longSet = aggregationResultHolder.getResult();
+          if (longSet == null) {
+            longSet = new LongOpenHashSet();
+            aggregationResultHolder.setValue(longSet);
           }
-        }
+          for (int i = from; i < to; i++) {
+            for (long value : longValues[i]) {
+              longSet.add(value);
+            }
+          }
+        });
         break;
       case FLOAT:
         float[][] floatValues = blockValSet.getFloatValuesMV();
-        FloatOpenHashSet floatSet = aggregationResultHolder.getResult();
-        if (floatSet == null) {
-          floatSet = new FloatOpenHashSet();
-          aggregationResultHolder.setValue(floatSet);
-        }
-        for (int i = 0; i < length; i++) {
-          for (float value : floatValues[i]) {
-            floatSet.add(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          FloatOpenHashSet floatSet = aggregationResultHolder.getResult();
+          if (floatSet == null) {
+            floatSet = new FloatOpenHashSet();
+            aggregationResultHolder.setValue(floatSet);
           }
-        }
+          for (int i = from; i < to; i++) {
+            for (float value : floatValues[i]) {
+              floatSet.add(value);
+            }
+          }
+        });
         break;
       case DOUBLE:
         double[][] doubleValues = blockValSet.getDoubleValuesMV();
-        DoubleOpenHashSet doubleSet = aggregationResultHolder.getResult();
-        if (doubleSet == null) {
-          doubleSet = new DoubleOpenHashSet();
-          aggregationResultHolder.setValue(doubleSet);
-        }
-        for (int i = 0; i < length; i++) {
-          for (double value : doubleValues[i]) {
-            doubleSet.add(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          DoubleOpenHashSet doubleSet = aggregationResultHolder.getResult();
+          if (doubleSet == null) {
+            doubleSet = new DoubleOpenHashSet();
+            aggregationResultHolder.setValue(doubleSet);
           }
-        }
+          for (int i = from; i < to; i++) {
+            for (double value : doubleValues[i]) {
+              doubleSet.add(value);
+            }
+          }
+        });
         break;
       case STRING:
         String[][] stringValues = blockValSet.getStringValuesMV();
-        ObjectOpenHashSet<String> stringSet = aggregationResultHolder.getResult();
-        if (stringSet == null) {
-          stringSet = new ObjectOpenHashSet<>();
-          aggregationResultHolder.setValue(stringSet);
-        }
-        for (int i = 0; i < length; i++) {
-          for (String value : stringValues[i]) {
-            stringSet.add(value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          ObjectOpenHashSet<String> stringSet = aggregationResultHolder.getResult();
+          if (stringSet == null) {
+            stringSet = new ObjectOpenHashSet<>();
+            aggregationResultHolder.setValue(stringSet);
           }
-        }
+          for (int i = from; i < to; i++) {
+            for (String value : stringValues[i]) {
+              stringSet.add(value);
+            }
+          }
+        });
         break;
       case BYTES:
         byte[][][] bytesValues = blockValSet.getBytesValuesMV();
-        ObjectOpenHashSet<ByteArray> bytesSet = aggregationResultHolder.getResult();
-        if (bytesSet == null) {
-          bytesSet = new ObjectOpenHashSet<>();
-          aggregationResultHolder.setValue(bytesSet);
-        }
-        for (int i = 0; i < length; i++) {
-          for (byte[] value : bytesValues[i]) {
-            bytesSet.add(new ByteArray(value));
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          ObjectOpenHashSet<ByteArray> bytesSet = aggregationResultHolder.getResult();
+          if (bytesSet == null) {
+            bytesSet = new ObjectOpenHashSet<>();
+            aggregationResultHolder.setValue(bytesSet);
           }
-        }
+          for (int i = from; i < to; i++) {
+            for (byte[] value : bytesValues[i]) {
+              bytesSet.add(new ByteArray(value));
+            }
+          }
+        });
         break;
       default:
         throw new IllegalStateException(
@@ -282,9 +311,11 @@ public class SegmentPartitionedDistinctCountAggregationFunction extends BaseSing
     // For dictionary-encoded expression, store dictionary ids into a RoaringBitmap
     if (blockValSet.isDictionaryEncoded()) {
       int[] dictIds = blockValSet.getDictionaryIdsSV();
-      for (int i = 0; i < length; i++) {
-        setIntValueForGroup(groupByResultHolder, groupKeyArray[i], dictIds[i]);
-      }
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          setIntValueForGroup(groupByResultHolder, groupKeyArray[i], dictIds[i]);
+        }
+      });
       return;
     }
 
@@ -293,39 +324,51 @@ public class SegmentPartitionedDistinctCountAggregationFunction extends BaseSing
     switch (storedType) {
       case INT:
         int[] intValues = blockValSet.getIntValuesSV();
-        for (int i = 0; i < length; i++) {
-          setIntValueForGroup(groupByResultHolder, groupKeyArray[i], intValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setIntValueForGroup(groupByResultHolder, groupKeyArray[i], intValues[i]);
+          }
+        });
         break;
       case LONG:
         long[] longValues = blockValSet.getLongValuesSV();
-        for (int i = 0; i < length; i++) {
-          setLongValueForGroup(groupByResultHolder, groupKeyArray[i], longValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setLongValueForGroup(groupByResultHolder, groupKeyArray[i], longValues[i]);
+          }
+        });
         break;
       case FLOAT:
         float[] floatValues = blockValSet.getFloatValuesSV();
-        for (int i = 0; i < length; i++) {
-          setFloatValueForGroup(groupByResultHolder, groupKeyArray[i], floatValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setFloatValueForGroup(groupByResultHolder, groupKeyArray[i], floatValues[i]);
+          }
+        });
         break;
       case DOUBLE:
         double[] doubleValues = blockValSet.getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
-          setDoubleValueForGroup(groupByResultHolder, groupKeyArray[i], doubleValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setDoubleValueForGroup(groupByResultHolder, groupKeyArray[i], doubleValues[i]);
+          }
+        });
         break;
       case STRING:
         String[] stringValues = blockValSet.getStringValuesSV();
-        for (int i = 0; i < length; i++) {
-          setStringValueForGroup(groupByResultHolder, groupKeyArray[i], stringValues[i]);
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setStringValueForGroup(groupByResultHolder, groupKeyArray[i], stringValues[i]);
+          }
+        });
         break;
       case BYTES:
         byte[][] bytesValues = blockValSet.getBytesValuesSV();
-        for (int i = 0; i < length; i++) {
-          setBytesValueForGroup(groupByResultHolder, groupKeyArray[i], new ByteArray(bytesValues[i]));
-        }
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            setBytesValueForGroup(groupByResultHolder, groupKeyArray[i], new ByteArray(bytesValues[i]));
+          }
+        });
         break;
       default:
         throw new IllegalStateException(
@@ -338,11 +381,13 @@ public class SegmentPartitionedDistinctCountAggregationFunction extends BaseSing
     // For dictionary-encoded expression, store dictionary ids into a RoaringBitmap
     if (blockValSet.isDictionaryEncoded()) {
       int[][] dictIds = blockValSet.getDictionaryIdsMV();
-      for (int i = 0; i < length; i++) {
-        for (int dictId : dictIds[i]) {
-          setIntValueForGroup(groupByResultHolder, groupKeyArray[i], dictId);
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          for (int dictId : dictIds[i]) {
+            setIntValueForGroup(groupByResultHolder, groupKeyArray[i], dictId);
+          }
         }
-      }
+      });
       return;
     }
 
@@ -351,51 +396,63 @@ public class SegmentPartitionedDistinctCountAggregationFunction extends BaseSing
     switch (storedType) {
       case INT:
         int[][] intValues = blockValSet.getIntValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (int value : intValues[i]) {
-            setIntValueForGroup(groupByResultHolder, groupKeyArray[i], value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int value : intValues[i]) {
+              setIntValueForGroup(groupByResultHolder, groupKeyArray[i], value);
+            }
           }
-        }
+        });
         break;
       case LONG:
         long[][] longValues = blockValSet.getLongValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (long value : longValues[i]) {
-            setLongValueForGroup(groupByResultHolder, groupKeyArray[i], value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (long value : longValues[i]) {
+              setLongValueForGroup(groupByResultHolder, groupKeyArray[i], value);
+            }
           }
-        }
+        });
         break;
       case FLOAT:
         float[][] floatValues = blockValSet.getFloatValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (float value : floatValues[i]) {
-            setFloatValueForGroup(groupByResultHolder, groupKeyArray[i], value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (float value : floatValues[i]) {
+              setFloatValueForGroup(groupByResultHolder, groupKeyArray[i], value);
+            }
           }
-        }
+        });
         break;
       case DOUBLE:
         double[][] doubleValues = blockValSet.getDoubleValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (double value : doubleValues[i]) {
-            setDoubleValueForGroup(groupByResultHolder, groupKeyArray[i], value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (double value : doubleValues[i]) {
+              setDoubleValueForGroup(groupByResultHolder, groupKeyArray[i], value);
+            }
           }
-        }
+        });
         break;
       case STRING:
         String[][] stringValues = blockValSet.getStringValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (String value : stringValues[i]) {
-            setStringValueForGroup(groupByResultHolder, groupKeyArray[i], value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (String value : stringValues[i]) {
+              setStringValueForGroup(groupByResultHolder, groupKeyArray[i], value);
+            }
           }
-        }
+        });
         break;
       case BYTES:
         byte[][][] bytesValues = blockValSet.getBytesValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (byte[] value : bytesValues[i]) {
-            setBytesValueForGroup(groupByResultHolder, groupKeyArray[i], new ByteArray(value));
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (byte[] value : bytesValues[i]) {
+              setBytesValueForGroup(groupByResultHolder, groupKeyArray[i], new ByteArray(value));
+            }
           }
-        }
+        });
         break;
       default:
         throw new IllegalStateException(
@@ -419,12 +476,14 @@ public class SegmentPartitionedDistinctCountAggregationFunction extends BaseSing
     // For dictionary-encoded expression, store dictionary ids into a RoaringBitmap
     if (blockValSet.isDictionaryEncoded()) {
       int[] dictIds = blockValSet.getDictionaryIdsSV();
-      for (int i = 0; i < length; i++) {
-        int dictId = dictIds[i];
-        for (int groupKey : groupKeysArray[i]) {
-          setIntValueForGroup(groupByResultHolder, groupKey, dictId);
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          int dictId = dictIds[i];
+          for (int groupKey : groupKeysArray[i]) {
+            setIntValueForGroup(groupByResultHolder, groupKey, dictId);
+          }
         }
-      }
+      });
       return;
     }
 
@@ -433,57 +492,69 @@ public class SegmentPartitionedDistinctCountAggregationFunction extends BaseSing
     switch (storedType) {
       case INT:
         int[] intValues = blockValSet.getIntValuesSV();
-        for (int i = 0; i < length; i++) {
-          int value = intValues[i];
-          for (int groupKey : groupKeysArray[i]) {
-            setIntValueForGroup(groupByResultHolder, groupKey, value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            int value = intValues[i];
+            for (int groupKey : groupKeysArray[i]) {
+              setIntValueForGroup(groupByResultHolder, groupKey, value);
+            }
           }
-        }
+        });
         break;
       case LONG:
         long[] longValues = blockValSet.getLongValuesSV();
-        for (int i = 0; i < length; i++) {
-          long value = longValues[i];
-          for (int groupKey : groupKeysArray[i]) {
-            setLongValueForGroup(groupByResultHolder, groupKey, value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            long value = longValues[i];
+            for (int groupKey : groupKeysArray[i]) {
+              setLongValueForGroup(groupByResultHolder, groupKey, value);
+            }
           }
-        }
+        });
         break;
       case FLOAT:
         float[] floatValues = blockValSet.getFloatValuesSV();
-        for (int i = 0; i < length; i++) {
-          float value = floatValues[i];
-          for (int groupKey : groupKeysArray[i]) {
-            setFloatValueForGroup(groupByResultHolder, groupKey, value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            float value = floatValues[i];
+            for (int groupKey : groupKeysArray[i]) {
+              setFloatValueForGroup(groupByResultHolder, groupKey, value);
+            }
           }
-        }
+        });
         break;
       case DOUBLE:
         double[] doubleValues = blockValSet.getDoubleValuesSV();
-        for (int i = 0; i < length; i++) {
-          double value = doubleValues[i];
-          for (int groupKey : groupKeysArray[i]) {
-            setDoubleValueForGroup(groupByResultHolder, groupKey, value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            double value = doubleValues[i];
+            for (int groupKey : groupKeysArray[i]) {
+              setDoubleValueForGroup(groupByResultHolder, groupKey, value);
+            }
           }
-        }
+        });
         break;
       case STRING:
         String[] stringValues = blockValSet.getStringValuesSV();
-        for (int i = 0; i < length; i++) {
-          String value = stringValues[i];
-          for (int groupKey : groupKeysArray[i]) {
-            setStringValueForGroup(groupByResultHolder, groupKey, value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            String value = stringValues[i];
+            for (int groupKey : groupKeysArray[i]) {
+              setStringValueForGroup(groupByResultHolder, groupKey, value);
+            }
           }
-        }
+        });
         break;
       case BYTES:
         byte[][] bytesValues = blockValSet.getBytesValuesSV();
-        for (int i = 0; i < length; i++) {
-          ByteArray value = new ByteArray(bytesValues[i]);
-          for (int groupKey : groupKeysArray[i]) {
-            setBytesValueForGroup(groupByResultHolder, groupKey, value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            ByteArray value = new ByteArray(bytesValues[i]);
+            for (int groupKey : groupKeysArray[i]) {
+              setBytesValueForGroup(groupByResultHolder, groupKey, value);
+            }
           }
-        }
+        });
         break;
       default:
         throw new IllegalStateException(
@@ -496,14 +567,16 @@ public class SegmentPartitionedDistinctCountAggregationFunction extends BaseSing
     // For dictionary-encoded expression, store dictionary ids into a RoaringBitmap
     if (blockValSet.isDictionaryEncoded()) {
       int[][] dictIds = blockValSet.getDictionaryIdsMV();
-      for (int i = 0; i < length; i++) {
-        int[] rowDictIds = dictIds[i];
-        for (int groupKey : groupKeysArray[i]) {
-          for (int dictId : rowDictIds) {
-            setIntValueForGroup(groupByResultHolder, groupKey, dictId);
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          int[] rowDictIds = dictIds[i];
+          for (int groupKey : groupKeysArray[i]) {
+            for (int dictId : rowDictIds) {
+              setIntValueForGroup(groupByResultHolder, groupKey, dictId);
+            }
           }
         }
-      }
+      });
       return;
     }
 
@@ -512,69 +585,81 @@ public class SegmentPartitionedDistinctCountAggregationFunction extends BaseSing
     switch (storedType) {
       case INT:
         int[][] intValues = blockValSet.getIntValuesMV();
-        for (int i = 0; i < length; i++) {
-          int[] intRow = intValues[i];
-          for (int groupKey : groupKeysArray[i]) {
-            for (int value : intRow) {
-              setIntValueForGroup(groupByResultHolder, groupKey, value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            int[] intRow = intValues[i];
+            for (int groupKey : groupKeysArray[i]) {
+              for (int value : intRow) {
+                setIntValueForGroup(groupByResultHolder, groupKey, value);
+              }
             }
           }
-        }
+        });
         break;
       case LONG:
         long[][] longValues = blockValSet.getLongValuesMV();
-        for (int i = 0; i < length; i++) {
-          long[] longRow = longValues[i];
-          for (int groupKey : groupKeysArray[i]) {
-            for (long value : longRow) {
-              setLongValueForGroup(groupByResultHolder, groupKey, value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            long[] longRow = longValues[i];
+            for (int groupKey : groupKeysArray[i]) {
+              for (long value : longRow) {
+                setLongValueForGroup(groupByResultHolder, groupKey, value);
+              }
             }
           }
-        }
+        });
         break;
       case FLOAT:
         float[][] floatValues = blockValSet.getFloatValuesMV();
-        for (int i = 0; i < length; i++) {
-          float[] floatRow = floatValues[i];
-          for (int groupKey : groupKeysArray[i]) {
-            for (float value : floatRow) {
-              setFloatValueForGroup(groupByResultHolder, groupKey, value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            float[] floatRow = floatValues[i];
+            for (int groupKey : groupKeysArray[i]) {
+              for (float value : floatRow) {
+                setFloatValueForGroup(groupByResultHolder, groupKey, value);
+              }
             }
           }
-        }
+        });
         break;
       case DOUBLE:
         double[][] doubleValues = blockValSet.getDoubleValuesMV();
-        for (int i = 0; i < length; i++) {
-          double[] doubleRow = doubleValues[i];
-          for (int groupKey : groupKeysArray[i]) {
-            for (double value : doubleRow) {
-              setDoubleValueForGroup(groupByResultHolder, groupKey, value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            double[] doubleRow = doubleValues[i];
+            for (int groupKey : groupKeysArray[i]) {
+              for (double value : doubleRow) {
+                setDoubleValueForGroup(groupByResultHolder, groupKey, value);
+              }
             }
           }
-        }
+        });
         break;
       case STRING:
         String[][] stringValues = blockValSet.getStringValuesMV();
-        for (int i = 0; i < length; i++) {
-          String[] stringRow = stringValues[i];
-          for (int groupKey : groupKeysArray[i]) {
-            for (String value : stringRow) {
-              setStringValueForGroup(groupByResultHolder, groupKey, value);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            String[] stringRow = stringValues[i];
+            for (int groupKey : groupKeysArray[i]) {
+              for (String value : stringRow) {
+                setStringValueForGroup(groupByResultHolder, groupKey, value);
+              }
             }
           }
-        }
+        });
         break;
       case BYTES:
         byte[][][] bytesValues = blockValSet.getBytesValuesMV();
-        for (int i = 0; i < length; i++) {
-          for (byte[] value : bytesValues[i]) {
-            ByteArray byteArray = new ByteArray(value);
-            for (int groupKey : groupKeysArray[i]) {
-              setBytesValueForGroup(groupByResultHolder, groupKey, byteArray);
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (byte[] value : bytesValues[i]) {
+              ByteArray byteArray = new ByteArray(value);
+              for (int groupKey : groupKeysArray[i]) {
+                setBytesValueForGroup(groupByResultHolder, groupKey, byteArray);
+              }
             }
           }
-        }
+        });
         break;
       default:
         throw new IllegalStateException(

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/SyntheticBlockValSets.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/SyntheticBlockValSets.java
@@ -439,6 +439,44 @@ public class SyntheticBlockValSets {
     }
   }
 
+  /// A simple [BlockValSet] for nullable, not dictionary-encoded multi-value string values.
+  public static class StrMV extends Base {
+
+    @Nullable
+    final RoaringBitmap _nullBitmap;
+    final String[][] _values;
+
+    private StrMV(@Nullable RoaringBitmap nullBitmap, String[][] values) {
+      _nullBitmap = nullBitmap;
+      _values = values;
+    }
+
+    public static StrMV create(@Nullable RoaringBitmap nullBitmap, String[][] values) {
+      return new StrMV(nullBitmap, values);
+    }
+
+    @Nullable
+    @Override
+    public RoaringBitmap getNullBitmap() {
+      return _nullBitmap;
+    }
+
+    @Override
+    public DataType getValueType() {
+      return DataType.STRING;
+    }
+
+    @Override
+    public boolean isSingleValue() {
+      return false;
+    }
+
+    @Override
+    public String[][] getStringValuesMV() {
+      return _values;
+    }
+  }
+
   /// A simple [BlockValSet] for nullable, not dictionary-encoded byte array values.
   public static class Bytes extends Base {
 
@@ -482,6 +520,44 @@ public class SyntheticBlockValSets {
 
     @Override
     public byte[][] getBytesValuesSV() {
+      return _values;
+    }
+  }
+
+  /// A simple [BlockValSet] for nullable, not dictionary-encoded multi-value byte array values.
+  public static class BytesMV extends Base {
+
+    @Nullable
+    final RoaringBitmap _nullBitmap;
+    final byte[][][] _values;
+
+    private BytesMV(@Nullable RoaringBitmap nullBitmap, byte[][][] values) {
+      _nullBitmap = nullBitmap;
+      _values = values;
+    }
+
+    public static BytesMV create(@Nullable RoaringBitmap nullBitmap, byte[][][] values) {
+      return new BytesMV(nullBitmap, values);
+    }
+
+    @Nullable
+    @Override
+    public RoaringBitmap getNullBitmap() {
+      return _nullBitmap;
+    }
+
+    @Override
+    public DataType getValueType() {
+      return DataType.BYTES;
+    }
+
+    @Override
+    public boolean isSingleValue() {
+      return false;
+    }
+
+    @Override
+    public byte[][][] getBytesValuesMV() {
       return _values;
     }
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionNullContractTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionNullContractTest.java
@@ -156,8 +156,8 @@ public class AggregationFunctionNullContractTest {
   ///
   /// Returning is not enough to prove the `null` was resolved: a function can wrap the `null` in a serializer that only
   /// dereferences it when the value is rendered, which moves the failure out of this method and into the response path.
-  /// [ColumnDataType#convert] is the step that threw in production, so it is exercised alongside `toString`; a
-  /// serializer wrapping a `null` can survive one and fail the other.
+  /// [org.apache.pinot.common.utils.DataSchema.ColumnDataType#convert] is the step that threw in production, so it is
+  /// exercised alongside `toString`; a serializer wrapping a `null` can survive one and fail the other.
   private static void render(AggregationFunction function, @Nullable Object finalResult) {
     if (finalResult != null) {
       finalResult.toString();
@@ -257,7 +257,19 @@ public class AggregationFunctionNullContractTest {
       // Given the option so they can skip null rows. These two were in this set once before, on the strength of an
       // identity comparison that reported every serializer-valued function as honouring it; they belong here now
       // because they genuinely do.
-      AggregationFunctionType.FREQUENTSTRINGSSKETCH, AggregationFunctionType.FREQUENTLONGSSKETCH
+      AggregationFunctionType.FREQUENTSTRINGSSKETCH, AggregationFunctionType.FREQUENTLONGSSKETCH,
+      // Given the option so they can skip null rows. A distinct count over nothing is 0 in every one of these, so
+      // the empty-input answer is unchanged; what changed is that a null row no longer contributes the column default.
+      AggregationFunctionType.SEGMENTPARTITIONEDDISTINCTCOUNT, AggregationFunctionType.DISTINCTCOUNTBITMAP,
+      AggregationFunctionType.DISTINCTCOUNTHLL, AggregationFunctionType.DISTINCTCOUNTRAWHLL,
+      AggregationFunctionType.DISTINCTCOUNTSMARTHLL, AggregationFunctionType.DISTINCTCOUNTHLLPLUS,
+      AggregationFunctionType.DISTINCTCOUNTRAWHLLPLUS, AggregationFunctionType.DISTINCTCOUNTSMARTHLLPLUS,
+      AggregationFunctionType.DISTINCTCOUNTULL, AggregationFunctionType.DISTINCTCOUNTRAWULL,
+      AggregationFunctionType.DISTINCTCOUNTSMARTULL, AggregationFunctionType.DISTINCTCOUNTTHETASKETCH,
+      AggregationFunctionType.DISTINCTCOUNTRAWTHETASKETCH, AggregationFunctionType.DISTINCTCOUNTCPCSKETCH,
+      AggregationFunctionType.DISTINCTCOUNTRAWCPCSKETCH, AggregationFunctionType.DISTINCTCOUNTBITMAPMV,
+      AggregationFunctionType.DISTINCTCOUNTHLLMV, AggregationFunctionType.DISTINCTCOUNTRAWHLLMV,
+      AggregationFunctionType.DISTINCTCOUNTHLLPLUSMV, AggregationFunctionType.DISTINCTCOUNTRAWHLLPLUSMV
   );
 
   /// Functions this test cannot drive with a one-column synthetic block, pinned so that a silent drop-out is always a

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountCPCSketchAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountCPCSketchAggregationFunctionTest.java
@@ -39,7 +39,7 @@ public class DistinctCountCPCSketchAggregationFunctionTest {
   @Test
   public void testCanUseStarTreeDefaultLgK() {
     DistinctCountCPCSketchAggregationFunction function =
-        new DistinctCountCPCSketchAggregationFunction(List.of(ExpressionContext.forIdentifier("col")));
+        new DistinctCountCPCSketchAggregationFunction(List.of(ExpressionContext.forIdentifier("col")), false);
 
     Assert.assertTrue(function.canUseStarTree(Map.of()));
     Assert.assertTrue(function.canUseStarTree(Map.of(Constants.CPCSKETCH_LGK_KEY, "12")));
@@ -47,7 +47,7 @@ public class DistinctCountCPCSketchAggregationFunctionTest {
     Assert.assertFalse(function.canUseStarTree(Map.of(Constants.CPCSKETCH_LGK_KEY, 11)));
 
     function = new DistinctCountCPCSketchAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col"), ExpressionContext.forLiteral(Literal.intValue(12))));
+        List.of(ExpressionContext.forIdentifier("col"), ExpressionContext.forLiteral(Literal.intValue(12))), false);
 
     Assert.assertTrue(function.canUseStarTree(Map.of()));
     Assert.assertTrue(function.canUseStarTree(Map.of(Constants.CPCSKETCH_LGK_KEY, "12")));
@@ -59,7 +59,7 @@ public class DistinctCountCPCSketchAggregationFunctionTest {
   public void testCanUseCustomLgK() {
     DistinctCountCPCSketchAggregationFunction function = new DistinctCountCPCSketchAggregationFunction(
         List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(Literal.stringValue("nominalEntries=8192"))));
+            ExpressionContext.forLiteral(Literal.stringValue("nominalEntries=8192"))), false);
 
     // Default lgK = 12 / K=4096
     Assert.assertFalse(function.canUseStarTree(Map.of()));
@@ -74,7 +74,7 @@ public class DistinctCountCPCSketchAggregationFunctionTest {
   @Test
   public void testEmptyResultProducesConvertibleFinalResult() {
     DistinctCountCPCSketchAggregationFunction function =
-        new DistinctCountCPCSketchAggregationFunction(List.of(ExpressionContext.forIdentifier("col")));
+        new DistinctCountCPCSketchAggregationFunction(List.of(ExpressionContext.forIdentifier("col")), false);
 
     AggregationResultHolder holder = function.createAggregationResultHolder();
     CpcSketchAccumulator accumulator = function.extractAggregationResult(holder);
@@ -92,7 +92,7 @@ public class DistinctCountCPCSketchAggregationFunctionTest {
   @Test
   public void testEmptyResultProducesConvertibleRawFinalResult() {
     DistinctCountRawCPCSketchAggregationFunction function =
-        new DistinctCountRawCPCSketchAggregationFunction(List.of(ExpressionContext.forIdentifier("col")));
+        new DistinctCountRawCPCSketchAggregationFunction(List.of(ExpressionContext.forIdentifier("col")), false);
 
     AggregationResultHolder holder = function.createAggregationResultHolder();
     CpcSketchAccumulator accumulator = function.extractAggregationResult(holder);
@@ -117,7 +117,7 @@ public class DistinctCountCPCSketchAggregationFunctionTest {
   @Test
   public void testMergeWithEmptyAccumulators() {
     DistinctCountCPCSketchAggregationFunction function =
-        new DistinctCountCPCSketchAggregationFunction(List.of(ExpressionContext.forIdentifier("col")));
+        new DistinctCountCPCSketchAggregationFunction(List.of(ExpressionContext.forIdentifier("col")), false);
 
     CpcSketchAccumulator empty1 = new CpcSketchAccumulator(12, 2);
     CpcSketchAccumulator empty2 = new CpcSketchAccumulator(12, 2);

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunctionTest.java
@@ -39,7 +39,7 @@ public class DistinctCountHLLAggregationFunctionTest {
   @Test
   public void testCanUseStarTreeDefaultLog2m() {
     DistinctCountHLLAggregationFunction function = new DistinctCountHLLAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col")));
+        List.of(ExpressionContext.forIdentifier("col")), false);
 
     Assert.assertTrue(function.canUseStarTree(Map.of()));
     Assert.assertTrue(function.canUseStarTree(Map.of(Constants.HLL_LOG2M_KEY, "8")));
@@ -47,7 +47,7 @@ public class DistinctCountHLLAggregationFunctionTest {
     Assert.assertFalse(function.canUseStarTree(Map.of(Constants.HLL_LOG2M_KEY, 16)));
 
     function = new DistinctCountHLLAggregationFunction(List.of(ExpressionContext.forIdentifier("col"),
-        ExpressionContext.forLiteral(Literal.stringValue("8"))));
+        ExpressionContext.forLiteral(Literal.stringValue("8"))), false);
 
     Assert.assertTrue(function.canUseStarTree(Map.of()));
     Assert.assertTrue(function.canUseStarTree(Map.of(Constants.HLL_LOG2M_KEY, "8")));
@@ -58,7 +58,7 @@ public class DistinctCountHLLAggregationFunctionTest {
   @Test
   public void testCanUseStarTreeCustomLog2m() {
     DistinctCountHLLAggregationFunction function = new DistinctCountHLLAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col"), ExpressionContext.forLiteral(Literal.intValue(16))));
+        List.of(ExpressionContext.forIdentifier("col"), ExpressionContext.forLiteral(Literal.intValue(16))), false);
 
     Assert.assertFalse(function.canUseStarTree(Map.of()));
     Assert.assertFalse(function.canUseStarTree(Map.of(Constants.HLL_LOG2M_KEY, "8")));
@@ -86,7 +86,7 @@ public class DistinctCountHLLAggregationFunctionTest {
     ObjectAggregationResultHolder holder = new ObjectAggregationResultHolder();
     DistinctCountHLLAggregationFunction function = new DistinctCountHLLAggregationFunction(
         List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(Literal.intValue(12))));
+            ExpressionContext.forLiteral(Literal.intValue(12))), false);
 
     BitSet bitSet = DistinctCountHLLAggregationFunction.getDictIdBitSet(holder, dictionary);
     for (int dictId : dictIds) {
@@ -119,7 +119,7 @@ public class DistinctCountHLLAggregationFunctionTest {
     ObjectAggregationResultHolder holder = new ObjectAggregationResultHolder();
     DistinctCountHLLAggregationFunction function = new DistinctCountHLLAggregationFunction(
         List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(Literal.intValue(14))));
+            ExpressionContext.forLiteral(Literal.intValue(14))), false);
 
     BitSet bitSet = DistinctCountHLLAggregationFunction.getDictIdBitSet(holder, dictionary);
     for (int dictId : dictIds) {
@@ -146,7 +146,7 @@ public class DistinctCountHLLAggregationFunctionTest {
     ObjectAggregationResultHolder holder = new ObjectAggregationResultHolder();
     DistinctCountHLLAggregationFunction function = new DistinctCountHLLAggregationFunction(
         List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(Literal.intValue(12))));
+            ExpressionContext.forLiteral(Literal.intValue(12))), false);
 
     // Batch 1: dict IDs 0–99
     int[] batch1 = new int[100];

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLPlusAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLPlusAggregationFunctionTest.java
@@ -32,7 +32,7 @@ public class DistinctCountHLLPlusAggregationFunctionTest {
   @Test
   public void testCanUseStarTreeDefaultP() {
     DistinctCountHLLPlusAggregationFunction function = new DistinctCountHLLPlusAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col")));
+        List.of(ExpressionContext.forIdentifier("col")), false);
 
     Assert.assertTrue(function.canUseStarTree(Map.of()));
     Assert.assertTrue(function.canUseStarTree(Map.of(Constants.HLLPLUS_ULL_P_KEY, "14")));
@@ -40,7 +40,7 @@ public class DistinctCountHLLPlusAggregationFunctionTest {
     Assert.assertFalse(function.canUseStarTree(Map.of(Constants.HLLPLUS_ULL_P_KEY, 16)));
 
     function = new DistinctCountHLLPlusAggregationFunction(List.of(ExpressionContext.forIdentifier("col"),
-        ExpressionContext.forLiteral(Literal.stringValue("14"))));
+        ExpressionContext.forLiteral(Literal.stringValue("14"))), false);
 
     Assert.assertTrue(function.canUseStarTree(Map.of()));
     Assert.assertTrue(function.canUseStarTree(Map.of(Constants.HLLPLUS_ULL_P_KEY, "14")));
@@ -49,7 +49,7 @@ public class DistinctCountHLLPlusAggregationFunctionTest {
 
     // sp value isn't checked
     function = new DistinctCountHLLPlusAggregationFunction(List.of(ExpressionContext.forIdentifier("col"),
-        ExpressionContext.forLiteral(Literal.intValue(14)), ExpressionContext.forLiteral(Literal.intValue(20))));
+        ExpressionContext.forLiteral(Literal.intValue(14)), ExpressionContext.forLiteral(Literal.intValue(20))), false);
 
     Assert.assertTrue(function.canUseStarTree(Map.of()));
     Assert.assertTrue(function.canUseStarTree(Map.of(Constants.HLLPLUS_ULL_P_KEY, "14")));
@@ -60,7 +60,7 @@ public class DistinctCountHLLPlusAggregationFunctionTest {
   @Test
   public void testCanUseStarTreeCustomP() {
     DistinctCountHLLPlusAggregationFunction function = new DistinctCountHLLPlusAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col"), ExpressionContext.forLiteral(Literal.intValue(16))));
+        List.of(ExpressionContext.forIdentifier("col"), ExpressionContext.forLiteral(Literal.intValue(16))), false);
 
     Assert.assertFalse(function.canUseStarTree(Map.of()));
     Assert.assertFalse(function.canUseStarTree(Map.of(Constants.HLLPLUS_ULL_P_KEY, "8")));

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSketchNullHandlingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSketchNullHandlingTest.java
@@ -1,0 +1,279 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import com.clearspring.analytics.stream.cardinality.HyperLogLog;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.datasketches.cpc.CpcSketch;
+import org.apache.datasketches.theta.UpdatableThetaSketch;
+import org.apache.pinot.common.request.Literal;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
+import org.apache.pinot.core.common.SyntheticBlockValSets;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.roaringbitmap.RoaringBitmap;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+/// Null handling for the sketch-backed distinct counts, across the paths [AggregationFunctionNullContractTest]
+/// cannot reach.
+///
+/// That harness drives one synthetic single-value block through `aggregate` only, so the group-by paths, the
+/// multi-value column paths, and the serialized-sketch input are checked nowhere else. The `BYTES` value cases are
+/// newer still — they arrived with UUID support and treat `BYTES` as a value to hash rather than as a serialized
+/// sketch, which is a different branch from the logical-`BYTES` one.
+public class DistinctCountSketchNullHandlingTest {
+  private static final ExpressionContext COLUMN = ExpressionContext.forIdentifier("column");
+  private static final int NUM_DOCS = 4;
+  private static final long[] VALUES = {10L, 20L, 30L, 40L};
+
+  private static DistinctCountHLLAggregationFunction hll(boolean nullHandlingEnabled) {
+    return new DistinctCountHLLAggregationFunction(List.of(COLUMN), nullHandlingEnabled);
+  }
+
+  private static Map<ExpressionContext, BlockValSet> longBlock(@Nullable RoaringBitmap nullBitmap) {
+    return Map.of(COLUMN, SyntheticBlockValSets.Long.create(nullBitmap, VALUES));
+  }
+
+  private static RoaringBitmap allNull() {
+    RoaringBitmap bitmap = new RoaringBitmap();
+    bitmap.add(0L, NUM_DOCS);
+    return bitmap;
+  }
+
+  private static long aggregate(DistinctCountHLLAggregationFunction function, int length,
+      Map<ExpressionContext, BlockValSet> block) {
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    function.aggregate(length, resultHolder, block);
+    return function.extractFinalResult(function.extractAggregationResult(resultHolder));
+  }
+
+  /// Only the rows that carry a value are counted.
+  @Test
+  public void testNullRowsAreSkipped() {
+    assertEquals(aggregate(hll(true), NUM_DOCS, longBlock(RoaringBitmap.bitmapOf(1, 3))), 2L);
+  }
+
+  /// With the option disabled every row counts, including the column default the null rows read as. That is the
+  /// answer this mode has always given.
+  @Test
+  public void testNullRowsCountedWhenOptionDisabled() {
+    assertEquals(aggregate(hll(false), NUM_DOCS, longBlock(RoaringBitmap.bitmapOf(1, 3))), 4L);
+  }
+
+  /// A distinct count over nothing is zero in both modes, so the empty answer is unchanged by this work.
+  @Test
+  public void testEveryRowNullCountsZero() {
+    assertEquals(aggregate(hll(true), NUM_DOCS, longBlock(allNull())), 0L);
+    assertEquals(hll(true).extractFinalResult(null).longValue(), 0L);
+    assertEquals(hll(false).extractFinalResult(null).longValue(), 0L);
+  }
+
+  /// A zero-length block still reaches the range callback, and must not aggregate anything.
+  @Test
+  public void testZeroLengthBlockCountsZero() {
+    assertEquals(aggregate(hll(true), 0, longBlock(null)), 0L);
+  }
+
+  /// The group-by path skips null rows per group, and a group whose every row is null stays empty.
+  @Test
+  public void testGroupBySVSkipsNullRows() {
+    DistinctCountHLLAggregationFunction function = hll(true);
+    GroupByResultHolder resultHolder = new ObjectGroupByResultHolder(4, 4);
+    // Rows 0 and 2 go to group 0, rows 1 and 3 to group 1; rows 1 and 3 are null, so group 1 gets nothing
+    function.aggregateGroupBySV(NUM_DOCS, new int[]{0, 1, 0, 1}, resultHolder,
+        longBlock(RoaringBitmap.bitmapOf(1, 3)));
+
+    assertEquals(function.extractFinalResult(function.extractGroupByResult(resultHolder, 0)).longValue(), 2L);
+    assertEquals(function.extractFinalResult(function.extractGroupByResult(resultHolder, 1)).longValue(), 0L);
+  }
+
+  /// A null row is skipped for every group key it would have fed, not just the first.
+  @Test
+  public void testGroupByMVSkipsNullRowsForAllKeys() {
+    DistinctCountHLLAggregationFunction function = hll(true);
+    GroupByResultHolder resultHolder = new ObjectGroupByResultHolder(4, 4);
+    int[][] groupKeys = {{0, 1}, {0, 1}, {0, 1}, {0, 1}};
+    function.aggregateGroupByMV(NUM_DOCS, groupKeys, resultHolder, longBlock(RoaringBitmap.bitmapOf(1, 3)));
+
+    assertEquals(function.extractFinalResult(function.extractGroupByResult(resultHolder, 0)).longValue(), 2L);
+    assertEquals(function.extractFinalResult(function.extractGroupByResult(resultHolder, 1)).longValue(), 2L);
+  }
+
+  /// A serialized sketch column is deserialized and merged only for the rows that carry one. This is the logical
+  /// `BYTES` branch, which is distinct from the `BYTES` value case below.
+  @Test
+  public void testSerializedSketchRowsMergedOnlyWhenNotNull() throws Exception {
+    HyperLogLog first = new HyperLogLog(8);
+    first.offer("a");
+    HyperLogLog second = new HyperLogLog(8);
+    second.offer("b");
+    byte[][] serialized = {
+        ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.serialize(first),
+        ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.serialize(second)
+    };
+
+    DistinctCountHLLAggregationFunction function = hll(true);
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    function.aggregate(2, resultHolder,
+        Map.of(COLUMN, SyntheticBlockValSets.Bytes.create(RoaringBitmap.bitmapOf(1), serialized)));
+
+    // Only the first sketch was merged, so its single distinct value is the whole answer
+    assertEquals(function.extractFinalResult(function.extractAggregationResult(resultHolder)).longValue(), 1L);
+  }
+
+  /// A multi-value column contributes every value of a non-null row and nothing at all from a null row.
+  @Test
+  public void testMVColumnSkipsNullRows() {
+    long[][] values = {{1L, 2L}, {3L, 4L}, {5L, 6L}, {7L, 8L}};
+    DistinctCountHLLAggregationFunction function = hll(true);
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    function.aggregate(NUM_DOCS, resultHolder,
+        Map.of(COLUMN, SyntheticBlockValSets.LongMV.create(RoaringBitmap.bitmapOf(1, 3), values)));
+
+    // Rows 0 and 2 survive, contributing 1, 2, 5 and 6
+    assertEquals(function.extractFinalResult(function.extractAggregationResult(resultHolder)).longValue(), 4L);
+  }
+
+  /// A serialized CPC sketch column merges only the rows that carry one.
+  ///
+  /// The `bytes.length > 0` test inside `deserializeSketches` makes an empty default look skipped, but that is
+  /// incidental: a column with a non-empty `defaultNullValue` deserializes into a real sketch, so the null row has to
+  /// be excluded by the null bitmap rather than by the payload happening to be empty.
+  @Test
+  public void testCpcSerializedRowsMergedOnlyWhenNotNull() {
+    CpcSketch first = new CpcSketch(12);
+    first.update("a");
+    CpcSketch second = new CpcSketch(12);
+    second.update("b");
+    byte[][] serialized = {first.toByteArray(), second.toByteArray()};
+
+    DistinctCountCPCSketchAggregationFunction function =
+        new DistinctCountCPCSketchAggregationFunction(List.of(COLUMN), true);
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    function.aggregate(2, resultHolder,
+        Map.of(COLUMN, SyntheticBlockValSets.Bytes.create(RoaringBitmap.bitmapOf(1), serialized)));
+
+    assertEquals(((Number) function.extractFinalResult(function.extractAggregationResult(resultHolder))).longValue(),
+        1L);
+  }
+
+  /// The default sketch of `DISTINCTCOUNTTHETASKETCH` folds in only the rows that carry a value.
+  ///
+  /// Without a filter predicate this is the whole aggregation, and it is a separate loop from the filtered one, so a
+  /// plain `DISTINCTCOUNTTHETASKETCH(sketchColumn)` is the path that this covers.
+  @Test
+  public void testThetaDefaultSketchMergesOnlyNotNullRows() {
+    UpdatableThetaSketch first = UpdatableThetaSketch.builder().build();
+    first.update("a");
+    UpdatableThetaSketch second = UpdatableThetaSketch.builder().build();
+    second.update("b");
+    byte[][] serialized = {first.compact().toByteArray(), second.compact().toByteArray()};
+
+    DistinctCountThetaSketchAggregationFunction function =
+        new DistinctCountThetaSketchAggregationFunction(List.of(COLUMN), true);
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    function.aggregate(2, resultHolder,
+        Map.of(COLUMN, SyntheticBlockValSets.Bytes.create(RoaringBitmap.bitmapOf(1), serialized)));
+
+    assertEquals(((Number) function.extractFinalResult(function.extractAggregationResult(resultHolder))).longValue(),
+        1L);
+  }
+
+  /// A null row is never deserialized, so its payload does not have to be a valid sketch.
+  ///
+  /// The default for a `BYTES` column is an empty array, which `ThetaSketch.wrap` cannot read. Deserializing the whole
+  /// block up front meant that default was wrapped before any filtering could skip the row.
+  @Test
+  public void testThetaNullRowWithEmptyDefaultIsNotDeserialized() {
+    UpdatableThetaSketch present = UpdatableThetaSketch.builder().build();
+    present.update("a");
+    // Row 1 is null and carries the BYTES default rather than a sketch
+    byte[][] serialized = {present.compact().toByteArray(), new byte[0]};
+
+    DistinctCountThetaSketchAggregationFunction function =
+        new DistinctCountThetaSketchAggregationFunction(List.of(COLUMN), true);
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    function.aggregate(2, resultHolder,
+        Map.of(COLUMN, SyntheticBlockValSets.Bytes.create(RoaringBitmap.bitmapOf(1), serialized)));
+
+    assertEquals(((Number) function.extractFinalResult(function.extractAggregationResult(resultHolder))).longValue(),
+        1L);
+  }
+
+  /// A multi-value `BYTES` column carries values to hash, not serialized sketches.
+  ///
+  /// The serialized-sketch branch reads the single-value representation, so it has to be reached only when the column
+  /// is single-value; a multi-value `BYTES` column belongs on the value path with the other multi-value types.
+  @Test
+  public void testThetaMultiValueBytesColumnIsTreatedAsValues() {
+    byte[][][] rows = {
+        {new byte[]{1}, new byte[]{2}},
+        {new byte[]{3}, new byte[]{4}}
+    };
+
+    DistinctCountThetaSketchAggregationFunction function =
+        new DistinctCountThetaSketchAggregationFunction(List.of(COLUMN), true);
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    // Row 1 is null, so only the two values of row 0 are counted
+    function.aggregate(2, resultHolder,
+        Map.of(COLUMN, SyntheticBlockValSets.BytesMV.create(RoaringBitmap.bitmapOf(1), rows)));
+
+    assertEquals(((Number) function.extractFinalResult(function.extractAggregationResult(resultHolder))).longValue(),
+        2L);
+  }
+
+  /// A filtered `DISTINCTCOUNTTHETASKETCH` grouped by a multi-value column merges the sketch of the row it is on.
+  ///
+  /// A null row leaves a hole in the deserialized array, so reading that array at anything other than the row index
+  /// can land on the hole. `CustomObjectAccumulator.apply` opens with a null check, which turns the wrong answer into
+  /// a crash on `DISTINCTCOUNTTHETASKETCH(sketchCol, params, predicate, '$1') ... GROUP BY mvCol`.
+  @Test
+  public void testThetaFilteredGroupByMVMergesTheSketchOfItsOwnRow() {
+    UpdatableThetaSketch present = UpdatableThetaSketch.builder().build();
+    present.update("a");
+    // Row 0 is null and carries the BYTES default, so its slot in the deserialized array stays empty
+    byte[][] serialized = {new byte[0], present.compact().toByteArray()};
+
+    ExpressionContext filterColumn = ExpressionContext.forIdentifier("dim");
+    DistinctCountThetaSketchAggregationFunction function = new DistinctCountThetaSketchAggregationFunction(
+        List.of(COLUMN, ExpressionContext.forLiteral(Literal.stringValue("nominalEntries=4096")),
+            ExpressionContext.forLiteral(Literal.stringValue("dim = 1")),
+            ExpressionContext.forLiteral(Literal.stringValue("$1"))), true);
+
+    GroupByResultHolder resultHolder = new ObjectGroupByResultHolder(2, 2);
+    // The predicate matches both rows; row 0 belongs to group 0 and row 1 to group 1
+    function.aggregateGroupByMV(2, new int[][]{{0}, {1}}, resultHolder,
+        Map.of(COLUMN, SyntheticBlockValSets.Bytes.create(RoaringBitmap.bitmapOf(0), serialized),
+            filterColumn, SyntheticBlockValSets.Int.create(null, new int[]{1, 1})));
+
+    assertEquals(((Number) function.extractFinalResult(function.extractGroupByResult(resultHolder, 1))).longValue(),
+        1L);
+    // Group 0 saw only the null row, so nothing was ever accumulated for it
+    assertEquals(((Number) function.extractFinalResult(function.extractGroupByResult(resultHolder, 0))).longValue(),
+        0L);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartHLLAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartHLLAggregationFunctionTest.java
@@ -39,67 +39,72 @@ public class DistinctCountSmartHLLAggregationFunctionTest {
   public void testParameterParsing() {
     // Test default values
     DistinctCountSmartHLLAggregationFunction function = new DistinctCountSmartHLLAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col")));
+        List.of(ExpressionContext.forIdentifier("col")), false);
     assertEquals(function.getThreshold(), 100_000);
     assertEquals(function.getDictIdCardinalityThreshold(), 100_000);
 
     // Test individual parameters
     function = new DistinctCountSmartHLLAggregationFunction(
         List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "threshold=50000")));
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "threshold=50000")), false);
     assertEquals(function.getThreshold(), 50_000);
     assertEquals(function.getDictIdCardinalityThreshold(), 100_000);
 
     function = new DistinctCountSmartHLLAggregationFunction(
         List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "log2m=8")));
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "log2m=8")), false);
     assertEquals(function.getThreshold(), 100_000);
     assertEquals(function.getDictIdCardinalityThreshold(), 100_000);
 
     function = new DistinctCountSmartHLLAggregationFunction(
         List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=50000")));
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=50000")), false);
     assertEquals(function.getThreshold(), 100_000);
     assertEquals(function.getDictIdCardinalityThreshold(), 50_000);
 
     // Test disabled dictThreshold (non-positive values)
     function = new DistinctCountSmartHLLAggregationFunction(
         List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=-1")));
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=-1")), false);
     assertEquals(function.getDictIdCardinalityThreshold(), Integer.MAX_VALUE);
 
     function = new DistinctCountSmartHLLAggregationFunction(
         List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=0")));
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=0")), false);
     assertEquals(function.getDictIdCardinalityThreshold(), Integer.MAX_VALUE);
 
     // Test multiple parameters together
     function = new DistinctCountSmartHLLAggregationFunction(
         List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "threshold=200000;log2m=10;dictThreshold=150000")));
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING,
+                "threshold=200000;log2m=10;dictThreshold=150000")), false);
     assertEquals(function.getThreshold(), 200_000);
     assertEquals(function.getDictIdCardinalityThreshold(), 150_000);
 
     // Test parameter order independence
     DistinctCountSmartHLLAggregationFunction function1 = new DistinctCountSmartHLLAggregationFunction(
         List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=50000;threshold=100000;log2m=8")));
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=50000;threshold=100000;log2m=8")),
+                false);
     DistinctCountSmartHLLAggregationFunction function2 = new DistinctCountSmartHLLAggregationFunction(
         List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "log2m=8;dictThreshold=50000;threshold=100000")));
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "log2m=8;dictThreshold=50000;threshold=100000")),
+                false);
     assertEquals(function1.getThreshold(), function2.getThreshold());
     assertEquals(function1.getDictIdCardinalityThreshold(), function2.getDictIdCardinalityThreshold());
 
     // Test legacy parameter names
     function = new DistinctCountSmartHLLAggregationFunction(
         List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "hllConversionThreshold=50000;hllLog2m=10")));
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "hllConversionThreshold=50000;hllLog2m=10")),
+                false);
     assertEquals(function.getThreshold(), 50_000);
 
     // Test case-insensitive parameters
     function = new DistinctCountSmartHLLAggregationFunction(
         List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "THRESHOLD=50000;LOG2M=8;DICTTHRESHOLD=100000")));
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "THRESHOLD=50000;LOG2M=8;DICTTHRESHOLD=100000")),
+                false);
     assertEquals(function.getThreshold(), 50_000);
     assertEquals(function.getDictIdCardinalityThreshold(), 100_000);
   }
@@ -107,7 +112,7 @@ public class DistinctCountSmartHLLAggregationFunctionTest {
   @Test
   public void testFunctionMetadata() {
     DistinctCountSmartHLLAggregationFunction function = new DistinctCountSmartHLLAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col")));
+        List.of(ExpressionContext.forIdentifier("col")), false);
 
     // Test function type
     assertEquals(function.getType().getName(), "distinctCountSmartHLL");
@@ -124,7 +129,7 @@ public class DistinctCountSmartHLLAggregationFunctionTest {
   @Test
   public void testHLLOperations() {
     DistinctCountSmartHLLAggregationFunction function = new DistinctCountSmartHLLAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col")));
+        List.of(ExpressionContext.forIdentifier("col")), false);
 
     // Test merge final results (should sum)
     Integer finalResult = function.mergeFinalResult(100, 200);
@@ -158,7 +163,7 @@ public class DistinctCountSmartHLLAggregationFunctionTest {
   public void itExtractsHLLFromGroupByResultHolderWhenSketchConverted() {
     DistinctCountSmartHLLAggregationFunction function = new DistinctCountSmartHLLAggregationFunction(
         List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "threshold=5;dictThreshold=5")));
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "threshold=5;dictThreshold=5")), false);
 
     ObjectGroupByResultHolder holder = new ObjectGroupByResultHolder(10, 10);
 
@@ -181,25 +186,25 @@ public class DistinctCountSmartHLLAggregationFunctionTest {
   public void testAdaptiveConversion() {
     // Test adaptive conversion enabled by default (100K threshold)
     DistinctCountSmartHLLAggregationFunction function = new DistinctCountSmartHLLAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col")));
+        List.of(ExpressionContext.forIdentifier("col")), false);
     assertEquals(function.getDictIdCardinalityThreshold(), 100_000);
 
     // Test adaptive conversion with custom threshold
     function = new DistinctCountSmartHLLAggregationFunction(
         List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=50000")));
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=50000")), false);
     assertEquals(function.getDictIdCardinalityThreshold(), 50_000);
 
     // Test adaptive conversion disabled (Integer.MAX_VALUE)
     function = new DistinctCountSmartHLLAggregationFunction(
         List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=" + Integer.MAX_VALUE)));
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=" + Integer.MAX_VALUE)), false);
     assertEquals(function.getDictIdCardinalityThreshold(), Integer.MAX_VALUE);
 
     // Test non-positive threshold converted to Integer.MAX_VALUE (disabled)
     function = new DistinctCountSmartHLLAggregationFunction(
         List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=-1")));
+            ExpressionContext.forLiteral(FieldSpec.DataType.STRING, "dictThreshold=-1")), false);
     assertEquals(function.getDictIdCardinalityThreshold(), Integer.MAX_VALUE);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunctionTest.java
@@ -22,9 +22,16 @@ import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.request.Literal;
 import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.SyntheticBlockValSets;
+import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
 import org.apache.pinot.segment.spi.Constants;
-import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 
 public class DistinctCountThetaSketchAggregationFunctionTest {
@@ -33,25 +40,87 @@ public class DistinctCountThetaSketchAggregationFunctionTest {
   public void testCanUseStarTreeDefaultK() {
     // Default aggregation function lgK = 12 / K=4096
     DistinctCountThetaSketchAggregationFunction function =
-        new DistinctCountThetaSketchAggregationFunction(List.of(ExpressionContext.forIdentifier("col")));
+        new DistinctCountThetaSketchAggregationFunction(List.of(ExpressionContext.forIdentifier("col")), false);
 
-    Assert.assertTrue(function.canUseStarTree(Map.of()));
-    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, "4096")));
-    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 4096)));
-    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 2048)));
+    assertTrue(function.canUseStarTree(Map.of()));
+    assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, "4096")));
+    assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 4096)));
+    assertFalse(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 2048)));
   }
 
   @Test
   public void testCanUseCustomK() {
     DistinctCountThetaSketchAggregationFunction function = new DistinctCountThetaSketchAggregationFunction(
         List.of(ExpressionContext.forIdentifier("col"),
-            ExpressionContext.forLiteral(Literal.stringValue("nominalEntries=32768"))));
+            ExpressionContext.forLiteral(Literal.stringValue("nominalEntries=32768"))), false);
 
     // Default StarTree lgK = 14 / K=16384
-    Assert.assertFalse(function.canUseStarTree(Map.of()));
-    Assert.assertFalse(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, "16384")));
-    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, "65536")));
-    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 32768)));
-    Assert.assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, "32768")));
+    assertFalse(function.canUseStarTree(Map.of()));
+    assertFalse(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, "16384")));
+    assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, "65536")));
+    assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, 32768)));
+    assertTrue(function.canUseStarTree(Map.of(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, "32768")));
+  }
+
+  private static final ExpressionContext VALUE_COLUMN = ExpressionContext.forIdentifier("value");
+  private static final ExpressionContext FILTER_COLUMN = ExpressionContext.forIdentifier("dim");
+  // Row 0 goes to group 0, rows 1 and 2 to group 1
+  private static final int[][] GROUP_KEYS = {{0}, {1}, {1}};
+
+  /// Builds `DISTINCTCOUNTTHETASKETCH(value, params, 'dim = 1', '$1')`, whose only accumulator is the filtered one.
+  private static DistinctCountThetaSketchAggregationFunction filtered() {
+    return new DistinctCountThetaSketchAggregationFunction(
+        List.of(VALUE_COLUMN, ExpressionContext.forLiteral(Literal.stringValue("nominalEntries=4096")),
+            ExpressionContext.forLiteral(Literal.stringValue("dim = 1")),
+            ExpressionContext.forLiteral(Literal.stringValue("$1"))), false);
+  }
+
+  /// Every row passes the predicate, so the filter never decides which rows count - only which group they land in.
+  private static Map<ExpressionContext, BlockValSet> block(BlockValSet values) {
+    return Map.of(VALUE_COLUMN, values, FILTER_COLUMN, SyntheticBlockValSets.Int.create(null, new int[]{1, 1, 1}));
+  }
+
+  private static long groupResult(DistinctCountThetaSketchAggregationFunction function, GroupByResultHolder holder,
+      int groupKey) {
+    return ((Number) function.extractFinalResult(function.extractGroupByResult(holder, groupKey))).longValue();
+  }
+
+  /// A filtered group-by over a multi-value key column credits each row to its own group keys.
+  ///
+  /// The group keys are read per row, so reading them at anything else collapses every matching row onto one row's
+  /// groups.
+  @Test
+  public void testFilteredSVColumnGroupByMVCreditsEachRowToItsOwnGroups() {
+    DistinctCountThetaSketchAggregationFunction function = filtered();
+    GroupByResultHolder resultHolder = new ObjectGroupByResultHolder(2, 2);
+    function.aggregateGroupByMV(3, GROUP_KEYS, resultHolder,
+        block(SyntheticBlockValSets.Long.create(null, new long[]{10L, 20L, 30L})));
+
+    assertEquals(groupResult(function, resultHolder, 0), 1L);
+    assertEquals(groupResult(function, resultHolder, 1), 2L);
+  }
+
+  /// A filtered group-by over a multi-value column reads both the group keys and the values of the row it is on.
+  @Test
+  public void testFilteredMVColumnGroupByMVCreditsEachRowToItsOwnGroups() {
+    DistinctCountThetaSketchAggregationFunction function = filtered();
+    GroupByResultHolder resultHolder = new ObjectGroupByResultHolder(2, 2);
+    function.aggregateGroupByMV(3, GROUP_KEYS, resultHolder,
+        block(SyntheticBlockValSets.LongMV.create(null, new long[][]{{10L, 20L}, {30L}, {40L, 50L}})));
+
+    assertEquals(groupResult(function, resultHolder, 0), 2L);
+    assertEquals(groupResult(function, resultHolder, 1), 3L);
+  }
+
+  /// The string branch is a separate switch case from the numeric ones, with the same per-row reads.
+  @Test
+  public void testFilteredStringMVColumnGroupByMVCreditsEachRowToItsOwnGroups() {
+    DistinctCountThetaSketchAggregationFunction function = filtered();
+    GroupByResultHolder resultHolder = new ObjectGroupByResultHolder(2, 2);
+    function.aggregateGroupByMV(3, GROUP_KEYS, resultHolder,
+        block(SyntheticBlockValSets.StrMV.create(null, new String[][]{{"a", "b"}, {"c"}, {"d", "e"}})));
+
+    assertEquals(groupResult(function, resultHolder, 0), 2L);
+    assertEquals(groupResult(function, resultHolder, 1), 3L);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountULLAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/DistinctCountULLAggregationFunctionTest.java
@@ -30,6 +30,7 @@ import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder
 import org.apache.pinot.segment.spi.Constants;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.roaringbitmap.RoaringBitmap;
 import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -45,7 +46,7 @@ public class DistinctCountULLAggregationFunctionTest {
   @Test
   public void testCanUseStarTreeDefaultP() {
     DistinctCountULLAggregationFunction function = new DistinctCountULLAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col")));
+        List.of(ExpressionContext.forIdentifier("col")), false);
 
     assertTrue(function.canUseStarTree(Map.of()));
     assertTrue(function.canUseStarTree(Map.of(Constants.HLLPLUS_ULL_P_KEY, "12")));
@@ -53,7 +54,7 @@ public class DistinctCountULLAggregationFunctionTest {
     assertFalse(function.canUseStarTree(Map.of(Constants.HLLPLUS_ULL_P_KEY, 16)));
 
     function = new DistinctCountULLAggregationFunction(List.of(ExpressionContext.forIdentifier("col"),
-        ExpressionContext.forLiteral(Literal.intValue(12))));
+        ExpressionContext.forLiteral(Literal.intValue(12))), false);
 
     assertTrue(function.canUseStarTree(Map.of()));
     assertTrue(function.canUseStarTree(Map.of(Constants.HLLPLUS_ULL_P_KEY, "12")));
@@ -64,7 +65,8 @@ public class DistinctCountULLAggregationFunctionTest {
   @Test
   public void testCanUseStarTreeCustomP() {
     DistinctCountULLAggregationFunction function = new DistinctCountULLAggregationFunction(
-        List.of(ExpressionContext.forIdentifier("col"), ExpressionContext.forLiteral(Literal.stringValue("16"))));
+        List.of(ExpressionContext.forIdentifier("col"), ExpressionContext.forLiteral(Literal.stringValue("16"))),
+            false);
 
     assertFalse(function.canUseStarTree(Map.of()));
     assertFalse(function.canUseStarTree(Map.of(Constants.HLLPLUS_ULL_P_KEY, "12")));
@@ -77,7 +79,11 @@ public class DistinctCountULLAggregationFunctionTest {
   private static final long[] FLATTENED = {1L, 2L, 3L, 4L, 5L, 6L, 1L, 3L};
 
   private static DistinctCountULLAggregationFunction create() {
-    return new DistinctCountULLAggregationFunction(List.of(COLUMN));
+    return create(false);
+  }
+
+  private static DistinctCountULLAggregationFunction create(boolean nullHandlingEnabled) {
+    return new DistinctCountULLAggregationFunction(List.of(COLUMN), nullHandlingEnabled);
   }
 
   private static Map<ExpressionContext, BlockValSet> mvBlock() {
@@ -141,5 +147,29 @@ public class DistinctCountULLAggregationFunctionTest {
         Map.of(COLUMN, SyntheticBlockValSets.DictIdsMV.create(null, dictIds, dictionary, DataType.LONG)));
 
     assertEquals((long) function.extractFinalResult(function.extractAggregationResult(resultHolder)), 6L);
+  }
+
+  /// With null handling enabled, a null row of a multi-value column contributes none of its values.
+  @Test
+  public void testMVColumnSkipsNullRowsWhenNullHandlingEnabled() {
+    DistinctCountULLAggregationFunction function = create(true);
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    function.aggregate(MV_ROWS.length, resultHolder,
+        Map.of(COLUMN, SyntheticBlockValSets.LongMV.create(RoaringBitmap.bitmapOf(1, 3), MV_ROWS)));
+
+    // Rows 1 and 3 are null, so only 1, 2, 5 and 6 are counted
+    assertEquals(function.extractFinalResult(function.extractAggregationResult(resultHolder)), 4L);
+  }
+
+  /// With null handling disabled the null rows are read as the column default and still counted, which is the
+  /// answer this mode has always given.
+  @Test
+  public void testMVColumnCountsNullRowsWhenNullHandlingDisabled() {
+    DistinctCountULLAggregationFunction function = create(false);
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    function.aggregate(MV_ROWS.length, resultHolder,
+        Map.of(COLUMN, SyntheticBlockValSets.LongMV.create(RoaringBitmap.bitmapOf(1, 3), MV_ROWS)));
+
+    assertEquals(function.extractFinalResult(function.extractAggregationResult(resultHolder)), 6L);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/FrequentSketchNullHandlingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/FrequentSketchNullHandlingTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
 import java.util.Map;
+import org.apache.datasketches.frequencies.FrequentItemsSketch;
 import org.apache.datasketches.frequencies.FrequentLongsSketch;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
@@ -33,18 +34,27 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.expectThrows;
 
 
-/// Null handling and row bounding for `FREQUENTLONGSSKETCH`.
+/// Null handling and row bounding for `FREQUENTLONGSSKETCH` and `FREQUENTSTRINGSSKETCH`. A test named without a
+/// prefix covers the longs sketch, a `Strings` one covers the strings sketch.
 ///
-/// [AggregationFunctionNullContractTest] drives these functions through one synthetic block shape and only through
-/// `aggregate`, so the group-by paths and the row-bounding below are checked nowhere else.
+/// [AggregationFunctionNullContractTest] drives these functions through one synthetic single-value block and only
+/// through `aggregate`, so the group-by paths, the multi-value column paths and the row-bounding below are checked
+/// nowhere else.
 public class FrequentSketchNullHandlingTest {
   private static final ExpressionContext COLUMN = ExpressionContext.forIdentifier("column");
   private static final long[] VALUES = {10L, 20L, 30L, 40L};
+  private static final long[][] MV_ROWS = {{10L, 20L}, {30L}, {20L, 20L, 40L}};
+  private static final String[][] MV_STRING_ROWS = {{"a", "b"}, {"c"}, {"b", "b", "d"}};
 
   private static FrequentLongsSketchAggregationFunction longs(boolean nullHandlingEnabled) {
     return new FrequentLongsSketchAggregationFunction(List.of(COLUMN), nullHandlingEnabled);
+  }
+
+  private static FrequentStringsSketchAggregationFunction strings(boolean nullHandlingEnabled) {
+    return new FrequentStringsSketchAggregationFunction(List.of(COLUMN), nullHandlingEnabled);
   }
 
   private static Map<ExpressionContext, BlockValSet> block(RoaringBitmap nullBitmap, long[] values) {
@@ -58,7 +68,19 @@ public class FrequentSketchNullHandlingTest {
     return function.extractAggregationResult(resultHolder);
   }
 
+  private static Map<ExpressionContext, BlockValSet> mvBlock(RoaringBitmap nullBitmap) {
+    return Map.of(COLUMN, SyntheticBlockValSets.LongMV.create(nullBitmap, MV_ROWS));
+  }
+
+  private static Map<ExpressionContext, BlockValSet> mvStringBlock(RoaringBitmap nullBitmap) {
+    return Map.of(COLUMN, SyntheticBlockValSets.StrMV.create(nullBitmap, MV_STRING_ROWS));
+  }
+
   private static long estimate(FrequentLongsSketch sketch, long item) {
+    return sketch.getEstimate(item);
+  }
+
+  private static long estimate(FrequentItemsSketch<String> sketch, String item) {
     return sketch.getEstimate(item);
   }
 
@@ -155,5 +177,206 @@ public class FrequentSketchNullHandlingTest {
     assertNotNull(sketch);
     assertEquals(estimate(sketch, 10L), 1L);
     assertEquals(estimate(sketch, 20L), 0L);
+  }
+
+  /// Every value of a multi-value row is counted, once per occurrence.
+  @Test
+  public void testMVColumnCountsEveryValue() {
+    FrequentLongsSketchAggregationFunction function = longs(false);
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    function.aggregate(MV_ROWS.length, resultHolder, mvBlock(null));
+
+    FrequentLongsSketch sketch = function.extractAggregationResult(resultHolder);
+    assertNotNull(sketch);
+    assertEquals(estimate(sketch, 10L), 1L);
+    // 20 appears once in row 0 and twice in row 2
+    assertEquals(estimate(sketch, 20L), 3L);
+    assertEquals(estimate(sketch, 30L), 1L);
+    assertEquals(estimate(sketch, 40L), 1L);
+  }
+
+  /// A null row of a multi-value column contributes none of its values.
+  @Test
+  public void testMVColumnSkipsNullRowsWhenNullHandlingEnabled() {
+    FrequentLongsSketchAggregationFunction function = longs(true);
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    function.aggregate(MV_ROWS.length, resultHolder, mvBlock(RoaringBitmap.bitmapOf(1)));
+
+    FrequentLongsSketch sketch = function.extractAggregationResult(resultHolder);
+    assertNotNull(sketch);
+    assertEquals(estimate(sketch, 10L), 1L);
+    assertEquals(estimate(sketch, 20L), 3L);
+    assertEquals(estimate(sketch, 30L), 0L);
+    assertEquals(estimate(sketch, 40L), 1L);
+  }
+
+  /// With the option disabled the values of a null row are still counted, which is the answer this mode has always
+  /// given.
+  @Test
+  public void testMVColumnCountsNullRowsWhenNullHandlingDisabled() {
+    FrequentLongsSketchAggregationFunction function = longs(false);
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    function.aggregate(MV_ROWS.length, resultHolder, mvBlock(RoaringBitmap.bitmapOf(1)));
+
+    FrequentLongsSketch sketch = function.extractAggregationResult(resultHolder);
+    assertNotNull(sketch);
+    assertEquals(estimate(sketch, 30L), 1L);
+  }
+
+  /// The sketch is created inside the range, so a multi-value block with no non-null row leaves the holder untouched.
+  @Test
+  public void testMVColumnEveryRowNullYieldsNoIntermediateResult() {
+    RoaringBitmap allNull = new RoaringBitmap();
+    allNull.add(0L, MV_ROWS.length);
+
+    FrequentLongsSketchAggregationFunction function = longs(true);
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    function.aggregate(MV_ROWS.length, resultHolder, mvBlock(allNull));
+
+    assertNull(function.extractAggregationResult(resultHolder));
+  }
+
+  /// A zero-length multi-value block still reaches the range callback, and must not mark the holder as aggregated.
+  @Test
+  public void testMVColumnZeroLengthBlockLeavesTheHolderUntouched() {
+    FrequentLongsSketchAggregationFunction function = longs(true);
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    function.aggregate(0, resultHolder, mvBlock(null));
+
+    assertNull(function.extractAggregationResult(resultHolder));
+  }
+
+  /// Every value of a row lands in that row's group, and a group whose only row is null is never created.
+  @Test
+  public void testMVColumnGroupBySV() {
+    FrequentLongsSketchAggregationFunction function = longs(true);
+    GroupByResultHolder resultHolder = new ObjectGroupByResultHolder(2, 2);
+    // Rows 0 and 2 go to group 0; row 1 is the only row of group 1 and it is null
+    function.aggregateGroupBySV(MV_ROWS.length, new int[]{0, 1, 0}, resultHolder,
+        mvBlock(RoaringBitmap.bitmapOf(1)));
+
+    FrequentLongsSketch group0 = function.extractGroupByResult(resultHolder, 0);
+    assertNotNull(group0);
+    assertEquals(estimate(group0, 10L), 1L);
+    assertEquals(estimate(group0, 20L), 3L);
+    assertEquals(estimate(group0, 40L), 1L);
+    assertNull(function.extractGroupByResult(resultHolder, 1));
+  }
+
+  /// A row's values land in every group key that row carries, and a null row is skipped for all of its keys.
+  @Test
+  public void testMVColumnGroupByMV() {
+    FrequentLongsSketchAggregationFunction function = longs(true);
+    GroupByResultHolder resultHolder = new ObjectGroupByResultHolder(2, 2);
+    // Row 0 feeds both groups, row 1 is null, row 2 feeds group 1
+    function.aggregateGroupByMV(MV_ROWS.length, new int[][]{{0, 1}, {0, 1}, {1}}, resultHolder,
+        mvBlock(RoaringBitmap.bitmapOf(1)));
+
+    FrequentLongsSketch group0 = function.extractGroupByResult(resultHolder, 0);
+    assertNotNull(group0);
+    assertEquals(estimate(group0, 10L), 1L);
+    assertEquals(estimate(group0, 20L), 1L);
+    assertEquals(estimate(group0, 30L), 0L);
+    assertEquals(estimate(group0, 40L), 0L);
+
+    FrequentLongsSketch group1 = function.extractGroupByResult(resultHolder, 1);
+    assertNotNull(group1);
+    assertEquals(estimate(group1, 10L), 1L);
+    assertEquals(estimate(group1, 20L), 3L);
+    assertEquals(estimate(group1, 30L), 0L);
+    assertEquals(estimate(group1, 40L), 1L);
+  }
+
+  /// A multi-value `BYTES` column cannot hold a serialized sketch, and this function reads no values from `BYTES`, so
+  /// it is rejected instead of reaching the single-value serialized-sketch branch.
+  @Test
+  public void testMVBytesColumnIsRejected() {
+    byte[][][] rows = {{new byte[]{1}}, {new byte[]{2}}};
+    FrequentLongsSketchAggregationFunction function = longs(true);
+
+    IllegalStateException e = expectThrows(IllegalStateException.class,
+        () -> function.aggregate(rows.length, function.createAggregationResultHolder(),
+            Map.of(COLUMN, SyntheticBlockValSets.BytesMV.create(null, rows))));
+    assertEquals(e.getMessage(), "FREQUENT_LONGS_SKETCH only supports INT/LONG column");
+  }
+
+  /// Every value of a multi-value row is counted, and a null row contributes none of its values.
+  @Test
+  public void testStringsMVColumnCountsEveryValueAndSkipsNullRows() {
+    FrequentStringsSketchAggregationFunction function = strings(true);
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    function.aggregate(MV_STRING_ROWS.length, resultHolder, mvStringBlock(RoaringBitmap.bitmapOf(1)));
+
+    FrequentItemsSketch<String> sketch = function.extractAggregationResult(resultHolder);
+    assertNotNull(sketch);
+    assertEquals(estimate(sketch, "a"), 1L);
+    // b appears once in row 0 and twice in row 2
+    assertEquals(estimate(sketch, "b"), 3L);
+    assertEquals(estimate(sketch, "c"), 0L);
+    assertEquals(estimate(sketch, "d"), 1L);
+  }
+
+  /// The sketch is created inside the range, so a multi-value block with no non-null row leaves the holder untouched.
+  @Test
+  public void testStringsMVColumnEveryRowNullYieldsNoIntermediateResult() {
+    RoaringBitmap allNull = new RoaringBitmap();
+    allNull.add(0L, MV_STRING_ROWS.length);
+
+    FrequentStringsSketchAggregationFunction function = strings(true);
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    function.aggregate(MV_STRING_ROWS.length, resultHolder, mvStringBlock(allNull));
+
+    assertNull(function.extractAggregationResult(resultHolder));
+  }
+
+  /// A zero-length multi-value block still reaches the range callback, and must not mark the holder as aggregated.
+  @Test
+  public void testStringsMVColumnZeroLengthBlockLeavesTheHolderUntouched() {
+    FrequentStringsSketchAggregationFunction function = strings(true);
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    function.aggregate(0, resultHolder, mvStringBlock(null));
+
+    assertNull(function.extractAggregationResult(resultHolder));
+  }
+
+  /// Every value of a row lands in that row's group, and a group whose only row is null is never created.
+  @Test
+  public void testStringsMVColumnGroupBySV() {
+    FrequentStringsSketchAggregationFunction function = strings(true);
+    GroupByResultHolder resultHolder = new ObjectGroupByResultHolder(2, 2);
+    // Rows 0 and 2 go to group 0; row 1 is the only row of group 1 and it is null
+    function.aggregateGroupBySV(MV_STRING_ROWS.length, new int[]{0, 1, 0}, resultHolder,
+        mvStringBlock(RoaringBitmap.bitmapOf(1)));
+
+    FrequentItemsSketch<String> group0 = function.extractGroupByResult(resultHolder, 0);
+    assertNotNull(group0);
+    assertEquals(estimate(group0, "a"), 1L);
+    assertEquals(estimate(group0, "b"), 3L);
+    assertEquals(estimate(group0, "d"), 1L);
+    assertNull(function.extractGroupByResult(resultHolder, 1));
+  }
+
+  /// A row's values land in every group key that row carries, and a null row is skipped for all of its keys.
+  @Test
+  public void testStringsMVColumnGroupByMV() {
+    FrequentStringsSketchAggregationFunction function = strings(true);
+    GroupByResultHolder resultHolder = new ObjectGroupByResultHolder(2, 2);
+    // Row 0 feeds both groups, row 1 is null, row 2 feeds group 1
+    function.aggregateGroupByMV(MV_STRING_ROWS.length, new int[][]{{0, 1}, {0, 1}, {1}}, resultHolder,
+        mvStringBlock(RoaringBitmap.bitmapOf(1)));
+
+    FrequentItemsSketch<String> group0 = function.extractGroupByResult(resultHolder, 0);
+    assertNotNull(group0);
+    assertEquals(estimate(group0, "a"), 1L);
+    assertEquals(estimate(group0, "b"), 1L);
+    assertEquals(estimate(group0, "c"), 0L);
+    assertEquals(estimate(group0, "d"), 0L);
+
+    FrequentItemsSketch<String> group1 = function.extractGroupByResult(resultHolder, 1);
+    assertNotNull(group1);
+    assertEquals(estimate(group1, "a"), 1L);
+    assertEquals(estimate(group1, "b"), 3L);
+    assertEquals(estimate(group1, "c"), 0L);
+    assertEquals(estimate(group1, "d"), 1L);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/SegmentPartitionedDistinctCountAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/SegmentPartitionedDistinctCountAggregationFunctionTest.java
@@ -28,6 +28,7 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.roaringbitmap.RoaringBitmap;
 import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -47,7 +48,11 @@ public class SegmentPartitionedDistinctCountAggregationFunctionTest {
   private static final long[] FLATTENED = {1L, 2L, 3L, 4L, 5L, 6L, 1L, 3L};
 
   private static SegmentPartitionedDistinctCountAggregationFunction create() {
-    return new SegmentPartitionedDistinctCountAggregationFunction(List.of(COLUMN));
+    return create(false);
+  }
+
+  private static SegmentPartitionedDistinctCountAggregationFunction create(boolean nullHandlingEnabled) {
+    return new SegmentPartitionedDistinctCountAggregationFunction(List.of(COLUMN), nullHandlingEnabled);
   }
 
   private static Map<ExpressionContext, BlockValSet> mvBlock() {
@@ -114,6 +119,30 @@ public class SegmentPartitionedDistinctCountAggregationFunctionTest {
     AggregationResultHolder resultHolder = function.createAggregationResultHolder();
     function.aggregate(dictIds.length, resultHolder,
         Map.of(COLUMN, SyntheticBlockValSets.DictIdsMV.create(null, dictIds, dictionary, DataType.LONG)));
+
+    assertEquals(function.extractFinalResult(function.extractAggregationResult(resultHolder)).longValue(), 6L);
+  }
+
+  /// With null handling enabled, a null row of a multi-value column contributes none of its values.
+  @Test
+  public void testMVColumnSkipsNullRowsWhenNullHandlingEnabled() {
+    SegmentPartitionedDistinctCountAggregationFunction function = create(true);
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    function.aggregate(MV_ROWS.length, resultHolder,
+        Map.of(COLUMN, SyntheticBlockValSets.LongMV.create(RoaringBitmap.bitmapOf(1, 3), MV_ROWS)));
+
+    // Rows 1 and 3 are null, so only 1, 2, 5 and 6 are counted
+    assertEquals(function.extractFinalResult(function.extractAggregationResult(resultHolder)).longValue(), 4L);
+  }
+
+  /// With null handling disabled the null rows are read as the column default and still counted, which is the
+  /// answer this mode has always given.
+  @Test
+  public void testMVColumnCountsNullRowsWhenNullHandlingDisabled() {
+    SegmentPartitionedDistinctCountAggregationFunction function = create(false);
+    AggregationResultHolder resultHolder = function.createAggregationResultHolder();
+    function.aggregate(MV_ROWS.length, resultHolder,
+        Map.of(COLUMN, SyntheticBlockValSets.LongMV.create(RoaringBitmap.bitmapOf(1, 3), MV_ROWS)));
 
     assertEquals(function.extractFinalResult(function.extractAggregationResult(resultHolder)).longValue(), 6L);
   }

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkDistinctCountHLLThreshold.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkDistinctCountHLLThreshold.java
@@ -20,6 +20,7 @@ package org.apache.pinot.perf.aggregation;
 
 import it.unimi.dsi.fastutil.ints.IntSet;
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
@@ -78,10 +79,9 @@ public class BenchmarkDistinctCountHLLThreshold {
   private int _numBatches;
   private int[][] _batchedDictIds;
 
-  public static void main(String[] args) throws RunnerException {
-    Options opt = new OptionsBuilder()
-        .include(BenchmarkDistinctCountHLLThreshold.class.getSimpleName())
-        .build();
+  public static void main(String[] args)
+      throws RunnerException {
+    Options opt = new OptionsBuilder().include(BenchmarkDistinctCountHLLThreshold.class.getSimpleName()).build();
     new Runner(opt).run();
   }
 
@@ -102,8 +102,7 @@ public class BenchmarkDistinctCountHLLThreshold {
 
     for (int i = 0; i < _numBatches; i++) {
       int[] dictIds = _batchedDictIds[i];
-      Map<ExpressionContext, BlockValSet> blockValSetMap =
-          Map.of(EXPR, new TestBlockValSet(_dictionary, dictIds));
+      Map<ExpressionContext, BlockValSet> blockValSetMap = Map.of(EXPR, new TestBlockValSet(_dictionary, dictIds));
       _aggregationFunction.aggregate(dictIds.length, resultHolder, blockValSetMap);
     }
 
@@ -137,10 +136,8 @@ public class BenchmarkDistinctCountHLLThreshold {
 
   private static class TestDistinctCountSmartHLLAggregationFunction extends DistinctCountSmartHLLAggregationFunction {
     public TestDistinctCountSmartHLLAggregationFunction(int dictThreshold) {
-      super(java.util.Arrays.asList(
-          EXPR,
-          ExpressionContext.forLiteral(DataType.STRING, String.format("dictThreshold=%d", dictThreshold))
-      ));
+      super(List.of(EXPR,
+          ExpressionContext.forLiteral(DataType.STRING, String.format("dictThreshold=%d", dictThreshold))), false);
     }
   }
 


### PR DESCRIPTION
## Summary

Part of #19218.

`DISTINCTCOUNTBITMAP`, `DISTINCTCOUNTHLL`, `DISTINCTCOUNTHLLPLUS`, `DISTINCTCOUNTULL`,
`DISTINCTCOUNTTHETASKETCH`, `DISTINCTCOUNTCPCSKETCH`, `FASTHLL`, `SEGMENTPARTITIONEDDISTINCTCOUNT`
and the raw and smart variants of each never received the query's null handling option. A null row
was aggregated as the column default whatever the query asked for, so `DISTINCTCOUNTHLL` over a
column of all nulls answered `1` — the default counted once — instead of `0`.

They now extend `NullableSingleInputAggregationFunction` and skip null rows when the option is
enabled. The change reaches every aggregation path: `aggregate`, `aggregateGroupBySV` and
`aggregateGroupByMV`, single-value and multi-value columns, and the dictionary, raw and
serialized-sketch input paths.

### What does not change

With the option disabled, null rows are still read as the column default. That is the answer this
mode has always given and is a backward-compatibility constraint, not an oversight.

The empty-input answer is unchanged in every case. Each counting function already returned `0` for a
null intermediate result, and the extractors that substitute an empty accumulator are untouched — so
the raw CPC and theta sketch variants still render a serialized empty sketch for a locally empty
segment rather than `NULL`. That distinction is per-class and was checked one class at a time rather
than assumed.

### Two things a loop-shaped fix does not reach

Not every read of the block is a loop. Two range operations needed the same treatment:
`RoaringBitmap#addN` over an entire dictionary-id array, and a `subList` of the entire string array
in the smart sketch base. Both took every row regardless of the null bitmap.

### A pre-existing wrong-results fix, pulled in

`DistinctCountThetaSketchAggregationFunction#aggregateGroupByMV` indexed the group keys and the
multi-value arrays by the filter ordinal instead of by the row — `groupKeysArray[filterIndex]`,
where `filterIndex` counts filters. With a single filter, every matching row was credited to row 0's
group keys using row 0's values. Seventeen subscripts across the single-value and multi-value
branches. `.get(filterIndex + 1)`, which really is a filter ordinal, is unchanged.

The plan was to send this separately, but one of the seventeen could not be deferred. Making
`deserializeSketches` null-aware leaves `null` in the array for a null row, and that subscript reads
the array, so `CustomObjectAccumulator#apply`'s null check turned the wrong answer into an NPE for
`DISTINCTCOUNTTHETASKETCH(sketchCol, params, predicate, '$1') … GROUP BY mvCol`. Fixing one of a
pair and deferring its twin reads worse than fixing both, so the whole set is here.

**A filtered `DISTINCTCOUNTTHETASKETCH` grouped by a multi-value column therefore returns different,
correct, results after this change — independently of the null handling option.**

### Testing

`DistinctCountSketchNullHandlingTest` is new. It covers what
`AggregationFunctionNullContractTest` cannot: that harness drives one synthetic single-value block
through `aggregate` only, so the group-by paths, the multi-value column paths and the serialized
sketch input are checked nowhere else. `DistinctCountULLAggregationFunctionTest` and
`SegmentPartitionedDistinctCountAggregationFunctionTest` gain enabled/disabled multi-value cases.

The multi-value and dictionary-encoded cases were verified by mutation rather than by inspection:
reverting a wrapped range back to the full block makes them fail with the null rows counted, so they
guard the behaviour instead of passing vacuously.

The indexing fix adds filtered group-by-MV cases to
`DistinctCountThetaSketchAggregationFunctionTest` for the single-value, multi-value and string
branches, plus the null-hole case in `DistinctCountSketchNullHandlingTest`. Run against the pre-fix
commit all four fail with the specific wrong answers — every row collapsed onto one group — rather
than merely throwing.

`AggregationFunctionNullContractTest` pins the nineteen types that now honour the option. That set
came from a run, not a prediction.
