### PR TITLE
Support JSON and UUID data types in ARRAY_AGG

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -334,9 +334,11 @@ public class AggregationFunctionFactory {
                 case BIG_DECIMAL:
                   return new ArrayAggDistinctBigDecimalFunction(firstArgument, nullHandlingEnabled);
                 case STRING:
+                case JSON:
                   return new ArrayAggDistinctStringFunction(firstArgument, nullHandlingEnabled);
                 case BYTES:
-                  return new ArrayAggDistinctBytesFunction(firstArgument, nullHandlingEnabled);
+                case UUID:
+                  return new ArrayAggDistinctBytesFunction(firstArgument, dataType, nullHandlingEnabled);
                 default:
                   throw new IllegalArgumentException("Unsupported data type for ARRAY_AGG: " + dataType);
               }
@@ -355,9 +357,11 @@ public class AggregationFunctionFactory {
               case BIG_DECIMAL:
                 return new ArrayAggBigDecimalFunction(firstArgument, nullHandlingEnabled);
               case STRING:
+              case JSON:
                 return new ArrayAggStringFunction(firstArgument, nullHandlingEnabled);
               case BYTES:
-                return new ArrayAggBytesFunction(firstArgument, nullHandlingEnabled);
+              case UUID:
+                return new ArrayAggBytesFunction(firstArgument, dataType, nullHandlingEnabled);
               default:
                 throw new IllegalArgumentException("Unsupported data type for ARRAY_AGG: " + dataType);
             }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggBytesFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggBytesFunction.java
