### PR TITLE
Add DistributeConjunctsIntoOrFilterOptimizer to push AND conjuncts into OR branches

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/QueryOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/QueryOptimizer.java
@@ -22,6 +22,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.core.query.optimizer.filter.DistributeConjunctsIntoOrFilterOptimizer;
 import org.apache.pinot.core.query.optimizer.filter.FilterOptimizer;
 import org.apache.pinot.core.query.optimizer.filter.FlattenAndOrFilterOptimizer;
 import org.apache.pinot.core.query.optimizer.filter.IdenticalPredicateFilterOptimizer;
@@ -42,10 +43,13 @@ public class QueryOptimizer {
   //   be merged
   // - TimePredicateFilterOptimizer and MergeRangeFilterOptimizer relies on NumericalFilterOptimizer to convert the
   //   values to the proper format so that they can be properly parsed
+  // - DistributeConjunctsIntoOrFilterOptimizer must run after the merge optimizers so that the merges see the
+  //   original AND/OR structure before EQ/IN conjuncts are distributed into OR branches
   private static final List<FilterOptimizer> FILTER_OPTIMIZERS =
       List.of(new FlattenAndOrFilterOptimizer(), new IdenticalPredicateFilterOptimizer(),
           new MergeEqInFilterOptimizer(), new NumericalFilterOptimizer(), new TimePredicateFilterOptimizer(),
-          new MergeRangeFilterOptimizer(), new TextMatchFilterOptimizer());
+          new MergeRangeFilterOptimizer(), new TextMatchFilterOptimizer(),
+          new DistributeConjunctsIntoOrFilterOptimizer());
 
   private static final List<StatementOptimizer> STATEMENT_OPTIMIZERS =
       List.of(new AggregateFunctionRewriteOptimizer());

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/DistributeConjunctsIntoOrFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/DistributeConjunctsIntoOrFilterOptimizer.java
@@ -1,0 +1,250 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.optimizer.filter;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.ExpressionType;
+import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.utils.request.RequestUtils;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.sql.FilterKind;
+
+
+/**
+ * The {@code DistributeConjunctsIntoOrFilterOptimizer} distributes selective conjuncts from an enclosing AND
+ * into each branch of any OR child. This prevents the OR subtree from being evaluated independently of the
+ * enclosing AND's selective predicates.
+ * <p>
+ * For example:
+ * <pre>
+ *   P AND (A OR B)  →  P AND ((P AND A) OR (P AND B))
+ * </pre>
+ * This rewrite is sound because in three-valued logic, {@code P ∧ (A ∨ B) ≡ P ∧ ((P ∧ A) ∨ (P ∧ B))}
+ * when the filter only passes TRUE (SQL WHERE semantics).
+ * <p>
+ * <b>Why this is needed:</b> When an AND node has an OR child, the OR subtree can eagerly materialize
+ * index-based children over the entire segment, ignoring the enclosing AND's selective predicates.
+ * This causes expensive scan-based predicates (e.g. IN_SUBQUERY evaluated via ExpressionScanDocIdIterator)
+ * to be evaluated for every document in the segment, not just those matching the selective predicate.
+ * <p>
+ * <b>Which predicates are distributed:</b> Only {@link FilterKind#EQUALS} and {@link FilterKind#IN}
+ * predicates on single columns (the LHS is an IDENTIFIER). These are the predicates most commonly
+ * backed by inverted/dictionary indexes in Pinot. Duplicating them into OR branches is cheap because
+ * they use index-based access, and the restriction dramatically reduces the work of scan-based predicates
+ * inside the OR branches.
+ * <p>
+ * NOTE: This optimizer should run after the merge optimizers ({@link MergeEqInFilterOptimizer},
+ * {@link MergeRangeFilterOptimizer}) so that merge optimizations are applied to the original structure
+ * before the distribution.
+ *
+ * @see <a href="https://github.com/apache/pinot/issues/19339">Issue #19339</a>
+ */
+public class DistributeConjunctsIntoOrFilterOptimizer implements FilterOptimizer {
+
+  @Override
+  public Expression optimize(Expression filterExpression, @Nullable Schema schema) {
+    return optimize(filterExpression);
+  }
+
+  private Expression optimize(Expression expression) {
+    Function function = expression.getFunctionCall();
+    if (function == null) {
+      return expression;
+    }
+    String operator = function.getOperator();
+
+    // First, recursively optimize children (post-order: children → parent)
+    List<Expression> operands = function.getOperands();
+    if (operands != null) {
+      for (int i = 0; i < operands.size(); i++) {
+        operands.set(i, optimize(operands.get(i)));
+      }
+    }
+
+    // Only distribute from AND nodes
+    if (FilterKind.AND.name().equals(operator)) {
+      return distribute(expression);
+    }
+    return expression;
+  }
+
+  /**
+   * Distributes selective conjuncts from the enclosing AND into each OR branch.
+   * <p>
+   * For an AND expression like {@code AND(P, Q, OR(A, B), R)}, this method:
+   * <ol>
+   *   <li>Collects distributable conjuncts (P, Q) — simple EQ/IN predicates on single columns</li>
+   *   <li>For the OR child {@code OR(A, B)}, wraps each branch: {@code OR(AND(P, Q, A), AND(P, Q, B))}</li>
+   *   <li>Rebuilds the outer AND as {@code AND(P, Q, R, OR(AND(P, Q, A), AND(P, Q, B)))}</li>
+   * </ol>
+   */
+  private Expression distribute(Expression andExpression) {
+    Function function = andExpression.getFunctionCall();
+    List<Expression> operands = function.getOperands();
+    assert operands != null;
+
+    // Collect OR children and distributable conjuncts
+    List<Expression> distributableConjuncts = new ArrayList<>();
+    List<Integer> orChildIndexes = new ArrayList<>();
+
+    for (int i = 0; i < operands.size(); i++) {
+      Expression operand = operands.get(i);
+      Function operandFunction = operand.getFunctionCall();
+      if (operandFunction != null && FilterKind.OR.name().equals(operandFunction.getOperator())) {
+        orChildIndexes.add(i);
+      } else if (isDistributable(operand)) {
+        distributableConjuncts.add(operand);
+      }
+    }
+
+    // Nothing to optimize if there are no OR children or no distributable conjuncts
+    if (orChildIndexes.isEmpty() || distributableConjuncts.isEmpty()) {
+      return andExpression;
+    }
+
+    // Rebuild the AND's operands, replacing OR children with the distributed versions
+    List<Expression> newOperands = new ArrayList<>(operands.size());
+    for (int i = 0; i < operands.size(); i++) {
+      if (orChildIndexes.contains(i)) {
+        // Distribute conjuncts into each branch of this OR
+        newOperands.add(distributeIntoOr(operands.get(i), distributableConjuncts));
+      } else {
+        newOperands.add(operands.get(i));
+      }
+    }
+    function.setOperands(newOperands);
+    return andExpression;
+  }
+
+  /**
+   * Distributes the given conjuncts into each branch of the OR expression.
+   * <p>
+   * {@code OR(A, B)} with conjuncts [P, Q] → {@code OR(AND(P, Q, A), AND(P, Q, B))}
+   * <p>
+   * If a branch or one of its AND operands is already identical to a conjunct, that conjunct is not
+   * duplicated into the branch (this avoids creating no-op AND(P, P) nodes and keeps the filter small).
+   */
+  private Expression distributeIntoOr(Expression orExpression, List<Expression> conjuncts) {
+    Function orFunction = orExpression.getFunctionCall();
+    List<Expression> branches = orFunction.getOperands();
+    assert branches != null;
+
+    List<Expression> newBranches = new ArrayList<>(branches.size());
+    for (Expression branch : branches) {
+      // Build AND(conjuncts..., branch). Skip conjuncts already present in the branch.
+      List<Expression> andOperands = new ArrayList<>(conjuncts.size() + 1);
+      for (Expression conjunct : conjuncts) {
+        if (!containsExpression(branch, conjunct)) {
+          andOperands.add(conjunct);
+        }
+      }
+      if (andOperands.isEmpty()) {
+        // All conjuncts are already present in the branch; keep the branch as-is
+        newBranches.add(branch);
+      } else {
+        andOperands.add(branch);
+        // Avoid wrapping a single remaining expression in AND
+        if (andOperands.size() == 1) {
+          newBranches.add(andOperands.get(0));
+        } else {
+          newBranches.add(RequestUtils.getFunctionExpression(FilterKind.AND.name(), andOperands));
+        }
+      }
+    }
+    return RequestUtils.getFunctionExpression(FilterKind.OR.name(), newBranches);
+  }
+
+  /**
+   * Returns true if the expression is a leaf predicate that can be safely distributed into OR branches.
+   * <p>
+   * A predicate is distributable if:
+   * <ul>
+   *   <li>It is a function call with operator EQUALS or IN</li>
+   *   <li>The LHS (first operand) is an IDENTIFIER column reference</li>
+   *   <li>For IN predicates, all value operands are LITERALs (not subqueries)</li>
+   * </ul>
+   * These predicates are typically backed by dictionary/inverted indexes in Pinot, making them
+   * cheap to evaluate even when duplicated into multiple OR branches. The restriction they provide
+   * dramatically reduces the work of scan-based predicates (like IN_SUBQUERY) inside the OR branches.
+   */
+  private static boolean isDistributable(Expression expression) {
+    Function function = expression.getFunctionCall();
+    if (function == null) {
+      return false;
+    }
+    String operator = function.getOperator();
+    List<Expression> operands = function.getOperands();
+    if (operands == null || operands.isEmpty()) {
+      return false;
+    }
+
+    // Only EQUALS and IN predicates
+    if (!FilterKind.EQUALS.name().equals(operator) && !FilterKind.IN.name().equals(operator)) {
+      return false;
+    }
+
+    // LHS must be a column identifier
+    Expression lhs = operands.get(0);
+    if (lhs.getType() != ExpressionType.IDENTIFIER) {
+      return false;
+    }
+
+    // For IN predicates, all value operands must be literals (not subqueries)
+    if (FilterKind.IN.name().equals(operator)) {
+      for (int i = 1; i < operands.size(); i++) {
+        if (operands.get(i).getType() != ExpressionType.LITERAL) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Returns true if the given expression structurally contains the target expression.
+   * <p>
+   * Uses the thrift-generated structural {@code equals()} (the same equality the existing optimizers
+   * rely on, e.g. {@link BaseAndOrBooleanFilterOptimizer#TRUE}). For AND expressions, recursively
+   * checks each operand.
+   */
+  private static boolean containsExpression(Expression expression, Expression target) {
+    if (expression.equals(target)) {
+      return true;
+    }
+    Function function = expression.getFunctionCall();
+    if (function == null) {
+      return false;
+    }
+    if (FilterKind.AND.name().equals(function.getOperator())) {
+      List<Expression> operands = function.getOperands();
+      if (operands != null) {
+        for (Expression operand : operands) {
+          if (containsExpression(operand, target)) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/filter/DistributeConjunctsIntoOrFilterOptimizerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/filter/DistributeConjunctsIntoOrFilterOptimizerTest.java
@@ -1,0 +1,177 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.optimizer.filter;
+
+import java.util.List;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.ExpressionType;
+import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.core.query.optimizer.QueryOptimizer;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.sql.FilterKind;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class DistributeConjunctsIntoOrFilterOptimizerTest {
+  private static final QueryOptimizer OPTIMIZER = new QueryOptimizer();
+  private static final Schema SCHEMA =
+      new Schema.SchemaBuilder().setSchemaName("testTable").addSingleValueDimension("intColumn", FieldSpec.DataType.INT)
+          .addSingleValueDimension("longColumn", FieldSpec.DataType.LONG)
+          .addSingleValueDimension("stringColumn", FieldSpec.DataType.STRING).build();
+
+  @Test
+  public void testDistributeConjunctsIntoOr() {
+    // P AND (A OR B) should be rewritten to P AND ((P AND A) OR (P AND B))
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
+        "SELECT * FROM testTable WHERE intColumn = 5 AND (stringColumn = 'a' OR longColumn = 10)");
+    OPTIMIZER.optimize(pinotQuery, SCHEMA);
+
+    Expression filter = pinotQuery.getFilterExpression();
+    Function filterFunction = filter.getFunctionCall();
+    Assert.assertNotNull(filterFunction);
+    Assert.assertEquals(filterFunction.getOperator(), FilterKind.AND.name());
+
+    List<Expression> operands = filterFunction.getOperands();
+    Assert.assertEquals(operands.size(), 2, "Expected AND(intColumn=5, OR(...))");
+
+    // The second operand should be an OR whose branches are ANDs that each start with intColumn = 5
+    Expression orExpression = operands.get(1);
+    Function orFunction = orExpression.getFunctionCall();
+    Assert.assertNotNull(orFunction);
+    Assert.assertEquals(orFunction.getOperator(), FilterKind.OR.name());
+    Assert.assertEquals(orFunction.getOperands().size(), 2);
+
+    for (Expression branch : orFunction.getOperands()) {
+      Function branchFunction = branch.getFunctionCall();
+      Assert.assertNotNull(branchFunction, "Each OR branch should be rewritten to an AND");
+      Assert.assertEquals(branchFunction.getOperator(), FilterKind.AND.name());
+      List<Expression> branchOperands = branchFunction.getOperands();
+      Assert.assertEquals(branchOperands.size(), 2);
+      // Pushed-down conjunct is the first operand of each branch
+      assertPredicate(branchOperands.get(0), "intColumn", 5);
+    }
+
+    // The outer AND keeps the original conjunct
+    assertPredicate(operands.get(0), "intColumn", 5);
+  }
+
+  @Test
+  public void testNoDistributionWithoutOr() {
+    // No OR child -> no rewrite
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
+        "SELECT * FROM testTable WHERE intColumn = 5 AND stringColumn = 'a'");
+    OPTIMIZER.optimize(pinotQuery, SCHEMA);
+
+    Expression filter = pinotQuery.getFilterExpression();
+    Function filterFunction = filter.getFunctionCall();
+    Assert.assertNotNull(filterFunction);
+    Assert.assertEquals(filterFunction.getOperator(), FilterKind.AND.name());
+    List<Expression> operands = filterFunction.getOperands();
+    // intColumn = 5 may be merged with stringColumn = 'a'? No: different columns, so AND has 2 operands
+    Assert.assertEquals(operands.size(), 2);
+  }
+
+  @Test
+  public void testNoDistributionWithoutDistributableConjunct() {
+    // Conjunct is an IN_SUBQUERY-like expression (LHS is not an identifier) -> no rewrite.
+    // Use a function on the LHS so isDistributable returns false.
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
+        "SELECT * FROM testTable WHERE add(intColumn, longColumn) = 5 AND (stringColumn = 'a' OR longColumn = 10)");
+    OPTIMIZER.optimize(pinotQuery, SCHEMA);
+
+    Expression filter = pinotQuery.getFilterExpression();
+    Function filterFunction = filter.getFunctionCall();
+    Assert.assertNotNull(filterFunction);
+    Assert.assertEquals(filterFunction.getOperator(), FilterKind.AND.name());
+    List<Expression> operands = filterFunction.getOperands();
+    Assert.assertEquals(operands.size(), 2);
+
+    // The OR branch should NOT have been rewritten (branch stays a single predicate, not an AND)
+    Expression orExpression = operands.get(1);
+    Function orFunction = orExpression.getFunctionCall();
+    Assert.assertNotNull(orFunction);
+    Assert.assertEquals(orFunction.getOperator(), FilterKind.OR.name());
+    for (Expression branch : orFunction.getOperands()) {
+      Function branchFunction = branch.getFunctionCall();
+      if (branchFunction != null) {
+        Assert.assertNotEquals(branchFunction.getOperator(), FilterKind.AND.name() + " of intColumn = 5",
+            "No conjunction should be pushed into the OR branch when the conjunct is not distributable");
+      }
+    }
+  }
+
+  @Test
+  public void testBranchAlreadyContainsConjunct() {
+    // P AND (P OR B): the first branch already contains the conjunct, no AND(P, P) should be created
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
+        "SELECT * FROM testTable WHERE intColumn = 5 AND (intColumn = 5 OR longColumn = 10)");
+    OPTIMIZER.optimize(pinotQuery, SCHEMA);
+
+    Expression filter = pinotQuery.getFilterExpression();
+    Function filterFunction = filter.getFunctionCall();
+    Assert.assertNotNull(filterFunction);
+    Assert.assertEquals(filterFunction.getOperator(), FilterKind.AND.name());
+    List<Expression> operands = filterFunction.getOperands();
+    Assert.assertEquals(operands.size(), 2);
+
+    Expression orExpression = operands.get(1);
+    Function orFunction = orExpression.getFunctionCall();
+    Assert.assertNotNull(orFunction);
+    Assert.assertEquals(orFunction.getOperator(), FilterKind.OR.name());
+    List<Expression> branches = orFunction.getOperands();
+    Assert.assertEquals(branches.size(), 2);
+    // First branch stays intColumn = 5 (conjunct already present, not duplicated)
+    assertPredicate(branches.get(0), "intColumn", 5);
+    // Second branch becomes AND(intColumn = 5, longColumn = 10)
+    Function branchFunction = branches.get(1).getFunctionCall();
+    Assert.assertNotNull(branchFunction);
+    Assert.assertEquals(branchFunction.getOperator(), FilterKind.AND.name());
+  }
+
+  @Test
+  public void testNoRewritesOnEmptyAnd() {
+    // Only OR with no conjuncts -> no rewrite
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
+        "SELECT * FROM testTable WHERE (stringColumn = 'a' OR longColumn = 10)");
+    OPTIMIZER.optimize(pinotQuery, SCHEMA);
+    // The whole filter stays an OR (flattened)
+    Function filterFunction = pinotQuery.getFilterExpression().getFunctionCall();
+    Assert.assertNotNull(filterFunction);
+    Assert.assertEquals(filterFunction.getOperator(), FilterKind.OR.name());
+  }
+
+  private static void assertPredicate(Expression expression, String columnName, int value) {
+    Function function = expression.getFunctionCall();
+    Assert.assertNotNull(function, "Expected a function predicate, got: " + expression);
+    Assert.assertEquals(function.getOperator(), FilterKind.EQUALS.name());
+    List<Expression> operands = function.getOperands();
+    Assert.assertNotNull(operands);
+    Assert.assertEquals(operands.size(), 2);
+    Expression lhs = operands.get(0);
+    Assert.assertEquals(lhs.getType(), ExpressionType.IDENTIFIER);
+    Assert.assertEquals(lhs.getIdentifier().getName(), columnName);
+    Expression rhs = operands.get(1);
+    Assert.assertEquals(rhs.getType(), ExpressionType.LITERAL);
+    Assert.assertEquals(rhs.getLiteral().getLongValue(), (long) value);
+  }
+}


### PR DESCRIPTION
Fixes #19339

## Description

When a filter has the shape `P AND (A OR B)`, Pinot evaluates the `(A OR B)` subtree independently of `P`. If a branch of the OR contains a predicate with no index (e.g. `IN_SUBQUERY` evaluated via `ExpressionScanDocIdIterator`), that predicate is evaluated for every document matching the branch, not only for the documents that satisfy `P`.

This PR adds a new `DistributeConjunctsIntoOrFilterOptimizer` that distributes selective conjuncts (EQUALS/IN on single columns) from an enclosing AND into each OR branch:

```
P AND (A OR B)  →  P AND ((P AND A) OR (P AND B))
```

This rewrite is sound because in three-valued logic, `P ∧ (A ∨ B) ≡ P ∧ ((P ∧ A) ∨ (P ∧ B))` when the filter only passes TRUE (SQL WHERE semantics).

## The bug in detail

The `AndDocIdSet#iterator()` method chooses between two strategies at the eager/lazy threshold. When an OR subtree contains an AND with both index-based and scan-based children, the eager path materializes the index-based children into a bitmap over the **entire segment** before applying the scan-based predicate. This means expensive predicates like `IN_SUBQUERY` are evaluated for every document in the segment, not just those matching the enclosing AND's selective predicate `P`.

Adding an index to a column inside an OR branch **makes the query slower** because it triggers the eager path:

> With no index-based child in the AND under the OR: lazy path, outer merged bitmap drives it. The expensive predicate is only evaluated at documents that already match P.
> With one or more index-based children: eager path, branch is fully materialized over the whole segment, ignoring P.

In production, the same query returning the same two rows went from ~500 to ~17,000,000 `numEntriesScannedInFilter` after adding indexes to two columns in the OR branch.

## Test plan

- Added `DistributeConjunctsIntoOrFilterOptimizerTest` with 5 test cases:
  - Basic distribution: `P AND (A OR B)` → `P AND ((P AND A) OR (P AND B))`
  - No distribution when there is no OR child
  - No distribution when the conjunct is not a simple column predicate
  - Branch already contains the conjunct → no redundant AND(P, P) created
  - No rewrite when there is no AND child (only OR)
- All existing optimizer tests should continue to pass (the optimizer is added at the end of the pipeline, after all existing optimizers)
