### PR TITLE
Fix flaky UpsertTableSegmentPreloadIntegrationTest by verifying snapshots only for uploaded segments

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentPreloadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentPreloadIntegrationTest.java
@@ -217,13 +217,19 @@ public class UpsertTableSegmentPreloadIntegrationTest extends BaseClusterIntegra
     // Resume consumption to trigger snapshot
     getOrCreateAdminClient().getTableClient().resumeConsumption(rawTableName, null);
 
-    // All the immutable (committed and uploaded) segments should have snapshots generated
+    // All the uploaded segments should have snapshots generated. Snapshots for the just committed segments are best
+    // effort: the snapshot round triggered by the new consuming segment skips a segment without retry when its
+    // segmentLock is still held, e.g. by the committing thread or the CONSUMING -> ONLINE state transition. Only the
+    // latest committed segment of each partition is best effort, but this test has a single commit cycle, so every
+    // LLC segment is a just committed one, and all of them are excluded from the check.
     String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(rawTableName);
     TestUtils.waitForCondition(aVoid -> {
       for (BaseServerStarter serverStarter : _serverStarters) {
         String segmentDir = serverStarter.getConfig().getProperty(Server.CONFIG_OF_INSTANCE_DATA_DIR);
-        File[] files = new File(segmentDir, realtimeTableName).listFiles((dir, name) -> name.startsWith(rawTableName));
+        File[] files = new File(segmentDir, realtimeTableName).listFiles(
+            (dir, name) -> name.startsWith(rawTableName) && LLCSegmentName.of(name) == null);
         assertNotNull(files);
+        assertEquals(files.length, 3);
         for (File file : files) {
           if (!new File(new File(file, "v3"), V1Constants.VALID_DOC_IDS_SNAPSHOT_FILE_NAME).exists()) {
             return false;


### PR DESCRIPTION
## Summary

Fixes a flake in `UpsertTableSegmentPreloadIntegrationTest.testSegmentAssignment` where `waitForSnapshotCreation` timed out after 600s with `Failed to verify snapshots` (e.g. [this run](https://github.com/apache/pinot/actions/runs/32252324986) on an unrelated dependency bump).

The test required a validDocIds snapshot under every immutable segment directory, but snapshots for the just committed segments are only best effort:
- Upsert snapshots are taken once per partition when the new consuming segment starts consuming (triggered here by resuming consumption). `doTakeSnapshot` acquires each segment's `segmentLock` with `tryLock` and skips the segment on contention, and a skipped segment is not retried until the next snapshot round — which never comes in this test because no more data is consumed after the resume.
- The just committed segment's lock is exactly the contended one: the committing thread holds it across build + commit + replace, and the CONSUMING -> ONLINE state transition (dispatched by the controller mid-commit) queues on the same lock and holds it across ZK reads right after. The query-based wait before resuming only observes `registerSegment`, which happens before both holders release the lock, so the snapshot round's single `tryLock` can land while the lock is still held.

The uploaded segments have no lock contenders at that point (and the skip cascade cannot trigger since no segment has a prior snapshot on disk), so their snapshots are guaranteed. Update the check to verify snapshots only for the uploaded segments, excluding LLC segment dirs — which in this single-commit-cycle test are exactly the just committed ones — and assert the expected dir count so the check cannot pass vacuously. The restart that follows still exercises preload either way, since preload handles segments with or without snapshots.
