### PR TITLE
Enable filtered search on mutable HNSW indexes

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/vector/MutableVectorIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/vector/MutableVectorIndex.java
@@ -20,7 +20,9 @@ package org.apache.pinot.segment.local.realtime.impl.vector;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -28,35 +30,52 @@ import java.util.concurrent.Future;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.lucene.document.Document;
-import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.MultiDocValues;
+import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.KnnFloatVectorQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.util.IOUtils;
 import org.apache.pinot.segment.local.realtime.impl.invertedindex.RealtimeLuceneTextIndexSearcherPool;
 import org.apache.pinot.segment.local.segment.creator.impl.vector.XKnnFloatVectorField;
 import org.apache.pinot.segment.local.segment.index.readers.vector.LuceneHnswRuntimeControlUtils;
 import org.apache.pinot.segment.local.segment.store.VectorIndexUtils;
-import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.index.VectorIndexConfigProvider;
 import org.apache.pinot.segment.spi.index.creator.VectorIndexConfig;
 import org.apache.pinot.segment.spi.index.mutable.MutableIndex;
 import org.apache.pinot.segment.spi.index.reader.EfSearchAware;
-import org.apache.pinot.segment.spi.index.reader.VectorIndexReader;
+import org.apache.pinot.segment.spi.index.reader.FilterAwareVectorIndexReader;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-/// A Vector index reader for the real-time Vector index values on the fly.
-/// Since there is no good mutable vector index implementation for topK search, we just do brute force search.
+/// A vector index reader for real-time vector values indexed on the fly.
 ///
