### PR TITLE
Use compact primitive storage for star-tree record offsets in OffHeapSingleTreeBuilder

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilder.java
@@ -18,17 +18,18 @@
  */
 package org.apache.pinot.segment.local.startree.v2.builder;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.List;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.spi.ImmutableSegment;
@@ -46,31 +47,22 @@ public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
   private final File _segmentRecordFile;
   private final File _starTreeRecordFile;
   private final BufferedOutputStream _starTreeRecordOutputStream;
-  private final List<Long> _starTreeRecordOffsets;
+  private final RecordOffsets _starTreeRecordOffsets = new RecordOffsets();
 
   private PinotDataBuffer _starTreeRecordBuffer;
   private int _numReadableStarTreeRecords;
 
-  /// Constructor for the off-heap single star-tree builder.
-  ///
-  /// @param builderConfig Builder config
-  /// @param outputDir Directory to store the index files
-  /// @param segment Index segment
-  /// @param metadataProperties Segment metadata properties
-  /// @throws FileNotFoundException
   public OffHeapSingleTreeBuilder(StarTreeV2BuilderConfig builderConfig, File outputDir, ImmutableSegment segment,
       Configuration metadataProperties)
       throws FileNotFoundException {
     super(builderConfig, outputDir, segment, metadataProperties);
     _segmentRecordFile = new File(_outputDir, SEGMENT_RECORD_FILE_NAME);
-    Preconditions
-        .checkState(!_segmentRecordFile.exists(), "Segment record file: " + _segmentRecordFile + " already exists");
+    Preconditions.checkState(!_segmentRecordFile.exists(), "Segment record file: %s already exists",
+        _segmentRecordFile);
     _starTreeRecordFile = new File(_outputDir, STAR_TREE_RECORD_FILE_NAME);
-    Preconditions
-        .checkState(!_starTreeRecordFile.exists(), "Star-tree record file: " + _starTreeRecordFile + " already exists");
+    Preconditions.checkState(!_starTreeRecordFile.exists(), "Star-tree record file: %s already exists",
+        _starTreeRecordFile);
     _starTreeRecordOutputStream = new BufferedOutputStream(new FileOutputStream(_starTreeRecordFile));
-    _starTreeRecordOffsets = new ArrayList<>();
-    _starTreeRecordOffsets.add(0L);
   }
 
   @SuppressWarnings("unchecked")
@@ -154,21 +146,22 @@ public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
       throws IOException {
     byte[] bytes = serializeStarTreeRecord(record);
     _starTreeRecordOutputStream.write(bytes);
-    _starTreeRecordOffsets.add(_starTreeRecordOffsets.get(_numDocs) + bytes.length);
+    _starTreeRecordOffsets.addRecord(bytes.length);
   }
 
   @Override
   Record getStarTreeRecord(int docId)
       throws IOException {
     ensureBufferReadable(docId);
-    return deserializeStarTreeRecord(_starTreeRecordBuffer, _starTreeRecordOffsets.get(docId));
+    return deserializeStarTreeRecord(_starTreeRecordBuffer, _starTreeRecordOffsets.getStartOffset(docId));
   }
 
   @Override
   int getDimensionValue(int docId, int dimensionId)
       throws IOException {
     ensureBufferReadable(docId);
-    return _starTreeRecordBuffer.getInt(_starTreeRecordOffsets.get(docId) + (long) dimensionId * Integer.BYTES);
+    return _starTreeRecordBuffer.getInt(
+        _starTreeRecordOffsets.getStartOffset(docId) + (long) dimensionId * Integer.BYTES);
   }
 
   private void ensureBufferReadable(int docId)
@@ -178,9 +171,9 @@ public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
       if (_starTreeRecordBuffer != null) {
         _starTreeRecordBuffer.close();
       }
-      _starTreeRecordBuffer = PinotDataBuffer
-          .mapFile(_starTreeRecordFile, true, 0, _starTreeRecordOffsets.get(_numDocs), PinotDataBuffer.NATIVE_ORDER,
-              "OffHeapSingleTreeBuilder: star-tree record buffer");
+      _starTreeRecordBuffer =
+          PinotDataBuffer.mapFile(_starTreeRecordFile, true, 0, _starTreeRecordOffsets.getEndOffset(),
+              PinotDataBuffer.NATIVE_ORDER, "OffHeapSingleTreeBuilder: star-tree record buffer");
       _numReadableStarTreeRecords = _numDocs;
     }
   }
