### PR TITLE
Notify a late-registering mailbox reader about buffered blocks

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/ReceivingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/ReceivingMailbox.java
@@ -740,13 +740,23 @@ public class ReceivingMailbox {
     }
 
     public void registerReader(Reader reader) {
-      if (_reader != null) {
-        throw new IllegalArgumentException("Only one reader is supported");
+      ReentrantLock lock = _lock;
+      lock.lock();
+      try {
+        if (_reader != null) {
+          throw new IllegalArgumentException("Only one reader is supported");
+        }
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug("==[MAILBOX]== Reader registered for mailbox: " + _id);
+        }
+        _reader = reader;
+        // Offers made before registration found no reader to notify, so deliver the pending wake-up.
+        if (_count > 0 || _eos != null) {
+          notifyReader();
+        }
+      } finally {
+        lock.unlock();
       }
-      if (LOGGER.isDebugEnabled()) {
-        LOGGER.debug("==[MAILBOX]== Reader registered for mailbox: " + _id);
-      }
-      _reader = reader;
     }
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/ReceivingMailboxTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/ReceivingMailboxTest.java
@@ -39,6 +39,8 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.testng.Assert.*;
 
 
@@ -370,5 +372,41 @@ public class ReceivingMailboxTest {
       assertTrue(allocatedBytes > 0);
       _resourceUsageUpdated = true;
     }
+  }
+
+  @Test
+  public void readerRegisteredAfterDataIsNotified() {
+    ReceivingMailbox receivingMailbox = new ReceivingMailbox("id", 10);
+
+    ReceivingMailbox.ReceivingMailboxStatus status = receivingMailbox.offer(DATA_BLOCK, List.of(), 10);
+    assertEquals(status, ReceivingMailbox.ReceivingMailboxStatus.SUCCESS, "Should be able to offer without a reader");
+
+    receivingMailbox.registeredReader(_reader);
+
+    verify(_reader).blockReadyToRead();
+    assertNotNull(receivingMailbox.poll(), "Block offered before registration should still be readable");
+  }
+
+  @Test
+  public void readerRegisteredAfterEosIsNotified() {
+    ReceivingMailbox receivingMailbox = new ReceivingMailbox("id", 10);
+
+    assertEquals(receivingMailbox.offer(DATA_BLOCK, List.of(), 10), ReceivingMailbox.ReceivingMailboxStatus.SUCCESS,
+        "Should be able to offer without a reader");
+    assertEquals(receivingMailbox.offer(SuccessMseBlock.INSTANCE, List.of(), 10),
+        ReceivingMailbox.ReceivingMailboxStatus.LAST_BLOCK, "Should be able to offer EOS without a reader");
+
+    receivingMailbox.registeredReader(_reader);
+
+    verify(_reader).blockReadyToRead();
+  }
+
+  @Test
+  public void readerRegisteredOnEmptyMailboxIsNotNotified() {
+    ReceivingMailbox receivingMailbox = new ReceivingMailbox("id", 10);
+
+    receivingMailbox.registeredReader(_reader);
+
+    verifyNoInteractions(_reader);
   }
 }


### PR DESCRIPTION
`ReceivingMailbox.registerReader` only assigned the reader. If a sender had already offered data or EOS, the earlier `notifyReader()` found no reader and the wake-up was dropped, so the reader blocked until the query deadline and the query failed with `EXECUTION_TIMEOUT` (250).

Reachable whenever a sender completes before the receiving stage registers — most easily on the in-memory path, where a leaf worker co-located with the consuming stage can finish in ~1ms. Observed in production on a `count(*)` that otherwise takes single-digit ms.

`registerReader` now delivers the pending wake-up if blocks or EOS are already buffered, under the existing lock. Three tests cover data-before-registration, EOS-before-registration, and the empty-mailbox case (must not notify).
