### PR TITLE
Upgrade checkstyle from 10.26.1 to 14.0.0

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -223,13 +223,6 @@
                 value="Use /// markdown doc comments (JEP 467) instead of /** */ Javadoc."/>
     </module>
 
-    <!-- If you have a Javadoc comment, make sure it is properly formed.
-         NOTE: this only inspects /** */ comments, so it no longer applies to the /// doc
-         comments that the codebase now uses. -->
-    <module name="JavadocStyle">
-      <property name="checkFirstSentence" value="false"/>
-    </module>
-
     <!-- NAMING CONVENTIONS -->
 
     <!-- Generic parameters for a class must be uppercase letters (e.g. <T>, <OLD>) -->

--- a/pinot-plugins/pinot-metrics/pinot-compound-metrics/src/main/java/org/apache/pinot/plugin/metrics/compound/CompoundPinotMetricsFactory.java
+++ b/pinot-plugins/pinot-metrics/pinot-compound-metrics/src/main/java/org/apache/pinot/plugin/metrics/compound/CompoundPinotMetricsFactory.java
@@ -184,13 +184,12 @@ public class CompoundPinotMetricsFactory implements PinotMetricsFactory {
       protected Stream<PinotMetricsFactory> streamInstances(PinotConfiguration metricsConfiguration) {
         return PinotMetricUtils.getPinotMetricsFactoryClasses().stream()
             .map(clazz -> {
-                  try {
-                    return (PinotMetricsFactory) clazz.getDeclaredConstructor().newInstance();
-                  } catch (Exception ex) {
-                    throw new IllegalArgumentException("Cannot instantiate class " + clazz, ex);
-                  }
-                }
-            );
+              try {
+                return (PinotMetricsFactory) clazz.getDeclaredConstructor().newInstance();
+              } catch (Exception ex) {
+                throw new IllegalArgumentException("Cannot instantiate class " + clazz, ex);
+              }
+            });
       }
     },
     /// An algorithm returns all the factories listed in the config under the [#LIST_KEY].
@@ -199,15 +198,14 @@ public class CompoundPinotMetricsFactory implements PinotMetricsFactory {
       protected Stream<PinotMetricsFactory> streamInstances(PinotConfiguration metricsConfiguration) {
         return metricsConfiguration.getProperty(LIST_KEY, List.of()).stream()
             .map(className -> {
-                  try {
-                    return PluginManager.get().createInstance(className);
-                  } catch (ClassNotFoundException ex) {
-                    throw new IllegalArgumentException("Cannot find metric factory named " + className, ex);
-                  } catch (Exception ex) {
-                    throw new IllegalArgumentException("Cannot instantiate class " + className, ex);
-                  }
-                }
-            );
+              try {
+                return PluginManager.get().createInstance(className);
+              } catch (ClassNotFoundException ex) {
+                throw new IllegalArgumentException("Cannot find metric factory named " + className, ex);
+              } catch (Exception ex) {
+                throw new IllegalArgumentException("Cannot instantiate class " + className, ex);
+              }
+            });
       }
     };
 

--- a/pom.xml
+++ b/pom.xml
@@ -2534,7 +2534,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.26.1</version>
+            <version>14.0.0</version>
           </dependency>
         </dependencies>
         <executions>


### PR DESCRIPTION
## Summary

Supersedes #19345, where every CI job fails because the checkstyle config no longer loads under checkstyle 14.

- Bump `com.puppycrawl.tools:checkstyle` from 10.26.1 to 14.0.0.
- Remove the `JavadocStyle` module from `config/checkstyle.xml`: the check was removed upstream in checkstyle 13.9.0. Its suggested replacement (`SummaryJavadoc`) only covers first-sentence checking, which we had explicitly disabled (`checkFirstSentence=false`), and the module only ever inspected `/** */` comments, which the codebase has already migrated away from in favor of `///` markdown doc comments — so it was dead weight rather than something to replace.
- Reformat two lambda bodies in `CompoundPinotMetricsFactory` that the tightened `Indentation` check in checkstyle 14 flags.

Verified by cross-checking every module in `config/checkstyle.xml` against the checkstyle 14.0.0 jar (`JavadocStyle` was the only removed one) and running the standalone checkstyle 14.0.0 CLI with our config over all Java sources and `.properties` resources — zero violations on files the Maven plugin scans.