@@ -195,8 +188,8 @@ public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
       dataBuffer = PinotDataBuffer.mapFile(_segmentRecordFile, false, 0, bufferSize, PinotDataBuffer.NATIVE_ORDER,
           "OffHeapSingleTreeBuilder: segment record buffer");
     } else {
-      dataBuffer = PinotDataBuffer
-          .allocateDirect(bufferSize, PinotDataBuffer.NATIVE_ORDER, "OffHeapSingleTreeBuilder: segment record buffer");
+      dataBuffer = PinotDataBuffer.allocateDirect(bufferSize, PinotDataBuffer.NATIVE_ORDER,
+          "OffHeapSingleTreeBuilder: segment record buffer");
     }
     int[] sortedDocIds = new int[numDocs];
     for (int i = 0; i < numDocs; i++) {
@@ -275,8 +268,8 @@ public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
       sortedDocIds[i] = startDocId + i;
     }
     it.unimi.dsi.fastutil.Arrays.quickSort(0, numDocs, (i1, i2) -> {
-      long offset1 = _starTreeRecordOffsets.get(sortedDocIds[i1]);
-      long offset2 = _starTreeRecordOffsets.get(sortedDocIds[i2]);
+      long offset1 = _starTreeRecordOffsets.getStartOffset(sortedDocIds[i1]);
+      long offset2 = _starTreeRecordOffsets.getStartOffset(sortedDocIds[i2]);
       for (int i = dimensionId + 1; i < _numDimensions; i++) {
         int dimension1 = _starTreeRecordBuffer.getInt(offset1 + (long) i * Integer.BYTES);
         int dimension2 = _starTreeRecordBuffer.getInt(offset2 + (long) i * Integer.BYTES);
@@ -344,5 +337,35 @@ public class OffHeapSingleTreeBuilder extends BaseSingleTreeBuilder {
     }
     _starTreeRecordOutputStream.close();
     FileUtils.forceDelete(_starTreeRecordFile);
+  }
+
+  /// Memory-efficient list of record offsets within the star-tree record file, tracked as a prefix sum of the appended
+  /// record lengths. Start offsets are stored as `int` (4 bytes per record) until the first record starting beyond
+  /// `Integer.MAX_VALUE`, and as `long` (8 bytes per record) afterwards. The number of star-tree records can go into
+  /// the hundreds of millions for large segments, where a boxed `List<Long>` (~28 bytes per record) would dominate the
+  /// heap.
+  @VisibleForTesting
+  static class RecordOffsets {
+    private final IntArrayList _intOffsets = new IntArrayList();
+    private final LongArrayList _longOffsets = new LongArrayList();
+    private long _endOffset;
+
+    void addRecord(int numBytes) {
+      if (_endOffset <= Integer.MAX_VALUE) {
+        _intOffsets.add((int) _endOffset);
+      } else {
+        _longOffsets.add(_endOffset);
+      }
+      _endOffset += numBytes;
+    }
+
+    long getStartOffset(int index) {
+      int numIntOffsets = _intOffsets.size();
+      return index < numIntOffsets ? _intOffsets.getInt(index) : _longOffsets.getLong(index - numIntOffsets);
+    }
+
+    long getEndOffset() {
+      return _endOffset;
+    }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilderTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/startree/v2/builder/OffHeapSingleTreeBuilderTest.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.startree.v2.builder;
+
+import org.apache.pinot.segment.local.startree.v2.builder.OffHeapSingleTreeBuilder.RecordOffsets;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class OffHeapSingleTreeBuilderTest {
+
+  @Test
+  public void testRecordOffsets() {
+    RecordOffsets offsets = new RecordOffsets();
+    offsets.addRecord(123);
+    offsets.addRecord(Integer.MAX_VALUE - 123);
+    offsets.addRecord(456);
+    offsets.addRecord(789);
+    assertEquals(offsets.getStartOffset(0), 0L);
+    assertEquals(offsets.getStartOffset(1), 123L);
+    assertEquals(offsets.getStartOffset(2), Integer.MAX_VALUE);
+    assertEquals(offsets.getStartOffset(3), Integer.MAX_VALUE + 456L);
+    assertEquals(offsets.getEndOffset(), Integer.MAX_VALUE + 456L + 789L);
+  }
+}


### PR DESCRIPTION
## Summary

`OffHeapSingleTreeBuilder` keeps the star-tree record file offsets in a `List<Long>`, which costs ~28 bytes of heap per record (24-byte boxed `Long` plus a 4-byte reference under compressed oops). The number of star-tree records can go into the hundreds of millions for large segments with a wide `dimensionsSplitOrder`; in one production incident the offsets list alone held ~700M boxed `Long`s (~19.6GB including the `ArrayList` backing array), OOMing the server during realtime segment conversion.

This PR replaces the boxed list with a compact `RecordOffsets` structure:
- Offsets are tracked as a prefix sum of the appended record lengths, so `appendRecord` passes the record length instead of computing the next offset from a read-back of the last element.
- Start offsets are stored in an `IntArrayList` (4 bytes per record) until the record file grows beyond `Integer.MAX_VALUE`, and in a `LongArrayList` (8 bytes per record) afterwards. Offsets increase monotonically, so the switch happens at most once and needs no copy: reads pick the list by comparing the index against the int head's size.
- The end offset (total file length) is a plain `long` field, removing the extra end-sentinel entry and the boxing/unboxing on every append and on every read in the star-node sort comparator.

For the build above this reduces the offset bookkeeping from ~19.6GB to ~5.6GB of heap (4 bytes per record while the record file stays under 2GB), and removes the `Long` allocation churn from the build hot path.