-/// This class is thread-safe for single writer multiple readers.
-public class MutableVectorIndex implements VectorIndexReader, MutableIndex, VectorIndexConfigProvider, EfSearchAware {
+/// Searches open a near-real-time Lucene reader from the active writer, so completed additions are visible without a
+/// commit. Pinot document IDs are stored explicitly and translated from the same reader generation used for search.
+/// Each instance owns a unique temporary directory, preventing Lucene write-lock collisions between replicas hosted
+/// in the same JVM.
+///
+/// This class is thread-safe for a single writer and multiple readers. Lifecycle coordination must prevent [#close()]
+/// from racing with active additions or searches.
+public class MutableVectorIndex
+    implements FilterAwareVectorIndexReader, MutableIndex, VectorIndexConfigProvider, EfSearchAware {
   private static final Logger LOGGER = LoggerFactory.getLogger(MutableVectorIndex.class);
   private static final RealtimeLuceneTextIndexSearcherPool SEARCHER_POOL =
       RealtimeLuceneTextIndexSearcherPool.getInstance();
@@ -73,7 +92,7 @@ public class MutableVectorIndex implements VectorIndexReader, MutableIndex, Vect
   private final File _indexDir;
   private final FSDirectory _indexDirectory;
   private final IndexWriter _indexWriter;
-  private int _nextDocId;
+  private volatile int _numDocs;
 
   private long _lastCommitTime;
   private final ThreadLocal<Integer> _efSearchOverride = new ThreadLocal<>();
@@ -90,10 +109,7 @@ public class MutableVectorIndex implements VectorIndexReader, MutableIndex, Vect
     _commitDocs = Long.parseLong(
         vectorIndexConfig.getProperties().getOrDefault("commitDocs", String.valueOf(DEFAULT_COMMIT_DOCS)));
     _vectorSimilarityFunction = VectorIndexUtils.toSimilarityFunction(vectorIndexConfig.getVectorDistanceFunction());
-    // Each column of a segment gets its own directory, so that cleaning up one column does not remove the index of
-    // another column of the same segment.
-    _indexDir = new File(new File(FileUtils.getTempDirectory(), segmentName),
-        _vectorColumn + V1Constants.Indexes.VECTOR_V912_HNSW_INDEX_FILE_EXTENSION);
+    _indexDir = createIndexDir(segmentName, vectorColumn);
 
     FSDirectory indexDirectory = null;
     IndexWriter indexWriter = null;
@@ -136,10 +152,13 @@ public class MutableVectorIndex implements VectorIndexReader, MutableIndex, Vect
     XKnnFloatVectorField xKnnFloatVectorField =
         new XKnnFloatVectorField(_vectorColumn, floatValues, _vectorSimilarityFunction);
     docToIndex.add(xKnnFloatVectorField);
-    docToIndex.add(new StoredField(VECTOR_INDEX_DOC_ID_COLUMN_NAME, _nextDocId++));
+    // The numeric doc value drives filtered traversal and translates Lucene hits back to Pinot document IDs from the
+    // same near-real-time reader generation.
+    docToIndex.add(new NumericDocValuesField(VECTOR_INDEX_DOC_ID_COLUMN_NAME, docId));
     try {
       _indexWriter.addDocument(docToIndex);
-      if ((_lastCommitTime + _commitIntervalMs < System.currentTimeMillis()) || (_nextDocId % _commitDocs == 0)) {
+      _numDocs++;
+      if ((_lastCommitTime + _commitIntervalMs < System.currentTimeMillis()) || (_numDocs % _commitDocs == 0)) {
         _indexWriter.commit();
         _lastCommitTime = System.currentTimeMillis();
         LOGGER.debug("Committed index for column: {}, segment: {}", _vectorColumn, _segmentName);
@@ -152,6 +171,21 @@ public class MutableVectorIndex implements VectorIndexReader, MutableIndex, Vect
 
   @Override
   public MutableRoaringBitmap getDocIds(float[] vector, int topK) {
+    return submitVectorSearch(Arrays.copyOf(vector, vector.length), topK, null);
+  }
+
+  @Override
+  public ImmutableRoaringBitmap getDocIds(float[] vector, int topK, ImmutableRoaringBitmap preFilterBitmap) {
+    ImmutableRoaringBitmap preFilterCopy =
+        preFilterBitmap.toMutableRoaringBitmap().toImmutableRoaringBitmap();
+    if (preFilterCopy.isEmpty()) {
+      return new MutableRoaringBitmap();
+    }
+    return submitVectorSearch(Arrays.copyOf(vector, vector.length), topK, preFilterCopy);
+  }
+
+  private MutableRoaringBitmap submitVectorSearch(float[] vector, int topK,
+      @Nullable ImmutableRoaringBitmap preFilterBitmap) {
     int effectiveEfSearch = getEffectiveEfSearch();
     boolean effectiveUseRelativeDistance = getEffectiveUseRelativeDistance();
     boolean effectiveUseBoundedQueue = getEffectiveUseBoundedQueue();
@@ -161,7 +195,7 @@ public class MutableVectorIndex implements VectorIndexReader, MutableIndex, Vect
     // See https://github.com/apache/lucene/issues/3315 and https://github.com/apache/lucene/issues/9309
     Future<MutableRoaringBitmap> searchFuture = SEARCHER_POOL.getExecutorService().submit(
         () -> executeVectorSearch(vector, topK, effectiveEfSearch, effectiveUseRelativeDistance,
-            effectiveUseBoundedQueue));
+            effectiveUseBoundedQueue, preFilterBitmap));
     try {
       return searchFuture.get();
     } catch (InterruptedException e) {
@@ -230,15 +264,15 @@ public class MutableVectorIndex implements VectorIndexReader, MutableIndex, Vect
     info.put("effectiveEfSearch", getEffectiveEfSearch());
     info.put("effectiveHnswUseRelativeDistance", getEffectiveUseRelativeDistance());
     info.put("effectiveHnswUseBoundedQueue", getEffectiveUseBoundedQueue());
-    info.put("supportsPreFilter", false);
-    try (DirectoryReader directoryReader = DirectoryReader.open(_indexDirectory)) {
+    info.put("supportsPreFilter", true);
+    try (DirectoryReader directoryReader = DirectoryReader.open(_indexWriter)) {
       info.put("numDocs", directoryReader.numDocs());
       info.put("numDeletedDocs", directoryReader.numDeletedDocs());
       info.put("luceneSegments", directoryReader.leaves().size());
     } catch (IOException e) {
       LOGGER.warn("Failed to load mutable HNSW debug stats for segment: {}, column: {}", _segmentName, _vectorColumn,
           e);
-      info.put("numDocs", _nextDocId);
+      info.put("numDocs", _numDocs);
       info.put("numDeletedDocs", 0);
       info.put("luceneSegments", 0);
     }
@@ -246,17 +280,37 @@ public class MutableVectorIndex implements VectorIndexReader, MutableIndex, Vect
   }
 
   private MutableRoaringBitmap executeVectorSearch(float[] vector, int topK, int efSearch,
-      boolean useRelativeDistance, boolean useBoundedQueue) throws IOException {
-    try (DirectoryReader directoryReader = DirectoryReader.open(_indexDirectory)) {
+      boolean useRelativeDistance, boolean useBoundedQueue,
+      @Nullable ImmutableRoaringBitmap preFilterBitmap) throws IOException {
+    // Open from the writer rather than the directory so completed, uncommitted additions are visible to the query.
+    try (DirectoryReader directoryReader = DirectoryReader.open(_indexWriter)) {
       IndexSearcher indexSearcher = new IndexSearcher(directoryReader);
+      Query filterQuery = preFilterBitmap != null
+          ? new PinotDocIdFilterQuery(preFilterBitmap, VECTOR_INDEX_DOC_ID_COLUMN_NAME) : null;
       KnnFloatVectorQuery query =
           LuceneHnswRuntimeControlUtils.createQuery(_vectorColumn, vector, topK, efSearch,
-              useRelativeDistance, useBoundedQueue, null);
-      MutableRoaringBitmap docIds = new MutableRoaringBitmap();
+              useRelativeDistance, useBoundedQueue, filterQuery);
       TopDocs search = indexSearcher.search(query, topK);
-      Arrays.stream(search.scoreDocs).map(scoreDoc -> scoreDoc.doc).forEach(docIds::add);
-      return docIds;
+      return translateTopDocs(directoryReader, search);
     }
+  }
+
+  private static MutableRoaringBitmap translateTopDocs(DirectoryReader directoryReader, TopDocs topDocs)
+      throws IOException {
+    MutableRoaringBitmap docIds = new MutableRoaringBitmap();
+    NumericDocValues pinotDocIds = MultiDocValues.getNumericValues(directoryReader, VECTOR_INDEX_DOC_ID_COLUMN_NAME);
+    if (pinotDocIds == null) {
+      throw new IllegalStateException("Missing Pinot document ID doc values");
+    }
+    ScoreDoc[] scoreDocs = Arrays.copyOf(topDocs.scoreDocs, topDocs.scoreDocs.length);
+    Arrays.sort(scoreDocs, Comparator.comparingInt(scoreDoc -> scoreDoc.doc));
+    for (ScoreDoc scoreDoc : scoreDocs) {
+      if (!pinotDocIds.advanceExact(scoreDoc.doc)) {
+        throw new IllegalStateException("Missing Pinot document ID for Lucene document: " + scoreDoc.doc);
+      }
+      docIds.add(Math.toIntExact(pinotDocIds.longValue()));
+    }
+    return docIds;
   }
 
   private int getEffectiveEfSearch() {
@@ -289,12 +343,147 @@ public class MutableVectorIndex implements VectorIndexReader, MutableIndex, Vect
     }
   }
 
-  /// Deletes the temporary index directory of this column, then the segment directory holding it if this was the last
-  /// column with an index under it.
+  /// Creates a directory private to this instance, so replicas of the same segment hosted in one JVM cannot collide
+  /// on a Lucene write lock. The segment and column are kept in the name so a directory left behind by a crashed
+  /// process can still be attributed.
+  private static File createIndexDir(String segmentName, String vectorColumn) {
+    String prefix = sanitizeForFileName(segmentName) + '-' + sanitizeForFileName(vectorColumn) + '-';
+    try {
+      return Files.createTempDirectory("pinot-mutable-vector-" + prefix).toFile();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to create temporary directory for mutable vector index", e);
+    }
+  }
+
+  /// Keeps the name filesystem-safe and bounded; the random suffix supplied by the JDK still guarantees uniqueness.
+  private static String sanitizeForFileName(String value) {
+    String sanitized = value.replaceAll("[^A-Za-z0-9._-]", "_");
+    return sanitized.length() <= 64 ? sanitized : sanitized.substring(0, 64);
+  }
+
+  /// Deletes this instance's private temporary index directory.
   private void deleteIndexDir() {
     FileUtils.deleteQuietly(_indexDir);
-    // Only succeeds when no other column of the same segment still has an index directory under it.
-    //noinspection ResultOfMethodCallIgnored
-    _indexDir.getParentFile().delete();
+  }
+
+  /// A Lucene filter query that tests Pinot document IDs stored as numeric doc values against a private bitmap copy.
+  /// Numeric doc values are resolved from each leaf of the same near-real-time reader used by the vector query, so the
+  /// mapping cannot drift across Lucene generations.
+  private static final class PinotDocIdFilterQuery extends Query {
+    private final ImmutableRoaringBitmap _bitmap;
+    private final String _docIdField;
+
+    private PinotDocIdFilterQuery(ImmutableRoaringBitmap bitmap, String docIdField) {
+      _bitmap = bitmap;
+      _docIdField = docIdField;
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) {
+      return new ConstantScoreWeight(this, boost) {
+        @Override
+        public Scorer scorer(LeafReaderContext context) throws IOException {
+          NumericDocValues pinotDocIds = context.reader().getNumericDocValues(_docIdField);
+          if (pinotDocIds == null) {
+            return null;
+          }
+          DocIdSetIterator iterator = new FilteredDocIdSetIterator(pinotDocIds, _bitmap);
+          float constantScore = score();
+          return new Scorer(this) {
+            @Override
+            public DocIdSetIterator iterator() {
+              return iterator;
+            }
+
+            @Override
+            public float getMaxScore(int upTo) {
+              return constantScore;
+            }
+
+            @Override
+            public float score() {
+              return constantScore;
+            }
+
+            @Override
+            public int docID() {
+              return iterator.docID();
+            }
+          };
+        }
+
+        @Override
+        public boolean isCacheable(LeafReaderContext context) {
+          return false;
+        }
+      };
+    }
+
+    @Override
+    public String toString(String field) {
+      return "PinotDocIdFilterQuery(cardinality=" + _bitmap.getCardinality() + ')';
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      }
+      if (!(other instanceof PinotDocIdFilterQuery)) {
+        return false;
+      }
+      PinotDocIdFilterQuery that = (PinotDocIdFilterQuery) other;
+      return _bitmap == that._bitmap && _docIdField.equals(that._docIdField);
+    }
+
+    @Override
+    public int hashCode() {
+      return System.identityHashCode(_bitmap) * 31 + _docIdField.hashCode();
+    }
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+      visitor.visitLeaf(this);
+    }
+  }
+
+  private static final class FilteredDocIdSetIterator extends DocIdSetIterator {
+    private final NumericDocValues _pinotDocIds;
+    private final ImmutableRoaringBitmap _bitmap;
+
+    private FilteredDocIdSetIterator(NumericDocValues pinotDocIds, ImmutableRoaringBitmap bitmap) {
+      _pinotDocIds = pinotDocIds;
+      _bitmap = bitmap;
+    }
+
+    @Override
+    public int docID() {
+      return _pinotDocIds.docID();
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+      return advanceToAllowed(_pinotDocIds.nextDoc());
+    }
+
+    @Override
+    public int advance(int target) throws IOException {
+      return advanceToAllowed(_pinotDocIds.advance(target));
+    }
+
+    private int advanceToAllowed(int luceneDocId) throws IOException {
+      while (luceneDocId != NO_MORE_DOCS) {
+        if (_bitmap.contains((int) _pinotDocIds.longValue())) {
+          return luceneDocId;
+        }
+        luceneDocId = _pinotDocIds.nextDoc();
+      }
+      return NO_MORE_DOCS;
+    }
+
+    @Override
+    public long cost() {
+      return Math.min(_pinotDocIds.cost(), _bitmap.getLongCardinality());
+    }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/vector/MutableVectorIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/vector/MutableVectorIndexTest.java
@@ -20,8 +20,15 @@ package org.apache.pinot.segment.local.realtime.impl.vector;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.apache.pinot.segment.local.realtime.impl.invertedindex.RealtimeLuceneTextIndexSearcherPool;
 import org.apache.pinot.segment.spi.index.creator.VectorIndexConfig;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -80,7 +87,7 @@ public class MutableVectorIndexTest {
       Assert.assertEquals(debugInfo.get("effectiveEfSearch"), 6);
       Assert.assertEquals(debugInfo.get("effectiveHnswUseRelativeDistance"), Boolean.FALSE);
       Assert.assertEquals(debugInfo.get("effectiveHnswUseBoundedQueue"), Boolean.FALSE);
-      Assert.assertEquals(debugInfo.get("supportsPreFilter"), Boolean.FALSE);
+      Assert.assertEquals(debugInfo.get("supportsPreFilter"), Boolean.TRUE);
     } finally {
       index.close();
     }
@@ -100,6 +107,136 @@ public class MutableVectorIndexTest {
     }
   }
 
+  @Test
+  public void testSearchReturnsSuppliedPinotDocumentIds() {
+    MutableVectorIndex index = createEmptyIndex(createConfig(1, 3_600_000L));
+    try {
+      addVector(index, new float[]{1.0F, 0.0F, 0.0F, 0.0F, 0.0F}, 17);
+      addVector(index, new float[]{0.0F, 1.0F, 0.0F, 0.0F, 0.0F}, 91);
+
+      Assert.assertEquals(index.getDocIds(new float[]{1.0F, 0.0F, 0.0F, 0.0F, 0.0F}, 1).toArray(),
+          new int[]{17}, "Search results must contain the supplied Pinot ID, not Lucene's internal document ID");
+      Assert.assertEquals(index.getDocIds(new float[]{0.0F, 1.0F, 0.0F, 0.0F, 0.0F}, 2).toArray(),
+          new int[]{17, 91},
+          "Pinot ID translation must work when relevance order is the reverse of Lucene document order");
+    } finally {
+      index.close();
+    }
+  }
+
+  @Test
+  public void testFilteredSearchExcludesNearerDisallowedDocuments() {
+    MutableVectorIndex index = createEmptyIndex(createConfig(1, 3_600_000L));
+    try {
+      addFilterFixture(index);
+      float[] queryVector = {1.0F, 0.0F, 0.0F, 0.0F, 0.0F};
+      Assert.assertEquals(index.getDocIds(queryVector, 1).toArray(), new int[]{101},
+          "The nearest unfiltered document should be outside the allowed set");
+
+      MutableRoaringBitmap allowedDocIds = bitmapOf(7, 42);
+      Assert.assertEquals(index.getDocIds(queryVector, 2, allowedDocIds).toArray(), new int[]{7, 42});
+      Assert.assertEquals(allowedDocIds, bitmapOf(7, 42), "Filtered search must not mutate the caller bitmap");
+    } finally {
+      index.close();
+    }
+  }
+
+  @Test
+  public void testUncommittedAdditionIsNearRealTimeVisible() {
+    MutableVectorIndex index = createEmptyIndex(createConfig(1_000, 3_600_000L));
+    try {
+      addVector(index, new float[]{1.0F, 0.0F, 0.0F, 0.0F, 0.0F}, 23);
+
+      Assert.assertEquals(index.getDocIds(new float[]{1.0F, 0.0F, 0.0F, 0.0F, 0.0F}, 1).toArray(),
+          new int[]{23}, "A completed addition must be visible before the commit threshold is reached");
+      Assert.assertEquals(index.getIndexDebugInfo().get("numDocs"), 1);
+    } finally {
+      index.close();
+    }
+  }
+
+  @Test
+  public void testFilteredSearchSeesUncommittedVectorAndDocValueInSameReader() {
+    MutableVectorIndex index = createEmptyIndex(createConfig(1_000, 3_600_000L));
+    try {
+      addVector(index, new float[]{0.0F, 1.0F, 0.0F, 0.0F, 0.0F}, 5);
+      addVector(index, new float[]{1.0F, 0.0F, 0.0F, 0.0F, 0.0F}, 137);
+
+      Assert.assertEquals(
+          index.getDocIds(new float[]{1.0F, 0.0F, 0.0F, 0.0F, 0.0F}, 1, bitmapOf(137)).toArray(),
+          new int[]{137},
+          "Filtered NRT search must see the vector and its Pinot-ID doc value in one reader generation");
+      Assert.assertEquals(index.getIndexDebugInfo().get("numDocs"), 2);
+    } finally {
+      index.close();
+    }
+  }
+
+  @Test
+  public void testSameSegmentAndColumnIndexesUseIsolatedDirectories() {
+    String segmentName = "mutableVectorIndexTest_" + System.nanoTime();
+    MutableVectorIndex firstIndex = createIndex(segmentName, COLUMN_NAME);
+    boolean firstIndexClosed = false;
+    try {
+      MutableVectorIndex secondIndex = createIndex(segmentName, COLUMN_NAME);
+      try {
+        firstIndex.close();
+        firstIndexClosed = true;
+        int[] matches =
+            secondIndex.getDocIds(new float[]{5.0F, 42.0F, 54.33333F, 42.24F, 3413.4F}, 3).toArray();
+        Assert.assertEquals(matches.length, 3,
+            "Closing one instance must not remove another instance's same-segment, same-column index");
+      } finally {
+        secondIndex.close();
+      }
+    } finally {
+      if (!firstIndexClosed) {
+        firstIndex.close();
+      }
+    }
+  }
+
+  @Test
+  public void testFilteredSearchCopiesBitmapBeforeAsyncDispatch()
+      throws Exception {
+    MutableVectorIndex index = createEmptyIndex(createConfig(1, 3_600_000L));
+    ExecutorService callerExecutor = Executors.newSingleThreadExecutor();
+    CountDownLatch searcherBlocked = new CountDownLatch(1);
+    CountDownLatch releaseSearcher = new CountDownLatch(1);
+    Future<?> blocker = RealtimeLuceneTextIndexSearcherPool.getInstance().getExecutorService().submit(() -> {
+      searcherBlocked.countDown();
+      try {
+        releaseSearcher.await();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
+      }
+    });
+    try {
+      Assert.assertTrue(searcherBlocked.await(10, TimeUnit.SECONDS));
+      addFilterFixture(index);
+      CountDownLatch bitmapCopied = new CountDownLatch(1);
+      CopySignalingBitmap allowedDocIds = new CopySignalingBitmap(bitmapCopied);
+      allowedDocIds.add(7);
+      allowedDocIds.add(42);
+
+      Future<ImmutableRoaringBitmap> search = callerExecutor.submit(
+          () -> index.getDocIds(new float[]{1.0F, 0.0F, 0.0F, 0.0F, 0.0F}, 2, allowedDocIds));
+      Assert.assertTrue(bitmapCopied.await(10, TimeUnit.SECONDS));
+      allowedDocIds.clear();
+      allowedDocIds.add(101);
+      releaseSearcher.countDown();
+
+      Assert.assertEquals(search.get(10, TimeUnit.SECONDS), bitmapOf(7, 42),
+          "Queued search must use the bitmap state captured before dispatch");
+      blocker.get(10, TimeUnit.SECONDS);
+    } finally {
+      releaseSearcher.countDown();
+      callerExecutor.shutdownNow();
+      index.close();
+    }
+  }
+
   private static MutableVectorIndex createIndex() {
     return createIndex("mutableVectorIndexTest_" + System.nanoTime(), COLUMN_NAME);
   }
@@ -113,6 +250,16 @@ public class MutableVectorIndexTest {
     return index;
   }
 
+  private static MutableVectorIndex createEmptyIndex(VectorIndexConfig config) {
+    return new MutableVectorIndex("mutableVectorIndexTest_" + System.nanoTime(), COLUMN_NAME, config);
+  }
+
+  private static void addFilterFixture(MutableVectorIndex index) {
+    addVector(index, new float[]{1.0F, 0.0F, 0.0F, 0.0F, 0.0F}, 101);
+    addVector(index, new float[]{0.0F, 1.0F, 0.0F, 0.0F, 0.0F}, 7);
+    addVector(index, new float[]{-1.0F, 0.0F, 0.0F, 0.0F, 0.0F}, 42);
+  }
+
   private static void addVector(MutableVectorIndex index, float[] values, int docId) {
     Object[] boxed = new Object[values.length];
     for (int i = 0; i < values.length; i++) {
@@ -122,11 +269,37 @@ public class MutableVectorIndexTest {
   }
 
   private static VectorIndexConfig createConfig() {
+    return createConfig(4, MutableVectorIndex.DEFAULT_COMMIT_INTERVAL_MS);
+  }
+
+  private static VectorIndexConfig createConfig(long commitDocs, long commitIntervalMs) {
     Map<String, String> properties = new HashMap<>();
-    properties.put("commitDocs", "4");
+    properties.put("commitDocs", Long.toString(commitDocs));
+    properties.put("commitIntervalMs", Long.toString(commitIntervalMs));
     properties.put("vectorIndexType", "HNSW");
     properties.put("vectorDimension", "5");
     return new VectorIndexConfig(false, "HNSW", 5, 1, VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN,
         properties);
+  }
+
+  private static MutableRoaringBitmap bitmapOf(int... docIds) {
+    MutableRoaringBitmap bitmap = new MutableRoaringBitmap();
+    bitmap.add(docIds);
+    return bitmap;
+  }
+
+  private static final class CopySignalingBitmap extends MutableRoaringBitmap {
+    private final CountDownLatch _bitmapCopied;
+
+    private CopySignalingBitmap(CountDownLatch bitmapCopied) {
+      _bitmapCopied = bitmapCopied;
+    }
+
+    @Override
+    public MutableRoaringBitmap toMutableRoaringBitmap() {
+      MutableRoaringBitmap copy = super.toMutableRoaringBitmap();
+      _bitmapCopied.countDown();
+      return copy;
+    }
   }
 }


### PR DESCRIPTION
## Summary

`MutableVectorIndex` could not restrict its search to a document set, so every vector
query on a consuming segment of an upsert table fell back to a brute-force exact scan
over the forward index. This implements `FilterAwareVectorIndexReader` so those queries
use filtered ANN instead.

- Store the Pinot document ID as a numeric doc value rather than a stored field, so it
  can drive filtered graph traversal and translate hits back from the same reader
  generation used for search.
- Take the document ID from the caller instead of an internal counter. `MutableIndex.add`
  documents that rows may arrive in any order, so the counter produced wrong document IDs
  under out-of-order ingestion — a latent bug independent of filtering.
- Open the reader from the writer so completed additions are searchable without waiting
  for a commit.
- Give each instance its own temporary directory, so replicas of the same segment hosted
  in one JVM cannot collide on a Lucene write lock. The segment and column stay in the
  directory name so one left behind by a crashed process can still be attributed.

No planner change is required. `FilterPlanNode` already routes a required candidate
document set to filtered ANN whenever the reader advertises the capability, and to
`ExactVectorScanFilterOperator` when it does not, so this change alone flips consuming
segments of upsert tables off the exact-scan path.

## Rebased

This was a cumulative draft stacked on #19287. That work has since landed as
#19297, #19298, #19299 and #19300, so this branch is now rebased directly onto `master`
and contains only the mutable-index layer: **2 files, +383/-31**, down from 15 files.

Dropped as obsolete during the rebase:

- all `pinot-core` plumbing (`VectorCandidateScope`, `FilterPlanNode`,
  `VectorSimilarityFilterOperator`, `ExactVectorScanFilterOperator`,
  `VectorSearchStrategy`) — superseded by the merged design, which reaches the same
  outcome with no changes here;
- the `org.jetbrains:annotations` dependency added to `pinot-segment-local`, which was
  unused (the module compiles without it).

## Publication boundary

Opening the reader from the writer makes rows visible to search as soon as they are
added, which is slightly ahead of when the segment publishes them to queries (a row is
added to the indexes, then the document count is raised). Documents past that boundary
cannot produce wrong data: `BitmapDocIdIterator` stops at the segment's `numDocs`, so
they are never read. The residual effect is that such a document can occupy a top-K slot
and then be dropped, so a query against a consuming segment can return fewer than K rows
within that window.

The window is narrow and the same shape as the pre-existing one (a commit could already
land between a row being added and the count being raised), but it is wider now.
Bounding candidate traversal by the published watermark would close it; testing
`pinotDocId < numPublishedDocs` inside the filter iterator is O(1) per candidate and
needs no allocation, unlike materializing a dense bitmap per query.

## Follow-ups worth considering

- Reuse the existing `HnswVectorIndexReader.RoaringBitmapFilterQuery` instead of the
  second filter-query implementation added here; extracting a shared base would keep the
  two from drifting.
- A near-real-time reader is opened per search. Lucene's `SearcherManager` /
  `ReaderManager` with `maybeRefresh()` is the usual pattern and is worth benchmarking
  now that this is the default path for realtime vector queries.

## Validation

- `MutableVectorIndexTest`: 10 tests passed, covering supplied document IDs, filtered
  exclusion of nearer disallowed documents, near-real-time visibility of uncommitted
  additions, same-reader-generation translation, directory isolation, and the bitmap copy
  before async dispatch.
- `HnswVectorIndexCreatorTest`: 6 tests passed.
- Spotless, Checkstyle, and license checks passed on `pinot-segment-local`.