@@ -26,12 +26,13 @@ import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
 
 
 public class ArrayAggBytesFunction extends BaseArrayAggBytesFunction<ObjectArrayList<ByteArray>> {
-  public ArrayAggBytesFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
-    super(expression, nullHandlingEnabled);
+  public ArrayAggBytesFunction(ExpressionContext expression, DataType dataType, boolean nullHandlingEnabled) {
+    super(expression, dataType, nullHandlingEnabled);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctBytesFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctBytesFunction.java
@@ -28,12 +28,13 @@ import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
 
 
 public class ArrayAggDistinctBytesFunction extends BaseArrayAggBytesFunction<ObjectSet<ByteArray>> {
-  public ArrayAggDistinctBytesFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
-    super(expression, nullHandlingEnabled);
+  public ArrayAggDistinctBytesFunction(ExpressionContext expression, DataType dataType, boolean nullHandlingEnabled) {
+    super(expression, dataType, nullHandlingEnabled);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggBytesFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggBytesFunction.java
@@ -24,17 +24,18 @@ import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
 
 
-/// Shared base for BYTES ARRAY_AGG variants. Both non-distinct (`ObjectArrayList<ByteArray>`) and distinct
-/// (`ObjectOpenHashSet<ByteArray>`) subclasses store `ByteArray` so content-based equality works for the
-/// distinct case and the element type stays consistent with the DataTable/wire layer.
+/// Shared base for ARRAY_AGG variants on types stored as BYTES (`BYTES` and the `UUID` logical type). Both
+/// non-distinct (`ObjectArrayList<ByteArray>`) and distinct (`ObjectOpenHashSet<ByteArray>`) subclasses store
+/// `ByteArray` so content-based equality works for the distinct case and the element type stays consistent with
+/// the DataTable/wire layer.
 public abstract class BaseArrayAggBytesFunction<I extends ObjectCollection<ByteArray>>
     extends BaseArrayAggFunction<I, ObjectArrayList<ByteArray>> {
-  public BaseArrayAggBytesFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
-    super(expression, FieldSpec.DataType.BYTES, nullHandlingEnabled);
+  public BaseArrayAggBytesFunction(ExpressionContext expression, DataType dataType, boolean nullHandlingEnabled) {
+    super(expression, dataType, nullHandlingEnabled);
   }
 
   abstract void setGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey, byte[] value);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ArrayAggQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ArrayAggQueriesTest.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.UUID;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.HashUtil;
@@ -53,7 +54,6 @@ import static org.testng.Assert.assertNotNull;
 
 
 /// Queries test for ArrayAgg queries.
-@SuppressWarnings("unchecked")
 public class ArrayAggQueriesTest extends BaseQueriesTest {
   private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "ArrayAggQueriesTest");
   private static final String RAW_TABLE_NAME = "testTable";
@@ -68,12 +68,21 @@ public class ArrayAggQueriesTest extends BaseQueriesTest {
   private static final String FLOAT_COLUMN = "floatColumn";
   private static final String DOUBLE_COLUMN = "doubleColumn";
   private static final String STRING_COLUMN = "stringColumn";
-  private static final Schema SCHEMA = new Schema.SchemaBuilder().addSingleValueDimension(INT_COLUMN, DataType.INT)
-      .addSingleValueDimension(LONG_COLUMN, DataType.LONG).addSingleValueDimension(FLOAT_COLUMN, DataType.FLOAT)
-      .addSingleValueDimension(DOUBLE_COLUMN, DataType.DOUBLE).addSingleValueDimension(STRING_COLUMN, DataType.STRING)
-      .build();
+  private static final String JSON_COLUMN = "jsonColumn";
+  private static final String BYTES_COLUMN = "bytesColumn";
+  private static final String UUID_COLUMN = "uuidColumn";
   private static final TableConfig TABLE_CONFIG =
       new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+  private static final Schema SCHEMA = new Schema.SchemaBuilder().setSchemaName(RAW_TABLE_NAME)
+      .addSingleValueDimension(INT_COLUMN, DataType.INT)
+      .addSingleValueDimension(LONG_COLUMN, DataType.LONG)
+      .addSingleValueDimension(FLOAT_COLUMN, DataType.FLOAT)
+      .addSingleValueDimension(DOUBLE_COLUMN, DataType.DOUBLE)
+      .addSingleValueDimension(STRING_COLUMN, DataType.STRING)
+      .addSingleValueDimension(JSON_COLUMN, DataType.JSON)
+      .addSingleValueDimension(BYTES_COLUMN, DataType.BYTES)
+      .addSingleValueDimension(UUID_COLUMN, DataType.UUID)
+      .build();
 
   private Set<Integer> _values;
   private int[] _expectedCardinalityResults;
@@ -107,6 +116,9 @@ public class ArrayAggQueriesTest extends BaseQueriesTest {
     Set<Integer> floatResultSet = new HashSet<>(hashMapCapacity);
     Set<Integer> doubleResultSet = new HashSet<>(hashMapCapacity);
     Set<Integer> stringResultSet = new HashSet<>(hashMapCapacity);
+    Set<Integer> jsonResultSet = new HashSet<>(hashMapCapacity);
+    Set<Integer> bytesResultSet = new HashSet<>(hashMapCapacity);
+    Set<Integer> uuidResultSet = new HashSet<>(hashMapCapacity);
     for (int i = 0; i < NUM_RECORDS; i++) {
       int value = RANDOM.nextInt(MAX_VALUE);
       GenericRow record = new GenericRow();
@@ -121,10 +133,22 @@ public class ArrayAggQueriesTest extends BaseQueriesTest {
       String stringValue = Integer.toString(value);
       record.putValue(STRING_COLUMN, stringValue);
       stringResultSet.add(stringValue.hashCode());
+      String jsonValue = "{\"value\":" + value + "}";
+      record.putValue(JSON_COLUMN, jsonValue);
+      jsonResultSet.add(jsonValue.hashCode());
+      byte[] bytesValue = {(byte) (value >> 8), (byte) value};
+      record.putValue(BYTES_COLUMN, bytesValue);
+      // Track the int value: the 2-byte encoding is bijective with it, while Arrays.hashCode collides on 2-byte
+      // arrays.
+      bytesResultSet.add(value);
+      String uuidValue = new UUID(0L, value).toString();
+      record.putValue(UUID_COLUMN, uuidValue);
+      uuidResultSet.add(uuidValue.hashCode());
       records.add(record);
     }
     _expectedCardinalityResults = new int[]{
-        _values.size(), longResultSet.size(), floatResultSet.size(), doubleResultSet.size(), stringResultSet.size()
+        _values.size(), longResultSet.size(), floatResultSet.size(), doubleResultSet.size(), stringResultSet.size(),
+        jsonResultSet.size(), bytesResultSet.size(), uuidResultSet.size()
     };
 
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(TABLE_CONFIG, SCHEMA);
@@ -143,59 +167,63 @@ public class ArrayAggQueriesTest extends BaseQueriesTest {
 
   @Test
   public void testArrayAggNonDistinct() {
-    String query =
-        "SELECT ArrayAgg(intColumn, 'INT'), ArrayAgg(longColumn, 'LONG'), ArrayAgg(floatColumn, 'FLOAT'), "
-            + "ArrayAgg(doubleColumn, 'DOUBLE'), ArrayAgg(stringColumn, 'STRING')"
-            + " FROM testTable";
+    String query = "SELECT ArrayAgg(intColumn, 'INT'), ArrayAgg(longColumn, 'LONG'), ArrayAgg(floatColumn, 'FLOAT'), "
+        + "ArrayAgg(doubleColumn, 'DOUBLE'), ArrayAgg(stringColumn, 'STRING'), ArrayAgg(jsonColumn, 'JSON'), "
+        + "ArrayAgg(bytesColumn, 'BYTES'), ArrayAgg(uuidColumn, 'UUID')" + " FROM testTable";
 
     // Inner segment
     AggregationOperator aggregationOperator = getOperator(query);
     AggregationResultsBlock resultsBlock = aggregationOperator.nextBlock();
     QueriesTestUtils.testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), NUM_RECORDS, 0,
-        5 * NUM_RECORDS, NUM_RECORDS);
+        8 * NUM_RECORDS, NUM_RECORDS);
     List<Object> aggregationResult = resultsBlock.getResults();
     assertNotNull(aggregationResult);
-    for (int i = 0; i < 5; i++) {
+    for (int i = 0; i < 8; i++) {
       assertEquals(((List) aggregationResult.get(i)).size(), NUM_RECORDS);
     }
 
     // Inter segments
     ResultTable resultTable = getBrokerResponse(query).getResultTable();
-    assertEquals(resultTable.getRows().get(0).length, 5);
+    assertEquals(resultTable.getRows().get(0).length, 8);
     assertEquals(((int[]) resultTable.getRows().get(0)[0]).length, 4 * NUM_RECORDS);
     assertEquals(((long[]) resultTable.getRows().get(0)[1]).length, 4 * NUM_RECORDS);
     assertEquals(((float[]) resultTable.getRows().get(0)[2]).length, 4 * NUM_RECORDS);
     assertEquals(((double[]) resultTable.getRows().get(0)[3]).length, 4 * NUM_RECORDS);
     assertEquals(((String[]) resultTable.getRows().get(0)[4]).length, 4 * NUM_RECORDS);
+    assertEquals(((String[]) resultTable.getRows().get(0)[5]).length, 4 * NUM_RECORDS);
+    assertEquals(((String[]) resultTable.getRows().get(0)[6]).length, 4 * NUM_RECORDS);
+    assertEquals(((String[]) resultTable.getRows().get(0)[7]).length, 4 * NUM_RECORDS);
   }
 
   @Test
   public void testArrayAggDistinct() {
-    String query =
-        "SELECT ArrayAgg(intColumn, 'INT', true), ArrayAgg(longColumn, 'LONG', true), "
-            + "ArrayAgg(floatColumn, 'FLOAT', true), ArrayAgg(doubleColumn, 'DOUBLE', true), "
-            + "ArrayAgg(stringColumn, 'STRING', true)"
-            + " FROM testTable";
+    String query = "SELECT ArrayAgg(intColumn, 'INT', true), ArrayAgg(longColumn, 'LONG', true), "
+        + "ArrayAgg(floatColumn, 'FLOAT', true), ArrayAgg(doubleColumn, 'DOUBLE', true), "
+        + "ArrayAgg(stringColumn, 'STRING', true), ArrayAgg(jsonColumn, 'JSON', true), "
+        + "ArrayAgg(bytesColumn, 'BYTES', true), ArrayAgg(uuidColumn, 'UUID', true)" + " FROM testTable";
 
     // Inner segment
     AggregationOperator aggregationOperator = getOperator(query);
     AggregationResultsBlock resultsBlock = aggregationOperator.nextBlock();
     QueriesTestUtils.testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), NUM_RECORDS, 0,
-        5 * NUM_RECORDS, NUM_RECORDS);
+        8 * NUM_RECORDS, NUM_RECORDS);
     List<Object> aggregationResult = resultsBlock.getResults();
     assertNotNull(aggregationResult);
-    for (int i = 0; i < 5; i++) {
+    for (int i = 0; i < 8; i++) {
       assertEquals(((Set) aggregationResult.get(i)).size(), _expectedCardinalityResults[i]);
     }
 
     // Inter segments
     ResultTable resultTable = getBrokerResponse(query).getResultTable();
-    assertEquals(resultTable.getRows().get(0).length, 5);
+    assertEquals(resultTable.getRows().get(0).length, 8);
     assertEquals(((int[]) resultTable.getRows().get(0)[0]).length, _expectedCardinalityResults[0]);
     assertEquals(((long[]) resultTable.getRows().get(0)[1]).length, _expectedCardinalityResults[1]);
     assertEquals(((float[]) resultTable.getRows().get(0)[2]).length, _expectedCardinalityResults[2]);
     assertEquals(((double[]) resultTable.getRows().get(0)[3]).length, _expectedCardinalityResults[3]);
     assertEquals(((String[]) resultTable.getRows().get(0)[4]).length, _expectedCardinalityResults[4]);
+    assertEquals(((String[]) resultTable.getRows().get(0)[5]).length, _expectedCardinalityResults[5]);
+    assertEquals(((String[]) resultTable.getRows().get(0)[6]).length, _expectedCardinalityResults[6]);
+    assertEquals(((String[]) resultTable.getRows().get(0)[7]).length, _expectedCardinalityResults[7]);
   }
 
   @AfterClass


### PR DESCRIPTION
## Summary

Add `JSON` and `UUID` data type support to the `ARRAY_AGG` aggregation function, for both the regular and `DISTINCT` variants:
- `JSON` is dispatched to the STRING variants. Its stored type is `STRING` and there is no `JSON_ARRAY` column data type, so the result surfaces as `STRING_ARRAY`.
- `UUID` is dispatched to the BYTES variants with the logical type passed through (mirroring how `BOOLEAN`/`TIMESTAMP` are passed to the INT/LONG variants), so the final result column type resolves to `UUID_ARRAY` and values render as canonical UUID strings instead of hex.

The BYTES `ARRAY_AGG` functions now take the `DataType` in their constructors instead of hardcoding `BYTES`. No changes are needed at the MSE/DataTable boundaries: they are keyed on stored types (`UUID_ARRAY` -> `BYTES_ARRAY`), which already handle the `ObjectArrayList<ByteArray>` result shape.

Also extends `ArrayAggQueriesTest` with end-to-end coverage for `JSON`, `BYTES` and `UUID`.
