### PR TITLE
Notify the mailbox reader when the last pending data offer gives up

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/ReceivingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/ReceivingMailbox.java
@@ -490,7 +490,8 @@ public class ReceivingMailbox {
       _dataBlocks = new MseBlock.Data[capacity];
     }
 
-    /// Notifies the downstream that there is data to read.
+    /// Notifies the downstream that the mailbox became readable, either because a data block was buffered or
+    /// because the EOS block is now the next thing to read.
     private void notifyReader() {
       Reader reader = _reader;
       if (reader != null) {
@@ -580,6 +581,9 @@ public class ReceivingMailbox {
     /// distinguish between a timeout and other reasons for not being able to add the block to the queue in order to
     /// report different error messages.
     ///
+    /// On every exit path, if this is the last pending offer and the upstream has finished, the reader is
+    /// notified, because the mailbox becomes readable at that point and no other call site notifies.
+    ///
     /// @return true if the block was added successfully, false if the state changed while waiting.
     /// @throws InterruptedException if the thread is interrupted while waiting for space in the queue.
     /// @throws TimeoutException if the timeout specified elapsed before space was available in the queue.
@@ -625,7 +629,12 @@ public class ReceivingMailbox {
         _count++;
         return true;
       } finally {
-        _pendingData--;
+        // poll() returns null while offers are pending, so the mailbox becomes readable when the last one completes.
+        // A sender that gives up returns without notifying, so deliver the wake-up here. On the success path this
+        // duplicates the notification from offerData, which is harmless because notifications coalesce.
+        if (--_pendingData == 0 && _state == State.UPSTREAM_FINISHED) {
+          notifyReader();
+        }
       }
     }
 
@@ -656,6 +665,7 @@ public class ReceivingMailbox {
             if (_count == 0) {
               if (_pendingData > 0) {
                 // There are still threads trying to add data to the queue. We should wait for them to finish.
+                // The reader is woken again when the last of them completes, see offerDataToBuffer.
                 LOGGER.debug("Mailbox: {} has pending {} data blocks, waiting for them to finish", _id, _pendingData);
                 return null;
               } else {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/ReceivingMailboxTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/ReceivingMailboxTest.java
@@ -20,11 +20,15 @@ package org.apache.pinot.query.mailbox;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.runtime.blocks.ErrorMseBlock;
@@ -47,6 +51,7 @@ public class ReceivingMailboxTest {
   private static final DataSchema DATA_SCHEMA =
       new DataSchema(new String[]{"intCol"}, new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT});
   private static final MseBlock.Data DATA_BLOCK = new RowHeapDataBlock(List.of(), DATA_SCHEMA, null);
+  private static final ErrorMseBlock ERROR_BLOCK = ErrorMseBlock.fromError(QueryErrorCode.INTERNAL, "test");
   private ReceivingMailbox.Reader _reader;
 
   @BeforeClass
@@ -352,6 +357,76 @@ public class ReceivingMailboxTest {
     receivingMailbox.offerRaw(DataBlockUtils.serialize(DATA_BLOCK.asSerialized().getDataBlock()), 10_000);
     receivingMailbox.registerReceiveOperatorThreadContext(threadContext);
     assertTrue(receivingMailbox._resourceUsageUpdated);
+  }
+
+  /// An error EOS drains the queued data blocks and makes every parked sender give up. While those offers are still
+  /// in flight `poll` returns `null` and asks the reader to wait for them, but a sender that gives up returns
+  /// `ALREADY_TERMINATED` without notifying, and the reader's notification slot coalesces, so the EOS notification
+  /// cannot stand in for the missing one. Unless the last pending offer notifies on its way out, the reader parks
+  /// until the query deadline and the query reports a timeout instead of the error that caused it.
+  ///
+  /// Asserting on the notification count rather than on a blocking read keeps this deterministic: the wake-up is
+  /// delivered when the last pending offer completes, whether or not the reader managed to poll first.
+  @Test(timeOut = 60_000)
+  public void shouldNotifyReaderWhenLastPendingOfferGivesUp()
+      throws Exception {
+    CountingReader reader = new CountingReader();
+    ReceivingMailbox mailbox = new ReceivingMailbox("id", 1);
+    mailbox.registeredReader(reader);
+
+    // Fill the only queue slot, so the sender below has to park waiting for space.
+    assertEquals(mailbox.offer(DATA_BLOCK, List.of(), 10_000), ReceivingMailbox.ReceivingMailboxStatus.SUCCESS);
+    assertEquals(reader._notifications.get(), 1, "The buffered data block should notify the reader");
+
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      AtomicReference<Thread> senderThread = new AtomicReference<>();
+      CountDownLatch offering = new CountDownLatch(1);
+      Future<ReceivingMailbox.ReceivingMailboxStatus> sender = executor.submit(() -> {
+        senderThread.set(Thread.currentThread());
+        offering.countDown();
+        return mailbox.offer(DATA_BLOCK, List.of(), 30_000);
+      });
+      assertTrue(offering.await(30, TimeUnit.SECONDS), "Sender should reach the offer call");
+      awaitParked(senderThread.get());
+
+      // The error EOS drains the buffered block and rejects the parked sender.
+      assertEquals(mailbox.offer(ERROR_BLOCK, List.of(), 10_000), ReceivingMailbox.ReceivingMailboxStatus.LAST_BLOCK);
+      assertEquals(reader._notifications.get(), 2, "The EOS should notify the reader");
+      assertEquals(sender.get(30, TimeUnit.SECONDS), ReceivingMailbox.ReceivingMailboxStatus.ALREADY_TERMINATED,
+          "The parked sender should be rejected by the error EOS");
+
+      // Once the sender has given up the mailbox is readable again, so the reader owes one more notification. Without
+      // it a reader that already polled and was told to wait for the pending offer is never woken again.
+      assertEquals(reader._notifications.get(), 3,
+          "The last pending offer should notify the reader on its way out, but the reader was left blocked");
+      ReceivingMailbox.MseBlockWithStats read = mailbox.poll();
+      assertNotNull(read, "The reader should be able to read the EOS");
+      assertTrue(read.getBlock().isError(), "The EOS should be the error block");
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  /// Waits until the sender thread is parked waiting for space in the queue.
+  private static void awaitParked(Thread thread)
+      throws Exception {
+    long deadlineNs = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+    while (thread.getState() != Thread.State.TIMED_WAITING) {
+      assertTrue(System.nanoTime() < deadlineNs, "Sender never parked waiting for space in the queue");
+      Thread.sleep(1);
+    }
+  }
+
+  /// Counts the wake-ups delivered to the reader. The production reader coalesces them into a single slot and always
+  /// polls the mailbox before parking on that slot, so a wake-up dropped while it is parked is never recovered.
+  private static class CountingReader implements ReceivingMailbox.Reader {
+    final AtomicInteger _notifications = new AtomicInteger();
+
+    @Override
+    public void blockReadyToRead() {
+      _notifications.incrementAndGet();
+    }
   }
 
   private static class TestReceivingMailbox extends ReceivingMailbox {


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Notify reader when last pending offer completes and upstream finished\.

```mermaid
flowchart TD
  N0["offerDataToBuffer finally block #40;F1#41;"]:::stAdded
  N1["decrement #95;pendingData #40;F1#41;"]:::stAdded
  N2["check #95;pendingData #61;#61; 0 #38;#38; #95;state #61;#61; UPSTREAM#95;FINISHED #40;F1#41;"]:::stAdded
  N3["notifyReader#40;#41; #40;F1#41;"]:::stModified
  N4["reader#46;blockReadyToRead#40;#41; #40;F1#41;"]:::stModified
  N5["poll wakes reader #40;F1#41;"]:::stModified
  N0 -->|"sequential"| N1
  N1 -->|"value transfer"| N2
  N2 -->|"branch #40;true#41;"| N3
  N3 -->|"call"| N4
  N4 -->|"wake#45;up"| N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/mailbox/ReceivingMailbox\.java — [before](https://github.com/apache/pinot/blob/22a1be9d918f7b986dcb3c1807e3abf4295ca680/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/ReceivingMailbox.java) · [after](https://github.com/apache/pinot/blob/61b4b6893b363f4288087a05895292fc20a9baed/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/ReceivingMailbox.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjIyYTFiZTlkOTE4ZjdiOTg2ZGNiM2MxODA3ZTNhYmY0Mjk1Y2E2ODAiLCJjb250ZXh0X2hhc2giOiJmMjhlOGFjYWRhMTI4YTE0NmE4NWRkYTllMTViYWNkMjMzMWExOTE3NzgwYTgwNGZjNmFjM2QwNzBjYzEyODlkIiwiZ2VuZXJhdGVkX2F0IjoxNzg4OTI0ODc2LCJoZWFkX3NoYSI6IjYxYjRiNjg5M2IzNjNmNDI4ODA4N2EwNTg5NTI5MmZjMjBhOWJhZWQiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIyMmExYmU5ZDkxOGY3Yjk4NmRjYjNjMTgwN2UzYWJmNDI5NWNhNjgwIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 50030ae80d4385d7c755582fd9dfec421b7fb2ddb1e02b8656a7bc82d6ea1d91 -->
<!-- pinot-pr-flow:end -->

An error EOS drains the queued data blocks and makes every parked sender give up. While those offers are still in flight, `poll` returns `null` and asks the reader to wait for them (`ReceivingMailbox.java:657`). But a sender that gives up returns `ALREADY_TERMINATED` without notifying, and the reader coalesces notifications into a single slot, so the EOS notification cannot stand in for the missing one. Nothing wakes the reader again: it blocks until the query deadline and the query reports `EXECUTION_TIMEOUT` instead of the error that actually caused it.

Reachable whenever the queue is full and senders are parked when an error EOS or a cancellation arrives. The same gap swallows the `TimeoutException` and `InterruptedException` paths out of `offerDataToBuffer`, which unwind into an `offerEos` that is rejected as already terminated.

`offerDataToBuffer` now notifies on every exit path when it is the last pending offer and the upstream has finished — exactly the condition `poll` waits on. The lock is held there, since `awaitNanos` reacquires it on all three exits. On the success path this duplicates the notification from `offerData`, which is harmless because notifications coalesce.

The test asserts the notification count rather than blocking on a read, so it is deterministic: the wake-up is delivered when the last pending offer completes, whether or not the reader managed to poll first. It fails on master with `expected [3] but found [2]`.

Supersedes #19323, which proposed a fix for a lost wake-up at reader registration. That one turned out to be unreachable: registration precedes the reader's first scan, and the scan makes the dropped notification redundant. Thanks to @yashmayya for pushing back on it and pointing at this path instead.