### PR TITLE
Wait for external view convergence before the single validation run in pauseless ingestion tests

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasePauselessRealtimeIngestionTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasePauselessRealtimeIngestionTest.java
@@ -202,6 +202,12 @@ public abstract class BasePauselessRealtimeIngestionTest extends BaseClusterInte
 
     disableFailure();
 
+    // The repair performed by the validation run below discovers the server hosting each stranded segment through
+    // the external view, so wait for the external view to catch up with the ideal state first. E.g. when commit-end
+    // fails, the stranded segments are already ONLINE in the ideal state, but on a loaded host the server may not
+    // have processed the CONSUMING -> ONLINE transitions yet, and the one-shot repair would permanently miss them.
+    PauselessRealtimeTestUtils.waitForExternalViewToConverge(_helixResourceManager, tableNameWithType, 100_000L);
+
     // Force-expire the segments stranded by the injected failure instead of waiting out the max segment completion
     // time: they become immediately eligible for repair, and their in-flight commit attempts keep getting rejected,
     // so the single validation run below stays the only recovery path under test. Segments created afterwards keep

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/PauselessRealtimeTestUtils.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/PauselessRealtimeTestUtils.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.helix.HelixManager;
+import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.utils.LLCSegmentName;
@@ -30,6 +31,7 @@ import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.util.TestUtils;
 
 import static org.testng.Assert.assertEquals;
 
@@ -43,6 +45,29 @@ public class PauselessRealtimeTestUtils {
     IdealState idealState = HelixHelper.getTableIdealState(helixManager, tableName);
     Map<String, Map<String, String>> segmentAssignment = idealState.getRecord().getMapFields();
     assertEquals(segmentAssignment.size(), numSegmentsExpected);
+  }
+
+  /// Waits until the external view of the given table converges to its ideal state, i.e. every instance of every
+  /// segment in the ideal state reaches the prescribed state in the external view.
+  ///
+  /// The segment repair performed by the validation task discovers segment replicas through the external view, so a
+  /// test that relies on a single validation run must wait for convergence before triggering it: a still-pending
+  /// `CONSUMING -> ONLINE` transition would make the one-shot repair permanently miss the segment.
+  public static void waitForExternalViewToConverge(PinotHelixResourceManager helixResourceManager,
+      String tableNameWithType, long timeoutMs) {
+    TestUtils.waitForCondition(aVoid -> {
+      IdealState idealState = helixResourceManager.getTableIdealState(tableNameWithType);
+      ExternalView externalView = helixResourceManager.getTableExternalView(tableNameWithType);
+      if (idealState == null || externalView == null) {
+        return false;
+      }
+      for (Map.Entry<String, Map<String, String>> entry : idealState.getRecord().getMapFields().entrySet()) {
+        if (!entry.getValue().equals(externalView.getStateMap(entry.getKey()))) {
+          return false;
+        }
+      }
+      return true;
+    }, 1000, timeoutMs, "External view failed to converge to ideal state for table: " + tableNameWithType);
   }
 
   /// Marks all current segments of the given table as exceeding the max segment completion time, making them


### PR DESCRIPTION
## Summary

Follow-up to #19292. `PauselessRealtimeIngestionIntegrationTest.testCommitEndMetadataFailure` [failed on CI](https://github.com/apache/pinot/actions/runs/32532078722/job/96925969353) with "Some segments still have missing url" even with #19292 in place, because the test still races Helix convergence:

- When commit-start succeeds, the stranded segment is already ONLINE in the ideal state, but the server still has to process the `CONSUMING -> ONLINE` transition before the external view shows ONLINE. On a loaded CI host these transitions queue up — in the failing run, one segment had not converged 26 seconds after its commit-start.
- The repair for COMMITTING segments (`uploadToDeepStoreIfMissing`) discovers the hosting server through the external view via `PeerServerSegmentFinder`, which retries only 5 times over ~8-15s, and the upload is deliberately not retried within a run — production relies on the periodic validation runs to retry.
- The test triggers a single validation run, so a still-pending transition at that moment makes the one-shot repair permanently miss the segment, and the URL wait can only time out.

## Fix

Make the repair's precondition explicit instead of racing it:

- Add `PauselessRealtimeTestUtils.waitForExternalViewToConverge` which polls until every instance of every segment in the ideal state reaches the prescribed state in the external view.
- Call it in `BasePauselessRealtimeIngestionTest.runValidationAndVerify` after disabling the failure injection and before force-expiring + triggering the validation run.

Convergence is guaranteed (the server already holds the locally built segment, so the ONLINE transition always eventually completes), so the wait is deterministic, and once the external view matches the ideal state the peer finder cannot miss. This also strengthens the tested contract: given a converged cluster, a **single** validation run must repair every stranded segment.

For the ideal-state-update and new-segment-metadata failure scenarios the external view already trivially matches the ideal state, so the wait is a no-op there. One deliberate trade-off: if a state transition genuinely fails (segment ERROR in the external view), the test now fails fast at the convergence wait with a clear message instead of a misleading "missing url" timeout — that case was unrecoverable in a single run anyway, since the ERROR-reset happens after the upload step within the same run.
